### PR TITLE
CodeQL: Fix potential ReDoS vulnerability

### DIFF
--- a/public/app/plugins/datasource/prometheus/legend.test.ts
+++ b/public/app/plugins/datasource/prometheus/legend.test.ts
@@ -20,11 +20,25 @@ describe('renderLegendFormat()', () => {
     expect(renderLegendFormat('{{ a }}', labels)).toEqual('AAA');
   });
 
+  it('Missing label', () => {
+    // it's unclear if this is expected behavior
+    expect(renderLegendFormat('value: {{c}}', labels)).toEqual('value: c');
+    expect(renderLegendFormat('{{        }}', labels)).toEqual('');
+  });
+
+  it('Nested brackets', () => {
+    // it's unclear if this is expected behavior
+    expect(renderLegendFormat('{{{a}}}', labels)).toEqual('{AAA}');
+    expect(renderLegendFormat('{{{{a}}}}', labels)).toEqual('{{AAA}}');
+    expect(renderLegendFormat('{{ {{ a }} }}', labels)).toEqual('{{ AAA }}');
+  });
+
   it('Bad syntax', () => {
     expect(renderLegendFormat('value: {{a}', labels)).toEqual('value: {{a}');
     expect(renderLegendFormat('value: {a}}}', labels)).toEqual('value: {a}}}');
-
-    // Current behavior -- not sure if expected or not
-    expect(renderLegendFormat('value: {{{a}}}', labels)).toEqual('value: {a}');
+    expect(renderLegendFormat('{{}}', labels)).toEqual('{{}}');
+    expect(renderLegendFormat('{{{}} }', labels)).toEqual('{{{}} }');
+    expect(renderLegendFormat('{{{}}}', labels)).toEqual('{{{}}}');
+    expect(renderLegendFormat('{{a}d}}', labels)).toEqual('{{a}d}}');
   });
 });

--- a/public/app/plugins/datasource/prometheus/legend.test.ts
+++ b/public/app/plugins/datasource/prometheus/legend.test.ts
@@ -28,8 +28,8 @@ describe('renderLegendFormat()', () => {
 
   it('Nested brackets', () => {
     // it's unclear if this is expected behavior
-    expect(renderLegendFormat('{{{a}}}', labels)).toEqual('{{{a}}}');
-    expect(renderLegendFormat('{{{{a}}}}', labels)).toEqual('{{{{a}}}}');
+    expect(renderLegendFormat('{{{a}}}', labels)).toEqual('{AAA}');
+    expect(renderLegendFormat('{{{{a}}}}', labels)).toEqual('{{AAA}}');
     expect(renderLegendFormat('{{ {{ a }} }}', labels)).toEqual('{{ AAA }}');
   });
 

--- a/public/app/plugins/datasource/prometheus/legend.test.ts
+++ b/public/app/plugins/datasource/prometheus/legend.test.ts
@@ -28,8 +28,8 @@ describe('renderLegendFormat()', () => {
 
   it('Nested brackets', () => {
     // it's unclear if this is expected behavior
-    expect(renderLegendFormat('{{{a}}}', labels)).toEqual('{AAA}');
-    expect(renderLegendFormat('{{{{a}}}}', labels)).toEqual('{{AAA}}');
+    expect(renderLegendFormat('{{{a}}}', labels)).toEqual('{{{a}}}');
+    expect(renderLegendFormat('{{{{a}}}}', labels)).toEqual('{{{{a}}}}');
     expect(renderLegendFormat('{{ {{ a }} }}', labels)).toEqual('{{ AAA }}');
   });
 

--- a/public/app/plugins/datasource/prometheus/legend.ts
+++ b/public/app/plugins/datasource/prometheus/legend.ts
@@ -2,7 +2,9 @@ import { Labels } from '@grafana/data';
 
 /** replace labels in a string.  Used for loki+prometheus legend formats */
 export function renderLegendFormat(aliasPattern: string, aliasData: Labels): string {
-  // Negative lookbehind is to avoid https://github.com/github/codeql/blob/ddd4ccbb4b39adf3c2427088f4876432202c4eaa/javascript/ql/src/Performance/PolynomialReDoS.ql
-  const aliasRegex = /\{\{\s*(.+?)(?<!\s)\s*\}\}/g;
-  return aliasPattern.replace(aliasRegex, (_, g1) => (aliasData[g1] ? aliasData[g1] : g1));
+  const aliasRegex = /\{\{(.+?)\}\}/g;
+  return aliasPattern.replace(aliasRegex, (_, g1: string) => {
+    const trimmedMatch = g1.trim();
+    return aliasData[trimmedMatch] ?? trimmedMatch;
+  });
 }

--- a/public/app/plugins/datasource/prometheus/legend.ts
+++ b/public/app/plugins/datasource/prometheus/legend.ts
@@ -2,7 +2,7 @@ import { Labels } from '@grafana/data';
 
 /** replace labels in a string.  Used for loki+prometheus legend formats */
 export function renderLegendFormat(aliasPattern: string, aliasData: Labels): string {
-  const aliasRegex = /(?!<\{)\{\{([^\{\}]+?)\}\}(?!\})/g;
+  const aliasRegex = /\{\{([^\{\}]+?)\}\}/g;
   return aliasPattern.replace(aliasRegex, (_, g1: string) => {
     const trimmedMatch = g1.trim();
     return aliasData[trimmedMatch] ?? trimmedMatch;

--- a/public/app/plugins/datasource/prometheus/legend.ts
+++ b/public/app/plugins/datasource/prometheus/legend.ts
@@ -2,7 +2,7 @@ import { Labels } from '@grafana/data';
 
 /** replace labels in a string.  Used for loki+prometheus legend formats */
 export function renderLegendFormat(aliasPattern: string, aliasData: Labels): string {
-  const aliasRegex = /\{\{([^\{\}]+?)\}\}/g;
+  const aliasRegex = /(?!<\{)\{\{([^\{\}]+?)\}\}(?!\})/g;
   return aliasPattern.replace(aliasRegex, (_, g1: string) => {
     const trimmedMatch = g1.trim();
     return aliasData[trimmedMatch] ?? trimmedMatch;

--- a/public/app/plugins/datasource/prometheus/legend.ts
+++ b/public/app/plugins/datasource/prometheus/legend.ts
@@ -2,7 +2,7 @@ import { Labels } from '@grafana/data';
 
 /** replace labels in a string.  Used for loki+prometheus legend formats */
 export function renderLegendFormat(aliasPattern: string, aliasData: Labels): string {
-  const aliasRegex = /\{\{(.+?)\}\}/g;
+  const aliasRegex = /\{\{([^\{\}]+?)\}\}/g;
   return aliasPattern.replace(aliasRegex, (_, g1: string) => {
     const trimmedMatch = g1.trim();
     return aliasData[trimmedMatch] ?? trimmedMatch;

--- a/public/app/plugins/datasource/prometheus/legend.ts
+++ b/public/app/plugins/datasource/prometheus/legend.ts
@@ -2,6 +2,7 @@ import { Labels } from '@grafana/data';
 
 /** replace labels in a string.  Used for loki+prometheus legend formats */
 export function renderLegendFormat(aliasPattern: string, aliasData: Labels): string {
-  const aliasRegex = /\{\{\s*(.+?)\s*\}\}/g;
+  // Negative lookbehind is to avoid https://github.com/github/codeql/blob/ddd4ccbb4b39adf3c2427088f4876432202c4eaa/javascript/ql/src/Performance/PolynomialReDoS.ql
+  const aliasRegex = /\{\{\s*(.+?)(?<!\s)\s*\}\}/g;
   return aliasPattern.replace(aliasRegex, (_, g1) => (aliasData[g1] ? aliasData[g1] : g1));
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a potential [ReDoS](https://github.com/github/codeql/blob/ddd4ccbb4b39adf3c2427088f4876432202c4eaa/javascript/ql/src/Performance/PolynomialReDoS.ql) vulnerability that CodeQL was reporting.

