### PR TITLE
BarChart: support log scale

### DIFF
--- a/public/app/plugins/panel/barchart/module.tsx
+++ b/public/app/plugins/panel/barchart/module.tsx
@@ -58,7 +58,7 @@ export const plugin = new PanelPlugin<BarChartOptions, BarChartFieldConfig>(BarC
           },
         });
 
-      commonOptionsBuilder.addAxisConfig(builder, cfg, true);
+      commonOptionsBuilder.addAxisConfig(builder, cfg, false);
       commonOptionsBuilder.addHideFrom(builder);
     },
   })

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -183,6 +183,8 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptions> = ({
       softMax: customConfig.axisSoftMax,
       orientation: vizOrientation.yOri,
       direction: vizOrientation.yDir,
+      distribution: customConfig.scaleDistribution?.type,
+      log: customConfig.scaleDistribution?.log,
     });
 
     if (customConfig.axisPlacement !== AxisPlacement.Hidden) {

--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -102,7 +102,7 @@ $text-color: rgb(204, 204, 220);
 $text-color-semi-weak: rgba(204, 204, 220, 0.65);
 $text-color-weak: rgba(204, 204, 220, 0.65);
 $text-color-faint: rgba(204, 204, 220, 0.6);
-$text-color-emphasis: #fff;
+$text-color-emphasis: #FFFFFF;
 $text-blue: #6E9FFF;
 
 $text-shadow-faint: 1px 1px 4px rgb(45, 45, 45);
@@ -116,7 +116,7 @@ $brand-gradient-vertical: linear-gradient(#f05a28 30%, #fbca0a 99%);
 // -------------------------
 $link-color: rgb(204, 204, 220);
 $link-color-disabled: rgba(204, 204, 220, 0.6);
-$link-hover-color: #fff;
+$link-hover-color: #FFFFFF;
 $external-link-color: #6E9FFF;
 
 // Typography

--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -102,7 +102,7 @@ $text-color: rgb(204, 204, 220);
 $text-color-semi-weak: rgba(204, 204, 220, 0.65);
 $text-color-weak: rgba(204, 204, 220, 0.65);
 $text-color-faint: rgba(204, 204, 220, 0.6);
-$text-color-emphasis: #FFFFFF;
+$text-color-emphasis: #fff;
 $text-blue: #6E9FFF;
 
 $text-shadow-faint: 1px 1px 4px rgb(45, 45, 45);
@@ -116,7 +116,7 @@ $brand-gradient-vertical: linear-gradient(#f05a28 30%, #fbca0a 99%);
 // -------------------------
 $link-color: rgb(204, 204, 220);
 $link-color-disabled: rgba(204, 204, 220, 0.6);
-$link-hover-color: #FFFFFF;
+$link-hover-color: #fff;
 $external-link-color: #6E9FFF;
 
 // Typography


### PR DESCRIPTION
While looking though bar-chart issues/discussions, I stumbled into: https://github.com/grafana/grafana/discussions/38500 and was surprised it did not already work.


![Peek 2021-12-17 13-38](https://user-images.githubusercontent.com/705951/146611076-56525044-c657-40c7-8a78-26216cc5f442.gif)


Any reason we should not support this mode?