### PR TITLE
Dashboard: Prevent crash when expanding a row containing panels with …

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.test.ts
@@ -464,6 +464,46 @@ describe('DashboardModel', () => {
     });
   });
 
+  describe('When expanding row with panels that do not contain an x and y pos', () => {
+    let dashboard: DashboardModel;
+
+    beforeEach(() => {
+      dashboard = new DashboardModel({
+        panels: [
+          { id: 1, type: 'graph', gridPos: { x: 0, y: 0, w: 24, h: 6 } },
+          {
+            id: 2,
+            type: 'row',
+            gridPos: { x: 0, y: 6, w: 24, h: 1 },
+            collapsed: true,
+            panels: [
+              { id: 3, type: 'graph', gridPos: { w: 12, h: 2 } },
+              { id: 4, type: 'graph', gridPos: { w: 12, h: 2 } },
+            ],
+          },
+          { id: 5, type: 'row', gridPos: { x: 0, y: 7, w: 1, h: 1 } },
+        ],
+      });
+      dashboard.toggleRow(dashboard.panels[1]);
+    });
+
+    it('should correctly set the x and y values for the inner panels', () => {
+      expect(dashboard.panels[2].gridPos).toMatchObject({
+        x: 0,
+        y: 7,
+        w: 12,
+        h: 2,
+      });
+
+      expect(dashboard.panels[3].gridPos).toMatchObject({
+        x: 0,
+        y: 7,
+        w: 12,
+        h: 2,
+      });
+    });
+  });
+
   describe('Given model with time', () => {
     let model: DashboardModel;
 

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -942,6 +942,8 @@ export class DashboardModel {
 
       if (row.panels.length > 0) {
         // Use first panel to figure out if it was moved or pushed
+        // If the panel doesn't have gridPos.y, use the row gridPos.y instead.
+        // This can happen for some generated dashboards.
         const firstPanelYPos = row.panels[0].gridPos.y ?? row.gridPos.y;
         const yDiff = firstPanelYPos - (row.gridPos.y + row.gridPos.h);
 

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -942,8 +942,8 @@ export class DashboardModel {
 
       if (row.panels.length > 0) {
         // Use first panel to figure out if it was moved or pushed
-        const firstPanel = row.panels[0];
-        const yDiff = firstPanel.gridPos.y - (row.gridPos.y + row.gridPos.h);
+        const firstPanelYPos = row.panels[0].gridPos.y ?? row.gridPos.y;
+        const yDiff = firstPanelYPos - (row.gridPos.y + row.gridPos.h);
 
         // start inserting after row
         let insertPos = rowIndex + 1;
@@ -952,8 +952,9 @@ export class DashboardModel {
         let yMax = row.gridPos.y;
 
         for (const panel of row.panels) {
+          // set the y gridPos if it wasn't already set
+          panel.gridPos.y ??= row.gridPos.y;
           // make sure y is adjusted (in case row moved while collapsed)
-          // console.log('yDiff', yDiff);
           panel.gridPos.y -= yDiff;
           // insert after row
           this.panels.splice(insertPos, 0, new PanelModel(panel));


### PR DESCRIPTION
…no yPos defined

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- grafonnet can generate panels inside rows with no x or y gridPos (see https://github.com/grafana/grafonnet-lib/blob/master/grafonnet-7.0/DOCS.md#setgridpos-2)
- when expanding the row, this causes the browser to crash in an infinite loop
- default to the row yPos if no panel yPos is set (the y gridPos is the only one we strictly need)
- add a unit test to make sure this doesn't regress

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/42579

**Special notes for your reviewer**:

