### PR TITLE
Live: move back to ojg lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.7
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
+	github.com/ohler55/ojg v1.12.9
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/browser v0.0.0-20210904010418-6d279e18f982 // indirect
@@ -88,7 +89,6 @@ require (
 	github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/russellhaering/goxmldsig v1.1.1
-	github.com/spyzhov/ajson v0.4.2
 	github.com/stretchr/testify v1.7.0
 	github.com/teris-io/shortid v0.0.0-20171029131806-771a37caa5cf
 	github.com/timberio/go-datemath v0.1.1-0.20200323150745-74ddef604fff

--- a/go.sum
+++ b/go.sum
@@ -1812,6 +1812,8 @@ github.com/nsqio/go-nsq v1.0.7/go.mod h1:XP5zaUs3pqf+Q71EqUJs3HYfBIqfK6G83WQMdNN
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/ohler55/ojg v1.12.9 h1:HIHORjvA/i2IyDGgf9zzkFZc0yhEZIi3Tte+m+XBzTs=
+github.com/ohler55/ojg v1.12.9/go.mod h1:LBbIVRAgoFbYBXQhRhuEpaJIqq+goSO63/FQ+nyJU88=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
@@ -2217,8 +2219,6 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
-github.com/spyzhov/ajson v0.4.2 h1:JMByd/jZApPKDvNsmO90X2WWGbmT2ahDFp73QhZbg3s=
-github.com/spyzhov/ajson v0.4.2/go.mod h1:63V+CGM6f1Bu/p4nLIN8885ojBdt88TbLoSFzyqMuVA=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20180528204448-e5adc2ada8b8/go.mod h1:1WNBiOZtZQLpVAyu0iTduoJL9hEsMloAK5XWrtW0xdY=

--- a/pkg/services/live/pipeline/converter_json_exact_test.go
+++ b/pkg/services/live/pipeline/converter_json_exact_test.go
@@ -36,6 +36,37 @@ func checkExactConversion(tb testing.TB, file string, fields []Field) *backend.D
 	return dr
 }
 
+func BenchmarkExactJsonConverter_Convert(b *testing.B) {
+	content := loadTestJson(b, "json_exact")
+
+	converter := NewExactJsonConverter(ExactJsonConverterConfig{
+		Fields: []Field{
+			{
+				Name:  "ax",
+				Value: "$.ax",
+				Type:  data.FieldTypeNullableFloat64,
+			}, {
+				Name:  "array_value",
+				Value: "$.string_array[0]",
+				Type:  data.FieldTypeNullableString,
+			}, {
+				Name:  "map_key",
+				Value: "$.map_with_floats['key1']",
+				Type:  data.FieldTypeNullableFloat64,
+			},
+		},
+	})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := converter.Convert(context.Background(), Vars{}, content)
+		require.NoError(b, err)
+		//require.Len(b, cf, 1)
+		//require.Len(b, cf[0].Frame.Fields, 3)
+	}
+}
+
 func TestExactJsonConverter_Convert(t *testing.T) {
 	checkExactConversion(t, "json_exact", []Field{
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

In 5fcc9fe193d0915cc32e639034bad5e1f82483f1 we replaced ojg library with an alternative solution temporary due to 32-bit build problems and go 1.16 compatibility concerns. Switching back since the issue is now resolved and Grafana has go1.17 in go.mod now.

Also added benchmark. Currently:

```
BenchmarkExactJsonConverter_Convert-12    	   84834	     12940 ns/op	    8600 B/op	     190 allocs/op
```

ojg:

```
BenchmarkExactJsonConverter_Convert-12    	  229069	      5232 ns/op	    5127 B/op	      80 allocs/op
```