### PR TITLE
Azure Monitor: Clean up fields when editing Metrics

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
@@ -109,46 +109,8 @@ describe('Azure Monitor QueryEditor', () => {
       azureMonitor: {
         ...mockQuery.azureMonitor,
         metricName: 'metric-b',
-      },
-    });
-  });
-
-  it('should auto select a default aggregation if none exists once a metric is selected', async () => {
-    const mockDatasource = createMockDatasource();
-    const onChange = jest.fn();
-    const mockQuery = createMockQuery();
-    (mockQuery.azureMonitor ?? {}).aggregation = undefined;
-    mockDatasource.getMetricNames = jest.fn().mockResolvedValue([
-      {
-        value: 'metric-a',
-        text: 'Metric A',
-      },
-      {
-        value: 'metric-b',
-        text: 'Metric B',
-      },
-    ]);
-    render(
-      <MetricsQueryEditor
-        subscriptionId="123"
-        query={createMockQuery()}
-        datasource={mockDatasource}
-        variableOptionGroup={variableOptionGroup}
-        onChange={onChange}
-        setError={() => {}}
-      />
-    );
-    await waitFor(() => expect(screen.getByTestId('azure-monitor-metrics-query-editor')).toBeInTheDocument());
-
-    const metrics = await screen.findByLabelText('Metric');
-    await selectOptionInTest(metrics, 'Metric B');
-
-    expect(onChange).toHaveBeenLastCalledWith({
-      ...mockQuery,
-      azureMonitor: {
-        ...mockQuery.azureMonitor,
-        metricName: 'metric-b',
-        aggregation: 'Average',
+        aggregation: undefined,
+        timeGrain: '',
       },
     });
   });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.ts
@@ -55,8 +55,38 @@ export function useAsyncState<T>(asyncFn: () => Promise<T>, setError: Function, 
   return finalValue;
 }
 
-export const useSubscriptions: DataHook = (query, datasource, onChange, setError) => {
+export const updateSubscriptions = (
+  query: AzureMonitorQuery,
+  subscriptionOptions: AzureMonitorOption[],
+  onChange: OnChangeFn,
+  defaultSubscription?: string
+) => {
   const { subscription } = query;
+
+  // Return early if subscriptions havent loaded, or if the query already has a subscription
+  if (!subscriptionOptions.length || (subscription && hasOption(subscriptionOptions, subscription))) {
+    return;
+  }
+
+  const defaultSub = defaultSubscription || subscriptionOptions[0].value;
+
+  if (!subscription && defaultSub && hasOption(subscriptionOptions, defaultSub)) {
+    onChange(setSubscriptionID(query, defaultSub));
+  }
+
+  // Check if the current subscription is in the list of subscriptions
+  if (subscription && !hasOption(subscriptionOptions, subscription)) {
+    if (hasOption(subscriptionOptions, defaultSub)) {
+      // Use the default sub if is on theh list
+      onChange(setSubscriptionID(query, defaultSub));
+    } else {
+      // Neither the current subscription nor the defaultSub is on the list, remove it
+      onChange(setSubscriptionID(query, ''));
+    }
+  }
+};
+
+export const useSubscriptions: DataHook = (query, datasource, onChange, setError) => {
   const defaultSubscription = datasource.azureMonitorDatasource.defaultSubscriptionId;
 
   const subscriptionOptions = useAsyncState(
@@ -69,17 +99,8 @@ export const useSubscriptions: DataHook = (query, datasource, onChange, setError
   );
 
   useEffect(() => {
-    // Return early if subscriptions havent loaded, or if the query already has a subscription
-    if (!subscriptionOptions.length || (subscription && hasOption(subscriptionOptions, subscription))) {
-      return;
-    }
-
-    const defaultSub = defaultSubscription || subscriptionOptions[0].value;
-
-    if (!subscription && defaultSub && hasOption(subscriptionOptions, defaultSub)) {
-      onChange(setSubscriptionID(query, defaultSub));
-    }
-  }, [subscriptionOptions, query, subscription, defaultSubscription, onChange]);
+    updateSubscriptions(query, subscriptionOptions, onChange, defaultSubscription);
+  }, [subscriptionOptions, query, defaultSubscription, onChange]);
 
   return subscriptionOptions;
 };

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/setQueryValue.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/setQueryValue.ts
@@ -11,6 +11,13 @@ export function setSubscriptionID(query: AzureMonitorQuery, subscriptionID: stri
     azureMonitor: {
       ...query.azureMonitor,
       resourceGroup: undefined,
+      metricDefinition: undefined,
+      metricNamespace: undefined,
+      resourceName: undefined,
+      metricName: undefined,
+      aggregation: undefined,
+      timeGrain: '',
+      dimensionFilters: [],
     },
   };
 }
@@ -25,7 +32,13 @@ export function setResourceGroup(query: AzureMonitorQuery, resourceGroup: string
     azureMonitor: {
       ...query.azureMonitor,
       resourceGroup: resourceGroup,
+      metricDefinition: undefined,
+      metricNamespace: undefined,
       resourceName: undefined,
+      metricName: undefined,
+      aggregation: undefined,
+      timeGrain: '',
+      dimensionFilters: [],
     },
   };
 }
@@ -44,6 +57,9 @@ export function setResourceType(query: AzureMonitorQuery, resourceType: string |
       resourceName: undefined,
       metricNamespace: undefined,
       metricName: undefined,
+      aggregation: undefined,
+      timeGrain: '',
+      dimensionFilters: [],
     },
   };
 
@@ -60,6 +76,11 @@ export function setResourceName(query: AzureMonitorQuery, resourceName: string |
     azureMonitor: {
       ...query.azureMonitor,
       resourceName: resourceName,
+      metricNamespace: undefined,
+      metricName: undefined,
+      aggregation: undefined,
+      timeGrain: '',
+      dimensionFilters: [],
     },
   };
 }
@@ -75,6 +96,9 @@ export function setMetricNamespace(query: AzureMonitorQuery, metricNamespace: st
       ...query.azureMonitor,
       metricNamespace: metricNamespace,
       metricName: undefined,
+      aggregation: undefined,
+      timeGrain: '',
+      dimensionFilters: [],
     },
   };
 }
@@ -89,6 +113,9 @@ export function setMetricName(query: AzureMonitorQuery, metricName: string | und
     azureMonitor: {
       ...query.azureMonitor,
       metricName: metricName,
+      aggregation: undefined,
+      timeGrain: '',
+      dimensionFilters: [],
     },
   };
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR contains two changes:

 - When selecting a new Azure Monitor data source, if the new data source does not include the current subscription, the editor will be cleaned up.
 - When changing any of the other properties, the dependent fields are clean up in cascade.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #35222

**Special notes for your reviewer**:

Please take a look @kostrse !