### PR TITLE
Chore: Fix flaky serverlock integration test

### DIFF
--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServerLok(t *testing.T) {
@@ -16,21 +16,22 @@ func TestServerLok(t *testing.T) {
 
 	counter := 0
 	fn := func(context.Context) { counter++ }
-	atInterval := time.Second * 1
+	atInterval := time.Hour
 	ctx := context.Background()
 
 	//this time `fn` should be executed
-	assert.Nil(t, sl.LockAndExecute(ctx, "test-operation", atInterval, fn))
+	require.Nil(t, sl.LockAndExecute(ctx, "test-operation", atInterval, fn))
+	require.Equal(t, 1, counter)
 
 	//this should not execute `fn`
-	assert.Nil(t, sl.LockAndExecute(ctx, "test-operation", atInterval, fn))
-	assert.Nil(t, sl.LockAndExecute(ctx, "test-operation", atInterval, fn))
+	require.Nil(t, sl.LockAndExecute(ctx, "test-operation", atInterval, fn))
+	require.Nil(t, sl.LockAndExecute(ctx, "test-operation", atInterval, fn))
+	require.Equal(t, 1, counter)
 
-	// wait 2 second.
-	<-time.After(time.Second * 2)
+	atInterval = time.Millisecond
 
 	// now `fn` should be executed again
 	err := sl.LockAndExecute(ctx, "test-operation", atInterval, fn)
-	assert.Nil(t, err)
-	assert.Equal(t, counter, 2)
+	require.Nil(t, err)
+	require.Equal(t, 2, counter)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This changes the test a bit I guess. The only other alternative I can see is to mock the time comparison under test.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

