### PR TITLE
Elasticsearch: Use field configured in query editor as field for date_histogram aggregations

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -96,7 +96,7 @@ export class ElasticQueryBuilder {
     const esAgg: any = {};
     const settings = aggDef.settings || {};
     esAgg.interval = settings.interval;
-    esAgg.field = this.timeField;
+    esAgg.field = aggDef.field || this.timeField;
     esAgg.min_doc_count = settings.min_doc_count || 0;
     esAgg.extended_bounds = { min: '$timeFrom', max: '$timeTo' };
     esAgg.format = 'epoch_millis';

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
@@ -885,6 +885,45 @@ describe('ElasticQueryBuilder', () => {
 
         expect(query.aggs['2'].date_histogram.time_zone).toBe(expectedTimezone);
       });
+
+      describe('field property', () => {
+        it('should use timeField from datasource when not specified', () => {
+          const expectedTimezone = 'America/Los_angeles';
+          const query = builder.build({
+            refId: 'A',
+            metrics: [{ type: 'count', id: '1' }],
+            timeField: '@timestamp',
+            bucketAggs: [
+              {
+                type: 'date_histogram',
+                id: '2',
+                settings: { min_doc_count: '1', timeZone: expectedTimezone },
+              },
+            ],
+          });
+
+          expect(query.aggs['2'].date_histogram.field).toBe('@timestamp');
+        });
+
+        it('should use field from bucket agg when specified', () => {
+          const expectedTimezone = 'America/Los_angeles';
+          const query = builder.build({
+            refId: 'A',
+            metrics: [{ type: 'count', id: '1' }],
+            timeField: '@timestamp',
+            bucketAggs: [
+              {
+                type: 'date_histogram',
+                id: '2',
+                field: '@time',
+                settings: { min_doc_count: '1', timeZone: expectedTimezone },
+              },
+            ],
+          });
+
+          expect(query.aggs['2'].date_histogram.field).toBe('@time');
+        });
+      });
     });
   });
 });


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
when executing queries from the frontend, the `field` property from `date_histogram` aggregations is ignored in favor of the datasource level `timeField` setting. The editor still allowed users to pick a different field for the aggregation, it just wasn't used when building the query.

**Note**: the filtering is still done based on the `timeField` property, setting a different field in the date histogram aggregation only changes the bucketing.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #8260





