### PR TITLE
influxdb: config: accessibility fixes

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/ConfigEditor.tsx
@@ -112,6 +112,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
               isConfigured={(secureJsonFields && secureJsonFields.token) as boolean}
               value={secureJsonData.token || ''}
               label="Token"
+              aria-label="Token"
               labelWidth={10}
               inputWidth={20}
               onReset={this.onResetToken}
@@ -212,6 +213,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
               isConfigured={(secureJsonFields && secureJsonFields.password) as boolean}
               value={secureJsonData.password || ''}
               label="Password"
+              aria-label="Password"
               labelWidth={10}
               inputWidth={20}
               onReset={this.onResetPassword}

--- a/public/app/plugins/datasource/influxdb/components/__snapshots__/ConfigEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/influxdb/components/__snapshots__/ConfigEditor.test.tsx.snap
@@ -169,6 +169,7 @@ exports[`Render should disable basic auth password input 1`] = `
         className="gf-form"
       >
         <SecretFormField
+          aria-label="Password"
           inputWidth={20}
           label="Password"
           labelWidth={10}
@@ -435,6 +436,7 @@ exports[`Render should hide basic auth fields when switch off 1`] = `
         className="gf-form"
       >
         <SecretFormField
+          aria-label="Password"
           inputWidth={20}
           label="Password"
           labelWidth={10}
@@ -701,6 +703,7 @@ exports[`Render should hide white listed cookies input when browser access chose
         className="gf-form"
       >
         <SecretFormField
+          aria-label="Password"
           inputWidth={20}
           label="Password"
           labelWidth={10}
@@ -967,6 +970,7 @@ exports[`Render should render component 1`] = `
         className="gf-form"
       >
         <SecretFormField
+          aria-label="Password"
           inputWidth={20}
           label="Password"
           labelWidth={10}


### PR DESCRIPTION
this pull request fixes accessibility problems as described in https://github.com/grafana/grafana/issues/41206

added aria-labels on the influxdb config page, on two places:
- in InfluxQL mode, for the Password field
- in Flux mode, for the Token field

NOTE: the widget (SecretFormField) could also be modified to handle this automatically, but it's part of LegacyForms, so they will probably not be updated anymore.

fixes most of https://github.com/grafana/grafana/issues/42713