### PR TITLE
loki: remove unused variable

### DIFF
--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -128,7 +128,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		},
 	}
 
-	queries, err := parseQuery(dsInfo, req)
+	queries, err := parseQuery(req)
 	if err != nil {
 		return result, err
 	}

--- a/pkg/tsdb/loki/parse_query.go
+++ b/pkg/tsdb/loki/parse_query.go
@@ -37,7 +37,7 @@ func interpolateVariables(expr string, interval time.Duration, timeRange time.Du
 	return expr
 }
 
-func parseQuery(dsInfo *datasourceInfo, queryContext *backend.QueryDataRequest) ([]*lokiQuery, error) {
+func parseQuery(queryContext *backend.QueryDataRequest) ([]*lokiQuery, error) {
 	qs := []*lokiQuery{}
 	for _, query := range queryContext.Queries {
 		model := &QueryModel{}

--- a/pkg/tsdb/loki/parse_query_test.go
+++ b/pkg/tsdb/loki/parse_query_test.go
@@ -29,8 +29,7 @@ func TestParseQuery(t *testing.T) {
 				},
 			},
 		}
-		dsInfo := &datasourceInfo{}
-		models, err := parseQuery(dsInfo, queryContext)
+		models, err := parseQuery(queryContext)
 		require.NoError(t, err)
 		require.Equal(t, time.Second*15, models[0].Step)
 		require.Equal(t, "go_goroutines 15s 15000 3000s 3000 3000000", models[0].Expr)


### PR DESCRIPTION
this removes an unused variable. i forgot to remove it when the function `parseQuery` was refactored in https://github.com/grafana/grafana/pull/42126
