### PR TITLE
Table: Add space between values on JSONViewCell

### DIFF
--- a/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
+++ b/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
@@ -23,7 +23,7 @@ export function JSONViewCell(props: TableCellProps): JSX.Element {
       value = JSON.parse(value);
     } catch {} // ignore errors
   } else {
-    displayValue = JSON.stringify(value);
+    displayValue = JSON.stringify(value, null, ' ');
   }
 
   const content = <JSONTooltip value={value} />;


### PR DESCRIPTION
**What this PR does / why we need it**:
Addresses #42024 by adding a space after the separator. 

**Which issue(s) this PR fixes**:
Fixes #42024 

**Special notes for your reviewer**:
Adding the  `space` parameter to the `JSON.stringify` (doc [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)) also adds a space after the opening and closing brackets (see below). Maybe this is undesirable?

![image](https://user-images.githubusercontent.com/201163/143068518-8cd87bfe-9f73-44c6-9102-e3a661dfe722.png)
