### PR TITLE
Docs CI: Make script not fail if `reports/docs` directory doesn't exist

### DIFF
--- a/scripts/ci-reference-docs-lint.sh
+++ b/scripts/ci-reference-docs-lint.sh
@@ -13,10 +13,10 @@ pretty_print_result_of_report() {
 }
 
 BUILD_MODE="${1-local}"
-REPORT_PATH="$(realpath "$(dirname "$0")/../reports/docs/")"
 BUILD_SCRIPT_PATH="$(realpath "$(dirname "$0")/ci-reference-docs-build.sh")"
 
-if [ ! -d "$REPORT_PATH" ]; then
+if [ ! -d "$(realpath "$(dirname "$0")/../reports/docs/")" ]; then
+  echo "reports/docs directory doesn't exist. creating..."
   # this script needs to be run after the packages have been built and the api-extractor has completed.
   # shellcheck source=/scripts/ci-reference-docs-build.sh
   if ! . "$BUILD_SCRIPT_PATH" "$BUILD_MODE";
@@ -28,6 +28,7 @@ if [ ! -d "$REPORT_PATH" ]; then
   fi
 fi
 
+REPORT_PATH="$(realpath "$(dirname "$0")/../reports/docs/")"
 WARNINGS_COUNT="$(find "$REPORT_PATH" -type f -name \*.log -print0 | xargs -0 grep -o "Warning:.*(ae-\|Warning:.*(tsdoc-" | wc -l | xargs)"
 WARNINGS_COUNT_LIMIT=1212
 


### PR DESCRIPTION
**What this PR does / why we need it**:

While trying to reorder CI dependencies, I realised that `build-frontend-docs` need `test-frontend` to run before. That happens because `test-frontend` step produces `reports/*` folder.

On my way to fix that, I realised that if this folder has not been created, `REPORT_PATH="$(realpath "$(dirname "$0")/../reports/docs/")"` exits with status `0`, a few lines below, there is the condition `if [ ! -d "$REPORT_PATH" ]; then`.

Using the realpath, if the path doesn't exist, it will never reach this condition. 
This PR fixes the case where the `REPORT_PATH` doesn't exist, by running the `scripts/ci-reference-docs-build.sh`, which generates this folder, and runs lint against it.
