### PR TITLE
Dashboards: Fix so that empty folders can be deleted from the manage dashboards/folders page

### DIFF
--- a/public/app/features/search/components/ConfirmDeleteModal.tsx
+++ b/public/app/features/search/components/ConfirmDeleteModal.tsx
@@ -32,7 +32,7 @@ export const ConfirmDeleteModal: FC<Props> = ({ results, onDeleteItems, isOpen, 
     text += `selected folder${folderEnding} and dashboard${dashEnding}?\n`;
     subtitle = `All dashboards and alerts of the selected folder${folderEnding} will also be deleted`;
   } else if (folderCount > 0) {
-    text += `selected folder${folderEnding} and all their dashboards and alerts?`;
+    text += `selected folder${folderEnding} and all ${folderCount === 1 ? 'its' : 'their'} dashboards and alerts?`;
   } else {
     text += `selected dashboard${dashEnding}?`;
   }

--- a/public/app/features/search/hooks/useManageDashboards.test.ts
+++ b/public/app/features/search/hooks/useManageDashboards.test.ts
@@ -197,4 +197,26 @@ describe('useManageDashboards', () => {
       expect(result.current.canDelete).toBe(false);
     });
   });
+
+  describe('when called on an empty folder', () => {
+    it('then canDelete should be true', () => {
+      const results: DashboardSection[] = [
+        { id: 1, checked: true, items: [], title: 'One', type: DashboardSearchItemType.DashFolder, toggle, url: '/' },
+        {
+          id: GENERAL_FOLDER_ID,
+          checked: false,
+          items: [],
+          title: 'General',
+          type: DashboardSearchItemType.DashFolder,
+          toggle,
+          url: '/',
+        },
+        { id: 2, checked: false, items: [], title: 'Two', type: DashboardSearchItemType.DashFolder, toggle, url: '/' },
+      ];
+
+      const { result } = setupTestContext({ results });
+
+      expect(result.current.canDelete).toBe(true);
+    });
+  });
 });

--- a/public/app/features/search/hooks/useManageDashboards.ts
+++ b/public/app/features/search/hooks/useManageDashboards.ts
@@ -42,14 +42,13 @@ export const useManageDashboards = (
     dispatch({ type: MOVE_ITEMS, payload: { dashboards: selectedDashboards, folder } });
   };
 
-  const canMove = useMemo(() => results.some((result) => result.items && result.items.some((item) => item.checked)), [
-    results,
-  ]);
+  const canMove = useMemo(() => results.some((result) => result.items.some((item) => item.checked)), [results]);
 
   const canDelete = useMemo(() => {
+    const somethingChecked = results.some((result) => result.checked || result.items.some((item) => item.checked));
     const includesGeneralFolder = results.find((result) => result.checked && result.id === GENERAL_FOLDER_ID);
-    return canMove && !includesGeneralFolder;
-  }, [canMove, results]);
+    return somethingChecked && !includesGeneralFolder;
+  }, [results]);
 
   const canSave = folder?.canSave;
   const hasEditPermissionInFolders = folder ? canSave : contextSrv.hasEditPermissionInFolders;

--- a/public/app/features/search/hooks/useManageDashboards.ts
+++ b/public/app/features/search/hooks/useManageDashboards.ts
@@ -1,11 +1,15 @@
 import { useCallback, useMemo, useReducer } from 'react';
 import { FolderDTO } from 'app/types';
 import { contextSrv } from 'app/core/services/context_srv';
-import { DashboardQuery, OnDeleteItems, OnMoveItems, OnToggleChecked } from '../types';
+import { DashboardQuery, DashboardSection, OnDeleteItems, OnMoveItems, OnToggleChecked } from '../types';
 import { DELETE_ITEMS, MOVE_ITEMS, TOGGLE_ALL_CHECKED, TOGGLE_CHECKED } from '../reducers/actionTypes';
 import { manageDashboardsReducer, manageDashboardsState, ManageDashboardsState } from '../reducers/manageDashboards';
 import { useSearch } from './useSearch';
 import { GENERAL_FOLDER_ID } from '../constants';
+
+const hasChecked = (section: DashboardSection) => {
+  return section.checked || section.items.some((item) => item.checked);
+};
 
 export const useManageDashboards = (
   query: DashboardQuery,
@@ -45,7 +49,7 @@ export const useManageDashboards = (
   const canMove = useMemo(() => results.some((result) => result.items.some((item) => item.checked)), [results]);
 
   const canDelete = useMemo(() => {
-    const somethingChecked = results.some((result) => result.checked || result.items.some((item) => item.checked));
+    const somethingChecked = results.some(hasChecked);
     const includesGeneralFolder = results.find((result) => result.checked && result.id === GENERAL_FOLDER_ID);
     return somethingChecked && !includesGeneralFolder;
   }, [results]);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- there is no way to currently delete an empty folder. this is because `canDelete` is currently based on `canMove`, and `canMove` is only true if a dashboard is selected.
- change the logic so `canDelete` is enabled if **anything** is selected. this allows us to select empty folders, and also allows us to delete folders before they've been expanded.
- add a new unit test to make sure we can delete empty folders

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/42486

**Special notes for your reviewer**:

- we should probably hold off on merging this until the release is complete 😱 