### PR TITLE
Prometheus: Fix passing of custom params when running queries

### DIFF
--- a/pkg/tsdb/prometheus/custom_query_params_middleware.go
+++ b/pkg/tsdb/prometheus/custom_query_params_middleware.go
@@ -1,7 +1,6 @@
 package prometheus
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 
@@ -50,8 +49,6 @@ func customQueryParametersMiddleware(logger log.Logger) sdkhttpclient.Middleware
 				}
 			}
 			req.URL.RawQuery = q.Encode()
-			fmt.Println("HEREEEEE2")
-			fmt.Println(req.URL.RawQuery)
 
 			return next.RoundTrip(req)
 		})

--- a/pkg/tsdb/prometheus/custom_query_params_middleware_test.go
+++ b/pkg/tsdb/prometheus/custom_query_params_middleware_test.go
@@ -114,7 +114,9 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 		mw := customQueryParametersMiddleware(log.New("test"))
 		rt := mw.CreateMiddleware(httpclient.Options{
 			CustomOptions: map[string]interface{}{
-				customQueryParametersKey: "custom=par/am&second=f oo",
+				grafanaDataKey: map[string]interface{}{
+					customQueryParametersKey: "custom=par/am&second=f oo",
+				},
 			},
 		}, finalRoundTripper)
 		require.NotNil(t, rt)
@@ -144,7 +146,9 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 		mw := customQueryParametersMiddleware(log.New("test"))
 		rt := mw.CreateMiddleware(httpclient.Options{
 			CustomOptions: map[string]interface{}{
-				customQueryParametersKey: "custom=par/am&second=f oo",
+				grafanaDataKey: map[string]interface{}{
+					customQueryParametersKey: "custom=par/am&second=f oo",
+				},
 			},
 		}, finalRoundTripper)
 		require.NotNil(t, rt)


### PR DESCRIPTION
**What this PR does / why we need it**:
There are 2 issues related to https://github.com/grafana/grafana/issues/42672:
1. HTTP method is not respected
2. Custom params weren't send

This PR fixes the second one. 

At some point, there was probably a change at some point and `customQueryParameters` were moved from  `CustomOptions` to `CustomOptions > grafanaData`. The code in middleware wasn't updated when this changed.

This PR fixes it. 

**Which issue(s) this PR fixes**:

Related to https://github.com/grafana/grafana/issues/42672


