### PR TITLE
Azure Monitor: Fix bug with template variables.

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/grafanaTemplateVariableFns.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/grafanaTemplateVariableFns.ts
@@ -75,15 +75,6 @@ const createGrafanaTemplateVariableQuery = (rawQuery: string, datasource: DataSo
       return queryDetails;
     }
 
-    if (matchesForQuery.resourceGroups && defaultSubscriptionId) {
-      const queryDetails: ResourceGroupsQuery = {
-        kind: 'ResourceGroupsQuery',
-        rawQuery,
-        subscription: defaultSubscriptionId,
-      };
-      return queryDetails;
-    }
-
     if (matchesForQuery.resourceGroupsWithSub) {
       const queryDetails: ResourceGroupsQuery = {
         kind: 'ResourceGroupsQuery',
@@ -93,12 +84,11 @@ const createGrafanaTemplateVariableQuery = (rawQuery: string, datasource: DataSo
       return queryDetails;
     }
 
-    if (matchesForQuery.metricDefinitions && defaultSubscriptionId) {
-      const queryDetails: MetricDefinitionsQuery = {
-        kind: 'MetricDefinitionsQuery',
+    if (matchesForQuery.resourceGroups && defaultSubscriptionId) {
+      const queryDetails: ResourceGroupsQuery = {
+        kind: 'ResourceGroupsQuery',
         rawQuery,
         subscription: defaultSubscriptionId,
-        resourceGroup: matchesForQuery.metricDefinitions[1],
       };
       return queryDetails;
     }
@@ -113,13 +103,12 @@ const createGrafanaTemplateVariableQuery = (rawQuery: string, datasource: DataSo
       return queryDetails;
     }
 
-    if (matchesForQuery.resourceNames && defaultSubscriptionId) {
-      const queryDetails: ResourceNamesQuery = {
-        kind: 'ResourceNamesQuery',
+    if (matchesForQuery.metricDefinitions && defaultSubscriptionId) {
+      const queryDetails: MetricDefinitionsQuery = {
+        kind: 'MetricDefinitionsQuery',
         rawQuery,
         subscription: defaultSubscriptionId,
-        resourceGroup: matchesForQuery.resourceNames[1],
-        metricDefinition: matchesForQuery.resourceNames[2],
+        resourceGroup: matchesForQuery.metricDefinitions[1],
       };
       return queryDetails;
     }
@@ -135,14 +124,13 @@ const createGrafanaTemplateVariableQuery = (rawQuery: string, datasource: DataSo
       return queryDetails;
     }
 
-    if (matchesForQuery.metricNamespace && defaultSubscriptionId) {
-      const queryDetails: MetricNamespaceQuery = {
-        kind: 'MetricNamespaceQuery',
+    if (matchesForQuery.resourceNames && defaultSubscriptionId) {
+      const queryDetails: ResourceNamesQuery = {
+        kind: 'ResourceNamesQuery',
         rawQuery,
         subscription: defaultSubscriptionId,
-        resourceGroup: matchesForQuery.metricNamespace[1],
-        metricDefinition: matchesForQuery.metricNamespace[2],
-        resourceName: matchesForQuery.metricNamespace[3],
+        resourceGroup: matchesForQuery.resourceNames[1],
+        metricDefinition: matchesForQuery.resourceNames[2],
       };
       return queryDetails;
     }
@@ -155,6 +143,18 @@ const createGrafanaTemplateVariableQuery = (rawQuery: string, datasource: DataSo
         resourceGroup: matchesForQuery.metricNamespaceWithSub[2],
         metricDefinition: matchesForQuery.metricNamespaceWithSub[3],
         resourceName: matchesForQuery.metricNamespaceWithSub[4],
+      };
+      return queryDetails;
+    }
+
+    if (matchesForQuery.metricNamespace && defaultSubscriptionId) {
+      const queryDetails: MetricNamespaceQuery = {
+        kind: 'MetricNamespaceQuery',
+        rawQuery,
+        subscription: defaultSubscriptionId,
+        resourceGroup: matchesForQuery.metricNamespace[1],
+        metricDefinition: matchesForQuery.metricNamespace[2],
+        resourceName: matchesForQuery.metricNamespace[3],
       };
       return queryDetails;
     }
@@ -187,20 +187,20 @@ const createGrafanaTemplateVariableQuery = (rawQuery: string, datasource: DataSo
       return queryDetails;
     }
 
-    if (matchesForQuery.workspacesQuery && defaultSubscriptionId) {
-      const queryDetails: WorkspacesQuery = {
-        kind: 'WorkspacesQuery',
-        rawQuery,
-        subscription: defaultSubscriptionId,
-      };
-      return queryDetails;
-    }
-
     if (matchesForQuery.workspacesQueryWithSub) {
       const queryDetails: WorkspacesQuery = {
         kind: 'WorkspacesQuery',
         rawQuery,
         subscription: (matchesForQuery.workspacesQueryWithSub[1] || '').trim(),
+      };
+      return queryDetails;
+    }
+
+    if (matchesForQuery.workspacesQuery && defaultSubscriptionId) {
+      const queryDetails: WorkspacesQuery = {
+        kind: 'WorkspacesQuery',
+        rawQuery,
+        subscription: defaultSubscriptionId,
       };
       return queryDetails;
     }

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/grafanaTemplateVariables.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/grafanaTemplateVariables.test.ts
@@ -1,0 +1,241 @@
+import { migrateStringQueriesToObjectQueries } from './grafanaTemplateVariableFns';
+import { AzureMonitorQuery, AzureQueryType } from './types';
+import createMockDatasource from './__mocks__/datasource';
+
+describe('migrateStringQueriesToObjectQueries', () => {
+  const expectedMigrations: Array<{ input: string; output: AzureMonitorQuery }> = [
+    {
+      input: 'Subscriptions()',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.GrafanaTemplateVariableFn,
+        grafanaTemplateVariableFn: { kind: 'SubscriptionsQuery', rawQuery: 'Subscriptions()' },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+    {
+      input: 'ResourceGroups()',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.GrafanaTemplateVariableFn,
+        grafanaTemplateVariableFn: {
+          kind: 'ResourceGroupsQuery',
+          rawQuery: 'ResourceGroups()',
+          subscription: 'defaultSubscriptionId',
+        },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+    {
+      input: 'ResourceGroups(subId)',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.GrafanaTemplateVariableFn,
+        grafanaTemplateVariableFn: {
+          kind: 'ResourceGroupsQuery',
+          rawQuery: 'ResourceGroups(subId)',
+          subscription: 'subId',
+        },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+    {
+      input: 'Namespaces(rg)',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.GrafanaTemplateVariableFn,
+        grafanaTemplateVariableFn: {
+          kind: 'MetricDefinitionsQuery',
+          rawQuery: 'Namespaces(rg)',
+          subscription: 'defaultSubscriptionId',
+          resourceGroup: 'rg',
+        },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+    {
+      input: 'Namespaces(subId, rg)',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.GrafanaTemplateVariableFn,
+        grafanaTemplateVariableFn: {
+          kind: 'MetricDefinitionsQuery',
+          rawQuery: 'Namespaces(subId, rg)',
+          subscription: 'subId',
+          resourceGroup: 'rg',
+        },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+    {
+      input: 'ResourceNames(rg, md)',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.GrafanaTemplateVariableFn,
+        grafanaTemplateVariableFn: {
+          kind: 'ResourceNamesQuery',
+          rawQuery: 'ResourceNames(rg, md)',
+          subscription: 'defaultSubscriptionId',
+          resourceGroup: 'rg',
+          metricDefinition: 'md',
+        },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+    {
+      input: 'ResourceNames(subId, rg, md)',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.GrafanaTemplateVariableFn,
+        grafanaTemplateVariableFn: {
+          kind: 'ResourceNamesQuery',
+          rawQuery: 'ResourceNames(subId, rg, md)',
+          subscription: 'subId',
+          resourceGroup: 'rg',
+          metricDefinition: 'md',
+        },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+    {
+      input: 'MetricNamespace(rg, md, rn)',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.GrafanaTemplateVariableFn,
+        grafanaTemplateVariableFn: {
+          kind: 'MetricNamespaceQuery',
+          rawQuery: 'MetricNamespace(rg, md, rn)',
+          subscription: 'defaultSubscriptionId',
+          resourceGroup: 'rg',
+          metricDefinition: 'md',
+          resourceName: 'rn',
+        },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+    {
+      input: 'MetricNamespace(subId, rg, md, rn)',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.GrafanaTemplateVariableFn,
+        grafanaTemplateVariableFn: {
+          kind: 'MetricNamespaceQuery',
+          rawQuery: 'MetricNamespace(subId, rg, md, rn)',
+          subscription: 'subId',
+          resourceGroup: 'rg',
+          metricDefinition: 'md',
+          resourceName: 'rn',
+        },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+    {
+      input: 'MetricNames(rg, md, rn, mn)',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.GrafanaTemplateVariableFn,
+        grafanaTemplateVariableFn: {
+          kind: 'MetricNamesQuery',
+          rawQuery: 'MetricNames(rg, md, rn, mn)',
+          subscription: 'defaultSubscriptionId',
+          resourceGroup: 'rg',
+          metricDefinition: 'md',
+          resourceName: 'rn',
+          metricNamespace: 'mn',
+        },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+    {
+      input: 'MetricNames(subId, rg, md, rn, mn)',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.GrafanaTemplateVariableFn,
+        grafanaTemplateVariableFn: {
+          kind: 'MetricNamesQuery',
+          rawQuery: 'MetricNames(subId, rg, md, rn, mn)',
+          subscription: 'subId',
+          resourceGroup: 'rg',
+          metricDefinition: 'md',
+          resourceName: 'rn',
+          metricNamespace: 'mn',
+        },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+    {
+      input: 'AppInsightsMetricNames()',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.GrafanaTemplateVariableFn,
+        grafanaTemplateVariableFn: {
+          kind: 'AppInsightsMetricNameQuery',
+          rawQuery: 'AppInsightsMetricNames()',
+        },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+    {
+      input: 'AppInsightsGroupBys(mn)',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.GrafanaTemplateVariableFn,
+        grafanaTemplateVariableFn: {
+          kind: 'AppInsightsGroupByQuery',
+          rawQuery: 'AppInsightsGroupBys(mn)',
+          metricName: 'mn',
+        },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+    {
+      input: 'workspaces()',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.GrafanaTemplateVariableFn,
+        grafanaTemplateVariableFn: {
+          kind: 'WorkspacesQuery',
+          rawQuery: 'workspaces()',
+          subscription: 'defaultSubscriptionId',
+        },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+    {
+      input: 'workspaces(subId)',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.GrafanaTemplateVariableFn,
+        grafanaTemplateVariableFn: {
+          kind: 'WorkspacesQuery',
+          rawQuery: 'workspaces(subId)',
+          subscription: 'subId',
+        },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+    {
+      input: 'some kind of kql query',
+      output: {
+        refId: 'A',
+        queryType: AzureQueryType.LogAnalytics,
+        azureLogAnalytics: {
+          query: 'some kind of kql query',
+          resource: '',
+        },
+        subscription: 'defaultSubscriptionId',
+      },
+    },
+  ];
+  it('successfully converts all old string queries into formatted query objects', async () => {
+    return expectedMigrations.map(async ({ input, output }) => {
+      const datasource = createMockDatasource({
+        azureMonitorDatasource: {
+          defaultSubscriptionId: 'defaultSubscriptionId',
+        },
+      });
+      const actual = await migrateStringQueriesToObjectQueries(input, { datasource });
+      expect(actual).toEqual(output);
+    });
+  });
+});


### PR DESCRIPTION
**What this PR does / why we need it**:
While I was reviewing #40725 I noticed I had some trouble getting my Namespaces template variable function to load. I realized what was happening was that we using one of our pre-built functions for fetching Namespaces like so:
```
Namespaces(subscription, resourceGroup)
```
but it was making the request with resourceGroup set as the subscription id. This was because in my refactoring of our grafana template variables in #40841 I had some faulty logic that stated that if you have a defaultSubscriptionId we assume that you are only calling Namespaces with one argument, the resource group, so it was pulling the first argument as the resourcegroup.

This code changes it so that if you pass the maximum number of arguments, that is what we call first. 

To test this code try using some azure template variable functions with and without a default subscription id.

**Which issue(s) this PR fixes**:

(no issue just made a fix)

**Special notes for your reviewer**:
I believe this bug was introduced in #40841 and has not been released yet as it's set for 8.3.0 beta so I'm not tagging it with a milestone or anything.  
