### PR TITLE
theme: fixed colors to be monaco-compatible

### DIFF
--- a/packages/grafana-data/src/themes/palette.ts
+++ b/packages/grafana-data/src/themes/palette.ts
@@ -1,6 +1,6 @@
 export const palette = {
-  white: '#fff',
-  black: '#000',
+  white: '#FFFFFF',
+  black: '#000000',
 
   gray25: '#2c3235',
   gray15: '#22252b', //'#202226',

--- a/packages/grafana-ui/src/components/ColorPicker/ColorPickerPopover.test.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/ColorPickerPopover.test.tsx
@@ -29,7 +29,7 @@ describe('ColorPickerPopover', () => {
       expect(colorSwatchWrapper[0]).toBeInTheDocument();
 
       userEvent.click(colorSwatchWrapper[0]);
-      expect(color).toHaveStyle('box-shadow: inset 0 0 0 2px #73BF69, inset 0 0 0 4px #000');
+      expect(color).toHaveStyle('box-shadow: inset 0 0 0 2px #73BF69, inset 0 0 0 4px #000000');
     });
   });
 


### PR DESCRIPTION
hotfix for https://github.com/grafana/grafana/issues/43052

NOTE: this is not the correct, final fix, because this can get broken again later. but this will help main-branch to be usable again with prometheus.