### PR TITLE
DataProxy: Fix overriding response body when response is a WebSocket upgrade

### DIFF
--- a/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
+++ b/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
@@ -96,7 +96,7 @@ func executeMiddleware(next http.RoundTripper, datasourceLabel prometheus.Labels
 			return nil, err
 		}
 
-		if res != nil {
+		if res != nil && res.StatusCode != http.StatusSwitchingProtocols {
 			res.Body = httpclient.CountBytesReader(res.Body, func(bytesRead int64) {
 				responseSizeSummary.Observe(float64(bytesRead))
 			})

--- a/pkg/infra/httpclient/httpclientprovider/response_limit_middleware.go
+++ b/pkg/infra/httpclient/httpclientprovider/response_limit_middleware.go
@@ -21,7 +21,10 @@ func ResponseLimitMiddleware(limit int64) sdkhttpclient.Middleware {
 				return nil, err
 			}
 
-			res.Body = httpclient.MaxBytesReader(res.Body, limit)
+			if res != nil && res.StatusCode != http.StatusSwitchingProtocols {
+				res.Body = httpclient.MaxBytesReader(res.Body, limit)
+			}
+
 			return res, nil
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
When a request going through Grafana data source proxy responds with a websocket upgrade response we cannot override the response body since it produces an error, see issue for details. This problem seems to have been introduced in Grafana v8.0 by #38962. In addition #40303 added same problem.

**Which issue(s) this PR fixes**:
Fixes #41292 

**Special notes for your reviewer**:

