### PR TITLE
Macaron: Prevent WriteHeader invalid HTTP status code panic

### DIFF
--- a/pkg/macaron/go.mod
+++ b/pkg/macaron/go.mod
@@ -1,3 +1,11 @@
 module gopkg.in/macaron.v1
 
 go 1.17
+
+require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/pkg/macaron/go.sum
+++ b/pkg/macaron/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/macaron/response_writer.go
+++ b/pkg/macaron/response_writer.go
@@ -56,6 +56,14 @@ type responseWriter struct {
 
 func (rw *responseWriter) WriteHeader(s int) {
 	rw.callBefore()
+
+	// Avoid panic if status code is not a valid HTTP status code
+	if s < 100 || s > 999 {
+		rw.ResponseWriter.WriteHeader(500)
+		rw.status = 500
+		return
+	}
+
 	rw.ResponseWriter.WriteHeader(s)
 	rw.status = s
 }

--- a/pkg/macaron/response_writer_test.go
+++ b/pkg/macaron/response_writer_test.go
@@ -1,0 +1,43 @@
+package macaron_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/macaron.v1"
+)
+
+func Test_responseWriter_WriteHeader(t *testing.T) {
+	t.Run("it should set status code as expected", func(t *testing.T) {
+		f := fakeResponseWriter{}
+		rw := macaron.NewResponseWriter("GET", &f)
+		rw.WriteHeader(200)
+		require.Equal(t, 200, rw.Status())
+		require.Equal(t, 200, f.Status)
+	})
+
+	t.Run("it should set status code to 500 if WriteHeader is called with invalid HTTP status", func(t *testing.T) {
+		f := fakeResponseWriter{}
+		rw := macaron.NewResponseWriter("GET", &f)
+		rw.WriteHeader(0)
+		require.Equal(t, 500, rw.Status())
+		require.Equal(t, 500, f.Status)
+	})
+}
+
+type fakeResponseWriter struct {
+	Status int
+}
+
+func (f *fakeResponseWriter) Header() http.Header {
+	return http.Header{}
+}
+
+func (f *fakeResponseWriter) Write([]byte) (int, error) {
+	return 0, nil
+}
+
+func (f *fakeResponseWriter) WriteHeader(statusCode int) {
+	f.Status = statusCode
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

If a backend plugin sets the `CallResourceResponse` status code to an invalid HTTP status code, then Grafana will panic & exit:
```
panic: invalid WriteHeader code 0

goroutine 2076 [running]:
net/http.checkWriteHeaderCode(...)
        /usr/local/go/src/net/http/server.go:1089
net/http.(*response).WriteHeader(0xc0005cc460, 0x0)
        /usr/local/go/src/net/http/server.go:1123 +0x5c8
gopkg.in/macaron%2ev1.(*responseWriter).WriteHeader(0xc000ea2d20, 0x0)
        /drone/src/pkg/macaron/response_writer.go:59 +0x7e
github.com/grafana/grafana/pkg/plugins/manager.flushStream({0x345d910, 0xc001255500}, {0x33db1c8, 0xc00102de60}, {0x33e4ec0, 0xc000ea2d20})
        /drone/src/pkg/plugins/manager/manager.go:395 +0x59d
github.com/grafana/grafana/pkg/plugins/manager.(*PluginManager).callResourceInternal.func1.2()
        /drone/src/pkg/plugins/manager/manager.go:329 +0x4d
created by github.com/grafana/grafana/pkg/plugins/manager.(*PluginManager).callResourceInternal.func1
        /drone/src/pkg/plugins/manager/manager.go:328 +0x287
```

Example plugin code to trigger the issue:

```go
func (d *SampleDatasource) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
	resp := backend.CallResourceResponse{
		Status:  0,
		Headers: make(map[string][]string),
		Body:    make([]byte, 0),
	}
	return sender.Send(&resp)
}
```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

