### PR TITLE
Fix flaky tests in several notifiers

### DIFF
--- a/pkg/services/ngalert/notifier/channels/sensugo.go
+++ b/pkg/services/ngalert/notifier/channels/sensugo.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -120,7 +119,7 @@ func (sn *SensuGoNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool
 				},
 			},
 			"output":   tmpl(sn.Message),
-			"issued":   time.Now().Unix(),
+			"issued":   timeNow().Unix(),
 			"interval": 86400,
 			"status":   status,
 			"handlers": handlers,

--- a/pkg/services/ngalert/notifier/channels/sensugo_test.go
+++ b/pkg/services/ngalert/notifier/channels/sensugo_test.go
@@ -20,6 +20,9 @@ import (
 )
 
 func TestSensuGoNotifier(t *testing.T) {
+	constNow := time.Now()
+	defer mockTimeNow(constNow)()
+
 	tmpl := templateForTests(t)
 
 	externalURL, err := url.Parse("http://localhost")
@@ -60,7 +63,7 @@ func TestSensuGoNotifier(t *testing.T) {
 						},
 					},
 					"output":   "**Firing**\n\nValue: <no value>\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
-					"issued":   time.Now().Unix(),
+					"issued":   timeNow().Unix(),
 					"interval": 86400,
 					"status":   2,
 					"handlers": nil,
@@ -107,7 +110,7 @@ func TestSensuGoNotifier(t *testing.T) {
 						},
 					},
 					"output":   "2 alerts are firing, 0 are resolved",
-					"issued":   time.Now().Unix(),
+					"issued":   timeNow().Unix(),
 					"interval": 86400,
 					"status":   2,
 					"handlers": []string{"myhandler"},

--- a/pkg/services/ngalert/notifier/channels/slack_test.go
+++ b/pkg/services/ngalert/notifier/channels/slack_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"sync"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -299,13 +298,10 @@ func TestSendSlackRequest(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
-			var mtx sync.Mutex
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				mtx.Lock()
 				w.WriteHeader(test.statusCode)
 				_, err := w.Write([]byte(test.slackResponse))
 				require.NoError(tt, err)
-				mtx.Unlock()
 			}))
 			defer server.Close()
 			req, err := http.NewRequest(http.MethodGet, server.URL, nil)


### PR DESCRIPTION
- Non-mocked time in sensu go tests
- Close server in Slack tests
- ~~Use a mutex for writing responses in the fake slack server~~ Turns out, I can't reproduce the failure that I saw 🤷 