### PR TITLE
Azure Monitor: Bug fix for variable interpolations in metrics dropdowns

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricNameField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricNameField.tsx
@@ -34,6 +34,7 @@ const MetricNameField: React.FC<MetricNameProps> = ({ metricNames, query, variab
         onChange={handleChange}
         options={options}
         width={38}
+        allowCustomValue
       />
     </Field>
   );

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricNamespaceField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricNamespaceField.tsx
@@ -44,6 +44,7 @@ const MetricNamespaceField: React.FC<MetricNamespaceFieldProps> = ({
         onChange={handleChange}
         options={options}
         width={38}
+        allowCustomValue
       />
     </Field>
   );

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/ResourceGroupsField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/ResourceGroupsField.tsx
@@ -36,6 +36,7 @@ const ResourceGroupsField: React.FC<ResourceGroupsFieldProps> = ({
         onChange={handleChange}
         options={options}
         width={38}
+        allowCustomValue
       />
     </Field>
   );

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/ResourceNameField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/ResourceNameField.tsx
@@ -36,6 +36,7 @@ const ResourceNameField: React.FC<ResourceNameFieldProps> = ({
         onChange={handleChange}
         options={options}
         width={38}
+        allowCustomValue
       />
     </Field>
   );

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/ResourceTypeField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/ResourceTypeField.tsx
@@ -40,6 +40,7 @@ const NamespaceField: React.FC<NamespaceFieldProps> = ({
         onChange={handleChange}
         options={options}
         width={38}
+        allowCustomValue
       />
     </Field>
   );

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.test.ts
@@ -88,13 +88,11 @@ interface TestScenario {
   name: string;
   hook: DataHook;
 
-  // For conviencence, only need to define the azureMonitor part of the query
+  // For convenience, only need to define the azureMonitor part of the query
   emptyQueryPartial: AzureMetricQuery;
-  validQueryPartial: AzureMetricQuery;
-  invalidQueryPartial: AzureMetricQuery;
-  templateVariableQueryPartial: AzureMetricQuery;
+  customProperties: AzureMetricQuery;
 
-  expectedClearedQueryPartial?: AzureMetricQuery;
+  expectedCustomPropertyResults?: Array<AzureMonitorOption<string>>;
   expectedOptions: AzureMonitorOption[];
 }
 
@@ -110,14 +108,8 @@ describe('AzureMonitor: metrics dataHooks', () => {
       name: 'useResourceGroups',
       hook: useResourceGroups,
       emptyQueryPartial: {},
-      validQueryPartial: {
-        resourceGroup: 'web-app-development',
-      },
-      invalidQueryPartial: {
-        resourceGroup: 'wrong-resource-group`',
-      },
-      templateVariableQueryPartial: {
-        resourceGroup: '$rg',
+      customProperties: {
+        resourceGroup: 'resource-group-$ENVIRONMENT',
       },
       expectedOptions: [
         {
@@ -129,9 +121,11 @@ describe('AzureMonitor: metrics dataHooks', () => {
           value: 'web-app-development',
         },
       ],
-      expectedClearedQueryPartial: {
-        resourceGroup: undefined,
-      },
+      expectedCustomPropertyResults: [
+        { label: 'Web App - Production', value: 'web-app-production' },
+        { label: 'Web App - Development', value: 'web-app-development' },
+        { label: 'resource-group-$ENVIRONMENT', value: 'resource-group-$ENVIRONMENT' },
+      ],
     },
 
     {
@@ -140,17 +134,9 @@ describe('AzureMonitor: metrics dataHooks', () => {
       emptyQueryPartial: {
         resourceGroup: 'web-app-development',
       },
-      validQueryPartial: {
+      customProperties: {
         resourceGroup: 'web-app-development',
-        metricDefinition: 'azure/vm',
-      },
-      invalidQueryPartial: {
-        resourceGroup: 'web-app-development',
-        metricDefinition: 'azure/invalid-resource-type',
-      },
-      templateVariableQueryPartial: {
-        resourceGroup: 'web-app-development',
-        metricDefinition: '$rt',
+        metricDefinition: 'azure/resource-type-$ENVIRONMENT',
       },
       expectedOptions: [
         {
@@ -162,12 +148,12 @@ describe('AzureMonitor: metrics dataHooks', () => {
           value: 'azure/db',
         },
       ],
-      expectedClearedQueryPartial: {
-        resourceGroup: 'web-app-development',
-        metricDefinition: undefined,
-      },
+      expectedCustomPropertyResults: [
+        { label: 'Virtual Machine', value: 'azure/vm' },
+        { label: 'Database', value: 'azure/db' },
+        { label: 'azure/resource-type-$ENVIRONMENT', value: 'azure/resource-type-$ENVIRONMENT' },
+      ],
     },
-
     {
       name: 'useResourceNames',
       hook: useResourceNames,
@@ -175,20 +161,10 @@ describe('AzureMonitor: metrics dataHooks', () => {
         resourceGroup: 'web-app-development',
         metricDefinition: 'azure/vm',
       },
-      validQueryPartial: {
+      customProperties: {
         resourceGroup: 'web-app-development',
         metricDefinition: 'azure/vm',
-        resourceName: 'web-server',
-      },
-      invalidQueryPartial: {
-        resourceGroup: 'web-app-development',
-        metricDefinition: 'azure/vm',
-        resourceName: 'resource-that-doesnt-exist',
-      },
-      templateVariableQueryPartial: {
-        resourceGroup: 'web-app-development',
-        metricDefinition: 'azure/vm',
-        resourceName: '$variable',
+        resourceName: 'resource-name-$ENVIRONMENT',
       },
       expectedOptions: [
         {
@@ -200,11 +176,11 @@ describe('AzureMonitor: metrics dataHooks', () => {
           value: 'job-server',
         },
       ],
-      expectedClearedQueryPartial: {
-        resourceGroup: 'web-app-development',
-        metricDefinition: 'azure/vm',
-        resourceName: undefined,
-      },
+      expectedCustomPropertyResults: [
+        { label: 'Web server', value: 'web-server' },
+        { label: 'Job server', value: 'job-server' },
+        { label: 'resource-name-$ENVIRONMENT', value: 'resource-name-$ENVIRONMENT' },
+      ],
     },
 
     {
@@ -216,25 +192,12 @@ describe('AzureMonitor: metrics dataHooks', () => {
         resourceName: 'web-server',
         metricNamespace: 'azure/vm',
       },
-      validQueryPartial: {
+      customProperties: {
         resourceGroup: 'web-app-development',
         metricDefinition: 'azure/vm',
         resourceName: 'web-server',
         metricNamespace: 'azure/vm',
-      },
-      invalidQueryPartial: {
-        resourceGroup: 'web-app-development',
-        metricDefinition: 'azure/vm',
-        resourceName: 'web-server',
-        metricNamespace: 'azure/vm',
-        metricName: 'invalid-metric',
-      },
-      templateVariableQueryPartial: {
-        resourceGroup: 'web-app-development',
-        metricDefinition: 'azure/vm',
-        resourceName: 'web-server',
-        metricNamespace: 'azure/vm',
-        metricName: '$variable',
+        metricName: 'metric-$ENVIRONMENT',
       },
       expectedOptions: [
         {
@@ -246,13 +209,11 @@ describe('AzureMonitor: metrics dataHooks', () => {
           value: 'free-memory',
         },
       ],
-      expectedClearedQueryPartial: {
-        resourceGroup: 'web-app-development',
-        metricDefinition: 'azure/vm',
-        resourceName: 'web-server',
-        metricNamespace: 'azure/vm',
-        metricName: undefined,
-      },
+      expectedCustomPropertyResults: [
+        { label: 'Percentage CPU', value: 'percentage-cpu' },
+        { label: 'Free memory', value: 'free-memory' },
+        { label: 'metric-$ENVIRONMENT', value: 'metric-$ENVIRONMENT' },
+      ],
     },
 
     {
@@ -264,25 +225,12 @@ describe('AzureMonitor: metrics dataHooks', () => {
         resourceName: 'web-server',
         metricNamespace: 'azure/vm',
       },
-      validQueryPartial: {
+      customProperties: {
         resourceGroup: 'web-app-development',
         metricDefinition: 'azure/vm',
         resourceName: 'web-server',
-        metricNamespace: 'azure/vm',
-      },
-      invalidQueryPartial: {
-        resourceGroup: 'web-app-development',
-        metricDefinition: 'azure/vm',
-        resourceName: 'web-server',
-        metricNamespace: 'azure/vm',
-        metricName: 'invalid-metric',
-      },
-      templateVariableQueryPartial: {
-        resourceGroup: 'web-app-development',
-        metricDefinition: 'azure/vm',
-        resourceName: 'web-server',
-        metricNamespace: 'azure/vm',
-        metricName: '$variable',
+        metricNamespace: 'azure/vm-$ENVIRONMENT',
+        metricName: 'metric-name',
       },
       expectedOptions: [
         {
@@ -293,6 +241,15 @@ describe('AzureMonitor: metrics dataHooks', () => {
           label: 'Database NS',
           value: 'azure/dbns',
         },
+        {
+          label: 'azure/vm',
+          value: 'azure/vm',
+        },
+      ],
+      expectedCustomPropertyResults: [
+        { label: 'Compute Virtual Machine', value: 'azure/vmc' },
+        { label: 'Database NS', value: 'azure/dbns' },
+        { label: 'azure/vm-$ENVIRONMENT', value: 'azure/vm-$ENVIRONMENT' },
       ],
     },
   ];
@@ -343,59 +300,15 @@ describe('AzureMonitor: metrics dataHooks', () => {
       expect(result.current).toEqual(scenario.expectedOptions);
     });
 
-    it('does not call onChange when the property has not been set', async () => {
+    it('adds custom properties as a valid option', async () => {
       const query = {
         ...bareQuery,
-        azureMonitor: scenario.emptyQueryPartial,
+        azureMonitor: scenario.customProperties,
       };
-      const { waitForNextUpdate } = renderHook(() => scenario.hook(query, datasource, onChange, setError));
+      const { result, waitForNextUpdate } = renderHook(() => scenario.hook(query, datasource, onChange, setError));
       await waitForNextUpdate(WAIT_OPTIONS);
 
-      expect(onChange).not.toHaveBeenCalled();
-    });
-
-    it('does not clear the property when it is a valid option', async () => {
-      const query = {
-        ...bareQuery,
-        azureMonitor: scenario.validQueryPartial,
-      };
-      const { waitForNextUpdate } = renderHook(() => scenario.hook(query, datasource, onChange, setError));
-      await waitForNextUpdate(WAIT_OPTIONS);
-
-      expect(onChange).not.toHaveBeenCalled();
-    });
-
-    it('does not clear the property when it is a template variable', async () => {
-      const query = {
-        ...bareQuery,
-        azureMonitor: scenario.templateVariableQueryPartial,
-      };
-      const { waitForNextUpdate } = renderHook(() => scenario.hook(query, datasource, onChange, setError));
-      await waitForNextUpdate(WAIT_OPTIONS);
-
-      expect(onChange).not.toHaveBeenCalled();
-    });
-
-    it('clears the property when it is not a valid option', async () => {
-      const query = {
-        ...bareQuery,
-        azureMonitor: scenario.invalidQueryPartial,
-      };
-      const { waitForNextUpdate } = renderHook(() => scenario.hook(query, datasource, onChange, setError));
-      await waitForNextUpdate(WAIT_OPTIONS);
-
-      if (scenario.expectedClearedQueryPartial) {
-        expect(onChange).toHaveBeenCalledWith({
-          ...query,
-          azureMonitor: {
-            ...scenario.expectedClearedQueryPartial,
-            dimensionFilters: [],
-            timeGrain: '',
-          },
-        });
-      } else {
-        expect(onChange).not.toHaveBeenCalled();
-      }
+      expect(result.current).toEqual(scenario.expectedCustomPropertyResults);
     });
   });
 });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.ts
@@ -282,7 +282,7 @@ function formatOptions(
     text: string;
     value: string;
   }>,
-  selectedValue: string | undefined
+  selectedValue?: string
 ) {
   const options = rawResults.map(toOption);
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.ts
@@ -81,11 +81,14 @@ export const updateSubscriptions = (
 
 export const useSubscriptions: DataHook = (query, datasource, onChange, setError) => {
   const defaultSubscription = datasource.azureMonitorDatasource.defaultSubscriptionId;
+  const { subscription } = query;
 
   const subscriptionOptions = useAsyncState(
     async () => {
       const results = await datasource.azureMonitorDatasource.getSubscriptions();
-      return results.map((v) => ({ label: v.text, value: v.value, description: v.value }));
+      const options = formatOptions(results, subscription);
+
+      return options;
     },
     setError,
     []

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/SubscriptionField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/SubscriptionField.tsx
@@ -85,6 +85,7 @@ const SubscriptionField: React.FC<SubscriptionFieldProps> = ({
         onChange={handleChange}
         options={options}
         width={38}
+        allowCustomValue
       />
     </Field>
   );


### PR DESCRIPTION
**What this PR does / why we need it**:
In approximately 8.2 we started clearing dropdown fields in Azure Monitor Metrics if the selected value was not a valid option. This was done to make it a smoother UX experience as we felt it was somewhat confusing to edit one field that invalidated the other fields, and yet we kept the old fields. We would request for a list of valid options for the select, and if the selected option was not one of those options on a template variable, then we would clear the selection.

Unfortunately, we mistakenly then broke dashboards for users who had a selection in the dropdown that was not a template variable but used a template variable such as `resource-group-$TEMPLATE_VARIABLE_NAME`. This was easy to miss because it's not really supported by our UI, but it is a feature that is possible to do by importing a json file or manually editing/saving the json directly. 

This pr removes the clear functionality for invalid selections and instead will rely on errored out queries to prompt users to fix their selection.

**Which issue(s) this PR fixes**: 

Fixes #42746

**Special notes for your reviewer**:

Initially I explored doing better validation and keeping the clear functionality, such as verifying that the resource group a user has created with a template variable interpolates correctly, but it occurred to me that if a user mistypes a resource/metric it'll be very difficult to debug if it just automatically clears. I think better to see the failures directly.

An easy way to test this is with the App Insights curated dashboard. In that you'll notice that you can see everything fine until you try to edit a panel, at which point you'll notice the query fails because the dropdowns reset. With this pr you'll notice the data loads properly in edit panels. 
