### PR TITLE
Plugins: Add OAuth pass-through logic to api/ds/query endpoint

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -84,7 +86,7 @@ func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDTO dtos.MetricReq
 		return response.Error(http.StatusForbidden, "Access denied", err)
 	}
 
-	req, err := hs.createRequest(ds, request)
+	req, err := hs.createRequest(c.Req.Context(), ds, request)
 	if err != nil {
 		return response.Error(http.StatusBadRequest, "Request formation error", err)
 	}
@@ -224,10 +226,22 @@ func (hs *HTTPServer) QueryMetrics(c *models.ReqContext, reqDto dtos.MetricReque
 }
 
 // nolint:staticcheck // plugins.DataQueryResponse deprecated
-func (hs *HTTPServer) createRequest(ds *models.DataSource, query plugins.DataQuery) (*backend.QueryDataRequest, error) {
+func (hs *HTTPServer) createRequest(ctx context.Context, ds *models.DataSource,
+	query plugins.DataQuery) (*backend.QueryDataRequest, error) {
 	instanceSettings, err := adapters.ModelToInstanceSettings(ds, hs.decryptSecureJsonDataFn())
 	if err != nil {
 		return nil, err
+	}
+
+	if query.Headers == nil {
+		query.Headers = make(map[string]string)
+	}
+
+	if hs.OAuthTokenService.IsOAuthPassThruEnabled(ds) {
+		if token := hs.OAuthTokenService.GetCurrentOAuthToken(ctx, query.User); token != nil {
+			delete(query.Headers, "Authorization")
+			query.Headers["Authorization"] = fmt.Sprintf("%s %s", token.Type(), token.AccessToken)
+		}
 	}
 
 	req := &backend.QueryDataRequest{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Adds missing logic that was previously picked up by Core plugins when they were routed through the `DataQuery` adapter (https://github.com/grafana/grafana/blob/main/pkg/tsdb/data_plugin_adapter.go#L43). Now that the `api/ds/query` flow is used, the logic needs to be copied over there too.

<!--
**Which issue(s) this PR fixes**:



- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"



#Fixes #

**Special notes for your reviewer**:
-->
