### PR TITLE
Alerting: update response text assertion

### DIFF
--- a/public/app/features/alerting/unified/api/ruler.ts
+++ b/public/app/features/alerting/unified/api/ruler.ts
@@ -1,9 +1,14 @@
 import { lastValueFrom } from 'rxjs';
-import { getBackendSrv } from '@grafana/runtime';
+import { FetchResponse, getBackendSrv } from '@grafana/runtime';
 
 import { PostableRulerRuleGroupDTO, RulerRuleGroupDTO, RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
 import { getDatasourceAPIId, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
 import { RULER_NOT_SUPPORTED_MSG } from '../utils/constants';
+
+interface ErrorResponseMessage {
+  message?: string;
+  error?: string;
+}
 
 // upsert a rule group. use this to update rules
 export async function setRulerRuleGroup(
@@ -97,26 +102,45 @@ async function rulerGetRequest<T>(url: string, empty: T, params?: Record<string,
       })
     );
     return response.data;
-  } catch (e) {
-    if (e?.status === 404) {
-      if (e?.data?.message?.includes('group does not exist') || e?.data?.message?.includes('no rule groups found')) {
+  } catch (error) {
+    if (!isResponseError(error)) {
+      throw error;
+    }
+
+    const notFoundError = error.status === 404;
+    const rulerNotSupported =
+      error.status === 500 &&
+      error.data?.error?.includes('unexpected content type from upstream. expected YAML, got text/html');
+
+    if (notFoundError) {
+      // the endpoint will return 404 but confirm that it's a Cortex endpoint
+      if (isCortexErrorResponse(error)) {
         return empty;
       }
+      // any other 404 should throw an exception
       throw new Error('404 from rules config endpoint. Perhaps ruler API is not enabled?');
-    } else if (
-      e?.status === 500 &&
-      e?.data?.message?.includes('unexpected content type from upstream. expected YAML, got text/html')
-    ) {
+    } else if (rulerNotSupported) {
+      // assert if the endoint is not supported at all
       throw {
-        ...e,
+        ...error,
         data: {
-          ...e?.data,
+          ...error?.data,
           message: RULER_NOT_SUPPORTED_MSG,
         },
       };
     }
-    throw e;
+    throw error;
   }
+}
+
+function isResponseError(error: unknown): error is FetchResponse<ErrorResponseMessage> {
+  const hasErrorMessage = (error as FetchResponse<ErrorResponseMessage>).data != null;
+  const hasErrorCode = Number.isFinite((error as FetchResponse<ErrorResponseMessage>).status);
+  return hasErrorCode && hasErrorMessage;
+}
+
+function isCortexErrorResponse(error: FetchResponse<ErrorResponseMessage>) {
+  return error?.data?.error?.includes('group does not exist') || error?.data?.error?.includes('no rule groups found');
 }
 
 export async function deleteNamespace(dataSourceName: string, namespace: string): Promise<void> {

--- a/public/app/features/alerting/unified/api/ruler.ts
+++ b/public/app/features/alerting/unified/api/ruler.ts
@@ -110,7 +110,7 @@ async function rulerGetRequest<T>(url: string, empty: T, params?: Record<string,
     const notFoundError = error.status === 404;
     const rulerNotSupported =
       error.status === 500 &&
-      error.data?.error?.includes('unexpected content type from upstream. expected YAML, got text/html');
+      error.data.error?.includes('unexpected content type from upstream. expected YAML, got text/html');
 
     if (notFoundError) {
       // the endpoint will return 404 but confirm that it's a Cortex endpoint
@@ -124,7 +124,7 @@ async function rulerGetRequest<T>(url: string, empty: T, params?: Record<string,
       throw {
         ...error,
         data: {
-          ...error?.data,
+          ...error.data,
           message: RULER_NOT_SUPPORTED_MSG,
         },
       };
@@ -140,7 +140,7 @@ function isResponseError(error: unknown): error is FetchResponse<ErrorResponseMe
 }
 
 function isCortexErrorResponse(error: FetchResponse<ErrorResponseMessage>) {
-  return error?.data?.error?.includes('group does not exist') || error?.data?.error?.includes('no rule groups found');
+  return error.data.error?.includes('group does not exist') || error.data.error?.includes('no rule groups found');
 }
 
 export async function deleteNamespace(dataSourceName: string, namespace: string): Promise<void> {


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes in https://github.com/grafana/grafana/pull/43192 have updated the error response that broke detection of Cortex datasources.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

The current assertions are much too brittle but since we lack other options to detect if a Prometheus datasource is a Cortex endpoint we're stuck with it for now.

Alternative options are being investigated but this one at least updates the current incorrect assertions.

