### PR TITLE
Suggestions: Make the visualization suggestions more accessible

### DIFF
--- a/public/app/features/panel/components/VizTypePicker/VisualizationPreview.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationPreview.tsx
@@ -34,25 +34,29 @@ export function VisualizationPreview({ data, suggestion, onChange, width, showTi
   }
 
   return (
-    <div onClick={onClick} data-testid={selectors.components.VisualizationPreview.card(suggestion.name)}>
+    <button
+      aria-label={suggestion.name}
+      className={styles.vizBox}
+      data-testid={selectors.components.VisualizationPreview.card(suggestion.name)}
+      style={outerStyles}
+      onClick={onClick}
+    >
       {showTitle && <div className={styles.name}>{suggestion.name}</div>}
-      <div className={styles.vizBox} style={outerStyles}>
-        <Tooltip content={suggestion.name}>
-          <div style={innerStyles} className={styles.renderContainer}>
-            <PanelRenderer
-              title=""
-              data={data}
-              pluginId={suggestion.pluginId}
-              width={renderWidth}
-              height={renderHeight}
-              options={preview.options}
-              fieldConfig={preview.fieldConfig}
-            />
-            <div className={styles.hoverPane} />
-          </div>
-        </Tooltip>
-      </div>
-    </div>
+      <Tooltip content={suggestion.name}>
+        <div style={innerStyles} className={styles.renderContainer}>
+          <PanelRenderer
+            title=""
+            data={data}
+            pluginId={suggestion.pluginId}
+            width={renderWidth}
+            height={renderHeight}
+            options={preview.options}
+            fieldConfig={preview.fieldConfig}
+          />
+          <div className={styles.hoverPane} />
+        </div>
+      </Tooltip>
+    </button>
   );
 }
 
@@ -68,6 +72,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     vizBox: css`
       position: relative;
+      background: none;
       border-radius: ${theme.shape.borderRadius(1)};
       cursor: pointer;
       border: 1px solid ${theme.colors.border.strong};

--- a/public/app/features/panel/components/VizTypePicker/VisualizationPreview.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationPreview.tsx
@@ -34,29 +34,31 @@ export function VisualizationPreview({ data, suggestion, onChange, width, showTi
   }
 
   return (
-    <button
-      aria-label={suggestion.name}
-      className={styles.vizBox}
-      data-testid={selectors.components.VisualizationPreview.card(suggestion.name)}
-      style={outerStyles}
-      onClick={onClick}
-    >
+    <div>
       {showTitle && <div className={styles.name}>{suggestion.name}</div>}
-      <Tooltip content={suggestion.name}>
-        <div style={innerStyles} className={styles.renderContainer}>
-          <PanelRenderer
-            title=""
-            data={data}
-            pluginId={suggestion.pluginId}
-            width={renderWidth}
-            height={renderHeight}
-            options={preview.options}
-            fieldConfig={preview.fieldConfig}
-          />
-          <div className={styles.hoverPane} />
-        </div>
-      </Tooltip>
-    </button>
+      <button
+        aria-label={suggestion.name}
+        className={styles.vizBox}
+        data-testid={selectors.components.VisualizationPreview.card(suggestion.name)}
+        style={outerStyles}
+        onClick={onClick}
+      >
+        <Tooltip content={suggestion.name}>
+          <div style={innerStyles} className={styles.renderContainer}>
+            <PanelRenderer
+              title=""
+              data={data}
+              pluginId={suggestion.pluginId}
+              width={renderWidth}
+              height={renderHeight}
+              options={preview.options}
+              fieldConfig={preview.fieldConfig}
+            />
+            <div className={styles.hoverPane} />
+          </div>
+        </Tooltip>
+      </button>
+    </div>
   );
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- converts the `VisualizationSuggestion` to a button - this allows the element to be focusable and show focus rings correctly
- adds an `aria-label` for the button

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/40804

**Special notes for your reviewer**:
- this isn't perfect - you have to tab through each `VisualizationSuggestion`. ideal behaviour would probably be tab to the grid and use arrow keys from there. there's a `useGrid` hook in `react-aria` that i _think_ would be perfect, but it's in alpha and currently has no documentation so i can't quite get it to work.

