### PR TITLE
Alerting: Fix a bug where the metric in the evaluation string was not correctly populated

### DIFF
--- a/pkg/expr/mathexp/type_series.go
+++ b/pkg/expr/mathexp/type_series.go
@@ -142,7 +142,7 @@ func (s Series) GetLabels() data.Labels { return s.Frame.Fields[seriesTypeValIdx
 
 func (s Series) SetLabels(ls data.Labels) { s.Frame.Fields[seriesTypeValIdx].Labels = ls }
 
-func (s Series) GetName() string { return s.Frame.Name }
+func (s Series) GetName() string { return s.Frame.Fields[seriesTypeValIdx].Name }
 
 func (s Series) GetMeta() interface{} {
 	return s.Frame.Meta.Custom

--- a/pkg/expr/mathexp/type_series.go
+++ b/pkg/expr/mathexp/type_series.go
@@ -118,6 +118,11 @@ FIELDS:
 	frame.Fields = fields
 	s.Frame = frame
 
+	// We use the frame name as series name if the frame name is set
+	if s.Frame.Name != "" {
+		s.Frame.Fields[seriesTypeValIdx].Name = s.Frame.Name
+	}
+
 	return s, nil
 }
 

--- a/pkg/expr/mathexp/types_test.go
+++ b/pkg/expr/mathexp/types_test.go
@@ -77,7 +77,6 @@ func TestSeriesFromFrame(t *testing.T) {
 		{
 			name: "[]time, []float frame should convert",
 			frame: &data.Frame{
-				Name: "test",
 				Fields: []*data.Field{
 					data.NewField("time", nil, []time.Time{}),
 					data.NewField("value", nil, []float64{}),
@@ -87,7 +86,6 @@ func TestSeriesFromFrame(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
-					Name: "test",
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{}),
 						data.NewField("value", nil, []*float64{}),
@@ -98,7 +96,6 @@ func TestSeriesFromFrame(t *testing.T) {
 		{
 			name: "[]time, []*float frame should convert",
 			frame: &data.Frame{
-				Name: "test",
 				Fields: []*data.Field{
 					data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 					data.NewField("value", nil, []*float64{float64Pointer(5)}),
@@ -108,7 +105,6 @@ func TestSeriesFromFrame(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
-					Name: "test",
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("value", nil, []*float64{float64Pointer(5)}),
@@ -119,7 +115,6 @@ func TestSeriesFromFrame(t *testing.T) {
 		{
 			name: "[]*float, []time frame should convert",
 			frame: &data.Frame{
-				Name: "test",
 				Fields: []*data.Field{
 					data.NewField("value", nil, []*float64{float64Pointer(5)}),
 					data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
@@ -129,7 +124,6 @@ func TestSeriesFromFrame(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
-					Name: "test",
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("value", nil, []*float64{float64Pointer(5)}),
@@ -140,7 +134,6 @@ func TestSeriesFromFrame(t *testing.T) {
 		{
 			name: "[]*int, []*time frame should convert",
 			frame: &data.Frame{
-				Name: "test",
 				Fields: []*data.Field{
 					data.NewField("time", nil, []*time.Time{unixTimePointer(5, 0)}),
 					data.NewField("value", nil, []*int64{int64Pointer(5)}),
@@ -150,7 +143,6 @@ func TestSeriesFromFrame(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
-					Name: "test",
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("value", nil, []*float64{float64Pointer(5)}),
@@ -161,7 +153,6 @@ func TestSeriesFromFrame(t *testing.T) {
 		{
 			name: "[]int, []*time frame should convert",
 			frame: &data.Frame{
-				Name: "test",
 				Fields: []*data.Field{
 					data.NewField("time", nil, []*time.Time{unixTimePointer(5, 0)}),
 					data.NewField("value", nil, []int64{5}),
@@ -171,7 +162,6 @@ func TestSeriesFromFrame(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
-					Name: "test",
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("value", nil, []*float64{float64Pointer(5)}),
@@ -182,7 +172,6 @@ func TestSeriesFromFrame(t *testing.T) {
 		{
 			name: "[]string, []*time frame should convert",
 			frame: &data.Frame{
-				Name: "test",
 				Fields: []*data.Field{
 					data.NewField("time", nil, []*time.Time{unixTimePointer(5, 0)}),
 					data.NewField("value", nil, []string{"5"}),
@@ -192,7 +181,6 @@ func TestSeriesFromFrame(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
-					Name: "test",
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("value", nil, []*float64{float64Pointer(5)}),
@@ -203,7 +191,6 @@ func TestSeriesFromFrame(t *testing.T) {
 		{
 			name: "[]*string, []*time frame should convert",
 			frame: &data.Frame{
-				Name: "test",
 				Fields: []*data.Field{
 					data.NewField("time", nil, []*time.Time{unixTimePointer(5, 0)}),
 					data.NewField("value", nil, []*string{strPointer("5")}),
@@ -213,7 +200,6 @@ func TestSeriesFromFrame(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
-					Name: "test",
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("value", nil, []*float64{float64Pointer(5)}),
@@ -224,7 +210,6 @@ func TestSeriesFromFrame(t *testing.T) {
 		{
 			name: "[]bool, []*time frame should convert",
 			frame: &data.Frame{
-				Name: "test",
 				Fields: []*data.Field{
 					data.NewField("time", nil, []*time.Time{unixTimePointer(5, 0)}),
 					data.NewField("value", nil, []bool{true}),
@@ -234,7 +219,6 @@ func TestSeriesFromFrame(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
-					Name: "test",
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("value", nil, []*float64{float64Pointer(1)}),
@@ -245,7 +229,6 @@ func TestSeriesFromFrame(t *testing.T) {
 		{
 			name: "[]*bool, []*time frame should convert",
 			frame: &data.Frame{
-				Name: "test",
 				Fields: []*data.Field{
 					data.NewField("time", nil, []*time.Time{unixTimePointer(5, 0)}),
 					data.NewField("value", nil, []*bool{boolPointer(true)}),
@@ -255,7 +238,6 @@ func TestSeriesFromFrame(t *testing.T) {
 			Is:    assert.Equal,
 			Series: Series{
 				Frame: &data.Frame{
-					Name: "test",
 					Fields: []*data.Field{
 						data.NewField("time", nil, []time.Time{time.Unix(5, 0)}),
 						data.NewField("value", nil, []*float64{float64Pointer(1)}),
@@ -266,7 +248,6 @@ func TestSeriesFromFrame(t *testing.T) {
 		{
 			name: "[]*time, []*time frame should error",
 			frame: &data.Frame{
-				Name: "test",
 				Fields: []*data.Field{
 					data.NewField("time", nil, []*time.Time{}),
 					data.NewField("time", nil, []*time.Time{}),
@@ -277,7 +258,6 @@ func TestSeriesFromFrame(t *testing.T) {
 		{
 			name: "[]*float64, []float64 frame should error",
 			frame: &data.Frame{
-				Name: "test",
 				Fields: []*data.Field{
 					data.NewField("value", nil, []*float64{}),
 					data.NewField("value", nil, []*float64{}),
@@ -288,7 +268,6 @@ func TestSeriesFromFrame(t *testing.T) {
 		{
 			name: "[]*float64 frame should error",
 			frame: &data.Frame{
-				Name: "test",
 				Fields: []*data.Field{
 					data.NewField("value", nil, []*float64{}),
 				},

--- a/pkg/expr/mathexp/types_test.go
+++ b/pkg/expr/mathexp/types_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSeriesSort(t *testing.T) {
@@ -302,6 +303,44 @@ func TestSeriesFromFrame(t *testing.T) {
 			if err == nil {
 				tt.Is(t, s, tt.Series)
 			}
+		})
+	}
+}
+
+func TestSeriesName(t *testing.T) {
+	tests := []struct {
+		name               string
+		frame              *data.Frame
+		expectedSeriesName string
+	}{
+		{
+			name: "when the frame got a name this name should be used",
+			frame: &data.Frame{
+				Name: "test",
+				Fields: []*data.Field{
+					data.NewField("time", nil, []time.Time{}),
+					data.NewField("value", nil, []float64{}),
+				},
+			},
+			expectedSeriesName: "test",
+		},
+		{
+			name: "when a frame got no name the name of the value column should be used",
+			frame: &data.Frame{
+				Name: "",
+				Fields: []*data.Field{
+					data.NewField("time", nil, []time.Time{}),
+					data.NewField("value", nil, []float64{}),
+				},
+			},
+			expectedSeriesName: "value",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s, err := SeriesFromFrame(test.frame)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedSeriesName, s.GetName())
 		})
 	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Instead of using the frame name as the series name, we now use the name of the series value column if the frame name is not set. Queries to some datasources may end up with an empty frame name, which leads to an empty series name. As the series name is used in the frontend to display which metrics were queried etc. it shouldn't be empty.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #39696 

**Special notes for your reviewer**:

I did check how we create series to make sure we don't get any panic. A panic would be possible though if a series is created manually and not using the `new` or the transformation functions.

