### PR TITLE
[v8.3.0-beta1] Remove Linux `grabpl` download step from Windows enterprise builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1582,12 +1582,6 @@ platform:
 services: []
 steps:
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.6.1/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - echo $env:DRONE_RUNNER_NAME
   image: mcr.microsoft.com/windows:1809
   name: identify-runner
@@ -2502,12 +2496,6 @@ platform:
 services: []
 steps:
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.6.1/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - echo $env:DRONE_RUNNER_NAME
   image: mcr.microsoft.com/windows:1809
   name: identify-runner
@@ -3404,12 +3392,6 @@ platform:
 services: []
 steps:
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.6.1/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - echo $env:DRONE_RUNNER_NAME
   image: mcr.microsoft.com/windows:1809
   name: identify-runner
@@ -3538,6 +3520,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 45c40d0ca9041f596e025fd4252fb226d41e7826e1e29e2112663036e1d5bfaf
+hmac: c5c3ca4ee288cbf1dc35bb9b0bee010d5ec51caa87a2553f75d488200e65a4f1
 
 ...

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -184,7 +184,7 @@ def get_enterprise_pipelines(trigger, ver_mode):
         ),
         pipeline(
             name='enterprise-windows-{}'.format(ver_mode), edition=edition, trigger=trigger,
-            steps=[download_grabpl_step()] + initialize_step(edition, platform='windows', ver_mode=ver_mode) + windows_package_steps,
+            steps=initialize_step(edition, platform='windows', ver_mode=ver_mode) + windows_package_steps,
             platform='windows', depends_on=['enterprise-build-{}'.format(ver_mode)],
         ),
     ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes Linux `grabpl` download step from Windows enterprise builds