### PR TITLE
Autobreakdowns: Make exemplars for autobreakdowns available in datasource

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromExploreQueryEditor.tsx
@@ -25,6 +25,10 @@ export const PromExploreQueryEditor: FC<Props> = (props: Props) => {
     }
   }, [onChange, query]);
 
+  useEffect(() => {
+    console.log(datasource.exemplarsForAutoBreakdowns);
+  }, [datasource.exemplarsForAutoBreakdowns]);
+
   return (
     <PromQueryField
       app={CoreApp.Explore}

--- a/public/app/plugins/datasource/prometheus/result_transformer.test.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.test.ts
@@ -313,8 +313,8 @@ describe('Prometheus Result Transformer', () => {
             result: null,
           },
         };
-        const series = transform({ data: response } as any, options);
-        expect(series).toEqual([]);
+        const { data } = transform({ data: response } as any, options);
+        expect(data).toEqual([]);
       });
       it('should return empty array', () => {
         const response = {
@@ -324,8 +324,8 @@ describe('Prometheus Result Transformer', () => {
             result: null,
           },
         };
-        const result = transform({ data: response } as any, { ...options, target: { format: 'table' } });
-        expect(result).toHaveLength(0);
+        const { data } = transform({ data: response } as any, { ...options, target: { format: 'table' } });
+        expect(data).toHaveLength(0);
       });
     });
 
@@ -358,7 +358,7 @@ describe('Prometheus Result Transformer', () => {
       };
 
       it('should return data frame', () => {
-        const result = transform({ data: response } as any, {
+        const { data } = transform({ data: response } as any, {
           ...options,
           target: {
             responseListLength: 0,
@@ -366,32 +366,32 @@ describe('Prometheus Result Transformer', () => {
             format: 'table',
           },
         });
-        expect(result[0].fields[0].values.toArray()).toEqual([
+        expect(data[0].fields[0].values.toArray()).toEqual([
           1443454528000,
           1443454530000,
           1443454529000,
           1443454531000,
         ]);
-        expect(result[0].fields[0].name).toBe('Time');
-        expect(result[0].fields[0].type).toBe(FieldType.time);
-        expect(result[0].fields[1].values.toArray()).toEqual(['test', 'test', 'test2', 'test2']);
-        expect(result[0].fields[1].name).toBe('__name__');
-        expect(result[0].fields[1].config.filterable).toBe(true);
-        expect(result[0].fields[1].type).toBe(FieldType.string);
-        expect(result[0].fields[2].values.toArray()).toEqual(['', '', 'localhost:8080', 'localhost:8080']);
-        expect(result[0].fields[2].name).toBe('instance');
-        expect(result[0].fields[2].type).toBe(FieldType.string);
-        expect(result[0].fields[3].values.toArray()).toEqual(['testjob', 'testjob', 'otherjob', 'otherjob']);
-        expect(result[0].fields[3].name).toBe('job');
-        expect(result[0].fields[3].type).toBe(FieldType.string);
-        expect(result[0].fields[4].values.toArray()).toEqual([3846, 3848, 3847, 3849]);
-        expect(result[0].fields[4].name).toEqual('Value');
-        expect(result[0].fields[4].type).toBe(FieldType.number);
-        expect(result[0].refId).toBe('A');
+        expect(data[0].fields[0].name).toBe('Time');
+        expect(data[0].fields[0].type).toBe(FieldType.time);
+        expect(data[0].fields[1].values.toArray()).toEqual(['test', 'test', 'test2', 'test2']);
+        expect(data[0].fields[1].name).toBe('__name__');
+        expect(data[0].fields[1].config.filterable).toBe(true);
+        expect(data[0].fields[1].type).toBe(FieldType.string);
+        expect(data[0].fields[2].values.toArray()).toEqual(['', '', 'localhost:8080', 'localhost:8080']);
+        expect(data[0].fields[2].name).toBe('instance');
+        expect(data[0].fields[2].type).toBe(FieldType.string);
+        expect(data[0].fields[3].values.toArray()).toEqual(['testjob', 'testjob', 'otherjob', 'otherjob']);
+        expect(data[0].fields[3].name).toBe('job');
+        expect(data[0].fields[3].type).toBe(FieldType.string);
+        expect(data[0].fields[4].values.toArray()).toEqual([3846, 3848, 3847, 3849]);
+        expect(data[0].fields[4].name).toEqual('Value');
+        expect(data[0].fields[4].type).toBe(FieldType.number);
+        expect(data[0].refId).toBe('A');
       });
 
       it('should include refId if response count is more than 2', () => {
-        const result = transform({ data: response } as any, {
+        const { data } = transform({ data: response } as any, {
           ...options,
           target: {
             refId: 'B',
@@ -400,7 +400,7 @@ describe('Prometheus Result Transformer', () => {
           responseListLength: 2,
         });
 
-        expect(result[0].fields[4].name).toEqual('Value #B');
+        expect(data[0].fields[4].name).toEqual('Value #B');
       });
     });
 
@@ -419,15 +419,15 @@ describe('Prometheus Result Transformer', () => {
       };
 
       it('should return data frame', () => {
-        const result = transform({ data: response } as any, { ...options, target: { format: 'table' } });
-        expect(result[0].fields[0].values.toArray()).toEqual([1443454528000]);
-        expect(result[0].fields[0].name).toBe('Time');
-        expect(result[0].fields[1].values.toArray()).toEqual(['test']);
-        expect(result[0].fields[1].name).toBe('__name__');
-        expect(result[0].fields[2].values.toArray()).toEqual(['testjob']);
-        expect(result[0].fields[2].name).toBe('job');
-        expect(result[0].fields[3].values.toArray()).toEqual([3846]);
-        expect(result[0].fields[3].name).toEqual('Value');
+        const { data } = transform({ data: response } as any, { ...options, target: { format: 'table' } });
+        expect(data[0].fields[0].values.toArray()).toEqual([1443454528000]);
+        expect(data[0].fields[0].name).toBe('Time');
+        expect(data[0].fields[1].values.toArray()).toEqual(['test']);
+        expect(data[0].fields[1].name).toBe('__name__');
+        expect(data[0].fields[2].values.toArray()).toEqual(['testjob']);
+        expect(data[0].fields[2].name).toBe('job');
+        expect(data[0].fields[3].values.toArray()).toEqual([3846]);
+        expect(data[0].fields[3].name).toEqual('Value');
       });
 
       it('should return le label values parsed as numbers', () => {
@@ -443,9 +443,9 @@ describe('Prometheus Result Transformer', () => {
             ],
           },
         };
-        const result = transform({ data: response } as any, { ...options, target: { format: 'table' } });
-        expect(result[0].fields[1].values.toArray()).toEqual([102]);
-        expect(result[0].fields[1].type).toEqual(FieldType.number);
+        const { data } = transform({ data: response } as any, { ...options, target: { format: 'table' } });
+        expect(data[0].fields[1].values.toArray()).toEqual([102]);
+        expect(data[0].fields[1].type).toEqual(FieldType.number);
       });
     });
 
@@ -464,8 +464,8 @@ describe('Prometheus Result Transformer', () => {
       };
 
       it('should return data frame', () => {
-        const result: DataFrame[] = transform({ data: response } as any, { ...options, query: { instant: true } });
-        expect(result[0].name).toBe('test{job="testjob"}');
+        const { data } = transform({ data: response } as any, { ...options, query: { instant: true } });
+        expect(data[0].name).toBe('test{job="testjob"}');
       });
     });
 
@@ -513,13 +513,13 @@ describe('Prometheus Result Transformer', () => {
           },
         ]);
 
-        const result = transform({ data: response } as any, { query: options, target: options } as any);
-        expect(result[0].fields[0].values.toArray()).toEqual([1445000010000, 1445000020000, 1445000030000]);
-        expect(result[0].fields[1].values.toArray()).toEqual([10, 10, 0]);
-        expect(result[1].fields[0].values.toArray()).toEqual([1445000010000, 1445000020000, 1445000030000]);
-        expect(result[1].fields[1].values.toArray()).toEqual([10, 0, 30]);
-        expect(result[2].fields[0].values.toArray()).toEqual([1445000010000, 1445000020000, 1445000030000]);
-        expect(result[2].fields[1].values.toArray()).toEqual([10, 0, 10]);
+        const { data } = transform({ data: response } as any, { query: options, target: options } as any);
+        expect(data[0].fields[0].values.toArray()).toEqual([1445000010000, 1445000020000, 1445000030000]);
+        expect(data[0].fields[1].values.toArray()).toEqual([10, 10, 0]);
+        expect(data[1].fields[0].values.toArray()).toEqual([1445000010000, 1445000020000, 1445000030000]);
+        expect(data[1].fields[1].values.toArray()).toEqual([10, 0, 30]);
+        expect(data[2].fields[0].values.toArray()).toEqual([1445000010000, 1445000020000, 1445000030000]);
+        expect(data[2].fields[1].values.toArray()).toEqual([10, 0, 10]);
       });
 
       it('should handle missing datapoints', () => {
@@ -547,10 +547,10 @@ describe('Prometheus Result Transformer', () => {
             ],
           },
         ]);
-        const result = transform({ data: response } as any, { query: options, target: options } as any);
-        expect(result[0].fields[1].values.toArray()).toEqual([1, 2]);
-        expect(result[1].fields[1].values.toArray()).toEqual([1, 3, 1]);
-        expect(result[2].fields[1].values.toArray()).toEqual([1, 2]);
+        const { data } = transform({ data: response } as any, { query: options, target: options } as any);
+        expect(data[0].fields[1].values.toArray()).toEqual([1, 2]);
+        expect(data[1].fields[1].values.toArray()).toEqual([1, 3, 1]);
+        expect(data[2].fields[1].values.toArray()).toEqual([1, 2]);
       });
     });
 
@@ -573,13 +573,13 @@ describe('Prometheus Result Transformer', () => {
           },
         };
 
-        const result: DataFrame[] = transform({ data: response } as any, {
+        const { data } = transform({ data: response } as any, {
           ...options,
         });
 
-        expect(result[0].fields[1].labels).toBeDefined();
-        expect(result[0].fields[1].labels?.instance).toBe('testinstance');
-        expect(result[0].fields[1].labels?.job).toBe('testjob');
+        expect(data[0].fields[1].labels).toBeDefined();
+        expect(data[0].fields[1].labels?.instance).toBe('testinstance');
+        expect(data[0].fields[1].labels?.job).toBe('testjob');
       });
 
       it('should transform into a data frame', () => {
@@ -600,30 +600,30 @@ describe('Prometheus Result Transformer', () => {
           },
         };
 
-        const result: DataFrame[] = transform({ data: response } as any, {
+        const { data } = transform({ data: response } as any, {
           ...options,
           query: {
             start: 0,
             end: 2,
           },
         });
-        expect(result[0].fields[0].values.toArray()).toEqual([0, 1000, 2000]);
-        expect(result[0].fields[1].values.toArray()).toEqual([10, 10, 0]);
-        expect(result[0].name).toBe('test{job="testjob"}');
+        expect(data[0].fields[0].values.toArray()).toEqual([0, 1000, 2000]);
+        expect(data[0].fields[1].values.toArray()).toEqual([10, 10, 0]);
+        expect(data[0].name).toBe('test{job="testjob"}');
       });
 
       it('should fill null values', () => {
-        const result = transform({ data: matrixResponse } as any, {
+        const { data } = transform({ data: matrixResponse } as any, {
           ...options,
           query: { step: 1, start: 0, end: 2 },
         });
 
-        expect(result[0].fields[0].values.toArray()).toEqual([0, 1000, 2000]);
-        expect(result[0].fields[1].values.toArray()).toEqual([null, 10, 0]);
+        expect(data[0].fields[0].values.toArray()).toEqual([0, 1000, 2000]);
+        expect(data[0].fields[1].values.toArray()).toEqual([null, 10, 0]);
       });
 
       it('should use __name__ label as series name', () => {
-        const result = transform({ data: matrixResponse } as any, {
+        const { data } = transform({ data: matrixResponse } as any, {
           ...options,
           query: {
             step: 1,
@@ -631,7 +631,7 @@ describe('Prometheus Result Transformer', () => {
             end: 2,
           },
         });
-        expect(result[0].name).toEqual('test{job="testjob"}');
+        expect(data[0].name).toEqual('test{job="testjob"}');
       });
 
       it('should use query as series name when __name__ is not available and metric is empty', () => {
@@ -648,7 +648,7 @@ describe('Prometheus Result Transformer', () => {
           },
         };
         const expr = 'histogram_quantile(0.95, sum(rate(tns_request_duration_seconds_bucket[5m])) by (le))';
-        const result = transform({ data: response } as any, {
+        const { data } = transform({ data: response } as any, {
           ...options,
           query: {
             step: 1,
@@ -657,7 +657,7 @@ describe('Prometheus Result Transformer', () => {
             expr,
           },
         });
-        expect(result[0].name).toEqual(expr);
+        expect(data[0].name).toEqual(expr);
       });
 
       it('should set frame name to undefined if no __name__ label but there are other labels', () => {
@@ -677,7 +677,7 @@ describe('Prometheus Result Transformer', () => {
           },
         };
 
-        const result = transform({ data: response } as any, {
+        const { data } = transform({ data: response } as any, {
           ...options,
           query: {
             step: 1,
@@ -685,13 +685,13 @@ describe('Prometheus Result Transformer', () => {
             end: 2,
           },
         });
-        expect(result[0].name).toBe('{job="testjob"}');
+        expect(data[0].name).toBe('{job="testjob"}');
       });
 
       it('should not set displayName for ValueFields', () => {
-        const result = transform({ data: matrixResponse } as any, options);
-        expect(result[0].fields[1].config.displayName).toBeUndefined();
-        expect(result[0].fields[1].config.displayNameFromDS).toBe('test{job="testjob"}');
+        const { data } = transform({ data: matrixResponse } as any, options);
+        expect(data[0].fields[1].config.displayName).toBeUndefined();
+        expect(data[0].fields[1].config.displayNameFromDS).toBe('test{job="testjob"}');
       });
 
       it('should align null values with step', () => {
@@ -711,9 +711,9 @@ describe('Prometheus Result Transformer', () => {
           },
         };
 
-        const result = transform({ data: response } as any, { ...options, query: { step: 2, start: 0, end: 8 } });
-        expect(result[0].fields[0].values.toArray()).toEqual([0, 2000, 4000, 6000, 8000]);
-        expect(result[0].fields[1].values.toArray()).toEqual([null, null, 10, null, 10]);
+        const { data } = transform({ data: response } as any, { ...options, query: { step: 2, start: 0, end: 8 } });
+        expect(data[0].fields[0].values.toArray()).toEqual([0, 2000, 4000, 6000, 8000]);
+        expect(data[0].fields[1].values.toArray()).toEqual([null, null, 10, null, 10]);
       });
     });
 
@@ -728,11 +728,11 @@ describe('Prometheus Result Transformer', () => {
         };
 
         it('should correctly parse values', () => {
-          const result: DataFrame[] = transform({ data: response } as any, {
+          const { data } = transform({ data: response } as any, {
             ...options,
             target: { format: 'table' },
           });
-          expect(result[0].fields[1].values.toArray()).toEqual([Number.POSITIVE_INFINITY]);
+          expect(data[0].fields[1].values.toArray()).toEqual([Number.POSITIVE_INFINITY]);
         });
       });
 
@@ -756,11 +756,11 @@ describe('Prometheus Result Transformer', () => {
 
         describe('When format is table', () => {
           it('should correctly parse values', () => {
-            const result: DataFrame[] = transform({ data: response } as any, {
+            const { data } = transform({ data: response } as any, {
               ...options,
               target: { format: 'table' },
             });
-            expect(result[0].fields[3].values.toArray()).toEqual([Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]);
+            expect(data[0].fields[3].values.toArray()).toEqual([Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]);
           });
         });
       });
@@ -784,15 +784,15 @@ describe('Prometheus Result Transformer', () => {
 
     describe('When the response is exemplar data', () => {
       it('should return as an data frame with a dataTopic annotations', () => {
-        const result = transform({ data: exemplarsResponse } as any, options);
+        const { data } = transform({ data: exemplarsResponse } as any, options);
 
-        expect(result[0].meta?.dataTopic).toBe('annotations');
-        expect(result[0].fields.length).toBe(4); // __name__, traceID, Time, Value
-        expect(result[0].length).toBe(1);
+        expect(data[0].meta?.dataTopic).toBe('annotations');
+        expect(data[0].fields.length).toBe(4); // __name__, traceID, Time, Value
+        expect(data[0].length).toBe(1);
       });
 
       it('should return with an empty array when data is empty', () => {
-        const result = transform(
+        const { data } = transform(
           {
             data: {
               status: 'success',
@@ -802,7 +802,7 @@ describe('Prometheus Result Transformer', () => {
           options
         );
 
-        expect(result).toHaveLength(0);
+        expect(data).toHaveLength(0);
       });
 
       it('should remove exemplars that are too close to each other', () => {
@@ -835,33 +835,33 @@ describe('Prometheus Result Transformer', () => {
          * the standard deviation for the above values is 8.4 this means that we show the highest
          * value (20) and then the next value should be 2 times the standard deviation which is 1
          **/
-        const result = transform({ data: response } as any, options);
-        expect(result[0].length).toBe(2);
+        const { data } = transform({ data: response } as any, options);
+        expect(data[0].length).toBe(2);
       });
 
       describe('data link', () => {
         it('should be added to the field if found with url', () => {
-          const result = transform({ data: exemplarsResponse } as any, {
+          const { data } = transform({ data: exemplarsResponse } as any, {
             ...options,
             exemplarTraceIdDestinations: [{ name: 'traceID', url: 'http://localhost' }],
           });
 
-          expect(result[0].fields.some((f) => f.config.links?.length)).toBe(true);
+          expect(data[0].fields.some((f) => f.config.links?.length)).toBe(true);
         });
 
         it('should be added to the field if found with internal link', () => {
-          const result = transform({ data: exemplarsResponse } as any, {
+          const { data } = transform({ data: exemplarsResponse } as any, {
             ...options,
             exemplarTraceIdDestinations: [{ name: 'traceID', datasourceUid: 'jaeger' }],
           });
 
-          expect(result[0].fields.some((f) => f.config.links?.length)).toBe(true);
+          expect(data[0].fields.some((f) => f.config.links?.length)).toBe(true);
         });
 
         it('should not add link if exemplarTraceIdDestinations is not configured', () => {
-          const result = transform({ data: exemplarsResponse } as any, options);
+          const { data } = transform({ data: exemplarsResponse } as any, options);
 
-          expect(result[0].fields.some((f) => f.config.links?.length)).toBe(false);
+          expect(data[0].fields.some((f) => f.config.links?.length)).toBe(false);
         });
       });
     });


### PR DESCRIPTION
This is a quick (not polished) solution to make all exemplars available for autobreakdowns. Basically we are using sampling for exemplars that are going to be visualised in the graph, but we are storing all exemplars in following form `[{time, value, ...labels}, {time, value, ...labels}]` on data source level in `this.exemplarsForAutoBreakdowns`. This is definitely not the best place as every new query will override it, but we can figure out the structure later. 

We are currently console loging all available exemplars in PromExploreQueryEditor. 

![image](https://user-images.githubusercontent.com/30407135/144832356-2edc0140-0153-4d0b-a49d-e6263bfac16e.png)
