### PR TITLE
loki: alerting: simplified config

### DIFF
--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -142,11 +142,9 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		defer span.Finish()
 
 		//Currently hard coded as not used - applies to log queries
-		limit := 1000
-		//Currently hard coded as not used - applies to queries which produce a stream response
-		interval := time.Second * 1
+		limit := 1
 
-		value, err := client.QueryRange(query.Expr, limit, query.Start, query.End, logproto.BACKWARD, query.Step, interval, false)
+		value, err := client.QueryRange(query.Expr, limit, query.Start, query.End, logproto.BACKWARD, query.Step, 0, false)
 		if err != nil {
 			return result, err
 		}

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -141,10 +141,14 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		span.SetTag("stop_unixnano", query.End.UnixNano())
 		defer span.Finish()
 
-		//Currently hard coded as not used - applies to log queries
+		// `limit` only applies to log-producing queries, and we
+		// currently only support metric queries, so this can be set to any value.
 		limit := 1
 
-		value, err := client.QueryRange(query.Expr, limit, query.Start, query.End, logproto.BACKWARD, query.Step, 0, false)
+		// we do not use `interval`, so we set it to zero
+		interval := time.Duration(0)
+
+		value, err := client.QueryRange(query.Expr, limit, query.Start, query.End, logproto.BACKWARD, query.Step, interval, false)
 		if err != nil {
 			return result, err
 		}


### PR DESCRIPTION
there are two params that we handle in the loki alerting code that are not really used, i adjusted them a little:

- `interval`. alerting code currently only deals with queries that return metric data, and for those, `interval` is not used. but, truth is, even for logs, grafana does not use `interval`. we do not use it anywhere.
  - so i thought it's better to just not have it there at all as a separate variable
- `limit`. alerting code currently only deals with queries that return metric data, and for those, `limit` is not used.
  - even if it is not used, we have to set a value. the current value is `1000`, i adjusted it to `1`
    - i think it does not matter what value it has, but, if some bug happens and it starts to matter, this way we find out sooner 😁 .
      - btw. first i tried to set it to `0`, but then the loki-code complained that it has to be a positive value. i guess you can not-send-it, but if you do send it, it cannot be zero. unfortunately there does not seem to be a way to not-send-it :-(, so we go with the smallest possible number.
