### PR TITLE
Alerting: Fix panic while proxying 4xx responses of requests to cortex/loki

### DIFF
--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -116,7 +116,10 @@ func (p *AlertingProxy) withReq(
 			var m map[string]interface{}
 			if err := json.Unmarshal(resp.Body(), &m); err == nil {
 				if message, ok := m["message"]; ok {
-					errMessage = message.(string)
+					errMessageStr, isString := message.(string)
+					if isString {
+						errMessage = errMessageStr
+					}
 				}
 			}
 		} else if strings.HasPrefix(resp.Header().Get("Content-Type"), "text/html") {


### PR DESCRIPTION

Fixes a panic that would occur as we proxy 4xx responses. When this happens and the content type of the response is JSON we try to check if the response has a "message" key. Then, we assume that the key will contain a value of string but we don't take into account that this value can potentially be `null`.

This adds a type assertion check to this assumption so that we can keep the original JSON body as the response if we're unable to extract a `message`.