### PR TITLE
Alerting: Refactor API handlers to use web.Bind

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -92,16 +92,19 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 		NewLotexRuler(proxy, logger),
 		RulerSrv{DatasourceCache: api.DatasourceCache, QuotaService: api.QuotaService, manager: api.StateManager, store: api.RuleStore, log: logger},
 	), m)
-	api.RegisterTestingApiEndpoints(TestingApiSrv{
-		AlertingProxy:     proxy,
-		Cfg:               api.Cfg,
-		ExpressionService: api.ExpressionService,
-		DatasourceCache:   api.DatasourceCache,
-		log:               logger,
-	}, m)
-	api.RegisterConfigurationApiEndpoints(AdminSrv{
-		store:     api.AdminConfigStore,
-		log:       logger,
-		scheduler: api.Schedule,
-	}, m)
+	api.RegisterTestingApiEndpoints(NewForkedTestingApi(
+		TestingApiSrv{
+			AlertingProxy:     proxy,
+			Cfg:               api.Cfg,
+			ExpressionService: api.ExpressionService,
+			DatasourceCache:   api.DatasourceCache,
+			log:               logger,
+		}), m)
+	api.RegisterConfigurationApiEndpoints(NewForkedConfiguration(
+		AdminSrv{
+			store:     api.AdminConfigStore,
+			log:       logger,
+			scheduler: api.Schedule,
+		},
+	), m)
 }

--- a/pkg/services/ngalert/api/fork_ruler.go
+++ b/pkg/services/ngalert/api/fork_ruler.go
@@ -24,83 +24,83 @@ func NewForkedRuler(datasourceCache datasources.CacheService, lotex, grafana Rul
 	}
 }
 
-func (r *ForkedRulerApi) forkRouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
-	t, err := backendType(ctx, r.DatasourceCache)
+func (f *ForkedRulerApi) forkRouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
+	t, err := backendType(ctx, f.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
 	switch t {
 	case apimodels.GrafanaBackend:
-		return r.GrafanaRuler.RouteDeleteNamespaceRulesConfig(ctx)
+		return f.GrafanaRuler.RouteDeleteNamespaceRulesConfig(ctx)
 	case apimodels.LoTexRulerBackend:
-		return r.LotexRuler.RouteDeleteNamespaceRulesConfig(ctx)
+		return f.LotexRuler.RouteDeleteNamespaceRulesConfig(ctx)
 	default:
 		return ErrResp(400, fmt.Errorf("unexpected backend type (%v)", t), "")
 	}
 }
 
-func (r *ForkedRulerApi) forkRouteDeleteRuleGroupConfig(ctx *models.ReqContext) response.Response {
-	t, err := backendType(ctx, r.DatasourceCache)
+func (f *ForkedRulerApi) forkRouteDeleteRuleGroupConfig(ctx *models.ReqContext) response.Response {
+	t, err := backendType(ctx, f.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
 	switch t {
 	case apimodels.GrafanaBackend:
-		return r.GrafanaRuler.RouteDeleteRuleGroupConfig(ctx)
+		return f.GrafanaRuler.RouteDeleteRuleGroupConfig(ctx)
 	case apimodels.LoTexRulerBackend:
-		return r.LotexRuler.RouteDeleteRuleGroupConfig(ctx)
+		return f.LotexRuler.RouteDeleteRuleGroupConfig(ctx)
 	default:
 		return ErrResp(400, fmt.Errorf("unexpected backend type (%v)", t), "")
 	}
 }
 
-func (r *ForkedRulerApi) forkRouteGetNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
-	t, err := backendType(ctx, r.DatasourceCache)
+func (f *ForkedRulerApi) forkRouteGetNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
+	t, err := backendType(ctx, f.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
 	switch t {
 	case apimodels.GrafanaBackend:
-		return r.GrafanaRuler.RouteGetNamespaceRulesConfig(ctx)
+		return f.GrafanaRuler.RouteGetNamespaceRulesConfig(ctx)
 	case apimodels.LoTexRulerBackend:
-		return r.LotexRuler.RouteGetNamespaceRulesConfig(ctx)
+		return f.LotexRuler.RouteGetNamespaceRulesConfig(ctx)
 	default:
 		return ErrResp(400, fmt.Errorf("unexpected backend type (%v)", t), "")
 	}
 }
 
-func (r *ForkedRulerApi) forkRouteGetRulegGroupConfig(ctx *models.ReqContext) response.Response {
-	t, err := backendType(ctx, r.DatasourceCache)
+func (f *ForkedRulerApi) forkRouteGetRulegGroupConfig(ctx *models.ReqContext) response.Response {
+	t, err := backendType(ctx, f.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
 	switch t {
 	case apimodels.GrafanaBackend:
-		return r.GrafanaRuler.RouteGetRulegGroupConfig(ctx)
+		return f.GrafanaRuler.RouteGetRulegGroupConfig(ctx)
 	case apimodels.LoTexRulerBackend:
-		return r.LotexRuler.RouteGetRulegGroupConfig(ctx)
+		return f.LotexRuler.RouteGetRulegGroupConfig(ctx)
 	default:
 		return ErrResp(400, fmt.Errorf("unexpected backend type (%v)", t), "")
 	}
 }
 
-func (r *ForkedRulerApi) forkRouteGetRulesConfig(ctx *models.ReqContext) response.Response {
-	t, err := backendType(ctx, r.DatasourceCache)
+func (f *ForkedRulerApi) forkRouteGetRulesConfig(ctx *models.ReqContext) response.Response {
+	t, err := backendType(ctx, f.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
 	switch t {
 	case apimodels.GrafanaBackend:
-		return r.GrafanaRuler.RouteGetRulesConfig(ctx)
+		return f.GrafanaRuler.RouteGetRulesConfig(ctx)
 	case apimodels.LoTexRulerBackend:
-		return r.LotexRuler.RouteGetRulesConfig(ctx)
+		return f.LotexRuler.RouteGetRulesConfig(ctx)
 	default:
 		return ErrResp(400, fmt.Errorf("unexpected backend type (%v)", t), "")
 	}
 }
 
-func (r *ForkedRulerApi) forkRoutePostNameRulesConfig(ctx *models.ReqContext, conf apimodels.PostableRuleGroupConfig) response.Response {
-	backendType, err := backendType(ctx, r.DatasourceCache)
+func (f *ForkedRulerApi) forkRoutePostNameRulesConfig(ctx *models.ReqContext, conf apimodels.PostableRuleGroupConfig) response.Response {
+	backendType, err := backendType(ctx, f.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
@@ -112,9 +112,9 @@ func (r *ForkedRulerApi) forkRoutePostNameRulesConfig(ctx *models.ReqContext, co
 
 	switch backendType {
 	case apimodels.GrafanaBackend:
-		return r.GrafanaRuler.RoutePostNameRulesConfig(ctx, conf)
+		return f.GrafanaRuler.RoutePostNameRulesConfig(ctx, conf)
 	case apimodels.LoTexRulerBackend:
-		return r.LotexRuler.RoutePostNameRulesConfig(ctx, conf)
+		return f.LotexRuler.RoutePostNameRulesConfig(ctx, conf)
 	default:
 		return ErrResp(400, fmt.Errorf("unexpected backend type (%v)", backendType), "")
 	}

--- a/pkg/services/ngalert/api/fork_ruler.go
+++ b/pkg/services/ngalert/api/fork_ruler.go
@@ -9,22 +9,22 @@ import (
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 )
 
-// ForkedRuler will validate and proxy requests to the correct backend type depending on the datasource.
-type ForkedRuler struct {
+// ForkedRulerApi will validate and proxy requests to the correct backend type depending on the datasource.
+type ForkedRulerApi struct {
 	LotexRuler, GrafanaRuler RulerApiService
 	DatasourceCache          datasources.CacheService
 }
 
 // NewForkedRuler implements a set of routes that proxy to various Cortex Ruler-compatible backends.
-func NewForkedRuler(datasourceCache datasources.CacheService, lotex, grafana RulerApiService) *ForkedRuler {
-	return &ForkedRuler{
+func NewForkedRuler(datasourceCache datasources.CacheService, lotex, grafana RulerApiService) *ForkedRulerApi {
+	return &ForkedRulerApi{
 		LotexRuler:      lotex,
 		GrafanaRuler:    grafana,
 		DatasourceCache: datasourceCache,
 	}
 }
 
-func (r *ForkedRuler) RouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
+func (r *ForkedRulerApi) forkRouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
 	t, err := backendType(ctx, r.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -39,7 +39,7 @@ func (r *ForkedRuler) RouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) re
 	}
 }
 
-func (r *ForkedRuler) RouteDeleteRuleGroupConfig(ctx *models.ReqContext) response.Response {
+func (r *ForkedRulerApi) forkRouteDeleteRuleGroupConfig(ctx *models.ReqContext) response.Response {
 	t, err := backendType(ctx, r.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -54,7 +54,7 @@ func (r *ForkedRuler) RouteDeleteRuleGroupConfig(ctx *models.ReqContext) respons
 	}
 }
 
-func (r *ForkedRuler) RouteGetNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
+func (r *ForkedRulerApi) forkRouteGetNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
 	t, err := backendType(ctx, r.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -69,7 +69,7 @@ func (r *ForkedRuler) RouteGetNamespaceRulesConfig(ctx *models.ReqContext) respo
 	}
 }
 
-func (r *ForkedRuler) RouteGetRulegGroupConfig(ctx *models.ReqContext) response.Response {
+func (r *ForkedRulerApi) forkRouteGetRulegGroupConfig(ctx *models.ReqContext) response.Response {
 	t, err := backendType(ctx, r.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -84,7 +84,7 @@ func (r *ForkedRuler) RouteGetRulegGroupConfig(ctx *models.ReqContext) response.
 	}
 }
 
-func (r *ForkedRuler) RouteGetRulesConfig(ctx *models.ReqContext) response.Response {
+func (r *ForkedRulerApi) forkRouteGetRulesConfig(ctx *models.ReqContext) response.Response {
 	t, err := backendType(ctx, r.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -99,7 +99,7 @@ func (r *ForkedRuler) RouteGetRulesConfig(ctx *models.ReqContext) response.Respo
 	}
 }
 
-func (r *ForkedRuler) RoutePostNameRulesConfig(ctx *models.ReqContext, conf apimodels.PostableRuleGroupConfig) response.Response {
+func (r *ForkedRulerApi) forkRoutePostNameRulesConfig(ctx *models.ReqContext, conf apimodels.PostableRuleGroupConfig) response.Response {
 	backendType, err := backendType(ctx, r.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")

--- a/pkg/services/ngalert/api/forked_admin.go
+++ b/pkg/services/ngalert/api/forked_admin.go
@@ -18,18 +18,18 @@ func NewForkedConfiguration(grafana ConfigurationApiService) *ForkedConfiguratio
 	}
 }
 
-func (r *ForkedConfigurationApi) forkRouteGetAlertmanagers(c *models.ReqContext) response.Response {
-	return r.grafana.RouteGetAlertmanagers(c)
+func (f *ForkedConfigurationApi) forkRouteGetAlertmanagers(c *models.ReqContext) response.Response {
+	return f.grafana.RouteGetAlertmanagers(c)
 }
 
-func (r *ForkedConfigurationApi) forkRouteGetNGalertConfig(c *models.ReqContext) response.Response {
-	return r.grafana.RouteGetNGalertConfig(c)
+func (f *ForkedConfigurationApi) forkRouteGetNGalertConfig(c *models.ReqContext) response.Response {
+	return f.grafana.RouteGetNGalertConfig(c)
 }
 
-func (r *ForkedConfigurationApi) forkRoutePostNGalertConfig(c *models.ReqContext, body apimodels.PostableNGalertConfig) response.Response {
-	return r.grafana.RoutePostNGalertConfig(c, body)
+func (f *ForkedConfigurationApi) forkRoutePostNGalertConfig(c *models.ReqContext, body apimodels.PostableNGalertConfig) response.Response {
+	return f.grafana.RoutePostNGalertConfig(c, body)
 }
 
-func (r *ForkedConfigurationApi) forkRouteDeleteNGalertConfig(c *models.ReqContext) response.Response {
-	return r.grafana.RouteDeleteNGalertConfig(c)
+func (f *ForkedConfigurationApi) forkRouteDeleteNGalertConfig(c *models.ReqContext) response.Response {
+	return f.grafana.RouteDeleteNGalertConfig(c)
 }

--- a/pkg/services/ngalert/api/forked_admin.go
+++ b/pkg/services/ngalert/api/forked_admin.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/models"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+)
+
+// ForkedConfigurationApi always forwards requests to grafana backend
+type ForkedConfigurationApi struct {
+	grafana ConfigurationApiService
+}
+
+// NewForkedConfiguration creates a new ForkedConfigurationApi instance
+func NewForkedConfiguration(grafana ConfigurationApiService) *ForkedConfigurationApi {
+	return &ForkedConfigurationApi{
+		grafana: grafana,
+	}
+}
+
+func (r *ForkedConfigurationApi) forkRouteGetAlertmanagers(c *models.ReqContext) response.Response {
+	return r.grafana.RouteGetAlertmanagers(c)
+}
+
+func (r *ForkedConfigurationApi) forkRouteGetNGalertConfig(c *models.ReqContext) response.Response {
+	return r.grafana.RouteGetNGalertConfig(c)
+}
+
+func (r *ForkedConfigurationApi) forkRoutePostNGalertConfig(c *models.ReqContext, body apimodels.PostableNGalertConfig) response.Response {
+	return r.grafana.RoutePostNGalertConfig(c, body)
+}
+
+func (r *ForkedConfigurationApi) forkRouteDeleteNGalertConfig(c *models.ReqContext) response.Response {
+	return r.grafana.RouteDeleteNGalertConfig(c)
+}

--- a/pkg/services/ngalert/api/forked_am.go
+++ b/pkg/services/ngalert/api/forked_am.go
@@ -9,21 +9,21 @@ import (
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 )
 
-type ForkedAMSvc struct {
+type ForkedAlertmanagerApi struct {
 	AMSvc, GrafanaSvc AlertmanagerApiService
 	DatasourceCache   datasources.CacheService
 }
 
 // NewForkedAM implements a set of routes that proxy to various Alertmanager-compatible backends.
-func NewForkedAM(datasourceCache datasources.CacheService, proxy, grafana AlertmanagerApiService) *ForkedAMSvc {
-	return &ForkedAMSvc{
+func NewForkedAM(datasourceCache datasources.CacheService, proxy, grafana AlertmanagerApiService) *ForkedAlertmanagerApi {
+	return &ForkedAlertmanagerApi{
 		AMSvc:           proxy,
 		GrafanaSvc:      grafana,
 		DatasourceCache: datasourceCache,
 	}
 }
 
-func (am *ForkedAMSvc) getService(ctx *models.ReqContext) (AlertmanagerApiService, error) {
+func (am *ForkedAlertmanagerApi) getService(ctx *models.ReqContext) (AlertmanagerApiService, error) {
 	t, err := backendType(ctx, am.DatasourceCache)
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func (am *ForkedAMSvc) getService(ctx *models.ReqContext) (AlertmanagerApiServic
 	}
 }
 
-func (am *ForkedAMSvc) RouteGetAMStatus(ctx *models.ReqContext) response.Response {
+func (am *ForkedAlertmanagerApi) forkRouteGetAMStatus(ctx *models.ReqContext) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
 		return response.Error(400, err.Error(), nil)
@@ -48,7 +48,7 @@ func (am *ForkedAMSvc) RouteGetAMStatus(ctx *models.ReqContext) response.Respons
 	return s.RouteGetAMStatus(ctx)
 }
 
-func (am *ForkedAMSvc) RouteCreateSilence(ctx *models.ReqContext, body apimodels.PostableSilence) response.Response {
+func (am *ForkedAlertmanagerApi) forkRouteCreateSilence(ctx *models.ReqContext, body apimodels.PostableSilence) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -57,7 +57,7 @@ func (am *ForkedAMSvc) RouteCreateSilence(ctx *models.ReqContext, body apimodels
 	return s.RouteCreateSilence(ctx, body)
 }
 
-func (am *ForkedAMSvc) RouteDeleteAlertingConfig(ctx *models.ReqContext) response.Response {
+func (am *ForkedAlertmanagerApi) forkRouteDeleteAlertingConfig(ctx *models.ReqContext) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -66,7 +66,7 @@ func (am *ForkedAMSvc) RouteDeleteAlertingConfig(ctx *models.ReqContext) respons
 	return s.RouteDeleteAlertingConfig(ctx)
 }
 
-func (am *ForkedAMSvc) RouteDeleteSilence(ctx *models.ReqContext) response.Response {
+func (am *ForkedAlertmanagerApi) forkRouteDeleteSilence(ctx *models.ReqContext) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -75,7 +75,7 @@ func (am *ForkedAMSvc) RouteDeleteSilence(ctx *models.ReqContext) response.Respo
 	return s.RouteDeleteSilence(ctx)
 }
 
-func (am *ForkedAMSvc) RouteGetAlertingConfig(ctx *models.ReqContext) response.Response {
+func (am *ForkedAlertmanagerApi) forkRouteGetAlertingConfig(ctx *models.ReqContext) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -84,7 +84,7 @@ func (am *ForkedAMSvc) RouteGetAlertingConfig(ctx *models.ReqContext) response.R
 	return s.RouteGetAlertingConfig(ctx)
 }
 
-func (am *ForkedAMSvc) RouteGetAMAlertGroups(ctx *models.ReqContext) response.Response {
+func (am *ForkedAlertmanagerApi) forkRouteGetAMAlertGroups(ctx *models.ReqContext) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -93,7 +93,7 @@ func (am *ForkedAMSvc) RouteGetAMAlertGroups(ctx *models.ReqContext) response.Re
 	return s.RouteGetAMAlertGroups(ctx)
 }
 
-func (am *ForkedAMSvc) RouteGetAMAlerts(ctx *models.ReqContext) response.Response {
+func (am *ForkedAlertmanagerApi) forkRouteGetAMAlerts(ctx *models.ReqContext) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -102,7 +102,7 @@ func (am *ForkedAMSvc) RouteGetAMAlerts(ctx *models.ReqContext) response.Respons
 	return s.RouteGetAMAlerts(ctx)
 }
 
-func (am *ForkedAMSvc) RouteGetSilence(ctx *models.ReqContext) response.Response {
+func (am *ForkedAlertmanagerApi) forkRouteGetSilence(ctx *models.ReqContext) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -111,7 +111,7 @@ func (am *ForkedAMSvc) RouteGetSilence(ctx *models.ReqContext) response.Response
 	return s.RouteGetSilence(ctx)
 }
 
-func (am *ForkedAMSvc) RouteGetSilences(ctx *models.ReqContext) response.Response {
+func (am *ForkedAlertmanagerApi) forkRouteGetSilences(ctx *models.ReqContext) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -120,7 +120,7 @@ func (am *ForkedAMSvc) RouteGetSilences(ctx *models.ReqContext) response.Respons
 	return s.RouteGetSilences(ctx)
 }
 
-func (am *ForkedAMSvc) RoutePostAlertingConfig(ctx *models.ReqContext, body apimodels.PostableUserConfig) response.Response {
+func (am *ForkedAlertmanagerApi) forkRoutePostAlertingConfig(ctx *models.ReqContext, body apimodels.PostableUserConfig) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -138,7 +138,7 @@ func (am *ForkedAMSvc) RoutePostAlertingConfig(ctx *models.ReqContext, body apim
 	return s.RoutePostAlertingConfig(ctx, body)
 }
 
-func (am *ForkedAMSvc) RoutePostAMAlerts(ctx *models.ReqContext, body apimodels.PostableAlerts) response.Response {
+func (am *ForkedAlertmanagerApi) forkRoutePostAMAlerts(ctx *models.ReqContext, body apimodels.PostableAlerts) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -147,7 +147,7 @@ func (am *ForkedAMSvc) RoutePostAMAlerts(ctx *models.ReqContext, body apimodels.
 	return s.RoutePostAMAlerts(ctx, body)
 }
 
-func (am *ForkedAMSvc) RoutePostTestReceivers(ctx *models.ReqContext, body apimodels.TestReceiversConfigBodyParams) response.Response {
+func (am *ForkedAlertmanagerApi) forkRoutePostTestReceivers(ctx *models.ReqContext, body apimodels.TestReceiversConfigBodyParams) response.Response {
 	s, err := am.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")

--- a/pkg/services/ngalert/api/forked_am.go
+++ b/pkg/services/ngalert/api/forked_am.go
@@ -23,24 +23,24 @@ func NewForkedAM(datasourceCache datasources.CacheService, proxy, grafana Alertm
 	}
 }
 
-func (am *ForkedAlertmanagerApi) getService(ctx *models.ReqContext) (AlertmanagerApiService, error) {
-	t, err := backendType(ctx, am.DatasourceCache)
+func (f *ForkedAlertmanagerApi) getService(ctx *models.ReqContext) (AlertmanagerApiService, error) {
+	t, err := backendType(ctx, f.DatasourceCache)
 	if err != nil {
 		return nil, err
 	}
 
 	switch t {
 	case apimodels.GrafanaBackend:
-		return am.GrafanaSvc, nil
+		return f.GrafanaSvc, nil
 	case apimodels.AlertmanagerBackend:
-		return am.AMSvc, nil
+		return f.AMSvc, nil
 	default:
 		return nil, fmt.Errorf("unexpected backend type (%v)", t)
 	}
 }
 
-func (am *ForkedAlertmanagerApi) forkRouteGetAMStatus(ctx *models.ReqContext) response.Response {
-	s, err := am.getService(ctx)
+func (f *ForkedAlertmanagerApi) forkRouteGetAMStatus(ctx *models.ReqContext) response.Response {
+	s, err := f.getService(ctx)
 	if err != nil {
 		return response.Error(400, err.Error(), nil)
 	}
@@ -48,8 +48,8 @@ func (am *ForkedAlertmanagerApi) forkRouteGetAMStatus(ctx *models.ReqContext) re
 	return s.RouteGetAMStatus(ctx)
 }
 
-func (am *ForkedAlertmanagerApi) forkRouteCreateSilence(ctx *models.ReqContext, body apimodels.PostableSilence) response.Response {
-	s, err := am.getService(ctx)
+func (f *ForkedAlertmanagerApi) forkRouteCreateSilence(ctx *models.ReqContext, body apimodels.PostableSilence) response.Response {
+	s, err := f.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
@@ -57,8 +57,8 @@ func (am *ForkedAlertmanagerApi) forkRouteCreateSilence(ctx *models.ReqContext, 
 	return s.RouteCreateSilence(ctx, body)
 }
 
-func (am *ForkedAlertmanagerApi) forkRouteDeleteAlertingConfig(ctx *models.ReqContext) response.Response {
-	s, err := am.getService(ctx)
+func (f *ForkedAlertmanagerApi) forkRouteDeleteAlertingConfig(ctx *models.ReqContext) response.Response {
+	s, err := f.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
@@ -66,8 +66,8 @@ func (am *ForkedAlertmanagerApi) forkRouteDeleteAlertingConfig(ctx *models.ReqCo
 	return s.RouteDeleteAlertingConfig(ctx)
 }
 
-func (am *ForkedAlertmanagerApi) forkRouteDeleteSilence(ctx *models.ReqContext) response.Response {
-	s, err := am.getService(ctx)
+func (f *ForkedAlertmanagerApi) forkRouteDeleteSilence(ctx *models.ReqContext) response.Response {
+	s, err := f.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
@@ -75,8 +75,8 @@ func (am *ForkedAlertmanagerApi) forkRouteDeleteSilence(ctx *models.ReqContext) 
 	return s.RouteDeleteSilence(ctx)
 }
 
-func (am *ForkedAlertmanagerApi) forkRouteGetAlertingConfig(ctx *models.ReqContext) response.Response {
-	s, err := am.getService(ctx)
+func (f *ForkedAlertmanagerApi) forkRouteGetAlertingConfig(ctx *models.ReqContext) response.Response {
+	s, err := f.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
@@ -84,8 +84,8 @@ func (am *ForkedAlertmanagerApi) forkRouteGetAlertingConfig(ctx *models.ReqConte
 	return s.RouteGetAlertingConfig(ctx)
 }
 
-func (am *ForkedAlertmanagerApi) forkRouteGetAMAlertGroups(ctx *models.ReqContext) response.Response {
-	s, err := am.getService(ctx)
+func (f *ForkedAlertmanagerApi) forkRouteGetAMAlertGroups(ctx *models.ReqContext) response.Response {
+	s, err := f.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
@@ -93,8 +93,8 @@ func (am *ForkedAlertmanagerApi) forkRouteGetAMAlertGroups(ctx *models.ReqContex
 	return s.RouteGetAMAlertGroups(ctx)
 }
 
-func (am *ForkedAlertmanagerApi) forkRouteGetAMAlerts(ctx *models.ReqContext) response.Response {
-	s, err := am.getService(ctx)
+func (f *ForkedAlertmanagerApi) forkRouteGetAMAlerts(ctx *models.ReqContext) response.Response {
+	s, err := f.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
@@ -102,8 +102,8 @@ func (am *ForkedAlertmanagerApi) forkRouteGetAMAlerts(ctx *models.ReqContext) re
 	return s.RouteGetAMAlerts(ctx)
 }
 
-func (am *ForkedAlertmanagerApi) forkRouteGetSilence(ctx *models.ReqContext) response.Response {
-	s, err := am.getService(ctx)
+func (f *ForkedAlertmanagerApi) forkRouteGetSilence(ctx *models.ReqContext) response.Response {
+	s, err := f.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
@@ -111,8 +111,8 @@ func (am *ForkedAlertmanagerApi) forkRouteGetSilence(ctx *models.ReqContext) res
 	return s.RouteGetSilence(ctx)
 }
 
-func (am *ForkedAlertmanagerApi) forkRouteGetSilences(ctx *models.ReqContext) response.Response {
-	s, err := am.getService(ctx)
+func (f *ForkedAlertmanagerApi) forkRouteGetSilences(ctx *models.ReqContext) response.Response {
+	s, err := f.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
@@ -120,13 +120,13 @@ func (am *ForkedAlertmanagerApi) forkRouteGetSilences(ctx *models.ReqContext) re
 	return s.RouteGetSilences(ctx)
 }
 
-func (am *ForkedAlertmanagerApi) forkRoutePostAlertingConfig(ctx *models.ReqContext, body apimodels.PostableUserConfig) response.Response {
-	s, err := am.getService(ctx)
+func (f *ForkedAlertmanagerApi) forkRoutePostAlertingConfig(ctx *models.ReqContext, body apimodels.PostableUserConfig) response.Response {
+	s, err := f.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
 
-	b, err := backendType(ctx, am.DatasourceCache)
+	b, err := backendType(ctx, f.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
@@ -138,8 +138,8 @@ func (am *ForkedAlertmanagerApi) forkRoutePostAlertingConfig(ctx *models.ReqCont
 	return s.RoutePostAlertingConfig(ctx, body)
 }
 
-func (am *ForkedAlertmanagerApi) forkRoutePostAMAlerts(ctx *models.ReqContext, body apimodels.PostableAlerts) response.Response {
-	s, err := am.getService(ctx)
+func (f *ForkedAlertmanagerApi) forkRoutePostAMAlerts(ctx *models.ReqContext, body apimodels.PostableAlerts) response.Response {
+	s, err := f.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
@@ -147,8 +147,8 @@ func (am *ForkedAlertmanagerApi) forkRoutePostAMAlerts(ctx *models.ReqContext, b
 	return s.RoutePostAMAlerts(ctx, body)
 }
 
-func (am *ForkedAlertmanagerApi) forkRoutePostTestReceivers(ctx *models.ReqContext, body apimodels.TestReceiversConfigBodyParams) response.Response {
-	s, err := am.getService(ctx)
+func (f *ForkedAlertmanagerApi) forkRoutePostTestReceivers(ctx *models.ReqContext, body apimodels.TestReceiversConfigBodyParams) response.Response {
+	s, err := f.getService(ctx)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}

--- a/pkg/services/ngalert/api/forked_prom.go
+++ b/pkg/services/ngalert/api/forked_prom.go
@@ -23,33 +23,33 @@ func NewForkedProm(datasourceCache datasources.CacheService, proxy, grafana Prom
 	}
 }
 
-func (p *ForkedPrometheusApi) forkRouteGetAlertStatuses(ctx *models.ReqContext) response.Response {
-	t, err := backendType(ctx, p.DatasourceCache)
+func (f *ForkedPrometheusApi) forkRouteGetAlertStatuses(ctx *models.ReqContext) response.Response {
+	t, err := backendType(ctx, f.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
 
 	switch t {
 	case apimodels.GrafanaBackend:
-		return p.GrafanaSvc.RouteGetAlertStatuses(ctx)
+		return f.GrafanaSvc.RouteGetAlertStatuses(ctx)
 	case apimodels.LoTexRulerBackend:
-		return p.ProxySvc.RouteGetAlertStatuses(ctx)
+		return f.ProxySvc.RouteGetAlertStatuses(ctx)
 	default:
 		return ErrResp(400, fmt.Errorf("unexpected backend type (%v)", t), "")
 	}
 }
 
-func (p *ForkedPrometheusApi) forkRouteGetRuleStatuses(ctx *models.ReqContext) response.Response {
-	t, err := backendType(ctx, p.DatasourceCache)
+func (f *ForkedPrometheusApi) forkRouteGetRuleStatuses(ctx *models.ReqContext) response.Response {
+	t, err := backendType(ctx, f.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")
 	}
 
 	switch t {
 	case apimodels.GrafanaBackend:
-		return p.GrafanaSvc.RouteGetRuleStatuses(ctx)
+		return f.GrafanaSvc.RouteGetRuleStatuses(ctx)
 	case apimodels.LoTexRulerBackend:
-		return p.ProxySvc.RouteGetRuleStatuses(ctx)
+		return f.ProxySvc.RouteGetRuleStatuses(ctx)
 	default:
 		return ErrResp(400, fmt.Errorf("unexpected backend type (%v)", t), "")
 	}

--- a/pkg/services/ngalert/api/forked_prom.go
+++ b/pkg/services/ngalert/api/forked_prom.go
@@ -9,21 +9,21 @@ import (
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 )
 
-type ForkedPromSvc struct {
+type ForkedPrometheusApi struct {
 	ProxySvc, GrafanaSvc PrometheusApiService
 	DatasourceCache      datasources.CacheService
 }
 
 // NewForkedProm implements a set of routes that proxy to various Prometheus-compatible backends.
-func NewForkedProm(datasourceCache datasources.CacheService, proxy, grafana PrometheusApiService) *ForkedPromSvc {
-	return &ForkedPromSvc{
+func NewForkedProm(datasourceCache datasources.CacheService, proxy, grafana PrometheusApiService) *ForkedPrometheusApi {
+	return &ForkedPrometheusApi{
 		ProxySvc:        proxy,
 		GrafanaSvc:      grafana,
 		DatasourceCache: datasourceCache,
 	}
 }
 
-func (p *ForkedPromSvc) RouteGetAlertStatuses(ctx *models.ReqContext) response.Response {
+func (p *ForkedPrometheusApi) forkRouteGetAlertStatuses(ctx *models.ReqContext) response.Response {
 	t, err := backendType(ctx, p.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")
@@ -39,7 +39,7 @@ func (p *ForkedPromSvc) RouteGetAlertStatuses(ctx *models.ReqContext) response.R
 	}
 }
 
-func (p *ForkedPromSvc) RouteGetRuleStatuses(ctx *models.ReqContext) response.Response {
+func (p *ForkedPrometheusApi) forkRouteGetRuleStatuses(ctx *models.ReqContext) response.Response {
 	t, err := backendType(ctx, p.DatasourceCache)
 	if err != nil {
 		return ErrResp(400, err, "")

--- a/pkg/services/ngalert/api/forked_testing.go
+++ b/pkg/services/ngalert/api/forked_testing.go
@@ -18,10 +18,10 @@ func NewForkedTestingApi(grafana TestingApiService) *ForkedTestingApi {
 	}
 }
 
-func (srv *ForkedTestingApi) forkRouteTestRuleConfig(c *models.ReqContext, body apimodels.TestRulePayload) response.Response {
-	return srv.grafana.RouteTestRuleConfig(c, body)
+func (f *ForkedTestingApi) forkRouteTestRuleConfig(c *models.ReqContext, body apimodels.TestRulePayload) response.Response {
+	return f.grafana.RouteTestRuleConfig(c, body)
 }
 
-func (srv *ForkedTestingApi) forkRouteEvalQueries(c *models.ReqContext, body apimodels.EvalQueriesPayload) response.Response {
-	return srv.grafana.RouteEvalQueries(c, body)
+func (f *ForkedTestingApi) forkRouteEvalQueries(c *models.ReqContext, body apimodels.EvalQueriesPayload) response.Response {
+	return f.grafana.RouteEvalQueries(c, body)
 }

--- a/pkg/services/ngalert/api/forked_testing.go
+++ b/pkg/services/ngalert/api/forked_testing.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/models"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+)
+
+// ForkedTestingApi always forwards requests to grafana backend
+type ForkedTestingApi struct {
+	grafana TestingApiService
+}
+
+// NewForkedTestingApi creates a new ForkedTestingApi instance
+func NewForkedTestingApi(grafana TestingApiService) *ForkedTestingApi {
+	return &ForkedTestingApi{
+		grafana: grafana,
+	}
+}
+
+func (srv *ForkedTestingApi) forkRouteTestRuleConfig(c *models.ReqContext, body apimodels.TestRulePayload) response.Response {
+	return srv.grafana.RouteTestRuleConfig(c, body)
+}
+
+func (srv *ForkedTestingApi) forkRouteEvalQueries(c *models.ReqContext, body apimodels.EvalQueriesPayload) response.Response {
+	return srv.grafana.RouteEvalQueries(c, body)
+}

--- a/pkg/services/ngalert/api/generated_base_api_alertmanager.go
+++ b/pkg/services/ngalert/api/generated_base_api_alertmanager.go
@@ -49,68 +49,68 @@ type AlertmanagerApiService interface {
 	RoutePostTestReceivers(*models.ReqContext, apimodels.TestReceiversConfigBodyParams) response.Response
 }
 
-func (r *ForkedAlertmanagerApi) RouteCreateSilence(ctx *models.ReqContext) response.Response {
+func (f *ForkedAlertmanagerApi) RouteCreateSilence(ctx *models.ReqContext) response.Response {
 	conf := apimodels.PostableSilence{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
-	return r.forkRouteCreateSilence(ctx, conf)
+	return f.forkRouteCreateSilence(ctx, conf)
 }
 
-func (r *ForkedAlertmanagerApi) RouteDeleteAlertingConfig(ctx *models.ReqContext) response.Response {
-	return r.forkRouteDeleteAlertingConfig(ctx)
+func (f *ForkedAlertmanagerApi) RouteDeleteAlertingConfig(ctx *models.ReqContext) response.Response {
+	return f.forkRouteDeleteAlertingConfig(ctx)
 }
 
-func (r *ForkedAlertmanagerApi) RouteDeleteSilence(ctx *models.ReqContext) response.Response {
-	return r.forkRouteDeleteSilence(ctx)
+func (f *ForkedAlertmanagerApi) RouteDeleteSilence(ctx *models.ReqContext) response.Response {
+	return f.forkRouteDeleteSilence(ctx)
 }
 
-func (r *ForkedAlertmanagerApi) RouteGetAMAlertGroups(ctx *models.ReqContext) response.Response {
-	return r.forkRouteGetAMAlertGroups(ctx)
+func (f *ForkedAlertmanagerApi) RouteGetAMAlertGroups(ctx *models.ReqContext) response.Response {
+	return f.forkRouteGetAMAlertGroups(ctx)
 }
 
-func (r *ForkedAlertmanagerApi) RouteGetAMAlerts(ctx *models.ReqContext) response.Response {
-	return r.forkRouteGetAMAlerts(ctx)
+func (f *ForkedAlertmanagerApi) RouteGetAMAlerts(ctx *models.ReqContext) response.Response {
+	return f.forkRouteGetAMAlerts(ctx)
 }
 
-func (r *ForkedAlertmanagerApi) RouteGetAMStatus(ctx *models.ReqContext) response.Response {
-	return r.forkRouteGetAMStatus(ctx)
+func (f *ForkedAlertmanagerApi) RouteGetAMStatus(ctx *models.ReqContext) response.Response {
+	return f.forkRouteGetAMStatus(ctx)
 }
 
-func (r *ForkedAlertmanagerApi) RouteGetAlertingConfig(ctx *models.ReqContext) response.Response {
-	return r.forkRouteGetAlertingConfig(ctx)
+func (f *ForkedAlertmanagerApi) RouteGetAlertingConfig(ctx *models.ReqContext) response.Response {
+	return f.forkRouteGetAlertingConfig(ctx)
 }
 
-func (r *ForkedAlertmanagerApi) RouteGetSilence(ctx *models.ReqContext) response.Response {
-	return r.forkRouteGetSilence(ctx)
+func (f *ForkedAlertmanagerApi) RouteGetSilence(ctx *models.ReqContext) response.Response {
+	return f.forkRouteGetSilence(ctx)
 }
 
-func (r *ForkedAlertmanagerApi) RouteGetSilences(ctx *models.ReqContext) response.Response {
-	return r.forkRouteGetSilences(ctx)
+func (f *ForkedAlertmanagerApi) RouteGetSilences(ctx *models.ReqContext) response.Response {
+	return f.forkRouteGetSilences(ctx)
 }
 
-func (r *ForkedAlertmanagerApi) RoutePostAMAlerts(ctx *models.ReqContext) response.Response {
+func (f *ForkedAlertmanagerApi) RoutePostAMAlerts(ctx *models.ReqContext) response.Response {
 	conf := apimodels.PostableAlerts{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
-	return r.forkRoutePostAMAlerts(ctx, conf)
+	return f.forkRoutePostAMAlerts(ctx, conf)
 }
 
-func (r *ForkedAlertmanagerApi) RoutePostAlertingConfig(ctx *models.ReqContext) response.Response {
+func (f *ForkedAlertmanagerApi) RoutePostAlertingConfig(ctx *models.ReqContext) response.Response {
 	conf := apimodels.PostableUserConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
-	return r.forkRoutePostAlertingConfig(ctx, conf)
+	return f.forkRoutePostAlertingConfig(ctx, conf)
 }
 
-func (r *ForkedAlertmanagerApi) RoutePostTestReceivers(ctx *models.ReqContext) response.Response {
+func (f *ForkedAlertmanagerApi) RoutePostTestReceivers(ctx *models.ReqContext) response.Response {
 	conf := apimodels.TestReceiversConfigBodyParams{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
-	return r.forkRoutePostTestReceivers(ctx, conf)
+	return f.forkRoutePostTestReceivers(ctx, conf)
 }
 
 func (api *API) RegisterAlertmanagerApiEndpoints(srv AlertmanagerApiForkingService, m *metrics.API) {

--- a/pkg/services/ngalert/api/generated_base_api_configuration.go
+++ b/pkg/services/ngalert/api/generated_base_api_configuration.go
@@ -33,24 +33,24 @@ type ConfigurationApiService interface {
 	RoutePostNGalertConfig(*models.ReqContext, apimodels.PostableNGalertConfig) response.Response
 }
 
-func (r *ForkedConfigurationApi) RouteDeleteNGalertConfig(ctx *models.ReqContext) response.Response {
-	return r.forkRouteDeleteNGalertConfig(ctx)
+func (f *ForkedConfigurationApi) RouteDeleteNGalertConfig(ctx *models.ReqContext) response.Response {
+	return f.forkRouteDeleteNGalertConfig(ctx)
 }
 
-func (r *ForkedConfigurationApi) RouteGetAlertmanagers(ctx *models.ReqContext) response.Response {
-	return r.forkRouteGetAlertmanagers(ctx)
+func (f *ForkedConfigurationApi) RouteGetAlertmanagers(ctx *models.ReqContext) response.Response {
+	return f.forkRouteGetAlertmanagers(ctx)
 }
 
-func (r *ForkedConfigurationApi) RouteGetNGalertConfig(ctx *models.ReqContext) response.Response {
-	return r.forkRouteGetNGalertConfig(ctx)
+func (f *ForkedConfigurationApi) RouteGetNGalertConfig(ctx *models.ReqContext) response.Response {
+	return f.forkRouteGetNGalertConfig(ctx)
 }
 
-func (r *ForkedConfigurationApi) RoutePostNGalertConfig(ctx *models.ReqContext) response.Response {
+func (f *ForkedConfigurationApi) RoutePostNGalertConfig(ctx *models.ReqContext) response.Response {
 	conf := apimodels.PostableNGalertConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
-	return r.forkRoutePostNGalertConfig(ctx, conf)
+	return f.forkRoutePostNGalertConfig(ctx, conf)
 }
 
 func (api *API) RegisterConfigurationApiEndpoints(srv ConfigurationApiForkingService, m *metrics.API) {

--- a/pkg/services/ngalert/api/generated_base_api_configuration.go
+++ b/pkg/services/ngalert/api/generated_base_api_configuration.go
@@ -4,12 +4,11 @@
  *
  *Do not manually edit these files, please find ngalert/api/swagger-codegen/ for commands on how to generate them.
  */
+
 package api
 
 import (
 	"net/http"
-
-	"github.com/go-macaron/binding"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
@@ -17,7 +16,15 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
+	"github.com/grafana/grafana/pkg/web"
 )
+
+type ConfigurationApiForkingService interface {
+	RouteDeleteNGalertConfig(*models.ReqContext) response.Response
+	RouteGetAlertmanagers(*models.ReqContext) response.Response
+	RouteGetNGalertConfig(*models.ReqContext) response.Response
+	RoutePostNGalertConfig(*models.ReqContext) response.Response
+}
 
 type ConfigurationApiService interface {
 	RouteDeleteNGalertConfig(*models.ReqContext) response.Response
@@ -26,7 +33,27 @@ type ConfigurationApiService interface {
 	RoutePostNGalertConfig(*models.ReqContext, apimodels.PostableNGalertConfig) response.Response
 }
 
-func (api *API) RegisterConfigurationApiEndpoints(srv ConfigurationApiService, m *metrics.API) {
+func (r *ForkedConfigurationApi) RouteDeleteNGalertConfig(ctx *models.ReqContext) response.Response {
+	return r.forkRouteDeleteNGalertConfig(ctx)
+}
+
+func (r *ForkedConfigurationApi) RouteGetAlertmanagers(ctx *models.ReqContext) response.Response {
+	return r.forkRouteGetAlertmanagers(ctx)
+}
+
+func (r *ForkedConfigurationApi) RouteGetNGalertConfig(ctx *models.ReqContext) response.Response {
+	return r.forkRouteGetNGalertConfig(ctx)
+}
+
+func (r *ForkedConfigurationApi) RoutePostNGalertConfig(ctx *models.ReqContext) response.Response {
+	conf := apimodels.PostableNGalertConfig{}
+	if err := web.Bind(ctx.Req, &conf); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+	return r.forkRoutePostNGalertConfig(ctx, conf)
+}
+
+func (api *API) RegisterConfigurationApiEndpoints(srv ConfigurationApiForkingService, m *metrics.API) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Delete(
 			toMacaronPath("/api/v1/ngalert/admin_config"),
@@ -57,7 +84,6 @@ func (api *API) RegisterConfigurationApiEndpoints(srv ConfigurationApiService, m
 		)
 		group.Post(
 			toMacaronPath("/api/v1/ngalert/admin_config"),
-			binding.Bind(apimodels.PostableNGalertConfig{}),
 			metrics.Instrument(
 				http.MethodPost,
 				"/api/v1/ngalert/admin_config",

--- a/pkg/services/ngalert/api/generated_base_api_prometheus.go
+++ b/pkg/services/ngalert/api/generated_base_api_prometheus.go
@@ -4,6 +4,7 @@
  *
  *Do not manually edit these files, please find ngalert/api/swagger-codegen/ for commands on how to generate them.
  */
+
 package api
 
 import (
@@ -16,12 +17,25 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 )
 
+type PrometheusApiForkingService interface {
+	RouteGetAlertStatuses(*models.ReqContext) response.Response
+	RouteGetRuleStatuses(*models.ReqContext) response.Response
+}
+
 type PrometheusApiService interface {
 	RouteGetAlertStatuses(*models.ReqContext) response.Response
 	RouteGetRuleStatuses(*models.ReqContext) response.Response
 }
 
-func (api *API) RegisterPrometheusApiEndpoints(srv PrometheusApiService, m *metrics.API) {
+func (r *ForkedPrometheusApi) RouteGetAlertStatuses(ctx *models.ReqContext) response.Response {
+	return r.forkRouteGetAlertStatuses(ctx)
+}
+
+func (r *ForkedPrometheusApi) RouteGetRuleStatuses(ctx *models.ReqContext) response.Response {
+	return r.forkRouteGetRuleStatuses(ctx)
+}
+
+func (api *API) RegisterPrometheusApiEndpoints(srv PrometheusApiForkingService, m *metrics.API) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Get(
 			toMacaronPath("/api/prometheus/{Recipient}/api/v1/alerts"),

--- a/pkg/services/ngalert/api/generated_base_api_prometheus.go
+++ b/pkg/services/ngalert/api/generated_base_api_prometheus.go
@@ -27,12 +27,12 @@ type PrometheusApiService interface {
 	RouteGetRuleStatuses(*models.ReqContext) response.Response
 }
 
-func (r *ForkedPrometheusApi) RouteGetAlertStatuses(ctx *models.ReqContext) response.Response {
-	return r.forkRouteGetAlertStatuses(ctx)
+func (f *ForkedPrometheusApi) RouteGetAlertStatuses(ctx *models.ReqContext) response.Response {
+	return f.forkRouteGetAlertStatuses(ctx)
 }
 
-func (r *ForkedPrometheusApi) RouteGetRuleStatuses(ctx *models.ReqContext) response.Response {
-	return r.forkRouteGetRuleStatuses(ctx)
+func (f *ForkedPrometheusApi) RouteGetRuleStatuses(ctx *models.ReqContext) response.Response {
+	return f.forkRouteGetRuleStatuses(ctx)
 }
 
 func (api *API) RegisterPrometheusApiEndpoints(srv PrometheusApiForkingService, m *metrics.API) {

--- a/pkg/services/ngalert/api/generated_base_api_ruler.go
+++ b/pkg/services/ngalert/api/generated_base_api_ruler.go
@@ -4,12 +4,11 @@
  *
  *Do not manually edit these files, please find ngalert/api/swagger-codegen/ for commands on how to generate them.
  */
+
 package api
 
 import (
 	"net/http"
-
-	"github.com/go-macaron/binding"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
@@ -17,7 +16,17 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
+	"github.com/grafana/grafana/pkg/web"
 )
+
+type RulerApiForkingService interface {
+	RouteDeleteNamespaceRulesConfig(*models.ReqContext) response.Response
+	RouteDeleteRuleGroupConfig(*models.ReqContext) response.Response
+	RouteGetNamespaceRulesConfig(*models.ReqContext) response.Response
+	RouteGetRulegGroupConfig(*models.ReqContext) response.Response
+	RouteGetRulesConfig(*models.ReqContext) response.Response
+	RoutePostNameRulesConfig(*models.ReqContext) response.Response
+}
 
 type RulerApiService interface {
 	RouteDeleteNamespaceRulesConfig(*models.ReqContext) response.Response
@@ -28,7 +37,35 @@ type RulerApiService interface {
 	RoutePostNameRulesConfig(*models.ReqContext, apimodels.PostableRuleGroupConfig) response.Response
 }
 
-func (api *API) RegisterRulerApiEndpoints(srv RulerApiService, m *metrics.API) {
+func (r *ForkedRulerApi) RouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
+	return r.forkRouteDeleteNamespaceRulesConfig(ctx)
+}
+
+func (r *ForkedRulerApi) RouteDeleteRuleGroupConfig(ctx *models.ReqContext) response.Response {
+	return r.forkRouteDeleteRuleGroupConfig(ctx)
+}
+
+func (r *ForkedRulerApi) RouteGetNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
+	return r.forkRouteGetNamespaceRulesConfig(ctx)
+}
+
+func (r *ForkedRulerApi) RouteGetRulegGroupConfig(ctx *models.ReqContext) response.Response {
+	return r.forkRouteGetRulegGroupConfig(ctx)
+}
+
+func (r *ForkedRulerApi) RouteGetRulesConfig(ctx *models.ReqContext) response.Response {
+	return r.forkRouteGetRulesConfig(ctx)
+}
+
+func (r *ForkedRulerApi) RoutePostNameRulesConfig(ctx *models.ReqContext) response.Response {
+	conf := apimodels.PostableRuleGroupConfig{}
+	if err := web.Bind(ctx.Req, &conf); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+	return r.forkRoutePostNameRulesConfig(ctx, conf)
+}
+
+func (api *API) RegisterRulerApiEndpoints(srv RulerApiForkingService, m *metrics.API) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Delete(
 			toMacaronPath("/api/ruler/{Recipient}/api/v1/rules/{Namespace}"),
@@ -77,7 +114,6 @@ func (api *API) RegisterRulerApiEndpoints(srv RulerApiService, m *metrics.API) {
 		)
 		group.Post(
 			toMacaronPath("/api/ruler/{Recipient}/api/v1/rules/{Namespace}"),
-			binding.Bind(apimodels.PostableRuleGroupConfig{}),
 			metrics.Instrument(
 				http.MethodPost,
 				"/api/ruler/{Recipient}/api/v1/rules/{Namespace}",

--- a/pkg/services/ngalert/api/generated_base_api_ruler.go
+++ b/pkg/services/ngalert/api/generated_base_api_ruler.go
@@ -37,32 +37,32 @@ type RulerApiService interface {
 	RoutePostNameRulesConfig(*models.ReqContext, apimodels.PostableRuleGroupConfig) response.Response
 }
 
-func (r *ForkedRulerApi) RouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
-	return r.forkRouteDeleteNamespaceRulesConfig(ctx)
+func (f *ForkedRulerApi) RouteDeleteNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
+	return f.forkRouteDeleteNamespaceRulesConfig(ctx)
 }
 
-func (r *ForkedRulerApi) RouteDeleteRuleGroupConfig(ctx *models.ReqContext) response.Response {
-	return r.forkRouteDeleteRuleGroupConfig(ctx)
+func (f *ForkedRulerApi) RouteDeleteRuleGroupConfig(ctx *models.ReqContext) response.Response {
+	return f.forkRouteDeleteRuleGroupConfig(ctx)
 }
 
-func (r *ForkedRulerApi) RouteGetNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
-	return r.forkRouteGetNamespaceRulesConfig(ctx)
+func (f *ForkedRulerApi) RouteGetNamespaceRulesConfig(ctx *models.ReqContext) response.Response {
+	return f.forkRouteGetNamespaceRulesConfig(ctx)
 }
 
-func (r *ForkedRulerApi) RouteGetRulegGroupConfig(ctx *models.ReqContext) response.Response {
-	return r.forkRouteGetRulegGroupConfig(ctx)
+func (f *ForkedRulerApi) RouteGetRulegGroupConfig(ctx *models.ReqContext) response.Response {
+	return f.forkRouteGetRulegGroupConfig(ctx)
 }
 
-func (r *ForkedRulerApi) RouteGetRulesConfig(ctx *models.ReqContext) response.Response {
-	return r.forkRouteGetRulesConfig(ctx)
+func (f *ForkedRulerApi) RouteGetRulesConfig(ctx *models.ReqContext) response.Response {
+	return f.forkRouteGetRulesConfig(ctx)
 }
 
-func (r *ForkedRulerApi) RoutePostNameRulesConfig(ctx *models.ReqContext) response.Response {
+func (f *ForkedRulerApi) RoutePostNameRulesConfig(ctx *models.ReqContext) response.Response {
 	conf := apimodels.PostableRuleGroupConfig{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
-	return r.forkRoutePostNameRulesConfig(ctx, conf)
+	return f.forkRoutePostNameRulesConfig(ctx, conf)
 }
 
 func (api *API) RegisterRulerApiEndpoints(srv RulerApiForkingService, m *metrics.API) {

--- a/pkg/services/ngalert/api/generated_base_api_testing.go
+++ b/pkg/services/ngalert/api/generated_base_api_testing.go
@@ -29,20 +29,20 @@ type TestingApiService interface {
 	RouteTestRuleConfig(*models.ReqContext, apimodels.TestRulePayload) response.Response
 }
 
-func (r *ForkedTestingApi) RouteEvalQueries(ctx *models.ReqContext) response.Response {
+func (f *ForkedTestingApi) RouteEvalQueries(ctx *models.ReqContext) response.Response {
 	conf := apimodels.EvalQueriesPayload{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
-	return r.forkRouteEvalQueries(ctx, conf)
+	return f.forkRouteEvalQueries(ctx, conf)
 }
 
-func (r *ForkedTestingApi) RouteTestRuleConfig(ctx *models.ReqContext) response.Response {
+func (f *ForkedTestingApi) RouteTestRuleConfig(ctx *models.ReqContext) response.Response {
 	conf := apimodels.TestRulePayload{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
-	return r.forkRouteTestRuleConfig(ctx, conf)
+	return f.forkRouteTestRuleConfig(ctx, conf)
 }
 
 func (api *API) RegisterTestingApiEndpoints(srv TestingApiForkingService, m *metrics.API) {

--- a/pkg/services/ngalert/api/generated_base_api_testing.go
+++ b/pkg/services/ngalert/api/generated_base_api_testing.go
@@ -4,12 +4,11 @@
  *
  *Do not manually edit these files, please find ngalert/api/swagger-codegen/ for commands on how to generate them.
  */
+
 package api
 
 import (
 	"net/http"
-
-	"github.com/go-macaron/binding"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
@@ -17,18 +16,39 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
+	"github.com/grafana/grafana/pkg/web"
 )
+
+type TestingApiForkingService interface {
+	RouteEvalQueries(*models.ReqContext) response.Response
+	RouteTestRuleConfig(*models.ReqContext) response.Response
+}
 
 type TestingApiService interface {
 	RouteEvalQueries(*models.ReqContext, apimodels.EvalQueriesPayload) response.Response
 	RouteTestRuleConfig(*models.ReqContext, apimodels.TestRulePayload) response.Response
 }
 
-func (api *API) RegisterTestingApiEndpoints(srv TestingApiService, m *metrics.API) {
+func (r *ForkedTestingApi) RouteEvalQueries(ctx *models.ReqContext) response.Response {
+	conf := apimodels.EvalQueriesPayload{}
+	if err := web.Bind(ctx.Req, &conf); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+	return r.forkRouteEvalQueries(ctx, conf)
+}
+
+func (r *ForkedTestingApi) RouteTestRuleConfig(ctx *models.ReqContext) response.Response {
+	conf := apimodels.TestRulePayload{}
+	if err := web.Bind(ctx.Req, &conf); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+	return r.forkRouteTestRuleConfig(ctx, conf)
+}
+
+func (api *API) RegisterTestingApiEndpoints(srv TestingApiForkingService, m *metrics.API) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Post(
 			toMacaronPath("/api/v1/eval"),
-			binding.Bind(apimodels.EvalQueriesPayload{}),
 			metrics.Instrument(
 				http.MethodPost,
 				"/api/v1/eval",
@@ -38,7 +58,6 @@ func (api *API) RegisterTestingApiEndpoints(srv TestingApiService, m *metrics.AP
 		)
 		group.Post(
 			toMacaronPath("/api/v1/rule/test/{Recipient}"),
-			binding.Bind(apimodels.TestRulePayload{}),
 			metrics.Instrument(
 				http.MethodPost,
 				"/api/v1/rule/test/{Recipient}",

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -3680,8 +3680,9 @@
       "x-go-package": "github.com/prometheus/alertmanager/timeinterval"
     },
     "URL": {
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "URL is a custom URL type that allows validation at configuration load time.",
+      "title": "A URL represents a parsed URL (technically, a URI reference).",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -3714,7 +3715,7 @@
           "$ref": "#/definitions/Userinfo"
         }
       },
-      "x-go-package": "github.com/prometheus/common/config"
+      "x-go-package": "net/url"
     },
     "Userinfo": {
       "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -4135,6 +4136,7 @@
       "$ref": "#/definitions/gettableAlerts"
     },
     "gettableSilence": {
+      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -4187,8 +4189,6 @@
           "x-go-name": "UpdatedAt"
         }
       },
-      "x-go-name": "GettableSilence",
-      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/gettableSilence"
     },
     "gettableSilences": {
@@ -4371,7 +4371,6 @@
       "$ref": "#/definitions/postableSilence"
     },
     "receiver": {
-      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "name"
@@ -4383,6 +4382,8 @@
           "x-go-name": "Name"
         }
       },
+      "x-go-name": "Receiver",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/receiver"
     },
     "silence": {

--- a/pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache
+++ b/pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache
@@ -13,15 +13,33 @@ import (
 	"github.com/grafana/grafana/pkg/middleware"
 )
 
+type {{classname}}ForkingService interface { {{#operation}}
+	{{nickname}}(*models.ReqContext) response.Response{{/operation}}
+}
+
 type {{classname}}Service interface { {{#operation}}
 	{{nickname}}(*models.ReqContext{{#bodyParams}}, apimodels.{{dataType}}{{/bodyParams}}) response.Response{{/operation}}
 }
 
-func (api *API) Register{{classname}}Endpoints(srv {{classname}}Service, m *metrics.API) {
+{{#operations}}{{#operation}}
+func (r *Forked{{classname}}) {{nickname}}(ctx *models.ReqContext) response.Response {
+	{{#bodyParams}}
+	conf := apimodels.{{dataType}}{}
+	if err := web.Bind(ctx.Req, &conf); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+	return  r.fork{{nickname}}(ctx, conf)
+	{{/bodyParams}}
+	{{^bodyParams}}
+	return  r.fork{{nickname}}(ctx)
+	{{/bodyParams}}
+}
+{{/operation}}{{/operations}}
+
+func (api *API) Register{{classname}}Endpoints(srv {{classname}}ForkingService, m *metrics.API) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister){ {{#operations}}{{#operation}}
 	group.{{httpMethod}}(
-		toMacaronPath("{{{path}}}"){{#bodyParams}},
-		binding.Bind(apimodels.{{dataType}}{}){{/bodyParams}},
+		toMacaronPath("{{{path}}}"),
 		metrics.Instrument(
 			http.Method{{httpMethod}},
 			"{{{path}}}",

--- a/pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache
+++ b/pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache
@@ -22,16 +22,16 @@ type {{classname}}Service interface { {{#operation}}
 }
 
 {{#operations}}{{#operation}}
-func (r *Forked{{classname}}) {{nickname}}(ctx *models.ReqContext) response.Response {
+func (f *Forked{{classname}}) {{nickname}}(ctx *models.ReqContext) response.Response {
 	{{#bodyParams}}
 	conf := apimodels.{{dataType}}{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
-	return  r.fork{{nickname}}(ctx, conf)
+	return  f.fork{{nickname}}(ctx, conf)
 	{{/bodyParams}}
 	{{^bodyParams}}
-	return  r.fork{{nickname}}(ctx)
+	return  f.fork{{nickname}}(ctx)
 	{{/bodyParams}}
 }
 {{/operation}}{{/operations}}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Follow up of #42199 for ngalert handlers

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #42186

**Special notes for your reviewer**:
I have updated [the mustache template](https://github.com/grafana/grafana/blob/b1e66e77f401a68e33016784a655c241536eb500/pkg/services/ngalert/api/tooling/swagger-codegen/templates/controller-api.mustache) for generating server stubs for removing macaron binding.
We used to generate [an interface](https://github.com/grafana/grafana/blob/7b1aee5220d6bd28424792d14b452ec265508977/pkg/services/ngalert/api/generated_base_api_ruler.go#L22) for each service that all backends (grafana, lotex, as well as the forking service) implemented.
I had to split it in two different interfaces: [one for the forking service](https://github.com/grafana/grafana/blob/b1e66e77f401a68e33016784a655c241536eb500/pkg/services/ngalert/api/generated_base_api_ruler.go#L22) and [one for the actual backends](https://github.com/grafana/grafana/blob/b1e66e77f401a68e33016784a655c241536eb500/pkg/services/ngalert/api/generated_base_api_ruler.go#L31) so that `web.Bind()` is called only by the forking service.
Each handler of the forking service, before forking to the right backend, binds any body parameters ([example](https://github.com/grafana/grafana/blob/b1e66e77f401a68e33016784a655c241536eb500/pkg/services/ngalert/api/generated_base_api_ruler.go#L60-L67))
I had also to create a forking service even for admin and testing endpoints (it always calls the grafana backend) and rename the forking services for having a consistent name.