### PR TITLE
Change 'grafana-expression' to ExpressionDatasourceRef.type so isExpr…

### DIFF
--- a/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
@@ -25,7 +25,7 @@ import { PrometheusDatasource } from 'app/plugins/datasource/prometheus/datasour
 import { DataSourceApi } from '@grafana/data';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { PromOptions } from 'app/plugins/datasource/prometheus/types';
-import { ExpressionDatasourceRef } from '../../../../../packages/grafana-runtime/src/utils/DataSourceWithBackend';
+import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 
 jest.mock('./api/prometheus');
 jest.mock('./api/ruler');

--- a/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
@@ -25,6 +25,7 @@ import { PrometheusDatasource } from 'app/plugins/datasource/prometheus/datasour
 import { DataSourceApi } from '@grafana/data';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { PromOptions } from 'app/plugins/datasource/prometheus/types';
+import { ExpressionDatasourceRef } from '../../../../../packages/grafana-runtime/src/utils/DataSourceWithBackend';
 
 jest.mock('./api/prometheus');
 jest.mock('./api/ruler');
@@ -308,7 +309,7 @@ describe('PanelAlertTabContent', () => {
             hide: false,
             type: 'classic_conditions',
             datasource: {
-              type: 'grafana-expression',
+              type: ExpressionDatasourceRef.type,
               uid: '-100',
             },
             conditions: [

--- a/public/app/features/alerting/unified/components/rule-editor/util.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.test.ts
@@ -1,6 +1,7 @@
 import { ClassicCondition, ExpressionQuery } from 'app/features/expressions/types';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 import { queriesWithUpdatedReferences, updateMathExpressionRefs } from './util';
+import { ExpressionDatasourceRef } from '../../../../../../../packages/grafana-runtime/src/utils/DataSourceWithBackend';
 
 describe('rule-editor', () => {
   const dataSource: AlertQuery = {
@@ -25,7 +26,7 @@ describe('rule-editor', () => {
       type: 'classic_conditions',
       datasource: {
         uid: '-100',
-        type: 'grafana-expression',
+        type: ExpressionDatasourceRef.type,
       },
       conditions: [
         {
@@ -58,7 +59,7 @@ describe('rule-editor', () => {
       type: 'math',
       datasource: {
         uid: '-100',
-        type: 'grafana-expression',
+        type: ExpressionDatasourceRef.type,
       },
       conditions: [],
       expression: 'abs($A) + $A',
@@ -74,7 +75,7 @@ describe('rule-editor', () => {
       type: 'reduce',
       datasource: {
         uid: '-100',
-        type: 'grafana-expression',
+        type: ExpressionDatasourceRef.type,
       },
       conditions: [],
       reducer: 'mean',

--- a/public/app/features/alerting/unified/components/rule-editor/util.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.test.ts
@@ -1,7 +1,7 @@
 import { ClassicCondition, ExpressionQuery } from 'app/features/expressions/types';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 import { queriesWithUpdatedReferences, updateMathExpressionRefs } from './util';
-import { ExpressionDatasourceRef } from '../../../../../../../packages/grafana-runtime/src/utils/DataSourceWithBackend';
+import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 
 describe('rule-editor', () => {
   const dataSource: AlertQuery = {

--- a/public/app/features/alerting/unified/components/rule-editor/util.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.test.ts
@@ -24,10 +24,7 @@ describe('rule-editor', () => {
     model: {
       refId: 'B',
       type: 'classic_conditions',
-      datasource: {
-        uid: '-100',
-        type: ExpressionDatasourceRef.type,
-      },
+      datasource: ExpressionDatasourceRef,
       conditions: [
         {
           type: 'query',
@@ -57,10 +54,7 @@ describe('rule-editor', () => {
     model: {
       refId: 'B',
       type: 'math',
-      datasource: {
-        uid: '-100',
-        type: ExpressionDatasourceRef.type,
-      },
+      datasource: ExpressionDatasourceRef,
       conditions: [],
       expression: 'abs($A) + $A',
     },
@@ -73,10 +67,7 @@ describe('rule-editor', () => {
     model: {
       refId: 'B',
       type: 'reduce',
-      datasource: {
-        uid: '-100',
-        type: ExpressionDatasourceRef.type,
-      },
+      datasource: ExpressionDatasourceRef,
       conditions: [],
       reducer: 'mean',
       expression: 'A',

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -30,7 +30,7 @@ import { isGrafanaRulesSource } from './datasource';
 import { arrayToRecord, recordToArray } from './misc';
 import { isAlertingRulerRule, isGrafanaRulerRule, isRecordingRulerRule } from './rules';
 import { parseInterval } from './time';
-import { ExpressionDatasourceRef } from '../../../../../../packages/grafana-runtime/src/utils/DataSourceWithBackend';
+import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 
 export const getDefaultFormValues = (): RuleFormValues =>
   Object.freeze({

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -30,6 +30,7 @@ import { isGrafanaRulesSource } from './datasource';
 import { arrayToRecord, recordToArray } from './misc';
 import { isAlertingRulerRule, isGrafanaRulerRule, isRecordingRulerRule } from './rules';
 import { parseInterval } from './time';
+import { ExpressionDatasourceRef } from '../../../../../../packages/grafana-runtime/src/utils/DataSourceWithBackend';
 
 export const getDefaultFormValues = (): RuleFormValues =>
   Object.freeze({
@@ -192,7 +193,7 @@ const getDefaultExpression = (refId: string): AlertQuery => {
     type: ExpressionQueryType.classic,
     datasource: {
       uid: ExpressionDatasourceUID,
-      type: 'grafana-expression',
+      type: ExpressionDatasourceRef.type,
     },
     conditions: [
       {

--- a/public/app/features/expressions/ExpressionDatasource.ts
+++ b/public/app/features/expressions/ExpressionDatasource.ts
@@ -36,7 +36,7 @@ export const instanceSettings: DataSourceInstanceSettings = {
   id: -100,
   uid: ExpressionDatasourceUID,
   name: ExpressionDatasourceRef.type,
-  type: 'grafana-expression',
+  type: ExpressionDatasourceRef.type,
   access: 'proxy',
   meta: {
     baseUrl: '',


### PR DESCRIPTION
I was looking at using https://github.com/grafana/grafana/blob/5766c624ff4f59be8d35387c3df9b4877e50fc25/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts#L37 and noticed that it checks `v.type === ExpressionDatasourceRef.type` but that the expression datasource type is actually `grafana-expression`.

Rather than change `isExpressionDatasource` to check `t.name === ExpressionDatasourceRef.type` I changed all instances of `grafana-expression` to `ExpressionDatasourceRef.type`