### PR TITLE
Docs: Adding details about how to enable dynamic imports in plugins

### DIFF
--- a/packages/grafana-toolkit/README.md
+++ b/packages/grafana-toolkit/README.md
@@ -310,7 +310,7 @@ module.exports.getWebpackConfig = (config, options) => ({
   ...config,
   output: {
     ...config.output,
-    publicPath: 'public/plugins/plugin-id/',
+    publicPath: 'public/plugins/<plugin-id>/',
   },
 });
 ```

--- a/packages/grafana-toolkit/README.md
+++ b/packages/grafana-toolkit/README.md
@@ -306,11 +306,12 @@ Create a webpack.config.js with this content (in the root of _your_ plugin)
 
 ```ts
 // webpack.config.js
+const pluginJson = require('./src/plugin.json');
 module.exports.getWebpackConfig = (config, options) => ({
   ...config,
   output: {
     ...config.output,
-    publicPath: 'public/plugins/<plugin-id>/',
+    publicPath: `public/plugins/${pluginJson.id}/`,
   },
 });
 ```

--- a/packages/grafana-toolkit/README.md
+++ b/packages/grafana-toolkit/README.md
@@ -300,6 +300,23 @@ If your comments include ES2016 code, then SystemJS v0.20.19, which Grafana uses
 
 To fix this error, remove the ES2016 code from your comments.
 
+### I would like to dynamically import modules in my plugin
+
+Create a webpack.config.js with this content (in the root of _your_ plugin)
+
+```ts
+// webpack.config.js
+module.exports.getWebpackConfig = (config, options) => ({
+  ...config,
+  output: {
+    ...config.output,
+    publicPath: 'public/plugins/plugin-id/',
+  },
+});
+```
+
+The plugin id is the id written in the plugin.json file.
+
 ## Contribute to grafana-toolkit
 
 You can contribute to grafana-toolkit by helping develop it or by debugging it.


### PR DESCRIPTION
**What this PR does / why we need it**:
Added some documentation on how to configure webpack to enable dynamic loading of javascript files. 

**Which issue(s) this PR fixes**:
Fixes #40671

**Special notes for your reviewer**:
I'm a bit afraid adding the actual change to the grafana-toolkit will break older angular plugins that uses the "legacy" imports.
