### PR TITLE
Candlestick: fix volume histogram height by using mapped field name

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -6,6 +6,7 @@ import {
   DataFrame,
   DataHoverClearEvent,
   DataHoverEvent,
+  Field,
   FieldMatcherID,
   fieldMatchers,
   LegacyGraphHoverEvent,
@@ -44,8 +45,8 @@ export interface GraphNGProps extends Themeable2 {
   legend: VizLegendOptions;
   fields?: XYFieldMatchers; // default will assume timeseries data
   renderers?: Renderers;
-  tweakScale?: (opts: ScaleProps) => ScaleProps;
-  tweakAxis?: (opts: AxisProps) => AxisProps;
+  tweakScale?: (opts: ScaleProps, forField: Field) => ScaleProps;
+  tweakAxis?: (opts: AxisProps, forField: Field) => AxisProps;
   onLegendClick?: (event: GraphNGLegendEvent) => void;
   children?: (builder: UPlotConfigBuilder, alignedFrame: DataFrame) => React.ReactNode;
   prepConfig: (alignedFrame: DataFrame, allFrames: DataFrame[], getTimeRange: () => TimeRange) => UPlotConfigBuilder;

--- a/packages/grafana-ui/src/components/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/components/TimeSeries/utils.ts
@@ -146,17 +146,20 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{ sync: DashboardCursor
 
     // The builder will manage unique scaleKeys and combine where appropriate
     builder.addScale(
-      tweakScale({
-        scaleKey,
-        orientation: ScaleOrientation.Vertical,
-        direction: ScaleDirection.Up,
-        distribution: customConfig.scaleDistribution?.type,
-        log: customConfig.scaleDistribution?.log,
-        min: field.config.min,
-        max: field.config.max,
-        softMin: customConfig.axisSoftMin,
-        softMax: customConfig.axisSoftMax,
-      })
+      tweakScale(
+        {
+          scaleKey,
+          orientation: ScaleOrientation.Vertical,
+          direction: ScaleDirection.Up,
+          distribution: customConfig.scaleDistribution?.type,
+          log: customConfig.scaleDistribution?.log,
+          min: field.config.min,
+          max: field.config.max,
+          softMin: customConfig.axisSoftMin,
+          softMax: customConfig.axisSoftMax,
+        },
+        field
+      )
     );
 
     if (!yScaleKey) {
@@ -165,15 +168,18 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{ sync: DashboardCursor
 
     if (customConfig.axisPlacement !== AxisPlacement.Hidden) {
       builder.addAxis(
-        tweakAxis({
-          scaleKey,
-          label: customConfig.axisLabel,
-          size: customConfig.axisWidth,
-          placement: customConfig.axisPlacement ?? AxisPlacement.Auto,
-          formatValue: (v) => formattedValueToString(fmt(v)),
-          theme,
-          grid: { show: customConfig.axisGridShow },
-        })
+        tweakAxis(
+          {
+            scaleKey,
+            label: customConfig.axisLabel,
+            size: customConfig.axisWidth,
+            placement: customConfig.axisPlacement ?? AxisPlacement.Auto,
+            formatValue: (v) => formattedValueToString(fmt(v)),
+            theme,
+            grid: { show: customConfig.axisGridShow },
+          },
+          field
+        )
       );
     }
 

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -4,6 +4,7 @@ import {
   DataFrame,
   DefaultTimeZone,
   EventBus,
+  Field,
   getTimeZoneInfo,
   GrafanaTheme2,
   TimeRange,
@@ -287,8 +288,8 @@ type UPlotConfigPrepOpts<T extends Record<string, any> = {}> = {
   eventBus: EventBus;
   allFrames: DataFrame[];
   renderers?: Renderers;
-  tweakScale?: (opts: ScaleProps) => ScaleProps;
-  tweakAxis?: (opts: AxisProps) => AxisProps;
+  tweakScale?: (opts: ScaleProps, forField: Field) => ScaleProps;
+  tweakAxis?: (opts: AxisProps, forField: Field) => AxisProps;
 } & T;
 
 /** @alpha */

--- a/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
+++ b/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
@@ -43,8 +43,8 @@ export const MarketTrendPanel: React.FC<CandlestickPanelProps> = ({
   const info = useMemo(() => prepareCandlestickFields(data?.series, options, theme), [data, options, theme]);
 
   const { renderers, tweakScale, tweakAxis } = useMemo(() => {
-    let tweakScale = (opts: ScaleProps) => opts;
-    let tweakAxis = (opts: AxisProps) => opts;
+    let tweakScale = (opts: ScaleProps, forField: Field) => opts;
+    let tweakAxis = (opts: AxisProps, forField: Field) => opts;
 
     let doNothing = {
       renderers: [],
@@ -97,8 +97,9 @@ export const MarketTrendPanel: React.FC<CandlestickPanelProps> = ({
             theme: config.theme2,
           });
 
-          tweakAxis = (opts: AxisProps) => {
-            if (opts.scaleKey.indexOf('short/') === 0) {
+          tweakAxis = (opts: AxisProps, forField: Field) => {
+            // we can't do forField === info.volume because of copies :(
+            if (forField.name === info.volume?.name) {
               let filter = (u: uPlot, splits: number[]) => {
                 let _splits = [];
                 let max = u.series[volumeIdx].max as number;
@@ -122,8 +123,9 @@ export const MarketTrendPanel: React.FC<CandlestickPanelProps> = ({
             return opts;
           };
 
-          tweakScale = (opts: ScaleProps) => {
-            if (opts.scaleKey.indexOf('short/') === 0) {
+          tweakScale = (opts: ScaleProps, forField: Field) => {
+            // we can't do forField === info.volume because of copies :(
+            if (forField.name === info.volume?.name) {
               opts.range = (u: uPlot, min: number, max: number) => [0, max * 7];
             }
 

--- a/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
+++ b/public/app/plugins/panel/candlestick/CandlestickPanel.tsx
@@ -98,7 +98,7 @@ export const MarketTrendPanel: React.FC<CandlestickPanelProps> = ({
           });
 
           tweakAxis = (opts: AxisProps) => {
-            if (opts.scaleKey === 'short') {
+            if (opts.scaleKey.indexOf('short/') === 0) {
               let filter = (u: uPlot, splits: number[]) => {
                 let _splits = [];
                 let max = u.series[volumeIdx].max as number;
@@ -123,7 +123,7 @@ export const MarketTrendPanel: React.FC<CandlestickPanelProps> = ({
           };
 
           tweakScale = (opts: ScaleProps) => {
-            if (opts.scaleKey === 'short') {
+            if (opts.scaleKey.indexOf('short/') === 0) {
               opts.range = (u: uPlot, min: number, max: number) => [0, max * 7];
             }
 


### PR DESCRIPTION
in https://github.com/grafana/grafana/pull/41635 we changed how y scale keys are named. previously it was just unit, but now is a composite of multiple unique axis properties / overrides.

the candlestick panel relied on the `short` scaleKey name to adjust the range of the volume axis. ~~this PR adjusts the strategy to check the key prefix (which is still the unit).~~ this PR uses a more robust strategy of testing against the pre-determined field name rather than a specific scaleKey.

before (volume collides with candles):

![image](https://user-images.githubusercontent.com/43234/142502347-9b974624-9fea-480f-ab77-00a010f59c39.png)

after (shorter axis, collisions less likely):

![image](https://user-images.githubusercontent.com/43234/142502530-45beb4d6-6099-43d0-be0b-e0b6d74c5da8.png)
