### PR TITLE
Autobreakdowns: Updates

### DIFF
--- a/public/app/features/explore/AutoBreakdowns.tsx
+++ b/public/app/features/explore/AutoBreakdowns.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { css } from '@emotion/css';
 import { Collapse } from '@grafana/ui';
-import { AbsoluteTimeRange, LoadingState, TimeZone, DataFrame, DataSourceApi, GrafanaTheme2 } from '@grafana/data';
+import { AbsoluteTimeRange, LoadingState, TimeZone, DataFrame, DataSourceApi } from '@grafana/data';
 import { ExploreGraph } from './ExploreGraph';
-import { EXPLORE_GRAPH_STYLES } from 'app/core/utils/explore';
-
 export interface Props {
   timeZone: TimeZone;
   datasourceInstance?: DataSourceApi | null;

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -31,6 +31,7 @@ const dummyProps: Props = {
   loading: false,
   modifyQueries: jest.fn(),
   scanStart: jest.fn(),
+  changeBreakdowns: jest.fn(),
   scanStopAction: scanStopAction,
   setQueries: jest.fn(),
   queryKeys: [],
@@ -87,6 +88,7 @@ const dummyProps: Props = {
   loadLogsVolumeData: () => {},
   changeGraphStyle: () => {},
   graphStyle: 'lines',
+  isBreakdowns: false,
 };
 
 describe('Explore', () => {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -255,6 +255,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
             annotations={queryResponse.annotations}
             splitOpenFn={splitOpen}
             loadingState={queryResponse.state}
+            isBreakdowns={isBreakdowns}
           />
         </Collapse>
         {isBreakdowns && (

--- a/public/app/features/explore/ExploreGraph.tsx
+++ b/public/app/features/explore/ExploreGraph.tsx
@@ -51,7 +51,8 @@ interface Props {
   onChangeTime: (timeRange: AbsoluteTimeRange) => void;
   graphStyle: ExploreGraphStyle;
   pluginId?: string;
-  showLegend: boolean;
+  showLegend?: boolean;
+  isBreakdowns?: boolean;
 }
 
 export function ExploreGraph({
@@ -69,6 +70,7 @@ export function ExploreGraph({
   pluginId = 'timeseries',
   tooltipDisplayMode = TooltipDisplayMode.Single,
   showLegend = true,
+  isBreakdowns = false,
 }: Props) {
   const theme = useTheme2();
   const [showAllTimeSeries, setShowAllTimeSeries] = useState(false);
@@ -172,6 +174,7 @@ export function ExploreGraph({
           {
             tooltip: { mode: tooltipDisplayMode },
             legend: { displayMode: legendDisplayMode, placement: 'bottom', calcs: [] },
+            enabledAutoBreakdowns: isBreakdowns,
           } as TimeSeriesOptions
         }
       />

--- a/public/app/features/explore/ExploreGraphLabel.tsx
+++ b/public/app/features/explore/ExploreGraphLabel.tsx
@@ -48,7 +48,7 @@ export function ExploreGraphLabel(props: Props) {
               size="sm"
               aria-label="Show-auto-breakdowns-button"
               className={cx({ ['explore-active-button']: isBreakdowns, [styles.buttonMargins]: true })}
-              onClick={onChangeBreakdowns}
+              onClick={onChangeBreakdowns as any}
             >
               Breakdowns
             </Button>

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -20,6 +20,7 @@ import {
   AbsoluteTimeRange,
   FieldType,
   ArrayDataFrame,
+  FieldColorModeId,
 } from '@grafana/data';
 import {
   BackendSrvRequest,
@@ -490,6 +491,18 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
         //Add name and set field type
         dataFrame.name = label;
         dataFrame.setFieldType('name', FieldType.string);
+        const field1 = dataFrame.fields[1];
+        const field2 = dataFrame.fields[2];
+        if (field1) {
+          field1.config.color = {
+            mode: FieldColorModeId.Fixed,
+            fixedColor: field1.name === 'mean (selected)' ? 'orange' : 'green',
+          };
+        }
+
+        if (field2) {
+          field2.config.color = { mode: FieldColorModeId.Fixed, fixedColor: 'green' };
+        }
       }
       return dataFrame;
     });
@@ -502,7 +515,7 @@ export class PrometheusDatasource extends DataSourceWithBackend<PromQuery, PromO
     const highCardinalityLabels: string[] = [];
     const highCardinalityLimit = 100;
     let exemplarsBaseline = this.exemplarsForAutoBreakdowns;
-    let exemplarsSelected = [];
+    let exemplarsSelected: ExemplarEvent[] = [];
     if (timeRange) {
       [exemplarsSelected, exemplarsBaseline] = partition(
         this.exemplarsForAutoBreakdowns,

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -40,7 +40,8 @@ export const TimeSeriesPanel: React.FC<TimeSeriesPanelProps> = ({
   }
 
   const enableAnnotationCreation = Boolean(canAddAnnotations && canAddAnnotations());
-  const enabledAutoBreakdowns = !!data?.annotations?.some((df) => df?.meta?.custom?.autoBreakdownsEnabled);
+  const enabledAutoBreakdowns =
+    options.enabledAutoBreakdowns && !!data?.annotations?.some((df) => df?.meta?.custom?.autoBreakdownsEnabled);
 
   return (
     <TimeSeries
@@ -55,7 +56,7 @@ export const TimeSeriesPanel: React.FC<TimeSeriesPanelProps> = ({
       {(config, alignedDataFrame) => {
         return (
           <>
-            {/* <ZoomPlugin config={config} onZoom={onChangeTimeRange} /> */}
+            {!enabledAutoBreakdowns && <ZoomPlugin config={config} onZoom={onChangeTimeRange} />}
             {options.tooltip.mode === TooltipDisplayMode.None || (
               <TooltipPlugin
                 data={alignedDataFrame}
@@ -116,7 +117,7 @@ export const TimeSeriesPanel: React.FC<TimeSeriesPanelProps> = ({
                 timeZone={timeZone}
                 getFieldLinks={getFieldLinks}
                 onSelect={onChangeTimeRange}
-                autoBreakdownsEnabled={enabledAutoBreakdowns}
+                enabledAutoBreakdowns={enabledAutoBreakdowns}
               />
             )}
 

--- a/public/app/plugins/panel/timeseries/plugins/ExemplarMarker.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ExemplarMarker.tsx
@@ -21,6 +21,7 @@ interface ExemplarMarkerProps {
   dataFrameFieldIndex: DataFrameFieldIndex;
   config: UPlotConfigBuilder;
   getFieldLinks: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
+  enabledAutoBreakdowns?: boolean;
 }
 
 export const ExemplarMarker: React.FC<ExemplarMarkerProps> = ({
@@ -29,6 +30,7 @@ export const ExemplarMarker: React.FC<ExemplarMarkerProps> = ({
   dataFrameFieldIndex,
   config,
   getFieldLinks,
+  enabledAutoBreakdowns = false,
 }) => {
   const styles = useStyles(getExemplarMarkerStyles);
   const [isOpen, setIsOpen] = useState(false);
@@ -152,7 +154,7 @@ export const ExemplarMarker: React.FC<ExemplarMarkerProps> = ({
           {getSymbol()}
         </svg>
       </div>
-      {isOpen && <Portal>{renderMarker()}</Portal>}
+      {!enabledAutoBreakdowns && isOpen && <Portal>{renderMarker()}</Portal>}
     </>
   );
 };

--- a/public/app/plugins/panel/timeseries/plugins/ExemplarsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ExemplarsPlugin.tsx
@@ -18,7 +18,7 @@ interface ExemplarsPluginProps {
   timeZone: TimeZone;
   getFieldLinks: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
   onSelect?: (range: { from: number; to: number }) => void;
-  autoBreakdownsEnabled?: boolean;
+  enabledAutoBreakdowns?: boolean;
 }
 
 export const ExemplarsPlugin: React.FC<ExemplarsPluginProps> = ({
@@ -26,7 +26,7 @@ export const ExemplarsPlugin: React.FC<ExemplarsPluginProps> = ({
   timeZone,
   getFieldLinks,
   config,
-  autoBreakdownsEnabled = false,
+  enabledAutoBreakdowns = false,
   onSelect,
 }) => {
   const plotInstance = useRef<uPlot>();
@@ -51,7 +51,7 @@ export const ExemplarsPlugin: React.FC<ExemplarsPluginProps> = ({
       plotInstance.current = u;
     });
 
-    if (autoBreakdownsEnabled) {
+    if (enabledAutoBreakdowns) {
       config.addHook('setSelect', (u) => {
         setSelection({
           min: u.posToVal(u.select.left, 'x'),
@@ -70,7 +70,7 @@ export const ExemplarsPlugin: React.FC<ExemplarsPluginProps> = ({
           let left = u.valToPos(selection.min, 'x', true);
           let right = u.valToPos(selection.max, 'x', true);
           u.ctx.save();
-          u.ctx.fillStyle = 'rgba(0,255,0,0.1)';
+          u.ctx.fillStyle = 'rgba(255,120,8,0.2)';
           u.ctx.fillRect(left, u.bbox.top, right - left, u.bbox.height);
           u.ctx.restore();
         }
@@ -83,7 +83,7 @@ export const ExemplarsPlugin: React.FC<ExemplarsPluginProps> = ({
       //   },
       // });
     }
-  }, [config, selection, autoBreakdownsEnabled]);
+  }, [config, selection, enabledAutoBreakdowns]);
 
   const mapExemplarToXYCoords = useCallback((dataFrame: DataFrame, dataFrameFieldIndex: DataFrameFieldIndex) => {
     const time = dataFrame.fields.find((f) => f.name === TIME_SERIES_TIME_FIELD_NAME);
@@ -125,10 +125,11 @@ export const ExemplarsPlugin: React.FC<ExemplarsPluginProps> = ({
           dataFrame={dataFrame}
           dataFrameFieldIndex={dataFrameFieldIndex}
           config={config}
+          enabledAutoBreakdowns={enabledAutoBreakdowns}
         />
       );
     },
-    [config, timeZone, getFieldLinks]
+    [config, timeZone, getFieldLinks, enabledAutoBreakdowns]
   );
 
   return (

--- a/public/app/plugins/panel/timeseries/types.ts
+++ b/public/app/plugins/panel/timeseries/types.ts
@@ -1,3 +1,5 @@
 import { OptionsWithLegend, OptionsWithTooltip } from '@grafana/schema';
 
-export interface TimeSeriesOptions extends OptionsWithLegend, OptionsWithTooltip {}
+export interface TimeSeriesOptions extends OptionsWithLegend, OptionsWithTooltip {
+  enabledAutoBreakdowns?: boolean;
+}


### PR DESCRIPTION
1. Fix interaction between Zoom and Exemplars plugins
2. Hide exemplar popover info when in breakdown mode
3. Change colors
