### PR TITLE
Chore: Add renovate[bot] to the ignore list

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -183,6 +183,7 @@
     "type": "author",
     "name": "pr/external",
     "notMemberOf": { "org": "grafana" },
+    "ignoreList": ["renovate"],
     "action": "updateLabel",
     "addLabel": "pr/external"
   }

--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -183,7 +183,7 @@
     "type": "author",
     "name": "pr/external",
     "notMemberOf": { "org": "grafana" },
-    "ignoreList": ["renovate"],
+    "ignoreList": ["renovate[bot]"],
     "action": "updateLabel",
     "addLabel": "pr/external"
   }


### PR DESCRIPTION
It won't flag renovate pr's as external.
