### PR TITLE
Visualizations: Limit y label width to 40% of visualization width

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotAxisBuilder.ts
@@ -75,7 +75,10 @@ export class UPlotAxisBuilder extends PlotConfigBuilder<AxisProps, Axis> {
         (acc, value) => Math.max(acc, measureText(value, UPLOT_AXIS_FONT_SIZE).width),
         0
       );
-      axisSize += axis!.gap! + axis!.labelGap! + maxTextWidth;
+      // limit y tick label width to 40% of visualization
+      const textWidthWithLimit = Math.min(self.width * 0.4, maxTextWidth);
+      // Not sure why this += and not normal assignment
+      axisSize += axis!.gap! + axis!.labelGap! + textWidthWithLimit;
     }
 
     return Math.ceil(axisSize);


### PR DESCRIPTION
Before
![Screenshot from 2021-11-26 10-52-36](https://user-images.githubusercontent.com/10999/143561800-c8b9ab3e-fb93-4dbf-ac2a-ca7c87776626.png)

suggestions state timeline
![Screenshot from 2021-11-26 10-52-47](https://user-images.githubusercontent.com/10999/143561823-daf62513-ae27-4757-8fc7-237e03494ac0.png)

suggestions bar chart
![Screenshot from 2021-11-26 10-52-55](https://user-images.githubusercontent.com/10999/143561846-908d7f64-fb73-453e-a3fb-d9a6dbea5308.png)

After:
![Screenshot from 2021-11-26 10-50-01](https://user-images.githubusercontent.com/10999/143561871-f5b48099-730c-437c-8e53-1518d5a1bef9.png)

suggestions state timeline:
![Screenshot from 2021-11-26 10-50-14](https://user-images.githubusercontent.com/10999/143561902-06d62468-88be-4144-8dc2-671d82422d30.png)

suggestions bar chart:

![Screenshot from 2021-11-26 10-54-26](https://user-images.githubusercontent.com/10999/143562040-dad171fe-8f8d-4fb4-bc1a-96f722114f3a.png)

