### PR TITLE
Chore: updated code owners for frontend plugin management code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,6 +63,7 @@ go.sum @grafana/backend-platform
 /pkg/plugins @grafana/plugins-platform-backend
 /pkg/services/datasourceproxy @grafana/plugins-platform-backend
 /pkg/services/datasources @grafana/plugins-platform-backend
+/public/app/features/plugins @grafana/plugins-platform-frontend
 
 # Backend code docs
 /contribute/style-guides/backend.md @grafana/backend-platform


### PR DESCRIPTION
**What this PR does / why we need it**:
I have noticed that PRs with changes in the plugin management code gets assigned to the user-essentials. This should hopefully change that so the `plugins-platform-squad` will get assigned to these PRs.