### PR TITLE
Chore: Remove GoConvey docs

### DIFF
--- a/contribute/style-guides/backend.md
+++ b/contribute/style-guides/backend.md
@@ -36,8 +36,6 @@ We value clean and readable code, that is loosely coupled and covered by unit te
 
 Tests must use the standard library, `testing`. For assertions, prefer using [testify](https://github.com/stretchr/testify).
 
-The majority of our tests uses [GoConvey](http://goconvey.co/) but that's something we want to avoid going forward.
-
 In the `sqlstore` package we do database operations in tests and while some might say that's not suited for unit tests. We think they are fast enough and provide a lot of value.
 
 ### Assertions

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -55,10 +55,6 @@ The plan is to move all settings to from package level vars in settings package 
 [Cfg struct](https://github.com/grafana/grafana/blob/df917663e6f358a076ed3daa9b199412e95c11f4/pkg/setting/setting.go#L210)
 [Injection example](https://github.com/grafana/grafana/blob/df917663e6f358a076ed3daa9b199412e95c11f4/pkg/services/cleanup/cleanup.go#L20)
 
-### Reduce the use of GoConvey
-
-We want to migrate away from using GoConvey. Instead, we want to use stdlib testing, because it's the most common approach in the Go community and we think it will be easier for new contributors. Read more about how we want to write tests in the [style guide](/contribute/style-guides/backend.md).
-
 ### Refactor SqlStore
 
 The `sqlstore` handlers all use a global xorm engine variable. Refactor them to use the `SqlStore` instance.


### PR DESCRIPTION
Remove mentions of GoConvey migration in the docs. Related to #40633 