### PR TITLE
Runtime: remove updateLocation from window context

### DIFF
--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -56,9 +56,6 @@ standardEditorsRegistry.setInit(getStandardOptionEditors);
 standardFieldConfigEditorRegistry.setInit(getStandardFieldConfigs);
 
 type PanelSchemeUpgradeHandler = (panel: PanelModel) => PanelModel;
-
-export const DASHBOARD_SCHEMA_VERSION = 34;
-
 export class DashboardMigrator {
   dashboard: DashboardModel;
 
@@ -70,7 +67,7 @@ export class DashboardMigrator {
     let i, j, k, n;
     const oldVersion = this.dashboard.schemaVersion;
     const panelUpgrades: PanelSchemeUpgradeHandler[] = [];
-    this.dashboard.schemaVersion = DASHBOARD_SCHEMA_VERSION;
+    this.dashboard.schemaVersion = 34;
 
     if (oldVersion === this.dashboard.schemaVersion) {
       return;

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -56,6 +56,9 @@ standardEditorsRegistry.setInit(getStandardOptionEditors);
 standardFieldConfigEditorRegistry.setInit(getStandardFieldConfigs);
 
 type PanelSchemeUpgradeHandler = (panel: PanelModel) => PanelModel;
+
+export const DASHBOARD_SCHEMA_VERSION = 34;
+
 export class DashboardMigrator {
   dashboard: DashboardModel;
 
@@ -67,7 +70,7 @@ export class DashboardMigrator {
     let i, j, k, n;
     const oldVersion = this.dashboard.schemaVersion;
     const panelUpgrades: PanelSchemeUpgradeHandler[] = [];
-    this.dashboard.schemaVersion = 34;
+    this.dashboard.schemaVersion = DASHBOARD_SCHEMA_VERSION;
 
     if (oldVersion === this.dashboard.schemaVersion) {
       return;

--- a/public/app/features/runtime/init.ts
+++ b/public/app/features/runtime/init.ts
@@ -1,7 +1,6 @@
 import { PanelData } from '@grafana/data';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
-import { DASHBOARD_SCHEMA_VERSION } from 'app/features/dashboard/state/DashboardMigrator';
 
 /**
  * This will setup features that are accessible through the root window location
@@ -12,9 +11,6 @@ import { DASHBOARD_SCHEMA_VERSION } from 'app/features/dashboard/state/Dashboard
  */
 export function initWindowRuntime() {
   (window as any).grafanaRuntime = {
-    /** The expected schema version */
-    dashboardSchemaVersion: DASHBOARD_SCHEMA_VERSION,
-
     /** Get info for the current dashboard.  This will include the migrated dashboard JSON */
     getDashboardSaveModel: () => {
       const d = getDashboardSrv().getCurrent();

--- a/public/app/features/runtime/init.ts
+++ b/public/app/features/runtime/init.ts
@@ -1,7 +1,7 @@
-import { UrlQueryMap, PanelData } from '@grafana/data';
-import { getLocationSrv } from '@grafana/runtime';
-import { getDashboardSrv } from '../dashboard/services/DashboardSrv';
-import { getTimeSrv } from '../dashboard/services/TimeSrv';
+import { PanelData } from '@grafana/data';
+import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
+import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
+import { DASHBOARD_SCHEMA_VERSION } from 'app/features/dashboard/state/DashboardMigrator';
 
 /**
  * This will setup features that are accessible through the root window location
@@ -12,18 +12,8 @@ import { getTimeSrv } from '../dashboard/services/TimeSrv';
  */
 export function initWindowRuntime() {
   (window as any).grafanaRuntime = {
-    /** Navigate the page within the currently loaded application */
-    updateLocation: (path: string, query?: UrlQueryMap) => {
-      if (query?.theme) {
-        throw new Error(`chaning theme requires full page refresh`);
-      }
-      getLocationSrv().update({
-        path,
-        query,
-        replace: true,
-        partial: false,
-      });
-    },
+    /** The expected schema version */
+    dashboardSchemaVersion: DASHBOARD_SCHEMA_VERSION,
 
     /** Get info for the current dashboard.  This will include the migrated dashboard JSON */
     getDashboardSaveModel: () => {


### PR DESCRIPTION
This function was added recently hopping would speed up some browser automation.  But the we can safely remove it since the speeds are pretty good without it.  It just avoids a few trivial 304 requests:

![image](https://user-images.githubusercontent.com/705951/145126565-5fc508e7-dedb-42d2-b9df-4c97a8a4864f.png)
