### PR TITLE
Live: adopt latest fixes from gin route tree

### DIFF
--- a/pkg/services/live/pipeline/rule_cache_segmented.go
+++ b/pkg/services/live/pipeline/rule_cache_segmented.go
@@ -75,8 +75,7 @@ func (s *CacheSegmentedTree) Get(orgID int64, channel string) (*LiveChannelRule,
 	if !ok {
 		return nil, false, nil
 	}
-	ps := make(tree.Params, 0, 20)
-	nodeValue := t.GetValue("/"+channel, &ps, true)
+	nodeValue := t.GetValue("/"+channel, true)
 	if nodeValue.Handler == nil {
 		return nil, false, nil
 	}

--- a/pkg/services/live/pipeline/tree/tree.go
+++ b/pkg/services/live/pipeline/tree/tree.go
@@ -15,6 +15,7 @@ import (
 var (
 	strColon = []byte(":")
 	strStar  = []byte("*")
+	strSlash = []byte("/")
 )
 
 func min(a, b int) int {
@@ -51,6 +52,11 @@ func countParams(path string) uint16 {
 	return n
 }
 
+func countSections(path string) uint16 {
+	s := StringToBytes(path)
+	return uint16(bytes.Count(s, strSlash))
+}
+
 type nodeType uint8
 
 const (
@@ -66,14 +72,22 @@ func New() *Node {
 }
 
 type Node struct {
-	path      string
-	indices   string
-	wildChild bool
-	nType     nodeType
-	priority  uint32
-	children  []*Node // child nodes, at most 1 :param style Node at the end of the array
-	handler   Handler
-	fullPath  string
+	path        string
+	indices     string
+	wildChild   bool
+	nType       nodeType
+	priority    uint32
+	children    []*Node // child nodes, at most 1 :param style Node at the end of the array
+	handler     Handler
+	fullPath    string
+	maxParams   uint16
+	maxSections uint16
+}
+
+type skippedNode struct {
+	path        string
+	node        *Node
+	paramsCount int16
 }
 
 // Increments priority of the given child and reorders if necessary
@@ -100,6 +114,12 @@ func (n *Node) incrementChildPrio(pos int) int {
 }
 
 func (n *Node) AddRoute(path string, handlers Handler) {
+	if paramsCount := countParams(path); paramsCount > n.maxParams {
+		n.maxParams = paramsCount
+	}
+	if sectionsCount := countSections(path); sectionsCount > n.maxSections {
+		n.maxSections = sectionsCount
+	}
 	n.addRoute(path, handlers)
 }
 
@@ -356,8 +376,10 @@ type NodeValue struct {
 	FullPath string
 }
 
-func (n *Node) GetValue(path string, params *Params, unescape bool) (value NodeValue) {
-	return n.getValue(path, params, unescape)
+func (n *Node) GetValue(path string, unescape bool) (value NodeValue) {
+	skippedNodes := make([]skippedNode, 0, n.maxSections)
+	ps := make(Params, 0, n.maxParams)
+	return n.getValue(path, &ps, &skippedNodes, unescape)
 }
 
 // Returns the handle registered with the given path (key). The values of
@@ -366,11 +388,8 @@ func (n *Node) GetValue(path string, params *Params, unescape bool) (value NodeV
 // made if a handle exists with an extra (without the) trailing slash for the
 // given path.
 // nolint:gocyclo
-func (n *Node) getValue(path string, params *Params, unescape bool) (value NodeValue) {
-	var (
-		skippedPath string
-		latestNode  = n // Caching the latest Node
-	)
+func (n *Node) getValue(path string, params *Params, skippedNodes *[]skippedNode, unescape bool) (value NodeValue) {
+	var globalParamsCount int16
 
 walk: // Outer loop for walking the tree
 	for {
@@ -385,15 +404,20 @@ walk: // Outer loop for walking the tree
 					if c == idxc {
 						//  strings.HasPrefix(n.children[len(n.children)-1].path, ":") == n.wildChild
 						if n.wildChild {
-							skippedPath = prefix + path
-							latestNode = &Node{
-								path:      n.path,
-								wildChild: n.wildChild,
-								nType:     n.nType,
-								priority:  n.priority,
-								children:  n.children,
-								handler:   n.handler,
-								fullPath:  n.fullPath,
+							index := len(*skippedNodes)
+							*skippedNodes = (*skippedNodes)[:index+1]
+							(*skippedNodes)[index] = skippedNode{
+								path: prefix + path,
+								node: &Node{
+									path:      n.path,
+									wildChild: n.wildChild,
+									nType:     n.nType,
+									priority:  n.priority,
+									children:  n.children,
+									handler:   n.handler,
+									fullPath:  n.fullPath,
+								},
+								paramsCount: globalParamsCount,
 							}
 						}
 
@@ -401,15 +425,26 @@ walk: // Outer loop for walking the tree
 						continue walk
 					}
 				}
-				// If the path at the end of the loop is not equal to '/' and the current Node has no child nodes
-				// the current Node needs to be equal to the latest matching Node
-				matched := path != "/" && !n.wildChild
-				if matched {
-					n = latestNode
-				}
 
-				// If there is no wildcard pattern, recommend a redirection
 				if !n.wildChild {
+					// If the path at the end of the loop is not equal to '/' and the current node has no child nodes
+					// the current node needs to roll back to last vaild skippedNode
+					if path != "/" {
+						for l := len(*skippedNodes); l > 0; {
+							skippedNode := (*skippedNodes)[l-1]
+							*skippedNodes = (*skippedNodes)[:l-1]
+							if strings.HasSuffix(skippedNode.path, path) {
+								path = skippedNode.path
+								n = skippedNode.node
+								if value.Params != nil {
+									*value.Params = (*value.Params)[:skippedNode.paramsCount]
+								}
+								globalParamsCount = skippedNode.paramsCount
+								continue walk
+							}
+						}
+					}
+
 					// Nothing found.
 					// We can recommend to redirect to the same URL without a
 					// trailing slash if a leaf exists for that path.
@@ -419,18 +454,12 @@ walk: // Outer loop for walking the tree
 
 				// Handle wildcard child, which is always at the end of the array
 				n = n.children[len(n.children)-1]
+				globalParamsCount++
 
 				switch n.nType {
 				case param:
 					// fix truncate the parameter
 					// tree_test.go  line: 204
-					if matched {
-						path = prefix + path
-						// The saved path is used after the prefix route is intercepted by matching
-						if n.indices == "/" {
-							path = skippedPath[1:]
-						}
-					}
 
 					// Find param end (either '/' or path end)
 					end := 0
@@ -516,9 +545,22 @@ walk: // Outer loop for walking the tree
 
 		if path == prefix {
 			// If the current path does not equal '/' and the Node does not have a registered handle and the most recently matched Node has a child Node
-			// the current Node needs to be equal to the latest matching Node
-			if latestNode.wildChild && n.handler == nil && path != "/" {
-				n = latestNode.children[len(latestNode.children)-1]
+			// the current node needs to roll back to last vaild skippedNode
+			if n.handler == nil && path != "/" {
+				for l := len(*skippedNodes); l > 0; {
+					skippedNode := (*skippedNodes)[l-1]
+					*skippedNodes = (*skippedNodes)[:l-1]
+					if strings.HasSuffix(skippedNode.path, path) {
+						path = skippedNode.path
+						n = skippedNode.node
+						if value.Params != nil {
+							*value.Params = (*value.Params)[:skippedNode.paramsCount]
+						}
+						globalParamsCount = skippedNode.paramsCount
+						continue walk
+					}
+				}
+				//	n = latestNode.children[len(latestNode.children)-1]
 			}
 			// We should have reached the Node containing the handle.
 			// Check if this Node has a handle registered.
@@ -549,25 +591,29 @@ walk: // Outer loop for walking the tree
 			return
 		}
 
-		if path != "/" && len(skippedPath) > 0 && strings.HasSuffix(skippedPath, path) {
-			path = skippedPath
-			// Reduce the number of cycles
-			n, latestNode = latestNode, n
-			// skippedPath cannot execute
-			// example:
-			// * /:cc/cc
-			// call /a/cc 	     expectations:match/200      Actual:match/200
-			// call /a/dd 	     expectations:unmatch/404    Actual: panic
-			// call /addr/dd/aa  expectations:unmatch/404    Actual: panic
-			// skippedPath: It can only be executed if the secondary route is not found
-			skippedPath = ""
-			continue walk
-		}
-
 		// Nothing found. We can recommend to redirect to the same URL with an
 		// extra trailing slash if a leaf exists for that path
 		value.Tsr = path == "/" ||
-			(len(prefix) == len(path)+1 && n.handler != nil)
+			(len(prefix) == len(path)+1 && prefix[len(path)] == '/' &&
+				path == prefix[:len(prefix)-1] && n.handler != nil)
+
+		// roll back to last valid skippedNode
+		if !value.Tsr && path != "/" {
+			for l := len(*skippedNodes); l > 0; {
+				skippedNode := (*skippedNodes)[l-1]
+				*skippedNodes = (*skippedNodes)[:l-1]
+				if strings.HasSuffix(skippedNode.path, path) {
+					path = skippedNode.path
+					n = skippedNode.node
+					if value.Params != nil {
+						*value.Params = (*value.Params)[:skippedNode.paramsCount]
+					}
+					globalParamsCount = skippedNode.paramsCount
+					continue walk
+				}
+			}
+		}
+
 		return
 	}
 }

--- a/pkg/services/live/pipeline/tree/tree_test.go
+++ b/pkg/services/live/pipeline/tree/tree_test.go
@@ -29,16 +29,6 @@ type testRequests []struct {
 	ps         Params
 }
 
-func getParams() *Params {
-	ps := make(Params, 0, 20)
-	return &ps
-}
-
-func getSkippedNodes() *[]skippedNode {
-	ps := make([]skippedNode, 0, 20)
-	return &ps
-}
-
 func checkRequests(t *testing.T, tree *Node, requests testRequests, unescapes ...bool) {
 	unescape := false
 	if len(unescapes) >= 1 {
@@ -46,7 +36,7 @@ func checkRequests(t *testing.T, tree *Node, requests testRequests, unescapes ..
 	}
 
 	for _, request := range requests {
-		value := tree.getValue(request.path, getParams(), getSkippedNodes(), unescape)
+		value := tree.GetValue(request.path, unescape)
 
 		if value.Handler == nil {
 			if !request.nilHandler {
@@ -657,7 +647,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/foo/p/p",
 	}
 	for _, route := range noTsrRoutes {
-		value := tree.getValue(route, nil, getSkippedNodes(), false)
+		value := tree.GetValue(route, false)
 		if value.Handler != nil {
 			t.Fatalf("non-nil handler for No-TSR route '%s", route)
 		} else if value.Tsr {
@@ -676,7 +666,7 @@ func TestTreeRootTrailingSlashRedirect(t *testing.T) {
 		t.Fatalf("panic inserting test route: %v", recv)
 	}
 
-	value := tree.getValue("/", nil, getSkippedNodes(), false)
+	value := tree.GetValue("/", false)
 	if value.Handler != nil {
 		t.Fatalf("non-nil handler")
 	} else if value.Tsr {
@@ -856,7 +846,7 @@ func TestTreeInvalidNodeType(t *testing.T) {
 
 	// normal lookup
 	recv := catchPanic(func() {
-		tree.getValue("/test", nil, getSkippedNodes(), false)
+		tree.GetValue("/test", false)
 	})
 	if rs, ok := recv.(string); !ok || rs != panicMsg {
 		t.Fatalf("Expected panic '"+panicMsg+"', got '%v'", recv)
@@ -877,11 +867,8 @@ func TestTreeInvalidParamsType(t *testing.T) {
 	tree.children = append(tree.children, &Node{})
 	tree.children[0].nType = 2
 
-	// set invalid Params type
-	params := make(Params, 0)
-
 	// try to trigger slice bounds out of range with capacity 0
-	tree.getValue("/test", &params, getSkippedNodes(), false)
+	tree.GetValue("/test", false)
 }
 
 func TestTreeWildcardConflictEx(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adopt fixes in route finding logic:

https://github.com/gin-gonic/gin/commit/3fe928994b7ba7ed16b0c5114ca82a9dafa7a974#diff-050830ac4334170e8d335e1b95519052a3461c5b57a4ca38a0531e35a8f3d388
https://github.com/gin-gonic/gin/commit/1c2aa59b20c8cff5b3c601708afe22100eac25e6#diff-050830ac4334170e8d335e1b95519052a3461c5b57a4ca38a0531e35a8f3d388
https://github.com/gin-gonic/gin/commit/cbdd47a7e108217d4672f0e24d423b632a8cd900#diff-050830ac4334170e8d335e1b95519052a3461c5b57a4ca38a0531e35a8f3d388 

Also, get rid of hardcoded params slice capacity on value get. And updated tests to use public Node API.