### PR TITLE
Chore: cleanup ES query_builder test

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
@@ -888,7 +888,6 @@ describe('ElasticQueryBuilder', () => {
 
       describe('field property', () => {
         it('should use timeField from datasource when not specified', () => {
-          const expectedTimezone = 'America/Los_angeles';
           const query = builder.build({
             refId: 'A',
             metrics: [{ type: 'count', id: '1' }],
@@ -897,7 +896,7 @@ describe('ElasticQueryBuilder', () => {
               {
                 type: 'date_histogram',
                 id: '2',
-                settings: { min_doc_count: '1', timeZone: expectedTimezone },
+                settings: { min_doc_count: '1' },
               },
             ],
           });
@@ -906,7 +905,6 @@ describe('ElasticQueryBuilder', () => {
         });
 
         it('should use field from bucket agg when specified', () => {
-          const expectedTimezone = 'America/Los_angeles';
           const query = builder.build({
             refId: 'A',
             metrics: [{ type: 'count', id: '1' }],
@@ -916,7 +914,7 @@ describe('ElasticQueryBuilder', () => {
                 type: 'date_histogram',
                 id: '2',
                 field: '@time',
-                settings: { min_doc_count: '1', timeZone: expectedTimezone },
+                settings: { min_doc_count: '1' },
               },
             ],
           });


### PR DESCRIPTION
Just some cleanup on 2 recently introduced tests: the timezone setting is not being tested in those 2 scenarios, it was a leftover from copying the test from a few lines above.