### PR TITLE
Explore: Support custom display label for exemplar links for Prometheus datasource

### DIFF
--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -31,6 +31,7 @@ To access Prometheus settings, hover your mouse over the **Configuration** (gear
 | `Custom Query Parameters` | Add custom parameters to the Prometheus query URL. For example `timeout`, `partial_response`, `dedup`, or `max_source_resolution`. Multiple parameters should be concatenated together with an '&amp;'.                                                           |
 | `Label name`              | Add the name of the field in the label object.                                                                                                                                                                                                                    |
 | `URL`                     | If the link is external, then enter the full link URL. You can interpolate the value from the field with `${__value.raw }` macro.                                                                                                                                 |
+| `URL Label`               | (Optional) Set a custom display label for the link URL. The link label defaults to the full external URL and is overridden by this setting.                                                                                                                       |
 | `Internal link`           | Select if the link is internal or external. In the case of an internal link, a data source selector allows you to select the target data source. Supports tracing data sources only.                                                                              |
 
 ## Prometheus query editor

--- a/public/app/plugins/datasource/prometheus/configuration/ExemplarSetting.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/ExemplarSetting.tsx
@@ -74,6 +74,32 @@ export default function ExemplarSetting({ value, onChange, onDelete }: Props) {
                 datasourceUid: undefined,
                 name: value.name,
                 url: event.currentTarget.value,
+                urlDisplayLabel: value.urlDisplayLabel,
+              })
+            }
+          />
+        </InlineField>
+      )}
+
+      {isInternalLink ? (
+        ''
+      ) : (
+        <InlineField
+          label="URL Label"
+          labelWidth={24}
+          tooltip="Use to override the label of the URL link."
+        >
+          <Input
+            placeholder="Go to example.com"
+            spellCheck={false}
+            width={40}
+            value={value.urlDisplayLabel}
+            onChange={(event) =>
+              onChange({
+                datasourceUid: undefined,
+                name: value.name,
+                url: value.url,
+                urlDisplayLabel: event.currentTarget.value,
               })
             }
           />

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -296,7 +296,7 @@ function getDataLinks(options: ExemplarTraceIdDestination): DataLink[] {
 
   if (options.url) {
     dataLinks.push({
-      title: `Go to ${options.url}`,
+      title: options.urlDisplayLabel || `Go to ${options.url}`,
       url: options.url,
       targetBlank: true,
     });

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -35,6 +35,7 @@ export enum PromQueryType {
 export type ExemplarTraceIdDestination = {
   name: string;
   url?: string;
+  urlDisplayLabel?: string;
   datasourceUid?: string;
 };
 


### PR DESCRIPTION
What this PR does / why we need it:
Adds a configuration option for a custom URL label for exemplar link. Sets the label when generated DataLinks. Updates docs as well.

Which issue(s) this PR fixes:
