### PR TITLE
Encryption: Increase context timeout on flaky test

### DIFF
--- a/pkg/services/secrets/manager/manager_test.go
+++ b/pkg/services/secrets/manager/manager_test.go
@@ -277,15 +277,15 @@ func TestSecretsService_Run(t *testing.T) {
 		require.Len(t, svc.dataKeyCache, 1)
 
 		// Execute background process after key's TTL, to force
-		// clean up process, during a millisecond with gc ticker
-		// configured on every nanosecond, to ensure the ticker
-		// is triggered.
+		// clean up process, during a hundred milliseconds with
+		// gc ticker configured on every nanosecond, to ensure
+		// the ticker is triggered.
 		gcInterval = time.Nanosecond
 
 		t.Cleanup(func() { now = time.Now })
 		now = func() time.Time { return time.Now().Add(dekTTL) }
 
-		ctx, cancel := context.WithTimeout(ctx, time.Millisecond)
+		ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 		defer cancel()
 
 		err = svc.Run(ctx)


### PR DESCRIPTION
**What this PR does / why we need it**:

There's a flaky test (see this failure example: https://drone.grafana.net/grafana/grafana/46382/1/10) due to small context timeout. So, it increases that time to avoid failures from time to time on CI pipelines.

**Special notes for your reviewer**:

These changes were introduced [here](https://github.com/grafana/grafana/pull/43129). So, as [the corresponding automatic backport failed](https://github.com/grafana/grafana/pull/43129#issuecomment-1002009123), [the manual backport](https://github.com/grafana/grafana/pull/43551) should be merged first to be able to backport this one. 

