### PR TITLE
Dashboard: Remove "flash" of grid placeholder when moving panel

### DIFF
--- a/public/sass/components/_dashboard_grid.scss
+++ b/public/sass/components/_dashboard_grid.scss
@@ -60,7 +60,7 @@
 .react-grid-item.react-grid-placeholder {
   box-shadow: $panel-grid-placeholder-shadow;
   background: $panel-grid-placeholder-bg;
-  z-index: 0;
+  z-index: -1;
   opacity: unset;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Gets rid of the brief flash of the grid item placeholder when you start dragging a panel.

https://user-images.githubusercontent.com/45561153/145818778-8fbd452a-35c9-409d-a0a2-615c86304541.mp4

https://user-images.githubusercontent.com/45561153/145818808-78abff7a-5ebe-4629-b1dc-a582980077ac.mp4
