### PR TITLE
Chore: Amend log statement structure for log15

### DIFF
--- a/pkg/tsdb/prometheus/time_series_query.go
+++ b/pkg/tsdb/prometheus/time_series_query.go
@@ -69,7 +69,7 @@ func (s *Service) executeTimeSeriesQuery(ctx context.Context, req *backend.Query
 		if query.RangeQuery {
 			rangeResponse, _, err := client.QueryRange(ctx, query.Expr, timeRange)
 			if err != nil {
-				plog.Error("Range query", query.Expr, "failed with", err)
+				plog.Error("Range query failed", "query", query.Expr, "err", err)
 				result.Responses[query.RefId] = backend.DataResponse{Error: err}
 			} else {
 				response[RangeQueryType] = rangeResponse
@@ -79,7 +79,7 @@ func (s *Service) executeTimeSeriesQuery(ctx context.Context, req *backend.Query
 		if query.InstantQuery {
 			instantResponse, _, err := client.Query(ctx, query.Expr, query.End)
 			if err != nil {
-				plog.Error("Instant query", query.Expr, "failed with", err)
+				plog.Error("Instant query failed", "query", query.Expr, "err", err)
 				result.Responses[query.RefId] = backend.DataResponse{Error: err}
 			} else {
 				response[InstantQueryType] = instantResponse
@@ -89,7 +89,7 @@ func (s *Service) executeTimeSeriesQuery(ctx context.Context, req *backend.Query
 		if query.ExemplarQuery {
 			exemplarResponse, err := client.QueryExemplars(ctx, query.Expr, timeRange.Start, timeRange.End)
 			if err != nil {
-				plog.Error("Exemplar query", query.Expr, "failed with", err)
+				plog.Error("Exemplar query failed", "query", query.Expr, "err", err)
 				result.Responses[query.RefId] = backend.DataResponse{Error: err}
 			} else {
 				response[ExemplarQueryType] = exemplarResponse
@@ -230,7 +230,7 @@ func parseTimeSeriesResponse(value map[TimeSeriesQueryType]interface{}, query *P
 		case []apiv1.ExemplarQueryResult:
 			nextFrames = exemplarToDataFrames(v, query, nextFrames)
 		default:
-			plog.Error("Query", query.Expr, "returned unexpected result type", v)
+			plog.Error("Query returned unexpected result type", "type", v, "query", query.Expr)
 			continue
 		}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Some backend log statements in the `prometheus` package are not correctly formed. As a result, here's what happens:

```
EROR[11-01|10:04:53] Range query logger=tsdb.prometheus rate(prometheus_http_requests_total[5m])="failed with" LOG15_ERROR= LOG15_ERROR="Normalized odd number of arguments by adding nil"
EROR[11-01|10:04:55] Range query logger=tsdb.prometheus rate(prometheus_http_requests_total[5m])="failed with" LOG15_ERROR= LOG15_ERROR="Normalized odd number of arguments by adding nil"
```

