### PR TITLE
Graphite: Run onChange/onRunQuery after reducer action finishes

### DIFF
--- a/public/app/plugins/datasource/graphite/state/helpers.ts
+++ b/public/app/plugins/datasource/graphite/state/helpers.ts
@@ -161,7 +161,7 @@ export function handleTargetChanged(state: GraphiteQueryEditorState): void {
   );
 
   if (state.queryModel.target.target !== oldTarget && !state.paused) {
-    state.refresh(state.target.target);
+    state.refresh();
   }
 }
 

--- a/public/app/plugins/datasource/graphite/state/store.ts
+++ b/public/app/plugins/datasource/graphite/state/store.ts
@@ -25,7 +25,7 @@ export type GraphiteQueryEditorState = {
   // external dependencies
   datasource: GraphiteDatasource;
   target: GraphiteTarget;
-  refresh: (target: string) => void;
+  refresh: () => void;
   queries?: DataQuery[];
   templateSrv: TemplateSrv;
   range?: TimeRange;
@@ -134,7 +134,7 @@ const reducer = async (action: Action, state: GraphiteQueryEditorState): Promise
   }
   if (actions.unpause.match(action)) {
     state.paused = false;
-    state.refresh(state.target.target);
+    state.refresh();
   }
   if (actions.addFunction.match(action)) {
     const newFunc = state.datasource.createFuncInstance(action.payload.name, {
@@ -175,7 +175,7 @@ const reducer = async (action: Action, state: GraphiteQueryEditorState): Promise
     handleTargetChanged(state);
   }
   if (actions.runQuery.match(action)) {
-    state.refresh(state.target.target);
+    state.refresh();
   }
   if (actions.toggleEditorMode.match(action)) {
     state.target.textEditor = !state.target.textEditor;

--- a/public/app/plugins/datasource/graphite/types.ts
+++ b/public/app/plugins/datasource/graphite/types.ts
@@ -77,5 +77,6 @@ export type GraphiteQueryEditorDependencies = {
   range?: TimeRange;
   templateSrv: TemplateSrv;
   queries: DataQuery[];
-  refresh: (target: string) => void;
+  // schedule onChange/onRunQuery after the reducer actions finishes
+  refresh: () => void;
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This should fix two bugs:
* Problem with drag & drop mentioned in https://github.com/grafana/grafana/issues/41557
* Problem with play button mentioned in https://github.com/grafana/grafana/issues/41675

First problem was caused by `onChange` callback not being updated in the query state. These callbacks may change in https://github.com/grafana/grafana/blob/main/public/app/features/query/components/QueryEditorRows.tsx#L127 after dragging. What was happening is GraphiteQueryEditor would use the previous callback so after drag and drop it would attempt to change a different query.

The second problem is caused by race condition. ["unpause" reducer action](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/graphite/state/store.ts#L135) calls `onChange` (via `refresh()`) before it finishes. The problem is `onChange` may cause the state to change overriding the values that were supposed to be changed by the reducer. 

Both issues are fixed by ensuring the up-to-date onChange/onRunQuery is run only after the state changes. I'm working on cleaning up the state synchronization but it will require more changes and I didn't want to include in beta fix too many changes.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to #41675
Related to #41557 

**Special notes for your reviewer**:

**How to test it?**

Just add some tags and click on play button. It should disappear and query should be run. For drag & drop please follow [this comment](https://github.com/grafana/grafana/issues/41557#issuecomment-974190199) - it can be done with any other query locally.
