### PR TITLE
Alerting: add settings for peer reconnection in HA mode

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -767,6 +767,15 @@ ha_peers = ""
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 ha_peer_timeout = 15s
 
+# Length of time to attempt to reconnect to a lost peer. After this timeout
+# peers that are lost and not part of the configuration will be removed from 
+# the cluster. In ephemeral setups like kubernetes this should be set to a 
+# lower value to avoid error log spam on ungraceful shutdown.
+ha_peer_reconnect_timeout = 6h
+
+# Interval between attempting to reconnect to lost peers.
+ha_peer_reconnect_interval = 10s
+
 # The interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated
 # across cluster more quickly at the expense of increased bandwidth usage.
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -744,6 +744,15 @@
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 ;ha_peer_timeout = "15s"
 
+# Length of time to attempt to reconnect to a lost peer. After this timeout
+# peers that are lost and not part of the configuration will be removed from 
+# the cluster. In ephemeral setups like kubernetes this should be set to a 
+# lower value to avoid error log spam on ungraceful shutdown.
+;ha_peer_reconnect_timeout = 6h
+
+# Interval between attempting to reconnect to lost peers.
+;ha_peer_reconnect_interval = 10s
+
 # The interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated
 # across cluster more quickly at the expense of increased bandwidth usage.
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1157,6 +1157,23 @@ each instance wait before sending the notification to take into account replicat
 
 The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 
+### ha_peer_reconnect_timeout
+
+Length of time to attempt to reconnect to a lost peer. After this timeout
+peers that are lost and not part of the configuration will be removed from
+the cluster. In ephemeral setups like kubernetes this should be set to a
+lower value to avoid error log spam on ungraceful shutdown. The default value
+is `6h`.
+
+The timeout string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
+
+### ha_peer_reconnect_interval
+
+Interval between attempting to reconnect to lost peers. The default value is
+`10s`.
+
+The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
+
 ### ha_gossip_interval
 
 The interval between sending gossip messages. By lowering this value (more frequent) gossip messages are propagated

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -85,7 +85,7 @@ func NewMultiOrgAlertmanager(cfg *setting.Cfg, configStore store.AlertingStore, 
 			return nil, fmt.Errorf("unable to initialize gossip mesh: %w", err)
 		}
 
-		err = peer.Join(cluster.DefaultReconnectInterval, cluster.DefaultReconnectTimeout)
+		err = peer.Join(cfg.UnifiedAlerting.HAPeerReconnectInterval, cfg.UnifiedAlerting.HAPeerReconnectTimeout)
 		if err != nil {
 			l.Error("msg", "unable to join gossip mesh while initializing cluster for high availability mode", "err", err)
 		}

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -15,11 +15,13 @@ import (
 )
 
 const (
-	alertmanagerDefaultClusterAddr        = "0.0.0.0:9094"
-	alertmanagerDefaultPeerTimeout        = 15 * time.Second
-	alertmanagerDefaultGossipInterval     = cluster.DefaultGossipInterval
-	alertmanagerDefaultPushPullInterval   = cluster.DefaultPushPullInterval
-	alertmanagerDefaultConfigPollInterval = 60 * time.Second
+	alertmanagerDefaultClusterAddr           = "0.0.0.0:9094"
+	alertmanagerDefaultPeerTimeout           = 15 * time.Second
+	alertmanagerDefaultPeerReconnectTimeout  = cluster.DefaultReconnectTimeout
+	alertmanagerDefaultPeerReconnectInterval = cluster.DefaultReconnectInterval
+	alertmanagerDefaultGossipInterval        = cluster.DefaultGossipInterval
+	alertmanagerDefaultPushPullInterval      = cluster.DefaultPushPullInterval
+	alertmanagerDefaultConfigPollInterval    = 60 * time.Second
 	// To start, the alertmanager needs at least one route defined.
 	// TODO: we should move this to Grafana settings and define this as the default.
 	alertmanagerDefaultConfiguration = `{
@@ -57,6 +59,8 @@ type UnifiedAlertingSettings struct {
 	HAAdvertiseAddr                string
 	HAPeers                        []string
 	HAPeerTimeout                  time.Duration
+	HAPeerReconnectTimeout         time.Duration
+	HAPeerReconnectInterval        time.Duration
 	HAGossipInterval               time.Duration
 	HAPushPullInterval             time.Duration
 	MaxAttempts                    int64
@@ -139,6 +143,14 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 		return err
 	}
 	uaCfg.HAPeerTimeout, err = gtime.ParseDuration(valueAsString(ua, "ha_peer_timeout", (alertmanagerDefaultPeerTimeout).String()))
+	if err != nil {
+		return err
+	}
+	uaCfg.HAPeerReconnectTimeout, err = gtime.ParseDuration(valueAsString(ua, "ha_peer_reconnect_timeout", (alertmanagerDefaultPeerReconnectTimeout).String()))
+	if err != nil {
+		return err
+	}
+	uaCfg.HAPeerReconnectInterval, err = gtime.ParseDuration(valueAsString(ua, "ha_peer_reconnect_interval", (alertmanagerDefaultPeerReconnectInterval).String()))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: 
This PR adds the ability to configure the peer reconnection settings. One can set the desired timeout and reconnect interval. This is very useful when running in an ephemeral environment like Kubernetes, where an ungraceful shutdown might happen, and you don't want to try old peers for 6 hours (which is the default). 

**Special notes for your reviewer**: This is not a breaking change, as the default values stay the same.

