### PR TITLE
BarChart: refactor x tick label placement logic

### DIFF
--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -108,6 +108,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptions> = ({
   builder.addScale({
     scaleKey: 'x',
     isTime: false,
+    range: config.xRange,
     distribution: ScaleDistribution.Ordinal,
     orientation: vizOrientation.xOri,
     direction: vizOrientation.xDir,


### PR DESCRIPTION
Part 2 of 3 #41510 (we decided to break it up to backport selectively)

this reworks how BarChart x tick label placement is computed.

previously, it caused uPlot's internals to create `undefined` values when ordinal `distr: 2` scales attempted to map backwards from fractional indicies, e.g. `u.data[0][1.2345]`. this did not have much effect because we re-computed the positions later in the draw pass, but that made these offsets useless earlier in the pipeline, such as scales.

the new strategy is much more robust. it expands the scale range by the proper amount to align the integer indices at the correct justified positions. therefore these offsets are now moved into the earlier scale-computing pass. this allows us to:

1. skip too-dense labels by an index modulus (needed for #41510)
2. seamlessly overlay uPlot's native pathbuilders over justified bargroups in the future. e.g.: ![image](https://user-images.githubusercontent.com/43234/146497182-7bae7295-c32e-4bd5-b123-1091aaba99ef.png)
