### PR TITLE
Storybook: Fix decorator height

### DIFF
--- a/packages/grafana-ui/.storybook/preview-head.html
+++ b/packages/grafana-ui/.storybook/preview-head.html
@@ -1,0 +1,6 @@
+<!-- Make sure iframe dom elements fill all available space for background consistency -->
+<style>
+  #root {
+    height: 100%;
+  }
+</style>

--- a/packages/grafana-ui/src/components/Badge/Badge.story.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.story.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Story, Meta } from '@storybook/react';
+import { Story } from '@storybook/react';
 import { Badge, BadgeProps } from '@grafana/ui';
 import { iconOptions } from '../../utils/storybook/knobs';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
@@ -16,7 +16,7 @@ export default {
     color: { control: 'select' },
     text: { control: 'text' },
   },
-} as Meta;
+};
 
 const Template: Story<BadgeProps> = (args) => <Badge {...args} />;
 

--- a/packages/grafana-ui/src/components/Badge/Badge.story.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.story.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Story } from '@storybook/react';
+import { Story, Meta } from '@storybook/react';
 import { Badge, BadgeProps } from '@grafana/ui';
 import { iconOptions } from '../../utils/storybook/knobs';
 
 export default {
   title: 'Data Display/Badge',
   component: Badge,
-  decorators: [],
+  decorators: [(story) => <div>{story()}</div>],
   parameters: {
     docs: {},
   },
@@ -15,7 +15,7 @@ export default {
     color: { control: 'select' },
     text: { control: 'text' },
   },
-};
+} as Meta;
 
 const Template: Story<BadgeProps> = (args) => <Badge {...args} />;
 

--- a/packages/grafana-ui/src/components/Badge/Badge.story.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.story.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { Story, Meta } from '@storybook/react';
 import { Badge, BadgeProps } from '@grafana/ui';
 import { iconOptions } from '../../utils/storybook/knobs';
+import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 
 export default {
   title: 'Data Display/Badge',
   component: Badge,
-  decorators: [(story) => <div>{story()}</div>],
+  decorators: [withCenteredStory],
   parameters: {
     docs: {},
   },

--- a/packages/grafana-ui/src/utils/storybook/withPaddedStory.tsx
+++ b/packages/grafana-ui/src/utils/storybook/withPaddedStory.tsx
@@ -11,7 +11,7 @@ const PaddedStory: React.FunctionComponent<{}> = ({ children }) => {
         width: '100%',
         padding: '20px',
         display: 'flex',
-        minHeight: '80vh',
+        minHeight: '100%',
         background: `${theme.colors.background.primary}`,
       }}
     >

--- a/packages/grafana-ui/src/utils/storybook/withRightAlignedStory.tsx
+++ b/packages/grafana-ui/src/utils/storybook/withRightAlignedStory.tsx
@@ -5,7 +5,7 @@ const RightAlignedStory: React.FunctionComponent<{}> = ({ children }) => {
   return (
     <div
       style={{
-        height: '100vh  ',
+        minHeight: '100%',
         display: 'flex',
         alignItems: 'flex-start',
         justifyContent: 'flex-end',

--- a/packages/grafana-ui/src/utils/storybook/withTheme.tsx
+++ b/packages/grafana-ui/src/utils/storybook/withTheme.tsx
@@ -21,7 +21,7 @@ const ThemeableStory: React.FunctionComponent<{ handleSassThemeChange: SassTheme
           width: '100%',
           padding: '20px',
           display: 'flex',
-          minHeight: '80vh',
+          minHeight: '100%',
           background: `${theme.colors.background.primary}`,
         }}
       >


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
There is a "gap" at the bottom of stories. This PR addresses it along with another issue with the badge component filling all available height.

| Before | After |
| --- | --- |
| <img width="1678" alt="Screenshot 2021-11-09 at 13 13 21" src="https://user-images.githubusercontent.com/73201/140922661-9633872b-24c6-42c2-bb4a-5116b9003819.png"> | <img width="1676" alt="Screenshot 2021-11-09 at 13 13 31" src="https://user-images.githubusercontent.com/73201/140922657-178dded4-7a4e-4a51-88dd-0e0e734fb07b.png"> |

| Before | After |
| --- | --- |
| <img width="1678" alt="Screenshot 2021-11-09 at 13 13 52" src="https://user-images.githubusercontent.com/73201/140922793-cc3504bb-0aa3-4030-a3ae-a6daaf58afce.png"> | <img width="1679" alt="Screenshot 2021-11-09 at 13 24 12" src="https://user-images.githubusercontent.com/73201/140923804-e92f5306-da26-482b-b9d8-368596bb7146.png"> |


**Special notes for your reviewer**:

