### PR TITLE
Recorded Queries: Split extension reducers init and extension init

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -96,8 +96,9 @@ export class GrafanaApp {
       setLocationSrv(locationService);
       setTimeZoneResolver(() => config.bootData.user.timezone);
       // Important that extensions are initialized before store
-      initExtensions();
+      addExtensionReducers();
       configureStore();
+      initExtensions();
 
       standardEditorsRegistry.setInit(getAllOptionEditors);
       standardFieldConfigEditorRegistry.setInit(getStandardFieldConfigs);
@@ -142,6 +143,12 @@ export class GrafanaApp {
       console.error('Failed to start Grafana', error);
       window.__grafana_load_failed();
     }
+  }
+}
+
+function addExtensionReducers() {
+  if (extensionsExports.length > 0) {
+    extensionsExports[0].addExtensionReducers();
   }
 }
 

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -95,7 +95,7 @@ export class GrafanaApp {
       setPanelRenderer(PanelRenderer);
       setLocationSrv(locationService);
       setTimeZoneResolver(() => config.bootData.user.timezone);
-      // Important that extensions are initialized before store
+      // Important that extension reducers are initialized before store
       addExtensionReducers();
       configureStore();
       initExtensions();


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Currently extensions are initialized before the store:
https://github.com/grafana/grafana/blob/d3b513ab59d9ac56cc8578c8c61b38ddab594067/public/app/app.ts#L98-L100

It seems like this is needed to support [adding reducers](https://github.com/grafana/grafana-enterprise/blob/3e72b17753f0ceb3a3f82815eaef58288c1d9223/src/public/index.ts#L24-L29) before the store is created, but this prevents the preloading of data during extension initialization.

This PR splits extension initialization into two parts, which allows preloading of the recorded query write target config in https://github.com/grafana/grafana-enterprise/pull/2281

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

