### PR TITLE
@grafana/data: Update xss dependency

### DIFF
--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -39,7 +39,7 @@
     "rxjs": "7.3.0",
     "tslib": "2.3.1",
     "uplot": "1.6.16",
-    "xss": "1.0.6"
+    "xss": "1.0.10"
   },
   "devDependencies": {
     "@grafana/tsconfig": "^1.0.0-rc1",

--- a/packages/grafana-data/src/text/sanitize.ts
+++ b/packages/grafana-data/src/text/sanitize.ts
@@ -1,13 +1,12 @@
-import xss from 'xss';
+import { FilterXSS, whiteList, IWhiteList } from 'xss';
 import { sanitizeUrl as braintreeSanitizeUrl } from '@braintree/sanitize-url';
 
-const XSSWL = Object.keys(xss.whiteList).reduce((acc, element) => {
-  // @ts-ignore
-  acc[element] = xss.whiteList[element].concat(['class', 'style']);
+const XSSWL = Object.keys(whiteList).reduce((acc, element) => {
+  acc[element] = whiteList[element]?.concat(['class', 'style']);
   return acc;
-}, {});
+}, {} as IWhiteList);
 
-const sanitizeXSS = new xss.FilterXSS({
+const sanitizeXSS = new FilterXSS({
   whiteList: XSSWL,
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3472,7 +3472,7 @@ __metadata:
     tslib: 2.3.1
     typescript: 4.4.3
     uplot: 1.6.16
-    xss: 1.0.6
+    xss: 1.0.10
   languageName: unknown
   linkType: soft
 
@@ -14171,7 +14171,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:2, commander@npm:^2.19.0, commander@npm:^2.20.0, commander@npm:^2.7.1, commander@npm:^2.9.0":
+"commander@npm:2, commander@npm:^2.19.0, commander@npm:^2.20.0, commander@npm:^2.20.3, commander@npm:^2.7.1, commander@npm:^2.9.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
@@ -36102,15 +36102,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xss@npm:1.0.6":
-  version: 1.0.6
-  resolution: "xss@npm:1.0.6"
+"xss@npm:1.0.10":
+  version: 1.0.10
+  resolution: "xss@npm:1.0.10"
   dependencies:
-    commander: ^2.9.0
+    commander: ^2.20.3
     cssfilter: 0.0.10
   bin:
-    xss: ./bin/xss
-  checksum: 529baa20ee4cd82e45e0aca26d0069e2b80ae82c9eaff06b39cd2e3d1320031e53b8f001e5024e880796927e0bb450bc36d47607d44e25aa0c86f2ee049b76db
+    xss: bin/xss
+  checksum: 0dbc70a716020d854569610d5bc949ba9d3b7f530b7af5508ffe84edaea228c34a4e1227f71cb3a4741373b1c49c3cb691f69dddefda45a594a31f112ae6a738
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
I was looking into the HTML rendering support of the annotations tooltip for an escalation and noticed that the [xss dependency version](https://github.com/grafana/grafana/blob/b41c3124bb4223b5688dc305bf612957d4e47e7b/packages/grafana-data/package.json#L42) used to [sanitize user inpu](https://github.com/grafana/grafana/blob/d52a6e3d3b0ade2d2f926c3f317446c65c5d865c/public/app/plugins/panel/timeseries/plugins/annotations/AnnotationTooltip.tsx#L76)t fixed a [ReDoS issue](https://github.com/leizongmin/js-xss/pull/239) in a release a couple months ago.

This PR upgrades the `xss` dependency to `1.0.10` and fixes some typing issues caused by the upgrade. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

