### PR TITLE
Live: support multiple random60hz channels for performance testing

### DIFF
--- a/pkg/services/live/pipeline/devdata.go
+++ b/pkg/services/live/pipeline/devdata.go
@@ -99,7 +99,7 @@ type DevRuleBuilder struct {
 func (f *DevRuleBuilder) BuildRules(_ context.Context, _ int64) ([]*LiveChannelRule, error) {
 	return []*LiveChannelRule{
 		{
-			Pattern: "plugin/testdata/random-20Hz-stream",
+			Pattern: "plugin/testdata/random-20Hz-stream:rest",
 			DataOutputters: []DataOutputter{
 				NewLokiDataOutput(
 					os.Getenv("GF_LIVE_LOKI_ENDPOINT"),

--- a/pkg/tsdb/testdatasource/stream_handler.go
+++ b/pkg/tsdb/testdatasource/stream_handler.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"regexp"
 	"strings"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
+
+var random20HzStreamRegex = regexp.MustCompile(`random-20Hz-stream(-\d+)?`)
 
 func (s *Service) SubscribeStream(_ context.Context, req *backend.SubscribeStreamRequest) (*backend.SubscribeStreamResponse, error) {
 	s.logger.Debug("Allowing access to stream", "path", req.Path, "user", req.PluginContext.User)
@@ -55,30 +58,30 @@ func (s *Service) PublishStream(_ context.Context, req *backend.PublishStreamReq
 func (s *Service) RunStream(ctx context.Context, request *backend.RunStreamRequest, sender *backend.StreamSender) error {
 	s.logger.Debug("New stream call", "path", request.Path)
 	var conf testStreamConfig
-	switch request.Path {
-	case "random-2s-stream":
+	switch {
+	case request.Path == "random-2s-stream":
 		conf = testStreamConfig{
 			Interval: 2 * time.Second,
 		}
-	case "random-flakey-stream":
+	case request.Path == "random-flakey-stream":
 		conf = testStreamConfig{
 			Interval: 100 * time.Millisecond,
 			Drop:     0.75, // keep 25%
 		}
-	case "random-labeled-stream":
+	case request.Path == "random-labeled-stream":
 		conf = testStreamConfig{
 			Interval: 200 * time.Millisecond,
 			Drop:     0.2, // keep 80%
 			Labeled:  true,
 		}
-	case "random-20Hz-stream":
-		conf = testStreamConfig{
-			Interval: 50 * time.Millisecond,
-		}
-	case "flight-5hz-stream":
+	case request.Path == "flight-5hz-stream":
 		conf = testStreamConfig{
 			Interval: 200 * time.Millisecond,
 			Flight:   newFlightConfig(),
+		}
+	case random20HzStreamRegex.MatchString(request.Path):
+		conf = testStreamConfig{
+			Interval: 50 * time.Millisecond,
 		}
 	default:
 		return fmt.Errorf("testdata plugin does not support path: %s", request.Path)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

https://github.com/grafana/grafana/issues/41993

**Which issue(s) this PR fixes**:

Part 1 of https://github.com/grafana/grafana/issues/41993

added an option to create more random 60hz in the test data source

**Special notes for your reviewer**:




extracted from https://github.com/grafana/grafana/pull/42230