### PR TITLE
CloudWatch: Handle nested panels when migrating CloudWatch queries

### DIFF
--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -162,7 +162,7 @@ describe('DashboardModel', () => {
     });
 
     it('dashboard schema version should be set to latest', () => {
-      expect(model.schemaVersion).toBe(31);
+      expect(model.schemaVersion).toBe(32);
     });
 
     it('graph thresholds should be migrated', () => {

--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -1455,7 +1455,7 @@ describe('DashboardModel', () => {
 
   describe('migrating legacy CloudWatch queries', () => {
     let model: any;
-    let targets: any;
+    let panelTargets: any;
 
     beforeEach(() => {
       model = new DashboardModel({
@@ -1540,33 +1540,34 @@ describe('DashboardModel', () => {
           },
         ],
       });
-      targets = model.panels[0].targets;
+      panelTargets = model.panels[0].targets;
     });
 
     it('multiple stats query should have been split into three', () => {
-      expect(targets.length).toBe(4);
+      expect(panelTargets.length).toBe(4);
     });
 
     it('new stats query should get the right statistic', () => {
-      expect(targets[0].statistic).toBe('Average');
-      expect(targets[1].statistic).toBe('Sum');
-      expect(targets[2].statistic).toBe('Minimum');
-      expect(targets[3].statistic).toBe('p12.21');
+      expect(panelTargets[0].statistic).toBe('Average');
+      expect(panelTargets[1].statistic).toBe('Sum');
+      expect(panelTargets[2].statistic).toBe('Minimum');
+      expect(panelTargets[3].statistic).toBe('p12.21');
     });
 
     it('new stats queries should be put in the end of the array', () => {
-      expect(targets[0].refId).toBe('A');
-      expect(targets[1].refId).toBe('B');
-      expect(targets[2].refId).toBe('C');
-      expect(targets[3].refId).toBe('D');
+      expect(panelTargets[0].refId).toBe('A');
+      expect(panelTargets[1].refId).toBe('B');
+      expect(panelTargets[2].refId).toBe('C');
+      expect(panelTargets[3].refId).toBe('D');
     });
 
     describe('with nested panels', () => {
       let panel1Targets: any;
       let panel2Targets: any;
+      let nestedModel: DashboardModel;
 
       beforeEach(() => {
-        model = new DashboardModel({
+        nestedModel = new DashboardModel({
           annotations: {
             list: [
               {
@@ -1716,8 +1717,8 @@ describe('DashboardModel', () => {
             },
           ],
         });
-        panel1Targets = model.panels[0].panels[0].targets;
-        panel2Targets = model.panels[0].panels[1].targets;
+        panel1Targets = nestedModel.panels[0].panels[0].targets;
+        panel2Targets = nestedModel.panels[0].panels[1].targets;
       });
 
       it('multiple stats query should have been split into one query per stat', () => {

--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -1455,7 +1455,7 @@ describe('DashboardModel', () => {
 
   describe('migrating legacy CloudWatch queries', () => {
     let model: any;
-    let panelTargets: any;
+    let targets: any;
 
     beforeEach(() => {
       model = new DashboardModel({
@@ -1540,25 +1540,212 @@ describe('DashboardModel', () => {
           },
         ],
       });
-      panelTargets = model.panels[0].targets;
+      targets = model.panels[0].targets;
     });
 
     it('multiple stats query should have been split into three', () => {
-      expect(panelTargets.length).toBe(4);
+      expect(targets.length).toBe(4);
     });
 
     it('new stats query should get the right statistic', () => {
-      expect(panelTargets[0].statistic).toBe('Average');
-      expect(panelTargets[1].statistic).toBe('Sum');
-      expect(panelTargets[2].statistic).toBe('Minimum');
-      expect(panelTargets[3].statistic).toBe('p12.21');
+      expect(targets[0].statistic).toBe('Average');
+      expect(targets[1].statistic).toBe('Sum');
+      expect(targets[2].statistic).toBe('Minimum');
+      expect(targets[3].statistic).toBe('p12.21');
     });
 
     it('new stats queries should be put in the end of the array', () => {
-      expect(panelTargets[0].refId).toBe('A');
-      expect(panelTargets[1].refId).toBe('B');
-      expect(panelTargets[2].refId).toBe('C');
-      expect(panelTargets[3].refId).toBe('D');
+      expect(targets[0].refId).toBe('A');
+      expect(targets[1].refId).toBe('B');
+      expect(targets[2].refId).toBe('C');
+      expect(targets[3].refId).toBe('D');
+    });
+
+    describe('with nested panels', () => {
+      let panel1Targets: any;
+      let panel2Targets: any;
+
+      beforeEach(() => {
+        model = new DashboardModel({
+          annotations: {
+            list: [
+              {
+                actionPrefix: '',
+                alarmNamePrefix: '',
+                alias: '',
+                dimensions: {
+                  InstanceId: 'i-123',
+                },
+                enable: true,
+                expression: '',
+                iconColor: 'red',
+                id: '',
+                matchExact: true,
+                metricName: 'CPUUtilization',
+                name: 'test',
+                namespace: 'AWS/EC2',
+                period: '',
+                prefixMatching: false,
+                region: 'us-east-2',
+                statistics: ['Minimum', 'Sum'],
+              },
+            ],
+          },
+          panels: [
+            {
+              collapsed: false,
+              gridPos: {
+                h: 1,
+                w: 24,
+                x: 0,
+                y: 89,
+              },
+              id: 96,
+              title: 'DynamoDB',
+              type: 'row',
+              panels: [
+                {
+                  gridPos: {
+                    h: 8,
+                    w: 12,
+                    x: 0,
+                    y: 0,
+                  },
+                  id: 4,
+                  options: {
+                    legend: {
+                      calcs: [],
+                      displayMode: 'list',
+                      placement: 'bottom',
+                    },
+                    tooltipOptions: {
+                      mode: 'single',
+                    },
+                  },
+                  targets: [
+                    {
+                      alias: '',
+                      dimensions: {
+                        InstanceId: 'i-123',
+                      },
+                      expression: '',
+                      id: '',
+                      matchExact: true,
+                      metricName: 'CPUUtilization',
+                      namespace: 'AWS/EC2',
+                      period: '',
+                      refId: 'C',
+                      region: 'default',
+                      statistics: ['Average', 'Minimum', 'p12.21'],
+                    },
+                    {
+                      alias: '',
+                      dimensions: {
+                        InstanceId: 'i-123',
+                      },
+                      expression: '',
+                      hide: false,
+                      id: '',
+                      matchExact: true,
+                      metricName: 'CPUUtilization',
+                      namespace: 'AWS/EC2',
+                      period: '',
+                      refId: 'B',
+                      region: 'us-east-2',
+                      statistics: ['Sum'],
+                    },
+                  ],
+                  title: 'Panel Title',
+                  type: 'timeseries',
+                },
+                {
+                  gridPos: {
+                    h: 8,
+                    w: 12,
+                    x: 0,
+                    y: 0,
+                  },
+                  id: 4,
+                  options: {
+                    legend: {
+                      calcs: [],
+                      displayMode: 'list',
+                      placement: 'bottom',
+                    },
+                    tooltipOptions: {
+                      mode: 'single',
+                    },
+                  },
+                  targets: [
+                    {
+                      alias: '',
+                      dimensions: {
+                        InstanceId: 'i-123',
+                      },
+                      expression: '',
+                      id: '',
+                      matchExact: true,
+                      metricName: 'CPUUtilization',
+                      namespace: 'AWS/EC2',
+                      period: '',
+                      refId: 'A',
+                      region: 'default',
+                      statistics: ['Average'],
+                    },
+                    {
+                      alias: '',
+                      dimensions: {
+                        InstanceId: 'i-123',
+                      },
+                      expression: '',
+                      hide: false,
+                      id: '',
+                      matchExact: true,
+                      metricName: 'CPUUtilization',
+                      namespace: 'AWS/EC2',
+                      period: '',
+                      refId: 'B',
+                      region: 'us-east-2',
+                      statistics: ['Sum', 'Min'],
+                    },
+                  ],
+                  title: 'Panel Title',
+                  type: 'timeseries',
+                },
+              ],
+            },
+          ],
+        });
+        panel1Targets = model.panels[0].panels[0].targets;
+        panel2Targets = model.panels[0].panels[1].targets;
+      });
+
+      it('multiple stats query should have been split into one query per stat', () => {
+        expect(panel1Targets.length).toBe(4);
+        expect(panel2Targets.length).toBe(3);
+      });
+
+      it('new stats query should get the right statistic', () => {
+        expect(panel1Targets[0].statistic).toBe('Average');
+        expect(panel1Targets[1].statistic).toBe('Sum');
+        expect(panel1Targets[2].statistic).toBe('Minimum');
+        expect(panel1Targets[3].statistic).toBe('p12.21');
+
+        expect(panel2Targets[0].statistic).toBe('Average');
+        expect(panel2Targets[1].statistic).toBe('Sum');
+        expect(panel2Targets[2].statistic).toBe('Min');
+      });
+
+      it('new stats queries should be put in the end of the array', () => {
+        expect(panel1Targets[0].refId).toBe('C');
+        expect(panel1Targets[1].refId).toBe('B');
+        expect(panel1Targets[2].refId).toBe('A');
+        expect(panel1Targets[3].refId).toBe('D');
+
+        expect(panel2Targets[0].refId).toBe('A');
+        expect(panel2Targets[1].refId).toBe('B');
+        expect(panel2Targets[2].refId).toBe('C');
+      });
     });
   });
 });

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -708,7 +708,7 @@ export class DashboardMigrator {
   migrateCloudWatchQueries() {
     for (const p of this.dashboard.panels) {
       // if the panel is a row, it may have nested panels
-      const panels = p.type === 'row' && !p.targets.length && p.panels.length ? p.panels : [p];
+      const panels = p.type === 'row' && p.panels.length ? p.panels : [p];
       for (const panel of panels) {
         for (const target of panel.targets) {
           if (isLegacyCloudWatchQuery(target)) {

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -706,12 +706,16 @@ export class DashboardMigrator {
   // E.g query.statistics = ['Max', 'Min'] will be migrated to two queries - query1.statistic = 'Max' and query2.statistic = 'Min'
   // New queries, that were created during migration, are put at the end of the array.
   migrateCloudWatchQueries() {
-    for (const panel of this.dashboard.panels) {
-      for (const target of panel.targets) {
-        if (isLegacyCloudWatchQuery(target)) {
-          const newQueries = migrateMultipleStatsMetricsQuery(target, [...panel.targets]);
-          for (const newQuery of newQueries) {
-            panel.targets.push(newQuery);
+    for (const p of this.dashboard.panels) {
+      // if the panel is a row, it may have nested panels
+      const panels = p.type === 'row' && !p.targets.length && p.panels.length ? p.panels : [p];
+      for (const panel of panels) {
+        for (const target of panel.targets) {
+          if (isLegacyCloudWatchQuery(target)) {
+            const newQueries = migrateMultipleStatsMetricsQuery(target, [...panel.targets]);
+            for (const newQuery of newQueries) {
+              panel.targets.push(newQuery);
+            }
           }
         }
       }

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -62,7 +62,7 @@ export class DashboardMigrator {
     let i, j, k, n;
     const oldVersion = this.dashboard.schemaVersion;
     const panelUpgrades: PanelSchemeUpgradeHandler[] = [];
-    this.dashboard.schemaVersion = 31;
+    this.dashboard.schemaVersion = 32;
 
     if (oldVersion === this.dashboard.schemaVersion) {
       return;
@@ -686,6 +686,15 @@ export class DashboardMigrator {
       });
     }
 
+    if (oldVersion < 32) {
+      panelUpgrades.push((panel: PanelModel) => {
+        this.migrateCloudWatchQueries(panel);
+        return panel;
+      });
+
+      this.migrateCloudWatchAnnotationQuery();
+    }
+
     if (panelUpgrades.length === 0) {
       return;
     }
@@ -705,22 +714,18 @@ export class DashboardMigrator {
   // Migrates metric queries and/or annotation queries that use more than one statistic.
   // E.g query.statistics = ['Max', 'Min'] will be migrated to two queries - query1.statistic = 'Max' and query2.statistic = 'Min'
   // New queries, that were created during migration, are put at the end of the array.
-  migrateCloudWatchQueries() {
-    for (const p of this.dashboard.panels) {
-      // if the panel is a row, it may have nested panels
-      const panels = p.type === 'row' && p.panels.length ? p.panels : [p];
-      for (const panel of panels) {
-        for (const target of panel.targets) {
-          if (isLegacyCloudWatchQuery(target)) {
-            const newQueries = migrateMultipleStatsMetricsQuery(target, [...panel.targets]);
-            for (const newQuery of newQueries) {
-              panel.targets.push(newQuery);
-            }
-          }
+  migrateCloudWatchQueries(panel: PanelModel) {
+    for (const target of panel.targets || []) {
+      if (isLegacyCloudWatchQuery(target)) {
+        const newQueries = migrateMultipleStatsMetricsQuery(target, [...panel.targets]);
+        for (const newQuery of newQueries) {
+          panel.targets.push(newQuery);
         }
       }
     }
+  }
 
+  migrateCloudWatchAnnotationQuery() {
     for (const annotation of this.dashboard.annotations.list) {
       if (isLegacyCloudWatchAnnotationQuery(annotation)) {
         const newAnnotationQueries = migrateMultipleStatsAnnotationQuery(annotation);

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -1041,7 +1041,6 @@ export class DashboardModel {
   private updateSchema(old: any) {
     const migrator = new DashboardMigrator(this);
     migrator.updateSchema(old);
-    migrator.migrateCloudWatchQueries();
   }
 
   resetOriginalTime() {


### PR DESCRIPTION
**What this PR does / why we need it**:
In 8.2, the CloudWatch query model was partly migrated to get rid of some legacy. See [this](https://github.com/grafana/grafana/pull/36925) PR for details. This PR makes sure migrations are also happening to queries inside nested panels. 

**Which issue(s) this PR fixes**:

Fixes #40985


