### PR TITLE
Live: move StreamingDataFrame to core app/features

### DIFF
--- a/packages/grafana-data/src/dataframe/index.ts
+++ b/packages/grafana-data/src/dataframe/index.ts
@@ -6,6 +6,5 @@ export * from './processDataFrame';
 export * from './dimensions';
 export * from './ArrayDataFrame';
 export * from './DataFrameJSON';
-export { StreamingDataFrame, StreamingFrameOptions, StreamingFrameAction } from './StreamingDataFrame';
 export * from './frameComparisons';
 export { anySeriesWithTimeField } from './utils';

--- a/packages/grafana-data/src/transformations/index.ts
+++ b/packages/grafana-data/src/transformations/index.ts
@@ -11,6 +11,6 @@ export {
 } from './standardTransformersRegistry';
 export { RegexpOrNamesMatcherOptions, ByNamesMatcherOptions, ByNamesMatcherMode } from './matchers/nameMatcher';
 export { RenameByRegexTransformerOptions } from './transformers/renameByRegex';
-export { outerJoinDataFrames } from './transformers/joinDataFrames';
+export { outerJoinDataFrames, join as joinAlignedData } from './transformers/joinDataFrames';
 export * from './transformers/histogram';
 export { ensureTimeField } from './transformers/convertFieldType';

--- a/packages/grafana-runtime/src/services/live.ts
+++ b/packages/grafana-runtime/src/services/live.ts
@@ -1,10 +1,9 @@
 import {
   DataFrame,
-  DataQueryError,
+  DataQueryResponse,
   LiveChannelAddress,
   LiveChannelEvent,
   LiveChannelPresenceStatus,
-  LoadingState,
 } from '@grafana/data';
 import { Observable } from 'rxjs';
 
@@ -56,35 +55,6 @@ export interface LiveDataStreamOptions {
   filter?: LiveDataFilter;
 }
 
-type StreamingResponseData = any; // ????
-
-/**
- * @alpha -- experimental
- */
-export type StreamingDataQueryResponse = {
-  /**
-   * The response data.  When streaming, this may be empty
-   * or a partial result set
-   */
-  data: [StreamingResponseData];
-
-  /**
-   * Unique subscription key
-   */
-  key: string;
-
-  /**
-   * Optionally include error info along with the response data
-   */
-  error?: DataQueryError;
-
-  /**
-   * Use this to control which state the response should have
-   * Defaults to LoadingState.Done if state is not defined
-   */
-  state: LoadingState;
-};
-
 /**
  * @alpha -- experimental
  */
@@ -102,7 +72,7 @@ export interface GrafanaLiveSrv {
   /**
    * Connect to a channel and return results as DataFrames
    */
-  getDataStream(options: LiveDataStreamOptions): Observable<StreamingDataQueryResponse>;
+  getDataStream(options: LiveDataStreamOptions): Observable<DataQueryResponse>;
 
   /**
    * For channels that support presence, this will request the current state from the server.

--- a/packages/grafana-runtime/src/services/live.ts
+++ b/packages/grafana-runtime/src/services/live.ts
@@ -1,14 +1,10 @@
 import {
   DataFrame,
   DataQueryError,
-  DataQueryResponseData,
-  isDataFrame,
   LiveChannelAddress,
   LiveChannelEvent,
   LiveChannelPresenceStatus,
   LoadingState,
-  StreamingDataFrame,
-  StreamingFrameOptions,
 } from '@grafana/data';
 import { Observable } from 'rxjs';
 
@@ -17,6 +13,36 @@ import { Observable } from 'rxjs';
  */
 export interface LiveDataFilter {
   fields?: string[];
+}
+
+/**
+ * Indicate if the frame is appened or replace
+ *
+ * @public -- but runtime
+ */
+export enum StreamingFrameAction {
+  Append = 'append',
+  Replace = 'replace',
+}
+
+/**
+ * @alpha
+ */
+export interface StreamingFrameOptions {
+  maxLength: number; // 1000
+  maxDelta: number; // how long to keep things
+  action: StreamingFrameAction; // default will append
+}
+
+/**
+ * @alpha
+ */
+export function getStreamingFrameOptions(opts?: Partial<StreamingFrameOptions>): StreamingFrameOptions {
+  return {
+    maxLength: opts?.maxLength ?? 1000,
+    maxDelta: opts?.maxDelta ?? Infinity,
+    action: opts?.action ?? StreamingFrameAction.Append,
+  };
 }
 
 /**
@@ -30,58 +56,7 @@ export interface LiveDataStreamOptions {
   filter?: LiveDataFilter;
 }
 
-/**
- * @alpha -- experimental
- */
-export enum StreamingResponseDataType {
-  NewValuesSameSchema = 'NewValuesSameSchema',
-  FullFrame = 'FullFrame',
-}
-
-/**
- * @alpha -- experimental
- */
-export type StreamingResponseDataTypeToData = {
-  [StreamingResponseDataType.NewValuesSameSchema]: {
-    values: unknown[][];
-  };
-  [StreamingResponseDataType.FullFrame]: {
-    frame: ReturnType<StreamingDataFrame['serialize']>;
-  };
-};
-
-/**
- * @alpha -- experimental
- */
-export type StreamingResponseData<T = StreamingResponseDataType> = T extends StreamingResponseDataType
-  ? {
-      type: T;
-    } & StreamingResponseDataTypeToData[T]
-  : never;
-
-/**
- * @alpha -- experimental
- */
-export const isStreamingResponseData = <T extends StreamingResponseDataType>(
-  responseData: DataQueryResponseData,
-  type: T
-): responseData is StreamingResponseData<T> => 'type' in responseData && responseData.type === type;
-
-const AllStreamingResponseDataTypes = Object.values(StreamingResponseDataType);
-
-/**
- * @alpha -- experimental
- */
-export const isAnyStreamingResponseData = (
-  responseData: DataQueryResponseData
-): responseData is StreamingResponseData =>
-  'type' in responseData && AllStreamingResponseDataTypes.includes(responseData.type);
-
-/**
- * @alpha -- experimental
- */
-export const isStreamingDataFrame = (data: DataQueryResponseData): data is StreamingDataFrame =>
-  isDataFrame(data) && 'packetInfo' in data;
+type StreamingResponseData = any; // ????
 
 /**
  * @alpha -- experimental

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -9,15 +9,19 @@ import {
   makeClassES5Compatible,
   DataFrame,
   parseLiveChannelAddress,
-  StreamingFrameOptions,
-  StreamingFrameAction,
   getDataSourceRef,
   DataSourceRef,
-  StreamingDataFrame,
 } from '@grafana/data';
 import { merge, Observable, of } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
-import { getBackendSrv, getDataSourceSrv, getGrafanaLiveSrv } from '../services';
+import {
+  getBackendSrv,
+  getDataSourceSrv,
+  getGrafanaLiveSrv,
+  StreamingFrameOptions,
+  StreamingFrameAction,
+  getStreamingFrameOptions,
+} from '../services';
 import { BackendDataSourceResponse, toDataQueryResponse } from './queryResponse';
 
 /**
@@ -307,7 +311,7 @@ export const standardStreamOptionsProvider: StreamOptionsProvider = (request: Da
   if (request.rangeRaw?.to === 'now') {
     buffer.maxDelta = request.range.to.valueOf() - request.range.from.valueOf();
   }
-  return StreamingDataFrame.optionsWithDefaults(buffer);
+  return getStreamingFrameOptions(buffer);
 };
 
 //@ts-ignore

--- a/public/app/features/live/centrifuge/LiveDataStream.test.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.test.ts
@@ -9,17 +9,13 @@ import {
   LiveChannelLeaveEvent,
   LiveChannelScope,
   LoadingState,
-  StreamingDataFrame,
-  StreamingFrameAction,
 } from '@grafana/data';
 import { Observable, Subject, Subscription, Unsubscribable } from 'rxjs';
 import { DataStreamHandlerDeps, LiveDataStream } from './LiveDataStream';
 import { mapValues } from 'lodash';
-import {
-  isStreamingResponseData,
-  StreamingResponseData,
-  StreamingResponseDataType,
-} from '@grafana/runtime/src/services/live';
+import { StreamingFrameAction } from '@grafana/runtime';
+import { isStreamingResponseData, StreamingResponseData, StreamingResponseDataType } from '../data/utils';
+import { StreamingDataFrame } from '../data/StreamingDataFrame';
 
 type SubjectsInsteadOfObservables<T> = {
   [key in keyof T]: T[key] extends Observable<infer U> ? Subject<U> : T[key];

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -1,8 +1,4 @@
-import type {
-  LiveDataStreamOptions,
-  StreamingDataQueryResponse,
-  StreamingFrameOptions,
-} from '@grafana/runtime/src/services/live';
+import type { LiveDataStreamOptions, StreamingFrameOptions } from '@grafana/runtime/src/services/live';
 import { toDataQueryError } from '@grafana/runtime/src/utils/toDataQueryError';
 import {
   DataFrameJSON,
@@ -17,7 +13,7 @@ import {
   LoadingState,
 } from '@grafana/data';
 import { map, Observable, ReplaySubject, Subject, Subscriber, Subscription } from 'rxjs';
-import { DataStreamSubscriptionKey } from './service';
+import { DataStreamSubscriptionKey, StreamingDataQueryResponse } from './service';
 import { StreamingDataFrame } from '../data/StreamingDataFrame';
 import { StreamingResponseDataType } from '../data/utils';
 

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -1,4 +1,8 @@
-import { LiveDataStreamOptions, StreamingDataQueryResponse, StreamingFrameOptions } from '@grafana/runtime';
+import type {
+  LiveDataStreamOptions,
+  StreamingDataQueryResponse,
+  StreamingFrameOptions,
+} from '@grafana/runtime/src/services/live';
 import { toDataQueryError } from '@grafana/runtime/src/utils/toDataQueryError';
 import {
   DataFrameJSON,

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -1,8 +1,4 @@
-import {
-  LiveDataStreamOptions,
-  StreamingDataQueryResponse,
-  StreamingResponseDataType,
-} from '@grafana/runtime/src/services/live';
+import { LiveDataStreamOptions, StreamingDataQueryResponse, StreamingFrameOptions } from '@grafana/runtime';
 import { toDataQueryError } from '@grafana/runtime/src/utils/toDataQueryError';
 import {
   DataFrameJSON,
@@ -15,11 +11,11 @@ import {
   LiveChannelEvent,
   LiveChannelId,
   LoadingState,
-  StreamingDataFrame,
-  StreamingFrameOptions,
 } from '@grafana/data';
 import { map, Observable, ReplaySubject, Subject, Subscriber, Subscription } from 'rxjs';
 import { DataStreamSubscriptionKey } from './service';
+import { StreamingDataFrame } from '../data/StreamingDataFrame';
+import { StreamingResponseDataType } from '../data/utils';
 
 const bufferIfNot = (canEmitObservable: Observable<boolean>) => <T>(source: Observable<T>): Observable<T[]> => {
   return new Observable((subscriber: Subscriber<T[]>) => {

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -6,9 +6,16 @@ import {
   StreamingFrameOptions,
 } from '@grafana/runtime/src/services/live';
 import { BehaviorSubject, Observable, share, startWith } from 'rxjs';
-import { LiveChannelAddress, LiveChannelConnectionState, LiveChannelId, toLiveChannelId } from '@grafana/data';
+import {
+  DataQueryResponse,
+  LiveChannelAddress,
+  LiveChannelConnectionState,
+  LiveChannelId,
+  toLiveChannelId,
+} from '@grafana/data';
 import { CentrifugeLiveChannel } from './channel';
 import { LiveDataStream } from './LiveDataStream';
+import { StreamingResponseData } from '../data/utils';
 
 export type CentrifugeSrvDeps = {
   appUrl: string;
@@ -19,7 +26,11 @@ export type CentrifugeSrvDeps = {
   dataStreamSubscriberReadiness: Observable<boolean>;
 };
 
-export type CentrifugeSrv = Omit<GrafanaLiveSrv, 'publish'>;
+export type StreamingDataQueryResponse = Omit<DataQueryResponse, 'data'> & { data: [StreamingResponseData] };
+
+export type CentrifugeSrv = Omit<GrafanaLiveSrv, 'publish' | 'getDataStream'> & {
+  getDataStream: (options: LiveDataStreamOptions) => Observable<StreamingDataQueryResponse>;
+};
 
 export type DataStreamSubscriptionKey = string;
 

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -1,14 +1,12 @@
 import Centrifuge from 'centrifuge/dist/centrifuge';
-import { GrafanaLiveSrv, LiveDataStreamOptions } from '@grafana/runtime/src/services/live';
-import { BehaviorSubject, Observable, share, startWith } from 'rxjs';
 import {
-  LiveChannelAddress,
-  LiveChannelConnectionState,
-  LiveChannelId,
+  GrafanaLiveSrv,
+  LiveDataStreamOptions,
   StreamingFrameAction,
   StreamingFrameOptions,
-  toLiveChannelId,
-} from '@grafana/data';
+} from '@grafana/runtime/src/services/live';
+import { BehaviorSubject, Observable, share, startWith } from 'rxjs';
+import { LiveChannelAddress, LiveChannelConnectionState, LiveChannelId, toLiveChannelId } from '@grafana/data';
 import { CentrifugeLiveChannel } from './channel';
 import { LiveDataStream } from './LiveDataStream';
 

--- a/public/app/features/live/data/StreamingDataFrame.test.ts
+++ b/public/app/features/live/data/StreamingDataFrame.test.ts
@@ -1,7 +1,4 @@
-import { reduceField, ReducerID, StreamingFrameAction, StreamingFrameOptions } from '..';
-import { getFieldDisplayName } from '../field';
-import { DataFrame, FieldType } from '../types';
-import { DataFrameJSON } from './DataFrameJSON';
+import { reduceField, ReducerID, StreamingFrameAction, StreamingFrameOptions, getFieldDisplayName, DataFrame, FieldType, DataFrameJSON } from '@grafana/data';
 import { StreamingDataFrame } from './StreamingDataFrame';
 
 describe('Streaming JSON', () => {

--- a/public/app/features/live/data/StreamingDataFrame.test.ts
+++ b/public/app/features/live/data/StreamingDataFrame.test.ts
@@ -1,4 +1,5 @@
-import { reduceField, ReducerID, StreamingFrameAction, StreamingFrameOptions, getFieldDisplayName, DataFrame, FieldType, DataFrameJSON } from '@grafana/data';
+import { reduceField, ReducerID, getFieldDisplayName, DataFrame, FieldType, DataFrameJSON } from '@grafana/data';
+import { getStreamingFrameOptions, StreamingFrameAction, StreamingFrameOptions } from '@grafana/runtime';
 import { StreamingDataFrame } from './StreamingDataFrame';
 
 describe('Streaming JSON', () => {
@@ -411,7 +412,7 @@ describe('Streaming JSON', () => {
 
   describe('options with defaults', function () {
     it('should provide defaults', function () {
-      expect(StreamingDataFrame.optionsWithDefaults()).toEqual({
+      expect(getStreamingFrameOptions()).toEqual({
         action: StreamingFrameAction.Append,
         maxDelta: Infinity,
         maxLength: 1000,

--- a/public/app/features/live/data/StreamingDataFrame.ts
+++ b/public/app/features/live/data/StreamingDataFrame.ts
@@ -1,16 +1,7 @@
 import { DataFrame, Field, FieldDTO, FieldType, Labels, QueryResultMeta, DataFrameJSON, decodeFieldValueEntities, FieldSchema, guessFieldTypeFromValue, ArrayVector, toFilteredDataFrameDTO } from '@grafana/data';
 import { join } from '@grafana/data/src/transformations/transformers/joinDataFrames';
+import { StreamingFrameAction, StreamingFrameOptions, getStreamingFrameOptions } from '@grafana/runtime';
 import { AlignedData } from 'uplot';
-
-/**
- * Indicate if the frame is appened or replace
- *
- * @public -- but runtime
- */
-export enum StreamingFrameAction {
-  Append = 'append',
-  Replace = 'replace',
-}
 
 /**
  * Stream packet info is attached to StreamingDataFrames and indicate how many
@@ -24,15 +15,6 @@ export interface StreamPacketInfo {
   action: StreamingFrameAction;
   length: number;
   schemaChanged: boolean;
-}
-
-/**
- * @alpha
- */
-export interface StreamingFrameOptions {
-  maxLength: number; // 1000
-  maxDelta: number; // how long to keep things
-  action: StreamingFrameAction; // default will append
 }
 
 enum PushMode {
@@ -164,20 +146,12 @@ export class StreamingDataFrame implements DataFrame {
   };
 
   static empty = (opts?: Partial<StreamingFrameOptions>): StreamingDataFrame =>
-    new StreamingDataFrame(StreamingDataFrame.optionsWithDefaults(opts));
+    new StreamingDataFrame(getStreamingFrameOptions(opts));
 
   static fromDataFrameJSON = (frame: DataFrameJSON, opts?: Partial<StreamingFrameOptions>): StreamingDataFrame => {
-    const streamingDataFrame = new StreamingDataFrame(StreamingDataFrame.optionsWithDefaults(opts));
+    const streamingDataFrame = new StreamingDataFrame(getStreamingFrameOptions(opts));
     streamingDataFrame.push(frame);
     return streamingDataFrame;
-  };
-
-  static optionsWithDefaults = (opts?: Partial<StreamingFrameOptions>): StreamingFrameOptions => {
-    return {
-      maxLength: opts?.maxLength ?? 1000,
-      maxDelta: opts?.maxDelta ?? Infinity,
-      action: opts?.action ?? StreamingFrameAction.Append,
-    };
   };
 
   private get alwaysReplace() {

--- a/public/app/features/live/data/StreamingDataFrame.ts
+++ b/public/app/features/live/data/StreamingDataFrame.ts
@@ -11,8 +11,8 @@ import {
   guessFieldTypeFromValue,
   ArrayVector,
   toFilteredDataFrameDTO,
+  joinAlignedData,
 } from '@grafana/data';
-import { join } from '@grafana/data/src/transformations/transformers/joinDataFrames';
 import {
   StreamingFrameAction,
   StreamingFrameOptions,
@@ -283,7 +283,7 @@ export class StreamingDataFrame implements DataFrame {
           tables.push(labeledTables.get(label) ?? dummyTable);
         });
 
-        values = join(tables);
+        values = joinAlignedData(tables);
       }
 
       if (values.length !== this.fields.length) {

--- a/public/app/features/live/data/StreamingDataFrame.ts
+++ b/public/app/features/live/data/StreamingDataFrame.ts
@@ -1,8 +1,5 @@
-import { DataFrame, Field, FieldDTO, FieldType, Labels, QueryResultMeta } from '../types';
-import { ArrayVector } from '../vector';
-import { DataFrameJSON, decodeFieldValueEntities, FieldSchema } from './DataFrameJSON';
-import { guessFieldTypeFromValue, toFilteredDataFrameDTO } from './processDataFrame';
-import { join } from '../transformations/transformers/joinDataFrames';
+import { DataFrame, Field, FieldDTO, FieldType, Labels, QueryResultMeta, DataFrameJSON, decodeFieldValueEntities, FieldSchema, guessFieldTypeFromValue, ArrayVector, toFilteredDataFrameDTO } from '@grafana/data';
+import { join } from '@grafana/data/src/transformations/transformers/joinDataFrames';
 import { AlignedData } from 'uplot';
 
 /**

--- a/public/app/features/live/data/StreamingDataFrame.ts
+++ b/public/app/features/live/data/StreamingDataFrame.ts
@@ -1,6 +1,23 @@
-import { DataFrame, Field, FieldDTO, FieldType, Labels, QueryResultMeta, DataFrameJSON, decodeFieldValueEntities, FieldSchema, guessFieldTypeFromValue, ArrayVector, toFilteredDataFrameDTO } from '@grafana/data';
+import {
+  DataFrame,
+  Field,
+  FieldDTO,
+  FieldType,
+  Labels,
+  QueryResultMeta,
+  DataFrameJSON,
+  decodeFieldValueEntities,
+  FieldSchema,
+  guessFieldTypeFromValue,
+  ArrayVector,
+  toFilteredDataFrameDTO,
+} from '@grafana/data';
 import { join } from '@grafana/data/src/transformations/transformers/joinDataFrames';
-import { StreamingFrameAction, StreamingFrameOptions, getStreamingFrameOptions } from '@grafana/runtime';
+import {
+  StreamingFrameAction,
+  StreamingFrameOptions,
+  getStreamingFrameOptions,
+} from '@grafana/runtime/src/services/live';
 import { AlignedData } from 'uplot';
 
 /**

--- a/public/app/features/live/data/utils.ts
+++ b/public/app/features/live/data/utils.ts
@@ -1,0 +1,55 @@
+import { DataQueryResponseData, isDataFrame } from "@grafana/data";
+import { StreamingDataFrame } from "./StreamingDataFrame";
+
+/**
+ * @alpha -- experimental
+ */
+ export enum StreamingResponseDataType {
+    NewValuesSameSchema = 'NewValuesSameSchema',
+    FullFrame = 'FullFrame',
+  }
+  
+  /**
+   * @alpha -- experimental
+   */
+  export type StreamingResponseDataTypeToData = {
+    [StreamingResponseDataType.NewValuesSameSchema]: {
+      values: unknown[][];
+    };
+    [StreamingResponseDataType.FullFrame]: {
+      frame: ReturnType<StreamingDataFrame['serialize']>;
+    };
+  };
+  
+  /**
+   * @alpha -- experimental
+   */
+  export type StreamingResponseData<T = StreamingResponseDataType> = T extends StreamingResponseDataType
+    ? {
+        type: T;
+      } & StreamingResponseDataTypeToData[T]
+    : never;
+  
+  /**
+   * @alpha -- experimental
+   */
+  export const isStreamingResponseData = <T extends StreamingResponseDataType>(
+    responseData: DataQueryResponseData,
+    type: T
+  ): responseData is StreamingResponseData<T> => 'type' in responseData && responseData.type === type;
+  
+  const AllStreamingResponseDataTypes = Object.values(StreamingResponseDataType);
+  
+  /**
+   * @alpha -- experimental
+   */
+  export const isAnyStreamingResponseData = (
+    responseData: DataQueryResponseData
+  ): responseData is StreamingResponseData =>
+    'type' in responseData && AllStreamingResponseDataTypes.includes(responseData.type);
+  
+  /**
+   * @alpha -- experimental
+   */
+  export const isStreamingDataFrame = (data: DataQueryResponseData): data is StreamingDataFrame =>
+    isDataFrame(data) && 'packetInfo' in data;

--- a/public/app/features/live/data/utils.ts
+++ b/public/app/features/live/data/utils.ts
@@ -1,55 +1,55 @@
-import { DataQueryResponseData, isDataFrame } from "@grafana/data";
-import { StreamingDataFrame } from "./StreamingDataFrame";
+import { DataQueryResponseData, isDataFrame } from '@grafana/data';
+import { StreamingDataFrame } from './StreamingDataFrame';
 
 /**
  * @alpha -- experimental
  */
- export enum StreamingResponseDataType {
-    NewValuesSameSchema = 'NewValuesSameSchema',
-    FullFrame = 'FullFrame',
-  }
-  
-  /**
-   * @alpha -- experimental
-   */
-  export type StreamingResponseDataTypeToData = {
-    [StreamingResponseDataType.NewValuesSameSchema]: {
-      values: unknown[][];
-    };
-    [StreamingResponseDataType.FullFrame]: {
-      frame: ReturnType<StreamingDataFrame['serialize']>;
-    };
+export enum StreamingResponseDataType {
+  NewValuesSameSchema = 'NewValuesSameSchema',
+  FullFrame = 'FullFrame',
+}
+
+/**
+ * @alpha -- experimental
+ */
+export type StreamingResponseDataTypeToData = {
+  [StreamingResponseDataType.NewValuesSameSchema]: {
+    values: unknown[][];
   };
-  
-  /**
-   * @alpha -- experimental
-   */
-  export type StreamingResponseData<T = StreamingResponseDataType> = T extends StreamingResponseDataType
-    ? {
-        type: T;
-      } & StreamingResponseDataTypeToData[T]
-    : never;
-  
-  /**
-   * @alpha -- experimental
-   */
-  export const isStreamingResponseData = <T extends StreamingResponseDataType>(
-    responseData: DataQueryResponseData,
-    type: T
-  ): responseData is StreamingResponseData<T> => 'type' in responseData && responseData.type === type;
-  
-  const AllStreamingResponseDataTypes = Object.values(StreamingResponseDataType);
-  
-  /**
-   * @alpha -- experimental
-   */
-  export const isAnyStreamingResponseData = (
-    responseData: DataQueryResponseData
-  ): responseData is StreamingResponseData =>
-    'type' in responseData && AllStreamingResponseDataTypes.includes(responseData.type);
-  
-  /**
-   * @alpha -- experimental
-   */
-  export const isStreamingDataFrame = (data: DataQueryResponseData): data is StreamingDataFrame =>
-    isDataFrame(data) && 'packetInfo' in data;
+  [StreamingResponseDataType.FullFrame]: {
+    frame: ReturnType<StreamingDataFrame['serialize']>;
+  };
+};
+
+/**
+ * @alpha -- experimental
+ */
+export type StreamingResponseData<T = StreamingResponseDataType> = T extends StreamingResponseDataType
+  ? {
+      type: T;
+    } & StreamingResponseDataTypeToData[T]
+  : never;
+
+/**
+ * @alpha -- experimental
+ */
+export const isStreamingResponseData = <T extends StreamingResponseDataType>(
+  responseData: DataQueryResponseData,
+  type: T
+): responseData is StreamingResponseData<T> => 'type' in responseData && responseData.type === type;
+
+const AllStreamingResponseDataTypes = Object.values(StreamingResponseDataType);
+
+/**
+ * @alpha -- experimental
+ */
+export const isAnyStreamingResponseData = (
+  responseData: DataQueryResponseData
+): responseData is StreamingResponseData =>
+  'type' in responseData && AllStreamingResponseDataTypes.includes(responseData.type);
+
+/**
+ * @alpha -- experimental
+ */
+export const isStreamingDataFrame = (data: DataQueryResponseData): data is StreamingDataFrame =>
+  isDataFrame(data) && 'packetInfo' in data;

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -4,7 +4,7 @@ import { MonoTypeOperatorFunction, Observable, of, ReplaySubject, Unsubscribable
 import { map, mergeMap } from 'rxjs/operators';
 
 // Services & Utils
-import { getTemplateSrv, isStreamingDataFrame } from '@grafana/runtime';
+import { getTemplateSrv } from '@grafana/runtime';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { preProcessPanelData, runRequest } from './runRequest';
 import { isSharedDashboardQuery, runSharedRequest } from '../../../plugins/datasource/dashboard';
@@ -28,7 +28,6 @@ import {
   PanelData,
   rangeUtil,
   ScopedVars,
-  StreamingDataFrame,
   TimeRange,
   TimeZone,
   toDataFrame,
@@ -37,6 +36,8 @@ import {
 import { getDashboardQueryRunner } from './DashboardQueryRunner/DashboardQueryRunner';
 import { mergePanelAndDashData } from './mergePanelAndDashData';
 import { PanelModel } from '../../dashboard/state';
+import { isStreamingDataFrame } from 'app/features/live/data/utils';
+import { StreamingDataFrame } from 'app/features/live/data/StreamingDataFrame';
 
 export interface QueryRunnerOptions<
   TQuery extends DataQuery = DataQuery,

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -17,21 +17,21 @@ import {
   guessFieldTypes,
   LoadingState,
   PanelData,
-  StreamingDataFrame,
   TimeRange,
   toDataFrame,
 } from '@grafana/data';
-import {
-  isAnyStreamingResponseData,
-  isStreamingResponseData,
-  StreamingResponseDataType,
-  toDataQueryError,
-} from '@grafana/runtime';
+import { toDataQueryError } from '@grafana/runtime';
 import { emitDataRequestEvent } from './queryAnalytics';
 import { dataSource as expressionDatasource } from 'app/features/expressions/ExpressionDatasource';
 import { ExpressionQuery } from 'app/features/expressions/types';
 import { cancelNetworkRequestsOnUnsubscribe } from './processing/canceler';
 import { isExpressionReference } from '@grafana/runtime/src/utils/DataSourceWithBackend';
+import {
+  isAnyStreamingResponseData,
+  isStreamingResponseData,
+  StreamingResponseDataType,
+} from 'app/features/live/data/utils';
+import { StreamingDataFrame } from 'app/features/live/data/StreamingDataFrame';
 
 type MapOfResponsePackets = { [str: string]: DataQueryResponse };
 

--- a/public/app/plugins/datasource/grafana/datasource.ts
+++ b/public/app/plugins/datasource/grafana/datasource.ts
@@ -1,5 +1,12 @@
 import { from, merge, Observable, of } from 'rxjs';
-import { DataSourceWithBackend, getBackendSrv, getGrafanaLiveSrv, getTemplateSrv } from '@grafana/runtime';
+import {
+  DataSourceWithBackend,
+  getBackendSrv,
+  getGrafanaLiveSrv,
+  getStreamingFrameOptions,
+  getTemplateSrv,
+  StreamingFrameOptions,
+} from '@grafana/runtime';
 import {
   AnnotationQuery,
   AnnotationQueryRequest,
@@ -10,8 +17,6 @@ import {
   DataSourceRef,
   isValidLiveChannelAddress,
   parseLiveChannelAddress,
-  StreamingDataFrame,
-  StreamingFrameOptions,
   toDataFrame,
 } from '@grafana/data';
 
@@ -104,7 +109,7 @@ export class GrafanaDatasource extends DataSourceWithBackend<GrafanaQuery> {
             key: `${request.requestId}.${counter++}`,
             addr: addr!,
             filter,
-            buffer: StreamingDataFrame.optionsWithDefaults(buffer),
+            buffer: getStreamingFrameOptions(buffer),
           })
         );
       } else {

--- a/public/app/plugins/datasource/testdata/runStreams.ts
+++ b/public/app/plugins/datasource/testdata/runStreams.ts
@@ -9,7 +9,6 @@ import {
   CSVReader,
   Field,
   LoadingState,
-  StreamingDataFrame,
   DataFrameSchema,
   DataFrameData,
 } from '@grafana/data';
@@ -17,6 +16,7 @@ import {
 import { TestDataQuery, StreamingQuery } from './types';
 import { getRandomLine } from './LogIpsum';
 import { liveTimer } from 'app/features/dashboard/dashgrid/liveTimer';
+import { StreamingDataFrame } from 'app/features/live/data/StreamingDataFrame';
 
 export const defaultStreamQuery: StreamingQuery = {
   type: 'signal',

--- a/public/app/plugins/panel/live/LivePanel.tsx
+++ b/public/app/plugins/panel/live/LivePanel.tsx
@@ -13,7 +13,6 @@ import {
   PanelData,
   LoadingState,
   applyFieldOverrides,
-  StreamingDataFrame,
   LiveChannelAddress,
 } from '@grafana/data';
 import { TablePanel } from '../table/TablePanel';
@@ -21,6 +20,7 @@ import { LivePanelOptions, MessageDisplayMode } from './types';
 import { config, getGrafanaLiveSrv } from '@grafana/runtime';
 import { css, cx } from '@emotion/css';
 import { isEqual } from 'lodash';
+import { StreamingDataFrame } from 'app/features/live/data/StreamingDataFrame';
 
 interface Props extends PanelProps<LivePanelOptions> {}
 

--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
@@ -5,7 +5,7 @@ import { TimelineMode, TimelineOptions } from './types';
 import { TimelineChart } from './TimelineChart';
 import { prepareTimelineFields, prepareTimelineLegendItems } from './utils';
 import { StateTimelineTooltip } from './StateTimelineTooltip';
-import { getLastStreamingDataFramePacket } from '@grafana/data/src/dataframe/StreamingDataFrame';
+import { getLastStreamingDataFramePacket } from 'app/features/live/data/StreamingDataFrame';
 
 interface TimelinePanelProps extends PanelProps<TimelineOptions> {}
 


### PR DESCRIPTION
In an effort to keep the gory details out of `@grafana/data` this moves StreamingDataFrame out of the data package into core

Targeting:
https://github.com/grafana/grafana/pull/41492