### PR TITLE
InfluxDB: Fix numeric aliases in queries

### DIFF
--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -120,6 +120,7 @@ You can switch to raw query mode by clicking hamburger icon and then `Switch edi
 
 - $m = replaced with measurement name
 - $measurement = replaced with measurement name
+- $1 - $9 = replaced with part of measurement name (if you separate your measurement name with dots)
 - $col = replaced with column name
 - $tag_exampletag = replaced with the value of the `exampletag` tag. The syntax is `$tag*yourTagName`(must start with`$tag*`). To use your tag as an alias in the ALIAS BY field then the tag must be used to group by in the query.
 - You can also use [[tag_hostname]] pattern replacement syntax. For example, in the ALIAS BY field using this text `Host: [[tag_hostname]]` would substitute in the `hostname` tag value for each legend value and an example legend value would be: `Host: server1`.

--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -113,7 +113,7 @@ func formatFrameName(row Row, column string, query *Query) string {
 		}
 
 		pos, err := strconv.Atoi(aliasFormat)
-		if err == nil && len(nameSegment) >= pos {
+		if err == nil && len(nameSegment) > pos {
 			return []byte(nameSegment[pos])
 		}
 

--- a/pkg/tsdb/influxdb/response_parser_test.go
+++ b/pkg/tsdb/influxdb/response_parser_test.go
@@ -293,6 +293,16 @@ func TestInfluxdbResponseParser(t *testing.T) {
 				t.Errorf("Result mismatch (-want +got):\n%s", diff)
 			}
 
+			query = &Query{Alias: "alias $0 $1 $2 $3 $4"}
+			result = parser.Parse(prepare(response), query)
+			frame = result.Responses["A"]
+			name = "alias cpu upc $2 $3 $4"
+			testFrame.Name = name
+			testFrame.Fields[1].Config.DisplayNameFromDS = name
+			if diff := cmp.Diff(testFrame, frame.Frames[0], data.FrameTestCompareOptions()...); diff != "" {
+				t.Errorf("Result mismatch (-want +got):\n%s", diff)
+			}
+
 			query = &Query{Alias: "alias $1"}
 			result = parser.Parse(prepare(response), query)
 			frame = result.Responses["A"]


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/41290

in InfluxDB, when you have a query like this:
`SELECT value from "computer.cpu"`, when the result is drawn on the screen, the time-series will be named "computer.cpu".
you can change this by using the ALIAS field in the query, there are many formats supported by the ALIAS field, but there is one where you use numbers, like `$0` or `[[1]]`. in this case the following will happen:
  - we take the measurement name (in this case `computer.cpu`)
  - split it into parts by the dot-character, so we get the array `["computer","cpu"]`
  - and then use the item from the array at the index specified by the alias (so, in our case, if you use the alias `AL $1`, the timeseries-name will be `AL cpu`

this works both in dashboard-queries and alert-queries, but in alert-queries there was a bug, where if you used a number that is outside the array, for example, for the array `["computer","cpu"]` you used the index 2, it crashed. (NOTE: it handled indexes that were even more outside the array, it only had problems with the index that is exactly outside the array.

this mode is documented in the help-text in the query-editor (when you press the question-mark next to the datasource-name) at https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/influxdb/query_help.md, but it is not documented at https://grafana.com/docs/grafana/latest/datasources/influxdb/#alias-patterns, so i updated the corresponding markdown file.

P.S: if you'd like to know more about why this feature exists, you can start by reading the commit where this was implemented: https://github.com/grafana/grafana/commit/ead451a97987e49b417ff57944f7d70ef4f6d5f2