### PR TITLE
Alerting: Fix no data behaviour in Legacy Alerting for alert rules using the AND operator (#41305)

### DIFF
--- a/pkg/services/alerting/eval_handler.go
+++ b/pkg/services/alerting/eval_handler.go
@@ -52,11 +52,14 @@ func (e *DefaultEvalHandler) Eval(context *EvalContext) {
 		// calculating Firing based on operator
 		if cr.Operator == "or" {
 			firing = firing || cr.Firing
-			noDataFound = noDataFound || cr.NoDataFound
 		} else {
 			firing = firing && cr.Firing
-			noDataFound = noDataFound && cr.NoDataFound
 		}
+
+		// We cannot evaluate the expression when one or more conditions are missing data
+		// and so noDataFound should be true if at least one condition returns no data,
+		// irrespective of the operator.
+		noDataFound = noDataFound || cr.NoDataFound
 
 		if i > 0 {
 			conditionEvals = "[" + conditionEvals + " " + strings.ToUpper(cr.Operator) + " " + strconv.FormatBool(cr.Firing) + "]"

--- a/pkg/services/alerting/eval_handler_test.go
+++ b/pkg/services/alerting/eval_handler_test.go
@@ -182,7 +182,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 			So(context.NoDataFound, ShouldBeTrue)
 		})
 
-		Convey("Should not return no data if at least one condition has no data and using AND", func() {
+		Convey("Should return no data if at least one condition has no data and using AND", func() {
 			context := NewEvalContext(context.TODO(), &Rule{
 				Conditions: []Condition{
 					&conditionStub{operator: "and", noData: true},
@@ -191,7 +191,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 			}, &validations.OSSPluginRequestValidator{})
 
 			handler.Eval(context)
-			So(context.NoDataFound, ShouldBeFalse)
+			So(context.NoDataFound, ShouldBeTrue)
 		})
 
 		Convey("Should return no data if at least one condition has no data and using OR", func() {


### PR DESCRIPTION
Backport `a77bcaf` from #41305.