### PR TITLE
WIP Explore: Improve heuristics to detect logs

### DIFF
--- a/public/app/features/explore/utils/decorators.ts
+++ b/public/app/features/explore/utils/decorators.ts
@@ -51,8 +51,12 @@ export const decorateWithFrameTypeMetadata = (data: PanelData): ExplorePanelData
           graphFrames.push(frame);
           tableFrames.push(frame);
         } else {
-          // We fallback to table if we do not have any better meta info about the dataframe.
-          tableFrames.push(frame);
+          if (isLogs(frame)) {
+            logsFrames.push(frame);
+          } else {
+            // We fallback to table if we do not have any better meta info about the dataframe.
+            tableFrames.push(frame);
+          }
         }
     }
   }
@@ -178,5 +182,17 @@ function isTimeSeries(frame: DataFrame): boolean {
   const grouped = groupBy(frame.fields, (field) => field.type);
   return Boolean(
     Object.keys(grouped).length === 2 && grouped[FieldType.time]?.length === 1 && grouped[FieldType.number]
+  );
+}
+
+/**
+ * Check if frame contains logs, which for our purpose means 1 time column and 1 text columns
+ */
+function isLogs(frame: DataFrame): boolean {
+  const grouped = groupBy(frame.fields, (field) => field.type);
+  return Boolean(
+    Object.keys(grouped).length === 2 &&
+      grouped[FieldType.time]?.length === 1 &&
+      grouped[FieldType.string]?.length === 1
   );
 }


### PR DESCRIPTION
WIP

this is mostly for influxdb queries. the influxdb-influxql query-editor has a format_as_logs option, but that one does not format data the way we want it in the logs panel (creates fields from labels, like when displaying data as table).

(an alternative approach would be to change how the format_as_logs option works in the influxdb-query-editor, but this breaks backward compatibility.)

this change is technically backward-incompatbile, because: if you had data from a datasource that had exactly 1 timestamp column and exactly 1 string-column, without preferred-visualization-style set, those were detected until now as TABLE, and now they will be LOGS. i think that is acceptable.