### PR TITLE
UI/Plot: Implement keyboard controls for plot cursor (v2)

### DIFF
--- a/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
+++ b/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
@@ -76,8 +76,10 @@ export const VizLayout: VizLayoutComponentType = ({ width, height, legend, child
 
   return (
     <div style={containerStyle}>
-      <div style={vizStyle}>{size && children(size.width, size.height)}</div>
-      <div style={legendStyle} ref={legendRef}>
+      <div tabIndex={0} style={vizStyle}>
+        {size && children(size.width, size.height)}
+      </div>
+      <div tabIndex={0} style={legendStyle} ref={legendRef}>
         <CustomScrollbar hideHorizontalTrack>{legend}</CustomScrollbar>
       </div>
     </div>

--- a/packages/grafana-ui/src/components/uPlot/plugins/KeyboardPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/KeyboardPlugin.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useLayoutEffect, useState } from 'react';
+import { UPlotConfigBuilder } from '../config/UPlotConfigBuilder';
+// import { pluginLog } from '../utils';
+// import { PlotSelection } from '../types';
+import uPlot from 'uplot';
+
+interface KeyboardPluginProps {
+  config: UPlotConfigBuilder; // onkeypress, onkeyup, onkeydown (triggered by vizlayout handlers)
+}
+
+/**
+ * @alpha
+ */
+export const KeyboardPlugin: React.FC<KeyboardPluginProps> = ({ config }) => {
+  // const [selection, setSelection] = useState<PlotSelection | null>(null);
+
+  // useEffect(() => {
+  //   if (selection) {
+  //     pluginLog('ZoomPlugin', false, 'selected', selection);
+  //     if (selection.bbox.width < MIN_ZOOM_DIST) {
+  //       return;
+  //     }
+  //     onZoom({ from: selection.min, to: selection.max });
+  //   }
+  // }, [selection]);
+
+  useLayoutEffect(() => {
+    let plotInstance: uPlot | undefined = undefined;
+    let bbox: DOMRect | undefined = undefined;
+
+    // cache uPlot plotting area bounding box
+    config.addHook('syncRect', (u, rect) => {
+      bbox = rect;
+    });
+
+    config.addHook('init', (u) => {
+      plotInstance = u;
+
+      let vizLayoutViz = u.root.closest('[tabindex]');
+
+      let knownKeys = new Set(['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown']);
+      let pressedKeys = new Set();
+
+      let pxPerKeydownMin = 1;
+      let pxPerKeydownMax = 100;
+      let rampCount = 200;
+      let count = -1;
+
+      let isDragging = false;
+
+      vizLayoutViz?.addEventListener('keydown', (e) => {
+        if (!knownKeys.has(e.key)) {
+          return;
+        }
+
+        let left = u.cursor.left!;
+        let top = u.cursor.top!;
+
+        pressedKeys.add(e.key);
+
+        count++;
+
+        let dpx = pxPerKeydownMin + Math.min(count / rampCount, 1) * (pxPerKeydownMax - pxPerKeydownMin);
+
+        left += pressedKeys.has('ArrowRight') ? dpx : pressedKeys.has('ArrowLeft') ? -dpx : 0;
+        top += pressedKeys.has('ArrowDown') ? dpx : pressedKeys.has('ArrowUp') ? -dpx : 0;
+
+        // dispatch mouse events
+        let move = new MouseEvent('mousemove', { clientX: bbox!.left + left, clientY: bbox!.top + top });
+        u.over.dispatchEvent(move);
+
+        if (!isDragging && e.shiftKey) {
+          isDragging = true;
+          let down = new MouseEvent('mousedown', { clientX: bbox!.left + left, clientY: bbox!.top + top, button: 1 });
+          u.over.dispatchEvent(down);
+        }
+      });
+
+      vizLayoutViz?.addEventListener('keyup', (e) => {
+        if (isDragging && e.key === 'Shift') {
+          isDragging = false;
+          let up = new MouseEvent('mouseup', {
+            clientX: bbox!.left + u.cursor.left,
+            clientY: bbox!.top + u.cursor.top,
+            button: 1,
+          });
+          u.over.dispatchEvent(up);
+        }
+
+        if (knownKeys.has(e.key)) {
+          pressedKeys.delete(e.key);
+
+          if (pressedKeys.size === 0) {
+            count = -1;
+          }
+        }
+      });
+
+      vizLayoutViz?.addEventListener('focus', (e) => {
+        // let enter = new MouseEvent('mouseenter');
+        // u.over.dispatchEvent(enter);
+
+        u.setCursor({ left: bbox!.width / 2, top: bbox!.height / 2 });
+      });
+
+      vizLayoutViz?.addEventListener('blur', (e) => {
+        // let enter = new MouseEvent('mouseleave');
+        // u.over.dispatchEvent(enter);
+
+        u.setCursor({ left: -10, top: -10 });
+      });
+    });
+  }, [config]);
+
+  return null;
+};

--- a/packages/grafana-ui/src/components/uPlot/plugins/index.ts
+++ b/packages/grafana-ui/src/components/uPlot/plugins/index.ts
@@ -1,2 +1,3 @@
 export { ZoomPlugin } from './ZoomPlugin';
 export { TooltipPlugin } from './TooltipPlugin';
+export { KeyboardPlugin } from './KeyboardPlugin';

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { Field, PanelProps } from '@grafana/data';
 import { TooltipDisplayMode } from '@grafana/schema';
-import { usePanelContext, TimeSeries, TooltipPlugin, ZoomPlugin } from '@grafana/ui';
+import { usePanelContext, TimeSeries, TooltipPlugin, ZoomPlugin, KeyboardPlugin } from '@grafana/ui';
 import { getFieldLinksForExplore } from 'app/features/explore/utils/links';
 import { AnnotationsPlugin } from './plugins/AnnotationsPlugin';
 import { ContextMenuPlugin } from './plugins/ContextMenuPlugin';
@@ -54,6 +54,7 @@ export const TimeSeriesPanel: React.FC<TimeSeriesPanelProps> = ({
       {(config, alignedDataFrame) => {
         return (
           <>
+            <KeyboardPlugin config={config} />
             <ZoomPlugin config={config} onZoom={onChangeTimeRange} />
             {options.tooltip.mode === TooltipDisplayMode.None || (
               <TooltipPlugin


### PR DESCRIPTION
this is an attempt at an alternative and more general approach to https://github.com/grafana/grafana/pull/42244.

- it relies on VizLayout to make legend and viz independently tab-able for all panels that use it
- it tries to make a uPlot plugin that implements keyboard nav
- it uses dom event dispatching to simulate mouse events from key events, which hopefully helps get 100% existing behavior without too many hacks.
- it uses a gradual speed ramp to accelerate the cursor rather than a modifier key
- it uses Shift as the selection modifier key, which seems more natural than Space

selection with synced cursor mostly works as expected, but currrently has trouble terminating the selection on Shift key release.

there's still work/refactoring to do, but initial results look somewhat promising and much less intrusive that a PR that integrates this functionality into the very core, which i prefer to keep as simple and straightforward as possible, with minimal dependencies like theming, etc.

cc @kaydelaney 