### PR TITLE
Populate missing UID of provisioned data source only for new records

### DIFF
--- a/pkg/services/provisioning/datasources/config_reader.go
+++ b/pkg/services/provisioning/datasources/config_reader.go
@@ -2,17 +2,17 @@ package datasources
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/provisioning/utils"
-	"gopkg.in/yaml.v2"
 )
 
 type configReader struct {
@@ -36,12 +36,6 @@ func (cr *configReader) readConfig(ctx context.Context, path string) ([]*configs
 			}
 
 			if datasource != nil {
-				for _, ds := range datasource.Datasources {
-					if ds.UID == "" && ds.Name != "" {
-						ds.UID = safeUIDFromName(ds.Name)
-					}
-				}
-
 				datasources = append(datasources, datasource)
 			}
 		}
@@ -144,11 +138,4 @@ func (cr *configReader) validateAccessAndOrgID(ctx context.Context, ds *upsertDa
 		ds.Access = models.DS_ACCESS_PROXY
 	}
 	return nil
-}
-
-func safeUIDFromName(name string) string {
-	h := sha256.New()
-	_, _ = h.Write([]byte(name))
-	bs := h.Sum(nil)
-	return strings.ToUpper(fmt.Sprintf("P%x", bs[:8]))
 }

--- a/pkg/services/provisioning/datasources/config_reader_test.go
+++ b/pkg/services/provisioning/datasources/config_reader_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/util"
 
 	"github.com/stretchr/testify/require"
 )
@@ -39,19 +40,40 @@ func TestDatasourceAsConfig(t *testing.T) {
 		bus.AddHandlerCtx("test", mockGetOrg)
 	}
 
-	t.Run("apply default values when missing", func(t *testing.T) {
-		setup()
-		dc := newDatasourceProvisioner(logger)
-		err := dc.applyChanges(context.Background(), withoutDefaults)
-		if err != nil {
-			t.Fatalf("applyChanges return an error %v", err)
-		}
+	t.Run("when some values missing", func(t *testing.T) {
+		t.Run("should apply default on insert", func(t *testing.T) {
+			setup()
+			dc := newDatasourceProvisioner(logger)
+			err := dc.applyChanges(context.Background(), withoutDefaults)
+			if err != nil {
+				t.Fatalf("applyChanges return an error %v", err)
+			}
 
-		require.Equal(t, len(fakeRepo.inserted), 1)
-		require.Equal(t, fakeRepo.inserted[0].OrgId, int64(1))
-		require.Equal(t, fakeRepo.inserted[0].Access, models.DsAccess("proxy"))
-		require.Equal(t, fakeRepo.inserted[0].Name, "My datasource name")
-		require.Equal(t, fakeRepo.inserted[0].Uid, "P2AD1F727255C56BA")
+			require.Equal(t, len(fakeRepo.inserted), 1)
+			require.Equal(t, fakeRepo.inserted[0].OrgId, int64(1))
+			require.Equal(t, fakeRepo.inserted[0].Access, models.DsAccess("proxy"))
+			require.Equal(t, fakeRepo.inserted[0].Name, "My datasource name")
+			require.Equal(t, fakeRepo.inserted[0].Uid, "P2AD1F727255C56BA")
+		})
+
+		t.Run("should not change UID when updates", func(t *testing.T) {
+			setup()
+
+			fakeRepo.loadAll = []*models.DataSource{
+				{Name: "My datasource name", OrgId: 1, Id: 1, Uid: util.GenerateShortUID()},
+			}
+
+			dc := newDatasourceProvisioner(logger)
+			err := dc.applyChanges(context.Background(), withoutDefaults)
+			if err != nil {
+				t.Fatalf("applyChanges return an error %v", err)
+			}
+
+			require.Equal(t, len(fakeRepo.deleted), 0)
+			require.Equal(t, len(fakeRepo.inserted), 0)
+			require.Equal(t, len(fakeRepo.updated), 1)
+			require.Equal(t, "", fakeRepo.updated[0].Uid) // XORM will not update the field if its value is default
+		})
 	})
 
 	t.Run("no datasource in database", func(t *testing.T) {
@@ -219,14 +241,6 @@ func TestDatasourceAsConfig(t *testing.T) {
 
 		validateDatasource(t, dsCfg)
 		validateDeleteDatasources(t, dsCfg)
-	})
-}
-
-func TestUIDFromNames(t *testing.T) {
-	t.Run("generate safe uid from name", func(t *testing.T) {
-		require.Equal(t, safeUIDFromName("Hello world"), "P64EC88CA00B268E5")
-		require.Equal(t, safeUIDFromName("Hello World"), "PA591A6D40BF42040")
-		require.Equal(t, safeUIDFromName("AAA"), "PCB1AD2119D8FAFB6")
 	})
 }
 

--- a/pkg/services/provisioning/datasources/datasources.go
+++ b/pkg/services/provisioning/datasources/datasources.go
@@ -51,14 +51,14 @@ func (dc *DatasourceProvisioner) apply(ctx context.Context, cfg *configs) error 
 		}
 
 		if errors.Is(err, models.ErrDataSourceNotFound) {
-			dc.log.Info("inserting datasource from configuration ", "name", ds.Name, "uid", ds.UID)
 			insertCmd := createInsertCommand(ds)
+			dc.log.Info("inserting datasource from configuration ", "name", insertCmd.Name, "uid", insertCmd.Uid)
 			if err := bus.DispatchCtx(ctx, insertCmd); err != nil {
 				return err
 			}
 		} else {
-			dc.log.Debug("updating datasource from configuration", "name", ds.Name, "uid", ds.UID)
 			updateCmd := createUpdateCommand(ds, cmd.Result.Id)
+			dc.log.Debug("updating datasource from configuration", "name", updateCmd.Name, "uid", updateCmd.Uid)
 			if err := bus.DispatchCtx(ctx, updateCmd); err != nil {
 				return err
 			}

--- a/pkg/services/provisioning/datasources/types_test.go
+++ b/pkg/services/provisioning/datasources/types_test.go
@@ -1,0 +1,15 @@
+package datasources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUIDFromNames(t *testing.T) {
+	t.Run("generate safe uid from name", func(t *testing.T) {
+		require.Equal(t, safeUIDFromName("Hello world"), "P64EC88CA00B268E5")
+		require.Equal(t, safeUIDFromName("Hello World"), "PA591A6D40BF42040")
+		require.Equal(t, safeUIDFromName("AAA"), "PCB1AD2119D8FAFB6")
+	})
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
PR https://github.com/grafana/grafana/pull/41769 updated Grafana to generate UID for provisioned data source if it is empty. However, it introduced breaking change: during the upgrade from the previous versions to Grafana 8.3, Grafana provisions data sources and updates the existing records in the database with the new UID. This breaks Grafana alerting that refers to data sources by UID. 

This PR changes the behavior to populate UID only for provisioned data sources that are being added to the database. 

**Which issue(s) this PR fixes**:
Fixes: https://github.com/grafana/grafana/issues/42699
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

