### PR TITLE
A11y: Add missing aria labels in Prometheus QueryEditor and Config

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx
@@ -101,6 +101,7 @@ export class Select<T> extends PureComponent<LegacySelectProps<T>> {
       onOpenMenu,
       allowCustomValue,
       formatCreateLabel,
+      'aria-label': ariaLabel,
     } = this.props;
 
     let widthClass = '';
@@ -151,6 +152,7 @@ export class Select<T> extends PureComponent<LegacySelectProps<T>> {
               onMenuOpen={onOpenMenuInternal}
               onMenuClose={onCloseMenuInternal}
               tabSelectsValue={tabSelectsValue}
+              aria-label={ariaLabel}
               {...creatableOptions}
             />
           );

--- a/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryEditor.tsx
@@ -161,6 +161,7 @@ export class PromQueryEditor extends PureComponent<PromQueryEditorProps, State> 
               <input
                 type="text"
                 className="gf-form-input width-8"
+                aria-label="Set lower limit for the step parameter"
                 placeholder={interval}
                 onChange={this.onIntervalChange}
                 onBlur={this.onRunQuery}
@@ -171,6 +172,7 @@ export class PromQueryEditor extends PureComponent<PromQueryEditorProps, State> 
             <div className="gf-form">
               <div className="gf-form-label">Resolution</div>
               <Select
+                aria-label="Select resolution"
                 menuShouldPortal
                 isSearchable={false}
                 options={INTERVAL_FACTOR_OPTIONS}
@@ -189,6 +191,7 @@ export class PromQueryEditor extends PureComponent<PromQueryEditorProps, State> 
                 options={FORMAT_OPTIONS}
                 onChange={this.onFormatChange}
                 value={formatOption}
+                aria-label="Select format"
               />
               <Switch label="Instant" checked={instant} onChange={this.onInstantChange} />
 

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -75,6 +75,7 @@ export const PromSettings = (props: Props) => {
             HTTP Method
           </InlineFormLabel>
           <Select
+            aria-label="Select HTTP method"
             menuShouldPortal
             options={httpOptions}
             value={httpOptions.find((o) => o.value === options.jsonData.httpMethod)}


### PR DESCRIPTION
**What this PR does / why we need it:**
Adding missing aria-labels to pass fastpass checks in Loki query editor and config page. There is still an issue with QueryField, but that is an issue for all data sources that use QueryField.

**Which issue(s) this PR fixes:**

Related to #41206