### PR TITLE
Add basic resource trimming command

### DIFF
--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -170,6 +170,22 @@ so must be recompiled to validate newly-added CUE files.`,
 		},
 	},
 	{
+		Name:   "trim-resource",
+		Usage:  "trim schema-specified defaults from a resource",
+		Action: runCueCommand(cmd.trimResource),
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "dashboard",
+				Usage: "path to file containing (valid) dashboard JSON",
+			},
+			&cli.BoolFlag{
+				Name:  "apply",
+				Usage: "invert the operation: apply defaults instead of trimming them",
+				Value: false,
+			},
+		},
+	},
+	{
 		Name:  "gen-ts",
 		Usage: "generate TypeScript from all known CUE file types",
 		Description: `gen-ts generates TypeScript from all CUE files at

--- a/pkg/cmd/grafana-cli/commands/trim_command.go
+++ b/pkg/cmd/grafana-cli/commands/trim_command.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"bytes"
+	"encoding/json"
 	gerrors "errors"
 	"fmt"
 	"io"
@@ -45,8 +47,12 @@ func (cmd Command) trimResource(c utils.CommandLine) error {
 		return gerrors.New(errors.Details(err, nil))
 	}
 
-	b = out.Value.([]byte)
-	// mb, err := json.MarshalIndent()
-	fmt.Println(out.Value)
+	b = []byte(out.Value.(string))
+	var buf bytes.Buffer
+	err = json.Indent(&buf, b, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(buf.String())
 	return nil
 }

--- a/pkg/cmd/grafana-cli/commands/trim_command.go
+++ b/pkg/cmd/grafana-cli/commands/trim_command.go
@@ -39,6 +39,7 @@ func (cmd Command) trimResource(c utils.CommandLine) error {
 
 	var out schema.Resource
 	if apply {
+		out, err = schema.ApplyDefaults(res, sch.CUE())
 	} else {
 		out, err = schema.TrimDefaults(res, sch.CUE())
 	}

--- a/pkg/cmd/grafana-cli/commands/trim_command.go
+++ b/pkg/cmd/grafana-cli/commands/trim_command.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	gerrors "errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"cuelang.org/go/cue/errors"
+	"github.com/grafana/grafana/pkg/cmd/grafana-cli/utils"
+	"github.com/grafana/grafana/pkg/schema"
+	"github.com/grafana/grafana/pkg/schema/load"
+)
+
+func (cmd Command) trimResource(c utils.CommandLine) error {
+	filename := c.String("dashboard")
+	if filename == "" {
+		return gerrors.New("must specify dashboard file path with --dashboard")
+	}
+	apply := c.Bool("apply")
+
+	f, err := os.Open(filepath.Clean(filename))
+	if err != nil {
+		return err
+	}
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	res := schema.Resource{Value: string(b), Name: filename}
+	sch, err := load.DistDashboardFamily(paths)
+	if err != nil {
+		return fmt.Errorf("error while loading dashboard scuemata, err: %w", err)
+	}
+
+	var out schema.Resource
+	if apply {
+	} else {
+		out, err = schema.TrimDefaults(res, sch.CUE())
+	}
+
+	if err != nil {
+		return gerrors.New(errors.Details(err, nil))
+	}
+
+	b = out.Value.([]byte)
+	// mb, err := json.MarshalIndent()
+	fmt.Println(out.Value)
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a CLI command to run default trimming on resources. (Currently just dashboards, since that's all we have the schema for.)

I did this ages ago and ended up not finishing. But, here 'tis now! Most dashboards i see, we're trimming only around 10% of the total contents - this will improve considerably as we improve the defaults in the underlying schema.

Fixes #40082 

