### PR TITLE
InfluxDB: Fix regular expression to parse aliases according to documentation

### DIFF
--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -16,7 +16,7 @@ import (
 type ResponseParser struct{}
 
 var (
-	legendFormat = regexp.MustCompile(`\[\[([\@\/\w-]+)(\.[\@\/\w-]+)*\]\]*|(\$*([\@\w-]+?))*`)
+	legendFormat = regexp.MustCompile(`\[\[([\@\/\w-]+)(\.[\@\/\w-]+)*\]\]*|\$(\s*([\@\w-]+?))*`)
 )
 
 func (rp *ResponseParser) Parse(buf io.ReadCloser, query *Query) *backend.QueryDataResponse {

--- a/pkg/tsdb/influxdb/response_parser_test.go
+++ b/pkg/tsdb/influxdb/response_parser_test.go
@@ -218,9 +218,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 			newField,
 		)
 		result := parser.Parse(prepare(response), query)
-
 		t.Run("should parse aliases", func(t *testing.T) {
-
 			frame := result.Responses["A"]
 			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
 				t.Errorf("Result mismatch (-want +got):\n%s", diff)

--- a/pkg/tsdb/influxdb/response_parser_test.go
+++ b/pkg/tsdb/influxdb/response_parser_test.go
@@ -219,169 +219,203 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		)
 		result := parser.Parse(prepare(response), query)
 
-		frame := result.Responses["A"]
-		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
+		t.Run("should parse aliases", func(t *testing.T) {
 
-		query = &Query{Alias: "alias $m $measurement", Measurement: "10m"}
-		result = parser.Parse(prepare(response), query)
+			frame := result.Responses["A"]
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
 
-		frame = result.Responses["A"]
-		name := "alias 10m 10m"
-		testFrame.Name = name
-		testFrame.Fields[1].Config.DisplayNameFromDS = name
-		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
+			query = &Query{Alias: "alias $m $measurement", Measurement: "10m"}
+			result = parser.Parse(prepare(response), query)
 
-		query = &Query{Alias: "alias $col", Measurement: "10m"}
-		result = parser.Parse(prepare(response), query)
-		frame = result.Responses["A"]
-		name = "alias mean"
-		testFrame.Name = name
-		testFrame.Fields[1].Config.DisplayNameFromDS = name
-		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
-		name = "alias sum"
-		testFrame.Name = name
-		newField = data.NewField("value", labels, []*float64{
-			pointer.Float64(333),
+			frame = result.Responses["A"]
+			name := "alias 10m 10m"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			query = &Query{Alias: "alias $col", Measurement: "10m"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "alias mean"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+			name = "alias sum"
+			testFrame.Name = name
+			newField = data.NewField("value", labels, []*float64{
+				pointer.Float64(333),
+			})
+			testFrame.Fields[1] = newField
+			testFrame.Fields[1].Config = &data.FieldConfig{DisplayNameFromDS: name}
+			if diff := cmp.Diff(testFrame, frame.Frames[1], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			query = &Query{Alias: "alias $tag_datacenter"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "alias America"
+			testFrame.Name = name
+			newField = data.NewField("value", labels, []*float64{
+				pointer.Float64(222),
+			})
+			testFrame.Fields[1] = newField
+			testFrame.Fields[1].Config = &data.FieldConfig{DisplayNameFromDS: name}
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			query = &Query{Alias: "alias $tag_datacenter/$tag_datacenter"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "alias America/America"
+			testFrame.Name = name
+			newField = data.NewField("value", labels, []*float64{
+				pointer.Float64(222),
+			})
+			testFrame.Fields[1] = newField
+			testFrame.Fields[1].Config = &data.FieldConfig{DisplayNameFromDS: name}
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			query = &Query{Alias: "alias [[col]]", Measurement: "10m"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "alias mean"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			query = &Query{Alias: "alias $1"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "alias upc"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			query = &Query{Alias: "alias $5"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "alias $5"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			query = &Query{Alias: "series alias"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "series alias"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			query = &Query{Alias: "alias [[m]] [[measurement]]", Measurement: "10m"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "alias 10m 10m"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			query = &Query{Alias: "alias [[tag_datacenter]]"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "alias America"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			query = &Query{Alias: "alias [[tag_dc.region.name]]"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "alias Northeast"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			query = &Query{Alias: "alias [[tag_cluster-name]]"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "alias Cluster"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			query = &Query{Alias: "alias [[tag_/cluster/name/]]"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "alias Cluster/"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			query = &Query{Alias: "alias [[tag_@cluster@name@]]"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "alias Cluster@"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
 		})
-		testFrame.Fields[1] = newField
-		testFrame.Fields[1].Config = &data.FieldConfig{DisplayNameFromDS: name}
-		if diff := cmp.Diff(testFrame, frame.Frames[1], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
+		t.Run("shouldn't parse aliases", func(t *testing.T) {
+			query = &Query{Alias: "alias words with no brackets"}
+			result = parser.Parse(prepare(response), query)
+			frame := result.Responses["A"]
+			name := "alias words with no brackets"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
 
-		query = &Query{Alias: "alias $tag_datacenter"}
-		result = parser.Parse(prepare(response), query)
-		frame = result.Responses["A"]
-		name = "alias America"
-		testFrame.Name = name
-		newField = data.NewField("value", labels, []*float64{
-			pointer.Float64(222),
+			query = &Query{Alias: "alias Test 1.5"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "alias Test 1.5"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
+			query = &Query{Alias: "alias Test -1"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "alias Test -1"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
 		})
-		testFrame.Fields[1] = newField
-		testFrame.Fields[1].Config = &data.FieldConfig{DisplayNameFromDS: name}
-		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
-
-		query = &Query{Alias: "alias $tag_datacenter/$tag_datacenter"}
-		result = parser.Parse(prepare(response), query)
-		frame = result.Responses["A"]
-		name = "alias America/America"
-		testFrame.Name = name
-		newField = data.NewField("value", labels, []*float64{
-			pointer.Float64(222),
-		})
-		testFrame.Fields[1] = newField
-		testFrame.Fields[1].Config = &data.FieldConfig{DisplayNameFromDS: name}
-		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
-
-		query = &Query{Alias: "alias [[col]]", Measurement: "10m"}
-		result = parser.Parse(prepare(response), query)
-		frame = result.Responses["A"]
-		name = "alias mean"
-		testFrame.Name = name
-		testFrame.Fields[1].Config.DisplayNameFromDS = name
-		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
-
-		query = &Query{Alias: "alias $1"}
-		result = parser.Parse(prepare(response), query)
-		frame = result.Responses["A"]
-		name = "alias upc"
-		testFrame.Name = name
-		testFrame.Fields[1].Config.DisplayNameFromDS = name
-		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
-
-		query = &Query{Alias: "alias $5"}
-		result = parser.Parse(prepare(response), query)
-		frame = result.Responses["A"]
-		name = "alias $5"
-		testFrame.Name = name
-		testFrame.Fields[1].Config.DisplayNameFromDS = name
-		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
-
-		query = &Query{Alias: "series alias"}
-		result = parser.Parse(prepare(response), query)
-		frame = result.Responses["A"]
-		name = "series alias"
-		testFrame.Name = name
-		testFrame.Fields[1].Config.DisplayNameFromDS = name
-		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
-
-		query = &Query{Alias: "alias [[m]] [[measurement]]", Measurement: "10m"}
-		result = parser.Parse(prepare(response), query)
-		frame = result.Responses["A"]
-		name = "alias 10m 10m"
-		testFrame.Name = name
-		testFrame.Fields[1].Config.DisplayNameFromDS = name
-		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
-
-		query = &Query{Alias: "alias [[tag_datacenter]]"}
-		result = parser.Parse(prepare(response), query)
-		frame = result.Responses["A"]
-		name = "alias America"
-		testFrame.Name = name
-		testFrame.Fields[1].Config.DisplayNameFromDS = name
-		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
-
-		query = &Query{Alias: "alias [[tag_dc.region.name]]"}
-		result = parser.Parse(prepare(response), query)
-		frame = result.Responses["A"]
-		name = "alias Northeast"
-		testFrame.Name = name
-		testFrame.Fields[1].Config.DisplayNameFromDS = name
-		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
-
-		query = &Query{Alias: "alias [[tag_cluster-name]]"}
-		result = parser.Parse(prepare(response), query)
-		frame = result.Responses["A"]
-		name = "alias Cluster"
-		testFrame.Name = name
-		testFrame.Fields[1].Config.DisplayNameFromDS = name
-		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
-
-		query = &Query{Alias: "alias [[tag_/cluster/name/]]"}
-		result = parser.Parse(prepare(response), query)
-		frame = result.Responses["A"]
-		name = "alias Cluster/"
-		testFrame.Name = name
-		testFrame.Fields[1].Config.DisplayNameFromDS = name
-		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
-
-		query = &Query{Alias: "alias [[tag_@cluster@name@]]"}
-		result = parser.Parse(prepare(response), query)
-		frame = result.Responses["A"]
-		name = "alias Cluster@"
-		testFrame.Name = name
-		testFrame.Fields[1].Config.DisplayNameFromDS = name
-		if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
-			t.Errorf("Result mismatch (-want +got):\n%s", diff)
-		}
 	})
 
 	t.Run("Influxdb response parser with errors", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows only parsing of aliases that contain `[[` **AND** `]]` **OR** start with `$`.

**Which issue(s) this PR fixes**:

Fixes #41103

Documentation on aliases: https://grafana.com/docs/grafana/latest/datasources/influxdb/#alias-patterns