### PR TITLE
AzureAD OAuth: Add optional strict parsing of role_attribute_path

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -508,6 +508,7 @@ auth_url = https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/authorize
 token_url = https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token
 allowed_domains =
 allowed_groups =
+role_attribute_strict = false
 
 #################################### Okta OAuth #######################
 [auth.okta]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -493,6 +493,7 @@
 ;token_url = https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token
 ;allowed_domains =
 ;allowed_groups =
+;role_attribute_strict = false
 
 #################################### Okta OAuth #######################
 [auth.okta]

--- a/docs/sources/auth/azuread.md
+++ b/docs/sources/auth/azuread.md
@@ -109,6 +109,7 @@ auth_url = https://login.microsoftonline.com/TENANT_ID/oauth2/v2.0/authorize
 token_url = https://login.microsoftonline.com/TENANT_ID/oauth2/v2.0/token
 allowed_domains =
 allowed_groups =
+role_attribute_strict = false
 ```
 
 You can also use these environment variables to configure **client_id** and **client_secret**:

--- a/pkg/login/social/azuread_oauth.go
+++ b/pkg/login/social/azuread_oauth.go
@@ -71,6 +71,9 @@ func (s *SocialAzureAD) UserInfo(client *http.Client, token *oauth2.Token) (*Bas
 	}
 
 	role := extractRole(claims, s.autoAssignOrgRole, s.roleAttributeStrict)
+	if role == "" {
+		return nil, errors.New("user does not have a valid role")
+	}
 	logger.Debug("AzureAD OAuth: extracted role", "email", email, "role", role)
 
 	groups, err := extractGroups(client, claims, token)

--- a/pkg/login/social/azuread_oauth.go
+++ b/pkg/login/social/azuread_oauth.go
@@ -70,11 +70,8 @@ func (s *SocialAzureAD) UserInfo(client *http.Client, token *oauth2.Token) (*Bas
 		return nil, errors.New("error getting user info: no email found in access token")
 	}
 
-	role := extractRole(claims, s.autoAssignOrgRole)
+	role := extractRole(claims, s.autoAssignOrgRole, s.roleAttributeStrict)
 	logger.Debug("AzureAD OAuth: extracted role", "email", email, "role", role)
-	if s.roleAttributeStrict && !role.IsValid() {
-		return nil, errors.New("invalid role")
-	}
 
 	groups, err := extractGroups(client, claims, token)
 	if err != nil {
@@ -122,7 +119,7 @@ func extractEmail(claims azureClaims) string {
 	return claims.Email
 }
 
-func extractRole(claims azureClaims, autoAssignRole string) models.RoleType {
+func extractRole(claims azureClaims, autoAssignRole string, strictMode bool) models.RoleType {
 	if len(claims.Roles) == 0 {
 		return models.RoleType(autoAssignRole)
 	}
@@ -139,7 +136,11 @@ func extractRole(claims azureClaims, autoAssignRole string) models.RoleType {
 		}
 	}
 
-	return models.RoleType("")
+	if strictMode {
+		return models.RoleType("")
+	}
+
+	return models.ROLE_VIEWER
 }
 
 func hasRole(roles []string, role models.RoleType) bool {

--- a/pkg/login/social/azuread_oauth_test.go
+++ b/pkg/login/social/azuread_oauth_test.go
@@ -302,7 +302,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				Role:    "",
 				Groups:  []string{},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/login/social/azuread_oauth_test.go
+++ b/pkg/login/social/azuread_oauth_test.go
@@ -18,9 +18,10 @@ import (
 
 func TestSocialAzureAD_UserInfo(t *testing.T) {
 	type fields struct {
-		SocialBase        *SocialBase
-		allowedGroups     []string
-		autoAssignOrgRole string
+		SocialBase          *SocialBase
+		allowedGroups       []string
+		autoAssignOrgRole   string
+		roleAttributeStrict bool
 	}
 	type args struct {
 		client *http.Client
@@ -150,7 +151,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				Email:   "me@example.com",
 				Login:   "me@example.com",
 				Company: "",
-				Role:    "Viewer",
+				Role:    "",
 				Groups:  []string{},
 			},
 		},
@@ -279,13 +280,30 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Error if user role is invalid and strict attribute role is true",
+			fields: fields{
+				roleAttributeStrict: true,
+			},
+			claims: &azureClaims{
+				Email:             "me@example.com",
+				PreferredUsername: "",
+				Roles:             []string{"foo"},
+				Groups:            []string{},
+				Name:              "My Name",
+				ID:                "1234",
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &SocialAzureAD{
-				SocialBase:        tt.fields.SocialBase,
-				allowedGroups:     tt.fields.allowedGroups,
-				autoAssignOrgRole: tt.fields.autoAssignOrgRole,
+				SocialBase:          tt.fields.SocialBase,
+				allowedGroups:       tt.fields.allowedGroups,
+				autoAssignOrgRole:   tt.fields.autoAssignOrgRole,
+				roleAttributeStrict: tt.fields.roleAttributeStrict,
 			}
 
 			key := []byte("secret")

--- a/pkg/login/social/azuread_oauth_test.go
+++ b/pkg/login/social/azuread_oauth_test.go
@@ -151,7 +151,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				Email:   "me@example.com",
 				Login:   "me@example.com",
 				Company: "",
-				Role:    "",
+				Role:    "Viewer",
 				Groups:  []string{},
 			},
 		},
@@ -281,7 +281,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Error if user role is invalid and strict attribute role is true",
+			name: "Fetch empty role when strict attribute role is true and no match",
 			fields: fields{
 				roleAttributeStrict: true,
 			},
@@ -293,8 +293,16 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				Name:              "My Name",
 				ID:                "1234",
 			},
-			want:    nil,
-			wantErr: true,
+			want: &BasicUserInfo{
+				Id:      "1234",
+				Name:    "My Name",
+				Email:   "me@example.com",
+				Login:   "me@example.com",
+				Company: "",
+				Role:    "",
+				Groups:  []string{},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/login/social/azuread_oauth_test.go
+++ b/pkg/login/social/azuread_oauth_test.go
@@ -293,15 +293,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				Name:              "My Name",
 				ID:                "1234",
 			},
-			want: &BasicUserInfo{
-				Id:      "1234",
-				Name:    "My Name",
-				Email:   "me@example.com",
-				Login:   "me@example.com",
-				Company: "",
-				Role:    "",
-				Groups:  []string{},
-			},
+			want:    nil,
 			wantErr: true,
 		},
 	}

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -149,9 +149,10 @@ func ProvideService(cfg *setting.Cfg) *SocialService {
 		// AzureAD.
 		if name == "azuread" {
 			ss.socialMap["azuread"] = &SocialAzureAD{
-				SocialBase:        newSocialBase(name, &config, info),
-				allowedGroups:     util.SplitString(sec.Key("allowed_groups").String()),
-				autoAssignOrgRole: cfg.AutoAssignOrgRole,
+				SocialBase:          newSocialBase(name, &config, info),
+				allowedGroups:       util.SplitString(sec.Key("allowed_groups").String()),
+				autoAssignOrgRole:   cfg.AutoAssignOrgRole,
+				roleAttributeStrict: info.RoleAttributeStrict,
 			}
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Using Azure AD, it is not possible to deny users access to Grafana outside of setting `allowed_groups` and `groupMembershipClaims`. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/22741
References https://github.com/grafana/grafana/issues/40186

**Special notes for your reviewer**:
There has been a lot of discussion in restricting access for users in https://github.com/grafana/grafana/issues/23218 but the problem is that the solution was not implemented for Azure AD. There are several issues filed, as I tagged in the PR fixes section above, that needs this solution implemented for the Azure AD scenario as well. 

This PR is also based on the changes made in https://github.com/grafana/grafana/pull/28021