### PR TITLE
ThresholdControls: Use correct scale key when calculating handle position

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/utils.ts
+++ b/packages/grafana-ui/src/components/GraphNG/utils.ts
@@ -1,6 +1,8 @@
 import { XYFieldMatchers } from './types';
-import { ArrayVector, DataFrame, FieldType, outerJoinDataFrames } from '@grafana/data';
+import { ArrayVector, DataFrame, FieldConfig, FieldType, outerJoinDataFrames } from '@grafana/data';
 import { nullToUndefThreshold } from './nullToUndefThreshold';
+import { AxisPlacement, GraphFieldConfig, ScaleDistribution, ScaleDistributionConfig } from '@grafana/schema';
+import { FIXED_UNIT } from './GraphNG';
 
 // will mutate the DataFrame's fields' values
 function applySpanNullsThresholds(frame: DataFrame) {
@@ -37,4 +39,37 @@ export function preparePlotFrame(frames: DataFrame[], dimFields: XYFieldMatchers
   });
 
   return alignedFrame && applySpanNullsThresholds(alignedFrame);
+}
+
+export function buildScaleKey(config: FieldConfig<GraphFieldConfig>) {
+  const defaultPart = 'na';
+
+  const scaleRange = `${config.min !== undefined ? config.min : defaultPart}-${
+    config.max !== undefined ? config.max : defaultPart
+  }`;
+
+  const scaleSoftRange = `${config.custom?.axisSoftMin !== undefined ? config.custom.axisSoftMin : defaultPart}-${
+    config.custom?.axisSoftMax !== undefined ? config.custom.axisSoftMax : defaultPart
+  }`;
+
+  const scalePlacement = `${
+    config.custom?.axisPlacement !== undefined ? config.custom?.axisPlacement : AxisPlacement.Auto
+  }`;
+
+  const scaleUnit = config.unit ?? FIXED_UNIT;
+
+  const scaleDistribution = config.custom?.scaleDistribution
+    ? getScaleDistributionPart(config.custom.scaleDistribution)
+    : ScaleDistribution.Linear;
+
+  const scaleLabel = Boolean(config.custom?.axisLabel) ? config.custom!.axisLabel : defaultPart;
+
+  return `${scaleUnit}/${scaleRange}/${scaleSoftRange}/${scalePlacement}/${scaleDistribution}/${scaleLabel}`;
+}
+
+function getScaleDistributionPart(config: ScaleDistributionConfig) {
+  if (config.type === ScaleDistribution.Log) {
+    return `${config.type}${config.log}`;
+  }
+  return config.type;
 }

--- a/packages/grafana-ui/src/components/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/components/TimeSeries/utils.ts
@@ -14,7 +14,6 @@ import {
 } from '@grafana/data';
 
 import { UPlotConfigBuilder, UPlotConfigPrepFn } from '../uPlot/config/UPlotConfigBuilder';
-import { FIXED_UNIT } from '../GraphNG/GraphNG';
 import {
   AxisPlacement,
   GraphDrawStyle,
@@ -24,11 +23,10 @@ import {
   ScaleDirection,
   ScaleOrientation,
   VizLegendOptions,
-  ScaleDistributionConfig,
-  ScaleDistribution,
 } from '@grafana/schema';
 import { collectStackingGroups, orderIdsByCalcs, preparePlotData } from '../uPlot/utils';
 import uPlot from 'uplot';
+import { buildScaleKey } from '../GraphNG/utils';
 
 const defaultFormatter = (v: any) => (v == null ? '-' : v.toFixed(1));
 
@@ -440,35 +438,4 @@ export function getNamesToFieldIndex(frame: DataFrame, allFrames: DataFrame[]): 
     }
   });
   return originNames;
-}
-
-function buildScaleKey(config: FieldConfig<GraphFieldConfig>) {
-  const defaultPart = 'na';
-
-  const scaleRange = `${config.min !== undefined ? config.min : defaultPart}-${
-    config.max !== undefined ? config.max : defaultPart
-  }`;
-
-  const scaleSoftRange = `${config.custom?.axisSoftMin !== undefined ? config.custom.axisSoftMin : defaultPart}-${
-    config.custom?.axisSoftMax !== undefined ? config.custom.axisSoftMax : defaultPart
-  }`;
-
-  const scalePlacement = `${config.custom?.axisPlacement !== undefined ? config.custom?.axisPlacement : defaultPart}`;
-
-  const scaleUnit = config.unit ?? FIXED_UNIT;
-
-  const scaleDistribution = config.custom?.scaleDistribution
-    ? getScaleDistributionPart(config.custom.scaleDistribution)
-    : ScaleDistribution.Linear;
-
-  const scaleLabel = Boolean(config.custom?.axisLabel) ? config.custom!.axisLabel : defaultPart;
-
-  return `${scaleUnit}/${scaleRange}/${scaleSoftRange}/${scalePlacement}/${scaleDistribution}/${scaleLabel}`;
-}
-
-function getScaleDistributionPart(config: ScaleDistributionConfig) {
-  if (config.type === ScaleDistribution.Log) {
-    return `${config.type}${config.log}`;
-  }
-  return config.type;
 }

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -265,7 +265,7 @@ export { UPlotConfigPrepFn } from './uPlot/config/UPlotConfigBuilder';
 export { GraphNG, GraphNGProps, FIXED_UNIT } from './GraphNG/GraphNG';
 export { TimeSeries } from './TimeSeries/TimeSeries';
 export { useGraphNGContext } from './GraphNG/hooks';
-export { preparePlotFrame } from './GraphNG/utils';
+export { preparePlotFrame, buildScaleKey } from './GraphNG/utils';
 export { GraphNGLegendEvent } from './GraphNG/types';
 export * from './PanelChrome/types';
 export { EmotionPerfTest } from './ThemeDemos/EmotionPerfTest';

--- a/public/app/plugins/panel/timeseries/plugins/ThresholdControlsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ThresholdControlsPlugin.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useLayoutEffect, useMemo, useRef } from 'react';
-import { FieldConfigSource, ThresholdsConfig, getValueFormat } from '@grafana/data';
-import { UPlotConfigBuilder, FIXED_UNIT } from '@grafana/ui';
+import { FieldConfigSource, ThresholdsConfig, getValueFormat, FieldConfig } from '@grafana/data';
+import { UPlotConfigBuilder, buildScaleKey, GraphFieldConfig } from '@grafana/ui';
 import { ThresholdDragHandle } from './ThresholdDragHandle';
 import uPlot from 'uplot';
 
@@ -42,7 +42,8 @@ export const ThresholdControlsPlugin: React.FC<ThresholdControlsPluginProps> = (
     if (!thresholds) {
       return null;
     }
-    const scale = fieldConfig.defaults.unit ?? FIXED_UNIT;
+    const scale = buildScaleKey(fieldConfig as FieldConfig<GraphFieldConfig>);
+
     const decimals = fieldConfig.defaults.decimals;
     const handles = [];
 


### PR DESCRIPTION
With https://github.com/grafana/grafana/pull/41635 I forgot to update the scale key used by `ThresholdControlsPlugin` what resulted in alerting failing in a nasty way:

```
TypeError: Cannot read properties of undefined (reading 'ori')

    at ThresholdControlsPlugin (http://localhost:3000/public/build/app.js?0ab434af4e237aec1e7d:201685:3)
    at div
    at UPlotChart (http://localhost:3000/public/build/app.js?0ab434af4e237aec1e7d:87454:5)
    at div
```