### PR TITLE
Templating: Partly fixes flickering of repeated panels and rows

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.repeat.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.repeat.test.ts
@@ -3,6 +3,7 @@ import { DashboardModel } from '../state/DashboardModel';
 import { expect } from 'test/lib/common';
 import { getDashboardModel } from '../../../../test/helpers/getDashboardModel';
 import { PanelModel } from './PanelModel';
+import { DashboardPanelsChangedEvent } from 'app/types/events';
 
 jest.mock('app/core/services/context_srv', () => ({}));
 
@@ -533,7 +534,7 @@ describe('given dashboard with row repeat', () => {
 });
 
 describe('given dashboard with row and panel repeat', () => {
-  let dashboard: any, dashboardJSON: any;
+  let dashboard: DashboardModel, dashboardJSON: any;
 
   beforeEach(() => {
     dashboardJSON = {
@@ -605,11 +606,16 @@ describe('given dashboard with row and panel repeat', () => {
       },
       { id: 12, type: 'graph', repeatPanelId: 2, repeatIteration: 101, gridPos: { x: 0, y: 3, h: 1, w: 6 } },
     ];
+
+    let panelChangedEvents: DashboardPanelsChangedEvent[] = [];
     dashboard = getDashboardModel(dashboardJSON);
+    dashboard.events.subscribe(DashboardPanelsChangedEvent, (evt) => panelChangedEvents.push(evt));
     dashboard.processRepeats();
 
     const panelTypes = map(dashboard.panels, 'type');
     expect(panelTypes).toEqual(['row', 'graph', 'graph', 'row', 'graph', 'graph']);
+    // Make sure only a single DashboardPanelsChangedEvent event is emitted when processing repeats
+    expect(panelChangedEvents.length).toBe(1);
   });
 
   it('should set scopedVars for each row', () => {

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -556,7 +556,6 @@ export class DashboardModel {
     pull(this.panels, ...panelsToRemove);
     panelsToRemove.map((p) => p.destroy());
     this.sortPanelsByGridPos();
-    this.events.publish(new DashboardPanelsChangedEvent());
   }
 
   processRepeats() {


### PR DESCRIPTION
Fixes #43234

This looks like an old issue, the cleanup function has for some reason always emitted this event and triggered a re-render with all repeated panels
removed.

This reduces flicking but's not removed. The introduction of a uuid panel key is causing repeated panel cleanup and re-creation to trigger
unmount and re-mounts of all repeated panels on every refresh. But that looks trickier to fix. Need to investigate that one more.
