### PR TITLE
CI: Install `netcat` to build-container and update the version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,7 @@ steps:
   - make gen-go
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   - yarn install --immutable
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: initialize
 - commands:
   - ./bin/grabpl verify-drone
@@ -43,13 +43,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition oss
@@ -57,7 +57,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -67,19 +67,19 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-frontend
 - commands:
   - ./bin/grabpl test-backend --edition oss
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -87,7 +87,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-frontend
 trigger:
   event:
@@ -118,7 +118,7 @@ steps:
   - make gen-go
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   - yarn install --immutable
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: initialize
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -126,27 +126,27 @@ steps:
   depends_on:
   - initialize
   environment: {}
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id
     ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps
   depends_on:
   - initialize
   environment: null
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -167,7 +167,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: ensure-cuetsified
 - commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss
@@ -177,7 +177,7 @@ steps:
   - build-backend
   - build-frontend
   environment: null
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: package
 - commands:
   - ./e2e/start-server
@@ -186,7 +186,7 @@ steps:
   detach: true
   environment:
     PORT: 3001
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -204,7 +204,7 @@ steps:
   - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-storybook
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -223,7 +223,7 @@ steps:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-frontend-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana
@@ -238,7 +238,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -291,7 +291,7 @@ steps:
   - make gen-go
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   - yarn install --immutable
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: initialize
 - commands:
   - apt-get update
@@ -306,7 +306,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -321,7 +321,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: mysql-integration-tests
 trigger:
   event:
@@ -365,7 +365,7 @@ steps:
   - make gen-go
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   - yarn install --immutable
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: initialize
 - commands:
   - ./bin/grabpl verify-drone
@@ -396,13 +396,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition oss
@@ -410,7 +410,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -420,19 +420,19 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-frontend
 - commands:
   - ./bin/grabpl test-backend --edition oss
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -440,7 +440,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-frontend
 - commands:
   - apt-get update
@@ -455,7 +455,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -470,7 +470,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: mysql-integration-tests
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -478,14 +478,14 @@ steps:
   depends_on:
   - initialize
   environment: {}
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id
     ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
@@ -494,13 +494,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -521,7 +521,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
@@ -541,7 +541,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: package
 - commands:
   - ./e2e/start-server
@@ -550,7 +550,7 @@ steps:
   detach: true
   environment:
     PORT: 3001
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -568,7 +568,7 @@ steps:
   - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-storybook
 - commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
@@ -603,20 +603,20 @@ steps:
     GRAFANA_MISC_STATS_API_KEY:
       from_secret: grafana_misc_stats_api_key
   failure: ignore
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: publish-frontend-metrics
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-frontend-docs
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -649,7 +649,7 @@ steps:
   environment:
     GITHUB_PACKAGE_TOKEN:
       from_secret: github_package_token
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: release-canary-npm-packages
 - commands:
   - ./bin/grabpl upload-packages --edition oss --packages-bucket grafana-downloads
@@ -744,7 +744,7 @@ steps:
   name: identify-runner
 - commands:
   - make gen-go
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: initialize
 - commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
@@ -837,7 +837,7 @@ steps:
   - ./bin/grabpl verify-version ${DRONE_TAG}
   - ./bin/grabpl gen-version ${DRONE_TAG}
   - yarn install --immutable
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: initialize
 - commands:
   - |-
@@ -851,13 +851,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition oss
@@ -865,7 +865,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -875,19 +875,19 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-frontend
 - commands:
   - ./bin/grabpl test-backend --edition oss
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -895,7 +895,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-frontend
 - commands:
   - apt-get update
@@ -910,7 +910,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -925,7 +925,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: mysql-integration-tests
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN}
@@ -935,14 +935,14 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps
     --edition oss --no-pull-enterprise ${DRONE_TAG}
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
@@ -951,13 +951,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -978,7 +978,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise
@@ -998,7 +998,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: package
 - commands:
   - ./e2e/start-server
@@ -1007,7 +1007,7 @@ steps:
   detach: true
   environment:
     PORT: 3001
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -1023,7 +1023,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -1056,7 +1056,7 @@ steps:
   - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition oss --bucket "grafana-static-assets"
@@ -1098,7 +1098,7 @@ steps:
       from_secret: github_package_token
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: release-npm-packages
 trigger:
   ref:
@@ -1205,7 +1205,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: clone
 - commands:
   - mv bin/grabpl /tmp/
@@ -1221,7 +1221,7 @@ steps:
   - yarn install --immutable
   depends_on:
   - clone
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: initialize
 - commands:
   - |-
@@ -1235,13 +1235,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise
@@ -1249,7 +1249,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -1259,19 +1259,19 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-frontend
 - commands:
   - ./bin/grabpl test-backend --edition enterprise
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -1279,7 +1279,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-frontend
 - commands:
   - apt-get update
@@ -1294,7 +1294,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -1309,7 +1309,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: mysql-integration-tests
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN}
@@ -1319,14 +1319,14 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps
     --edition enterprise --no-pull-enterprise ${DRONE_TAG}
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign
@@ -1336,13 +1336,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -1363,7 +1363,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise2
@@ -1371,19 +1371,19 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-backend-enterprise2
 - commands:
   - ./bin/grabpl test-backend --edition enterprise2
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend-enterprise2
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend-integration-enterprise2
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN}
@@ -1393,7 +1393,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN}
@@ -1415,7 +1415,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: package
 - commands:
   - ./e2e/start-server
@@ -1426,7 +1426,7 @@ steps:
     PACKAGE_FILE: dist/grafana-enterprise-*linux-amd64.tar.gz
     PORT: 3001
     RUNDIR: e2e/tmp-grafana-enterprise
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -1442,7 +1442,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -1475,7 +1475,7 @@ steps:
   - initialize
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -1484,7 +1484,7 @@ steps:
   - initialize
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: memcached-integration-tests
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise --bucket "grafana-static-assets"
@@ -1526,7 +1526,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: package-enterprise2
 - commands:
   - ./e2e/start-server
@@ -1537,7 +1537,7 @@ steps:
     PACKAGE_FILE: dist/grafana-enterprise2-*linux-amd64.tar.gz
     PORT: 3002
     RUNDIR: e2e/tmp-grafana-enterprise2
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: end-to-end-tests-server-enterprise2
 - commands:
   - yarn run cypress install
@@ -1671,7 +1671,7 @@ steps:
 - commands:
   - make gen-go
   - ./bin/grabpl verify-version ${DRONE_TAG}
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: initialize
 - commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
@@ -1782,7 +1782,7 @@ steps:
   - ./bin/grabpl verify-version v7.3.0-test
   - ./bin/grabpl gen-version v7.3.0-test
   - yarn install --immutable
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: initialize
 - commands:
   - |-
@@ -1796,13 +1796,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition oss
@@ -1810,7 +1810,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -1820,19 +1820,19 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-frontend
 - commands:
   - ./bin/grabpl test-backend --edition oss
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -1840,7 +1840,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-frontend
 - commands:
   - apt-get update
@@ -1855,7 +1855,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -1870,7 +1870,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: mysql-integration-tests
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --github-token $${GITHUB_TOKEN}
@@ -1880,14 +1880,14 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps
     --edition oss --no-pull-enterprise v7.3.0-test
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
@@ -1896,13 +1896,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -1923,7 +1923,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --github-token $${GITHUB_TOKEN} --no-pull-enterprise
@@ -1943,7 +1943,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: package
 - commands:
   - ./e2e/start-server
@@ -1952,7 +1952,7 @@ steps:
   detach: true
   environment:
     PORT: 3001
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -1968,7 +1968,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -1993,7 +1993,7 @@ steps:
   - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition oss --bucket "grafana-static-assets"
@@ -2031,7 +2031,7 @@ steps:
       from_secret: github_package_token
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: release-npm-packages
 trigger:
   event:
@@ -2139,7 +2139,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: clone
 - commands:
   - mv bin/grabpl /tmp/
@@ -2155,7 +2155,7 @@ steps:
   - yarn install --immutable
   depends_on:
   - clone
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: initialize
 - commands:
   - |-
@@ -2169,13 +2169,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise
@@ -2183,7 +2183,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -2193,19 +2193,19 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-frontend
 - commands:
   - ./bin/grabpl test-backend --edition enterprise
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -2213,7 +2213,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-frontend
 - commands:
   - apt-get update
@@ -2228,7 +2228,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -2243,7 +2243,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: mysql-integration-tests
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN}
@@ -2253,14 +2253,14 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --github-token $${GITHUB_TOKEN} --no-install-deps
     --edition enterprise --no-pull-enterprise v7.3.0-test
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign
@@ -2270,13 +2270,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -2297,7 +2297,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise2
@@ -2305,19 +2305,19 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-backend-enterprise2
 - commands:
   - ./bin/grabpl test-backend --edition enterprise2
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend-enterprise2
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend-integration-enterprise2
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --github-token $${GITHUB_TOKEN}
@@ -2327,7 +2327,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --github-token $${GITHUB_TOKEN}
@@ -2349,7 +2349,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: package
 - commands:
   - ./e2e/start-server
@@ -2360,7 +2360,7 @@ steps:
     PACKAGE_FILE: dist/grafana-enterprise-*linux-amd64.tar.gz
     PORT: 3001
     RUNDIR: e2e/tmp-grafana-enterprise
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -2376,7 +2376,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -2401,7 +2401,7 @@ steps:
   - initialize
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -2410,7 +2410,7 @@ steps:
   - initialize
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: memcached-integration-tests
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise --bucket "grafana-static-assets"
@@ -2452,7 +2452,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: package-enterprise2
 - commands:
   - ./e2e/start-server
@@ -2463,7 +2463,7 @@ steps:
     PACKAGE_FILE: dist/grafana-enterprise2-*linux-amd64.tar.gz
     PORT: 3002
     RUNDIR: e2e/tmp-grafana-enterprise2
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: end-to-end-tests-server-enterprise2
 - commands:
   - yarn run cypress install
@@ -2598,7 +2598,7 @@ steps:
 - commands:
   - make gen-go
   - ./bin/grabpl verify-version v7.3.0-test
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: initialize
 - commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
@@ -2713,7 +2713,7 @@ steps:
   - make gen-go
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   - yarn install --immutable
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: initialize
 - commands:
   - |-
@@ -2727,13 +2727,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition oss
@@ -2741,7 +2741,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -2751,19 +2751,19 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-frontend
 - commands:
   - ./bin/grabpl test-backend --edition oss
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition oss
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -2771,7 +2771,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-frontend
 - commands:
   - apt-get update
@@ -2786,7 +2786,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -2801,7 +2801,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: mysql-integration-tests
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -2809,14 +2809,14 @@ steps:
   depends_on:
   - initialize
   environment: {}
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition oss --build-id
     ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss --no-install-deps --sign --signing-admin
@@ -2825,13 +2825,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -2852,7 +2852,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --no-pull-enterprise
@@ -2872,7 +2872,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: package
 - commands:
   - ./e2e/start-server
@@ -2881,7 +2881,7 @@ steps:
   detach: true
   environment:
     PORT: 3001
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -2897,7 +2897,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -2922,7 +2922,7 @@ steps:
   - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition oss --bucket "grafana-static-assets"
@@ -3043,7 +3043,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: clone
 - commands:
   - mv bin/grabpl /tmp/
@@ -3058,7 +3058,7 @@ steps:
   - yarn install --immutable
   depends_on:
   - clone
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: initialize
 - commands:
   - |-
@@ -3072,13 +3072,13 @@ steps:
   - rm words_to_ignore.txt
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: shellcheck
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise
@@ -3086,7 +3086,7 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -3096,19 +3096,19 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-frontend
 - commands:
   - ./bin/grabpl test-backend --edition enterprise
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -3116,7 +3116,7 @@ steps:
   - initialize
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-frontend
 - commands:
   - apt-get update
@@ -3131,7 +3131,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -3146,7 +3146,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: mysql-integration-tests
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -3154,14 +3154,14 @@ steps:
   depends_on:
   - initialize
   environment: {}
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --no-install-deps --edition enterprise --build-id
     ${DRONE_BUILD_NUMBER} --no-pull-enterprise
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-frontend
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise --no-install-deps --sign
@@ -3171,13 +3171,13 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-plugins
 - commands:
   - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
   depends_on:
   - build-backend
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: validate-scuemata
 - commands:
   - '# Make sure the git tree is clean.'
@@ -3198,7 +3198,7 @@ steps:
   - git stash pop
   depends_on:
   - validate-scuemata
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: ensure-cuetsified
 - commands:
   - ./bin/grabpl lint-backend --edition enterprise2
@@ -3206,19 +3206,19 @@ steps:
   - initialize
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: lint-backend-enterprise2
 - commands:
   - ./bin/grabpl test-backend --edition enterprise2
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend-enterprise2
 - commands:
   - ./bin/grabpl integration-tests --edition enterprise2
   depends_on:
   - initialize
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: test-backend-integration-enterprise2
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
@@ -3226,7 +3226,7 @@ steps:
   depends_on:
   - initialize
   environment: {}
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -3248,7 +3248,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: package
 - commands:
   - ./e2e/start-server
@@ -3259,7 +3259,7 @@ steps:
     PACKAGE_FILE: dist/grafana-enterprise-*linux-amd64.tar.gz
     PORT: 3001
     RUNDIR: e2e/tmp-grafana-enterprise
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: end-to-end-tests-server
 - commands:
   - yarn run cypress install
@@ -3275,7 +3275,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: copy-packages-for-docker
 - depends_on:
   - copy-packages-for-docker
@@ -3300,7 +3300,7 @@ steps:
   - build-frontend
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: build-storybook
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -3309,7 +3309,7 @@ steps:
   - initialize
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -3318,7 +3318,7 @@ steps:
   - initialize
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: memcached-integration-tests
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise --bucket "grafana-static-assets"
@@ -3360,7 +3360,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: package-enterprise2
 - commands:
   - ./e2e/start-server
@@ -3371,7 +3371,7 @@ steps:
     PACKAGE_FILE: dist/grafana-enterprise2-*linux-amd64.tar.gz
     PORT: 3002
     RUNDIR: e2e/tmp-grafana-enterprise2
-  image: grafana/build-container:1.4.5
+  image: grafana/build-container:1.4.6
   name: end-to-end-tests-server-enterprise2
 - commands:
   - yarn run cypress install
@@ -3556,6 +3556,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 12c6a397733d4624d68b34b9eeb4b3b0728eb9a1c678cf6eeb9b435f9b9a652f
+hmac: 46f1ce0ef92d50ed725851ede9ef4981cab7b186f8d777b2736bd633b33de3ef
 
 ...

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -127,7 +127,7 @@ COPY --from=toolchain /tmp/dockerize /usr/local/bin/
 
 RUN apt-get update && \
     apt-get install -yq  \
-        build-essential clang gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf gcc-mingw-w64-x86-64 \
+        build-essential netcat-traditional clang gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf gcc-mingw-w64-x86-64 \
         apt-transport-https \
         python-pip      \
         ca-certificates \

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1,7 +1,7 @@
 load('scripts/drone/vault.star', 'from_secret', 'github_token', 'pull_secret', 'drone_token')
 
 grabpl_version = '2.6.1'
-build_image = 'grafana/build-container:1.4.5'
+build_image = 'grafana/build-container:1.4.6'
 publish_image = 'grafana/grafana-ci-deploy:1.3.1'
 grafana_docker_image = 'grafana/drone-grafana-docker:0.3.2'
 deploy_docker_image = 'us.gcr.io/kubernetes-dev/drone/plugins/deploy-image'


### PR DESCRIPTION
**What this PR does / why we need it**:

Installs `netcat` and bumps `build-container` to `1.4.6`

