### PR TITLE
Fix bug that was breaking aws-sdk ConnectionConfig

### DIFF
--- a/packages/grafana-data/src/utils/datasource.ts
+++ b/packages/grafana-data/src/utils/datasource.ts
@@ -136,7 +136,7 @@ export const updateDatasourcePluginResetOption = <J, S extends {} = KeyValue>(
   props.onOptionsChange({
     ...config,
     secureJsonData: {
-      ...config.secureJsonData,
+      ...(config.secureJsonData ? config.secureJsonData : {}),
       [key]: '',
     } as S,
     secureJsonFields: {

--- a/packages/grafana-data/src/utils/datasource.ts
+++ b/packages/grafana-data/src/utils/datasource.ts
@@ -122,9 +122,9 @@ export const updateDatasourcePluginSecureJsonDataOption = <J, S extends {} = Key
   props.onOptionsChange({
     ...config,
     secureJsonData: {
-      ...(config.secureJsonData ? config.secureJsonData : {}),
+      ...(config.secureJsonData ? config.secureJsonData : ({} as S)),
       [key]: val,
-    } as S,
+    },
   });
 };
 
@@ -136,9 +136,9 @@ export const updateDatasourcePluginResetOption = <J, S extends {} = KeyValue>(
   props.onOptionsChange({
     ...config,
     secureJsonData: {
-      ...(config.secureJsonData ? config.secureJsonData : {}),
+      ...(config.secureJsonData ? config.secureJsonData : ({} as S)),
       [key]: '',
-    } as S,
+    },
     secureJsonFields: {
       ...config.secureJsonFields,
       [key]: false,

--- a/packages/grafana-data/src/utils/datasource.ts
+++ b/packages/grafana-data/src/utils/datasource.ts
@@ -118,16 +118,13 @@ export const updateDatasourcePluginSecureJsonDataOption = <J, S extends {} = Key
   val: any
 ) => {
   const config = props.options;
-  if (!config.secureJsonData) {
-    return;
-  }
 
   props.onOptionsChange({
     ...config,
     secureJsonData: {
-      ...config.secureJsonData,
+      ...(config.secureJsonData ? config.secureJsonData : {}),
       [key]: val,
-    },
+    } as S,
   });
 };
 

--- a/packages/grafana-data/src/utils/datasource.ts
+++ b/packages/grafana-data/src/utils/datasource.ts
@@ -133,16 +133,12 @@ export const updateDatasourcePluginResetOption = <J, S extends {} = KeyValue>(
   key: string
 ) => {
   const config = props.options;
-  if (!config.secureJsonData) {
-    return;
-  }
-
   props.onOptionsChange({
     ...config,
     secureJsonData: {
       ...config.secureJsonData,
       [key]: '',
-    },
+    } as S,
     secureJsonFields: {
       ...config.secureJsonFields,
       [key]: false,


### PR DESCRIPTION
**What this PR does / why we need it**:
I believe in [one of our typescript fixes](https://github.com/grafana/grafana/pull/40675/files#diff-0b7f2cb8a0cff4dccdfd5b50ce6c6963d3ffa3f476341d6bd79beb7fe2b2611cR85), we accidentally introduced a bug (that was easy to write because of a lack of typing haha). Hopefully use strict will make this sort of thing, a thing of the past.

**Which issue(s) this PR fixes**:

Fixes #41211

**Special notes for your reviewer**:
To reproduce bug/fix:
- try to add a datasource that uses the aws-sdk ConnectionConfig (ex: Cloudwatch)
- select keys/access id
- notice you can't type in the access key.
- I then hacked a local version of our aws-sdk (I did this by making a folder in core grafana and copying over the src files from the aws-sdk and changing the import ConnectionConfig to import from that folder instead, although I'm sure there are much better ways to do this)

Tbh I'm not sure on the difference between secureJsonFields vs secureJsonData, I think we're expecting one but getting the other. This seems like a hacky fix that should work for now tho as I think it's basically what we had before and the problem goes away for me when I do this. 

Edit to add:
Just noting that I'm not adding a milestone because I think the bug was both introduced for 8.3 and then fixed before 8.3 could be released so I don't think it's necessary
