### PR TITLE
Chore: Refactor GoConvey in services/dashboards package

### DIFF
--- a/pkg/services/dashboards/dashboard_service_test.go
+++ b/pkg/services/dashboards/dashboard_service_test.go
@@ -11,11 +11,12 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/guardian"
-	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDashboardService(t *testing.T) {
-	Convey("Dashboard service tests", t, func() {
+	t.Run("Dashboard service tests", func(t *testing.T) {
 		bus.ClearBusHandlers()
 
 		fakeStore := fakeDashboardStore{}
@@ -25,35 +26,36 @@ func TestDashboardService(t *testing.T) {
 		}
 
 		origNewDashboardGuardian := guardian.New
+		defer func() { guardian.New = origNewDashboardGuardian }()
 		guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanSaveValue: true})
 
-		Convey("Save dashboard validation", func() {
+		t.Run("Save dashboard validation", func(t *testing.T) {
 			dto := &SaveDashboardDTO{}
 
-			Convey("When saving a dashboard with empty title it should return error", func() {
+			t.Run("When saving a dashboard with empty title it should return error", func(t *testing.T) {
 				titles := []string{"", " ", "   \t   "}
 
 				for _, title := range titles {
 					dto.Dashboard = models.NewDashboard(title)
 					_, err := service.SaveDashboard(dto, false)
-					So(err, ShouldEqual, models.ErrDashboardTitleEmpty)
+					require.Equal(t, err, models.ErrDashboardTitleEmpty)
 				}
 			})
 
-			Convey("Should return validation error if it's a folder and have a folder id", func() {
+			t.Run("Should return validation error if it's a folder and have a folder id", func(t *testing.T) {
 				dto.Dashboard = models.NewDashboardFolder("Folder")
 				dto.Dashboard.FolderId = 1
 				_, err := service.SaveDashboard(dto, false)
-				So(err, ShouldEqual, models.ErrDashboardFolderCannotHaveParent)
+				require.Equal(t, err, models.ErrDashboardFolderCannotHaveParent)
 			})
 
-			Convey("Should return validation error if folder is named General", func() {
+			t.Run("Should return validation error if folder is named General", func(t *testing.T) {
 				dto.Dashboard = models.NewDashboardFolder("General")
 				_, err := service.SaveDashboard(dto, false)
-				So(err, ShouldEqual, models.ErrDashboardFolderNameExists)
+				require.Equal(t, err, models.ErrDashboardFolderNameExists)
 			})
 
-			Convey("When saving a dashboard should validate uid", func() {
+			t.Run("When saving a dashboard should validate uid", func(t *testing.T) {
 				origValidateAlerts := validateAlerts
 				t.Cleanup(func() {
 					validateAlerts = origValidateAlerts
@@ -81,11 +83,11 @@ func TestDashboardService(t *testing.T) {
 					dto.User = &models.SignedInUser{}
 
 					_, err := service.buildSaveDashboardCommand(dto, true, false)
-					So(err, ShouldEqual, tc.Error)
+					require.Equal(t, err, tc.Error)
 				}
 			})
 
-			Convey("Should return validation error if dashboard is provisioned", func() {
+			t.Run("Should return validation error if dashboard is provisioned", func(t *testing.T) {
 				t.Cleanup(func() {
 					fakeStore.provisionedData = nil
 				})
@@ -103,10 +105,10 @@ func TestDashboardService(t *testing.T) {
 				dto.Dashboard.SetId(3)
 				dto.User = &models.SignedInUser{UserId: 1}
 				_, err := service.SaveDashboard(dto, false)
-				So(err, ShouldEqual, models.ErrDashboardCannotSaveProvisionedDashboard)
+				require.Equal(t, err, models.ErrDashboardCannotSaveProvisionedDashboard)
 			})
 
-			Convey("Should not return validation error if dashboard is provisioned but UI updates allowed", func() {
+			t.Run("Should not return validation error if dashboard is provisioned but UI updates allowed", func(t *testing.T) {
 				origValidateAlerts := validateAlerts
 				t.Cleanup(func() {
 					validateAlerts = origValidateAlerts
@@ -119,10 +121,10 @@ func TestDashboardService(t *testing.T) {
 				dto.Dashboard.SetId(3)
 				dto.User = &models.SignedInUser{UserId: 1}
 				_, err := service.SaveDashboard(dto, true)
-				So(err, ShouldBeNil)
+				require.NoError(t, err)
 			})
 
-			Convey("Should return validation error if alert data is invalid", func() {
+			t.Run("Should return validation error if alert data is invalid", func(t *testing.T) {
 				origValidateAlerts := validateAlerts
 				t.Cleanup(func() {
 					validateAlerts = origValidateAlerts
@@ -133,14 +135,14 @@ func TestDashboardService(t *testing.T) {
 
 				dto.Dashboard = models.NewDashboard("Dash")
 				_, err := service.SaveDashboard(dto, false)
-				So(err.Error(), ShouldEqual, "alert validation error")
+				require.Equal(t, err.Error(), "alert validation error")
 			})
 		})
 
-		Convey("Save provisioned dashboard validation", func() {
+		t.Run("Save provisioned dashboard validation", func(t *testing.T) {
 			dto := &SaveDashboardDTO{}
 
-			Convey("Should not return validation error if dashboard is provisioned", func() {
+			t.Run("Should not return validation error if dashboard is provisioned", func(t *testing.T) {
 				origUpdateAlerting := UpdateAlerting
 				t.Cleanup(func() {
 					UpdateAlerting = origUpdateAlerting
@@ -162,10 +164,10 @@ func TestDashboardService(t *testing.T) {
 				dto.Dashboard.SetId(3)
 				dto.User = &models.SignedInUser{UserId: 1}
 				_, err := service.SaveProvisionedDashboard(dto, nil)
-				So(err, ShouldBeNil)
+				require.NoError(t, err)
 			})
 
-			Convey("Should override invalid refresh interval if dashboard is provisioned", func() {
+			t.Run("Should override invalid refresh interval if dashboard is provisioned", func(t *testing.T) {
 				oldRefreshInterval := setting.MinRefreshInterval
 				setting.MinRefreshInterval = "5m"
 				defer func() { setting.MinRefreshInterval = oldRefreshInterval }()
@@ -192,15 +194,15 @@ func TestDashboardService(t *testing.T) {
 				dto.User = &models.SignedInUser{UserId: 1}
 				dto.Dashboard.Data.Set("refresh", "1s")
 				_, err := service.SaveProvisionedDashboard(dto, nil)
-				So(err, ShouldBeNil)
-				So(dto.Dashboard.Data.Get("refresh").MustString(), ShouldEqual, "5m")
+				require.NoError(t, err)
+				require.Equal(t, dto.Dashboard.Data.Get("refresh").MustString(), "5m")
 			})
 		})
 
-		Convey("Import dashboard validation", func() {
+		t.Run("Import dashboard validation", func(t *testing.T) {
 			dto := &SaveDashboardDTO{}
 
-			Convey("Should return validation error if dashboard is provisioned", func() {
+			t.Run("Should return validation error if dashboard is provisioned", func(t *testing.T) {
 				t.Cleanup(func() {
 					fakeStore.provisionedData = nil
 				})
@@ -227,45 +229,42 @@ func TestDashboardService(t *testing.T) {
 				dto.Dashboard.SetId(3)
 				dto.User = &models.SignedInUser{UserId: 1}
 				_, err := service.ImportDashboard(dto)
-				So(err, ShouldEqual, models.ErrDashboardCannotSaveProvisionedDashboard)
+				require.Equal(t, err, models.ErrDashboardCannotSaveProvisionedDashboard)
 			})
 		})
 
-		Convey("Given provisioned dashboard", func() {
-			result := setupDeleteHandlers(t, &fakeStore, true)
-
-			Convey("DeleteProvisionedDashboard should delete it", func() {
+		t.Run("Given provisioned dashboard", func(t *testing.T) {
+			t.Run("DeleteProvisionedDashboard should delete it", func(t *testing.T) {
+				result := setupDeleteHandlers(t, &fakeStore, true)
 				err := service.DeleteProvisionedDashboard(1, 1)
-				So(err, ShouldBeNil)
-				So(result.deleteWasCalled, ShouldBeTrue)
+				require.NoError(t, err)
+				require.True(t, result.deleteWasCalled)
 			})
 
-			Convey("DeleteDashboard should fail to delete it", func() {
+			t.Run("DeleteDashboard should fail to delete it", func(t *testing.T) {
+				result := setupDeleteHandlers(t, &fakeStore, true)
 				err := service.DeleteDashboard(1, 1)
-				So(err, ShouldEqual, models.ErrDashboardCannotDeleteProvisionedDashboard)
-				So(result.deleteWasCalled, ShouldBeFalse)
+				require.Equal(t, err, models.ErrDashboardCannotDeleteProvisionedDashboard)
+				require.False(t, result.deleteWasCalled)
 			})
 		})
 
-		Convey("Given non provisioned dashboard", func() {
+		t.Run("Given non provisioned dashboard", func(t *testing.T) {
 			result := setupDeleteHandlers(t, &fakeStore, false)
 
-			Convey("DeleteProvisionedDashboard should delete it", func() {
+			t.Run("DeleteProvisionedDashboard should delete it", func(t *testing.T) {
 				err := service.DeleteProvisionedDashboard(1, 1)
-				So(err, ShouldBeNil)
-				So(result.deleteWasCalled, ShouldBeTrue)
+				require.NoError(t, err)
+				require.True(t, result.deleteWasCalled)
 			})
 
-			Convey("DeleteDashboard should delete it", func() {
+			t.Run("DeleteDashboard should delete it", func(t *testing.T) {
 				err := service.DeleteDashboard(1, 1)
-				So(err, ShouldBeNil)
-				So(result.deleteWasCalled, ShouldBeTrue)
+				require.NoError(t, err)
+				require.True(t, result.deleteWasCalled)
 			})
 		})
 
-		Reset(func() {
-			guardian.New = origNewDashboardGuardian
-		})
 	})
 }
 
@@ -285,8 +284,8 @@ func setupDeleteHandlers(t *testing.T, fakeStore *fakeDashboardStore, provisione
 
 	result := &Result{}
 	bus.AddHandler("test", func(cmd *models.DeleteDashboardCommand) error {
-		So(cmd.Id, ShouldEqual, 1)
-		So(cmd.OrgId, ShouldEqual, 1)
+		require.Equal(t, cmd.Id, int64(1))
+		require.Equal(t, cmd.OrgId, int64(1))
 		result.deleteWasCalled = true
 		return nil
 	})

--- a/pkg/services/dashboards/dashboard_service_test.go
+++ b/pkg/services/dashboards/dashboard_service_test.go
@@ -264,7 +264,6 @@ func TestDashboardService(t *testing.T) {
 				require.True(t, result.deleteWasCalled)
 			})
 		})
-
 	})
 }
 


### PR DESCRIPTION
Related to #40633 this removes GoConvey test framework from the services/dashboard package.