### PR TITLE
prometheus: monaco: better suggestions inside quotes

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -162,6 +162,7 @@ async function getLabelValues(
 async function getLabelValuesForMetricCompletions(
   metric: string | undefined,
   labelName: string,
+  betweenQuotes: boolean,
   otherLabels: Label[],
   dataProvider: DataProvider
 ): Promise<Completion[]> {
@@ -169,7 +170,7 @@ async function getLabelValuesForMetricCompletions(
   return values.map((text) => ({
     type: 'LABEL_VALUE',
     label: text,
-    insertText: `"${text}"`, // FIXME: escaping strange characters?
+    insertText: betweenQuotes ? text : `"${text}"`, // FIXME: escaping strange characters?
   }));
 }
 
@@ -195,6 +196,7 @@ export async function getCompletions(situation: Situation, dataProvider: DataPro
       return getLabelValuesForMetricCompletions(
         situation.metricName,
         situation.labelName,
+        situation.betweenQuotes,
         situation.otherLabels,
         dataProvider
       );

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/index.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/index.ts
@@ -74,7 +74,7 @@ export function getCompletionProvider(
   };
 
   return {
-    triggerCharacters: ['{', ',', '[', '(', '=', '~', ' '],
+    triggerCharacters: ['{', ',', '[', '(', '=', '~', ' ', '"'],
     provideCompletionItems,
   };
 }

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -96,6 +96,7 @@ describe('situation', () => {
       type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME',
       metricName: 'something',
       labelName: 'job',
+      betweenQuotes: false,
       otherLabels: [],
     });
 
@@ -103,6 +104,7 @@ describe('situation', () => {
       type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME',
       metricName: 'something',
       labelName: 'job',
+      betweenQuotes: false,
       otherLabels: [],
     });
 
@@ -110,6 +112,7 @@ describe('situation', () => {
       type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME',
       metricName: 'something',
       labelName: 'job',
+      betweenQuotes: false,
       otherLabels: [],
     });
 
@@ -117,6 +120,7 @@ describe('situation', () => {
       type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME',
       metricName: 'something',
       labelName: 'job',
+      betweenQuotes: false,
       otherLabels: [],
     });
 
@@ -124,12 +128,22 @@ describe('situation', () => {
       type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME',
       metricName: 'something',
       labelName: 'job',
+      betweenQuotes: false,
       otherLabels: [{ name: 'host', value: 'h1', op: '=' }],
+    });
+
+    assertSituation('something{job="j1",host="^"}', {
+      type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME',
+      metricName: 'something',
+      labelName: 'host',
+      betweenQuotes: true,
+      otherLabels: [{ name: 'job', value: 'j1', op: '=' }],
     });
 
     assertSituation('{job=^,host="h1"}', {
       type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME',
       labelName: 'job',
+      betweenQuotes: false,
       otherLabels: [{ name: 'host', value: 'h1', op: '=' }],
     });
 
@@ -137,6 +151,7 @@ describe('situation', () => {
       type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME',
       metricName: 'something',
       labelName: 'three',
+      betweenQuotes: false,
       otherLabels: [
         { name: 'one', value: 'val1', op: '=' },
         { name: 'two', value: 'val2', op: '!=' },

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -111,6 +111,7 @@ export type Situation =
       type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME';
       metricName?: string;
       labelName: string;
+      betweenQuotes: boolean;
       otherLabels: Label[];
     };
 
@@ -139,8 +140,12 @@ const RESOLVERS: Resolver[] = [
     fun: resolveInFunction,
   },
   {
+    path: ['StringLiteral', 'LabelMatcher'],
+    fun: resolveLabelMatcher,
+  },
+  {
     path: [ERROR_NODE_NAME, 'LabelMatcher'],
-    fun: resolveLabelMatcherError,
+    fun: resolveLabelMatcher,
   },
   {
     path: [ERROR_NODE_NAME, 'MatrixSelector'],
@@ -290,9 +295,12 @@ function resolveLabelsForGrouping(node: SyntaxNode, text: string, pos: number): 
   };
 }
 
-function resolveLabelMatcherError(node: SyntaxNode, text: string, pos: number): Situation | null {
-  // we are probably in the scenario where the user is before entering the
-  // label-value, like `{job=^}` (^ marks the cursor)
+function resolveLabelMatcher(node: SyntaxNode, text: string, pos: number): Situation | null {
+  // we can arrive here in two situation. `node` is either:
+  // - a StringNode (like in `{job="^"}`)
+  // - or an error node (like in `{job=^}`)
+  const inStringNode = !node.type.isError;
+
   const parent = walk(node, [['parent', 'LabelMatcher']]);
   if (parent === null) {
     return null;
@@ -344,7 +352,11 @@ function resolveLabelMatcherError(node: SyntaxNode, text: string, pos: number): 
   }
 
   // now we need to find the other names
-  const otherLabels = getLabels(labelMatchersNode, text);
+  const allLabels = getLabels(labelMatchersNode, text);
+
+  const otherLabels = allLabels.filter((label) => label.name !== labelName);
+
+  // we need to remove "our" label from all-labels, if it is in there
 
   const metricNameNode = walk(labelMatchersNode, [
     ['parent', 'VectorSelector'],
@@ -357,6 +369,7 @@ function resolveLabelMatcherError(node: SyntaxNode, text: string, pos: number): 
     return {
       type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME',
       labelName,
+      betweenQuotes: inStringNode,
       otherLabels,
     };
   }
@@ -367,6 +380,7 @@ function resolveLabelMatcherError(node: SyntaxNode, text: string, pos: number): 
     type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME',
     metricName,
     labelName,
+    betweenQuotes: inStringNode,
     otherLabels,
   };
 }

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -354,9 +354,8 @@ function resolveLabelMatcher(node: SyntaxNode, text: string, pos: number): Situa
   // now we need to find the other names
   const allLabels = getLabels(labelMatchersNode, text);
 
-  const otherLabels = allLabels.filter((label) => label.name !== labelName);
-
   // we need to remove "our" label from all-labels, if it is in there
+  const otherLabels = allLabels.filter((label) => label.name !== labelName);
 
   const metricNameNode = walk(labelMatchersNode, [
     ['parent', 'VectorSelector'],


### PR DESCRIPTION
in the monaco based prometheus query field, this pull request improves the situation for suggestions when inside double-quotes.

how to test:
- enter this text into the query-field: `go_goroutines{job=}` (cancel any autocomplete popups if they appear)
- move the cursor to be between `=` and `}`
- write a `"` character
- monaco will write both the "start" `"` and "end" `"`, and it should offer you suggestions.
- when you choose a suggestion, it should insert it correctly, it should not cause too many doublequotes.
