### PR TITLE
renovate: block updating eslint for now

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,7 @@
     "@types/d3-force",
     "d3",
     "d3-force", // we should bump this once we move to esm modules
+    "eslint", // wait until `eslint-plugin-react-hooks>4.2.0` is released
     "globby", // we should bump this once we move to esm modules
     "slate",
     "slate-plain-serializer",


### PR DESCRIPTION
newest eslint (8.x) requires an updated `eslint-plugin-react-hooks`, which is not released yet. so for now we wait.