### PR TITLE
AccessControl: Renamed `orgs` roles, removed `fixed:orgs:reader` introduced in beta1

### DIFF
--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -168,11 +168,11 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		Grants: []string{string(models.ROLE_ADMIN)},
 	}
 
-	orgManagerRole := accesscontrol.RoleRegistration{
+	orgMaintainerRole := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
 			Version:     5,
-			Name:        "fixed:organization:manager",
-			DisplayName: "Organization manager",
+			Name:        "fixed:organization:maintainer",
+			DisplayName: "Organization maintainer",
 			Description: "Create, read, write, or delete an organization. Read or write an organization's quotas. Needs to be assigned globally.",
 			Group:       "Organizations",
 			Permissions: accesscontrol.ConcatPermissions(orgReaderRole.Role.Permissions, []accesscontrol.Permission{
@@ -187,7 +187,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	return hs.AccessControl.DeclareFixedRoles(
 		provisioningWriterRole, datasourcesReaderRole, datasourcesWriterRole, datasourcesIdReaderRole,
-		datasourcesCompatibilityReaderRole, orgReaderRole, orgWriterRole, orgManagerRole,
+		datasourcesCompatibilityReaderRole, orgReaderRole, orgWriterRole, orgMaintainerRole,
 	)
 }
 

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -157,7 +157,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			Version:     5,
 			Name:        "fixed:organization:writer",
 			DisplayName: "Organization writer",
-			Description: "Read an organization, its quotas, or its preferences. Update an organization properties, or its preferences.",
+			Description: "Read an organization, its quotas, or its preferences. Update organization properties, or its preferences.",
 			Group:       "Organizations",
 			Permissions: accesscontrol.ConcatPermissions(orgReaderRole.Role.Permissions, []accesscontrol.Permission{
 				{Action: ActionOrgsPreferencesRead},

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -139,7 +139,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	orgReaderRole := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
-			Version:     1,
+			Version:     5,
 			Name:        "fixed:organization:reader",
 			DisplayName: "Organization reader",
 			Description: "Read an organization, such as its ID, name, address, or quotas.",
@@ -154,7 +154,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	orgWriterRole := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
-			Version:     1,
+			Version:     5,
 			Name:        "fixed:organization:writer",
 			DisplayName: "Organization writer",
 			Description: "Read an organization, its quotas, or its preferences. Update an organization properties, or its preferences.",
@@ -170,7 +170,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	orgManagerRole := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
-			Version:     1,
+			Version:     5,
 			Name:        "fixed:organization:manager",
 			DisplayName: "Organization manager",
 			Description: "Create, read, write, or delete an organization. Read or write an organization's quotas. Needs to be assigned globally.",

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -137,29 +137,29 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		Grants: []string{string(models.ROLE_VIEWER)},
 	}
 
-	currentOrgReaderRole := accesscontrol.RoleRegistration{
+	orgReaderRole := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
-			Version:     4,
-			Name:        "fixed:current.org:reader",
-			DisplayName: "Current Organization reader",
-			Description: "Read the current organization, such as its ID, name, address, or quotas.",
+			Version:     1,
+			Name:        "fixed:organization:reader",
+			DisplayName: "Organization reader",
+			Description: "Read an organization, such as its ID, name, address, or quotas.",
 			Group:       "Organizations",
 			Permissions: []accesscontrol.Permission{
 				{Action: ActionOrgsRead},
 				{Action: ActionOrgsQuotasRead},
 			},
 		},
-		Grants: []string{string(models.ROLE_VIEWER)},
+		Grants: []string{string(models.ROLE_VIEWER), accesscontrol.RoleGrafanaAdmin},
 	}
 
-	currentOrgWriterRole := accesscontrol.RoleRegistration{
+	orgWriterRole := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
-			Version:     4,
-			Name:        "fixed:current.org:writer",
-			DisplayName: "Current Organization writer",
-			Description: "Read the current organization, its quotas, or its preferences. Update the current organization properties, or its preferences.",
+			Version:     1,
+			Name:        "fixed:organization:writer",
+			DisplayName: "Organization writer",
+			Description: "Read an organization, its quotas, or its preferences. Update an organization properties, or its preferences.",
 			Group:       "Organizations",
-			Permissions: accesscontrol.ConcatPermissions(currentOrgReaderRole.Role.Permissions, []accesscontrol.Permission{
+			Permissions: accesscontrol.ConcatPermissions(orgReaderRole.Role.Permissions, []accesscontrol.Permission{
 				{Action: ActionOrgsPreferencesRead},
 				{Action: ActionOrgsWrite},
 				{Action: ActionOrgsPreferencesWrite},
@@ -168,27 +168,12 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		Grants: []string{string(models.ROLE_ADMIN)},
 	}
 
-	orgReaderRole := accesscontrol.RoleRegistration{
+	orgManagerRole := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
-			Version:     2,
-			Name:        "fixed:orgs:reader",
-			DisplayName: "Organization reader",
-			Description: "Read the organization and its quotas.",
-			Group:       "Organizations",
-			Permissions: []accesscontrol.Permission{
-				{Action: ActionOrgsRead},
-				{Action: ActionOrgsQuotasRead},
-			},
-		},
-		Grants: []string{string(accesscontrol.RoleGrafanaAdmin)},
-	}
-
-	orgWriterRole := accesscontrol.RoleRegistration{
-		Role: accesscontrol.RoleDTO{
-			Version:     4,
-			Name:        "fixed:orgs:writer",
-			DisplayName: "Organization writer",
-			Description: "Create, read, write, or delete an organization. Read or write an organization's quotas.",
+			Version:     1,
+			Name:        "fixed:organization:manager",
+			DisplayName: "Organization manager",
+			Description: "Create, read, write, or delete an organization. Read or write an organization's quotas. Needs to be assigned globally.",
 			Group:       "Organizations",
 			Permissions: accesscontrol.ConcatPermissions(orgReaderRole.Role.Permissions, []accesscontrol.Permission{
 				{Action: ActionOrgsCreate},
@@ -202,7 +187,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	return hs.AccessControl.DeclareFixedRoles(
 		provisioningWriterRole, datasourcesReaderRole, datasourcesWriterRole, datasourcesIdReaderRole,
-		datasourcesCompatibilityReaderRole, currentOrgReaderRole, currentOrgWriterRole, orgReaderRole, orgWriterRole,
+		datasourcesCompatibilityReaderRole, orgReaderRole, orgWriterRole, orgManagerRole,
 	)
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Currently, we defined four roles for orgs:
| name                         | permissions                                                                          | grant       |
|------------------------------|--------------------------------------------------------------------------------------|-------------|
| `"fixed:current.org:reader"` | `"orgs:read"`, `"orgs.quotas:read"`                                                  | OrgAdmin    |
| `"fixed:current.org:writer"` | :arrow_up: + `"orgs.preferences:read"`,  `"orgs:write"`, `"orgs.preferences:write"`  | OrgAdmin    |
| `"fixed:orgs:reader"`        | `"orgs:read"`, `"orgs.quotas:read"`                                                  | ServerAdmin |
| `"fixed:orgs:writer"`        | :arrow_up: + `"orgs:create"`, `"orgs:write"`, `"orgs:delete"`, `"orgs.quotas:write"` | ServerAdmin |

Here are two things we could improve:
- The `current` keyword and the plural for `orgs` are misleading, only the assignment (local, global) makes the role able to target a single organization or multiple organizations.
- `"fixed:orgs:reader"` is a duplicate of `"fixed:current.org:reader"`

Here is a replacement set of roles that we could have:
| name                           | permissions                                                                                               | grant                 | description                                                                                                            |
|--------------------------------|-----------------------------------------------------------------------------------------------------------|-----------------------|------------------------------------------------------------------------------------------------------------------------|
| `"fixed:organization:reader"`  | `"orgs:read"`, `"orgs.quotas:read"`                                                                       | OrgAdmin, ServerAdmin | Read an organization and its quotas.                                                                                   |
| `"fixed:organization:writer"`  | (`"fixed:organization:reader"`) + `"orgs:write"`, `"orgs.preferences:read"`, `"orgs.preferences:write"`   | OrgAdmin              | Read an organization, its quotas, or its preferences. Update an organization’s properties, or its preferences.           |
| `"fixed:organization:manager"` | (`"fixed:organization:reader"`) + `"orgs:write"`, `"orgs:create"`, `"orgs:delete"`, `"orgs.quotas:write"` | ServerAdmin           | Create, read, write, or delete an organization. Read or write an organization's quotas. Needs to be assigned globally. |

Note: I don't know if `"fixed:organization:manager"` is the best name we could find. cc. @osg-grafana @mjseaman 

@kalleep, @sakjur should I also deprecate the previous roles given they will be shipped with v8.3.0-beta1


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/2308

**Special notes for your reviewer**:

I will update the docs accordingly in another PR.
