### PR TITLE
prometheus: query field: better handle label-values with unusual characters

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/completions.ts
@@ -2,6 +2,7 @@ import type { Situation, Label } from './situation';
 import { NeverCaseError } from './util';
 // FIXME: we should not load this from the "outside", but we cannot do that while we have the "old" query-field too
 import { FUNCTIONS } from '../../../promql';
+import { escapeLabelValueInExactSelector } from '../../../language_utils';
 
 export type CompletionType = 'HISTORY' | 'FUNCTION' | 'METRIC_NAME' | 'DURATION' | 'LABEL_NAME' | 'LABEL_VALUE';
 
@@ -90,7 +91,9 @@ function makeSelector(metricName: string | undefined, labels: Label[]): string {
     allLabels.push({ name: '__name__', value: metricName, op: '=' });
   }
 
-  const allLabelTexts = allLabels.map((label) => `${label.name}${label.op}"${label.value}"`);
+  const allLabelTexts = allLabels.map(
+    (label) => `${label.name}${label.op}"${escapeLabelValueInExactSelector(label.value)}"`
+  );
 
   return `{${allLabelTexts.join(',')}}`;
 }

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/situation.test.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/situation.test.ts
@@ -89,6 +89,24 @@ describe('situation', () => {
       type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
       otherLabels: [{ name: 'one', value: 'val1', op: '=' }],
     });
+
+    // single-quoted label-values with escape
+    assertSituation("{one='val\\'1',^}", {
+      type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
+      otherLabels: [{ name: 'one', value: "val'1", op: '=' }],
+    });
+
+    // double-quoted label-values with escape
+    assertSituation('{one="val\\"1",^}', {
+      type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
+      otherLabels: [{ name: 'one', value: 'val"1', op: '=' }],
+    });
+
+    // backticked label-values with escape (the escape should not be interpreted)
+    assertSituation('{one=`val\\"1`,^}', {
+      type: 'IN_LABEL_SELECTOR_NO_LABEL_NAME',
+      otherLabels: [{ name: 'one', value: 'val\\"1', op: '=' }],
+    });
   });
 
   it('handles label values', () => {

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/situation.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/monaco-completion-provider/situation.ts
@@ -63,17 +63,34 @@ function getNodeText(node: SyntaxNode, text: string): string {
 }
 
 function parsePromQLStringLiteral(text: string): string {
+  // if it is a string-literal, it is inside quotes of some kind
+  const inside = text.slice(1, text.length - 1);
+
   // FIXME: support https://prometheus.io/docs/prometheus/latest/querying/basics/#string-literals
   // FIXME: maybe check other promql code, if all is supported or not
+
+  // for now we do only some very simple un-escaping
+
   // we start with double-quotes
   if (text.startsWith('"') && text.endsWith('"')) {
-    if (text.indexOf('\\') !== -1) {
-      throw new Error('FIXME: escape-sequences not supported in label-values');
-    }
-    return text.slice(1, text.length - 1);
-  } else {
-    throw new Error('FIXME: invalid string literal');
+    // NOTE: this is not 100% perfect, we only unescape the double-quote,
+    // there might be other characters too
+    return inside.replace(/\\"/, '"');
   }
+
+  // then single-quote
+  if (text.startsWith("'") && text.endsWith("'")) {
+    // NOTE: this is not 100% perfect, we only unescape the single-quote,
+    // there might be other characters too
+    return inside.replace(/\\'/, "'");
+  }
+
+  // then backticks
+  if (text.startsWith('`') && text.endsWith('`')) {
+    return inside;
+  }
+
+  throw new Error('FIXME: invalid string literal');
 }
 
 type LabelOperator = '=' | '!=' | '=~' | '!~';


### PR DESCRIPTION
in prometheus, label-values can by any characters, including the "complicated" ones, like single-quote, double-quote etc.

also, in promQL, label-values can be between double-quotes or between single-quotes or between backticks.

this pull request improves the autocomplete-handling when strings are in single-quotes or in backticks.

NOTE: we are not trying to do this perfectly, not every possible case is supported, we are aiming for a good-enough situation.

how to test:
- you need label-value with strange characters in your prometheus database. one easy approach is: modify your `devenv/docker/blocks/prometheus/prometheus.yml`, like this:
```diff
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']
+        labels:
+          lbl1: "lblv1"
+          lbl2: 'lblv"2'
+          lbl3: "lblv'3"
```

so `lbl2` contains a double-quote, and `lbl3` contains a single-quote.

- `make devenv sources=prometheus`
- wait 20seconds
- go to explore-mode
- try queries like: 
  - `go_goroutines{lbl2='lblv"2'}`, put the cursor before the closing `}` and press `,`. you should get autocomplete-options for the next label-name
  - same with `go_goroutines{lbl3="lblv'3"}` or with ``go_goroutines{lbl3=`lblv'3`}`` or with ``go_goroutines{lbl3=`lblv"2`}``

NOTE: in some cases, when you choose from the autocomplete-options a label-value with a double-quote, it will be inserted the wrong way. that is ok, that is a separate issue that we can decide if we should fix or not later.