### PR TITLE
Prometheus: Fix running of exemplar queries for non-histogram metrics

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -1667,6 +1667,35 @@ describe('PrometheusDatasource', () => {
       templateSrvStub.replace = jest.fn((a: string) => a);
     });
   });
+
+  it('should give back 1 exemplar target when multiple queries with exemplar enabled and same metric', () => {
+    const targetA: PromQuery = {
+      refId: 'A',
+      expr: 'histogram_quantile(0.95, sum(rate(tns_request_duration_seconds_bucket[5m])) by (le))',
+      exemplar: true,
+    };
+    const targetB: PromQuery = {
+      refId: 'B',
+      expr: 'histogram_quantile(0.5, sum(rate(tns_request_duration_seconds_bucket[5m])) by (le))',
+      exemplar: true,
+    };
+
+    ds.languageProvider = {
+      histogramMetrics: ['tns_request_duration_seconds_bucket'],
+    } as any;
+
+    const request = ({
+      targets: [targetA, targetB, targetC],
+      interval: '1s',
+      panelId: '',
+    } as any) as DataQueryRequest<PromQuery>;
+
+    const Aexemplars = ds.shouldRunExemplarQuery(targetA, request);
+    const BExpemplars = ds.shouldRunExemplarQuery(targetB, request);
+
+    expect(Aexemplars).toBe(true);
+    expect(BExpemplars).toBe(false);
+  });
 });
 
 describe('PrometheusDatasource for POST', () => {

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -1685,7 +1685,7 @@ describe('PrometheusDatasource', () => {
     } as any;
 
     const request = ({
-      targets: [targetA, targetB, targetC],
+      targets: [targetA, targetB],
       interval: '1s',
       panelId: '',
     } as any) as DataQueryRequest<PromQuery>;

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -300,21 +300,18 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
     };
   };
 
-  shouldRunExemplarQuery(target: PromQuery): boolean {
-    /* We want to run exemplar query only for histogram metrics:
-    1. If we haven't processd histogram metrics yet, we need to check if expr includes "_bucket" which means that it is probably histogram metric (can rarely lead to false positive).
-    2. If we have processed histogram metrics, check if it is part of query expr.
-    */
+  shouldRunExemplarQuery(target: PromQuery, request: DataQueryRequest<PromQuery>): boolean {
     if (target.exemplar) {
-      const histogramMetrics = this.languageProvider.histogramMetrics;
-
-      if (histogramMetrics.length > 0) {
-        return !!histogramMetrics.find((metric) => target.expr.includes(metric));
-      } else {
-        return target.expr.includes('_bucket');
+      // We check all already processed targets and only create exemplar target for not used metric names
+      const metricName = this.languageProvider.histogramMetrics.find((m) => target.expr.includes(m));
+      const targets = [...request.targets];
+      // Remove targets that weren't processed yet (in targets array they are after current target)
+      targets.splice(request.targets.findIndex((t) => t.refId === target.refId));
+      if (!metricName || (metricName && !targets.some((t) => t.expr.includes(metricName)))) {
+        return true;
       }
+      return false;
     }
-
     return false;
   }
 
@@ -322,7 +319,7 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
     const processedTarget = {
       ...target,
       queryType: PromQueryType.timeSeriesQuery,
-      exemplar: this.shouldRunExemplarQuery(target),
+      exemplar: this.shouldRunExemplarQuery(target, request),
       requestId: request.panelId + target.refId,
       // We need to pass utcOffsetSec to backend to calculate aligned range
       utcOffsetSec: this.timeSrv.timeRange().to.utcOffset() * 60,

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -304,9 +304,10 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
     if (target.exemplar) {
       // We check all already processed targets and only create exemplar target for not used metric names
       const metricName = this.languageProvider.histogramMetrics.find((m) => target.expr.includes(m));
-      const targets = [...request.targets];
       // Remove targets that weren't processed yet (in targets array they are after current target)
-      targets.splice(request.targets.findIndex((t) => t.refId === target.refId));
+      const currentTargetIdx = request.targets.findIndex((t) => t.refId === target.refId);
+      const targets = request.targets.slice(0, currentTargetIdx);
+
       if (!metricName || (metricName && !targets.some((t) => t.expr.includes(metricName)))) {
         return true;
       }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes running of exemplar queries for non-histogram metrics. We should only check if we've already created an exemplar query for the same metric. If so, in that case don't run duplicated exemplars queries. This is a logic that should be in shouldRunExemplarQuery : https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/prometheus/datasource.ts#L252-L264

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/42566


**How to review:**
1. Create a query that doesn't include histogram metric (e.g. `up`) with exemplars toggled on - exemplar in request should be `true`.
![image](https://user-images.githubusercontent.com/30407135/144630938-e17785df-a9a2-46ce-a9eb-aa9aec594ff5.png)

2. Create a query that includes 2 queries with the same histogram metric (e.g. `prometheus_http_response_size_bytes_bucket{}`) with exemplars toggled on - exemplar in the first request should be `true`, in the second false.

![image](https://user-images.githubusercontent.com/30407135/144631212-bb32778f-becd-41b4-a01e-0204a8f99937.png)