### PR TITLE
Removed packages_api relrefs.

### DIFF
--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-grafana-managed-rule.md
@@ -48,7 +48,7 @@ Use the classic condition expression to create a rule that triggers a single ale
 
 To generate a separate alert for each series, create a multi-dimensional rule. Use `Math`, `Reduce`, or `Resample` expressions to create a multi-dimensional rule. For example:
 
-- Add a `Reduce` expression for each query to aggregate values in the selected time range into a single value. (Not needed for [rules using numeric data]({{< relref "../fundamentals/grafana-managed-numeric-rule.md" >}})).
+- Add a `Reduce` expression for each query to aggregate values in the selected time range into a single value. (Not needed for [rules using numeric data]({{< relref "../fundamentals/evaluate-grafana-alerts.md#alerting-on-numeric-data-1" >}})).
 - Add a `Math` expression with the condition for the rule. Not needed in case a query or a reduce expression already returns 0 if rule should not fire, or a positive number if it should fire. Some examples: `$B > 70` if it should fire in case value of B query/expression is more than 70. `$B < $C * 100` in case it should fire if value of B is less than value of C multiplied by 100. If queries being compared have multiple series in their results, series from different queries are matched if they have the same labels or one is a subset of the other.
 
 ![Query section multi dimensional](/static/img/docs/alerting/unified/rule-edit-multi-8-0.png 'Query section multi dimensional screenshot')

--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -76,9 +76,9 @@ Learn more about Grafana options and packages.
 
 #### Typescript
 
-- [Grafana Data]({{< relref "../../packages_api/data/_index.md" >}})
-- [Grafana Runtime]({{< relref "../../packages_api/runtime/_index.md" >}})
-- [Grafana UI]({{< relref "../../packages_api/ui/_index.md" >}})
+- Grafana Data
+- Grafana Runtime
+- Grafana UI
 
 #### Go
 

--- a/docs/sources/developers/plugins/add-support-for-explore-queries.md
+++ b/docs/sources/developers/plugins/add-support-for-explore-queries.md
@@ -46,7 +46,7 @@ The query editor for Explore is similar to the query editor for the data source 
      .setExploreQueryField(ExploreQueryEditor);
    ```
 
-1. Add a [QueryField]({{< relref "../../packages_api/ui/queryfield.md" >}}) to `ExploreQueryEditor`.
+1. Add a `QueryField` to `ExploreQueryEditor`.
 
    ```ts
    import { QueryField } from '@grafana/ui';

--- a/docs/sources/developers/plugins/add-support-for-variables.md
+++ b/docs/sources/developers/plugins/add-support-for-variables.md
@@ -24,7 +24,7 @@ Grafana provides a couple of helper functions to interpolate variables in a stri
 
 ## Interpolate variables in panel plugins
 
-For panels, the [replaceVariables]({{< relref "../../packages_api/data/panelprops.md#replacevariables-property" >}}) function is available in the [PanelProps]({{< relref "../../packages_api/data/panelprops.md" >}}).
+For panels, the `replaceVariables` function is available in the PanelProps.
 
 Add `replaceVariables` to the argument list, and pass it a user-defined template string.
 
@@ -38,7 +38,7 @@ export const SimplePanel: React.FC<Props> = ({ options, data, width, height, rep
 
 ## Interpolate variables in data source plugins
 
-For data sources, you need to use the [getTemplateSrv]({{< relref "../../packages_api/runtime/gettemplatesrv.md" >}}), which returns an instance of [TemplateSrv]({{< relref "../../packages_api/runtime/templatesrv.md" >}}).
+For data sources, you need to use the getTemplateSrv, which returns an instance of TemplateSrv.
 
 1. Import `getTemplateSrv` from the `runtime` package.
 
@@ -80,7 +80,7 @@ For more information on the available variable formats, refer to [Advanced varia
 
 ## Set a variable from your plugin
 
-Not only can you read the value of a variable, you can also update the variable from your plugin. Use [LocationSrv.update()]({{< relref "../../packages_api/runtime/locationsrv.md/#update-method" >}}) to update a variable using query parameters.
+Not only can you read the value of a variable, you can also update the variable from your plugin. Use LocationSrv.update()
 
 The following example shows how to update a variable called `service`.
 
@@ -117,7 +117,7 @@ export interface MyVariableQuery {
 }
 ```
 
-For a data source to support query variables, you must override the [`metricFindQuery`]({{< relref "../../packages_api/data/datasourceapi.md#metricfindquery-method" >}}) in your `DataSourceApi` class. `metricFindQuery` returns an array of [`MetricFindValue`]({{< relref "../../packages_api/data/metricfindvalue.md" >}}) which has a single property, `text`:
+For a data source to support query variables, you must override the `metricFindQuery` in your `DataSourceApi` class. `metricFindQuery` returns an array of `MetricFindValue` which has a single property, `text`:
 
 ```ts
 async metricFindQuery(query: MyVariableQuery, options?: any) {

--- a/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
+++ b/docs/sources/developers/plugins/build-a-logs-data-source-plugin.md
@@ -74,7 +74,7 @@ const frame = new MutableDataFrame({
 
 To help filter log lines, many log systems let you query logs based on metadata, or _labels_.
 
-You can add labels to a stream of logs by setting the [labels](../../packages_api/data/field.md#labels-property) property on the [Field]({{< relref "../../packages_api/data/field.md" >}}).
+You can add labels to a stream of logs by setting the labels property on the Field.
 
 **Example**:
 

--- a/docs/sources/developers/plugins/working-with-data-frames.md
+++ b/docs/sources/developers/plugins/working-with-data-frames.md
@@ -6,7 +6,7 @@ title = "Working with data frames"
 
 The data frame is a columnar data structure which allows efficient querying of large amounts of data. Since data frames are a central concept when developing plugins for Grafana, in this guide we'll look at some ways you can use them.
 
-The [DataFrame]({{< relref "../../packages_api/data/dataframe.md" >}}) interface contains a `name` and an array of `fields` where each field contains the name, type, and the values for the field.
+The DataFrame interface contains a `name` and an array of `fields` where each field contains the name, type, and the values for the field.
 
 > **Note:** If you're looking to migrate an existing plugin to use the data frame format, refer to [Migrate to data frames]({{< relref "migration-guide.md#migrate-to-data-frames" >}}).
 
@@ -14,7 +14,7 @@ The [DataFrame]({{< relref "../../packages_api/data/dataframe.md" >}}) interface
 
 If you build a data source plugin, then you'll most likely want to convert a response from an external API to a data frame. Let's look at how to create a data frame.
 
-Let's start with creating a simple data frame that represents a time series. The easiest way to create a data frame is to use the [toDataFrame]({{< relref "../../packages_api/data/todataframe.md" >}}) function.
+Let's start with creating a simple data frame that represents a time series. The easiest way to create a data frame is to use the toDataFrame function.
 
 ```ts
 // Need to be of the same length.
@@ -78,7 +78,7 @@ for (let i = 0; i < frame.length; i++) {
 }
 ```
 
-Alternatively, you can use the [DataFrameView]({{< relref "../../packages_api/data/dataframeview.md" >}}), which gives you an array of objects that contain a property for each field in the frame.
+Alternatively, you can use the DataFrameView, which gives you an array of objects that contain a property for each field in the frame.
 
 ```ts
 const view = new DataFrameView(frame);
@@ -113,7 +113,7 @@ return (
 );
 ```
 
-To apply field options to the name of a field, use [getFieldDisplayName]({{< relref "../../packages_api/data/getfielddisplayname.md" >}}).
+To apply field options to the name of a field, use getFieldDisplayName.
 
 ```ts
 const valueField = frame.fields.find((field) => field.type === FieldType.number);


### PR DESCRIPTION
Fixes issue https://github.com/grafana/technical-documentation/issues/147. The broken relrefs are constraining the docs squad from creating a clean local doc build. That is why we have opened this PR.

Note: Although we have the plugins folder under `developers` in source, it does not show up in the rendered docs. @wbrowne or @marcusolsson or anyone from the plugins team, can you provide any clarification? TY.