### PR TITLE
Docs: Clarify relative time range overrides

### DIFF
--- a/docs/sources/dashboards/time-range-controls.md
+++ b/docs/sources/dashboards/time-range-controls.md
@@ -112,7 +112,7 @@ For more advanced time settings, click the **Dashboard settings** (gear) icon at
 
 In [Query options]({{< relref "../panels/queries.md#query-options" >}}), you can override the relative time range for individual panels, causing them to be different than what is selected in the dashboard time picker in the upper right. This allows you to show metrics from different time periods or days at the same time.
 
-> **Note:** Panel time overrides have no effect when the time range for the dashboard is set to an absolute time range.
+> **Note:** Panel time overrides have no effect when the time range for the dashboard is absolute.
 
 ## Control the time range using a URL
 

--- a/docs/sources/dashboards/time-range-controls.md
+++ b/docs/sources/dashboards/time-range-controls.md
@@ -112,6 +112,8 @@ For more advanced time settings, click the **Dashboard settings** (gear) icon at
 
 In [Query options]({{< relref "../panels/queries.md#query-options" >}}), you can override the relative time range for individual panels, causing them to be different than what is selected in the dashboard time picker in the upper right. This allows you to show metrics from different time periods or days at the same time.
 
+> **Note:** Panel time overrides have no effect when the time range for the dashboard is set to an absolute time range.
+
 ## Control the time range using a URL
 
 Time range of a dashboard can be controlled by providing following query parameters in the dashboard URL:

--- a/docs/sources/panels/queries.md
+++ b/docs/sources/panels/queries.md
@@ -95,7 +95,7 @@ Panel data source query options:
 
 - **Relative time -** You can override the relative time range for individual panels, causing them to be different than what is selected in the dashboard time picker in the top right corner of the dashboard. This allows you to show metrics from different time periods or days on the same dashboard.
 
-  > **Note:** Panel time overrides have no effect when the time range for the dashboard is set to an absolute time range.
+  > **Note:** Panel time overrides have no effect when the time range for the dashboard is absolute.
 
 - **Time shift -** The time shift function is another way to override the time range for individual panels. It only works with relative time ranges and allows you to adjust the time range.
 

--- a/docs/sources/panels/queries.md
+++ b/docs/sources/panels/queries.md
@@ -95,6 +95,8 @@ Panel data source query options:
 
 - **Relative time -** You can override the relative time range for individual panels, causing them to be different than what is selected in the dashboard time picker in the top right corner of the dashboard. This allows you to show metrics from different time periods or days on the same dashboard.
 
+  > **Note:** Panel time overrides have no effect when the time range for the dashboard is set to an absolute time range.
+
 - **Time shift -** The time shift function is another way to override the time range for individual panels. It only works with relative time ranges and allows you to adjust the time range.
 
   For example, you could shift the time range for the panel to be two hours earlier than the dashboard time picker. For more information, refer to [Time range controls]({{< relref "../dashboards/time-range-controls.md" >}}).


### PR DESCRIPTION
**What this PR does / why we need it**:
We recently received an issue related to the usage of relative time overrides in panels for a dashboard with a time range set to an absolute time range. This PR tries to clarify this a bit.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Friendly reminder to myself not to backport this before 8.3.2 is released 👍 
