### PR TITLE
prometheus: monaco: fix a corner-case with quotes

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -140,6 +140,10 @@ describe('situation', () => {
       otherLabels: [{ name: 'job', value: 'j1', op: '=' }],
     });
 
+    assertSituation('something{job="j1"^}', null);
+    assertSituation('something{job="j1" ^ }', null);
+    assertSituation('something{job="j1" ^   ,   }', null);
+
     assertSituation('{job=^,host="h1"}', {
       type: 'IN_LABEL_SELECTOR_WITH_LABEL_NAME',
       labelName: 'job',


### PR DESCRIPTION
in the prometheus monaco-based query field we have this problem:
- enter a query like `go_goroutines{job="prometheus"}`
- move the cursor to be between the `"` and the `}`
- delete the `"` to the left, and write the `"` again
- at this point you will get autocomplete for a label-name. it should not offer such an autocomplete, it should only offer it after you add a ","

this pull-request fixes the problem.