### PR TITLE
Docs: Add easier to find deprecation notices to certain data sources and to the changelog

### DIFF
--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -20,12 +20,12 @@ visualize logs or metrics stored in Elasticsearch. You can also annotate your gr
 
 > **Note:** If you're not seeing the `Data Sources` link in your side menu it means that your current user does not have the `Admin` role for the current organization.
 
-| Name      | Description                                                                                                                           |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `Name`    | The data source name. This is how you refer to the data source in panels and queries.                                                 |
-| `Default` | Default data source means that it will be pre-selected for new panels.                                                                |
-| `Url`     | The HTTP protocol, IP, and port of your Elasticsearch server.                                                                         |
-| `Access`  | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser = URL needs to be accessible from the browser. |
+| Name      | Description                                                                                                                                       |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Name`    | The data source name. This is how you refer to the data source in panels and queries.                                                             |
+| `Default` | Default data source means that it will be pre-selected for new panels.                                                                            |
+| `Url`     | The HTTP protocol, IP, and port of your Elasticsearch server.                                                                                     |
+| `Access`  | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser (deprecated)= URL needs to be accessible from the browser. |
 
 Access mode controls how requests to the data source will be handled. Server should be the preferred way if nothing else stated.
 

--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -25,7 +25,7 @@ visualize logs or metrics stored in Elasticsearch. You can also annotate your gr
 | `Name`    | The data source name. This is how you refer to the data source in panels and queries.                                                             |
 | `Default` | Default data source means that it will be pre-selected for new panels.                                                                            |
 | `Url`     | The HTTP protocol, IP, and port of your Elasticsearch server.                                                                                     |
-| `Access`  | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser (deprecated)= URL needs to be accessible from the browser. |
+| `Access`  | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser (deprecated) = URL needs to be accessible from the browser. |
 
 Access mode controls how requests to the data source will be handled. Server should be the preferred way if nothing else stated.
 

--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -20,11 +20,11 @@ visualize logs or metrics stored in Elasticsearch. You can also annotate your gr
 
 > **Note:** If you're not seeing the `Data Sources` link in your side menu it means that your current user does not have the `Admin` role for the current organization.
 
-| Name      | Description                                                                                                                                       |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Name`    | The data source name. This is how you refer to the data source in panels and queries.                                                             |
-| `Default` | Default data source means that it will be pre-selected for new panels.                                                                            |
-| `Url`     | The HTTP protocol, IP, and port of your Elasticsearch server.                                                                                     |
+| Name      | Description                                                                                                                                        |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Name`    | The data source name. This is how you refer to the data source in panels and queries.                                                              |
+| `Default` | Default data source means that it will be pre-selected for new panels.                                                                             |
+| `Url`     | The HTTP protocol, IP, and port of your Elasticsearch server.                                                                                      |
 | `Access`  | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser (deprecated) = URL needs to be accessible from the browser. |
 
 Access mode controls how requests to the data source will be handled. Server should be the preferred way if nothing else stated.

--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -27,12 +27,12 @@ InfluxDB data source options differ depending on which [query language](#query-l
 
 These options apply if you are using the InfluxQL query language. If you are using Flux, refer to [Flux support in Grafana]({{< relref "influxdb-flux.md" >}}).
 
-| Name      | Description                                                                                                                            |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `Name`    | The data source name. This is how you refer to the data source in panels and queries. We recommend something like `InfluxDB-InfluxQL`. |
-| `Default` | Default data source means that it will be pre-selected for new panels.                                                                 |
-| `URL`     | The HTTP protocol, IP address and port of your InfluxDB API. InfluxDB API port is by default 8086.                                     |
-| `Access`  | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser = URL needs to be accessible from the browser.  |
+| Name      | Description                                                                                                                                       |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Name`    | The data source name. This is how you refer to the data source in panels and queries. We recommend something like `InfluxDB-InfluxQL`.            |
+| `Default` | Default data source means that it will be pre-selected for new panels.                                                                            |
+| `URL`     | The HTTP protocol, IP address and port of your InfluxDB API. InfluxDB API port is by default 8086.                                                |
+| `Access`  | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser (deprecated)= URL needs to be accessible from the browser. |
 
 **Note**: Browser access is deprecated and will be removed in a future release.
 `Allowed cookies`| Cookies that will be forwarded to the data source. All other cookies will be deleted.

--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -27,11 +27,11 @@ InfluxDB data source options differ depending on which [query language](#query-l
 
 These options apply if you are using the InfluxQL query language. If you are using Flux, refer to [Flux support in Grafana]({{< relref "influxdb-flux.md" >}}).
 
-| Name      | Description                                                                                                                                       |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Name`    | The data source name. This is how you refer to the data source in panels and queries. We recommend something like `InfluxDB-InfluxQL`.            |
-| `Default` | Default data source means that it will be pre-selected for new panels.                                                                            |
-| `URL`     | The HTTP protocol, IP address and port of your InfluxDB API. InfluxDB API port is by default 8086.                                                |
+| Name      | Description                                                                                                                                        |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Name`    | The data source name. This is how you refer to the data source in panels and queries. We recommend something like `InfluxDB-InfluxQL`.             |
+| `Default` | Default data source means that it will be pre-selected for new panels.                                                                             |
+| `URL`     | The HTTP protocol, IP address and port of your InfluxDB API. InfluxDB API port is by default 8086.                                                 |
 | `Access`  | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser (deprecated) = URL needs to be accessible from the browser. |
 
 **Note**: Browser access is deprecated and will be removed in a future release.

--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -32,7 +32,7 @@ These options apply if you are using the InfluxQL query language. If you are usi
 | `Name`    | The data source name. This is how you refer to the data source in panels and queries. We recommend something like `InfluxDB-InfluxQL`.            |
 | `Default` | Default data source means that it will be pre-selected for new panels.                                                                            |
 | `URL`     | The HTTP protocol, IP address and port of your InfluxDB API. InfluxDB API port is by default 8086.                                                |
-| `Access`  | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser (deprecated)= URL needs to be accessible from the browser. |
+| `Access`  | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser (deprecated) = URL needs to be accessible from the browser. |
 
 **Note**: Browser access is deprecated and will be removed in a future release.
 `Allowed cookies`| Cookies that will be forwarded to the data source. All other cookies will be deleted.


### PR DESCRIPTION
the access=browser mode is deprecated in the following datasources: promtheus, elasticsearch, loki.

this pull request adds some more, easier to spot deprecation-notices to various places.

# Deprecation notice

The access mode "browser" is deprecated in the following data sources and will be removed in a later release:
- Prometheus
- InfluxDB
- Elasticsearch