### PR TITLE
Catalog: Provide default tab fallback in Plugin Details page

### DIFF
--- a/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
@@ -13,12 +13,13 @@ import { PluginDashboards } from '../../PluginDashboards';
 type Props = {
   plugin: CatalogPlugin;
   queryParams: UrlQueryMap;
+  defaultPageId: string;
 };
 
-export function PluginDetailsBody({ plugin, queryParams }: Props): JSX.Element {
+export function PluginDetailsBody({ plugin, queryParams, defaultPageId }: Props): JSX.Element {
   const styles = useStyles2(getStyles);
   const { value: pluginConfig } = usePluginConfig(plugin);
-  const pageId = queryParams.page;
+  const pageId = queryParams.page || defaultPageId;
 
   if (pageId === PluginTabIds.OVERVIEW) {
     return (

--- a/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
@@ -13,13 +13,12 @@ import { PluginDashboards } from '../../PluginDashboards';
 type Props = {
   plugin: CatalogPlugin;
   queryParams: UrlQueryMap;
-  defaultPageId: string;
+  pageId: string;
 };
 
-export function PluginDetailsBody({ plugin, queryParams, defaultPageId }: Props): JSX.Element {
+export function PluginDetailsBody({ plugin, queryParams, pageId }: Props): JSX.Element {
   const styles = useStyles2(getStyles);
   const { value: pluginConfig } = usePluginConfig(plugin);
-  const pageId = queryParams.page || defaultPageId;
 
   if (pageId === PluginTabIds.OVERVIEW) {
     return (

--- a/public/app/features/plugins/admin/components/PluginListItem.test.tsx
+++ b/public/app/features/plugins/admin/components/PluginListItem.test.tsx
@@ -59,7 +59,7 @@ describe('PluginListItem', () => {
   it('renders a card with link, image, name, orgName and badges', () => {
     render(<PluginListItem plugin={plugin} pathName="/plugins" />);
 
-    expect(screen.getByRole('link')).toHaveAttribute('href', '/plugins/test-plugin?page=overview');
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/plugins/test-plugin');
 
     const logo = screen.getByRole('img');
     expect(logo).toHaveAttribute('src', plugin.info.logos.small);
@@ -102,7 +102,7 @@ describe('PluginListItem', () => {
   it('renders a row with link, image, name, orgName and badges', () => {
     render(<PluginListItem plugin={plugin} pathName="/plugins" displayMode={PluginListDisplayMode.List} />);
 
-    expect(screen.getByRole('link')).toHaveAttribute('href', '/plugins/test-plugin?page=overview');
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/plugins/test-plugin');
 
     const logo = screen.getByRole('img');
     expect(logo).toHaveAttribute('src', plugin.info.logos.small);

--- a/public/app/features/plugins/admin/components/PluginListItem.tsx
+++ b/public/app/features/plugins/admin/components/PluginListItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { CatalogPlugin, PluginIconName, PluginListDisplayMode, PluginTabIds } from '../types';
+import { CatalogPlugin, PluginIconName, PluginListDisplayMode } from '../types';
 import { PluginListItemBadges } from './PluginListItemBadges';
 import { PluginLogo } from './PluginLogo';
 import { Icon, useStyles2 } from '@grafana/ui';
@@ -19,10 +19,7 @@ export function PluginListItem({ plugin, pathName, displayMode = PluginListDispl
   const isList = displayMode === PluginListDisplayMode.List;
 
   return (
-    <a
-      href={`${pathName}/${plugin.id}?page=${PluginTabIds.OVERVIEW}`}
-      className={cx(styles.container, { [styles.list]: isList })}
-    >
+    <a href={`${pathName}/${plugin.id}`} className={cx(styles.container, { [styles.list]: isList })}>
       <PluginLogo src={plugin.info.logos.small} className={styles.pluginLogo} height={LOGO_SIZE} alt="" />
       <h2 className={cx(styles.name, 'plugin-name')}>{plugin.name}</h2>
       <div className={cx(styles.content, 'plugin-content')}>

--- a/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.test.tsx
@@ -40,7 +40,7 @@ jest.mock('../hooks/usePluginConfig.tsx', () => ({
 const renderPluginDetails = (
   pluginOverride: Partial<CatalogPlugin>,
   {
-    pageId = PluginTabIds.OVERVIEW,
+    pageId,
     pluginsStateOverride,
   }: {
     pageId?: PluginTabIds;
@@ -55,7 +55,7 @@ const renderPluginDetails = (
     location: {
       hash: '',
       pathname: `/plugins/${id}`,
-      search: `?page=${pageId}`,
+      search: pageId ? `?page=${pageId}` : '',
       state: undefined,
     },
   });
@@ -118,11 +118,11 @@ describe('Plugin details page', () => {
 
       const props = getRouteComponentProps({
         match: { params: { pluginId: id }, isExact: true, url: '', path: '' },
-        queryParams: { page: PluginTabIds.OVERVIEW },
+        queryParams: {},
         location: {
           hash: '',
           pathname: `/plugins/${id}`,
-          search: `?page=${PluginTabIds.OVERVIEW}`,
+          search: '',
           state: undefined,
         },
       });
@@ -143,6 +143,40 @@ describe('Plugin details page', () => {
       const { queryByText } = renderPluginDetails({ id });
 
       await waitFor(() => expect(queryByText(/licensed under the apache 2.0 license/i)).toBeInTheDocument());
+    });
+
+    it('should display an app config page by default for installed app plugins', async () => {
+      const name = 'Akumuli';
+
+      // @ts-ignore
+      usePluginConfig.mockReturnValue({
+        value: {
+          meta: {
+            type: PluginType.app,
+            enabled: false,
+            pinned: false,
+            jsonData: {},
+          },
+          configPages: [
+            {
+              title: 'Config',
+              icon: 'cog',
+              id: 'configPage',
+              body: function ConfigPage() {
+                return <div>Custom Config Page!</div>;
+              },
+            },
+          ],
+        },
+      });
+
+      const { queryByText } = renderPluginDetails({
+        name,
+        isInstalled: true,
+        type: PluginType.app,
+      });
+
+      await waitFor(() => expect(queryByText(/custom config page/i)).toBeInTheDocument());
     });
 
     it('should display the number of downloads in the header', async () => {

--- a/public/app/features/plugins/admin/pages/PluginDetails.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.tsx
@@ -25,7 +25,6 @@ export default function PluginDetails({ match, queryParams }: Props): JSX.Elemen
     params: { pluginId = '' },
     url,
   } = match;
-  const pageId = (queryParams.page as PluginTabIds) || PluginTabIds.OVERVIEW;
   const parentUrl = url.substring(0, url.lastIndexOf('/'));
   const defaultTabs: PluginDetailsTab[] = [
     {
@@ -36,11 +35,12 @@ export default function PluginDetails({ match, queryParams }: Props): JSX.Elemen
     },
   ];
   const plugin = useGetSingle(pluginId); // fetches the localplugin settings
-  const { tabs } = usePluginDetailsTabs(plugin, defaultTabs);
+  const { tabs, defaultTab } = usePluginDetailsTabs(plugin, defaultTabs);
   const { isLoading: isFetchLoading } = useFetchStatus();
   const { isLoading: isFetchDetailsLoading } = useFetchDetailsStatus();
   const styles = useStyles2(getStyles);
   const prevTabs = usePrevious(tabs);
+  const pageId = (queryParams.page as PluginTabIds) || defaultTab.current;
 
   // If an app plugin is uninstalled we need to reset the active tab when the config / dashboards tabs are removed.
   useEffect(() => {
@@ -95,7 +95,7 @@ export default function PluginDetails({ match, queryParams }: Props): JSX.Elemen
         <TabContent className={styles.tabContent}>
           <PluginDetailsSignature plugin={plugin} className={styles.alert} />
           <PluginDetailsDisabledError plugin={plugin} className={styles.alert} />
-          <PluginDetailsBody queryParams={queryParams} plugin={plugin} />
+          <PluginDetailsBody queryParams={queryParams} plugin={plugin} defaultPageId={defaultTab.current} />
         </TabContent>
       </PluginPage>
     </Page>

--- a/public/app/features/plugins/admin/pages/PluginDetails.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.tsx
@@ -40,7 +40,7 @@ export default function PluginDetails({ match, queryParams }: Props): JSX.Elemen
   const { isLoading: isFetchDetailsLoading } = useFetchDetailsStatus();
   const styles = useStyles2(getStyles);
   const prevTabs = usePrevious(tabs);
-  const pageId = (queryParams.page as PluginTabIds) || defaultTab.current;
+  const pageId = (queryParams.page as PluginTabIds) || defaultTab;
 
   // If an app plugin is uninstalled we need to reset the active tab when the config / dashboards tabs are removed.
   useEffect(() => {
@@ -95,7 +95,7 @@ export default function PluginDetails({ match, queryParams }: Props): JSX.Elemen
         <TabContent className={styles.tabContent}>
           <PluginDetailsSignature plugin={plugin} className={styles.alert} />
           <PluginDetailsDisabledError plugin={plugin} className={styles.alert} />
-          <PluginDetailsBody queryParams={queryParams} plugin={plugin} defaultPageId={defaultTab.current} />
+          <PluginDetailsBody queryParams={queryParams} plugin={plugin} pageId={pageId} />
         </TabContent>
       </PluginPage>
     </Page>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When navigating to the legacy plugin details page the default "tab" was chosen based on the plugin type and its config pages, rather than just relying on the query param in the url. This PR introduces this functionality to the Catalog so:

- [x] Navigating directly to a plugin details (`/plugins/grafana-timestream-datasource`) without query param will now fallback to showing the default tab rather than a "no page found"
- [x] Installed app plugins default to showing the Config tab

| Before | After |
| --- | --- |
| <img width="1678" alt="Screenshot 2021-11-19 at 14 41 50" src="https://user-images.githubusercontent.com/73201/142632276-d6aebd40-ea17-4c4c-8ef4-5c9d2bab6185.png"> | <img width="1680" alt="Screenshot 2021-11-19 at 14 41 13" src="https://user-images.githubusercontent.com/73201/142632294-c6a5aced-ae93-489a-a4d7-69bc492b5336.png"> |


https://user-images.githubusercontent.com/73201/142637716-4a7d29ea-3118-45d0-b398-a0d152959923.mp4


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #41975

**Special notes for your reviewer**:

