### PR TITLE
Alerting: Fixing threshold handle color

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -9,7 +9,7 @@ import {
   ThresholdsConfig,
   ThresholdsMode,
 } from '@grafana/data';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { config, getDataSourceSrv } from '@grafana/runtime';
 import { QueryWrapper } from './QueryWrapper';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 import { isExpressionQuery } from 'app/features/expressions/guards';
@@ -211,7 +211,7 @@ export class QueryRows extends PureComponent<Props, State> {
             steps: [
               {
                 value: -Infinity,
-                color: 'green',
+                color: config.theme2.colors.success.main,
               },
             ],
           };
@@ -219,7 +219,7 @@ export class QueryRows extends PureComponent<Props, State> {
 
         record[refId].steps.push({
           value: threshold,
-          color: 'red',
+          color: config.theme2.colors.error.main,
         });
       });
     }

--- a/public/app/plugins/panel/timeseries/plugins/ThresholdDragHandle.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ThresholdDragHandle.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { css } from '@emotion/css';
 import { Threshold, GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, useTheme2 } from '@grafana/ui';
@@ -24,10 +24,8 @@ export const ThresholdDragHandle: React.FC<ThresholdDragHandleProps> = ({
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
   const [currentValue, setCurrentValue] = useState(step.value);
-
-  const textColor = useMemo(() => {
-    return theme.colors.getContrastText(theme.visualization.getColorByName(step.color));
-  }, [step.color, theme]);
+  const bgColor = theme.visualization.getColorByName(step.color);
+  const textColor = theme.colors.getContrastText(bgColor);
 
   return (
     <Draggable
@@ -44,7 +42,7 @@ export const ThresholdDragHandle: React.FC<ThresholdDragHandleProps> = ({
     >
       <div
         className={styles.handle}
-        style={{ color: textColor, background: step.color, borderColor: step.color, borderWidth: 0 }}
+        style={{ color: textColor, background: bgColor, borderColor: bgColor, borderWidth: 0 }}
       >
         <span className={styles.handleText}>{formatValue(currentValue)}</span>
       </div>


### PR DESCRIPTION
Not sure how this plain html red color slipped past notice :) 
Current
![Screenshot from 2021-11-17 15-54-20](https://user-images.githubusercontent.com/10999/142224040-7fcf2758-2ca7-4086-930c-f7d7296d500b.png)

First fix is fixing the bug in the drag handle, it's not looking up the real color from the visualization color palette:
![Screenshot from 2021-11-17 15-52-50](https://user-images.githubusercontent.com/10999/142224165-06a64f07-f1ff-464d-b065-b84fb788d258.png)

Here is also a test using our theme error color:  (which is currently not the same as the visualization palette red). Meaning this is the red we use for error buttons and error labels. 
![Screenshot from 2021-11-17 15-52-15](https://user-images.githubusercontent.com/10999/142224310-0c5d563d-f5d0-4d41-a861-561e45be112f.png)

Any preferences? 
