### PR TITLE
Toolkit: Revert build config so tslib is bundled with plugins to prevent plugins from crashing.

### DIFF
--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
@@ -171,7 +171,6 @@ const getBaseWebpackConfig: WebpackConfigurationGetter = async (options) => {
 
     performance: { hints: false },
     externals: [
-      'tslib',
       'lodash',
       'jquery',
       'moment',

--- a/plugins-bundled/internal/input-datasource/package.json
+++ b/plugins-bundled/internal/input-datasource/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@types/jest": "26.0.15",
     "@types/react": "17.0.30",
+    "pnp-webpack-plugin": "^1.7.0",
     "ts-loader": "8.0.11",
     "webpack": "5.58.1"
   },

--- a/plugins-bundled/internal/input-datasource/package.json
+++ b/plugins-bundled/internal/input-datasource/package.json
@@ -16,7 +16,9 @@
   "author": "Grafana Labs",
   "devDependencies": {
     "@types/jest": "26.0.15",
+    "@types/lodash": "4.14.149",
     "@types/react": "17.0.30",
+    "lodash": "4.17.21",
     "pnp-webpack-plugin": "^1.7.0",
     "ts-loader": "8.0.11",
     "webpack": "5.58.1"

--- a/plugins-bundled/internal/input-datasource/webpack.config.js
+++ b/plugins-bundled/internal/input-datasource/webpack.config.js
@@ -1,0 +1,15 @@
+const { merge } = require('lodash');
+const PnpWebpackPlugin = require('pnp-webpack-plugin');
+
+module.exports = {
+  getWebpackConfig: (baseConfig) => {
+    return merge(baseConfig, {
+      resolve: {
+        plugins: [PnpWebpackPlugin],
+      },
+      resolveLoader: {
+        plugins: [PnpWebpackPlugin.moduleLoader(module)],
+      },
+    });
+  },
+};

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -5,7 +5,6 @@ import kbn from 'app/core/utils/kbn';
 import moment from 'moment'; // eslint-disable-line no-restricted-imports
 import angular from 'angular';
 import jquery from 'jquery';
-import * as tslib from 'tslib';
 
 // Experimental module exports
 import prismjs from 'prismjs';
@@ -82,7 +81,6 @@ function exposeToPlugin(name: string, component: any) {
   });
 }
 
-exposeToPlugin('tslib', tslib);
 exposeToPlugin('@grafana/data', grafanaData);
 exposeToPlugin('@grafana/ui', grafanaUI);
 exposeToPlugin('@grafana/runtime', grafanaRuntime);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3383,8 +3383,10 @@ __metadata:
     "@grafana/toolkit": 8.4.0-pre
     "@grafana/ui": 8.4.0-pre
     "@types/jest": 26.0.15
+    "@types/lodash": 4.14.149
     "@types/react": 17.0.30
     jquery: 3.5.1
+    lodash: 4.17.21
     pnp-webpack-plugin: ^1.7.0
     react: 17.0.1
     react-dom: 17.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -3385,6 +3385,7 @@ __metadata:
     "@types/jest": 26.0.15
     "@types/react": 17.0.30
     jquery: 3.5.1
+    pnp-webpack-plugin: ^1.7.0
     react: 17.0.1
     react-dom: 17.0.1
     react-hook-form: 7.5.3
@@ -27096,6 +27097,15 @@ __metadata:
   dependencies:
     ts-pnp: ^1.1.6
   checksum: 0606a63db96400b07f182300168298da9518727a843f9e10cf5045d2a102a4be06bb18c73dc481281e3e0f1ed8d04ef0d285a342b6dcd0eff1340e28e5d2328d
+  languageName: node
+  linkType: hard
+
+"pnp-webpack-plugin@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "pnp-webpack-plugin@npm:1.7.0"
+  dependencies:
+    ts-pnp: ^1.1.6
+  checksum: a41716d13607be5a3e06ba58b17e9e619cf07da3a0a7b10bd41cd89362873041054fd2b7966ad30a1b26b826cfb8fecc0469a95902d5b1b8ba8f591e2fe6b96d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The following https://github.com/grafana/grafana/pull/40300 adds the `tslib` as an external library provided by Grafana to plugins. This will exclude `tslib` from the bundle when building a plugin and expect it to be provided by Grafana during runtime. 

This causes issues when trying to run a plugin built with `@grafana/toolkit` version `8.3.0-8.3.3` in Grafana versions _prior_ to `8.3.0`. The reason for this is that the build configuration used in `@grafana/toolkit` will expect the `tslib` to be available in Grafana during runtime. But it is not exposed during runtime in Grafana versions _prior_ to `8.3.0`.

This means that we have introduced a breaking change in Grafana `8.3.0`. This PR will revert that breaking change.

One big drawback with this approach is that plugins built with `@grafana/toolkit` versions `8.3.0-8.3.3` will need to be built again with `@garana/toolkit` version `>8.3.4` and re-published to properly function in versions prior to Grafana `8.3.0`.

An alternative approach is that we backport the build configuration that exposes `tslib` to plugins in earlier versions of Grafana (e.g. https://github.com/grafana/grafana/pull/43497). The problem with that is that we might end up in a situation where we have a version miss match between the `typescript` version used to build the plugin and `tslib` exposed by Grafana.

Looking at the commit history of the https://github.com/grafana/grafana/pull/40300 it looks like we added `tslib` as an external dependency due to build failure when trying to build plugins in the `plugins-bundled` folder. That build failed because we could not resolve the dependencies when they are using `yarn pnp` instead of regular `node_modules`. I resolved it in this PR by adding the `pnp-webpack-plugin` as recommended here: https://github.com/TypeStrong/ts-loader#yarn-plugnplay.

This could probably be skipped if we do a proper migration of the `/packages/grafana-toolkit/src/config/webpack.plugin.config.ts` to webpack 5 (as described here https://webpack.js.org/migrate/5/) since webpack 5 support pnp natively.

**How to test:**
Didn't manage to test it locally by link it so I merged to master and tested it with the canary package,

**Follow up issues:**
- Migrate the `/packages/grafana-toolkit/src/config/webpack.plugin.config.ts` to webpack 5.

**Special notes for your reviewer**:
I think doing it this way is preferable since we otherwise could get a version miss match between the typescript version used to build the plugin and the one used to build Grafana.