### PR TITLE
AnnoListPanel: Fix interpolation of variables in tags

### DIFF
--- a/public/app/plugins/panel/annolist/AnnoListPanel.test.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.test.tsx
@@ -76,7 +76,7 @@ async function setupTestContext({
     onOptionsChange: jest.fn(),
     options,
     renderCounter: 1,
-    replaceVariables: jest.fn(),
+    replaceVariables: (str: string) => str,
     timeRange: getDefaultTimeRange(),
     timeZone: 'utc',
     title: 'Test Title',

--- a/public/app/plugins/panel/annolist/AnnoListPanel.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.tsx
@@ -12,7 +12,7 @@ import {
   locationUtil,
   PanelProps,
 } from '@grafana/data';
-import { config, getBackendSrv, getTemplateSrv, locationService } from '@grafana/runtime';
+import { config, getBackendSrv, locationService } from '@grafana/runtime';
 import { AbstractList } from '@grafana/ui/src/components/List/AbstractList';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import appEvents from 'app/core/app_events';
@@ -90,7 +90,7 @@ export class AnnoListPanel extends PureComponent<Props, State> {
     const { queryUser, queryTags } = this.state;
 
     const params: any = {
-      tags: options.tags.map((e) => getTemplateSrv().replace(e)),
+      tags: options.tags,
       limit: options.limit,
       type: 'annotation', // Skip the Annotations that are really alerts.  (Use the alerts panel!)
     };
@@ -113,7 +113,7 @@ export class AnnoListPanel extends PureComponent<Props, State> {
     }
 
     if (options.tags && options.tags.length) {
-      params.tags = options.tags;
+      params.tags = options.tags.map((e) => this.props.replaceVariables(e));
     }
 
     if (queryTags.length) {

--- a/public/app/plugins/panel/annolist/AnnoListPanel.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.tsx
@@ -12,7 +12,7 @@ import {
   locationUtil,
   PanelProps,
 } from '@grafana/data';
-import { config, getBackendSrv, locationService } from '@grafana/runtime';
+import { config, getBackendSrv, getTemplateSrv, locationService } from '@grafana/runtime';
 import { AbstractList } from '@grafana/ui/src/components/List/AbstractList';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import appEvents from 'app/core/app_events';
@@ -90,7 +90,7 @@ export class AnnoListPanel extends PureComponent<Props, State> {
     const { queryUser, queryTags } = this.state;
 
     const params: any = {
-      tags: options.tags,
+      tags: options.tags.map(e => getTemplateSrv().replace(e)),
       limit: options.limit,
       type: 'annotation', // Skip the Annotations that are really alerts.  (Use the alerts panel!)
     };

--- a/public/app/plugins/panel/annolist/AnnoListPanel.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.tsx
@@ -113,7 +113,9 @@ export class AnnoListPanel extends PureComponent<Props, State> {
     }
 
     if (options.tags && options.tags.length) {
-      params.tags = options.tags.map((tag) => this.props.replaceVariables(tag) ? this.props.replaceVariables(tag) : tag);
+      params.tags = options.tags.map((tag) =>
+        this.props.replaceVariables(tag) ? this.props.replaceVariables(tag) : tag
+      );
     }
 
     if (queryTags.length) {

--- a/public/app/plugins/panel/annolist/AnnoListPanel.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.tsx
@@ -113,7 +113,7 @@ export class AnnoListPanel extends PureComponent<Props, State> {
     }
 
     if (options.tags && options.tags.length) {
-      params.tags = options.tags.map((e) => this.props.replaceVariables(e));
+      params.tags = options.tags.map((tag) => this.props.replaceVariables(tag) ? this.props.replaceVariables(tag) : tag);
     }
 
     if (queryTags.length) {

--- a/public/app/plugins/panel/annolist/AnnoListPanel.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.tsx
@@ -113,9 +113,7 @@ export class AnnoListPanel extends PureComponent<Props, State> {
     }
 
     if (options.tags && options.tags.length) {
-      params.tags = options.tags.map((tag) =>
-        this.props.replaceVariables(tag) ? this.props.replaceVariables(tag) : tag
-      );
+      params.tags = options.tags.map((tag) => this.props.replaceVariables(tag));
     }
 
     if (queryTags.length) {

--- a/public/app/plugins/panel/annolist/AnnoListPanel.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.tsx
@@ -90,7 +90,7 @@ export class AnnoListPanel extends PureComponent<Props, State> {
     const { queryUser, queryTags } = this.state;
 
     const params: any = {
-      tags: options.tags.map(e => getTemplateSrv().replace(e)),
+      tags: options.tags.map((e) => getTemplateSrv().replace(e)),
       limit: options.limit,
       type: 'annotation', // Skip the Annotations that are really alerts.  (Use the alerts panel!)
     };


### PR DESCRIPTION
**What this PR does / why we need it**:

The AnnoList panel does not replace variables such as `$instance` in tags. This PR tries to add this functionality.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

