### PR TITLE
BarChart: fix constant re-init due to legend prop strict inequality

### DIFF
--- a/public/app/plugins/panel/barchart/BarChart.tsx
+++ b/public/app/plugins/panel/barchart/BarChart.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, isEqual } from 'lodash';
 import { DataFrame, FieldType, TimeRange } from '@grafana/data';
 import { GraphNG, GraphNGProps, PlotLegend, UPlotConfigBuilder, usePanelContext, useTheme2 } from '@grafana/ui';
 import { LegendDisplayMode } from '@grafana/schema';
@@ -22,7 +22,7 @@ const propsToDiff: Array<string | PropDiffFn> = [
   'groupWidth',
   'stacking',
   'showValue',
-  'legend',
+  (prev: BarChartProps, next: BarChartProps) => isEqual(prev.legend, next.legend),
   (prev: BarChartProps, next: BarChartProps) => next.text?.valueSize === prev.text?.valueSize,
 ];
 

--- a/public/app/plugins/panel/barchart/BarChart.tsx
+++ b/public/app/plugins/panel/barchart/BarChart.tsx
@@ -1,5 +1,4 @@
 import React, { useRef } from 'react';
-import { cloneDeep, isEqual } from 'lodash';
 import { DataFrame, FieldType, TimeRange } from '@grafana/data';
 import { GraphNG, GraphNGProps, PlotLegend, UPlotConfigBuilder, usePanelContext, useTheme2 } from '@grafana/ui';
 import { LegendDisplayMode } from '@grafana/schema';
@@ -22,7 +21,7 @@ const propsToDiff: Array<string | PropDiffFn> = [
   'groupWidth',
   'stacking',
   'showValue',
-  (prev: BarChartProps, next: BarChartProps) => isEqual(prev.legend, next.legend),
+  'legend',
   (prev: BarChartProps, next: BarChartProps) => next.text?.valueSize === prev.text?.valueSize,
 ];
 
@@ -91,8 +90,7 @@ export const BarChart: React.FC<BarChartProps> = (props) => {
 
   return (
     <GraphNG
-      // My heart is bleeding with the clone deep here, but nested options...
-      {...cloneDeep(props)}
+      {...props}
       theme={theme}
       frames={props.frames}
       prepConfig={prepConfig}


### PR DESCRIPTION
this fixes a performance regression introduced by https://github.com/grafana/grafana/pull/40226 which added `'legend'` to `propsToDiff`, which by default uses shallow comparison to determine if the viz should be re-initialized.

the fix is to use an fn-style signature and do a deep compare of `legend` objects...or alternatively stop re-creating `legend` to make the shallow compare sufficient.

@zoltanbedi @dprokop plz make sure this doesnt break the features introduced in your prior PR :pray: . also would be good to understand why adding `'legend'` to `propsToDiff` only affected BarChart re-init, but not TimeSeries re-init, since they look basically the same. are we doing something different for the barchart legend that re-creates its config on every re-render, while the TimeSeries legend config is referentially stable?