### PR TITLE
Plugins: Prometheus always using /label/.../values

### DIFF
--- a/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
@@ -99,40 +99,11 @@ describe('PrometheusMetricFindQuery', () => {
       });
     });
 
-    it('label_values(metric, resource) should generate series query with correct time', async () => {
+    it('label_values(metric, resource) should generate label values query with correct time', async () => {
       const query = setupMetricFindQuery({
         query: 'label_values(metric, resource)',
         response: {
-          data: [
-            { __name__: 'metric', resource: 'value1' },
-            { __name__: 'metric', resource: 'value2' },
-            { __name__: 'metric', resource: 'value3' },
-          ],
-        },
-      });
-      const results = await query.process();
-
-      expect(results).toHaveLength(3);
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-      expect(fetchMock).toHaveBeenCalledWith({
-        method: 'GET',
-        url: `proxied/api/v1/series?match${encodeURIComponent(
-          '[]'
-        )}=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
-        hideFromInspector: true,
-        headers: {},
-      });
-    });
-
-    it('label_values(metric{label1="foo", label2="bar", label3="baz"}, resource) should generate series query with correct time', async () => {
-      const query = setupMetricFindQuery({
-        query: 'label_values(metric{label1="foo", label2="bar", label3="baz"}, resource)',
-        response: {
-          data: [
-            { __name__: 'metric', resource: 'value1' },
-            { __name__: 'metric', resource: 'value2' },
-            { __name__: 'metric', resource: 'value3' },
-          ],
+          data: ['value1', 'value2', 'value3'],
         },
       });
       const results = await query.process();
@@ -142,34 +113,31 @@ describe('PrometheusMetricFindQuery', () => {
       expect(fetchMock).toHaveBeenCalledWith({
         method: 'GET',
         url:
-          'proxied/api/v1/series?match%5B%5D=metric%7Blabel1%3D%22foo%22%2C%20label2%3D%22bar%22%2C%20label3%3D%22baz%22%7D&start=1524650400&end=1524654000',
+          `proxied/api/v1/label/resource/values?` +
+          `${encodeURIComponent('match[]')}=metric` +
+          `&start=${raw.from.unix()}&end=${raw.to.unix()}`,
         hideFromInspector: true,
         headers: {},
       });
     });
 
-    it('label_values(metric, resource) result should not contain empty string', async () => {
+    it('label_values(metric{label1="foo", label2="bar", label3="baz"}, resource) should generate label values query with correct time', async () => {
       const query = setupMetricFindQuery({
-        query: 'label_values(metric, resource)',
+        query: 'label_values(metric{label1="foo", label2="bar", label3="baz"}, resource)',
         response: {
-          data: [
-            { __name__: 'metric', resource: 'value1' },
-            { __name__: 'metric', resource: 'value2' },
-            { __name__: 'metric', resource: '' },
-          ],
+          data: ['value1', 'value2', 'value3'],
         },
       });
-      const results: any = await query.process();
+      const results = await query.process();
 
-      expect(results).toHaveLength(2);
-      expect(results[0].text).toBe('value1');
-      expect(results[1].text).toBe('value2');
+      expect(results).toHaveLength(3);
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith({
         method: 'GET',
-        url: `proxied/api/v1/series?match${encodeURIComponent(
-          '[]'
-        )}=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
+        url:
+          `proxied/api/v1/label/resource/values?` +
+          `${encodeURIComponent('match[]')}=${encodeURIComponent('metric{label1="foo", label2="bar", label3="baz"}')}` +
+          `&start=${raw.from.unix()}&end=${raw.to.unix()}`,
         hideFromInspector: true,
         headers: {},
       });

--- a/public/app/plugins/datasource/prometheus/metric_find_query.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.ts
@@ -70,44 +70,27 @@ export default class PrometheusMetricFindQuery {
     const start = this.datasource.getPrometheusTime(this.range.from, false);
     const end = this.datasource.getPrometheusTime(this.range.to, true);
 
-    let url: string;
-
+    let params: object;
     if (!metric) {
-      const params = {
+      params = {
         start: start.toString(),
         end: end.toString(),
       };
-      // return label values globally
-      url = `/api/v1/label/${label}/values`;
-
-      return this.datasource.metadataRequest(url, params).then((result: any) => {
-        return _map(result.data.data, (value) => {
-          return { text: value };
-        });
-      });
     } else {
-      const params = {
+      params = {
         'match[]': metric,
         start: start.toString(),
         end: end.toString(),
       };
-      url = `/api/v1/series`;
-
-      return this.datasource.metadataRequest(url, params).then((result: any) => {
-        const _labels = _map(result.data.data, (metric) => {
-          return metric[label] || '';
-        }).filter((label) => {
-          return label !== '';
-        });
-
-        return uniq(_labels).map((metric) => {
-          return {
-            text: metric,
-            expandable: true,
-          };
-        });
-      });
     }
+
+    const url = `/api/v1/label/${label}/values`;
+
+    return this.datasource.metadataRequest(url, params).then((result: any) => {
+      return _map(result.data.data, (value) => {
+        return { text: value };
+      });
+    });
   }
 
   metricNameQuery(metricFilterPattern: string) {

--- a/public/app/plugins/datasource/prometheus/metric_find_query.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.ts
@@ -1,4 +1,4 @@
-import { chain, map as _map, uniq } from 'lodash';
+import { chain, map as _map } from 'lodash';
 import { lastValueFrom } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { MetricFindValue, TimeRange } from '@grafana/data';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Previously prometheus /label/<name>/values endpoint did not support matchers so we used /series endpoint when `label_values(matchers, name)` was requested. 

The support for matchers [was added](https://github.com/prometheus/prometheus/pull/8301) in label values endpoint a year ago, so now it should be safe to rely on it.

This endpoint is more efficient than `/series` so this should speed up the dashboard loading where template variables use this call.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/33487

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

<!-- **Special notes for your reviewer**: -->
