### PR TITLE
Prometheus: Fix exemplars error clearing

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromExemplarField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExemplarField.tsx
@@ -26,7 +26,8 @@ export function PromExemplarField({ datasource, onChange, query }: Props) {
       onChange(false);
     } else {
       setError(null);
-      if (prevError !== error) {
+      // If error is cleared, we want to change exemplar to true
+      if (prevError && !error) {
         onChange(true);
       }
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
In dashboard, when we disable exemplars, save it and reload it, exemplars are set to true. This is because faulty logic in useEffect. We want to have stricter rules and only set exemplars to true if previous error was truthy and current error is faulty - e.g. error was cleared. 

**Which issue(s) this PR fixes**:
Fixes https://raintank-corp.slack.com/archives/C036J5B39/p1635173351056800


