### PR TITLE
Explore: persist every query that was executed in the URL and in query history

### DIFF
--- a/public/app/features/explore/state/explorePane.test.ts
+++ b/public/app/features/explore/state/explorePane.test.ts
@@ -33,6 +33,7 @@ const defaultInitialState = {
       eventBridge: {} as EventBusExtended,
       queries: [] as DataQuery[],
       range: testRange,
+      history: [],
       refreshInterval: {
         label: 'Off',
         value: 0,

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -63,6 +63,7 @@ const defaultInitialState = {
       eventBridge: { emit: () => {} } as any,
       queries: [{ expr: 'test' }] as any[],
       range: testRange,
+      history: [],
       refreshInterval: {
         label: 'Off',
         value: 0,


### PR DESCRIPTION
in explore, currently we only update the URL (and query history), when a query returns successfully. for failed queries we do not do this.

this pull request changes this so that every query that is run, is added to the URL and to the query history.