### PR TITLE
datasources: config: add aria-label

### DIFF
--- a/packages/grafana-ui/src/components/DataSourceSettings/CustomHeadersSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/CustomHeadersSettings.tsx
@@ -68,6 +68,7 @@ const CustomHeaderRow: React.FC<CustomHeaderRowProps> = ({ header, onBlur, onCha
       />
       <SecretFormField
         label="Value"
+        aria-label="Value"
         name="value"
         isConfigured={header.configured}
         value={header.value}


### PR DESCRIPTION
this fixes an accessibility problem with the "Custom HTTP Headers" section in a datasource's config page (applies to many datasources, for example Prometheus or InfluxDB).

how to reproduce the problem:
1. go to the config page for the datasource, for example Prometheus or InfluxDB
2. add a custom http header, fill in name and value, and store it
3. reload the page
4. check for a11y problems with FastPass
5. on main-branch this will highlight the "value" part of the http-header field as missing label

i simply used the aria-label prop to fix this. in theory, the widget (SecretFormField) itself could be modified to handle this automatically, but it is from LegacyForms so it will probably not get updated.