### PR TITLE
Prometheus: Add isRemoteWriteAvailable flag check

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -99,6 +99,33 @@ describe('PrometheusDatasource', () => {
     });
   });
 
+  describe('Remote write status', () => {
+    it('should perform a GET request to /api/v1/status/flags', () => {
+      ds.isRemoteWriteAvailable();
+      expect(fetchMock.mock.calls.length).toBe(1);
+      expect(fetchMock.mock.calls[0][0].method).toBe('GET');
+      expect(fetchMock.mock.calls[0][0].url).toContain('/api/v1/status/flags');
+    });
+
+    it('should return true if remote-write-receiver is enabled', async () => {
+      fetchMock.mockReturnValue(of({ data: { data: { ['enable-feature']: 'remote-write-receiver' } } }));
+      let result = await ds.isRemoteWriteAvailable();
+      expect(result).toEqual(true);
+    });
+
+    it('should return false if remote write is not enabled', async () => {
+      fetchMock.mockReturnValue(of({ data: { data: { ['enable-feature']: '' } } }));
+      let result = await ds.isRemoteWriteAvailable();
+      expect(result).toEqual(false);
+    });
+
+    it('should return false if enable-feature is not part of the response', async () => {
+      fetchMock.mockReturnValue(of({ data: {} }));
+      let result = await ds.isRemoteWriteAvailable();
+      expect(result).toEqual(false);
+    });
+  });
+
   describe('Datasource metadata requests', () => {
     it('should perform a GET request with the default config', () => {
       ds.metadataRequest('/foo', { bar: 'baz baz', foo: 'foo' });

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -73,6 +73,7 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
   lookupsDisabled: boolean;
   customQueryParameters: any;
   exemplarsAvailable: boolean;
+  remoteWriteAvailable?: boolean;
 
   constructor(
     instanceSettings: DataSourceInstanceSettings<PromOptions>,
@@ -106,6 +107,7 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
   init = async () => {
     this.loadRules();
     this.exemplarsAvailable = await this.areExemplarsAvailable();
+    this.remoteWriteAvailable = await this.isRemoteWriteAvailable();
   };
 
   getQueryDisplayText(query: PromQuery) {
@@ -849,6 +851,15 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
         return true;
       }
       return false;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  async isRemoteWriteAvailable() {
+    try {
+      const res = await this.metadataRequest('/api/v1/status/flags');
+      return res.data?.data['enable-feature']?.includes('remote-write-receiver') ?? false;
     } catch (err) {
       return false;
     }

--- a/public/app/plugins/datasource/prometheus/plugin.json
+++ b/public/app/plugins/datasource/prometheus/plugin.json
@@ -5,6 +5,11 @@
   "category": "tsdb",
   "routes": [
     {
+      "method": "GET",
+      "path": "api/v1/status/flags",
+      "reqRole": "Admin"
+    },
+    {
       "method": "POST",
       "path": "api/v1/query",
       "reqRole": "Viewer"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Recorded queries needs to be able to identify prometheus data sources that have remote write enabled. This PR adds a `isRemoteWriteAvailable` check, which is based on the existing `areExemplarsAvailable` check. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Required for https://github.com/grafana/integrations-team/issues/249

**Special notes for your reviewer**:

