### PR TITLE
PanelEdit: Display drag indicators on draggable sections

### DIFF
--- a/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
@@ -134,20 +134,29 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
   const paneSpacing = theme.spacing.md;
 
   const resizer = css`
-    font-style: italic;
-    background: transparent;
-    border-top: 0;
-    border-right: 0;
-    border-bottom: 0;
-    border-left: 0;
-    border-color: transparent;
-    border-style: solid;
     position: relative;
-    transition: 0.2s border-color ease-in-out;
-    z-index: ${theme.zIndex.navbarFixed};
+
+    &::before {
+      content: '';
+      position: absolute;
+      transition: 0.2s border-color ease-in-out;
+    }
+
+    &::after {
+      background: ${theme.colors.panelBorder};
+      content: '';
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      transition: 0.2s background ease-in-out;
+      transform: translate(-50%, -50%);
+      border-radius: 4px;
+    }
 
     &:hover {
-      border-color: ${handleColor};
+      &::before {
+        border-color: ${handleColor};
+      }
 
       &::after {
         background: ${handleColor};
@@ -161,19 +170,17 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       css`
         cursor: col-resize;
         width: ${paneSpacing};
-        border-right-width: 1px;
+
+        &::before {
+          border-right: 1px solid transparent;
+          height: 100%;
+          left: 50%;
+          transform: translateX(-50%);
+        }
 
         &::after {
-          background: ${theme.colors.panelBorder};
-          content: '';
-          position: absolute;
           height: 200px;
-          width: 7px;
-          left: calc(100% + 1px);
-          top: 50%;
-          transform: translate(-50%, -50%);
-          transition: 0.2s background ease-in-out;
-          border-radius: 4px;
+          width: 4px;
         }
       `
     ),
@@ -182,23 +189,18 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       css`
         height: ${paneSpacing};
         cursor: row-resize;
-        position: relative;
-        top: 0px;
-        z-index: 1;
-        border-top-width: 1px;
         margin-left: ${paneSpacing};
 
+        &::before {
+          border-top: 1px solid transparent;
+          top: 50%;
+          transform: translateY(-50%);
+          width: 100%;
+        }
+
         &::after {
-          background: ${theme.colors.panelBorder};
-          content: '';
-          position: absolute;
-          height: 7px;
+          height: 4px;
           width: 200px;
-          left: 50%;
-          top: -1px;
-          transform: translate(-50%, -50%);
-          transition: 0.2s background ease-in-out;
-          border-radius: 4px;
         }
       `
     ),

--- a/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
@@ -142,10 +142,16 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
     border-left: 0;
     border-color: transparent;
     border-style: solid;
+    position: relative;
     transition: 0.2s border-color ease-in-out;
+    z-index: ${theme.zIndex.navbarFixed};
 
     &:hover {
       border-color: ${handleColor};
+
+      &::after {
+        background: ${handleColor};
+      }
     }
   `;
 
@@ -156,7 +162,19 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
         cursor: col-resize;
         width: ${paneSpacing};
         border-right-width: 1px;
-        margin-top: 18px;
+
+        &::after {
+          background: ${theme.colors.panelBorder};
+          content: '';
+          position: absolute;
+          height: 200px;
+          width: 7px;
+          left: calc(100% + 1px);
+          top: 50%;
+          transform: translate(-50%, -50%);
+          transition: 0.2s background ease-in-out;
+          border-radius: 4px;
+        }
       `
     ),
     resizerH: cx(
@@ -169,6 +187,19 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
         z-index: 1;
         border-top-width: 1px;
         margin-left: ${paneSpacing};
+
+        &::after {
+          background: ${theme.colors.panelBorder};
+          content: '';
+          position: absolute;
+          height: 7px;
+          width: 200px;
+          left: 50%;
+          top: -1px;
+          transform: translate(-50%, -50%);
+          transition: 0.2s background ease-in-out;
+          border-radius: 4px;
+        }
       `
     ),
   };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- adds draggable indicators to the sections that can be dragged in `PanelEdit`
- this matches the style seen in `Explore`'s query history

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/20999846/141820864-81d271fa-85ad-4832-97fb-c12ac23409b8.png) | ![image](https://user-images.githubusercontent.com/20999846/141820776-073aac66-563e-443f-974e-cbec9c50d212.png) |
| ![image](https://user-images.githubusercontent.com/20999846/141821001-6242bfa4-2193-46f7-a0c1-03f9673dc6bf.png) | ![image](https://user-images.githubusercontent.com/20999846/141821161-181ca0ac-0001-44ef-ac6f-eae0de6dc13a.png) |
| ![image](https://user-images.githubusercontent.com/20999846/141821078-6a2eafb1-ca29-40fd-87df-ba2a0b128b03.png) | ![image](https://user-images.githubusercontent.com/20999846/141821224-a7212afc-0029-49be-ae58-8234bf626867.png) |

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/24665

**Special notes for your reviewer**:

not sure if this is the way we wanna go or not, but i thought i'd give it a go anyway and see what everyone thinks.
the main reason for hesitation is that the explore page is slightly different in that the draggable element is a drawer, whereas here the draggable element is the gap between the 2 sections.

my preference would be something akin to a [handlebar between the sections](https://uxdesign.cc/handlebars-in-ui-design-4b36af67733b)

edit: here's what that would look like:
![image](https://user-images.githubusercontent.com/20999846/141823636-330afbd5-9eae-4bc0-a76f-4586fb9f3911.png)
