### PR TITLE
Prometheus: Fix showing of errors

### DIFF
--- a/pkg/tsdb/prometheus/time_series_query.go
+++ b/pkg/tsdb/prometheus/time_series_query.go
@@ -72,9 +72,8 @@ func (s *Service) executeTimeSeriesQuery(ctx context.Context, req *backend.Query
 				plog.Error("Range query failed", "query", query.Expr, "err", err)
 				result.Responses[query.RefId] = backend.DataResponse{Error: err}
 				continue
-			} else {
-				response[RangeQueryType] = rangeResponse
 			}
+			response[RangeQueryType] = rangeResponse
 		}
 
 		if query.InstantQuery {
@@ -83,11 +82,12 @@ func (s *Service) executeTimeSeriesQuery(ctx context.Context, req *backend.Query
 				plog.Error("Instant query failed", "query", query.Expr, "err", err)
 				result.Responses[query.RefId] = backend.DataResponse{Error: err}
 				continue
-			} else {
-				response[InstantQueryType] = instantResponse
 			}
+			response[InstantQueryType] = instantResponse
 		}
 
+		// This is a special case
+		// If exemplar query returns error, we want to only log it and continue with other results processing
 		if query.ExemplarQuery {
 			exemplarResponse, err := client.QueryExemplars(ctx, query.Expr, timeRange.Start, timeRange.End)
 			if err != nil {

--- a/pkg/tsdb/prometheus/time_series_query.go
+++ b/pkg/tsdb/prometheus/time_series_query.go
@@ -71,6 +71,7 @@ func (s *Service) executeTimeSeriesQuery(ctx context.Context, req *backend.Query
 			if err != nil {
 				plog.Error("Range query failed", "query", query.Expr, "err", err)
 				result.Responses[query.RefId] = backend.DataResponse{Error: err}
+				continue
 			} else {
 				response[RangeQueryType] = rangeResponse
 			}
@@ -81,6 +82,7 @@ func (s *Service) executeTimeSeriesQuery(ctx context.Context, req *backend.Query
 			if err != nil {
 				plog.Error("Instant query failed", "query", query.Expr, "err", err)
 				result.Responses[query.RefId] = backend.DataResponse{Error: err}
+				continue
 			} else {
 				response[InstantQueryType] = instantResponse
 			}
@@ -90,7 +92,6 @@ func (s *Service) executeTimeSeriesQuery(ctx context.Context, req *backend.Query
 			exemplarResponse, err := client.QueryExemplars(ctx, query.Expr, timeRange.Start, timeRange.End)
 			if err != nil {
 				plog.Error("Exemplar query failed", "query", query.Expr, "err", err)
-				result.Responses[query.RefId] = backend.DataResponse{Error: err}
 			} else {
 				response[ExemplarQueryType] = exemplarResponse
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Errors in Prometheus are not shown. During this refactor https://github.com/grafana/grafana/pull/40765/files, the `continue` was removed, but it is needed, because we can have multiple types of queries and we want to show error if any of these occurs. Then we need to exit the loop so the error is added for that refId response. Otherwise we send empty frame and error message is lost. 

We also don't want to show exemplar errors (maybe we want in the future, but that's how it's been done previously) and we just want to log them. 

**Which issue(s) this PR fixes**:

Fix issue reported here https://raintank-corp.slack.com/archives/C8C98CETS/p1636110948090600?thread_ts=1634291058.343200&cid=C8C98CETS

