### PR TITLE
Chore: Support PR checks for forks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,6 +1,6 @@
 name: PR Checks
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
**What this PR does / why we need it**:
Use `pull_request_target` event instead of `pull_request` event to support PR checks for PRs opened from forked branches.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

