### PR TITLE
Avoid template execution errors on missing values

### DIFF
--- a/pkg/services/ngalert/state/template.go
+++ b/pkg/services/ngalert/state/template.go
@@ -54,7 +54,7 @@ func expandTemplate(name, text string, labels map[string]string, alertInstance e
 			return nil, nil
 		},
 		externalURL,
-		[]string{"missingkey=error"},
+		[]string{"missingkey=invalid"},
 	)
 
 	expander.Funcs(text_template.FuncMap{

--- a/pkg/services/ngalert/state/template_test.go
+++ b/pkg/services/ngalert/state/template_test.go
@@ -56,10 +56,10 @@ func TestExpandTemplate(t *testing.T) {
 		labels:   data.Labels{"instance": "foo"},
 		expected: "foo is down",
 	}, {
-		name:          "missing label in $labels returns error",
-		text:          "{{ $labels.instance }} is down",
-		labels:        data.Labels{},
-		expectedError: errors.New("error executing template __alert_test: template: __alert_test:1:86: executing \"__alert_test\" at <$labels.instance>: map has no entry for key \"instance\""),
+		name:     "missing label in $labels returns <no value>",
+		text:     "{{ $labels.instance }} is down",
+		labels:   data.Labels{},
+		expected: "<no value> is down",
 	}, {
 		name: "values are expanded into $values",
 		text: "{{ $values.A.Labels.instance }} has value {{ $values.A }}",
@@ -87,7 +87,7 @@ func TestExpandTemplate(t *testing.T) {
 		},
 		expected: "foo has value 1.1",
 	}, {
-		name: "missing label in $values returns error",
+		name: "missing label in $values returns <no value>",
 		text: "{{ $values.A.Labels.instance }} has value {{ $values.A }}",
 		alertInstance: eval.Result{
 			Values: map[string]eval.NumberValueCapture{
@@ -98,7 +98,7 @@ func TestExpandTemplate(t *testing.T) {
 				},
 			},
 		},
-		expectedError: errors.New("error executing template __alert_test: template: __alert_test:1:86: executing \"__alert_test\" at <$values.A.Labels.instance>: map has no entry for key \"instance\""),
+		expected: "<no value> has value 1",
 	}, {
 		name: "missing value in $values is returned as NaN",
 		text: "{{ $values.A.Labels.instance }} has value {{ $values.A }}",


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently if a value is missing when parsing a template, the template string is returned unchanged and an error is logged. This can be confusing for users since they have to read the logs to figure out which part of the template string is causing this error.

A better alternative is to return the template string partially parsed and to indicate exactly where there is a missing value. This PR does exactly that.

![Screen Shot 2021-11-11 at 14 49 29](https://user-images.githubusercontent.com/41638679/141347146-f1606753-1fb0-4f5f-94ba-1869651abf8b.png)

This is an improvement over the option `keymissing=zero` since the zero value for a string is an empty string, and that could cause issues like alerts with empty labels (see [issue #35943](https://github.com/grafana/grafana/issues/35943).)

Parsing errors of a different nature (for example, passing the wrong number of arguments to a template function or syntax errors) still return the original template string and result in a logged error.

**Edit for more context:**

With the introduction of `NoData` and `Error` alerts we reduce the chances of an alert not returning its labels. However, we still can't know when incomplete label sets will be returned or when there will be missing labels. Also, custom labels could be missing, or a user could be trying to render the value of a label that was never defined in the first place. In cases like these it's convenient to have some way of making obvious what is happening.

There are 3 options available when executing templates:

- `missingkey=error`: return an error when a key is missing.
- `missingkey=zero`: print the zero value for that key.
- `missingkey=invalid`: print `<no data>` in the exact place where the missing value would be.

Returning a placeholder like `<no data>` makes it easy for the user to know exactly what is wrong with their templates. This is a better alternative than returning the zero value for that label (since we would be modifying data and this can result in [empty labels being rendered](https://github.com/grafana/grafana/issues/35943)) or just erroring out (which [makes it difficult for the user to understand exactly what went wrong](https://github.com/grafana/grafana/issues/40918)).

**Which issue(s) this PR fixes**:

https://github.com/grafana/grafana/issues/40918