### PR TITLE
CloudWatch Logs: Add selected region to autocomplete requests

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
@@ -263,7 +263,7 @@ export class CloudWatchLogsQueryField extends React.PureComponent<CloudWatchLogs
   };
 
   onTypeahead = async (typeahead: TypeaheadInput): Promise<TypeaheadOutput> => {
-    const { datasource } = this.props;
+    const { datasource, query } = this.props;
     const { selectedLogGroups } = this.state;
 
     if (!datasource.languageProvider) {
@@ -276,7 +276,12 @@ export class CloudWatchLogsQueryField extends React.PureComponent<CloudWatchLogs
 
     return await cloudwatchLanguageProvider.provideCompletionItems(
       { text, value, prefix, wrapperClasses, labelKey, editor },
-      { history, absoluteRange, logGroupNames: selectedLogGroups.map((logGroup) => logGroup.value!) }
+      {
+        history,
+        absoluteRange,
+        logGroupNames: selectedLogGroups.map((logGroup) => logGroup.value!),
+        region: query.region,
+      }
     );
   };
 

--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -125,6 +125,34 @@ describe('datasource', () => {
       expect(fetchMock.mock.calls[1][0].data.queries[0].region).toBe('eu-east');
     });
   });
+
+  describe('getLogGroupFields', () => {
+    it('passes region correctly', async () => {
+      const { datasource, fetchMock } = setupMockedDataSource();
+      fetchMock.mockReturnValueOnce(
+        of({
+          data: {
+            results: {
+              A: {
+                frames: [
+                  dataFrameToJSON(
+                    new MutableDataFrame({
+                      fields: [
+                        { name: 'key', values: [] },
+                        { name: 'val', values: [] },
+                      ],
+                    })
+                  ),
+                ],
+              },
+            },
+          },
+        })
+      );
+      await datasource.getLogGroupFields({ region: 'us-west-1', logGroupName: 'test' });
+      expect(fetchMock.mock.calls[0][0].data.queries[0].region).toBe('us-west-1');
+    });
+  });
 });
 
 function setupForLogs() {

--- a/public/app/plugins/datasource/cloudwatch/language_provider.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/language_provider.test.ts
@@ -127,7 +127,7 @@ function getProvideCompletionItems(query: string): Promise<TypeaheadOutput> {
     {
       value,
     } as any,
-    { logGroupNames: ['logGroup1'] }
+    { logGroupNames: ['logGroup1'], region: 'custom' }
   );
 }
 

--- a/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/specs/datasource.test.ts
@@ -164,7 +164,7 @@ describe('CloudWatchDatasource', () => {
         'container-insights-prometheus-demo',
       ];
 
-      const logGroups = await ds.describeLogGroups({});
+      const logGroups = await ds.describeLogGroups({ region: 'default' });
 
       expect(logGroups).toEqual(expectedLogGroups);
     });

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -122,6 +122,12 @@ export interface QueryStatistics {
 
 export type QueryStatus = 'Scheduled' | 'Running' | 'Complete' | 'Failed' | 'Cancelled' | string;
 
+export type CloudWatchLogsRequest =
+  | GetLogEventsRequest
+  | StartQueryRequest
+  | DescribeLogGroupsRequest
+  | GetLogGroupFieldsRequest;
+
 export interface GetLogEventsRequest {
   /**
    * The name of the log group.
@@ -182,7 +188,7 @@ export interface DescribeLogGroupsRequest {
    */
   limit?: number;
   refId?: string;
-  region?: string;
+  region: string;
 }
 
 export interface TSDBResponse<T = any> {
@@ -256,6 +262,7 @@ export interface GetLogGroupFieldsRequest {
    * The time to set as the center of the query. If you specify time, the 8 minutes before and 8 minutes after this time are searched. If you omit time, the past 15 minutes are queried. The time value is specified as epoch time, the number of seconds since January 1, 1970, 00:00:00 UTC.
    */
   time?: number;
+  region: string;
 }
 
 export interface LogGroupField {


### PR DESCRIPTION
Part of this issue https://github.com/grafana/grafana/issues/41689

This fixes case for autocomplete request where we query the available fields in a log group. Region was added to the payload type and propagated to the request.

There is still query for log context where the region isn't available and would need a refactoring of the log context API to be available. That is not part of this PR.