### PR TITLE
Make the checkbox size editable

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Checkbox.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.story.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import mdx from './Checkbox.mdx';
 import { Checkbox } from './Checkbox';
-import { VerticalGroup } from '../Layout/Layout';
+import { HorizontalGroup, VerticalGroup } from '../Layout/Layout';
 import { Field } from './Field';
 
 export default {
@@ -38,6 +38,16 @@ export const uncontrolled = () => {
         description="Set to true if you want to skip TLS cert validation"
       />
     </div>
+  );
+};
+
+export const Variants = () => {
+  return (
+    <HorizontalGroup>
+      <Checkbox defaultChecked={true} label="Small - default" size={'sm'} />
+      <Checkbox defaultChecked={true} label="Medium" size={'md'} />
+      <Checkbox defaultChecked={true} label="Large" size={'lg'} />
+    </HorizontalGroup>
   );
 };
 

--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -9,10 +9,11 @@ export interface CheckboxProps extends Omit<HTMLProps<HTMLInputElement>, 'value'
   label?: string;
   description?: string;
   value?: boolean;
+  size?: number;
 }
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ label, description, value, onChange, disabled, className, ...inputProps }, ref) => {
+  ({ label, description, value, size, onChange, disabled, className, ...inputProps }, ref) => {
     const handleOnChange = useCallback(
       (e: React.ChangeEvent<HTMLInputElement>) => {
         if (onChange) {
@@ -21,7 +22,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
       },
       [onChange]
     );
-    const styles = useStyles2(getCheckboxStyles);
+    const styles = useStyles2(getCheckboxStyles(size));
 
     return (
       <label className={cx(styles.wrapper, className)}>
@@ -42,112 +43,114 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
   }
 );
 
-export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
-  const labelStyles = getLabelStyles(theme);
-  const checkboxSize = 2;
-  const labelPadding = 1;
+export function getCheckboxStyles(checkboxSize?: number) {
+  return stylesFactory((theme: GrafanaTheme2) => {
+    const labelStyles = getLabelStyles(theme);
+    const labelPadding = 1;
+    const cbSize = checkboxSize ? checkboxSize : 2;
 
-  return {
-    wrapper: css`
-      position: relative;
-      vertical-align: middle;
-      font-size: 0;
-    `,
-    input: css`
-      position: absolute;
-      z-index: 1;
-      top: 0;
-      left: 0;
-      width: 100% !important; // global styles unset this
-      height: 100%;
-      opacity: 0;
+    return {
+      wrapper: css`
+        position: relative;
+        vertical-align: middle;
+        font-size: 0;
+      `,
+      input: css`
+        position: absolute;
+        z-index: 1;
+        top: 0;
+        left: 0;
+        width: 100% !important; // global styles unset this
+        height: 100%;
+        opacity: 0;
 
-      &:focus + span,
-      &:focus-visible + span {
-        ${getFocusStyles(theme)}
-      }
+        &:focus + span,
+        &:focus-visible + span {
+          ${getFocusStyles(theme)}
+        }
 
-      &:focus:not(:focus-visible) + span {
-        ${getMouseFocusStyles(theme)}
-      }
+        &:focus:not(:focus-visible) + span {
+          ${getMouseFocusStyles(theme)}
+        }
 
-      /**
+        /**
        * Using adjacent sibling selector to style checked state.
        * Primarily to limit the classes necessary to use when these classes will be used
        * for angular components styling
        * */
-      &:checked + span {
-        background: blue;
-        background: ${theme.colors.primary.main};
-        border: none;
+        &:checked + span {
+          background: blue;
+          background: ${theme.colors.primary.main};
+          border: none;
 
-        &:hover {
-          background: ${theme.colors.primary.shade};
+          &:hover {
+            background: ${theme.colors.primary.shade};
+          }
+
+          &:after {
+            content: '';
+            position: absolute;
+            z-index: 2;
+            left: ${2.5 * cbSize}px;
+            top: 1px;
+            width: ${3 * cbSize}px;
+            height: ${6 * cbSize}px;
+            border: solid ${theme.colors.primary.contrastText};
+            border-width: 0 3px 3px 0;
+            transform: rotate(45deg);
+          }
         }
 
-        &:after {
-          content: '';
-          position: absolute;
-          z-index: 2;
-          left: 5px;
-          top: 1px;
-          width: 6px;
-          height: 12px;
-          border: solid ${theme.colors.primary.contrastText};
-          border-width: 0 3px 3px 0;
-          transform: rotate(45deg);
-        }
-      }
-
-      &:disabled + span {
-        background-color: ${theme.colors.action.disabledBackground};
-        cursor: not-allowed;
-
-        &:hover {
+        &:disabled + span {
           background-color: ${theme.colors.action.disabledBackground};
-        }
+          cursor: not-allowed;
 
-        &:after {
-          border-color: ${theme.colors.action.disabledText};
-        }
-      }
-    `,
-    checkmark: css`
-      position: relative; /* Checkbox should be layered on top of the invisible input so it recieves :hover */
-      z-index: 2;
-      display: inline-block;
-      width: ${theme.spacing(checkboxSize)};
-      height: ${theme.spacing(checkboxSize)};
-      border-radius: ${theme.shape.borderRadius()};
-      background: ${theme.components.input.background};
-      border: 1px solid ${theme.components.input.borderColor};
+          &:hover {
+            background-color: ${theme.colors.action.disabledBackground};
+          }
 
-      &:hover {
-        cursor: pointer;
-        border-color: ${theme.components.input.borderHover};
-      }
-    `,
-    label: cx(
-      labelStyles.label,
-      css`
-        position: relative;
+          &:after {
+            border-color: ${theme.colors.action.disabledText};
+          }
+        }
+      `,
+      checkmark: css`
+        position: relative; /* Checkbox should be layered on top of the invisible input so it recieves :hover */
         z-index: 2;
-        padding-left: ${theme.spacing(labelPadding)};
-        white-space: nowrap;
-        cursor: pointer;
-        position: relative;
-        top: -3px;
-      `
-    ),
-    description: cx(
-      labelStyles.description,
-      css`
-        line-height: ${theme.typography.bodySmall.lineHeight};
-        padding-left: ${theme.spacing(checkboxSize + labelPadding)};
-        margin-top: 0; /* The margin effectively comes from the top: -2px on the label above it */
-      `
-    ),
-  };
-});
+        display: inline-block;
+        width: ${theme.spacing(cbSize)};
+        height: ${theme.spacing(cbSize)};
+        border-radius: ${theme.shape.borderRadius()};
+        background: ${theme.components.input.background};
+        border: 1px solid ${theme.components.input.borderColor};
+
+        &:hover {
+          cursor: pointer;
+          border-color: ${theme.components.input.borderHover};
+        }
+      `,
+      label: cx(
+        labelStyles.label,
+        css`
+          position: relative;
+          z-index: 2;
+          padding-left: ${theme.spacing(labelPadding)};
+          white-space: nowrap;
+          cursor: pointer;
+          position: relative;
+          top: -3px;
+        `
+      ),
+      description: cx(
+        labelStyles.description,
+        css`
+          line-height: ${theme.typography.bodySmall.lineHeight};
+          padding-left: ${theme.spacing(cbSize + labelPadding)};
+          margin-top: 0; /* The margin effectively comes from the top: -2px on the label above it */
+        `
+      ),
+    };
+  });
+}
 
 Checkbox.displayName = 'Checkbox';

--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -23,160 +23,362 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
       },
       [onChange]
     );
-    const styles = useStyles2(getCheckboxStyles(size));
+    const styles = useStyles2(getCheckboxStyles);
+    const { inputStyle, checkmarkStyle, labelStyle, descriptionStyle } = getPropertiesForCheckboxSize(styles, size);
 
     return (
       <label className={cx(styles.wrapper, className)}>
         <input
           type="checkbox"
-          className={styles.input}
+          className={inputStyle}
           checked={value}
           disabled={disabled}
           onChange={handleOnChange}
           {...inputProps}
           ref={ref}
         />
-        <span className={styles.checkmark} />
-        {label && <span className={styles.label}>{label}</span>}
-        {description && <span className={styles.description}>{description}</span>}
+        <span className={checkmarkStyle} />
+        {label && <span className={labelStyle}>{label}</span>}
+        {description && <span className={descriptionStyle}>{description}</span>}
       </label>
     );
   }
 );
 
-export function getCheckboxStyles(size?: ComponentSize) {
-  return stylesFactory((theme: GrafanaTheme2) => {
-    const labelStyles = getLabelStyles(theme);
-    const labelPadding = 1;
-    const { padding, checkPadding, checkWidth, checkHeight } = getPropertiesForCheckboxSize(size);
+interface CheckboxStyles {
+  wrapper: string;
+  smInput: string;
+  smCheckmark: string;
+  smLabel: string;
+  smDescription: string;
+  mdInput: string;
+  mdCheckmark: string;
+  mdLabel: string;
+  mdDescription: string;
+  lgInput: string;
+  lgCheckmark: string;
+  lgLabel: string;
+  lgDescription: string;
+}
 
-    return {
-      wrapper: css`
-        position: relative;
-        vertical-align: middle;
-        font-size: 0;
-      `,
-      input: css`
-        position: absolute;
-        z-index: 1;
-        top: 0;
-        left: 0;
-        width: 100% !important; // global styles unset this
-        height: 100%;
-        opacity: 0;
+export const getCheckboxStyles = stylesFactory((theme: GrafanaTheme2) => {
+  const labelStyles = getLabelStyles(theme);
+  const labelPadding = 1;
 
-        &:focus + span,
-        &:focus-visible + span {
-          ${getFocusStyles(theme)}
-        }
+  return {
+    wrapper: css`
+      position: relative;
+      vertical-align: middle;
+      font-size: 0;
+    `,
+    smInput: css`
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      left: 0;
+      width: 100% !important; // global styles unset this
+      height: 100%;
+      opacity: 0;
 
-        &:focus:not(:focus-visible) + span {
-          ${getMouseFocusStyles(theme)}
-        }
+      &:focus + span,
+      &:focus-visible + span {
+        ${getFocusStyles(theme)}
+      }
 
-        /**
+      &:focus:not(:focus-visible) + span {
+        ${getMouseFocusStyles(theme)}
+      }
+
+      /**
        * Using adjacent sibling selector to style checked state.
        * Primarily to limit the classes necessary to use when these classes will be used
        * for angular components styling
        * */
-        &:checked + span {
-          background: blue;
-          background: ${theme.colors.primary.main};
-          border: none;
-
-          &:hover {
-            background: ${theme.colors.primary.shade};
-          }
-
-          &:after {
-            content: '';
-            position: absolute;
-            z-index: 2;
-            left: ${checkPadding};
-            top: 1px;
-            width: ${checkWidth};
-            height: ${checkHeight};
-            border: solid ${theme.colors.primary.contrastText};
-            border-width: 0 3px 3px 0;
-            transform: rotate(45deg);
-          }
-        }
-
-        &:disabled + span {
-          background-color: ${theme.colors.action.disabledBackground};
-          cursor: not-allowed;
-
-          &:hover {
-            background-color: ${theme.colors.action.disabledBackground};
-          }
-
-          &:after {
-            border-color: ${theme.colors.action.disabledText};
-          }
-        }
-      `,
-      checkmark: css`
-        position: relative; /* Checkbox should be layered on top of the invisible input so it recieves :hover */
-        z-index: 2;
-        display: inline-block;
-        width: ${theme.spacing(padding)};
-        height: ${theme.spacing(padding)};
-        border-radius: ${theme.shape.borderRadius()};
-        background: ${theme.components.input.background};
-        border: 1px solid ${theme.components.input.borderColor};
+      &:checked + span {
+        background: blue;
+        background: ${theme.colors.primary.main};
+        border: none;
 
         &:hover {
-          cursor: pointer;
-          border-color: ${theme.components.input.borderHover};
+          background: ${theme.colors.primary.shade};
         }
-      `,
-      label: cx(
-        labelStyles.label,
-        css`
-          position: relative;
-          z-index: 2;
-          padding-left: ${theme.spacing(labelPadding)};
-          white-space: nowrap;
-          cursor: pointer;
-          position: relative;
-          top: -3px;
-        `
-      ),
-      description: cx(
-        labelStyles.description,
-        css`
-          line-height: ${theme.typography.bodySmall.lineHeight};
-          padding-left: ${theme.spacing(padding + labelPadding)};
-          margin-top: 0; /* The margin effectively comes from the top: -2px on the label above it */
-        `
-      ),
-    };
-  });
-}
 
-function getPropertiesForCheckboxSize(size?: ComponentSize) {
+        &:after {
+          content: '';
+          position: absolute;
+          z-index: 2;
+          left: 5px;
+          top: 1px;
+          width: 6px;
+          height: 12px;
+          border: solid ${theme.colors.primary.contrastText};
+          border-width: 0 3px 3px 0;
+          transform: rotate(45deg);
+        }
+      }
+
+      &:disabled + span {
+        background-color: ${theme.colors.action.disabledBackground};
+        cursor: not-allowed;
+
+        &:hover {
+          background-color: ${theme.colors.action.disabledBackground};
+        }
+
+        &:after {
+          border-color: ${theme.colors.action.disabledText};
+        }
+      }
+    `,
+    smCheckmark: css`
+      position: relative; /* Checkbox should be layered on top of the invisible input so it recieves :hover */
+      z-index: 2;
+      display: inline-block;
+      width: ${theme.spacing(2)};
+      height: ${theme.spacing(2)};
+      border-radius: ${theme.shape.borderRadius()};
+      background: ${theme.components.input.background};
+      border: 1px solid ${theme.components.input.borderColor};
+
+      &:hover {
+        cursor: pointer;
+        border-color: ${theme.components.input.borderHover};
+      }
+    `,
+    smLabel: cx(
+      labelStyles.label,
+      css`
+        position: relative;
+        z-index: 2;
+        padding-left: ${theme.spacing(labelPadding)};
+        white-space: nowrap;
+        cursor: pointer;
+        position: relative;
+        top: -3px;
+      `
+    ),
+    smDescription: cx(
+      labelStyles.description,
+      css`
+        line-height: ${theme.typography.bodySmall.lineHeight};
+        padding-left: ${theme.spacing(2 + labelPadding)};
+        margin-top: 0; /* The margin effectively comes from the top: -2px on the label above it */
+      `
+    ),
+    mdInput: css`
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      left: 0;
+      width: 100% !important; // global styles unset this
+      height: 100%;
+      opacity: 0;
+
+      &:focus + span,
+      &:focus-visible + span {
+        ${getFocusStyles(theme)}
+      }
+
+      &:focus:not(:focus-visible) + span {
+        ${getMouseFocusStyles(theme)}
+      }
+
+      /**
+       * Using adjacent sibling selector to style checked state.
+       * Primarily to limit the classes necessary to use when these classes will be used
+       * for angular components styling
+       * */
+      &:checked + span {
+        background: blue;
+        background: ${theme.colors.primary.main};
+        border: none;
+
+        &:hover {
+          background: ${theme.colors.primary.shade};
+        }
+
+        &:after {
+          content: '';
+          position: absolute;
+          z-index: 2;
+          left: 10px;
+          top: 1px;
+          width: 12px;
+          height: 24px;
+          border: solid ${theme.colors.primary.contrastText};
+          border-width: 0 3px 3px 0;
+          transform: rotate(45deg);
+        }
+      }
+
+      &:disabled + span {
+        background-color: ${theme.colors.action.disabledBackground};
+        cursor: not-allowed;
+
+        &:hover {
+          background-color: ${theme.colors.action.disabledBackground};
+        }
+
+        &:after {
+          border-color: ${theme.colors.action.disabledText};
+        }
+      }
+    `,
+    mdCheckmark: css`
+      position: relative; /* Checkbox should be layered on top of the invisible input so it recieves :hover */
+      z-index: 2;
+      display: inline-block;
+      width: ${theme.spacing(4)};
+      height: ${theme.spacing(4)};
+      border-radius: ${theme.shape.borderRadius()};
+      background: ${theme.components.input.background};
+      border: 1px solid ${theme.components.input.borderColor};
+
+      &:hover {
+        cursor: pointer;
+        border-color: ${theme.components.input.borderHover};
+      }
+    `,
+    mdLabel: cx(
+      labelStyles.label,
+      css`
+        position: relative;
+        z-index: 2;
+        padding-left: ${theme.spacing(labelPadding)};
+        white-space: nowrap;
+        cursor: pointer;
+        position: relative;
+        top: -11px;
+      `
+    ),
+    mdDescription: cx(
+      labelStyles.description,
+      css`
+        line-height: ${theme.typography.bodySmall.lineHeight};
+        padding-left: ${theme.spacing(4 + labelPadding)};
+        margin-top: 0; /* The margin effectively comes from the top: -2px on the label above it */
+      `
+    ),
+    lgInput: css`
+      position: absolute;
+      z-index: 1;
+      top: 0;
+      left: 0;
+      width: 100% !important; // global styles unset this
+      height: 100%;
+      opacity: 0;
+
+      &:focus + span,
+      &:focus-visible + span {
+        ${getFocusStyles(theme)}
+      }
+
+      &:focus:not(:focus-visible) + span {
+        ${getMouseFocusStyles(theme)}
+      }
+
+      /**
+       * Using adjacent sibling selector to style checked state.
+       * Primarily to limit the classes necessary to use when these classes will be used
+       * for angular components styling
+       * */
+      &:checked + span {
+        background: blue;
+        background: ${theme.colors.primary.main};
+        border: none;
+
+        &:hover {
+          background: ${theme.colors.primary.shade};
+        }
+
+        &:after {
+          content: '';
+          position: absolute;
+          z-index: 2;
+          left: 15px;
+          top: 1px;
+          width: 18px;
+          height: 36px;
+          border: solid ${theme.colors.primary.contrastText};
+          border-width: 0 3px 3px 0;
+          transform: rotate(45deg);
+        }
+      }
+
+      &:disabled + span {
+        background-color: ${theme.colors.action.disabledBackground};
+        cursor: not-allowed;
+
+        &:hover {
+          background-color: ${theme.colors.action.disabledBackground};
+        }
+
+        &:after {
+          border-color: ${theme.colors.action.disabledText};
+        }
+      }
+    `,
+    lgCheckmark: css`
+      position: relative; /* Checkbox should be layered on top of the invisible input so it recieves :hover */
+      z-index: 2;
+      display: inline-block;
+      width: ${theme.spacing(6)};
+      height: ${theme.spacing(6)};
+      border-radius: ${theme.shape.borderRadius()};
+      background: ${theme.components.input.background};
+      border: 1px solid ${theme.components.input.borderColor};
+
+      &:hover {
+        cursor: pointer;
+        border-color: ${theme.components.input.borderHover};
+      }
+    `,
+    lgLabel: cx(
+      labelStyles.label,
+      css`
+        position: relative;
+        z-index: 2;
+        padding-left: ${theme.spacing(labelPadding)};
+        white-space: nowrap;
+        cursor: pointer;
+        position: relative;
+        top: -18px;
+      `
+    ),
+    lgDescription: cx(
+      labelStyles.description,
+      css`
+        line-height: ${theme.typography.bodySmall.lineHeight};
+        padding-left: ${theme.spacing(6 + labelPadding)};
+        margin-top: 0; /* The margin effectively comes from the top: -2px on the label above it */
+      `
+    ),
+  };
+});
+
+function getPropertiesForCheckboxSize(styles: CheckboxStyles, size?: ComponentSize) {
   switch (size) {
     case 'md':
       return {
-        padding: 4,
-        checkPadding: `10px`,
-        checkWidth: `12px`,
-        checkHeight: `26px`,
+        inputStyle: styles.mdInput,
+        checkmarkStyle: styles.mdCheckmark,
+        labelStyle: styles.mdLabel,
+        descriptionStyle: styles.mdDescription,
       };
     case 'lg':
       return {
-        padding: 6,
-        checkPadding: `15px`,
-        checkWidth: `18px`,
-        checkHeight: `36px`,
+        inputStyle: styles.lgInput,
+        checkmarkStyle: styles.lgCheckmark,
+        labelStyle: styles.lgLabel,
+        descriptionStyle: styles.lgDescription,
       };
     case 'sm':
     default:
       return {
-        padding: 2,
-        checkPadding: `5px`,
-        checkWidth: `6px`,
-        checkHeight: `12px`,
+        inputStyle: styles.smInput,
+        checkmarkStyle: styles.smCheckmark,
+        labelStyle: styles.smLabel,
+        descriptionStyle: styles.smDescription,
       };
   }
 }

--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -4,12 +4,13 @@ import { getLabelStyles } from './Label';
 import { stylesFactory, useStyles2 } from '../../themes';
 import { css, cx } from '@emotion/css';
 import { getFocusStyles, getMouseFocusStyles } from '../../themes/mixins';
+import { ComponentSize } from '../../types/size';
 
-export interface CheckboxProps extends Omit<HTMLProps<HTMLInputElement>, 'value'> {
+export interface CheckboxProps extends Omit<HTMLProps<HTMLInputElement>, 'value' | 'size'> {
   label?: string;
   description?: string;
   value?: boolean;
-  size?: number;
+  size?: ComponentSize;
 }
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
@@ -43,11 +44,11 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
   }
 );
 
-export function getCheckboxStyles(checkboxSize?: number) {
+export function getCheckboxStyles(size?: ComponentSize) {
   return stylesFactory((theme: GrafanaTheme2) => {
     const labelStyles = getLabelStyles(theme);
     const labelPadding = 1;
-    const cbSize = checkboxSize ? checkboxSize : 2;
+    const { padding, checkPadding, checkWidth, checkHeight } = getPropertiesForCheckboxSize(size);
 
     return {
       wrapper: css`
@@ -91,10 +92,10 @@ export function getCheckboxStyles(checkboxSize?: number) {
             content: '';
             position: absolute;
             z-index: 2;
-            left: ${2.5 * cbSize}px;
+            left: ${checkPadding};
             top: 1px;
-            width: ${3 * cbSize}px;
-            height: ${6 * cbSize}px;
+            width: ${checkWidth};
+            height: ${checkHeight};
             border: solid ${theme.colors.primary.contrastText};
             border-width: 0 3px 3px 0;
             transform: rotate(45deg);
@@ -118,8 +119,8 @@ export function getCheckboxStyles(checkboxSize?: number) {
         position: relative; /* Checkbox should be layered on top of the invisible input so it recieves :hover */
         z-index: 2;
         display: inline-block;
-        width: ${theme.spacing(cbSize)};
-        height: ${theme.spacing(cbSize)};
+        width: ${theme.spacing(padding)};
+        height: ${theme.spacing(padding)};
         border-radius: ${theme.shape.borderRadius()};
         background: ${theme.components.input.background};
         border: 1px solid ${theme.components.input.borderColor};
@@ -145,12 +146,39 @@ export function getCheckboxStyles(checkboxSize?: number) {
         labelStyles.description,
         css`
           line-height: ${theme.typography.bodySmall.lineHeight};
-          padding-left: ${theme.spacing(cbSize + labelPadding)};
+          padding-left: ${theme.spacing(padding + labelPadding)};
           margin-top: 0; /* The margin effectively comes from the top: -2px on the label above it */
         `
       ),
     };
   });
+}
+
+function getPropertiesForCheckboxSize(size?: ComponentSize) {
+  switch (size) {
+    case 'md':
+      return {
+        padding: 4,
+        checkPadding: `10px`,
+        checkWidth: `12px`,
+        checkHeight: `26px`,
+      };
+    case 'lg':
+      return {
+        padding: 6,
+        checkPadding: `15px`,
+        checkWidth: `18px`,
+        checkHeight: `36px`,
+      };
+    case 'sm':
+    default:
+      return {
+        padding: 2,
+        checkPadding: `5px`,
+        checkWidth: `6px`,
+        checkHeight: `12px`,
+      };
+  }
 }
 
 Checkbox.displayName = 'Checkbox';

--- a/packages/grafana-ui/src/components/Forms/getFormStyles.ts
+++ b/packages/grafana-ui/src/components/Forms/getFormStyles.ts
@@ -3,7 +3,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { getLabelStyles } from './Label';
 import { getLegendStyles } from './Legend';
 import { getFieldValidationMessageStyles } from './FieldValidationMessage';
-import { getButtonStyles, ButtonVariant } from '../Button';
+import { ButtonVariant, getButtonStyles } from '../Button';
 import { ComponentSize } from '../../types/size';
 import { getInputStyles } from '../Input/Input';
 import { getCheckboxStyles } from './Checkbox';
@@ -23,7 +23,7 @@ export const getFormStyles = stylesFactory(
         size: options.size,
       }),
       input: getInputStyles({ theme, invalid: options.invalid }),
-      checkbox: getCheckboxStyles(theme),
+      checkbox: getCheckboxStyles()(theme),
     };
   }
 );

--- a/packages/grafana-ui/src/components/Forms/getFormStyles.ts
+++ b/packages/grafana-ui/src/components/Forms/getFormStyles.ts
@@ -23,7 +23,7 @@ export const getFormStyles = stylesFactory(
         size: options.size,
       }),
       input: getInputStyles({ theme, invalid: options.invalid }),
-      checkbox: getCheckboxStyles()(theme),
+      checkbox: getCheckboxStyles(theme),
     };
   }
 );


### PR DESCRIPTION
We would like a larger checkbox but all the size values are hard coded. This PR allows setting an optional `size` parameter. CSS sizes that don't come from the `themes` package are calculated from the relative checkbox size.

