### PR TITLE
Live: fix closing ws conns for push endpoints

### DIFF
--- a/pkg/services/live/pushws/push_pipeline.go
+++ b/pkg/services/live/pushws/push_pipeline.go
@@ -55,6 +55,7 @@ func (s *PipelinePushHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request)
 	if err != nil {
 		return
 	}
+	defer func() { _ = conn.Close() }()
 	setupWSConn(r.Context(), conn, s.config)
 
 	for {

--- a/pkg/services/live/pushws/push_pipeline.go
+++ b/pkg/services/live/pushws/push_pipeline.go
@@ -61,6 +61,7 @@ func (s *PipelinePushHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request)
 	for {
 		_, body, err := conn.ReadMessage()
 		if err != nil {
+			logger.Debug("Error reading websocket connection", "error", err)
 			break
 		}
 

--- a/pkg/services/live/pushws/push_stream.go
+++ b/pkg/services/live/pushws/push_stream.go
@@ -57,6 +57,7 @@ func (s *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
+	defer func() { _ = conn.Close() }()
 	setupWSConn(r.Context(), conn, s.config)
 
 	for {

--- a/pkg/services/live/pushws/push_stream.go
+++ b/pkg/services/live/pushws/push_stream.go
@@ -63,6 +63,7 @@ func (s *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	for {
 		_, body, err := conn.ReadMessage()
 		if err != nil {
+			logger.Debug("Error reading websocket connection", "error", err)
 			break
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This properly closes WS connections in Live push endpoints upon exiting a reading loop.