### PR TITLE
Tempo: Add error details when json upload fails

### DIFF
--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -291,7 +291,8 @@ export function transformFromOTLP(
       }
     }
   } catch (error) {
-    return { error: { message: 'JSON is not valid OpenTelemetry format' }, data: [] };
+    console.error(error);
+    return { error: { message: 'JSON is not valid OpenTelemetry format: ' + error }, data: [] };
   }
 
   let data = [frame];


### PR DESCRIPTION
Just add console log and append the error to the message for quicker debugging. 