### PR TITLE
Azure monitor: Make sure alert rule editor is not enabled when template variables are being used

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/variables.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/variables.ts
@@ -1,0 +1,51 @@
+import { CustomVariableModel, initialVariableModelState, VariableHide } from 'app/features/variables/types';
+
+export const subscriptionsVariable: CustomVariableModel = {
+  ...initialVariableModelState,
+  id: 'subs',
+  name: 'subs',
+  index: 3,
+  current: { value: ['sub-foo', 'sub-baz'], text: 'sub-foo + sub-baz', selected: true },
+  options: [
+    { selected: true, value: 'sub-foo', text: 'sub-foo' },
+    { selected: false, value: 'sub-bar', text: 'sub-bar' },
+    { selected: true, value: 'sub-baz', text: 'sub-baz' },
+  ],
+  multi: true,
+  includeAll: false,
+  query: '',
+  hide: VariableHide.dontHide,
+  type: 'custom',
+};
+
+export const singleVariable: CustomVariableModel = {
+  ...initialVariableModelState,
+  id: 'var1',
+  name: 'var1',
+  index: 0,
+  current: { value: 'var1-foo', text: 'var1-foo', selected: true },
+  options: [{ value: 'var1-foo', text: 'var1-foo', selected: true }],
+  multi: false,
+  includeAll: false,
+  query: '',
+  hide: VariableHide.dontHide,
+  type: 'custom',
+};
+
+export const multiVariable: CustomVariableModel = {
+  ...initialVariableModelState,
+  id: 'var3',
+  name: 'var3',
+  index: 2,
+  current: { value: ['var3-foo', 'var3-baz'], text: 'var3-foo + var3-baz', selected: true },
+  options: [
+    { selected: true, value: 'var3-foo', text: 'var3-foo' },
+    { selected: false, value: 'var3-bar', text: 'var3-bar' },
+    { selected: true, value: 'var3-baz', text: 'var3-baz' },
+  ],
+  multi: true,
+  includeAll: false,
+  query: '',
+  hide: VariableHide.dontHide,
+  type: 'custom',
+};

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.test.ts
@@ -4,7 +4,6 @@ import { TemplateSrv } from 'app/features/templating/template_srv';
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { AzureDataSourceJsonData, AzureQueryType, DatasourceValidationResult } from '../types';
 import createMockQuery from '../__mocks__/query';
-import { CustomVariableModel, initialVariableModelState, VariableHide } from 'app/features/variables/types';
 import { singleVariable, subscriptionsVariable } from '../__mocks__/variables';
 
 const templateSrv = new TemplateSrv();
@@ -489,23 +488,25 @@ describe('AzureMonitorDatasource', () => {
     });
 
     describe('When performing targetContainsTemplate', () => {
-      const query = createMockQuery();
       it('should return false when no variable is being used', () => {
+        const query = createMockQuery();
         query.queryType = AzureQueryType.AzureMonitor;
         expect(ctx.ds.targetContainsTemplate(query)).toEqual(false);
       });
 
       it('should return true when subscriptions field is using a variable', () => {
+        const query = createMockQuery();
         const templateSrv = new TemplateSrv();
         templateSrv.init([subscriptionsVariable]);
 
         const ds = new AzureMonitorDatasource(ctx.instanceSettings, templateSrv);
         query.queryType = AzureQueryType.AzureMonitor;
-        query.subscription = '$subs';
+        query.subscription = `$${subscriptionsVariable.name}`;
         expect(ds.targetContainsTemplate(query)).toEqual(true);
       });
 
       it('should return false when a variable is used in a different part of the query', () => {
+        const query = createMockQuery();
         const templateSrv = new TemplateSrv();
         templateSrv.init([singleVariable]);
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_resource_graph/azure_resource_graph_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_resource_graph/azure_resource_graph_datasource.test.ts
@@ -1,64 +1,14 @@
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { backendSrv } from 'app/core/services/backend_srv';
 import AzureResourceGraphDatasource from './azure_resource_graph_datasource';
-import { CustomVariableModel, initialVariableModelState, VariableHide } from 'app/features/variables/types';
-
-const single: CustomVariableModel = {
-  ...initialVariableModelState,
-  id: 'var1',
-  name: 'var1',
-  index: 0,
-  current: { value: 'var1-foo', text: 'var1-foo', selected: true },
-  options: [{ value: 'var1-foo', text: 'var1-foo', selected: true }],
-  multi: false,
-  includeAll: false,
-  query: '',
-  hide: VariableHide.dontHide,
-  type: 'custom',
-};
-
-const multi: CustomVariableModel = {
-  ...initialVariableModelState,
-  id: 'var3',
-  name: 'var3',
-  index: 2,
-  current: { value: ['var3-foo', 'var3-baz'], text: 'var3-foo + var3-baz', selected: true },
-  options: [
-    { selected: true, value: 'var3-foo', text: 'var3-foo' },
-    { selected: false, value: 'var3-bar', text: 'var3-bar' },
-    { selected: true, value: 'var3-baz', text: 'var3-baz' },
-  ],
-  multi: true,
-  includeAll: false,
-  query: '',
-  hide: VariableHide.dontHide,
-  type: 'custom',
-};
-
-const subs: CustomVariableModel = {
-  ...initialVariableModelState,
-  id: 'subs',
-  name: 'subs',
-  index: 3,
-  current: { value: ['sub-foo', 'sub-baz'], text: 'sub-foo + sub-baz', selected: true },
-  options: [
-    { selected: true, value: 'sub-foo', text: 'sub-foo' },
-    { selected: false, value: 'sub-bar', text: 'sub-bar' },
-    { selected: true, value: 'sub-baz', text: 'sub-baz' },
-  ],
-  multi: true,
-  includeAll: false,
-  query: '',
-  hide: VariableHide.dontHide,
-  type: 'custom',
-};
+import { multiVariable, singleVariable, subscriptionsVariable } from '../__mocks__/variables';
 
 const templateSrv = new TemplateSrv({
-  getVariables: () => [subs, single, multi],
+  getVariables: () => [subscriptionsVariable, singleVariable, multiVariable],
   getVariableWithName: jest.fn(),
   getFilteredVariables: jest.fn(),
 });
-templateSrv.init([subs, single, multi]);
+templateSrv.init([subscriptionsVariable, singleVariable, multiVariable]);
 
 jest.mock('app/core/services/backend_srv');
 jest.mock('@grafana/runtime', () => ({

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_resource_graph/azure_resource_graph_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_resource_graph/azure_resource_graph_datasource.test.ts
@@ -112,6 +112,18 @@ describe('AzureResourceGraphDatasource', () => {
       expect(ds.targetContainsTemplate(query)).toEqual(true);
     });
 
+    it('should return true when resource field is using a variable in the subscriptions field', () => {
+      const query = createMockQuery();
+      const templateSrv = new TemplateSrv();
+      templateSrv.init([multiVariable]);
+
+      const ds = new AzureMonitorDatasource(ctx.instanceSettings, templateSrv);
+      query.queryType = AzureQueryType.AzureResourceGraph;
+      query.subscriptions = [multiVariable.name];
+      query.azureResourceGraph = { query: `$${multiVariable.name}` };
+      expect(ds.targetContainsTemplate(query)).toEqual(true);
+    });
+
     it('should return false when a variable is used in a different part of the query', () => {
       const query = createMockQuery();
       const templateSrv = new TemplateSrv();

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
@@ -14,7 +14,7 @@ import {
   ScopedVars,
 } from '@grafana/data';
 import { forkJoin, Observable, of } from 'rxjs';
-import { getTemplateSrv, TemplateSrv } from '@grafana/runtime';
+import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
 import InsightsAnalyticsDatasource from './insights_analytics/insights_analytics_datasource';
 import { datasourceMigrations } from './utils/migrateQuery';
 import { map } from 'rxjs/operators';
@@ -129,6 +129,23 @@ export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDa
     }
 
     return of({ state: LoadingState.Done, data: [] });
+  }
+
+  targetContainsTemplate(query: AzureMonitorQuery) {
+    if (query.subscription && this.templateSrv.variableExists(query.subscription)) {
+      return true;
+    }
+
+    let subQuery;
+    if (query.queryType === AzureQueryType.AzureMonitor) {
+      subQuery = JSON.stringify(query.azureMonitor);
+    } else if (query.queryType === AzureQueryType.LogAnalytics) {
+      subQuery = JSON.stringify(query.azureLogAnalytics);
+    } else if (query.queryType === AzureQueryType.AzureResourceGraph) {
+      subQuery = JSON.stringify([query.azureResourceGraph, query.subscriptions]);
+    }
+
+    return !!(subQuery && this.templateSrv.variableExists(subQuery));
   }
 
   async annotationQuery(options: any) {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
@@ -145,7 +145,7 @@ export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDa
       subQuery = JSON.stringify([query.azureResourceGraph, query.subscriptions]);
     }
 
-    return !!(subQuery && this.templateSrv.variableExists(subQuery));
+    return !!subQuery && this.templateSrv.variableExists(subQuery);
   }
 
   async annotationQuery(options: any) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Checks if the currently active subquery contains a variable. This is necessary because otherwise the alerting rule editor will be enabled. 

**Which issue(s) this PR fixes**:

Fixes #40249


