### PR TITLE
Autobreakdowns: dont show selected median if no selection

### DIFF
--- a/public/app/features/explore/AutoBreakdowns.tsx
+++ b/public/app/features/explore/AutoBreakdowns.tsx
@@ -9,6 +9,7 @@ export interface Props {
   timeZone: TimeZone;
   datasourceInstance?: DataSourceApi | null;
   autoBreakdownRange?: AbsoluteTimeRange;
+  absoluteRange: AbsoluteTimeRange;
 }
 
 const spacing = css({
@@ -25,8 +26,8 @@ function calcWidth(df: DataFrame): number {
 }
 
 export const AutoBreakdowns = (props: Props) => {
-  const { datasourceInstance, autoBreakdownRange, timeZone } = props;
-  if (!datasourceInstance || !autoBreakdownRange) {
+  const { datasourceInstance, autoBreakdownRange, timeZone, absoluteRange } = props;
+  if (!datasourceInstance) {
     return null;
   }
   //@ts-ignore
@@ -44,7 +45,7 @@ export const AutoBreakdowns = (props: Props) => {
                 height={150}
                 width={calcWidth(df)}
                 timeZone={timeZone}
-                absoluteRange={autoBreakdownRange}
+                absoluteRange={absoluteRange}
                 loadingState={LoadingState.Done}
                 onChangeTime={() => {}}
                 pluginId="barchart"

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -170,8 +170,10 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
   };
 
   onUpdateAutoBreakdownTimeRange = (timeRange: AbsoluteTimeRange) => {
+    // Click one point in the graph has same start and endpoint, using this to reset
+    const autoBreakdownRange = timeRange.to === timeRange.from ? undefined : timeRange;
     this.setState({
-      autoBreakdownRange: timeRange,
+      autoBreakdownRange,
     });
   };
 

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -179,6 +179,10 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
     const { exploreId, changeBreakdowns, isBreakdowns } = this.props;
     const nextIsBreakdowns = !isBreakdowns;
     changeBreakdowns(exploreId, nextIsBreakdowns);
+    // Resetting selection range
+    if (!nextIsBreakdowns) {
+      this.setState({ autoBreakdownRange: undefined });
+    }
   };
 
   onChangeGraphStyle = (graphStyle: ExploreGraphStyle) => {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -179,8 +179,6 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
     const { exploreId, changeBreakdowns, isBreakdowns } = this.props;
     const nextIsBreakdowns = !isBreakdowns;
     changeBreakdowns(exploreId, nextIsBreakdowns);
-    const autoBreakdownRange = nextIsBreakdowns ? this.props.absoluteRange : undefined;
-    this.setState({ autoBreakdownRange });
   };
 
   onChangeGraphStyle = (graphStyle: ExploreGraphStyle) => {
@@ -253,11 +251,14 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
             loadingState={queryResponse.state}
           />
         </Collapse>
-        <AutoBreakdowns
-          datasourceInstance={datasourceInstance}
-          timeZone={timeZone}
-          autoBreakdownRange={this.state.autoBreakdownRange}
-        />
+        {isBreakdowns && (
+          <AutoBreakdowns
+            datasourceInstance={datasourceInstance}
+            timeZone={timeZone}
+            autoBreakdownRange={this.state.autoBreakdownRange}
+            absoluteRange={absoluteRange}
+          />
+        )}
       </>
     );
   }


### PR DESCRIPTION
- don't partition exemplars if no breakdown selection is present.