### PR TITLE
PanelEditor: remove showCategory on exit

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -127,6 +127,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
     locationService.partial({
       editPanel: null,
       tab: null,
+      showCategory: null,
     });
   };
 
@@ -421,7 +422,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
   }
 
   onGoBackToDashboard = () => {
-    locationService.partial({ editPanel: null, tab: null });
+    locationService.partial({ editPanel: null, tab: null, showCategory: null });
   };
 
   onConfirmAndDismissLibarayPanelModel = () => {


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/40734, we added a url parameter for the currenlty open category -- this helps us link to an open section in the config and to force a section open from a panel.

However, that setting now sticks around when you edit and then return to a panel.  This PR clearks the `showCategory` param when you exist the panel editor:
![Peek 2021-11-01 22-57](https://user-images.githubusercontent.com/705951/139794153-aa8c1dd4-7c86-47b0-9d47-440242220427.gif)


