### PR TITLE
Alerting: Fix issue after AzureMonitor fix

### DIFF
--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
@@ -2,7 +2,7 @@ import {
   ArrayVector,
   DataFrame,
   DataFrameJSON,
-  DataQuery,
+  DataSourceApi,
   Field,
   FieldType,
   getDefaultRelativeTimeRange,
@@ -189,7 +189,7 @@ describe('AlertingQueryRunner', () => {
       mockBackendSrv({
         fetch: () => throwError(new Error("shouldn't happen")),
       }),
-      mockDataSourceSrv(() => false)
+      mockDataSourceSrv({ filterQuery: () => false })
     );
 
     const data = runner.get();
@@ -218,12 +218,9 @@ const mockBackendSrv = ({ fetch }: MockBackendSrvConfig): BackendSrv => {
   } as unknown) as BackendSrv;
 };
 
-const mockDataSourceSrv = (filterQuery: (query: DataQuery) => boolean = () => true) => {
+const mockDataSourceSrv = (dsApi?: Partial<DataSourceApi>) => {
   return ({
-    get: () =>
-      Promise.resolve({
-        filterQuery,
-      }),
+    get: () => Promise.resolve(dsApi ?? {}),
   } as unknown) as DataSourceSrv;
 };
 

--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.ts
@@ -52,7 +52,7 @@ export class AlertingQueryRunner {
     for (const query of queries) {
       if (!isExpressionQuery(query.model)) {
         const ds = await this.dataSourceSrv.get(query.datasourceUid);
-        if (!ds.filterQuery?.(query.model)) {
+        if (ds.filterQuery && !ds.filterQuery(query.model)) {
           const empty = initialState(queries, LoadingState.Done);
           return this.subject.next(empty);
         }


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduced a bug in https://github.com/grafana/grafana/pull/41317 where we did not check if filterQuery existed on a datasourse.

