### PR TITLE
prometheus: query-field: improve autocomplete for label operators

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -80,10 +80,10 @@ function makeSelector(metricName: string | undefined, labels: Label[]): string {
 
   // we transform the metricName to a label, if it exists
   if (metricName !== undefined) {
-    allLabels.push({ name: '__name__', value: metricName });
+    allLabels.push({ name: '__name__', value: metricName, op: '=' });
   }
 
-  const allLabelTexts = allLabels.map((label) => `${label.name}="${label.value}"`);
+  const allLabelTexts = allLabels.map((label) => `${label.name}${label.op}"${label.value}"`);
 
   return `{${allLabelTexts.join(',')}}`;
 }

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/index.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/index.ts
@@ -74,7 +74,7 @@ export function getCompletionProvider(
   };
 
   return {
-    triggerCharacters: ['{', ',', '[', '(', '='],
+    triggerCharacters: ['{', ',', '[', '(', '=', '~'],
     provideCompletionItems,
   };
 }

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/intent.test.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/intent.test.ts
@@ -67,12 +67,14 @@ describe('intent', () => {
       otherLabels: [],
     });
 
-    assertIntent('something{one="val1",two="val2",^}', {
+    assertIntent('something{one="val1",two!="val2",three=~"val3",four!~"val4",^}', {
       type: 'LABEL_NAMES_FOR_SELECTOR',
       metricName: 'something',
       otherLabels: [
-        { name: 'one', value: 'val1' },
-        { name: 'two', value: 'val2' },
+        { name: 'one', value: 'val1', op: '=' },
+        { name: 'two', value: 'val2', op: '!=' },
+        { name: 'three', value: 'val3', op: '=~' },
+        { name: 'four', value: 'val4', op: '!~' },
       ],
     });
 
@@ -83,7 +85,7 @@ describe('intent', () => {
 
     assertIntent('{one="val1",^}', {
       type: 'LABEL_NAMES_FOR_SELECTOR',
-      otherLabels: [{ name: 'one', value: 'val1' }],
+      otherLabels: [{ name: 'one', value: 'val1', op: '=' }],
     });
   });
 
@@ -95,28 +97,49 @@ describe('intent', () => {
       otherLabels: [],
     });
 
+    assertIntent('something{job!=^}', {
+      type: 'LABEL_VALUES',
+      metricName: 'something',
+      labelName: 'job',
+      otherLabels: [],
+    });
+
+    assertIntent('something{job=~^}', {
+      type: 'LABEL_VALUES',
+      metricName: 'something',
+      labelName: 'job',
+      otherLabels: [],
+    });
+
+    assertIntent('something{job!~^}', {
+      type: 'LABEL_VALUES',
+      metricName: 'something',
+      labelName: 'job',
+      otherLabels: [],
+    });
+
     assertIntent('something{job=^,host="h1"}', {
       type: 'LABEL_VALUES',
       metricName: 'something',
       labelName: 'job',
-      otherLabels: [{ name: 'host', value: 'h1' }],
+      otherLabels: [{ name: 'host', value: 'h1', op: '=' }],
     });
 
     assertIntent('{job=^,host="h1"}', {
       type: 'LABEL_VALUES',
       labelName: 'job',
-      otherLabels: [{ name: 'host', value: 'h1' }],
+      otherLabels: [{ name: 'host', value: 'h1', op: '=' }],
     });
 
-    assertIntent('something{one="val1",two="val2",three=^,four="val4",five="val5"}', {
+    assertIntent('something{one="val1",two!="val2",three=^,four=~"val4",five!~"val5"}', {
       type: 'LABEL_VALUES',
       metricName: 'something',
       labelName: 'three',
       otherLabels: [
-        { name: 'one', value: 'val1' },
-        { name: 'two', value: 'val2' },
-        { name: 'four', value: 'val4' },
-        { name: 'five', value: 'val5' },
+        { name: 'one', value: 'val1', op: '=' },
+        { name: 'two', value: 'val2', op: '!=' },
+        { name: 'four', value: 'val4', op: '=~' },
+        { name: 'five', value: 'val5', op: '!~' },
       ],
     });
   });


### PR DESCRIPTION
in the monaco-based new prometheus query field:
when we autocomplete label-names and label-values, until now we assumed the operator used in the labels is always `=`. with this change we support the other possible operators too ( `!=` , `=~`, `!~`).

how to test:
- what we want to see, is if we have a query like `something{l1!="test^}` (`^` marks the cursor), and you now press `,`, the system offers autocomplete with correctly filtered labels. now in more detail:
  - when you start writing the query, you write a metric name, then write `{`. the editor auto-creates the closing `}`, your cursor is between the `{}`, and you get a list of possible label-names.
  - now you choose a label name
  - the system automatically uses the `=` operator
  - simply delete the inserted `=` character, and write `!=`
  - the system should offer you label values, choose one
  - make sure you have browser devtools open, network tab, watch the AJAX requests
  - now write a `,` character
  - you should see an ajax-request going to the `series` endpoint. check the query-params of the request. it should have a param named `match[]`, it's value should be the correct prometheus label-selector (meaning, the operator should be the same as you used)
  - it should work also for `=~` and for `!~`
