### PR TITLE
prometheus: monaco: autocomplete: offer function-names in functions

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -47,6 +47,11 @@ const FUNCTION_COMPLETIONS: Completion[] = FUNCTIONS.map((f) => ({
   documentation: f.documentation,
 }));
 
+async function getAllFunctionsAndMetricNamesCompletions(dataProvider: DataProvider): Promise<Completion[]> {
+  const metricNames = await getAllMetricNamesCompletions(dataProvider);
+  return [...FUNCTION_COMPLETIONS, ...metricNames];
+}
+
 const DURATION_COMPLETIONS: Completion[] = [
   '$__interval',
   '$__range',
@@ -144,10 +149,9 @@ export async function getCompletions(situation: Situation, dataProvider: DataPro
     case 'IN_DURATION':
       return DURATION_COMPLETIONS;
     case 'IN_FUNCTION':
-      return getAllMetricNamesCompletions(dataProvider);
+      return getAllFunctionsAndMetricNamesCompletions(dataProvider);
     case 'AT_ROOT': {
-      const metricNames = await getAllMetricNamesCompletions(dataProvider);
-      return [...FUNCTION_COMPLETIONS, ...metricNames];
+      return getAllFunctionsAndMetricNamesCompletions(dataProvider);
     }
     case 'EMPTY': {
       const metricNames = await getAllMetricNamesCompletions(dataProvider);


### PR DESCRIPTION
using the prometheus query field, when autocomplete happens inside a function, it should offer both functions and metrics, like the not-prometheus query-field does.. currently we only offer metrics inside functions. this pull-request fixes this.