### PR TITLE
Elasticsearch: Add time zone setting to Date Histogram aggregation

### DIFF
--- a/packages/grafana-data/src/datetime/timezones.ts
+++ b/packages/grafana-data/src/datetime/timezones.ts
@@ -48,11 +48,13 @@ export const getTimeZoneInfo = (zone: string, timestamp: number): TimeZoneInfo |
   return mapToInfo(zone, timestamp);
 };
 
-export const getTimeZones = memoize((includeInternal = false): TimeZone[] => {
+export const getTimeZones = memoize((includeInternal: boolean | InternalTimeZones[] = false): TimeZone[] => {
   const initial: TimeZone[] = [];
 
-  if (includeInternal) {
+  if (includeInternal === true) {
     initial.push.apply(initial, [InternalTimeZones.default, InternalTimeZones.localBrowserTime, InternalTimeZones.utc]);
+  } else if (includeInternal) {
+    initial.push.apply(initial, includeInternal);
   }
 
   return moment.tz.names().reduce((zones: TimeZone[], zone: string) => {
@@ -67,32 +69,34 @@ export const getTimeZones = memoize((includeInternal = false): TimeZone[] => {
   }, initial);
 });
 
-export const getTimeZoneGroups = memoize((includeInternal = false): GroupedTimeZones[] => {
-  const timeZones = getTimeZones(includeInternal);
+export const getTimeZoneGroups = memoize(
+  (includeInternal: boolean | InternalTimeZones[] = false): GroupedTimeZones[] => {
+    const timeZones = getTimeZones(includeInternal);
 
-  const groups = timeZones.reduce((groups: Record<string, TimeZone[]>, zone: TimeZone) => {
-    const delimiter = zone.indexOf('/');
+    const groups = timeZones.reduce((groups: Record<string, TimeZone[]>, zone: TimeZone) => {
+      const delimiter = zone.indexOf('/');
 
-    if (delimiter === -1) {
-      const group = '';
+      if (delimiter === -1) {
+        const group = '';
+        groups[group] = groups[group] ?? [];
+        groups[group].push(zone);
+
+        return groups;
+      }
+
+      const group = zone.substr(0, delimiter);
       groups[group] = groups[group] ?? [];
       groups[group].push(zone);
 
       return groups;
-    }
+    }, {});
 
-    const group = zone.substr(0, delimiter);
-    groups[group] = groups[group] ?? [];
-    groups[group].push(zone);
-
-    return groups;
-  }, {});
-
-  return Object.keys(groups).map((name) => ({
-    name,
-    zones: groups[name],
-  }));
-});
+    return Object.keys(groups).map((name) => ({
+      name,
+      zones: groups[name],
+    }));
+  }
+);
 
 const mapInternal = (zone: string, timestamp: number): TimeZoneInfo | undefined => {
   switch (zone) {

--- a/packages/grafana-data/src/datetime/timezones.ts
+++ b/packages/grafana-data/src/datetime/timezones.ts
@@ -52,9 +52,9 @@ export const getTimeZones = memoize((includeInternal: boolean | InternalTimeZone
   const initial: TimeZone[] = [];
 
   if (includeInternal === true) {
-    initial.push.apply(initial, [InternalTimeZones.default, InternalTimeZones.localBrowserTime, InternalTimeZones.utc]);
+    initial.push(InternalTimeZones.default, InternalTimeZones.localBrowserTime, InternalTimeZones.utc);
   } else if (includeInternal) {
-    initial.push.apply(initial, includeInternal);
+    initial.push(...includeInternal);
   }
 
   return moment.tz.names().reduce((zones: TimeZone[], zone: string) => {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.tsx
@@ -20,7 +20,7 @@ export interface Props {
   width?: number;
   autoFocus?: boolean;
   onBlur?: () => void;
-  includeInternal?: boolean;
+  includeInternal?: boolean | InternalTimeZones[];
   disabled?: boolean;
 }
 
@@ -63,7 +63,7 @@ interface SelectableZoneGroup extends SelectableValue<string> {
   options: SelectableZone[];
 }
 
-const useTimeZones = (includeInternal: boolean): SelectableZoneGroup[] => {
+const useTimeZones = (includeInternal: boolean | InternalTimeZones[]): SelectableZoneGroup[] => {
   const now = Date.now();
 
   const timeZoneGroups = getTimeZoneGroups(includeInternal).map((group: GroupedTimeZones) => {

--- a/pkg/tsdb/elasticsearch/client/models.go
+++ b/pkg/tsdb/elasticsearch/client/models.go
@@ -244,6 +244,7 @@ type DateHistogramAgg struct {
 	ExtendedBounds *ExtendedBounds `json:"extended_bounds"`
 	Format         string          `json:"format"`
 	Offset         string          `json:"offset,omitempty"`
+	TimeZone       string          `json:"time_zone,omitempty"`
 }
 
 // FiltersAggregation represents a filters aggregation

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -264,6 +264,12 @@ func addDateHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, timeFro
 			a.Missing = &missing
 		}
 
+		if timezone, err := bucketAgg.Settings.Get("time_zone").String(); err == nil {
+			if timezone != "utc" {
+				a.TimeZone = timezone
+			}
+		}
+
 		aggBuilder = b
 	})
 

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -264,7 +264,7 @@ func addDateHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, timeFro
 			a.Missing = &missing
 		}
 
-		if timezone, err := bucketAgg.Settings.Get("time_zone").String(); err == nil {
+		if timezone, err := bucketAgg.Settings.Get("timeZone").String(); err == nil {
 			if timezone != "utc" {
 				a.TimeZone = timezone
 			}

--- a/pkg/tsdb/elasticsearch/time_series_query_test.go
+++ b/pkg/tsdb/elasticsearch/time_series_query_test.go
@@ -422,8 +422,8 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 				require.NoError(t, err)
 				sr := c.multisearchRequests[0].Requests[0]
 
-				deteHistogram := sr.Aggs[0].Aggregation.Aggregation.(*es.DateHistogramAgg)
-				require.Empty(t, deteHistogram.TimeZone)
+				dateHistogram := sr.Aggs[0].Aggregation.Aggregation.(*es.DateHistogramAgg)
+				require.Empty(t, dateHistogram.TimeZone)
 			})
 
 			t.Run("Should include time_zone when timeZone is not utc", func(t *testing.T) {

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
@@ -102,10 +102,10 @@ export const DateHistogramSettingsEditor = ({ bucketAgg }: Props) => {
 
       <InlineField label="Timezone" {...inlineFieldProps}>
         <TimeZonePicker
-          value={bucketAgg.settings?.time_zone || bucketAggregationConfig.date_histogram.defaultSettings?.time_zone}
+          value={bucketAgg.settings?.timeZone || bucketAggregationConfig.date_histogram.defaultSettings?.timeZone}
           includeInternal={[InternalTimeZones.utc]}
           onChange={(timeZone) => {
-            dispatch(changeBucketAggregationSetting({ bucketAgg, settingName: 'time_zone', newValue: timeZone }));
+            dispatch(changeBucketAggregationSetting({ bucketAgg, settingName: 'timeZone', newValue: timeZone }));
           }}
         />
       </InlineField>

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/DateHistogramSettingsEditor.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { InlineField, Input, Select } from '@grafana/ui';
+import { InlineField, Input, Select, TimeZonePicker } from '@grafana/ui';
 import { DateHistogram } from '../aggregations';
 import { bucketAggregationConfig } from '../utils';
 import { useDispatch } from '../../../../hooks/useStatelessReducer';
-import { SelectableValue } from '@grafana/data';
+import { InternalTimeZones, SelectableValue } from '@grafana/data';
 import { changeBucketAggregationSetting } from '../state/actions';
 import { inlineFieldProps } from '.';
 import { uniqueId } from 'lodash';
@@ -97,6 +97,16 @@ export const DateHistogramSettingsEditor = ({ bucketAgg }: Props) => {
             dispatch(changeBucketAggregationSetting({ bucketAgg, settingName: 'offset', newValue: e.target.value }))
           }
           defaultValue={bucketAgg.settings?.offset || bucketAggregationConfig.date_histogram.defaultSettings?.offset}
+        />
+      </InlineField>
+
+      <InlineField label="Timezone" {...inlineFieldProps}>
+        <TimeZonePicker
+          value={bucketAgg.settings?.time_zone || bucketAggregationConfig.date_histogram.defaultSettings?.time_zone}
+          includeInternal={[InternalTimeZones.utc]}
+          onChange={(timeZone) => {
+            dispatch(changeBucketAggregationSetting({ bucketAgg, settingName: 'time_zone', newValue: timeZone }));
+          }}
         />
       </InlineField>
     </>

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/aggregations.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/aggregations.ts
@@ -19,6 +19,7 @@ export interface DateHistogram extends BucketAggregationWithField {
     min_doc_count?: string;
     trimEdges?: string;
     offset?: string;
+    time_zone?: string;
   };
 }
 

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/aggregations.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/aggregations.ts
@@ -19,7 +19,7 @@ export interface DateHistogram extends BucketAggregationWithField {
     min_doc_count?: string;
     trimEdges?: string;
     offset?: string;
-    time_zone?: string;
+    timeZone?: string;
   };
 }
 

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/utils.ts
@@ -1,6 +1,6 @@
 import { BucketsConfiguration } from '../../../types';
 import { defaultFilter } from './SettingsEditor/FiltersSettingsEditor/utils';
-import { SelectableValue } from '@grafana/data';
+import { InternalTimeZones, SelectableValue } from '@grafana/data';
 
 export const bucketAggregationConfig: BucketsConfiguration = {
   terms: {
@@ -34,6 +34,7 @@ export const bucketAggregationConfig: BucketsConfiguration = {
       interval: 'auto',
       min_doc_count: '0',
       trimEdges: '0',
+      time_zone: InternalTimeZones.utc,
     },
   },
   histogram: {

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/utils.ts
@@ -34,7 +34,7 @@ export const bucketAggregationConfig: BucketsConfiguration = {
       interval: 'auto',
       min_doc_count: '0',
       trimEdges: '0',
-      time_zone: InternalTimeZones.utc,
+      timeZone: InternalTimeZones.utc,
     },
   },
   histogram: {

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -1,3 +1,4 @@
+import { InternalTimeZones } from '@grafana/data';
 import { gte, lt } from 'semver';
 import {
   Filters,
@@ -99,6 +100,9 @@ export class ElasticQueryBuilder {
     esAgg.min_doc_count = settings.min_doc_count || 0;
     esAgg.extended_bounds = { min: '$timeFrom', max: '$timeTo' };
     esAgg.format = 'epoch_millis';
+    if (settings.time_zone && settings.time_zone !== InternalTimeZones.utc) {
+      esAgg.time_zone = settings.time_zone;
+    }
 
     if (settings.offset !== '') {
       esAgg.offset = settings.offset;

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -100,8 +100,8 @@ export class ElasticQueryBuilder {
     esAgg.min_doc_count = settings.min_doc_count || 0;
     esAgg.extended_bounds = { min: '$timeFrom', max: '$timeTo' };
     esAgg.format = 'epoch_millis';
-    if (settings.time_zone && settings.time_zone !== InternalTimeZones.utc) {
-      esAgg.time_zone = settings.time_zone;
+    if (settings.timeZone && settings.timeZone !== InternalTimeZones.utc) {
+      esAgg.time_zone = settings.timeZone;
     }
 
     if (settings.offset !== '') {

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
@@ -841,5 +841,50 @@ describe('ElasticQueryBuilder', () => {
 
       expect(serialDiff.lag).toBe(1);
     });
+
+    describe('date_histogram', () => {
+      it('should not include time_zone if not present in the query model', () => {
+        const query = builder.build({
+          refId: 'A',
+          metrics: [{ type: 'count', id: '1' }],
+          timeField: '@timestamp',
+          bucketAggs: [{ type: 'date_histogram', field: '@timestamp', id: '2', settings: { min_doc_count: '1' } }],
+        });
+
+        expect(query.aggs['2'].date_histogram.time_zone).not.toBeDefined();
+      });
+
+      it('should not include time_zone if "utc" in the query model', () => {
+        const query = builder.build({
+          refId: 'A',
+          metrics: [{ type: 'count', id: '1' }],
+          timeField: '@timestamp',
+          bucketAggs: [
+            { type: 'date_histogram', field: '@timestamp', id: '2', settings: { min_doc_count: '1', timeZone: 'utc' } },
+          ],
+        });
+
+        expect(query.aggs['2'].date_histogram.time_zone).not.toBeDefined();
+      });
+
+      it('should include time_zone if not "utc" in the query model', () => {
+        const expectedTimezone = 'America/Los_angeles';
+        const query = builder.build({
+          refId: 'A',
+          metrics: [{ type: 'count', id: '1' }],
+          timeField: '@timestamp',
+          bucketAggs: [
+            {
+              type: 'date_histogram',
+              field: '@timestamp',
+              id: '2',
+              settings: { min_doc_count: '1', timeZone: expectedTimezone },
+            },
+          ],
+        });
+
+        expect(query.aggs['2'].date_histogram.time_zone).toBe(expectedTimezone);
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Adds a `time_zone` setting to Elasticsearch's Date Histogram aggregation.
Internally ES uses UTC for bucketing, with this PR we allow users to specify a different timezone when performing Date Histogram aggregations so that bucketing can be aligned to their preferred timezone. when not set defaults to UTC to keep retro compatibility.

In order to reuse the TimeZonePicker component `from @grafana/ui` and given that from all of the internal timezones only `utc` is needed, as discussed with @ifrost, `includeInternal` is now `boolean | InternalTimezone[]`. the previous behavior remains the same (`true` will include all internal timezones`) but it is be now possible to include only a subset of internal timezones by providing an array.

![Screenshot 2021-10-27 at 05 05 45](https://user-images.githubusercontent.com/1170767/138998216-686e5c60-aa29-4405-a5c2-a7a391578c23.png)

/cc. @simianhacker 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #6222
Fixes #38672
Closes #38789



