### PR TITLE
Prometheus: Fix interpolation of variables in annotation queries

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -1062,6 +1062,31 @@ describe('PrometheusDatasource', () => {
         expect(results.map((result) => [result.time, result.timeEnd])).toEqual([[120000, 120000]]);
       });
     });
+    describe('with template variables', () => {
+      const originalReplaceMock = jest.fn((a: string, ...rest: any) => a);
+      afterAll(() => {
+        templateSrvStub.replace = originalReplaceMock;
+      });
+
+      it('should interpolate variables in query expr', () => {
+        const query = {
+          ...options,
+          annotation: {
+            ...options.annotation,
+            expr: '$variable',
+          },
+          range: {
+            from: time({ seconds: 1 }),
+            to: time({ seconds: 2 }),
+          },
+        };
+        const interpolated = 'interpolated_expr';
+        templateSrvStub.replace.mockReturnValue(interpolated);
+        ds.annotationQuery(query);
+        const req = fetchMock.mock.calls[0][0];
+        expect(req.data.queries[0].expr).toBe(interpolated);
+      });
+    });
   });
 
   describe('When resultFormat is table and instant = true', () => {

--- a/public/app/plugins/datasource/prometheus/datasource.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.ts
@@ -688,7 +688,7 @@ export class PrometheusDatasource
           data: {
             from: (this.getPrometheusTime(options.range.from, false) * 1000).toString(),
             to: (this.getPrometheusTime(options.range.to, true) * 1000).toString(),
-            queries: [queryModel],
+            queries: [this.applyTemplateVariables(queryModel, {})],
           },
           requestId: `prom-query-${annotation.name}`,
         })


### PR DESCRIPTION
**What this PR does / why we need it**:
During Prometheus backend migration we have forgotten to add interpolation of variables in annotation queries. This PR fixes this bu using `applyTemplateVariables` method that is used in all backend queries. 

Regarding possible issues mentioned in #43438

>Think there might be more bugs introduced by this change (all the logic inside createQuery to align time range & step etc, seems to be missing in new version)

Everything that is currently handled in `createQuery` should be implemented on backend so we have 1 place for it, instead of handling it differently for explore/dashboard queries and alerting queries. 

**Which issue(s) this PR fixes**:

Fixes #43438
Fixes #43008

