### PR TITLE
Alerting: fix WeCom channel notifier test assertion

### DIFF
--- a/pkg/services/ngalert/notifier/channels/wecom_test.go
+++ b/pkg/services/ngalert/notifier/channels/wecom_test.go
@@ -47,7 +47,7 @@ func TestWeComNotifier(t *testing.T) {
 			},
 			expMsg: map[string]interface{}{
 				"markdown": map[string]interface{}{
-					"content": "# [FIRING:1]  (val1)\n**Firing**\n\nValue: <no value>\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n\n",
+					"content": "# [FIRING:1]  (val1)\n**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n\n",
 				},
 				"msgtype": "markdown",
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes failing CI builds on `main` by asserting the correct string output for the `WeCom` channel notifier.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Introduced in https://github.com/grafana/grafana/pull/43148 – which did not yet have the WeCom channel notifier at the time it forked from `main` (introduced in https://github.com/grafana/grafana/pull/40975).

