### PR TITLE
Explore: Fix ANSI dim style being unreadable in dark mode

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogMessageAnsi.test.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogMessageAnsi.test.tsx
@@ -1,19 +1,18 @@
-import React from 'react';
+import { createTheme } from '@grafana/data';
 import { shallow } from 'enzyme';
-
-import { LogMessageAnsi } from './LogMessageAnsi';
+import React from 'react';
+import { UnThemedLogMessageAnsi as LogMessageAnsi } from './LogMessageAnsi';
 
 describe('<LogMessageAnsi />', () => {
   it('renders string without ANSI codes', () => {
-    const wrapper = shallow(<LogMessageAnsi value="Lorem ipsum" />);
+    const wrapper = shallow(<LogMessageAnsi value="Lorem ipsum" theme={createTheme()} />);
 
     expect(wrapper.find('span').exists()).toBe(false);
     expect(wrapper.text()).toBe('Lorem ipsum');
   });
-
   it('renders string with ANSI codes', () => {
     const value = 'Lorem \u001B[31mipsum\u001B[0m et dolor';
-    const wrapper = shallow(<LogMessageAnsi value={value} />);
+    const wrapper = shallow(<LogMessageAnsi value={value} theme={createTheme()} />);
 
     expect(wrapper.find('span')).toHaveLength(1);
     expect(wrapper.find('span').first().prop('style')).toMatchObject(
@@ -24,13 +23,25 @@ describe('<LogMessageAnsi />', () => {
     expect(wrapper.find('span').first().text()).toBe('ipsum');
   });
   it('renders string with ANSI codes with correctly converted css classnames', () => {
-    const value = 'Lorem [1;32mIpsum';
-    const wrapper = shallow(<LogMessageAnsi value={value} />);
+    const value = 'Lorem \u001B[1;32mIpsum';
+    const wrapper = shallow(<LogMessageAnsi value={value} theme={createTheme()} />);
 
     expect(wrapper.find('span')).toHaveLength(1);
     expect(wrapper.find('span').first().prop('style')).toMatchObject(
       expect.objectContaining({
         fontWeight: expect.any(String),
+      })
+    );
+  });
+  it('renders string with ANSI dim code with appropriate themed color', () => {
+    const value = 'Lorem \u001B[1;2mIpsum';
+    const theme = createTheme();
+    const wrapper = shallow(<LogMessageAnsi value={value} theme={theme} />);
+
+    expect(wrapper.find('span')).toHaveLength(1);
+    expect(wrapper.find('span').first().prop('style')).toMatchObject(
+      expect.objectContaining({
+        color: theme.colors.text.secondary,
       })
     );
   });

--- a/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
@@ -14,12 +14,19 @@ interface ParsedChunk {
 }
 
 function convertCSSToStyle(css: string): Style {
-  return css.split(/;\s*/).reduce((accumulated, line) => {
+  return css.split(/;\s*/).reduce<Style>((accumulated, line) => {
+    // The ansicolor package returns this color if the chunk has the ANSI dim
+    // style (`\e[2m`), but it is nearly unreadable in the dark theme, so we use
+    // `opacity` instead to style it in a way that works across all themes.
+    if (line === 'color:rgba(0,0,0,0.5)') {
+      accumulated['opacity'] = '0.5';
+      return accumulated;
+    }
+
     const match = line.match(/([^:\s]+)\s*:\s*(.+)/);
 
     if (match && match[1] && match[2]) {
       const key = match[1].replace(/-([a-z])/g, (_, character) => character.toUpperCase());
-      // @ts-ignore
       accumulated[key] = match[2];
     }
 

--- a/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
@@ -1,8 +1,9 @@
-import { findHighlightChunksInText } from '@grafana/data';
+import { findHighlightChunksInText, GrafanaTheme2 } from '@grafana/data';
 import ansicolor from 'ansicolor';
 import React, { PureComponent } from 'react';
 // @ts-ignore
 import Highlighter from 'react-highlight-words';
+import { Themeable2, withTheme2 } from 'src';
 
 interface Style {
   [key: string]: string;
@@ -13,13 +14,13 @@ interface ParsedChunk {
   text: string;
 }
 
-function convertCSSToStyle(css: string): Style {
+function convertCSSToStyle(theme: GrafanaTheme2, css: string): Style {
   return css.split(/;\s*/).reduce<Style>((accumulated, line) => {
     // The ansicolor package returns this color if the chunk has the ANSI dim
     // style (`\e[2m`), but it is nearly unreadable in the dark theme, so we use
     // `opacity` instead to style it in a way that works across all themes.
     if (line === 'color:rgba(0,0,0,0.5)') {
-      accumulated['opacity'] = '0.5';
+      accumulated['color'] = theme.colors.text.secondary;
       return accumulated;
     }
 
@@ -34,7 +35,7 @@ function convertCSSToStyle(css: string): Style {
   }, {});
 }
 
-interface Props {
+interface Props extends Themeable2 {
   value: string;
   highlight?: {
     searchWords: string[];
@@ -47,7 +48,7 @@ interface State {
   prevValue: string;
 }
 
-export class LogMessageAnsi extends PureComponent<Props, State> {
+class UnThemedLogMessageAnsi extends PureComponent<Props, State> {
   state: State = {
     chunks: [],
     prevValue: '',
@@ -64,7 +65,7 @@ export class LogMessageAnsi extends PureComponent<Props, State> {
       chunks: parsed.spans.map((span) => {
         return span.css
           ? {
-              style: convertCSSToStyle(span.css),
+              style: convertCSSToStyle(props.theme, span.css),
               text: span.text,
             }
           : { text: span.text };
@@ -97,3 +98,5 @@ export class LogMessageAnsi extends PureComponent<Props, State> {
     });
   }
 }
+
+export const LogMessageAnsi = withTheme2(UnThemedLogMessageAnsi);

--- a/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
@@ -100,3 +100,4 @@ export class UnThemedLogMessageAnsi extends PureComponent<Props, State> {
 }
 
 export const LogMessageAnsi = withTheme2(UnThemedLogMessageAnsi);
+LogMessageAnsi.displayName = 'LogMessageAnsi';

--- a/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
@@ -18,10 +18,9 @@ function convertCSSToStyle(theme: GrafanaTheme2, css: string): Style {
   return css.split(/;\s*/).reduce<Style>((accumulated, line) => {
     // The ansicolor package returns this color if the chunk has the ANSI dim
     // style (`\e[2m`), but it is nearly unreadable in the dark theme, so we use
-    // `opacity` instead to style it in a way that works across all themes.
+    // GrafanaTheme2 instead to style it in a way that works across all themes.
     if (line === 'color:rgba(0,0,0,0.5)') {
-      accumulated['color'] = theme.colors.text.secondary;
-      return accumulated;
+      return { color: theme.colors.text.secondary };
     }
 
     const match = line.match(/([^:\s]+)\s*:\s*(.+)/);

--- a/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
@@ -3,7 +3,8 @@ import ansicolor from 'ansicolor';
 import React, { PureComponent } from 'react';
 // @ts-ignore
 import Highlighter from 'react-highlight-words';
-import { Themeable2, withTheme2 } from 'src';
+import { withTheme2 } from '../../themes';
+import { Themeable2 } from '../../types';
 
 interface Style {
   [key: string]: string;
@@ -47,7 +48,7 @@ interface State {
   prevValue: string;
 }
 
-class UnThemedLogMessageAnsi extends PureComponent<Props, State> {
+export class UnThemedLogMessageAnsi extends PureComponent<Props, State> {
   state: State = {
     chunks: [],
     prevValue: '',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The ANSI dim style (`ESC[2m`) is nearly unreadable in dark mode, because the underlying `ansicolor` library returns a dark grey colour, without regard for the background that it is displayed on.

This PR adds a workaround to intercept the dark grey colour that `ansicolor` returns and replaces it with `opacity: 0.5` instead, which works on both light and dark themes. The corrected text is pictured below:

![image](https://user-images.githubusercontent.com/11541660/139969259-b4aa25f0-f017-41b9-9c40-13f1ad9dbc2c.png)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #40976

**Special notes for your reviewer**: