### PR TITLE
bug修复

### DIFF
--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -296,7 +296,10 @@ export class TimeSrv {
       urlParams.from = urlRange.from.toString();
       urlParams.to = urlRange.to.toString();
 
-      locationService.partial(urlParams);
+      locationService.push({
+        ...locationService.getLocation(),
+        search: urlParams.get('kiosk') === '' ? urlParams.toString().replace(/kiosk=/, 'kiosk') : urlParams.toString(),
+      });
     }
 
     this.refreshDashboard();


### PR DESCRIPTION
Hi,sir
For the problem of missing kiosk parameters, I see that other partners fixed a version a few days ago, but I found a problem. The original URL should pass the from and to parameters. Now they are filtered out directly. See if you can fix this on the original basis.
I have a compromise. Do you think so.
![image](https://user-images.githubusercontent.com/54847848/147204002-47580376-3728-46d3-8288-c8b14c998841.png)
