### PR TITLE
Chore: Refactor some dashboard code to eliminate type assertions

### DIFF
--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -338,11 +338,12 @@ export class PanelQueryRunner {
 }
 
 async function getDataSource(
-  datasource: DataSourceRef | string | DataSourceApi | null,
+  datasource: DataSourceRef | DataSourceApi | null,
   scopedVars: ScopedVars
 ): Promise<DataSourceApi> {
-  if (datasource && (datasource as any).query) {
-    return datasource as DataSourceApi;
+  if (datasource && 'query' in datasource) {
+    return datasource;
   }
-  return await getDatasourceSrv().get(datasource as string, scopedVars);
+
+  return await getDatasourceSrv().get(datasource, scopedVars);
 }

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -41,7 +41,7 @@ export interface QueryRunnerOptions<
   TQuery extends DataQuery = DataQuery,
   TOptions extends DataSourceJsonData = DataSourceJsonData
 > {
-  datasource: DataSourceRef | DataSourceApi<TQuery, TOptions> | null;
+  datasource: DataSourceRef | DataSourceApi<TQuery, TOptions> | string | null;
   queries: TQuery[];
   panelId?: number;
   dashboardId?: number;
@@ -338,10 +338,10 @@ export class PanelQueryRunner {
 }
 
 async function getDataSource(
-  datasource: DataSourceRef | DataSourceApi | null,
+  datasource: string | DataSourceRef | DataSourceApi | null,
   scopedVars: ScopedVars
 ): Promise<DataSourceApi> {
-  if (datasource && 'query' in datasource) {
+  if (datasource && typeof datasource !== 'string' && 'query' in datasource) {
     return datasource;
   }
 

--- a/public/app/features/query/state/QueryRunner.ts
+++ b/public/app/features/query/state/QueryRunner.ts
@@ -144,8 +144,9 @@ async function getDataSource(
   datasource: DataSourceRef | DataSourceApi | null,
   scopedVars: ScopedVars
 ): Promise<DataSourceApi> {
-  if (datasource && (datasource as any).query) {
-    return datasource as DataSourceApi;
+  if (datasource && 'query' in datasource) {
+    return datasource;
   }
+
   return await getDatasourceSrv().get(datasource, scopedVars);
 }

--- a/public/app/plugins/datasource/dashboard/runSharedRequest.ts
+++ b/public/app/plugins/datasource/dashboard/runSharedRequest.ts
@@ -17,11 +17,16 @@ export function isSharedDashboardQuery(datasource: string | DataSourceRef | Data
     // default datasource
     return false;
   }
-  if (datasource === SHARED_DASHBOARD_QUERY || (datasource as any)?.uid === SHARED_DASHBOARD_QUERY) {
-    return true;
+
+  if (typeof datasource === 'string') {
+    return datasource === SHARED_DASHBOARD_QUERY;
   }
-  const ds = datasource as DataSourceApi;
-  return ds.meta && ds.meta.name === SHARED_DASHBOARD_QUERY;
+
+  if ('meta' in datasource) {
+    return datasource.meta.name === SHARED_DASHBOARD_QUERY;
+  }
+
+  return datasource?.uid === SHARED_DASHBOARD_QUERY;
 }
 
 export function runSharedRequest(options: QueryRunnerOptions): Observable<PanelData> {


### PR DESCRIPTION
**What this PR does / why we need it**:

Spotted in #41826, there was some unnecessary unsafe type assertions around the different types that `datasource` can be. This sorts it out with some plain old type narrowing!


