### PR TITLE
AccessControl: Fix orgs edit UserTable RolePicker to fetch roles in org

### DIFF
--- a/public/app/features/admin/AdminEditOrgPage.tsx
+++ b/public/app/features/admin/AdminEditOrgPage.tsx
@@ -98,6 +98,7 @@ export const AdminEditOrgPage: FC<Props> = ({ match }) => {
             {canReadUsers && !!users.length && (
               <UsersTable
                 users={users}
+                orgId={orgId}
                 onRoleChange={(role, orgUser) => {
                   updateOrgUserRole({ ...orgUser, role }, orgId);
                   setUsers(

--- a/public/app/features/users/UsersTable.tsx
+++ b/public/app/features/users/UsersTable.tsx
@@ -8,12 +8,13 @@ import { fetchBuiltinRoles, fetchRoleOptions, UserRolePicker } from 'app/core/co
 
 export interface Props {
   users: OrgUser[];
+  orgId?: number;
   onRoleChange: (role: OrgRole, user: OrgUser) => void;
   onRemoveUser: (user: OrgUser) => void;
 }
 
 const UsersTable: FC<Props> = (props) => {
-  const { users, onRoleChange, onRemoveUser } = props;
+  const { users, orgId, onRoleChange, onRemoveUser } = props;
   const canUpdateRole = contextSrv.hasPermission(AccessControlAction.OrgUsersRoleUpdate);
   const canRemoveFromOrg = contextSrv.hasPermission(AccessControlAction.OrgUsersRemove);
   const rolePickerDisabled = !canUpdateRole;
@@ -25,9 +26,9 @@ const UsersTable: FC<Props> = (props) => {
   useEffect(() => {
     async function fetchOptions() {
       try {
-        let options = await fetchRoleOptions();
+        let options = await fetchRoleOptions(orgId);
         setRoleOptions(options);
-        const builtInRoles = await fetchBuiltinRoles();
+        const builtInRoles = await fetchBuiltinRoles(orgId);
         setBuiltinRoles(builtInRoles);
       } catch (e) {
         console.error('Error loading options');
@@ -36,7 +37,7 @@ const UsersTable: FC<Props> = (props) => {
     if (contextSrv.accessControlEnabled()) {
       fetchOptions();
     }
-  }, []);
+  }, [orgId]);
 
   const getRoleOptions = async () => roleOptions;
   const getBuiltinRoles = async () => builtinRoles;
@@ -83,6 +84,7 @@ const UsersTable: FC<Props> = (props) => {
                 {contextSrv.accessControlEnabled() ? (
                   <UserRolePicker
                     userId={user.userId}
+                    orgId={orgId}
                     builtInRole={user.role}
                     onBuiltinRoleChange={(newRole) => onRoleChange(newRole, user)}
                     getRoleOptions={getRoleOptions}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When you navigate to edit an org and get the user list, the roles associated to a user are not the one from the target org.
![fetch_from_signedin_org](https://user-images.githubusercontent.com/5232696/142433310-2a3d061a-21eb-45cc-a053-f22f1850af72.gif)
Opening firefox helper tools we can see that the request is performed without specifying the `targetOrgId`.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/2291

**Special notes for your reviewer**:

