### PR TITLE
Prometheus: Interpolate template variables in interval

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -591,6 +591,19 @@ describe('PrometheusDatasource', () => {
       expect(interpolatedQuery.legendFormat).toBe(legend);
     });
 
+    it('should call replace function for interval', () => {
+      const query = {
+        expr: 'test{job="bar"}',
+        interval: '$step',
+        refId: 'A',
+      };
+      const step = '5s';
+      templateSrvStub.replace.mockReturnValue(step);
+
+      const interpolatedQuery = ds.applyTemplateVariables(query, { step: { text: step, value: step } });
+      expect(interpolatedQuery.interval).toBe(step);
+    });
+
     it('should call replace function for expr', () => {
       const query = {
         expr: 'test{job="$job"}',

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -616,19 +616,6 @@ describe('PrometheusDatasource', () => {
       expect(interpolatedQuery.expr).toBe(job);
     });
 
-    it('should not call replace function for interval', () => {
-      const query = {
-        expr: 'test{job="bar"}',
-        interval: '$interval',
-        refId: 'A',
-      };
-      const interval = '10s';
-      templateSrvStub.replace.mockReturnValue(interval);
-
-      const interpolatedQuery = ds.applyTemplateVariables(query, { interval: { text: interval, value: interval } });
-      expect(interpolatedQuery.interval).not.toBe(interval);
-    });
-
     it('should add ad-hoc filters to expr', () => {
       templateSrvStub.replace = jest.fn((a: string) => a);
       templateSrvStub.getAdhocFilters.mockReturnValue([

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -961,6 +961,7 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
       ...target,
       legendFormat: this.templateSrv.replace(target.legendFormat, variables),
       expr: this.templateSrv.replace(expr, variables, this.interpolateQueryExpr),
+      interval: this.templateSrv.replace(target.interval, variables),
     };
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
During the backend migration we didn't include interpolation of min step. This. PR fixes it.  

How to reproduce:
1. Create dashboard with custom variables `$step` `1s,5s,1m`
2. Use that variable in Prometheus query in Min step input
3. The query should work

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/42605

