### PR TITLE
CI: Remove Linux `grabpl` step dependency from Windows builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3520,6 +3520,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 8629c9b9916c59c0da88b885639206657912c6f334a1a0d94da9f1fcd45e58c7
+hmac: 506f659ace94bf2db684864909ea29b8963f3655d4f02b5dbd0d3440271be38f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1116,12 +1116,6 @@ platform:
 services: []
 steps:
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.6.1/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - echo $env:DRONE_RUNNER_NAME
   image: mcr.microsoft.com/windows:1809
   name: identify-runner
@@ -2049,12 +2043,6 @@ platform:
 services: []
 steps:
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.6.1/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - echo $env:DRONE_RUNNER_NAME
   image: mcr.microsoft.com/windows:1809
   name: identify-runner
@@ -2958,12 +2946,6 @@ platform:
 services: []
 steps:
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.6.1/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - echo $env:DRONE_RUNNER_NAME
   image: mcr.microsoft.com/windows:1809
   name: identify-runner
@@ -3556,6 +3538,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: b39d46b8db4a124e8c99b85e07c802abf8f4e1ced98783d9193c1f5af202fbc2
+hmac: 08b0032e0e7e03633d94189e2f55045f84ce5e2094352e4c50e8a706e1cfe3e0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1582,12 +1582,6 @@ platform:
 services: []
 steps:
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.6.1/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - echo $env:DRONE_RUNNER_NAME
   image: mcr.microsoft.com/windows:1809
   name: identify-runner
@@ -2502,12 +2496,6 @@ platform:
 services: []
 steps:
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.6.1/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - echo $env:DRONE_RUNNER_NAME
   image: mcr.microsoft.com/windows:1809
   name: identify-runner
@@ -3404,12 +3392,6 @@ platform:
 services: []
 steps:
 - commands:
-  - mkdir -p bin
-  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.6.1/grabpl
-  - chmod +x bin/grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: grabpl
-- commands:
   - echo $env:DRONE_RUNNER_NAME
   image: mcr.microsoft.com/windows:1809
   name: identify-runner
@@ -3538,6 +3520,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 08b0032e0e7e03633d94189e2f55045f84ce5e2094352e4c50e8a706e1cfe3e0
+hmac: 8629c9b9916c59c0da88b885639206657912c6f334a1a0d94da9f1fcd45e58c7
 
 ...

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -167,7 +167,7 @@ def get_oss_pipelines(trigger, ver_mode):
         ),
         pipeline(
             name='oss-windows-{}'.format(ver_mode), edition=edition, trigger=trigger,
-            steps=[download_grabpl_step()] + initialize_step(edition, platform='windows', ver_mode=ver_mode) + windows_package_steps,
+            steps=initialize_step(edition, platform='windows', ver_mode=ver_mode) + windows_package_steps,
             platform='windows', depends_on=['oss-build-{}'.format(ver_mode)],
         ),
     ]

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -184,7 +184,7 @@ def get_enterprise_pipelines(trigger, ver_mode):
         ),
         pipeline(
             name='enterprise-windows-{}'.format(ver_mode), edition=edition, trigger=trigger,
-            steps=[download_grabpl_step()] + initialize_step(edition, platform='windows', ver_mode=ver_mode) + windows_package_steps,
+            steps=initialize_step(edition, platform='windows', ver_mode=ver_mode) + windows_package_steps,
             platform='windows', depends_on=['enterprise-build-{}'.format(ver_mode)],
         ),
     ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes Linux `grabpl` step dependency from Windows builds, since Windows download `grabpl` using `Invoke-Request` commands and not `curl`