### PR TITLE
Variables: Fix so panels in expanded rows have correct variable values

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -44,7 +44,7 @@ import { isAllVariable } from '../../variables/utils';
 import { DashboardPanelsChangedEvent, RenderEvent } from 'app/types/events';
 import { getTimeSrv } from '../services/TimeSrv';
 import { mergePanels, PanelMergeInfo } from '../utils/panelMerge';
-import { isOnTheSameGridRow } from './utils';
+import { deleteScopeVars, isOnTheSameGridRow } from './utils';
 import { RefreshEvent, TimeRangeUpdatedEvent } from '@grafana/runtime';
 import { sortedDeepCloneWithoutNulls } from 'app/core/utils/object';
 import { Subscription } from 'rxjs';
@@ -553,9 +553,7 @@ export class DashboardModel {
     const panelsToRemove = [];
 
     // cleanup scopedVars
-    for (const panel of this.panels) {
-      delete panel.scopedVars;
-    }
+    deleteScopeVars(this.panels);
 
     for (let i = 0; i < this.panels.length; i++) {
       const panel = this.panels[i];

--- a/public/app/features/dashboard/state/utils.test.ts
+++ b/public/app/features/dashboard/state/utils.test.ts
@@ -1,5 +1,5 @@
 import { PanelModel } from './PanelModel';
-import { isOnTheSameGridRow } from './utils';
+import { deleteScopeVars, isOnTheSameGridRow } from './utils';
 import { REPEAT_DIR_HORIZONTAL } from '../../../core/constants';
 
 describe('isOnTheSameGridRow', () => {
@@ -30,6 +30,33 @@ describe('isOnTheSameGridRow', () => {
       const otherPanel: PanelModel = ({ gridPos: { x: 4, y: 1, w: 4, h: 4 } } as unknown) as PanelModel;
 
       expect(isOnTheSameGridRow(sourcePanel, otherPanel)).toBe(false);
+    });
+  });
+});
+
+describe('deleteScopeVars', () => {
+  describe('when called with a collapsed row with panels', () => {
+    it('then scopedVars should be deleted on the row and all collapsed panels', () => {
+      const panel1 = new PanelModel({
+        id: 1,
+        type: 'row',
+        collapsed: true,
+        scopedVars: { job: { value: 'myjob', text: 'myjob' } },
+        panels: [
+          { id: 2, type: 'graph', title: 'Graph', scopedVars: { job: { value: 'myjob', text: 'myjob' } } },
+          { id: 3, type: 'graph2', title: 'Graph2', scopedVars: { job: { value: 'myjob', text: 'myjob' } } },
+        ],
+      });
+
+      expect(panel1.scopedVars).toBeDefined();
+      expect(panel1.panels[0].scopedVars).toBeDefined();
+      expect(panel1.panels[1].scopedVars).toBeDefined();
+
+      deleteScopeVars([panel1]);
+
+      expect(panel1.scopedVars).toBeUndefined();
+      expect(panel1.panels[0].scopedVars).toBeUndefined();
+      expect(panel1.panels[1].scopedVars).toBeUndefined();
     });
   });
 });

--- a/public/app/features/dashboard/state/utils.ts
+++ b/public/app/features/dashboard/state/utils.ts
@@ -15,3 +15,14 @@ export function isOnTheSameGridRow(sourcePanel: PanelModel, otherPanel: PanelMod
 
   return false;
 }
+
+export function deleteScopeVars(panels: PanelModel[]) {
+  for (const panel of panels) {
+    delete panel.scopedVars;
+    if (panel.panels?.length) {
+      for (const collapsedPanel of panel.panels) {
+        delete collapsedPanel.scopedVars;
+      }
+    }
+  }
+}

--- a/public/app/features/variables/inspect/utils.test.ts
+++ b/public/app/features/variables/inspect/utils.test.ts
@@ -1,14 +1,15 @@
 import {
+  flattenPanels,
   getAffectedPanelIdsForVariable,
   getAllAffectedPanelIdsForVariableChange,
   getDependenciesForVariable,
   getPropsWithVariable,
 } from './utils';
-import { PanelModel } from '@grafana/data';
 import { variableAdapters } from '../adapters';
 import { createDataSourceVariableAdapter } from '../datasource/adapter';
 import { createCustomVariableAdapter } from '../custom/adapter';
 import { createQueryVariableAdapter } from '../query/adapter';
+import { PanelModel } from 'app/features/dashboard/state';
 
 describe('getPropsWithVariable', () => {
   it('when called it should return the correct graph', () => {
@@ -306,6 +307,49 @@ describe('getAllAffectedPanelIdsForVariableChange ', () => {
       );
       const result = getAllAffectedPanelIdsForVariableChange('unknown', variables, panels);
       expect(result).toEqual([2, 3]);
+    });
+  });
+});
+
+describe('flattenPanels', () => {
+  describe('when called with a row with collapsed panels', () => {
+    it('then the result should be correct', () => {
+      const panel1 = new PanelModel({
+        id: 1,
+        type: 'row',
+        collapsed: true,
+        panels: [
+          { id: 2, type: 'graph', title: 'Graph' },
+          { id: 3, type: 'graph2', title: 'Graph2' },
+        ],
+      });
+      const panel2 = new PanelModel({ id: 2, type: 'graph', title: 'Graph' });
+      const panel3 = new PanelModel({ id: 3, type: 'graph2', title: 'Graph2' });
+
+      const result = flattenPanels([panel1]);
+
+      expect(result[0].getSaveModel()).toEqual(panel1.getSaveModel());
+      expect(result[1].getSaveModel()).toEqual(panel2.getSaveModel());
+      expect(result[2].getSaveModel()).toEqual(panel3.getSaveModel());
+    });
+  });
+
+  describe('when called with a row with expanded panels', () => {
+    it('then the result should be correct', () => {
+      const panel1 = new PanelModel({
+        id: 1,
+        type: 'row',
+        collapsed: false,
+        panels: [],
+      });
+      const panel2 = new PanelModel({ id: 2, type: 'graph', title: 'Graph' });
+      const panel3 = new PanelModel({ id: 3, type: 'graph2', title: 'Graph2' });
+
+      const result = flattenPanels([panel1, panel2, panel3]);
+
+      expect(result[0].getSaveModel()).toEqual(panel1.getSaveModel());
+      expect(result[1].getSaveModel()).toEqual(panel2.getSaveModel());
+      expect(result[2].getSaveModel()).toEqual(panel3.getSaveModel());
     });
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
When we clean up all the repeats we forgot to clean up any collapsed panels. This PR fixes this.

**Which issue(s) this PR fixes**:
Fixes #41127

**Special notes for your reviewer**:
You need to read the issue carefully and I used the attached dashboard.json to repro and fix the issue (you'll need a prometheus data source like 
![image](https://user-images.githubusercontent.com/562238/141941906-c53676a6-b29b-4345-961a-a5f2b723356d.png)


```json
{
  "__inputs": [
    {
      "name": "DS_PROMETHEUS_DEMO",
      "label": "Prometheus Demo",
      "description": "",
      "type": "datasource",
      "pluginId": "prometheus",
      "pluginName": "Prometheus"
    }
  ],
  "__elements": [],
  "__requires": [
    {
      "type": "grafana",
      "id": "grafana",
      "name": "Grafana",
      "version": "8.3.0-pre"
    },
    {
      "type": "datasource",
      "id": "prometheus",
      "name": "Prometheus",
      "version": "1.0.0"
    },
    {
      "type": "panel",
      "id": "stat",
      "name": "Stat",
      "version": ""
    },
    {
      "type": "panel",
      "id": "timeseries",
      "name": "Time series",
      "version": ""
    }
  ],
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": "-- Grafana --",
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": null,
  "iteration": 1637046364182,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "collapsed": false,
      "gridPos": {
        "h": 1,
        "w": 24,
        "x": 0,
        "y": 0
      },
      "id": 4,
      "panels": [],
      "repeat": "job",
      "title": "Job $job",
      "type": "row"
    },
    {
      "datasource": "${DS_PROMETHEUS_DEMO}",
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 1
      },
      "id": 2,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom"
        },
        "tooltip": {
          "mode": "single"
        }
      },
      "targets": [
        {
          "exemplar": true,
          "expr": "go_gc_duration_seconds{instance=~\"demo.robustperception.io:(${port:pipe})\", job=~\"(${job:pipe})\", quantile=\"1\"}",
          "interval": "",
          "legendFormat": "",
          "refId": "A"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    },
    {
      "datasource": "${DS_PROMETHEUS_DEMO}",
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 12,
        "y": 1
      },
      "id": 5,
      "options": {
        "colorMode": "value",
        "graphMode": "area",
        "justifyMode": "auto",
        "orientation": "auto",
        "reduceOptions": {
          "calcs": [
            "lastNotNull"
          ],
          "fields": "",
          "values": false
        },
        "text": {},
        "textMode": "auto"
      },
      "pluginVersion": "8.3.0-pre",
      "targets": [
        {
          "exemplar": true,
          "expr": "go_gc_duration_seconds{job=~\"(${job:pipe})\", quantile=\"1\"}",
          "interval": "",
          "legendFormat": "",
          "refId": "A"
        }
      ],
      "title": "Panel Title",
      "type": "stat"
    }
  ],
  "schemaVersion": 33,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": [
      {
        "current": {
          "selected": true,
          "text": [
            "1337"
          ],
          "value": [
            "1337"
          ]
        },
        "hide": 0,
        "includeAll": true,
        "multi": true,
        "name": "port",
        "options": [
          {
            "selected": false,
            "text": "All",
            "value": "$__all"
          },
          {
            "selected": false,
            "text": "9090",
            "value": "9090"
          },
          {
            "selected": false,
            "text": "9091",
            "value": "9091"
          },
          {
            "selected": false,
            "text": "9093",
            "value": "9093"
          },
          {
            "selected": false,
            "text": "9100",
            "value": "9100"
          },
          {
            "selected": true,
            "text": "1337",
            "value": "1337"
          }
        ],
        "query": "9090,9091, 9093,9100,1337",
        "queryValue": "",
        "skipUrlSync": false,
        "type": "custom"
      },
      {
        "current": {},
        "datasource": "${DS_PROMETHEUS_DEMO}",
        "definition": "label_values(go_memstats_gc_cpu_fraction{instance=~\"demo.robustperception.io:(${port:pipe})\"}, job)",
        "hide": 0,
        "includeAll": true,
        "multi": true,
        "name": "job",
        "options": [],
        "query": {
          "query": "label_values(go_memstats_gc_cpu_fraction{instance=~\"demo.robustperception.io:(${port:pipe})\"}, job)",
          "refId": "StandardVariableQuery"
        },
        "refresh": 1,
        "regex": "",
        "skipUrlSync": false,
        "sort": 0,
        "type": "query"
      }
    ]
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "Panel not refreshed when collapsed and variable value has changed #41127 Copy",
  "uid": "efKvXz5nkasd",
  "version": 1,
  "weekStart": ""
}
```
