### PR TITLE
Access Control: show admin nav link to users who only have access to licensing page

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -334,12 +334,11 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 	adminNavLinks := hs.buildAdminNavLinks(c)
 
 	if len(adminNavLinks) > 0 {
-		serverAdminNode := navlinks.GetServerAdminNode(adminNavLinks)
+		navSection := dtos.NavSectionCore
 		if hs.Cfg.IsNewNavigationEnabled() {
-			serverAdminNode.Section = dtos.NavSectionConfig
-		} else {
-			serverAdminNode.Section = dtos.NavSectionCore
+			navSection = dtos.NavSectionConfig
 		}
+		serverAdminNode := navlinks.GetServerAdminNode(adminNavLinks, navSection)
 		navTree = append(navTree, serverAdminNode)
 	}
 

--- a/pkg/api/navlinks/navlinks.go
+++ b/pkg/api/navlinks/navlinks.go
@@ -2,7 +2,7 @@ package navlinks
 
 import "github.com/grafana/grafana/pkg/api/dtos"
 
-func GetServerAdminNode(children []*dtos.NavLink) *dtos.NavLink {
+func GetServerAdminNode(children []*dtos.NavLink, navSection string) *dtos.NavLink {
 	url := ""
 	if len(children) > 0 {
 		url = children[0].Url
@@ -15,6 +15,7 @@ func GetServerAdminNode(children []*dtos.NavLink) *dtos.NavLink {
 		Icon:         "shield",
 		Url:          url,
 		SortWeight:   dtos.WeightAdmin,
+		Section:      navSection,
 		Children:     children,
 	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Currently with FGAC enabled user will not be able to see `Admin` nav link if they only have access to stats and licensing page and not other pages that reside under `Admin` section. This PR fixes it together with https://github.com/grafana/grafana-enterprise/pull/2296