### PR TITLE
Docs: Fixed broken link in the plugin migration guide

### DIFF
--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -17,7 +17,7 @@ This guide helps you identify the steps you need to take based on the Grafana ve
     - [1. Add dependency on grafana-plugin-sdk-go](#1-add-dependency-on-grafana-plugin-sdk-go)
     - [2. Update the way you bootstrap your plugin](#2-update-the-way-you-bootstrap-your-plugin)
     - [3. Update the plugin package](#3-update-the-plugin-package)
-  - [Unsigned backend plugins will not be loaded](#unsigned-backend-plugins-will-not-be-loaded)
+  - [Unsigned backend plugins will not be loaded](#sign-and-load-backend-plugins)
   - [Update react-hook-form from v6 to v7](#update-react-hook-form-from-v6-to-v7)
   - [Update the plugin.json](#update-the-pluginjson)
   - [Update imports to match emotion 11](#update-imports-to-match-emotion-11)

--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -17,7 +17,7 @@ This guide helps you identify the steps you need to take based on the Grafana ve
     - [1. Add dependency on grafana-plugin-sdk-go](#1-add-dependency-on-grafana-plugin-sdk-go)
     - [2. Update the way you bootstrap your plugin](#2-update-the-way-you-bootstrap-your-plugin)
     - [3. Update the plugin package](#3-update-the-plugin-package)
-  - [Unsigned backend plugins will not be loaded](#sign-and-load-backend-plugins)
+  - [Sign and load backend plugins](#sign-and-load-backend-plugins)
   - [Update react-hook-form from v6 to v7](#update-react-hook-form-from-v6-to-v7)
   - [Update the plugin.json](#update-the-pluginjson)
   - [Update imports to match emotion 11](#update-imports-to-match-emotion-11)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing the broken "Sign and load backend plugins" link in the migration guide.

**Which issue(s) this PR fixes**:
Fixes #41067

**Special notes for your reviewer**:
Should we add a note about how this works in Grafana Cloud? (HG)
