### PR TITLE
Grafana-mixin: change owner to the hosted-grafana team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -143,4 +143,4 @@ lerna.json @grafana/frontend-ops
 /public/app/plugins/datasource/alertmanager @grafana/alerting-squad
 
 # Cloud middleware
-/grafana-mixin/ @grafana/cloud-middleware
+/grafana-mixin/ @grafana/hosted-grafana-team


### PR DESCRIPTION
Change owner to the hosted-grafana team since its more update to date. 

Signed-off-by: bergquist <carl.bergquist@gmail.com>
