### PR TITLE
Alerting: validate mute timings in the alertmanager configuration

### DIFF
--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -338,10 +338,6 @@ func (srv AlertmanagerSrv) RoutePostAlertingConfig(c *models.ReqContext, body ap
 		return ErrResp(http.StatusForbidden, errors.New("permission denied"), "")
 	}
 
-	if err := srv.vaildateAlertManagerConfig(body.AlertmanagerConfig); err != nil {
-		return ErrResp(http.StatusBadRequest, fmt.Errorf("error validating Alertmanager config: %w", err), "")
-	}
-
 	// Get the last known working configuration
 	query := ngmodels.GetLatestAlertmanagerConfigurationQuery{OrgID: c.OrgId}
 	if err := srv.store.GetLatestAlertmanagerConfiguration(&query); err != nil {
@@ -374,17 +370,6 @@ func (srv AlertmanagerSrv) RoutePostAlertingConfig(c *models.ReqContext, body ap
 	}
 
 	return response.JSON(http.StatusAccepted, util.DynMap{"message": "configuration created"})
-}
-
-func (srv AlertmanagerSrv) vaildateAlertManagerConfig(config apimodels.PostableApiAlertingConfig) error {
-	muteNames := make(map[string]struct{}, len(config.MuteTimeIntervals))
-	for _, muteTime := range config.MuteTimeIntervals {
-		if _, exists := muteNames[muteTime.Name]; exists {
-			return fmt.Errorf("mute time interval \"%s\" is not unique", muteTime.Name)
-		}
-		muteNames[muteTime.Name] = struct{}{}
-	}
-	return nil
 }
 
 func (srv AlertmanagerSrv) RoutePostAMAlerts(_ *models.ReqContext, _ apimodels.PostableAlerts) response.Response {

--- a/pkg/services/ngalert/api/api_alertmanager.go
+++ b/pkg/services/ngalert/api/api_alertmanager.go
@@ -338,6 +338,10 @@ func (srv AlertmanagerSrv) RoutePostAlertingConfig(c *models.ReqContext, body ap
 		return ErrResp(http.StatusForbidden, errors.New("permission denied"), "")
 	}
 
+	if err := srv.vaildateAlertManagerConfig(body.AlertmanagerConfig); err != nil {
+		return ErrResp(http.StatusBadRequest, fmt.Errorf("error validating Alertmanager config: %w", err), "")
+	}
+
 	// Get the last known working configuration
 	query := ngmodels.GetLatestAlertmanagerConfigurationQuery{OrgID: c.OrgId}
 	if err := srv.store.GetLatestAlertmanagerConfiguration(&query); err != nil {
@@ -370,6 +374,17 @@ func (srv AlertmanagerSrv) RoutePostAlertingConfig(c *models.ReqContext, body ap
 	}
 
 	return response.JSON(http.StatusAccepted, util.DynMap{"message": "configuration created"})
+}
+
+func (srv AlertmanagerSrv) vaildateAlertManagerConfig(config apimodels.PostableApiAlertingConfig) error {
+	muteNames := make(map[string]struct{}, len(config.MuteTimeIntervals))
+	for _, muteTime := range config.MuteTimeIntervals {
+		if _, exists := muteNames[muteTime.Name]; exists {
+			return fmt.Errorf("mute time interval \"%s\" is not unique", muteTime.Name)
+		}
+		muteNames[muteTime.Name] = struct{}{}
+	}
+	return nil
 }
 
 func (srv AlertmanagerSrv) RoutePostAMAlerts(_ *models.ReqContext, _ apimodels.PostableAlerts) response.Response {

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -755,6 +755,9 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 
 	tiNames := make(map[string]struct{})
 	for _, mt := range c.MuteTimeIntervals {
+		if mt.Name == "" {
+			return fmt.Errorf("missing name in mute time interval")
+		}
 		if _, ok := tiNames[mt.Name]; ok {
 			return fmt.Errorf("mute time interval %q is not unique", mt.Name)
 		}

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -746,6 +746,9 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 	if len(c.Route.Match) > 0 || len(c.Route.MatchRE) > 0 {
 		return fmt.Errorf("root route must not have any matchers")
 	}
+	if len(c.Route.MuteTimeIntervals) > 0 {
+		return fmt.Errorf("root route must not have any mute time intervals")
+	}
 
 	for _, r := range c.InhibitRules {
 		if err := r.UnmarshalYAML(noopUnmarshal); err != nil {

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
@@ -742,36 +742,6 @@ alertmanager_config: ""
 			},
 		},
 		{
-			desc: "empty mute times name",
-			input: `
-template_files: {foo: bar}
-alertmanager_config: |
-                      route:
-                          receiver: am
-                          continue: false
-                          routes:
-                          - receiver: am
-                            continue: false
-                      templates: []
-                      mute_time_intervals:
-                      - name: ''
-                        time_intervals:
-                        - years:
-                          - 2020:2022
-                          - "2030"
-                      receivers:
-                      - name: am
-                        email_configs:
-                        - to: foo
-                          from: bar
-                          headers:
-                            Bazz: buzz
-                          text: hi
-                          html: there
-`,
-			err: false,
-		},
-		{
 			desc: "existing am config",
 			input: `
 template_files: {foo: bar}

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
@@ -2,6 +2,7 @@ package definitions
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -407,13 +408,12 @@ email_configs:
 
 func Test_ConfigUnmashaling(t *testing.T) {
 	for _, tc := range []struct {
-		desc, input, errMsg string
-		err                 bool
+		desc, input string
+		err         error
 	}{
 		{
-			desc:   "empty mute time name should error",
-			err:    true,
-			errMsg: "missing name in mute time interval",
+			desc: "empty mute time name should error",
+			err:  errors.New("missing name in mute time interval"),
 			input: `
 				{
 				  "route": {
@@ -456,9 +456,8 @@ func Test_ConfigUnmashaling(t *testing.T) {
 			`,
 		},
 		{
-			desc:   "not unique mute time names should error",
-			err:    true,
-			errMsg: "mute time interval \"test1\" is not unique",
+			desc: "not unique mute time names should error",
+			err:  errors.New("mute time interval \"test1\" is not unique"),
 			input: `
 				{
 				  "route": {
@@ -514,9 +513,8 @@ func Test_ConfigUnmashaling(t *testing.T) {
 			`,
 		},
 		{
-			desc:   "mute time intervals on root route should error",
-			err:    true,
-			errMsg: "root route must not have any mute time intervals",
+			desc: "mute time intervals on root route should error",
+			err:  errors.New("root route must not have any mute time intervals"),
 			input: `
 				{
 				  "route": {
@@ -560,9 +558,8 @@ func Test_ConfigUnmashaling(t *testing.T) {
 			`,
 		},
 		{
-			desc:   "undefined mute time names in routes should error",
-			err:    true,
-			errMsg: "undefined time interval \"test2\" used in route",
+			desc: "undefined mute time names in routes should error",
+			err:  errors.New("undefined time interval \"test2\" used in route"),
 			input: `
 				{
 				  "route": {
@@ -681,12 +678,7 @@ func Test_ConfigUnmashaling(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			var out Config
 			err := json.Unmarshal([]byte(tc.input), &out)
-			if tc.err {
-				require.Error(t, err)
-				require.Equal(t, tc.errMsg, err.Error())
-				return
-			}
-			require.Nil(t, err)
+			require.Equal(t, tc.err, err)
 		})
 	}
 }

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
@@ -456,13 +456,14 @@ func Test_ConfigUnmashaling(t *testing.T) {
 			`,
 		},
 		{
-			desc:   "not unique mute time names should error",
+			desc:   "mute time intervals on root route should error",
 			err:    true,
-			errMsg: "mute time interval \"test1\" is not unique",
+			errMsg: "root route must not have any mute time intervals",
 			input: `
 				{
 				  "route": {
-					"receiver": "grafana-default-email"
+					"receiver": "grafana-default-email",
+					"mute_time_intervals": ["test1"]
 				  },
 				  "mute_time_intervals": [
 					{
@@ -477,20 +478,7 @@ func Test_ConfigUnmashaling(t *testing.T) {
 						  ]
 						}
 					  ]
-					},
-					{
-						"name": "test1",
-						"time_intervals": [
-						  {
-							"times": [
-							  {
-								"start_time": "00:00",
-								"end_time": "12:00"
-							  }
-							]
-						  }
-						]
-					  }
+					}
 				  ],
 				  "templates": null,
 				  "receivers": [

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
@@ -456,6 +456,64 @@ func Test_ConfigUnmashaling(t *testing.T) {
 			`,
 		},
 		{
+			desc:   "not unique mute time names should error",
+			err:    true,
+			errMsg: "mute time interval \"test1\" is not unique",
+			input: `
+				{
+				  "route": {
+					"receiver": "grafana-default-email"
+				  },
+				  "mute_time_intervals": [
+					{
+					  "name": "test1",
+					  "time_intervals": [
+						{
+						  "times": [
+							{
+							  "start_time": "00:00",
+							  "end_time": "12:00"
+							}
+						  ]
+						}
+					  ]
+					},
+					{
+						"name": "test1",
+						"time_intervals": [
+						  {
+							"times": [
+							  {
+								"start_time": "00:00",
+								"end_time": "12:00"
+							  }
+							]
+						  }
+						]
+					  }
+				  ],
+				  "templates": null,
+				  "receivers": [
+					{
+					  "name": "grafana-default-email",
+					  "grafana_managed_receiver_configs": [
+						{
+						  "uid": "uxwfZvtnz",
+						  "name": "email receiver",
+						  "type": "email",
+						  "disableResolveMessage": false,
+						  "settings": {
+							"addresses": "<example@email.com>"
+						  },
+						  "secureFields": {}
+						}
+					  ]
+					}
+				  ]
+				}
+			`,
+		},
+		{
 			desc:   "mute time intervals on root route should error",
 			err:    true,
 			errMsg: "root route must not have any mute time intervals",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: We already ensure that mute timing names are unique one runtime but should also check uniqueness when updating configs through the API.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

The validation code is taken from the upstream alertmanager, so the behavior is the same.