### PR TITLE
Dashboard: Fix queries for panels with non-integer widths

### DIFF
--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -313,7 +313,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
       timezone: dashboardTimezone,
       timeRange: timeData.timeRange,
       timeInfo: timeData.timeInfo,
-      maxDataPoints: this.maxDataPoints || Math.trunc(width),
+      maxDataPoints: this.maxDataPoints || Math.floor(width),
       minInterval: this.interval,
       scopedVars: this.scopedVars,
       cacheTimeout: this.cacheTimeout,

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -313,7 +313,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
       timezone: dashboardTimezone,
       timeRange: timeData.timeRange,
       timeInfo: timeData.timeInfo,
-      maxDataPoints: this.maxDataPoints || width,
+      maxDataPoints: this.maxDataPoints || Math.trunc(width),
       minInterval: this.interval,
       scopedVars: this.scopedVars,
       cacheTimeout: this.cacheTimeout,


### PR DESCRIPTION
when we run a dashboard-query, we use the max-data-points value. it is calculated from the width-of-the-panel, or from a value that the user enters. a problem can happen in the width-of-the-panel case.

max-data-points should always be an integer, but the width-of-the-panel can be a non-integer value. this happens because at https://github.com/grafana/grafana/blob/d9cdcb550e5ea25bd7b1f8db2a01d3102f7b3918/public/app/features/dashboard/components/PanelEditor/utils.ts#L17 we calculate a scaling factor, and this is non-integer, so after-scale values can become non-integer too.

so we have to truncate this number to an integer somewhere. i am not 100% sure where. somewhere between the scale-factor thing and the point where the query is running.

this pull request does it at a place that i think could be the correct place, but i'm open to moving it to somewhere else.

how to reproduce the problem:
- create a dashboard panel, when editing it set the mode at the top-left to "Actual", not "Fill".
- start resizing the window and pressing the refresh-query button. watch the `Query options` line below the panel, it should say `MD = auto = <number>`, and `<number>` sometimes will be a non-integer value.