### PR TITLE
Alerting: use better type assertion for `initialAsyncRequestState` 

### DIFF
--- a/public/app/features/alerting/unified/AmRoutes.tsx
+++ b/public/app/features/alerting/unified/AmRoutes.tsx
@@ -58,6 +58,10 @@ const AmRoutes: FC = () => {
 
   useCleanup((state) => state.unifiedAlerting.saveAMConfig);
   const handleSave = (data: Partial<FormAmRoute>) => {
+    if (!result) {
+      return;
+    }
+
     const newData = formAmRouteToAmRoute(
       alertManagerSourceName,
       {

--- a/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.tsx
+++ b/public/app/features/alerting/unified/components/admin/AlertmanagerConfig.tsx
@@ -55,7 +55,7 @@ export default function AlertmanagerConfig(): JSX.Element {
   const loading = isDeleting || isLoadingConfig || isSaving;
 
   const onSubmit = (values: FormValues) => {
-    if (alertManagerSourceName) {
+    if (alertManagerSourceName && config) {
       dispatch(
         updateAlertManagerConfigAction({
           newConfig: JSON.parse(values.configJSON),

--- a/public/app/features/alerting/unified/utils/redux.ts
+++ b/public/app/features/alerting/unified/utils/redux.ts
@@ -13,8 +13,13 @@ export interface AsyncRequestState<T> {
   requestId?: string;
 }
 
-export const initialAsyncRequestState: AsyncRequestState<any> = Object.freeze({
+export const initialAsyncRequestState: Pick<
+  AsyncRequestState<undefined>,
+  'loading' | 'dispatched' | 'result' | 'error'
+> = Object.freeze({
   loading: false,
+  result: undefined,
+  error: undefined,
   dispatched: false,
 });
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The `result` of `initialAsyncRequestState` would be inferred as `any` instead of `undefined`, this adds proper type inference for statements such as 

```
const { result: config, loading, error } =
    (alertManagerSourceName && configRequests[alertManagerSourceName]) || initialAsyncRequestState;
```

where before it would infer `result: any` instead of `result: AlertManagerCortextConfig | undefined`

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

