### PR TITLE
Explore: Fix url update inconsistency

### DIFF
--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -391,7 +391,7 @@ export const runQueries = (
       const timeZone = getTimeZone(getState().user);
       const transaction = buildQueryTransaction(exploreId, queries, queryOptions, range, scanning, timeZone);
 
-      let firstResponse = true;
+      let querySaved = false;
       dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Loading }));
 
       newQuerySub = runRequest(datasourceInstance, transaction.request)
@@ -413,7 +413,7 @@ export const runQueries = (
         )
         .subscribe(
           (data) => {
-            if (!data.error && firstResponse) {
+            if (data.state !== LoadingState.Loading && !data.error && !querySaved) {
               // Side-effect: Saving history in localstorage
               const nextHistory = updateHistory(history, datasourceId, queries);
               const { richHistory: nextRichHistory, localStorageFull, limitExceeded } = addToRichHistory(
@@ -438,9 +438,8 @@ export const runQueries = (
 
               // We save queries to the URL here so that only successfully run queries change the URL.
               dispatch(stateSave({ replace: options?.replaceUrl }));
+              querySaved = true;
             }
-
-            firstResponse = false;
 
             dispatch(queryStreamUpdatedAction({ exploreId, response: data }));
 


### PR DESCRIPTION
related (maybe fixes): https://github.com/grafana/grafana/issues/40936 and https://github.com/grafana/grafana/issues/35971

when in explore-mode we run a query, we update the URL with the query if the query is "successful". we check the condition here: https://github.com/grafana/grafana/blob/main/public/app/features/explore/state/query.ts#L416

so, whenever we receive data, we check for two things:
A. if this is the first time we received data (i gues so that when a response is streaming we do not update the URL many times)
B. if this is a "success" response.

[B] has a problem.

normally, when a query runs, the check-place (the place i linked to above) is only called once, with `data.state` being either `Done` or `Error`. in that case everything is ok.

but, when the response arrives slowly, grafana-code emits an artificial data-block with `state=Loading`, see here: https://github.com/grafana/grafana/blob/main/public/app/features/query/state/runRequest.ts#L161-L164

we should skip this Loading-event, but the current code does not skip it.

i modified the check in two ways:
1. we skip the loading-event
2. we check for error not by checking the `.error` attribute, but by checking the `state` attribute

i'm quite sure we need [1], i don't know if [2] is the best way to do it.

the current approach checks for "known bad" cases, and makes sure we do not run in those cases. alternatively, we could check for "known good" cases and only run in those... i checked the `LoadingState` enum ( https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/data.ts#L14-L20 ) , and that would mean allowing `Done` and `Streaming`, probably.. what do you think?