### PR TITLE
[v8.2.x] Security Fix: Fine-grained access control enables organization admins to create/modify/delete user roles in other organization

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -248,7 +248,7 @@ func (hs *HTTPServer) registerRoutes() {
 			orgsRoute.Delete("/users/:userId", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRemove, userIDScope)), routing.Wrap(RemoveOrgUser))
 			orgsRoute.Get("/quotas", reqGrafanaAdmin, routing.Wrap(GetOrgQuotas))
 			orgsRoute.Put("/quotas/:target", reqGrafanaAdmin, bind(models.UpdateOrgQuotaCmd{}), routing.Wrap(UpdateOrgQuota))
-		})
+		}, acmiddleware.ReplaceContextOrgMiddleware)
 
 		// orgs (admin routes)
 		apiRoute.Group("/orgs/name/:name", func(orgsRoute routing.RouteRegister) {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -242,13 +242,13 @@ func (hs *HTTPServer) registerRoutes() {
 			orgsRoute.Put("/", reqGrafanaAdmin, bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateOrg))
 			orgsRoute.Put("/address", reqGrafanaAdmin, bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateOrgAddress))
 			orgsRoute.Delete("/", reqGrafanaAdmin, routing.Wrap(DeleteOrgByID))
-			orgsRoute.Get("/users", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.GetOrgUsers))
-			orgsRoute.Post("/users", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), bind(models.AddOrgUserCommand{}), routing.Wrap(AddOrgUser))
-			orgsRoute.Patch("/users/:userId", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRoleUpdate, userIDScope)), bind(models.UpdateOrgUserCommand{}), routing.Wrap(UpdateOrgUser))
-			orgsRoute.Delete("/users/:userId", authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRemove, userIDScope)), routing.Wrap(RemoveOrgUser))
+			orgsRoute.Get("/users", acmiddleware.ReplaceContextOrgMiddleware, authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.GetOrgUsers))
+			orgsRoute.Post("/users", acmiddleware.ReplaceContextOrgMiddleware, authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), bind(models.AddOrgUserCommand{}), routing.Wrap(AddOrgUser))
+			orgsRoute.Patch("/users/:userId", acmiddleware.ReplaceContextOrgMiddleware, authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRoleUpdate, userIDScope)), bind(models.UpdateOrgUserCommand{}), routing.Wrap(UpdateOrgUser))
+			orgsRoute.Delete("/users/:userId", acmiddleware.ReplaceContextOrgMiddleware, authorize(reqGrafanaAdmin, ac.EvalPermission(ac.ActionOrgUsersRemove, userIDScope)), routing.Wrap(RemoveOrgUser))
 			orgsRoute.Get("/quotas", reqGrafanaAdmin, routing.Wrap(GetOrgQuotas))
 			orgsRoute.Put("/quotas/:target", reqGrafanaAdmin, bind(models.UpdateOrgQuotaCmd{}), routing.Wrap(UpdateOrgQuota))
-		}, acmiddleware.ReplaceContextOrgMiddleware)
+		})
 
 		// orgs (admin routes)
 		apiRoute.Group("/orgs/name/:name", func(orgsRoute routing.RouteRegister) {

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -16,10 +17,13 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/fs"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
+	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/quota"
@@ -233,4 +237,113 @@ type accessControlTestCase struct {
 	url          string
 	method       string
 	permissions  []*accesscontrol.Permission
+}
+
+// accessControlScenarioContext contains the setups for accesscontrol tests
+type accessControlScenarioContext struct {
+	// server we registered hs routes on.
+	server *macaron.Macaron
+
+	// initCtx is used in a middleware to set the initial context
+	// of the request server side. Can be used to pretend sign in.
+	initCtx *models.ReqContext
+
+	// hs is a minimal HTTPServer for the accesscontrol tests to pass.
+	hs *HTTPServer
+
+	// acmock is an accesscontrol mock used to fake users rights
+	acmock *accesscontrolmock.Mock
+
+	// db is a test database initialized with InitTestDB
+	db *sqlstore.SQLStore
+
+	// cfg is the setting provider
+	cfg *setting.Cfg
+}
+
+func setupHTTPServer(t *testing.T, useFakeAccessControl bool, enableAccessControl bool) accessControlScenarioContext {
+	t.Helper()
+
+	var acmock *accesscontrolmock.Mock
+	var ac *ossaccesscontrol.OSSAccessControlService
+
+	// Use a new conf
+	cfg := setting.NewCfg()
+	cfg.FeatureToggles = make(map[string]bool)
+	if enableAccessControl {
+		cfg.FeatureToggles["accesscontrol"] = enableAccessControl
+	}
+
+	// Use a test DB
+	db := sqlstore.InitTestDB(t)
+	db.Cfg = cfg
+
+	bus := bus.GetBus()
+
+	// Create minimal HTTP Server
+	hs := &HTTPServer{
+		Cfg:                cfg,
+		Bus:                bus,
+		Live:               newTestLive(t),
+		QuotaService:       &quota.QuotaService{Cfg: cfg},
+		RouteRegister:      routing.NewRouteRegister(),
+		SQLStore:           db,
+		searchUsersService: searchusers.ProvideUsersService(bus),
+	}
+
+	// Defining the accesscontrol service has to be done before registering routes
+	if useFakeAccessControl {
+		acmock = accesscontrolmock.New()
+		if !enableAccessControl {
+			acmock = acmock.WithDisabled()
+		}
+		hs.AccessControl = acmock
+	} else {
+		ac = ossaccesscontrol.ProvideService(cfg, &usagestats.UsageStatsService{})
+		hs.AccessControl = ac
+		// Perform role registration
+		err := hs.declareFixedRoles()
+		require.NoError(t, err)
+		err = ac.RegisterFixedRoles()
+		require.NoError(t, err)
+	}
+
+	// Instantiate a new Server
+	m := macaron.New()
+
+	// middleware to set the test initial context
+	initCtx := &models.ReqContext{}
+	m.Use(func(c *macaron.Context) {
+		initCtx.Context = c
+		initCtx.Logger = log.New("api-test")
+		c.Map(initCtx)
+	})
+
+	// Register all routes
+	hs.registerRoutes()
+	hs.RouteRegister.Register(m.Router)
+
+	return accessControlScenarioContext{
+		server:  m,
+		initCtx: initCtx,
+		hs:      hs,
+		acmock:  acmock,
+		db:      db,
+		cfg:     cfg,
+	}
+}
+
+func callAPI(server *macaron.Macaron, method, path string, body io.Reader, t *testing.T) *httptest.ResponseRecorder {
+	req, err := http.NewRequest(method, path, body)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
+	return recorder
+}
+
+// setSignedInUser sets a copy of the user in initCtx
+func setSignedInUser(initCtx *models.ReqContext, user models.SignedInUser) {
+	initCtx.IsSignedIn = true
+	initCtx.SignedInUser = &user
 }

--- a/pkg/services/accesscontrol/middleware/middleware.go
+++ b/pkg/services/accesscontrol/middleware/middleware.go
@@ -74,10 +74,9 @@ func ReplaceContextOrgMiddleware(c *models.ReqContext) {
 	orgID := c.ParamsInt64(":orgId")
 	// Special case of macaron handling invalid params
 	if orgID == 0 {
-		c.JsonApiErr(404, "Org not found", fmt.Errorf("Invalid org"))
+		c.JsonApiErr(http.StatusNotFound, "Org not found", fmt.Errorf("invalid org"))
 		return
 	}
-	// TODO wouldn't it be better to have a target org in the context for accesscontrol
 	// Set the context organization.
 	c.OrgId = orgID
 }

--- a/pkg/services/accesscontrol/middleware/middleware.go
+++ b/pkg/services/accesscontrol/middleware/middleware.go
@@ -69,3 +69,15 @@ func newID() string {
 	}
 	return "ACE" + id
 }
+
+func ReplaceContextOrgMiddleware(c *models.ReqContext) {
+	orgID := c.ParamsInt64(":orgId")
+	// Special case of macaron handling invalid params
+	if orgID == 0 {
+		c.JsonApiErr(404, "Org not found", fmt.Errorf("Invalid org"))
+		return
+	}
+	// TODO wouldn't it be better to have a target org in the context for accesscontrol
+	// Set the context organization.
+	c.OrgId = orgID
+}

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
@@ -95,8 +95,7 @@ func (ac *OSSAccessControlService) GetUserPermissions(ctx context.Context, user 
 	return permissions, nil
 }
 
-// TODO shouldn't this be placed in the replace org middleware instead
-func fetchUserRole(ctx context.Context, userID, orgID int64) (models.RoleType, error) {
+func fetchUserRole(ctx context.Context, orgID, userID int64) (models.RoleType, error) {
 	var err error
 	query := models.GetSignedInUserQuery{UserId: userID, OrgId: orgID}
 	if err := sqlstore.GetSignedInUser(ctx, &query); err != nil {
@@ -111,9 +110,8 @@ func fetchUserRole(ctx context.Context, userID, orgID int64) (models.RoleType, e
 	return userOrgRole, err
 }
 
-// TODO maybe modify the signature of this function (+in: context, +out: error), but this will require enterprise changes
 func (ac *OSSAccessControlService) GetUserBuiltInRoles(user *models.SignedInUser) []string {
-	userOrgRole, err := fetchUserRole(context.TODO(), user.UserId, user.OrgId)
+	userOrgRole, err := fetchUserRole(context.TODO(), user.OrgId, user.UserId)
 	if err != nil {
 		ac.Log.Debug(fmt.Sprintf("could not fetch user %v role in org %v: %v", user.UserId, user.OrgId, err))
 		return []string{}


### PR DESCRIPTION
**What this PR does / why we need it**:

With fine-grained access control enabled, organization admins can list, add, remove and update users' roles in another organization, where they do not have organization admin role. This PR intends to fix that.

In this PR we remove the FGAC permissions from the /orgs/:orgId/users endpoints.