### PR TITLE
InfluxDB: fix table data processing with renamed time field in InfluxQL

### DIFF
--- a/public/app/plugins/datasource/influxdb/influx_series.ts
+++ b/public/app/plugins/datasource/influxdb/influx_series.ts
@@ -171,19 +171,24 @@ export default class InfluxSeries {
       return table;
     }
 
+    // the order is:
+    // - first the first item from the value-array (this is often (always?) the timestamp)
+    // - then all the tag-values
+    // - then the rest of the value-array
+    //
+    // we have to keep this order both in table.columns and table.rows
+
     each(this.series, (series: any, seriesIndex: number) => {
       if (seriesIndex === 0) {
-        j = 0;
-        // Check that the first column is indeed 'time'
-        if (series.columns[0] === 'time') {
-          // Push this now before the tags and with the right type
-          table.columns.push({ text: 'Time', type: FieldType.time });
-          j++;
-        }
+        const firstCol = series.columns[0];
+        // Check the first column's name, if it is `time`, we
+        // mark it as having the type time
+        const firstTableCol = firstCol === 'time' ? { text: 'Time', type: FieldType.time } : { text: firstCol };
+        table.columns.push(firstTableCol);
         each(keys(series.tags), (key) => {
           table.columns.push({ text: key });
         });
-        for (; j < series.columns.length; j++) {
+        for (j = 1; j < series.columns.length; j++) {
           table.columns.push({ text: series.columns[j] });
         }
       }

--- a/public/app/plugins/datasource/influxdb/specs/influx_series.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/influx_series.test.ts
@@ -1,3 +1,4 @@
+import produce from 'immer';
 import InfluxSeries from '../influx_series';
 
 describe('when generating timeseries from influxdb response', () => {
@@ -298,6 +299,63 @@ describe('when generating timeseries from influxdb response', () => {
         expect(annotations[0].tags.length).toBe(2);
         expect(annotations[0].tags[0]).toBe('America');
         expect(annotations[0].tags[1]).toBe('backend');
+      });
+    });
+
+    describe('given a time-column in the json-response', () => {
+      const options = {
+        alias: '',
+        series: [
+          {
+            name: 'cpu',
+            tags: { cpu: 'cpu1' },
+            columns: ['time', 'usage_idle'],
+            values: [[1481549440372, 42]],
+          },
+        ],
+      };
+
+      it('the column-names should be correct if the time-column is not renamed', () => {
+        const series = new InfluxSeries(options);
+        const table = series.getTable();
+
+        expect(table.columns).toStrictEqual([
+          {
+            text: 'Time',
+            type: 'time',
+          },
+          {
+            text: 'cpu',
+          },
+          {
+            text: 'usage_idle',
+          },
+        ]);
+
+        expect(table.rows).toStrictEqual([[1481549440372, 'cpu1', 42]]);
+      });
+
+      it('the column-names should be correct if the time-column is renamed', () => {
+        const renamedOptions = produce(options, (draft) => {
+          // we rename the time-column to `zeit`
+          draft.series[0].columns[0] = 'zeit';
+        });
+        const series = new InfluxSeries(renamedOptions);
+        const table = series.getTable();
+
+        expect(table.columns).toStrictEqual([
+          {
+            text: 'zeit',
+          },
+          {
+            text: 'cpu',
+          },
+          {
+            text: 'usage_idle',
+          },
+        ]);
+
+        expect(table.rows).toStrictEqual([[1481549440372, 'cpu1', 42]]);
       });
     });
   });


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/41043 . i recommend reading the bug-report first, it has instructions to how to reproduce the bug.

this is about running an influxdb-influxql query with format_as=table.
when we get back the response from influxdb, the relevant part looks like this:
```json
[
  {
    "columns": ["time", "usage_idle"],
    "name": "cpu",
    "tags": {
      "cpu": "cpu1"
    },
    "values": [[1635487540000, 45]]
  },
  {
    "columns": ["time", "usage_idle"],
    "name": "cpu",
    "tags": {
      "cpu": "cpu2"
    },
    "values": [[1635487540000, 46]]
  }
]
```

two time-series, both with only 1 timestamp, one for `cpu=cpu1` and one for `cpu=cpu2`.

we are converting this to a table-format, where we want the table-columns be:
- first table-column should be the timestamp
- the next table-columns will be made by the tag-values
- the remaining table-columns will be made by the remaining items from the values-array

so this converts to this table (only showing the relevant parts):
```javascript
{
  columns: [
    {
      text: "Time",
      type: "time",
    },
    {
      text: "cpu",
    },
    {
      text: "usage_idle",
    },
  ];
  rows: [
    [1635487540000, "cpu1", 45],
    [1635487540000, "cpu2", 46],
  ];
}
```

as you can see, for the "time" column we add the extra info that it has the type `time`. there is no way to know this from the json-data we receive from the server, so there is an `if` in the code that checks that if the first column-name is `"time"`, there is some special code that orders the columns and also adds the `time` type. that reordering part is the bug, because if that `if` does not trigger, the order of columns will be different.
so if you run an influxql query that renames the time-column using the ` as ` construct, the column-names will be mixed up.
the fix is about only `if`-ing the add-time-type part, we always do the reordering part, this way the bug does not happen.

NOTE: when you test it, you will see that with renamed-time-column, the column-names are correct, but the timestamps will not be time-formatted, they stay as numbers. there is nothing we can do about this, it can be fixed by applying the "Convert field type" transform. alternatively, one can just not rename the time-column in influxql, and do the renaming in the dashboard (either by a rename-by-regex transform, or by adding a field override to the table-visualization).

how to test: do the thing in the bug description, it should work now.
