### PR TITLE
Renovate: ignore packages/grafana-toolkit

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,24 +20,11 @@
     "ts-loader", // we should remove ts-loader and use babel-loader instead
     "ora" // we should bump this once we move to esm modules
   ],
-  "ignorePaths": ["emails/**", "plugins-bundled/**", "**/mocks/**"],
+  "ignorePaths": ["packages/grafana-toolkit/package.json", "emails/**", "plugins-bundled/**", "**/mocks/**"],
   "labels": ["area/frontend", "dependencies"],
   "minor": {
     "enabled": false
   },
-  "packageRules": [
-    {
-      "matchPaths": ["grafana-toolkit/package.json"],
-      "ignoreDeps": [
-        "copy-webpack-plugin", // need to wait for Grafana 9 to upgrade toolkit to webpack 5
-        "css-loader", // need to wait for Grafana 9 to upgrade toolkit to webpack 5
-        "html-loader", // need to wait for Grafana 9 to upgrade toolkit to webpack 5
-        "postcss-loader", // need to wait for Grafana 9 to upgrade toolkit to webpack 5
-        "less", // need to wait for Grafana 9 to upgrade toolkit to webpack 5
-        "less-loader", // need to wait for Grafana 9 to upgrade toolkit to webpack 5
-      ]
-    }
-  ],
   "patch": {
     "enabled": false
   },


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/41593

we will handle updating grafana-toolkit's dependencies separately.