### PR TITLE
AccessControl: Remove scopes from orgs endpoints

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -253,7 +253,7 @@ func (hs *HTTPServer) registerRoutes() {
 		})
 
 		// orgs (admin routes)
-		apiRoute.Get("/orgs/name/:name/", authorizeInOrg(reqGrafanaAdmin, acmiddleware.UseOrgFromContextParamsByName(hs.SQLStore), ac.EvalPermission(ActionOrgsRead)), routing.Wrap(hs.GetOrgByName))
+		apiRoute.Get("/orgs/name/:name/", authorizeInOrg(reqGrafanaAdmin, acmiddleware.UseGlobalOrg, ac.EvalPermission(ActionOrgsRead)), routing.Wrap(hs.GetOrgByName))
 
 		// auth api keys
 		apiRoute.Group("/auth/keys", func(keysRoute routing.RouteRegister) {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -33,6 +33,7 @@ func (hs *HTTPServer) registerRoutes() {
 	reqSnapshotPublicModeOrSignedIn := middleware.SnapshotPublicModeOrSignedIn(hs.Cfg)
 	redirectFromLegacyPanelEditURL := middleware.RedirectFromLegacyPanelEditURL(hs.Cfg)
 	authorize := acmiddleware.Middleware(hs.AccessControl)
+	authorizeInOrg := acmiddleware.AuthorizeInOrgMiddleware(hs.AccessControl, hs.SQLStore)
 	quota := middleware.Quota(hs.QuotaService)
 	bind := binding.Bind
 
@@ -200,20 +201,20 @@ func (hs *HTTPServer) registerRoutes() {
 
 		// org information available to all users.
 		apiRoute.Group("/org", func(orgRoute routing.RouteRegister) {
-			orgRoute.Get("/", authorize(reqSignedIn, ac.EvalPermission(ActionOrgsRead, ScopeOrgCurrentID)), routing.Wrap(GetCurrentOrg))
-			orgRoute.Get("/quotas", authorize(reqSignedIn, ac.EvalPermission(ActionOrgsQuotasRead, ScopeOrgCurrentID)), routing.Wrap(hs.GetCurrentOrgQuotas))
+			orgRoute.Get("/", authorize(reqSignedIn, ac.EvalPermission(ActionOrgsRead)), routing.Wrap(GetCurrentOrg))
+			orgRoute.Get("/quotas", authorize(reqSignedIn, ac.EvalPermission(ActionOrgsQuotasRead)), routing.Wrap(hs.GetCurrentOrgQuotas))
 		})
 
 		// current org
 		apiRoute.Group("/org", func(orgRoute routing.RouteRegister) {
 			userIDScope := ac.Scope("users", "id", ac.Parameter(":userId"))
-			orgRoute.Put("/", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgCurrentID)), bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateCurrentOrg))
-			orgRoute.Put("/address", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgCurrentID)), bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateCurrentOrgAddress))
+			orgRoute.Put("/", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsWrite)), bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateCurrentOrg))
+			orgRoute.Put("/address", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsWrite)), bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateCurrentOrgAddress))
 			orgRoute.Get("/users", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.GetOrgUsersForCurrentOrg))
 			orgRoute.Get("/users/search", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.SearchOrgUsersWithPaging))
-			orgRoute.Post("/users", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), quota("user"), bind(models.AddOrgUserCommand{}), routing.Wrap(AddOrgUserToCurrentOrg))
-			orgRoute.Patch("/users/:userId", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRoleUpdate, userIDScope)), bind(models.UpdateOrgUserCommand{}), routing.Wrap(UpdateOrgUserForCurrentOrg))
-			orgRoute.Delete("/users/:userId", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRemove, userIDScope)), routing.Wrap(RemoveOrgUserForCurrentOrg))
+			orgRoute.Post("/users", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), quota("user"), bind(models.AddOrgUserCommand{}), routing.Wrap(hs.AddOrgUserToCurrentOrg))
+			orgRoute.Patch("/users/:userId", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRoleUpdate, userIDScope)), bind(models.UpdateOrgUserCommand{}), routing.Wrap(hs.UpdateOrgUserForCurrentOrg))
+			orgRoute.Delete("/users/:userId", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRemove, userIDScope)), routing.Wrap(hs.RemoveOrgUserForCurrentOrg))
 
 			// invites
 			orgRoute.Get("/invites", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionUsersCreate)), routing.Wrap(GetPendingOrgInvites))
@@ -221,8 +222,8 @@ func (hs *HTTPServer) registerRoutes() {
 			orgRoute.Patch("/invites/:code/revoke", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionUsersCreate)), routing.Wrap(RevokeInvite))
 
 			// prefs
-			orgRoute.Get("/preferences", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsPreferencesRead, ScopeOrgCurrentID)), routing.Wrap(hs.GetOrgPreferences))
-			orgRoute.Put("/preferences", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsPreferencesWrite, ScopeOrgCurrentID)), bind(dtos.UpdatePrefsCmd{}), routing.Wrap(hs.UpdateOrgPreferences))
+			orgRoute.Get("/preferences", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsPreferencesRead)), routing.Wrap(hs.GetOrgPreferences))
+			orgRoute.Put("/preferences", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsPreferencesWrite)), bind(dtos.UpdatePrefsCmd{}), routing.Wrap(hs.UpdateOrgPreferences))
 		})
 
 		// current org without requirement of user to be org admin
@@ -231,27 +232,28 @@ func (hs *HTTPServer) registerRoutes() {
 		})
 
 		// create new org
-		apiRoute.Post("/orgs", authorize(reqSignedIn, ac.EvalPermission(ActionOrgsCreate)), quota("org"), bind(models.CreateOrgCommand{}), routing.Wrap(hs.CreateOrg))
+		apiRoute.Post("/orgs", authorizeInOrg(reqSignedIn, acmiddleware.UseGlobalOrg, ac.EvalPermission(ActionOrgsCreate)), quota("org"), bind(models.CreateOrgCommand{}), routing.Wrap(hs.CreateOrg))
 
 		// search all orgs
-		apiRoute.Get("/orgs", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgsAll)), routing.Wrap(SearchOrgs))
+		apiRoute.Get("/orgs", authorizeInOrg(reqGrafanaAdmin, acmiddleware.UseGlobalOrg, ac.EvalPermission(ActionOrgsRead)), routing.Wrap(SearchOrgs))
 
 		// orgs (admin routes)
 		apiRoute.Group("/orgs/:orgId", func(orgsRoute routing.RouteRegister) {
-			orgsRoute.Get("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgID)), routing.Wrap(GetOrgByID))
-			orgsRoute.Put("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgID)), bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateOrg))
-			orgsRoute.Put("/address", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsWrite, ScopeOrgID)), bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateOrgAddress))
-			orgsRoute.Delete("/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsDelete, ScopeOrgID)), routing.Wrap(DeleteOrgByID))
-			orgsRoute.Get("/users", reqGrafanaAdmin, routing.Wrap(hs.GetOrgUsers))
-			orgsRoute.Post("/users", reqGrafanaAdmin, bind(models.AddOrgUserCommand{}), routing.Wrap(AddOrgUser))
-			orgsRoute.Patch("/users/:userId", reqGrafanaAdmin, bind(models.UpdateOrgUserCommand{}), routing.Wrap(UpdateOrgUser))
-			orgsRoute.Delete("/users/:userId", reqGrafanaAdmin, routing.Wrap(RemoveOrgUser))
-			orgsRoute.Get("/quotas", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsQuotasRead, ScopeOrgID)), routing.Wrap(hs.GetOrgQuotas))
-			orgsRoute.Put("/quotas/:target", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsQuotasWrite, ScopeOrgID)), bind(models.UpdateOrgQuotaCmd{}), routing.Wrap(hs.UpdateOrgQuota))
+			userIDScope := ac.Scope("users", "id", ac.Parameter(":userId"))
+			orgsRoute.Get("/", authorizeInOrg(reqGrafanaAdmin, acmiddleware.UseOrgFromContextParams, ac.EvalPermission(ActionOrgsRead)), routing.Wrap(GetOrgByID))
+			orgsRoute.Put("/", authorizeInOrg(reqGrafanaAdmin, acmiddleware.UseOrgFromContextParams, ac.EvalPermission(ActionOrgsWrite)), bind(dtos.UpdateOrgForm{}), routing.Wrap(UpdateOrg))
+			orgsRoute.Put("/address", authorizeInOrg(reqGrafanaAdmin, acmiddleware.UseOrgFromContextParams, ac.EvalPermission(ActionOrgsWrite)), bind(dtos.UpdateOrgAddressForm{}), routing.Wrap(UpdateOrgAddress))
+			orgsRoute.Delete("/", authorizeInOrg(reqGrafanaAdmin, acmiddleware.UseOrgFromContextParams, ac.EvalPermission(ActionOrgsDelete)), routing.Wrap(DeleteOrgByID))
+			orgsRoute.Get("/users", authorizeInOrg(reqGrafanaAdmin, acmiddleware.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.GetOrgUsers))
+			orgsRoute.Post("/users", authorizeInOrg(reqGrafanaAdmin, acmiddleware.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), bind(models.AddOrgUserCommand{}), routing.Wrap(hs.AddOrgUser))
+			orgsRoute.Patch("/users/:userId", authorizeInOrg(reqGrafanaAdmin, acmiddleware.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgUsersRoleUpdate, userIDScope)), bind(models.UpdateOrgUserCommand{}), routing.Wrap(hs.UpdateOrgUser))
+			orgsRoute.Delete("/users/:userId", authorizeInOrg(reqGrafanaAdmin, acmiddleware.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgUsersRemove, userIDScope)), routing.Wrap(hs.RemoveOrgUser))
+			orgsRoute.Get("/quotas", authorizeInOrg(reqGrafanaAdmin, acmiddleware.UseOrgFromContextParams, ac.EvalPermission(ActionOrgsQuotasRead)), routing.Wrap(hs.GetOrgQuotas))
+			orgsRoute.Put("/quotas/:target", authorizeInOrg(reqGrafanaAdmin, acmiddleware.UseOrgFromContextParams, ac.EvalPermission(ActionOrgsQuotasWrite)), bind(models.UpdateOrgQuotaCmd{}), routing.Wrap(hs.UpdateOrgQuota))
 		})
 
 		// orgs (admin routes)
-		apiRoute.Get("/orgs/name/:name/", authorize(reqGrafanaAdmin, ac.EvalPermission(ActionOrgsRead, ScopeOrgName)), routing.Wrap(hs.GetOrgByName))
+		apiRoute.Get("/orgs/name/:name/", authorizeInOrg(reqGrafanaAdmin, acmiddleware.UseOrgFromContextParamsByName(hs.SQLStore), ac.EvalPermission(ActionOrgsRead)), routing.Wrap(hs.GetOrgByName))
 
 		// auth api keys
 		apiRoute.Group("/auth/keys", func(keysRoute routing.RouteRegister) {

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -9,7 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -37,12 +40,169 @@ var (
 	testCreateOrgCmd = `{ "name": "TestOrg%v"}`
 )
 
-func TestAPIEndpoint_CreateOrgs_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, false)
+// `/api/org` endpoints test
+
+func TestAPIEndpoint_GetCurrentOrg_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true, false)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
+
+	t.Run("Viewer can view CurrentOrg", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodGet, getCurrentOrgURL, nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	sc.initCtx.IsSignedIn = false
+	t.Run("Unsigned user cannot view CurrentOrg", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodGet, getCurrentOrgURL, nil, t)
+		assert.Equal(t, http.StatusUnauthorized, response.Code)
+	})
+}
+
+func TestAPIEndpoint_GetCurrentOrg_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	t.Run("AccessControl allows viewing CurrentOrg with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead}}, sc.initCtx.OrgId)
+		response := callAPI(sc.server, http.MethodGet, getCurrentOrgURL, nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+	t.Run("AccessControl prevents viewing CurrentOrg with correct permissions in another org", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead}}, 2)
+		response := callAPI(sc.server, http.MethodGet, getCurrentOrgURL, nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+	t.Run("AccessControl prevents viewing CurrentOrg with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}}, sc.initCtx.OrgId)
+		response := callAPI(sc.server, http.MethodGet, getCurrentOrgURL, nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrg_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true, false)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgNameForm)
+
+	setInitCtxSignedInViewer(sc.initCtx)
+	t.Run("Viewer cannot update current org", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	setInitCtxSignedInOrgAdmin(sc.initCtx)
+	t.Run("Admin can update current org", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrg_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", sc.initCtx.UserId)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgNameForm)
+	t.Run("AccessControl allows updating current org with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite}}, sc.initCtx.OrgId)
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	t.Run("AccessControl prevents updating current org with correct permissions in another org", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite}}, 2)
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	t.Run("AccessControl prevents updating current org with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}}, sc.initCtx.OrgId)
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrgAddress_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true, false)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgAddressForm)
+
+	setInitCtxSignedInViewer(sc.initCtx)
+	t.Run("Viewer cannot update current org address", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	setInitCtxSignedInOrgAdmin(sc.initCtx)
+	t.Run("Admin can update current org address", func(t *testing.T) {
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+}
+
+func TestAPIEndpoint_PutCurrentOrgAddress_AccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true, true)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
+	require.NoError(t, err)
+
+	input := strings.NewReader(testUpdateOrgAddressForm)
+	t.Run("AccessControl allows updating current org address with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite}}, sc.initCtx.OrgId)
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+	})
+
+	input = strings.NewReader(testUpdateOrgAddressForm)
+	t.Run("AccessControl prevents updating current org address with correct permissions in another org", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite}}, 2)
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	t.Run("AccessControl prevents updating current org address with incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}}, sc.initCtx.OrgId)
+		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+// `/api/orgs/` endpoints test
+
+// setupOrgsDBForAccessControlTests stores users and create three
+func setupOrgsDBForAccessControlTests(t *testing.T, db sqlstore.SQLStore, user models.SignedInUser, orgsCount int) {
+	t.Helper()
+
+	_, err := db.CreateUser(context.Background(), models.CreateUserCommand{Email: user.Email, SkipOrgSetup: true, Login: user.Login})
+	require.NoError(t, err)
+
+	// Create three orgs
+	for i := 1; i <= orgsCount; i++ {
+		_, err = db.CreateOrgWithMember(fmt.Sprintf("TestOrg%v", i), 0)
+		require.NoError(t, err)
+		err = db.AddOrgUser(context.Background(), &models.AddOrgUserCommand{LoginOrEmail: user.Login, Role: user.OrgRole, OrgId: int64(i), UserId: user.UserId})
+		require.NoError(t, err)
+	}
+}
+
+func TestAPIEndpoint_CreateOrgs_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true, false)
+	setInitCtxSignedInViewer(sc.initCtx)
 
 	setting.AllowUserOrgCreate = false
 	input := strings.NewReader(fmt.Sprintf(testCreateOrgCmd, 2))
@@ -68,36 +228,31 @@ func TestAPIEndpoint_CreateOrgs_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_CreateOrgs_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true)
+	sc := setupHTTPServer(t, true, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
+	setupOrgsDBForAccessControlTests(t, *sc.db, *sc.initCtx.SignedInUser, 0)
 
 	input := strings.NewReader(fmt.Sprintf(testCreateOrgCmd, 2))
 	t.Run("AccessControl allows creating Orgs with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsCreate}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsCreate}}, accesscontrol.GlobalOrgID)
 		response := callAPI(sc.server, http.MethodPost, createOrgsURL, input, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 
 	input = strings.NewReader(fmt.Sprintf(testCreateOrgCmd, 3))
 	t.Run("AccessControl prevents creating Orgs with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}}, accesscontrol.GlobalOrgID)
 		response := callAPI(sc.server, http.MethodPost, createOrgsURL, input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }
 
 func TestAPIEndpoint_DeleteOrgs_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, false)
+	sc := setupHTTPServer(t, true, false)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	// Create two orgs
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
+	setupOrgsDBForAccessControlTests(t, *sc.db, *sc.initCtx.SignedInUser, 2)
 
 	t.Run("Viewer cannot delete Orgs", func(t *testing.T) {
 		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
@@ -112,48 +267,31 @@ func TestAPIEndpoint_DeleteOrgs_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_DeleteOrgs_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true)
+	sc := setupHTTPServer(t, true, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	// Create three orgs (to delete org2 then org3)
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg3", testUserID)
-	require.NoError(t, err)
+	setupOrgsDBForAccessControlTests(t, *sc.db, *sc.initCtx.SignedInUser, 2)
 
-	t.Run("AccessControl allows deleting Orgs with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsDelete, Scope: ScopeOrgsAll}})
-		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-	t.Run("AccessControl allows deleting Orgs with exact permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsDelete, Scope: accesscontrol.Scope("orgs", "id", "3")}})
-		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 3), nil, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-	t.Run("AccessControl prevents deleting Orgs with too narrow permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsDelete, Scope: accesscontrol.Scope("orgs", "id", "1")}})
-		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
-	})
 	t.Run("AccessControl prevents deleting Orgs with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}}, 2)
 		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+	t.Run("AccessControl prevents deleting Orgs with correct permissions in another org", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsDelete}}, 1)
+		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+	t.Run("AccessControl allows deleting Orgs with correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsDelete}}, 2)
+		response := callAPI(sc.server, http.MethodDelete, fmt.Sprintf(deleteOrgsURL, 2), nil, t)
+		assert.Equal(t, http.StatusOK, response.Code)
 	})
 }
 
 func TestAPIEndpoint_SearchOrgs_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, false)
+	sc := setupHTTPServer(t, true, false)
 	setInitCtxSignedInViewer(sc.initCtx)
-
-	// Create two orgs
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
 
 	t.Run("Viewer cannot list Orgs", func(t *testing.T) {
 		response := callAPI(sc.server, http.MethodGet, searchOrgsURL, nil, t)
@@ -168,84 +306,32 @@ func TestAPIEndpoint_SearchOrgs_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_SearchOrgs_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true)
+	sc := setupHTTPServer(t, true, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	// Create two orgs
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
-
 	t.Run("AccessControl allows listing Orgs with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead}}, accesscontrol.GlobalOrgID)
 		response := callAPI(sc.server, http.MethodGet, searchOrgsURL, nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
-	t.Run("AccessControl prevents listing Orgs with too narrow permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+	t.Run("AccessControl prevents listing Orgs with correct permissions not granted globally", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead}}, 1)
 		response := callAPI(sc.server, http.MethodGet, searchOrgsURL, nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 	t.Run("AccessControl prevents listing Orgs with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}}, accesscontrol.GlobalOrgID)
 		response := callAPI(sc.server, http.MethodGet, searchOrgsURL, nil, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
-	})
-}
-
-func TestAPIEndpoint_GetCurrentOrg_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, false)
-	setInitCtxSignedInViewer(sc.initCtx)
-
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-
-	t.Run("Viewer can view CurrentOrg", func(t *testing.T) {
-		response := callAPI(sc.server, http.MethodGet, getCurrentOrgURL, nil, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-
-	sc.initCtx.IsSignedIn = false
-	t.Run("Unsigned user cannot view CurrentOrg", func(t *testing.T) {
-		response := callAPI(sc.server, http.MethodGet, getCurrentOrgURL, nil, t)
-		assert.Equal(t, http.StatusUnauthorized, response.Code)
-	})
-}
-
-func TestAPIEndpoint_GetCurrentOrg_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true)
-	setInitCtxSignedInViewer(sc.initCtx)
-
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-
-	t.Run("AccessControl allows viewing CurrentOrg with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
-		response := callAPI(sc.server, http.MethodGet, getCurrentOrgURL, nil, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-	t.Run("AccessControl allows viewing CurrentOrg with exact permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "id", "1")}})
-		response := callAPI(sc.server, http.MethodGet, getCurrentOrgURL, nil, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-	t.Run("AccessControl prevents viewing CurrentOrg with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
-		response := callAPI(sc.server, http.MethodGet, getCurrentOrgURL, nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }
 
 func TestAPIEndpoint_GetOrg_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, false)
+	sc := setupHTTPServer(t, true, false)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to fetch another one than the logged in one
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
+	setupOrgsDBForAccessControlTests(t, *sc.db, *sc.initCtx.SignedInUser, 2)
 
 	t.Run("Viewer cannot view another Org", func(t *testing.T) {
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsURL, 2), nil, t)
@@ -260,46 +346,35 @@ func TestAPIEndpoint_GetOrg_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_GetOrg_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true)
+	sc := setupHTTPServer(t, true, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to fetch another one than the logged in one
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
+	setupOrgsDBForAccessControlTests(t, *sc.db, *sc.initCtx.SignedInUser, 2)
 
 	t.Run("AccessControl allows viewing another org with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead}}, 2)
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsURL, 2), nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
-	t.Run("AccessControl allows viewing another org with exact permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "id", "2")}})
-		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsURL, 2), nil, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-	t.Run("AccessControl prevents viewing another org with too narrow permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+	t.Run("AccessControl prevents viewing another org with correct permissions in another org", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead}}, 1)
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsURL, 2), nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 	t.Run("AccessControl prevents viewing another org with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}}, 2)
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsURL, 2), nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }
 
 func TestAPIEndpoint_GetOrgByName_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, false)
+	sc := setupHTTPServer(t, true, false)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to fetch another one than the logged in one
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
+	setupOrgsDBForAccessControlTests(t, *sc.db, *sc.initCtx.SignedInUser, 2)
 
 	t.Run("Viewer cannot view another Org", func(t *testing.T) {
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
@@ -314,101 +389,35 @@ func TestAPIEndpoint_GetOrgByName_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_GetOrgByName_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true)
+	sc := setupHTTPServer(t, true, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to fetch another one than the logged in one
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
+	setupOrgsDBForAccessControlTests(t, *sc.db, *sc.initCtx.SignedInUser, 2)
 
 	t.Run("AccessControl allows viewing another org with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: ScopeOrgsAll}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead}}, 2)
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
-	t.Run("AccessControl allows viewing another org with exact permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "name", "TestOrg2")}})
-		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-	t.Run("AccessControl prevents viewing another org with too narrow permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead, Scope: accesscontrol.Scope("orgs", "name", "TestOrg1")}})
+	t.Run("AccessControl prevents viewing another org with correct permissions in another org", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead}}, 1)
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 	t.Run("AccessControl prevents viewing another org with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}}, 2)
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
-	})
-}
-
-func TestAPIEndpoint_PutCurrentOrg_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, false)
-
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-
-	input := strings.NewReader(testUpdateOrgNameForm)
-
-	setInitCtxSignedInViewer(sc.initCtx)
-	t.Run("Viewer cannot update current org", func(t *testing.T) {
-		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
-	})
-
-	setInitCtxSignedInOrgAdmin(sc.initCtx)
-	t.Run("Admin can update current org", func(t *testing.T) {
-		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-}
-
-func TestAPIEndpoint_PutCurrentOrg_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true)
-	setInitCtxSignedInViewer(sc.initCtx)
-
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-
-	input := strings.NewReader(testUpdateOrgNameForm)
-	t.Run("AccessControl allows updating current org with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: ScopeOrgsAll}})
-		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-
-	input = strings.NewReader(testUpdateOrgNameForm)
-	t.Run("AccessControl allows updating current org with exact permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "1")}})
-		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-
-	t.Run("AccessControl prevents updating current org with too narrow permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "2")}})
-		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
-	})
-
-	t.Run("AccessControl prevents updating current org with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
-		response := callAPI(sc.server, http.MethodPut, putCurrentOrgURL, input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }
 
 func TestAPIEndpoint_PutOrg_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, false)
+	sc := setupHTTPServer(t, true, false)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to update another one than the logged in one
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
+	setupOrgsDBForAccessControlTests(t, *sc.db, *sc.initCtx.SignedInUser, 2)
 
 	input := strings.NewReader(testUpdateOrgNameForm)
 
@@ -425,101 +434,38 @@ func TestAPIEndpoint_PutOrg_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutOrg_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true)
+	sc := setupHTTPServer(t, true, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to update another one than the logged in one
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
+	setupOrgsDBForAccessControlTests(t, *sc.db, *sc.initCtx.SignedInUser, 2)
 
 	input := strings.NewReader(testUpdateOrgNameForm)
 	t.Run("AccessControl allows updating another org with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: ScopeOrgsAll}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite}}, 2)
 		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsURL, 2), input, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 
-	input = strings.NewReader(testUpdateOrgNameForm)
-	t.Run("AccessControl allows updating another org with exact permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "2")}})
-		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsURL, 2), input, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-
-	input = strings.NewReader(testUpdateOrgNameForm)
-	t.Run("AccessControl prevents updating another org with too narrow permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+	t.Run("AccessControl prevents updating another org with correct permissions in another org", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite}}, 1)
 		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsURL, 2), input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 
 	t.Run("AccessControl prevents updating another org with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}}, 2)
 		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsURL, 2), input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }
 
-func TestAPIEndpoint_PutCurrentOrgAddress_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, false)
-
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-
-	input := strings.NewReader(testUpdateOrgAddressForm)
-
-	setInitCtxSignedInViewer(sc.initCtx)
-	t.Run("Viewer cannot update current org address", func(t *testing.T) {
-		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
-	})
-
-	setInitCtxSignedInOrgAdmin(sc.initCtx)
-	t.Run("Admin can update current org address", func(t *testing.T) {
-		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-}
-
-func TestAPIEndpoint_PutCurrentOrgAddress_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true)
-	setInitCtxSignedInViewer(sc.initCtx)
-
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-
-	input := strings.NewReader(testUpdateOrgAddressForm)
-	t.Run("AccessControl allows updating current org address with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: ScopeOrgsAll}})
-		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-
-	input = strings.NewReader(testUpdateOrgAddressForm)
-	t.Run("AccessControl allows updating current org address with exact permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "1")}})
-		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-
-	t.Run("AccessControl prevents updating current org address with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
-		response := callAPI(sc.server, http.MethodPut, putCurrentOrgAddressURL, input, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
-	})
-}
-
 func TestAPIEndpoint_PutOrgAddress_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, false)
+	sc := setupHTTPServer(t, true, false)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to update another one than the logged in one
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
+	setupOrgsDBForAccessControlTests(t, *sc.db, *sc.initCtx.SignedInUser, 2)
 
 	input := strings.NewReader(testUpdateOrgAddressForm)
 
@@ -536,31 +482,28 @@ func TestAPIEndpoint_PutOrgAddress_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutOrgAddress_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true)
+	sc := setupHTTPServer(t, true, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to update another one than the logged in one
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
+	setupOrgsDBForAccessControlTests(t, *sc.db, *sc.initCtx.SignedInUser, 2)
 
 	input := strings.NewReader(testUpdateOrgAddressForm)
 	t.Run("AccessControl allows updating another org address with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: ScopeOrgsAll}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite}}, 2)
 		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsAddressURL, 2), input, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 
 	input = strings.NewReader(testUpdateOrgAddressForm)
-	t.Run("AccessControl prevents updating another org address with too narrow permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+	t.Run("AccessControl prevents updating another org address with too correct permissions in another org", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite}}, 1)
 		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsAddressURL, 2), input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 
 	t.Run("AccessControl prevents updating another org address with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}}, 2)
 		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsAddressURL, 2), input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -396,17 +396,12 @@ func TestAPIEndpoint_GetOrgByName_AccessControl(t *testing.T) {
 	setupOrgsDBForAccessControlTests(t, *sc.db, *sc.initCtx.SignedInUser, 2)
 
 	t.Run("AccessControl allows viewing another org with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead}}, 2)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead}}, accesscontrol.GlobalOrgID)
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
-	t.Run("AccessControl prevents viewing another org with correct permissions in another org", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsRead}}, 1)
-		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
-		assert.Equal(t, http.StatusForbidden, response.Code)
-	})
 	t.Run("AccessControl prevents viewing another org with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}}, 2)
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}}, accesscontrol.GlobalOrgID)
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsByNameURL, "TestOrg2"), nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -491,7 +491,7 @@ func TestAPIEndpoint_PutOrgAddress_AccessControl(t *testing.T) {
 	})
 
 	input = strings.NewReader(testUpdateOrgAddressForm)
-	t.Run("AccessControl prevents updating another org address with too correct permissions in another org", func(t *testing.T) {
+	t.Run("AccessControl prevents updating another org address with correct permissions in the current org", func(t *testing.T) {
 		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsWrite}}, 1)
 		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsAddressURL, 2), input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -184,14 +184,14 @@ func TestAPIEndpoint_PutCurrentOrgAddress_AccessControl(t *testing.T) {
 
 // `/api/orgs/` endpoints test
 
-// setupOrgsDBForAccessControlTests stores users and create three
+// setupOrgsDBForAccessControlTests stores users and create specified number of orgs
 func setupOrgsDBForAccessControlTests(t *testing.T, db sqlstore.SQLStore, user models.SignedInUser, orgsCount int) {
 	t.Helper()
 
 	_, err := db.CreateUser(context.Background(), models.CreateUserCommand{Email: user.Email, SkipOrgSetup: true, Login: user.Login})
 	require.NoError(t, err)
 
-	// Create three orgs
+	// Create `orgsCount` orgs
 	for i := 1; i <= orgsCount; i++ {
 		_, err = db.CreateOrgWithMember(fmt.Sprintf("TestOrg%v", i), 0)
 		require.NoError(t, err)

--- a/pkg/api/quota_test.go
+++ b/pkg/api/quota_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/setting"
@@ -29,17 +28,24 @@ var testOrgQuota = setting.OrgQuota{
 	AlertRule:  10,
 }
 
-func TestAPIEndpoint_GetCurrentOrgQuotas_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, false)
-	setInitCtxSignedInViewer(sc.initCtx)
+// setupDBAndSettingsForAccessControlQuotaTests stores users and create two orgs
+func setupDBAndSettingsForAccessControlQuotaTests(t *testing.T, sc accessControlScenarioContext) {
+	t.Helper()
 
 	sc.hs.Cfg.Quota.Enabled = true
 	sc.hs.Cfg.Quota.Org = &testOrgQuota
 	// Required while sqlstore quota.go relies on setting global variables
 	setting.Quota = sc.hs.Cfg.Quota
 
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
+	// Create two orgs with the context user
+	setupOrgsDBForAccessControlTests(t, *sc.db, *sc.initCtx.SignedInUser, 2)
+}
+
+func TestAPIEndpoint_GetCurrentOrgQuotas_LegacyAccessControl(t *testing.T) {
+	sc := setupHTTPServer(t, true, false)
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
 
 	t.Run("Viewer can view CurrentOrgQuotas", func(t *testing.T) {
 		response := callAPI(sc.server, http.MethodGet, getCurrentOrgQuotasURL, nil, t)
@@ -54,48 +60,33 @@ func TestAPIEndpoint_GetCurrentOrgQuotas_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_GetCurrentOrgQuotas_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true)
+	sc := setupHTTPServer(t, true, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	sc.hs.Cfg.Quota.Enabled = true
-	sc.hs.Cfg.Quota.Org = &testOrgQuota
-	// Required while sqlstore quota.go relies on setting global variables
-	setting.Quota = sc.hs.Cfg.Quota
-
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
+	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
 
 	t.Run("AccessControl allows viewing CurrentOrgQuotas with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasRead, Scope: ScopeOrgsAll}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasRead}}, sc.initCtx.OrgId)
 		response := callAPI(sc.server, http.MethodGet, getCurrentOrgQuotasURL, nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
-	t.Run("AccessControl allows viewing CurrentOrgQuotas with exact permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasRead, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+	t.Run("AccessControl prevents viewing CurrentOrgQuotas with correct permissions in another org", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasRead}}, 2)
 		response := callAPI(sc.server, http.MethodGet, getCurrentOrgQuotasURL, nil, t)
-		assert.Equal(t, http.StatusOK, response.Code)
+		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 	t.Run("AccessControl prevents viewing CurrentOrgQuotas with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}}, sc.initCtx.OrgId)
 		response := callAPI(sc.server, http.MethodGet, getCurrentOrgQuotasURL, nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }
 
 func TestAPIEndpoint_GetOrgQuotas_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, false)
+	sc := setupHTTPServer(t, true, false)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	sc.hs.Cfg.Quota.Enabled = true
-	sc.hs.Cfg.Quota.Org = &testOrgQuota
-	// Required while sqlstore quota.go relies on setting global variables
-	setting.Quota = sc.hs.Cfg.Quota
-
-	// Create two orgs, to fetch another one than the logged in one
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
+	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
 
 	t.Run("Viewer cannot view another org quotas", func(t *testing.T) {
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
@@ -110,54 +101,33 @@ func TestAPIEndpoint_GetOrgQuotas_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_GetOrgQuotas_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true)
+	sc := setupHTTPServer(t, true, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	sc.hs.Cfg.Quota.Enabled = true
-	sc.hs.Cfg.Quota.Org = &testOrgQuota
-	// Required while sqlstore quota.go relies on setting global variables
-	setting.Quota = sc.hs.Cfg.Quota
-
-	// Create two orgs, to fetch another one than the logged in one
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
+	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
 
 	t.Run("AccessControl allows viewing another org quotas with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasRead, Scope: ScopeOrgsAll}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasRead}}, 2)
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
-	t.Run("AccessControl allows viewing another org quotas with exact permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasRead, Scope: accesscontrol.Scope("orgs", "id", "2")}})
-		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-	t.Run("AccessControl prevents viewing another org quotas with too narrow permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasRead, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+	t.Run("AccessControl prevents viewing another org quotas with correct permissions in another org", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasRead}}, 1)
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 	t.Run("AccessControl prevents viewing another org quotas with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}}, 2)
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 }
 
 func TestAPIEndpoint_PutOrgQuotas_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, false)
+	sc := setupHTTPServer(t, true, false)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	sc.hs.Cfg.Quota.Enabled = true
-	sc.hs.Cfg.Quota.Org = &testOrgQuota
-
-	// Create two orgs, to update another one than the logged in one
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
+	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
 
 	input := strings.NewReader(testUpdateOrgQuotaCmd)
 	t.Run("Viewer cannot update another org quotas", func(t *testing.T) {
@@ -174,42 +144,28 @@ func TestAPIEndpoint_PutOrgQuotas_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutOrgQuotas_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true)
+	sc := setupHTTPServer(t, true, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
-	sc.hs.Cfg.Quota.Enabled = true
-	sc.hs.Cfg.Quota.Org = &testOrgQuota
-
-	// Create two orgs, to update another one than the logged in one
-	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
-	require.NoError(t, err)
-	_, err = sc.db.CreateOrgWithMember("TestOrg2", testUserID)
-	require.NoError(t, err)
+	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
 
 	input := strings.NewReader(testUpdateOrgQuotaCmd)
 	t.Run("AccessControl allows updating another org quotas with correct permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasWrite, Scope: ScopeOrgsAll}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasWrite}}, 2)
 		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 
 	input = strings.NewReader(testUpdateOrgQuotaCmd)
-	t.Run("AccessControl allows updating another org quotas with exact permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasWrite, Scope: accesscontrol.Scope("orgs", "id", "2")}})
-		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input, t)
-		assert.Equal(t, http.StatusOK, response.Code)
-	})
-
-	input = strings.NewReader(testUpdateOrgQuotaCmd)
-	t.Run("AccessControl prevents updating another org quotas with too narrow permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasWrite, Scope: accesscontrol.Scope("orgs", "id", "1")}})
+	t.Run("AccessControl prevents updating another org quotas with correct permissions in another org", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: ActionOrgsQuotasWrite}}, 1)
 		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 
 	input = strings.NewReader(testUpdateOrgQuotaCmd)
 	t.Run("AccessControl prevents updating another org quotas with incorrect permissions", func(t *testing.T) {
-		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}})
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "orgs:invalid"}}, 2)
 		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -38,12 +38,6 @@ var (
 	ScopeDatasourceID   = accesscontrol.Scope("datasources", "id", accesscontrol.Parameter(":id"))
 	ScopeDatasourceUID  = accesscontrol.Scope("datasources", "uid", accesscontrol.Parameter(":uid"))
 	ScopeDatasourceName = accesscontrol.Scope("datasources", "name", accesscontrol.Parameter(":name"))
-
-	ScopeOrgsAll      = accesscontrol.Scope("orgs", "*")
-	ScopeOrgID        = accesscontrol.Scope("orgs", "id", accesscontrol.Parameter(":orgId"))
-	ScopeOrgCurrentID = accesscontrol.Scope("orgs", "id", accesscontrol.Field("OrgID"))
-	ScopeOrgName      = accesscontrol.Scope("orgs", "name", accesscontrol.Parameter(":name"))
-	ScopeOrgCurrent   = accesscontrol.Scope("orgs", "current")
 )
 
 // declareFixedRoles declares to the AccessControl service fixed roles and their
@@ -121,17 +115,15 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		},
 		{
 			Role: accesscontrol.RoleDTO{
-				Version:     1,
+				Version:     2,
 				Name:        "fixed:current:org:reader",
 				Description: "Read current organization and its quotas.",
 				Permissions: []accesscontrol.Permission{
 					{
 						Action: ActionOrgsRead,
-						Scope:  ScopeOrgCurrent,
 					},
 					{
 						Action: ActionOrgsQuotasRead,
-						Scope:  ScopeOrgCurrent,
 					},
 				},
 			},
@@ -139,64 +131,29 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		},
 		{
 			Role: accesscontrol.RoleDTO{
-				Version:     1,
-				Name:        "fixed:current:org:writer",
-				Description: "Read current organization, its quotas, and its preferences. Write current organization and its preferences.",
-				Permissions: []accesscontrol.Permission{
-					{
-						Action: ActionOrgsRead,
-						Scope:  ScopeOrgCurrent,
-					},
-					{
-						Action: ActionOrgsQuotasRead,
-						Scope:  ScopeOrgCurrent,
-					},
-					{
-						Action: ActionOrgsPreferencesRead,
-						Scope:  ScopeOrgCurrent,
-					},
-					{
-						Action: ActionOrgsWrite,
-						Scope:  ScopeOrgCurrent,
-					},
-					{
-						Action: ActionOrgsPreferencesWrite,
-						Scope:  ScopeOrgCurrent,
-					},
-				},
-			},
-			Grants: []string{string(models.ROLE_ADMIN)},
-		},
-		{
-			Role: accesscontrol.RoleDTO{
-				Version:     1,
+				Version:     2,
 				Name:        "fixed:orgs:writer",
 				Description: "Create, read, write, or delete an organization. Read or write an organization's quotas.",
 				Permissions: []accesscontrol.Permission{
 					{Action: ActionOrgsCreate},
 					{
 						Action: ActionOrgsRead,
-						Scope:  ScopeOrgsAll,
 					},
 					{
 						Action: ActionOrgsWrite,
-						Scope:  ScopeOrgsAll,
 					},
 					{
 						Action: ActionOrgsDelete,
-						Scope:  ScopeOrgsAll,
 					},
 					{
 						Action: ActionOrgsQuotasRead,
-						Scope:  ScopeOrgsAll,
 					},
 					{
 						Action: ActionOrgsQuotasWrite,
-						Scope:  ScopeOrgsAll,
 					},
 				},
 			},
-			Grants: []string{string(accesscontrol.RoleGrafanaAdmin)},
+			Grants: []string{accesscontrol.RoleGrafanaAdmin, string(models.ROLE_ADMIN)},
 		},
 	}
 

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -132,6 +132,31 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		{
 			Role: accesscontrol.RoleDTO{
 				Version:     2,
+				Name:        "fixed:current:org:writer",
+				Description: "Read current organization, its quotas, and its preferences. Write current organization and its preferences.",
+				Permissions: []accesscontrol.Permission{
+					{
+						Action: ActionOrgsRead,
+					},
+					{
+						Action: ActionOrgsQuotasRead,
+					},
+					{
+						Action: ActionOrgsPreferencesRead,
+					},
+					{
+						Action: ActionOrgsWrite,
+					},
+					{
+						Action: ActionOrgsPreferencesWrite,
+					},
+				},
+			},
+			Grants: []string{string(models.ROLE_ADMIN)},
+		},
+		{
+			Role: accesscontrol.RoleDTO{
+				Version:     2,
 				Name:        "fixed:orgs:writer",
 				Description: "Create, read, write, or delete an organization. Read or write an organization's quotas.",
 				Permissions: []accesscontrol.Permission{
@@ -153,7 +178,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 					},
 				},
 			},
-			Grants: []string{accesscontrol.RoleGrafanaAdmin, string(models.ROLE_ADMIN)},
+			Grants: []string{accesscontrol.RoleGrafanaAdmin},
 		},
 	}
 

--- a/pkg/services/accesscontrol/middleware/middleware.go
+++ b/pkg/services/accesscontrol/middleware/middleware.go
@@ -114,7 +114,7 @@ func AuthorizeInOrgMiddleware(ac accesscontrol.AccessControl, db *sqlstore.SQLSt
 					Deny(c, nil, fmt.Errorf("failed to authenticate user in target org: %w", err))
 					return
 				}
-				userCopy.OrgId = query.OrgId
+				userCopy.OrgId = query.Result.OrgId
 				userCopy.OrgName = query.Result.OrgName
 				userCopy.OrgRole = query.Result.OrgRole
 			}
@@ -136,14 +136,4 @@ func UseOrgFromContextParams(c *models.ReqContext) (int64, error) {
 
 func UseGlobalOrg(c *models.ReqContext) (int64, error) {
 	return accesscontrol.GlobalOrgID, nil
-}
-
-func UseOrgFromContextParamsByName(db *sqlstore.SQLStore) OrgIDGetter {
-	return func(c *models.ReqContext) (int64, error) {
-		org, err := db.GetOrgByName(web.Params(c.Req)[":name"])
-		if err != nil {
-			return 0, err
-		}
-		return org.Id, nil
-	}
 }

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
@@ -536,13 +536,6 @@ func TestOSSAccessControlService_GetUserPermissions(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name:     "Translate orgs:current",
-			user:     testUser,
-			rawPerm:  accesscontrol.Permission{Action: "orgs:read", Scope: "orgs:current"},
-			wantPerm: accesscontrol.Permission{Action: "orgs:read", Scope: "orgs:id:3"},
-			wantErr:  false,
-		},
-		{
 			name:     "Translate users:self",
 			user:     testUser,
 			rawPerm:  accesscontrol.Permission{Action: "users:read", Scope: "users:self"},

--- a/pkg/services/accesscontrol/scope.go
+++ b/pkg/services/accesscontrol/scope.go
@@ -42,14 +42,9 @@ type ScopeResolver struct {
 func NewScopeResolver() ScopeResolver {
 	return ScopeResolver{
 		keywordResolvers: map[string]KeywordScopeResolveFunc{
-			"orgs:current": resolveCurrentOrg,
-			"users:self":   resolveUserSelf,
+			"users:self": resolveUserSelf,
 		},
 	}
-}
-
-func resolveCurrentOrg(u *models.SignedInUser) (string, error) {
-	return Scope("orgs", "id", fmt.Sprintf("%v", u.OrgId)), nil
 }
 
 func resolveUserSelf(u *models.SignedInUser) (string, error) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
For orgs endpoints, we needed to implement a way to verify that the end user had rights to modify (or list users) in a target org. We also needed to remove the org scopes defined previously as it lead to some inconsistencies (for instance having `{ orgs:read, orgs:3 }` granted in org `2`).

Note on the design:
We added a middle-ware that performs the assessment in a given org without changing the user's signed in org (in the context) by working with a copy of the user. I believe this is good for now, but we might want to rethink the design to allow a little bit of customization of the `authorize` middle-ware.
We tried to switch the signed in user org, but it didn't work for the `DELETE /api/org/:orgID` endpoint and did not make sense for the `POST /orgs/` and `GET /orgs` endpoints.
The `GET "/orgs/name/:name/"` endpoint requires a global assignment of `orgs:read` for now, because adding a middle-ware to check the user's permission lead to return `403` when the org wasn't found which broke the frontend upon creation of a new org.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Partially fixes https://github.com/grafana/grafana-enterprise/issues/1550

**Special notes for your reviewer**:
