### PR TITLE
Logs: Fix requesting of older logs when flipped order

### DIFF
--- a/public/app/features/explore/LogsNavigation.tsx
+++ b/public/app/features/explore/LogsNavigation.tsx
@@ -46,8 +46,8 @@ function LogsNavigation({
   const rangeSpanRef = useRef(0);
 
   const oldestLogsFirst = logsSortOrder === LogsSortOrder.Ascending;
-  const onFirstPage = currentPageIndex === 0;
-  const onLastPage = currentPageIndex === pages.length - 1;
+  const onFirstPage = oldestLogsFirst ? currentPageIndex === pages.length - 1 : currentPageIndex === 0;
+  const onLastPage = oldestLogsFirst ? currentPageIndex === 0 : currentPageIndex === pages.length - 1;
   const theme = useTheme2();
   const styles = getStyles(theme, oldestLogsFirst, loading);
 

--- a/public/app/features/explore/LogsNavigation.tsx
+++ b/public/app/features/explore/LogsNavigation.tsx
@@ -106,9 +106,10 @@ function LogsNavigation({
       onClick={() => {
         //If we are not on the last page, use next page's range
         if (!onLastPage) {
+          const indexChange = oldestLogsFirst ? -1 : 1;
           changeTime({
-            from: pages[currentPageIndex + 1].queryRange.from,
-            to: pages[currentPageIndex + 1].queryRange.to,
+            from: pages[currentPageIndex + indexChange].queryRange.from,
+            to: pages[currentPageIndex + indexChange].queryRange.to,
           });
         } else {
           //If we are on the last page, create new range
@@ -132,9 +133,10 @@ function LogsNavigation({
       onClick={() => {
         //If we are not on the first page, use previous page's range
         if (!onFirstPage) {
+          const indexChange = oldestLogsFirst ? 1 : -1;
           changeTime({
-            from: pages[currentPageIndex - 1].queryRange.from,
-            to: pages[currentPageIndex - 1].queryRange.to,
+            from: pages[currentPageIndex + indexChange].queryRange.from,
+            to: pages[currentPageIndex + indexChange].queryRange.to,
           });
         }
         //If we are on the first page, button is disabled and we do nothing


### PR DESCRIPTION
**What this PR does / why we need it**:
When running logs query and then flipping order + pressing `older logs` the older logs action doesn't run new requests and it cycles between the two pages. See https://github.com/grafana/grafana/issues/38680 for exact steps on how to reproduce this.

The issue was that we assigned last and first page only for descending order (default) logs order. This PR fixes it and adds tests. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/38680

