### PR TITLE
Chore: Refactor isSharedDashboardQuery to narrow type natrually

### DIFF
--- a/public/app/plugins/datasource/dashboard/runSharedRequest.test.ts
+++ b/public/app/plugins/datasource/dashboard/runSharedRequest.test.ts
@@ -6,8 +6,8 @@ describe('SharedQueryRunner', () => {
     expect(isSharedDashboardQuery('-- Dashboard --')).toBe(true);
 
     expect(isSharedDashboardQuery('')).toBe(false);
-    expect(isSharedDashboardQuery((undefined as unknown) as string | DataSourceApi)).toBe(false);
-    expect(isSharedDashboardQuery((null as unknown) as string | DataSourceApi)).toBe(false);
+    expect(isSharedDashboardQuery((undefined as unknown) as null)).toBe(false);
+    expect(isSharedDashboardQuery(null)).toBe(false);
 
     const ds = {
       meta: {

--- a/public/app/plugins/datasource/dashboard/runSharedRequest.ts
+++ b/public/app/plugins/datasource/dashboard/runSharedRequest.ts
@@ -17,11 +17,16 @@ export function isSharedDashboardQuery(datasource: string | DataSourceRef | Data
     // default datasource
     return false;
   }
-  if (datasource === SHARED_DASHBOARD_QUERY || (datasource as any)?.uid === SHARED_DASHBOARD_QUERY) {
-    return true;
+
+  if (typeof datasource === 'string') {
+    return datasource === SHARED_DASHBOARD_QUERY;
   }
-  const ds = datasource as DataSourceApi;
-  return ds.meta && ds.meta.name === SHARED_DASHBOARD_QUERY;
+
+  if ('meta' in datasource) {
+    return datasource.meta.name === SHARED_DASHBOARD_QUERY || datasource.uid === SHARED_DASHBOARD_QUERY;
+  }
+
+  return datasource.uid === SHARED_DASHBOARD_QUERY;
 }
 
 export function runSharedRequest(options: QueryRunnerOptions): Observable<PanelData> {


### PR DESCRIPTION
**What this PR does / why we need it**:

Broken out from https://github.com/grafana/grafana/pull/41866

There's some unnecessary unsafe type assertions, so I cleaned it up so we can be a bit more confident about our code :) 

I tested using the shared "-- Dashboard --" datasource, using expressions, transformations, and mixed data sources.