### PR TITLE
Plugins Catalog: Fix plugin details header styles

### DIFF
--- a/public/app/features/plugins/admin/components/PluginDetailsHeader.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsHeader.tsx
@@ -124,7 +124,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       align-items: center;
       margin-top: ${theme.spacing()};
       margin-bottom: ${theme.spacing()};
-
+      flex-flow: wrap;
       & > * {
         &::after {
           content: '|';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: details page will behave properly on a narrow screen

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #40856

**Special notes for your reviewer**:
Screenshots on different screen width:
* 1024 px
![1024x1153](https://user-images.githubusercontent.com/36892657/138846746-4ddcc736-c734-4755-afdc-a0908f36bff9.png)

* 768 px
![768x1153](https://user-images.githubusercontent.com/36892657/138846737-cb595705-125e-4f16-95b3-91f66f2feec0.png)

* 425 px
![425x1153](https://user-images.githubusercontent.com/36892657/138846728-6b33fb24-78f0-46be-84c3-98c6e6082a12.png)

*375 px
![375x1153](https://user-images.githubusercontent.com/36892657/138846758-fdad2ea3-daf5-4adf-a418-a7b86a857000.png)

* 320x1153
![320x1153](https://user-images.githubusercontent.com/36892657/138846753-8d9c9245-307c-4f08-b158-bcac1c22753d.png)



