### PR TITLE
Build: publish artifacts to correct GCS buckets for main and release builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -770,7 +770,7 @@ steps:
   image: grafana/build-container:1.4.8
   name: release-canary-npm-packages
 - commands:
-  - ./bin/grabpl upload-packages --edition oss --packages-bucket $${PRERELEASE_BUCKET}/artifacts/downloads
+  - ./bin/grabpl upload-packages --edition oss --packages-bucket grafana-downloads
   depends_on:
   - end-to-end-tests-dashboards-suite
   - end-to-end-tests-panels-suite
@@ -4302,6 +4302,6 @@ kind: secret
 name: prerelease_bucket
 ---
 kind: signature
-hmac: 9ad9988b102790652afdf8e76325c6c57367c4eaa0d6590ff7a4701fa5840b8b
+hmac: b317cdb286ce7683f0e191387eca33d68ee56e1147105bdf147c42a708085ae1
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -784,7 +784,7 @@ steps:
   image: grafana/grafana-ci-deploy:1.3.1
   name: upload-packages
 - commands:
-  - ./bin/grabpl upload-cdn --edition oss --bucket "$${PRERELEASE_BUCKET}/artifacts/static-assets"
+  - ./bin/grabpl upload-cdn --edition oss --bucket "grafana-static-assets"
   depends_on:
   - end-to-end-tests-server
   environment:
@@ -4302,6 +4302,6 @@ kind: secret
 name: prerelease_bucket
 ---
 kind: signature
-hmac: b317cdb286ce7683f0e191387eca33d68ee56e1147105bdf147c42a708085ae1
+hmac: 63011a7e74dab6811078cf83929581cc25cc8a2133c388a93b8284b98de1d379
 
 ...

--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -111,7 +111,7 @@ def get_steps(edition, is_downstream=False):
     steps.extend([
         release_canary_npm_packages_step(edition),
         upload_packages_step(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream),
-        upload_cdn_step(edition=edition)
+        upload_cdn_step(edition=edition, ver_mode=ver_mode)
     ])
 
     if include_enterprise2:
@@ -125,7 +125,7 @@ def get_steps(edition, is_downstream=False):
             e2e_tests_step('panels-suite', edition=edition2, port=3002),
             e2e_tests_step('various-suite', edition=edition2, port=3002),
             upload_packages_step(edition=edition2, ver_mode=ver_mode, is_downstream=is_downstream),
-            upload_cdn_step(edition=edition2)
+            upload_cdn_step(edition=edition2, ver_mode=ver_mode)
         ])
 
     windows_steps = get_windows_steps(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream)

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -177,7 +177,7 @@ def get_steps(edition, ver_mode):
       build_steps.extend([redis_integration_tests_step(edition=edition2, ver_mode=ver_mode), memcached_integration_tests_step(edition=edition2, ver_mode=ver_mode)])
 
     if should_upload:
-        publish_steps.append(upload_cdn_step(edition=edition))
+        publish_steps.append(upload_cdn_step(edition=edition, ver_mode=ver_mode))
         publish_steps.append(upload_packages_step(edition=edition, ver_mode=ver_mode))
     if should_publish:
         publish_step = publish_storybook_step(edition=edition, ver_mode=ver_mode)
@@ -199,7 +199,7 @@ def get_steps(edition, ver_mode):
             e2e_tests_step('smoke-tests-suite', edition=edition2, port=3002, tries=3),
             e2e_tests_step('panels-suite', edition=edition2, port=3002, tries=3),
             e2e_tests_step('various-suite', edition=edition2, port=3002, tries=3),
-            upload_cdn_step(edition=edition2),
+            upload_cdn_step(edition=edition2, ver_mode=ver_mode),
         ])
         if should_upload:
             step = upload_packages_step(edition=edition2, ver_mode=ver_mode)

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -289,7 +289,12 @@ def publish_storybook_step(edition, ver_mode):
     }
 
 
-def upload_cdn_step(edition):
+def upload_cdn_step(edition, ver_mode):
+    if ver_mode == "main":
+        bucket = "grafana-static-assets"
+    else:
+        bucket = "$${PRERELEASE_BUCKET}/artifacts/static-assets"
+
     return {
         'name': 'upload-cdn-assets' + enterprise2_suffix(edition),
         'image': publish_image,
@@ -301,7 +306,7 @@ def upload_cdn_step(edition):
             'PRERELEASE_BUCKET': from_secret(prerelease_bucket)
         },
         'commands': [
-            './bin/grabpl upload-cdn --edition {} --bucket "$${{PRERELEASE_BUCKET}}/artifacts/static-assets"'.format(edition),
+            './bin/grabpl upload-cdn --edition {} --bucket "{}"'.format(edition, bucket),
         ],
     }
 

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -911,12 +911,13 @@ def upload_packages_step(edition, ver_mode, is_downstream=False):
     if ver_mode == 'main' and edition in ('enterprise', 'enterprise2') and not is_downstream:
         return None
 
-    packages_bucket = ' --packages-bucket $${PRERELEASE_BUCKET}/artifacts/downloads' + enterprise2_suffix(edition)
-
     if ver_mode == 'test-release':
         cmd = './bin/grabpl upload-packages --edition {} '.format(edition) + \
               '--packages-bucket grafana-downloads-test'
+    elif ver_mode == 'main':
+        cmd = './bin/grabpl upload-packages --edition {} --packages-bucket grafana-downloads'.format(edition)
     else:
+        packages_bucket = ' --packages-bucket $${PRERELEASE_BUCKET}/artifacts/downloads' + enterprise2_suffix(edition)
         cmd = './bin/grabpl upload-packages --edition {}{}'.format(edition, packages_bucket)
 
     dependencies = [


### PR DESCRIPTION
The publish location was changed for deb/rpm/etc packages for releases. However, this was also used within the main build, so main build packages were placed in the wrong place for the next "publish" step to find.

This fixes that - it provides the correct bucket to the `upload` step depending on whether we are in `main` or `release` phase.