### PR TITLE
Graphite: Add from and until params to tag handling methods

### DIFF
--- a/public/app/plugins/datasource/graphite/specs/store.test.ts
+++ b/public/app/plugins/datasource/graphite/specs/store.test.ts
@@ -210,6 +210,20 @@ describe('Graphite actions', async () => {
     });
   });
 
+  it('current time range is passed when getting list of tags when editing', async () => {
+    const currentRange = { from: 0, to: 1 };
+    ctx.state.range = currentRange;
+    await getTagsSelectables(ctx.state, 0, 'any');
+    expect(ctx.state.datasource.getTagsAutoComplete).toBeCalledWith([], 'any', { range: currentRange });
+  });
+
+  it('current time range is passed when getting list of tags for adding', async () => {
+    const currentRange = { from: 0, to: 1 };
+    ctx.state.range = currentRange;
+    await getTagsAsSegmentsSelectables(ctx.state, 'any');
+    expect(ctx.state.datasource.getTagsAutoComplete).toBeCalledWith([], 'any', { range: currentRange });
+  });
+
   describe('when autocomplete for metric names is not available', () => {
     silenceConsoleOutput();
     beforeEach(() => {

--- a/public/app/plugins/datasource/graphite/state/providers.ts
+++ b/public/app/plugins/datasource/graphite/state/providers.ts
@@ -106,7 +106,7 @@ export function getTagOperatorsSelectables(): Array<SelectableValue<GraphiteTagO
 async function getTags(state: GraphiteQueryEditorState, index: number, tagPrefix: string): Promise<string[]> {
   try {
     const tagExpressions = state.queryModel.renderTagExpressions(index);
-    const values = await state.datasource.getTagsAutoComplete(tagExpressions, tagPrefix);
+    const values = await state.datasource.getTagsAutoComplete(tagExpressions, tagPrefix, { range: state.range });
 
     const altTags = map(values, 'text');
     altTags.splice(0, 0, state.removeTagValue);
@@ -134,7 +134,7 @@ async function getTagsAsSegments(state: GraphiteQueryEditorState, tagPrefix: str
   let tagsAsSegments: GraphiteSegment[];
   try {
     const tagExpressions = state.queryModel.renderTagExpressions();
-    const values = await state.datasource.getTagsAutoComplete(tagExpressions, tagPrefix);
+    const values = await state.datasource.getTagsAutoComplete(tagExpressions, tagPrefix, { range: state.range });
     tagsAsSegments = map(values, (val) => {
       return {
         value: val.text,


### PR DESCRIPTION
This PR adds from and until params to the /tags endpoint. This change will fix an issue in which no tags will appear in the UI if metrics have not been ingested in the last hour. 
