### PR TITLE
Variables: Exclude adhoc variables from the impacted by logic

### DIFF
--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -47,6 +47,7 @@ import {
   hasLegacyVariableSupport,
   hasOptions,
   hasStandardVariableSupport,
+  isAdHoc,
   isMulti,
   isQuery,
 } from '../guard';
@@ -517,7 +518,9 @@ export const variableUpdated = (
     const variables = getVariables(state);
     const g = createGraph(variables);
     const panels = state.dashboard?.getModel()?.panels ?? [];
-    const affectedPanelIds = getAllAffectedPanelIdsForVariableChange(variableInState.id, variables, panels);
+    const affectedPanelIds = isAdHoc(variableInState)
+      ? undefined // for adhoc variables we don't know which panels that will be impacted
+      : getAllAffectedPanelIdsForVariableChange(variableInState.id, variables, panels);
 
     const node = g.getNode(variableInState.name);
     let promises: Array<Promise<any>> = [];


### PR DESCRIPTION
**What this PR does / why we need it**:
Because of the nature of adhoc filters it would be hard to figure out which panels that are impacted by variable change so this PR excludes adhoc from this logic.

**Which issue(s) this PR fixes**:
Fixes #41695

**Special notes for your reviewer**:

