### PR TITLE
Explore: fix footer margin in Query History

### DIFF
--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
@@ -105,7 +105,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme, height: number) => {
     `,
     footer: css`
       height: 60px;
-      margin-top: ${theme.spacing.lg};
+      margin: ${theme.spacing.lg} auto;
       display: flex;
       justify-content: center;
       font-weight: ${theme.typography.weight.light};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
the footer in query history tab in explore lacks a margin that makes it being cut off:

before:
![Screenshot 2021-10-27 at 06 47 02](https://user-images.githubusercontent.com/1170767/139007274-2d3d7f00-ec91-4c0f-a9de-78985e0e948c.png)


after:
![Screenshot 2021-10-27 at 06 45 49](https://user-images.githubusercontent.com/1170767/139007229-a253827c-2db7-48d8-aeb9-ab67bbfa64ac.png)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:



