### PR TITLE
CloudWatch: Make sure MatchExact flag gets the right value

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
@@ -87,4 +87,17 @@ describe('MetricStatEditor', () => {
       expect(screen.queryByText('Match exact')).toBeNull();
     });
   });
+
+  describe('match exact', () => {
+    it('should be checked when value is true', () => {
+      render(<MetricStatEditor {...props} disableExpressions={false} />);
+      expect(screen.getByLabelText('Match exact - optional')).toBeChecked();
+    });
+
+    it('should be unchecked when value is false', () => {
+      props.query.matchExact = false;
+      render(<MetricStatEditor {...props} disableExpressions={false} />);
+      expect(screen.getByLabelText('Match exact - optional')).not.toBeChecked();
+    });
+  });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
@@ -95,8 +95,7 @@ describe('MetricStatEditor', () => {
     });
 
     it('should be unchecked when value is false', () => {
-      props.query.matchExact = false;
-      render(<MetricStatEditor {...props} disableExpressions={false} />);
+      render(<MetricStatEditor {...props} query={{ ...props.query, matchExact: false }} disableExpressions={false} />);
       expect(screen.getByLabelText('Match exact - optional')).not.toBeChecked();
     });
   });

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
@@ -109,7 +109,8 @@ export function MetricStatEditor({
             tooltip="Only show metrics that exactly match all defined dimension names."
           >
             <Switch
-              checked={!!query.matchExact}
+              id="cloudwatch-match-exact"
+              value={!!query.matchExact}
               onChange={(e) => {
                 onQueryChange({
                   ...query,


### PR DESCRIPTION
**What this PR does / why we need it**:
When [adding support for Metric Insights](https://github.com/grafana/grafana/pull/42487) in the CW plugin, the whole UI was rewritten. While doing this, the legacy form field switch component that was used for the `Match exact` toggle in the metric search editor was replaced with the new switch component. Like the legacy switch, the new switch component has a prop for `checked`. However, while using it the component receives the incorrect default value. So instead, the `value` prop should be used. 

**Which issue(s) this PR fixes**:
Fixes #42618

