### PR TITLE
CI: Update `grafana/build-container` version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,7 @@ steps:
   - make gen-go
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   - yarn install --immutable
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: initialize
 - commands:
   - |-
@@ -48,13 +48,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition oss
@@ -62,7 +62,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -73,20 +73,20 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-frontend
 - commands:
   - '[ $(grep FocusConvey -R pkg | wc -l) -eq "0" ] || exit 1'
   - ./bin/grabpl test-backend --edition oss
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -94,7 +94,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-frontend
 - commands:
   - apt-get update
@@ -109,7 +109,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -124,7 +124,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: mysql-integration-tests
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -132,27 +132,27 @@ steps:
   depends_on:
   - test-backend
   environment: {}
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id
     ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
   - test-frontend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps
   depends_on:
   - lint-backend
   environment: null
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -173,7 +173,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: ensure-cuetsified
 - commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss
@@ -183,7 +183,7 @@ steps:
   - build-backend
   - build-frontend
   environment: null
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: package
 - commands:
   - ./e2e/start-server
@@ -192,7 +192,7 @@ steps:
   detach: true
   environment:
     PORT: 3001
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -210,7 +210,7 @@ steps:
   - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-storybook
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -229,7 +229,7 @@ steps:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-frontend-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana
@@ -244,7 +244,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -295,7 +295,7 @@ steps:
   - make gen-go
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   - yarn install --immutable
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: initialize
 - image: grafana/drone-downstream
   name: trigger-enterprise-downstream
@@ -320,13 +320,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition oss
@@ -334,7 +334,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -345,20 +345,20 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-frontend
 - commands:
   - '[ $(grep FocusConvey -R pkg | wc -l) -eq "0" ] || exit 1'
   - ./bin/grabpl test-backend --edition oss
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -366,7 +366,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-frontend
 - commands:
   - apt-get update
@@ -381,7 +381,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -396,7 +396,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: mysql-integration-tests
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -404,14 +404,14 @@ steps:
   depends_on:
   - test-backend
   environment: {}
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id
     ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
   - test-frontend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
@@ -420,13 +420,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -447,7 +447,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
@@ -467,7 +467,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: package
 - commands:
   - ./e2e/start-server
@@ -476,7 +476,7 @@ steps:
   detach: true
   environment:
     PORT: 3001
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -494,7 +494,7 @@ steps:
   - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-storybook
 - commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
@@ -529,20 +529,20 @@ steps:
     GRAFANA_MISC_STATS_API_KEY:
       from_secret: grafana_misc_stats_api_key
   failure: ignore
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: publish-frontend-metrics
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-frontend-docs
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -575,7 +575,7 @@ steps:
   environment:
     GITHUB_PACKAGE_TOKEN:
       from_secret: github_package_token
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: release-canary-npm-packages
 - commands:
   - ./bin/grabpl upload-packages --edition oss --packages-bucket grafana-downloads
@@ -668,7 +668,7 @@ steps:
   - chmod +x bin/grabpl
   - ./bin/grabpl verify-drone
   - make gen-go
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: initialize
 - commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
@@ -759,7 +759,7 @@ steps:
   - ./bin/grabpl verify-version ${DRONE_TAG}
   - ./bin/grabpl gen-version ${DRONE_TAG}
   - yarn install --immutable
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: initialize
 - commands:
   - |-
@@ -773,13 +773,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition oss
@@ -787,7 +787,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -798,20 +798,20 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-frontend
 - commands:
   - '[ $(grep FocusConvey -R pkg | wc -l) -eq "0" ] || exit 1'
   - ./bin/grabpl test-backend --edition oss
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -819,7 +819,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-frontend
 - commands:
   - apt-get update
@@ -834,7 +834,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -849,7 +849,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: mysql-integration-tests
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN}
@@ -859,14 +859,14 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps
     --edition oss --no-pull-enterprise ${DRONE_TAG}
   depends_on:
   - test-frontend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
@@ -875,13 +875,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -902,7 +902,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise
@@ -922,7 +922,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: package
 - commands:
   - ./e2e/start-server
@@ -931,7 +931,7 @@ steps:
   detach: true
   environment:
     PORT: 3001
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -947,7 +947,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -980,7 +980,7 @@ steps:
   - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition oss --bucket "grafana-static-assets"
@@ -1022,7 +1022,7 @@ steps:
       from_secret: github_package_token
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: release-npm-packages
 trigger:
   ref:
@@ -1120,7 +1120,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: clone
 - commands:
   - mv bin/grabpl /tmp/
@@ -1137,7 +1137,7 @@ steps:
   - yarn install --immutable
   depends_on:
   - clone
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: initialize
 - commands:
   - |-
@@ -1151,13 +1151,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise
@@ -1165,7 +1165,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -1176,20 +1176,20 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-frontend
 - commands:
   - '[ $(grep FocusConvey -R pkg | wc -l) -eq "0" ] || exit 1'
   - ./bin/grabpl test-backend --edition enterprise
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -1197,7 +1197,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-frontend
 - commands:
   - apt-get update
@@ -1212,7 +1212,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -1227,7 +1227,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: mysql-integration-tests
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN}
@@ -1237,14 +1237,14 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps
     --edition enterprise --no-pull-enterprise ${DRONE_TAG}
   depends_on:
   - test-frontend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign
@@ -1254,13 +1254,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -1281,7 +1281,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise2
@@ -1289,20 +1289,20 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-backend-enterprise2
 - commands:
   - '[ $(grep FocusConvey -R pkg | wc -l) -eq "0" ] || exit 1'
   - ./bin/grabpl test-backend --edition enterprise2
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend-enterprise2
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend-integration-enterprise2
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN}
@@ -1312,7 +1312,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN}
@@ -1334,7 +1334,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: package
 - commands:
   - ./e2e/start-server
@@ -1345,7 +1345,7 @@ steps:
     PACKAGE_FILE: dist/grafana-enterprise-*linux-amd64.tar.gz
     PORT: 3001
     RUNDIR: e2e/tmp-grafana-enterprise
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -1361,7 +1361,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -1395,7 +1395,7 @@ steps:
   - test-frontend
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -1405,7 +1405,7 @@ steps:
   - test-frontend
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: memcached-integration-tests
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise --bucket "grafana-static-assets"
@@ -1447,7 +1447,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: package-enterprise2
 - commands:
   - ./e2e/start-server
@@ -1458,7 +1458,7 @@ steps:
     PACKAGE_FILE: dist/grafana-enterprise2-*linux-amd64.tar.gz
     PORT: 3002
     RUNDIR: e2e/tmp-grafana-enterprise2
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: end-to-end-tests-server-enterprise2
 - commands:
   - yarn run cypress install
@@ -1584,7 +1584,7 @@ steps:
   - ./bin/grabpl verify-drone
   - make gen-go
   - ./bin/grabpl verify-version ${DRONE_TAG}
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: initialize
 - commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
@@ -1693,7 +1693,7 @@ steps:
   - ./bin/grabpl verify-version v7.3.0-test
   - ./bin/grabpl gen-version v7.3.0-test
   - yarn install --immutable
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: initialize
 - commands:
   - |-
@@ -1707,13 +1707,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition oss
@@ -1721,7 +1721,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -1732,20 +1732,20 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-frontend
 - commands:
   - '[ $(grep FocusConvey -R pkg | wc -l) -eq "0" ] || exit 1'
   - ./bin/grabpl test-backend --edition oss
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -1753,7 +1753,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-frontend
 - commands:
   - apt-get update
@@ -1768,7 +1768,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -1783,7 +1783,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: mysql-integration-tests
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN}
@@ -1793,14 +1793,14 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps
     --edition oss --no-pull-enterprise v7.3.0-test
   depends_on:
   - test-frontend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
@@ -1809,13 +1809,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -1836,7 +1836,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise
@@ -1856,7 +1856,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: package
 - commands:
   - ./e2e/start-server
@@ -1865,7 +1865,7 @@ steps:
   detach: true
   environment:
     PORT: 3001
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -1881,7 +1881,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -1906,7 +1906,7 @@ steps:
   - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition oss --bucket "grafana-static-assets"
@@ -1944,7 +1944,7 @@ steps:
       from_secret: github_package_token
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: release-npm-packages
 trigger:
   event:
@@ -2043,7 +2043,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: clone
 - commands:
   - mv bin/grabpl /tmp/
@@ -2060,7 +2060,7 @@ steps:
   - yarn install --immutable
   depends_on:
   - clone
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: initialize
 - commands:
   - |-
@@ -2074,13 +2074,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise
@@ -2088,7 +2088,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -2099,20 +2099,20 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-frontend
 - commands:
   - '[ $(grep FocusConvey -R pkg | wc -l) -eq "0" ] || exit 1'
   - ./bin/grabpl test-backend --edition enterprise
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -2120,7 +2120,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-frontend
 - commands:
   - apt-get update
@@ -2135,7 +2135,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -2150,7 +2150,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: mysql-integration-tests
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN}
@@ -2160,14 +2160,14 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps
     --edition enterprise --no-pull-enterprise v7.3.0-test
   depends_on:
   - test-frontend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign
@@ -2177,13 +2177,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -2204,7 +2204,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise2
@@ -2212,20 +2212,20 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-backend-enterprise2
 - commands:
   - '[ $(grep FocusConvey -R pkg | wc -l) -eq "0" ] || exit 1'
   - ./bin/grabpl test-backend --edition enterprise2
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend-enterprise2
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend-integration-enterprise2
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN}
@@ -2235,7 +2235,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN}
@@ -2257,7 +2257,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: package
 - commands:
   - ./e2e/start-server
@@ -2268,7 +2268,7 @@ steps:
     PACKAGE_FILE: dist/grafana-enterprise-*linux-amd64.tar.gz
     PORT: 3001
     RUNDIR: e2e/tmp-grafana-enterprise
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -2284,7 +2284,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -2310,7 +2310,7 @@ steps:
   - test-frontend
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -2320,7 +2320,7 @@ steps:
   - test-frontend
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: memcached-integration-tests
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise --bucket "grafana-static-assets"
@@ -2362,7 +2362,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: package-enterprise2
 - commands:
   - ./e2e/start-server
@@ -2373,7 +2373,7 @@ steps:
     PACKAGE_FILE: dist/grafana-enterprise2-*linux-amd64.tar.gz
     PORT: 3002
     RUNDIR: e2e/tmp-grafana-enterprise2
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: end-to-end-tests-server-enterprise2
 - commands:
   - yarn run cypress install
@@ -2500,7 +2500,7 @@ steps:
   - ./bin/grabpl verify-drone
   - make gen-go
   - ./bin/grabpl verify-version v7.3.0-test
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: initialize
 - commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
@@ -2613,7 +2613,7 @@ steps:
   - make gen-go
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   - yarn install --immutable
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: initialize
 - commands:
   - |-
@@ -2627,13 +2627,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition oss
@@ -2641,7 +2641,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -2652,20 +2652,20 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-frontend
 - commands:
   - '[ $(grep FocusConvey -R pkg | wc -l) -eq "0" ] || exit 1'
   - ./bin/grabpl test-backend --edition oss
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -2673,7 +2673,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-frontend
 - commands:
   - apt-get update
@@ -2688,7 +2688,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -2703,7 +2703,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: mysql-integration-tests
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -2711,14 +2711,14 @@ steps:
   depends_on:
   - test-backend
   environment: {}
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id
     ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
   - test-frontend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
@@ -2727,13 +2727,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -2754,7 +2754,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
@@ -2774,7 +2774,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: package
 - commands:
   - ./e2e/start-server
@@ -2783,7 +2783,7 @@ steps:
   detach: true
   environment:
     PORT: 3001
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -2799,7 +2799,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -2824,7 +2824,7 @@ steps:
   - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition oss --bucket "grafana-static-assets"
@@ -2936,7 +2936,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: clone
 - commands:
   - mv bin/grabpl /tmp/
@@ -2952,7 +2952,7 @@ steps:
   - yarn install --immutable
   depends_on:
   - clone
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: initialize
 - commands:
   - |-
@@ -2966,13 +2966,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise
@@ -2980,7 +2980,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -2991,20 +2991,20 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-frontend
 - commands:
   - '[ $(grep FocusConvey -R pkg | wc -l) -eq "0" ] || exit 1'
   - ./bin/grabpl test-backend --edition enterprise
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -3012,7 +3012,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-frontend
 - commands:
   - apt-get update
@@ -3027,7 +3027,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -3042,7 +3042,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: mysql-integration-tests
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -3050,14 +3050,14 @@ steps:
   depends_on:
   - test-backend
   environment: {}
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition enterprise --build-id
     ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
   - test-frontend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign
@@ -3067,13 +3067,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -3094,7 +3094,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise2
@@ -3102,20 +3102,20 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: lint-backend-enterprise2
 - commands:
   - '[ $(grep FocusConvey -R pkg | wc -l) -eq "0" ] || exit 1'
   - ./bin/grabpl test-backend --edition enterprise2
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend-enterprise2
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
   - lint-backend
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: test-backend-integration-enterprise2
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
@@ -3123,7 +3123,7 @@ steps:
   depends_on:
   - test-backend-enterprise2
   environment: {}
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -3145,7 +3145,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: package
 - commands:
   - ./e2e/start-server
@@ -3156,7 +3156,7 @@ steps:
     PACKAGE_FILE: dist/grafana-enterprise-*linux-amd64.tar.gz
     PORT: 3001
     RUNDIR: e2e/tmp-grafana-enterprise
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -3172,7 +3172,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -3197,7 +3197,7 @@ steps:
   - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: build-storybook
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -3207,7 +3207,7 @@ steps:
   - test-frontend
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -3217,7 +3217,7 @@ steps:
   - test-frontend
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: memcached-integration-tests
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise --bucket "grafana-static-assets"
@@ -3259,7 +3259,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: package-enterprise2
 - commands:
   - ./e2e/start-server
@@ -3270,7 +3270,7 @@ steps:
     PACKAGE_FILE: dist/grafana-enterprise2-*linux-amd64.tar.gz
     PORT: 3002
     RUNDIR: e2e/tmp-grafana-enterprise2
-  image: grafana/build-container:1.4.3
+  image: grafana/build-container:1.4.4
   name: end-to-end-tests-server-enterprise2
 - commands:
   - yarn run cypress install
@@ -3449,6 +3449,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: c8c7de29c5b4390cab96212211d21c14defa84d3029560e6b19c47a1377a6137
+hmac: 0fc151dbfb52c9055ebe8b2c8393d351bed186b1c52a1ca61e67a58c1e7fce52
 
 ...

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -113,8 +113,8 @@ FROM debian:stretch-20210208
 ENV GOVERSION=1.17 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
-    NODEVERSION=14.17.6-1nodesource1 \
-    YARNVERSION=3.1.0-rc.5
+    NODEVERSION=14.18.1-1nodesource1 \
+    YARNVERSION=1.22.15-1
 
 # Use ARG so as not to persist environment variable in image
 ARG DEBIAN_FRONTEND=noninteractive

--- a/scripts/build/ci-build/build-deploy.sh
+++ b/scripts/build/ci-build/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.4.3"
+_version="1.4.5"
 _tag="grafana/build-container:${_version}"
 
 _dpath=$(dirname "${BASH_SOURCE[0]}")

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1,7 +1,7 @@
 load('scripts/drone/vault.star', 'from_secret', 'github_token', 'pull_secret', 'drone_token')
 
 grabpl_version = '2.5.5'
-build_image = 'grafana/build-container:1.4.3'
+build_image = 'grafana/build-container:1.4.4'
 publish_image = 'grafana/grafana-ci-deploy:1.3.1'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.3.2'
 deploy_docker_image = 'us.gcr.io/kubernetes-dev/drone/plugins/deploy-image'


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates `grafana/build-container` version to `1.4.4`, which includes node and yarn updates.

