### PR TITLE
LogsPanel: Show message and actions if panel cannot visualize data

### DIFF
--- a/public/app/features/panel/components/PanelDataErrorView.tsx
+++ b/public/app/features/panel/components/PanelDataErrorView.tsx
@@ -64,7 +64,8 @@ function getMessageFor(
     return message;
   }
 
-  if (!data.series || data.series.length === 0) {
+  // In some cases there is a data frame but with no fields
+  if (!data.series || data.series.length === 0 || (data.series.length === 1 && data.series[0].fields.length === 0)) {
     return 'No data';
   }
 

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -15,6 +15,7 @@ import { Options } from './types';
 import { dataFrameToLogsModel, dedupLogRows } from 'app/core/logs_model';
 import { getFieldLinksForExplore } from 'app/features/explore/utils/links';
 import { COMMON_LABELS } from '../../../core/logs_model';
+import { PanelDataErrorView } from 'app/features/panel/components/PanelDataErrorView';
 
 interface LogsPanelProps extends PanelProps<Options> {}
 
@@ -32,6 +33,7 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
     enableLogDetails,
   },
   title,
+  id,
 }) => {
   const isAscending = sortOrder === LogsSortOrder.Ascending;
   const style = useStyles2(getStyles(title, isAscending));
@@ -80,12 +82,8 @@ export const LogsPanel: React.FunctionComponent<LogsPanelProps> = ({
     [data]
   );
 
-  if (!data) {
-    return (
-      <div className="panel-empty">
-        <p>No data found in response</p>
-      </div>
-    );
+  if (!data || logRows.length === 0) {
+    return <PanelDataErrorView panelId={id} data={data} needsStringField />;
   }
 
   const renderCommonLabels = () => (


### PR DESCRIPTION
When working with a logs query and logs panel, if you add a rate function to your query the logs panel is just blank with no message.

This uses the new PanelDataErrorView to show both the "No data" scenario or if there is data but no string field it will show the normal
actions seen below.

Before: 
![Screenshot from 2021-12-08 11-58-47](https://user-images.githubusercontent.com/10999/145197034-f51ca3e6-5423-496b-861b-3bbbcfa510ff.png)


After
![Screenshot from 2021-12-08 11-54-17](https://user-images.githubusercontent.com/10999/145196847-20caffef-e787-4522-ac30-39e5762a6769.png)


