### PR TITLE
Build container: Add `isl` and `expat` libs as tarballs explicitly

### DIFF
--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -69,6 +69,11 @@ RUN cd /tmp/crosstool-ng-${CTNG}        && \
     echo 'CT_EXPERIMENTAL=y' >> .config && \
     echo 'CT_ALLOW_BUILD_AS_ROOT=y' >> .config && \
     echo 'CT_ALLOW_BUILD_AS_ROOT_SURE=y' >> .config && \
+    mkdir -p .build/tarballs && \
+    cd .build/tarballs && \
+    curl -fLO https://libisl.sourceforge.io/isl-0.20.tar.gz && \
+    curl -fLO https://github.com/libexpat/libexpat/releases/download/R_2_1_0/expat-2.1.0.tar.gz && \
+    cd - && \
     ./ct-ng build
 RUN cd /tmp && \
     rm /tmp/x86_64-centos6-linux-gnu/build.log.bz2 && \


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, mirror for ISL (Integer Set Library) tarball is down. This has been the case for more than a month now. Related issue: https://github.com/pfalcon/esp-open-sdk/issues/237.

This PR, adds the ISL and Expat tarballs explicitly, for the Docker image to be able to be built.

**Special notes for your reviewer**:

Try run `docker build .` in `scripts/build/ci-build` directory.
