### PR TITLE
Loki: simplify interval calculation

### DIFF
--- a/pkg/tsdb/loki/loki_test.go
+++ b/pkg/tsdb/loki/loki_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
 	"github.com/grafana/loki/pkg/loghttp"
 	p "github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
@@ -57,24 +56,18 @@ func TestLoki(t *testing.T) {
 						From: time.Now().Add(-30 * time.Second),
 						To:   time.Now(),
 					},
-				},
-			},
-		}
-		service := &Service{
-			intervalCalculator: mockCalculator{
-				interval: intervalv2.Interval{
-					Value: time.Second * 30,
+					Interval: time.Second * 30,
 				},
 			},
 		}
 		dsInfo := &datasourceInfo{}
-		models, err := service.parseQuery(dsInfo, queryContext)
+		models, err := parseQuery(dsInfo, queryContext)
 		require.NoError(t, err)
 		require.Equal(t, time.Second*30, models[0].Step)
 	})
 
 	t.Run("parsing query model without step parameter", func(t *testing.T) {
-		queryContext := &backend.QueryDataRequest{
+		queryContext1 := &backend.QueryDataRequest{
 			Queries: []backend.DataQuery{
 				{
 					JSON: []byte(`
@@ -88,29 +81,35 @@ func TestLoki(t *testing.T) {
 						From: time.Now().Add(-48 * time.Hour),
 						To:   time.Now(),
 					},
-				},
-			},
-		}
-		service := &Service{
-			intervalCalculator: mockCalculator{
-				interval: intervalv2.Interval{
-					Value: time.Minute * 2,
+					Interval: time.Minute * 2,
 				},
 			},
 		}
 		dsInfo := &datasourceInfo{}
-		models, err := service.parseQuery(dsInfo, queryContext)
+		models, err := parseQuery(dsInfo, queryContext1)
 		require.NoError(t, err)
 		require.Equal(t, time.Minute*2, models[0].Step)
 
-		service = &Service{
-			intervalCalculator: mockCalculator{
-				interval: intervalv2.Interval{
-					Value: time.Second * 2,
+		queryContext2 := &backend.QueryDataRequest{
+			Queries: []backend.DataQuery{
+				{
+					JSON: []byte(`
+					{
+						"expr": "go_goroutines",
+						"format": "time_series",
+						"refId": "A"
+					}`,
+					),
+					TimeRange: backend.TimeRange{
+						From: time.Now().Add(-48 * time.Hour),
+						To:   time.Now(),
+					},
+					Interval: time.Second * 2,
 				},
 			},
 		}
-		models, err = service.parseQuery(dsInfo, queryContext)
+
+		models, err = parseQuery(dsInfo, queryContext2)
 		require.NoError(t, err)
 		fmt.Println(models)
 		require.Equal(t, time.Second*2, models[0].Step)
@@ -172,16 +171,4 @@ func TestParseResponse(t *testing.T) {
 			t.Errorf("Result mismatch (-want +got):\n%s", diff)
 		}
 	})
-}
-
-type mockCalculator struct {
-	interval intervalv2.Interval
-}
-
-func (m mockCalculator) Calculate(timerange backend.TimeRange, minInterval time.Duration, maxDataPoints int64) intervalv2.Interval {
-	return m.interval
-}
-
-func (m mockCalculator) CalculateSafeInterval(timerange backend.TimeRange, resolution int64) intervalv2.Interval {
-	return m.interval
 }


### PR DESCRIPTION
in Loki we can simply use the value in `DataQuery.Interval`, no need to manually calculate it.