### PR TITLE
Analytics: RudderStack custom URLs to fetch SDK and Config

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -208,6 +208,12 @@ rudderstack_write_key =
 # Rudderstack data plane url, enabled only if rudderstack_write_key is also set
 rudderstack_data_plane_url =
 
+# Rudderstack SDK url, optional, only valid if rudderstack_write_key and rudderstack_data_plane_url is also set
+rudderstack_sdk_url =
+
+# Rudderstack Config url, optional, used by Rudderstack SDK to fetch source config
+rudderstack_config_url =
+
 # Application Insights connection string. Specify an URL string to enable this feature.
 application_insights_connection_string =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -208,6 +208,18 @@
 # Google Tag Manager ID, only enabled if you specify an id here
 ;google_tag_manager_id =
 
+# Rudderstack write key, enabled only if rudderstack_data_plane_url is also set
+;rudderstack_write_key =
+
+# Rudderstack data plane url, enabled only if rudderstack_write_key is also set
+;rudderstack_data_plane_url =
+
+# Rudderstack SDK url, optional, only valid if rudderstack_write_key and rudderstack_data_plane_url is also set
+;rudderstack_sdk_url =
+
+# Rudderstack Config url, optional, used by Rudderstack SDK to fetch source config
+;rudderstack_config_url =
+
 #################################### Security ####################################
 [security]
 # disable creation of admin user on first start of grafana

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -464,6 +464,27 @@ Analytics ID here. By default this feature is disabled.
 
 Google Tag Manager ID, only enabled if you enter an ID here.
 
+### rudderstack_write_key
+
+If you want to track Grafana usage via Rudderstack specify _your_ Rudderstack
+Write Key here. The `rudderstack_data_plane_url` must also be provided for this
+feature to be enabled. By default this feature is disabled.
+
+### rudderstack_data_plane_url
+
+Rudderstack data plane url that will receive Rudderstack events. The
+`rudderstack_write_key` must also be provided for this feature to be enabled.
+
+### rudderstack_sdk_url
+
+Optional. If tracking with Rudderstack is enabled, you can provide a custom
+URL to load the Rudderstack SDK.
+
+### rudderstack_config_url
+
+Optional. If tracking with Rudderstack is enabled, you can provide a custom
+URL to load the Rudderstack config.
+
 ### application_insights_connection_string
 
 If you want to track Grafana usage via Azure Application Insights, then specify _your_ Application Insights connection string. Since the connection string contains semicolons, you need to wrap it in backticks (`). By default, tracking usage is disabled.

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -233,6 +233,8 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"googleAnalyticsId":                   setting.GoogleAnalyticsId,
 		"rudderstackWriteKey":                 setting.RudderstackWriteKey,
 		"rudderstackDataPlaneUrl":             setting.RudderstackDataPlaneUrl,
+		"rudderstackSdkUrl":                   setting.RudderstackSdkUrl,
+		"rudderstackConfigUrl":                setting.RudderstackConfigUrl,
 		"applicationInsightsConnectionString": hs.Cfg.ApplicationInsightsConnectionString,
 		"applicationInsightsEndpointUrl":      hs.Cfg.ApplicationInsightsEndpointUrl,
 		"disableLoginForm":                    setting.DisableLoginForm,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -143,6 +143,8 @@ var (
 	GoogleTagManagerId      string
 	RudderstackDataPlaneUrl string
 	RudderstackWriteKey     string
+	RudderstackSdkUrl       string
+	RudderstackConfigUrl    string
 
 	// LDAP
 	LDAPEnabled           bool
@@ -945,6 +947,8 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 	GoogleTagManagerId = analytics.Key("google_tag_manager_id").String()
 	RudderstackWriteKey = analytics.Key("rudderstack_write_key").String()
 	RudderstackDataPlaneUrl = analytics.Key("rudderstack_data_plane_url").String()
+	RudderstackSdkUrl = analytics.Key("rudderstack_sdk_url").String()
+	RudderstackConfigUrl = analytics.Key("rudderstack_config_url").String()
 	cfg.ReportingEnabled = analytics.Key("reporting_enabled").MustBool(true)
 	cfg.ReportingDistributor = analytics.Key("reporting_distributor").MustString("grafana-labs")
 	if len(cfg.ReportingDistributor) >= 100 {

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -208,6 +208,8 @@ function initEchoSrv() {
         writeKey: (config as any).rudderstackWriteKey,
         dataPlaneUrl: (config as any).rudderstackDataPlaneUrl,
         user: config.bootData.user,
+        sdkUrl: (config as any).rudderstackSdkUrl,
+        configUrl: (config as any).rudderstackConfigUrl,
       })
     );
   }

--- a/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
@@ -6,13 +6,15 @@ export interface RudderstackBackendOptions {
   writeKey: string;
   dataPlaneUrl: string;
   user?: User;
+  sdkUrl?: string;
+  configUrl?: string;
 }
 
 export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, RudderstackBackendOptions> {
   supportedEvents = [EchoEventType.Pageview, EchoEventType.Interaction];
 
   constructor(public options: RudderstackBackendOptions) {
-    const url = `https://cdn.rudderlabs.com/v1/rudder-analytics.min.js`;
+    const url = options.sdkUrl || `https://cdn.rudderlabs.com/v1/rudder-analytics.min.js`;
 
     $.ajax({
       url,
@@ -45,7 +47,7 @@ export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, Rudder
       })(method);
     }
 
-    (rds as any).load(options.writeKey, options.dataPlaneUrl);
+    (rds as any).load(options.writeKey, options.dataPlaneUrl, { configUrl: options.configUrl });
 
     if (options.user) {
       (rds as any).identify(options.user.email, {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds two optional config options under `analytics`:
1. `rudderstack_sdk_url`: Overrides the default `https://cdn.rudderlabs.com/v1/rudder-analytics.min.js` URL to load the RudderStack SDK
2. `rudderstack_config_url`: Overrides the default URL used by the SDK to fetch the source configuration



