### PR TITLE
Explore: Show ANSI colors when highlighting matched words in the logs panel

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
@@ -1,5 +1,8 @@
-import React, { PureComponent } from 'react';
+import { findHighlightChunksInText } from '@grafana/data';
 import ansicolor from 'ansicolor';
+import React, { PureComponent } from 'react';
+// @ts-ignore
+import Highlighter from 'react-highlight-words';
 
 interface Style {
   [key: string]: string;
@@ -26,6 +29,10 @@ function convertCSSToStyle(css: string): Style {
 
 interface Props {
   value: string;
+  highlight?: {
+    searchWords: string[];
+    highlightClassName: string;
+  };
 }
 
 interface State {
@@ -62,14 +69,24 @@ export class LogMessageAnsi extends PureComponent<Props, State> {
   render() {
     const { chunks } = this.state;
 
-    return chunks.map((chunk, index) =>
-      chunk.style ? (
-        <span key={index} style={chunk.style} data-testid="ansiLogLine">
-          {chunk.text}
-        </span>
+    return chunks.map((chunk, index) => {
+      const chunkText = this.props.highlight?.searchWords ? (
+        <Highlighter
+          textToHighlight={chunk.text}
+          searchWords={this.props.highlight.searchWords}
+          findChunks={findHighlightChunksInText}
+          highlightClassName={this.props.highlight.highlightClassName}
+        />
       ) : (
         chunk.text
-      )
-    );
+      );
+      return chunk.style ? (
+        <span key={index} style={chunk.style} data-testid="ansiLogLine">
+          {chunkText}
+        </span>
+      ) : (
+        chunkText
+      );
+    });
   }
 }

--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -65,7 +65,7 @@ function renderLogMessage(
     highlights && highlights.length > 0 && highlights[0] && highlights[0].length > 0 && entry.length < MAX_CHARACTERS;
   const searchWords = highlights ?? [];
   if (hasAnsi) {
-    const highlight = needsHighlighter ? {searchWords, highlightClassName} : undefined;
+    const highlight = needsHighlighter ? { searchWords, highlightClassName } : undefined;
     return <LogMessageAnsi value={entry} highlight={highlight} />;
   } else if (needsHighlighter) {
     return (

--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -65,7 +65,8 @@ function renderLogMessage(
     highlights && highlights.length > 0 && highlights[0] && highlights[0].length > 0 && entry.length < MAX_CHARACTERS;
   const searchWords = highlights ?? [];
   if (hasAnsi) {
-    return <LogMessageAnsi value={entry} highlight={{ searchWords, highlightClassName }} />;
+    const highlight = needsHighlighter ? {searchWords, highlightClassName} : undefined;
+    return <LogMessageAnsi value={entry} highlight={highlight} />;
   } else if (needsHighlighter) {
     return (
       <Highlighter

--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -63,17 +63,18 @@ function renderLogMessage(
 ) {
   const needsHighlighter =
     highlights && highlights.length > 0 && highlights[0] && highlights[0].length > 0 && entry.length < MAX_CHARACTERS;
-  if (needsHighlighter) {
+  const searchWords = highlights ?? [];
+  if (hasAnsi) {
+    return <LogMessageAnsi value={entry} highlight={{ searchWords, highlightClassName }} />;
+  } else if (needsHighlighter) {
     return (
       <Highlighter
         textToHighlight={entry}
-        searchWords={highlights ?? []}
+        searchWords={searchWords}
         findChunks={findHighlightChunksInText}
         highlightClassName={highlightClassName}
       />
     );
-  } else if (hasAnsi) {
-    return <LogMessageAnsi value={entry} />;
   } else {
     return entry;
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Currently, ANSI color codes are rendered in the Explore view for Loki logs. However, if a line filter is used (e.g. `|= "info"`) then the ANSI color codes are no longer rendered, and are instead displayed in their escaped form (e.g. `[36m`) in the log line. This is because a `Highlighter` component is used to highlight the searched for word in the output, which is not ANSI-aware.

![image](https://user-images.githubusercontent.com/11541660/139013723-bad01209-fcb3-440d-9457-fe060a0252d9.png)

This PR modifies the existing ANSI-aware `LogMessageAnsi` component to be capable of highlighting the searched for word (still using the `Highlighter` component) in addition to the ANSI coloring.

![image](https://user-images.githubusercontent.com/11541660/139013793-30c9f90d-d387-4d5e-a434-50b7e34704a7.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #40265 

**Special notes for your reviewer**:

This is my first Grafana PR, and first time working with React. I'm not sure if my use of multiple `Highlighter` components is problematic in terms of performance - my intention was to avoid having to re-implement its functionality inside `LogMessageAnsi`.

A known issue: highlighting won't work across chunks (blocks of text separated by ANSI escape characters, as I understand) because the `Highlighter` component wraps each `chunk` individually. I don't think this is actually a problem in practice, however, because Loki doesn't support matching line filters that have substrings containing escape codes (see https://github.com/grafana/loki/issues/2861 for more details)
