### PR TITLE
Build: Still auto-publish non-release artifacts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3353,7 +3353,7 @@ steps:
   image: grafana/grafana-ci-deploy:1.3.1
   name: upload-cdn-assets
 - commands:
-  - ./bin/grabpl upload-packages --edition oss --packages-bucket $${PRERELEASE_BUCKET}/artifacts/downloads
+  - ./bin/grabpl upload-packages --edition oss --packages-bucket grafana-downloads
   depends_on:
   - end-to-end-tests-dashboards-suite
   - end-to-end-tests-panels-suite
@@ -3827,7 +3827,7 @@ steps:
   image: grafana/grafana-ci-deploy:1.3.1
   name: upload-cdn-assets
 - commands:
-  - ./bin/grabpl upload-packages --edition enterprise --packages-bucket $${PRERELEASE_BUCKET}/artifacts/downloads
+  - ./bin/grabpl upload-packages --edition enterprise --packages-bucket grafana-downloads
   depends_on:
   - package
   - redis-integration-tests
@@ -3873,7 +3873,7 @@ steps:
   image: grafana/grafana-ci-deploy:1.3.1
   name: upload-cdn-assets-enterprise2
 - commands:
-  - ./bin/grabpl upload-packages --edition enterprise2 --packages-bucket $${PRERELEASE_BUCKET}/artifacts/downloads-enterprise2
+  - ./bin/grabpl upload-packages --edition enterprise2 --packages-bucket grafana-downloads
   depends_on:
   - package-enterprise2
   - redis-integration-tests
@@ -4109,6 +4109,6 @@ kind: secret
 name: prerelease_bucket
 ---
 kind: signature
-hmac: e84ccb068a1b18aa34aaee36b44d2372d6c97bac8becd42261661952ca847b0c
+hmac: 0c6499564400a2892b18ca2a3e6ee855b4dec73ca913c1147fccff2978050bbe
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1296,7 +1296,7 @@ steps:
   image: grafana/grafana-ci-deploy:1.3.1
   name: upload-cdn-assets
 - commands:
-  - ./bin/grabpl upload-packages --edition oss --packages-bucket $${PRERELEASE_BUCKET}/artifacts/downloads
+  - ./bin/grabpl upload-packages --edition oss --packages-bucket $${PRERELEASE_BUCKET}/artifacts/downloads/${DRONE_TAG}
   depends_on:
   - end-to-end-tests-dashboards-suite
   - end-to-end-tests-panels-suite
@@ -1812,7 +1812,7 @@ steps:
   image: grafana/grafana-ci-deploy:1.3.1
   name: upload-cdn-assets
 - commands:
-  - ./bin/grabpl upload-packages --edition enterprise --packages-bucket $${PRERELEASE_BUCKET}/artifacts/downloads
+  - ./bin/grabpl upload-packages --edition enterprise --packages-bucket $${PRERELEASE_BUCKET}/artifacts/downloads/${DRONE_TAG}
   depends_on:
   - package
   - redis-integration-tests
@@ -1858,7 +1858,7 @@ steps:
   image: grafana/grafana-ci-deploy:1.3.1
   name: upload-cdn-assets-enterprise2
 - commands:
-  - ./bin/grabpl upload-packages --edition enterprise2 --packages-bucket $${PRERELEASE_BUCKET}/artifacts/downloads-enterprise2
+  - ./bin/grabpl upload-packages --edition enterprise2 --packages-bucket $${PRERELEASE_BUCKET}/artifacts/downloads-enterprise2/${DRONE_TAG}
   depends_on:
   - package-enterprise2
   - redis-integration-tests
@@ -4109,6 +4109,6 @@ kind: secret
 name: prerelease_bucket
 ---
 kind: signature
-hmac: 0c6499564400a2892b18ca2a3e6ee855b4dec73ca913c1147fccff2978050bbe
+hmac: 1025f93a644fd0d45ff40a31dc99362e64157ef529604baa7f83b824a9a0ee82
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -931,7 +931,7 @@ def upload_packages_step(edition, ver_mode, is_downstream=False):
         cmd = './bin/grabpl upload-packages --edition {} '.format(edition) + \
               '--packages-bucket grafana-downloads-test'
     elif ver_mode == 'release':
-        packages_bucket = '$${PRERELEASE_BUCKET}/artifacts/downloads' + enterprise2_suffix(edition)
+        packages_bucket = '$${{PRERELEASE_BUCKET}}/artifacts/downloads{}/${{DRONE_TAG}}'.format(enterprise2_suffix(edition))
         cmd = './bin/grabpl upload-packages --edition {} --packages-bucket {}'.format(edition, packages_bucket)
     else:
         cmd = './bin/grabpl upload-packages --edition {} --packages-bucket grafana-downloads'.format(edition)

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -930,11 +930,11 @@ def upload_packages_step(edition, ver_mode, is_downstream=False):
     if ver_mode == 'test-release':
         cmd = './bin/grabpl upload-packages --edition {} '.format(edition) + \
               '--packages-bucket grafana-downloads-test'
-    elif ver_mode == 'main':
-        cmd = './bin/grabpl upload-packages --edition {} --packages-bucket grafana-downloads'.format(edition)
+    elif ver_mode == 'release':
+        packages_bucket = '$${PRERELEASE_BUCKET}/artifacts/downloads' + enterprise2_suffix(edition)
+        cmd = './bin/grabpl upload-packages --edition {} --packages-bucket {}'.format(edition, packages_bucket)
     else:
-        packages_bucket = ' --packages-bucket $${PRERELEASE_BUCKET}/artifacts/downloads' + enterprise2_suffix(edition)
-        cmd = './bin/grabpl upload-packages --edition {}{}'.format(edition, packages_bucket)
+        cmd = './bin/grabpl upload-packages --edition {} --packages-bucket grafana-downloads'.format(edition)
 
     deps = []
     if edition in 'enterprise2':


### PR DESCRIPTION
Recent changes to the build process that were intended to add a pause between packaging and publishing of release artifacts, also inadvertently added this same pause in the publishing of non-release artifacts.

This PR resolves this: only release artifacts are redirected to a 'prerelease' location. All others go to the standard GCS bucket.


This PR also places prerelease artifacts into versioned folders. This makes copying them to release folders using a wildcard much simpler.