### PR TITLE
App: Get injector from angular for now

### DIFF
--- a/public/app/angular/lazyBootAngular.ts
+++ b/public/app/angular/lazyBootAngular.ts
@@ -1,4 +1,4 @@
-import { auto } from 'angular';
+import angular, { auto } from 'angular';
 
 let injector: auto.IInjectorService | undefined;
 
@@ -11,7 +11,10 @@ export async function getAngularInjector(): Promise<auto.IInjectorService> {
   }
 
   const { AngularApp } = await import(/* webpackChunkName: "AngularApp" */ './index');
-  if (injector) {
+  // Remove this logic once AngularApp is loaded asynchronously everywhere
+  if (!injector) {
+    const $injector = angular.element('#ngRoot').injector();
+    injector = $injector;
     return injector;
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the issue that happened after the angular isolation https://github.com/grafana/grafana/pull/41440
The `getAngularInjector` function was trying to bootstrap angular again. My code is just a hack that returns the injector from the angular instance and doesn't fix the lazy loading of the angular app.

**Which issue(s) this PR fixes**:

Fixes https://raintank-corp.slack.com/archives/C023A30M3S7/p1636559668151400

**Special notes for your reviewer**:

I used the google-big-query datasource (from doit) for testing.