### PR TITLE
docs: feature_toggles have to be separated by commas

### DIFF
--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1778,7 +1778,12 @@ For more information about Grafana Enterprise, refer to [Grafana Enterprise]({{<
 
 ### enable
 
-Keys of alpha features to enable, separated by space.
+Keys of alpha features to enable, separated by commas. Example:
+  
+```ini
+[feature_toggles]
+enable = tempoSearch,tempoServiceGraph
+```
 
 ## [date_formats]
 


### PR DESCRIPTION

**What this PR does / why we need it**:
From my tests multiple feature toggles have to be separated by commas to work, the docs mentioned you should use spaces.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
No
