### PR TITLE
Grafana Toolkit: Prevent installation of outdated FE dependencies

### DIFF
--- a/packages/grafana-toolkit/src/cli/tasks/plugin.create.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin.create.ts
@@ -11,6 +11,7 @@ import {
   promptPluginType,
   removeGitFiles,
   verifyGitExists,
+  removeLockFile,
 } from './plugin/create';
 import { Task, TaskRunner } from './task';
 
@@ -40,10 +41,14 @@ const pluginCreateRunner: TaskRunner<PluginCreateOptions> = async ({ name }) => 
   // 5. Update json files (package.json, src/plugin.json)
   await prepareJsonFiles({ type: type, pluginDetails, pluginPath: destPath });
 
-  // 6. Remove cloned repository .git dir
+  // 6. Starter templates include `yarn.lock` files which will rarely (if ever) be in sync with `latest` dist-tag
+  // so best to remove it after cloning.
+  removeLockFile({ pluginPath: destPath });
+
+  // 7. Remove cloned repository .git dir
   await removeGitFiles(destPath);
 
-  // 7. Promote Grafana Tutorials :)
+  // 8. Promote Grafana Tutorials :)
   printGrafanaTutorialsDetails(type);
 };
 

--- a/packages/grafana-toolkit/src/cli/tasks/plugin/create.ts
+++ b/packages/grafana-toolkit/src/cli/tasks/plugin/create.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import commandExists from 'command-exists';
-import { promises as fs, readFileSync } from 'fs';
+import { promises as fs, readFileSync, existsSync, unlinkSync } from 'fs';
 import { prompt } from 'inquirer';
 import { kebabCase } from 'lodash';
 import path from 'path';
@@ -177,6 +177,7 @@ export const printGrafanaTutorialsDetails = (type: PluginType) => {
   console.group();
   console.log();
   console.log(chalk.bold.yellow(`Congrats! You have just created ${PluginNames[type]}.`));
+  console.log('Please run `yarn install` to install frontend dependencies.');
   console.log();
   if (type !== 'backend-datasource-plugin') {
     console.log(`${PluginNames[type]} tutorial: ${TutorialPaths[type]}`);
@@ -188,3 +189,10 @@ export const printGrafanaTutorialsDetails = (type: PluginType) => {
   console.groupEnd();
 };
 /* eslint-enable no-console */
+
+export const removeLockFile = ({ pluginPath }: { pluginPath: string }) => {
+  const lockFilePath = path.resolve(pluginPath, 'yarn.lock');
+  if (existsSync(lockFilePath)) {
+    unlinkSync(lockFilePath);
+  }
+};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When creating plugins using the toolkit it will pull from our starter template repos which contain `yarn.lock` files. The template `package.json` files use the `latest` keyword but yarn will write the "latest" version at the time `yarn install` was run in the template repo clone. 

This currently results in devs scaffolding plugins that use `@grafana/<package_name>@7.x.x` which have nested deps that don't build with `node@16`.

Keeping these up to date with Grafana releases right now seems tricky. This PR adds a step to remove the templates `yarn.lock` and asks the developer to run `yarn install` when the toolkit has finished scaffolding.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #40764

**Special notes for your reviewer**:
Tested locally against `panel plugin`, `datasource plugin` and `backend datasource plugin` templates.

