### PR TITLE
Loki: Pass log volume hint as a request header

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -184,14 +184,26 @@ describe('LokiDatasource', () => {
 
       it('should add volume hint param for log volume queries', () => {
         const target = { expr: '{job="grafana"}', refId: 'B', volumeQuery: true };
-        const req = ds.createRangeQuery(target, options as any, 1000);
-        expect(req.hint).toBe('logvolhist');
+        ds.runRangeQuery(target, options);
+        expect(backendSrv.fetch).toBeCalledWith(
+          expect.objectContaining({
+            headers: {
+              'X-Query-Tag': 'Source=logvolhist',
+            },
+          })
+        );
       });
 
       it('should not add volume hint param for regular queries', () => {
         const target = { expr: '{job="grafana"}', refId: 'B', volumeQuery: false };
-        const req = ds.createRangeQuery(target, options as any, 1000);
-        expect(req.hint).not.toBeDefined();
+        ds.runRangeQuery(target, options);
+        expect(backendSrv.fetch).not.toBeCalledWith(
+          expect.objectContaining({
+            headers: {
+              'X-Query-Tag': 'Source=logvolhist',
+            },
+          })
+        );
       });
     });
   });

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -248,12 +248,9 @@ export class LokiDatasource
       };
     }
 
-    const hint: { hint?: 'logvolhist' } = target.volumeQuery ? { hint: 'logvolhist' } : {};
-
     return {
       ...DEFAULT_QUERY_PARAMS,
       ...range,
-      ...hint,
       query,
       limit,
     };
@@ -284,7 +281,9 @@ export class LokiDatasource
     }
     const query = this.createRangeQuery(target, options, maxDataPoints);
 
-    return this._request(RANGE_QUERY_ENDPOINT, query).pipe(
+    const headers = target.volumeQuery ? { 'X-Query-Tag': 'Source=logvolhist' } : undefined;
+
+    return this._request(RANGE_QUERY_ENDPOINT, query, { headers }).pipe(
       catchError((err) => throwError(() => this.processError(err, target))),
       switchMap((response) =>
         processRangeQueryResponse(

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -14,8 +14,6 @@ export interface LokiRangeQueryRequest {
   end?: number;
   step?: number;
   direction?: 'BACKWARD' | 'FORWARD';
-  // extra info passed to Loki API when a log volume query is run to distinguish it from any other query
-  hint?: 'logvolhist';
 }
 
 export enum LokiResultType {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

`hint` param is a meta data and should not be passed with request params in the URL. @grafana/loki-team decided it should be a request header.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes N/A

**Special notes for your reviewer**:

**How to test it?**

`hint` param should no longer be passed and new request header should be added, but only to log volume query:

| regular query | log volume query |
|--------------|-------------------|
|  <img width="974" alt="Screen Shot 2021-11-23 at 09 17 07" src="https://user-images.githubusercontent.com/745532/142990241-ae7b61ef-7c61-4925-9c43-27d18663630f.png"> | <img width="1017" alt="Screen Shot 2021-11-23 at 09 18 12" src="https://user-images.githubusercontent.com/745532/142990270-2a010ac5-6aec-430e-885f-9323f601331b.png"> |

CC: @slim-bean @kavirajk 