### PR TITLE
loki: rename ResponseModel to QueryModel

### DIFF
--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -64,7 +64,7 @@ type datasourceInfo struct {
 	TimeInterval      string `json:"timeInterval"`
 }
 
-type ResponseModel struct {
+type QueryModel struct {
 	Expr         string `json:"expr"`
 	LegendFormat string `json:"legendFormat"`
 	Interval     string `json:"interval"`

--- a/pkg/tsdb/loki/parse_query.go
+++ b/pkg/tsdb/loki/parse_query.go
@@ -40,7 +40,7 @@ func interpolateVariables(expr string, interval time.Duration, timeRange time.Du
 func parseQuery(dsInfo *datasourceInfo, queryContext *backend.QueryDataRequest) ([]*lokiQuery, error) {
 	qs := []*lokiQuery{}
 	for _, query := range queryContext.Queries {
-		model := &ResponseModel{}
+		model := &QueryModel{}
 		err := json.Unmarshal(query.JSON, model)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
in Loki datasource backend code the structure holding the json-data that is sent from the browser to the server is named "ResponseModel". i think "QueryModel" is a better name.

(i'm doing this pull request separately because this change could get very confusing as part of a larger pull request)