### PR TITLE
Chore: parse parseDuration values as numbers

### DIFF
--- a/packages/grafana-data/src/datetime/durationutil.test.ts
+++ b/packages/grafana-data/src/datetime/durationutil.test.ts
@@ -18,12 +18,12 @@ describe('Duration util', () => {
   describe('parseDuration', () => {
     it('parses a duration string', () => {
       const durationString = '3M 5d 20m';
-      expect(parseDuration(durationString)).toEqual({ months: '3', days: '5', minutes: '20' });
+      expect(parseDuration(durationString)).toEqual({ months: 3, days: 5, minutes: 20 });
     });
 
     it('strips out non valid durations', () => {
       const durationString = '3M 6v 5b 4m';
-      expect(parseDuration(durationString)).toEqual({ months: '3', minutes: '4' });
+      expect(parseDuration(durationString)).toEqual({ months: 3, minutes: 4 });
     });
   });
 

--- a/packages/grafana-data/src/datetime/durationutil.ts
+++ b/packages/grafana-data/src/datetime/durationutil.ts
@@ -35,19 +35,25 @@ export function intervalToAbbreviatedDurationString(interval: Interval, includeS
 /**
  * parseDuration parses duration string into datefns Duration object
  *
- * @param duration - string to convert. For example '2m', '5h 20s'
+ * @param durationString - string to convert. For example '2m', '5h 20s'
  *
  * @public
  */
-export function parseDuration(duration: string): Duration {
-  return duration.split(' ').reduce<Duration>((acc, value) => {
+export function parseDuration(durationString: string): Duration {
+  return durationString.split(' ').reduce<Duration>((acc, value) => {
     const match = value.match(/(\d+)(.+)/);
-    if (match === null || match.length !== 3) {
+
+    const rawLength = match?.[1];
+    const unit = match?.[2];
+
+    if (!(rawLength && unit)) {
       return acc;
     }
 
-    const key = Object.entries(durationMap).find(([_, abbreviations]) => abbreviations?.includes(match[2]))?.[0];
-    return !key ? acc : { ...acc, [key]: match[1] };
+    const mapping = Object.entries(durationMap).find(([_, abbreviations]) => abbreviations?.includes(match[2]));
+    const length = parseInt(rawLength, 10);
+
+    return mapping ? { ...acc, [mapping[0]]: length } : acc;
   }, {});
 }
 

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.test.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.test.tsx
@@ -35,5 +35,16 @@ describe('RefreshPicker', () => {
         ]);
       });
     });
+
+    it('should format durations with multiple units', () => {
+      const intervals = ['10s', '1m 30s'];
+
+      const result = intervalsToOptions({ intervals });
+      expect(result).toEqual([
+        { value: '', label: 'Off', ariaLabel: 'Turn off auto refresh' },
+        { value: '10s', label: '10s', ariaLabel: '10 seconds' },
+        { value: '1m 30s', label: '1m 30s', ariaLabel: '1 minute 30 seconds' },
+      ]);
+    });
   });
 });

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -102,12 +102,7 @@ export function intervalsToOptions({ intervals = defaultIntervals }: { intervals
 > {
   const intervalsOrDefault = intervals || defaultIntervals;
   const options = intervalsOrDefault.map((interval) => {
-    const duration: { [key: string]: string | number } = parseDuration(interval);
-
-    const key = Object.keys(duration)[0];
-    const value = duration[key];
-    duration[key] = Number(value);
-
+    const duration = parseDuration(interval);
     const ariaLabel = formatDuration(duration);
 
     return {


### PR DESCRIPTION
**What this PR does / why we need it**:

Minor refactor of parseDuration so it returns the correct type.

As a side effect, this fixes a minor bug in the Refresh Picker where the label would only include one unit of duration, if the refresh interval is specified as something like `1m 30s`, because only the first value was converted to a number to format, and the remaining strings were ignored.

**Which issue(s) this PR fixes**:

Fixes #41558

**Special notes for your reviewer**:

I did a smoke test and things seemed fine - the dashboard refresh picker works as expected.
