### PR TITLE
devenv: disable managed-alerts for datasources

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -34,11 +34,15 @@ datasources:
     type: prometheus
     access: proxy
     url: http://localhost:9090
+    jsonData:
+      manageAlerts: false
 
   - name: gdev-slow-prometheus
     type: prometheus
     access: proxy
     url: http://localhost:3011
+    jsonData:
+      manageAlerts: false
 
   - name: gdev-testdata
     isDefault: true
@@ -293,6 +297,7 @@ datasources:
     url: http://localhost:3100
     editable: false
     jsonData:
+      manageAlerts: false
       derivedFields:
         - name: "traceID"
           matcherRegex: "traceID=(\\w+)"


### PR DESCRIPTION
when running `devenv/setup.sh` , dev-datasources are provisioned. the provisioned Prometheus and Loki datasources have the `Manage alerts via Alerting UI` setting enabled (because that is the default).

the problem is, when you go to the alerting-page (new alerting) in grafana, it tries to load alerting-info from all datasources that have that setting enabled. and if it is unable to load them, you get an error-message. and one usually does not run all 3 of these at the same time: gdev-prometheus, gdev-slow-prometheus,gdev-loki. so you will always have the error-message on that page.

this pull-request adjusts these 3 datasources to have the setting disabled.

of course, this means that if you used one of these datasources to test some managed-alerts things, now you cannot (you can still change the yaml file, and run `devenv/setup.sh` again, but it is more work). unfortunately i do not see an option to support both use-cases, so i guess we will have to decide which way to go.