### PR TITLE
Chore: fixes DataSourceRef for adhoc variables

### DIFF
--- a/public/app/features/variables/adhoc/AdHocVariableEditor.tsx
+++ b/public/app/features/variables/adhoc/AdHocVariableEditor.tsx
@@ -40,8 +40,8 @@ export class AdHocVariableEditorUnConnected extends PureComponent<Props> {
     const { variable, editor } = this.props;
     const dataSources = editor.extended?.dataSources ?? [];
     const infoText = editor.extended?.infoText ?? null;
-    const options = dataSources.map((ds) => ({ label: ds.text, value: { uid: ds.value } }));
-    const value = options.find((o) => o.value === variable.datasource) ?? options[0];
+    const options = dataSources.map((ds) => ({ label: ds.text, value: ds.value }));
+    const value = options.find((o) => o.value?.uid === variable.datasource?.uid) ?? options[0];
 
     return (
       <VerticalGroup spacing="xs">

--- a/public/app/features/variables/adhoc/actions.ts
+++ b/public/app/features/variables/adhoc/actions.ts
@@ -16,7 +16,7 @@ import {
 import { AdHocVariableFilter, AdHocVariableModel } from 'app/features/variables/types';
 import { variableUpdated } from '../state/actions';
 import { isAdHoc } from '../guard';
-import { DataSourceRef } from '@grafana/data';
+import { DataSourceRef, getDataSourceRef } from '@grafana/data';
 
 export interface AdHocTableOptions {
   datasource: DataSourceRef;
@@ -111,19 +111,20 @@ export const changeVariableDatasource = (datasource?: DataSourceRef): ThunkResul
 };
 
 export const initAdHocVariableEditor = (): ThunkResult<void> => (dispatch) => {
-  const dataSources = getDatasourceSrv().getMetricSources();
+  const dataSources = getDatasourceSrv().getList({ metrics: true, variables: false });
   const selectable = dataSources.reduce(
-    (all: Array<{ text: string; value: string | null }>, ds) => {
+    (all: Array<{ text: string; value: DataSourceRef | null }>, ds) => {
       if (ds.meta.mixed) {
         return all;
       }
 
-      const text = ds.value === null ? `${ds.name} (default)` : ds.name;
-      all.push({ text: text, value: ds.value });
+      const text = ds.isDefault ? `${ds.name} (default)` : ds.name;
+      const value = getDataSourceRef(ds);
+      all.push({ text, value });
 
       return all;
     },
-    [{ text: '', value: '' }]
+    [{ text: '', value: {} }]
   );
 
   dispatch(

--- a/public/app/features/variables/adhoc/adapter.ts
+++ b/public/app/features/variables/adhoc/adapter.ts
@@ -1,4 +1,6 @@
 import { cloneDeep } from 'lodash';
+import { getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceRef } from '@grafana/data';
 
 import { AdHocVariableModel } from '../types';
 import { dispatch } from '../../../store/store';
@@ -9,8 +11,6 @@ import { AdHocVariableEditor } from './AdHocVariableEditor';
 import { setFiltersFromUrl } from './actions';
 import * as urlParser from './urlParser';
 import { isAdHoc, isLegacyAdHocDataSource } from '../guard';
-import { getDataSourceSrv } from '../../../../../packages/grafana-runtime';
-import { getDataSourceRef } from '../../../../../packages/grafana-data';
 
 const noop = async () => {};
 

--- a/public/app/features/variables/adhoc/reducer.ts
+++ b/public/app/features/variables/adhoc/reducer.ts
@@ -1,6 +1,8 @@
-import { AdHocVariableFilter, AdHocVariableModel, initialVariableModelState } from 'app/features/variables/types';
-import { getInstanceState, VariablePayload, initialVariablesState, VariablesState } from '../state/types';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { DataSourceRef } from '@grafana/data';
+
+import { AdHocVariableFilter, AdHocVariableModel, initialVariableModelState } from 'app/features/variables/types';
+import { getInstanceState, initialVariablesState, VariablePayload, VariablesState } from '../state/types';
 
 export interface AdHocVariabelFilterUpdate {
   index: number;
@@ -8,7 +10,7 @@ export interface AdHocVariabelFilterUpdate {
 }
 export interface AdHocVariableEditorState {
   infoText: string;
-  dataSources: Array<{ text: string; value: string }>;
+  dataSources: Array<{ text: string; value: DataSourceRef | null }>;
 }
 
 export const initialAdHocVariableModelState: AdHocVariableModel = {

--- a/public/app/features/variables/guard.ts
+++ b/public/app/features/variables/guard.ts
@@ -7,6 +7,7 @@ import {
   DataQueryResponse,
   DataSourceApi,
   DataSourceJsonData,
+  DataSourceRef,
   MetricFindValue,
   StandardVariableQuery,
   StandardVariableSupport,
@@ -57,6 +58,14 @@ function hasObjectProperty(model: VariableModel, property: string): model is Var
 
   const withProperty = model as Record<string, any>;
   return withProperty.hasOwnProperty(property) && typeof withProperty[property] === 'object';
+}
+
+export function isLegacyAdHocDataSource(datasource: null | DataSourceRef | string): datasource is string {
+  if (datasource === null) {
+    return false;
+  }
+
+  return typeof datasource === 'string';
 }
 
 interface DataSourceWithLegacyVariableSupport<


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes 2 things for adhoc variables introduced by #33817:
- When editing a adhoc variable the drop down wouldn't show which data source that was selected
- When changing the adhoc variable value the filters weren't applied at all

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Verified with InfluxDB, unfortunately the Prometheus data source has been broken before #33817 so @grafana/observability-squad need to have a look at that
