### PR TITLE
Chore: Propagate context for search

### DIFF
--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -89,7 +89,7 @@ func GetAlerts(c *models.ReqContext) response.Response {
 			Permission:   models.PERMISSION_VIEW,
 		}
 
-		err := bus.Dispatch(&searchQuery)
+		err := bus.DispatchCtx(c.Req.Context(), &searchQuery)
 		if err != nil {
 			return response.Error(500, "List alerts failed", err)
 		}

--- a/pkg/api/playlist.go
+++ b/pkg/api/playlist.go
@@ -117,7 +117,7 @@ func GetPlaylistItems(c *models.ReqContext) response.Response {
 func GetPlaylistDashboards(c *models.ReqContext) response.Response {
 	playlistID := c.ParamsInt64(":id")
 
-	playlists, err := LoadPlaylistDashboards(c.OrgId, c.SignedInUser, playlistID)
+	playlists, err := LoadPlaylistDashboards(c.Req.Context(), c.OrgId, c.SignedInUser, playlistID)
 	if err != nil {
 		return response.Error(500, "Could not load dashboards", err)
 	}

--- a/pkg/api/playlist_play.go
+++ b/pkg/api/playlist_play.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"sort"
 	"strconv"
 
@@ -35,7 +36,7 @@ func populateDashboardsByID(dashboardByIDs []int64, dashboardIDOrder map[int64]i
 	return result, nil
 }
 
-func populateDashboardsByTag(orgID int64, signedInUser *models.SignedInUser, dashboardByTag []string, dashboardTagOrder map[string]int) dtos.PlaylistDashboardsSlice {
+func populateDashboardsByTag(ctx context.Context, orgID int64, signedInUser *models.SignedInUser, dashboardByTag []string, dashboardTagOrder map[string]int) dtos.PlaylistDashboardsSlice {
 	result := make(dtos.PlaylistDashboardsSlice, 0)
 
 	for _, tag := range dashboardByTag {
@@ -48,7 +49,7 @@ func populateDashboardsByTag(orgID int64, signedInUser *models.SignedInUser, das
 			OrgId:        orgID,
 		}
 
-		if err := bus.Dispatch(&searchQuery); err == nil {
+		if err := bus.DispatchCtx(ctx, &searchQuery); err == nil {
 			for _, item := range searchQuery.Result {
 				result = append(result, dtos.PlaylistDashboard{
 					Id:    item.ID,
@@ -65,7 +66,7 @@ func populateDashboardsByTag(orgID int64, signedInUser *models.SignedInUser, das
 	return result
 }
 
-func LoadPlaylistDashboards(orgID int64, signedInUser *models.SignedInUser, playlistID int64) (dtos.PlaylistDashboardsSlice, error) {
+func LoadPlaylistDashboards(ctx context.Context, orgID int64, signedInUser *models.SignedInUser, playlistID int64) (dtos.PlaylistDashboardsSlice, error) {
 	playlistItems, _ := LoadPlaylistItems(playlistID)
 
 	dashboardByIDs := make([]int64, 0)
@@ -90,7 +91,7 @@ func LoadPlaylistDashboards(orgID int64, signedInUser *models.SignedInUser, play
 
 	var k, _ = populateDashboardsByID(dashboardByIDs, dashboardIDOrder)
 	result = append(result, k...)
-	result = append(result, populateDashboardsByTag(orgID, signedInUser, dashboardByTag, dashboardTagOrder)...)
+	result = append(result, populateDashboardsByTag(ctx, orgID, signedInUser, dashboardByTag, dashboardTagOrder)...)
 
 	sort.Sort(result)
 	return result, nil

--- a/pkg/api/search.go
+++ b/pkg/api/search.go
@@ -62,7 +62,7 @@ func Search(c *models.ReqContext) response.Response {
 		Sort:         sort,
 	}
 
-	err := bus.Dispatch(&searchQuery)
+	err := bus.DispatchCtx(c.Req.Context(), &searchQuery)
 	if err != nil {
 		return response.Error(500, "Search failed", err)
 	}

--- a/pkg/services/dashboards/folder_service.go
+++ b/pkg/services/dashboards/folder_service.go
@@ -45,7 +45,7 @@ func (dr *dashboardServiceImpl) GetFolders(ctx context.Context, limit int64, pag
 		Page:         page,
 	}
 
-	if err := bus.Dispatch(&searchQuery); err != nil {
+	if err := bus.DispatchCtx(ctx, &searchQuery); err != nil {
 		return nil, err
 	}
 

--- a/pkg/services/search/service.go
+++ b/pkg/services/search/service.go
@@ -19,7 +19,7 @@ func ProvideService(cfg *setting.Cfg, bus bus.Bus) *SearchService {
 			SortAlphaDesc.Name: SortAlphaDesc,
 		},
 	}
-	s.Bus.AddHandler(s.searchHandler)
+	s.Bus.AddHandlerCtx(s.searchHandler)
 	return s
 }
 
@@ -66,7 +66,7 @@ type SearchService struct {
 	sortOptions map[string]SortOption
 }
 
-func (s *SearchService) searchHandler(query *Query) error {
+func (s *SearchService) searchHandler(ctx context.Context, query *Query) error {
 	dashboardQuery := FindPersistedDashboardsQuery{
 		Title:        query.Title,
 		SignedInUser: query.SignedInUser,
@@ -84,7 +84,7 @@ func (s *SearchService) searchHandler(query *Query) error {
 		dashboardQuery.Sort = sortOpt
 	}
 
-	if err := bus.DispatchCtx(context.TODO(), &dashboardQuery); err != nil {
+	if err := bus.DispatchCtx(ctx, &dashboardQuery); err != nil {
 		return err
 	}
 
@@ -93,7 +93,7 @@ func (s *SearchService) searchHandler(query *Query) error {
 		hits = sortedHits(hits)
 	}
 
-	if err := setStarredDashboards(query.SignedInUser.UserId, hits); err != nil {
+	if err := setStarredDashboards(ctx, query.SignedInUser.UserId, hits); err != nil {
 		return err
 	}
 
@@ -115,12 +115,12 @@ func sortedHits(unsorted HitList) HitList {
 	return hits
 }
 
-func setStarredDashboards(userID int64, hits []*Hit) error {
+func setStarredDashboards(ctx context.Context, userID int64, hits []*Hit) error {
 	query := models.GetUserStarsQuery{
 		UserId: userID,
 	}
 
-	if err := bus.DispatchCtx(context.TODO(), &query); err != nil {
+	if err := bus.DispatchCtx(ctx, &query); err != nil {
 		return err
 	}
 

--- a/pkg/services/search/service_test.go
+++ b/pkg/services/search/service_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSearch_SortedResults(t *testing.T) {
-	bus.AddHandler("test", func(query *FindPersistedDashboardsQuery) error {
+	bus.AddHandlerCtx("test", func(_ context.Context, query *FindPersistedDashboardsQuery) error {
 		query.Result = HitList{
 			&Hit{ID: 16, Title: "CCAA", Type: "dash-db", Tags: []string{"BB", "AA"}},
 			&Hit{ID: 10, Title: "AABB", Type: "dash-db", Tags: []string{"CC", "AA"}},
@@ -22,12 +22,12 @@ func TestSearch_SortedResults(t *testing.T) {
 		return nil
 	})
 
-	bus.AddHandler("test", func(query *models.GetUserStarsQuery) error {
+	bus.AddHandlerCtx("test", func(_ context.Context, query *models.GetUserStarsQuery) error {
 		query.Result = map[int64]bool{10: true, 12: true}
 		return nil
 	})
 
-	bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+	bus.AddHandlerCtx("test", func(_ context.Context, query *models.GetSignedInUserQuery) error {
 		query.Result = &models.SignedInUser{IsGrafanaAdmin: true}
 		return nil
 	})
@@ -41,7 +41,7 @@ func TestSearch_SortedResults(t *testing.T) {
 		},
 	}
 
-	err := svc.searchHandler(query)
+	err := svc.searchHandler(context.Background(), query)
 	require.Nil(t, err)
 
 	// Assert results are sorted.

--- a/pkg/services/sqlstore/dashboard_folder_test.go
+++ b/pkg/services/sqlstore/dashboard_folder_test.go
@@ -38,7 +38,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 						OrgId:        1,
 						DashboardIds: []int64{folder.Id, dashInRoot.Id},
 					}
-					err := SearchDashboards(context.Background(), query)
+					err := sqlStore.SearchDashboards(context.Background(), query)
 					require.NoError(t, err)
 					require.Equal(t, len(query.Result), 2)
 					require.Equal(t, query.Result[0].ID, folder.Id)
@@ -61,7 +61,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 						SignedInUser: &models.SignedInUser{UserId: currentUser.Id, OrgId: 1, OrgRole: models.ROLE_VIEWER},
 						OrgId:        1, DashboardIds: []int64{folder.Id, dashInRoot.Id},
 					}
-					err := SearchDashboards(context.Background(), query)
+					err := sqlStore.SearchDashboards(context.Background(), query)
 					require.NoError(t, err)
 
 					require.Equal(t, len(query.Result), 1)
@@ -80,7 +80,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 							OrgId:        1,
 							DashboardIds: []int64{folder.Id, dashInRoot.Id},
 						}
-						err := SearchDashboards(context.Background(), query)
+						err := sqlStore.SearchDashboards(context.Background(), query)
 						require.NoError(t, err)
 						require.Equal(t, len(query.Result), 2)
 						require.Equal(t, query.Result[0].ID, folder.Id)
@@ -99,7 +99,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 							OrgId:        1,
 							DashboardIds: []int64{folder.Id, dashInRoot.Id},
 						}
-						err := SearchDashboards(context.Background(), query)
+						err := sqlStore.SearchDashboards(context.Background(), query)
 						require.NoError(t, err)
 						require.Equal(t, len(query.Result), 2)
 						require.Equal(t, query.Result[0].ID, folder.Id)
@@ -121,7 +121,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 					query := &search.FindPersistedDashboardsQuery{
 						SignedInUser: &models.SignedInUser{UserId: currentUser.Id, OrgId: 1, OrgRole: models.ROLE_VIEWER}, OrgId: 1, DashboardIds: []int64{folder.Id, childDash.Id, dashInRoot.Id},
 					}
-					err := SearchDashboards(context.Background(), query)
+					err := sqlStore.SearchDashboards(context.Background(), query)
 					require.NoError(t, err)
 					require.Equal(t, len(query.Result), 1)
 					require.Equal(t, query.Result[0].ID, dashInRoot.Id)
@@ -135,7 +135,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 
 					t.Run("should be able to search for child dashboard but not folder", func(t *testing.T) {
 						query := &search.FindPersistedDashboardsQuery{SignedInUser: &models.SignedInUser{UserId: currentUser.Id, OrgId: 1, OrgRole: models.ROLE_VIEWER}, OrgId: 1, DashboardIds: []int64{folder.Id, childDash.Id, dashInRoot.Id}}
-						err := SearchDashboards(context.Background(), query)
+						err := sqlStore.SearchDashboards(context.Background(), query)
 						require.NoError(t, err)
 						require.Equal(t, len(query.Result), 2)
 						require.Equal(t, query.Result[0].ID, childDash.Id)
@@ -154,7 +154,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 							OrgId:        1,
 							DashboardIds: []int64{folder.Id, dashInRoot.Id, childDash.Id},
 						}
-						err := SearchDashboards(context.Background(), query)
+						err := sqlStore.SearchDashboards(context.Background(), query)
 						require.NoError(t, err)
 						require.Equal(t, len(query.Result), 3)
 						require.Equal(t, query.Result[0].ID, folder.Id)
@@ -192,7 +192,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 						},
 						OrgId: 1,
 					}
-					err := SearchDashboards(context.Background(), query)
+					err := sqlStore.SearchDashboards(context.Background(), query)
 					require.NoError(t, err)
 					require.Equal(t, len(query.Result), 4)
 					require.Equal(t, query.Result[0].ID, folder1.Id)
@@ -218,7 +218,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 							OrgId:        1,
 							DashboardIds: []int64{folder1.Id, childDash1.Id, childDash2.Id, dashInRoot.Id},
 						}
-						err := SearchDashboards(context.Background(), query)
+						err := sqlStore.SearchDashboards(context.Background(), query)
 						require.NoError(t, err)
 						require.Equal(t, len(query.Result), 1)
 						require.Equal(t, query.Result[0].ID, dashInRoot.Id)
@@ -234,7 +234,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 							OrgId:        1,
 							DashboardIds: []int64{folder2.Id, childDash1.Id, childDash2.Id, dashInRoot.Id},
 						}
-						err := SearchDashboards(context.Background(), query)
+						err := sqlStore.SearchDashboards(context.Background(), query)
 						require.NoError(t, err)
 						require.Equal(t, len(query.Result), 4)
 						require.Equal(t, query.Result[0].ID, folder2.Id)
@@ -258,7 +258,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 							OrgId:        1,
 							DashboardIds: []int64{folder2.Id, childDash1.Id, childDash2.Id, dashInRoot.Id},
 						}
-						err = SearchDashboards(context.Background(), query)
+						err = sqlStore.SearchDashboards(context.Background(), query)
 						require.NoError(t, err)
 						require.Equal(t, len(query.Result), 4)
 						require.Equal(t, query.Result[0].ID, folder2.Id)
@@ -296,7 +296,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 						Type:         "dash-folder",
 					}
 
-					err := SearchDashboards(context.Background(), &query)
+					err := sqlStore.SearchDashboards(context.Background(), &query)
 					require.NoError(t, err)
 
 					require.Equal(t, len(query.Result), 2)
@@ -349,7 +349,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 				}
 
 				t.Run("Should have write access to all dashboard folders with default ACL", func(t *testing.T) {
-					err := SearchDashboards(context.Background(), &query)
+					err := sqlStore.SearchDashboards(context.Background(), &query)
 					require.NoError(t, err)
 
 					require.Equal(t, len(query.Result), 2)
@@ -381,7 +381,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 					})
 					require.NoError(t, err)
 
-					err = SearchDashboards(context.Background(), &query)
+					err = sqlStore.SearchDashboards(context.Background(), &query)
 					require.NoError(t, err)
 
 					require.Equal(t, len(query.Result), 1)
@@ -415,7 +415,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 				}
 
 				t.Run("Should have no write access to any dashboard folders with default ACL", func(t *testing.T) {
-					err := SearchDashboards(context.Background(), &query)
+					err := sqlStore.SearchDashboards(context.Background(), &query)
 					require.NoError(t, err)
 
 					require.Equal(t, len(query.Result), 0)
@@ -447,7 +447,7 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 					})
 					require.NoError(t, err)
 
-					err = SearchDashboards(context.Background(), &query)
+					err = sqlStore.SearchDashboards(context.Background(), &query)
 					require.NoError(t, err)
 
 					require.Equal(t, len(query.Result), 1)

--- a/pkg/services/sqlstore/dashboard_test.go
+++ b/pkg/services/sqlstore/dashboard_test.go
@@ -236,7 +236,7 @@ func TestDashboardDataAccess(t *testing.T) {
 			SignedInUser: &models.SignedInUser{},
 		}
 
-		err = SearchDashboards(context.Background(), &query)
+		err = sqlStore.SearchDashboards(context.Background(), &query)
 		require.NoError(t, err)
 
 		require.Equal(t, len(query.Result), 0)
@@ -305,7 +305,7 @@ func TestDashboardDataAccess(t *testing.T) {
 			SignedInUser: &models.SignedInUser{OrgId: 1, OrgRole: models.ROLE_EDITOR},
 		}
 
-		err := SearchDashboards(context.Background(), &query)
+		err := sqlStore.SearchDashboards(context.Background(), &query)
 		require.NoError(t, err)
 
 		require.Equal(t, len(query.Result), 1)
@@ -323,7 +323,7 @@ func TestDashboardDataAccess(t *testing.T) {
 			SignedInUser: &models.SignedInUser{OrgId: 1, OrgRole: models.ROLE_EDITOR},
 		}
 
-		err := SearchDashboards(context.Background(), &query)
+		err := sqlStore.SearchDashboards(context.Background(), &query)
 		require.NoError(t, err)
 
 		require.Equal(t, len(query.Result), 1)
@@ -339,7 +339,7 @@ func TestDashboardDataAccess(t *testing.T) {
 			SignedInUser: &models.SignedInUser{OrgId: 1, OrgRole: models.ROLE_EDITOR},
 		}
 
-		err := SearchDashboards(context.Background(), &query)
+		err := sqlStore.SearchDashboards(context.Background(), &query)
 		require.NoError(t, err)
 
 		require.Equal(t, len(query.Result), 1)
@@ -355,7 +355,7 @@ func TestDashboardDataAccess(t *testing.T) {
 			SignedInUser: &models.SignedInUser{OrgId: 1, OrgRole: models.ROLE_EDITOR},
 		}
 
-		err := SearchDashboards(context.Background(), &query)
+		err := sqlStore.SearchDashboards(context.Background(), &query)
 		require.NoError(t, err)
 
 		require.Equal(t, len(query.Result), 3)
@@ -370,7 +370,7 @@ func TestDashboardDataAccess(t *testing.T) {
 			SignedInUser: &models.SignedInUser{OrgId: 1, OrgRole: models.ROLE_EDITOR},
 		}
 
-		err := SearchDashboards(context.Background(), &query)
+		err := sqlStore.SearchDashboards(context.Background(), &query)
 		require.NoError(t, err)
 
 		require.Equal(t, len(query.Result), 2)
@@ -390,7 +390,7 @@ func TestDashboardDataAccess(t *testing.T) {
 			SignedInUser: &models.SignedInUser{OrgId: 1, OrgRole: models.ROLE_EDITOR},
 		}
 
-		err := SearchDashboards(context.Background(), &query)
+		err := sqlStore.SearchDashboards(context.Background(), &query)
 		require.NoError(t, err)
 
 		require.Equal(t, len(query.Result), 2)
@@ -421,7 +421,7 @@ func TestDashboardDataAccess(t *testing.T) {
 			SignedInUser: &models.SignedInUser{UserId: 10, OrgId: 1, OrgRole: models.ROLE_EDITOR},
 			IsStarred:    true,
 		}
-		err = SearchDashboards(context.Background(), &query)
+		err = sqlStore.SearchDashboards(context.Background(), &query)
 
 		require.NoError(t, err)
 		require.Equal(t, len(query.Result), 1)
@@ -463,7 +463,7 @@ func TestDashboard_SortingOptions(t *testing.T) {
 				searchstore.TitleSorter{Descending: true},
 			},
 		}
-		dashboards, err := findDashboards(q)
+		dashboards, err := sqlStore.findDashboards(context.Background(), q)
 		require.NoError(t, err)
 		require.Len(t, dashboards, 2)
 		assert.Equal(t, dashA.Id, dashboards[0].ID)


### PR DESCRIPTION
**What this PR does / why we need it**:
Propagate context for `search.Query`, `FindPersistedDashboardsQuery`, `GetUserStarsQuery`. Followup on `context.TODO` added by #40810.

**Which issue(s) this PR fixes**:
Ref #36734

**Special notes for your reviewer**:
![image](https://user-images.githubusercontent.com/1668778/139119164-f724ce38-1218-476f-910f-b6636a9cbdc2.png)