### PR TITLE
Select: Memoize custom styles

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -6,7 +6,7 @@ import { default as AsyncCreatable } from 'react-select/async-creatable';
 
 import { Icon } from '../Icon/Icon';
 import { Spinner } from '../Spinner/Spinner';
-import resetSelectStyles from './resetSelectStyles';
+import { useCustomSelectStyles } from './resetSelectStyles';
 import { SelectMenu, SelectMenuOptions } from './SelectMenu';
 import { IndicatorsContainer } from './IndicatorsContainer';
 import { ValueContainer } from './ValueContainer';
@@ -147,6 +147,7 @@ export function SelectBase<T>({
 
   const reactSelectRef = useRef<{ controlRef: HTMLElement }>(null);
   const [closeToBottom, setCloseToBottom] = useState<boolean>(false);
+  const selectStyles = useCustomSelectStyles(theme, width);
 
   // Infer the menu position for asynchronously loaded options. menuPlacement="auto" doesn't work when the menu is
   // automatically opened when the component is created (it happens in SegmentSelect by setting menuIsOpen={true}).
@@ -339,29 +340,7 @@ export function SelectBase<T>({
           SelectContainer,
           ...components,
         }}
-        styles={{
-          ...resetSelectStyles(theme),
-          menuPortal: (base: any) => ({
-            ...base,
-            zIndex: theme.zIndex.portal,
-          }),
-          //These are required for the menu positioning to function
-          menu: ({ top, bottom, position }: any) => ({
-            top,
-            bottom,
-            position,
-            minWidth: '100%',
-            zIndex: theme.zIndex.dropdown,
-          }),
-          container: () => ({
-            width: width ? theme.spacing(width) : '100%',
-            display: width === 'auto' ? 'inline-flex' : 'flex',
-          }),
-          option: (provided: any, state: any) => ({
-            ...provided,
-            opacity: state.isDisabled ? 0.5 : 1,
-          }),
-        }}
+        styles={selectStyles}
         className={className}
         {...commonSelectProps}
         {...creatableProps}

--- a/packages/grafana-ui/src/components/Select/resetSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/resetSelectStyles.ts
@@ -1,4 +1,5 @@
 import { GrafanaTheme2 } from '@grafana/data';
+import { useMemo } from 'react';
 import { CSSObjectWithLabel } from 'react-select';
 
 export default function resetSelectStyles(theme: GrafanaTheme2) {
@@ -39,4 +40,38 @@ export default function resetSelectStyles(theme: GrafanaTheme2) {
     singleValue: () => ({}),
     valueContainer: () => ({}),
   };
+}
+
+export function useCustomSelectStyles(theme: GrafanaTheme2, width: number | string | undefined) {
+  return useMemo(() => {
+    return {
+      ...resetSelectStyles(theme),
+      menuPortal: (base: any) => {
+        // Would like to correct top position when menu is placed bottom, but have props are not sent to this style function.
+        // Only state is. https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/components/Menu.tsx#L605
+        return {
+          ...base,
+          zIndex: theme.zIndex.portal,
+        };
+      },
+      //These are required for the menu positioning to function
+      menu: ({ top, bottom, position }: any) => {
+        return {
+          top,
+          bottom,
+          position,
+          minWidth: '100%',
+          zIndex: theme.zIndex.dropdown,
+        };
+      },
+      container: () => ({
+        width: width ? theme.spacing(width) : '100%',
+        display: width === 'auto' ? 'inline-flex' : 'flex',
+      }),
+      option: (provided: any, state: any) => ({
+        ...provided,
+        opacity: state.isDisabled ? 0.5 : 1,
+      }),
+    };
+  }, [theme, width]);
 }


### PR DESCRIPTION
Was trying to fix the menu position, it's about 6px too high, intersecting the input and just looks off. So refactored the
styles generation and tried to fix it sadly the menu portal styles function does not know the placement of menu (if it's bottom) so was
in the end unable to fix it without messing with position for a top positioned menu.

This triggers my OCD: 
![Screenshot from 2021-12-14 09-44-57](https://user-images.githubusercontent.com/10999/145963969-c7ef0448-1407-4d90-abb3-7d432352cf86.png)


Sadly I think we need to update react-select upstream to fix this line: https://github.com/JedWatson/react-select/blob/master/packages/react-select/src/components/Menu.tsx#L605 
so that it does not pass state but pass props like with other style functions 