### PR TITLE
Encryption: Fix decrypting settings in datasource update

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -294,14 +294,13 @@ func (hs *HTTPServer) fillWithSecureJSONData(ctx context.Context, cmd *models.Up
 		return models.ErrDatasourceIsReadOnly
 	}
 
-	secureJSONData, err := hs.SecretsService.DecryptJsonData(ctx, ds.SecureJsonData)
-	if err != nil {
-		return err
-	}
-
-	for k, v := range secureJSONData {
+	for k, v := range ds.SecureJsonData {
 		if _, ok := cmd.SecureJsonData[k]; !ok {
-			cmd.SecureJsonData[k] = v
+			decrypted, err := hs.SecretsService.Decrypt(ctx, v)
+			if err != nil {
+				return err
+			}
+			cmd.SecureJsonData[k] = string(decrypted)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently I can't set a new password for a data source if its password was encrypted with a key that is not available anymore. It happens because during update we try to decrypt data source's secure json settings, and if decrypting fails (which is expected in this case) we return an error that the data source can't be updated.

This PR makes it possible to update secure settings for a data source, if they were encrypted with a key that is not available anymore.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

