### PR TITLE
CloudMonitoring: Fix annotation queries

### DIFF
--- a/pkg/tsdb/cloudmonitoring/annotation_query.go
+++ b/pkg/tsdb/cloudmonitoring/annotation_query.go
@@ -26,7 +26,6 @@ func (s *Service) executeAnnotationQuery(ctx context.Context, req *backend.Query
 	mq := struct {
 		Title string `json:"title"`
 		Text  string `json:"text"`
-		Tags  string `json:"tags"`
 	}{}
 
 	firstQuery := req.Queries[0]
@@ -34,7 +33,7 @@ func (s *Service) executeAnnotationQuery(ctx context.Context, req *backend.Query
 	if err != nil {
 		return resp, nil
 	}
-	err = queries[0].parseToAnnotations(queryRes, dr, mq.Title, mq.Text, mq.Tags)
+	err = queries[0].parseToAnnotations(queryRes, dr, mq.Title, mq.Text)
 	resp.Responses[firstQuery.RefID] = *queryRes
 
 	return resp, err

--- a/pkg/tsdb/cloudmonitoring/annotation_query_test.go
+++ b/pkg/tsdb/cloudmonitoring/annotation_query_test.go
@@ -17,7 +17,7 @@ func TestExecutor_parseToAnnotations(t *testing.T) {
 	query := &cloudMonitoringTimeSeriesFilter{}
 
 	err = query.parseToAnnotations(res, d, "atitle {{metric.label.instance_name}} {{metric.value}}",
-		"atext {{resource.label.zone}}", "atag")
+		"atext {{resource.label.zone}}")
 	require.NoError(t, err)
 
 	require.Len(t, res.Frames, 3)
@@ -34,7 +34,7 @@ func TestCloudMonitoringExecutor_parseToAnnotations_emptyTimeSeries(t *testing.T
 		TimeSeries: []timeSeries{},
 	}
 
-	err := query.parseToAnnotations(res, response, "atitle", "atext", "atag")
+	err := query.parseToAnnotations(res, response, "atitle", "atext")
 	require.NoError(t, err)
 
 	require.Len(t, res.Frames, 0)
@@ -50,7 +50,7 @@ func TestCloudMonitoringExecutor_parseToAnnotations_noPointsInSeries(t *testing.
 		},
 	}
 
-	err := query.parseToAnnotations(res, response, "atitle", "atext", "atag")
+	err := query.parseToAnnotations(res, response, "atitle", "atext")
 	require.NoError(t, err)
 
 	require.Len(t, res.Frames, 0)

--- a/pkg/tsdb/cloudmonitoring/time_series_filter.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter.go
@@ -293,7 +293,7 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) handleNonDistributionSe
 }
 
 func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) parseToAnnotations(dr *backend.DataResponse,
-	response cloudMonitoringResponse, title, text, tags string) error {
+	response cloudMonitoringResponse, title, text string) error {
 	frames := data.Frames{}
 	for _, series := range response.TimeSeries {
 		if len(series.Points) == 0 {
@@ -309,7 +309,7 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) parseToAnnotations(dr *
 			annotation["time"] = append(annotation["time"], point.Interval.EndTime.UTC().Format(time.RFC3339))
 			annotation["title"] = append(annotation["title"], formatAnnotationText(title, value, series.Metric.Type,
 				series.Metric.Labels, series.Resource.Labels))
-			annotation["tags"] = append(annotation["tags"], tags)
+			annotation["tags"] = append(annotation["tags"], "")
 			annotation["text"] = append(annotation["text"], formatAnnotationText(text, value, series.Metric.Type,
 				series.Metric.Labels, series.Resource.Labels))
 		}

--- a/pkg/tsdb/cloudmonitoring/time_series_query.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_query.go
@@ -273,7 +273,7 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) parseResponse(queryRes *ba
 }
 
 func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) parseToAnnotations(queryRes *backend.DataResponse,
-	data cloudMonitoringResponse, title, text, tags string) error {
+	data cloudMonitoringResponse, title, text string) error {
 	annotations := make([]map[string]string, 0)
 
 	for _, series := range data.TimeSeriesData {
@@ -313,7 +313,7 @@ func (timeSeriesQuery cloudMonitoringTimeSeriesQuery) parseToAnnotations(queryRe
 				annotation := make(map[string]string)
 				annotation["time"] = point.TimeInterval.EndTime.UTC().Format(time.RFC3339)
 				annotation["title"] = formatAnnotationText(title, value, d.MetricKind, metricLabels, resourceLabels)
-				annotation["tags"] = tags
+				annotation["tags"] = ""
 				annotation["text"] = formatAnnotationText(text, value, d.MetricKind, metricLabels, resourceLabels)
 				annotations = append(annotations, annotation)
 			}

--- a/pkg/tsdb/cloudmonitoring/types.go
+++ b/pkg/tsdb/cloudmonitoring/types.go
@@ -13,7 +13,7 @@ type (
 		run(ctx context.Context, req *backend.QueryDataRequest, s *Service, dsInfo datasourceInfo) (
 			*backend.DataResponse, cloudMonitoringResponse, string, error)
 		parseResponse(dr *backend.DataResponse, data cloudMonitoringResponse, executedQueryString string) error
-		parseToAnnotations(dr *backend.DataResponse, data cloudMonitoringResponse, title, text, tags string) error
+		parseToAnnotations(dr *backend.DataResponse, data cloudMonitoringResponse, title, text string) error
 		buildDeepLink() string
 		getRefID() string
 	}

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -67,7 +67,6 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
         metricType: this.templateSrv.replace(annotation.target.metricType, options.scopedVars || {}),
         title: this.templateSrv.replace(annotation.target.title, options.scopedVars || {}),
         text: this.templateSrv.replace(annotation.target.text, options.scopedVars || {}),
-        tags: (annotation.target.tags || []).map((t: string) => this.templateSrv.replace(t, options.scopedVars || {})),
         projectName: this.templateSrv.replace(
           annotation.target.projectName ? annotation.target.projectName : this.getDefaultProject(),
           options.scopedVars || {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, CloudMonitoring annotation queries always return an error because the tags prop in the annotation query model passed from the frontend is an array meanwhile the backend [expects a string](https://github.com/grafana/grafana/blob/main/pkg/tsdb/cloudmonitoring/annotation_query.go#L33). 

I don't know why the [tags prop](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/cloud-monitoring/datasource.ts#L65) is passed to the backend in the first place, because it's not part of the annotation query model and it's not possible to specify tags in the annotation query editor. Also, the returned tags were completely [ignored](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/cloud-monitoring/datasource.ts#L94) in the frontend, so it could never have worked anyway. So for now, I'm just removing tags from the query to fix this bug.  

In the future, we should return something meaningful, like labels, in the annotation tag field. 

**Which issue(s) this PR fixes**:
Fixes #41526 


