### PR TITLE
grafana/ui: Enable slider marks display

### DIFF
--- a/packages/grafana-data/src/field/overrides/processors.ts
+++ b/packages/grafana-data/src/field/overrides/processors.ts
@@ -1,5 +1,13 @@
 import { ComponentType } from 'react';
-import { DataLink, Field, FieldOverrideContext, SelectableValue, ThresholdsConfig, ValueMapping } from '../../types';
+import {
+  DataLink,
+  Field,
+  FieldOverrideContext,
+  SelectableValue,
+  SliderMarks,
+  ThresholdsConfig,
+  ValueMapping,
+} from '../../types';
 
 export const identityOverrideProcessor = <T>(value: T, _context: FieldOverrideContext, _settings: any) => {
   return value;
@@ -39,6 +47,8 @@ export interface SliderFieldConfigSettings {
   min: number;
   max: number;
   step?: number;
+  included?: boolean;
+  marks?: SliderMarks;
   ariaLabelForHandle?: string;
 }
 

--- a/packages/grafana-data/src/types/index.ts
+++ b/packages/grafana-data/src/types/index.ts
@@ -38,3 +38,4 @@ export * from './geometry';
 export { isUnsignedPluginSignature } from './pluginSignature';
 export { GrafanaConfig, BuildInfo, FeatureToggles, LicenseInfo } from './config';
 export * from './alerts';
+export * from './slider';

--- a/packages/grafana-data/src/types/slider.ts
+++ b/packages/grafana-data/src/types/slider.ts
@@ -1,0 +1,1 @@
+export type SliderMarks = Record<number, React.ReactNode | { style?: React.CSSProperties; label?: string }>;

--- a/packages/grafana-ui/src/components/OptionsUI/slider.tsx
+++ b/packages/grafana-ui/src/components/OptionsUI/slider.tsx
@@ -16,6 +16,8 @@ export const SliderValueEditor: React.FC<FieldConfigEditorProps<number, SliderFi
       min={settings?.min || 0}
       max={settings?.max || 100}
       step={settings?.step}
+      marks={settings?.marks}
+      included={settings?.included}
       onChange={onChange}
       ariaLabelForHandle={settings?.ariaLabelForHandle}
     />

--- a/packages/grafana-ui/src/components/Slider/Slider.story.tsx
+++ b/packages/grafana-ui/src/components/Slider/Slider.story.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Slider } from '@grafana/ui';
 import { SliderProps } from './types';
+import { Orientation } from '../../types/orientation';
 import { Story, Meta } from '@storybook/react';
 
 export default {
@@ -20,6 +21,16 @@ export default {
   },
 } as Meta;
 
+const commonArgs = {
+  min: 0,
+  max: 100,
+  value: 10,
+  isStep: false,
+  orientation: 'horizontal' as Orientation,
+  reverse: false,
+  included: true,
+};
+
 interface StoryProps extends Partial<SliderProps> {
   isStep: boolean;
 }
@@ -38,10 +49,23 @@ export const Basic: Story<StoryProps> = (args) => {
   );
 };
 Basic.args = {
-  min: 0,
-  max: 100,
-  value: 10,
-  isStep: false,
-  orientation: 'horizontal',
-  reverse: false,
+  ...commonArgs,
+};
+
+export const WithMarks: Story<StoryProps> = (args) => {
+  return (
+    <div style={{ width: '300px', height: '300px' }}>
+      <Slider
+        step={args.isStep ? 10 : undefined}
+        value={args.value}
+        min={args.min as number}
+        max={args.max as number}
+        {...args}
+      />
+    </div>
+  );
+};
+WithMarks.args = {
+  ...commonArgs,
+  marks: { 0: '0', 25: '25', 50: '50', 75: '75', 100: '100' },
 };

--- a/packages/grafana-ui/src/components/Slider/Slider.tsx
+++ b/packages/grafana-ui/src/components/Slider/Slider.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, ChangeEvent, FunctionComponent, FocusEvent } from 'react';
 import SliderComponent from 'rc-slider';
+
 import { cx } from '@emotion/css';
 import { Global } from '@emotion/react';
 import { useTheme2 } from '../../themes/ThemeContext';
@@ -20,6 +21,8 @@ export const Slider: FunctionComponent<SliderProps> = ({
   step,
   value,
   ariaLabelForHandle,
+  marks,
+  included,
 }) => {
   const isHorizontal = orientation === 'horizontal';
   const theme = useTheme2();
@@ -93,6 +96,8 @@ export const Slider: FunctionComponent<SliderProps> = ({
           vertical={!isHorizontal}
           reverse={reverse}
           ariaLabelForHandle={ariaLabelForHandle}
+          marks={marks}
+          included={included}
         />
         {/* Uses text input so that the number spinners are not shown */}
         <Input

--- a/packages/grafana-ui/src/components/Slider/styles.ts
+++ b/packages/grafana-ui/src/components/Slider/styles.ts
@@ -23,6 +23,16 @@ export const getStyles = stylesFactory((theme: GrafanaTheme2, isHorizontal: bool
         flex-grow: 1;
         margin-left: 7px; // half the size of the handle to align handle to the left on 0 value
       }
+      .rc-slider-mark {
+        top: ${theme.spacing(1.75)};
+      }
+      .rc-slider-mark-text {
+        color: ${theme.colors.text.disabled};
+        font-size: ${theme.typography.bodySmall.fontSize};
+      }
+      .rc-slider-mark-text-active {
+        color: ${theme.colors.text.primary};
+      }
       .rc-slider-vertical .rc-slider-handle {
         margin-top: -10px;
       }

--- a/packages/grafana-ui/src/components/Slider/types.ts
+++ b/packages/grafana-ui/src/components/Slider/types.ts
@@ -1,30 +1,30 @@
+import { SliderMarks } from '@grafana/data';
 import { Orientation } from '../../types/orientation';
 
-export interface SliderProps {
+interface CommonSliderProps {
   min: number;
   max: number;
   orientation?: Orientation;
   /** Set current positions of handle(s). If only 1 value supplied, only 1 handle displayed. */
-  value?: number;
   reverse?: boolean;
   step?: number;
   tooltipAlwaysVisible?: boolean;
-  formatTooltipResult?: (value: number) => number;
+  /** Marks on the slider. The key determines the position, and the value determines what will show. If you want to set the style of a specific mark point, the value should be an object which contains style and label properties. */
+  marks?: SliderMarks;
+  /** If the value is true, it means a continuous value interval, otherwise, it is a independent value. */
+  included?: boolean;
+}
+export interface SliderProps extends CommonSliderProps {
+  value?: number;
   onChange?: (value: number) => void;
   onAfterChange?: (value?: number) => void;
+  formatTooltipResult?: (value: number) => number;
   ariaLabelForHandle?: string;
 }
 
-export interface RangeSliderProps {
-  min: number;
-  max: number;
-  orientation?: Orientation;
-  /** Set current positions of handle(s). If only 1 value supplied, only 1 handle displayed. */
+export interface RangeSliderProps extends CommonSliderProps {
   value?: number[];
-  reverse?: boolean;
-  step?: number;
-  tooltipAlwaysVisible?: boolean;
-  formatTooltipResult?: (value: number) => number | string;
   onChange?: (value: number[]) => void;
-  onAfterChange?: (value: number[]) => void;
+  onAfterChange?: (value?: number[]) => void;
+  formatTooltipResult?: (value: number) => number | string;
 }

--- a/public/app/plugins/panel/barchart/module.tsx
+++ b/public/app/plugins/panel/barchart/module.tsx
@@ -84,6 +84,8 @@ export const plugin = new PanelPlugin<BarChartOptions, BarChartFieldConfig>(BarC
           min: -90,
           max: 90,
           step: 15,
+          marks: { '-90': '-90°', '-45': '-45°', 0: '0°', 45: '45°', 90: '90°' },
+          included: false,
         },
         showIf: (opts) => {
           return opts.orientation === VizOrientation.Auto || opts.orientation === VizOrientation.Vertical;


### PR DESCRIPTION
Allows slider marks control:

![image](https://user-images.githubusercontent.com/2376619/140078747-d3b91ff1-edeb-44d6-afc5-5331e2df8c6c.png)


Based on https://github.com/grafana/grafana/pull/40299