### PR TITLE
Tempo: Update tempo search to use tags query param

### DIFF
--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -132,15 +132,14 @@ class TempoQueryFieldComponent extends React.PureComponent<Props, State> {
               size="md"
             />
           </InlineField>
-
-          {query.queryType === 'nativeSearch' && (
-            <p style={{ maxWidth: '65ch' }}>
-              <Badge icon="rocket" text="Beta" color="blue" />
-              &nbsp;Tempo search is currently in beta and is designed to return recent traces only. It ignores the time
-              range picker. We are actively working on full backend search. Look for improvements in the near future!
-            </p>
-          )}
         </InlineFieldRow>
+        {query.queryType === 'nativeSearch' && (
+          <p style={{ maxWidth: '65ch' }}>
+            <Badge icon="rocket" text="Beta" color="blue" />
+            &nbsp;Tempo search is currently in beta and is designed to return recent traces only. It ignores the time
+            range picker. We are actively working on full backend search. Look for improvements in the near future!
+          </p>
+        )}
         {query.queryType === 'search' && (
           <SearchSection
             linkedDatasourceUid={logsDatasourceUid}

--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -134,7 +134,7 @@ class TempoQueryFieldComponent extends React.PureComponent<Props, State> {
           </InlineField>
 
           {query.queryType === 'nativeSearch' && (
-            <p>
+            <p style={{ maxWidth: '65ch' }}>
               <Badge icon="rocket" text="Beta" color="blue" />
               &nbsp;Tempo search is currently in beta and is designed to return recent traces only. It ignores the time
               range picker. We are actively working on full backend search. Look for improvements in the near future!

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -147,9 +147,7 @@ describe('Tempo data source', () => {
     };
     const builtQuery = ds.buildSearchQuery(tempoQuery);
     expect(builtQuery).toStrictEqual({
-      'service.name': 'frontend',
-      name: '/config',
-      'root.http.status_code': '500',
+      tags: 'root.http.status_code=500 service.name="frontend" name="/config"',
       minDuration: '1ms',
       maxDuration: '100s',
       limit: 10,
@@ -166,6 +164,7 @@ describe('Tempo data source', () => {
     };
     const builtQuery = ds.buildSearchQuery(tempoQuery);
     expect(builtQuery).toStrictEqual({
+      tags: '',
       limit: DEFAULT_LIMIT,
     });
   });
@@ -181,7 +180,7 @@ describe('Tempo data source', () => {
     const builtQuery = ds.buildSearchQuery(tempoQuery);
     expect(builtQuery).toStrictEqual({
       limit: DEFAULT_LIMIT,
-      'root.http.status_code': '500',
+      tags: 'root.ip root.http.status_code=500',
     });
   });
 

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -169,21 +169,6 @@ describe('Tempo data source', () => {
     });
   });
 
-  it('should ignore incomplete tag queries', () => {
-    const ds = new TempoDatasource(defaultSettings);
-    const tempoQuery: TempoQuery = {
-      queryType: 'search',
-      refId: 'A',
-      query: '',
-      search: 'root.ip root.http.status_code=500',
-    };
-    const builtQuery = ds.buildSearchQuery(tempoQuery);
-    expect(builtQuery).toStrictEqual({
-      limit: DEFAULT_LIMIT,
-      tags: 'root.ip root.http.status_code=500',
-    });
-  });
-
   it('formats native search query history correctly', () => {
     const ds = new TempoDatasource(defaultSettings);
     const tempoQuery: TempoQuery = {


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates tempo search to pass tags (including service.name and name) in the tags query param which gives the tempo backend some more flexibility with how they handle requests. 

**Which issue(s) this PR fixes**:
Fixes #40708

**Special notes for your reviewer**:
I don't think this introduces breaking changes with the current implementation and the backend will support both versions going forward although there might be something I'm missing. 

Also, this relies on the backend properly parsing the tags param since we're just sending the raw string. @kvrhdn can you confirm this will handle incomplete tags and other edge cases like when tags is the string "value value2= valid.value=asdlfkj" since we're removing the logic that would ignore value and value2=.
