### PR TITLE
prometheus: monaco: handle in-dashboard and in-explore use cases

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -1,5 +1,5 @@
 import React, { memo, FC, useEffect } from 'react';
-import { QueryEditorProps } from '@grafana/data';
+import { QueryEditorProps, CoreApp } from '@grafana/data';
 import { PrometheusDatasource } from '../datasource';
 import { PromQuery, PromOptions } from '../types';
 import PromQueryField from './PromQueryField';
@@ -26,6 +26,7 @@ export const PromExploreQueryEditor: FC<Props> = (props: Props) => {
 
   return (
     <PromQueryField
+      app={CoreApp.Explore}
       datasource={datasource}
       query={query}
       range={range}

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -299,7 +299,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
                 <div className="gf-form gf-form--grow flex-shrink-1 min-width-15">
                   {isMonacoEditorEnabled ? (
                     <MonacoQueryFieldWrapper
-                      isExplore={this.props.app === CoreApp.Explore}
+                      runQueryOnBlur={this.props.app !== CoreApp.Explore}
                       languageProvider={languageProvider}
                       history={history}
                       onChange={this.onChangeQuery}

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -304,7 +304,6 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
                       history={history}
                       onChange={this.onChangeQuery}
                       onRunQuery={this.props.onRunQuery}
-                      onBlur={this.props.onBlur}
                       initialValue={query.expr ?? ''}
                     />
                   ) : (

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -19,7 +19,7 @@ import { LanguageMap, languages as prismLanguages } from 'prismjs';
 import { PromQuery, PromOptions } from '../types';
 import { roundMsToMin } from '../language_utils';
 import { CancelablePromise, makePromiseCancelable } from 'app/core/utils/CancelablePromise';
-import { QueryEditorProps, QueryHint, isDataFrame, toLegacyResponseData, TimeRange } from '@grafana/data';
+import { QueryEditorProps, QueryHint, isDataFrame, toLegacyResponseData, TimeRange, CoreApp } from '@grafana/data';
 import { PrometheusDatasource } from '../datasource';
 import { PrometheusMetricsBrowser } from './PrometheusMetricsBrowser';
 import { MonacoQueryFieldWrapper } from './monaco-query-field/MonacoQueryFieldWrapper';
@@ -299,6 +299,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
                 <div className="gf-form gf-form--grow flex-shrink-1 min-width-15">
                   {isMonacoEditorEnabled ? (
                     <MonacoQueryFieldWrapper
+                      isExplore={this.props.app === CoreApp.Explore}
                       languageProvider={languageProvider}
                       history={history}
                       onChange={this.onChangeQuery}

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -22,7 +22,7 @@ import { CancelablePromise, makePromiseCancelable } from 'app/core/utils/Cancela
 import { QueryEditorProps, QueryHint, isDataFrame, toLegacyResponseData, TimeRange } from '@grafana/data';
 import { PrometheusDatasource } from '../datasource';
 import { PrometheusMetricsBrowser } from './PrometheusMetricsBrowser';
-import { MonacoQueryFieldLazy } from './monaco-query-field/MonacoQueryFieldLazy';
+import { MonacoQueryFieldWrapper } from './monaco-query-field/MonacoQueryFieldWrapper';
 import { LocalStorageValueProvider } from 'app/core/components/LocalStorageValueProvider';
 
 export const RECORDING_RULES_GROUP = '__recording_rules__';
@@ -298,11 +298,12 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
 
                 <div className="gf-form gf-form--grow flex-shrink-1 min-width-15">
                   {isMonacoEditorEnabled ? (
-                    <MonacoQueryFieldLazy
+                    <MonacoQueryFieldWrapper
                       languageProvider={languageProvider}
                       history={history}
                       onChange={this.onChangeQuery}
                       onRunQuery={this.props.onRunQuery}
+                      onBlur={this.props.onBlur}
                       initialValue={query.expr ?? ''}
                     />
                   ) : (

--- a/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/prometheus/components/__snapshots__/PromExploreQueryEditor.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`PromExploreQueryEditor should render component 1`] = `
       }
     />
   }
+  app="explore"
   data={
     Object {
       "request": Object {

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -62,11 +62,12 @@ const getStyles = (theme: GrafanaTheme2) => {
 
 const MonacoQueryField = (props: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  const { languageProvider, history, onChange, initialValue } = props;
+  const { languageProvider, history, onBlur, onRunQuery, initialValue } = props;
 
   const lpRef = useLatest(languageProvider);
   const historyRef = useLatest(history);
-  const onChangeRef = useLatest(onChange);
+  const onRunQueryRef = useLatest(onRunQuery);
+  const onBlurRef = useLatest(onBlur);
 
   const autocompleteDisposeFun = useRef<(() => void) | null>(null);
 
@@ -96,7 +97,7 @@ const MonacoQueryField = (props: Props) => {
         onMount={(editor, monaco) => {
           // we setup on-blur
           editor.onDidBlurEditorWidget(() => {
-            onChangeRef.current(editor.getValue());
+            onBlurRef.current(editor.getValue());
           });
 
           // we construct a DataProvider object
@@ -169,9 +170,7 @@ const MonacoQueryField = (props: Props) => {
           // handle: shift + enter
           // FIXME: maybe move this functionality into CodeEditor?
           editor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, () => {
-            const text = editor.getValue();
-            props.onChange(text);
-            props.onRunQuery();
+            onRunQueryRef.current(editor.getValue());
           });
         }}
       />

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldProps.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldProps.ts
@@ -10,6 +10,6 @@ export type Props = {
   initialValue: string;
   languageProvider: PromQlLanguageProvider;
   history: Array<HistoryItem<PromQuery>>;
-  onChange: (query: string) => void;
-  onRunQuery: () => void;
+  onRunQuery: (value: string) => void;
+  onBlur: (value: string) => void;
 };

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
@@ -5,12 +5,12 @@ import { Props as MonacoProps } from './MonacoQueryFieldProps';
 type Props = Omit<MonacoProps, 'onRunQuery' | 'onBlur'> & {
   onChange: (query: string) => void;
   onRunQuery: () => void;
-  isExplore: boolean;
+  runQueryOnBlur: boolean;
 };
 
 export const MonacoQueryFieldWrapper = (props: Props) => {
   const lastRunValueRef = useRef<string | null>(null);
-  const { isExplore, onRunQuery, onChange, ...rest } = props;
+  const { runQueryOnBlur, onRunQuery, onChange, ...rest } = props;
 
   const handleRunQuery = (value: string) => {
     lastRunValueRef.current = value;
@@ -19,13 +19,13 @@ export const MonacoQueryFieldWrapper = (props: Props) => {
   };
 
   const handleBlur = (value: string) => {
-    if (isExplore) {
-      onChange(value);
-    } else {
+    if (runQueryOnBlur) {
       // run handleRunQuery only if the current value is different from the last-time-executed value
       if (value !== lastRunValueRef.current) {
         handleRunQuery(value);
       }
+    } else {
+      onChange(value);
     }
   };
 

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
@@ -27,7 +27,7 @@ export const MonacoQueryFieldWrapper = (props: Props) => {
     onBlur?.();
 
     if (!isExplore) {
-      // is the current value different from the last-time-executed value?
+      // run handleRunQuery only if the current value is different from the last-time-executed value
       if (value !== lastRunValueRef.current) {
         handleRunQuery(value);
       }

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
@@ -6,12 +6,11 @@ type Props = Omit<MonacoProps, 'onRunQuery' | 'onBlur'> & {
   onChange: (query: string) => void;
   onRunQuery: () => void;
   isExplore: boolean;
-  onBlur?: () => void;
 };
 
 export const MonacoQueryFieldWrapper = (props: Props) => {
   const lastRunValueRef = useRef<string | null>(null);
-  const { isExplore, onBlur, onRunQuery, onChange, ...rest } = props;
+  const { isExplore, onRunQuery, onChange, ...rest } = props;
 
   const handleRunQuery = (value: string) => {
     lastRunValueRef.current = value;
@@ -20,9 +19,9 @@ export const MonacoQueryFieldWrapper = (props: Props) => {
   };
 
   const handleBlur = (value: string) => {
-    onBlur?.();
-
-    if (!isExplore) {
+    if (isExplore) {
+      onChange(value);
+    } else {
       // run handleRunQuery only if the current value is different from the last-time-executed value
       if (value !== lastRunValueRef.current) {
         handleRunQuery(value);

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
@@ -2,10 +2,6 @@ import React, { useRef } from 'react';
 import { MonacoQueryFieldLazy } from './MonacoQueryFieldLazy';
 import { Props as MonacoProps } from './MonacoQueryFieldProps';
 
-// NOTE: in not-explore modes we want to run the query on onBlur.
-
-// the props are mostly what is the inner monaco widget,
-// except the `on*` callbacks
 type Props = Omit<MonacoProps, 'onRunQuery' | 'onBlur'> & {
   onChange: (query: string) => void;
   onRunQuery: () => void;

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
@@ -1,0 +1,52 @@
+import React, { useRef } from 'react';
+import { MonacoQueryFieldLazy } from './MonacoQueryFieldLazy';
+import { Props as MonacoProps } from './MonacoQueryFieldProps';
+
+// NOTE: the behavior is different between in-explore-mode
+// and in-dashboard-mode. the way this is signalized
+// is by the onBlur prop:
+// - if onBlur is not nullish => explore-mode, so we do not run the query on blur
+// - if onBlur is nullish     => dashboard-mode, so we do run the query on blur
+// FIXME: this could be probably done in a better way,
+// because for example, in explore-mode, onBlur is not nullish, but it is just an empty-function,
+// purely used to signalize the explore-situation. we could probably
+// replace it with a boolean or something.
+// but, to keep the monaco-widget compatible with the non-monaco widget,
+// we will keep this behavior, and extract it to a separate file,
+// because this needs keeping around the previously run value etc,
+// and i did not want to make the monaco widget even more complex.
+
+// the props are mostly what is the inner monaco widget,
+// except the `on*` callbacks
+type Props = Omit<MonacoProps, 'onRunQuery' | 'onBlur'> & {
+  onChange: (query: string) => void;
+  onRunQuery: () => void;
+  onBlur?: () => void;
+};
+
+export const MonacoQueryFieldWrapper = (props: Props) => {
+  const lastRunValueRef = useRef<string | null>(null);
+  const { onBlur, onRunQuery, onChange, ...rest } = props;
+
+  const handleRunQuery = (value: string) => {
+    lastRunValueRef.current = value;
+    onChange(value);
+    onRunQuery();
+  };
+
+  const handleBlur = (value: string) => {
+    if (onBlur !== undefined) {
+      // explore-mode
+      onChange(value);
+      onBlur();
+    } else {
+      // dashboard-mode
+      // is the current value different from the last-time-executed value?
+      if (value !== lastRunValueRef.current) {
+        handleRunQuery(value);
+      }
+    }
+  };
+
+  return <MonacoQueryFieldLazy onRunQuery={handleRunQuery} onBlur={handleBlur} {...rest} />;
+};

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
@@ -2,19 +2,7 @@ import React, { useRef } from 'react';
 import { MonacoQueryFieldLazy } from './MonacoQueryFieldLazy';
 import { Props as MonacoProps } from './MonacoQueryFieldProps';
 
-// NOTE: the behavior is different between in-explore-mode
-// and in-dashboard-mode. the way this is signalized
-// is by the onBlur prop:
-// - if onBlur is not nullish => explore-mode, so we do not run the query on blur
-// - if onBlur is nullish     => dashboard-mode, so we do run the query on blur
-// FIXME: this could be probably done in a better way,
-// because for example, in explore-mode, onBlur is not nullish, but it is just an empty-function,
-// purely used to signalize the explore-situation. we could probably
-// replace it with a boolean or something.
-// but, to keep the monaco-widget compatible with the non-monaco widget,
-// we will keep this behavior, and extract it to a separate file,
-// because this needs keeping around the previously run value etc,
-// and i did not want to make the monaco widget even more complex.
+// NOTE: in not-explore modes we want to run the query on onBlur.
 
 // the props are mostly what is the inner monaco widget,
 // except the `on*` callbacks
@@ -22,11 +10,12 @@ type Props = Omit<MonacoProps, 'onRunQuery' | 'onBlur'> & {
   onChange: (query: string) => void;
   onRunQuery: () => void;
   onBlur?: () => void;
+  isExplore: boolean;
 };
 
 export const MonacoQueryFieldWrapper = (props: Props) => {
   const lastRunValueRef = useRef<string | null>(null);
-  const { onBlur, onRunQuery, onChange, ...rest } = props;
+  const { isExplore, onBlur, onRunQuery, onChange, ...rest } = props;
 
   const handleRunQuery = (value: string) => {
     lastRunValueRef.current = value;
@@ -35,12 +24,9 @@ export const MonacoQueryFieldWrapper = (props: Props) => {
   };
 
   const handleBlur = (value: string) => {
-    if (onBlur !== undefined) {
-      // explore-mode
-      onChange(value);
-      onBlur();
-    } else {
-      // dashboard-mode
+    onBlur?.();
+
+    if (!isExplore) {
       // is the current value different from the last-time-executed value?
       if (value !== lastRunValueRef.current) {
         handleRunQuery(value);

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldWrapper.tsx
@@ -5,8 +5,8 @@ import { Props as MonacoProps } from './MonacoQueryFieldProps';
 type Props = Omit<MonacoProps, 'onRunQuery' | 'onBlur'> & {
   onChange: (query: string) => void;
   onRunQuery: () => void;
-  onBlur?: () => void;
   isExplore: boolean;
+  onBlur?: () => void;
 };
 
 export const MonacoQueryFieldWrapper = (props: Props) => {


### PR DESCRIPTION
the way `PromQueryField` works, it is different in dashboard-mode and in explore-mode. the way to differentiate is by checking the `onBlur` prop, whether it is `undefined` or not. this pull-request applies this behavior to the monaco-based query-editor too.

i decided to keep the monaco-query-field widget simple, and put this onBlur-handling into a separate wrapper component.