### PR TITLE
Prometheus: Fix applying of ad-hoc variables after backend migration

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -503,7 +503,7 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
     let expr = target.expr;
 
     // Apply adhoc filters
-    expr = this.enahnceExprWithAdHocFilters(expr);
+    expr = this.enhanceExprWithAdHocFilters(expr);
 
     // Only replace vars in expression after having (possibly) updated interval vars
     query.expr = this.templateSrv.replace(expr, scopedVars, this.interpolateQueryExpr);
@@ -901,7 +901,7 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
     return getOriginalMetricName(labelData);
   }
 
-  enahnceExprWithAdHocFilters(expr: string) {
+  enhanceExprWithAdHocFilters(expr: string) {
     const adhocFilters = this.templateSrv.getAdhocFilters(this.name);
     let finalQuery = expr;
     finalQuery = adhocFilters.reduce((acc: string, filter: { key?: any; operator?: any; value?: any }) => {
@@ -932,7 +932,7 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
     delete variables.__interval_ms;
 
     //Add ad hoc filters
-    const expr = this.enahnceExprWithAdHocFilters(target.expr);
+    const expr = this.enhanceExprWithAdHocFilters(target.expr);
 
     return {
       ...target,

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -503,15 +503,7 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
     let expr = target.expr;
 
     // Apply adhoc filters
-    const adhocFilters = this.templateSrv.getAdhocFilters(this.name);
-    expr = adhocFilters.reduce((acc: string, filter: { key?: any; operator?: any; value?: any }) => {
-      const { key, operator } = filter;
-      let { value } = filter;
-      if (operator === '=~' || operator === '!~') {
-        value = prometheusRegularEscape(value);
-      }
-      return addLabelToQuery(acc, key, value, operator);
-    }, expr);
+    expr = this.enahnceExprWithAdHocFilters(expr);
 
     // Only replace vars in expression after having (possibly) updated interval vars
     query.expr = this.templateSrv.replace(expr, scopedVars, this.interpolateQueryExpr);
@@ -909,6 +901,20 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
     return getOriginalMetricName(labelData);
   }
 
+  enahnceExprWithAdHocFilters(expr: string) {
+    const adhocFilters = this.templateSrv.getAdhocFilters(this.name);
+    let finalQuery = expr;
+    finalQuery = adhocFilters.reduce((acc: string, filter: { key?: any; operator?: any; value?: any }) => {
+      const { key, operator } = filter;
+      let { value } = filter;
+      if (operator === '=~' || operator === '!~') {
+        value = prometheusRegularEscape(value);
+      }
+      return addLabelToQuery(acc, key, value, operator);
+    }, finalQuery);
+    return finalQuery;
+  }
+
   // Used when running queries trough backend
   filterQuery(query: PromQuery): boolean {
     if (query.hide || !query.expr) {
@@ -920,14 +926,18 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
   // Used when running queries trough backend
   applyTemplateVariables(target: PromQuery, scopedVars: ScopedVars): Record<string, any> {
     const variables = cloneDeep(scopedVars);
+
     // We want to interpolate these variables on backend
     delete variables.__interval;
     delete variables.__interval_ms;
 
+    //Add ad hoc filters
+    const expr = this.enahnceExprWithAdHocFilters(target.expr);
+
     return {
       ...target,
       legendFormat: this.templateSrv.replace(target.legendFormat, variables),
-      expr: this.templateSrv.replace(target.expr, variables, this.interpolateQueryExpr),
+      expr: this.templateSrv.replace(expr, variables, this.interpolateQueryExpr),
     };
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
During Prometheus backend migration I have forgotten to add adding of ad-hoc variables. I incorrectly thought that they were added in applyTemplateVariable step, but they weren't added. This PR fixes this and adds test. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/41280

