### PR TITLE
ValueMappings: Fixes issue with regex value mapping that only sets color

### DIFF
--- a/packages/grafana-data/src/utils/valueMappings.test.ts
+++ b/packages/grafana-data/src/utils/valueMappings.test.ts
@@ -67,6 +67,13 @@ const testSet2: ValueMapping[] = [
       result: { text: 'Hostname $1' },
     },
   },
+  {
+    type: MappingType.RegexToText,
+    options: {
+      pattern: '/hello/',
+      result: { color: 'red' },
+    },
+  },
 ];
 
 describe('Format value with value mappings', () => {
@@ -163,6 +170,10 @@ describe('Format value with regex mappings', () => {
   it('should return null with unmatched value', () => {
     const value = 'www.baz.com';
     expect(getValueMappingResult(testSet2, value)).toBeNull();
+  });
+
+  it('should return not replace match when replace text is null', () => {
+    expect(getValueMappingResult(testSet2, 'hello my name is')).toEqual({ color: 'red' });
   });
 });
 

--- a/packages/grafana-data/src/utils/valueMappings.test.ts
+++ b/packages/grafana-data/src/utils/valueMappings.test.ts
@@ -172,7 +172,7 @@ describe('Format value with regex mappings', () => {
     expect(getValueMappingResult(testSet2, value)).toBeNull();
   });
 
-  it('should return not replace match when replace text is null', () => {
+  it('should not replace match when replace text is null', () => {
     expect(getValueMappingResult(testSet2, 'hello my name is')).toEqual({ color: 'red' });
   });
 });

--- a/packages/grafana-data/src/utils/valueMappings.ts
+++ b/packages/grafana-data/src/utils/valueMappings.ts
@@ -58,9 +58,13 @@ export function getValueMappingResult(valueMappings: ValueMapping[], value: any)
 
         const regex = stringToJsRegex(vm.options.pattern);
         if (value.match(regex)) {
-          const thisResult = Object.create(vm.options.result);
-          thisResult.text = value.replace(regex, vm.options.result.text || '');
-          return thisResult;
+          const res = { ...vm.options.result };
+
+          if (res.text != null) {
+            res.text = value.replace(regex, vm.options.result.text || '');
+          }
+
+          return res;
         }
 
       case MappingType.SpecialValue:


### PR DESCRIPTION
When investigating an issue I noticed that regex value mappings always matched and replaced the matched element even when
the replace with text was empty (which it is when you only want to set color).


