### PR TITLE
DataSourceRef: use reference rather than id where possible

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -55,7 +55,7 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
       {
         refId: 'annotationQuery',
         type: 'annotationQuery',
-        datasourceId: this.id,
+        datasource: this.getRef(),
         view: 'FULL',
         crossSeriesReducer: 'REDUCE_NONE',
         perSeriesAligner: 'ALIGN_NONE',
@@ -108,7 +108,7 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
     scopedVars: ScopedVars
   ): Record<string, any> {
     return {
-      datasourceId: this.id,
+      datasource: this.getRef(),
       refId,
       intervalMs: this.intervalMs,
       type: 'timeSeriesQuery',
@@ -133,7 +133,7 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
       targets: [
         {
           refId,
-          datasourceId: this.id,
+          datasource: this.getRef(),
           queryType: QueryType.METRICS,
           metricQuery: {
             projectName: this.templateSrv.replace(projectName),
@@ -212,7 +212,7 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
             {
               refId: 'getGCEDefaultProject',
               type: 'getGCEDefaultProject',
-              datasourceId: this.id,
+              datasource: this.getRef(),
             },
           ],
         })

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -222,7 +222,7 @@ export class CloudWatchDatasource
           return {
             intervalMs: options.intervalMs,
             maxDataPoints: options.maxDataPoints,
-            datasourceId: this.id,
+            datasource: this.getRef(),
             type: 'timeSeriesQuery',
             ...item,
           };
@@ -506,7 +506,7 @@ export class CloudWatchDatasource
             refId: 'metricFindQuery',
             intervalMs: 1, // dummy
             maxDataPoints: 1, // dummy
-            datasourceId: this.id,
+            datasource: this.getRef(),
             type: 'metricFindQuery',
             subtype: subtype,
             ...parameters,
@@ -541,7 +541,7 @@ export class CloudWatchDatasource
         refId: 'A',
         intervalMs: 1, // dummy
         maxDataPoints: 1, // dummy
-        datasourceId: this.id,
+        datasource: this.getRef(),
         type: 'logAction',
         subtype: subtype,
         ...param,
@@ -773,7 +773,7 @@ export class CloudWatchDatasource
         queries: [
           {
             refId: 'annotationQuery',
-            datasourceId: this.id,
+            datasource: this.getRef(),
             type: 'annotationQuery',
             ...parameters,
           },

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -222,9 +222,9 @@ export class CloudWatchDatasource
           return {
             intervalMs: options.intervalMs,
             maxDataPoints: options.maxDataPoints,
-            datasource: this.getRef(),
             type: 'timeSeriesQuery',
             ...item,
+            datasource: this.getRef(),
           };
         }
       );

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -1,4 +1,4 @@
-import { DataQuery, SelectableValue } from '@grafana/data';
+import { DataQuery, DataSourceRef, SelectableValue } from '@grafana/data';
 import { AwsAuthDataSourceSecureJsonData, AwsAuthDataSourceJsonData } from '@grafana/aws-sdk';
 
 export interface CloudWatchMetricsQuery extends DataQuery {
@@ -314,7 +314,7 @@ export interface MetricRequest {
 
 export interface MetricQuery {
   [key: string]: any;
-  datasourceId: number;
+  datasource: DataSourceRef;
   refId?: string;
   maxDataPoints?: number;
   intervalMs?: number;

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -320,20 +320,6 @@ export interface MetricQuery {
   intervalMs?: number;
 }
 
-// interface TsdbQuery {
-// 	TimeRange *TimeRange
-// 	Queries   []*Query
-// 	Debug     bool
-// }
-
-// type Query struct {
-// 	RefId         string
-// 	Model         *simplejson.Json
-// 	DataSource    *models.DataSource
-// 	MaxDataPoints int64
-// 	IntervalMs    int64
-// }
-
 export interface ExecutedQueryPreview {
   id: string;
   executedQuery: string;

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
@@ -8,7 +8,13 @@ import {
   AzureQueryType,
   DatasourceValidationResult,
 } from '../types';
-import { DataQueryRequest, DataQueryResponse, ScopedVars, DataSourceInstanceSettings } from '@grafana/data';
+import {
+  DataQueryRequest,
+  DataQueryResponse,
+  ScopedVars,
+  DataSourceInstanceSettings,
+  DataSourceRef,
+} from '@grafana/data';
 import { getTemplateSrv, DataSourceWithBackend } from '@grafana/runtime';
 import { Observable, from } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
@@ -17,7 +23,7 @@ import { isGUIDish } from '../components/ResourcePicker/utils';
 import { interpolateVariable, routeNames } from '../utils/common';
 
 interface AdhocQuery {
-  datasourceId: number;
+  datasource: DataSourceRef;
   path: string;
   resultFormat: string;
 }
@@ -234,7 +240,7 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
 
     const queries = [
       {
-        datasourceId: this.id,
+        datasource: this.getRef(),
         path: path,
         resultFormat: 'table',
       },

--- a/public/app/plugins/datasource/mssql/datasource.ts
+++ b/public/app/plugins/datasource/mssql/datasource.ts
@@ -74,7 +74,7 @@ export class MssqlDatasource extends DataSourceWithBackend<MssqlQuery, MssqlOpti
   applyTemplateVariables(target: MssqlQuery, scopedVars: ScopedVars): Record<string, any> {
     return {
       refId: target.refId,
-      datasourceId: this.id,
+      datasource: this.getRef(),
       rawSql: this.templateSrv.replace(target.rawSql, scopedVars, this.interpolateVariable),
       format: target.format,
     };
@@ -87,7 +87,7 @@ export class MssqlDatasource extends DataSourceWithBackend<MssqlQuery, MssqlOpti
 
     const query = {
       refId: options.annotation.name,
-      datasourceId: this.id,
+      datasource: this.getRef(),
       rawSql: this.templateSrv.replace(options.annotation.rawQuery, options.scopedVars, this.interpolateVariable),
       format: 'table',
     };
@@ -127,7 +127,7 @@ export class MssqlDatasource extends DataSourceWithBackend<MssqlQuery, MssqlOpti
 
     const interpolatedQuery = {
       refId: refId,
-      datasourceId: this.id,
+      datasource: this.getRef(),
       rawSql: this.templateSrv.replace(query, {}, this.interpolateVariable),
       format: 'table',
     };
@@ -169,7 +169,7 @@ export class MssqlDatasource extends DataSourceWithBackend<MssqlQuery, MssqlOpti
                 refId: 'A',
                 intervalMs: 1,
                 maxDataPoints: 1,
-                datasourceId: this.id,
+                datasource: this.getRef(),
                 rawSql: 'SELECT 1',
                 format: 'table',
               },

--- a/public/app/plugins/datasource/mysql/datasource.ts
+++ b/public/app/plugins/datasource/mysql/datasource.ts
@@ -80,7 +80,7 @@ export class MysqlDatasource extends DataSourceWithBackend<MySQLQuery, MySQLOpti
     const queryModel = new MySQLQueryModel(target, this.templateSrv, scopedVars);
     return {
       refId: target.refId,
-      datasourceId: this.id,
+      datasource: this.getRef(),
       rawSql: queryModel.render(this.interpolateVariable as any),
       format: target.format,
     };
@@ -95,7 +95,7 @@ export class MysqlDatasource extends DataSourceWithBackend<MySQLQuery, MySQLOpti
 
     const query = {
       refId: options.annotation.name,
-      datasourceId: this.id,
+      datasource: this.getRef(),
       rawSql: this.templateSrv.replace(options.annotation.rawQuery, options.scopedVars, this.interpolateVariable),
       format: 'table',
     };
@@ -135,7 +135,7 @@ export class MysqlDatasource extends DataSourceWithBackend<MySQLQuery, MySQLOpti
 
     const interpolatedQuery = {
       refId: refId,
-      datasourceId: this.id,
+      datasource: this.getRef(),
       rawSql,
       format: 'table',
     };
@@ -179,7 +179,7 @@ export class MysqlDatasource extends DataSourceWithBackend<MySQLQuery, MySQLOpti
                 refId: 'A',
                 intervalMs: 1,
                 maxDataPoints: 1,
-                datasourceId: this.id,
+                datasource: this.getRef(),
                 rawSql: 'SELECT 1',
                 format: 'table',
               },

--- a/public/app/plugins/datasource/postgres/datasource.ts
+++ b/public/app/plugins/datasource/postgres/datasource.ts
@@ -82,7 +82,7 @@ export class PostgresDatasource extends DataSourceWithBackend<PostgresQuery, Pos
     const queryModel = new PostgresQueryModel(target, this.templateSrv, scopedVars);
     return {
       refId: target.refId,
-      datasourceId: this.id,
+      datasource: this.getRef(),
       rawSql: queryModel.render(this.interpolateVariable as any),
       format: target.format,
     };
@@ -97,7 +97,7 @@ export class PostgresDatasource extends DataSourceWithBackend<PostgresQuery, Pos
 
     const query = {
       refId: options.annotation.name,
-      datasourceId: this.id,
+      datasource: this.getRef(),
       rawSql: this.templateSrv.replace(options.annotation.rawQuery, options.scopedVars, this.interpolateVariable),
       format: 'table',
     };
@@ -137,7 +137,7 @@ export class PostgresDatasource extends DataSourceWithBackend<PostgresQuery, Pos
 
     const interpolatedQuery = {
       refId: refId,
-      datasourceId: this.id,
+      datasource: this.getRef(),
       rawSql,
       format: 'table',
     };

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -672,7 +672,7 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
       interval: step,
       queryType: PromQueryType.timeSeriesQuery,
       refId: 'X',
-      datasourceId: this.id,
+      datasource: this.getRef(),
     };
 
     return await lastValueFrom(


### PR DESCRIPTION
After #41172, the query endpoint will now prefers to accept the type+uid rather than the internal `datasourceId`

This PR updates many datasources that call the endpoint directly so that we begin to wean ourselves from using internal ids primarily