### PR TITLE
ValueMappings: Don't apply field config defaults to time fields

### DIFF
--- a/packages/grafana-ui/src/utils/standardEditors.tsx
+++ b/packages/grafana-ui/src/utils/standardEditors.tsx
@@ -171,7 +171,7 @@ export const getStandardFieldConfigs = () => {
     process: valueMappingsOverrideProcessor,
     settings: {},
     defaultValue: [],
-    shouldApply: () => true,
+    shouldApply: (x) => x.type !== FieldType.time,
     category: ['Value mappings'],
     getItemsCount: (value?) => (value ? value.length : 0),
   };


### PR DESCRIPTION
An issue/PR to discuss if this is a good idea or not. 

Noticed https://github.com/grafana/grafana/discussions/41130  , not sure if solving it like this is a good idea. We had other issues before, for example unit only applied to number fields and we removed that condition. Will probably be some edge case where
using value mappings for time fields will be needed/expected but cannot think of any right now 