### PR TITLE
Access control: allow using targetOrgId parameter to set organization ID for a request

### DIFF
--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -497,6 +497,36 @@ func TestMiddlewareContext(t *testing.T) {
 			cfg.AuthProxyAutoSignUp = true
 		})
 
+		middlewareScenario(t, "Should use organisation specified by targetOrgId parameter", func(t *testing.T, sc *scenarioContext) {
+			var storedRoleInfo map[int64]models.RoleType = nil
+			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+				if query.UserId > 0 {
+					query.Result = &models.SignedInUser{OrgId: query.OrgId, UserId: userID, OrgRole: storedRoleInfo[orgID]}
+					return nil
+				}
+				return models.ErrUserNotFound
+			})
+
+			bus.AddHandler("test", func(cmd *models.UpsertUserCommand) error {
+				cmd.Result = &models.User{Id: userID}
+				storedRoleInfo = cmd.ExternalUser.OrgRoles
+				return nil
+			})
+
+			targetOrgID := 123
+			sc.fakeReq("GET", fmt.Sprintf("/?targetOrgId=%d", targetOrgID))
+			sc.req.Header.Set(sc.cfg.AuthProxyHeaderName, hdrName)
+			sc.exec()
+
+			assert.True(t, sc.context.IsSignedIn)
+			assert.Equal(t, userID, sc.context.UserId)
+			assert.Equal(t, int64(targetOrgID), sc.context.OrgId)
+		}, func(cfg *setting.Cfg) {
+			configure(cfg)
+			cfg.LDAPEnabled = false
+			cfg.AuthProxyAutoSignUp = true
+		})
+
 		middlewareScenario(t, "Should get an existing user from header", func(t *testing.T, sc *scenarioContext) {
 			const userID int64 = 12
 			const orgID int64 = 2

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -498,10 +498,9 @@ func TestMiddlewareContext(t *testing.T) {
 		})
 
 		middlewareScenario(t, "Should use organisation specified by targetOrgId parameter", func(t *testing.T, sc *scenarioContext) {
-			var storedRoleInfo map[int64]models.RoleType = nil
 			bus.AddHandlerCtx("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 				if query.UserId > 0 {
-					query.Result = &models.SignedInUser{OrgId: query.OrgId, UserId: userID, OrgRole: storedRoleInfo[orgID]}
+					query.Result = &models.SignedInUser{OrgId: query.OrgId, UserId: userID}
 					return nil
 				}
 				return models.ErrUserNotFound
@@ -509,7 +508,6 @@ func TestMiddlewareContext(t *testing.T) {
 
 			bus.AddHandler("test", func(cmd *models.UpsertUserCommand) error {
 				cmd.Result = &models.User{Id: userID}
-				storedRoleInfo = cmd.ExternalUser.OrgRoles
 				return nil
 			})
 

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -534,7 +534,10 @@ func TestMiddlewareContext(t *testing.T) {
 
 			sc.handlerFunc = func(c *models.ReqContext) {
 				t.Log("Handler called")
-				defer c.Req.Body.Close()
+				defer func() {
+					err := c.Req.Body.Close()
+					require.NoError(t, err)
+				}()
 
 				bodyAfterHandler, e := io.ReadAll(c.Req.Body)
 				require.NoError(t, e)

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -4,6 +4,7 @@ package contexthandler
 import (
 	"context"
 	"errors"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -102,6 +103,19 @@ func (h *ContextHandler) Middleware(mContext *web.Context) {
 			orgID = id
 		} else {
 			reqContext.Logger.Debug("Received invalid header", "header", headerName, "value", orgIDHeader)
+		}
+	}
+
+	queryParameters, err := url.ParseQuery(reqContext.Req.URL.RawQuery)
+	if err == nil {
+		reqContext.Logger.Error("Failed to parse query parameters", "error", err)
+	}
+	if queryParameters.Has("targetOrgId") {
+		targetOrg, err := strconv.ParseInt(queryParameters.Get("targetOrgId"), 10, 64)
+		if err == nil {
+			orgID = targetOrg
+		} else {
+			reqContext.Logger.Error("Invalid target organization ID", "error", err)
 		}
 	}
 

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -107,7 +107,7 @@ func (h *ContextHandler) Middleware(mContext *web.Context) {
 	}
 
 	queryParameters, err := url.ParseQuery(reqContext.Req.URL.RawQuery)
-	if err == nil {
+	if err != nil {
 		reqContext.Logger.Error("Failed to parse query parameters", "error", err)
 	}
 	if queryParameters.Has("targetOrgId") {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR allows setting organisation ID for the request by adding a targetOrgId parameter to it. It behaves the same as setting X-Grafana-Org-Id header, and will be used to set target organisation for requests issued by Grafana frontend (the exact current use case is role picker).


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/2245

**Special notes for your reviewer**:

This is the second iteration of this work. In the [first PR](https://github.com/grafana/grafana/pull/41561) Macaron's `QueryInt64` was used. However, it broke proxy requests as it reads request body when querying the parameters (more context [here](https://raintank-corp.slack.com/archives/C01JEKKTMCK/p1637063856166300)), so had to be [reverted](https://github.com/grafana/grafana/pull/41643).