### PR TITLE
PanelEdit: Always show delete icon button for overrides, even when collapsed

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/OverrideCategoryTitle.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OverrideCategoryTitle.tsx
@@ -29,7 +29,7 @@ export const OverrideCategoryTitle: FC<OverrideCategoryTitleProps> = ({
     <div>
       <HorizontalGroup justify="space-between">
         <div>{overrideName}</div>
-        {isExpanded && <IconButton name="trash-alt" onClick={onOverrideRemove} title="Remove override" />}
+        <IconButton name="trash-alt" onClick={onOverrideRemove} title="Remove override" />
       </HorizontalGroup>
       {!isExpanded && (
         <div className={styles.overrideDetails}>


### PR DESCRIPTION
Makes the delete icon always be visible even when the override section is collapsed.


