### PR TITLE
loki: alerting: handle curly-braces-style variables

### DIFF
--- a/pkg/tsdb/loki/parse_query.go
+++ b/pkg/tsdb/loki/parse_query.go
@@ -19,6 +19,14 @@ const (
 	varRangeMs    = "$__range_ms"
 )
 
+const (
+	varIntervalAlt   = "${__interval}"
+	varIntervalMsAlt = "${__interval_ms}"
+	varRangeAlt      = "${__range}"
+	varRangeSAlt     = "${__range_s}"
+	varRangeMsAlt    = "${__range_ms}"
+)
+
 func interpolateVariables(expr string, interval time.Duration, timeRange time.Duration) string {
 	intervalText := intervalv2.FormatDuration(interval)
 	intervalMsText := strconv.FormatInt(int64(interval/time.Millisecond), 10)
@@ -34,6 +42,13 @@ func interpolateVariables(expr string, interval time.Duration, timeRange time.Du
 	expr = strings.ReplaceAll(expr, varRangeS, rangeSText)
 	expr = strings.ReplaceAll(expr, varRange, rangeSText+"s")
 
+	// this is duplicated code, hopefully this can be handled in a nicer way when
+	// https://github.com/grafana/grafana/issues/42928 is done.
+	expr = strings.ReplaceAll(expr, varIntervalMsAlt, intervalMsText)
+	expr = strings.ReplaceAll(expr, varIntervalAlt, intervalText)
+	expr = strings.ReplaceAll(expr, varRangeMsAlt, rangeMsText)
+	expr = strings.ReplaceAll(expr, varRangeSAlt, rangeSText)
+	expr = strings.ReplaceAll(expr, varRangeAlt, rangeSText+"s")
 	return expr
 }
 

--- a/pkg/tsdb/loki/parse_query_test.go
+++ b/pkg/tsdb/loki/parse_query_test.go
@@ -50,4 +50,12 @@ func TestParseQuery(t *testing.T) {
 
 		require.Equal(t, "go_goroutines 50ms 50 0s 0 250", interpolateVariables(expr, interval, timeRange))
 	})
+	t.Run("interpolate variables, curly-braces syntax", func(t *testing.T) {
+		expr := "go_goroutines ${__interval} ${__interval_ms} ${__range} ${__range_s} ${__range_ms}"
+
+		interval := time.Second * 2
+		timeRange := time.Second * 50
+
+		require.Equal(t, "go_goroutines 2s 2000 50s 50 50000", interpolateVariables(expr, interval, timeRange))
+	})
 }


### PR DESCRIPTION
in loki alerting, currently we only handle variables in the `$__interval` style. this pull request adds support for variables in the `${__interval}` style.