### PR TITLE
Alerting: fix e2e testing selectors

### DIFF
--- a/.pa11yci-pr.conf.js
+++ b/.pa11yci-pr.conf.js
@@ -55,7 +55,9 @@ var config = {
       url: '${HOST}/alerting/list',
       wait: 500,
       rootElement: '.main-view',
-      threshold: 0,
+      // the unified alerting promotion alert's content contrast is too low
+      // see https://github.com/grafana/grafana/pull/41829
+      threshold: 5,
     },
     {
       url: '${HOST}/datasources',

--- a/public/app/features/alerting/components/UnifiedAlertingPromotion.test.tsx
+++ b/public/app/features/alerting/components/UnifiedAlertingPromotion.test.tsx
@@ -12,7 +12,6 @@ describe('Unified Alerting promotion', () => {
 
   it('should show by default', () => {
     const promotion = render(<UnifiedAlertingPromotion />);
-    console.log(selectors.components.Alert.alertV2('info'));
     expect(promotion.queryByTestId(selectors.components.Alert.alertV2('info'))).toBeInTheDocument();
   });
 

--- a/public/app/features/alerting/components/UnifiedAlertingPromotion.test.tsx
+++ b/public/app/features/alerting/components/UnifiedAlertingPromotion.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { render } from '@testing-library/react';
+import { selectors } from '@grafana/e2e-selectors';
 import userEvent from '@testing-library/user-event';
 import { UnifiedAlertingPromotion, LOCAL_STORAGE_KEY } from './UnifiedAlertingPromotion';
 
@@ -11,7 +12,8 @@ describe('Unified Alerting promotion', () => {
 
   it('should show by default', () => {
     const promotion = render(<UnifiedAlertingPromotion />);
-    expect(promotion.queryByLabelText('Alert info')).toBeInTheDocument();
+    console.log(selectors.components.Alert.alertV2('info'));
+    expect(promotion.queryByTestId(selectors.components.Alert.alertV2('info'))).toBeInTheDocument();
   });
 
   it('should be hidden if dismissed', () => {
@@ -21,7 +23,7 @@ describe('Unified Alerting promotion', () => {
     const dismissButton = promotion.getByRole('button');
     userEvent.click(dismissButton);
 
-    expect(promotion.queryByLabelText('Alert info')).not.toBeInTheDocument();
+    expect(promotion.queryByTestId(selectors.components.Alert.alertV2('info'))).not.toBeInTheDocument();
     expect(window.localStorage.getItem(LOCAL_STORAGE_KEY)).toBe('false');
   });
 
@@ -29,6 +31,6 @@ describe('Unified Alerting promotion', () => {
     window.localStorage.setItem(LOCAL_STORAGE_KEY, 'false');
     const promotion = render(<UnifiedAlertingPromotion />);
 
-    expect(promotion.queryByLabelText('Alert info')).not.toBeInTheDocument();
+    expect(promotion.queryByTestId(selectors.components.Alert.alertV2('info'))).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/components/UnifiedAlertingPromotion.test.tsx
+++ b/public/app/features/alerting/components/UnifiedAlertingPromotion.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import { render } from '@testing-library/react';
-import { selectors } from '@grafana/e2e-selectors';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { UnifiedAlertingPromotion, LOCAL_STORAGE_KEY } from './UnifiedAlertingPromotion';
 
@@ -11,8 +10,8 @@ describe('Unified Alerting promotion', () => {
   });
 
   it('should show by default', () => {
-    const promotion = render(<UnifiedAlertingPromotion />);
-    expect(promotion.queryByTestId(selectors.components.Alert.alertV2('info'))).toBeInTheDocument();
+    render(<UnifiedAlertingPromotion />);
+    expect(screen.queryByText('Try out the Grafana 8 alerting!')).toBeInTheDocument();
   });
 
   it('should be hidden if dismissed', () => {
@@ -22,14 +21,14 @@ describe('Unified Alerting promotion', () => {
     const dismissButton = promotion.getByRole('button');
     userEvent.click(dismissButton);
 
-    expect(promotion.queryByTestId(selectors.components.Alert.alertV2('info'))).not.toBeInTheDocument();
+    expect(screen.queryByText('Try out the Grafana 8 alerting!')).not.toBeInTheDocument();
     expect(window.localStorage.getItem(LOCAL_STORAGE_KEY)).toBe('false');
   });
 
   it('should not render if previously dismissed', () => {
     window.localStorage.setItem(LOCAL_STORAGE_KEY, 'false');
-    const promotion = render(<UnifiedAlertingPromotion />);
+    render(<UnifiedAlertingPromotion />);
 
-    expect(promotion.queryByTestId(selectors.components.Alert.alertV2('info'))).not.toBeInTheDocument();
+    expect(screen.queryByText('Try out the Grafana 8 alerting!')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**What this PR does / why we need it**:

Tests for the `UnifiedAlertingPromotion` component were using bad selectors, this PR updates the test to use text assertions.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

