### PR TITLE
Chore: Fix errant text appearing in AnnotationSettingsList table

### DIFF
--- a/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsList.tsx
+++ b/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsList.tsx
@@ -40,14 +40,13 @@ export const AnnotationSettingsList: React.FC<Props> = ({ dashboard, onNew, onEd
           <tbody>
             {dashboard.annotations.list.map((annotation, idx) => (
               <tr key={`${annotation.name}-${idx}`}>
-                {!annotation.builtIn && (
-                  <td className="pointer" onClick={() => onEdit(idx)}>
-                    <Icon name="comment-alt" /> &nbsp; {annotation.name}
-                  </td>
-                )}
-                {annotation.builtIn && (
+                {annotation.builtIn ? (
                   <td style={{ width: '90%' }} className="pointer" onClick={() => onEdit(idx)}>
                     <Icon name="comment-alt" /> &nbsp; <em className="muted">{annotation.name} (Built-in)</em>
+                  </td>
+                ) : (
+                  <td className="pointer" onClick={() => onEdit(idx)}>
+                    <Icon name="comment-alt" /> &nbsp; {annotation.name}
                   </td>
                 )}
                 <td className="pointer" onClick={() => onEdit(idx)}>


### PR DESCRIPTION
**What this PR does / why we need it**:

When we run tests this is logged to the console, which is annoying and confusing when looking for genuine failing tests:

```
PASS public/app/features/dashboard/components/DashboardSettings/AnnotationsSettings.test.tsx (21.086 s)
  ● Console

    console.error
      Warning: validateDOMNesting(...): Text nodes cannot appear as a child of <tr>.
          at tr
          at tbody
          at table
          at div
          at div
```

This was due to an improper conditional in the AnnotationSettingsList table which could output a `0` in the table as a child of the tr.

```html
<td class="pointer">
    <div class="css-1vzus6i-Icon"></div> &nbsp; Annotation 2
</td>
0
<td class="pointer">Prometheus</td>
```


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of #42359

