### PR TITLE
POC: support color a field using the color props from a sibling

### DIFF
--- a/packages/grafana-data/src/field/scale.ts
+++ b/packages/grafana-data/src/field/scale.ts
@@ -1,7 +1,7 @@
 import { isNumber } from 'lodash';
 import { GrafanaTheme2 } from '../themes/types';
 import { reduceField, ReducerID } from '../transformations/fieldReducer';
-import { Field, FieldConfig, FieldType, NumericRange, Threshold } from '../types';
+import { DataFrame, Field, FieldConfig, FieldType, NumericRange, Threshold } from '../types';
 import { getFieldColorModeForField } from './fieldColor';
 import { getActiveThresholdForValue } from './thresholds';
 
@@ -13,13 +13,13 @@ export interface ColorScaleValue {
 
 export type ScaleCalculator = (value: number) => ColorScaleValue;
 
-export function getScaleCalculator(field: Field, theme: GrafanaTheme2): ScaleCalculator {
+export function getScaleCalculator(field: Field, theme: GrafanaTheme2, frame?: DataFrame): ScaleCalculator {
   if (field.type === FieldType.boolean) {
     return getBooleanScaleCalculator(field, theme);
   }
 
   const mode = getFieldColorModeForField(field);
-  const getColor = mode.getCalculator(field, theme);
+  const getColor = mode.getCalculator(field, theme, frame);
   const info = field.state?.range ?? getMinMaxAndDelta(field);
 
   return (value: number) => {

--- a/packages/grafana-data/src/types/fieldColor.ts
+++ b/packages/grafana-data/src/types/fieldColor.ts
@@ -7,6 +7,7 @@ export enum FieldColorModeId {
   PaletteSaturated = 'palette-saturated',
   ContinuousGrYlRd = 'continuous-GrYlRd',
   Fixed = 'fixed',
+  Field = 'field',
 }
 
 /**
@@ -19,6 +20,8 @@ export interface FieldColor {
   fixedColor?: string;
   /** Some visualizations need to know how to assign a series color from by value color schemes */
   seriesBy?: FieldColorSeriesByMode;
+  /** Pick the field color based a sibling field */
+  fromField?: string;
 }
 
 /**

--- a/packages/grafana-ui/src/components/OptionsUI/fieldColor.tsx
+++ b/packages/grafana-ui/src/components/OptionsUI/fieldColor.tsx
@@ -17,12 +17,14 @@ import { useStyles2, useTheme2 } from '../../themes/ThemeContext';
 import { css } from '@emotion/css';
 import { Field } from '../Forms/Field';
 import { RadioButtonGroup } from '../Forms/RadioButtonGroup/RadioButtonGroup';
+import { FieldNamePicker } from '../MatchersUI/FieldNamePicker';
 
 export const FieldColorEditor: React.FC<FieldConfigEditorProps<FieldColor | undefined, FieldColorConfigSettings>> = ({
   value,
   onChange,
   item,
   id,
+  context,
 }) => {
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
@@ -54,11 +56,19 @@ export const FieldColorEditor: React.FC<FieldConfigEditorProps<FieldColor | unde
     });
   };
 
-  const onColorChange = (color?: string) => {
+  const onColorChange = (fixedColor?: string) => {
     onChange({
       ...value,
       mode,
-      fixedColor: color,
+      fixedColor,
+    });
+  };
+
+  const onFromFieldChange = (fromField?: string) => {
+    onChange({
+      ...value,
+      mode,
+      fromField,
     });
   };
 
@@ -86,6 +96,31 @@ export const FieldColorEditor: React.FC<FieldConfigEditorProps<FieldColor | unde
         />
         <ColorValueEditor value={value?.fixedColor} onChange={onColorChange} />
       </div>
+    );
+  }
+
+  if (mode === FieldColorModeId.Field) {
+    return (
+      <>
+        <div style={{ marginBottom: theme.spacing(2) }}>
+          <Select
+            menuShouldPortal
+            minMenuHeight={200}
+            options={options}
+            value={mode}
+            onChange={onModeChange}
+            inputId={id}
+          />
+        </div>
+        <Field label="Field">
+          <FieldNamePicker
+            value={value?.fromField ?? ''}
+            context={context}
+            onChange={onFromFieldChange}
+            item={{} as any} // HACK!
+          />
+        </Field>
+      </>
     );
   }
 

--- a/packages/grafana-ui/src/components/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/components/TimeSeries/utils.ts
@@ -125,7 +125,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{ sync: DashboardCursor
     const fmt = field.display ?? defaultFormatter;
     const scaleKey = config.unit || FIXED_UNIT;
     const colorMode = getFieldColorModeForField(field);
-    const scaleColor = getFieldSeriesColor(field, theme);
+    const scaleColor = getFieldSeriesColor(field, theme, frame);
     const seriesColor = scaleColor.color;
 
     // The builder will manage unique scaleKeys and combine where appropriate

--- a/packages/grafana-ui/src/components/uPlot/PlotLegend.tsx
+++ b/packages/grafana-ui/src/components/uPlot/PlotLegend.tsx
@@ -47,8 +47,9 @@ export const PlotLegend: React.FC<PlotLegendProps> = ({
         return undefined;
       }
 
-      const label = getFieldDisplayName(field, data[fieldIndex.frameIndex]!, data);
-      const scaleColor = getFieldSeriesColor(field, theme);
+      const frame = data[fieldIndex.frameIndex]!;
+      const label = getFieldDisplayName(field, frame, data);
+      const scaleColor = getFieldSeriesColor(field, theme, frame);
       const seriesColor = scaleColor.color;
 
       return {

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -141,7 +141,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptions> = ({
 
     const scaleKey = field.config.unit || FIXED_UNIT;
     const colorMode = getFieldColorModeForField(field);
-    const scaleColor = getFieldSeriesColor(field, theme);
+    const scaleColor = getFieldSeriesColor(field, theme, frame);
     const seriesColor = scaleColor.color;
 
     builder.addSeries({

--- a/public/app/plugins/panel/histogram/Histogram.tsx
+++ b/public/app/plugins/panel/histogram/Histogram.tsx
@@ -165,7 +165,7 @@ const prepConfig = (frame: DataFrame, theme: GrafanaTheme2) => {
 
     const scaleKey = 'y';
     const colorMode = getFieldColorModeForField(field);
-    const scaleColor = getFieldSeriesColor(field, theme);
+    const scaleColor = getFieldSeriesColor(field, theme, frame);
     const seriesColor = scaleColor.color;
 
     builder.addSeries({

--- a/public/app/plugins/panel/xychart/scatter.ts
+++ b/public/app/plugins/panel/xychart/scatter.ts
@@ -86,7 +86,7 @@ function getScatterSeries(
   //----------------
   let seriesColor = dims.pointColorFixed
     ? config.theme2.visualization.getColorByName(dims.pointColorFixed)
-    : getFieldSeriesColor(y, config.theme2).color;
+    : getFieldSeriesColor(y, config.theme2, frame).color;
   let pointColor: DimensionValues<string> = () => seriesColor;
   const fieldConfig: ScatterFieldConfig = { ...defaultScatterConfig, ...y.config.custom };
   let pointColorMode = fieldColorModeRegistry.get(FieldColorModeId.PaletteClassic);


### PR DESCRIPTION
Friday afternoon POC :)  

We are exploring how to have color values based on a sibling field -- for example the Y value may be based on time, but color should be based on "build status"

This feels powerful, but also a bit of a brain twister.  If we do support this structure, it should only show up in the overrieds options, not the core optoins

![Peek 2021-11-05 14-17](https://user-images.githubusercontent.com/705951/140579996-4f49508a-e435-49a3-9e40-1810f79cd532.gif)

![Peek 2021-11-05 14-31](https://user-images.githubusercontent.com/705951/140580920-d609e946-d62e-49d1-9130-6f6aca633a5c.gif)

