### PR TITLE
Add context for GetAlertNotificationUidQuery

### DIFF
--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -220,7 +220,7 @@ func (hs *HTTPServer) ImportDashboard(c *models.ReqContext, apiCmd dtos.ImportDa
 		}
 	}
 
-	dashInfo, dash, err := hs.pluginDashboardManager.ImportDashboard(apiCmd.PluginId, apiCmd.Path, c.OrgId, apiCmd.FolderId,
+	dashInfo, dash, err := hs.pluginDashboardManager.ImportDashboard(c.Req.Context(), apiCmd.PluginId, apiCmd.Path, c.OrgId, apiCmd.FolderId,
 		apiCmd.Dashboard, apiCmd.Overwrite, apiCmd.Inputs, c.SignedInUser)
 	if err != nil {
 		return hs.dashboardSaveErrorToApiResponse(err)

--- a/pkg/plugins/ifaces.go
+++ b/pkg/plugins/ifaces.go
@@ -90,7 +90,7 @@ type PluginDashboardManager interface {
 	// LoadPluginDashboard loads a plugin dashboard.
 	LoadPluginDashboard(pluginID, path string) (*models.Dashboard, error)
 	// ImportDashboard imports a dashboard.
-	ImportDashboard(pluginID, path string, orgID, folderID int64, dashboardModel *simplejson.Json,
+	ImportDashboard(ctx context.Context, pluginID, path string, orgID, folderID int64, dashboardModel *simplejson.Json,
 		overwrite bool, inputs []ImportDashboardInput, user *models.SignedInUser) (PluginDashboardInfoDTO,
 		*models.Dashboard, error)
 }

--- a/pkg/plugins/manager/dashboard_import_test.go
+++ b/pkg/plugins/manager/dashboard_import_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 
@@ -24,7 +25,7 @@ func TestDashboardImport(t *testing.T) {
 		mock := &dashboards.FakeDashboardService{}
 		dashboards.MockDashboardService(mock)
 
-		info, dash, err := pm.ImportDashboard("test-app", "dashboards/connections.json", 1, 0, nil, false,
+		info, dash, err := pm.ImportDashboard(context.Background(), "test-app", "dashboards/connections.json", 1, 0, nil, false,
 			[]plugins.ImportDashboardInput{
 				{Name: "*", Type: "datasource", Value: "graphite"},
 			}, &models.SignedInUser{UserId: 1, OrgRole: models.ROLE_ADMIN})

--- a/pkg/plugins/manager/dashboards.go
+++ b/pkg/plugins/manager/dashboards.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -101,7 +102,7 @@ func (m *PluginManager) LoadPluginDashboard(pluginID, path string) (*models.Dash
 	return models.NewDashboardFromJson(data), nil
 }
 
-func (m *PluginManager) ImportDashboard(pluginID, path string, orgID, folderID int64, dashboardModel *simplejson.Json,
+func (m *PluginManager) ImportDashboard(ctx context.Context, pluginID, path string, orgID, folderID int64, dashboardModel *simplejson.Json,
 	overwrite bool, inputs []plugins.ImportDashboardInput, user *models.SignedInUser) (plugins.PluginDashboardInfoDTO,
 	*models.Dashboard, error) {
 	var dashboard *models.Dashboard
@@ -140,7 +141,7 @@ func (m *PluginManager) ImportDashboard(pluginID, path string, orgID, folderID i
 		User:      user,
 	}
 
-	savedDash, err := dashboards.NewService(m.sqlStore).ImportDashboard(dto)
+	savedDash, err := dashboards.NewService(m.sqlStore).ImportDashboard(ctx, dto)
 	if err != nil {
 		return plugins.PluginDashboardInfoDTO{}, &models.Dashboard{}, err
 	}

--- a/pkg/plugins/plugindashboards/service.go
+++ b/pkg/plugins/plugindashboards/service.go
@@ -81,7 +81,7 @@ func (s *Service) syncPluginDashboards(ctx context.Context, pluginDef *plugins.P
 
 		// update updated ones
 		if dash.ImportedRevision != dash.Revision {
-			if err := s.autoUpdateAppDashboard(dash, orgID); err != nil {
+			if err := s.autoUpdateAppDashboard(ctx, dash, orgID); err != nil {
 				s.logger.Error("Failed to auto update app dashboard", "pluginId", pluginDef.ID, "error", err)
 				return
 			}
@@ -130,7 +130,7 @@ func (s *Service) handlePluginStateChanged(event *models.PluginStateChangedEvent
 	return nil
 }
 
-func (s *Service) autoUpdateAppDashboard(pluginDashInfo *plugins.PluginDashboardInfoDTO, orgID int64) error {
+func (s *Service) autoUpdateAppDashboard(ctx context.Context, pluginDashInfo *plugins.PluginDashboardInfoDTO, orgID int64) error {
 	dash, err := s.pluginDashboardManager.LoadPluginDashboard(pluginDashInfo.PluginId, pluginDashInfo.Path)
 	if err != nil {
 		return err
@@ -138,7 +138,7 @@ func (s *Service) autoUpdateAppDashboard(pluginDashInfo *plugins.PluginDashboard
 	s.logger.Info("Auto updating App dashboard", "dashboard", dash.Title, "newRev",
 		pluginDashInfo.Revision, "oldRev", pluginDashInfo.ImportedRevision)
 	user := &models.SignedInUser{UserId: 0, OrgRole: models.ROLE_ADMIN}
-	_, _, err = s.pluginDashboardManager.ImportDashboard(pluginDashInfo.PluginId, pluginDashInfo.Path, orgID, 0, dash.Data, true,
+	_, _, err = s.pluginDashboardManager.ImportDashboard(ctx, pluginDashInfo.PluginId, pluginDashInfo.Path, orgID, 0, dash.Data, true,
 		nil, user)
 	return err
 }

--- a/pkg/services/alerting/extractor_test.go
+++ b/pkg/services/alerting/extractor_test.go
@@ -68,7 +68,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 		require.Equal(t, getTarget(dashJSON), "")
 
 		extractor := NewDashAlertExtractor(dash, 1, nil)
-		_, _ = extractor.GetAlerts()
+		_, _ = extractor.GetAlerts(context.Background())
 
 		require.Equal(t, getTarget(dashJSON), "")
 	})
@@ -80,7 +80,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 		dash := models.NewDashboardFromJson(dashJSON)
 		extractor := NewDashAlertExtractor(dash, 1, nil)
 
-		alerts, err := extractor.GetAlerts()
+		alerts, err := extractor.GetAlerts(context.Background())
 
 		require.Nil(t, err)
 
@@ -130,7 +130,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 		dash := models.NewDashboardFromJson(dashJSON)
 		extractor := NewDashAlertExtractor(dash, 1, nil)
 
-		_, err = extractor.GetAlerts()
+		_, err = extractor.GetAlerts(context.Background())
 
 		require.NotNil(t, err)
 	})
@@ -144,7 +144,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 		dash := models.NewDashboardFromJson(dashJSON)
 		extractor := NewDashAlertExtractor(dash, 1, nil)
 
-		_, err = extractor.GetAlerts()
+		_, err = extractor.GetAlerts(context.Background())
 
 		require.NotNil(t, err)
 	})
@@ -158,7 +158,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 		dash := models.NewDashboardFromJson(dashJSON)
 		extractor := NewDashAlertExtractor(dash, 1, nil)
 
-		alerts, err := extractor.GetAlerts()
+		alerts, err := extractor.GetAlerts(context.Background())
 		require.Nil(t, err)
 
 		condition := simplejson.NewFromAny(alerts[0].Settings.Get("conditions").MustArray()[0])
@@ -175,7 +175,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 		dash := models.NewDashboardFromJson(dashJSON)
 		extractor := NewDashAlertExtractor(dash, 1, nil)
 
-		alerts, err := extractor.GetAlerts()
+		alerts, err := extractor.GetAlerts(context.Background())
 		require.Nil(t, err)
 
 		require.Len(t, alerts, 2)
@@ -200,7 +200,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 		dash := models.NewDashboardFromJson(dashJSON)
 		extractor := NewDashAlertExtractor(dash, 1, nil)
 
-		alerts, err := extractor.GetAlerts()
+		alerts, err := extractor.GetAlerts(context.Background())
 		require.Nil(t, err)
 
 		require.Len(t, alerts, 1)
@@ -225,7 +225,7 @@ func TestAlertRuleExtraction(t *testing.T) {
 		dash := models.NewDashboardFromJson(dashJSON)
 		extractor := NewDashAlertExtractor(dash, 1, nil)
 
-		alerts, err := extractor.GetAlerts()
+		alerts, err := extractor.GetAlerts(context.Background())
 		require.Nil(t, err)
 
 		require.Len(t, alerts, 4)
@@ -240,11 +240,11 @@ func TestAlertRuleExtraction(t *testing.T) {
 		dash := models.NewDashboardFromJson(dashJSON)
 		extractor := NewDashAlertExtractor(dash, 1, nil)
 
-		err = extractor.ValidateAlerts()
+		err = extractor.ValidateAlerts(context.Background())
 
 		require.Nil(t, err)
 
-		_, err = extractor.GetAlerts()
+		_, err = extractor.GetAlerts(context.Background())
 		require.Equal(t, err.Error(), "alert validation error: Panel id is not correct, alertName=Influxdb, panelId=1")
 	})
 
@@ -257,11 +257,11 @@ func TestAlertRuleExtraction(t *testing.T) {
 		dash := models.NewDashboardFromJson(dashJSON)
 		extractor := NewDashAlertExtractor(dash, 1, nil)
 
-		err = extractor.ValidateAlerts()
+		err = extractor.ValidateAlerts(context.Background())
 
 		require.Nil(t, err)
 
-		alerts, err := extractor.GetAlerts()
+		alerts, err := extractor.GetAlerts(context.Background())
 		require.Nil(t, err)
 
 		condition := simplejson.NewFromAny(alerts[0].Settings.Get("conditions").MustArray()[0])

--- a/pkg/services/alerting/reader.go
+++ b/pkg/services/alerting/reader.go
@@ -37,7 +37,7 @@ func (arr *defaultRuleReader) fetch(ctx context.Context) []*Rule {
 
 	res := make([]*Rule, 0)
 	for _, ruleDef := range cmd.Result {
-		if model, err := NewRuleFromDBAlert(ruleDef, false); err != nil {
+		if model, err := NewRuleFromDBAlert(ctx, ruleDef, false); err != nil {
 			arr.log.Error("Could not build alert model for rule", "ruleId", ruleDef.Id, "error", err)
 		} else {
 			res = append(res, model)

--- a/pkg/services/alerting/rule.go
+++ b/pkg/services/alerting/rule.go
@@ -1,6 +1,7 @@
 package alerting
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -144,7 +145,7 @@ func getForValue(rawFor string) (time.Duration, error) {
 
 // NewRuleFromDBAlert maps a db version of
 // alert to an in-memory version.
-func NewRuleFromDBAlert(ruleDef *models.Alert, logTranslationFailures bool) (*Rule, error) {
+func NewRuleFromDBAlert(ctx context.Context, ruleDef *models.Alert, logTranslationFailures bool) (*Rule, error) {
 	model := &Rule{}
 	model.ID = ruleDef.Id
 	model.OrgID = ruleDef.OrgId
@@ -169,7 +170,7 @@ func NewRuleFromDBAlert(ruleDef *models.Alert, logTranslationFailures bool) (*Ru
 	for _, v := range ruleDef.Settings.Get("notifications").MustArray() {
 		jsonModel := simplejson.NewFromAny(v)
 		if id, err := jsonModel.Get("id").Int64(); err == nil {
-			uid, err := translateNotificationIDToUID(id, ruleDef.OrgId)
+			uid, err := translateNotificationIDToUID(ctx, id, ruleDef.OrgId)
 			if err != nil {
 				if !errors.Is(err, models.ErrAlertNotificationFailedTranslateUniqueID) {
 					logger.Error("Failed to translate notification id to uid", "error", err.Error(), "dashboardId", model.DashboardID, "alert", model.Name, "panelId", model.PanelID, "notificationId", id)
@@ -210,8 +211,8 @@ func NewRuleFromDBAlert(ruleDef *models.Alert, logTranslationFailures bool) (*Ru
 	return model, nil
 }
 
-func translateNotificationIDToUID(id int64, orgID int64) (string, error) {
-	notificationUID, err := getAlertNotificationUIDByIDAndOrgID(id, orgID)
+func translateNotificationIDToUID(ctx context.Context, id int64, orgID int64) (string, error) {
+	notificationUID, err := getAlertNotificationUIDByIDAndOrgID(ctx, id, orgID)
 	if err != nil {
 		return "", err
 	}
@@ -219,13 +220,13 @@ func translateNotificationIDToUID(id int64, orgID int64) (string, error) {
 	return notificationUID, nil
 }
 
-func getAlertNotificationUIDByIDAndOrgID(notificationID int64, orgID int64) (string, error) {
+func getAlertNotificationUIDByIDAndOrgID(ctx context.Context, notificationID int64, orgID int64) (string, error) {
 	query := &models.GetAlertNotificationUidQuery{
 		OrgId: orgID,
 		Id:    notificationID,
 	}
 
-	if err := bus.Dispatch(query); err != nil {
+	if err := bus.DispatchCtx(ctx, query); err != nil {
 		return "", err
 	}
 

--- a/pkg/services/alerting/rule_test.go
+++ b/pkg/services/alerting/rule_test.go
@@ -130,7 +130,7 @@ func TestAlertRuleModel(t *testing.T) {
 			Settings: alertJSON,
 		}
 
-		alertRule, err := NewRuleFromDBAlert(alert, false)
+		alertRule, err := NewRuleFromDBAlert(context.Background(), alert, false)
 		require.Nil(t, err)
 
 		require.Len(t, alertRule.Conditions, 1)
@@ -169,7 +169,7 @@ func TestAlertRuleModel(t *testing.T) {
 			Settings: alertJSON,
 		}
 
-		alertRule, err := NewRuleFromDBAlert(alert, false)
+		alertRule, err := NewRuleFromDBAlert(context.Background(), alert, false)
 		require.Nil(t, err)
 		require.NotContains(t, alertRule.Notifications, "999")
 		require.Contains(t, alertRule.Notifications, "notifier2")
@@ -200,7 +200,7 @@ func TestAlertRuleModel(t *testing.T) {
 			Settings: alertJSON,
 		}
 
-		alertRule, err := NewRuleFromDBAlert(alert, false)
+		alertRule, err := NewRuleFromDBAlert(context.Background(), alert, false)
 		require.Nil(t, err)
 		require.EqualValues(t, alertRule.Frequency, 60)
 	})
@@ -238,7 +238,7 @@ func TestAlertRuleModel(t *testing.T) {
 			Settings: alertJSON,
 		}
 
-		_, err := NewRuleFromDBAlert(alert, false)
+		_, err := NewRuleFromDBAlert(context.Background(), alert, false)
 		require.NotNil(t, err)
 		require.EqualValues(t, err.Error(), "alert validation error: Neither id nor uid is specified in 'notifications' block, type assertion to string failed AlertId: 1 PanelId: 1 DashboardId: 1")
 	})

--- a/pkg/services/alerting/test_rule.go
+++ b/pkg/services/alerting/test_rule.go
@@ -13,7 +13,7 @@ func (e *AlertEngine) AlertTest(orgID int64, dashboard *simplejson.Json, panelID
 	dash := models.NewDashboardFromJson(dashboard)
 
 	extractor := NewDashAlertExtractor(dash, orgID, user)
-	alerts, err := extractor.GetAlerts()
+	alerts, err := extractor.GetAlerts(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -22,7 +22,7 @@ func (e *AlertEngine) AlertTest(orgID int64, dashboard *simplejson.Json, panelID
 		if alert.PanelId != panelID {
 			continue
 		}
-		rule, err := NewRuleFromDBAlert(alert, true)
+		rule, err := NewRuleFromDBAlert(context.Background(), alert, true)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/services/dashboards/dashboard_service_test.go
+++ b/pkg/services/dashboards/dashboard_service_test.go
@@ -61,7 +61,7 @@ func TestDashboardService(t *testing.T) {
 				t.Cleanup(func() {
 					validateAlerts = origValidateAlerts
 				})
-				validateAlerts = func(dash *models.Dashboard, user *models.SignedInUser) error {
+				validateAlerts = func(ctx context.Context, dash *models.Dashboard, user *models.SignedInUser) error {
 					return nil
 				}
 
@@ -83,7 +83,7 @@ func TestDashboardService(t *testing.T) {
 					dto.Dashboard.SetUid(tc.Uid)
 					dto.User = &models.SignedInUser{}
 
-					_, err := service.buildSaveDashboardCommand(dto, true, false)
+					_, err := service.buildSaveDashboardCommand(context.Background(), dto, true, false)
 					require.Equal(t, err, tc.Error)
 				}
 			})
@@ -98,7 +98,7 @@ func TestDashboardService(t *testing.T) {
 				t.Cleanup(func() {
 					validateAlerts = origValidateAlerts
 				})
-				validateAlerts = func(dash *models.Dashboard, user *models.SignedInUser) error {
+				validateAlerts = func(ctx context.Context, dash *models.Dashboard, user *models.SignedInUser) error {
 					return nil
 				}
 
@@ -114,7 +114,7 @@ func TestDashboardService(t *testing.T) {
 				t.Cleanup(func() {
 					validateAlerts = origValidateAlerts
 				})
-				validateAlerts = func(dash *models.Dashboard, user *models.SignedInUser) error {
+				validateAlerts = func(ctx context.Context, dash *models.Dashboard, user *models.SignedInUser) error {
 					return nil
 				}
 
@@ -130,7 +130,7 @@ func TestDashboardService(t *testing.T) {
 				t.Cleanup(func() {
 					validateAlerts = origValidateAlerts
 				})
-				validateAlerts = func(dash *models.Dashboard, user *models.SignedInUser) error {
+				validateAlerts = func(ctx context.Context, dash *models.Dashboard, user *models.SignedInUser) error {
 					return fmt.Errorf("alert validation error")
 				}
 
@@ -157,7 +157,7 @@ func TestDashboardService(t *testing.T) {
 				t.Cleanup(func() {
 					validateAlerts = origValidateAlerts
 				})
-				validateAlerts = func(dash *models.Dashboard, user *models.SignedInUser) error {
+				validateAlerts = func(ctx context.Context, dash *models.Dashboard, user *models.SignedInUser) error {
 					return nil
 				}
 
@@ -177,7 +177,7 @@ func TestDashboardService(t *testing.T) {
 				t.Cleanup(func() {
 					validateAlerts = origValidateAlerts
 				})
-				validateAlerts = func(dash *models.Dashboard, user *models.SignedInUser) error {
+				validateAlerts = func(ctx context.Context, dash *models.Dashboard, user *models.SignedInUser) error {
 					return nil
 				}
 
@@ -213,7 +213,7 @@ func TestDashboardService(t *testing.T) {
 				t.Cleanup(func() {
 					validateAlerts = origValidateAlerts
 				})
-				validateAlerts = func(dash *models.Dashboard, user *models.SignedInUser) error {
+				validateAlerts = func(ctx context.Context, dash *models.Dashboard, user *models.SignedInUser) error {
 					return nil
 				}
 
@@ -229,7 +229,7 @@ func TestDashboardService(t *testing.T) {
 				dto.Dashboard = models.NewDashboard("Dash")
 				dto.Dashboard.SetId(3)
 				dto.User = &models.SignedInUser{UserId: 1}
-				_, err := service.ImportDashboard(dto)
+				_, err := service.ImportDashboard(context.Background(), dto)
 				require.Equal(t, err, models.ErrDashboardCannotSaveProvisionedDashboard)
 			})
 		})

--- a/pkg/services/dashboards/folder_service.go
+++ b/pkg/services/dashboards/folder_service.go
@@ -137,7 +137,7 @@ func (dr *dashboardServiceImpl) CreateFolder(ctx context.Context, title, uid str
 		User:      dr.user,
 	}
 
-	saveDashboardCmd, err := dr.buildSaveDashboardCommand(dto, false, false)
+	saveDashboardCmd, err := dr.buildSaveDashboardCommand(ctx, dto, false, false)
 	if err != nil {
 		return nil, toFolderError(err)
 	}
@@ -172,7 +172,7 @@ func (dr *dashboardServiceImpl) UpdateFolder(ctx context.Context, existingUid st
 		Overwrite: cmd.Overwrite,
 	}
 
-	saveDashboardCmd, err := dr.buildSaveDashboardCommand(dto, false, false)
+	saveDashboardCmd, err := dr.buildSaveDashboardCommand(ctx, dto, false, false)
 	if err != nil {
 		return toFolderError(err)
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Context was added for the query GetAlertNotificationUidQuery, the method AddHandlerCtx was implemented, but the DispatchCtx was missing. This PR removes the warning on main.
```
WARN[11-11|16:52:52] Dispatch called with message handler registered using AddHandlerCtx and should be changed to use DispatchCtx logger=bus msgName=GetAlertNotificationUidQuery
```
**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

