### PR TITLE
BarGauge: Limit title width when name is really long

### DIFF
--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
@@ -218,9 +218,7 @@ describe('BarGauge', () => {
       const styles = getTitleStyles(props);
       expect(styles.wrapper.flexDirection).toBe('column');
     });
-  });
 
-  describe('Horizontal bar with title', () => {
     it('should place below if height < 40', () => {
       const props = getProps({
         height: 30,
@@ -247,6 +245,19 @@ describe('BarGauge', () => {
       });
       const styles2 = getTitleStyles(props2);
       expect(styles2.title.width).toBe('43px');
+    });
+
+    it('Should limit text length to 40%', () => {
+      const props = getProps({
+        height: 30,
+        value: getValue(
+          100,
+          'saaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        ),
+        orientation: VizOrientation.Horizontal,
+      });
+      const styles = getTitleStyles(props);
+      expect(styles.title.width).toBe('119px');
     });
 
     it('should use alignmentFactors if provided', () => {

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -268,10 +268,13 @@ function calculateTitleDimensions(props: Props): TitleDimensions {
   const titleFontSize = titleHeight / TITLE_LINE_HEIGHT;
   const textSize = measureText(title, titleFontSize);
 
+  // Do not allow title to take up more than 40% width
+  const textWidth = Math.min(textSize.width + 15, width * 0.4);
+
   return {
     fontSize: text?.titleSize ?? titleFontSize,
     height: 0,
-    width: textSize.width + 15,
+    width: textWidth,
     placement: 'left',
   };
 }


### PR DESCRIPTION
Improves look of bar gauge when title is really long

Before:
![Screenshot from 2021-11-26 10-32-52](https://user-images.githubusercontent.com/10999/143559040-ae2dbbde-0b70-4572-8fc3-8a6657285ec2.png)
Suggestion preview: 
![Screenshot from 2021-11-26 10-32-45](https://user-images.githubusercontent.com/10999/143559047-1e526876-aa50-4c0a-9a7d-a6d042cae429.png)

After:
![Screenshot from 2021-11-26 10-32-17](https://user-images.githubusercontent.com/10999/143559078-e56f4ae0-5943-4d23-886c-afe2286af350.png)
![Screenshot from 2021-11-26 10-32-27](https://user-images.githubusercontent.com/10999/143559084-07cb9830-705a-4106-bb72-3823a807460b.png)

