### PR TITLE
Cloudwatch: Enable dimension filtering when loading dimension values

### DIFF
--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -436,7 +436,7 @@ func (e *cloudWatchExecutor) handleGetMetrics(ctx context.Context, parameters *s
 	return result, nil
 }
 
-// handleGetAllMetrics returns a slice of suggstData structs containing metric and its namespace
+// handleGetAllMetrics returns a slice of suggestData structs with metric and its namespace
 func (e *cloudWatchExecutor) handleGetAllMetrics(ctx context.Context, parameters *simplejson.Json, pluginCtx backend.PluginContext) ([]suggestData, error) {
 	result := make([]suggestData, 0)
 	for namespace, metrics := range metricsMap {
@@ -448,6 +448,9 @@ func (e *cloudWatchExecutor) handleGetAllMetrics(ctx context.Context, parameters
 	return result, nil
 }
 
+// handleGetDimensions returns a slice of suggestData structs with dimension keys.
+// If a dimension filters parameter is specified, a new api call to list metrics will be issued to load dimension keys for the given filter.
+// If no dimension filter is specified, dimension keys will be retrived from the hard coded map in this file.
 func (e *cloudWatchExecutor) handleGetDimensions(ctx context.Context, parameters *simplejson.Json, pluginCtx backend.PluginContext) ([]suggestData, error) {
 	region := parameters.Get("region").MustString()
 	namespace := parameters.Get("namespace").MustString()
@@ -534,6 +537,8 @@ func (e *cloudWatchExecutor) handleGetDimensions(ctx context.Context, parameters
 	return result, nil
 }
 
+// handleGetDimensionValues returns a slice of suggestData structs with dimension values.
+// A call to the list metrics api is issued to retrieve the dimension values. All parameters are used as input args to the list metrics call.
 func (e *cloudWatchExecutor) handleGetDimensionValues(ctx context.Context, parameters *simplejson.Json, pluginCtx backend.PluginContext) ([]suggestData, error) {
 	region := parameters.Get("region").MustString()
 	namespace := parameters.Get("namespace").MustString()

--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -450,7 +450,7 @@ func (e *cloudWatchExecutor) handleGetAllMetrics(ctx context.Context, parameters
 
 // handleGetDimensions returns a slice of suggestData structs with dimension keys.
 // If a dimension filters parameter is specified, a new api call to list metrics will be issued to load dimension keys for the given filter.
-// If no dimension filter is specified, dimension keys will be retrived from the hard coded map in this file.
+// If no dimension filter is specified, dimension keys will be retrieved from the hard coded map in this file.
 func (e *cloudWatchExecutor) handleGetDimensions(ctx context.Context, parameters *simplejson.Json, pluginCtx backend.PluginContext) ([]suggestData, error) {
 	region := parameters.Get("region").MustString()
 	namespace := parameters.Get("namespace").MustString()

--- a/pkg/tsdb/cloudwatch/metric_find_query_test.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query_test.go
@@ -465,6 +465,154 @@ func TestQuery_ResourceARNs(t *testing.T) {
 	})
 }
 
+func TestQuery_GetAllMetrics(t *testing.T) {
+	t.Run("all metrics in all namespaces are being returned", func(t *testing.T) {
+		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return datasourceInfo{}, nil
+		})
+
+		executor := newExecutor(nil, im, newTestConfig(), fakeSessionCache{})
+		resp, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+			Queries: []backend.DataQuery{
+				{
+					JSON: json.RawMessage(`{
+						"type":      "metricFindQuery",
+						"subtype":   "all_metrics",
+						"region":    "us-east-1"
+					}`),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		metricCount := 0
+		for _, metrics := range metricsMap {
+			metricCount += len(metrics)
+		}
+
+		assert.Equal(t, metricCount, resp.Responses[""].Frames[0].Fields[1].Len())
+	})
+}
+
+func TestQuery_GetDimensionKeys(t *testing.T) {
+	origNewCWClient := NewCWClient
+	t.Cleanup(func() {
+		NewCWClient = origNewCWClient
+	})
+
+	var client FakeCWClient
+
+	NewCWClient = func(sess *session.Session) cloudwatchiface.CloudWatchAPI {
+		return client
+	}
+
+	metrics := []*cloudwatch.Metric{
+		{MetricName: aws.String("Test_MetricName1"), Dimensions: []*cloudwatch.Dimension{
+			{Name: aws.String("Dimension1"), Value: aws.String("Dimension1")},
+			{Name: aws.String("Dimension2"), Value: aws.String("Dimension2")},
+		}},
+		{MetricName: aws.String("Test_MetricName2"), Dimensions: []*cloudwatch.Dimension{
+			{Name: aws.String("Dimension2"), Value: aws.String("Dimension2")},
+			{Name: aws.String("Dimension3"), Value: aws.String("Dimension3")},
+		}},
+	}
+
+	t.Run("should fetch dimension keys from list metrics api and return unique dimensions when a dimension filter is specified", func(t *testing.T) {
+		client = FakeCWClient{Metrics: metrics, MetricsPerPage: 2}
+		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return datasourceInfo{}, nil
+		})
+
+		executor := newExecutor(nil, im, newTestConfig(), fakeSessionCache{})
+		resp, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+			Queries: []backend.DataQuery{
+				{
+					JSON: json.RawMessage(`{
+						"type":      "metricFindQuery",
+						"subtype":   "dimension_keys",
+						"region":    "us-east-1",
+						"namespace": "AWS/EC2",
+						"dimensionFilters": {
+							"InstanceId": "",
+							"AutoscalingGroup": []
+						}
+					}`),
+				},
+			},
+		})
+
+		require.NoError(t, err)
+
+		expValues := []string{"Dimension1", "Dimension2", "Dimension3"}
+		expFrame := data.NewFrame(
+			"",
+			data.NewField("text", nil, expValues),
+			data.NewField("value", nil, expValues),
+		)
+		expFrame.Meta = &data.FrameMeta{
+			Custom: map[string]interface{}{
+				"rowCount": len(expValues),
+			},
+		}
+
+		assert.Equal(t, &backend.QueryDataResponse{Responses: backend.Responses{
+			"": {
+				Frames: data.Frames{expFrame},
+			},
+		},
+		}, resp)
+	})
+
+	t.Run("should return hard coded metrics when no dimension filter is specified", func(t *testing.T) {
+		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return datasourceInfo{}, nil
+		})
+
+		executor := newExecutor(nil, im, newTestConfig(), fakeSessionCache{})
+		resp, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+			Queries: []backend.DataQuery{
+				{
+					JSON: json.RawMessage(`{
+						"type":      "metricFindQuery",
+						"subtype":   "dimension_keys",
+						"region":    "us-east-1",
+						"namespace": "AWS/EC2",
+						"dimensionFilters": {}
+					}`),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		expValues := dimensionsMap["AWS/EC2"]
+		expFrame := data.NewFrame(
+			"",
+			data.NewField("text", nil, expValues),
+			data.NewField("value", nil, expValues),
+		)
+		expFrame.Meta = &data.FrameMeta{
+			Custom: map[string]interface{}{
+				"rowCount": len(expValues),
+			},
+		}
+
+		assert.Equal(t, &backend.QueryDataResponse{Responses: backend.Responses{
+			"": {
+				Frames: data.Frames{expFrame},
+			},
+		},
+		}, resp)
+	})
+}
 func Test_isCustomMetrics(t *testing.T) {
 	metricsMap = map[string][]string{
 		"AWS/EC2": {"ExampleMetric"},

--- a/public/app/plugins/datasource/cloudwatch/__mocks__/CloudWatchDataSource.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/CloudWatchDataSource.ts
@@ -1,0 +1,121 @@
+import { dateTime } from '@grafana/data';
+import { setBackendSrv } from '@grafana/runtime';
+import { TemplateSrvMock } from '../../../../features/templating/template_srv.mock';
+import { initialCustomVariableModelState } from 'app/features/variables/custom/reducer';
+import { CustomVariableModel } from 'app/features/variables/types';
+import { of } from 'rxjs';
+import { CloudWatchDatasource } from '../datasource';
+import { TemplateSrv } from 'app/features/templating/template_srv';
+
+export function setupMockedDataSource({ data = [], variables }: { data?: any; variables?: any } = {}) {
+  let templateService = new TemplateSrvMock({
+    region: 'templatedRegion',
+    fields: 'templatedField',
+    group: 'templatedGroup',
+  }) as any;
+  if (variables) {
+    templateService = new TemplateSrv();
+    templateService.init(variables);
+  }
+
+  const datasource = new CloudWatchDatasource(
+    {
+      jsonData: { defaultRegion: 'us-west-1', tracingDatasourceUid: 'xray' },
+    } as any,
+    templateService,
+    {
+      timeRange() {
+        const time = dateTime('2021-01-01T01:00:00Z');
+        const range = {
+          from: time.subtract(6, 'hour'),
+          to: time,
+        };
+
+        return {
+          ...range,
+          raw: range,
+        };
+      },
+    } as any
+  );
+  const fetchMock = jest.fn().mockReturnValue(of({ data }));
+  setBackendSrv({ fetch: fetchMock } as any);
+
+  return { datasource, fetchMock };
+}
+
+export const metricVariable: CustomVariableModel = {
+  ...initialCustomVariableModelState,
+  id: 'metric',
+  name: 'metric',
+  current: { value: 'CPUUtilization', text: 'CPUUtilizationEC2', selected: true },
+  options: [
+    { value: 'DroppedBytes', text: 'DroppedBytes', selected: false },
+    { value: 'CPUUtilization', text: 'CPUUtilization', selected: false },
+  ],
+  multi: false,
+};
+
+export const namespaceVariable: CustomVariableModel = {
+  ...initialCustomVariableModelState,
+  id: 'namespace',
+  name: 'namespace',
+  query: 'namespaces()',
+  current: { value: 'AWS/EC2', text: 'AWS/EC2', selected: true },
+  options: [
+    { value: 'AWS/Redshift', text: 'AWS/Redshift', selected: false },
+    { value: 'AWS/EC2', text: 'AWS/EC2', selected: false },
+    { value: 'AWS/MQ', text: 'AWS/MQ', selected: false },
+  ],
+  multi: false,
+};
+
+export const labelsVariable: CustomVariableModel = {
+  ...initialCustomVariableModelState,
+  id: 'labels',
+  name: 'labels',
+  current: {
+    value: ['InstanceId', 'InstanceType'],
+    text: ['InstanceId', 'InstanceType'].toString(),
+    selected: true,
+  },
+  options: [
+    { value: 'InstanceId', text: 'InstanceId', selected: false },
+    { value: 'InstanceType', text: 'InstanceType', selected: false },
+  ],
+  multi: true,
+};
+
+export const limitVariable: CustomVariableModel = {
+  ...initialCustomVariableModelState,
+  id: 'limit',
+  name: 'limit',
+  current: {
+    value: '100',
+    text: '100',
+    selected: true,
+  },
+  options: [
+    { value: '10', text: '10', selected: false },
+    { value: '100', text: '100', selected: false },
+    { value: '1000', text: '1000', selected: false },
+  ],
+  multi: false,
+};
+
+export const aggregationvariable: CustomVariableModel = {
+  ...initialCustomVariableModelState,
+  id: 'aggregation',
+  name: 'aggregation',
+  current: {
+    value: 'AVG',
+    text: 'AVG',
+    selected: true,
+  },
+  options: [
+    { value: 'AVG', text: 'AVG', selected: false },
+    { value: 'SUM', text: 'SUM', selected: false },
+    { value: 'MIN', text: 'MIN', selected: false },
+  ],
+  multi: false,
+};

--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -1,16 +1,15 @@
 import { lastValueFrom, of } from 'rxjs';
-import { setBackendSrv, setDataSourceSrv } from '@grafana/runtime';
+import { setDataSourceSrv } from '@grafana/runtime';
 import { ArrayVector, DataFrame, dataFrameToJSON, dateTime, Field, MutableDataFrame } from '@grafana/data';
 
-import { CloudWatchDatasource } from './datasource';
 import { toArray } from 'rxjs/operators';
+import { setupMockedDataSource } from './__mocks__/CloudWatchDataSource';
 import { CloudWatchLogsQueryStatus } from './types';
-import { TemplateSrvMock } from '../../../features/templating/template_srv.mock';
 
 describe('datasource', () => {
   describe('query', () => {
     it('should return error if log query and log groups is not specified', async () => {
-      const { datasource } = setup();
+      const { datasource } = setupMockedDataSource();
       const observable = datasource.query({ targets: [{ queryMode: 'Logs' as 'Logs' }] } as any);
 
       await expect(observable).toEmitValuesWith((received) => {
@@ -20,7 +19,7 @@ describe('datasource', () => {
     });
 
     it('should return empty response if queries are hidden', async () => {
-      const { datasource } = setup();
+      const { datasource } = setupMockedDataSource();
       const observable = datasource.query({ targets: [{ queryMode: 'Logs' as 'Logs', hide: true }] } as any);
 
       await expect(observable).toEmitValuesWith((received) => {
@@ -30,7 +29,7 @@ describe('datasource', () => {
     });
 
     it('should interpolate variables in the query', async () => {
-      const { datasource, fetchMock } = setup();
+      const { datasource, fetchMock } = setupMockedDataSource();
       datasource.query({
         targets: [
           {
@@ -86,7 +85,7 @@ describe('datasource', () => {
 
   describe('performTimeSeriesQuery', () => {
     it('should return the same length of data as result', async () => {
-      const { datasource } = setup({
+      const { datasource } = setupMockedDataSource({
         data: {
           results: {
             a: { refId: 'a', series: [{ name: 'cpu', points: [1, 1] }], meta: {} },
@@ -114,7 +113,7 @@ describe('datasource', () => {
 
   describe('describeLogGroup', () => {
     it('replaces region correctly in the query', async () => {
-      const { datasource, fetchMock } = setup();
+      const { datasource, fetchMock } = setupMockedDataSource();
       await datasource.describeLogGroups({ region: 'default' });
       expect(fetchMock.mock.calls[0][0].data.queries[0].region).toBe('us-west-1');
 
@@ -124,37 +123,12 @@ describe('datasource', () => {
   });
 });
 
-function setup({ data = [] }: { data?: any } = {}) {
-  const datasource = new CloudWatchDatasource(
-    { jsonData: { defaultRegion: 'us-west-1', tracingDatasourceUid: 'xray' } } as any,
-    new TemplateSrvMock({ region: 'templatedRegion', fields: 'templatedField', group: 'templatedGroup' }) as any,
-    {
-      timeRange() {
-        const time = dateTime('2021-01-01T01:00:00Z');
-        const range = {
-          from: time.subtract(6, 'hour'),
-          to: time,
-        };
-
-        return {
-          ...range,
-          raw: range,
-        };
-      },
-    } as any
-  );
-  const fetchMock = jest.fn().mockReturnValue(of({ data }));
-  setBackendSrv({ fetch: fetchMock } as any);
-
-  return { datasource, fetchMock };
-}
-
 function setupForLogs() {
   function envelope(frame: DataFrame) {
     return { data: { results: { a: { refId: 'a', frames: [dataFrameToJSON(frame)] } } } };
   }
 
-  const { datasource, fetchMock } = setup();
+  const { datasource, fetchMock } = setupMockedDataSource();
 
   const startQueryFrame = new MutableDataFrame({ fields: [{ name: 'queryId', values: ['queryid'] }] });
   fetchMock.mockReturnValueOnce(of(envelope(startQueryFrame)));

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -1,5 +1,8 @@
 import { DataQuery, DataSourceRef, SelectableValue } from '@grafana/data';
 import { AwsAuthDataSourceSecureJsonData, AwsAuthDataSourceJsonData } from '@grafana/aws-sdk';
+export interface Dimensions {
+  [key: string]: string | string[];
+}
 
 export interface CloudWatchMetricsQuery extends DataQuery {
   queryMode?: 'Metrics';
@@ -324,4 +327,10 @@ export interface ExecutedQueryPreview {
   id: string;
   executedQuery: string;
   period: string;
+}
+
+export interface MetricFindSuggestData {
+  text: string;
+  label: string;
+  value: string;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables dimension filtering when loading dimension values from the list metrics API. 

Also refactoring the datasource.ts file slightly so that setup test can reused in other parts of this datasource.

**Special notes for your reviewer**:
This PR does not need the add to changelog label since another PR that actually makes use of this filter will come soon. That PR should have that label. 
