### PR TITLE
Alerting: Fix Annotation Creation when the alerting state changes

### DIFF
--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/annotations"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
@@ -576,6 +577,8 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 func setupScheduler(t *testing.T, rs store.RuleStore, is store.InstanceStore, acs store.AdminConfigurationStore, registry *prometheus.Registry) (*schedule, *clock.Mock) {
 	t.Helper()
 
+	fakeAnnoRepo := NewFakeAnnotationsRepo()
+	annotations.SetRepository(fakeAnnoRepo)
 	mockedClock := clock.NewMock()
 	logger := log.New("ngalert schedule test")
 	if registry == nil {

--- a/pkg/services/ngalert/schedule/testing.go
+++ b/pkg/services/ngalert/schedule/testing.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/services/annotations"
+
 	models2 "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
@@ -378,4 +380,48 @@ func (am *FakeExternalAlertmanager) Handler() func(w http.ResponseWriter, r *htt
 
 func (am *FakeExternalAlertmanager) Close() {
 	am.server.Close()
+}
+
+type FakeAnnotationsRepo struct {
+	mtx   sync.Mutex
+	items []*annotations.Item
+}
+
+func NewFakeAnnotationsRepo() *FakeAnnotationsRepo {
+	return &FakeAnnotationsRepo{
+		items: make([]*annotations.Item, 0),
+	}
+}
+
+func (repo *FakeAnnotationsRepo) Len() int {
+	repo.mtx.Lock()
+	defer repo.mtx.Unlock()
+	return len(repo.items)
+}
+
+func (repo *FakeAnnotationsRepo) Delete(params *annotations.DeleteParams) error {
+	return nil
+}
+
+func (repo *FakeAnnotationsRepo) Save(item *annotations.Item) error {
+	repo.mtx.Lock()
+	defer repo.mtx.Unlock()
+	repo.items = append(repo.items, item)
+
+	return nil
+}
+func (repo *FakeAnnotationsRepo) Update(item *annotations.Item) error {
+	return nil
+}
+
+func (repo *FakeAnnotationsRepo) Find(query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
+	annotations := []*annotations.ItemDTO{{Id: 1}}
+	return annotations, nil
+}
+
+func (repo *FakeAnnotationsRepo) FindTags(query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
+	result := annotations.FindTagsResult{
+		Tags: []*annotations.TagsDTO{},
+	}
+	return result, nil
 }


### PR DESCRIPTION
While testing #42362 - I noticed a bunch of wrong things with the way we handle and create annotations. I've fixed some of them but while creating tests I found out a couple more.

I'll be marking this as a draft as I made the tests pass but some of the tests expectations don't make sense to me and I need to investigate further.


In a nutshell, this just adds three things:
- Create an annotation regardless of whether the rule is attached to a dashboard
- Test to ensure the annotations match the transitions
- Match an annotation to the corresponding alertRuleID