### PR TITLE
Plugins Catalog: Set external manage link to installation tab

### DIFF
--- a/public/app/features/plugins/admin/components/InstallControls/ExternallyManagedButton.tsx
+++ b/public/app/features/plugins/admin/components/InstallControls/ExternallyManagedButton.tsx
@@ -9,7 +9,7 @@ type ExternallyManagedButtonProps = {
 };
 
 export function ExternallyManagedButton({ pluginId, pluginStatus }: ExternallyManagedButtonProps) {
-  const externalManageLink = getExternalManageLink(pluginId);
+  const externalManageLink = `${getExternalManageLink(pluginId)}/?tab=installation`;
 
   if (pluginStatus === PluginStatus.UPDATE) {
     return (

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -180,7 +180,7 @@ export function mapToCatalogPlugin(local?: LocalPlugin, remote?: RemotePlugin, e
   };
 }
 
-export const getExternalManageLink = (pluginId: string) => `https://grafana.com/grafana/plugins/${pluginId}`;
+export const getExternalManageLink = (pluginId: string) => `${config.pluginCatalogURL}${pluginId}`;
 
 export enum Sorters {
   nameAsc = 'nameAsc',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Currently if the `plugin_admin_external_manage_enabled` flag is enabled the user to sent to the plugin page overview tab for installation / uninstallation and upgrade. However it's not obvious what they should do. This PR changes that so they are sent to the installation tab where they are presented with the buttons necessary to complete installation / uninstallation or upgrade of a plugin.


| Previous Redirect Page | New Redirect Page |
| --- | --- |
| <img width="1792" alt="Screenshot 2021-10-27 at 16 32 07" src="https://user-images.githubusercontent.com/73201/139086855-a4311ca7-cc71-48d2-81b5-823ca8e85989.png"> | <img width="1792" alt="Screenshot 2021-10-27 at 16 32 00" src="https://user-images.githubusercontent.com/73201/139086842-4fec6c98-a7f9-4b60-9828-c5bf84f166f6.png"> |




**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #40931

**Special notes for your reviewer**:

