### PR TITLE
Alerting: fix bug where user is able to access rules from namespaces user is not part of

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -109,9 +109,10 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 	}
 
 	alertRuleQuery := ngmodels.ListAlertRulesQuery{
-		OrgID:        c.SignedInUser.OrgId,
-		DashboardUID: dashboardUID,
-		PanelID:      panelID,
+		OrgID:         c.SignedInUser.OrgId,
+		DashboardUID:  dashboardUID,
+		PanelID:       panelID,
+		NamespaceUIDs: namespaceUIDs,
 	}
 	if err := srv.store.GetOrgAlertRules(&alertRuleQuery); err != nil {
 		ruleResponse.DiscoveryBase.Status = "error"

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -77,7 +77,7 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 	}
 
 	if len(namespaceMap) == 0 {
-		srv.log.Debug("User does not have access to any of the namespaces")
+		srv.log.Debug("User does not have access to any namespaces")
 		return response.JSON(http.StatusOK, ruleResponse)
 	}
 

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -77,7 +77,7 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 	}
 
 	if len(namespaceMap) == 0 {
-		srv.log.Debug("User has no access to any of namespaces")
+		srv.log.Debug("User does not have access to any of the namespaces")
 		return response.JSON(http.StatusOK, ruleResponse)
 	}
 

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -76,6 +76,10 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 		return ErrResp(http.StatusInternalServerError, err, "failed to get namespaces visible to the user")
 	}
 
+	if len(namespaceMap) == 0 {
+		return response.JSON(http.StatusOK, ruleResponse)
+	}
+
 	namespaceUIDs := make([]string, len(namespaceMap))
 	for k := range namespaceMap {
 		namespaceUIDs = append(namespaceUIDs, k)

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -123,6 +123,11 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 		}
 		groupId, namespaceUID, namespace := r[0], r[1], r[2]
 
+		_, ok := namespaceMap[namespaceUID]
+		if !ok {
+			continue
+		}
+
 		newGroup := &apimodels.RuleGroup{
 			Name: groupId,
 			// This doesn't make sense in our architecture

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -77,6 +77,7 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 	}
 
 	if len(namespaceMap) == 0 {
+		srv.log.Debug("User has no access to any of namespaces")
 		return response.JSON(http.StatusOK, ruleResponse)
 	}
 
@@ -126,11 +127,6 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 			continue
 		}
 		groupId, namespaceUID, namespace := r[0], r[1], r[2]
-
-		_, ok := namespaceMap[namespaceUID]
-		if !ok {
-			continue
-		}
 
 		newGroup := &apimodels.RuleGroup{
 			Name: groupId,

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -109,10 +109,9 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 	}
 
 	alertRuleQuery := ngmodels.ListAlertRulesQuery{
-		OrgID:         c.SignedInUser.OrgId,
-		DashboardUID:  dashboardUID,
-		PanelID:       panelID,
-		NamespaceUIDs: namespaceUIDs,
+		OrgID:        c.SignedInUser.OrgId,
+		DashboardUID: dashboardUID,
+		PanelID:      panelID,
 	}
 	if err := srv.store.GetOrgAlertRules(&alertRuleQuery); err != nil {
 		ruleResponse.DiscoveryBase.Status = "error"

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -154,7 +154,7 @@ func (srv RulerSrv) RouteGetRulesConfig(c *models.ReqContext) response.Response 
 	result := apimodels.NamespaceConfigResponse{}
 
 	if len(namespaceMap) == 0 {
-		srv.log.Debug("User has no access to any of namespaces")
+		srv.log.Debug("User has no access to any namespaces")
 		return response.JSON(http.StatusOK, result)
 	}
 

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -151,6 +151,12 @@ func (srv RulerSrv) RouteGetRulesConfig(c *models.ReqContext) response.Response 
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "failed to get namespaces visible to the user")
 	}
+	result := apimodels.NamespaceConfigResponse{}
+
+	if len(namespaceMap) == 0 {
+		srv.log.Debug("User has no access to any of namespaces")
+		return response.JSON(http.StatusOK, result)
+	}
 
 	namespaceUIDs := make([]string, len(namespaceMap))
 	for k := range namespaceMap {
@@ -214,7 +220,6 @@ func (srv RulerSrv) RouteGetRulesConfig(c *models.ReqContext) response.Response 
 		}
 	}
 
-	result := apimodels.NamespaceConfigResponse{}
 	for namespace, m := range configs {
 		for _, ruleGroupConfig := range m {
 			result[namespace] = append(result[namespace], ruleGroupConfig)

--- a/pkg/tests/api/alerting/api_prometheus_test.go
+++ b/pkg/tests/api/alerting/api_prometheus_test.go
@@ -767,7 +767,7 @@ func TestPrometheusRulesPermissions(t *testing.T) {
 	// remove permissions from _ALL_ folders
 	require.NoError(t, store.UpdateDashboardACL(1, nil))
 
-	// make sure that folder2 is not included in the response
+	// make sure that no folders are included in the response
 	{
 		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/prometheus/grafana/api/v1/rules", grafanaListedAddr)
 		// nolint:gosec

--- a/pkg/tests/api/alerting/api_prometheus_test.go
+++ b/pkg/tests/api/alerting/api_prometheus_test.go
@@ -763,4 +763,30 @@ func TestPrometheusRulesPermissions(t *testing.T) {
 	}
 }`, string(b))
 	}
+
+	// remove permissions from _ALL_ folders
+	require.NoError(t, store.UpdateDashboardACL(1, nil))
+
+	// make sure that folder2 is not included in the response
+	{
+		promRulesURL := fmt.Sprintf("http://grafana:password@%s/api/prometheus/grafana/api/v1/rules", grafanaListedAddr)
+		// nolint:gosec
+		resp, err := http.Get(promRulesURL)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+
+		require.JSONEq(t, `
+{
+	"status": "success",
+	"data": {
+		"groups": []
+	}
+}`, string(b))
+	}
 }

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -263,7 +263,6 @@ func TestAlertRulePermissions(t *testing.T) {
 		assert.Equal(t, resp.StatusCode, 200)
 		require.JSONEq(t, `{}`, string(b))
 	}
-
 }
 
 func createRule(t *testing.T, grafanaListedAddr string, folder string, user, password string) {

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -245,6 +245,25 @@ func TestAlertRulePermissions(t *testing.T) {
 		}`
 		assert.JSONEq(t, expectedGetNamespaceResponseBody, body)
 	}
+
+	// Remove permissions from ALL folders.
+	require.NoError(t, store.UpdateDashboardACL(1, nil))
+	{
+		u := fmt.Sprintf("http://grafana:password@%s/api/ruler/grafana/api/v1/rules", grafanaListedAddr)
+		// nolint:gosec
+		resp, err := http.Get(u)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		b, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		assert.Equal(t, resp.StatusCode, 200)
+		require.JSONEq(t, `{}`, string(b))
+	}
+
 }
 
 func createRule(t *testing.T, grafanaListedAddr string, folder string, user, password string) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a bug where a user is able to access rules from namespaces that the user is not part of.