### PR TITLE
Tooltips : Add ability to flag anchor tag as external link in a tooltip

### DIFF
--- a/packages/grafana-ui/src/components/Tooltip/_Tooltip.scss
+++ b/packages/grafana-ui/src/components/Tooltip/_Tooltip.scss
@@ -19,8 +19,11 @@ $popper-margin-from-ref: 5px;
     color: lighten($textColor, 20%);
   }
   a {
-    color: $white;
+    color: $tooltipLinkColor;
     text-decoration: underline;
+  }
+  a.external-link {
+    color: $tooltipExternalLinkColor;
   }
 }
 

--- a/packages/grafana-ui/src/themes/_variables.dark.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.dark.scss.tmpl.ts
@@ -282,6 +282,7 @@ $alert-info-bg: ${theme.colors.warning.main};
 // -------------------------
 $tooltipArrowWidth: 5px;
 $tooltipLinkColor: $link-color;
+$tooltipExternalLinkColor: $external-link-color;
 $graph-tooltip-bg: $dark-1;
 
 $tooltipBackground: ${theme.components.tooltip.background};

--- a/packages/grafana-ui/src/themes/_variables.light.scss.tmpl.ts
+++ b/packages/grafana-ui/src/themes/_variables.light.scss.tmpl.ts
@@ -293,6 +293,7 @@ $graph-tooltip-bg: $gray-5;
 
 $tooltipArrowWidth: 5px;
 $tooltipLinkColor: lighten($tooltipColor, 5%);
+$tooltipExternalLinkColor: #6E9FFF;
 
 $popover-error-bg: $btn-danger-bg;
 $popover-help-bg: $tooltipBackground;

--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -190,6 +190,7 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
                   Optional, if you want to extract part of a series name or metric node segment. Named capture groups
                   can be used to separate the display text and value (
                   <a
+                    className="external-link"
                     href="https://grafana.com/docs/grafana/latest/variables/filter-variables-with-regex#filter-and-modify-using-named-text-and-value-capture-groups"
                     target="__blank"
                   >

--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -285,6 +285,7 @@ $alert-info-bg: #F5B73D;
 // -------------------------
 $tooltipArrowWidth: 5px;
 $tooltipLinkColor: $link-color;
+$tooltipExternalLinkColor: $external-link-color;
 $graph-tooltip-bg: $dark-1;
 
 $tooltipBackground: #22252b;

--- a/public/sass/_variables.light.generated.scss
+++ b/public/sass/_variables.light.generated.scss
@@ -295,6 +295,7 @@ $graph-tooltip-bg: $gray-5;
 
 $tooltipArrowWidth: 5px;
 $tooltipLinkColor: lighten($tooltipColor, 5%);
+$tooltipExternalLinkColor: #6E9FFF;
 
 $popover-error-bg: $btn-danger-bg;
 $popover-help-bg: $tooltipBackground;

--- a/public/sass/components/_tooltip.scss
+++ b/public/sass/components/_tooltip.scss
@@ -111,6 +111,10 @@
   a {
     color: $tooltipLinkColor;
   }
+
+  a.external {
+    color: $tooltipExternalLinkColor;
+  }
 }
 
 .grafana-tip {

--- a/public/sass/components/_tooltip.scss
+++ b/public/sass/components/_tooltip.scss
@@ -112,7 +112,7 @@
     color: $tooltipLinkColor;
   }
 
-  a.external {
+  a.external-link {
     color: $tooltipExternalLinkColor;
   }
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

In https://github.com/grafana/grafana-enterprise/issues/1093 we identified an instance of a tooltip that had an external link. We'd like to indicate this similar to how we indicate external links in our typical anchor (highlight in blue color). 



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/1093

**Special notes for your reviewer**:

Note I did have to make the light theme a custom color as the background of a popup is black so the contract of the default external link was bad contrast.

# Related Images

## Before

See linked ticket (https://github.com/grafana/grafana-enterprise/issues/1093)

## After

<img width="499" alt="Screen Shot 2021-10-27 at 2 32 28 PM" src="https://user-images.githubusercontent.com/3534544/139138043-d08f1179-69aa-4152-8a67-af168827ba4e.png">
<img width="602" alt="Screen Shot 2021-10-27 at 2 33 19 PM" src="https://user-images.githubusercontent.com/3534544/139138051-fe70cf8a-f9cb-46bc-a759-f4ede2c3daf5.png">
