### PR TITLE
CloudWatch: Allow queries to have no dimensions specified

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -132,21 +132,26 @@ describe('datasource', () => {
         };
       });
 
-      it('should not allow queries that dont have `matchExact` or dimensions', async () => {
-        const valid = datasource.filterMetricQuery(baseQuery);
-        expect(valid).toBeFalsy();
+      it('should not allow builder queries that dont have namespace, metric or statistic', async () => {
+        expect(datasource.filterMetricQuery({ ...baseQuery, statistic: undefined })).toBeFalsy();
+        expect(datasource.filterMetricQuery({ ...baseQuery, metricName: undefined })).toBeFalsy();
+        expect(datasource.filterMetricQuery({ ...baseQuery, namespace: '' })).toBeFalsy();
       });
 
-      it('should allow queries that have `matchExact`', async () => {
-        baseQuery.matchExact = false;
-        const valid = datasource.filterMetricQuery(baseQuery);
-        expect(valid).toBeTruthy();
+      it('should allow builder queries that have namespace, metric or statistic', async () => {
+        expect(datasource.filterMetricQuery(baseQuery)).toBeTruthy();
       });
 
-      it('should allow queries that have dimensions', async () => {
-        baseQuery.dimensions = { instanceId: ['xyz'] };
-        const valid = datasource.filterMetricQuery(baseQuery);
-        expect(valid).toBeTruthy();
+      it('should not allow code queries that dont have an expression', async () => {
+        expect(
+          datasource.filterMetricQuery({ ...baseQuery, expression: undefined, metricEditorMode: MetricEditorMode.Code })
+        ).toBeFalsy();
+      });
+
+      it('should allow code queries that have an expression', async () => {
+        expect(
+          datasource.filterMetricQuery({ ...baseQuery, expression: 'x * 2', metricEditorMode: MetricEditorMode.Code })
+        ).toBeTruthy();
       });
     });
 

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -243,12 +243,7 @@ export class CloudWatchDatasource
     }
 
     if (metricQueryType === MetricQueryType.Search && metricEditorMode === MetricEditorMode.Builder) {
-      return (
-        !!namespace &&
-        !!metricName &&
-        !!statistic &&
-        (('matchExact' in rest && !rest.matchExact) || !isEmpty(dimensions))
-      );
+      return !!namespace && !!metricName && !!statistic;
     } else if (metricQueryType === MetricQueryType.Search && metricEditorMode === MetricEditorMode.Code) {
       return !!expression;
     } else if (metricQueryType === MetricQueryType.Query) {


### PR DESCRIPTION
**What this PR does / why we need it**:

While adding support for [Metric Insights](https://github.com/grafana/grafana/pull/42487), we deliberately decided to **not** issue a new query if no dimensions were specified in the query editor (meanwhile the `Match exact` switch was set to true). The reason for this was that all AWS metrics have dimensions, so firing a query without one would be unnecessary. However, custom metrics might not have dimensions, so it makes sense to allow these queries to be executed. This PR reverts that check and allows queries without dimensions. 

**Which issue(s) this PR fixes**:

Fixes #42798

