### PR TITLE
streamline kbn.addSlashes and add a test, streamline escaping in angular tip() function

### DIFF
--- a/public/app/angular/misc.ts
+++ b/public/app/angular/misc.ts
@@ -14,9 +14,8 @@ function tip($compile: any) {
         '<i class="grafana-tip fa fa-' +
         (attrs.icon || 'question-circle') +
         '" bs-tooltip="\'' +
-        kbn.addSlashes(elem.text()) +
+        kbn.addSlashes(elem.text()).replace(/[{}]/g, '\\$&') +
         '\'"></i>';
-      _t = _t.replace(/{/g, '\\{').replace(/}/g, '\\}');
       elem.replaceWith($compile(angular.element(_t))(scope));
     },
   };

--- a/public/app/angular/misc.ts
+++ b/public/app/angular/misc.ts
@@ -1,7 +1,6 @@
 import angular from 'angular';
 import Clipboard from 'clipboard';
 import coreModule from '../core/core_module';
-import kbn from 'app/core/utils/kbn';
 import { appEvents } from 'app/core/core';
 import { AppEvents } from '@grafana/data';
 
@@ -14,7 +13,10 @@ function tip($compile: any) {
         '<i class="grafana-tip fa fa-' +
         (attrs.icon || 'question-circle') +
         '" bs-tooltip="\'' +
-        kbn.addSlashes(elem.text()).replace(/[{}]/g, '\\$&') +
+        // here we double-html-encode any special characters in the source string
+        // this is needed so that the final html contains the encoded entities as they
+        // will be decoded when _t is parsed by angular
+        elem.text().replace(/[\'\"\\{}<>&]/g, (m: string) => '&amp;#' + m.charCodeAt(0) + ';') +
         '\'"></i>';
       elem.replaceWith($compile(angular.element(_t))(scope));
     },

--- a/public/app/core/utils/kbn.test.ts
+++ b/public/app/core/utils/kbn.test.ts
@@ -73,3 +73,11 @@ describe('describe_interval', () => {
     expect(() => kbn.describeInterval('xyz')).toThrow();
   });
 });
+
+describe('addSlashes', () => {
+  it('properly escapes backslashes, single-quotes, double-quotes and the number zero', () => {
+    expect(kbn.addSlashes('this is a \'test\' with "quotes" backslashes (\\) and zero (0)')).toEqual(
+      'this is a \\\'test\\\' with \\"quotes\\" backslashes (\\\\) and zero (\\0)'
+    );
+  });
+});

--- a/public/app/core/utils/kbn.ts
+++ b/public/app/core/utils/kbn.ts
@@ -47,13 +47,7 @@ const kbn = {
     return strings.join(':');
   },
   toPercent: (nr: number, outOf: number) => Math.floor((nr / outOf) * 10000) / 100 + '%',
-  addSlashes: (str: string) => {
-    str = str.replace(/\\/g, '\\\\');
-    str = str.replace(/\'/g, "\\'");
-    str = str.replace(/\"/g, '\\"');
-    str = str.replace(/\0/g, '\\0');
-    return str;
-  },
+  addSlashes: (str: string) => str.replace(/[\'\"\\0]/g, '\\$&'),
   /** @deprecated since 7.2, use grafana/data */
   describeInterval: (str: string) => {
     deprecationWarning('kbn.ts', 'kbn.stringToJsRegex()', '@grafana/data');


### PR DESCRIPTION
A user reported that their code scanning tool flagged the bracket-replacement code on line 19 of  `public/app/angular/misc.ts` as it replaces curly-braces but does not escape literal backslashes.

Looking into it, the alert is a false positive because we pass the dynamic parts of the string through `kbn.addSlashes` which does escape backslashes, single and double-quotes, and the number zero.  I did however note that `kbn.addSlashes` does not have any tests and could be streamlined into a single regex.  I have cleaned it up and added a test.

There is also no need to escape the entire string, so I updated the `tip()` function in `misc.ts` to only replace curly-braces in the dynamic portion of the string (after it's been escaped with `kbn.addSlashes`).