### PR TITLE
grafana-ui: legacy select: propagate aria-label attribute

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx
@@ -123,6 +123,7 @@ export class Select<T> extends PureComponent<LegacySelectProps<T>> {
         {(onOpenMenuInternal, onCloseMenuInternal) => {
           return (
             <SelectComponent
+              aria-label={this.props['aria-label']}
               captureMenuScroll={false}
               classNamePrefix="gf-form-select-box"
               className={selectClassNames}


### PR DESCRIPTION
the legacy-forms Select component accepts the `aria-label` attribute (based on the typescript props), but it does not propagate it to `react-select`. this pull request fixes that.