### PR TITLE
Chore: Don't to show console errors in grafana-toolkit tests

### DIFF
--- a/packages/grafana-toolkit/src/config/jest.plugin.config.test.ts
+++ b/packages/grafana-toolkit/src/config/jest.plugin.config.test.ts
@@ -1,7 +1,14 @@
 import { jestConfig, allowedJestConfigOverrides } from './jest.plugin.config';
 
 describe('Jest config', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should throw if not supported overrides provided', () => {
+    // Do not show console error,log when running test
+    jest.spyOn(console, 'error').mockImplementation();
+    jest.spyOn(console, 'log').mockImplementation();
     const getConfig = () => jestConfig(`${__dirname}/mocks/jestSetup/unsupportedOverrides`);
 
     expect(getConfig).toThrow('Provided Jest config is not supported');

--- a/packages/grafana-toolkit/src/config/webpack/loaders.test.ts
+++ b/packages/grafana-toolkit/src/config/webpack/loaders.test.ts
@@ -2,11 +2,10 @@ import { getStylesheetEntries, hasThemeStylesheets } from './loaders';
 
 describe('Loaders', () => {
   describe('stylesheet helpers', () => {
-    const logSpy = jest.spyOn(console, 'log').mockImplementation();
+    jest.spyOn(console, 'log').mockImplementation();
 
     afterAll(() => {
-      logSpy.mockRestore();
-      logSpy.mockRestore();
+      jest.restoreAllMocks();
     });
 
     describe('getStylesheetEntries', () => {
@@ -24,10 +23,12 @@ describe('Loaders', () => {
 
     describe('hasThemeStylesheets', () => {
       it('throws when only one theme file is defined', () => {
+        jest.spyOn(console, 'error').mockImplementation();
         const result = () => {
           hasThemeStylesheets(`${__dirname}/../mocks/stylesheetsSupport/missing-theme-file`);
         };
         expect(result).toThrow();
+        jest.restoreAllMocks();
       });
 
       it('returns false when no theme files present', () => {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR disables console error, log in the tests when it is expected in the grafana toolkit .

