### PR TITLE
Allow non-FGAC fallback to server admin role

### DIFF
--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -74,7 +74,11 @@ export class ContextSrv {
   }
 
   hasRole(role: string) {
-    return this.user.orgRole === role;
+    if (role === 'ServerAdmin') {
+      return this.isGrafanaAdmin;
+    } else {
+      return this.user.orgRole === role;
+    }
   }
 
   accessControlEnabled(): boolean {


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows permission checks to check for Server Admin status, not just organization admin status. This
role is more appropriate for server-wide information (like licensing).

**Special notes for your reviewer**:

It was unclear how to usefully test this. 
