### PR TITLE
Alerting: Make Unified Alerting enabled by default for those who do not use legacy alerting

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -735,8 +735,8 @@ global_alert_rule = -1
 
 #################################### Unified Alerting ####################
 [unified_alerting]
-# Enable the Unified Alerting sub-system and interface. When enabled we'll migrate all of your alert rules and notification channels to the new system. New alert rules will be created and your notification channels will be converted into an Alertmanager configuration. Previous data is preserved to enable backwards compatibility but new data is removed.
-enabled = false
+# Enable the Unified Alerting sub-system and interface. When enabled we'll migrate all of your alert rules and notification channels to the new system. New alert rules will be created and your notification channels will be converted into an Alertmanager configuration. Previous data is preserved to enable backwards compatibility but new data is removed. If it is not defined the actual state would be defined in runtime. See documentation for more details.
+enabled =
 
 # Comma-separated list of organization IDs for which to disable unified alerting. Only supported if unified alerting is enabled.
 disabled_orgs =
@@ -790,8 +790,8 @@ min_interval = 10s
 
 #################################### Alerting ############################
 [alerting]
-# Disable legacy alerting engine & UI features
-enabled = true
+# Enable\disable legacy alerting engine & UI features. If it is not defined, the actual state would be calculated in runtime. See documentation for more details.
+enabled =
 
 # Makes it possible to turn off alert execution but alerting UI is visible
 execute_alerts = true

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -713,7 +713,7 @@
 #################################### Unified Alerting ####################
 [unified_alerting]
 #Enable the Unified Alerting sub-system and interface. When enabled we'll migrate all of your alert rules and notification channels to the new system. New alert rules will be created and your notification channels will be converted into an Alertmanager configuration. Previous data is preserved to enable backwards compatibility but new data is removed.```
-;enabled = false
+;enabled = true
 
 # Comma-separated list of organization IDs for which to disable unified alerting. Only supported if unified alerting is enabled.
 ;disabled_orgs =
@@ -768,7 +768,7 @@
 #################################### Alerting ############################
 [alerting]
 # Disable legacy alerting engine & UI features
-;enabled = true
+;enabled = false
 
 # Makes it possible to turn off alert execution but alerting UI is visible
 ;execute_alerts = true

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -386,7 +386,7 @@ func (hs *HTTPServer) registerRoutes() {
 		})
 
 		apiRoute.Get("/alert-notifiers", reqEditorRole, routing.Wrap(
-			GetAlertNotifiers(hs.Cfg.UnifiedAlerting.Enabled)),
+			GetAlertNotifiers(hs.Cfg.UnifiedAlerting.IsEnabled())),
 		)
 
 		apiRoute.Group("/alert-notifications", func(alertNotifications routing.RouteRegister) {

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -205,9 +205,9 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 	}
 
 	_, uaIsDisabledForOrg := hs.Cfg.UnifiedAlerting.DisabledOrgs[c.OrgId]
-	uaVisibleForOrg := hs.Cfg.UnifiedAlerting.Enabled && !uaIsDisabledForOrg
+	uaVisibleForOrg := hs.Cfg.UnifiedAlerting.IsEnabled() && !uaIsDisabledForOrg
 
-	if setting.AlertingEnabled || uaVisibleForOrg {
+	if setting.AlertingEnabled != nil && *setting.AlertingEnabled || uaVisibleForOrg {
 		alertChildNavs := hs.buildAlertNavLinks(c, uaVisibleForOrg)
 		navTree = append(navTree, &dtos.NavLink{
 			Text:       "Alerting",
@@ -462,9 +462,9 @@ func (hs *HTTPServer) buildCreateNavLinks(c *models.ReqContext) []*dtos.NavLink 
 	})
 
 	_, uaIsDisabledForOrg := hs.Cfg.UnifiedAlerting.DisabledOrgs[c.OrgId]
-	uaVisibleForOrg := hs.Cfg.UnifiedAlerting.Enabled && !uaIsDisabledForOrg
+	uaVisibleForOrg := hs.Cfg.UnifiedAlerting.IsEnabled() && !uaIsDisabledForOrg
 
-	if setting.AlertingEnabled || uaVisibleForOrg {
+	if setting.AlertingEnabled != nil && *setting.AlertingEnabled || uaVisibleForOrg {
 		children = append(children, &dtos.NavLink{
 			Text: "Alert rule", SubTitle: "Create an alert rule", Id: "alert",
 			Icon: "bell", Url: hs.Cfg.AppSubURL + "/alerting/new",

--- a/pkg/services/alerting/engine.go
+++ b/pkg/services/alerting/engine.go
@@ -42,9 +42,9 @@ type AlertEngine struct {
 	usageStatsService usagestats.Service
 }
 
-// IsDisabled returns true if the alerting service is disable for this instance.
+// IsDisabled returns true if the alerting service is disabled for this instance.
 func (e *AlertEngine) IsDisabled() bool {
-	return (setting.AlertingEnabled != nil && !*setting.AlertingEnabled) || !setting.ExecuteAlerts || e.Cfg.UnifiedAlerting.IsEnabled()
+	return setting.AlertingEnabled == nil || !*setting.AlertingEnabled || !setting.ExecuteAlerts || e.Cfg.UnifiedAlerting.IsEnabled()
 }
 
 // ProvideAlertEngine returns a new AlertEngine.

--- a/pkg/services/alerting/engine.go
+++ b/pkg/services/alerting/engine.go
@@ -7,6 +7,11 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	tlog "github.com/opentracing/opentracing-go/log"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
@@ -15,10 +20,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/legacydata"
-	"github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
-	tlog "github.com/opentracing/opentracing-go/log"
-	"golang.org/x/sync/errgroup"
 )
 
 // AlertEngine is the background process that
@@ -43,7 +44,7 @@ type AlertEngine struct {
 
 // IsDisabled returns true if the alerting service is disable for this instance.
 func (e *AlertEngine) IsDisabled() bool {
-	return !setting.AlertingEnabled || !setting.ExecuteAlerts || e.Cfg.UnifiedAlerting.Enabled
+	return (setting.AlertingEnabled != nil && !*setting.AlertingEnabled) || !setting.ExecuteAlerts || e.Cfg.UnifiedAlerting.IsEnabled()
 }
 
 // ProvideAlertEngine returns a new AlertEngine.

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
@@ -23,7 +25,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -185,7 +186,7 @@ func (ng *AlertNG) IsDisabled() bool {
 	if ng.Cfg == nil {
 		return true
 	}
-	return !ng.Cfg.UnifiedAlerting.Enabled
+	return !ng.Cfg.UnifiedAlerting.IsEnabled()
 }
 
 // getRuleDefaultIntervalSeconds returns the default rule interval if the interval is not set.

--- a/pkg/services/quota/quota.go
+++ b/pkg/services/quota/quota.go
@@ -62,7 +62,7 @@ func (qs *QuotaService) QuotaReached(c *models.ReqContext, target string) (bool,
 				}
 				continue
 			}
-			query := models.GetGlobalQuotaByTargetQuery{Target: scope.Target, UnifiedAlertingEnabled: qs.Cfg.UnifiedAlerting.Enabled}
+			query := models.GetGlobalQuotaByTargetQuery{Target: scope.Target, UnifiedAlertingEnabled: qs.Cfg.UnifiedAlerting.IsEnabled()}
 			if err := bus.DispatchCtx(c.Req.Context(), &query); err != nil {
 				return true, err
 			}
@@ -77,7 +77,7 @@ func (qs *QuotaService) QuotaReached(c *models.ReqContext, target string) (bool,
 				OrgId:                  c.OrgId,
 				Target:                 scope.Target,
 				Default:                scope.DefaultLimit,
-				UnifiedAlertingEnabled: qs.Cfg.UnifiedAlerting.Enabled,
+				UnifiedAlertingEnabled: qs.Cfg.UnifiedAlerting.IsEnabled(),
 			}
 			if err := bus.DispatchCtx(c.Req.Context(), &query); err != nil {
 				return true, err
@@ -96,7 +96,7 @@ func (qs *QuotaService) QuotaReached(c *models.ReqContext, target string) (bool,
 			if !c.IsSignedIn || c.UserId == 0 {
 				continue
 			}
-			query := models.GetUserQuotaByTargetQuery{UserId: c.UserId, Target: scope.Target, Default: scope.DefaultLimit, UnifiedAlertingEnabled: qs.Cfg.UnifiedAlerting.Enabled}
+			query := models.GetUserQuotaByTargetQuery{UserId: c.UserId, Target: scope.Target, Default: scope.DefaultLimit, UnifiedAlertingEnabled: qs.Cfg.UnifiedAlerting.IsEnabled()}
 			if err := bus.DispatchCtx(c.Req.Context(), &query); err != nil {
 				return true, err
 			}

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -1,6 +1,8 @@
 package migrations
 
 import (
+	"os"
+
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/ualert"
 	. "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
@@ -46,7 +48,11 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	addUserAuthTokenMigrations(mg)
 	addCacheMigration(mg)
 	addShortURLMigrations(mg)
-	ualert.AddAlertingEnabledMigration(mg)
+	// TODO Delete when unified alerting is enabled by default unconditionally (Grafana v9)
+	if err := ualert.CheckUnifiedAlertingEnabledByDefault(mg); err != nil { // this should always go before any other ualert migration
+		mg.Logger.Error("failed to determine the status of alerting engine. Enable either legacy or unified alerting explicitly and try again", "err", err)
+		os.Exit(1)
+	}
 	ualert.AddTablesMigrations(mg)
 	ualert.AddDashAlertMigration(mg)
 	addLibraryElementsMigrations(mg)

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -46,6 +46,7 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	addUserAuthTokenMigrations(mg)
 	addCacheMigration(mg)
 	addShortURLMigrations(mg)
+	ualert.AddAlertingEnabledMigration(mg)
 	ualert.AddTablesMigrations(mg)
 	ualert.AddDashAlertMigration(mg)
 	addLibraryElementsMigrations(mg)

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -57,7 +57,7 @@ func AddDashAlertMigration(mg *migrator.Migrator) {
 	_, migrationRun := logs[migTitle]
 
 	switch {
-	case mg.Cfg.UnifiedAlerting.Enabled && !migrationRun:
+	case mg.Cfg.UnifiedAlerting.IsEnabled() && !migrationRun:
 		// Remove the migration entry that removes all unified alerting data. This is so when the feature
 		// flag is removed in future the "remove unified alerting data" migration will be run again.
 		mg.AddMigration(fmt.Sprintf(clearMigrationEntryTitle, rmMigTitle), &clearMigrationEntry{
@@ -72,7 +72,7 @@ func AddDashAlertMigration(mg *migrator.Migrator) {
 			portedChannelGroupsPerOrg: make(map[int64]map[string]string),
 			silences:                  make(map[int64][]*pb.MeshSilence),
 		})
-	case !mg.Cfg.UnifiedAlerting.Enabled && migrationRun:
+	case !mg.Cfg.UnifiedAlerting.IsEnabled() && migrationRun:
 		// Remove the migration entry that creates unified alerting data. This is so when the feature
 		// flag is enabled in the future the migration "move dashboard alerts to unified alerting" will be run again.
 		mg.AddMigration(fmt.Sprintf(clearMigrationEntryTitle, migTitle), &clearMigrationEntry{
@@ -97,7 +97,7 @@ func RerunDashAlertMigration(mg *migrator.Migrator) {
 	cloneMigTitle := fmt.Sprintf("clone %s", migTitle)
 
 	_, migrationRun := logs[cloneMigTitle]
-	ngEnabled := mg.Cfg.UnifiedAlerting.Enabled
+	ngEnabled := mg.Cfg.UnifiedAlerting.IsEnabled()
 
 	switch {
 	case ngEnabled && !migrationRun:
@@ -117,7 +117,7 @@ func AddDashboardUIDPanelIDMigration(mg *migrator.Migrator) {
 
 	migrationID := "update dashboard_uid and panel_id from existing annotations"
 	_, migrationRun := logs[migrationID]
-	ngEnabled := mg.Cfg.UnifiedAlerting.Enabled
+	ngEnabled := mg.Cfg.UnifiedAlerting.IsEnabled()
 	undoMigrationID := "undo " + migrationID
 
 	if ngEnabled && !migrationRun {

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -37,6 +37,8 @@ var rmMigTitle = "remove unified alerting data"
 
 const clearMigrationEntryTitle = "clear migration entry %q"
 
+var ClearRmMigTitle = fmt.Sprintf(clearMigrationEntryTitle, rmMigTitle)
+
 type MigrationError struct {
 	AlertId int64
 	Err     error
@@ -61,7 +63,7 @@ func AddDashAlertMigration(mg *migrator.Migrator) {
 	case mg.Cfg.UnifiedAlerting.IsEnabled() && !migrationRun:
 		// Remove the migration entry that removes all unified alerting data. This is so when the feature
 		// flag is removed in future the "remove unified alerting data" migration will be run again.
-		mg.AddMigration(fmt.Sprintf(clearMigrationEntryTitle, rmMigTitle), &clearMigrationEntry{
+		mg.AddMigration(ClearRmMigTitle, &clearMigrationEntry{
 			migrationID: rmMigTitle,
 		})
 		if err != nil {

--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -50,6 +50,14 @@ func (mg *Migrator) AddMigration(id string, m Migration) {
 	mg.migrations = append(mg.migrations, m)
 }
 
+func (mg *Migrator) GetMigrationIDs() []string {
+	result := make([]string, 0, len(mg.migrations))
+	for _, migration := range mg.migrations {
+		result = append(result, migration.Id())
+	}
+	return result
+}
+
 func (mg *Migrator) GetMigrationLog() (map[string]MigrationLog, error) {
 	logMap := make(map[string]MigrationLog)
 	logItems := make([]MigrationLog, 0)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/util"
 
@@ -153,7 +154,7 @@ var (
 	Quota QuotaSettings
 
 	// Alerting
-	AlertingEnabled            bool
+	AlertingEnabled            *bool
 	ExecuteAlerts              bool
 	AlertingRenderLimit        int
 	AlertingErrorOrTimeout     string
@@ -1377,7 +1378,12 @@ func (cfg *Cfg) readFeatureToggles(iniFile *ini.File) error {
 
 func readAlertingSettings(iniFile *ini.File) error {
 	alerting := iniFile.Section("alerting")
-	AlertingEnabled = alerting.Key("enabled").MustBool(true)
+	enabled, err := alerting.Key("enabled").Bool()
+	if err == nil {
+		AlertingEnabled = &enabled
+	} else {
+		AlertingEnabled = nil
+	}
 	ExecuteAlerts = alerting.Key("execute_alerts").MustBool(true)
 	AlertingRenderLimit = alerting.Key("concurrent_render_limit").MustInt(5)
 

--- a/pkg/setting/setting_quota.go
+++ b/pkg/setting/setting_quota.go
@@ -68,7 +68,7 @@ func (cfg *Cfg) readQuotaSettings() {
 
 	var alertOrgQuota int64
 	var alertGlobalQuota int64
-	if cfg.UnifiedAlerting.Enabled {
+	if cfg.UnifiedAlerting.IsEnabled() {
 		alertOrgQuota = quota.Key("org_alert_rule").MustInt64(100)
 		alertGlobalQuota = quota.Key("global_alert_rule").MustInt64(-1)
 	}

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -446,8 +446,10 @@ func TestAlertingEnabled(t *testing.T) {
 				require.NoError(t, err)
 				err = cfg.ReadUnifiedAlertingSettings(f)
 				require.NoError(t, err)
-				assert.Equal(t, cfg.UnifiedAlerting.Enabled, false)
-				assert.Equal(t, AlertingEnabled, true)
+				assert.NotNil(t, cfg.UnifiedAlerting.Enabled)
+				assert.Equal(t, *cfg.UnifiedAlerting.Enabled, false)
+				assert.NotNil(t, AlertingEnabled)
+				assert.Equal(t, *AlertingEnabled, true)
 			},
 		},
 		{
@@ -461,12 +463,14 @@ func TestAlertingEnabled(t *testing.T) {
 				require.NoError(t, err)
 				err = cfg.ReadUnifiedAlertingSettings(f)
 				require.NoError(t, err)
-				assert.Equal(t, cfg.UnifiedAlerting.Enabled, true)
-				assert.Equal(t, AlertingEnabled, false)
+				assert.NotNil(t, cfg.UnifiedAlerting.Enabled)
+				assert.Equal(t, *cfg.UnifiedAlerting.Enabled, true)
+				assert.NotNil(t, AlertingEnabled)
+				assert.Equal(t, *AlertingEnabled, false)
 			},
 		},
 		{
-			desc:                   "when both alerting are enabled, it should error",
+			desc:                   "when both alerting are enabled",
 			legacyAlertingEnabled:  "true",
 			unifiedAlertingEnabled: "true",
 			verifyCfg: func(t *testing.T, cfg Cfg, f *ini.File) {
@@ -479,8 +483,8 @@ func TestAlertingEnabled(t *testing.T) {
 			},
 		},
 		{
-			desc:                   "when legacy alerting is invalid and unified is disabled",
-			legacyAlertingEnabled:  "invalid",
+			desc:                   "when legacy alerting is invalid (or not defined) and unified is disabled",
+			legacyAlertingEnabled:  "",
 			unifiedAlertingEnabled: "false",
 			verifyCfg: func(t *testing.T, cfg Cfg, f *ini.File) {
 				err := readAlertingSettings(f)
@@ -489,13 +493,15 @@ func TestAlertingEnabled(t *testing.T) {
 				require.NoError(t, err)
 				err = cfg.ReadUnifiedAlertingSettings(f)
 				require.NoError(t, err)
-				assert.Equal(t, cfg.UnifiedAlerting.Enabled, false)
-				assert.Equal(t, AlertingEnabled, true)
+				assert.NotNil(t, cfg.UnifiedAlerting.Enabled)
+				assert.Equal(t, *cfg.UnifiedAlerting.Enabled, false)
+				assert.NotNil(t, AlertingEnabled)
+				assert.Equal(t, *AlertingEnabled, true)
 			},
 		},
 		{
-			desc:                   "when legacy alerting is invalid and unified is enabled",
-			legacyAlertingEnabled:  "invalid",
+			desc:                   "when legacy alerting is invalid (or not defined) and unified is enabled",
+			legacyAlertingEnabled:  "",
 			unifiedAlertingEnabled: "true",
 			verifyCfg: func(t *testing.T, cfg Cfg, f *ini.File) {
 				err := readAlertingSettings(f)
@@ -503,26 +509,30 @@ func TestAlertingEnabled(t *testing.T) {
 				err = cfg.readFeatureToggles(f)
 				require.NoError(t, err)
 				err = cfg.ReadUnifiedAlertingSettings(f)
-				require.Error(t, err)
+				require.NoError(t, err)
+				assert.NotNil(t, cfg.UnifiedAlerting.Enabled)
+				assert.Equal(t, *cfg.UnifiedAlerting.Enabled, true)
+				assert.NotNil(t, AlertingEnabled)
+				assert.Equal(t, *AlertingEnabled, false)
 			},
 		},
 		{
-			desc:                   "when legacy alerting is enabled and unified is invalid",
+			desc:                   "when legacy alerting is enabled and unified is invalid (or not defined)",
 			legacyAlertingEnabled:  "true",
-			unifiedAlertingEnabled: "invalid",
+			unifiedAlertingEnabled: "",
 			verifyCfg: func(t *testing.T, cfg Cfg, f *ini.File) {
 				err := readAlertingSettings(f)
 				require.NoError(t, err)
 				err = cfg.readFeatureToggles(f)
 				require.NoError(t, err)
 				err = cfg.ReadUnifiedAlertingSettings(f)
-				require.NoError(t, err)
-				assert.Equal(t, cfg.UnifiedAlerting.Enabled, false)
-				assert.Equal(t, AlertingEnabled, true)
+				assert.Nil(t, cfg.UnifiedAlerting.Enabled)
+				assert.NotNil(t, AlertingEnabled)
+				assert.Equal(t, *AlertingEnabled, true)
 			},
 		},
 		{
-			desc:                   "when legacy alerting is disabled and unified is invalid",
+			desc:                   "when legacy alerting is disabled and unified is invalid (or not defined)",
 			legacyAlertingEnabled:  "false",
 			unifiedAlertingEnabled: "invalid",
 			verifyCfg: func(t *testing.T, cfg Cfg, f *ini.File) {
@@ -532,12 +542,14 @@ func TestAlertingEnabled(t *testing.T) {
 				require.NoError(t, err)
 				err = cfg.ReadUnifiedAlertingSettings(f)
 				require.NoError(t, err)
-				assert.Equal(t, cfg.UnifiedAlerting.Enabled, false)
-				assert.Equal(t, AlertingEnabled, false)
+				assert.NotNil(t, cfg.UnifiedAlerting.Enabled)
+				assert.Equal(t, *cfg.UnifiedAlerting.Enabled, true)
+				assert.NotNil(t, AlertingEnabled)
+				assert.Equal(t, *AlertingEnabled, false)
 			},
 		},
 		{
-			desc:                   "when both are invalid",
+			desc:                   "when both are invalid (or not defined)",
 			legacyAlertingEnabled:  "invalid",
 			unifiedAlertingEnabled: "invalid",
 			verifyCfg: func(t *testing.T, cfg Cfg, f *ini.File) {
@@ -547,31 +559,14 @@ func TestAlertingEnabled(t *testing.T) {
 				require.NoError(t, err)
 				err = cfg.ReadUnifiedAlertingSettings(f)
 				require.NoError(t, err)
-				assert.Equal(t, cfg.UnifiedAlerting.Enabled, false)
-				assert.Equal(t, AlertingEnabled, true)
+				assert.Nil(t, cfg.UnifiedAlerting.Enabled)
+				assert.Nil(t, AlertingEnabled)
 			},
 		},
 		{
-			desc:                   "when legacy alerting is enabled and unified is disabled and feature toggle is set",
-			legacyAlertingEnabled:  "true",
-			unifiedAlertingEnabled: "false",
-			featureToggleSet:       true,
-			verifyCfg: func(t *testing.T, cfg Cfg, f *ini.File) {
-				err := readAlertingSettings(f)
-				require.NoError(t, err)
-				err = cfg.readFeatureToggles(f)
-				require.NoError(t, err)
-				err = cfg.ReadUnifiedAlertingSettings(f)
-				require.NoError(t, err)
-				assert.Equal(t, cfg.UnifiedAlerting.Enabled, true)
-				assert.Equal(t, AlertingEnabled, false)
-			},
-		},
-		{
-			desc:                   "when legacy alerting is disabled and unified is disabled and feature toggle is set",
+			desc:                   "when both are false",
 			legacyAlertingEnabled:  "false",
 			unifiedAlertingEnabled: "false",
-			featureToggleSet:       true,
 			verifyCfg: func(t *testing.T, cfg Cfg, f *ini.File) {
 				err := readAlertingSettings(f)
 				require.NoError(t, err)
@@ -579,70 +574,10 @@ func TestAlertingEnabled(t *testing.T) {
 				require.NoError(t, err)
 				err = cfg.ReadUnifiedAlertingSettings(f)
 				require.NoError(t, err)
-				assert.Equal(t, cfg.UnifiedAlerting.Enabled, true)
-				assert.Equal(t, AlertingEnabled, false)
-			},
-		},
-		{
-			desc:                   "when legacy alerting is disabled and unified is invalid and feature toggle is set",
-			legacyAlertingEnabled:  "false",
-			unifiedAlertingEnabled: "invalid",
-			featureToggleSet:       true,
-			verifyCfg: func(t *testing.T, cfg Cfg, f *ini.File) {
-				err := readAlertingSettings(f)
-				require.NoError(t, err)
-				err = cfg.readFeatureToggles(f)
-				require.NoError(t, err)
-				err = cfg.ReadUnifiedAlertingSettings(f)
-				require.NoError(t, err)
-				assert.Equal(t, cfg.UnifiedAlerting.Enabled, true)
-				assert.Equal(t, AlertingEnabled, false)
-			},
-		},
-		{
-			desc:                   "when legacy alerting is invalid and unified is disabled and feature toggle is set",
-			legacyAlertingEnabled:  "invalid",
-			unifiedAlertingEnabled: "false",
-			featureToggleSet:       true,
-			verifyCfg: func(t *testing.T, cfg Cfg, f *ini.File) {
-				err := readAlertingSettings(f)
-				require.NoError(t, err)
-				err = cfg.readFeatureToggles(f)
-				require.NoError(t, err)
-				err = cfg.ReadUnifiedAlertingSettings(f)
-				require.NoError(t, err)
-				assert.Equal(t, cfg.UnifiedAlerting.Enabled, true)
-				assert.Equal(t, AlertingEnabled, false)
-			},
-		},
-		{
-			desc:                   "when legacy alerting is invalid and unified is enabled and feature toggle is set",
-			legacyAlertingEnabled:  "invalid",
-			unifiedAlertingEnabled: "true",
-			featureToggleSet:       true,
-			verifyCfg: func(t *testing.T, cfg Cfg, f *ini.File) {
-				err := readAlertingSettings(f)
-				require.NoError(t, err)
-				err = cfg.readFeatureToggles(f)
-				require.NoError(t, err)
-				err = cfg.ReadUnifiedAlertingSettings(f)
-				require.Error(t, err)
-			},
-		},
-		{
-			desc:                   "when both are invalid and feature toggle is set",
-			legacyAlertingEnabled:  "invalid",
-			unifiedAlertingEnabled: "invalid",
-			featureToggleSet:       true,
-			verifyCfg: func(t *testing.T, cfg Cfg, f *ini.File) {
-				err := readAlertingSettings(f)
-				require.NoError(t, err)
-				err = cfg.readFeatureToggles(f)
-				require.NoError(t, err)
-				err = cfg.ReadUnifiedAlertingSettings(f)
-				require.NoError(t, err)
-				assert.Equal(t, cfg.UnifiedAlerting.Enabled, true)
-				assert.Equal(t, AlertingEnabled, false)
+				assert.NotNil(t, cfg.UnifiedAlerting.Enabled)
+				assert.Equal(t, *cfg.UnifiedAlerting.Enabled, false)
+				assert.NotNil(t, AlertingEnabled)
+				assert.Equal(t, *AlertingEnabled, false)
 			},
 		},
 	}
@@ -650,7 +585,7 @@ func TestAlertingEnabled(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Cleanup(func() {
-				AlertingEnabled = false
+				AlertingEnabled = nil
 			})
 
 			f := ini.Empty()
@@ -664,13 +599,6 @@ func TestAlertingEnabled(t *testing.T) {
 			require.NoError(t, err)
 			_, err = alertingSec.NewKey("enabled", tc.legacyAlertingEnabled)
 			require.NoError(t, err)
-
-			if tc.featureToggleSet {
-				alertingSec, err := f.NewSection("feature_toggles")
-				require.NoError(t, err)
-				_, err = alertingSec.NewKey("enable", "ngalert")
-				require.NoError(t, err)
-			}
 
 			tc.verifyCfg(t, *cfg, f)
 		})

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -526,6 +526,7 @@ func TestAlertingEnabled(t *testing.T) {
 				err = cfg.readFeatureToggles(f)
 				require.NoError(t, err)
 				err = cfg.ReadUnifiedAlertingSettings(f)
+				require.NoError(t, err)
 				assert.Nil(t, cfg.UnifiedAlerting.Enabled)
 				assert.NotNil(t, AlertingEnabled)
 				assert.Equal(t, *AlertingEnabled, true)

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -106,7 +106,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	if uaCfg.Enabled != nil && *uaCfg.Enabled && AlertingEnabled != nil && *AlertingEnabled {
 		return errors.New("both legacy and Grafana 8 Alerts are enabled. Disable one of them and restart")
 	}
-	// NOTE: in the case when at this point the enabled flag is still not defined, the final decision is made during migration. (see sqlstore.migrations.ualert.AddAlertingEnabledMigration)
+	// NOTE: in the case when at this point the enabled flag is still not defined, the final decision is made during migration. (see sqlstore.migrations.ualert.CheckUnifiedAlertingEnabledByDefault)
 	if uaCfg.Enabled == nil {
 		cfg.Logger.Info("The state of unified alerting is still not defined. The decision will be made during the migration phase")
 	}

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -105,6 +105,10 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	if uaCfg.Enabled != nil && *uaCfg.Enabled && AlertingEnabled != nil && *AlertingEnabled {
 		return errors.New("both legacy and Grafana 8 Alerts are enabled. Disable one of them and restart")
 	}
+	// NOTE: in the case when at this point the enabled flag is still not defined, the final decision is made during migration. (see sqlstore.migrations.ualert.AddAlertingEnabledMigration)
+	if uaCfg.Enabled == nil {
+		cfg.Logger.Info("The state of unified alerting is still not defined. The decision will be made during the migration phase")
+	}
 
 	uaCfg.DisabledOrgs = make(map[int64]struct{})
 	orgsStr := valueAsString(ua, "disabled_orgs", "")


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
TBD 

This is a less intrusive alternative to https://github.com/grafana/grafana/pull/41380 that changes the meaning of the undefined configurations of legacy and Grafana 8 alerting features. It adds a database to the equation. Therefore, the table mentioned in https://github.com/grafana/grafana/pull/41380 gets a little bit more complicated:

|  `GF_ALERTING_ENABLED` |  `GF_UNIFIED_ALERTING_ENABLED`  | DB has legacy alerts | Result |
| ---------------------- | ------------------------------- | --- | ------ |
| `true` | `true` | - | Error |
| `true` | `false` | - | Legacy |
| `true` | not set | `true` | Legacy |
| `true` | not set | `false` | Error |
| not set | `true` | - | UA |
| not set | `false` |  - | Legacy |
| not set | not set | true | Legacy |
| not set | not set | false | UA |
| `false` | `true` | - | UA |
| `false` | `false` | - | Alerting disabled |
| `false` | not set | - | UA |

where `-` in the 3rd column means that it the value does not matter.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

1. The changes made here are temporary. They are supposed to be removed in the next major release when Grafana 8 alerts be available as the only option.
2. I had to change visibility of DB engine in the Migrator because the function I added to the function that builds migration sequence needs access to database to determine the final state of the Grafana 8 alerts before other functions are executed.
3. The change broke test TestMigrations. Apparently, one of migrations for unified alerting updates the migration log, which makes the test very unhappy. I added some functions to provide more verbose failure in the case when expected migrations do not match db log.