### PR TITLE
Chore: fix typo in annotations.ts

### DIFF
--- a/packages/grafana-data/src/types/annotations.ts
+++ b/packages/grafana-data/src/types/annotations.ts
@@ -25,7 +25,7 @@ export interface AnnotationQuery<TQuery extends DataQuery = DataQuery> {
   // Convert a dataframe to an AnnotationEvent
   mappings?: AnnotationEventMappings;
 
-  // Sadly plugins can set any propery directly on the main object
+  // Sadly plugins can set any property directly on the main object
   [key: string]: any;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixed typo.

**Which issue(s) this PR fixes**:


```
propery -> property
```