### PR TITLE
feat: adds Unified Alerting promotion

### DIFF
--- a/public/app/features/alerting/AlertRuleList.tsx
+++ b/public/app/features/alerting/AlertRuleList.tsx
@@ -14,6 +14,7 @@ import { Button, LinkButton, Select, VerticalGroup, FilterInput } from '@grafana
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { ShowModalReactEvent } from '../../types/events';
 import { AlertHowToModal } from './AlertHowToModal';
+import { UnifiedAlertingPromotion } from './components/UnifiedAlertingPromotion';
 
 function mapStateToProps(state: StoreState) {
   return {
@@ -121,6 +122,7 @@ export class AlertRuleListUnconnected extends PureComponent<Props> {
               How to add an alert
             </Button>
           </div>
+          <UnifiedAlertingPromotion />
           <VerticalGroup spacing="none">
             {alertRules.map((rule) => {
               return (

--- a/public/app/features/alerting/components/UnifiedAlertingPromotion.test.tsx
+++ b/public/app/features/alerting/components/UnifiedAlertingPromotion.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UnifiedAlertingPromotion, LOCAL_STORAGE_KEY } from './UnifiedAlertingPromotion';
+
+describe('Unified Alerting promotion', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('should show by default', () => {
+    const promotion = render(<UnifiedAlertingPromotion />);
+    expect(promotion.queryByLabelText('Alert info')).toBeInTheDocument();
+  });
+
+  it('should be hidden if dismissed', () => {
+    const promotion = render(<UnifiedAlertingPromotion />);
+    expect(window.localStorage.getItem(LOCAL_STORAGE_KEY)).toBe('true');
+
+    const dismissButton = promotion.getByRole('button');
+    userEvent.click(dismissButton);
+
+    expect(promotion.queryByLabelText('Alert info')).not.toBeInTheDocument();
+    expect(window.localStorage.getItem(LOCAL_STORAGE_KEY)).toBe('false');
+  });
+
+  it('should not render if previously dismissed', () => {
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, 'false');
+    const promotion = render(<UnifiedAlertingPromotion />);
+
+    expect(promotion.queryByLabelText('Alert info')).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/components/UnifiedAlertingPromotion.tsx
+++ b/public/app/features/alerting/components/UnifiedAlertingPromotion.tsx
@@ -22,10 +22,10 @@ const UnifiedAlertingPromotion: FC<{}> = () => {
       onRemove={() => setShowUnifiedAlertingPromotion(false)}
     >
       <p>
-        You are using the legacy Grafana alerts feature.
+        You are using the legacy Grafana alerting.
         <br />
-        While this feature will not be deprecated any time soon and continue to work as intend, we invite you to give
-        the new Grafana 8 alerting a try.
+       While we have no plans of deprecating it any time soon, we invite you to give
+		 the improved Grafana 8 alerting a try.
       </p>
       <p>
         See{' '}

--- a/public/app/features/alerting/components/UnifiedAlertingPromotion.tsx
+++ b/public/app/features/alerting/components/UnifiedAlertingPromotion.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react';
 import { Alert } from '@grafana/ui';
 import { useLocalStorage } from 'react-use';
 
-export const LOCAL_STORAGE_KEY = 'LegacyAlerting.UnifiedAlertingPromotion';
+export const LOCAL_STORAGE_KEY = 'grafana.legacyalerting.unifiedalertingpromo';
 
 const UnifiedAlertingPromotion: FC<{}> = () => {
   const [showUnifiedAlertingPromotion, setShowUnifiedAlertingPromotion] = useLocalStorage<boolean>(
@@ -24,8 +24,8 @@ const UnifiedAlertingPromotion: FC<{}> = () => {
       <p>
         You are using the legacy Grafana alerting.
         <br />
-       While we have no plans of deprecating it any time soon, we invite you to give
-		 the improved Grafana 8 alerting a try.
+        While we have no plans of deprecating it any time soon, we invite you to give the improved Grafana 8 alerting a
+        try.
       </p>
       <p>
         See{' '}

--- a/public/app/features/alerting/components/UnifiedAlertingPromotion.tsx
+++ b/public/app/features/alerting/components/UnifiedAlertingPromotion.tsx
@@ -18,7 +18,7 @@ const UnifiedAlertingPromotion: FC<{}> = () => {
   return (
     <Alert
       severity="info"
-      title="Try out the new Grafana 8 alerting"
+      title="Try out the Grafana 8 alerting!"
       onRemove={() => setShowUnifiedAlertingPromotion(false)}
     >
       <p>

--- a/public/app/features/alerting/components/UnifiedAlertingPromotion.tsx
+++ b/public/app/features/alerting/components/UnifiedAlertingPromotion.tsx
@@ -1,0 +1,45 @@
+import React, { FC } from 'react';
+
+import { Alert } from '@grafana/ui';
+import { useLocalStorage } from 'react-use';
+
+export const LOCAL_STORAGE_KEY = 'LegacyAlerting.UnifiedAlertingPromotion';
+
+const UnifiedAlertingPromotion: FC<{}> = () => {
+  const [showUnifiedAlertingPromotion, setShowUnifiedAlertingPromotion] = useLocalStorage<boolean>(
+    LOCAL_STORAGE_KEY,
+    true
+  );
+
+  if (!showUnifiedAlertingPromotion) {
+    return null;
+  }
+
+  return (
+    <Alert
+      severity="info"
+      title="Try out the new Unified Alerting"
+      onRemove={() => setShowUnifiedAlertingPromotion(false)}
+    >
+      <p>
+        You are using the legacy Grafana alerts feature.
+        <br />
+        While this feature will not be deprecated any time soon and continue to work as intend, we invite you to give
+        the new Unified Alerting a try.
+      </p>
+      <p>
+        See{' '}
+        <a href="https://grafana.com/docs/grafana/latest/alerting/unified-alerting/difference-old-new/">
+          What’s New with Grafana 8 alerting
+        </a>{' '}
+        to learn more about what&lsquo;s new in Unified Alerting, or learn{' '}
+        <a href="https://grafana.com/docs/grafana/latest/alerting/unified-alerting/opt-in/">
+          how to enable the new unified alerting feature
+        </a>
+        .
+      </p>
+    </Alert>
+  );
+};
+
+export { UnifiedAlertingPromotion };

--- a/public/app/features/alerting/components/UnifiedAlertingPromotion.tsx
+++ b/public/app/features/alerting/components/UnifiedAlertingPromotion.tsx
@@ -18,23 +18,23 @@ const UnifiedAlertingPromotion: FC<{}> = () => {
   return (
     <Alert
       severity="info"
-      title="Try out the new Unified Alerting"
+      title="Try out the new Grafana 8 alerting"
       onRemove={() => setShowUnifiedAlertingPromotion(false)}
     >
       <p>
         You are using the legacy Grafana alerts feature.
         <br />
         While this feature will not be deprecated any time soon and continue to work as intend, we invite you to give
-        the new Unified Alerting a try.
+        the new Grafana 8 alerting a try.
       </p>
       <p>
         See{' '}
         <a href="https://grafana.com/docs/grafana/latest/alerting/unified-alerting/difference-old-new/">
           What’s New with Grafana 8 alerting
         </a>{' '}
-        to learn more about what&lsquo;s new in Unified Alerting, or learn{' '}
+        to learn more about what&lsquo;s new in Grafana 8 alerting or learn{' '}
         <a href="https://grafana.com/docs/grafana/latest/alerting/unified-alerting/opt-in/">
-          how to enable the new unified alerting feature
+          how to enable the new Grafana 8 alerting feature
         </a>
         .
       </p>


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an alert to promote the new Unified Alerting feature, see #41185

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/868844/141760603-525b8aa1-a3bd-4556-915b-14f4d1820b17.png">

**Which issue(s) this PR fixes**:

Fixes #41185

**Special notes for your reviewer**:

I'm open to feedback on the language, grammar and the overall visual style of the alert. Dismissing it will be persisted in `localStorage` and will no longer be shown to the user.

