### PR TITLE
Grafana UI: Prevent mandatory css prop in bundled types

### DIFF
--- a/packages/grafana-ui/tsconfig.build.json
+++ b/packages/grafana-ui/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "paths": {
-      "@emotion/core": ["../../src/types/emotion-core-stub.d.ts"],
+      "@emotion/core": ["./src/types/emotion-core-stub.d.ts"],
       "@grafana/slate-react": ["slate-react"],
       "@grafana/ui": ["."]
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Whilst testing `@grafana` packages output I discovered the mandatory css prop has somehow found its way back into the bundled output of `@grafana/ui`. Looks like something changed in how typescript is resolving paths (maybe yarn berry or PnP related????).

### Plugin build output against main

```
yarn build
yarn run v1.22.17
$ grafana-toolkit plugin:build
  Using Node.js v16.13.0
  Using @grafana/toolkit v8.2.3
✔ Preparing
✔ Linting
 PASS  src/module.test.ts

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        1.714 s
Ran all test suites with tests matching "".
✔ Running tests
⠙ Compiling...  Starting type checking service...
  Using 1 worker with 2048MB memory limit
⠸ Compiling...  ERROR in /Users/jackwestbrook/Projects/grafana-plugins/my-grafana-plugin/src/SimplePanel.tsx(16,16):
  TS2741: Property 'css' is missing in type '{ onChange: ChangeHandler; onBlur: ChangeHandler; ref: RefCallBack; name: string; }' but required in type 'Pick<Props, "onSubmit" | "accept" | "acceptCharset" | "action" | "allowFullScreen" | "allowTransparency" | "alt" | "as" | "async" | "autoComplete" | "autoFocus" | "autoPlay" | ... 352 more ... | "addonAfter">'.
  ERROR in /Users/jackwestbrook/Projects/grafana-plugins/my-grafana-plugin/src/SimplePanel.tsx(17,16):
  TS2741: Property 'css' is missing in type '{ onChange: ChangeHandler; onBlur: ChangeHandler; ref: RefCallBack; name: string; }' but required in type 'Pick<Props, "onSubmit" | "accept" | "acceptCharset" | "action" | "allowFullScreen" | "allowTransparency" | "alt" | "as" | "async" | "autoComplete" | "autoFocus" | "autoPlay" | ... 348 more ... | "invalid">'.
  ERROR in /Users/jackwestbrook/Projects/grafana-plugins/my-grafana-plugin/src/SimplePanel.tsx(19,14):
  TS2741: Property 'css' is missing in type '{ ref: MutableRefObject<null>; value: true; }' but required in type 'Pick<CheckboxProps, "onSubmit" | "accept" | "acceptCharset" | "action" | "allowFullScreen" | "allowTransparency" | "alt" | "as" | "async" | "autoComplete" | "autoFocus" | ... 350 more ... | "description">'.
✖ Build failed
```

### Plugin build output against this branch:

```
yarn build
yarn run v1.22.17
$ grafana-toolkit plugin:build
  Using Node.js v16.13.0
  Using @grafana/toolkit v8.2.5
✔ Preparing
✔ Linting
 PASS  src/module.test.ts

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        1.48 s
Ran all test suites with tests matching "".
✔ Running tests
⠙ Compiling...  Starting type checking service...
  Using 1 worker with 2048MB memory limit
⠸ Compiling...
   Hash: 4b68c49376e99102f2c6
  Version: webpack 4.41.5
  Time: 4065ms
  Built at: 11/24/2021 12:44:26 PM
                  Asset       Size  Chunks                   Chunk Names
           CHANGELOG.md   53 bytes          [emitted]
                LICENSE   11.1 KiB          [emitted]
              README.md   1.36 KiB          [emitted]
           img/logo.svg   1.55 KiB          [emitted]
              module.js   2.46 KiB       0  [emitted]        module
  module.js.LICENSE.txt  808 bytes          [emitted]
          module.js.map   18.6 KiB       0  [emitted] [dev]  module
            plugin.json  844 bytes          [emitted]
  Entrypoint module = module.js module.js.map
  [0] external "react" 42 bytes {0} [built]
  [1] external "@grafana/ui" 42 bytes {0} [built]
  [2] external "@grafana/data" 42 bytes {0} [built]
  [3] ./module.ts + 2 modules 11.7 KiB {0} [built]
      | ./module.ts 868 bytes [built]
      | ./SimplePanel.tsx 838 bytes [built]
      | ../node_modules/tslib/tslib.es6.js 10 KiB [built]

✔ Compiling...
✨  Done in 12.27s.
```


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related PR: #38078
Related Issue: #35878

**Special notes for your reviewer**:
I tested this by:

1. follow the repro steps outlined in the related issue
1. build the `grafana/ui` lib in this branch
2. replace the  contents of `node_modules/@grafana/ui` in the starter plugin (created in step1 of issue repo steps) with the contents of `grafana/ui/dist` folder created in previous step.
3. Restart IDE / run `yarn build` in starter panel to confirm TS errors are gone.

