### PR TITLE
InfluxDB: Improve handling of metadata query errors in InfluxQL

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/TagsSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/VisualInfluxQLEditor/TagsSection.tsx
@@ -40,10 +40,20 @@ const Tag = ({ tag, isFirst, onRemove, onChange, getTagKeyOptions, getTagValueOp
   const condition = getCondition(tag, isFirst);
 
   const getTagKeySegmentOptions = () => {
-    return getTagKeyOptions().then((tags) => [
-      { label: '-- remove filter --', value: undefined },
-      ...tags.map(toSelectableValue),
-    ]);
+    return getTagKeyOptions()
+      .catch((err) => {
+        // in this UI element we add a special item to the list of options,
+        // that is used to remove the element.
+        // this causes a problem: if `getTagKeyOptions` fails with an error,
+        // the remove-filter option is never added to the list,
+        // and the UI element can not be removed.
+        // to avoid it, we catch any potential errors coming from `getTagKeyOptions`,
+        // log the error, and pretend that the list of options is an empty list.
+        // this way the remove-item option can always be added to the list.
+        console.error(err);
+        return [];
+      })
+      .then((tags) => [{ label: '-- remove filter --', value: undefined }, ...tags.map(toSelectableValue)]);
   };
 
   const getTagValueSegmentOptions = () => {


### PR DESCRIPTION
in the influxdb influxql query editor:

if you add a field (not a tag) into the WHERE field, by manually entering it's name, you will not be able to remove it, because all metadata-queries about tags fail now, because InfluxDB does not support metadata-queries about tags that filter on fields.

how to see the problem, on main-branch:
1. `make devenv sources=influxdb`
2. wait 20 seconds
3. go to explore-mode, choose the `gdev-influxdb-influxql` datasource
4. in `select measurement` choose `cpu`, in the next line, in `field(value)` choose `usage_idle`. you should see a graph.
5. click the [+] next to the WHERE section, a dropdown opens. manually enter `usage_idle`, enter.
6. adjust the filter to be `usage_idle > 42`
7. you still should see the graph
8. now try to remove the `usage_idle > 42` filter by clicking on `usage_idle`. you see no remove-option in the dropdown.

the problem happens because:
- when you open the dropdown, we ask influxdb for the options to show in the list
- this query returns an error (because we have a field in the mix)
- so the code throws an exception, and the add-the-remove-item to the list is never called

this pull requests catches any errors from the influxdb metadata query, logs them and returns an empty-list, so at least the remove option is available.

how to test:
- do the same steps as the how-to-see-the-problem, in step 8 now you should be able to remove the filter

fixes https://github.com/grafana/grafana/issues/42438