### PR TITLE
Tracing: Make query editors available in dashboard for Tempo and Zipkin

### DIFF
--- a/public/app/plugins/datasource/jaeger/plugin.json
+++ b/public/app/plugins/datasource/jaeger/plugin.json
@@ -4,7 +4,7 @@
   "id": "jaeger",
   "category": "tracing",
 
-  "metrics": false,
+  "metrics": true,
   "alerting": false,
   "annotations": false,
   "logs": false,

--- a/public/app/plugins/datasource/tempo/module.ts
+++ b/public/app/plugins/datasource/tempo/module.ts
@@ -5,6 +5,7 @@ import { TempoDatasource } from './datasource';
 import { TempoQueryField } from './QueryEditor/QueryField';
 
 export const plugin = new DataSourcePlugin(TempoDatasource)
+  .setQueryEditor(TempoQueryField)
   .setConfigEditor(ConfigEditor)
   .setQueryEditorHelp(CheatSheet)
   .setExploreQueryField(TempoQueryField);

--- a/public/app/plugins/datasource/tempo/module.ts
+++ b/public/app/plugins/datasource/tempo/module.ts
@@ -7,5 +7,4 @@ import { TempoQueryField } from './QueryEditor/QueryField';
 export const plugin = new DataSourcePlugin(TempoDatasource)
   .setQueryEditor(TempoQueryField)
   .setConfigEditor(ConfigEditor)
-  .setQueryEditorHelp(CheatSheet)
-  .setExploreQueryField(TempoQueryField);
+  .setQueryEditorHelp(CheatSheet);

--- a/public/app/plugins/datasource/tempo/plugin.json
+++ b/public/app/plugins/datasource/tempo/plugin.json
@@ -4,7 +4,7 @@
   "id": "tempo",
   "category": "tracing",
 
-  "metrics": false,
+  "metrics": true,
   "alerting": false,
   "annotations": false,
   "logs": false,

--- a/public/app/plugins/datasource/zipkin/module.ts
+++ b/public/app/plugins/datasource/zipkin/module.ts
@@ -4,5 +4,5 @@ import { ZipkinQueryField } from './QueryField';
 import { ConfigEditor } from './ConfigEditor';
 
 export const plugin = new DataSourcePlugin(ZipkinDatasource)
-  .setConfigEditor(ConfigEditor)
-  .setExploreQueryField(ZipkinQueryField);
+  .setQueryEditor(ZipkinQueryField)
+  .setConfigEditor(ConfigEditor);

--- a/public/app/plugins/datasource/zipkin/plugin.json
+++ b/public/app/plugins/datasource/zipkin/plugin.json
@@ -4,7 +4,7 @@
   "id": "zipkin",
   "category": "tracing",
 
-  "metrics": false,
+  "metrics": true,
   "alerting": false,
   "annotations": false,
   "logs": false,


### PR DESCRIPTION
**What this PR does / why we need it**:

Make query editors available in dashboard for Tempo and Zipkin as they could be currently used only Explore.  We are setting `metrics:true` so the data sources are displayed in the dashboard data source list (recommended here https://github.com/grafana/grafana/issues/41976#issuecomment-974120683)
