### PR TITLE
Chore: Add PR Check action enforcing a milestone is set

### DIFF
--- a/.github/pr-checks.json
+++ b/.github/pr-checks.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "check-milestone",
+    "title": "Milestone Check",
+    "targetUrl": "https://github.com/grafana/grafana/blob/main/contribute/merge-pull-request.md#assign-a-milestone",
+    "success": "Milestone set",
+    "failure": "Milestone not set"
+  }
+]

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,28 @@
+name: PR Checks
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+  issues:
+    types:
+      - milestoned
+      - demilestoned
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          ref: main
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run PR Checks
+        uses: ./actions/pr-checks
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          configPath: pr-checks


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a PR Check action with a rule that enforces a milestone is set on the PR. We can make this check required for PR's to be merged (when we've verified it works as expected).

You can test it out [here](https://github.com/grafana/github-actions-testrepo/pull/50) by assigning/removing milestone (note it takes some time for the action to run).

**Which issue(s) this PR fixes**:
Ref https://github.com/grafana/grafana-github-actions/issues/34
Ref https://github.com/grafana/grafana-github-actions/pull/42

**Special notes for your reviewer**:
Before action has run:
![image](https://user-images.githubusercontent.com/1668778/145812396-155f37b1-22b1-4656-a1bf-17a21d76947c.png)

After action has run:
![image](https://user-images.githubusercontent.com/1668778/145812497-b9d48b93-ed35-4758-9fbe-617674ef4127.png)

After milestone assigned:
![image](https://user-images.githubusercontent.com/1668778/145812524-8942aaf2-a332-4edc-897d-f64b6948b1d6.png)

After milestone cleared:
![image](https://user-images.githubusercontent.com/1668778/145812548-357dee51-ef79-4057-b4b8-bb96bafbdc21.png)