### PR TITLE
Alerting: Fix refresh on legacy Alert List panel

### DIFF
--- a/public/app/plugins/panel/alertlist/AlertList.tsx
+++ b/public/app/plugins/panel/alertlist/AlertList.tsx
@@ -78,6 +78,7 @@ export function AlertList(props: PanelProps<AlertListOptions>) {
     props.options.folderId,
     props.options.alertName,
     props.options.sortOrder,
+    props.timeRange,
   ]);
 
   const recentStateChanges = useAsync(async () => {


### PR DESCRIPTION
**What this PR does / why we need it**:
The refresh on the Alert list panel for legacy alerting has been broken for a while.

**Which issue(s) this PR fixes**:

Fixes #20988, Fixes: #36165, Fixes: #41925 

**Special notes for your reviewer**:
To test: Make sure to set unified alerting: false, and legacy alerting: true.
