### PR TITLE
SQLStore CacheService: Use value instead of pointer

### DIFF
--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -501,7 +501,8 @@ func newSignedInUserCacheKey(orgID, userID int64) string {
 func (ss *SQLStore) GetSignedInUserWithCacheCtx(ctx context.Context, query *models.GetSignedInUserQuery) error {
 	cacheKey := newSignedInUserCacheKey(query.OrgId, query.UserId)
 	if cached, found := ss.CacheService.Get(cacheKey); found {
-		query.Result = cached.(*models.SignedInUser)
+		cachedUser := cached.(models.SignedInUser)
+		query.Result = &cachedUser
 		return nil
 	}
 
@@ -511,7 +512,7 @@ func (ss *SQLStore) GetSignedInUserWithCacheCtx(ctx context.Context, query *mode
 	}
 
 	cacheKey = newSignedInUserCacheKey(query.Result.OrgId, query.UserId)
-	ss.CacheService.Set(cacheKey, query.Result, time.Second*5)
+	ss.CacheService.Set(cacheKey, *query.Result, time.Second*5)
 	return nil
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
@alexanderzobnin and @sakjur noticed that the `ReqContext.SignedInUser` was shared among different request contexts due to the user `CacheService` working with a pointer to the user. This lead to some race conditions when sending multiple requests modifying the `ReqContext.SignedInUser`.

This PR intends to fix this.

Checkout https://github.com/grafana/grafana-enterprise/issues/2245 for more context.

The fix: https://raintank-corp.slack.com/archives/C01JEKKTMCK/p1636540755087500?thread_ts=1636538124.084600&cid=C01JEKKTMCK

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

