### PR TITLE
AzureMonitor: Exclude '(' in second capturing group for CodeQL ReDoS vulnerability

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/log_analytics/querystring_builder.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/log_analytics/querystring_builder.ts
@@ -5,7 +5,7 @@ export default class LogAnalyticsQuerystringBuilder {
 
   generate() {
     let queryString = this.rawQueryString;
-    const macroRegexp = /\$__([_a-zA-Z0-9]+)\(([^\)]*)\)/gi;
+    const macroRegexp = /\$__([_a-zA-Z0-9]+)\(([^()]*)\)/gi;
     queryString = queryString.replace(macroRegexp, (match, p1, p2) => {
       if (p1 === 'contains') {
         return this.getMultiContains(p2);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR attempts to make the regex on a raw query linear in time rather than polynomial: raised as a vulnerability by CodeQL. 

**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana/security/code-scanning/99
Closes #43421

**Special notes for your reviewer**:
https://regex101.com/r/G3VHta/5 can play around here
and this was useful https://devina.io/redos-checker
thanks @toddtreece for the help

@grafana/cloud-datasources I hope this is compatible with our use case. ~Also would it be appropriate to try to backport? I'll go ahead and assign milestone 8.3.4, let me know.~
