### PR TITLE
News: Reload feed when changing the time range or refreshing

### DIFF
--- a/public/app/plugins/panel/news/NewsPanel.tsx
+++ b/public/app/plugins/panel/news/NewsPanel.tsx
@@ -14,6 +14,8 @@ import { NewsItem } from './types';
 import { PanelOptions } from './models.gen';
 import { DEFAULT_FEED_URL, PROXY_PREFIX } from './constants';
 import { css, cx } from '@emotion/css';
+import { RefreshEvent } from '@grafana/runtime';
+import { Unsubscribable } from 'rxjs';
 
 interface Props extends PanelProps<PanelOptions> {}
 
@@ -23,14 +25,20 @@ interface State {
 }
 
 export class NewsPanel extends PureComponent<Props, State> {
+  private refreshSubscription: Unsubscribable;
+
   constructor(props: Props) {
     super(props);
-
+    this.refreshSubscription = this.props.eventBus.subscribe(RefreshEvent, this.loadChannel.bind(this));
     this.state = {};
   }
 
   componentDidMount(): void {
     this.loadChannel();
+  }
+
+  componentWillUnmount(): void {
+    this.refreshSubscription.unsubscribe();
   }
 
   componentDidUpdate(prevProps: Props): void {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- subscribes to the `RefreshEvent`, reloading the feed whenever this fires.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/27869

**Special notes for your reviewer**:
- not sure if this is the correct approach. in the issue, @ryantxu has linked another issue which seems to suggest this applies to all panels with `skipDataQuery: true`. this only solves it for the `NewsPanel`, but i can't repro in other panels anyway. it looks like each panel has implemented it's own solution for this, so maybe this is ok? 🤔

