### PR TITLE
docs: improved deprecation-info for elasticsearch and influxdb

### DIFF
--- a/docs/sources/datasources/elasticsearch.md
+++ b/docs/sources/datasources/elasticsearch.md
@@ -20,12 +20,12 @@ visualize logs or metrics stored in Elasticsearch. You can also annotate your gr
 
 > **Note:** If you're not seeing the `Data Sources` link in your side menu it means that your current user does not have the `Admin` role for the current organization.
 
-| Name      | Description                                                                                                                                        |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Name`    | The data source name. This is how you refer to the data source in panels and queries.                                                              |
-| `Default` | Default data source means that it will be pre-selected for new panels.                                                                             |
-| `Url`     | The HTTP protocol, IP, and port of your Elasticsearch server.                                                                                      |
-| `Access`  | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser (deprecated) = URL needs to be accessible from the browser. |
+| Name      | Description                                                                                                                                                                                                                    |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Name`    | The data source name. This is how you refer to the data source in panels and queries.                                                                                                                                          |
+| `Default` | Default data source means that it will be pre-selected for new panels.                                                                                                                                                         |
+| `Url`     | The HTTP protocol, IP, and port of your Elasticsearch server.                                                                                                                                                                  |
+| `Access`  | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser = URL needs to be accessible from the browser. **Note**: Browser (direct) access is deprecated and will be removed in a future release. |
 
 Access mode controls how requests to the data source will be handled. Server should be the preferred way if nothing else stated.
 

--- a/docs/sources/datasources/influxdb/_index.md
+++ b/docs/sources/datasources/influxdb/_index.md
@@ -27,21 +27,19 @@ InfluxDB data source options differ depending on which [query language](#query-l
 
 These options apply if you are using the InfluxQL query language. If you are using Flux, refer to [Flux support in Grafana]({{< relref "influxdb-flux.md" >}}).
 
-| Name      | Description                                                                                                                                        |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Name`    | The data source name. This is how you refer to the data source in panels and queries. We recommend something like `InfluxDB-InfluxQL`.             |
-| `Default` | Default data source means that it will be pre-selected for new panels.                                                                             |
-| `URL`     | The HTTP protocol, IP address and port of your InfluxDB API. InfluxDB API port is by default 8086.                                                 |
-| `Access`  | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser (deprecated) = URL needs to be accessible from the browser. |
-
-**Note**: Browser access is deprecated and will be removed in a future release.
-`Allowed cookies`| Cookies that will be forwarded to the data source. All other cookies will be deleted.
-`Database` | The ID of the bucket you want to query from, copied from the [Buckets page](https://docs.influxdata.com/influxdb/v2.0/organizations/buckets/view-buckets/) of the InfluxDB UI.
-`User` | The username you use to sign into InfluxDB.
-`Password` | The token you use to query the bucket above, copied from the [Tokens page](https://docs.influxdata.com/influxdb/v2.0/security/tokens/view-tokens/) of the InfluxDB UI.
-`HTTP mode` | How to query the database (`GET` or `POST` HTTP verb). The `POST` verb allows heavy queries that would return an error using the `GET` verb. Default is `GET`.
-`Min time interval` | (Optional) Refer to [Min time interval]({{< relref "#min-time-interval" >}}).
-`Max series`| (Optional) Limits the number of series/tables that Grafana processes. Lower this number to prevent abuse, and increase it if you have lots of small time series and not all are shown. Defaults to 1000.
+| Name                | Description                                                                                                                                                                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Name`              | The data source name. This is how you refer to the data source in panels and queries. We recommend something like `InfluxDB-InfluxQL`.                                                                                         |
+| `Default`           | Default data source means that it will be pre-selected for new panels.                                                                                                                                                         |
+| `URL`               | The HTTP protocol, IP address and port of your InfluxDB API. InfluxDB API port is by default 8086.                                                                                                                             |
+| `Access`            | Server (default) = URL needs to be accessible from the Grafana backend/server, Browser = URL needs to be accessible from the browser. **Note**: Browser (direct) access is deprecated and will be removed in a future release. |
+| `Allowed cookies`   | Cookies that will be forwarded to the data source. All other cookies will be deleted.                                                                                                                                          |
+| `Database`          | The ID of the bucket you want to query from, copied from the [Buckets page](https://docs.influxdata.com/influxdb/v2.0/organizations/buckets/view-buckets/) of the InfluxDB UI.                                                 |
+| `User`              | The username you use to sign into InfluxDB.                                                                                                                                                                                    |
+| `Password`          | The token you use to query the bucket above, copied from the [Tokens page](https://docs.influxdata.com/influxdb/v2.0/security/tokens/view-tokens/) of the InfluxDB UI.                                                         |
+| `HTTP mode`         | How to query the database (`GET` or `POST` HTTP verb). The `POST` verb allows heavy queries that would return an error using the `GET` verb. Default is `GET`.                                                                 |
+| `Min time interval` | (Optional) Refer to [Min time interval]({{< relref "#min-time-interval" >}}).                                                                                                                                                  |
+| `Max series`        | (Optional) Limits the number of series/tables that Grafana processes. Lower this number to prevent abuse, and increase it if you have lots of small time series and not all are shown. Defaults to 1000.                       |
 
 ### Flux
 


### PR DESCRIPTION
improved deprecation-notice text based on suggestion from @achatterjee-grafana . now prometheus & elasticsearch & influxdb all have the same description for the `Access` field.

NOTE: if you read the diff, for influxdb it looks a little chaotic. it is because it seems the current markdown-version has the table with the options broken. with this change that table will be ok again.