### PR TITLE
Alerting: Fix global state sensitivity in notifier channel tests

### DIFF
--- a/pkg/services/ngalert/notifier/channels/discord_test.go
+++ b/pkg/services/ngalert/notifier/channels/discord_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestDiscordNotifier(t *testing.T) {
@@ -48,7 +49,7 @@ func TestDiscordNotifier(t *testing.T) {
 					"color": 1.4037554e+07,
 					"footer": map[string]interface{}{
 						"icon_url": "https://grafana.com/assets/img/fav32.png",
-						"text":     "Grafana v",
+						"text":     "Grafana v" + setting.BuildVersion,
 					},
 					"title": "[FIRING:1]  (val1)",
 					"url":   "http://localhost/alerting/list",
@@ -85,7 +86,7 @@ func TestDiscordNotifier(t *testing.T) {
 					"color": 1.4037554e+07,
 					"footer": map[string]interface{}{
 						"icon_url": "https://grafana.com/assets/img/fav32.png",
-						"text":     "Grafana v",
+						"text":     "Grafana v" + setting.BuildVersion,
 					},
 					"title": "[FIRING:2]  ",
 					"url":   "http://localhost/alerting/list",
@@ -120,7 +121,7 @@ func TestDiscordNotifier(t *testing.T) {
 					"color": 1.4037554e+07,
 					"footer": map[string]interface{}{
 						"icon_url": "https://grafana.com/assets/img/fav32.png",
-						"text":     "Grafana v",
+						"text":     "Grafana v" + setting.BuildVersion,
 					},
 					"title": "[FIRING:1]  (val1)",
 					"url":   "http://localhost/alerting/list",

--- a/pkg/services/ngalert/notifier/channels/slack_test.go
+++ b/pkg/services/ngalert/notifier/channels/slack_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
+	"github.com/grafana/grafana/pkg/setting"
 
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
@@ -61,7 +62,7 @@ func TestSlackNotifier(t *testing.T) {
 						Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
 						Fallback:   "[FIRING:1]  (val1)",
 						Fields:     nil,
-						Footer:     "Grafana v",
+						Footer:     "Grafana v" + setting.BuildVersion,
 						FooterIcon: "https://grafana.com/assets/img/fav32.png",
 						Color:      "#D63232",
 						Ts:         0,
@@ -96,7 +97,7 @@ func TestSlackNotifier(t *testing.T) {
 						Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n",
 						Fallback:   "[FIRING:1]  (val1)",
 						Fields:     nil,
-						Footer:     "Grafana v",
+						Footer:     "Grafana v" + setting.BuildVersion,
 						FooterIcon: "https://grafana.com/assets/img/fav32.png",
 						Color:      "#D63232",
 						Ts:         0,
@@ -138,7 +139,7 @@ func TestSlackNotifier(t *testing.T) {
 						Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval1\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val2\nAnnotations:\n - ann1 = annv2\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matchers=alertname%3Dalert1%2Clbl1%3Dval2\n",
 						Fallback:   "2 firing, 0 resolved",
 						Fields:     nil,
-						Footer:     "Grafana v",
+						Footer:     "Grafana v" + setting.BuildVersion,
 						FooterIcon: "https://grafana.com/assets/img/fav32.png",
 						Color:      "#D63232",
 						Ts:         0,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Many channel tests involve templates, via a `TmplText` utility. This utility consumes values from the Grafana config, which is global and mutable.

If a developer has a different config state, tests may inconsistently pass or fail depending on environment. Also, new tests which use this state can cause other seemingly unrelated tests to fail, because the template output no longer matches.

Fix the Discord, Slack, and VictorOps tests to parameterize global state, rather than assert on hardcoded values.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

Only affects tests.
