### PR TITLE
Stats: Add monthlyActiveUsers to stats API and usage report

### DIFF
--- a/pkg/infra/usagestats/service/usage_stats.go
+++ b/pkg/infra/usagestats/service/usage_stats.go
@@ -60,6 +60,7 @@ func (uss *UsageStats) GetUsageReport(ctx context.Context) (usagestats.Report, e
 	metrics["stats.active_editors.count"] = statsQuery.Result.ActiveEditors
 	metrics["stats.active_viewers.count"] = statsQuery.Result.ActiveViewers
 	metrics["stats.active_sessions.count"] = statsQuery.Result.ActiveSessions
+	metrics["stats.monthly_active_users.count"] = statsQuery.Result.MonthlyActiveUsers
 	metrics["stats.daily_active_users.count"] = statsQuery.Result.DailyActiveUsers
 	metrics["stats.daily_active_admins.count"] = statsQuery.Result.DailyActiveAdmins
 	metrics["stats.daily_active_editors.count"] = statsQuery.Result.DailyActiveEditors

--- a/pkg/models/stats.go
+++ b/pkg/models/stats.go
@@ -6,6 +6,7 @@ type SystemStats struct {
 	Users                     int64
 	ActiveUsers               int64
 	DailyActiveUsers          int64
+	MonthlyActiveUsers        int64
 	Orgs                      int64
 	Playlists                 int64
 	Alerts                    int64
@@ -94,6 +95,7 @@ type AdminStats struct {
 	DailyActiveEditors  int64 `json:"dailyActiveEditors"`
 	DailyActiveViewers  int64 `json:"dailyActiveViewers"`
 	DailyActiveSessions int64 `json:"dailyActiveSessions"`
+	MonthlyActiveUsers  int64 `json:"monthlyActiveUsers"`
 }
 
 type GetAdminStatsQuery struct {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR adds a new variable to the stats API endpoint and the usage report called monthlyActiveUsers which considers only the active users of the current month, instead of using 30 days as offset.

This is necessary for grafana/grafana-enterprise-partnerships-team#2 since it will be used to measure monthly usage.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Closes grafana/grafana-enterprise-partnerships-team#7

**Special notes for your reviewer**:

