### PR TITLE
Alerting: Add matches to annotations when the result is NoData

### DIFF
--- a/pkg/services/alerting/eval_handler.go
+++ b/pkg/services/alerting/eval_handler.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/grafana/pkg/components/null"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/tsdb/legacydata"
@@ -60,6 +62,11 @@ func (e *DefaultEvalHandler) Eval(context *EvalContext) {
 		// and so noDataFound should be true if at least one condition returns no data,
 		// irrespective of the operator.
 		noDataFound = noDataFound || cr.NoDataFound
+
+		// Append an eval match to make sure we keep a record that at this point in time, this query returned no data.
+		if cr.NoDataFound {
+			cr.EvalMatches = append(cr.EvalMatches, &EvalMatch{Metric: "NoData", Value: null.Float{}})
+		}
 
 		if i > 0 {
 			conditionEvals = "[" + conditionEvals + " " + strings.ToUpper(cr.Operator) + " " + strconv.FormatBool(cr.Firing) + "]"

--- a/pkg/services/alerting/eval_handler.go
+++ b/pkg/services/alerting/eval_handler.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/components/null"
-
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/tsdb/legacydata"

--- a/pkg/services/alerting/eval_handler_test.go
+++ b/pkg/services/alerting/eval_handler_test.go
@@ -229,7 +229,6 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 		require.ElementsMatch(t, context.EvalMatches, []*EvalMatch{
 			{Value: null.Float{}, Metric: "NoData"},
 		})
-
 	})
 }
 

--- a/pkg/services/alerting/eval_handler_test.go
+++ b/pkg/services/alerting/eval_handler_test.go
@@ -26,17 +26,18 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 	handler := NewEvalHandler(nil)
 
 	t.Run("Show return triggered with single passing condition", func(t *testing.T) {
+		match := makeMatchWithValue(t, float64(3))
 		context := NewEvalContext(context.TODO(), &Rule{
 			Conditions: []Condition{&conditionStub{
 				firing:  true,
-				matches: evalMatchesBasedOnState(),
+				matches: []*EvalMatch{match},
 			}},
 		}, &validations.OSSPluginRequestValidator{})
 
 		handler.Eval(context)
 		require.Equal(t, true, context.Firing)
 		require.Equal(t, "true = true", context.ConditionEvals)
-		require.ElementsMatch(t, context.EvalMatches, []*EvalMatch{})
+		require.ElementsMatch(t, context.EvalMatches, []*EvalMatch{match})
 	})
 
 	t.Run("Show return triggered with single passing condition2", func(t *testing.T) {
@@ -232,8 +233,9 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 	})
 }
 
-//TODO: Create an eval match for cases where we should return data.
-func makeMatchWithValue(v float64) *EvalMatch {
+func makeMatchWithValue(t *testing.T, v float64) *EvalMatch {
+	t.Helper()
+
 	return &EvalMatch{
 		Metric: "High value",
 		Value:  null.FloatFrom(v),


### PR DESCRIPTION
On alerts that have multiple conditions and one of them results in no data, it is hard to know which condition had the resulted of no data at that time.

With this, we create an eval match (which is saved to the database) on the condition so that we can keep a history of it.