### PR TITLE
Alerting: fix sqlstore.GetFolderByTitle to search for folder

### DIFF
--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/grafana/grafana/pkg/services/sqlstore/permissions"
 	"github.com/grafana/grafana/pkg/services/sqlstore/searchstore"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/metrics"
@@ -214,18 +215,13 @@ func (ss *SQLStore) GetFolderByTitle(orgID int64, title string) (*models.Dashboa
 	// there is a unique constraint on org_id, folder_id, title
 	// there are no nested folders so the parent folder id is always 0
 	dashboard := models.Dashboard{OrgId: orgID, FolderId: 0, Title: title}
-	has, err := ss.engine.Get(&dashboard)
+	has, err := ss.engine.Table(&models.Dashboard{}).Where("is_folder = 1 AND folder_id = 0").Get(&dashboard)
 	if err != nil {
 		return nil, err
-	} else if !has {
+	}
+	if !has {
 		return nil, models.ErrDashboardNotFound
 	}
-
-	// if there is a dashboard instead of a folder with that title
-	if !dashboard.IsFolder {
-		return nil, models.ErrDashboardNotFound
-	}
-
 	dashboard.SetId(dashboard.Id)
 	dashboard.SetUid(dashboard.Uid)
 	return &dashboard, nil

--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -215,7 +215,7 @@ func (ss *SQLStore) GetFolderByTitle(orgID int64, title string) (*models.Dashboa
 	// there is a unique constraint on org_id, folder_id, title
 	// there are no nested folders so the parent folder id is always 0
 	dashboard := models.Dashboard{OrgId: orgID, FolderId: 0, Title: title}
-	has, err := ss.engine.Table(&models.Dashboard{}).Where("is_folder = 1 AND folder_id = 0").Get(&dashboard)
+	has, err := ss.engine.Table(&models.Dashboard{}).Where("is_folder = " + dialect.BooleanStr(true)).Where("folder_id=0").Get(&dashboard)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/sqlstore/dashboard_folder_test.go
+++ b/pkg/services/sqlstore/dashboard_folder_test.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/search"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDashboardFolderDataAccess(t *testing.T) {
@@ -505,6 +506,23 @@ func TestDashboardFolderDataAccess(t *testing.T) {
 						require.True(t, query.Result)
 					})
 				})
+			})
+		})
+
+		t.Run("Given dashboard and folder with the same title", func(t *testing.T) {
+			var orgId int64 = 1
+			title := "Very Unique Name"
+			var sqlStore *SQLStore
+			var folder1, folder2 *models.Dashboard
+			sqlStore = InitTestDB(t)
+			folder2 = insertTestDashboard(t, sqlStore, "TEST", orgId, 0, true, "prod")
+			_ = insertTestDashboard(t, sqlStore, title, orgId, folder2.Id, false, "prod")
+			folder1 = insertTestDashboard(t, sqlStore, title, orgId, 0, true, "prod")
+
+			t.Run("GetFolderByTitle should find the folder", func(t *testing.T) {
+				result, err := sqlStore.GetFolderByTitle(orgId, title)
+				require.NoError(t, err)
+				require.Equal(t, folder1.Id, result.Id)
 			})
 		})
 	})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The current implementation of the function `GetFolderByTitle` mentions `FolderId:0` the object that is used for the filter.

https://github.com/grafana/grafana/blob/2d2f7afbdede48864b2b1956b9378992bc079317/pkg/services/sqlstore/dashboard.go#L214-L217

However, XORM ignores this field and omits it from the filter expression. It produces the following SQL query:

```
 SELECT `id`, `uid`, `slug`, `org_id`, `gnet_id`, `version`, `plugin_id`, `created`, `updated`, `updated_by`, `created_by`, `folder_id`, `is_folder`, `has_acl`, `title`, `data` FROM `dashboard` WHERE `org_id`=? AND `title`=? LIMIT 1 []interface {}{1, "gdev dashboards"} 
```

Therefore, if there is a dashboard that has the same name as the folder, the result can be unexpected - it will contain a dashboard instead of a folder.

This bug was actually caught in alerting which API checks for folder\namespace prior to creating a new alert in it.

The PR adds the expression `is_folder=1 AND folder_id = 0` to the WHERE clause of the query. The resulting query looks
```
 SELECT `id`, `uid`, `slug`, `org_id`, `gnet_id`, `version`, `plugin_id`, `created`, `updated`, `updated_by`, `created_by`, `folder_id`, `is_folder`, `has_acl`, `title`, `data` FROM `dashboard` WHERE (is_folder = 1 AND folder_id = 0) AND `org_id`=? AND `title`=? LIMIT 1 []interface {}{1, "gdev dashboards"} 
```
