### PR TITLE
Chore: explicitly set nodeLinker in yarnrc

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,5 @@
 enableTelemetry: false
+nodeLinker: "pnp"
 
 packageExtensions:
   "@grafana/slate-react@0.22.10-grafana":


### PR DESCRIPTION
Explicitly sets nodeLinker to `pnp` so that this config is not overridden by upstream `.yarnrc.yml` files