### PR TITLE
Prometheus: Fix inconsistent backend query header propagation

### DIFF
--- a/pkg/tsdb/prometheus/backend_query_middleware.go
+++ b/pkg/tsdb/prometheus/backend_query_middleware.go
@@ -1,0 +1,33 @@
+package prometheus
+
+import (
+	"net/http"
+
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+const (
+	backendQueryMiddlewareName = "prom-backend-query"
+)
+
+type backendQueryHeaders struct{}
+
+var backendQueryHeadersKey = &backendQueryHeaders{}
+
+func backendQueryMiddleware(logger log.Logger) sdkhttpclient.Middleware {
+	return sdkhttpclient.NamedMiddlewareFunc(backendQueryMiddlewareName, func(opts sdkhttpclient.Options, next http.RoundTripper) http.RoundTripper {
+		return sdkhttpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			ctx := req.Context()
+			// Apply custom headers if set
+			if headers := ctx.Value(backendQueryHeadersKey); headers != nil {
+				if m, ok := headers.(map[string]string); ok {
+					for k, v := range m {
+						req.Header.Add(k, v)
+					}
+				}
+			}
+			return next.RoundTrip(req)
+		})
+	})
+}

--- a/pkg/tsdb/prometheus/backend_query_middleware_test.go
+++ b/pkg/tsdb/prometheus/backend_query_middleware_test.go
@@ -1,0 +1,87 @@
+package prometheus
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackendQueryMiddleware(t *testing.T) {
+	finalRoundTripper := httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	})
+
+	t.Run("Headers in the request context should be added to the request", func(t *testing.T) {
+		mw := backendQueryMiddleware(log.New("test"))
+		rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
+		require.NotNil(t, rt)
+		middlewareName, ok := mw.(httpclient.MiddlewareName)
+		require.True(t, ok)
+		require.Equal(t, backendQueryMiddlewareName, middlewareName.MiddlewareName())
+
+		ctx := context.WithValue(context.Background(), backendQueryHeadersKey, map[string]string{
+			"X-Grafana-Test":  "test",
+			"X-Grafana-Test2": "test2",
+		})
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://test.com/query", nil)
+		require.NoError(t, err)
+		res, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+
+		require.Equal(t, req.Header.Get("X-Grafana-Test"), "test")
+		require.Equal(t, req.Header.Get("X-Grafana-Test2"), "test2")
+	})
+
+	t.Run("If nil or empty headers are given, the request should not be modified", func(t *testing.T) {
+		mw := backendQueryMiddleware(log.New("test"))
+		rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
+		require.NotNil(t, rt)
+		middlewareName, ok := mw.(httpclient.MiddlewareName)
+		require.True(t, ok)
+		require.Equal(t, backendQueryMiddlewareName, middlewareName.MiddlewareName())
+
+		// Header present, but nil
+		{
+			ctx := context.WithValue(context.Background(), backendQueryHeadersKey, nil)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://test.com/query", nil)
+			headers := req.Header.Clone()
+			require.NoError(t, err)
+			res, err := rt.RoundTrip(req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			require.Equal(t, req.Header, headers)
+		}
+
+		// Header present, but empty
+		{
+			ctx := context.WithValue(context.Background(), backendQueryHeadersKey, map[string]string{})
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://test.com/query", nil)
+			headers := req.Header.Clone()
+			require.NoError(t, err)
+			res, err := rt.RoundTrip(req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			require.Equal(t, req.Header, headers)
+		}
+
+		// Header not present
+		{
+			ctx := context.Background()
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://test.com/query", nil)
+			headers := req.Header.Clone()
+			require.NoError(t, err)
+			res, err := rt.RoundTrip(req)
+			require.NoError(t, err)
+			require.NotNil(t, res)
+
+			require.Equal(t, req.Header, headers)
+		}
+	})
+}

--- a/pkg/tsdb/prometheus/backend_query_middleware_test.go
+++ b/pkg/tsdb/prometheus/backend_query_middleware_test.go
@@ -32,6 +32,9 @@ func TestBackendQueryMiddleware(t *testing.T) {
 		res, err := rt.RoundTrip(req)
 		require.NoError(t, err)
 		require.NotNil(t, res)
+		if res.Body != nil {
+			require.NoError(t, res.Body.Close())
+		}
 
 		require.Equal(t, req.Header.Get("X-Grafana-Test"), "test")
 		require.Equal(t, req.Header.Get("X-Grafana-Test2"), "test2")
@@ -54,6 +57,9 @@ func TestBackendQueryMiddleware(t *testing.T) {
 			res, err := rt.RoundTrip(req)
 			require.NoError(t, err)
 			require.NotNil(t, res)
+			if res.Body != nil {
+				require.NoError(t, res.Body.Close())
+			}
 
 			require.Equal(t, req.Header, headers)
 		}
@@ -67,6 +73,9 @@ func TestBackendQueryMiddleware(t *testing.T) {
 			res, err := rt.RoundTrip(req)
 			require.NoError(t, err)
 			require.NotNil(t, res)
+			if res.Body != nil {
+				require.NoError(t, res.Body.Close())
+			}
 
 			require.Equal(t, req.Header, headers)
 		}
@@ -80,6 +89,9 @@ func TestBackendQueryMiddleware(t *testing.T) {
 			res, err := rt.RoundTrip(req)
 			require.NoError(t, err)
 			require.NotNil(t, res)
+			if res.Body != nil {
+				require.NoError(t, res.Body.Close())
+			}
 
 			require.Equal(t, req.Header, headers)
 		}

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -144,8 +144,10 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 }
 
 func createClient(url string, httpOpts sdkhttpclient.Options, clientProvider httpclient.Provider, forceHttpGet bool) (apiv1.API, error) {
-	customParamsMiddleware := customQueryParametersMiddleware(plog)
-	middlewares := []sdkhttpclient.Middleware{customParamsMiddleware}
+	middlewares := []sdkhttpclient.Middleware{
+		customQueryParametersMiddleware(plog),
+		backendQueryMiddleware(plog),
+	}
 	if forceHttpGet {
 		middlewares = append(middlewares, forceHttpGetMiddleware(plog))
 	}

--- a/pkg/tsdb/prometheus/time_series_query.go
+++ b/pkg/tsdb/prometheus/time_series_query.go
@@ -54,6 +54,17 @@ func (s *Service) executeTimeSeriesQuery(ctx context.Context, req *backend.Query
 		Responses: backend.Responses{},
 	}
 
+	// If any custom headers are specified in the backend query request, they are
+	// added to the request context. These headers are used in the custom
+	// query headers middleware.
+	if len(req.Headers) > 0 {
+		copiedHeaders := make(map[string]string)
+		for k, v := range req.Headers {
+			copiedHeaders[k] = v
+		}
+		ctx = context.WithValue(ctx, backendQueryHeadersKey, copiedHeaders)
+	}
+
 	queries, err := s.parseTimeSeriesQuery(req, dsInfo)
 	if err != nil {
 		return &result, err


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This fixes an inconsistency with the Prometheus data source where HTTP headers added by the data source proxy would not be passed through to Prometheus when issuing a time series query (e.g /api/v1/query, /api/v1/query_range) but would be passed through in all other cases.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

This primarily affects authorization. If you check `With Credentials` and/or `Forward OAuth Identity` in the data source settings, Grafana will pass through `Authorization`, `X-Grafana-Org-Id`, etc. headers in all requests _except_ for `/api/v1/query` and `/api/v1/query_range` since those requests go through a separate code path where the prometheus go client is used.