### PR TITLE
Alerting: Fix no data behaviour in Legacy Alerting for alert rules using the AND operator

### DIFF
--- a/pkg/services/alerting/eval_handler.go
+++ b/pkg/services/alerting/eval_handler.go
@@ -52,11 +52,14 @@ func (e *DefaultEvalHandler) Eval(context *EvalContext) {
 		// calculating Firing based on operator
 		if cr.Operator == "or" {
 			firing = firing || cr.Firing
-			noDataFound = noDataFound || cr.NoDataFound
 		} else {
 			firing = firing && cr.Firing
-			noDataFound = noDataFound && cr.NoDataFound
 		}
+
+		// We cannot evaluate the expression when one or more conditions are missing data
+		// and so noDataFound should be true if at least one condition returns no data,
+		// irrespective of the operator.
+		noDataFound = noDataFound || cr.NoDataFound
 
 		if i > 0 {
 			conditionEvals = "[" + conditionEvals + " " + strings.ToUpper(cr.Operator) + " " + strconv.FormatBool(cr.Firing) + "]"

--- a/pkg/services/alerting/eval_handler_test.go
+++ b/pkg/services/alerting/eval_handler_test.go
@@ -181,7 +181,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 		require.True(t, context.NoDataFound)
 	})
 
-	t.Run("Should not return no data if at least one condition has no data and using AND", func(t *testing.T) {
+	t.Run("Should return no data if at least one condition has no data and using AND", func(t *testing.T) {
 		context := NewEvalContext(context.TODO(), &Rule{
 			Conditions: []Condition{
 				&conditionStub{operator: "and", noData: true},
@@ -190,7 +190,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 		}, &validations.OSSPluginRequestValidator{})
 
 		handler.Eval(context)
-		require.False(t, context.NoDataFound)
+		require.True(t, context.NoDataFound)
 	})
 
 	t.Run("Should return no data if at least one condition has no data and using OR", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue in alerting where `NoDataFound` is `false` when using the `AND` operator to compare two conditions in an alert rule and one of the conditions returns `No Data`.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/support-escalations/issues/1078

# Release notice breaking change

### Fix No Data behaviour in Legacy Alerting

In Grafana 8.2.5 and later, this change fixes a bug in the evaluation of alert rules when using the AND operator to compare two or more conditions. In Grafana 8.2.4 and earlier such alert rules would evaluate to `OK` if at least one, but not all, conditions returned no data. This change fixes that bug such that in Grafana 8.2.5 these alert rules now evaluate to `No Data`.

If an alert should evaluate to `OK` when one or all conditions return `No Data` then this can be done via changing `If no data or all values are null` to `OK`. However, this will not preserve the old behaviour in 8.2.4 where an alert will be `OK` if at least one, but not all, conditions return no data and then `No Data` if all conditions return `No Data`.