### PR TITLE
CloudWatch: Fix duplicated IDs

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
@@ -66,7 +66,7 @@ export function MetricStatEditor({
 
           <EditorField label="Statistic" width={16}>
             <Select
-              inputId="metric-stat-editor-select-statistic"
+              inputId={`${query.refId}-metric-stat-editor-select-statistic`}
               allowCustomValue
               value={toOption(query.statistic ?? datasource.standardStatistics[0])}
               options={appendTemplateVariables(
@@ -109,7 +109,7 @@ export function MetricStatEditor({
             tooltip="Only show metrics that exactly match all defined dimension names."
           >
             <Switch
-              id="cloudwatch-match-exact"
+              id={`${query.refId}-cloudwatch-match-exact`}
               value={!!query.matchExact}
               onChange={(e) => {
                 onQueryChange({

--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.tsx
@@ -59,7 +59,7 @@ const SQLBuilderSelectRow: React.FC<SQLBuilderSelectRowProps> = ({ datasource, q
         <EditorField label="Namespace" width={16}>
           <Select
             value={namespace ? toOption(namespace) : null}
-            inputId="cloudwatch-sql-namespace"
+            inputId={`${query.refId}-cloudwatch-sql-namespace`}
             options={namespaceOptions}
             allowCustomValue
             onChange={({ value }) => value && onQueryChange(setNamespace(query, value))}
@@ -69,7 +69,7 @@ const SQLBuilderSelectRow: React.FC<SQLBuilderSelectRowProps> = ({ datasource, q
 
         <EditorField label="With schema">
           <Switch
-            id="cloudwatch-sql-withSchema"
+            id={`${query.refId}-cloudwatch-sql-withSchema`}
             value={withSchemaEnabled}
             onChange={(ev) =>
               ev.target instanceof HTMLInputElement && onQueryChange(setWithSchema(query, ev.target.checked))
@@ -80,7 +80,7 @@ const SQLBuilderSelectRow: React.FC<SQLBuilderSelectRowProps> = ({ datasource, q
         {withSchemaEnabled && (
           <EditorField label="Schema labels">
             <Select
-              id="cloudwatch-sql-schema-label-keys"
+              id={`${query.refId}-cloudwatch-sql-schema-label-keys`}
               width="auto"
               isMulti={true}
               disabled={!namespace}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Fix the `id` property used in some elements within CloudWatch. This is specially important for the `Switch` component because in case there are multiple queries, modifying the switch in one query modifies the first query instead.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

