### PR TITLE
CodeQL: Fix prometheus ReDoS vulnerability

### DIFF
--- a/public/app/plugins/datasource/prometheus/legend.test.ts
+++ b/public/app/plugins/datasource/prometheus/legend.test.ts
@@ -18,13 +18,31 @@ describe('renderLegendFormat()', () => {
 
     // not sure if this is expected... but current behavior
     expect(renderLegendFormat('{{ a }}', labels)).toEqual('AAA');
+    expect(renderLegendFormat('{{             a                        }}', labels)).toEqual('AAA');
+  });
+
+  it('Missing label', () => {
+    expect(renderLegendFormat('value: {{c}}', labels)).toEqual('value: c');
+  });
+
+  it('Nested brackets', () => {
+    expect(renderLegendFormat('{{{a}}}', labels)).toEqual('{AAA}');
+    expect(renderLegendFormat('{{{{a}}}}', labels)).toEqual('{{AAA}}');
+    expect(renderLegendFormat('{{ {{ a }} }}', labels)).toEqual('{{ AAA }}');
   });
 
   it('Bad syntax', () => {
+    expect(renderLegendFormat('value: {{{a}', labels)).toEqual('value: {{{a}');
     expect(renderLegendFormat('value: {{a}', labels)).toEqual('value: {{a}');
+    expect(renderLegendFormat('value: {a}', labels)).toEqual('value: {a}');
     expect(renderLegendFormat('value: {a}}}', labels)).toEqual('value: {a}}}');
-
-    // Current behavior -- not sure if expected or not
-    expect(renderLegendFormat('value: {{{a}}}', labels)).toEqual('value: {a}');
+    expect(renderLegendFormat('value: {a}}', labels)).toEqual('value: {a}}');
+    expect(renderLegendFormat('value: { {a} }', labels)).toEqual('value: { {a} }');
+    expect(renderLegendFormat('value: { {a}}}', labels)).toEqual('value: { {a}}}');
+    expect(renderLegendFormat('{{        }}', labels)).toEqual('{{        }}');
+    expect(renderLegendFormat('{{}}', labels)).toEqual('{{}}');
+    expect(renderLegendFormat('{{{}} }', labels)).toEqual('{{{}} }');
+    expect(renderLegendFormat('{{{}}}', labels)).toEqual('{{{}}}');
+    expect(renderLegendFormat('{{a}d}}', labels)).toEqual('a}d');
   });
 });

--- a/public/app/plugins/datasource/prometheus/legend.test.ts
+++ b/public/app/plugins/datasource/prometheus/legend.test.ts
@@ -26,6 +26,7 @@ describe('renderLegendFormat()', () => {
   });
 
   it('Nested brackets', () => {
+    // it's unclear if this is expected behavior
     expect(renderLegendFormat('{{{a}}}', labels)).toEqual('{AAA}');
     expect(renderLegendFormat('{{{{a}}}}', labels)).toEqual('{{AAA}}');
     expect(renderLegendFormat('{{ {{ a }} }}', labels)).toEqual('{{ AAA }}');

--- a/public/app/plugins/datasource/prometheus/legend.test.ts
+++ b/public/app/plugins/datasource/prometheus/legend.test.ts
@@ -44,6 +44,6 @@ describe('renderLegendFormat()', () => {
     expect(renderLegendFormat('{{}}', labels)).toEqual('{{}}');
     expect(renderLegendFormat('{{{}} }', labels)).toEqual('{{{}} }');
     expect(renderLegendFormat('{{{}}}', labels)).toEqual('{{{}}}');
-    expect(renderLegendFormat('{{a}d}}', labels)).toEqual('a}d');
+    expect(renderLegendFormat('{{a}d}}', labels)).toEqual('{{a}d}}');
   });
 });

--- a/public/app/plugins/datasource/prometheus/legend.ts
+++ b/public/app/plugins/datasource/prometheus/legend.ts
@@ -9,37 +9,32 @@ export function renderLegendFormat(aliasPattern: string, aliasData: Labels): str
   // (?!  Negative lookahead. Specifies a group that can not match after the main
   //      expression (if it matches, the result is discarded).
   //
-  //        [ Character set. Match any character in the set below.
-  //          \s Whitespace. Matches any whitespace character (spaces, tabs, line breaks).
-  //          \{ Escaped character. Matches a "{" character (char code 123).
-  //          \} Escaped character. Matches a "}" character (char code 125).
-  //        ]
+  //        \s Whitespace. Matches any whitespace character (spaces, tabs, line breaks).
   //
   // )
   //
   // (    Capturing group #1. Groups multiple tokens together and creates a capture group for extracting a
   //      substring or using a backreference.
   //
-  //        . Dot. Matches any character except line breaks.
+  //      [^ Match a single character not present in the list below
+  //           \{ matches the character { (char code 123)
+  //           \} matches the character } (char code 123)
+  //      ]
   //        + Quantifier. Match 1 or more of the preceding token.
   //        ? Lazy. Makes the preceding quantifier lazy, causing it to match as few characters as possible.
   //
   // )
   //
-  // (?<! Negative lookbehind. Specifies a group that can not match before the main
+  // (?!  Negative lookbehind. Specifies a group that can not match before the main
   //      expression (if it matches, the result is discarded).
   //
-  //            [ Character set. Match any character in the set below.
-  //              \s Whitespace. Matches any whitespace character (spaces, tabs, line breaks).
-  //              \{ Escaped character. Matches a "{" character (char code 123).
-  //              \} Escaped character. Matches a "}" character (char code 125).
-  //            ]
+  //        \s Whitespace. Matches any whitespace character (spaces, tabs, line breaks).
   //
   // )
   //
   // \s*  Matches any whitespace character (spaces, tabs, line breaks) 0 or more times.
   //
   // \}\} Escaped "}}" characters (char code 125).
-  const aliasRegex = /\{\{\s*(?![\s\{\}])(.+?)(?<![s\{\}])\s*\}\}/g;
+  const aliasRegex = /\{\{\s*(?!\s)([^\{\}]+?)(?<!\s)\s*\}\}/g;
   return aliasPattern.replace(aliasRegex, (_, g1) => (aliasData[g1] ? aliasData[g1] : g1));
 }

--- a/public/app/plugins/datasource/prometheus/legend.ts
+++ b/public/app/plugins/datasource/prometheus/legend.ts
@@ -2,6 +2,44 @@ import { Labels } from '@grafana/data';
 
 /** replace labels in a string.  Used for loki+prometheus legend formats */
 export function renderLegendFormat(aliasPattern: string, aliasData: Labels): string {
-  const aliasRegex = /\{\{\s*(.+?)\s*\}\}/g;
+  // \{\{ Escaped "{{" characters (char code 123).
+  //
+  // \s*  Matches any whitespace character (spaces, tabs, line breaks) 0 or more times.
+  //
+  // (?!  Negative lookahead. Specifies a group that can not match after the main
+  //      expression (if it matches, the result is discarded).
+  //
+  //        [ Character set. Match any character in the set below.
+  //          \s Whitespace. Matches any whitespace character (spaces, tabs, line breaks).
+  //          \{ Escaped character. Matches a "{" character (char code 123).
+  //          \} Escaped character. Matches a "}" character (char code 125).
+  //        ]
+  //
+  // )
+  //
+  // (    Capturing group #1. Groups multiple tokens together and creates a capture group for extracting a
+  //      substring or using a backreference.
+  //
+  //        . Dot. Matches any character except line breaks.
+  //        + Quantifier. Match 1 or more of the preceding token.
+  //        ? Lazy. Makes the preceding quantifier lazy, causing it to match as few characters as possible.
+  //
+  // )
+  //
+  // (?<! Negative lookbehind. Specifies a group that can not match before the main
+  //      expression (if it matches, the result is discarded).
+  //
+  //            [ Character set. Match any character in the set below.
+  //              \s Whitespace. Matches any whitespace character (spaces, tabs, line breaks).
+  //              \{ Escaped character. Matches a "{" character (char code 123).
+  //              \} Escaped character. Matches a "}" character (char code 125).
+  //            ]
+  //
+  // )
+  //
+  // \s*  Matches any whitespace character (spaces, tabs, line breaks) 0 or more times.
+  //
+  // \}\} Escaped "}}" characters (char code 125).
+  const aliasRegex = /\{\{\s*(?![\s\{\}])(.+?)(?<![s\{\}])\s*\}\}/g;
   return aliasPattern.replace(aliasRegex, (_, g1) => (aliasData[g1] ? aliasData[g1] : g1));
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Fixes a potential [ReDoS](https://github.com/github/codeql/blob/ddd4ccbb4b39adf3c2427088f4876432202c4eaa/javascript/ql/src/Performance/PolynomialReDoS.ql) vulnerability that CodeQL was reporting.

https://github.com/grafana/grafana/pull/43337 is not currently passing the CodeQL scan, so this is testing an alternate approach.

**Which issue(s) this PR fixes**:

* #43080

**Special notes for your reviewer**:

