### PR TITLE
Chore: Add editor configs for yarn pnp support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,9 @@ public/css/*.min.css
 *.tmp
 .DS_Store
 .vscode/
+!.vscode/settings.json
 !.vscode/launch.json
+!.vscode/extensions.json
 .vs/
 .eslintcache
 .stylelintcache

--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,0 +1,6 @@
+{
+  "eslint.packageManager": "yarn",
+  "eslint.nodePath": ".yarn/sdks",
+  "workspace.workspaceFolderCheckCwd": false,
+  "tsserver.tsdk": ".yarn/sdks/typescript/lib"
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "arcanis.vscode-zipfs",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "stylelint.vscode-stylelint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "typescript.tsdk": ".yarn/sdks/typescript/lib",
+  "search.exclude": {
+    "**/.yarn": true,
+    "**/.pnp.*": true
+  },
+  "eslint.nodePath": ".yarn/sdks",
+  "prettier.prettierPath": ".yarn/sdks/prettier/index.js",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "stylelint.stylelintPath": ".yarn/sdks/stylelint/lib/index.js"
+}

--- a/.yarn/sdks/eslint/bin/eslint.js
+++ b/.yarn/sdks/eslint/bin/eslint.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-const { existsSync } = require(`fs`);
-const { createRequire, createRequireFromPath } = require(`module`);
-const { resolve } = require(`path`);
+const {existsSync} = require(`fs`);
+const {createRequire, createRequireFromPath} = require(`module`);
+const {resolve} = require(`path`);
 
-const relPnpApiPath = '../../../../.pnp.cjs';
+const relPnpApiPath = "../../../../.pnp.cjs";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);

--- a/.yarn/sdks/eslint/lib/api.js
+++ b/.yarn/sdks/eslint/lib/api.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-const { existsSync } = require(`fs`);
-const { createRequire, createRequireFromPath } = require(`module`);
-const { resolve } = require(`path`);
+const {existsSync} = require(`fs`);
+const {createRequire, createRequireFromPath} = require(`module`);
+const {resolve} = require(`path`);
 
-const relPnpApiPath = '../../../../.pnp.cjs';
+const relPnpApiPath = "../../../../.pnp.cjs";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);

--- a/.yarn/sdks/integrations.yml
+++ b/.yarn/sdks/integrations.yml
@@ -3,3 +3,4 @@
 
 integrations:
   - vscode
+  - vim

--- a/.yarn/sdks/prettier/index.js
+++ b/.yarn/sdks/prettier/index.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-const { existsSync } = require(`fs`);
-const { createRequire, createRequireFromPath } = require(`module`);
-const { resolve } = require(`path`);
+const {existsSync} = require(`fs`);
+const {createRequire, createRequireFromPath} = require(`module`);
+const {resolve} = require(`path`);
 
-const relPnpApiPath = '../../../.pnp.cjs';
+const relPnpApiPath = "../../../.pnp.cjs";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);

--- a/.yarn/sdks/stylelint/bin/stylelint.js
+++ b/.yarn/sdks/stylelint/bin/stylelint.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-const { existsSync } = require(`fs`);
-const { createRequire, createRequireFromPath } = require(`module`);
-const { resolve } = require(`path`);
+const {existsSync} = require(`fs`);
+const {createRequire, createRequireFromPath} = require(`module`);
+const {resolve} = require(`path`);
 
-const relPnpApiPath = '../../../../.pnp.cjs';
+const relPnpApiPath = "../../../../.pnp.cjs";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);

--- a/.yarn/sdks/stylelint/lib/index.js
+++ b/.yarn/sdks/stylelint/lib/index.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-const { existsSync } = require(`fs`);
-const { createRequire, createRequireFromPath } = require(`module`);
-const { resolve } = require(`path`);
+const {existsSync} = require(`fs`);
+const {createRequire, createRequireFromPath} = require(`module`);
+const {resolve} = require(`path`);
 
-const relPnpApiPath = '../../../../.pnp.cjs';
+const relPnpApiPath = "../../../../.pnp.cjs";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);

--- a/.yarn/sdks/typescript/lib/tsc.js
+++ b/.yarn/sdks/typescript/lib/tsc.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-const { existsSync } = require(`fs`);
-const { createRequire, createRequireFromPath } = require(`module`);
-const { resolve } = require(`path`);
+const {existsSync} = require(`fs`);
+const {createRequire, createRequireFromPath} = require(`module`);
+const {resolve} = require(`path`);
 
-const relPnpApiPath = '../../../../.pnp.cjs';
+const relPnpApiPath = "../../../../.pnp.cjs";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);

--- a/.yarn/sdks/typescript/lib/typescript.js
+++ b/.yarn/sdks/typescript/lib/typescript.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-const { existsSync } = require(`fs`);
-const { createRequire, createRequireFromPath } = require(`module`);
-const { resolve } = require(`path`);
+const {existsSync} = require(`fs`);
+const {createRequire, createRequireFromPath} = require(`module`);
+const {resolve} = require(`path`);
 
-const relPnpApiPath = '../../../../.pnp.cjs';
+const relPnpApiPath = "../../../../.pnp.cjs";
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absRequire = (createRequire || createRequireFromPath)(absPnpApiPath);


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds configs for vim and vscode so developers don't need to run `yarn dlx @yarnpkg/sdks vscode vim` manually.

