### PR TITLE
Chore: Stop resetting refresh on zoom

### DIFF
--- a/public/app/features/dashboard/services/TimeSrv.test.ts
+++ b/public/app/features/dashboard/services/TimeSrv.test.ts
@@ -218,7 +218,7 @@ describe('timeSrv', () => {
         from: dateTime([2011, 1, 1]),
         to: dateTime([2015, 1, 1]),
       });
-      expect(_dashboard.refresh).toBe(_dashboard.refresh);
+      expect(_dashboard.refresh).toBe('10s');
     });
 
     it('should keep refresh after relative time range is changed and now delay exists', () => {

--- a/public/app/features/dashboard/services/TimeSrv.test.ts
+++ b/public/app/features/dashboard/services/TimeSrv.test.ts
@@ -212,15 +212,13 @@ describe('timeSrv', () => {
       expect(_dashboard.refresh).toBe('30s');
     });
 
-    it('should restore refresh after relative time range is set', () => {
+    it('should not discard refresh after relative time range is set', () => {
       _dashboard.refresh = '10s';
       timeSrv.setTime({
         from: dateTime([2011, 1, 1]),
         to: dateTime([2015, 1, 1]),
       });
-      expect(_dashboard.refresh).toBe(false);
-      timeSrv.setTime({ from: '2011-01-01', to: 'now' });
-      expect(_dashboard.refresh).toBe('10s');
+      expect(_dashboard.refresh).toBe(_dashboard.refresh);
     });
 
     it('should keep refresh after relative time range is changed and now delay exists', () => {

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -277,7 +277,7 @@ export class TimeSrv {
 
     if (isDateTime(time.to)) {
       this.oldRefresh = this.dashboard?.refresh || this.oldRefresh;
-      this.setAutoRefresh(oldRefresh);
+      this.setAutoRefresh(this.oldRefresh);
     } else if (this.oldRefresh && this.oldRefresh !== this.dashboard?.refresh) {
       this.setAutoRefresh(this.oldRefresh);
       this.oldRefresh = null;

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -275,10 +275,9 @@ export class TimeSrv {
   setTime(time: RawTimeRange, fromRouteUpdate?: boolean) {
     extend(this.time, time);
 
-    // disable refresh if zoom in or zoom out
     if (isDateTime(time.to)) {
       this.oldRefresh = this.dashboard?.refresh || this.oldRefresh;
-      this.setAutoRefresh(false);
+      this.setAutoRefresh(oldRefresh);
     } else if (this.oldRefresh && this.oldRefresh !== this.dashboard?.refresh) {
       this.setAutoRefresh(this.oldRefresh);
       this.oldRefresh = null;


### PR DESCRIPTION
**What this PR does / why we need it**:
Stops resetting refresh setting on zoom in/out.
**Which issue(s) this PR fixes**:
Fixes #42127