### PR TITLE
Canvas: use name as UID

### DIFF
--- a/public/app/core/components/Layers/LayerDragDropList.tsx
+++ b/public/app/core/components/Layers/LayerDragDropList.tsx
@@ -50,6 +50,7 @@ export const LayerDragDropList = <T extends LayerElement>({
               // reverse order
               const rows: any = [];
               const lastLayerIndex = excludeBaseLayer ? 1 : 0;
+              const shouldRenderDragIconLengthThreshold = excludeBaseLayer ? 2 : 1;
               for (let i = layers.length - 1; i >= lastLayerIndex; i--) {
                 const element = layers[i];
                 const uid = element.getName();
@@ -91,7 +92,7 @@ export const LayerDragDropList = <T extends LayerElement>({
                               onClick={() => onDelete(element)}
                               surface="header"
                             />
-                            {layers.length > 2 && (
+                            {layers.length > shouldRenderDragIconLengthThreshold && (
                               <Icon
                                 title="Drag and drop to reorder"
                                 name="draggabledots"

--- a/public/app/core/components/Layers/LayerName.tsx
+++ b/public/app/core/components/Layers/LayerName.tsx
@@ -40,7 +40,7 @@ export const LayerName = ({ name, onChange, verifyLayerNameUniqueness }: LayerNa
       return;
     }
 
-    if (verifyLayerNameUniqueness && !verifyLayerNameUniqueness(newName)) {
+    if (verifyLayerNameUniqueness && !verifyLayerNameUniqueness(newName) && newName !== name) {
       setValidationError('Layer name already exists');
       return;
     }

--- a/public/app/features/canvas/registry.ts
+++ b/public/app/features/canvas/registry.ts
@@ -6,7 +6,7 @@ import { textBoxItem } from './elements/textBox';
 export const DEFAULT_CANVAS_ELEMENT_CONFIG: CanvasElementOptions = {
   ...iconItem.getNewOptions(),
   type: iconItem.id,
-  name: `Group ${Date.now()}.${Math.floor(Math.random() * 100)}`,
+  name: `Element 1`,
 };
 
 export const canvasElementRegistry = new Registry<CanvasElementItem>(() => [

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -13,6 +13,7 @@ import { DimensionContext } from 'app/features/dimensions';
 import { notFoundItem } from 'app/features/canvas/elements/notFound';
 import { GroupState } from './group';
 import { LayerElement } from 'app/core/components/Layers/types';
+import { Scene } from './scene';
 
 let counter = 0;
 
@@ -45,12 +46,26 @@ export class ElementState implements LayerElement {
     options.anchor = this.anchor;
     options.placement = this.placement;
 
+    const scene = this.getScene();
     if (!options.name) {
-      const newName = parent?.scene.getNextElementName();
+      const newName = scene?.getNextElementName();
       options.name = newName ?? fallbackName;
     }
 
-    parent?.scene.byName.set(options.name, this);
+    scene?.byName.set(options.name, this);
+  }
+
+  private getScene(): Scene | undefined {
+    let trav = this.parent;
+    while (trav) {
+      if (trav.isRoot()) {
+        return trav.scene;
+        break;
+      }
+      trav = trav.parent;
+    }
+
+    return undefined;
   }
 
   getName() {
@@ -110,8 +125,6 @@ export class ElementState implements LayerElement {
 
     this.options.anchor = this.anchor;
     this.options.placement = this.placement;
-
-    // console.log('validate', this.UID, this.item.id, this.placement, this.anchor);
   }
 
   // The parent size, need to set our own size based on offsets
@@ -212,8 +225,9 @@ export class ElementState implements LayerElement {
     }
 
     if (oldName !== newName) {
-      this.parent?.scene.byName.delete(oldName);
-      this.parent?.scene.byName.set(newName, this);
+      const scene = this.getScene();
+      scene?.byName.delete(oldName);
+      scene?.byName.set(newName, this);
     }
   }
 

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -51,7 +51,6 @@ export class ElementState implements LayerElement {
       const newName = scene?.getNextElementName();
       options.name = newName ?? fallbackName;
     }
-
     scene?.byName.set(options.name, this);
   }
 

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -224,10 +224,10 @@ export class ElementState implements LayerElement {
       trav = trav.parent;
     }
 
-    if (oldName !== newName) {
-      const scene = this.getScene();
-      scene?.byName.delete(oldName);
-      scene?.byName.set(newName, this);
+    const scene = this.getScene();
+    if (oldName !== newName && scene) {
+      scene.byName.delete(oldName);
+      scene.byName.set(newName, this);
     }
   }
 

--- a/public/app/features/canvas/runtime/group.tsx
+++ b/public/app/features/canvas/runtime/group.tsx
@@ -103,6 +103,7 @@ export class GroupState extends ElementState {
     switch (action) {
       case LayerActionID.Delete:
         this.elements = this.elements.filter((e) => e !== element);
+        this.scene.byName.delete(element.options.name);
         this.scene.save();
         this.reinitializeMoveable();
         break;
@@ -129,9 +130,10 @@ export class GroupState extends ElementState {
         copy.updateSize(element.width, element.height);
         copy.updateData(this.scene.context);
         if (updateName) {
-          copy.options.name = `Element ${copy.UID} (duplicate)`;
+          copy.options.name = `${this.scene.getNextElementName()} (duplicate)`;
         }
         this.elements.push(copy);
+        this.scene.byName.set(copy.options.name, copy);
         this.scene.save();
         this.reinitializeMoveable();
         break;

--- a/public/app/features/canvas/runtime/group.tsx
+++ b/public/app/features/canvas/runtime/group.tsx
@@ -130,7 +130,7 @@ export class GroupState extends ElementState {
         copy.updateSize(element.width, element.height);
         copy.updateData(this.scene.context);
         if (updateName) {
-          copy.options.name = `${this.scene.getNextElementName()} (duplicate)`;
+          copy.options.name = this.scene.getNextElementName();
         }
         this.elements.push(copy);
         this.scene.byName.set(copy.options.name, copy);

--- a/public/app/features/canvas/runtime/scene.tsx
+++ b/public/app/features/canvas/runtime/scene.tsx
@@ -130,8 +130,8 @@ export class Scene {
       );
 
       currentSelectedElements.forEach((element: ElementState) => {
-        newLayer.doAction(LayerActionID.Duplicate, element, false);
         currentLayer.doAction(LayerActionID.Delete, element);
+        newLayer.doAction(LayerActionID.Duplicate, element, false);
       });
 
       currentLayer.elements.push(newLayer);

--- a/public/app/features/canvas/runtime/scene.tsx
+++ b/public/app/features/canvas/runtime/scene.tsx
@@ -56,9 +56,10 @@ export class Scene {
 
   getNextElementName = (isGroup = false) => {
     const label = isGroup ? 'Group' : 'Element';
-    let idx = this.byName.size;
+    let idx = this.byName.size + 1;
 
-    while (true && idx < 100) {
+    const max = idx + 100;
+    while (true && idx < max) {
       const name = `${label} ${idx++}`;
       if (!this.byName.has(name)) {
         return name;

--- a/public/app/plugins/panel/canvas/editor/LayerElementListEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/LayerElementListEditor.tsx
@@ -156,7 +156,10 @@ export class LayerElementListEditor extends PureComponent<Props> {
 
     const { layer } = settings;
 
+    const scene = this.getScene();
+    scene?.byName.delete(layer.getName());
     layer.parent?.doAction(LayerActionID.Delete, layer);
+
     this.goUpLayer();
   };
 
@@ -215,6 +218,12 @@ export class LayerElementListEditor extends PureComponent<Props> {
       return element instanceof GroupState;
     };
 
+    const verifyLayerNameUniqueness = (nameToVerify: string) => {
+      const scene = this.getScene();
+
+      return Boolean(scene?.canRename(nameToVerify));
+    };
+
     const selection: string[] = settings.selected ? settings.selected.map((v) => v.getName()) : [];
     return (
       <>
@@ -241,6 +250,7 @@ export class LayerElementListEditor extends PureComponent<Props> {
           onDuplicate={onDuplicate}
           getLayerInfo={getLayerInfo}
           onNameChange={onNameChange}
+          verifyLayerNameUniqueness={verifyLayerNameUniqueness}
           isGroup={isGroup}
           layers={layer.elements}
           selection={selection}

--- a/public/app/plugins/panel/canvas/editor/LayerElementListEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/LayerElementListEditor.tsx
@@ -126,10 +126,10 @@ export class LayerElementListEditor extends PureComponent<Props> {
 
     const { layer } = settings;
 
+    this.deleteGroup();
     layer.elements.forEach((element: ElementState) => {
       layer.parent?.doAction(LayerActionID.Duplicate, element, false);
     });
-    this.deleteGroup();
   };
 
   private onDecoupleGroup = () => {
@@ -158,6 +158,7 @@ export class LayerElementListEditor extends PureComponent<Props> {
 
     const scene = this.getScene();
     scene?.byName.delete(layer.getName());
+    layer.elements.forEach((element) => scene?.byName.delete(element.getName()));
     layer.parent?.doAction(LayerActionID.Delete, layer);
 
     this.goUpLayer();

--- a/public/app/plugins/panel/canvas/module.tsx
+++ b/public/app/plugins/panel/canvas/module.tsx
@@ -28,7 +28,7 @@ export const plugin = new PanelPlugin<PanelOptions>(CanvasPanel)
         if (!(element instanceof GroupState)) {
           builder.addNestedOptions(
             getElementEditor({
-              category: [`Selected element (id: ${element.UID})`], // changing the ID forces reload
+              category: [`Selected element (${element.options.name})`], // changing the ID forces reload
               element,
               scene: state.scene,
             })

--- a/public/app/plugins/panel/canvas/module.tsx
+++ b/public/app/plugins/panel/canvas/module.tsx
@@ -28,7 +28,7 @@ export const plugin = new PanelPlugin<PanelOptions>(CanvasPanel)
         if (!(element instanceof GroupState)) {
           builder.addNestedOptions(
             getElementEditor({
-              category: [`Selected element (${element.options.name})`], // changing the ID forces reload
+              category: [`Selected element (${element.options.name})`],
               element,
               scene: state.scene,
             })


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Impact on user: element names now must be unique, meaning a more similar experience between geomap / canvas layer list editor UX.

Replace UID system for elements with using element name instead. Similar to switch we did for geomap as well: #41668

Keeps current UID for rendering keys as removing this made moveable library not happy 😬 

PORK:
- Address small UX issue where editing layer name to current name would result in validation error being displayed unnecessarily

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #42693

