### PR TITLE
Dashboard: Fix so panels in view are renderer during scroll

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, { PureComponent, CSSProperties } from 'react';
+import React, { CSSProperties, PureComponent } from 'react';
 import ReactGridLayout, { ItemCallback } from 'react-grid-layout';
 import classNames from 'classnames';
 import AutoSizer from 'react-virtualized-auto-sizer';
@@ -128,22 +128,24 @@ export class DashboardGrid extends PureComponent<Props, State> {
       return true;
     }
 
-    const scrollTop = this.props.scrollTop;
-    const panelTop = panel.gridPos.y * (GRID_CELL_HEIGHT + GRID_CELL_VMARGIN);
-    const panelBottom = panelTop + panel.gridPos.h * (GRID_CELL_HEIGHT + GRID_CELL_VMARGIN) - GRID_CELL_VMARGIN;
-
-    // Show things that are almost in the view
-    const buffer = 100;
-
-    // The panel is above the viewport
-    if (scrollTop > panelBottom + buffer) {
+    const panelElement = document.querySelector(`div[data-panelid="${panel.id}"]`);
+    if (!panelElement) {
       return false;
     }
 
-    const scrollViewBottom = scrollTop + this.windowHeight;
+    // Show things that are almost in the view
+    const buffer = 100;
+    const boundingRect = panelElement.getBoundingClientRect();
+
+    // The panel is above the viewport
+    if (boundingRect.bottom + buffer < 0) {
+      return false;
+    }
+
+    const scrollViewBottom = (window.innerHeight || document.documentElement.clientHeight) + buffer;
 
     // Panel is below view
-    if (panelTop > scrollViewBottom + buffer) {
+    if (boundingRect.top > scrollViewBottom) {
       return false;
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We took a unified squad approach when trying to solve this issue today. We identified that the function `isInview`https://github.com/grafana/grafana/blob/995afa22219e47d1bf083cdf5a15b9099443298f/public/app/features/dashboard/dashgrid/DashboardGrid.tsx#L126 is not working properly on mobile view. 

The challenge with this is that we have a domain model representation using `gridPos` in `PanelModel` that in mobile view isn't representative to what is actually renderer because of how elements are stacked in mobile view. The consequence is that the `PanelModel's`  `isInview` property is set to `false` when it should be `true`. This results in 2 things:
- Panels that are below the fold in mobile view will render a bit randomly when you scroll.
- If you have refresh set on the dashboard, then panels will not be refreshed because of the same reason, i.e. the `PanelModel` is reporting that it's not in view.

As suggested by @leeoniya we tried to solve this using an IntersectionObserver but hit a very hard wall. The observer triggers on scroll or window resize but in certain scenarios in Grafana that will not work:
- Reload a Dashboard with the edit panel url (`http://localhost:3000/.../&editPanel=29`) and then go back to the dashboard page. This will not trigger the observer, but at that point we need to trigger it.
- Reload a Dashboard with the view panel url (`http://localhost:3000/.../&viewPanel=29`) and then go back to the dashboard page. This will not trigger the observer, but at that point we need to trigger it.

We added more complex logic (hacks) trying to connect the "domain representation" with the "render representation" than we thought was reasonable. If someone has any suggestions on how to solve this, we really appreciate any help you can give. The work we did so far is in: https://github.com/grafana/grafana/compare/mob-ue/38771-intersection?expand=1

So this leaves us with this PR. This tries to solve the same challenge but solving it in the render path instead; and yes using `getBoundingClientRect`.

**Which issue(s) this PR fixes**:
Fixes #38771
Fixes #37778
Fixes #40776

**Special notes for your reviewer**:
Browsing on my Samsung S20 with this solution the issue is gone but I still think it's not the "smoothest" of experiences I've seen.
