### PR TITLE
DashboardLinks: Fix time in not being updated in links

### DIFF
--- a/packages/grafana-ui/src/utils/useForceUpdate.ts
+++ b/packages/grafana-ui/src/utils/useForceUpdate.ts
@@ -2,6 +2,6 @@ import { useState } from 'react';
 
 /** @internal */
 export function useForceUpdate() {
-  const [value, setValue] = useState(0); // integer state
-  return () => setValue(value + 1); // update the state to force render
+  const [_, setValue] = useState(0); // integer state
+  return () => setValue((prevState) => prevState + 1); // update the state to force render
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
It was pretty tricky to reproduce the original issue, so do this:

1. Checkout main
2. Import this dashboard https://gist.githubusercontent.com/hugohaggmark/14064bf08533b56e0715909770f986b7/raw/53ce954487b74881766b2da28d8a8cbec1a9fd85/40599.json
3. Check that all the dashboard links include the correct time, `from=now-6h&to=now` [**OK**]
4. Change the time to be `Last 1 hour`
5. Check that all the dashboard links include the correct time, `from=now-1h&to=now` [**OK**]
6. Goto dashboard settings => variables => and delete all the variables => go back to the dashboard
7. Check that all the dashboard links include the correct time, `from=now-1h&to=now` [**OK**]
8. Change the time to be `Last 30 min`
9. Check that all the dashboard links include the correct time, `from=now-30m&to=now` [**OK**]
10. Change the time to be `Last X min`
11. Check that all the dashboard links include the correct time, `from=now-Xm&to=now`
12. Repeat 10-11 until dashboard links include the previous time, usually in 1-2 attempts

This PR tries to fix this issue by making sure that the `useForceUpdate` works correctly even if renders get stacked.

**Which issue(s) this PR fixes**:
Fixes #40599

**Special notes for your reviewer**:

