### PR TITLE
Tracing: Show start time of trace with milliseconds precision

### DIFF
--- a/packages/jaeger-ui-components/src/TracePageHeader/TracePageHeader.test.js
+++ b/packages/jaeger-ui-components/src/TracePageHeader/TracePageHeader.test.js
@@ -61,9 +61,8 @@ describe('<TracePageHeader>', () => {
   });
 
   it('renders start time in header with millisecond precision', () => {
-    expect(wrapper.find(LabeledList).length).toBe(1);
-    const startTime = wrapper.find(LabeledList).props().items[0].value.props.children[1].props.children;
-    expect(startTime).toMatch(/:\d\d\.\d\d\d/g);
+    const startTimeMs = wrapper.find(LabeledList).props().items[0].value.props.children[1].props.children;
+    expect(startTimeMs).toMatch(/:\d\d\.\d\d\d/g);
   });
 
   it('renders a <SpanGraph>', () => {

--- a/packages/jaeger-ui-components/src/TracePageHeader/TracePageHeader.test.js
+++ b/packages/jaeger-ui-components/src/TracePageHeader/TracePageHeader.test.js
@@ -60,6 +60,12 @@ describe('<TracePageHeader>', () => {
     });
   });
 
+  it('renders start time in header with millisecond precision', () => {
+    expect(wrapper.find(LabeledList).length).toBe(1);
+    const startTime = wrapper.find(LabeledList).props().items[0].value.props.children[1].props.children;
+    expect(startTime).toMatch(/:\d\d\.\d\d\d/g);
+  });
+
   it('renders a <SpanGraph>', () => {
     expect(wrapper.find(SpanGraph).length).toBe(1);
   });

--- a/packages/jaeger-ui-components/src/TracePageHeader/TracePageHeader.tsx
+++ b/packages/jaeger-ui-components/src/TracePageHeader/TracePageHeader.tsx
@@ -167,7 +167,7 @@ export const HEADER_ITEMS = [
     label: 'Trace Start',
     renderer(trace: Trace, timeZone: TimeZone, styles: ReturnType<typeof getStyles>) {
       // Convert date from micro to milli seconds
-      const dateStr = dateTimeFormat(trace.startTime / 1000, { timeZone });
+      const dateStr = dateTimeFormat(trace.startTime / 1000, { timeZone, defaultWithMS: true });
       const match = dateStr.match(/^(.+)(:\d\d\.\d+)$/);
       return match ? (
         <span className={styles.TracePageHeaderOverviewItemValue}>


### PR DESCRIPTION
**What this PR does / why we need it**: 
Trace Start precision used to be in milliseconds (e.g. in Grafana 8.0.4). This changed at some point and in and the output format was in seconds (e.g on main branch). This PR fixes this and adds test. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/40935

