### PR TITLE
Alerting: Show full preview value in tooltip

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/PreviewRule.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/PreviewRule.tsx
@@ -94,6 +94,7 @@ function getStyles(theme: GrafanaTheme2) {
   return {
     container: css`
       margin-top: ${theme.spacing(2)};
+      max-width: ${theme.breakpoints.values.xxl}px;
     `,
   };
 }

--- a/public/app/features/alerting/unified/components/rule-editor/PreviewRuleResult.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/PreviewRuleResult.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { css } from '@emotion/css';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import { TableCellDisplayMode, useStyles2 } from '@grafana/ui';
@@ -15,17 +15,15 @@ type Props = {
 export function PreviewRuleResult(props: Props): React.ReactElement | null {
   const { preview } = props;
   const styles = useStyles2(getStyles);
-  const fieldConfig: FieldConfigSource = useMemo(() => {
-    return {
-      defaults: {},
-      overrides: [
-        {
-          matcher: { id: FieldMatcherID.byName, options: 'Info' },
-          properties: [{ id: 'custom.displayMode', value: TableCellDisplayMode.JSONView }],
-        },
-      ],
-    };
-  }, []);
+  const fieldConfig: FieldConfigSource = {
+    defaults: {},
+    overrides: [
+      {
+        matcher: { id: FieldMatcherID.byName, options: 'Info' },
+        properties: [{ id: 'custom.displayMode', value: TableCellDisplayMode.JSONView }],
+      },
+    ],
+  };
 
   if (!preview) {
     return null;
@@ -48,7 +46,6 @@ export function PreviewRuleResult(props: Props): React.ReactElement | null {
       </div>
     );
   }
-  console.log(data);
   return (
     <div className={styles.container}>
       <span>

--- a/public/app/features/alerting/unified/components/rule-editor/PreviewRuleResult.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/PreviewRuleResult.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { css } from '@emotion/css';
 import AutoSizer from 'react-virtualized-auto-sizer';
-import { useStyles2 } from '@grafana/ui';
+import { TableCellDisplayMode, useStyles2 } from '@grafana/ui';
 import { PanelRenderer } from '@grafana/runtime';
-import { GrafanaTheme2, LoadingState } from '@grafana/data';
+import { FieldConfigSource, FieldMatcherID, GrafanaTheme2, LoadingState } from '@grafana/data';
 import { PreviewRuleResponse } from '../../types/preview';
 import { RuleFormType } from '../../types/rule-form';
 import { messageFromError } from '../../utils/redux';
@@ -15,6 +15,17 @@ type Props = {
 export function PreviewRuleResult(props: Props): React.ReactElement | null {
   const { preview } = props;
   const styles = useStyles2(getStyles);
+  const fieldConfig: FieldConfigSource = useMemo(() => {
+    return {
+      defaults: {},
+      overrides: [
+        {
+          matcher: { id: FieldMatcherID.byName, options: 'Info' },
+          properties: [{ id: 'custom.displayMode', value: TableCellDisplayMode.JSONView }],
+        },
+      ],
+    };
+  }, []);
 
   if (!preview) {
     return null;
@@ -37,7 +48,7 @@ export function PreviewRuleResult(props: Props): React.ReactElement | null {
       </div>
     );
   }
-
+  console.log(data);
   return (
     <div className={styles.container}>
       <span>
@@ -48,7 +59,14 @@ export function PreviewRuleResult(props: Props): React.ReactElement | null {
         <AutoSizer>
           {({ width, height }) => (
             <div style={{ width: `${width}px`, height: `${height}px` }}>
-              <PanelRenderer title="" width={width} height={height} pluginId="table" data={data} />
+              <PanelRenderer
+                title=""
+                width={width}
+                height={height}
+                pluginId="table"
+                data={data}
+                fieldConfig={fieldConfig}
+              />
             </div>
           )}
         </AutoSizer>


### PR DESCRIPTION
**What this PR does / why we need it**:
Small fix for being able to display the full value in preview alert. This will view will be overhauled post 8.3

**Which issue(s) this PR fixes**:

Fixes #42324

![image](https://user-images.githubusercontent.com/946275/143878604-d14134cb-cec2-49a3-883a-2f93705cdfe5.png)

