### PR TITLE
Alerting: Support Unwrap for QueryError in expr package

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -28,6 +28,10 @@ func (e QueryError) Error() string {
 	return fmt.Sprintf("failed to execute query %s: %s", e.RefID, e.Err)
 }
 
+func (e QueryError) Unwrap() error {
+	return e.Err
+}
+
 // baseNode includes common properties used across DPNodes.
 type baseNode struct {
 	id    int64

--- a/pkg/expr/nodes_test.go
+++ b/pkg/expr/nodes_test.go
@@ -7,10 +7,36 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestQueryError(t *testing.T) {
+type expectedError struct{}
+
+func (e expectedError) Error() string {
+	return "expected"
+}
+
+func TestQueryError_Error(t *testing.T) {
 	e := QueryError{
 		RefID: "A",
 		Err:   errors.New("this is an error message"),
 	}
 	assert.EqualError(t, e, "failed to execute query A: this is an error message")
+}
+
+func TestQueryError_Unwrap(t *testing.T) {
+	t.Run("errors.Is", func(t *testing.T) {
+		expectedIsErr := errors.New("expected")
+		e := QueryError{
+			RefID: "A",
+			Err:   expectedIsErr,
+		}
+		assert.True(t, errors.Is(e, expectedIsErr))
+	})
+
+	t.Run("errors.As", func(t *testing.T) {
+		e := QueryError{
+			RefID: "A",
+			Err:   expectedError{},
+		}
+		var expectedAsError expectedError
+		assert.True(t, errors.As(e, &expectedAsError))
+	})
 }


### PR DESCRIPTION
This pull request supports unwrapping of `QueryError` for `errors.As` and `errors.Is`.