### PR TITLE
Select: Select menus now properly scroll during keyboard navigation

### DIFF
--- a/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
+++ b/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
@@ -43,7 +43,9 @@ export const CustomScrollbar: FC<Props> = ({
 }) => {
   const ref = useRef<Scrollbars & { view: HTMLDivElement }>(null);
   useEffect(() => {
-    scrollRefCallback?.(ref.current?.view ?? null);
+    if (ref.current) {
+      scrollRefCallback?.(ref.current?.view);
+    }
   }, [ref, scrollRefCallback]);
   const styles = useStyles2(getStyles);
 

--- a/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
+++ b/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
@@ -44,7 +44,7 @@ export const CustomScrollbar: FC<Props> = ({
   const ref = useRef<Scrollbars & { view: HTMLDivElement }>(null);
   useEffect(() => {
     if (ref.current) {
-      scrollRefCallback?.(ref.current?.view);
+      scrollRefCallback?.(ref.current.view);
     }
   }, [ref, scrollRefCallback]);
   const styles = useStyles2(getStyles);

--- a/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
+++ b/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useEffect, useRef } from 'react';
+import React, { FC, RefCallback, useCallback, useEffect, useRef } from 'react';
 import { isNil } from 'lodash';
 import classNames from 'classnames';
 import { css } from '@emotion/css';
@@ -16,6 +16,7 @@ interface Props {
   hideTracksWhenNotNeeded?: boolean;
   hideHorizontalTrack?: boolean;
   hideVerticalTrack?: boolean;
+  scrollRefCallback?: RefCallback<HTMLDivElement>;
   scrollTop?: number;
   setScrollTop?: (position: ScrollbarPosition) => void;
   autoHeightMin?: number | string;
@@ -35,11 +36,15 @@ export const CustomScrollbar: FC<Props> = ({
   hideTracksWhenNotNeeded = false,
   hideHorizontalTrack,
   hideVerticalTrack,
+  scrollRefCallback,
   updateAfterMountMs,
   scrollTop,
   children,
 }) => {
-  const ref = useRef<Scrollbars>(null);
+  const ref = useRef<Scrollbars & { view: HTMLDivElement }>(null);
+  useEffect(() => {
+    scrollRefCallback?.(ref.current?.view ?? null);
+  }, [ref, scrollRefCallback]);
   const styles = useStyles2(getStyles);
 
   const updateScroll = () => {

--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -8,7 +8,6 @@ import { Icon } from '../Icon/Icon';
 import { IconName } from '../../types';
 
 interface SelectMenuProps {
-  children: any;
   maxHeight: number;
   innerRef: RefCallback<HTMLDivElement>;
   innerProps: {};

--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC, RefCallback } from 'react';
 import { useTheme2 } from '../../themes/ThemeContext';
 import { getSelectStyles } from './getSelectStyles';
 import { cx } from '@emotion/css';
@@ -8,24 +8,24 @@ import { Icon } from '../Icon/Icon';
 import { IconName } from '../../types';
 
 interface SelectMenuProps {
+  children: any;
   maxHeight: number;
-  innerRef: React.Ref<any>;
+  innerRef: RefCallback<HTMLDivElement>;
   innerProps: {};
 }
 
-export const SelectMenu = React.forwardRef<HTMLDivElement, React.PropsWithChildren<SelectMenuProps>>((props, ref) => {
+export const SelectMenu: FC<SelectMenuProps> = ({ children, maxHeight, innerRef, innerProps }) => {
   const theme = useTheme2();
   const styles = getSelectStyles(theme);
-  const { children, maxHeight, innerRef, innerProps } = props;
 
   return (
-    <div {...innerProps} className={styles.menu} ref={innerRef} style={{ maxHeight }} aria-label="Select options menu">
-      <CustomScrollbar autoHide={false} autoHeightMax="inherit" hideHorizontalTrack>
+    <div {...innerProps} className={styles.menu} style={{ maxHeight }} aria-label="Select options menu">
+      <CustomScrollbar scrollRefCallback={innerRef} autoHide={false} autoHeightMax="inherit" hideHorizontalTrack>
         {children}
       </CustomScrollbar>
     </div>
   );
-});
+};
 
 SelectMenu.displayName = 'SelectMenu';
 
@@ -34,38 +34,44 @@ interface SelectMenuOptionProps<T> {
   isFocused: boolean;
   isSelected: boolean;
   innerProps: any;
+  innerRef: RefCallback<HTMLDivElement>;
   renderOptionLabel?: (value: SelectableValue<T>) => JSX.Element;
   data: SelectableValue<T>;
 }
 
-export const SelectMenuOptions = React.forwardRef<HTMLDivElement, React.PropsWithChildren<SelectMenuOptionProps<any>>>(
-  (props, ref) => {
-    const theme = useTheme2();
-    const styles = getSelectStyles(theme);
-    const { children, innerProps, data, renderOptionLabel, isSelected, isFocused } = props;
+export const SelectMenuOptions: FC<SelectMenuOptionProps<any>> = ({
+  children,
+  data,
+  innerProps,
+  innerRef,
+  isFocused,
+  isSelected,
+  renderOptionLabel,
+}) => {
+  const theme = useTheme2();
+  const styles = getSelectStyles(theme);
 
-    return (
-      <div
-        ref={ref}
-        className={cx(
-          styles.option,
-          isFocused && styles.optionFocused,
-          isSelected && styles.optionSelected,
-          data.isDisabled && styles.optionDisabled
-        )}
-        {...innerProps}
-        aria-label="Select option"
-      >
-        {data.icon && <Icon name={data.icon as IconName} className={styles.optionIcon} />}
-        {data.imgUrl && <img className={styles.optionImage} src={data.imgUrl} alt={data.label || data.value} />}
-        <div className={styles.optionBody}>
-          <span>{renderOptionLabel ? renderOptionLabel(data) : children}</span>
-          {data.description && <div className={styles.optionDescription}>{data.description}</div>}
-          {data.component && <data.component />}
-        </div>
+  return (
+    <div
+      ref={innerRef}
+      className={cx(
+        styles.option,
+        isFocused && styles.optionFocused,
+        isSelected && styles.optionSelected,
+        data.isDisabled && styles.optionDisabled
+      )}
+      {...innerProps}
+      aria-label="Select option"
+    >
+      {data.icon && <Icon name={data.icon as IconName} className={styles.optionIcon} />}
+      {data.imgUrl && <img className={styles.optionImage} src={data.imgUrl} alt={data.label || data.value} />}
+      <div className={styles.optionBody}>
+        <span>{renderOptionLabel ? renderOptionLabel(data) : children}</span>
+        {data.description && <div className={styles.optionDescription}>{data.description}</div>}
+        {data.component && <data.component />}
       </div>
-    );
-  }
-);
+    </div>
+  );
+};
 
 SelectMenuOptions.displayName = 'SelectMenuOptions';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- all `Select` menus in Grafana don't currently scroll properly when using the keyboard due to us not passing refs correctly. you can see this by pressing ⬆️  until you get to the top of the menu. the selected element wraps back around to the bottom, but the menu doesn't scroll to show you that. so let's fix that... 🤓 
- type `SelectMenu`/`SelectMenuOptions` correctly
  - they both receive [an `innerRef` property](https://react-select.com/components#inner-ref) (not a forwarded ref) which needs to be attached to the correct element
- add a new optional `scrollRefCallback` (open to suggestions on a better prop name here...) property to `CustomScrollbar`
  - when we pass a ref to the `Scrollbars` component, we get a reference to the React class instance when we actually need the [DOM element that is responsible for scrolling](https://github.com/JedWatson/react-select/blob/b0411ff46bc1ecf45d9bca4fb58fbce1e57f847c/packages/react-select/src/utils.js#L215). that is given by `<instance>.view` [which definitely does exist despite it being missed in the typings](https://github.com/RobPethick/react-custom-scrollbars-2/blob/master/src/Scrollbars/index.js#L576). `<instance>.container`, which also exists and **is** included in the typings, is not the actual scrollable element and so won't work.
- pass the `innerRef` callback from `react-select` through to `CustomScrollbar` and call it with the scrolling element.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/24640

**Special notes for your reviewer**:

- a simpler option probably would have been to remove the `CustomScrollbar` from `SelectMenu`, but it's presumably there because it looks nicer so have tried to keep it 