### PR TITLE
Add user essentials issues directly to project

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -49,5 +49,13 @@
     "action": "close",
     "addLabel": "not implemented",
     "comment": "This feature request has been open for a long time with few received upvotes or comments, so we are closing it. We're trying to limit open GitHub issues in order to better track planned work and features.  \r\n\r\nThis doesn't mean that we'll never ever implement it or that we will never accept a PR for it. A closed issue can still attract upvotes and act as a ticket to track feature demand\/interest. \r\n\r\nThank You to you for taking the time to create this issue!"
+  },
+  {
+    "type": "label",
+    "name": "oss-user-essentials",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/78"
+    }
   }
 ]


### PR DESCRIPTION
**What this PR does / why we need it**:
To automate part of our escalations flow, we'd like to automatically add issues with the oss-user-essentials label to our project.