### PR TITLE
Elasticsearch: Display custom values in version select

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
@@ -37,13 +37,12 @@ type Props = {
 export const ElasticDetails = ({ value, onChange }: Props) => {
   const currentVersion = esVersions.find((version) => version.value === value.jsonData.esVersion);
   const customOption =
-    (!currentVersion &&
-      valid(value.jsonData.esVersion) && {
-        label: value.jsonData.esVersion,
-        value: value.jsonData.esVersion,
-      }) ||
-    undefined;
-
+    !currentVersion && valid(value.jsonData.esVersion)
+      ? {
+          label: value.jsonData.esVersion,
+          value: value.jsonData.esVersion,
+        }
+      : undefined;
   return (
     <>
       <h3 className="page-heading">Elasticsearch details</h3>

--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
@@ -3,7 +3,8 @@ import { EventsWithValidation, regexValidation, LegacyForms } from '@grafana/ui'
 const { Switch, Select, Input, FormField } = LegacyForms;
 import { ElasticsearchOptions, Interval } from '../types';
 import { DataSourceSettings, SelectableValue } from '@grafana/data';
-import { gte, lt } from 'semver';
+import { gte, lt, valid } from 'semver';
+import { isTruthy } from './utils';
 
 const indexPatternTypes: Array<SelectableValue<'none' | Interval>> = [
   { label: 'No pattern', value: 'none' },
@@ -34,6 +35,15 @@ type Props = {
   onChange: (value: DataSourceSettings<ElasticsearchOptions>) => void;
 };
 export const ElasticDetails = ({ value, onChange }: Props) => {
+  const currentVersion = esVersions.find((version) => version.value === value.jsonData.esVersion);
+  const customOption =
+    (!currentVersion &&
+      valid(value.jsonData.esVersion) && {
+        label: value.jsonData.esVersion,
+        value: value.jsonData.esVersion,
+      }) ||
+    undefined;
+
   return (
     <>
       <h3 className="page-heading">Elasticsearch details</h3>
@@ -89,7 +99,7 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
             inputEl={
               <Select
                 menuShouldPortal
-                options={esVersions}
+                options={[customOption, ...esVersions].filter(isTruthy)}
                 onChange={(option) => {
                   const maxConcurrentShardRequests = getMaxConcurrenShardRequestOrDefault(
                     value.jsonData.maxConcurrentShardRequests,
@@ -104,7 +114,7 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
                     },
                   });
                 }}
-                value={esVersions.find((version) => version.value === value.jsonData.esVersion)}
+                value={currentVersion || customOption}
               />
             }
           />

--- a/public/app/plugins/datasource/elasticsearch/configuration/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/configuration/utils.ts
@@ -37,3 +37,7 @@ export const isValidOptions = (options: DataSourceSettings<ElasticsearchOptions,
     options.jsonData.logLevelField !== undefined
   );
 };
+
+type Truthy<T> = T extends false | '' | 0 | null | undefined ? never : T;
+
+export const isTruthy = <T>(value: T): value is Truthy<T> => Boolean(value);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
`esVersion` setting in Elasticsearch can be any semver version string when setup via provisioning. When users were using a version string not present in the default version array, the Select input in DS settings was showing as empty even when the value was set up correctly.

This PR fixes this behavior by prepending the custom version to the available options array in case none of the default ones matches exactly the version specified AND the provisioned `esVersion` value is a valid semver string.

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/41486



**Special notes for your reviewer**:

