### PR TITLE
Geomap: support hide from tooltip

### DIFF
--- a/public/app/plugins/panel/geomap/components/DataHoverView.tsx
+++ b/public/app/plugins/panel/geomap/components/DataHoverView.tsx
@@ -43,12 +43,17 @@ export class DataHoverView extends PureComponent<Props> {
     return (
       <table className={this.style.infoWrap}>
         <tbody>
-          {data.fields.map((f, i) => (
-            <tr key={`${i}/${rowIndex}`} className={i === columnIndex ? this.style.highlight : ''}>
-              <th>{getFieldDisplayName(f, data)}:</th>
-              <td>{fmt(f, rowIndex)}</td>
-            </tr>
-          ))}
+          {data.fields.map((f, i) => {
+            if (f.config.custom?.hideFrom?.tooltip) {
+              return null;
+            }
+            return (
+              <tr key={`${i}/${rowIndex}`} className={i === columnIndex ? this.style.highlight : ''}>
+                <th>{getFieldDisplayName(f, data)}:</th>
+                <td>{fmt(f, rowIndex)}</td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     );

--- a/public/app/plugins/panel/geomap/components/DataHoverView.tsx
+++ b/public/app/plugins/panel/geomap/components/DataHoverView.tsx
@@ -43,17 +43,14 @@ export class DataHoverView extends PureComponent<Props> {
     return (
       <table className={this.style.infoWrap}>
         <tbody>
-          {data.fields.map((f, i) => {
-            if (f.config.custom?.hideFrom?.tooltip) {
-              return null;
-            }
-            return (
+          {data.fields
+            .filter((f) => !Boolean(f.config.custom?.hideFrom?.tooltip))
+            .map((f, i) => (
               <tr key={`${i}/${rowIndex}`} className={i === columnIndex ? this.style.highlight : ''}>
                 <th>{getFieldDisplayName(f, data)}:</th>
                 <td>{fmt(f, rowIndex)}</td>
               </tr>
-            );
-          })}
+            ))}
         </tbody>
       </table>
     );

--- a/public/app/plugins/panel/geomap/module.tsx
+++ b/public/app/plugins/panel/geomap/module.tsx
@@ -7,12 +7,17 @@ import { mapPanelChangedHandler, mapMigrationHandler } from './migrations';
 import { getLayerEditor } from './editor/layerEditor';
 import { LayersEditor } from './editor/LayersEditor';
 import { config } from '@grafana/runtime';
+import { commonOptionsBuilder } from '@grafana/ui';
 
 export const plugin = new PanelPlugin<GeomapPanelOptions>(GeomapPanel)
   .setNoPadding()
   .setPanelChangeHandler(mapPanelChangedHandler)
   .setMigrationHandler(mapMigrationHandler)
-  .useFieldConfig()
+  .useFieldConfig({
+    useCustomConfig: (builder) => {
+      commonOptionsBuilder.addHideFrom(builder);
+    },
+  })
   .setPanelOptions((builder, context) => {
     let category = ['Map view'];
     builder.addCustomEditor({

--- a/public/app/plugins/panel/geomap/types.ts
+++ b/public/app/plugins/panel/geomap/types.ts
@@ -1,4 +1,5 @@
 import { MapLayerHandler, MapLayerOptions, SelectableValue } from '@grafana/data';
+import { HideableFieldConfig } from '@grafana/schema';
 import { LayerElement } from 'app/core/components/Layers/types';
 import BaseLayer from 'ol/layer/Base';
 import { Units } from 'ol/proj/Units';
@@ -39,6 +40,11 @@ export const defaultView: MapViewConfig = {
   lon: 0,
   zoom: 1,
 };
+
+/** Support hide from legend/tooltip */
+export interface GeomapFieldConfig extends HideableFieldConfig {
+  // nothing custom yet
+}
 
 export interface GeomapPanelOptions {
   view: MapViewConfig;


### PR DESCRIPTION
In the geomap, we may want to exclude some fields from the popup display.  This PR re-uses the same `hideFrom` setting used in the timeseries panel

![Peek 2021-12-14 13-06](https://user-images.githubusercontent.com/705951/146079575-ae310cc3-a4d6-4e47-9c2e-d2bc52a704d6.gif)

