### PR TITLE
Tempo: Fix basic auth password reset on adding tag

### DIFF
--- a/packages/grafana-ui/src/components/SecretFormField/SecretFormField.tsx
+++ b/packages/grafana-ui/src/components/SecretFormField/SecretFormField.tsx
@@ -63,7 +63,7 @@ export const SecretFormField: FunctionComponent<Props> = ({
               value="configured"
               {...omit(inputProps, 'value')}
             />
-            <Button onClick={onReset} variant="secondary">
+            <Button onClick={onReset} variant="secondary" type="button">
               Reset
             </Button>
           </>


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/41543

Seems like this was again an issue of button being by default submit and `enter` key press being bubbled up. 