### PR TITLE
Alerting: [Docs] Clarifications regarding what's supported in alerting message templates

### DIFF
--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -56,7 +56,7 @@ Use caution when deleting a template since Grafana does not prevent you from del
 
 You can embed templates within other templates.
 
-For example, you can define a template fragment can using the `define` keyword:
+For example, you can define a template fragment using the `define` keyword:
 
 ```
 {{ define "mytemplate" }}

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -129,4 +129,4 @@ Template to render entire notification message:
 
 HTML in Alerting message templates is escaped, and rendering of HTML in the resulting notification is not supported.
 
-Some notifiers which support rendered HTML (such as the body of emails) support alternative methods of changing the look and feel of the resulting notification. For example, the base template used in Alerting emails is installed to /usr/share/grafana/public/emails` on Linux.
+Some notifiers which support rendered HTML (such as the body of emails) support alternative methods of changing the look and feel of the resulting notification. For example, the base template used in Alerting emails is installed to `/usr/share/grafana/public/emails` on Linux.

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -54,7 +54,7 @@ Use caution when deleting a template since Grafana does not prevent you from del
 
 ### Nested templates
 
-Templates may embed other templates.
+You can embed templates within other templates.
 
 For example, a template fragment can be defined using the `define` keyword:
 

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -81,7 +81,7 @@ Grafana provides a few built-in templates, which can be embedded in custom templ
 
 ### Custom template examples
 
-Below are some sample usages of custom templates.
+Here are a few examples of how to use custom templates.
 
 Template to render a single alert:
 

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -71,7 +71,7 @@ Alert summary:
 {{ template "mytemplate" . }}
 ```
 
-Grafana provides a few built-in templates, which can be embedded in custom templates:
+You can use any of the following built-in template options to embed custom templates.
 
 | Name                    | Notes                                                         |
 | ----------------------- | ------------------------------------------------------------- |

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -14,7 +14,7 @@ Since most of the contact point fields can be templated, you can create reusable
 
 ### Using templates
 
-The following example shows the use of default templates to render an alert message in Slack. The message title contains a count of firing or resolved alerts and the message body has a list of alerts with status.
+The following example shows how to use default templates to render an alert message in Slack. The message title contains a count of alerts that are firing or were resolved. The message body lists the alerts and their status.
 
 <img  src="/static/img/docs/alerting/unified/contact-points-template-fields-8-0.png" width="450px">
 
@@ -73,11 +73,11 @@ Alert summary:
 
 Grafana provides a few built-in templates, which can be embedded in custom templates:
 
-| Name                    | Notes                                                                 |
-| ----------------------- | --------------------------------------------------------------------- |
-| `default.title`         | Displays high-level status information.                               |
-| `default.message`       | Provides a formatted summary of firing and resolved alerts.           |
-| `teams.default.message` |Similar to `default.messsage`, formatted for Microsoft Teams. |
+| Name                    | Notes                                                         |
+| ----------------------- | ------------------------------------------------------------- |
+| `default.title`         | Displays high-level status information.                       |
+| `default.message`       | Provides a formatted summary of firing and resolved alerts.   |
+| `teams.default.message` | Similar to `default.messsage`, formatted for Microsoft Teams. |
 
 ### Custom template examples
 
@@ -127,6 +127,6 @@ Template to render entire notification message:
 
 ### HTML in Message Templates
 
-HTML in Alerting message templates is escaped, and rendering of HTML in the resulting notification is not supported.
+HTML in alerting message templates is escaped. We do not support rendering of HTML in the resulting notification.
 
-Some notifiers which support rendered HTML (such as the body of emails) support alternative methods of changing the look and feel of the resulting notification. For example, the base template used in Alerting emails is installed to `/usr/share/grafana/public/emails` on Linux.
+Some notifiers support alternative methods of changing the look and feel of the resulting notification. For example, Grafana installs the base template for alerting emails to `<grafana-install-dir>/public/emails/ng_alert_notification.html`. You can edit this file to change the appearance of all alerting emails.

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -77,7 +77,7 @@ Grafana provides a few built-in templates, which can be embedded in custom templ
 | ----------------------- | --------------------------------------------------------------------- |
 | `default.title`         | Displays high-level status information.                               |
 | `default.message`       | Provides a formatted summary of firing and resolved alerts.           |
-| `teams.default.message` | Similar content to `default.messsage`, formatted for Microsoft Teams. |
+| `teams.default.message` |Similar to `default.messsage`, formatted for Microsoft Teams. |
 
 ### Custom template examples
 

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -116,11 +116,11 @@ Template to render entire notification message:
 {{ define "mymessage" }}
   {{ if gt (len .Alerts.Firing) 0 }}
     {{ len .Alerts.Firing }} firing:
-    {{ range .Alerts.Firing }} {{ template "alert" .}} {{ end }}
+    {{ range .Alerts.Firing }} {{ template "myalert" .}} {{ end }}
   {{ end }}
   {{ if gt (len .Alerts.Resolved) 0 }}
     {{ len .Alerts.Resolved }} resolved:
-    {{ range .Alerts.Resolved }} {{ template "alert" .}} {{ end }}
+    {{ range .Alerts.Resolved }} {{ template "myalert" .}} {{ end }}
   {{ end }}
 {{ end }}
 ```

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -14,7 +14,7 @@ Since most of the contact point fields can be templated, you can create reusable
 
 ### Using templates
 
-The following example shows the use of default templates to render an alert message in slack. The message title contains a count of firing or resolved alerts and the message body has a list of alerts with status.
+The following example shows the use of default templates to render an alert message in Slack. The message title contains a count of firing or resolved alerts and the message body has a list of alerts with status.
 
 <img  src="/static/img/docs/alerting/unified/contact-points-template-fields-8-0.png" width="450px">
 
@@ -52,12 +52,41 @@ The `define` tag in the Content section assigns the template name. This tag is o
 
 Use caution when deleting a template since Grafana does not prevent you from deleting templates that are in use.
 
+### Nested templates
+
+Templates may embed other templates.
+
+For example, a template fragment can be defined using the `define` keyword:
+
+```
+{{ define "mytemplate" }}
+  {{ len .Alerts.Firing }} firing. {{ len .Alerts.Resolved }} resolved.
+{{ end }}
+```
+
+Other custom templates may then embed the fragment using the `template` keyword:
+
+```
+Alert summary:
+{{ template "mytemplate" . }}
+```
+
+Grafana provides a few built-in templates, which can be embedded in custom templates:
+
+| Name                    | Notes                                                                 |
+| ----------------------- | --------------------------------------------------------------------- |
+| `default.title`         | Displays high-level status information.                               |
+| `default.message`       | Provides a formatted summary of firing and resolved alerts.           |
+| `teams.default.message` | Similar content to `default.messsage`, formatted for Microsoft Teams. |
+
 ### Custom template examples
+
+Below are some sample usages of custom templates.
 
 Template to render a single alert:
 
 ```
-{{ define "alert" }}
+{{ define "myalert" }}
   [{{.Status}}] {{ .Labels.alertname }}
 
   Labels:
@@ -84,7 +113,7 @@ Template to render a single alert:
 Template to render entire notification message:
 
 ```
-{{ define "message" }}
+{{ define "mymessage" }}
   {{ if gt (len .Alerts.Firing) 0 }}
     {{ len .Alerts.Firing }} firing:
     {{ range .Alerts.Firing }} {{ template "alert" .}} {{ end }}
@@ -95,3 +124,9 @@ Template to render entire notification message:
   {{ end }}
 {{ end }}
 ```
+
+### HTML in Message Templates
+
+HTML in Alerting message templates is escaped, and rendering of HTML in the resulting notification is not supported.
+
+Some notifiers which support rendered HTML (such as the body of emails) support alternative methods of changing the look and feel of the resulting notification. For example, the base template used in Alerting emails is installed to /usr/share/grafana/public/emails` on Linux.

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -56,7 +56,7 @@ Use caution when deleting a template since Grafana does not prevent you from del
 
 You can embed templates within other templates.
 
-For example, a template fragment can be defined using the `define` keyword:
+For example, you can define a template fragment can using the `define` keyword:
 
 ```
 {{ define "mytemplate" }}

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -64,7 +64,7 @@ For example, you can define a template fragment can using the `define` keyword:
 {{ end }}
 ```
 
-Other custom templates may then embed the fragment using the `template` keyword:
+You can then embed custom templates within this fragment using the `template` keyword. For example:
 
 ```
 Alert summary:


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Some customers are struggling with the difference between alerting message templates and the installed Grafana email template files. Add some clarification to the docs to guide the user in the right direction just a bit more.

**Which issue(s) this PR fixes**:

Contributes to #42946

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:
- Add an example showing how to properly embed templates.
- List the built-in embedded templates that we provide directly.
  - I left a few out, some are fragments of the default ones such as `__subject`. I avoided documenting anything prefixed with a double-underscore as it felt like it was for internal use.
- Alter example message names to make it very clear that they are custom. Specifically, the core email template engine also provides a different HTML-based template also called `alert` - avoid this term.
- Specifically note that HTML in alerting messages will be escaped and not rendered. In practice this is always true. The `safeHtml` template function ported [from prometheus](https://prometheus.io/docs/alerting/latest/notifications/#functions) always no-ops in practice in ngalerting. Luckily, @davidmparrott's prior docs overhaul #43178 already removed this in the next version of docs.
