### PR TITLE
Dashboard save interaction evt

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
@@ -138,10 +138,8 @@ export function DashboardSettings({ dashboard, editview }: Props) {
             <aside className="dashboard-settings__aside">
               {pages.map((page) => (
                 <Link
-                  to={(loc) => {
-                    reportInteraction(`Dashboard settings navigation to ${page.id}`);
-                    return locationUtil.updateSearchParams(loc.search, `editview=${page.id}`);
-                  }}
+                  onClick={() => reportInteraction(`Dashboard settings navigation to ${page.id}`)}
+                  to={(loc) => locationUtil.updateSearchParams(loc.search, `editview=${page.id}`)}
                   className={cx('dashboard-settings__nav-item', { active: page.id === editview })}
                   key={page.id}
                 >

--- a/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
@@ -5,7 +5,7 @@ import { SaveDashboardOptions } from './types';
 import appEvents from 'app/core/app_events';
 import { DashboardModel } from 'app/features/dashboard/state';
 import { saveDashboard as saveDashboardApiCall } from 'app/features/manage-dashboards/state/actions';
-import { locationService } from '@grafana/runtime';
+import { locationService, reportInteraction } from '@grafana/runtime';
 import { DashboardSavedEvent } from 'app/types/events';
 
 const saveDashboard = (saveModel: any, options: SaveDashboardOptions, dashboard: DashboardModel) => {
@@ -32,6 +32,10 @@ export const useDashboardSave = (dashboard: DashboardModel) => {
       // important that these happen before location redirect below
       appEvents.publish(new DashboardSavedEvent());
       appEvents.emit(AppEvents.alertSuccess, ['Dashboard saved']);
+      reportInteraction(`Dashboard ${dashboard.id ? 'saved' : 'created'}`, {
+        name: dashboard.title,
+        url: state.value.url,
+      });
 
       const currentPath = locationService.getLocation().pathname;
       const newUrl = locationUtil.stripBaseFromUrl(state.value.url);


### PR DESCRIPTION
**What this PR does / why we need it**:

* Fixes the Dashboard Settings page triggering `reportInteraction` for every navigation Link on page load:
![image](https://user-images.githubusercontent.com/35489495/146603233-98c4bb8e-b2b8-432d-8960-7e0f9fc5e4ad.png)

* Adds a `reportInteraction` for Dashboard created/saved

Happy to break this PR in two if necessary.