### PR TITLE
prometheus: monaco: allow listing label names + values without a metric

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -134,7 +134,11 @@ const MonacoQueryField = (props: Props) => {
             return Promise.resolve(result);
           };
 
-          const dataProvider = { getSeries, getHistory, getAllMetricNames };
+          const getAllLabelNames = () => Promise.resolve(lpRef.current.getLabelKeys());
+
+          const getLabelValues = (labelName: string) => lpRef.current.getLabelValues(labelName);
+
+          const dataProvider = { getSeries, getHistory, getAllMetricNames, getAllLabelNames, getLabelValues };
           const completionProvider = getCompletionProvider(monaco, dataProvider);
 
           // completion-providers in monaco are not registered directly to editor-instances,

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -23,7 +23,6 @@ type Metric = {
 export type DataProvider = {
   getHistory: () => Promise<string[]>;
   getAllMetricNames: () => Promise<Metric[]>;
-  // these mirror the prometheus endpoints
   getAllLabelNames: () => Promise<string[]>;
   getLabelValues: (labelName: string) => Promise<string[]>;
   getSeries: (selector: string) => Promise<Record<string, string[]>>;

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -23,6 +23,9 @@ type Metric = {
 export type DataProvider = {
   getHistory: () => Promise<string[]>;
   getAllMetricNames: () => Promise<Metric[]>;
+  // these mirror the prometheus endpoints
+  getAllLabelNames: () => Promise<string[]>;
+  getLabelValues: (labelName: string) => Promise<string[]>;
   getSeries: (selector: string) => Promise<Record<string, string[]>>;
 };
 
@@ -88,6 +91,23 @@ function makeSelector(metricName: string | undefined, labels: Label[]): string {
   return `{${allLabelTexts.join(',')}}`;
 }
 
+async function getLabelNames(
+  metric: string | undefined,
+  otherLabels: Label[],
+  dataProvider: DataProvider
+): Promise<string[]> {
+  if (metric === undefined && otherLabels.length === 0) {
+    // if there is no filtering, we have to use a special endpoint
+    return dataProvider.getAllLabelNames();
+  } else {
+    const selector = makeSelector(metric, otherLabels);
+    const data = await dataProvider.getSeries(selector);
+    const possibleLabelNames = Object.keys(data); // all names from prometheus
+    const usedLabelNames = new Set(otherLabels.map((l) => l.name)); // names used in the query
+    return possibleLabelNames.filter((l) => !usedLabelNames.has(l));
+  }
+}
+
 async function getLabelNamesForCompletions(
   metric: string | undefined,
   suffix: string,
@@ -95,11 +115,7 @@ async function getLabelNamesForCompletions(
   otherLabels: Label[],
   dataProvider: DataProvider
 ): Promise<Completion[]> {
-  const selector = makeSelector(metric, otherLabels);
-  const data = await dataProvider.getSeries(selector);
-  const possibleLabelNames = Object.keys(data); // all names from prometheus
-  const usedLabelNames = new Set(otherLabels.map((l) => l.name)); // names used in the query
-  const labelNames = possibleLabelNames.filter((l) => !usedLabelNames.has(l));
+  const labelNames = await getLabelNames(metric, otherLabels, dataProvider);
   return labelNames.map((text) => ({
     type: 'LABEL_NAME',
     label: text,
@@ -123,15 +139,29 @@ async function getLabelNamesForByCompletions(
   return getLabelNamesForCompletions(metric, '', false, otherLabels, dataProvider);
 }
 
+async function getLabelValues(
+  metric: string | undefined,
+  labelName: string,
+  otherLabels: Label[],
+  dataProvider: DataProvider
+): Promise<string[]> {
+  if (metric === undefined && otherLabels.length === 0) {
+    // if there is no filtering, we have to use a special endpoint
+    return dataProvider.getLabelValues(labelName);
+  } else {
+    const selector = makeSelector(metric, otherLabels);
+    const data = await dataProvider.getSeries(selector);
+    return data[labelName] ?? [];
+  }
+}
+
 async function getLabelValuesForMetricCompletions(
   metric: string | undefined,
   labelName: string,
   otherLabels: Label[],
   dataProvider: DataProvider
 ): Promise<Completion[]> {
-  const selector = makeSelector(metric, otherLabels);
-  const data = await dataProvider.getSeries(selector);
-  const values = data[labelName] ?? [];
+  const values = await getLabelValues(metric, labelName, otherLabels, dataProvider);
   return values.map((text) => ({
     type: 'LABEL_VALUE',
     label: text,


### PR DESCRIPTION
this is for the monaco-based prometheus query field.

this change allows you to do this:
- if you only write `{`, you will get offered a list of all label-names that exist (and then if you choose a label-name, you will correctly get a list of possible label-values)