### PR TITLE
Alerting: Add QueryError to expr package

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -19,6 +19,15 @@ var (
 	logger = log.New("expr")
 )
 
+type QueryError struct {
+	RefID string
+	Err   error
+}
+
+func (e QueryError) Error() string {
+	return fmt.Sprintf("failed to execute query %s: %s", e.RefID, e.Err)
+}
+
 // baseNode includes common properties used across DPNodes.
 type baseNode struct {
 	id    int64
@@ -240,7 +249,7 @@ func (dn *DSNode) Execute(ctx context.Context, vars mathexp.Vars, s *Service) (m
 	vals := make([]mathexp.Value, 0)
 	for refID, qr := range resp.Responses {
 		if qr.Error != nil {
-			return mathexp.Results{}, fmt.Errorf("failed to execute query %v: %w", refID, qr.Error)
+			return mathexp.Results{}, QueryError{RefID: refID, Err: qr.Error}
 		}
 
 		if len(qr.Frames) == 1 {

--- a/pkg/expr/nodes_test.go
+++ b/pkg/expr/nodes_test.go
@@ -1,0 +1,16 @@
+package expr
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryError(t *testing.T) {
+	e := QueryError{
+		RefID: "A",
+		Err:   errors.New("this is an error message"),
+	}
+	assert.EqualError(t, e, "failed to execute query A: this is an error message")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds `QueryError` to the `expr` package so we can know which `Ref ID` returned the error during evaluation of an alert rule in Grafana alerting. 

**Which issue(s) this PR fixes**:

Fixes #41331