### PR TITLE
WIP: old code: explore: styling: add url handling

### DIFF
--- a/packages/grafana-data/src/types/explore.ts
+++ b/packages/grafana-data/src/types/explore.ts
@@ -4,12 +4,19 @@ import { RawTimeRange, TimeRange } from './time';
 type AnyQuery = DataQuery & Record<string, any>;
 
 /** @internal */
+export const EXPLORE_GRAPH_STYLES = ['lines', 'bars', 'points', 'stacked_lines', 'stacked_bars'] as const;
+
+/** @internal */
+export type ExploreGraphStyle = typeof EXPLORE_GRAPH_STYLES[number];
+
+/** @internal */
 export interface ExploreUrlState<T extends DataQuery = AnyQuery> {
   datasource: string;
   queries: T[];
   range: RawTimeRange;
   originPanelId?: number;
   context?: string;
+  graphStyle?: ExploreGraphStyle;
 }
 
 /**

--- a/packages/grafana-data/src/utils/url.ts
+++ b/packages/grafana-data/src/utils/url.ts
@@ -197,7 +197,13 @@ export const urlUtil = {
 
 export function serializeStateToUrlParam(urlState: ExploreUrlState, compact?: boolean): string {
   if (compact) {
-    return JSON.stringify([urlState.range.from, urlState.range.to, urlState.datasource, ...urlState.queries]);
+    const items: unknown[] = [urlState.range.from, urlState.range.to, urlState.datasource, ...urlState.queries];
+    const { graphStyle } = urlState;
+    if (graphStyle) {
+      // only store `style` if a value is really provided
+      items.push({ style: { graph: graphStyle } });
+    }
+    return JSON.stringify(items);
   }
   return JSON.stringify(urlState);
 }

--- a/public/app/core/utils/explore.test.ts
+++ b/public/app/core/utils/explore.test.ts
@@ -23,6 +23,7 @@ const DEFAULT_EXPLORE_STATE: ExploreUrlState = {
   queries: [],
   range: DEFAULT_RANGE,
   originPanelId: undefined,
+  graphStyle: undefined,
 };
 
 describe('state functions', () => {
@@ -47,7 +48,7 @@ describe('state functions', () => {
       });
     });
 
-    it('returns a valid Explore state from a compact URL parameter', () => {
+    it('returns a valid Explore state from a compact URL parameter without grapStyle', () => {
       const paramValue = '["now-1h","now","Local",{"expr":"metric"},{"ui":[true,true,true,"none"]}]';
       expect(parseUrlState(paramValue)).toMatchObject({
         datasource: 'Local',
@@ -56,6 +57,19 @@ describe('state functions', () => {
           from: 'now-1h',
           to: 'now',
         },
+      });
+    });
+
+    it('returns a valid Explore state from a compact URL parameter with graphStyle', () => {
+      const paramValue = '["now-1h","now","Local",{"expr":"metric"},{"style":{"graph":"bars"}}]';
+      expect(parseUrlState(paramValue)).toMatchObject({
+        datasource: 'Local',
+        queries: [{ expr: 'metric' }],
+        range: {
+          from: 'now-1h',
+          to: 'now',
+        },
+        graphStyle: 'bars',
       });
     });
 

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -23,6 +23,8 @@ import {
   rangeUtil,
   DateTime,
   isDateTime,
+  ExploreGraphStyle,
+  EXPLORE_GRAPH_STYLES,
 } from '@grafana/data';
 import store from 'app/core/store';
 import { v4 as uuidv4 } from 'uuid';
@@ -201,10 +203,6 @@ export const safeStringifyValue = (value: any, space?: number) => {
   return '';
 };
 
-export const EXPLORE_GRAPH_STYLES = ['lines', 'bars', 'points', 'stacked_lines', 'stacked_bars'] as const;
-
-export type ExploreGraphStyle = typeof EXPLORE_GRAPH_STYLES[number];
-
 const DEFAULT_GRAPH_STYLE: ExploreGraphStyle = 'lines';
 // we use this function to take any kind of data we loaded
 // from an external source (URL, localStorage, whatever),
@@ -249,10 +247,12 @@ export function parseUrlState(initial: string | undefined): ExploreUrlState {
   };
   const datasource = parsed[ParseUrlStateIndex.Datasource];
   const parsedSegments = parsed.slice(ParseUrlStateIndex.SegmentsStart);
-  const queries = parsedSegments.filter((segment) => !isSegment(segment, 'ui', 'originPanelId', 'mode'));
+  const queries = parsedSegments.filter((segment) => !isSegment(segment, 'ui', 'originPanelId', 'mode', 'style'));
 
   const originPanelId = parsedSegments.filter((segment) => isSegment(segment, 'originPanelId'))[0];
-  return { datasource, queries, range, originPanelId };
+  const maybeGraphStyle = parsedSegments.filter((segment) => isSegment(segment, 'style'))[0]?.style?.graph;
+  const graphStyle = maybeGraphStyle === undefined ? undefined : toGraphStyle(maybeGraphStyle);
+  return { datasource, queries, range, originPanelId, graphStyle };
 }
 
 export function generateKey(index = 0): string {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -6,7 +6,15 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import memoizeOne from 'memoize-one';
 import { selectors } from '@grafana/e2e-selectors';
 import { Collapse, CustomScrollbar, ErrorBoundaryAlert, Themeable2, withTheme2 } from '@grafana/ui';
-import { AbsoluteTimeRange, DataFrame, DataQuery, GrafanaTheme2, LoadingState, RawTimeRange } from '@grafana/data';
+import {
+  AbsoluteTimeRange,
+  DataFrame,
+  DataQuery,
+  ExploreGraphStyle,
+  GrafanaTheme2,
+  LoadingState,
+  RawTimeRange,
+} from '@grafana/data';
 
 import LogsContainer from './LogsContainer';
 import { QueryRows } from './QueryRows';
@@ -30,7 +38,6 @@ import { TraceViewContainer } from './TraceView/TraceViewContainer';
 import { ExploreGraph } from './ExploreGraph';
 import { LogsVolumePanel } from './LogsVolumePanel';
 import { ExploreGraphLabel } from './ExploreGraphLabel';
-import { ExploreGraphStyle } from 'app/core/utils/explore';
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {

--- a/public/app/features/explore/ExploreGraph.tsx
+++ b/public/app/features/explore/ExploreGraph.tsx
@@ -7,6 +7,7 @@ import {
   createFieldConfigRegistry,
   DataFrame,
   dateTime,
+  ExploreGraphStyle,
   FieldColorModeId,
   FieldConfigSource,
   getFrameDisplayName,
@@ -26,7 +27,6 @@ import {
   useTheme2,
 } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
-import { ExploreGraphStyle } from 'app/core/utils/explore';
 import { defaultGraphConfig, getGraphFieldConfig } from 'app/plugins/panel/timeseries/config';
 import { TimeSeriesOptions } from 'app/plugins/panel/timeseries/types';
 import { identity } from 'lodash';

--- a/public/app/features/explore/ExploreGraphLabel.tsx
+++ b/public/app/features/explore/ExploreGraphLabel.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { css } from '@emotion/css';
-import { SelectableValue } from '@grafana/data';
+import { ExploreGraphStyle, SelectableValue, EXPLORE_GRAPH_STYLES } from '@grafana/data';
 import { RadioButtonGroup } from '@grafana/ui';
-import { ExploreGraphStyle, EXPLORE_GRAPH_STYLES } from 'app/core/utils/explore';
 
 const ALL_GRAPH_STYLE_OPTIONS: Array<SelectableValue<ExploreGraphStyle>> = EXPLORE_GRAPH_STYLES.map((style) => ({
   value: style,

--- a/public/app/features/explore/ExplorePaneContainer.tsx
+++ b/public/app/features/explore/ExplorePaneContainer.tsx
@@ -44,7 +44,15 @@ class ExplorePaneContainerUnconnected extends React.PureComponent<Props> {
   }
 
   componentDidMount() {
-    const { initialized, exploreId, initialDatasource, initialQueries, initialRange, originPanelId } = this.props;
+    const {
+      initialized,
+      exploreId,
+      initialDatasource,
+      initialQueries,
+      initialRange,
+      originPanelId,
+      graphStyle,
+    } = this.props;
     const width = this.el?.offsetWidth ?? 0;
 
     // initialize the whole explore first time we mount and if browser history contains a change in datasource
@@ -56,6 +64,7 @@ class ExplorePaneContainerUnconnected extends React.PureComponent<Props> {
         initialRange,
         width,
         this.exploreEvents,
+        graphStyle,
         originPanelId
       );
     }
@@ -101,7 +110,7 @@ function mapStateToProps(state: StoreState, props: OwnProps) {
   const timeZone = getTimeZone(state.user);
   const fiscalYearStartMonth = getFiscalYearStartMonth(state.user);
 
-  const { datasource, queries, range: urlRange, originPanelId } = (urlState || {}) as ExploreUrlState;
+  const { datasource, queries, range: urlRange, originPanelId, graphStyle } = (urlState || {}) as ExploreUrlState;
   const initialDatasource = datasource || store.get(lastUsedDatasourceKeyForOrgId(state.user.orgId));
   const initialQueries: DataQuery[] = ensureQueriesMemoized(queries);
   const initialRange = urlRange
@@ -114,6 +123,7 @@ function mapStateToProps(state: StoreState, props: OwnProps) {
     initialQueries,
     initialRange,
     originPanelId,
+    graphStyle,
   };
 }
 

--- a/public/app/features/explore/Wrapper.test.tsx
+++ b/public/app/features/explore/Wrapper.test.tsx
@@ -66,13 +66,21 @@ describe('Wrapper', () => {
     // At this point url should be initialised to some defaults
     expect(locationService.getSearchObject()).toEqual({
       orgId: '1',
-      left: JSON.stringify(['now-1h', 'now', 'loki', { refId: 'A' }]),
+      left: JSON.stringify(['now-1h', 'now', 'loki', { refId: 'A' }, { style: { graph: 'lines' } }]),
     });
     expect(datasources.loki.query).not.toBeCalled();
   });
 
   it('runs query when url contains query and renders results', async () => {
-    const query = { left: JSON.stringify(['now-1h', 'now', 'loki', { expr: '{ label="value"}', refId: 'A' }]) };
+    const query = {
+      left: JSON.stringify([
+        'now-1h',
+        'now',
+        'loki',
+        { expr: '{ label="value"}', refId: 'A' },
+        { style: { graph: 'stacked_bars' } },
+      ]),
+    };
     const { datasources, store } = setup({ query });
     (datasources.loki.query as Mock).mockReturnValueOnce(makeLogsQueryResponse());
 
@@ -144,7 +152,15 @@ describe('Wrapper', () => {
   });
 
   it('handles changing the datasource manually', async () => {
-    const query = { left: JSON.stringify(['now-1h', 'now', 'loki', { expr: '{ label="value"}', refId: 'A' }]) };
+    const query = {
+      left: JSON.stringify([
+        'now-1h',
+        'now',
+        'loki',
+        { expr: '{ label="value"}', refId: 'A' },
+        { style: { graph: 'points' } },
+      ]),
+    };
     const { datasources } = setup({ query });
     (datasources.loki.query as Mock).mockReturnValueOnce(makeLogsQueryResponse());
     // Wait for rendering the editor
@@ -155,7 +171,7 @@ describe('Wrapper', () => {
     expect(datasources.elastic.query).not.toBeCalled();
     expect(locationService.getSearchObject()).toEqual({
       orgId: '1',
-      left: JSON.stringify(['now-1h', 'now', 'elastic', { refId: 'A' }]),
+      left: JSON.stringify(['now-1h', 'now', 'elastic', { refId: 'A' }, { style: { graph: 'points' } }]),
     });
   });
 
@@ -172,8 +188,20 @@ describe('Wrapper', () => {
 
   it('inits with two panes if specified in url', async () => {
     const query = {
-      left: JSON.stringify(['now-1h', 'now', 'loki', { expr: '{ label="value"}', refId: 'A' }]),
-      right: JSON.stringify(['now-1h', 'now', 'elastic', { expr: 'error', refId: 'A' }]),
+      left: JSON.stringify([
+        'now-1h',
+        'now',
+        'loki',
+        { expr: '{ label="value"}', refId: 'A' },
+        { style: { graph: 'bars' } },
+      ]),
+      right: JSON.stringify([
+        'now-1h',
+        'now',
+        'elastic',
+        { expr: 'error', refId: 'A' },
+        { style: { graph: 'points' } },
+      ]),
     };
 
     const { datasources } = setup({ query });

--- a/public/app/features/explore/exploreGraphStyleUtils.ts
+++ b/public/app/features/explore/exploreGraphStyleUtils.ts
@@ -1,7 +1,6 @@
 import produce from 'immer';
-import { FieldConfigSource } from '@grafana/data';
+import { ExploreGraphStyle, FieldConfigSource } from '@grafana/data';
 import { GraphDrawStyle, GraphFieldConfig, StackingMode } from '@grafana/schema';
-import { ExploreGraphStyle } from 'app/core/utils/explore';
 
 export type FieldConfig = FieldConfigSource<GraphFieldConfig>;
 

--- a/public/app/features/explore/state/utils.ts
+++ b/public/app/features/explore/state/utils.ts
@@ -2,6 +2,7 @@ import {
   AbsoluteTimeRange,
   DataSourceApi,
   EventBusExtended,
+  ExploreGraphStyle,
   ExploreUrlState,
   getDefaultTimeRange,
   HistoryItem,
@@ -12,12 +13,7 @@ import {
 import { ExploreItemState } from 'app/types/explore';
 import { getDatasourceSrv } from '../../plugins/datasource_srv';
 import store from '../../../core/store';
-import {
-  clearQueryKeys,
-  ExploreGraphStyle,
-  lastUsedDatasourceKeyForOrgId,
-  toGraphStyle,
-} from '../../../core/utils/explore';
+import { clearQueryKeys, lastUsedDatasourceKeyForOrgId, toGraphStyle } from '../../../core/utils/explore';
 import { toRawTimeRange } from '../utils/time';
 
 export const DEFAULT_RANGE = {
@@ -113,6 +109,7 @@ export function getUrlStateFromPaneState(pane: ExploreItemState): ExploreUrlStat
     datasource: pane.datasourceInstance?.name || '',
     queries: pane.queries.map(clearQueryKeys),
     range: toRawTimeRange(pane.range),
+    graphStyle: pane.graphStyle,
   };
 }
 

--- a/public/app/types/explore.ts
+++ b/public/app/types/explore.ts
@@ -13,8 +13,8 @@ import {
   TimeRange,
   EventBusExtended,
   DataQueryResponse,
+  ExploreGraphStyle,
 } from '@grafana/data';
-import { ExploreGraphStyle } from 'app/core/utils/explore';
 
 export enum ExploreId {
   left = 'left',


### PR DESCRIPTION
this pull-request contains the original "add url handling" code that was planned for the explore-styling functionality.

later it was decided to rethink how we do URLs in explore, so this code will not happen.

i have it here to document what places need to be changed in explore to put this into the URL. it should be an useful starting point when we at a later point add this functionality.