### PR TITLE
Chore: Remove Github Packages publish step

### DIFF
--- a/scripts/build/release-npm-packages.sh
+++ b/scripts/build/release-npm-packages.sh
@@ -52,15 +52,6 @@ if [ $RELEASE_CHANNEL == "latest" ]; then
   done
 fi
 
-# Publish to Github Packages registry
-# We do this for the convenience of developers that make use of both the canary and next / latest channels.
-
-echo "@grafana:registry=https://npm.pkg.github.com" >> ~/.npmrc
-echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGE_TOKEN}" >> ~/.npmrc
-
-echo $'\nPublishing packages to Github Packages registry'
-yarn packages:${SCRIPT} --registry https://npm.pkg.github.com
-
 # When releasing stable(latest) version of packages we are updating previously published next tag(beta) to be the same version as latest
 if [ $RELEASE_CHANNEL == "latest" ]; then
   for i in "${PACKAGES[@]}"

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -115,7 +115,6 @@ def release_npm_packages_step(edition, ver_mode):
         ],
         'environment': {
             'NPM_TOKEN': from_secret('npm_token'),
-            'GITHUB_PACKAGE_TOKEN': from_secret('github_package_token'),
         },
         'commands': ['./scripts/build/release-npm-packages.sh ${DRONE_TAG}'],
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes Github packages publish step, as no longer needed.