### PR TITLE
AzureMonitor: resourcePicker should show resource in the correct subs…

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/argResourcePickerResponse.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/argResourcePickerResponse.ts
@@ -10,16 +10,23 @@ export const createMockARGResourceContainersResponse = (): AzureGraphResponse<Ra
     },
 
     {
-      subscriptionURI: '/subscription/def-456',
+      subscriptionURI: '/subscriptions/def-456',
       subscriptionName: 'Dev Subscription',
-      resourceGroupURI: '/subscription/def-456/resourceGroups/dev',
+      resourceGroupURI: '/subscriptions/def-456/resourceGroups/dev',
       resourceGroupName: 'Development',
     },
 
     {
-      subscriptionURI: '/subscription/def-456',
+      subscriptionURI: '/subscriptions/def-456',
       subscriptionName: 'Dev Subscription',
-      resourceGroupURI: '/subscription/def-456/resourceGroups/test',
+      resourceGroupURI: '/subscriptions/def-456/resourceGroups/test',
+      resourceGroupName: 'Test',
+    },
+
+    {
+      subscriptionURI: '/subscriptions/abc-123',
+      subscriptionName: 'Primary Subscription',
+      resourceGroupURI: '/subscriptions/abc-123/resourceGroups/test',
       resourceGroupName: 'Test',
     },
 
@@ -31,9 +38,9 @@ export const createMockARGResourceContainersResponse = (): AzureGraphResponse<Ra
     },
 
     {
-      subscriptionURI: '/subscription/def-456',
+      subscriptionURI: '/subscriptions/def-456',
       subscriptionName: 'Dev Subscription',
-      resourceGroupURI: '/subscription/def-456/resourceGroups/qa',
+      resourceGroupURI: '/subscriptions/def-456/resourceGroups/qa',
       resourceGroupName: 'QA',
     },
   ],
@@ -42,7 +49,7 @@ export const createMockARGResourceContainersResponse = (): AzureGraphResponse<Ra
 export const createARGResourcesResponse = (): AzureGraphResponse<RawAzureResourceItem[]> => ({
   data: [
     {
-      id: '/subscription/def-456/resourceGroups/dev/providers/Microsoft.Compute/virtualMachines/web-server',
+      id: '/subscriptions/def-456/resourceGroups/dev/providers/Microsoft.Compute/virtualMachines/web-server',
       name: 'web-server',
       type: 'Microsoft.Compute/virtualMachines',
       resourceGroup: 'dev',
@@ -51,7 +58,7 @@ export const createARGResourcesResponse = (): AzureGraphResponse<RawAzureResourc
     },
 
     {
-      id: '/subscription/def-456/resourceGroups/dev/providers/Microsoft.Compute/disks/web-server_DataDisk',
+      id: '/subscriptions/def-456/resourceGroups/dev/providers/Microsoft.Compute/disks/web-server_DataDisk',
       name: 'web-server_DataDisk',
       type: 'Microsoft.Compute/disks',
       resourceGroup: 'dev',
@@ -60,7 +67,7 @@ export const createARGResourcesResponse = (): AzureGraphResponse<RawAzureResourc
     },
 
     {
-      id: '/subscription/def-456/resourceGroups/dev/providers/Microsoft.Compute/virtualMachines/db-server',
+      id: '/subscriptions/def-456/resourceGroups/dev/providers/Microsoft.Compute/virtualMachines/db-server',
       name: 'db-server',
       type: 'Microsoft.Compute/virtualMachines',
       resourceGroup: 'dev',
@@ -69,7 +76,7 @@ export const createARGResourcesResponse = (): AzureGraphResponse<RawAzureResourc
     },
 
     {
-      id: '/subscription/def-456/resourceGroups/dev/providers/Microsoft.Compute/disks/db-server_DataDisk',
+      id: '/subscriptions/def-456/resourceGroups/dev/providers/Microsoft.Compute/disks/db-server_DataDisk',
       name: 'db-server_DataDisk',
       type: 'Microsoft.Compute/disks',
       resourceGroup: 'dev',

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.test.ts
@@ -25,6 +25,7 @@ describe('AzureMonitor resourcePickerData', () => {
 
       expect(argQuery).toContain(`where type == 'microsoft.resources/subscriptions'`);
       expect(argQuery).toContain(`where type == 'microsoft.resources/subscriptions/resourcegroups'`);
+      expect(argQuery).toContain(`project resourceGroupURI=id, resourceGroupName=name, resourceGroup, subscriptionId`);
     });
 
     it('returns only subscriptions at the top level', async () => {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.test.ts
@@ -30,7 +30,7 @@ describe('AzureMonitor resourcePickerData', () => {
     it('returns only subscriptions at the top level', async () => {
       const results = await resourcePickerData.getResourcePickerData();
 
-      expect(results.map((v) => v.id)).toEqual(['/subscriptions/abc-123', '/subscription/def-456']);
+      expect(results.map((v) => v.id)).toEqual(['/subscriptions/abc-123', '/subscriptions/def-456']);
     });
 
     it('nests resource groups under their subscriptions', async () => {
@@ -38,13 +38,14 @@ describe('AzureMonitor resourcePickerData', () => {
 
       expect(results[0].children?.map((v) => v.id)).toEqual([
         '/subscriptions/abc-123/resourceGroups/prod',
+        '/subscriptions/abc-123/resourceGroups/test',
         '/subscriptions/abc-123/resourceGroups/pre-prod',
       ]);
 
       expect(results[1].children?.map((v) => v.id)).toEqual([
-        '/subscription/def-456/resourceGroups/dev',
-        '/subscription/def-456/resourceGroups/test',
-        '/subscription/def-456/resourceGroups/qa',
+        '/subscriptions/def-456/resourceGroups/dev',
+        '/subscriptions/def-456/resourceGroups/test',
+        '/subscriptions/def-456/resourceGroups/qa',
       ]);
     });
 
@@ -76,20 +77,22 @@ describe('AzureMonitor resourcePickerData', () => {
         const results = await resourcePickerData.getResourcePickerData();
         expect(results[0].children?.map((v) => v.id)).toEqual([
           '/subscriptions/abc-123/resourceGroups/prod',
+          '/subscriptions/abc-123/resourceGroups/test',
           '/subscriptions/abc-123/resourceGroups/pre-prod',
           // second page
           '/subscriptions/abc-123/resourceGroups/prod',
+          '/subscriptions/abc-123/resourceGroups/test',
           '/subscriptions/abc-123/resourceGroups/pre-prod',
         ]);
 
         expect(results[1].children?.map((v) => v.id)).toEqual([
-          '/subscription/def-456/resourceGroups/dev',
-          '/subscription/def-456/resourceGroups/test',
-          '/subscription/def-456/resourceGroups/qa',
+          '/subscriptions/def-456/resourceGroups/dev',
+          '/subscriptions/def-456/resourceGroups/test',
+          '/subscriptions/def-456/resourceGroups/qa',
           // second page
-          '/subscription/def-456/resourceGroups/dev',
-          '/subscription/def-456/resourceGroups/test',
-          '/subscription/def-456/resourceGroups/qa',
+          '/subscriptions/def-456/resourceGroups/dev',
+          '/subscriptions/def-456/resourceGroups/test',
+          '/subscriptions/def-456/resourceGroups/qa',
         ]);
       });
     });
@@ -97,7 +100,7 @@ describe('AzureMonitor resourcePickerData', () => {
 
   describe('getResourcesForResourceGroup', () => {
     const resourceRow = {
-      id: '/subscription/def-456/resourceGroups/dev',
+      id: '/subscriptions/def-456/resourceGroups/dev',
       name: 'Dev',
       type: ResourceRowType.ResourceGroup,
       typeLabel: 'Resource group',
@@ -121,10 +124,10 @@ describe('AzureMonitor resourcePickerData', () => {
       const results = await resourcePickerData.getResourcesForResourceGroup(resourceRow);
 
       expect(results.map((v) => v.id)).toEqual([
-        '/subscription/def-456/resourceGroups/dev/providers/Microsoft.Compute/virtualMachines/web-server',
-        '/subscription/def-456/resourceGroups/dev/providers/Microsoft.Compute/disks/web-server_DataDisk',
-        '/subscription/def-456/resourceGroups/dev/providers/Microsoft.Compute/virtualMachines/db-server',
-        '/subscription/def-456/resourceGroups/dev/providers/Microsoft.Compute/disks/db-server_DataDisk',
+        '/subscriptions/def-456/resourceGroups/dev/providers/Microsoft.Compute/virtualMachines/web-server',
+        '/subscriptions/def-456/resourceGroups/dev/providers/Microsoft.Compute/disks/web-server_DataDisk',
+        '/subscriptions/def-456/resourceGroups/dev/providers/Microsoft.Compute/virtualMachines/db-server',
+        '/subscriptions/def-456/resourceGroups/dev/providers/Microsoft.Compute/disks/db-server_DataDisk',
       ]);
 
       results.forEach((v) => expect(v.type).toEqual(ResourceRowType.Resource));

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
@@ -45,8 +45,8 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
         | join kind=leftouter (
           ResourceContainers
             | where type == 'microsoft.resources/subscriptions/resourcegroups'
-            | project resourceGroupURI=id, resourceGroupName=name, resourceGroup
-          ) on resourceGroup
+            | project resourceGroupURI=id, resourceGroupName=name, resourceGroup, subscriptionId
+          ) on resourceGroup, subscriptionId
 
         | where type in (${logsSupportedResourceTypesKusto})
 


### PR DESCRIPTION
…cription

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fixes an error where if two subscriptions have a resource group with the same name, it would show up twice under both.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #40889 

**Special notes for your reviewer**:
The test doesn't actually replicate the bug (it had to do with the azure resource graph query) but I thought it would be good to have.

