### PR TITLE
Alerting: Fix migration of Graphite alerts that have sub query references

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/expr"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/tsdb/graphite"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -163,10 +164,10 @@ func migrateAlertRuleQueries(data []alertQuery) ([]alertQuery, error) {
 		}
 		// targetFull of Graphite data source contains the expanded version of field 'target'. The alert rule does not contain enough information to continue using the 'target'.
 		// Instead, it should use the expanded version. So, copy targetFull to target.
-		fullQuery, ok := fixedData["targetFull"]
+		fullQuery, ok := fixedData[graphite.TargetFullModelField]
 		if ok {
-			delete(fixedData, "targetFull")
-			fixedData["target"] = fullQuery
+			delete(fixedData, graphite.TargetFullModelField)
+			fixedData[graphite.TargetModelField] = fullQuery
 			updatedModel, err := json.Marshal(fixedData)
 			if err != nil {
 				return nil, err

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
@@ -1,0 +1,47 @@
+package ualert
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateAlertRuleQueries(t *testing.T) {
+	tc := []struct {
+		name     string
+		input    *simplejson.Json
+		expected string
+		err      error
+	}{
+		{
+			name:     "when a query has a sub query - it is extracted",
+			input:    simplejson.NewFromAny(map[string]interface{}{"targetFull": "thisisafullquery", "target": "ahalfquery"}),
+			expected: `{"target":"thisisafullquery"}`,
+		},
+		{
+			name:     "when a query does not have a sub query - it no-ops",
+			input:    simplejson.NewFromAny(map[string]interface{}{"target": "ahalfquery"}),
+			expected: `{"target":"ahalfquery"}`,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			model, err := tt.input.Encode()
+			require.NoError(t, err)
+			queries, err := migrateAlertRuleQueries([]alertQuery{{Model: model}})
+			if tt.err != nil {
+				require.Error(t, err)
+				require.EqualError(t, err, tt.err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			r, err := queries[0].Model.MarshalJSON()
+			require.NoError(t, err)
+			require.JSONEq(t, tt.expected, string(r))
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**Background**
Graphite data source (probably other too) supports sub-queries. For example,

<details><summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/25988953/142644587-97f2e472-8824-4a19-b30a-49370c025545.png)

Alert rule: 
![image](https://user-images.githubusercontent.com/25988953/142643413-d1b6a6fd-7363-4a43-9b16-5ee7975732d9.png)

</details>

However, when a user creates a legacy alert rule that uses the queries above, the alert rule contains only queries that are explicitly referenced by the alert rule 

<details> <summary> Legacy Alert Rule </summary>

```json
{
    "alertRuleTags": {},
    "conditions": [
        {
            "evaluator": {
                "params": [
                    50
                ],
                "type": "lt"
            },
            "operator": {
                "type": "and"
            },
            "query": {
                "datasourceId": 1,
                "model": {
                    "datasource": "gdev-graphite",
                    "hide": false,
                    "refCount": 1,
                    "refId": "C",
                    "target": "aliasByNode(reduceSeries(mapSeries(group(#A, #E), 0), 'asPercent', 1, 'now', 'avg'), 0)",
                    "targetFull": "aliasByNode(reduceSeries(mapSeries(group(aliasSub(aliasByNode(movingAverage(keepLastValue(removeAboveValue(perSecond(tsdb-gw.aggstats.*{east2-58844-mediamath,east2-17303-wix,west2-95382-justeat,west2-77217-sovrn}.metrics.published.counter32),1000000), 500), '5min'), 2), '(.*)', '\\1.now'), aliasSub(aliasByNode(movingMedian(keepLastValue(perSecond(tsdb-gw.aggstats.*{east2-636-fs}.metrics.published.counter32), 500), '24hours'), 2), '(.*)', '\\1.avg')), 0), 'asPercent', 1, 'now', 'avg'), 0)",
                    "textEditor": true
                },
                "params": [
                    "C",
                    "5m",
                    "now"
                ]
            },
            "reducer": {
                "params": [],
                "type": "avg"
            },
            "type": "query"
        },
        {
            "evaluator": {
                "params": [
                    60
                ],
                "type": "gt"
            },
            "operator": {
                "type": "and"
            },
            "query": {
                "datasourceId": 1,
                "model": {
                    "datasource": "gdev-graphite",
                    "hide": false,
                    "refCount": 1,
                    "refId": "F",
                    "target": "aliasByNode(reduceSeries(mapSeries(group(#D, #E), 0), 'asPercent', 1, 'now', 'avg'), 0)",
                    "targetFull": "aliasByNode(reduceSeries(mapSeries(group(aliasSub(aliasByNode(movingAverage(keepLastValue(perSecond(tsdb-gw.aggstats.*{east2-636-fs}.metrics.published.counter32), 500), '10min'), 2), '(.*)', '\\1.now'), aliasSub(aliasByNode(movingMedian(keepLastValue(perSecond(tsdb-gw.aggstats.*{east2-636-fs}.metrics.published.counter32), 500), '24hours'), 2), '(.*)', '\\1.avg')), 0), 'asPercent', 1, 'now', 'avg'), 0)",
                    "textEditor": true
                },
                "params": [
                    "F",
                    "5m",
                    "now"
                ]
            },
            "reducer": {
                "params": [],
                "type": "avg"
            },
            "type": "query"
        }
    ],
    "executionErrorState": "alerting",
    "for": "5m",
    "frequency": "1m",
    "handler": 1,
    "name": "Panel Title alert",
    "noDataState": "no_data",
    "notifications": []
}
```

</details>

During the migration, the rule is converted to the ngalert rule using the information above. Although it copies the `model` field as is, subqueries are lost because they are not part of the rule. 

<details><summary>NGAlert rule</summary>

```json
[
    {
        "refId": "A",
        "queryType": "",
        "relativeTimeRange": {
            "from": 0,
            "to": 0
        },
        "datasourceUid": "-100",
        "model": {
            "conditions": [
                {
                    "evaluator": {
                        "params": [
                            50
                        ],
                        "type": "lt"
                    },
                    "operator": {
                        "type": "and"
                    },
                    "query": {
                        "params": [
                            "C"
                        ]
                    },
                    "reducer": {
                        "type": "avg"
                    }
                },
                {
                    "evaluator": {
                        "params": [
                            60
                        ],
                        "type": "gt"
                    },
                    "operator": {
                        "type": "and"
                    },
                    "query": {
                        "params": [
                            "F"
                        ]
                    },
                    "reducer": {
                        "type": "avg"
                    }
                }
            ],
            "intervalMs": 1000,
            "maxDataPoints": 43200,
            "refId": "A",
            "type": "classic_conditions"
        }
    },
    {
        "refId": "C",
        "queryType": "",
        "relativeTimeRange": {
            "from": 300,
            "to": 0
        },
        "datasourceUid": "P6798F81BB5440721",
        "model": {
            "datasource": "gdev-graphite",
            "hide": false,
            "intervalMs": 1000,
            "maxDataPoints": 43200,
            "refCount": 1,
            "refId": "C",
            "target": "aliasByNode(reduceSeries(mapSeries(group(#A, #E), 0), 'asPercent', 1, 'now', 'avg'), 0)",
            "targetFull": "aliasByNode(reduceSeries(mapSeries(group(aliasSub(aliasByNode(movingAverage(keepLastValue(removeAboveValue(perSecond(tsdb-gw.aggstats.*{east2-58844-mediamath,east2-17303-wix,west2-95382-justeat,west2-77217-sovrn}.metrics.published.counter32),1000000), 500), '5min'), 2), '(.*)', '\\1.now'), aliasSub(aliasByNode(movingMedian(keepLastValue(perSecond(tsdb-gw.aggstats.*{east2-636-fs}.metrics.published.counter32), 500), '24hours'), 2), '(.*)', '\\1.avg')), 0), 'asPercent', 1, 'now', 'avg'), 0)",
            "textEditor": true
        }
    },
    {
        "refId": "F",
        "queryType": "",
        "relativeTimeRange": {
            "from": 300,
            "to": 0
        },
        "datasourceUid": "P6798F81BB5440721",
        "model": {
            "datasource": "gdev-graphite",
            "hide": false,
            "intervalMs": 1000,
            "maxDataPoints": 43200,
            "refCount": 1,
            "refId": "F",
            "target": "aliasByNode(reduceSeries(mapSeries(group(#D, #E), 0), 'asPercent', 1, 'now', 'avg'), 1)",
            "targetFull": "aliasByNode(reduceSeries(mapSeries(group(aliasSub(aliasByNode(movingAverage(keepLastValue(perSecond(tsdb-gw.aggstats.*{east2-636-fs}.metrics.published.counter32), 500), '10min'), 2), '(.*)', '\\1.now'), aliasSub(aliasByNode(movingMedian(keepLastValue(perSecond(tsdb-gw.aggstats.*{east2-636-fs}.metrics.published.counter32), 500), '24hours'), 2), '(.*)', '\\1.avg')), 0), 'asPercent', 1, 'now', 'avg'), 0)",
            "textEditor": true
        }
    }
]
```
</details>

The UI presents the migrated the following way:

<details><summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/25988953/142644699-28c228d0-2cda-439d-9bbb-c3e3d6beb457.png).
</details> 

The changes of queries affect only field `target` (see json above) in the model above but `targetFull` is still the same, and UI cannot change it.


**What this PR does / why we need it**:
As long as the legacy alert rule does not have enough information to correctly restore sub-queries, the simplest way to fix it is to copy the value of field `targetFull` to `target` and remove the field.

**Which issue(s) this PR fixes**:
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/41989

**Special notes for your reviewer**:

This does not fix already converted alert rules.