### PR TITLE
prometheus: monaco editor: visual fixes

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -15,23 +15,35 @@ const options: monacoTypes.editor.IStandaloneEditorConstructionOptions = {
   fixedOverflowWidgets: true,
   folding: false,
   fontSize: 14,
-  lineDecorationsWidth: 8,
+  lineDecorationsWidth: 8, // used as "padding-left"
   lineNumbers: 'off',
   minimap: { enabled: false },
   overviewRulerBorder: false,
   overviewRulerLanes: 0,
   padding: {
+    // these numbers were picked so that visually this matches the previous version
+    // of the query-editor the best
     top: 4,
-    bottom: 4,
+    bottom: 5,
   },
   renderLineHighlight: 'none',
   scrollbar: {
     vertical: 'hidden',
+    verticalScrollbarSize: 8, // used as "padding-right"
+    horizontal: 'hidden',
+    horizontalScrollbarSize: 0,
   },
   scrollBeyondLastLine: false,
   suggestFontSize: 12,
-  wordWrap: 'off',
+  wordWrap: 'on',
 };
+
+// this number was chosen by testing various values. it needs to do 2 things:
+// 1. when the editor is single-line, it should make the editor height be visually correct
+// 2. when the editor is multi-line, the editor shound not be "scrollable" (meaning,
+//    you do a scroll-movement in the editor, and it will scroll the content by a couple pixels
+//    up & down. this we want to avoid)
+const EDITOR_HEIGHT_OFFSET = 2;
 
 const PROMQL_LANG_ID = promLanguageDefinition.id;
 
@@ -157,7 +169,7 @@ const MonacoQueryField = (props: Props) => {
             const containerDiv = containerRef.current;
             if (containerDiv !== null) {
               const pixelHeight = editor.getContentHeight();
-              containerDiv.style.height = `${pixelHeight}px`;
+              containerDiv.style.height = `${pixelHeight + EDITOR_HEIGHT_OFFSET}px`;
               containerDiv.style.width = '100%';
               const pixelWidth = containerDiv.clientWidth;
               editor.layout({ width: pixelWidth, height: pixelHeight });

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -38,7 +38,9 @@ const options: monacoTypes.editor.IStandaloneEditorConstructionOptions = {
   wordWrap: 'on',
 };
 
-// this number was chosen by testing various values. it needs to do 2 things:
+// this number was chosen by testing various values. it might be necessary
+// because of the width of the border, not sure.
+//it needs to do 2 things:
 // 1. when the editor is single-line, it should make the editor height be visually correct
 // 2. when the editor is multi-line, the editor should not be "scrollable" (meaning,
 //    you do a scroll-movement in the editor, and it will scroll the content by a couple pixels

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -40,7 +40,7 @@ const options: monacoTypes.editor.IStandaloneEditorConstructionOptions = {
 
 // this number was chosen by testing various values. it needs to do 2 things:
 // 1. when the editor is single-line, it should make the editor height be visually correct
-// 2. when the editor is multi-line, the editor shound not be "scrollable" (meaning,
+// 2. when the editor is multi-line, the editor should not be "scrollable" (meaning,
 //    you do a scroll-movement in the editor, and it will scroll the content by a couple pixels
 //    up & down. this we want to avoid)
 const EDITOR_HEIGHT_OFFSET = 2;


### PR DESCRIPTION
visual fixes for the monaco-based new prometheus query editor:

1. make sure the height of the editor is exactly like the height of the old editor, so that the empty-space between the row of the query editor and the next row is "correct".
2. enabled word-wrap and made sure the "padding-right" that you can see when the line is completely full looks as good as possible (before this PR the padding-right was very large)
3. before this PR was this visual bug where if you made the query-field multi-line, you could use your mouse-scrollwheel to scroll the content of the query-field by a couple pixels up & down. i added a 2 pixel "reserve" so this does not happen.