### PR TITLE
Docs: Updated the plugin admin configuration default value

### DIFF
--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1582,7 +1582,7 @@ We do _not_ recommend using this option. For more information, refer to [Plugin 
 
 ### plugin_admin_enabled
 
-Available to Grafana administrators only, the plugin admin app is set to `false` by default. Set it to `true` to enable the app.
+Available to Grafana administrators only, the plugin admin app is set to `true` by default. Set it to `false` to disable the app.
 
 For more information, refer to [Plugin catalog]({{< relref "../plugins/catalog.md" >}}).
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This https://github.com/grafana/grafana/pull/39779 made the plugins catalog/admin the default way of managing plugins starting from Grafana 8.2 and later.

We forgot to update the configuration documentation to reflect this change hence this PR.
