### PR TITLE
Barchart: Fixes barchart switching from palette to thresholds color mode

### DIFF
--- a/public/app/plugins/panel/barchart/module.tsx
+++ b/public/app/plugins/panel/barchart/module.tsx
@@ -19,6 +19,7 @@ export const plugin = new PanelPlugin<BarChartOptions, BarChartFieldConfig>(BarC
       [FieldConfigProperty.Color]: {
         settings: {
           byValueSupport: true,
+          preferThresholdsMode: false,
         },
         defaultValue: {
           mode: FieldColorModeId.PaletteClassic,


### PR DESCRIPTION
in https://github.com/grafana/grafana/pull/38528 we enabled by value support in barchart but this missed setting the preferThresholdsMode to false.
Without this option set to false Grafana will automatically change the color mode to `from thresholds` when switching visualization. 
