### PR TITLE
Chore: Refactor GoConvey in the guardian package

### DIFF
--- a/pkg/services/guardian/guardian_test.go
+++ b/pkg/services/guardian/guardian_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
-	. "github.com/smartystreets/goconvey/convey"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -681,7 +681,7 @@ func (sc *scenarioContext) verifyUpdateChildDashboardPermissionsWithOverrideShou
 }
 
 func TestGuardianGetHiddenACL(t *testing.T) {
-	Convey("Get hidden ACL tests", t, func() {
+	t.Run("Get hidden ACL tests", func(t *testing.T) {
 		bus.ClearBusHandlers()
 
 		bus.AddHandler("test", func(query *models.GetDashboardAclInfoListQuery) error {
@@ -696,7 +696,7 @@ func TestGuardianGetHiddenACL(t *testing.T) {
 		cfg := setting.NewCfg()
 		cfg.HiddenUsers = map[string]struct{}{"user2": {}}
 
-		Convey("Should get hidden acl", func() {
+		t.Run("Should get hidden acl", func(t *testing.T) {
 			user := &models.SignedInUser{
 				OrgId:  orgID,
 				UserId: 1,
@@ -705,13 +705,13 @@ func TestGuardianGetHiddenACL(t *testing.T) {
 			g := New(context.Background(), dashboardID, orgID, user)
 
 			hiddenACL, err := g.GetHiddenACL(cfg)
-			So(err, ShouldBeNil)
+			require.NoError(t, err)
 
-			So(hiddenACL, ShouldHaveLength, 1)
-			So(hiddenACL[0].UserID, ShouldEqual, 2)
+			require.Equal(t, len(hiddenACL), 1)
+			require.Equal(t, hiddenACL[0].UserID, int64(2))
 		})
 
-		Convey("Grafana admin should not get hidden acl", func() {
+		t.Run("Grafana admin should not get hidden acl", func(t *testing.T) {
 			user := &models.SignedInUser{
 				OrgId:          orgID,
 				UserId:         1,
@@ -721,9 +721,9 @@ func TestGuardianGetHiddenACL(t *testing.T) {
 			g := New(context.Background(), dashboardID, orgID, user)
 
 			hiddenACL, err := g.GetHiddenACL(cfg)
-			So(err, ShouldBeNil)
+			require.NoError(t, err)
 
-			So(hiddenACL, ShouldHaveLength, 0)
+			require.Equal(t, len(hiddenACL), 0)
 		})
 	})
 }


### PR DESCRIPTION
This is also related to #40633 and like many other fairly boring PRs in the list this removes GoConvey from the guardian package.