### PR TITLE
OAuth2 ID tokens as access tokens

### DIFF
--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -721,6 +721,14 @@ URL to redirect the user to after they sign out.
 Set to `true` to attempt login with OAuth automatically, skipping the login screen.
 This setting is ignored if multiple OAuth providers are configured. Default is `false`.
 
+### oauth_use_id_tokens
+
+Set to `true` to use the ID token (if available) instead of the access token.
+The default is `false`. ID tokens may contain more context than their respective
+access-token counterpart.
+
+On-behalf-of authorization with Azure requires this setting for operation.
+
 ### oauth_state_cookie_max_age
 
 How many seconds the OAuth state cookie lives before being deleted. Default is `600` (seconds)

--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -197,6 +197,18 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 	}
 	// token.TokenType was defaulting to "bearer", which is out of spec, so we explicitly set to "Bearer"
 	token.TokenType = "Bearer"
+	if hs.Cfg.UseIDTokens {
+		switch t := token.Extra("id_token").(type) {
+		case nil:
+			oauthLogger.Warn("no ID token in OAuth2 grant response—continue with access token instead")
+		case string:
+			token.AccessToken = t
+			oauthLogger.Debug("access token replaced with ID token")
+
+		default:
+			oauthLogger.Error("wrong datatype for ID token from OAuth2 grant response—continue with access token instead")
+		}
+	}
 
 	oauthLogger.Debug("OAuthLogin Got token", "token", token)
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -303,6 +303,7 @@ type Cfg struct {
 	AuthProxySyncTTL          int
 
 	// OAuth
+	UseIDTokens       bool
 	OAuthCookieMaxAge int
 
 	// JWT Auth
@@ -1226,6 +1227,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	DisableLoginForm = auth.Key("disable_login_form").MustBool(false)
 	DisableSignoutMenu = auth.Key("disable_signout_menu").MustBool(false)
 	OAuthAutoLogin = auth.Key("oauth_auto_login").MustBool(false)
+	cfg.UseIDTokens = auth.Key("oauth_use_id_tokens").MustBool(false)
 	cfg.OAuthCookieMaxAge = auth.Key("oauth_state_cookie_max_age").MustInt(600)
 	SignoutRedirectUrl = valueAsString(auth, "signout_redirect_url", "")
 


### PR DESCRIPTION
Some authorization flows require use of ID tokens instead of access tokens. This change provides such option with an `use_id_tokens` toggle in the `oauth` section from the Grafana configuration.

> “The on-behalf-of swap only works with so called “ID tokens”—regular OAuth2 access tokens are denied.”
>  — https://github.com/pascaldekloe/obopoc#findings