### PR TITLE
Rendering: Check if default image exists to avoid breaking reports if it's moved

### DIFF
--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -159,9 +159,13 @@ func (rs *RenderingService) Version() string {
 
 func (rs *RenderingService) RenderErrorImage(err error) (*RenderResult, error) {
 	imgUrl := "public/img/rendering_error.png"
+	imgPath := filepath.Join(setting.HomePath, imgUrl)
+	if _, err := os.Stat(imgPath); errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
 
 	return &RenderResult{
-		FilePath: filepath.Join(setting.HomePath, imgUrl),
+		FilePath: imgPath,
 	}, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Report is using this image in the report when something goes wrong. If this file is changed or moved, it breaks the report.

So it adds a check if the file exists before return it.

