### PR TITLE
Exemplar: shorten exemplar link button text

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -296,7 +296,7 @@ function getDataLinks(options: ExemplarTraceIdDestination): DataLink[] {
 
   if (options.url) {
     dataLinks.push({
-      title: `Go to ${options.url}`,
+      title: `Go to trace detail`,
       url: options.url,
       targetBlank: true,
     });


### PR DESCRIPTION
Shorten exemplar link button text by using fixed word but not URL while using prometheus datasource and trace backend URL, because the URL must be very long within the traceID param.

Before:
<img width="1327" alt="grafana-before" src="https://user-images.githubusercontent.com/18722808/143587897-4f9c5bd0-7262-4fc3-b836-31ba0efa65c6.png">

After:
<img width="1088" alt="grafana-after" src="https://user-images.githubusercontent.com/18722808/143587328-8520520c-123b-4eb5-ba52-7a11fc7c8d4b.png">


