### PR TITLE
Improve bridge for Alertmanager logger 

### DIFF
--- a/pkg/services/ngalert/logging/logging.go
+++ b/pkg/services/ngalert/logging/logging.go
@@ -28,24 +28,24 @@ func (w *GoKitWrapper) Write(p []byte) (n int, err error) {
 // Log implements interface go-kit/log/Logger. It tries to extract level and message from the context and writes to underlying message.
 // To successfully extract the log level, the first pair of elements should be 'lvl' and log level. Otherwise, it falls back to info.
 // The following pair should be 'msg' and message. Otherwise, it uses the empty string as message.
-func (l *GoKitWrapper) Log(keyvals ...interface{}) error {
+func (w *GoKitWrapper) Log(keyvals ...interface{}) error {
 	if len(keyvals) == 0 {
 		return nil
 	}
 
-	f := l.logger.Info
+	f := w.logger.Info
 	startwith := 0
 	if keyvals[0] == level.Key() {
 		startwith = 2
 		switch keyvals[1] {
 		case level.DebugValue():
-			f = l.logger.Debug
+			f = w.logger.Debug
 		case level.InfoValue():
-			f = l.logger.Info
+			f = w.logger.Info
 		case level.WarnValue():
-			f = l.logger.Warn
+			f = w.logger.Warn
 		case level.ErrorValue():
-			f = l.logger.Error
+			f = w.logger.Error
 		}
 	}
 

--- a/pkg/services/ngalert/logging/logging.go
+++ b/pkg/services/ngalert/logging/logging.go
@@ -3,6 +3,8 @@ package logging
 import (
 	"strings"
 
+	"github.com/go-kit/log/level"
+
 	glog "github.com/grafana/grafana/pkg/infra/log"
 )
 
@@ -21,4 +23,41 @@ func (w *GoKitWrapper) Write(p []byte) (n int, err error) {
 	withoutNewline := strings.TrimSuffix(string(p), "\n")
 	w.logger.Info(withoutNewline)
 	return len(p), nil
+}
+
+// Log implements interface go-kit/log/Logger. It tries to extract level and message from the context and writes to underlying message.
+// To successfully extract the log level, the first pair of elements should be 'lvl' and log level. Otherwise, it falls back to info.
+// The following pair should be 'msg' and message. Otherwise, it uses the empty string as message.
+func (l *GoKitWrapper) Log(keyvals ...interface{}) error {
+	if len(keyvals) == 0 {
+		return nil
+	}
+
+	f := l.logger.Info
+	startwith := 0
+	if keyvals[0] == level.Key() {
+		startwith = 2
+		switch keyvals[1] {
+		case level.DebugValue():
+			f = l.logger.Debug
+		case level.InfoValue():
+			f = l.logger.Info
+		case level.WarnValue():
+			f = l.logger.Warn
+		case level.ErrorValue():
+			f = l.logger.Error
+		}
+	}
+
+	msg := ""
+	if keyvals[startwith] == "msg" {
+		str, ok := keyvals[startwith+1].(string)
+		if ok {
+			msg = str
+			startwith += 2
+		}
+	}
+
+	f(msg, keyvals[startwith:]...)
+	return nil
 }

--- a/pkg/services/ngalert/logging/logging_test.go
+++ b/pkg/services/ngalert/logging/logging_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func Test_GoKitWrapper(t *testing.T) {
-
 	getLogger := func(writer io.Writer) log.Logger {
 		log15Logger := log15.New()
 		log15Logger.SetHandler(log15.StreamHandler(writer, log15.LogfmtFormat()))
@@ -60,7 +59,7 @@ func Test_GoKitWrapper(t *testing.T) {
 		gokitLogger := getLogger(&data)
 		_ = gokitLogger.Log("msg", "test", "some", "more", "context", "data")
 		str := data.String()
-		require.Contains(t, str, fmt.Sprintf("lvl=info msg=test some=more context=data"))
+		require.Contains(t, str, "lvl=info msg=test some=more context=data")
 	})
 	t.Run("use empty msg when context misses msg", func(t *testing.T) {
 		var data bytes.Buffer

--- a/pkg/services/ngalert/logging/logging_test.go
+++ b/pkg/services/ngalert/logging/logging_test.go
@@ -1,0 +1,103 @@
+package logging
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	gokit_log "github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/inconshreveable/log15"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GoKitWrapper(t *testing.T) {
+
+	getLogger := func(writer io.Writer) log.Logger {
+		log15Logger := log15.New()
+		log15Logger.SetHandler(log15.StreamHandler(writer, log15.LogfmtFormat()))
+		return NewWrapper(log15Logger)
+	}
+
+	tests := []struct {
+		level         level.Value
+		expectedLevel string
+	}{
+		{
+			level.DebugValue(),
+			"dbug",
+		},
+		{
+			level.InfoValue(),
+			"info",
+		},
+		{
+			level.WarnValue(),
+			"warn",
+		},
+		{
+			level.ErrorValue(),
+			"eror",
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("when level %s", test.level.String()), func(t *testing.T) {
+			t.Run(fmt.Sprintf("rendered message should contain the level %s", test.expectedLevel), func(t *testing.T) {
+				var data bytes.Buffer
+				gokitLogger := getLogger(&data)
+				_ = log.WithPrefix(gokitLogger, level.Key(), test.level).Log("msg", "test", "some", "more", "context", "data")
+
+				str := data.String()
+				require.Contains(t, str, fmt.Sprintf("lvl=%s msg=test some=more context=data", test.expectedLevel))
+			})
+		})
+	}
+
+	t.Run("use info when level does not exist", func(t *testing.T) {
+		var data bytes.Buffer
+		gokitLogger := getLogger(&data)
+		_ = gokitLogger.Log("msg", "test", "some", "more", "context", "data")
+		str := data.String()
+		require.Contains(t, str, fmt.Sprintf("lvl=info msg=test some=more context=data"))
+	})
+	t.Run("use empty msg when context misses msg", func(t *testing.T) {
+		var data bytes.Buffer
+		gokitLogger := getLogger(&data)
+		_ = gokitLogger.Log("message", "test", "some", "more", "context", "data")
+		str := data.String()
+		require.Contains(t, str, "lvl=info msg= message=test some=more context=data")
+	})
+}
+
+func Benchmark_Baseline(t *testing.B) {
+	log15Logger := log15.New()
+	var buff bytes.Buffer
+	log15Logger.SetHandler(log15.StreamHandler(&buff, log15.LogfmtFormat()))
+
+	for i := 0; i < t.N; i++ {
+		log15Logger.Info("test", "some", "more", "context", "data")
+	}
+}
+
+func Benchmark_WrapperLogger(t *testing.B) {
+	log15Logger := log15.New()
+	var buff bytes.Buffer
+	log15Logger.SetHandler(log15.StreamHandler(&buff, log15.LogfmtFormat()))
+	gokit := NewWrapper(log15Logger)
+
+	for i := 0; i < t.N; i++ {
+		_ = level.Info(gokit).Log("msg", "test", "some", "more", "context", "data")
+	}
+}
+
+func Benchmark_WrapperWriter(t *testing.B) {
+	log15Logger := log15.New()
+	var buff bytes.Buffer
+	log15Logger.SetHandler(log15.StreamHandler(&buff, log15.LogfmtFormat()))
+	gokit := gokit_log.NewLogfmtLogger(NewWrapper(log15Logger))
+	for i := 0; i < t.N; i++ {
+		_ = level.Info(gokit).Log("msg", "test", "some", "more", "context", "data")
+	}
+}

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -144,7 +144,7 @@ func newAlertmanager(orgID int64, cfg *setting.Cfg, store store.AlertingStore, k
 		decryptFn:         decryptFn,
 	}
 
-	am.gokitLogger = gokit_log.NewLogfmtLogger(logging.NewWrapper(am.logger))
+	am.gokitLogger = logging.NewWrapper(am.logger)
 	am.fileStore = NewFileStore(am.orgID, kvStore, am.WorkingDirPath())
 
 	nflogFilepath, err := am.fileStore.FilepathFor(context.TODO(), notificationLogFilename)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
It is a known fact that Grafana embeds Alertmanager. One of the problems is that Alertmanager uses go-kit logger but Grafana - log15 and those two are not compatible with each other. Therefore, we had to implement a bridge between those two loggers. The current implementation is very straightforward: it works as a writer for logfmt formatter of go-kit logger. The downside is that it ignores the log level and therefore the user cannot control the level in Alertmanager. 

This PR provides an alternative to the current implementation: it implements the go-kit/log.Logger interface ie works on a higher level than the writer. Therefore, it has access to the key-value pairs. The nature of the go-kit logger as well as the way it is used in Alertmanager, allows us to imply two facts:
- the first pair in key-value collection is always log level (if it is used)
- the following pair - message.
Based on this assumption wrapper analyzes the context and extracts the level as well as a message from it. In the worst case, when the context misses either of keys (or both) the wrapper falls back to info level and empty message. 

Therefore, this PR allows us to better control log level of the logs emitted by Alertmanager.

**Which issue(s) this PR fixes**:
Fixes: https://github.com/grafana/grafana/issues/39146

**Special notes for your reviewer**:
- The PR contains a benchmark that shows that the proposed change has little overhead than the current solution
```
goos: windows
goarch: amd64
pkg: github.com/grafana/grafana/pkg/services/ngalert/logging
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
Benchmark_Baseline
Benchmark_Baseline-16           13380326              1727 ns/op
Benchmark_WrapperLogger
Benchmark_WrapperLogger-16      11174386              2190 ns/op
Benchmark_WrapperWriter
Benchmark_WrapperWriter-16       9513828              2539 ns/op
```
- This is a temporary solution while we are working on migration to go-kit 