### PR TITLE
GraphNG: uPlot 1.6.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -354,7 +354,7 @@
     "tether": "1.4.7",
     "tether-drop": "https://github.com/torkelo/drop",
     "tinycolor2": "1.4.1",
-    "uplot": "1.6.16",
+    "uplot": "1.6.17",
     "uuid": "8.3.0",
     "vendor": "link:./public/vendor",
     "visjs-network": "4.25.0",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -87,7 +87,7 @@
     "slate-plain-serializer": "0.7.10",
     "tinycolor2": "1.4.1",
     "tslib": "2.3.1",
-    "uplot": "1.6.16",
+    "uplot": "1.6.17",
     "uuid": "8.3.0"
   },
   "devDependencies": {

--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AlignedData } from 'uplot';
+import uPlot, { AlignedData } from 'uplot';
 import { Themeable2 } from '../../types';
 import { findMidPointYPosition, pluginLog } from '../uPlot/utils';
 import {

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotThresholds.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotThresholds.ts
@@ -2,6 +2,7 @@ import { GrafanaTheme2, ThresholdsConfig, ThresholdsMode } from '@grafana/data';
 import { GraphThresholdsStyleConfig, GraphTresholdsStyleMode } from '@grafana/schema';
 import { getGradientRange, GradientDirection, scaleGradient } from './gradientFills';
 import tinycolor from 'tinycolor2';
+import uPlot from 'uplot';
 
 export interface UPlotThresholdOptions {
   scaleKey: string;

--- a/packages/grafana-ui/src/components/uPlot/geometries/EventsCanvas.tsx
+++ b/packages/grafana-ui/src/components/uPlot/geometries/EventsCanvas.tsx
@@ -4,6 +4,7 @@ import { useMountedState } from 'react-use';
 import { UPlotConfigBuilder } from '../config/UPlotConfigBuilder';
 import { Marker } from './Marker';
 import { XYCanvas } from './XYCanvas';
+import uPlot from 'uplot';
 
 interface EventsCanvasProps {
   id: string;

--- a/packages/grafana-ui/src/components/uPlot/utils.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.ts
@@ -1,7 +1,7 @@
 import { DataFrame, ensureTimeField, Field, FieldType } from '@grafana/data';
 import { StackingMode, VizLegendOptions } from '@grafana/schema';
 import { orderBy } from 'lodash';
-import { AlignedData, Options, PaddingSide } from 'uplot';
+import uPlot, { AlignedData, Options, PaddingSide } from 'uplot';
 import { attachDebugger } from '../../utils';
 import { createLogger } from '../../utils/logger';
 

--- a/public/app/plugins/panel/market-trend/MarketTrendPanel.tsx
+++ b/public/app/plugins/panel/market-trend/MarketTrendPanel.tsx
@@ -17,6 +17,7 @@ import { defaultColors, MarketOptions, MarketTrendMode } from './models.gen';
 import { ScaleProps } from '@grafana/ui/src/components/uPlot/config/UPlotScaleBuilder';
 import { AxisProps } from '@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder';
 import { prepareCandlestickFields } from './fields';
+import uPlot from 'uplot';
 
 interface MarketPanelProps extends PanelProps<MarketOptions> {}
 

--- a/public/app/plugins/panel/state-timeline/utils.ts
+++ b/public/app/plugins/panel/state-timeline/utils.ts
@@ -34,6 +34,7 @@ import { VizLegendOptions, AxisPlacement, ScaleDirection, ScaleOrientation } fro
 import { TimelineFieldConfig, TimelineOptions } from './types';
 import { PlotTooltipInterpolator } from '@grafana/ui/src/components/uPlot/types';
 import { preparePlotData } from '../../../../../packages/grafana-ui/src/components/uPlot/utils';
+import uPlot from 'uplot';
 
 const defaultConfig: TimelineFieldConfig = {
   lineWidth: 0,

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationEditorPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationEditorPlugin.tsx
@@ -3,6 +3,7 @@ import { PlotSelection, UPlotConfigBuilder } from '@grafana/ui';
 import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { useMountedState } from 'react-use';
 import { AnnotationEditor } from './annotations/AnnotationEditor';
+import uPlot from 'uplot';
 
 type StartAnnotatingFn = (props: {
   // pixel coordinates of the clicked point on the uPlot canvas

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin.tsx
@@ -2,6 +2,7 @@ import { colorManipulator, DataFrame, DataFrameFieldIndex, DataFrameView, TimeZo
 import { EventsCanvas, UPlotConfigBuilder, useTheme2 } from '@grafana/ui';
 import React, { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { AnnotationMarker } from './annotations/AnnotationMarker';
+import uPlot from 'uplot';
 
 interface AnnotationsPluginProps {
   config: UPlotConfigBuilder;

--- a/public/app/plugins/panel/timeseries/plugins/ExemplarsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ExemplarsPlugin.tsx
@@ -10,6 +10,7 @@ import {
 import { EventsCanvas, FIXED_UNIT, UPlotConfigBuilder } from '@grafana/ui';
 import React, { useCallback, useLayoutEffect, useRef } from 'react';
 import { ExemplarMarker } from './ExemplarMarker';
+import uPlot from 'uplot';
 
 interface ExemplarsPluginProps {
   config: UPlotConfigBuilder;

--- a/public/app/plugins/panel/timeseries/plugins/ThresholdControlsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ThresholdControlsPlugin.tsx
@@ -2,6 +2,7 @@ import React, { useState, useLayoutEffect, useMemo, useRef } from 'react';
 import { FieldConfigSource, ThresholdsConfig, getValueFormat } from '@grafana/data';
 import { UPlotConfigBuilder, FIXED_UNIT } from '@grafana/ui';
 import { ThresholdDragHandle } from './ThresholdDragHandle';
+import uPlot from 'uplot';
 
 const GUTTER_SIZE = 60;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2845,7 +2845,7 @@ __metadata:
     ts-loader: 8.0.11
     tslib: 2.3.1
     typescript: 4.4.3
-    uplot: 1.6.16
+    uplot: 1.6.17
     uuid: 8.3.0
     webpack: 5.58.1
     webpack-filter-warnings-plugin: 1.2.1
@@ -18094,7 +18094,7 @@ __metadata:
     ts-node: 10.4.0
     tslib: 2.3.1
     typescript: 4.4.3
-    uplot: 1.6.16
+    uplot: 1.6.17
     uuid: 8.3.0
     vendor: "link:./public/vendor"
     visjs-network: 4.25.0
@@ -32532,6 +32532,13 @@ __metadata:
   version: 1.6.16
   resolution: "uplot@npm:1.6.16"
   checksum: f7243693f9319a47a92f758a0fe1315b2f713f68ec9bbabce4f8929525a8648ac5936e1448a4f122486de6fc78da4b6038f20b71a9416da6228572e305e0d171
+  languageName: node
+  linkType: hard
+
+"uplot@npm:1.6.17":
+  version: 1.6.17
+  resolution: "uplot@npm:1.6.17"
+  checksum: f63d3d4337c12dacc6940fa8e3a8a94416db787e175c715b4975a28fea85f340beb89d3907c83cd1663943d77abd26057098dc8152117d76f8fa184be295edbb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Adds `radius` and multi-color options to the bars pathbuilder (needed for https://github.com/grafana/grafana/pull/41510), demo: https://leeoniya.github.io/uPlot/demos/multi-bars.html
- Adds absolutely-positioned bounding rect `<div>`s over each axis, so they can be made interactive.
- Various bug & TS defs fixes.

(https://github.com/grafana/grafana/pull/41662 makes testing uPlot updates easier)