### PR TITLE
Market trend: fix bar width calc when time range exceeds data range

### DIFF
--- a/public/app/plugins/panel/market-trend/utils.ts
+++ b/public/app/plugins/panel/market-trend/utils.ts
@@ -71,7 +71,33 @@ export function drawMarkers(opts: RendererOpts) {
 
     let [idx0, idx1] = u.series[0].idxs!;
 
-    let colWidth = u.bbox.width / (idx1 - idx0);
+    let dataX = u.data[0];
+    let dataY = oData;
+
+    let colWidth = u.bbox.width;
+
+    if (dataX.length > 1) {
+      // prior index with non-undefined y data
+      let prevIdx = null;
+
+      // scan full dataset for smallest adjacent delta
+      // will not work properly for non-linear x scales, since does not do expensive valToPosX calcs till end
+      for (let i = 0, minDelta = Infinity; i < dataX.length; i++) {
+        if (dataY[i] !== undefined) {
+          if (prevIdx != null) {
+            let delta = Math.abs(dataX[i] - dataX[prevIdx]);
+
+            if (delta < minDelta) {
+              minDelta = delta;
+              colWidth = Math.abs(u.valToPos(dataX[i], 'x') - u.valToPos(dataX[prevIdx], 'x'));
+            }
+          }
+
+          prevIdx = i;
+        }
+      }
+    }
+
     let barWidth = Math.round(0.6 * colWidth);
 
     let stickWidth = 2;


### PR DESCRIPTION
this switches to the same bar width assessment strategy as our normal bar renderer.

before:

![image](https://user-images.githubusercontent.com/43234/140972170-dbb91289-abf2-49ee-b3b0-8cd34f462385.png)


after:

![image](https://user-images.githubusercontent.com/43234/140972205-aaed62b5-1acf-40d2-8289-5968f7cbf055.png)
