### PR TITLE
Chore: Add `deployment_tools_config.json` to `git` and `eslint` ignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,4 @@ data
 dist
 e2e/tmp
 public/lib/monaco
+deployment_tools_config.json

--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ compilation-stats.json
 
 # auto generated Go files
 *_gen.go
+
+deployment_tools_config.json


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `deployment_tools_config.json` to `.gitignore` and `.eslintignore` ignore

(cherry picked from commit 15a603dae0efcb257813069153aada7335078700)