### PR TITLE
Hackathon: lib credentials backend wip

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -263,8 +263,9 @@ func (hs *HTTPServer) registerRoutes() {
 			prefRoute.Post("/set-home-dash", routing.Wrap(SetHomeDashboard))
 		})
 
-		apiRoute.Group("/library-credentials", func(annotationsRoute routing.RouteRegister) {
-			annotationsRoute.Get("/", routing.Wrap(hs.GetLibraryCredentials))
+		apiRoute.Group("/library-credentials", func(libraryCredentials routing.RouteRegister) {
+			libraryCredentials.Get("/", routing.Wrap(hs.GetLibraryCredentials))
+			libraryCredentials.Post("/", routing.Wrap(hs.AddLibraryCredential))
 		})
 
 		// Data sources

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -263,6 +263,10 @@ func (hs *HTTPServer) registerRoutes() {
 			prefRoute.Post("/set-home-dash", routing.Wrap(SetHomeDashboard))
 		})
 
+		apiRoute.Group("/library-credentials", func(annotationsRoute routing.RouteRegister) {
+			annotationsRoute.Get("/", routing.Wrap(hs.GetLibraryCredentials))
+		})
+
 		// Data sources
 		apiRoute.Group("/datasources", func(datasourceRoute routing.RouteRegister) {
 			datasourceRoute.Get("/", authorize(reqOrgAdmin, ac.EvalPermission(ActionDatasourcesRead, ScopeDatasourcesAll)), routing.Wrap(hs.GetDataSources))

--- a/pkg/api/dtos/library_credential.go
+++ b/pkg/api/dtos/library_credential.go
@@ -1,0 +1,16 @@
+package dtos
+
+import (
+	"github.com/grafana/grafana/pkg/components/simplejson"
+)
+
+type LibraryCredentialDto struct {
+	Id               int64            `json:"id"`
+	UID              string           `json:"uid"`
+	OrgId            int64            `json:"orgId"`
+	Name             string           `json:"name"`
+	Type             string           `json:"type"`
+	JsonData         *simplejson.Json `json:"jsonData,omitempty"`
+	SecureJsonFields map[string]bool  `json:"secureJsonFields"`
+	ReadOnly         bool             `json:"readOnly"`
+}

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/encryption"
 	"github.com/grafana/grafana/pkg/services/hooks"
+	"github.com/grafana/grafana/pkg/services/librarycredentials"
 	"github.com/grafana/grafana/pkg/services/libraryelements"
 	"github.com/grafana/grafana/pkg/services/librarypanels"
 	"github.com/grafana/grafana/pkg/services/live"
@@ -115,6 +116,7 @@ type HTTPServer struct {
 	updateChecker             *updatechecker.Service
 	searchUsersService        searchusers.Service
 	expressionService         *expr.Service
+	LibraryCredentialService  librarycredentials.Service
 }
 
 type ServerOptions struct {
@@ -140,7 +142,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 	internalMetricsSvc *metrics.InternalMetricsService, quotaService *quota.QuotaService,
 	socialService social.Service, oauthTokenService oauthtoken.OAuthTokenService,
 	encryptionService encryption.Internal, updateChecker *updatechecker.Service, searchUsersService searchusers.Service,
-	dataSourcesService *datasources.Service, secretsService secrets.Service, expressionService *expr.Service) (*HTTPServer, error) {
+	dataSourcesService *datasources.Service, secretsService secrets.Service, expressionService *expr.Service, libraryCredentialService librarycredentials.Service) (*HTTPServer, error) {
 	web.Env = cfg.Env
 	m := web.New()
 
@@ -194,6 +196,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 		DataSourcesService:        dataSourcesService,
 		searchUsersService:        searchUsersService,
 		expressionService:         expressionService,
+		LibraryCredentialService:  libraryCredentialService,
 	}
 	if hs.Listener != nil {
 		hs.log.Debug("Using provided listener")

--- a/pkg/api/librarycredentials.go
+++ b/pkg/api/librarycredentials.go
@@ -1,10 +1,15 @@
 package api
 
 import (
+	"errors"
+	"net/http"
+
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 func (hs *HTTPServer) GetLibraryCredentials(c *models.ReqContext) response.Response {
@@ -30,4 +35,64 @@ func (hs *HTTPServer) GetLibraryCredentials(c *models.ReqContext) response.Respo
 	}
 
 	return response.JSON(200, &result)
+}
+
+func (hs *HTTPServer) AddLibraryCredential(c *models.ReqContext) response.Response {
+	cmd := models.AddLibraryCredentialCommand{}
+	if err := web.Bind(c.Req, &cmd); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+	cmd.OrgId = c.OrgId
+
+	if err := bus.DispatchCtx(c.Req.Context(), &cmd); err != nil {
+		if errors.Is(err, models.ErrLibraryCredentialNameExists) || errors.Is(err, models.ErrDataSourceFailedGenerateUniqueUid) {
+			return response.Error(409, err.Error(), err)
+		}
+
+		return response.Error(500, "Failed to add library credential", err)
+	}
+
+	credential := dtos.LibraryCredentialDto{
+		OrgId:    cmd.Result.OrgId,
+		Id:       cmd.Result.Id,
+		UID:      cmd.Result.Uid,
+		Name:     cmd.Result.Name,
+		Type:     cmd.Result.Type,
+		JsonData: cmd.Result.JsonData,
+		ReadOnly: cmd.Result.ReadOnly,
+	}
+	return response.JSON(200, util.DynMap{
+		"message":    "Library Credential added",
+		"id":         cmd.Result.Id,
+		"name":       cmd.Result.Name,
+		"credential": credential,
+	})
+}
+
+func (hs *HTTPServer) UpdateLibraryCredential(c *models.ReqContext) response.Response {
+	cmd := models.UpdateLibraryCredentialCommand{}
+	if err := web.Bind(c.Req, &cmd); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+	cmd.OrgId = c.OrgId
+
+	if err := bus.DispatchCtx(c.Req.Context(), &cmd); err != nil {
+		return response.Error(500, "Failed to add library credential", err)
+	}
+
+	credential := dtos.LibraryCredentialDto{
+		OrgId:    cmd.Result.OrgId,
+		Id:       cmd.Result.Id,
+		UID:      cmd.Result.Uid,
+		Name:     cmd.Result.Name,
+		Type:     cmd.Result.Type,
+		JsonData: cmd.Result.JsonData,
+		ReadOnly: cmd.Result.ReadOnly,
+	}
+	return response.JSON(200, util.DynMap{
+		"message":    "Library Credential added",
+		"id":         cmd.Result.Id,
+		"name":       cmd.Result.Name,
+		"credential": credential,
+	})
 }

--- a/pkg/api/librarycredentials.go
+++ b/pkg/api/librarycredentials.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/bus"
+	"github.com/grafana/grafana/pkg/models"
+)
+
+func (hs *HTTPServer) GetLibraryCredentials(c *models.ReqContext) response.Response {
+	query := models.GetLibraryCredentialsQuery{OrgId: c.OrgId}
+
+	if err := bus.DispatchCtx(c.Req.Context(), &query); err != nil {
+		return response.Error(500, "Failed to query library credentials", err)
+	}
+
+	result := []dtos.LibraryCredentialDto{}
+	for _, ds := range query.Result {
+		dsItem := dtos.LibraryCredentialDto{
+			OrgId:    ds.OrgId,
+			Id:       ds.Id,
+			UID:      ds.Uid,
+			Name:     ds.Name,
+			Type:     ds.Type,
+			JsonData: ds.JsonData,
+			ReadOnly: ds.ReadOnly,
+		}
+
+		result = append(result, dsItem)
+	}
+
+	return response.JSON(200, &result)
+}

--- a/pkg/api/librarycredentials.go
+++ b/pkg/api/librarycredentials.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
-	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
@@ -15,7 +14,7 @@ import (
 func (hs *HTTPServer) GetLibraryCredentials(c *models.ReqContext) response.Response {
 	query := models.GetLibraryCredentialsQuery{OrgId: c.OrgId}
 
-	if err := bus.DispatchCtx(c.Req.Context(), &query); err != nil {
+	if err := hs.LibraryCredentialService.GetLibraryCredentials(c.Req.Context(), &query); err != nil {
 		return response.Error(500, "Failed to query library credentials", err)
 	}
 
@@ -44,7 +43,7 @@ func (hs *HTTPServer) AddLibraryCredential(c *models.ReqContext) response.Respon
 	}
 	cmd.OrgId = c.OrgId
 
-	if err := bus.DispatchCtx(c.Req.Context(), &cmd); err != nil {
+	if err := hs.LibraryCredentialService.AddLibraryCredential(c.Req.Context(), &cmd); err != nil {
 		if errors.Is(err, models.ErrLibraryCredentialNameExists) || errors.Is(err, models.ErrDataSourceFailedGenerateUniqueUid) {
 			return response.Error(409, err.Error(), err)
 		}
@@ -76,7 +75,7 @@ func (hs *HTTPServer) UpdateLibraryCredential(c *models.ReqContext) response.Res
 	}
 	cmd.OrgId = c.OrgId
 
-	if err := bus.DispatchCtx(c.Req.Context(), &cmd); err != nil {
+	if err := hs.LibraryCredentialService.UpdateLibraryCredential(c.Req.Context(), &cmd); err != nil {
 		return response.Error(500, "Failed to add library credential", err)
 	}
 

--- a/pkg/models/librarycredential.go
+++ b/pkg/models/librarycredential.go
@@ -53,6 +53,14 @@ type UpdateLibraryCredentialCommand struct {
 	Result *LibraryCredential
 }
 
+type DeleteLibraryCredentialCommand struct {
+	Uid string `json:"uid"`
+
+	OrgId int64 `json:"-"`
+
+	NumDeleted int64
+}
+
 // QUERIES
 type GetLibraryCredentialsQuery struct {
 	OrgId  int64

--- a/pkg/models/librarycredential.go
+++ b/pkg/models/librarycredential.go
@@ -1,0 +1,60 @@
+package models
+
+import (
+	"errors"
+	"time"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+)
+
+var (
+	ErrLibraryCredentialNameExists = errors.New("library credential with the same name already exists")
+)
+
+type LibraryCredential struct {
+	Id             int64             `json:"id"`
+	OrgId          int64             `json:"orgId"`
+	Uid            string            `json:"uid"`
+	Type           string            `json:"type"`
+	Name           string            `json:"name"`
+	Created        time.Time         `json:"created"`
+	Updated        time.Time         `json:"updated"`
+	JsonData       *simplejson.Json  `json:"jsonData"`
+	SecureJsonData map[string][]byte `json:"secureJsonData"`
+	ReadOnly       bool              `json:"readOnly"`
+}
+
+// COMMANDS
+type AddLibraryCredentialCommand struct {
+	Name           string            `json:"name" binding:"Required"`
+	Type           string            `json:"type" binding:"Required"`
+	JsonData       *simplejson.Json  `json:"jsonData"`
+	SecureJsonData map[string]string `json:"secureJsonData"`
+	Uid            string            `json:"uid"`
+
+	OrgId                   int64             `json:"-"`
+	ReadOnly                bool              `json:"-"`
+	EncryptedSecureJsonData map[string][]byte `json:"-"`
+
+	Result *LibraryCredential
+}
+
+type UpdateLibraryCredentialCommand struct {
+	Name           string            `json:"name" binding:"Required"`
+	Type           string            `json:"type" binding:"Required"`
+	JsonData       *simplejson.Json  `json:"jsonData"`
+	SecureJsonData map[string]string `json:"secureJsonData"`
+	Uid            string            `json:"uid"`
+
+	OrgId                   int64             `json:"-"`
+	ReadOnly                bool              `json:"-"`
+	EncryptedSecureJsonData map[string][]byte `json:"-"`
+
+	Result *LibraryCredential
+}
+
+// QUERIES
+type GetLibraryCredentialsQuery struct {
+	OrgId  int64
+	Result []*DataSource
+}

--- a/pkg/models/librarycredential.go
+++ b/pkg/models/librarycredential.go
@@ -64,5 +64,5 @@ type DeleteLibraryCredentialCommand struct {
 // QUERIES
 type GetLibraryCredentialsQuery struct {
 	OrgId  int64
-	Result []*DataSource
+	Result []*LibraryCredential
 }

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -35,6 +35,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasourceproxy"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/hooks"
+	"github.com/grafana/grafana/pkg/services/librarycredentials"
 	"github.com/grafana/grafana/pkg/services/libraryelements"
 	"github.com/grafana/grafana/pkg/services/librarypanels"
 	"github.com/grafana/grafana/pkg/services/live"
@@ -143,6 +144,8 @@ var wireBasicSet = wire.NewSet(
 	wire.Bind(new(librarypanels.Service), new(*librarypanels.LibraryPanelService)),
 	libraryelements.ProvideService,
 	wire.Bind(new(libraryelements.Service), new(*libraryelements.LibraryElementService)),
+	librarycredentials.ProvideService,
+	wire.Bind(new(librarycredentials.Service), new(*librarycredentials.LibraryCredentialsService)),
 	notifications.ProvideService,
 	tracing.ProvideService,
 	metrics.ProvideService,

--- a/pkg/services/librarycredentials/librarycredentials.go
+++ b/pkg/services/librarycredentials/librarycredentials.go
@@ -1,0 +1,148 @@
+package librarycredentials
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/secrets"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/util/errutil"
+	"xorm.io/xorm"
+)
+
+func ProvideService(sqlStore *sqlstore.SQLStore) *LibraryCredentialsService {
+	return &LibraryCredentialsService{
+		SQLStore: sqlStore,
+	}
+}
+
+type Service interface {
+	GetLibraryCredentials(ctx context.Context, query models.GetLibraryCredentialsQuery) error
+	AddLibraryCredentials(ctx context.Context, cmd *models.AddLibraryCredentialCommand) error
+	UpdateLibraryCredentials(ctx context.Context, cmd *models.AddLibraryCredentialCommand) error
+	//need to add delete
+}
+
+type LibraryCredentialsService struct {
+	SQLStore       *sqlstore.SQLStore
+	SecretsService secrets.Service
+}
+
+func (s LibraryCredentialsService) GetLibraryCredentials(ctx context.Context, query models.GetLibraryCredentialsQuery) error {
+	return s.SQLStore.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+		query.Result = make([]*models.DataSource, 0)
+		return dbSession.Where("org_id=?", query.OrgId).Asc("name").Find(&query.Result)
+	})
+}
+
+func (s LibraryCredentialsService) AddLibraryCredential(ctx context.Context, cmd *models.AddLibraryCredentialCommand) error {
+	var err error
+	cmd.EncryptedSecureJsonData, err = s.SecretsService.EncryptJsonData(ctx, cmd.SecureJsonData, secrets.WithoutScope())
+	if err != nil {
+		return err
+	}
+
+	return s.SQLStore.WithTransactionalDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+		existing := models.LibraryCredential{OrgId: cmd.OrgId, Name: cmd.Name}
+		has, _ := dbSession.Get(&existing)
+
+		if has {
+			return models.ErrLibraryCredentialNameExists
+		}
+
+		if cmd.JsonData == nil {
+			cmd.JsonData = simplejson.New()
+		}
+
+		if cmd.Uid == "" {
+			uid, err := generateNewDatasourceUid(dbSession, cmd.OrgId)
+			if err != nil {
+				return errutil.Wrapf(err, "Failed to generate UID for libary credential %q", cmd.Name)
+			}
+			cmd.Uid = uid
+		}
+
+		ds := &models.LibraryCredential{
+			OrgId:          cmd.OrgId,
+			Name:           cmd.Name,
+			Type:           cmd.Type,
+			JsonData:       cmd.JsonData,
+			SecureJsonData: cmd.EncryptedSecureJsonData,
+			Created:        time.Now(),
+			Updated:        time.Now(),
+			ReadOnly:       cmd.ReadOnly,
+			Uid:            cmd.Uid,
+		}
+
+		if _, err := dbSession.Insert(ds); err != nil {
+			return err
+		}
+
+		cmd.Result = ds
+		return nil
+	})
+}
+
+func (s LibraryCredentialsService) UpdateLibraryCredential(ctx context.Context, cmd *models.UpdateLibraryCredentialCommand) error {
+	var err error
+	cmd.EncryptedSecureJsonData, err = s.SecretsService.EncryptJsonData(ctx, cmd.SecureJsonData, secrets.WithoutScope())
+	if err != nil {
+		return err
+	}
+
+	return s.SQLStore.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		if cmd.JsonData == nil {
+			cmd.JsonData = simplejson.New()
+		}
+
+		ds := &models.LibraryCredential{
+			OrgId:          cmd.OrgId,
+			Name:           cmd.Name,
+			Type:           cmd.Type,
+			JsonData:       cmd.JsonData,
+			SecureJsonData: cmd.EncryptedSecureJsonData,
+			Created:        time.Now(),
+			Updated:        time.Now(),
+			ReadOnly:       cmd.ReadOnly,
+			Uid:            cmd.Uid,
+		}
+
+		sess.UseBool("read_only")
+
+		var updateSession *xorm.Session
+
+		affected, err := updateSession.Update(ds)
+		if err != nil {
+			return err
+		}
+
+		if affected == 0 {
+			return models.ErrDataSourceUpdatingOldVersion
+		}
+
+		cmd.Result = ds
+		return err
+	})
+}
+
+var generateNewUid func() string = util.GenerateShortUID
+
+func generateNewDatasourceUid(sess *sqlstore.DBSession, orgId int64) (string, error) {
+	for i := 0; i < 3; i++ {
+		uid := generateNewUid()
+
+		exists, err := sess.Where("org_id=? AND uid=?", orgId, uid).Get(&models.DataSource{})
+		if err != nil {
+			return "", err
+		}
+
+		if !exists {
+			return uid, nil
+		}
+	}
+
+	return "", models.ErrDataSourceFailedGenerateUniqueUid
+}

--- a/pkg/services/librarycredentials/librarycredentials.go
+++ b/pkg/services/librarycredentials/librarycredentials.go
@@ -19,10 +19,10 @@ func ProvideService(sqlStore *sqlstore.SQLStore) *LibraryCredentialsService {
 	}
 }
 
-var _ Service = (*LibraryCredentialsService)(nil)
+// var _ Service = (*LibraryCredentialsService)(nil)
 
 type Service interface {
-	GetLibraryCredentials(ctx context.Context, query models.GetLibraryCredentialsQuery) error
+	GetLibraryCredentials(ctx context.Context, query *models.GetLibraryCredentialsQuery) error
 	AddLibraryCredential(ctx context.Context, cmd *models.AddLibraryCredentialCommand) error
 	UpdateLibraryCredential(ctx context.Context, cmd *models.UpdateLibraryCredentialCommand) error
 	DeleteLibraryCredential(ctx context.Context, cmd *models.DeleteLibraryCredentialCommand) error
@@ -33,9 +33,9 @@ type LibraryCredentialsService struct {
 	SecretsService secrets.Service
 }
 
-func (s LibraryCredentialsService) GetLibraryCredentials(ctx context.Context, query models.GetLibraryCredentialsQuery) error {
+func (s LibraryCredentialsService) GetLibraryCredentials(ctx context.Context, query *models.GetLibraryCredentialsQuery) error {
 	return s.SQLStore.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
-		query.Result = make([]*models.DataSource, 0)
+		query.Result = make([]*models.LibraryCredential, 0)
 		return dbSession.Where("org_id=?", query.OrgId).Asc("name").Find(&query.Result)
 	})
 }

--- a/pkg/services/sqlstore/migrations/library_credential_mig.go
+++ b/pkg/services/sqlstore/migrations/library_credential_mig.go
@@ -1,0 +1,29 @@
+package migrations
+
+import (
+	. "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+)
+
+func addLibraryCredentialMigrations(mg *Migrator) {
+	libraryCredentialsV1 := Table{
+		Name: "library_credential",
+		Columns: []*Column{
+			{Name: "id", Type: DB_BigInt, Nullable: false, IsPrimaryKey: true, IsAutoIncrement: true},
+			{Name: "org_id", Type: DB_BigInt, Nullable: false},
+			{Name: "uid", Type: DB_NVarchar, Length: 40, Nullable: false},
+			{Name: "type", Type: DB_NVarchar, Length: 255, Nullable: false},
+			{Name: "name", Type: DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "json_data", Type: DB_Text, Nullable: true},
+			{Name: "secure_json_data", Type: DB_Text, Nullable: true},
+			{Name: "created", Type: DB_DateTime, Nullable: false},
+			{Name: "updated", Type: DB_DateTime, Nullable: false},
+		},
+		Indices: []*Index{
+			{Cols: []string{"org_id", "uid"}, Type: UniqueIndex},
+		},
+	}
+
+	mg.AddMigration("create library_credential table v1", NewAddTableMigration(libraryCredentialsV1))
+
+	mg.AddMigration("add index library_credential.org_id-uid", NewAddIndexMigration(libraryCredentialsV1, libraryCredentialsV1.Indices[0]))
+}

--- a/pkg/services/sqlstore/migrations/library_credential_mig.go
+++ b/pkg/services/sqlstore/migrations/library_credential_mig.go
@@ -17,6 +17,7 @@ func addLibraryCredentialMigrations(mg *Migrator) {
 			{Name: "secure_json_data", Type: DB_Text, Nullable: true},
 			{Name: "created", Type: DB_DateTime, Nullable: false},
 			{Name: "updated", Type: DB_DateTime, Nullable: false},
+			{Name: "read_only", Type: DB_Bool, Nullable: true},
 		},
 		Indices: []*Index{
 			{Cols: []string{"org_id", "uid"}, Type: UniqueIndex},

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -47,7 +47,7 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	addServerlockMigrations(mg)
 	addUserAuthTokenMigrations(mg)
 	addCacheMigration(mg)
-	addShortURLMigrations(mg)
+	addLibraryCredentialMigrations(mg)
 	// TODO Delete when unified alerting is enabled by default unconditionally (Grafana v9)
 	if err := ualert.CheckUnifiedAlertingEnabledByDefault(mg); err != nil { // this should always go before any other ualert migration
 		mg.Logger.Error("failed to determine the status of alerting engine. Enable either legacy or unified alerting explicitly and try again", "err", err)
@@ -64,6 +64,7 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	addKVStoreMigrations(mg)
 	ualert.AddDashboardUIDPanelIDMigration(mg)
 	accesscontrol.AddMigration(mg)
+	addLibraryCredentialMigrations(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -47,6 +47,7 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	addServerlockMigrations(mg)
 	addUserAuthTokenMigrations(mg)
 	addCacheMigration(mg)
+	addShortURLMigrations(mg)
 	addLibraryCredentialMigrations(mg)
 	// TODO Delete when unified alerting is enabled by default unconditionally (Grafana v9)
 	if err := ualert.CheckUnifiedAlertingEnabledByDefault(mg); err != nil { // this should always go before any other ualert migration


### PR DESCRIPTION
What this does:
* adds migration that creates the library_credential table and index
* adds model, commands and queries for a few operation. delete command still missing, and might be more operations missing. most of this is copied from [datasource.go](https://github.com/grafana/grafana/blob/hackathon/list-library-credentials/pkg/services/sqlstore/datasource.go)
* add route and api handler for listing all library credentials. all other operations are missing