### PR TITLE
Allow 'Extract fields' transformer to extract into a single field

### DIFF
--- a/public/app/core/components/TransformersUI/extractFields/ExtractFieldsTransformerEditor.tsx
+++ b/public/app/core/components/TransformersUI/extractFields/ExtractFieldsTransformerEditor.tsx
@@ -9,7 +9,7 @@ import {
   TransformerUIProps,
 } from '@grafana/data';
 
-import { InlineField, InlineFieldRow, InlineSwitch, Select } from '@grafana/ui';
+import { InlineField, InlineFieldRow, InlineSwitch, Input, Select } from '@grafana/ui';
 import { FieldNamePicker } from '@grafana/ui/src/components/MatchersUI/FieldNamePicker';
 import { ExtractFieldsOptions, extractFieldsTransformer } from './extractFields';
 import { FieldExtractorID, fieldExtractors } from './fieldExtractors';
@@ -50,6 +50,36 @@ export const extractFieldsTransformerEditor: React.FC<TransformerUIProps<Extract
     });
   };
 
+  const onToggleSingleField = () => {
+    onChange({
+      ...options,
+      singleField: {
+        ...options.singleField,
+        enabled: !options.singleField.enabled,
+      },
+    });
+  };
+
+  const onToggleSingleFieldReplace = () => {
+    onChange({
+      ...options,
+      singleField: {
+        ...options.singleField,
+        replace: !options.singleField.replace,
+      },
+    });
+  };
+
+  const onSingleFieldOutputChange = (e: React.FormEvent<HTMLInputElement>) => {
+    onChange({
+      ...options,
+      singleField: {
+        ...options.singleField,
+        output: e.currentTarget.value,
+      },
+    });
+  };
+
   const format = fieldExtractors.selectOptions(options.format ? [options.format] : undefined);
 
   return (
@@ -79,6 +109,27 @@ export const extractFieldsTransformerEditor: React.FC<TransformerUIProps<Extract
         <InlineField label={'Replace all fields'} labelWidth={16}>
           <InlineSwitch value={options.replace ?? false} onChange={onToggleReplace} />
         </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField label={'Extract to single field'} labelWidth={24}>
+          <InlineSwitch value={options.singleField.enabled ?? false} onChange={onToggleSingleField} />
+        </InlineField>
+        {options.singleField.enabled ? (
+          <>
+            <InlineField label={'Replace existing field'} labelWidth={24}>
+              <InlineSwitch value={options.singleField.replace ?? false} onChange={onToggleSingleFieldReplace} />
+            </InlineField>
+            {options.singleField.replace ? null : (
+              <InlineField label={'Output field name'} labelWidth={24}>
+                <Input
+                  value={options.singleField.output}
+                  placeholder={options.source}
+                  onChange={onSingleFieldOutputChange}
+                />
+              </InlineField>
+            )}
+          </>
+        ) : null}
       </InlineFieldRow>
     </div>
   );

--- a/public/app/core/components/TransformersUI/extractFields/extractFields.test.ts
+++ b/public/app/core/components/TransformersUI/extractFields/extractFields.test.ts
@@ -6,6 +6,9 @@ describe('Fields from JSON', () => {
     const cfg: ExtractFieldsOptions = {
       source: 'line',
       replace: true,
+      singleField: {
+        enabled: false,
+      },
     };
     const data = toDataFrame({
       columns: ['ts', 'line'],


### PR DESCRIPTION
**What this PR does / why we need it**:

I've been playing around with #41994 and found that it requires fields
to contain array values, which can't be sent from a backend plugin. This
PR adds the ability for the `ExtractFieldsTransformer` to extract values
from a field into a complex object in a single field, rather than into
multiple separate fields. A field containing a JSONified array can then
be transformed into a field containing an actual array, which can in
turn be used for the table charts in #41994.

**Which issue(s) this PR fixes**:

Related: #36025

**Special notes for your reviewer**:

I originally added a whole separate `ParseJSONTransformer` which did
something similar, before finding that the `ExtractFieldsTransformer`
already had some JSON parsing responsibility. If this adds too much
complexity to `ExtractFieldsTransformer` I can submit a PR for the
separate transformer instead, though.

I'll add tests later if we decide to proceed with this PR!

(Alternatively, if there's already a way of creating an array field that
I'm missing, I'm happy to abandon this...)