### PR TITLE
query refactor to isolate from http

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -17,117 +18,55 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/legacydata"
 )
 
-// QueryMetricsV2 returns query metrics.
-// POST /api/ds/query   DataSource query w/ expressions
-func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDTO dtos.MetricRequest) response.Response {
-	parsedReq, err := hs.parseMetricRequest(c, reqDTO)
-	if err != nil {
-		return hs.handleGetDataSourceError(err, nil)
-	}
+var (
+	ErrNoQueries                   = errors.New("no queries found")
+	ErrMissingDatasourceIdentifier = errors.New("missing data source ID/UID")
+	ErrDifferentDatasources        = errors.New("all queries must use the same datasource")
+)
 
-	if parsedReq.hasExpression {
-		return hs.handleExpressions(c, parsedReq)
-	}
-
-	resp, err := hs.handleQueryData(c, parsedReq)
-	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Metric request error", err)
-	}
-
-	return toMacronResponse(resp)
+type MissingDatasourceInfoError struct {
+	RefID string
 }
 
-// handleExpressions handles POST /api/ds/query when there is an expression.
-func (hs *HTTPServer) handleExpressions(c *models.ReqContext, parsedReq *parsedRequest) response.Response {
-	exprReq := expr.Request{
-		OrgId:   c.OrgId,
-		Queries: []expr.Query{},
-	}
-
-	for _, pq := range parsedReq.parsedQueries {
-		if pq.datasource == nil {
-			return response.Error(http.StatusBadRequest, "Query mising datasource info: "+pq.query.RefID, nil)
-		}
-
-		exprReq.Queries = append(exprReq.Queries, expr.Query{
-			JSON:          pq.query.JSON,
-			Interval:      pq.query.Interval,
-			RefID:         pq.query.RefID,
-			MaxDataPoints: pq.query.MaxDataPoints,
-			QueryType:     pq.query.QueryType,
-			Datasource: expr.DataSourceRef{
-				Type: pq.datasource.Type,
-				UID:  pq.datasource.Uid,
-			},
-			TimeRange: expr.TimeRange{
-				From: pq.query.TimeRange.From,
-				To:   pq.query.TimeRange.To,
-			},
-		})
-	}
-
-	qdr, err := hs.expressionService.TransformData(c.Req.Context(), &exprReq)
-	if err != nil {
-		return response.Error(500, "expression request error", err)
-	}
-	return toMacronResponse(qdr)
+func (m MissingDatasourceInfoError) Error() string {
+	return fmt.Sprintf("query mising datasource info: %s", m.RefID)
 }
 
-func (hs *HTTPServer) handleQueryData(c *models.ReqContext, parsedReq *parsedRequest) (*backend.QueryDataResponse, error) {
-	ds := parsedReq.parsedQueries[0].datasource
-	if err := hs.PluginRequestValidator.Validate(ds.Url, nil); err != nil {
-		return nil, models.ErrDataSourceAccessDenied
-	}
-
-	instanceSettings, err := adapters.ModelToInstanceSettings(ds, hs.decryptSecureJsonDataFn())
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert data source to instance settings")
-	}
-
-	req := &backend.QueryDataRequest{
-		PluginContext: backend.PluginContext{
-			OrgID:                      ds.OrgId,
-			PluginID:                   ds.Type,
-			User:                       adapters.BackendUserFromSignedInUser(c.SignedInUser),
-			DataSourceInstanceSettings: instanceSettings,
-		},
-		Headers: map[string]string{},
-		Queries: []backend.DataQuery{},
-	}
-
-	if hs.OAuthTokenService.IsOAuthPassThruEnabled(ds) {
-		if token := hs.OAuthTokenService.GetCurrentOAuthToken(c.Req.Context(), c.SignedInUser); token != nil {
-			req.Headers["Authorization"] = fmt.Sprintf("%s %s", token.Type(), token.AccessToken)
-		}
-	}
-
-	for _, q := range parsedReq.parsedQueries {
-		req.Queries = append(req.Queries, q.query)
-	}
-
-	return hs.pluginClient.QueryData(c.Req.Context(), req)
-}
-
-func toMacronResponse(qdr *backend.QueryDataResponse) response.Response {
-	statusCode := http.StatusOK
-	for _, res := range qdr.Responses {
-		if res.Error != nil {
-			statusCode = http.StatusBadRequest
-		}
-	}
-
-	return response.JSONStreaming(statusCode, qdr)
-}
-
-func (hs *HTTPServer) handleGetDataSourceError(err error, datasourceRef interface{}) *response.NormalResponse {
-	hs.log.Debug("Encountered error getting data source", "err", err, "ref", datasourceRef)
+func (hs *HTTPServer) handleQueryMetricsError(err error) *response.NormalResponse {
+	hs.log.Debug("Error while querying data", "err", err)
 	if errors.Is(err, models.ErrDataSourceAccessDenied) {
 		return response.Error(http.StatusForbidden, "Access denied to data source", err)
 	}
 	if errors.Is(err, models.ErrDataSourceNotFound) {
 		return response.Error(http.StatusBadRequest, "Invalid data source ID", err)
 	}
-	return response.Error(http.StatusInternalServerError, "Unable to load data source metadata", err)
+
+	// TODO: combine all errors to ErrBadQuery with message details.
+	if errors.Is(err, ErrNoQueries) {
+		return response.Error(http.StatusBadRequest, "No queries found in request", err)
+	}
+	if errors.Is(err, ErrMissingDatasourceIdentifier) {
+		return response.Error(http.StatusBadRequest, "Query missing data source ID/UID", err)
+	}
+	if errors.Is(err, ErrDifferentDatasources) {
+		return response.Error(http.StatusBadRequest, "all queries must use the same datasource", err)
+	}
+	var missingRefError MissingDatasourceInfoError
+	if errors.As(err, &missingRefError) {
+		return response.Error(http.StatusBadRequest, "Query missing datasource info: "+missingRefError.RefID, err)
+	}
+
+	return response.Error(http.StatusInternalServerError, "Query data error", err)
+}
+
+// QueryMetricsV2 returns query metrics.
+// POST /api/ds/query   DataSource query w/ expressions
+func (hs *HTTPServer) QueryMetricsV2(c *models.ReqContext, reqDTO dtos.MetricRequest) response.Response {
+	resp, err := hs.queryMetrics(c.Req.Context(), c.SignedInUser, c.SkipCache, reqDTO, true)
+	if err != nil {
+		return hs.handleQueryMetricsError(err)
+	}
+	return toJsonStreamingResponse(resp)
 }
 
 // QueryMetrics returns query metrics
@@ -135,14 +74,9 @@ func (hs *HTTPServer) handleGetDataSourceError(err error, datasourceRef interfac
 //nolint: staticcheck // legacydata.DataResponse deprecated
 //nolint: staticcheck // legacydata.DataQueryResult deprecated
 func (hs *HTTPServer) QueryMetrics(c *models.ReqContext, reqDto dtos.MetricRequest) response.Response {
-	parsedReq, err := hs.parseMetricRequest(c, reqDto)
+	sdkResp, err := hs.queryMetrics(c.Req.Context(), c.SignedInUser, c.SkipCache, reqDto, false)
 	if err != nil {
-		return hs.handleGetDataSourceError(err, nil)
-	}
-
-	sdkResp, err := hs.handleQueryData(c, parsedReq)
-	if err != nil {
-		return response.Error(http.StatusInternalServerError, "Metric request error", err)
+		return hs.handleQueryMetricsError(err)
 	}
 
 	legacyResp := legacydata.DataResponse{
@@ -177,6 +111,88 @@ func (hs *HTTPServer) QueryMetrics(c *models.ReqContext, reqDto dtos.MetricReque
 	return response.JSON(statusCode, &legacyResp)
 }
 
+func (hs *HTTPServer) queryMetrics(ctx context.Context, user *models.SignedInUser, skipCache bool, reqDTO dtos.MetricRequest, handleExpressions bool) (*backend.QueryDataResponse, error) {
+	parsedReq, err := hs.parseMetricRequest(user, skipCache, reqDTO)
+	if err != nil {
+		return nil, err
+	}
+	if handleExpressions && parsedReq.hasExpression {
+		return hs.handleExpressions(ctx, user, parsedReq)
+	}
+	return hs.handleQueryData(ctx, user, parsedReq)
+}
+
+// handleExpressions handles POST /api/ds/query when there is an expression.
+func (hs *HTTPServer) handleExpressions(ctx context.Context, user *models.SignedInUser, parsedReq *parsedRequest) (*backend.QueryDataResponse, error) {
+	exprReq := expr.Request{
+		OrgId:   user.OrgId,
+		Queries: []expr.Query{},
+	}
+
+	for _, pq := range parsedReq.parsedQueries {
+		if pq.datasource == nil {
+			return nil, MissingDatasourceInfoError{RefID: pq.query.RefID}
+		}
+
+		exprReq.Queries = append(exprReq.Queries, expr.Query{
+			JSON:          pq.query.JSON,
+			Interval:      pq.query.Interval,
+			RefID:         pq.query.RefID,
+			MaxDataPoints: pq.query.MaxDataPoints,
+			QueryType:     pq.query.QueryType,
+			Datasource: expr.DataSourceRef{
+				Type: pq.datasource.Type,
+				UID:  pq.datasource.Uid,
+			},
+			TimeRange: expr.TimeRange{
+				From: pq.query.TimeRange.From,
+				To:   pq.query.TimeRange.To,
+			},
+		})
+	}
+
+	qdr, err := hs.expressionService.TransformData(ctx, &exprReq)
+	if err != nil {
+		return nil, fmt.Errorf("expression request error: %w", err)
+	}
+	return qdr, nil
+}
+
+func (hs *HTTPServer) handleQueryData(ctx context.Context, user *models.SignedInUser, parsedReq *parsedRequest) (*backend.QueryDataResponse, error) {
+	ds := parsedReq.parsedQueries[0].datasource
+	if err := hs.PluginRequestValidator.Validate(ds.Url, nil); err != nil {
+		return nil, models.ErrDataSourceAccessDenied
+	}
+
+	instanceSettings, err := adapters.ModelToInstanceSettings(ds, hs.decryptSecureJsonDataFn())
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert data source to instance settings")
+	}
+
+	req := &backend.QueryDataRequest{
+		PluginContext: backend.PluginContext{
+			OrgID:                      ds.OrgId,
+			PluginID:                   ds.Type,
+			User:                       adapters.BackendUserFromSignedInUser(user),
+			DataSourceInstanceSettings: instanceSettings,
+		},
+		Headers: map[string]string{},
+		Queries: []backend.DataQuery{},
+	}
+
+	if hs.OAuthTokenService.IsOAuthPassThruEnabled(ds) {
+		if token := hs.OAuthTokenService.GetCurrentOAuthToken(ctx, user); token != nil {
+			req.Headers["Authorization"] = fmt.Sprintf("%s %s", token.Type(), token.AccessToken)
+		}
+	}
+
+	for _, q := range parsedReq.parsedQueries {
+		req.Queries = append(req.Queries, q.query)
+	}
+
+	return hs.pluginClient.QueryData(ctx, req)
+}
+
 type parsedQuery struct {
 	datasource *models.DataSource
 	query      backend.DataQuery
@@ -187,9 +203,9 @@ type parsedRequest struct {
 	parsedQueries []parsedQuery
 }
 
-func (hs *HTTPServer) parseMetricRequest(c *models.ReqContext, reqDTO dtos.MetricRequest) (*parsedRequest, error) {
+func (hs *HTTPServer) parseMetricRequest(user *models.SignedInUser, skipCache bool, reqDTO dtos.MetricRequest) (*parsedRequest, error) {
 	if len(reqDTO.Queries) == 0 {
-		return nil, errors.New("no queries found in query")
+		return nil, ErrNoQueries
 	}
 
 	timeRange := legacydata.NewDataTimeRange(reqDTO.From, reqDTO.To)
@@ -201,12 +217,12 @@ func (hs *HTTPServer) parseMetricRequest(c *models.ReqContext, reqDTO dtos.Metri
 	// Parse the queries
 	datasources := map[string]*models.DataSource{}
 	for _, query := range reqDTO.Queries {
-		ds, err := hs.getDataSourceFromQuery(c, query, datasources)
+		ds, err := hs.getDataSourceFromQuery(user, skipCache, query, datasources)
 		if err != nil {
 			return nil, err
 		}
 		if ds == nil {
-			return nil, errors.New("datasource not found for query")
+			return nil, models.ErrDataSourceNotFound
 		}
 
 		datasources[ds.Uid] = ds
@@ -240,14 +256,14 @@ func (hs *HTTPServer) parseMetricRequest(c *models.ReqContext, reqDTO dtos.Metri
 	if !req.hasExpression {
 		if len(datasources) > 1 {
 			// We do not (yet) support mixed query type
-			return nil, fmt.Errorf("all queries must use the same datasource")
+			return nil, ErrDifferentDatasources
 		}
 	}
 
 	return req, nil
 }
 
-func (hs *HTTPServer) getDataSourceFromQuery(c *models.ReqContext, query *simplejson.Json, history map[string]*models.DataSource) (*models.DataSource, error) {
+func (hs *HTTPServer) getDataSourceFromQuery(user *models.SignedInUser, skipCache bool, query *simplejson.Json, history map[string]*models.DataSource) (*models.DataSource, error) {
 	var err error
 	uid := query.Get("datasource").Get("uid").MustString()
 
@@ -267,11 +283,11 @@ func (hs *HTTPServer) getDataSourceFromQuery(c *models.ReqContext, query *simple
 	}
 
 	if uid == grafanads.DatasourceUID {
-		return grafanads.DataSourceModel(c.OrgId), nil
+		return grafanads.DataSourceModel(user.OrgId), nil
 	}
 
 	if uid != "" {
-		ds, err = hs.DataSourceCache.GetDatasourceByUID(uid, c.SignedInUser, c.SkipCache)
+		ds, err = hs.DataSourceCache.GetDatasourceByUID(uid, user, skipCache)
 		if err != nil {
 			return nil, err
 		}
@@ -281,11 +297,22 @@ func (hs *HTTPServer) getDataSourceFromQuery(c *models.ReqContext, query *simple
 	// Fallback to the datasourceId
 	id, err := query.Get("datasourceId").Int64()
 	if err != nil {
-		return nil, errors.New("query missing data source ID/UID")
+		return nil, ErrMissingDatasourceIdentifier
 	}
-	ds, err = hs.DataSourceCache.GetDatasource(id, c.SignedInUser, c.SkipCache)
+	ds, err = hs.DataSourceCache.GetDatasource(id, user, skipCache)
 	if err != nil {
 		return nil, err
 	}
 	return ds, nil
+}
+
+func toJsonStreamingResponse(qdr *backend.QueryDataResponse) response.Response {
+	statusCode := http.StatusOK
+	for _, res := range qdr.Responses {
+		if res.Error != nil {
+			statusCode = http.StatusBadRequest
+		}
+	}
+
+	return response.JSONStreaming(statusCode, qdr)
 }

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -33,7 +33,6 @@ func (m MissingDatasourceInfoError) Error() string {
 }
 
 func (hs *HTTPServer) handleQueryMetricsError(err error) *response.NormalResponse {
-	hs.log.Debug("Error while querying data", "err", err)
 	if errors.Is(err, models.ErrDataSourceAccessDenied) {
 		return response.Error(http.StatusForbidden, "Access denied to data source", err)
 	}
@@ -49,7 +48,7 @@ func (hs *HTTPServer) handleQueryMetricsError(err error) *response.NormalRespons
 		return response.Error(http.StatusBadRequest, "Query missing data source ID/UID", err)
 	}
 	if errors.Is(err, ErrDifferentDatasources) {
-		return response.Error(http.StatusBadRequest, "all queries must use the same datasource", err)
+		return response.Error(http.StatusBadRequest, "All queries must use the same datasource", err)
 	}
 	var missingRefError MissingDatasourceInfoError
 	if errors.As(err, &missingRefError) {

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"unicode"
 )
 
 // StringsFallback2 returns the first of two not empty strings.
@@ -107,4 +108,13 @@ func ToCamelCase(str string) string {
 	}
 
 	return strings.Join(finalParts, "")
+}
+
+func Capitalize(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	r := []rune(s)
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
 }

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -88,8 +88,20 @@ func TestToCamelCase(t *testing.T) {
 		"snake_case_string": "snakeCaseString",
 		"mixed-case_string": "mixedCaseString",
 		"alreadyCamelCase":  "alreadyCamelCase",
+		"":                  "",
 	}
 	for input, expected := range tests {
 		assert.Equal(t, expected, ToCamelCase(input))
+	}
+}
+
+func TestCapitalize(t *testing.T) {
+	tests := map[string]string{
+		"properly capitalizes": "Properly capitalizes",
+		"Already capitalized":  "Already capitalized",
+		"":                     "",
+	}
+	for input, expected := range tests {
+		assert.Equal(t, expected, Capitalize(input))
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Some movements around to allow detaching query execution into a separate service as next step.