### PR TITLE
Chore: Improve wording of 'Now delay' option

### DIFF
--- a/docs/sources/dashboards/time-range-controls.md
+++ b/docs/sources/dashboards/time-range-controls.md
@@ -105,7 +105,7 @@ For more advanced time settings, click the **Dashboard settings** (gear) icon at
   - **Local browser time -** The time zone configured for the viewing user browser is used. This is usually the same time zone as set on the computer.
   - Standard [ISO 8601 time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), including UTC.
 - **Auto-refresh -** Customize the options displayed for relative time and the auto-refresh options. Entries are comma separated and accept any valid time unit.
-- **Now delay now- -** Override the `now` value by entering a time delay. Most commonly, this feature is used to accommodate known delays in data aggregation to avoid null values.
+- **Now delay** Override the `now` value by entering a time delay. Most commonly, this feature is used to accommodate known delays in data aggregation to avoid null values.
 - **Hide time picker -** Select this option if you do not want Grafana to display the time picker.
 
 ## Panel time overrides and timeshift

--- a/docs/sources/dashboards/time-range-controls.md
+++ b/docs/sources/dashboards/time-range-controls.md
@@ -105,7 +105,7 @@ For more advanced time settings, click the **Dashboard settings** (gear) icon at
   - **Local browser time -** The time zone configured for the viewing user browser is used. This is usually the same time zone as set on the computer.
   - Standard [ISO 8601 time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones), including UTC.
 - **Auto-refresh -** Customize the options displayed for relative time and the auto-refresh options. Entries are comma separated and accept any valid time unit.
-- **Now delay** Override the `now` value by entering a time delay. Most commonly, this feature is used to accommodate known delays in data aggregation to avoid null values.
+- **Now delay -** Override the `now` time by entering a time delay. Use this option to accommodate known delays in data aggregation to avoid null values.
 - **Hide time picker -** Select this option if you do not want Grafana to display the time picker.
 
 ## Panel time overrides and timeshift

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -80,7 +80,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
           refreshIntervals={this.props.refreshIntervals}
           onRefreshIntervalChange={this.props.onRefreshIntervalChange}
         />
-        <Field label="Now delay" description="Exclude recent data that may be incomplete">
+        <Field label="Now delay" description="Exclude recent data that may be incomplete.">
           <Input
             id="now-delay-input"
             invalid={!this.state.isNowDelayValid}

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -80,10 +80,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
           refreshIntervals={this.props.refreshIntervals}
           onRefreshIntervalChange={this.props.onRefreshIntervalChange}
         />
-        <Field
-          label="Now delay now"
-          description="Enter 1m to ignore the last minute. It might contain incomplete metrics."
-        >
+        <Field label="Now delay" description="Exclude recent data that may be incomplete">
           <Input
             id="now-delay-input"
             invalid={!this.state.isNowDelayValid}


### PR DESCRIPTION
**What this PR does / why we need it**:

It looks like over the various iterations of the dashboard settings page, the wording of this Now delay option has fallen by the wayside. I gave it a quick touch up, but would greatly appreciate input from @grafana/docs-squad on this one.

From the docs:
> - **Now delay** Override the `now` value by entering a time delay. Most commonly, this feature is used to accommodate known delays in data aggregation to avoid null values.


**Which issue(s) this PR fixes**:

Relates to #21085
