### PR TITLE
Table: Add LogViewCell to render long log lines in table

### DIFF
--- a/packages/grafana-schema/src/schema/graph.gen.ts
+++ b/packages/grafana-schema/src/schema/graph.gen.ts
@@ -226,6 +226,7 @@ export enum TableCellDisplayMode {
   Image = 'image',
   JSONView = 'json-view',
   LcdGauge = 'lcd-gauge',
+  LogView = 'log-view',
 }
 
 export interface VizTextDisplayOptions {

--- a/packages/grafana-ui/src/components/Table/LogViewCell.tsx
+++ b/packages/grafana-ui/src/components/Table/LogViewCell.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { css } from '@emotion/css';
+import { Tooltip } from '../Tooltip/Tooltip';
+import { useStyles2 } from '../../themes';
+import { TableCellProps } from './types';
+import { GrafanaTheme2 } from '@grafana/data';
+
+export function LogViewCell(props: TableCellProps): JSX.Element {
+  const { cell, tableStyles, cellProps } = props;
+  return (
+    <Tooltip placement="auto-start" content={<LogTooltip value={cell.value} />} theme="info-alt">
+      <div {...cellProps} className={tableStyles.cellContainer}>
+        <div className={tableStyles.cellText}>{cell.value}</div>
+      </div>
+    </Tooltip>
+  );
+}
+
+interface PopupProps {
+  value: any;
+}
+
+function LogTooltip(props: PopupProps): JSX.Element {
+  const styles = useStyles2(getStyles);
+  return (
+    <div className={styles.container}>
+      <div className={styles.content}>{props.value}</div>
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    container: css`
+      padding: ${theme.spacing(0.5)};
+    `,
+    content: css`
+      width: fit-content;
+      max-height: 70vh;
+      overflow-y: auto;
+    `,
+  };
+}

--- a/packages/grafana-ui/src/components/Table/utils.ts
+++ b/packages/grafana-ui/src/components/Table/utils.ts
@@ -14,6 +14,7 @@ import { DefaultCell } from './DefaultCell';
 import { BarGaugeCell } from './BarGaugeCell';
 import { CellComponent, TableCellDisplayMode, TableFieldOptions, FooterItem } from './types';
 import { JSONViewCell } from './JSONViewCell';
+import { LogViewCell } from './LogViewCell';
 import { ImageCell } from './ImageCell';
 import { getFooterValue } from './FooterRow';
 
@@ -129,6 +130,8 @@ function getCellComponent(displayMode: TableCellDisplayMode, field: Field): Cell
       return BarGaugeCell;
     case TableCellDisplayMode.JSONView:
       return JSONViewCell;
+    case TableCellDisplayMode.LogView:
+      return LogViewCell;
   }
 
   // Default or Auto

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -10,6 +10,7 @@ import {
   TraceLog,
   TraceSpanRow,
 } from '@grafana/data';
+import { TableCellDisplayMode } from '@grafana/schema';
 import { SpanKind, SpanStatus, SpanStatusCode } from '@opentelemetry/api';
 import { collectorTypes } from '@opentelemetry/exporter-collector';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
@@ -56,6 +57,11 @@ export function createTableFrame(
       {
         name: 'Message',
         type: FieldType.string,
+        config: {
+          custom: {
+            displayMode: TableCellDisplayMode.LogView,
+          },
+        },
       },
     ],
     meta: {

--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -71,6 +71,7 @@ export const plugin = new PanelPlugin<PanelOptions, TableFieldOptions>(TablePane
               { value: TableCellDisplayMode.BasicGauge, label: 'Basic gauge' },
               { value: TableCellDisplayMode.JSONView, label: 'JSON View' },
               { value: TableCellDisplayMode.Image, label: 'Image' },
+              { value: TableCellDisplayMode.LogView, label: 'Log View' },
             ],
           },
           defaultValue: defaultPanelFieldConfig.displayMode,


### PR DESCRIPTION
**What this PR does / why we need it**:
Long log lines are cut off which primarily impacts Loki search in Tempo. This PR adds a LogViewCell which renders an unformatted tooltip to display the entire log. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #36004

**Special notes for your reviewer**:
Currently rendering as text, but if there's a better way to format the log, I'm open to recommendations
