### PR TITLE
Alerting: Create DatasourceError alert if evaluation returns error

### DIFF
--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
@@ -69,7 +69,8 @@ Configure alerting behavior in the absence of data using information in the foll
 | Alerting       | Set alert rule state to `Alerting`.                                                                                                       |
 | Ok             | Set alert rule state to `Normal`.                                                                                                         |
 
-| Error or timeout option | Description                        |
-| ----------------------- | ---------------------------------- |
-| Alerting                | Set alert rule state to `Alerting` |
-| OK                      | Set alert rule state to `Normal`   |
+| Error or timeout option | Description                                                                                                                              |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Alerting                | Set alert rule state to `Alerting`                                                                                                       |
+| OK                      | Set alert rule state to `Normal`                                                                                                         |
+| Error                   | Create a new alert `DatasourceError` with the name and UID of the alert rule, and UID of the datasource that returned no data as labels. |

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -41,6 +41,7 @@ func (executionErrorState ExecutionErrorState) String() string {
 
 const (
 	AlertingErrState ExecutionErrorState = "Alerting"
+	ErrorErrState    ExecutionErrorState = "Error"
 )
 
 const (

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -1186,7 +1186,7 @@ func TestProcessEvalResults(t *testing.T) {
 				NamespaceUID: "test_namespace_uid",
 				Data: []models.AlertQuery{{
 					RefID:         "A",
-					DatasourceUID: "datasource1",
+					DatasourceUID: "datasource_uid_1",
 				}},
 				Annotations:     map[string]string{"annotation": "test"},
 				Labels:          map[string]string{"label": "test"},
@@ -1227,7 +1227,7 @@ func TestProcessEvalResults(t *testing.T) {
 						"alertname":                    "test_title",
 						"label":                        "test",
 						"instance_label":               "test",
-						"datasource_uid":               "datasource1",
+						"datasource_uid":               "datasource_uid_1",
 					},
 					State: eval.Error,
 					Error: expr.QueryError{

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -2,11 +2,13 @@ package state_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 
+	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
@@ -1172,6 +1174,79 @@ func TestProcessEvalResults(t *testing.T) {
 					LastEvaluationTime: evaluationTime.Add(10 * time.Second),
 					EvaluationDuration: evaluationDuration,
 					Annotations:        map[string]string{"annotation": "test"},
+				},
+			},
+		},
+		{
+			desc: "normal -> error when result is Error and ExecErrState is Error",
+			alertRule: &models.AlertRule{
+				OrgID:           1,
+				Title:           "test_title",
+				UID:             "test_alert_rule_uid_2",
+				NamespaceUID:    "test_namespace_uid",
+				Annotations:     map[string]string{"annotation": "test"},
+				Labels:          map[string]string{"label": "test"},
+				IntervalSeconds: 10,
+				For:             1 * time.Minute,
+				ExecErrState:    models.ErrorErrState,
+			},
+			evalResults: []eval.Results{
+				{
+					eval.Result{
+						Instance:           data.Labels{"instance_label": "test"},
+						State:              eval.Normal,
+						EvaluatedAt:        evaluationTime,
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+				{
+					eval.Result{
+						Instance: data.Labels{"instance_label": "test"},
+						Error: expr.QueryError{
+							RefID: "A",
+							Err:   errors.New("this is an error"),
+						},
+						State:              eval.Error,
+						EvaluatedAt:        evaluationTime.Add(10 * time.Second),
+						EvaluationDuration: evaluationDuration,
+					},
+				},
+			},
+			expectedStates: map[string]*state.State{
+				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
+					AlertRuleUID: "test_alert_rule_uid_2",
+					OrgID:        1,
+					CacheId:      `[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`,
+					Labels: data.Labels{
+						"__alert_rule_namespace_uid__": "test_namespace_uid",
+						"__alert_rule_uid__":           "test_alert_rule_uid_2",
+						"alertname":                    "test_title",
+						"label":                        "test",
+						"instance_label":               "test",
+						"ref_id":                       "A",
+					},
+					State: eval.Error,
+					Error: expr.QueryError{
+						RefID: "A",
+						Err:   errors.New("this is an error"),
+					},
+					Results: []state.Evaluation{
+						{
+							EvaluationTime:  evaluationTime,
+							EvaluationState: eval.Normal,
+							Values:          make(map[string]state.EvaluationValue),
+						},
+						{
+							EvaluationTime:  evaluationTime.Add(10 * time.Second),
+							EvaluationState: eval.Error,
+							Values:          make(map[string]state.EvaluationValue),
+						},
+					},
+					StartsAt:           evaluationTime.Add(10 * time.Second),
+					EndsAt:             evaluationTime.Add(10 * time.Second).Add(state.ResendDelay * 3),
+					LastEvaluationTime: evaluationTime.Add(10 * time.Second),
+					EvaluationDuration: evaluationDuration,
+					Annotations:        map[string]string{"annotation": "test", "Error": "failed to execute query A: this is an error"},
 				},
 			},
 		},

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -1180,10 +1180,14 @@ func TestProcessEvalResults(t *testing.T) {
 		{
 			desc: "normal -> error when result is Error and ExecErrState is Error",
 			alertRule: &models.AlertRule{
-				OrgID:           1,
-				Title:           "test_title",
-				UID:             "test_alert_rule_uid_2",
-				NamespaceUID:    "test_namespace_uid",
+				OrgID:        1,
+				Title:        "test_title",
+				UID:          "test_alert_rule_uid_2",
+				NamespaceUID: "test_namespace_uid",
+				Data: []models.AlertQuery{{
+					RefID:         "A",
+					DatasourceUID: "datasource1",
+				}},
 				Annotations:     map[string]string{"annotation": "test"},
 				Labels:          map[string]string{"label": "test"},
 				IntervalSeconds: 10,
@@ -1223,7 +1227,7 @@ func TestProcessEvalResults(t *testing.T) {
 						"alertname":                    "test_title",
 						"label":                        "test",
 						"instance_label":               "test",
-						"ref_id":                       "A",
+						"datasource_uid":               "datasource1",
 					},
 					State: eval.Error,
 					Error: expr.QueryError{

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -109,6 +109,7 @@ func (a *State) resultError(alertRule *ngModels.AlertRule, result eval.Result) {
 			for _, next := range alertRule.Data {
 				if next.RefID == queryError.RefID {
 					a.Labels["datasource_uid"] = next.DatasourceUID
+					break
 				}
 			}
 			a.Annotations["Error"] = queryError.Error()

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -101,12 +101,16 @@ func (a *State) resultError(alertRule *ngModels.AlertRule, result eval.Result) {
 		a.State = eval.Error
 
 		// If the evaluation failed because a query returned an error then
-		// update the state with the Ref ID as a label and the error message
-		// as an annotation so other code can use this metadata to add context
-		// to alerts
+		// update the state with the Datasource UID as a label and the error
+		// message as an annotation so other code can use this metadata to
+		// add context to alerts
 		var queryError expr.QueryError
 		if errors.As(a.Error, &queryError) {
-			a.Labels["ref_id"] = queryError.RefID
+			for _, next := range alertRule.Data {
+				if next.RefID == queryError.RefID {
+					a.Labels["datasource_uid"] = next.DatasourceUID
+				}
+			}
 			a.Annotations["Error"] = queryError.Error()
 		}
 	}

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -1,10 +1,12 @@
 package state
 
 import (
+	"errors"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 
+	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	ngModels "github.com/grafana/grafana/pkg/services/ngalert/models"
 )
@@ -87,6 +89,7 @@ func (a *State) resultAlerting(alertRule *ngModels.AlertRule, result eval.Result
 
 func (a *State) resultError(alertRule *ngModels.AlertRule, result eval.Result) {
 	a.Error = result.Error
+
 	if a.StartsAt.IsZero() {
 		a.StartsAt = result.EvaluatedAt
 	}
@@ -94,6 +97,18 @@ func (a *State) resultError(alertRule *ngModels.AlertRule, result eval.Result) {
 
 	if alertRule.ExecErrState == ngModels.AlertingErrState {
 		a.State = eval.Alerting
+	} else if alertRule.ExecErrState == ngModels.ErrorErrState {
+		a.State = eval.Error
+
+		// If the evaluation failed because a query returned an error then
+		// update the state with the Ref ID as a label and the error message
+		// as an annotation so other code can use this metadata to add context
+		// to alerts
+		var queryError expr.QueryError
+		if errors.As(a.Error, &queryError) {
+			a.Labels["ref_id"] = queryError.RefID
+			a.Annotations["Error"] = queryError.Error()
+		}
 	}
 }
 
@@ -114,7 +129,7 @@ func (a *State) resultNoData(alertRule *ngModels.AlertRule, result eval.Result) 
 }
 
 func (a *State) NeedsSending(resendDelay time.Duration) bool {
-	if a.State == eval.Pending || a.State == eval.Error || a.State == eval.Normal && !a.Resolved {
+	if a.State == eval.Pending || a.State == eval.Normal && !a.Resolved {
 		return false
 	}
 	// if LastSentAt is before or equal to LastEvaluationTime + resendDelay, send again

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -122,7 +122,7 @@ func TestNeedsSending(t *testing.T) {
 		},
 		{
 			name:        "state: error, needs to be re-sent",
-			expected:    false,
+			expected:    true,
 			resendDelay: 1 * time.Minute,
 			testState: &State{
 				State:              eval.Error,

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -131,6 +131,10 @@ func (m *migration) makeAlertRule(cond condition, da dashAlert, folderUID string
 		m.mg.Logger.Error("alert migration error: failed to create silence", "rule_name", ar.Title, "err", err)
 	}
 
+	if err := m.addErrorSilence(da, ar); err != nil {
+		m.mg.Logger.Error("alert migration error: failed to create silence for Error", "rule_name", ar.Title, "err", err)
+	}
+
 	if err := m.addNoDataSilence(da, ar); err != nil {
 		m.mg.Logger.Error("alert migration error: failed to create silence for NoData", "rule_name", ar.Title, "err", err)
 	}
@@ -215,7 +219,9 @@ func transExecErr(s string) (string, error) {
 	case "", "alerting":
 		return "Alerting", nil
 	case "keep_state":
-		return "Alerting", nil
+		// Keep last state is translated to error as we now emit a
+		// DatasourceError alert when the state is error
+		return "Error", nil
 	}
 	return "", fmt.Errorf("unrecognized Execution Error setting %v", s)
 }

--- a/pkg/services/sqlstore/migrations/ualert/silences.go
+++ b/pkg/services/sqlstore/migrations/ualert/silences.go
@@ -22,6 +22,8 @@ import (
 const (
 	// Should be the same as 'NoDataAlertName' in pkg/services/schedule/compat.go.
 	NoDataAlertName = "DatasourceNoData"
+
+	ErrorAlertName = "DatasourceError"
 )
 
 func (m *migration) addSilence(da dashAlert, rule *alertRule) error {
@@ -55,6 +57,45 @@ func (m *migration) addSilence(da dashAlert, rule *alertRule) error {
 
 	_, ok := m.silences[da.OrgId]
 	if !ok {
+		m.silences[da.OrgId] = make([]*pb.MeshSilence, 0)
+	}
+	m.silences[da.OrgId] = append(m.silences[da.OrgId], s)
+	return nil
+}
+
+func (m *migration) addErrorSilence(da dashAlert, rule *alertRule) error {
+	if da.ParsedSettings.ExecutionErrorState != "keep_state" {
+		return nil
+	}
+
+	uid, err := uuid.NewV4()
+	if err != nil {
+		return errors.New("failed to create uuid for silence")
+	}
+
+	s := &pb.MeshSilence{
+		Silence: &pb.Silence{
+			Id: uid.String(),
+			Matchers: []*pb.Matcher{
+				{
+					Type:    pb.Matcher_EQUAL,
+					Name:    model.AlertNameLabel,
+					Pattern: ErrorAlertName,
+				},
+				{
+					Type:    pb.Matcher_EQUAL,
+					Name:    "rule_uid",
+					Pattern: rule.UID,
+				},
+			},
+			StartsAt:  time.Now(),
+			EndsAt:    time.Now().AddDate(1, 0, 0), // 1 year
+			CreatedBy: "Grafana Migration",
+			Comment:   fmt.Sprintf("Created during migration to unified alerting to silence Error state for alert rule ID '%s' and Title '%s' because the option 'Keep Last State' was selected for Error state", rule.UID, rule.Title),
+		},
+		ExpiresAt: time.Now().AddDate(1, 0, 0), // 1 year
+	}
+	if _, ok := m.silences[da.OrgId]; !ok {
 		m.silences[da.OrgId] = make([]*pb.MeshSilence, 0)
 	}
 	m.silences[da.OrgId] = append(m.silences[da.OrgId], s)

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaAlertStatePicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaAlertStatePicker.tsx
@@ -6,20 +6,25 @@ import React, { FC, useMemo } from 'react';
 
 type Props = Omit<SelectBaseProps<GrafanaAlertStateDecision>, 'options'> & {
   includeNoData: boolean;
+  includeError: boolean;
 };
 
 const options: SelectableValue[] = [
   { value: GrafanaAlertStateDecision.Alerting, label: 'Alerting' },
   { value: GrafanaAlertStateDecision.NoData, label: 'No Data' },
   { value: GrafanaAlertStateDecision.OK, label: 'OK' },
+  { value: GrafanaAlertStateDecision.Error, label: 'Error' },
 ];
 
-export const GrafanaAlertStatePicker: FC<Props> = ({ includeNoData, ...props }) => {
+export const GrafanaAlertStatePicker: FC<Props> = ({ includeNoData, includeError, ...props }) => {
   const opts = useMemo(() => {
-    if (includeNoData) {
-      return options;
+    if (!includeNoData) {
+      return options.filter((opt) => opt.value !== GrafanaAlertStateDecision.NoData);
     }
-    return options.filter((opt) => opt.value !== GrafanaAlertStateDecision.NoData);
-  }, [includeNoData]);
+    if (!includeError) {
+      return options.filter((opt) => opt.value !== GrafanaAlertStateDecision.Error);
+    }
+    return options;
+  }, [includeNoData, includeError]);
   return <Select menuShouldPortal options={opts} {...props} />;
 };

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaConditionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaConditionsStep.tsx
@@ -108,6 +108,7 @@ export const GrafanaConditionsStep: FC = () => {
                   inputId="no-data-state-input"
                   width={42}
                   includeNoData={true}
+                  includeError={false}
                   onChange={(value) => onChange(value?.value)}
                 />
               )}
@@ -122,6 +123,7 @@ export const GrafanaConditionsStep: FC = () => {
                   inputId="exec-err-state-input"
                   width={42}
                   includeNoData={false}
+                  includeError={true}
                   onChange={(value) => onChange(value?.value)}
                 />
               )}

--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -99,6 +99,7 @@ export enum GrafanaAlertStateDecision {
   NoData = 'NoData',
   KeepLastState = 'KeepLastState',
   OK = 'OK',
+  Error = 'Error',
 }
 
 interface AlertDataQuery extends DataQuery {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request creates a special `DatasourceError` alert if the Error state for the alert rule is `Error` and evaluation of the alert rule returns an error.

**Which issue(s) this PR fixes**:

Fixes #41331

# Release notice breaking change

### Keep Last State for "If execution error or timeout" when upgrading to Grafana 8 alerting

In Grafana 8.3.0-beta2 we changed how alert rules that use `Keep Last State` for `If execution error or timeout` are upgraded from Legacy Alerting to Grafana 8 alerting. In 8.3.0-beta1 and earlier, alert rules with `Keep Last State` for `If execution error or timeout` were changed to `Alerting` when upgrading from Legacy Alerting to Grafana 8 alerting. However, in 8.3.0-beta2 these alert rules are now upgraded to a new option called `Error`. With this option, on encountering an error evaluating an alert rule, Grafana creates a special alert called `DatasourceError` with the `rule_uid` and `ref_id` as labels and an annotation called `Error` with the error message.