### PR TITLE
Geomap: use string comparison for eq operator

### DIFF
--- a/public/app/plugins/panel/geomap/editor/StyleRuleEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/StyleRuleEditor.tsx
@@ -152,7 +152,7 @@ export const StyleRuleEditor: FC<StandardEditorProps<FeatureStyleConfig, any, an
             options={comparators}
             onChange={onChangeComparison}
             aria-label={'Comparison operator'}
-            width={6}
+            width={8}
           />
         </InlineField>
         <InlineField className={styles.inline} grow={true}>

--- a/public/app/plugins/panel/geomap/utils/checkFeatureMatchesStyleRule.test.ts
+++ b/public/app/plugins/panel/geomap/utils/checkFeatureMatchesStyleRule.test.ts
@@ -21,6 +21,16 @@ describe('check if feature matches style rule', () => {
     expect(
       checkFeatureMatchesStyleRule(
         {
+          operation: ComparisonOperation.EQ,
+          property: 'number',
+          value: '3',
+        },
+        feature
+      )
+    ).toEqual(true);
+    expect(
+      checkFeatureMatchesStyleRule(
+        {
           operation: ComparisonOperation.LT,
           property: 'number',
           value: 2,

--- a/public/app/plugins/panel/geomap/utils/checkFeatureMatchesStyleRule.ts
+++ b/public/app/plugins/panel/geomap/utils/checkFeatureMatchesStyleRule.ts
@@ -11,7 +11,7 @@ export const checkFeatureMatchesStyleRule = (rule: FeatureRuleConfig, feature: F
   const val = feature.get(rule.property);
   switch (rule.operation) {
     case ComparisonOperation.EQ:
-      return val === rule.value;
+      return `${val}` === `${rule.value}`;
     case ComparisonOperation.NEQ:
       return val !== rule.value;
     case ComparisonOperation.GT:


### PR DESCRIPTION
The current "eq" comparison does not work when the values are string representations of numbers.  To avoid any confusion, we can just check if the string representation is the same