### PR TITLE
docs: Fix URL for Github callback in OAuth.

### DIFF
--- a/docs/sources/auth/github.md
+++ b/docs/sources/auth/github.md
@@ -16,7 +16,7 @@ settings page). When you create the application you will need to specify
 a callback URL. Specify this as callback:
 
 ```bash
-http://<my_grafana_server_name_or_ip>:<grafana_server_port>/login/github
+http://<my_grafana_server_name_or_ip>:<grafana_server_port>/grafana/login/github
 ```
 
 This callback URL must match the full HTTP address that you use in your


### PR DESCRIPTION
**What this PR does / why we need it**:

I was following along with [this tutorial](https://grafana.com/docs/grafana/latest/auth/github/) on a fresh instance of Grafana, deployed to Kubernetes via the [kube-prometheus-stack helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack).  When I tried to authenticate against GitHub, it failed because the callback URL that Grafana was sending to GitHub was `/grafana/login/github`, instead of `/login/github`.

(Although - I'm not sure if this is something specific to kube-prometheus-stack or not...)