### PR TITLE
Chore: Refactor GoConvey in notification service package

### DIFF
--- a/pkg/services/notifications/codes_test.go
+++ b/pkg/services/notifications/codes_test.go
@@ -5,34 +5,35 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
-	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestEmailCodes(t *testing.T) {
-	Convey("When generating code", t, func() {
+	t.Run("When generating code", func(t *testing.T) {
 		cfg := setting.NewCfg()
 		cfg.EmailCodeValidMinutes = 120
 
 		user := &models.User{Id: 10, Email: "t@a.com", Login: "asd", Password: "1", Rands: "2"}
 		code, err := createUserEmailCode(cfg, user, nil)
-		So(err, ShouldBeNil)
+		require.NoError(t, err)
 
-		Convey("getLoginForCode should return login", func() {
+		t.Run("getLoginForCode should return login", func(t *testing.T) {
 			login := getLoginForEmailCode(code)
-			So(login, ShouldEqual, "asd")
+			require.Equal(t, login, "asd")
 		})
 
-		Convey("Can verify valid code", func() {
+		t.Run("Can verify valid code", func(t *testing.T) {
 			isValid, err := validateUserEmailCode(cfg, user, code)
-			So(err, ShouldBeNil)
-			So(isValid, ShouldBeTrue)
+			require.NoError(t, err)
+			require.True(t, isValid)
 		})
 
-		Convey("Cannot verify in-valid code", func() {
+		t.Run("Cannot verify in-valid code", func(t *testing.T) {
 			code = "ASD"
 			isValid, err := validateUserEmailCode(cfg, user, code)
-			So(err, ShouldBeNil)
-			So(isValid, ShouldBeFalse)
+			require.NoError(t, err)
+			require.False(t, isValid)
 		})
 	})
 }

--- a/pkg/services/notifications/send_email_integration_test.go
+++ b/pkg/services/notifications/send_email_integration_test.go
@@ -7,11 +7,15 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
-	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestEmailIntegrationTest(t *testing.T) {
-	SkipConvey("Given the notifications service", t, func() {
+	t.Run("Given the notifications service", func(t *testing.T) {
+		t.Skip()
+		return // The original GoConvey test has been skipped
+
 		setting.StaticRootPath = "../../../public/"
 		setting.BuildVersion = "4.0.0"
 
@@ -24,7 +28,7 @@ func TestEmailIntegrationTest(t *testing.T) {
 		ns.Cfg.Smtp.FromName = "Grafana Admin"
 		ns.Cfg.Smtp.ContentTypes = []string{"text/html", "text/plain"}
 
-		Convey("When sending reset email password", func() {
+		t.Run("When sending reset email password", func(t *testing.T) {
 			cmd := &models.SendEmailCommand{
 
 				Data: map[string]interface{}{
@@ -54,15 +58,15 @@ func TestEmailIntegrationTest(t *testing.T) {
 			}
 
 			err := ns.sendEmailCommandHandler(cmd)
-			So(err, ShouldBeNil)
+			require.NoError(t, err)
 
 			sentMsg := <-ns.mailQueue
-			So(sentMsg.From, ShouldEqual, "Grafana Admin <from@address.com>")
-			So(sentMsg.To[0], ShouldEqual, "asdf@asdf.com")
+			require.Equal(t, sentMsg.From, "Grafana Admin <from@address.com>")
+			require.Equal(t, sentMsg.To[0], "asdf@asdf.com")
 			err = ioutil.WriteFile("../../../tmp/test_email.html", []byte(sentMsg.Body["text/html"]), 0777)
-			So(err, ShouldBeNil)
+			require.NoError(t, err)
 			err = ioutil.WriteFile("../../../tmp/test_email.txt", []byte(sentMsg.Body["text/plain"]), 0777)
-			So(err, ShouldBeNil)
+			require.NoError(t, err)
 		})
 	})
 }

--- a/pkg/services/notifications/send_email_integration_test.go
+++ b/pkg/services/notifications/send_email_integration_test.go
@@ -14,7 +14,6 @@ import (
 func TestEmailIntegrationTest(t *testing.T) {
 	t.Run("Given the notifications service", func(t *testing.T) {
 		t.Skip()
-		return // The original GoConvey test has been skipped
 
 		setting.StaticRootPath = "../../../public/"
 		setting.BuildVersion = "4.0.0"


### PR DESCRIPTION
This is related to #40633 and removes GoConvey from the notifications package. Keep in mind that one of the tests has been skipped in GoConvey and I left it like that, as it seemed to be hanging on channel read otherwise.