### PR TITLE
CloudWatch: Fix broken queries for users migrating from 8.2.4/8.2.5 to 8.3.0 

### DIFF
--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -179,7 +179,7 @@ describe('DashboardModel', () => {
     });
 
     it('dashboard schema version should be set to latest', () => {
-      expect(model.schemaVersion).toBe(33);
+      expect(model.schemaVersion).toBe(34);
     });
 
     it('graph thresholds should be migrated', () => {

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -67,7 +67,7 @@ export class DashboardMigrator {
     let i, j, k, n;
     const oldVersion = this.dashboard.schemaVersion;
     const panelUpgrades: PanelSchemeUpgradeHandler[] = [];
-    this.dashboard.schemaVersion = 33;
+    this.dashboard.schemaVersion = 34;
 
     if (oldVersion === this.dashboard.schemaVersion) {
       return;
@@ -692,12 +692,7 @@ export class DashboardMigrator {
     }
 
     if (oldVersion < 32) {
-      panelUpgrades.push((panel: PanelModel) => {
-        this.migrateCloudWatchQueries(panel);
-        return panel;
-      });
-
-      this.migrateCloudWatchAnnotationQuery();
+      // CloudWatch migrations have been moved to version 34
     }
 
     // Replace datasource name with reference, uid and type
@@ -725,6 +720,15 @@ export class DashboardMigrator {
 
         return panel;
       });
+    }
+
+    if (oldVersion < 34) {
+      panelUpgrades.push((panel: PanelModel) => {
+        this.migrateCloudWatchQueries(panel);
+        return panel;
+      });
+
+      this.migrateCloudWatchAnnotationQuery();
     }
 
     if (panelUpgrades.length === 0) {


### PR DESCRIPTION
**What this PR does / why we need it**:
In 8.2.4, a bug that caused nested panels not to be migrated, was fixed in [this PR](https://github.com/grafana/grafana/pull/40993). While doing so, the migration code was refactored so that the panelUpgrades array was used, locking the migration to a schema version lower than 32 instead of running the migration every time the dashboard migrator is executed. At the same time, we've been working on adding support for CloudWatch Metrics Insights in a private repo. In this private repo, we've added yet more migrations, however these were based on the initial version of the dashboard migrator that was not depending on a certain schema version. Consequently, the migration necessary for Metrics Insights are not being executed, causing all CloudWatch queries to break. Note that this is **only** a problem for users upgrading from 8.2.4 or 8.2.5 to 8.3.0, since that's the only way to get schema version 32. 

This PR simply moves these migrations from schema version 32 to schema version 34. 

**Which issue(s) this PR fixes**:

Fixes #42598

**Special notes for your reviewer**:

Tested this by exporting a pre-configured cloudwatch dashboards from 8.0.0 and 8.2.4 and importing them in main, and I can confirm it's working fine.  