### PR TITLE
Geomap: Geojson layer initial dynamic styling

### DIFF
--- a/public/app/plugins/panel/geomap/layers/data/geojsonLayer.ts
+++ b/public/app/plugins/panel/geomap/layers/data/geojsonLayer.ts
@@ -9,7 +9,7 @@ import { ComparisonOperation, FeatureRuleConfig, FeatureStyleConfig } from '../.
 import { Style } from 'ol/style';
 import { FeatureLike } from 'ol/Feature';
 import { GeomapStyleRulesEditor } from '../../editor/GeomapStyleRulesEditor';
-import { defaultStyleConfig, StyleConfig } from '../../style/types';
+import { defaultStyleConfig, StyleConfig, StyleConfigState } from '../../style/types';
 import { getStyleConfigState } from '../../style/utils';
 import { polyStyle } from '../../style/markers';
 import { StyleEditor } from './StyleEditor';
@@ -35,8 +35,9 @@ const defaultOptions: GeoJSONMapperConfig = {
 };
 
 interface StyleCheckerState {
-  poly: Style | Style[];
-  point: Style | Style[];
+  state: StyleConfigState;
+  poly?: Style | Style[];
+  point?: Style | Style[];
   rule?: FeatureRuleConfig;
 }
 
@@ -84,8 +85,7 @@ export const geojsonLayer: MapLayerRegistryItem<GeoJSONMapperConfig> = {
         if (r.style) {
           const s = await getStyleConfigState(r.style);
           styles.push({
-            point: s.maker(s.base),
-            poly: polyStyle(s.base),
+            state: s,
             rule: r.check,
           });
         }
@@ -94,8 +94,7 @@ export const geojsonLayer: MapLayerRegistryItem<GeoJSONMapperConfig> = {
     if (true) {
       const s = await getStyleConfigState(config.style);
       styles.push({
-        point: s.maker(s.base),
-        poly: polyStyle(s.base),
+        state: s,
       });
     }
 
@@ -108,7 +107,33 @@ export const geojsonLayer: MapLayerRegistryItem<GeoJSONMapperConfig> = {
           if (check.rule && !checkFeatureMatchesStyleRule(check.rule, feature)) {
             continue;
           }
-          return isPoint ? check.point : check.poly;
+
+          // Support dynamic values
+          if( check.state.fields ) {
+            const values = { ...check.state.base }; 
+            for(const [key, val] of Object.entries(check.state.fields)) {
+              if(val) {
+                (values as any)[key] = feature.get(val);
+              }
+            }
+            if(isPoint) {
+              return check.state.maker(values);
+            }
+            return polyStyle(values);
+          }
+
+          // Lazy create the style object
+          if(isPoint) {
+            if(!check.point) {
+              check.point = check.state.maker(check.state.base);
+            }
+            return check.point;
+          }
+
+          if(!check.poly) {
+            check.poly = polyStyle(check.state.base);
+          }
+          return check.poly;
         }
         return undefined; // unreachable
       },

--- a/public/app/plugins/panel/geomap/layers/data/geojsonLayer.ts
+++ b/public/app/plugins/panel/geomap/layers/data/geojsonLayer.ts
@@ -111,10 +111,10 @@ export const geojsonLayer: MapLayerRegistryItem<GeoJSONMapperConfig> = {
           // Support dynamic values
           if (check.state.fields) {
             const values = { ...check.state.base };
-            for (const [key, val] of Object.entries(check.state.fields)) {
-              if (val) {
-                values[key] = feature.get(val);
-              }
+            const { text } = check.state.fields;
+
+            if (text) {
+              values.text = `${feature.get(text)}`;
             }
             if (isPoint) {
               return check.state.maker(values);

--- a/public/app/plugins/panel/geomap/layers/data/geojsonLayer.ts
+++ b/public/app/plugins/panel/geomap/layers/data/geojsonLayer.ts
@@ -109,28 +109,28 @@ export const geojsonLayer: MapLayerRegistryItem<GeoJSONMapperConfig> = {
           }
 
           // Support dynamic values
-          if( check.state.fields ) {
-            const values = { ...check.state.base }; 
-            for(const [key, val] of Object.entries(check.state.fields)) {
-              if(val) {
-                (values as any)[key] = feature.get(val);
+          if (check.state.fields) {
+            const values = { ...check.state.base };
+            for (const [key, val] of Object.entries(check.state.fields)) {
+              if (val) {
+                values[key] = feature.get(val);
               }
             }
-            if(isPoint) {
+            if (isPoint) {
               return check.state.maker(values);
             }
             return polyStyle(values);
           }
 
           // Lazy create the style object
-          if(isPoint) {
-            if(!check.point) {
+          if (isPoint) {
+            if (!check.point) {
               check.point = check.state.maker(check.state.base);
             }
             return check.point;
           }
 
-          if(!check.poly) {
+          if (!check.poly) {
             check.poly = polyStyle(check.state.base);
           }
           return check.poly;

--- a/public/app/plugins/panel/geomap/style/markers.ts
+++ b/public/app/plugins/panel/geomap/style/markers.ts
@@ -75,6 +75,7 @@ export const circleMarker = (cfg: StyleConfigValues) => {
   });
 };
 
+// Does not have image
 export const polyStyle = (cfg: StyleConfigValues) => {
   return new Style({
     fill: getFillColor(cfg),

--- a/public/app/plugins/panel/geomap/style/types.ts
+++ b/public/app/plugins/panel/geomap/style/types.ts
@@ -93,7 +93,6 @@ export interface TextStyleConfig {
 
 // Applying the config to real data gives the values
 export interface StyleConfigValues {
-  [index: string]: string | number | TextStyleConfig | undefined;
   color: string;
   opacity?: number;
   lineWidth?: number;

--- a/public/app/plugins/panel/geomap/style/types.ts
+++ b/public/app/plugins/panel/geomap/style/types.ts
@@ -93,6 +93,7 @@ export interface TextStyleConfig {
 
 // Applying the config to real data gives the values
 export interface StyleConfigValues {
+  [index: string]: string | number | TextStyleConfig | undefined;
   color: string;
   opacity?: number;
   lineWidth?: number;


### PR DESCRIPTION
**What this PR does / why we need it**:
- enables passing dynamic values to style maker in the geojson layer

**Special notes for your reviewer**:
- can modify by editing panel json, does not have matching UI enabled for geojson layer

Example with airports.geojson:
<img width="1427" alt="Screen Shot 2021-12-20 at 9 22 46 AM" src="https://user-images.githubusercontent.com/42276368/146807507-a6deb54d-a7d5-4dea-9224-edac354741db.png">

With the following panel config (note that text has field set to "iata_code"):
`"config": {
          "rules": [],
          "src": "public/gazetteer/airports.geojson",
          "style": {
            "color": {
              "fixed": "dark-green"
            },
            "opacity": 0.4,
            "rotation": {
              "fixed": 0,
              "max": 360,
              "min": -360,
              "mode": "mod"
            },
            "size": {
              "fixed": 5,
              "max": 15,
              "min": 2
            },
            "symbol": {
              "mode": "fixed",
              "fixed": "",
              "field": ""
            },
            "text": {
              "field": "iata_code",
              "fixed": "",
              "mode": "field"
            },
            "textConfig": {
              "fontSize": 12,
              "offsetX": 0,
              "offsetY": 0,
              "textAlign": "center",
              "textBaseline": "middle"
            }
          }
        },`