### PR TITLE
Access control: use delegatable flag to check if role can be granted

### DIFF
--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -64,6 +64,7 @@ type RoleDTO struct {
 	Description string       `json:"description"`
 	Group       string       `xorm:"group_name" json:"group"`
 	Permissions []Permission `json:"permissions,omitempty"`
+	Delegatable *bool        `json:"delegatable,omitempty"`
 
 	ID    int64 `json:"-" xorm:"pk autoincr 'id'"`
 	OrgID int64 `json:"-" xorm:"org_id"`

--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -194,6 +194,7 @@ export const RolePickerMenu = ({
                       key={i}
                       isSelected={groupSelected(option.value) || groupPartiallySelected(option.value)}
                       partiallySelected={groupPartiallySelected(option.value)}
+                      disabled={option.options?.every(isDelegatable)}
                       onChange={onGroupChange}
                       onOpenSubMenu={onOpenSubMenu}
                       onCloseSubMenu={onCloseSubMenu}
@@ -221,6 +222,7 @@ export const RolePickerMenu = ({
                       data={option}
                       key={i}
                       isSelected={!!(option.uid && !!selectedOptions.find((opt) => opt.uid === option.uid))}
+                      disabled={isDelegatable(option)}
                       onChange={onChange}
                       hideDescription
                     />
@@ -237,6 +239,7 @@ export const RolePickerMenu = ({
                     data={option}
                     key={i}
                     isSelected={!!(option.uid && !!selectedOptions.find((opt) => opt.uid === option.uid))}
+                    disabled={isDelegatable(option)}
                     onChange={onChange}
                     hideDescription
                   />
@@ -329,7 +332,9 @@ export const RolePickerSubMenu = ({
                     disabledOptions?.find((opt) => opt.uid === option.uid))
                 )
               }
-              disabled={!!(option.uid && disabledOptions?.find((opt) => opt.uid === option.uid))}
+              disabled={
+                !!(option.uid && disabledOptions?.find((opt) => opt.uid === option.uid)) || isDelegatable(option)
+              }
               onChange={onSelect}
               hideDescription
             />
@@ -506,6 +511,10 @@ const capitalize = (s: string): string => {
 };
 
 const sortRolesByName = (a: Role, b: Role) => a.name.localeCompare(b.name);
+
+const isDelegatable = (role: Role) => {
+  return role.delegatable !== undefined && !role.delegatable;
+};
 
 export const getStyles = (theme: GrafanaTheme2) => {
   return {

--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -194,7 +194,7 @@ export const RolePickerMenu = ({
                       key={i}
                       isSelected={groupSelected(option.value) || groupPartiallySelected(option.value)}
                       partiallySelected={groupPartiallySelected(option.value)}
-                      disabled={option.options?.every(isDelegatable)}
+                      disabled={option.options?.every(isNotDelegatable)}
                       onChange={onGroupChange}
                       onOpenSubMenu={onOpenSubMenu}
                       onCloseSubMenu={onCloseSubMenu}
@@ -222,7 +222,7 @@ export const RolePickerMenu = ({
                       data={option}
                       key={i}
                       isSelected={!!(option.uid && !!selectedOptions.find((opt) => opt.uid === option.uid))}
-                      disabled={isDelegatable(option)}
+                      disabled={isNotDelegatable(option)}
                       onChange={onChange}
                       hideDescription
                     />
@@ -239,7 +239,7 @@ export const RolePickerMenu = ({
                     data={option}
                     key={i}
                     isSelected={!!(option.uid && !!selectedOptions.find((opt) => opt.uid === option.uid))}
-                    disabled={isDelegatable(option)}
+                    disabled={isNotDelegatable(option)}
                     onChange={onChange}
                     hideDescription
                   />
@@ -333,7 +333,7 @@ export const RolePickerSubMenu = ({
                 )
               }
               disabled={
-                !!(option.uid && disabledOptions?.find((opt) => opt.uid === option.uid)) || isDelegatable(option)
+                !!(option.uid && disabledOptions?.find((opt) => opt.uid === option.uid)) || isNotDelegatable(option)
               }
               onChange={onSelect}
               hideDescription
@@ -512,7 +512,7 @@ const capitalize = (s: string): string => {
 
 const sortRolesByName = (a: Role, b: Role) => a.name.localeCompare(b.name);
 
-const isDelegatable = (role: Role) => {
+const isNotDelegatable = (role: Role) => {
   return role.delegatable !== undefined && !role.delegatable;
 };
 

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -36,9 +36,9 @@ export const UserRolePicker: FC<Props> = ({
 };
 
 export const fetchRoleOptions = async (orgId?: number, query?: string): Promise<Role[]> => {
-  let rolesUrl = '/api/access-control/roles';
+  let rolesUrl = '/api/access-control/roles?delegatable=true';
   if (orgId) {
-    rolesUrl += `?targetOrgId=${orgId}`;
+    rolesUrl += `&targetOrgId=${orgId}`;
   }
   const roles = await getBackendSrv().get(rolesUrl);
   if (!roles || !roles.length) {

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -57,6 +57,7 @@ export interface Role {
   description: string;
   group: string;
   global: boolean;
+  delegatable?: boolean;
   version: number;
   created: string;
   updated: string;


### PR DESCRIPTION
This PR adds `delegatable` field to the role type which can be used to determine if role can be granted or not. On the backend flag is a pointer, so it only returned if `?delegatable=true` param provided. This allows to avoid unnecessary checks on the backend.

In the role picker roles that cannot be granted displayed in the disabled state.

![Screenshot from 2021-11-22 16-10-44](https://user-images.githubusercontent.com/4932851/142867526-2cf186c7-579e-47b0-857d-427d7a1e95ca.png)
