### PR TITLE
Variables: Adds change tracking

### DIFF
--- a/public/app/features/variables/state/selectors.ts
+++ b/public/app/features/variables/state/selectors.ts
@@ -49,3 +49,7 @@ export type GetVariables = typeof getVariables;
 export const getNewVariabelIndex = (state: StoreState = getState()): number => {
   return Object.values(state.templating.variables).length;
 };
+
+export function getVariablesIsDirty(state: StoreState = getState()): boolean {
+  return state.templating.transaction.isDirty;
+}

--- a/public/app/features/variables/state/transactionReducer.test.ts
+++ b/public/app/features/variables/state/transactionReducer.test.ts
@@ -1,4 +1,5 @@
 import { reducerTester } from '../../../../test/core/redux/reducerTester';
+import { removeVariable, variableStateNotStarted } from './sharedReducer';
 import {
   initialTransactionState,
   transactionReducer,
@@ -57,6 +58,58 @@ describe('transactionReducer', () => {
         })
         .whenActionIsDispatched(variablesClearTransaction())
         .thenStateShouldEqual({ ...initialTransactionState });
+    });
+  });
+
+  describe('extraReducers', () => {
+    describe('isDirty', () => {
+      describe('when called during fetch', () => {
+        it('then isDirty should not be changed', () => {
+          reducerTester<TransactionState>()
+            .givenReducer(transactionReducer, {
+              ...initialTransactionState,
+              status: TransactionStatus.Fetching,
+            })
+            .whenActionIsDispatched(removeVariable({} as any))
+            .thenStateShouldEqual({ uid: null, status: TransactionStatus.Fetching, isDirty: false });
+        });
+      });
+
+      describe('when called after clean', () => {
+        it('then isDirty should not be changed', () => {
+          reducerTester<TransactionState>()
+            .givenReducer(transactionReducer, {
+              ...initialTransactionState,
+              status: TransactionStatus.NotStarted,
+            })
+            .whenActionIsDispatched(removeVariable({} as any))
+            .thenStateShouldEqual({ uid: null, status: TransactionStatus.NotStarted, isDirty: false });
+        });
+      });
+
+      describe('when called after complete with action that affects isDirty', () => {
+        it('then isDirty should be changed', () => {
+          reducerTester<TransactionState>()
+            .givenReducer(transactionReducer, {
+              ...initialTransactionState,
+              status: TransactionStatus.Completed,
+            })
+            .whenActionIsDispatched(removeVariable({} as any))
+            .thenStateShouldEqual({ uid: null, status: TransactionStatus.Completed, isDirty: true });
+        });
+      });
+
+      describe('when called after complete with action that does not affect isDirty', () => {
+        it('then isDirty should be changed', () => {
+          reducerTester<TransactionState>()
+            .givenReducer(transactionReducer, {
+              ...initialTransactionState,
+              status: TransactionStatus.Completed,
+            })
+            .whenActionIsDispatched(variableStateNotStarted({} as any))
+            .thenStateShouldEqual({ uid: null, status: TransactionStatus.Completed, isDirty: false });
+        });
+      });
     });
   });
 });

--- a/public/app/features/variables/state/transactionReducer.ts
+++ b/public/app/features/variables/state/transactionReducer.ts
@@ -6,7 +6,6 @@ import {
   changeVariableType,
   duplicateVariable,
   removeVariable,
-  setCurrentVariableValue,
 } from './sharedReducer';
 
 export enum TransactionStatus {
@@ -65,7 +64,6 @@ function actionAffectsDirtyState(action: AnyAction): boolean {
     changeVariableOrder.type,
     duplicateVariable.type,
     changeVariableType.type,
-    setCurrentVariableValue.type,
   ].includes(action.type);
 }
 

--- a/public/app/features/variables/state/transactionReducer.ts
+++ b/public/app/features/variables/state/transactionReducer.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { AnyAction, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import {
   addVariable,
   changeVariableOrder,
@@ -57,7 +57,7 @@ const transactionSlice = createSlice({
     }),
 });
 
-function actionAffectsDirtyState(action: PayloadAction): boolean {
+function actionAffectsDirtyState(action: AnyAction): boolean {
   return [
     removeVariable.type,
     addVariable.type,

--- a/public/app/features/variables/state/transactionReducer.ts
+++ b/public/app/features/variables/state/transactionReducer.ts
@@ -1,4 +1,13 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import {
+  addVariable,
+  changeVariableOrder,
+  changeVariableProp,
+  changeVariableType,
+  duplicateVariable,
+  removeVariable,
+  setCurrentVariableValue,
+} from './sharedReducer';
 
 export enum TransactionStatus {
   NotStarted = 'Not started',
@@ -9,9 +18,14 @@ export enum TransactionStatus {
 export interface TransactionState {
   uid: string | undefined | null;
   status: TransactionStatus;
+  isDirty: boolean;
 }
 
-export const initialTransactionState: TransactionState = { uid: null, status: TransactionStatus.NotStarted };
+export const initialTransactionState: TransactionState = {
+  uid: null,
+  status: TransactionStatus.NotStarted,
+  isDirty: false,
+};
 
 const transactionSlice = createSlice({
   name: 'templating/transaction',
@@ -32,9 +46,28 @@ const transactionSlice = createSlice({
     variablesClearTransaction: (state, action: PayloadAction<undefined>) => {
       state.uid = null;
       state.status = TransactionStatus.NotStarted;
+      state.isDirty = false;
     },
   },
+  extraReducers: (builder) =>
+    builder.addMatcher(actionAffectsDirtyState, (state, action) => {
+      if (state.status === TransactionStatus.Completed) {
+        state.isDirty = true;
+      }
+    }),
 });
+
+function actionAffectsDirtyState(action: PayloadAction): boolean {
+  return [
+    removeVariable.type,
+    addVariable.type,
+    changeVariableProp.type,
+    changeVariableOrder.type,
+    duplicateVariable.type,
+    changeVariableType.type,
+    setCurrentVariableValue.type,
+  ].includes(action.type);
+}
 
 export const {
   variablesInitTransaction,


### PR DESCRIPTION
**What this PR does / why we need it**:
First naive implementation of change tracking for variables. 

For more clarity we could create a separate reducer for the change tracking and add extraReducers for both transaction and sharedReducer. I choose to add isDirty to the transaction instead.

**Which issue(s) this PR fixes**:
Relates #39671

**Special notes for your reviewer**:

