### PR TITLE
Dashboard: Fix repeats in snapshots

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -272,6 +272,9 @@ export class DashboardModel {
   private getPanelSaveModels() {
     return this.panels
       .filter((panel: PanelModel) => {
+        if (this.isSnapshotTruthy()) {
+          return true;
+        }
         if (panel.type === 'add-panel') {
           return false;
         }
@@ -295,6 +298,9 @@ export class DashboardModel {
         return panel.getSaveModel();
       })
       .map((model: any) => {
+        if (this.isSnapshotTruthy()) {
+          return model;
+        }
         // Clear any scopedVars from persisted mode. This cannot be part of getSaveModel as we need to be able to copy
         // panel models with preserved scopedVars, for example when going into edit mode.
         delete model.scopedVars;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes so we include repeats and repeating rows when we get the dashboard save model during snapshot processing.

**Which issue(s) this PR fixes**:
Fixes #38568

**Special notes for your reviewer**:

