### PR TITLE
Analytics: Add user id tracking to google analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@types/enzyme": "3.10.5",
     "@types/enzyme-adapter-react-16": "1.0.6",
     "@types/file-saver": "2.0.1",
+    "@types/google.analytics": "^0.0.42",
     "@types/grafana__slate-react": "npm:@types/slate-react@0.22.5",
     "@types/history": "^4.7.8",
     "@types/hoist-non-react-statics": "3.3.1",

--- a/public/app/core/services/echo/backends/analytics/GABackend.ts
+++ b/public/app/core/services/echo/backends/analytics/GABackend.ts
@@ -8,6 +8,7 @@ export interface GAEchoBackendOptions {
 
 export class GAEchoBackend implements EchoBackend<PageviewEchoEvent, GAEchoBackendOptions> {
   supportedEvents = [EchoEventType.Pageview];
+  trackedUserId: number | null = null;
 
   constructor(public options: GAEchoBackendOptions) {
     const url = `https://www.google-analytics.com/analytics${options.debug ? '_debug' : ''}.js`;
@@ -18,8 +19,8 @@ export class GAEchoBackend implements EchoBackend<PageviewEchoEvent, GAEchoBacke
       cache: true,
     });
 
-    const ga = ((window as any).ga =
-      (window as any).ga ||
+    const ga = (window.ga =
+      window.ga ||
       // this had the equivalent of `eslint-disable-next-line prefer-arrow/prefer-arrow-functions`
       function () {
         (ga.q = ga.q || []).push(arguments);
@@ -30,12 +31,18 @@ export class GAEchoBackend implements EchoBackend<PageviewEchoEvent, GAEchoBacke
   }
 
   addEvent = (e: PageviewEchoEvent) => {
-    if (!(window as any).ga) {
+    if (!window.ga) {
       return;
     }
 
-    (window as any).ga('set', { page: e.payload.page });
-    (window as any).ga('send', 'pageview');
+    window.ga('set', { page: e.payload.page });
+    window.ga('send', 'pageview');
+
+    const { userSignedIn, userId } = e.meta;
+    if (userSignedIn && userId !== this.trackedUserId) {
+      this.trackedUserId = userId;
+      window.ga('set', 'userId', userId);
+    }
   };
 
   // Not using Echo buffering, addEvent above sends events to GA as soon as they appear

--- a/yarn.lock
+++ b/yarn.lock
@@ -9104,6 +9104,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/google.analytics@npm:^0.0.42":
+  version: 0.0.42
+  resolution: "@types/google.analytics@npm:0.0.42"
+  checksum: c64b3f7991c4bcb1dfe8db902a2e2ebe821ce53a1ca36e6628b4d08d0c24213aa0d4f49492b3144dd6bfa661f53fb1ecf16e83cca522cddd6d9f8419a4b73fe8
+  languageName: node
+  linkType: hard
+
 "@types/graceful-fs@npm:^4.1.2":
   version: 4.1.5
   resolution: "@types/graceful-fs@npm:4.1.5"
@@ -19419,6 +19426,7 @@ __metadata:
     "@types/enzyme": 3.10.5
     "@types/enzyme-adapter-react-16": 1.0.6
     "@types/file-saver": 2.0.1
+    "@types/google.analytics": ^0.0.42
     "@types/grafana__slate-react": "npm:@types/slate-react@0.22.5"
     "@types/history": ^4.7.8
     "@types/hoist-non-react-statics": 3.3.1


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds user id tracking to google analytics. 

Grafana administrators may wish to leverage the User ID feature of Google Analytics ([docs](https://support.google.com/analytics/answer/3123662?hl=en#zippy=%2Cin-this-article))

This PR maps the grafana `userId` to the google analytics `userId`, and sets it in the google analytics api.

Note that User ID tracking must be explicitly enabled by an admin on the google analytics account ([docs](https://support.google.com/analytics/answer/3123666#zippy=%2Cin-this-article)). So this code change will not start tracking user ids / user data for all GA users - it only adds support for those who have enabled the feature.

**Special notes for your reviewer**:

I also added typings for google analytics to avoid all of the `(window as any)` type assertions. If that's not desirable I'm happy to roll it back.