### PR TITLE
CODEOWNERS: remove references on "@grafana/plugins-platform"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 # Documentation owner: Jita Chatterjee
 /docs/ @grafana/docs-squad @pkolyvas
 /contribute/ @marcusolsson @grafana/docs-squad @pkolyvas
-/docs/sources/developers/plugins/ @marcusolsson @grafana/docs-squad @grafana/plugins-platform
+/docs/sources/developers/plugins/ @marcusolsson @grafana/docs-squad @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
 /docs/sources/developers/plugins/backend @marcusolsson @grafana/docs-squad @grafana/plugins-platform-backend
 /docs/sources/enterprise/ @osg-grafana @grafana/docs-squad
 


### PR DESCRIPTION
**Related Slack discussion:** https://raintank-corp.slack.com/archives/C024NL6AEJH/p1637313769007500

**Why?**
Recently we have created `@grafana/plugins-platform-backend` and `@grafana/plugins-platform-frontend` to be able to give more precise reviewer suggestions. We have a feeling that if we keep the general `@grafana/plugins-platform` team then people might assign that immediately instead of the more specific ones, so we decided to remove it for now.