### PR TITLE
Alerting: Prevent folders from being deleted when they contain alerts

### DIFF
--- a/public/app/features/folders/state/actions.ts
+++ b/public/app/features/folders/state/actions.ts
@@ -30,8 +30,8 @@ export function saveFolder(folder: FolderState): ThunkResult<void> {
 }
 
 export function deleteFolder(uid: string): ThunkResult<void> {
-  return async (dispatch) => {
-    await backendSrv.delete(`/api/folders/${uid}?forceDeleteRules=true`);
+  return async () => {
+    await backendSrv.delete(`/api/folders/${uid}?forceDeleteRules=false`);
     locationService.push('/dashboards');
   };
 }

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -277,8 +277,8 @@ export function saveDashboard(options: SaveDashboardOptions) {
 function deleteFolder(uid: string, showSuccessAlert: boolean) {
   return getBackendSrv().request({
     method: 'DELETE',
-    url: `/api/folders/${uid}?forceDeleteRules=true`,
-    showSuccessAlert: showSuccessAlert === true,
+    url: `/api/folders/${uid}?forceDeleteRules=false`,
+    showSuccessAlert: showSuccessAlert,
   });
 }
 
@@ -298,7 +298,7 @@ export function deleteDashboard(uid: string, showSuccessAlert: boolean) {
   return getBackendSrv().request({
     method: 'DELETE',
     url: `/api/dashboards/uid/${uid}`,
-    showSuccessAlert: showSuccessAlert === true,
+    showSuccessAlert: showSuccessAlert,
   });
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Changing behavior from automatically deleting alerts to prevent folders from being deleted if they contain alerts.

**Which issue(s) this PR fixes**:

Fixes #39175

**Special notes for your reviewer**:

