### PR TITLE
[v8.3.x] Build: Correct syntax for directing release builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1319,7 +1319,8 @@ trigger:
   ref:
   - refs/tags/v*
   repo:
-    exclude: grafana/grafana
+    exclude:
+    - grafana/grafana
 type: docker
 volumes:
 - name: cypress_cache
@@ -1375,7 +1376,8 @@ trigger:
   ref:
   - refs/tags/v*
   repo:
-    exclude: grafana/grafana
+    exclude:
+    - grafana/grafana
 type: docker
 volumes:
 - name: cypress_cache
@@ -1843,7 +1845,8 @@ trigger:
   ref:
   - refs/tags/v*
   repo:
-    exclude: grafana/grafana
+    exclude:
+    - grafana/grafana
 type: docker
 volumes:
 - name: cypress_cache
@@ -1923,7 +1926,8 @@ trigger:
   ref:
   - refs/tags/v*
   repo:
-    exclude: grafana/grafana
+    exclude:
+    - grafana/grafana
 type: docker
 volumes:
 - name: cypress_cache
@@ -3997,6 +4001,6 @@ kind: secret
 name: prerelease_bucket
 ---
 kind: signature
-hmac: 5e3e4a50fb93e31f7c0c696d3c383fd73f27fd5e2201d412c14192eaa4121824
+hmac: 17bd201bc211982f0ee6c2c29631ac7638205e03bc5661e208f0624d86377bb0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1318,6 +1318,8 @@ steps:
 trigger:
   ref:
   - refs/tags/v*
+  repo:
+    exclude: grafana/grafana
 type: docker
 volumes:
 - name: cypress_cache
@@ -1372,6 +1374,8 @@ steps:
 trigger:
   ref:
   - refs/tags/v*
+  repo:
+    exclude: grafana/grafana
 type: docker
 volumes:
 - name: cypress_cache
@@ -1838,6 +1842,8 @@ steps:
 trigger:
   ref:
   - refs/tags/v*
+  repo:
+    exclude: grafana/grafana
 type: docker
 volumes:
 - name: cypress_cache
@@ -1916,6 +1922,8 @@ steps:
 trigger:
   ref:
   - refs/tags/v*
+  repo:
+    exclude: grafana/grafana
 type: docker
 volumes:
 - name: cypress_cache
@@ -3989,6 +3997,6 @@ kind: secret
 name: prerelease_bucket
 ---
 kind: signature
-hmac: 6ac2bc99903f8daae37ba7485e708cf36afe7ccf60ca884cbae2c393de14b73e
+hmac: 5e3e4a50fb93e31f7c0c696d3c383fd73f27fd5e2201d412c14192eaa4121824
 
 ...

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -241,7 +241,7 @@ def release_pipelines(ver_mode='release', trigger=None):
         trigger = {
             'ref': ['refs/tags/v*',],
             'repo': {
-              'exclude': 'grafana/grafana',
+              'exclude': ['grafana/grafana'],
             },
         }
 

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -240,6 +240,9 @@ def release_pipelines(ver_mode='release', trigger=None):
     if not trigger:
         trigger = {
             'ref': ['refs/tags/v*',],
+            'repo': {
+              'exclude': 'grafana/grafana',
+            },
         }
 
     should_publish = ver_mode in ('release', 'test-release',)


### PR DESCRIPTION
backports 6a5416bcecaba81d73d97f9c582ddb9ed9ab2d0d b6818718e9983fffd3351f4ab1545baba0e2b26f from https://github.com/grafana/grafana/pull/42785 https://github.com/grafana/grafana/pull/42789 