### PR TITLE
Alerting: make state duration column wider

### DIFF
--- a/public/app/features/alerting/unified/components/alert-groups/AlertGroupAlertsTable.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/AlertGroupAlertsTable.tsx
@@ -38,7 +38,7 @@ export const AlertGroupAlertsTable = ({ alerts, alertManagerSourceName }: Props)
             </span>
           </>
         ),
-        size: '190px',
+        size: '220px',
       },
       {
         id: 'labels',


### PR DESCRIPTION
**What this PR does / why we need it**:

Minor fix to the alert grouping view that would not account for long duration strings

**Before**

<img width="677" alt="image" src="https://user-images.githubusercontent.com/868844/145842359-0784ef21-be2d-41b6-b8e5-2c81c5d0a8bf.png">

**After**

<img width="648" alt="image" src="https://user-images.githubusercontent.com/868844/145841991-db4234a2-e851-4ac7-9085-107c67e39abf.png">


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

