### PR TITLE
Bra: Run wire re-gen on code change (attempt #2)

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -13,8 +13,10 @@ watch_dirs = [
   "$WORKDIR/conf",
 ]
 watch_exts = [".go", ".ini", ".toml", ".template.html"]
+ignore_files = ["wire_gen.go"] 
 build_delay = 1500
 cmds = [
+  ["make", "gen-go"],
   ["go", "run", "build.go", "-dev", "build-server"],
   ["./bin/grafana-server", "-packaging=dev", "cfg:app_mode=development"]
 ]


### PR DESCRIPTION
**What this PR does / why we need it**:
Runs gen-go on code changes. Will make it a bit slower, but hopefully makes switching branches less painful.


**Special notes for your reviewer**:
Follow up on https://github.com/grafana/grafana/pull/39774 , but doesn't have the loop issue since it ignores the generated wire file.