### PR TITLE
WIP: Live - subscription logic without `subscribers` array in the pipeline config

### DIFF
--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -554,6 +554,7 @@ func (g *GrafanaLive) handleOnSubscribe(client *centrifuge.Client, e centrifuge.
 	var reply models.SubscribeReply
 	var status backend.SubscribeStreamStatus
 	var ruleFound bool
+	var ruleHasSubscribers bool
 
 	if g.Pipeline != nil {
 		rule, ok, err := g.Pipeline.Get(user.OrgId, channel)
@@ -575,7 +576,8 @@ func (g *GrafanaLive) handleOnSubscribe(client *centrifuge.Client, e centrifuge.
 					return centrifuge.SubscribeReply{}, &centrifuge.Error{Code: uint32(code), Message: text}
 				}
 			}
-			if len(rule.Subscribers) > 0 {
+			ruleHasSubscribers = len(rule.Subscribers) > 0
+			if ruleHasSubscribers {
 				var err error
 				for _, sub := range rule.Subscribers {
 					reply, status, err = sub.Subscribe(client.Context(), pipeline.Vars{
@@ -593,7 +595,7 @@ func (g *GrafanaLive) handleOnSubscribe(client *centrifuge.Client, e centrifuge.
 			}
 		}
 	}
-	if !ruleFound {
+	if !ruleFound || !ruleHasSubscribers {
 		handler, addr, err := g.GetChannelHandler(user, channel)
 		if err != nil {
 			if errors.Is(err, live.ErrInvalidChannelID) {


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

When we remove the `subscriptions` array from the following pipeline config:

```js
{
  "rules": [
    {
      "pattern": "stream/sample/test",
      "settings": {
        "converter": {
          "type": "jsonAuto"
        },
        "frameOutputs": [
          {
            "type": "managedStream"
          }
        ],
        "subscribers": [
          {
            "type": "managedStream"
          }
        ]
      }
    }
  ]
}

```

Neither of the branches in the current `live.go` file will run part of the subscription logic retrieving last data+schema on a new connection:

- https://github.com/grafana/grafana/blob/57fcfd578dd43fae2b2df335fec7536fef7dd1e3/pkg/services/live/live.go#L581
- https://github.com/grafana/grafana/blob/57fcfd578dd43fae2b2df335fec7536fef7dd1e3/pkg/services/live/live.go#L606

I am not sure if it's intentional - maybe `subscribers` is supposed to be a required field? 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

