### PR TITLE
POC: support color a field using the color props from a sibling (take2)

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -184,6 +184,7 @@ export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFra
         field: field,
         theme: options.theme,
         timeZone: options.timeZone,
+        frame: newFrame,
       });
 
       // Wrap the display with a cache to avoid double calls
@@ -213,7 +214,7 @@ export function applyFieldOverrides(options: ApplyFieldOverrideOptions): DataFra
 function cachingDisplayProcessor(disp: DisplayProcessor, maxCacheSize = 2500): DisplayProcessor {
   const cache = new Map<any, DisplayValue>();
 
-  return (value: any) => {
+  return (value: any, index?: number) => {
     let v = cache.get(value);
 
     if (!v) {
@@ -222,7 +223,7 @@ function cachingDisplayProcessor(disp: DisplayProcessor, maxCacheSize = 2500): D
         cache.clear();
       }
 
-      v = disp(value);
+      v = disp(value, index);
 
       // convert to hex6 or hex8 so downstream we can cheaply test for alpha (and set new alpha)
       // via a simple length check (in colorManipulator) rather using slow parsing via tinycolor

--- a/packages/grafana-data/src/types/displayValue.ts
+++ b/packages/grafana-data/src/types/displayValue.ts
@@ -1,6 +1,6 @@
 import { FormattedValue } from '../valueFormats';
 
-export type DisplayProcessor = (value: any) => DisplayValue;
+export type DisplayProcessor = (value: any, index?: number) => DisplayValue;
 
 export interface DisplayValue extends FormattedValue {
   /**

--- a/packages/grafana-ui/src/components/Table/BarGaugeCell.tsx
+++ b/packages/grafana-ui/src/components/Table/BarGaugeCell.tsx
@@ -28,7 +28,7 @@ export const BarGaugeCell: FC<TableCellProps> = (props) => {
     };
   }
 
-  const displayValue = field.display!(cell.value);
+  const displayValue = field.display!(cell.value, cell.row.index);
   let barGaugeMode = BarGaugeDisplayMode.Gradient;
 
   if (field.config.custom && field.config.custom.displayMode === TableCellDisplayMode.LcdGauge) {

--- a/packages/grafana-ui/src/components/Table/DefaultCell.tsx
+++ b/packages/grafana-ui/src/components/Table/DefaultCell.tsx
@@ -10,7 +10,7 @@ import { getTextColorForBackground, getCellLinks } from '../../utils';
 export const DefaultCell: FC<TableCellProps> = (props) => {
   const { field, cell, tableStyles, row, cellProps } = props;
 
-  const displayValue = field.display!(cell.value);
+  const displayValue = field.display!(cell.value, cell.row.index);
 
   let value: string | ReactElement;
   if (React.isValidElement(cell.value)) {


### PR DESCRIPTION
Continuation/based on 
https://github.com/grafana/grafana/pull/41381

This is just a test to evaluate this option more, I am not sure if the added complexity to cover this use case is worth it or not. 

Changes 
* Color is not only derived from the color scale calculator but also value mappings so we have use the full display processor of the "color by field" 
* To make it possible to color by another sibling field value the display processor function needs to know the index of the value to know what value to lookup in the "color by field". Added index to displayProcesor function, needs to be added everywhere this is used to support this color mode. 

Unsolved
* This sort of breaks the caching display processor, or rather the caching display processor will make this break as it is caching on the wrong value (the current fields value not the lookup other fields value), https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/field/fieldOverrides.ts#L213 *
* This will not work in streaming scenarios where we skip field overrides so display processors will stay the same, so the "other field" will be an old other field instance with old values 

Could not test with bar chart (does not support time), nor time series (does not support color for individual bars). So had to test with table 
![Screenshot from 2021-11-10 10-52-16](https://user-images.githubusercontent.com/10999/141092805-a4e879ff-5200-4b85-b841-6fc9c5913d55.png)


