### PR TITLE
Alerting: fix broken datasource link

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
@@ -115,7 +115,7 @@ export const RuleDetailsActionButtons: FC<Props> = ({ rule, rulesSource }) => {
           <LinkButton
             className={style.button}
             size="xs"
-            key="dashboard"
+            key="panel"
             variant="primary"
             icon="apps"
             target="__blank"
@@ -172,6 +172,7 @@ export const RuleDetailsActionButtons: FC<Props> = ({ rule, rulesSource }) => {
     if (isViewMode) {
       rightButtons.push(
         <ClipboardButton
+          key="copy"
           onClipboardCopy={() => {
             appEvents.emit(AppEvents.alertSuccess, ['URL copied!']);
           }}

--- a/public/app/features/alerting/unified/components/rules/RuleListErrors.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListErrors.tsx
@@ -52,7 +52,7 @@ export function RuleListErrors(): ReactElement {
     rulerRequestErrors.forEach(({ dataSource, error }) =>
       result.push(
         <>
-          Failed to load rules config from <a href={'datasources/edit/${dataSource.uid}'}>{dataSource.name}</a>:{' '}
+          Failed to load rules config from <a href={`datasources/edit/${dataSource.uid}`}>{dataSource.name}</a>:{' '}
           {error.message || 'Unknown error.'}
         </>
       )
@@ -77,7 +77,7 @@ export function RuleListErrors(): ReactElement {
               {errors.length >= 2 && (
                 <Button
                   className={styles.moreButton}
-                  variant="link"
+                  fill="text"
                   icon="angle-right"
                   size="sm"
                   onClick={() => setExpanded(true)}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a broken link in the `RuleListErrors` component. 

Also includes a few smaller fixes cherry-picked from https://github.com/grafana/grafana/pull/42362

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

