### PR TITLE
AccessControl: Disable user remove and user update roles when they do not have the permissions

### DIFF
--- a/public/app/features/users/UsersTable.test.tsx
+++ b/public/app/features/users/UsersTable.test.tsx
@@ -8,6 +8,7 @@ import { ConfirmModal } from '@grafana/ui';
 jest.mock('app/core/core', () => ({
   contextSrv: {
     hasPermission: () => true,
+    hasPermissionInMetadata: () => true,
     accessControlEnabled: () => false,
   },
 }));

--- a/public/app/features/users/UsersTable.tsx
+++ b/public/app/features/users/UsersTable.tsx
@@ -15,9 +15,6 @@ export interface Props {
 
 const UsersTable: FC<Props> = (props) => {
   const { users, orgId, onRoleChange, onRemoveUser } = props;
-  const canUpdateRole = contextSrv.hasPermission(AccessControlAction.OrgUsersRoleUpdate);
-  const canRemoveFromOrg = contextSrv.hasPermission(AccessControlAction.OrgUsersRemove);
-  const rolePickerDisabled = !canUpdateRole;
 
   const [showRemoveModal, setShowRemoveModal] = useState<string | boolean>(false);
   const [roleOptions, setRoleOptions] = useState<Role[]>([]);
@@ -89,19 +86,19 @@ const UsersTable: FC<Props> = (props) => {
                     onBuiltinRoleChange={(newRole) => onRoleChange(newRole, user)}
                     getRoleOptions={getRoleOptions}
                     getBuiltinRoles={getBuiltinRoles}
-                    disabled={rolePickerDisabled}
+                    disabled={!contextSrv.hasPermissionInMetadata(AccessControlAction.OrgUsersRoleUpdate, user)}
                   />
                 ) : (
                   <OrgRolePicker
                     aria-label="Role"
                     value={user.role}
-                    disabled={!canUpdateRole}
+                    disabled={!contextSrv.hasPermissionInMetadata(AccessControlAction.OrgUsersRoleUpdate, user)}
                     onChange={(newRole) => onRoleChange(newRole, user)}
                   />
                 )}
               </td>
 
-              {canRemoveFromOrg && (
+              {contextSrv.hasPermissionInMetadata(AccessControlAction.OrgUsersRemove, user) && (
                 <td>
                   <Button
                     size="sm"

--- a/public/app/features/users/state/actions.ts
+++ b/public/app/features/users/state/actions.ts
@@ -3,10 +3,11 @@ import { getBackendSrv } from '@grafana/runtime';
 import { OrgUser } from 'app/types';
 import { inviteesLoaded, usersLoaded } from './reducers';
 import { contextSrv } from 'app/core/core';
+import { addAccessControlQueryParam } from 'app/core/utils/accessControl';
 
 export function loadUsers(): ThunkResult<void> {
   return async (dispatch) => {
-    const users = await getBackendSrv().get('/api/org/users');
+    const users = await getBackendSrv().get(addAccessControlQueryParam('/api/org/users'));
     dispatch(usersLoaded(users));
   };
 }

--- a/public/app/types/user.ts
+++ b/public/app/types/user.ts
@@ -1,7 +1,6 @@
 import { OrgRole } from '.';
-import { SelectableValue } from '@grafana/data';
-
-export interface OrgUser {
+import { SelectableValue, WithAccessControlMetadata } from '@grafana/data';
+export interface OrgUser extends WithAccessControlMetadata {
   avatarUrl: string;
   email: string;
   lastSeenAt: string;


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the front-end enables editing any user role and removing any user if the signed user has been granted `action: org.users:read, scope: users:*` and `org.users.role:update` on at least one user and `org.users:remove` on at least one user.

- Disable user remove and user update roles when they do not have the permissions

**Visual Result**

![image](https://user-images.githubusercontent.com/8071073/146955918-67632cae-33a8-4c2d-b0e1-3bacff0f8bd3.png)

**Backend component PR**:

https://github.com/grafana/grafana/pull/43362

**Issue(s) this PR fixes:**

Fixes [grafana/grafana-enterprise#2206](https://github.com/grafana/grafana-enterprise/issues/2443)

**Note to early draft reviewers**

- This PR is only meant for the frontend which are the 2 last commits