### PR TITLE
Geomap: Add default svg size

### DIFF
--- a/public/app/plugins/panel/geomap/style/markers.ts
+++ b/public/app/plugins/panel/geomap/style/markers.ts
@@ -216,7 +216,8 @@ const makers: SymbolMaker[] = [
   },
 ];
 
-async function prepareSVG(url: string): Promise<string> {
+async function prepareSVG(url: string, size?: number): Promise<string> {
+  const side = size ?? 100;
   return fetch(url, { method: 'GET' })
     .then((res) => {
       return res.text();
@@ -230,6 +231,8 @@ async function prepareSVG(url: string): Promise<string> {
       }
       // open layers requires a white fill becaues it uses tint to set color
       svg.setAttribute('fill', '#fff');
+      svg.setAttribute('width', `${side}px`);
+      svg.setAttribute('height', `${side}px`);
       const svgString = new XMLSerializer().serializeToString(svg);
       const svgURI = encodeURIComponent(svgString);
       return `data:image/svg+xml,${svgURI}`;

--- a/public/app/plugins/panel/geomap/style/markers.ts
+++ b/public/app/plugins/panel/geomap/style/markers.ts
@@ -217,7 +217,6 @@ const makers: SymbolMaker[] = [
 ];
 
 async function prepareSVG(url: string, size?: number): Promise<string> {
-  const side = size ?? 100;
   return fetch(url, { method: 'GET' })
     .then((res) => {
       return res.text();
@@ -229,10 +228,15 @@ async function prepareSVG(url: string, size?: number): Promise<string> {
       if (!svg) {
         return '';
       }
+
+      const svgSize = size ?? 100;
+      const width = svg.getAttribute('width') ?? svgSize;
+      const height = svg.getAttribute('height') ?? svgSize;
+
       // open layers requires a white fill becaues it uses tint to set color
       svg.setAttribute('fill', '#fff');
-      svg.setAttribute('width', `${side}px`);
-      svg.setAttribute('height', `${side}px`);
+      svg.setAttribute('width', `${width}px`);
+      svg.setAttribute('height', `${height}px`);
       const svgString = new XMLSerializer().serializeToString(svg);
       const svgURI = encodeURIComponent(svgString);
       return `data:image/svg+xml,${svgURI}`;


### PR DESCRIPTION
Fixes drawing SVG with width and height in Firefox and Safari

