### PR TITLE
Chore: Fix for query variables using DataSourceRef

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/actions.test.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.test.ts
@@ -459,7 +459,7 @@ function createMultiVariable(extend?: Partial<QueryVariableModel>): QueryVariabl
     options: [],
     query: 'options-query',
     name: 'Constant',
-    datasource: 'datasource',
+    datasource: { uid: 'datasource' },
     definition: '',
     sort: VariableSort.alphabeticalAsc,
     refresh: VariableRefresh.never,

--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/css';
 import { InlineField, InlineFieldRow, VerticalGroup } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
 import { DataSourcePicker, getTemplateSrv } from '@grafana/runtime';
-import { DataSourceInstanceSettings, LoadingState, SelectableValue } from '@grafana/data';
+import { DataSourceInstanceSettings, getDataSourceRef, LoadingState, SelectableValue } from '@grafana/data';
 
 import { SelectionOptionsEditor } from '../editor/SelectionOptionsEditor';
 import { QueryVariableModel, VariableRefresh, VariableSort, VariableWithMultiSupport } from '../types';
@@ -68,7 +68,7 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
   onDataSourceChange = (dsSettings: DataSourceInstanceSettings) => {
     this.props.onPropChange({
       propName: 'datasource',
-      propValue: dsSettings.isDefault ? null : dsSettings.name,
+      propValue: dsSettings.isDefault ? null : getDataSourceRef(dsSettings),
     });
   };
 

--- a/public/app/features/variables/query/actions.ts
+++ b/public/app/features/variables/query/actions.ts
@@ -1,4 +1,7 @@
+import { Subscription } from 'rxjs';
 import { getDataSourceSrv, toDataQueryError } from '@grafana/runtime';
+import { DataSourceRef } from '@grafana/data';
+
 import { updateOptions } from '../state/actions';
 import { QueryVariableModel } from '../types';
 import { ThunkResult } from '../../../types';
@@ -12,7 +15,6 @@ import {
 import { changeVariableProp } from '../state/sharedReducer';
 import { toVariableIdentifier, toVariablePayload, VariableIdentifier } from '../state/types';
 import { getVariableQueryEditor } from '../editor/getVariableQueryEditor';
-import { Subscription } from 'rxjs';
 import { getVariableQueryRunner } from './VariableQueryRunner';
 import { variableQueryObserver } from './variableQueryObserver';
 import { QueryVariableEditorState } from './reducer';
@@ -60,7 +62,7 @@ export const initQueryVariableEditor = (identifier: VariableIdentifier): ThunkRe
 
 export const changeQueryVariableDataSource = (
   identifier: VariableIdentifier,
-  name: string | null
+  name: DataSourceRef | null
 ): ThunkResult<void> => {
   return async (dispatch, getState) => {
     try {

--- a/public/app/features/variables/query/adapter.ts
+++ b/public/app/features/variables/query/adapter.ts
@@ -21,7 +21,7 @@ export const createQueryVariableAdapter = (): VariableAdapter<QueryVariableModel
     picker: optionPickerFactory<QueryVariableModel>(),
     editor: QueryVariableEditor,
     dependsOn: (variable, variableToTest) => {
-      return containsVariable(variable.query, variable.datasource, variable.regex, variableToTest.name);
+      return containsVariable(variable.query, variable.datasource?.uid, variable.regex, variableToTest.name);
     },
     setValue: async (variable, option, emitChanges = false) => {
       await dispatch(setOptionAsCurrent(toVariableIdentifier(variable), option, emitChanges));

--- a/public/app/features/variables/shared/testing/queryVariableBuilder.ts
+++ b/public/app/features/variables/shared/testing/queryVariableBuilder.ts
@@ -1,8 +1,10 @@
+import { DataSourceRef } from '@grafana/data';
+
 import { QueryVariableModel } from 'app/features/variables/types';
 import { DatasourceVariableBuilder } from './datasourceVariableBuilder';
 
 export class QueryVariableBuilder<T extends QueryVariableModel> extends DatasourceVariableBuilder<T> {
-  withDatasource(datasource: string) {
+  withDatasource(datasource: DataSourceRef) {
     this.variable.datasource = datasource;
     return this;
   }

--- a/public/app/features/variables/state/upgradeLegacyQueries.test.ts
+++ b/public/app/features/variables/state/upgradeLegacyQueries.test.ts
@@ -13,7 +13,13 @@ interface Args {
 }
 function getTestContext({ query = '', variable, datasource }: Args = {}) {
   variable =
-    variable ?? queryBuilder().withId('query').withName('query').withQuery(query).withDatasource('test-data').build();
+    variable ??
+    queryBuilder()
+      .withId('query')
+      .withName('query')
+      .withQuery(query)
+      .withDatasource({ uid: 'test-data', type: 'test-data' })
+      .build();
   const state = {
     templating: {
       variables: {
@@ -56,7 +62,7 @@ describe('upgradeLegacyQueries', () => {
         }),
       ]);
       expect(get).toHaveBeenCalledTimes(1);
-      expect(get).toHaveBeenCalledWith('test-data');
+      expect(get).toHaveBeenCalledWith({ uid: 'test-data', type: 'test-data' });
     });
   });
 
@@ -70,7 +76,7 @@ describe('upgradeLegacyQueries', () => {
 
       expect(dispatchedActions).toEqual([]);
       expect(get).toHaveBeenCalledTimes(1);
-      expect(get).toHaveBeenCalledWith('test-data');
+      expect(get).toHaveBeenCalledWith({ uid: 'test-data', type: 'test-data' });
     });
   });
 
@@ -88,7 +94,7 @@ describe('upgradeLegacyQueries', () => {
 
       expect(dispatchedActions).toEqual([]);
       expect(get).toHaveBeenCalledTimes(1);
-      expect(get).toHaveBeenCalledWith('test-data');
+      expect(get).toHaveBeenCalledWith({ uid: 'test-data', type: 'test-data' });
     });
   });
 
@@ -107,7 +113,7 @@ describe('upgradeLegacyQueries', () => {
 
       expect(dispatchedActions).toEqual([]);
       expect(get).toHaveBeenCalledTimes(1);
-      expect(get).toHaveBeenCalledWith('test-data');
+      expect(get).toHaveBeenCalledWith({ uid: 'test-data', type: 'test-data' });
     });
   });
 
@@ -126,7 +132,7 @@ describe('upgradeLegacyQueries', () => {
 
       expect(dispatchedActions).toEqual([]);
       expect(get).toHaveBeenCalledTimes(1);
-      expect(get).toHaveBeenCalledWith('test-data');
+      expect(get).toHaveBeenCalledWith({ uid: 'test-data', type: 'test-data' });
     });
   });
 

--- a/public/app/features/variables/types.ts
+++ b/public/app/features/variables/types.ts
@@ -68,7 +68,7 @@ export interface DataSourceVariableModel extends VariableWithMultiSupport {
 }
 
 export interface QueryVariableModel extends DataSourceVariableModel {
-  datasource: string | null;
+  datasource: DataSourceRef | null;
   definition: string;
   sort: VariableSort;
   queryValue?: string;


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a couple of things for query variables introduced by #33817:
- Whenever you updated the data source for a query variable the string was stored instead of DataSourceRef
- The variable chaining for variables depending on a data source variable was broken because the adapter.dependsOn was passing an object not a string

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


