### PR TITLE
Dashboard: Disable image renderer link for unsaved dashboards

### DIFF
--- a/public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx
@@ -7,6 +7,7 @@ import { initTemplateSrv } from '../../../../../test/helpers/initTemplateSrv';
 import { variableAdapters } from '../../../variables/adapters';
 import { createQueryVariableAdapter } from '../../../variables/query/adapter';
 import { PanelModel } from '../../state';
+import { getDefaultTimeRange } from '@grafana/data';
 
 jest.mock('app/features/dashboard/services/TimeSrv', () => ({
   getTimeSrv: () => ({
@@ -76,6 +77,7 @@ function shareLinkScenario(description: string, scenarioFn: (ctx: ScenarioContex
       mount: (propOverrides?: any) => {
         const props: any = {
           panel: undefined,
+          dashboard: { time: getDefaultTimeRange() },
         };
 
         Object.assign(props, propOverrides);

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.tsx
@@ -81,10 +81,11 @@ export class ShareLink extends PureComponent<Props, State> {
   };
 
   render() {
-    const { panel } = this.props;
-    const isRelativeTime = this.props.dashboard ? this.props.dashboard.time.to === 'now' : false;
+    const { panel, dashboard } = this.props;
+    const isRelativeTime = dashboard ? dashboard.time.to === 'now' : false;
     const { useCurrentTimeRange, useShortUrl, selectedTheme, shareUrl, imageUrl } = this.state;
     const selectors = e2eSelectors.pages.SharePanelModal;
+    const isDashboardSaved = Boolean(dashboard.id);
 
     return (
       <>
@@ -122,13 +123,25 @@ export class ShareLink extends PureComponent<Props, State> {
             />
           </Field>
         </FieldSet>
+
         {panel && config.rendererAvailable && (
-          <div className="gf-form">
-            <a href={imageUrl} target="_blank" rel="noreferrer" aria-label={selectors.linkToRenderedImage}>
-              <Icon name="camera" /> Direct link rendered image
-            </a>
-          </div>
+          <>
+            {isDashboardSaved && (
+              <div className="gf-form">
+                <a href={imageUrl} target="_blank" rel="noreferrer" aria-label={selectors.linkToRenderedImage}>
+                  <Icon name="camera" /> Direct link rendered image
+                </a>
+              </div>
+            )}
+
+            {!isDashboardSaved && (
+              <Alert severity="info" title="Dashboard is not saved" bottomSpacing={0}>
+                To render a panel image, you must save the dashboard first.
+              </Alert>
+            )}
+          </>
         )}
+
         {panel && !config.rendererAvailable && (
           <Alert severity="info" title="Image renderer plugin not installed" bottomSpacing={0}>
             <>To render a panel image, you must install the </>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Hide the image renderer link and display an alert when the user tries to share a panel before the dashboard has been saved.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #25648


