### PR TITLE
TimePicker: Clicking outside the TimePicker/TimePickerCalendar now pr…

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -85,7 +85,7 @@ export function UnthemedTimeRangePicker(props: TimeRangePickerProps): ReactEleme
   };
 
   const ref = createRef<HTMLElement>();
-  const { overlayProps } = useOverlay({ onClose, isOpen }, ref);
+  const { overlayProps } = useOverlay({ onClose, isDismissable: true, isOpen }, ref);
 
   const styles = getStyles(theme);
   const hasAbsolute = isDateTime(value.raw.from) || isDateTime(value.raw.to);

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerCalendar.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerCalendar.tsx
@@ -76,9 +76,14 @@ const stopPropagation = (event: React.MouseEvent<HTMLDivElement>) => event.stopP
 function TimePickerCalendar(props: TimePickerCalendarProps) {
   const theme = useTheme2();
   const styles = getStyles(theme, props.isReversed);
-  const { isOpen, isFullscreen } = props;
+  const { isOpen, isFullscreen, onClose } = props;
   const ref = React.createRef<HTMLElement>();
-  const { overlayProps } = useOverlay(props, ref);
+  const useOverlayProps = {
+    isDismissable: true,
+    isOpen,
+    onClose,
+  }
+  const { overlayProps } = useOverlay(useOverlayProps, ref);
 
   if (!isOpen) {
     return null;

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerCalendar.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerCalendar.tsx
@@ -78,12 +78,11 @@ function TimePickerCalendar(props: TimePickerCalendarProps) {
   const styles = getStyles(theme, props.isReversed);
   const { isOpen, isFullscreen, onClose } = props;
   const ref = React.createRef<HTMLElement>();
-  const useOverlayProps = {
+  const { overlayProps } = useOverlay({
     isDismissable: true,
     isOpen,
     onClose,
-  }
-  const { overlayProps } = useOverlay(useOverlayProps, ref);
+  }, ref);
 
   if (!isOpen) {
     return null;

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerCalendar.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerCalendar.tsx
@@ -78,11 +78,14 @@ function TimePickerCalendar(props: TimePickerCalendarProps) {
   const styles = getStyles(theme, props.isReversed);
   const { isOpen, isFullscreen, onClose } = props;
   const ref = React.createRef<HTMLElement>();
-  const { overlayProps } = useOverlay({
-    isDismissable: true,
-    isOpen,
-    onClose,
-  }, ref);
+  const { overlayProps } = useOverlay(
+    {
+      isDismissable: true,
+      isOpen,
+      onClose,
+    },
+    ref
+  );
 
   if (!isOpen) {
     return null;


### PR DESCRIPTION
…operly dismisses the popup

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- adds `isDismissable` to the `useOverlay` hook used by `TimeRangePicker`: 
![image](https://user-images.githubusercontent.com/20999846/138918018-22bd233b-b7d8-4d41-9f9b-368d31101dfa.png)
- tidies up the `useOverlay` hook used by `TimePickerCalendar` to not pass all the props to `useOverlay`, and also adds `isDismissable`

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/40951

**Special notes for your reviewer**:

