### PR TITLE
CI: Make integration tests depend on `initialize` for enterprise-release-* branches

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1289,7 +1289,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
   depends_on:
-  - clone-enterprise
+  - initialize
   environment:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
@@ -1305,7 +1305,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
   depends_on:
-  - clone-enterprise
+  - initialize
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
@@ -1472,7 +1472,7 @@ steps:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - clone-enterprise
+  - initialize
   environment:
     REDIS_URL: redis://redis:6379/0
   image: grafana/build-container:1.4.6
@@ -1481,7 +1481,7 @@ steps:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - clone-enterprise
+  - initialize
   environment:
     MEMCACHED_HOSTS: memcached:11211
   image: grafana/build-container:1.4.6
@@ -2223,7 +2223,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
   depends_on:
-  - clone-enterprise
+  - grabpl
   environment:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
@@ -2239,7 +2239,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
   depends_on:
-  - clone-enterprise
+  - grabpl
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
@@ -2398,7 +2398,7 @@ steps:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - clone-enterprise
+  - grabpl
   environment:
     REDIS_URL: redis://redis:6379/0
   image: grafana/build-container:1.4.6
@@ -2407,7 +2407,7 @@ steps:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - clone-enterprise
+  - grabpl
   environment:
     MEMCACHED_HOSTS: memcached:11211
   image: grafana/build-container:1.4.6
@@ -3126,7 +3126,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database postgres
   depends_on:
-  - clone-enterprise
+  - initialize
   environment:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
@@ -3142,7 +3142,7 @@ steps:
   - go clean -testcache
   - ./bin/grabpl integration-tests --database mysql
   depends_on:
-  - clone-enterprise
+  - initialize
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
@@ -3306,7 +3306,7 @@ steps:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - clone-enterprise
+  - initialize
   environment:
     REDIS_URL: redis://redis:6379/0
   image: grafana/build-container:1.4.6
@@ -3315,7 +3315,7 @@ steps:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - clone-enterprise
+  - initialize
   environment:
     MEMCACHED_HOSTS: memcached:11211
   image: grafana/build-container:1.4.6
@@ -3556,6 +3556,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 680fc6fbb881c5e05c62395a4583652197c108835adb25081522b85de926f739
+hmac: b39d46b8db4a124e8c99b85e07c802abf8f4e1ced98783d9193c1f5af202fbc2
 
 ...

--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -65,8 +65,8 @@ def get_steps(edition, is_downstream=False):
         test_backend_step(edition=edition),
         test_backend_integration_step(edition=edition),
         test_frontend_step(),
-        postgres_integration_tests_step(edition=edition),
-        mysql_integration_tests_step(edition=edition),
+        postgres_integration_tests_step(edition=edition, ver_mode=ver_mode),
+        mysql_integration_tests_step(edition=edition, ver_mode=ver_mode),
         build_backend_step(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream),
         build_frontend_step(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream),
         build_plugins_step(edition=edition, sign=True),
@@ -99,7 +99,7 @@ def get_steps(edition, is_downstream=False):
     ])
 
     if include_enterprise2:
-      steps.extend([redis_integration_tests_step(edition=edition2), memcached_integration_tests_step(edition=edition2)])
+      steps.extend([redis_integration_tests_step(edition=edition2, ver_mode=ver_mode), memcached_integration_tests_step(edition=edition2, ver_mode=ver_mode)])
 
     steps.extend([
         release_canary_npm_packages_step(edition),

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -66,8 +66,8 @@ def pr_pipelines(edition):
         ensure_cuetsified_step(),
     ]
     integration_test_steps = [
-        postgres_integration_tests_step(edition=edition),
-        mysql_integration_tests_step(edition=edition),
+        postgres_integration_tests_step(edition=edition, ver_mode=ver_mode),
+        mysql_integration_tests_step(edition=edition, ver_mode=ver_mode),
     ]
 
     if include_enterprise2:
@@ -98,8 +98,8 @@ def pr_pipelines(edition):
 
     if include_enterprise2:
         integration_test_steps.extend([
-            redis_integration_tests_step(edition=edition2),
-            memcached_integration_tests_step(edition=edition),
+            redis_integration_tests_step(edition=edition2, ver_mode=ver_mode),
+            memcached_integration_tests_step(edition=edition, ver_mode=ver_mode),
         ])
         build_steps.extend([
             package_step(edition=edition2, ver_mode=ver_mode, include_enterprise2=include_enterprise2, variants=['linux-x64']),

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -93,8 +93,8 @@ def get_steps(edition, ver_mode):
         test_backend_step(edition=edition),
         test_backend_integration_step(edition=edition),
         test_frontend_step(),
-        postgres_integration_tests_step(edition=edition),
-        mysql_integration_tests_step(edition=edition),
+        postgres_integration_tests_step(edition=edition, ver_mode=ver_mode),
+        mysql_integration_tests_step(edition=edition, ver_mode=ver_mode),
         build_backend_step(edition=edition, ver_mode=ver_mode),
         build_frontend_step(edition=edition, ver_mode=ver_mode),
         build_plugins_step(edition=edition, sign=True),
@@ -126,7 +126,7 @@ def get_steps(edition, ver_mode):
         build_steps.append(build_storybook)
 
     if include_enterprise2:
-      build_steps.extend([redis_integration_tests_step(edition=edition2), memcached_integration_tests_step(edition=edition2)])
+      build_steps.extend([redis_integration_tests_step(edition=edition2, ver_mode=ver_mode), memcached_integration_tests_step(edition=edition2, ver_mode=ver_mode)])
 
     if should_upload:
         publish_steps.append(upload_cdn_step(edition=edition))
@@ -162,7 +162,7 @@ def get_oss_pipelines(trigger, ver_mode):
     return [
         pipeline(
             name='oss-build-{}'.format(ver_mode), edition=edition, trigger=trigger, services=services,
-            steps=[download_grabpl_step()] + initialize_step(edition, platform='linux', ver_mode=ver_mode) + 
+            steps=[download_grabpl_step()] + initialize_step(edition, platform='linux', ver_mode=ver_mode) +
               build_steps + package_steps + publish_steps,
         ),
         pipeline(

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -730,10 +730,10 @@ def build_docker_images_step(edition, ver_mode, archs=None, ubuntu=False, publis
     }
 
 
-def postgres_integration_tests_step(edition):
+def postgres_integration_tests_step(edition, ver_mode):
     deps = []
-    if edition in ('enterprise', 'enterprise2'):
-        deps.extend(['clone-enterprise'])
+    if edition in ('enterprise', 'enterprise2') and ver_mode in ('release-branch', 'release'):
+        deps.extend(['initialize'])
     else:
         deps.extend(['grabpl'])
     return {
@@ -758,10 +758,10 @@ def postgres_integration_tests_step(edition):
     }
 
 
-def mysql_integration_tests_step(edition):
+def mysql_integration_tests_step(edition, ver_mode):
     deps = []
-    if edition in ('enterprise', 'enterprise2'):
-        deps.extend(['clone-enterprise'])
+    if edition in ('enterprise', 'enterprise2') and ver_mode in ('release-branch', 'release'):
+        deps.extend(['initialize'])
     else:
         deps.extend(['grabpl'])
     return {
@@ -784,10 +784,10 @@ def mysql_integration_tests_step(edition):
     }
 
 
-def redis_integration_tests_step(edition):
+def redis_integration_tests_step(edition, ver_mode):
     deps = []
-    if edition in ('enterprise', 'enterprise2'):
-        deps.extend(['clone-enterprise'])
+    if edition in ('enterprise', 'enterprise2') and ver_mode in ('release-branch', 'release'):
+        deps.extend(['initialize'])
     else:
         deps.extend(['grabpl'])
     return {
@@ -804,10 +804,10 @@ def redis_integration_tests_step(edition):
     }
 
 
-def memcached_integration_tests_step(edition):
+def memcached_integration_tests_step(edition, ver_mode):
     deps = []
-    if edition in ('enterprise', 'enterprise2'):
-        deps.extend(['clone-enterprise'])
+    if edition in ('enterprise', 'enterprise2') and ver_mode in ('release-branch', 'release'):
+        deps.extend(['initialize'])
     else:
         deps.extend(['grabpl'])
     return {


### PR DESCRIPTION
**What this PR does / why we need it**:

Make integration tests depend on `initialize` for enterprise-release-* branches

