### PR TITLE
[8.2.x] Elasticsearch: use field configured in query editor as field for date_histogram aggregations

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -95,7 +95,7 @@ export class ElasticQueryBuilder {
     const esAgg: any = {};
     const settings = aggDef.settings || {};
     esAgg.interval = settings.interval;
-    esAgg.field = this.timeField;
+    esAgg.field = aggDef.field || this.timeField;
     esAgg.min_doc_count = settings.min_doc_count || 0;
     esAgg.extended_bounds = { min: '$timeFrom', max: '$timeTo' };
     esAgg.format = 'epoch_millis';

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
@@ -841,5 +841,44 @@ describe('ElasticQueryBuilder', () => {
 
       expect(serialDiff.lag).toBe(1);
     });
+
+    describe('date_histogram', () => {
+      describe('field property', () => {
+        it('should use timeField from datasource when not specified', () => {
+          const query = builder.build({
+            refId: 'A',
+            metrics: [{ type: 'count', id: '1' }],
+            timeField: '@timestamp',
+            bucketAggs: [
+              {
+                type: 'date_histogram',
+                id: '2',
+                settings: { min_doc_count: '1' },
+              },
+            ],
+          });
+
+          expect(query.aggs['2'].date_histogram.field).toBe('@timestamp');
+        });
+
+        it('should use field from bucket agg when specified', () => {
+          const query = builder.build({
+            refId: 'A',
+            metrics: [{ type: 'count', id: '1' }],
+            timeField: '@timestamp',
+            bucketAggs: [
+              {
+                type: 'date_histogram',
+                id: '2',
+                field: '@time',
+                settings: { min_doc_count: '1' },
+              },
+            ],
+          });
+
+          expect(query.aggs['2'].date_histogram.field).toBe('@time');
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Backporting d524dc610861f4fb634f24a28a6a3949802f0d14 from https://github.com/grafana/grafana/pull/41258