### PR TITLE
WIP: devenv: influxdb: generate fake logs

### DIFF
--- a/devenv/docker/blocks/influxdb/docker-compose.yaml
+++ b/devenv/docker/blocks/influxdb/docker-compose.yaml
@@ -15,8 +15,8 @@
       - ./docker/blocks/influxdb/config.yaml:/etc/influxdb2/config.yaml
       - ./docker/blocks/influxdb/setup_influxql.sh:/docker-entrypoint-initdb.d/setup_influxql.sh
 
-  telegraf:
-    image: telegraf:latest
+  telegraf-with-fake-logs:
+    build: docker/blocks/influxdb/telegraf-with-fake-logs
     links:
       - influxdb
     depends_on:

--- a/devenv/docker/blocks/influxdb/telegraf-with-fake-logs/Dockerfile
+++ b/devenv/docker/blocks/influxdb/telegraf-with-fake-logs/Dockerfile
@@ -1,0 +1,3 @@
+FROM telegraf:latest
+RUN apt-get update && apt-get -y install --no-install-recommends python3
+COPY fake-logs.py /home/fake-logs.py

--- a/devenv/docker/blocks/influxdb/telegraf-with-fake-logs/fake-logs.py
+++ b/devenv/docker/blocks/influxdb/telegraf-with-fake-logs/fake-logs.py
@@ -1,0 +1,61 @@
+import sys
+import math
+import re
+import random
+import json
+import time
+import base64
+from datetime import datetime
+import urllib.request
+
+
+def getRandomLogText():
+    random_text = base64.b64encode(str(random.random()*1000).encode('utf8')).decode('utf8')
+    maybe_ansi_text = 'with ANSI \u001B[31mpart of the text\u001B[0m' if random.random() < 0.5 else ''
+    return f'log text {maybe_ansi_text} [{random_text}]'
+# return json.dumps({
+#     "line": f'log text {maybe_ansi_text} [{random_text}]',
+#     "number": 42 if random.random() < 0.5 else 69,
+# })
+
+SLEEP_ANGLE_STEP = math.pi / 200
+sleep_angle = 0
+def get_next_sine_wave_sleep_duration():
+    global sleep_angle
+    sleep_angle += SLEEP_ANGLE_STEP
+    return math.trunc(1000 * abs(math.sin(sleep_angle))) / 10000
+
+
+def writeLogLine(timestamp, tags, text):
+    # we write then in the influxdb line protocol format,
+    # because that is what we configured in telegraf.
+    # we could switch to something else too, whatever
+    # is easiest to generate here and then read by telegraf.
+		nano_timestamp = math.trunc(timestamp * 1000 * 1000 * 1000)
+		tags_part = ','.join([f'{a}={b}' for (a,b) in tags.items()])
+		escaped_text = text.replace('\\','\\\\').replace('"','\\"')
+		line = f'log,{tags_part} line="{escaped_text}" {nano_timestamp}'
+		print(line)
+		sys.stdout.flush()
+
+START_TIMESTAMP = datetime.utcnow().isoformat()
+
+while True:
+    time.sleep(get_next_sine_wave_sleep_duration())
+    timestamp = time.time()
+    text = getRandomLogText()
+    tag_key = 'level'
+    tag_value = random.choice(['info', 'error'])
+    tags = {
+        "level": random.choice([
+            "info",
+            "info",
+            "error"
+        ]),
+        "__name__": "test1",
+        "location": "moon",
+        "protocol": "http",
+        "start": START_TIMESTAMP,
+    }
+    tags_json = json.dumps(tags)
+    writeLogLine(timestamp, tags, text)

--- a/devenv/docker/blocks/influxdb/telegraf.conf
+++ b/devenv/docker/blocks/influxdb/telegraf.conf
@@ -42,11 +42,8 @@
 
 [[inputs.system]]
 
-[[inputs.logparser]]
-  files = [
-    "/var/log/host/*.log",
-    "/var/log/grafana/*.log"
-  ]
-  [inputs.logparser.grok]
-    measurement = "logs"
-    patterns = ['^%{GREEDYDATA:message:string}']
+[[inputs.execd]]
+  command = ["/usr/bin/python3","/home/fake-logs.py"]
+  signal = "none"
+  restart_delay = "10s"
+  data_format = "influx"


### PR DESCRIPTION
WIP

this is about generating fake logs and feeding them to Telegraf. then from telegraf they can go to any datasource. for now it is set up to go to InfluxDB, but it could also target anything that telegraf supports, loki elastic etc.

TODO: we should probably conver the `fake-data.py` script to go.