### PR TITLE
Docs: fixed typo in image name.

### DIFF
--- a/docs/sources/datasources/tempo.md
+++ b/docs/sources/datasources/tempo.md
@@ -36,7 +36,7 @@ This is a configuration for the [trace to logs feature]({{< relref "../explore/t
 - **Filter by Trace ID -** Toggle to append the trace ID to the Loki query.
 - **Filter by Span ID -** Toggle to append the span ID to the Loki query.
 
-![Trace to logs settings](/static/img/docs/explore/trace-to-logs-settings-8-2.png 'Screenshot of the trace to logs settings')
+{{< figure src="/static/img/docs/tempo/traces-to-logs-settings-8-2.png" class="docs-image--no-shadow" caption="Screenshot of the trace to logs settings" >}}
 
 ### Node Graph
 
@@ -49,17 +49,15 @@ This is a configuration for the beta Node Graph visualization. The Node Graph is
 You can query and display traces from Tempo via [Explore]({{< relref "../explore/_index.md" >}}).
 You can search for traces if you set up the trace to logs setting in the data source configuration page. To find traces to visualize, use the [Loki query editor]({{< relref "loki.md#loki-query-editor" >}}). To get search results, you must have [derived fields]({{< relref "loki.md#derived-fields" >}}) configured, which point to this data source.
 
-{{< figure src="/static/img/docs/tempo/query-editor-search.png" class="docs-image--no-shadow" caption="Screenshot of the Tempo query editor showing the search tab" >}}
+{{< figure src="/static/img/docs/tempo/query-editor-search.png" class="docs-image--no-shadow" max-width="750px" caption="Screenshot of the Tempo query editor showing the search tab" >}}
 
 To query a particular trace, select the **TraceID** query type, and then put the ID into the Trace ID field.
 
-{{< figure src="/static/img/docs/tempo/query-editor-traceid.png" class="docs-image--no-shadow" caption="Screenshot of the Tempo TraceID query type" >}}
+{{< figure src="/static/img/docs/tempo/query-editor-traceid.png" class="docs-image--no-shadow" max-width="750px" caption="Screenshot of the Tempo TraceID query type" >}}
 
 ## Upload JSON trace file
 
 You can upload a JSON file that contains a single trace to visualize it. If the file has multiple traces then the first trace is used for visualization.
-
-{{< figure src="/static/img/docs/explore/tempo-upload-json.png" class="docs-image--no-shadow" caption="Screenshot of the Tempo data source in explore with upload selected" >}}
 
 Here is an example JSON:
 


### PR DESCRIPTION
updated image name (fixed typo)
removed the redundant image 
resized images