### PR TITLE
fix for incomplete string escaping

### DIFF
--- a/packages/grafana-ui/src/components/JSONFormatter/json_explorer/helpers.test.ts
+++ b/packages/grafana-ui/src/components/JSONFormatter/json_explorer/helpers.test.ts
@@ -1,0 +1,24 @@
+import { getValuePreview } from './helpers';
+
+describe('getValuePreview', () => {
+  it('should put double quotes around a string value', () => {
+    const jsonObject: any = 'a string';
+    const output = getValuePreview(jsonObject, jsonObject.toString());
+
+    expect(output).toBe(`"a string"`);
+  });
+
+  it('should escape multiple double quotes in a string value', () => {
+    const jsonObject: any = '"a quoted string"';
+    const output = getValuePreview(jsonObject, jsonObject.toString());
+
+    expect(output).toBe(`"\\"a quoted string\\""`);
+  });
+
+  it('should escape backslashes in a string value', () => {
+    const jsonObject: any = 'a string with backslash \\ and quote"';
+    const output = getValuePreview(jsonObject, jsonObject.toString());
+
+    expect(output).toBe(`"a string with backslash \\\\ and quote\\\""`);
+  });
+});

--- a/packages/grafana-ui/src/components/JSONFormatter/json_explorer/helpers.ts
+++ b/packages/grafana-ui/src/components/JSONFormatter/json_explorer/helpers.ts
@@ -5,7 +5,7 @@
  * Escapes `"` characters from string
  */
 function escapeString(str: string): string {
-  return str.replace('"', '"');
+  return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 /*


### PR DESCRIPTION
Fix for CodeQL code alert: https://github.com/grafana/grafana/security/code-scanning/9\?query\=ref%3Arefs%2Fheads%2Fmain

Looks like this escapeString function has always been buggy. The older version and the newer version both just replace a double quote with a double quote and don't actually escape anything. This code is used in the Query Inspector for the JsonExplorer component that shows the json result on the Query tab (and in a few other places). I think it is rare to have double quotes in query results which is why it has never been noticed before.

5 years ago: `return str.replace('"', '\"');`
4 years ago after refactoring: `return str.replace('"', '"');`

Looking at the original [source of the code](https://github.com/mohsen1/json-formatter-js/blob/master/src/helpers.ts#L5), they have already [fixed this incomplete string escaping](https://github.com/mohsen1/json-formatter-js/pull/70). 

I just recreated the above fix in the Grafana version of the json-formatter-js file (helpers.ts) so this PR:
-  fixes the [security alert for incomplete string escaping](https://github.com/grafana/grafana/security/code-scanning/9%5C?query%5C=ref%3Arefs%2Fheads%2Fmain)
- fixes the [security alert for replacement of substring with itself](https://github.com/grafana/grafana/security/code-scanning/23?query=ref%3Arefs%2Fheads%2Fmain)
- actually makes the escapeString function escape a string
- adds escaping for backslashes
- adds tests for the getValuePreview function that calls the internal escapeString function

Should I be using the [sanitize function in textUtils](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/text/sanitize.ts#L43) instead of doing a string replace?

Ref #43080