### PR TITLE
Role picker: extend width to prevent menu being out of page

### DIFF
--- a/public/app/core/components/RolePicker/RolePickerInput.tsx
+++ b/public/app/core/components/RolePicker/RolePickerInput.tsx
@@ -111,7 +111,7 @@ const getRolePickerInputStyles = (
         `,
       disabled && styles.inputDisabled,
       css`
-        min-width: 260px;
+        min-width: 520px;
         min-height: 32px;
         height: auto;
         flex-direction: row;

--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -564,7 +564,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
     `,
     menuOptionBody: css`
       font-weight: ${theme.typography.fontWeightRegular};
-      padding: ${theme.spacing(0, 1, 0, 0)};
+      padding: ${theme.spacing(0, 1.5, 0, 0)};
     `,
     menuOptionDisabled: css`
       color: ${theme.colors.text.disabled};


### PR DESCRIPTION
This PR fixes issue with role picker on the `org/users` page where sub-menu is out of page and inaccessible.