### PR TITLE
Toolkit: Plugin version accessible from plugin code

### DIFF
--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
@@ -128,6 +128,11 @@ const getCommonPlugins = (options: WebpackConfigurationOptions) => {
         ],
       },
     ]),
+
+    new webpack.DefinePlugin({
+      'process.env.VERSION': JSON.stringify(packageJson.version),
+    }),
+
     new ForkTsCheckerWebpackPlugin({
       typescript: { configFile: path.join(process.cwd(), 'tsconfig.json') },
       issue: {


### PR DESCRIPTION
**What this PR does / why we need it**:

It's useful to have access to the plugin version from JavaScript code for things like for telemetry, UI etc.

The toolkit uses Webpack, and it's common to use Webpack to inject values into code at compile time (such as version, environment, feature flags, environment-specific endpoints etc.).

This PR updates Webpack configuration to pass version value via fake environment variable `process.env.VERSION`:

```ts
const pluginVersion = process.env.VERSION;

return (
  <p>{pluginVersion}</p>
)
```


**Special notes for your reviewer**:

`process.env.VERSION` was chosen because use of `process.env` is most common for such purposes: it's global object, not used by browsers and TypeScript has type definitions for it.