### PR TITLE
Navigation: remove redundant config nav link

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -309,15 +309,6 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 	}
 
 	if len(configNodes) > 0 {
-		navTree = append(navTree, &dtos.NavLink{
-			Id:         dtos.NavIDCfg,
-			Text:       "Configuration",
-			SubTitle:   "Organization: " + c.OrgName,
-			Icon:       "cog",
-			Url:        configNodes[0].Url,
-			SortWeight: dtos.WeightConfig,
-			Children:   configNodes,
-		})
 		configNode := &dtos.NavLink{
 			Id:         dtos.NavIDCfg,
 			Text:       "Configuration",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR (https://github.com/grafana/grafana/pull/41045) introduced a duplicated configuration section in the navigation tree. It doesn't seem to have any impact in OSS but it causes issue in Enterprise.

