### PR TITLE
Transformers: Ensure ISO 8601 date strings are not parsed in local TZ

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.test.ts
@@ -1,8 +1,14 @@
 import { toDataFrame } from '../../dataframe/processDataFrame';
-import { FieldType } from '../../types/dataFrame';
+import { Field, FieldType } from '../../types/dataFrame';
 import { mockTransformationsRegistry } from '../../utils/tests/mockTransformationsRegistry';
 import { ArrayVector } from '../../vector';
-import { ensureTimeField, convertFieldType, convertFieldTypes, convertFieldTypeTransformer } from './convertFieldType';
+import {
+  ensureTimeField,
+  convertFieldType,
+  convertFieldTypes,
+  convertFieldTypeTransformer,
+  fieldToTimeField,
+} from './convertFieldType';
 
 describe('field convert type', () => {
   it('will parse properly formatted strings to time', () => {
@@ -230,6 +236,27 @@ describe('ensureTimeField', () => {
       name: 'proper dates',
       type: FieldType.time,
       values: new ArrayVector([1626674400000, 1627020000000, 1627192800000, 1627797600000, 1627884000000]),
+    });
+  });
+});
+
+describe('fieldToTimeField', () => {
+  // this needs to run in a non-UTC timezone env to ensure the parsing is not dependent on env tz settings
+  //process.env.TZ = 'Pacific/Easter';
+
+  it('should always parse ISO 8601 date strings in UTC timezone (e.g. 2011-10-05T14:48:00.000Z)', () => {
+    const stringTimeField: Field = {
+      config: {},
+      name: 'ISO 8601 date strings',
+      type: FieldType.time,
+      values: new ArrayVector(['2021-11-11T19:45:00.000Z']),
+    };
+
+    expect(fieldToTimeField(stringTimeField)).toEqual({
+      config: {},
+      name: 'ISO 8601 date strings',
+      type: FieldType.time,
+      values: new ArrayVector([1636659900000]),
     });
   });
 });

--- a/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFieldType.ts
@@ -104,6 +104,9 @@ export function convertFieldType(field: Field, opts: ConvertFieldTypeOptions): F
   }
 }
 
+// matches ISO 8601, e.g. 2021-11-11T19:45:00.000Z (float portion optional)
+const iso8601Regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+
 /**
  * @internal
  */
@@ -112,9 +115,13 @@ export function fieldToTimeField(field: Field, dateFormat?: string): Field {
 
   const timeValues = field.values.toArray().slice();
 
+  let firstDefined = timeValues.find((v) => v != null);
+
+  let isISO8601 = typeof firstDefined === 'string' && iso8601Regex.test(firstDefined);
+
   for (let t = 0; t < timeValues.length; t++) {
     if (timeValues[t]) {
-      let parsed = dateTimeParse(timeValues[t], opts).valueOf();
+      let parsed = isISO8601 ? Date.parse(timeValues[t]) : dateTimeParse(timeValues[t], opts).valueOf();
       timeValues[t] = Number.isFinite(parsed) ? parsed : null;
     } else {
       timeValues[t] = null;


### PR DESCRIPTION
when we tried to convert string time fields with an ISO 8601 value format like `2021-11-11T19:45:00.000Z`, we were parsing in the context of the local timezone, rather than UTC, so the resulting timestamps were incorrect. this caused the data to be shifted by the environment's/browser's local timezone (in my case by -6h), and broke zooming in various fun ways.

![image](https://user-images.githubusercontent.com/43234/142275696-aa4ccec3-8f2e-4426-964a-840bce971083.png)
