### PR TITLE
JWT: Split race-y test into two stable tests

### DIFF
--- a/pkg/services/auth/jwt/auth_test.go
+++ b/pkg/services/auth/jwt/auth_test.go
@@ -165,26 +165,6 @@ func TestCachingJWKHTTPResponse(t *testing.T) {
 		cfg.JWTAuthCacheTTL = time.Minute
 	})
 
-	jwkCachingScenario(t, "respects TTL setting (expire cache item)", func(t *testing.T, sc cachingScenarioContext) {
-		var err error
-
-		token := sign(t, &jwKeys[0], jwt.Claims{Subject: subject})
-
-		_, err = sc.authJWTSvc.Verify(sc.ctx, token)
-		require.NoError(t, err)
-
-		// Sleep for longer than the cache TTL to ensure value is expelled from the cache.
-		time.Sleep(time.Millisecond)
-
-		_, err = sc.authJWTSvc.Verify(sc.ctx, token)
-		require.NoError(t, err)
-
-		assert.Equal(t, 2, *sc.reqCount)
-	}, func(t *testing.T, cfg *setting.Cfg) {
-		// Very low value, to have things enter the cache an then leave almost immediately.
-		cfg.JWTAuthCacheTTL = time.Microsecond
-	})
-
 	jwkCachingScenario(t, "does not cache the response when TTL is zero", func(t *testing.T, sc cachingScenarioContext) {
 		for i := 0; i < 2; i++ {
 			_, err := sc.authJWTSvc.Verify(sc.ctx, sign(t, &jwKeys[i], jwt.Claims{Subject: subject}))


### PR DESCRIPTION
**What this PR does / why we need it**:

The TTL test would fail if it stalled for more than a second between the first and second read (or third and fourth read), but it was dependent on being able to wait for longer than the cache duration.

**Which issue(s) this PR fixes**:

I removed the test that tests cache eviction (the cache seems to not support sufficiently small subsecond cache durations). The test now only tests that the key _is_ cached, and does so with a very high minute long cache TTL. No test runner should ever have a problem running this test within even a fraction of that 🤞

**Special notes for your reviewer**:

