### PR TITLE
Chore: add graph-ng tags to gdev test dashboards backed by uPlot

### DIFF
--- a/devenv/dev-dashboards/datasource-testdata/new_features_in_v74.json
+++ b/devenv/dev-dashboards/datasource-testdata/new_features_in_v74.json
@@ -2156,6 +2156,7 @@
   "style": "dark",
   "tags": [
     "gdev",
+    "graph-ng",
     "demo"
   ],
   "templating": {

--- a/devenv/dev-dashboards/datasource-testdata/new_features_in_v8.json
+++ b/devenv/dev-dashboards/datasource-testdata/new_features_in_v8.json
@@ -2746,6 +2746,7 @@
     "style": "dark",
     "tags": [
       "gdev",
+      "graph-ng",
       "demo"
     ],
     "templating": {

--- a/devenv/dev-dashboards/panel-barchart/barchart-autosizing.json
+++ b/devenv/dev-dashboards/panel-barchart/barchart-autosizing.json
@@ -524,7 +524,8 @@
   "tags": [
     "gdev",
     "panel-tests",
-    "barchart"
+    "barchart",
+    "graph-ng"
   ],
   "templating": {
     "list": []

--- a/devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json
+++ b/devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json
@@ -829,7 +829,8 @@
   "style": "dark",
   "tags": [
     "gdev",
-    "panel-tests"
+    "panel-tests",
+    "graph-ng"
   ],
   "templating": {
     "list": []

--- a/devenv/dev-dashboards/panel-graph/graph-ng-stacking.json
+++ b/devenv/dev-dashboards/panel-graph/graph-ng-stacking.json
@@ -880,7 +880,11 @@
   ],
   "schemaVersion": 27,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "gdev",
+    "panel-tests",
+    "graph-ng"
+  ],
   "templating": {
     "list": []
   },

--- a/devenv/dev-dashboards/panel-graph/graph-ng-thresholds.json
+++ b/devenv/dev-dashboards/panel-graph/graph-ng-thresholds.json
@@ -1231,7 +1231,8 @@
   "style": "dark",
   "tags": [
     "gdev",
-    "panel-tests"
+    "panel-tests",
+    "graph-ng"
   ],
   "templating": {
     "list": []

--- a/devenv/dev-dashboards/panel-histogram/histogram_tests.json
+++ b/devenv/dev-dashboards/panel-histogram/histogram_tests.json
@@ -413,7 +413,8 @@
     "style": "dark",
     "tags": [
       "gdev",
-      "panel-tests"
+      "panel-tests",
+      "graph-ng"
     ],
     "templating": {
       "list": []

--- a/devenv/dev-dashboards/panel-market/market-trend.json
+++ b/devenv/dev-dashboards/panel-market/market-trend.json
@@ -501,7 +501,11 @@
     "refresh": false,
     "schemaVersion": 33,
     "style": "dark",
-    "tags": [],
+    "tags": [
+      "gdev",
+      "panel-tests",
+      "graph-ng"
+    ],
     "templating": {
       "list": []
     },

--- a/devenv/dev-dashboards/panel-stat/panel-stat-tests.json
+++ b/devenv/dev-dashboards/panel-stat/panel-stat-tests.json
@@ -772,7 +772,11 @@
   ],
   "schemaVersion": 26,
   "style": "dark",
-  "tags": ["gdev", "panel-tests"],
+  "tags": [
+    "gdev",
+    "panel-tests",
+    "graph-ng"
+  ],
   "templating": {
     "list": []
   },

--- a/devenv/dev-dashboards/panel-timeline/timeline-demo.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-demo.json
@@ -414,6 +414,8 @@
   "style": "dark",
   "tags": [
     "gdev",
+    "panel-tests",
+    "graph-ng",
     "demo"
   ],
   "templating": {

--- a/devenv/dev-dashboards/panel-timeline/timeline-modes.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-modes.json
@@ -362,7 +362,8 @@
   "style": "dark",
   "tags": [
     "gdev",
-    "panel-tests"
+    "panel-tests",
+    "graph-ng"
   ],
   "templating": {
     "list": []


### PR DESCRIPTION
this makes my life easier when doing manual testing in conjunction with uPlot version bumps