### PR TITLE
docs: Move password information on password smtp section

### DIFF
--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -869,8 +869,6 @@ Email server settings.
 
 Enable this to allow Grafana to send email. Default is `false`.
 
-If the password contains `#` or `;`, then you have to wrap it with triple quotes. Example: """#password;"""
-
 ### host
 
 Default is `localhost:25`.
@@ -881,7 +879,7 @@ In case of SMTP auth, default is `empty`.
 
 ### password
 
-In case of SMTP auth, default is `empty`.
+In case of SMTP auth, default is `empty`. If the password contains `#` or `;`, then you have to wrap it with triple quotes. Example: """#password;"""
 
 ### cert_file
 


### PR DESCRIPTION
**What this PR does / why we need it:**

The password information is on [enabled section](https://grafana.com/docs/grafana/latest/administration/configuration/#enabled), I move it on [password section](https://grafana.com/docs/grafana/latest/administration/configuration/#password-1) like [database section](https://grafana.com/docs/grafana/latest/administration/configuration/#password).
