### PR TITLE
InfluxDB: Fix corner case where index is too large in ALIAS field

### DIFF
--- a/public/app/plugins/datasource/influxdb/influx_series.ts
+++ b/public/app/plugins/datasource/influxdb/influx_series.ts
@@ -80,7 +80,7 @@ export default class InfluxSeries {
         return series.columns[index];
       }
       if (!isNaN(segIndex)) {
-        return segments[segIndex];
+        return segments[segIndex] ?? match;
       }
       if (group.indexOf('tag_') !== 0) {
         return match;

--- a/public/app/plugins/datasource/influxdb/specs/influx_series.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/influx_series.test.ts
@@ -201,6 +201,14 @@ describe('when generating timeseries from influxdb response', () => {
 
       expect(result[0].target).toBe('alias: prod -> count');
     });
+
+    it('should handle too large indexes', () => {
+      options.alias = 'alias: $0 $1 $2 $3 $4 $5';
+      const series = new InfluxSeries(options);
+      const result = series.getTimeSeries();
+
+      expect(result[0].target).toBe('alias: app prod server1 count $4 $5');
+    });
   });
 
   describe('given table response', () => {


### PR DESCRIPTION
in InfluxDB, when you have a query like this:
`SELECT value from "computer.cpu"`, when the result is drawn on the screen, the time-series will be named "computer.cpu".
you can change this by using the ALIAS field in the query, there are many formats supported by the ALIAS field, but there is one where you use numbers, like `$0` or `[[1]]`. in this case the following will happen:
  - we take the measurement name (in this case `computer.cpu`)
  - split it into parts by the dot-character, so we get the array `["computer","cpu"]`
  - and then use the item from the array at the index specified by the alias (so, in our case, if you use the alias `AL $1`, the timeseries-name will be `AL cpu`

there is a problem, if you specify an index that is higher than the length of the array, the series will be named `undefined`. for example, if your measurement is named `computer.cpu` and you use the alias `AL $7`, the series will be named `AL undefined`.

this pull request changes this so that the series name will become `AL $7` in this case. this is consistent with how it happens in the influxdb-alerting-go-code, and also consistent with the approach that when we have a variable that does not exist, we just keep the original text.

how to test:
you need to have measurement with names that contain periods. the simplest way is to manually insert such values into influxdb:
- `make devenv sources=influxdb`
- run `docker ps`, and find the ID of the influxdb container.
- run `docker exec -it <docker_container_id> influx write -b mybucket -o myorg -t mytoken 'name.with.dots v=40'`
- now go to explore-mode, choose the datasource `gdev-influxdb-influxql`, and choose the measurement "name.with.dots", choose the field "v", and try out ALIAS values.