### PR TITLE
Access control: fix loop when cannot fetch roles

### DIFF
--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -60,11 +60,16 @@ export const fetchUserRoles = async (userId: number, orgId?: number): Promise<Ro
   if (orgId) {
     userRolesUrl += `?targetOrgId=${orgId}`;
   }
-  const roles = await getBackendSrv().get(userRolesUrl);
-  if (!roles || !roles.length) {
+  try {
+    const roles = await getBackendSrv().get(userRolesUrl);
+    if (!roles || !roles.length) {
+      return [];
+    }
+    return roles;
+  } catch (error) {
+    error.isHandled = true;
     return [];
   }
-  return roles;
 };
 
 export const updateUserRoles = (roleUids: string[], userId: number, orgId?: number) => {


### PR DESCRIPTION
This PR fixes endless loop on the `/org/users/` page when role picker displayed and user has no access to `/api/access-control/users/<id>/roles`. After some investigation, it looks like it happens when `getBackendSrv().get()` handles the error and shows an error message popup. It triggers `<UsersTable>` component re-render which triggers fetching roles again and getting into the endless loop. It doesn't happen on the `/admin/users/edit` page, so it's kinda strange and requires more investigation.
So this is a kind of quick fix.