### PR TITLE
Loki: Fix adding of ad hoc filters for queries with parser and line_format expressions

### DIFF
--- a/public/app/plugins/datasource/loki/add_label_to_query.test.ts
+++ b/public/app/plugins/datasource/loki/add_label_to_query.test.ts
@@ -1,0 +1,121 @@
+import { addLabelToQuery, addLabelToSelector } from './add_label_to_query';
+
+describe('addLabelToQuery()', () => {
+  it('should add label to simple query', () => {
+    expect(() => {
+      addLabelToQuery('foo', '', '');
+    }).toThrow();
+    expect(addLabelToQuery('{}', 'bar', 'baz')).toBe('{bar="baz"}');
+    expect(addLabelToQuery('{x="yy"}', 'bar', 'baz')).toBe('{bar="baz",x="yy"}');
+  });
+
+  it('should add custom operator', () => {
+    expect(addLabelToQuery('{}', 'bar', 'baz', '!=')).toBe('{bar!="baz"}');
+    expect(addLabelToQuery('{x="yy"}', 'bar', 'baz', '!=')).toBe('{bar!="baz",x="yy"}');
+  });
+
+  it('should not modify ranges', () => {
+    expect(addLabelToQuery('rate({}[1m])', 'foo', 'bar')).toBe('rate({foo="bar"}[1m])');
+  });
+
+  it('should detect in-order function use', () => {
+    expect(addLabelToQuery('sum by (xx) ({})', 'bar', 'baz')).toBe('sum by (xx) ({bar="baz"})');
+  });
+
+  it('should convert number Infinity to +Inf', () => {
+    expect(addLabelToQuery('sum(rate({}[5m])) by (le)', 'le', Infinity)).toBe('sum(rate({le="+Inf"}[5m])) by (le)');
+  });
+
+  it('should handle selectors with punctuation', () => {
+    expect(addLabelToQuery('{instance="my-host.com:9100"}', 'bar', 'baz')).toBe(
+      '{bar="baz",instance="my-host.com:9100"}'
+    );
+    expect(addLabelToQuery('{list="a,b,c"}', 'bar', 'baz')).toBe('{bar="baz",list="a,b,c"}');
+  });
+
+  it('should work on arithmetical expressions', () => {
+    expect(addLabelToQuery('{} + {}', 'bar', 'baz')).toBe('{bar="baz"} + {bar="baz"}');
+    expect(addLabelToQuery('avg({}) + sum({})', 'bar', 'baz')).toBe('avg({bar="baz"}) + sum({bar="baz"})');
+    expect(addLabelToQuery('{x="yy"} * {y="zz",a="bb"} * {}', 'bar', 'baz')).toBe(
+      '{bar="baz",x="yy"} * {a="bb",bar="baz",y="zz"} * {bar="baz"}'
+    );
+  });
+
+  it('should not add duplicate labels to a query', () => {
+    expect(addLabelToQuery(addLabelToQuery('{x="yy"}', 'bar', 'baz', '!='), 'bar', 'baz', '!=')).toBe(
+      '{bar!="baz",x="yy"}'
+    );
+    expect(addLabelToQuery(addLabelToQuery('rate({}[1m])', 'foo', 'bar'), 'foo', 'bar')).toBe('rate({foo="bar"}[1m])');
+    expect(addLabelToQuery(addLabelToQuery('{list="a,b,c"}', 'bar', 'baz'), 'bar', 'baz')).toBe(
+      '{bar="baz",list="a,b,c"}'
+    );
+    expect(addLabelToQuery(addLabelToQuery('avg({}) + sum({})', 'bar', 'baz'), 'bar', 'baz')).toBe(
+      'avg({bar="baz"}) + sum({bar="baz"})'
+    );
+  });
+
+  it('should not remove filters', () => {
+    expect(addLabelToQuery('{x="y"} |="yy"', 'bar', 'baz')).toBe('{bar="baz",x="y"} |="yy"');
+    expect(addLabelToQuery('{x="y"} |="yy" !~"xx"', 'bar', 'baz')).toBe('{bar="baz",x="y"} |="yy" !~"xx"');
+  });
+
+  it('should add label to query properly with Loki datasource', () => {
+    expect(addLabelToQuery('{job="grafana"} |= "foo-bar"', 'filename', 'test.txt', undefined, true)).toBe(
+      '{filename="test.txt",job="grafana"} |= "foo-bar"'
+    );
+  });
+
+  it('should add labels to metrics with logical operators', () => {
+    expect(addLabelToQuery('{} or {}', 'bar', 'baz')).toBe('{bar="baz"} or {bar="baz"}');
+    expect(addLabelToQuery('{} and {}', 'bar', 'baz')).toBe('{bar="baz"} and {bar="baz"}');
+  });
+
+  it('should not add ad-hoc filter to template variables', () => {
+    expect(addLabelToQuery('sum(rate({job="foo"}[2m])) by (value $variable)', 'bar', 'baz')).toBe(
+      'sum(rate({bar="baz",job="foo"}[2m])) by (value $variable)'
+    );
+  });
+
+  it('should not add ad-hoc filter to range', () => {
+    expect(addLabelToQuery('avg(rate(({job="foo"} > 0)[3h:])) by (label)', 'bar', 'baz')).toBe(
+      'avg(rate(({bar="baz",job="foo"} > 0)[3h:])) by (label)'
+    );
+  });
+  it('should not add ad-hoc filter to labels in label list provided with the group modifier', () => {
+    expect(
+      addLabelToQuery(
+        'max by (id, name, type) ({type=~"foo|bar|baz-test"}) * on(id) group_right(id, type, name) sum by (id) ({}) * 1000',
+        'bar',
+        'baz'
+      )
+    ).toBe(
+      'max by (id, name, type) ({bar="baz",type=~"foo|bar|baz-test"}) * on(id) group_right(id, type, name) sum by (id) ({bar="baz"}) * 1000'
+    );
+  });
+  it('should not add ad-hoc filter to labels in label list provided with the group modifier', () => {
+    expect(addLabelToQuery('rate({}[${__range_s}s])', 'bar', 'baz')).toBe('rate({bar="baz"}[${__range_s}s])');
+  });
+  it('should not add ad-hoc filter to labels to math operations', () => {
+    expect(addLabelToQuery('count({job!="foo"} < (5*1024*1024*1024) or vector(0)) - 1', 'bar', 'baz')).toBe(
+      'count({bar="baz",job!="foo"} < (5*1024*1024*1024) or vector(0)) - 1'
+    );
+  });
+  it('should not add adhoc filter to line_format expressions', () => {
+    expect(addLabelToQuery('{foo="bar"} | logfmt | line_format {{.status}}', 'bar', 'baz')).toBe(
+      '{bar="baz",foo="bar"} | logfmt | line_format {{.status}}'
+    );
+  });
+});
+
+describe('addLabelToSelector()', () => {
+  test('should add a label to an empty selector', () => {
+    expect(addLabelToSelector('{}', 'foo', 'bar')).toBe('{foo="bar"}');
+    expect(addLabelToSelector('', 'foo', 'bar')).toBe('{foo="bar"}');
+  });
+  test('should add a label to a selector', () => {
+    expect(addLabelToSelector('{foo="bar"}', 'baz', '42')).toBe('{baz="42",foo="bar"}');
+  });
+  test('should add a label to a selector with custom operator', () => {
+    expect(addLabelToSelector('{}', 'baz', '42', '!=')).toBe('{baz!="42"}');
+  });
+});

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -872,7 +872,7 @@ describe('LokiDatasource', () => {
       });
       describe('and query has parser', () => {
         it('then the correct label should be added for logs query', () => {
-          assertAdHocFilters('{bar="baz"} | logfmt', '{bar="baz"} | logfmt | job="grafana"', ds);
+          assertAdHocFilters('{bar="baz"} | logfmt', '{bar="baz",job="grafana"} | logfmt', ds);
         });
         it('then the correct label should be added for metrics query', () => {
           assertAdHocFilters('rate({bar="baz"} | logfmt [5m])', 'rate({bar="baz",job="grafana"} | logfmt [5m])', ds);
@@ -907,7 +907,7 @@ describe('LokiDatasource', () => {
       });
       describe('and query has parser', () => {
         it('then the correct label should be added for logs query', () => {
-          assertAdHocFilters('{bar="baz"} | logfmt', '{bar="baz"} | logfmt | job!="grafana"', ds);
+          assertAdHocFilters('{bar="baz"} | logfmt', '{bar="baz",job!="grafana"} | logfmt', ds);
         });
         it('then the correct label should be added for metrics query', () => {
           assertAdHocFilters('rate({bar="baz"} | logfmt [5m])', 'rate({bar="baz",job!="grafana"} | logfmt [5m])', ds);

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -33,7 +33,7 @@ import {
 } from '@grafana/data';
 import { BackendSrvRequest, FetchError, getBackendSrv } from '@grafana/runtime';
 import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
-import { addLabelToQuery } from 'app/plugins/datasource/prometheus/add_label_to_query';
+import { addLabelToQuery } from './add_label_to_query';
 import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { convertToWebSocketUrl } from 'app/core/utils/explore';
 import {
@@ -707,14 +707,21 @@ export class LokiDatasource
         value = lokiRegularEscape(value);
       }
 
-      return this.addLabelToQuery(acc, key, value, operator);
+      return this.addLabelToQuery(acc, key, value, operator, true);
     }, expr);
 
     return expr;
   }
 
-  addLabelToQuery(queryExpr: string, key: string, value: string | number, operator: string) {
-    if (queryHasPipeParser(queryExpr) && !isMetricsQuery(queryExpr)) {
+  addLabelToQuery(
+    queryExpr: string,
+    key: string,
+    value: string | number,
+    operator: string,
+    // Override to make sure that we use label as actual label and not parsed label
+    notParsedLabelOverride?: boolean
+  ) {
+    if (queryHasPipeParser(queryExpr) && !isMetricsQuery(queryExpr) && !notParsedLabelOverride) {
       // If query has parser, we treat all labels as parsed and use | key="value" syntax
       return addParsedLabelToQuery(queryExpr, key, value, operator);
     } else {

--- a/public/app/plugins/datasource/loki/syntax.ts
+++ b/public/app/plugins/datasource/loki/syntax.ts
@@ -168,6 +168,7 @@ export const RANGE_VEC_FUNCTIONS = [
 ];
 
 export const FUNCTIONS = [...AGGREGATION_OPERATORS, ...RANGE_VEC_FUNCTIONS];
+export const LOKI_KEYWORDS = [...FUNCTIONS, ...PIPE_OPERATORS, ...PIPE_PARSERS].map((keyword) => keyword.label);
 
 const tokenizer: Grammar = {
   comment: {

--- a/public/app/plugins/datasource/prometheus/promql.ts
+++ b/public/app/plugins/datasource/prometheus/promql.ts
@@ -16,6 +16,7 @@ export const RATE_RANGES: CompletionItem[] = [
 ];
 
 export const OPERATORS = ['by', 'group_left', 'group_right', 'ignoring', 'on', 'offset', 'without'];
+export const LOGICAL_OPERATORS = ['or', 'and', 'unless'];
 
 const AGGREGATION_OPERATORS: CompletionItem[] = [
   {
@@ -426,6 +427,8 @@ export const FUNCTIONS = [
     documentation: 'The most recent point value in specified interval.',
   },
 ];
+
+export const PROM_KEYWORDS = FUNCTIONS.map((keyword) => keyword.label);
 
 const tokenizer: Grammar = {
   comment: {


### PR DESCRIPTION
**What is the issue:**
The issue was that Loki log queries that includes parser + line_format + empty stream weren't working. This was due:
1. When using add-hoc filters for log queries with parser and empty stream (e.g. `{} | logfmt`), we added `label+value` pair as parsed labels (`{} | logfm | label="value"`) which resulted in incorrect query because we need at least 1 stream selector. This is easy to prevent as we always know, that ad-hoc filters includes actual labels and not parsed labels. 
2. When using `line format {{.status}}` expression, our regex caught `{{.status}}` as a stream selector and created incorrect query. We need to filter these out/use different regex.

**How are we fixing this:**
1. We were using `addLabelToQuery` functionality from Prometheus. This was useful at the beginning when query language was very similar and LogQL was quite simple. However, as LogQL improves and grows as a querying language, we need to include this changes and coupling with Prometheus language becomes more complex to solve. I feel like this is nice breaking point where Prometheus function doesn't need change, but Loki's does and therefore we should move the logic to Loki.

2. For Loki, we have added second false positive scenario => `Log queries can include {{.label}} syntax when line_format is used. We need to filter these out by checking if match starts with "{."`

3. For applying ad-hoc queries, we have added new `notParsedLabelOverride` param that is used to make sure that ad-hoc filters are added as real labels and not parsed labels.

4. This is not related, but we had hard-coded duplicated keywords and I have just used keywords from `promql` and `syntax` files. 

**Which issue(s) this PR fixes**:

Fixes isssue reported internally by @wardbekker 

**Special notes for your reviewer**:

How to test this:
1. Create dashboard with panel with Loki query such as `{} | logfmt |  line_format {{.status}}`
2. Create ad-hoc filters
3. Select filter such as `job="grafana"`
3. Check if generated query is correct  such as {job="grafana} } | logfmt | line_format {{.status}}
