### PR TITLE
QueryEditor: Add support for conditionally rendering actions

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -128,6 +128,7 @@ export interface DataSourcePluginMeta<T extends KeyValue = {}> extends PluginMet
   sort?: number;
   streaming?: boolean;
   unlicensed?: boolean;
+  backend?: boolean;
   isBackend?: boolean;
 }
 

--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -135,7 +135,7 @@ export function loadDataSourceMeta(dataSource: DataSourceSettings): ThunkResult<
     const isBackend = plugin.DataSourceClass.prototype instanceof DataSourceWithBackend;
     const meta = {
       ...pluginInfo,
-      isBackend: isBackend,
+      isBackend: pluginInfo.backend || isBackend,
     };
 
     dispatch(dataSourceMetaLoaded(meta));

--- a/public/app/features/query/components/QueryActionComponent.ts
+++ b/public/app/features/query/components/QueryActionComponent.ts
@@ -7,9 +7,10 @@ interface ActionComponentProps {
   onChangeDataSource?: (ds: DataSourceInstanceSettings) => void;
   timeRange?: TimeRange;
   dataSource?: DataSourceInstanceSettings;
+  key: string | number;
 }
 
-type QueryActionComponent = React.ComponentType<ActionComponentProps>;
+type QueryActionComponent = (props: ActionComponentProps) => JSX.Element | null;
 
 class QueryActionComponents {
   extraRenderActions: QueryActionComponent[] = [];

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -305,16 +305,18 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
 
   renderExtraActions = () => {
     const { query, queries, data, onAddQuery, dataSource } = this.props;
-    return RowActionComponents.getAllExtraRenderAction().map((c, index) => {
-      return React.createElement(c, {
-        query,
-        queries,
-        timeRange: data.timeRange,
-        onAddQuery: onAddQuery as (query: DataQuery) => void,
-        dataSource: dataSource,
-        key: index,
-      });
-    });
+    return RowActionComponents.getAllExtraRenderAction()
+      .map((action, index) =>
+        action({
+          query,
+          queries,
+          timeRange: data.timeRange,
+          onAddQuery: onAddQuery as (query: DataQuery) => void,
+          dataSource,
+          key: index,
+        })
+      )
+      .filter(Boolean);
   };
 
   renderActions = (props: QueryOperationRowRenderProps) => {

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -306,13 +306,15 @@ export class QueryGroup extends PureComponent<Props, State> {
   }
 
   renderExtraActions() {
-    return GroupActionComponents.getAllExtraRenderAction().map((c, index) => {
-      return React.createElement(c, {
-        onAddQuery: this.onAddQuery,
-        onChangeDataSource: this.onChangeDataSource,
-        key: index,
-      });
-    });
+    return GroupActionComponents.getAllExtraRenderAction()
+      .map((action, index) =>
+        action({
+          onAddQuery: this.onAddQuery,
+          onChangeDataSource: this.onChangeDataSource,
+          key: index,
+        })
+      )
+      .filter(Boolean);
   }
 
   renderAddQueryRow(dsSettings: DataSourceInstanceSettings, styles: QueriesTabStyles) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This allows us to conditionally render the recorded queries icon for backend data sources.

AppDynamics:
<img width="149" alt="image" src="https://user-images.githubusercontent.com/360020/142120948-737abc7b-563c-4877-98b3-3a8bcafdf16e.png">

Loki:
<img width="162" alt="image" src="https://user-images.githubusercontent.com/360020/142123288-a45578c2-e235-4434-868f-7970b468ab36.png">

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

Related PR: https://github.com/grafana/grafana-enterprise/pull/2280
