### PR TITLE
Dashboards: 'Copy' is no longer added to new dashboard titles

### DIFF
--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.test.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { SaveDashboardAsForm } from './SaveDashboardAsForm';
+import { SaveDashboardAsForm, SaveDashboardAsFormProps } from './SaveDashboardAsForm';
 import { DashboardModel } from 'app/features/dashboard/state';
 import { act } from 'react-dom/test-utils';
 import * as api from 'app/features/manage-dashboards/state/actions';
@@ -26,7 +26,11 @@ const prepareDashboardMock = (panel: any) => {
     getSaveModelClone: () => json,
   };
 };
-const renderAndSubmitForm = async (dashboard: any, submitSpy: any) => {
+const renderAndSubmitForm = async (
+  dashboard: unknown,
+  submitSpy: jest.Mock,
+  otherProps: Partial<SaveDashboardAsFormProps> = {}
+) => {
   const container = mount(
     <SaveDashboardAsForm
       dashboard={dashboard as DashboardModel}
@@ -36,6 +40,7 @@ const renderAndSubmitForm = async (dashboard: any, submitSpy: any) => {
         submitSpy(jsonModel);
         return {};
       }}
+      {...otherProps}
     />
   );
 
@@ -51,14 +56,29 @@ describe('SaveDashboardAsForm', () => {
       jest.spyOn(api, 'searchFolders').mockResolvedValue([]);
       const spy = jest.fn();
 
-      await renderAndSubmitForm(prepareDashboardMock({}), spy);
+      await renderAndSubmitForm(prepareDashboardMock({}), spy, {
+        isNew: true,
+      });
 
       expect(spy).toBeCalledTimes(1);
       const savedDashboardModel = spy.mock.calls[0][0];
       expect(savedDashboardModel.id).toBe(null);
-      expect(savedDashboardModel.title).toBe('name Copy');
+      expect(savedDashboardModel.title).toBe('name');
       expect(savedDashboardModel.editable).toBe(true);
       expect(savedDashboardModel.hideControls).toBe(false);
+    });
+
+    it("appends 'Copy' to the name when the dashboard isnt new", async () => {
+      jest.spyOn(api, 'searchFolders').mockResolvedValue([]);
+      const spy = jest.fn();
+
+      await renderAndSubmitForm(prepareDashboardMock({}), spy, {
+        isNew: false,
+      });
+
+      expect(spy).toBeCalledTimes(1);
+      const savedDashboardModel = spy.mock.calls[0][0];
+      expect(savedDashboardModel.title).toBe('name Copy');
     });
   });
 

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
@@ -34,14 +34,19 @@ const getSaveAsDashboardClone = (dashboard: DashboardModel) => {
   return clone;
 };
 
-export const SaveDashboardAsForm: React.FC<SaveDashboardFormProps & { isNew?: boolean }> = ({
+export interface SaveDashboardAsFormProps extends SaveDashboardFormProps {
+  isNew?: boolean;
+}
+
+export const SaveDashboardAsForm: React.FC<SaveDashboardAsFormProps> = ({
   dashboard,
+  isNew,
   onSubmit,
   onCancel,
   onSuccess,
 }) => {
   const defaultValues: SaveDashboardAsFormDTO = {
-    title: `${dashboard.title} Copy`,
+    title: isNew ? dashboard.title : `${dashboard.title} Copy`,
     $folder: {
       id: dashboard.meta.folderId,
       title: dashboard.meta.folderTitle,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the "Save Dashboard" form for new Dashboards from appending "Copy" to the end of the the title, even when not needed.

Also while I was in the area I made a minor change to SaveDashboardModalProxy (which is what picks which dashboard to return) to be a bit clearer about intent. 

**Which issue(s) this PR fixes**:

Fixes #41312

**Special notes for your reviewer**:

I'm not 100% sure if this is the right approach - definitely open to feedback!!! 

Generating the title (still) doesn't do any uniqueness checks (to automatically append copy, or some other discriminator) if the title isn't unique. That is just handled by the existing on-save logic.

