### PR TITLE
prometheus: monaco: stricter autocomplete and handle space

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/index.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/index.ts
@@ -74,7 +74,7 @@ export function getCompletionProvider(
   };
 
   return {
-    triggerCharacters: ['{', ',', '[', '(', '=', '~'],
+    triggerCharacters: ['{', ',', '[', '(', '=', '~', ' '],
     provideCompletionItems,
   };
 }

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/intent.test.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/intent.test.ts
@@ -46,6 +46,8 @@ describe('intent', () => {
     assertIntent('something{}[^]', {
       type: 'ALL_DURATIONS',
     });
+
+    assertIntent('something{label~^}', null);
   });
 
   it('handles label names', () => {

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/intent.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/intent.ts
@@ -389,7 +389,20 @@ function resolveDurations(node: SyntaxNode, text: string, pos: number): Intent {
   };
 }
 
+function subTreeHasError(node: SyntaxNode): boolean {
+  return getNodeInSubtree(node, ERROR_NODE_NAME) !== null;
+}
+
 function resolveLabelKeysWithEquals(node: SyntaxNode, text: string, pos: number): Intent | null {
+  // for example `something{^}`
+
+  // there are some false positives that can end up in this situation, that we want
+  // to eliminate, for example: `something{a~^}`
+  // basically, if this subtree contains any error-node, we stop
+  if (subTreeHasError(node)) {
+    return null;
+  }
+
   const metricNameNode = walk(node, [
     ['parent', 'VectorSelector'],
     ['firstChild', 'MetricIdentifier'],


### PR DESCRIPTION
this fixes the problem mentioned in https://github.com/grafana/grafana/pull/41004#discussion_r738088139 and in https://github.com/grafana/grafana/pull/41004#pullrequestreview-791461282

in short:
- when you have a query like `something{job~^}` (`^` marks the cursor), you should not get autocomplete.
- when you have a query like `something{job="a", ^}` (there is a space before the cursor), you should get label-name autocomplete.
