### PR TITLE
Chore: Fix pass context for SetAlertStateCommand

### DIFF
--- a/pkg/services/alerting/result_handler.go
+++ b/pkg/services/alerting/result_handler.go
@@ -58,7 +58,7 @@ func (handler *defaultResultHandler) handle(evalContext *EvalContext) error {
 			EvalData: annotationData,
 		}
 
-		if err := bus.Dispatch(cmd); err != nil {
+		if err := bus.DispatchCtx(evalContext.Ctx, cmd); err != nil {
 			if errors.Is(err, models.ErrCannotChangeStateOnPausedAlert) {
 				handler.log.Error("Cannot change state on alert that's paused", "error", err)
 				return err

--- a/pkg/services/sqlstore/alert.go
+++ b/pkg/services/sqlstore/alert.go
@@ -19,7 +19,7 @@ func (ss *SQLStore) addAlertQueryAndCommandHandlers() {
 	bus.AddHandlerCtx("sql", ss.HandleAlertsQuery)
 	bus.AddHandlerCtx("sql", ss.GetAlertById)
 	bus.AddHandlerCtx("sql", ss.GetAllAlertQueryHandler)
-	bus.AddHandlerCtx("sql", SetAlertState)
+	bus.AddHandlerCtx("sql", ss.SetAlertState)
 	bus.AddHandlerCtx("sql", ss.GetAlertStatesForDashboard)
 	bus.AddHandlerCtx("sql", PauseAlert)
 	bus.AddHandlerCtx("sql", PauseAllAlerts)
@@ -305,8 +305,8 @@ func GetAlertsByDashboardId2(dashboardId int64, sess *DBSession) ([]*models.Aler
 	return alerts, nil
 }
 
-func SetAlertState(ctx context.Context, cmd *models.SetAlertStateCommand) error {
-	return inTransaction(func(sess *DBSession) error {
+func (ss *SQLStore) SetAlertState(ctx context.Context, cmd *models.SetAlertStateCommand) error {
+	return ss.WithTransactionalDbSession(ctx, func(sess *DBSession) error {
 		alert := models.Alert{}
 
 		if has, err := sess.ID(cmd.AlertId).Get(&alert); err != nil {

--- a/pkg/services/sqlstore/alert_test.go
+++ b/pkg/services/sqlstore/alert_test.go
@@ -83,7 +83,7 @@ func TestAlertingDataAccess(t *testing.T) {
 				State:   models.AlertStateOK,
 			}
 
-			err := SetAlertState(context.Background(), cmd)
+			err := sqlStore.SetAlertState(context.Background(), cmd)
 			require.Nil(t, err)
 		})
 
@@ -100,7 +100,7 @@ func TestAlertingDataAccess(t *testing.T) {
 					State:   models.AlertStateOK,
 				}
 
-				err = SetAlertState(context.Background(), cmd)
+				err = sqlStore.SetAlertState(context.Background(), cmd)
 				require.Error(t, err)
 			})
 


### PR DESCRIPTION
Leftovers from https://github.com/grafana/grafana/pull/41161

Probably should fix for 8.3.x 