### PR TITLE
Geomap: simplify styles

### DIFF
--- a/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
@@ -75,7 +75,7 @@ export const markersLayer: MapLayerRegistryItem<MarkersConfig> = {
 
     // Set the default style
     const style = await getStyleConfigState(config.style);
-    if(!style.fields) {
+    if (!style.fields) {
       vectorLayer.setStyle(style.maker(style.base));
     }
 
@@ -96,16 +96,15 @@ export const markersLayer: MapLayerRegistryItem<MarkersConfig> = {
             continue; // ???
           }
 
-
-          if(style.fields) {
+          if (style.fields) {
             const dims: StyleDimensions = {};
-            if(style.fields.color) {
+            if (style.fields.color) {
               dims.color = getColorDimension(frame, style.config.color ?? defaultStyleConfig.color, theme);
             }
-            if(style.fields.size) {
+            if (style.fields.size) {
               dims.size = getScaledDimension(frame, style.config.size ?? defaultStyleConfig.size);
             }
-            if(style.fields.text) {
+            if (style.fields.text) {
               dims.text = getTextDimension(frame, style.config.text!);
             }
             style.dims = dims;
@@ -120,8 +119,8 @@ export const markersLayer: MapLayerRegistryItem<MarkersConfig> = {
           // Post updates to the legend component
           if (legend) {
             legendProps.next({
-              color: style.dims?.color, // ?? getColorDimension(frame, style.config.color ?? defaultStyleConfig.color, theme),
-              size: style.dims?.size, // ?? getScaledDimension(frame, style.config.size ?? defaultStyleConfig.size),
+              color: style.dims?.color,
+              size: style.dims?.size,
             });
           }
           break; // Only the first frame for now!

--- a/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
@@ -16,10 +16,10 @@ import { getScaledDimension, getColorDimension, getTextDimension } from 'app/fea
 import { ObservablePropsWrapper } from '../../components/ObservablePropsWrapper';
 import { MarkersLegend, MarkersLegendProps } from './MarkersLegend';
 import { ReplaySubject } from 'rxjs';
-import { FeaturesStylesBuilderConfig, getFeatures } from '../../utils/getFeatures';
-import { getMarkerMaker } from '../../style/markers';
-import { defaultStyleConfig, StyleConfig } from '../../style/types';
+import { getFeatures } from '../../utils/getFeatures';
+import { defaultStyleConfig, StyleConfig, StyleDimensions } from '../../style/types';
 import { StyleEditor } from './StyleEditor';
+import { getStyleConfigState } from '../../style/utils';
 
 // Configuration options for Circle overlays
 export interface MarkersConfig {
@@ -73,9 +73,11 @@ export const markersLayer: MapLayerRegistryItem<MarkersConfig> = {
       legend = <ObservablePropsWrapper watch={legendProps} initialSubProps={{}} child={MarkersLegend} />;
     }
 
-    const style = config.style ?? defaultStyleConfig;
-    const hasTextLabel = Boolean(style.text?.fixed || style.text?.field);
-    const markerMaker = await getMarkerMaker(style.symbol?.fixed, hasTextLabel);
+    // Set the default style
+    const style = await getStyleConfigState(config.style);
+    if(!style.fields) {
+      vectorLayer.setStyle(style.maker(style.base));
+    }
 
     return {
       init: () => vectorLayer,
@@ -94,24 +96,22 @@ export const markersLayer: MapLayerRegistryItem<MarkersConfig> = {
             continue; // ???
           }
 
-          const colorDim = getColorDimension(frame, style.color ?? defaultStyleConfig.color, theme);
-          const sizeDim = getScaledDimension(frame, style.size ?? defaultStyleConfig.size);
-          let textDim = undefined;
-          if (style?.text && (style.text.field || style.text.fixed)) {
-            textDim = getTextDimension(frame, style.text);
+
+          if(style.fields) {
+            const dims: StyleDimensions = {};
+            if(style.fields.color) {
+              dims.color = getColorDimension(frame, style.config.color ?? defaultStyleConfig.color, theme);
+            }
+            if(style.fields.size) {
+              dims.size = getScaledDimension(frame, style.config.size ?? defaultStyleConfig.size);
+            }
+            if(style.fields.text) {
+              dims.text = getTextDimension(frame, style.config.text!);
+            }
+            style.dims = dims;
           }
-          const opacity = style?.opacity ?? defaultStyleConfig.opacity;
 
-          const featureDimensionConfig: FeaturesStylesBuilderConfig = {
-            colorDim: colorDim,
-            sizeDim: sizeDim,
-            textDim: textDim,
-            textConfig: style?.textConfig,
-            opacity: opacity,
-            styleMaker: markerMaker,
-          };
-
-          const frameFeatures = getFeatures(frame, info, featureDimensionConfig);
+          const frameFeatures = getFeatures(frame, info, style);
 
           if (frameFeatures) {
             features.push(...frameFeatures);
@@ -120,8 +120,8 @@ export const markersLayer: MapLayerRegistryItem<MarkersConfig> = {
           // Post updates to the legend component
           if (legend) {
             legendProps.next({
-              color: colorDim,
-              size: sizeDim,
+              color: style.dims?.color, // ?? getColorDimension(frame, style.config.color ?? defaultStyleConfig.color, theme),
+              size: style.dims?.size, // ?? getScaledDimension(frame, style.config.size ?? defaultStyleConfig.size),
             });
           }
           break; // Only the first frame for now!

--- a/public/app/plugins/panel/geomap/style/types.ts
+++ b/public/app/plugins/panel/geomap/style/types.ts
@@ -91,6 +91,21 @@ export interface StyleConfigValues {
   textConfig?: TextStyleConfig;
 }
 
+/** When the style depends on a field */
+export interface StyleConfigFields {
+  color?: string;
+  size?: string;
+  text?: string;
+}
+
+export interface StyleConfigState {
+  config: TextStyleConfig;
+  hasText?: boolean;
+  base: StyleConfigValues;
+  fields?: StyleConfigFields;
+  maker: StyleMaker;
+}
+
 /**
  * Given values create a style
  */

--- a/public/app/plugins/panel/geomap/style/types.ts
+++ b/public/app/plugins/panel/geomap/style/types.ts
@@ -1,5 +1,6 @@
 import {
   ColorDimensionConfig,
+  DimensionSupplier,
   ResourceDimensionConfig,
   ResourceDimensionMode,
   ScaleDimensionConfig,
@@ -100,11 +101,18 @@ export interface StyleConfigFields {
   text?: string;
 }
 
+export interface StyleDimensions {
+  color?: DimensionSupplier<string>;
+  size?: DimensionSupplier<number>;
+  text?: DimensionSupplier<string>;
+}
+
 export interface StyleConfigState {
-  config: TextStyleConfig;
+  config: StyleConfig;
   hasText?: boolean;
   base: StyleConfigValues;
   fields?: StyleConfigFields;
+  dims?: StyleDimensions;
   maker: StyleMaker;
 }
 

--- a/public/app/plugins/panel/geomap/style/utils.test.ts
+++ b/public/app/plugins/panel/geomap/style/utils.test.ts
@@ -1,6 +1,7 @@
 import { ResourceDimensionMode } from 'app/features/dimensions';
 import { StyleConfig } from './types';
 import { getStyleConfigState } from './utils';
+
 describe('style utils', () => {
   it('should fill in default values', async () => {
     const cfg: StyleConfig = {
@@ -29,6 +30,7 @@ describe('style utils', () => {
     };
 
     const state = await getStyleConfigState(cfg);
+    state.config = null as any; // not interesting in the snapshot
     expect(state.hasText).toBe(false);
     expect(state).toMatchInlineSnapshot(`
       Object {
@@ -39,28 +41,7 @@ describe('style utils', () => {
           "rotation": 0,
           "size": 5,
         },
-        "config": Object {
-          "color": Object {
-            "field": "Price",
-            "fixed": "dark-green",
-          },
-          "opacity": 0.4,
-          "size": Object {
-            "field": "Count",
-            "fixed": 5,
-            "max": 15,
-            "min": 2,
-          },
-          "symbol": Object {
-            "fixed": "img/icons/marker/star.svg",
-            "mode": "fixed",
-          },
-          "textConfig": Object {
-            "fontSize": 12,
-            "offsetX": 0,
-            "offsetY": 0,
-          },
-        },
+        "config": null,
         "fields": Object {
           "color": "Price",
           "size": "Count",

--- a/public/app/plugins/panel/geomap/style/utils.test.ts
+++ b/public/app/plugins/panel/geomap/style/utils.test.ts
@@ -1,0 +1,73 @@
+import { ResourceDimensionMode } from 'app/features/dimensions';
+import { StyleConfig } from './types';
+import { getStyleConfigState } from './utils';
+describe('style utils', () => {
+  it('should fill in default values', async () => {
+    const cfg: StyleConfig = {
+      color: {
+        field: 'Price',
+        fixed: 'dark-green',
+      },
+      opacity: 0.4,
+      size: {
+        field: 'Count',
+        fixed: 5,
+        max: 15,
+        min: 2,
+      },
+      symbol: {
+        fixed: 'img/icons/marker/star.svg',
+        mode: ResourceDimensionMode.Fixed, // 'fixed',
+      },
+      textConfig: {
+        fontSize: 12,
+        offsetX: 0,
+        offsetY: 0,
+        // textAlign: 'center',
+        // textBaseline: 'middle',
+      },
+    };
+
+    const state = await getStyleConfigState(cfg);
+    expect(state.hasText).toBe(false);
+    expect(state).toMatchInlineSnapshot(`
+      Object {
+        "base": Object {
+          "color": "#37872D",
+          "lineWidth": 1,
+          "opacity": 0.4,
+          "rotation": 0,
+          "size": 5,
+        },
+        "config": Object {
+          "color": Object {
+            "field": "Price",
+            "fixed": "dark-green",
+          },
+          "opacity": 0.4,
+          "size": Object {
+            "field": "Count",
+            "fixed": 5,
+            "max": 15,
+            "min": 2,
+          },
+          "symbol": Object {
+            "fixed": "img/icons/marker/star.svg",
+            "mode": "fixed",
+          },
+          "textConfig": Object {
+            "fontSize": 12,
+            "offsetX": 0,
+            "offsetY": 0,
+          },
+        },
+        "fields": Object {
+          "color": "Price",
+          "size": "Count",
+        },
+        "hasText": false,
+        "maker": [Function],
+      }
+    `);
+  });
+});

--- a/public/app/plugins/panel/geomap/style/utils.ts
+++ b/public/app/plugins/panel/geomap/style/utils.ts
@@ -1,18 +1,37 @@
-import { StyleConfig } from './types';
+import { TextDimensionMode } from 'app/features/dimensions';
+import { defaultStyleConfig, StyleConfig, StyleConfigFields, StyleConfigState } from './types';
+
+/** Indicate if the style wants to show text values */
+export function styleUsesText(config: StyleConfig): boolean {
+  const { text } = config;
+  if (!text) {
+    return false;
+  }
+  if (text.mode === TextDimensionMode.Fixed && text.fixed?.length) {
+    return true;
+  }
+  if (text.mode === TextDimensionMode.Field && text.field?.length) {
+    return true;
+  }
+  return false;
+}
 
 /** Return a distinct list of fields used to dynamically change the style */
-export function getDependantFields(config: StyleConfig): Set<string> | undefined {
-  const fields = new Set<string>();
+export function getStyleConfigState(config: StyleConfig): StyleConfigState {
+  const hasText = styleUsesText(config);
+  const state: StyleConfigState = {
+    config,
+    hasText,
+    base: {
+      color: config.color?.fixed ?? defaultStyleConfig.color.fixed,
+    },
+  };
 
-  if (config.color?.field) {
-    fields.add(config.color.field);
-  }
-  if (config.size?.field) {
-    fields.add(config.size.field);
-  }
-  if (config.text?.field) {
-    fields.add(config.text.field);
-  }
+  const fields: StyleConfigFields = {
+    color: config.color?.field,
+    size: config.size?.field,
+    text: config.text?.field,
+  };
 
   return fields;
 }

--- a/public/app/plugins/panel/geomap/utils/getFeatures.ts
+++ b/public/app/plugins/panel/geomap/utils/getFeatures.ts
@@ -1,41 +1,19 @@
 import { DataFrame } from '@grafana/data';
-import { DimensionSupplier } from 'app/features/dimensions';
 import { Feature } from 'ol';
 import { Point } from 'ol/geom';
-import { StyleMaker, TextStyleConfig } from '../style/types';
+import { StyleConfigState } from '../style/types';
 import { LocationInfo } from './location';
-
-export interface FeaturesStylesBuilderConfig {
-  colorDim: DimensionSupplier<string>;
-  sizeDim: DimensionSupplier<number>;
-  opacity: number;
-  styleMaker: StyleMaker;
-  textDim?: DimensionSupplier<string>;
-  textConfig?: TextStyleConfig;
-}
 
 export const getFeatures = (
   frame: DataFrame,
   info: LocationInfo,
-  config: FeaturesStylesBuilderConfig
+  style: StyleConfigState
 ): Array<Feature<Point>> | undefined => {
   const features: Array<Feature<Point>> = [];
-  const opacity = config.opacity;
+  const values = { ...style.base };
 
   // Map each data value into new points
   for (let i = 0; i < frame.length; i++) {
-    // Get the color for the feature based on color scheme
-    const color = config.colorDim.get(i);
-
-    // Get the size for the feature based on size dimension
-    const size = config.sizeDim.get(i);
-
-    // Get the text for the feature based on text dimension
-    const text = config?.textDim ? config?.textDim.get(i) : undefined;
-
-    // Get the textConfig
-    const textConfig = config?.textConfig;
-
     // Create a new Feature for each point returned from dataFrameToPoints
     const dot = new Feature(info.points[i]);
     dot.setProperties({
@@ -43,7 +21,20 @@ export const getFeatures = (
       rowIndex: i,
     });
 
-    dot.setStyle(config.styleMaker({ color, size, text, opacity, textConfig }));
+    // Only create a new style if it depends on the data
+    if (style.dims) {
+      if (style.dims.color) {
+        values.color = style.dims.color.get(i);
+      }
+      if (style.dims.size) {
+        values.size = style.dims.size.get(i);
+      }
+      if (style.dims.text) {
+        values.text = style.dims.text.get(i);
+      }
+
+      dot.setStyle(style.maker(values));
+    }
     features.push(dot);
   }
 

--- a/public/app/plugins/panel/geomap/utils/getFeatures.ts
+++ b/public/app/plugins/panel/geomap/utils/getFeatures.ts
@@ -10,6 +10,7 @@ export const getFeatures = (
   style: StyleConfigState
 ): Array<Feature<Point>> | undefined => {
   const features: Array<Feature<Point>> = [];
+  const { dims } = style;
   const values = { ...style.base };
 
   // Map each data value into new points
@@ -21,16 +22,16 @@ export const getFeatures = (
       rowIndex: i,
     });
 
-    // Only create a new style if it depends on the data
-    if (style.dims) {
-      if (style.dims.color) {
-        values.color = style.dims.color.get(i);
+    // Update values used in dynamic styles
+    if (dims) {
+      if (dims.color) {
+        values.color = dims.color.get(i);
       }
-      if (style.dims.size) {
-        values.size = style.dims.size.get(i);
+      if (dims.size) {
+        values.size = dims.size.get(i);
       }
-      if (style.dims.text) {
-        values.text = style.dims.text.get(i);
+      if (dims.text) {
+        values.text = dims.text.get(i);
       }
 
       dot.setStyle(style.maker(values));


### PR DESCRIPTION
This is a pretty major refactor that sets things up so we can reuse the same style config between markers and geojson layers.

This also makes a clear distinction between the dynamic styles vs static ones -- this should improve the performance significantly!