### PR TITLE
Autobreakdowns: clear selection when toggle

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/ExemplarsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ExemplarsPlugin.tsx
@@ -48,6 +48,9 @@ export const ExemplarsPlugin: React.FC<ExemplarsPluginProps> = ({
 
   useLayoutEffect(() => {
     config.addHook('init', (u) => {
+      if (selection) {
+        setSelection(null);
+      }
       plotInstance.current = u;
     });
 


### PR DESCRIPTION
Fixes a selection  still showing up after it was toggled off and then on again. 