### PR TITLE
A11y: Add missing aria labels in Loki QueryEditor

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -154,7 +154,7 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
             onChange={onResolutionChange}
             options={RESOLUTION_OPTIONS}
             value={resolution}
-            aria-label="Loki resolution picker"
+            aria-label="Pick resolution"
           />
         </InlineField>
       </div>

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -154,7 +154,7 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
             onChange={onResolutionChange}
             options={RESOLUTION_OPTIONS}
             value={resolution}
-            aria-label="Pick resolution"
+            aria-label="Select resolution"
           />
         </InlineField>
       </div>

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -149,7 +149,13 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
             'Resolution 1/1 sets step parameter of Loki metrics range queries such that each pixel corresponds to one data point. For better performance, lower resolutions can be picked. 1/2 only retrieves a data point for every other pixel, and 1/10 retrieves one data point per 10 pixels.'
           }
         >
-          <Select isSearchable={false} onChange={onResolutionChange} options={RESOLUTION_OPTIONS} value={resolution} />
+          <Select
+            isSearchable={false}
+            onChange={onResolutionChange}
+            options={RESOLUTION_OPTIONS}
+            value={resolution}
+            aria-label="Loki resolution picker"
+          />
         </InlineField>
       </div>
     </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding missing aria-labels to pass fastpass checks in Loki query editor. There is still an issue with QueryField, but that is an issue for all data sources that use QueryField. 

**Which issue(s) this PR fixes**:

Related to #41206


