### PR TITLE
Access control: Redirect non-API calls from middleware

### DIFF
--- a/pkg/services/accesscontrol/middleware/middleware.go
+++ b/pkg/services/accesscontrol/middleware/middleware.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -44,6 +45,12 @@ func Deny(c *models.ReqContext, evaluator accesscontrol.Evaluator, err error) {
 			"accessErrorID", id,
 			"permissions", evaluator.String(),
 		)
+	}
+
+	if !c.IsApiRequest() {
+		// TODO(emil): I'd like to show a message after this redirect, not sure how that can be done?
+		c.Redirect(setting.AppSubUrl + "/")
+		return
 	}
 
 	// If the user triggers an error in the access control system, we


### PR DESCRIPTION
**What this PR does / why we need it**:

When I wrote the middleware for access control I never intended it to be used outside of the API so I omitted four lines from the implementation:

https://github.com/grafana/grafana/blob/5a087d27080dc57b40b89e1fc82dedf620b14449/pkg/middleware/auth.go#L24-L27

This pull request rectifies that by introducing that redirect for us. I'd like to get a message passed together with the redirect, but I'm not sure I can do that?

Ideally I'd like a forbidden page in the UI that we can redirect to.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

