### PR TITLE
CloudMonitoring: Fix forward slash being escaped erroneously when using regex comparison

### DIFF
--- a/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
@@ -416,7 +416,7 @@ func buildFilterString(metricType string, filterParts []string) string {
 			switch {
 			case operator == "=~" || operator == "!=~":
 				filterString = reverse(strings.Replace(reverse(filterString), "~", "", 1))
-				filterString += fmt.Sprintf(`monitoring.regex.full_match("%s")`, part)
+				filterString += fmt.Sprintf(`monitoring.regex.full_match("%s")`, removeEscapeSequences(part, '/'))
 			case strings.Contains(part, "*"):
 				filterString += interpolateFilterWildcards(part)
 			default:

--- a/pkg/tsdb/cloudmonitoring/utils.go
+++ b/pkg/tsdb/cloudmonitoring/utils.go
@@ -12,6 +12,30 @@ func reverse(s string) string {
 	return string(chars)
 }
 
+func removeEscapeSequences(s string, r rune) string {
+	chars := []rune(s)
+	var sb strings.Builder
+
+	for i, length := 0, len(chars); i < length; i++ {
+		char := chars[i]
+
+		if char == '\\' && i < length-1 {
+			i++
+			nextChar := chars[i]
+
+			if nextChar != r {
+				sb.WriteRune(char)
+			}
+
+			sb.WriteRune(nextChar)
+		} else {
+			sb.WriteRune(char)
+		}
+	}
+
+	return sb.String()
+}
+
 func toSnakeCase(str string) string {
 	return strings.ToLower(matchAllCap.ReplaceAllString(str, "${1}_${2}"))
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When using GCP CloudMonitoring metrics with variables, forward slashes are escaped with a proceeding `\`.

Currently `POST /myresource/5` gets escaped as `POST \/myresource\/5`, where these cases it should be left alone as a forward slash is not considered a character that needs to be escaped.  This in turn causes queries with the escaped forward slash to fail.

**Which issue(s) this PR fixes**:
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/41706

**Special notes for your reviewer**:

My first time programming Golang, it's probably not as efficient as it could be (whether this matters or not)