### PR TITLE
PieChart: Prioritize showing the legend over chart

### DIFF
--- a/packages/grafana-ui/src/components/VizLegend/types.ts
+++ b/packages/grafana-ui/src/components/VizLegend/types.ts
@@ -11,6 +11,8 @@ export enum SeriesVisibilityChangeBehavior {
 export interface VizLegendBaseProps<T> {
   placement: LegendPlacement;
   className?: string;
+  maxWidth?: string;
+  maxHeight?: string;
   items: Array<VizLegendItem<T>>;
   seriesVisibilityChangeBehavior?: SeriesVisibilityChangeBehavior;
   onLabelClick?: (item: VizLegendItem<T>, event: React.MouseEvent<HTMLElement>) => void;

--- a/public/app/plugins/panel/piechart/PieChartPanel.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.tsx
@@ -138,6 +138,7 @@ function getLegend(props: Props, displayValues: FieldDisplay[]) {
       items={legendItems}
       seriesVisibilityChangeBehavior={SeriesVisibilityChangeBehavior.Hide}
       placement={legendOptions.placement}
+      maxWidth="99%"
       displayMode={legendOptions.displayMode}
     />
   );


### PR DESCRIPTION

**What this PR does / why we need it**:

In a small viewport the max-width of the legend will make it clip
outside the panel. Showing all of the legend at the cost of a smaller
graph seems preferable.

![image](https://user-images.githubusercontent.com/468940/142888178-bac0c8d2-fa9d-4489-8021-d7a3697676a2.png) 
vs
![image](https://user-images.githubusercontent.com/468940/142888304-9875154c-7e5f-4b11-b35b-4562d8e60c1b.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #41688
