### PR TITLE
Datemath: Support fiscal years

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,11 +90,11 @@ require (
 	github.com/russellhaering/goxmldsig v1.1.1
 	github.com/stretchr/testify v1.7.0
 	github.com/teris-io/shortid v0.0.0-20171029131806-771a37caa5cf
-	github.com/timberio/go-datemath v0.1.1-0.20200323150745-74ddef604fff
 	github.com/ua-parser/uap-go v0.0.0-20211112212520-00c877edfe0f
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
 	github.com/unknwon/com v1.0.1
 	github.com/urfave/cli/v2 v2.3.0
+	github.com/vectordotdev/go-datemath v0.1.1-0.20211214152759-c03a58217724
 	github.com/weaveworks/common v0.0.0-20210913144402-035033b78a78
 	github.com/xorcare/pointer v1.1.0
 	github.com/yudai/gojsondiff v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -2299,8 +2299,6 @@ github.com/tidwall/pretty v1.0.2 h1:Z7S3cePv9Jwm1KwS0513MRaoUe3S01WPbLNV40pwWZU=
 github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/tinylru v1.0.2/go.mod h1:HDVL7TsWeezQ4g44Um84TOVBMFcq7Xa9giqNc805KJ8=
 github.com/tidwall/wal v0.1.4/go.mod h1:ww7Pd44/KnyETODJPUPKrzLlYjI72GZWlucNKt7pOt0=
-github.com/timberio/go-datemath v0.1.1-0.20200323150745-74ddef604fff h1:QCdUBuN+iKWAB9HqPTkBwyKPPUHDobJ2AuELSNZwd4o=
-github.com/timberio/go-datemath v0.1.1-0.20200323150745-74ddef604fff/go.mod h1:m7kjsbCuO4QKP3KLfnxiUZWiOiFXmxj30HeexjL3lc0=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
@@ -2351,6 +2349,8 @@ github.com/valyala/fasthttp v1.6.0/go.mod h1:FstJa9V+Pj9vQ7OJie2qMHdwemEDaDiSdBn
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
+github.com/vectordotdev/go-datemath v0.1.1-0.20211214152759-c03a58217724 h1:v2/Zact72KD/a+HJNb0ES/8JV0Lhlp9PjPdZQGiaBoQ=
+github.com/vectordotdev/go-datemath v0.1.1-0.20211214152759-c03a58217724/go.mod h1:PnwzbSst7KD3vpBzzlntZU5gjVa455Uqa5QPiKSYJzQ=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy7Y31EnHRDm1JkChoC7LXIJ7Ex0VYLWtZtQ=
 github.com/vishvananda/netlink v0.0.0-20171020171820-b2de5d10e38e/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=

--- a/pkg/extensions/main.go
+++ b/pkg/extensions/main.go
@@ -22,7 +22,7 @@ import (
 	_ "github.com/robfig/cron/v3"
 	_ "github.com/russellhaering/goxmldsig"
 	_ "github.com/stretchr/testify/require"
-	_ "github.com/timberio/go-datemath"
+	_ "github.com/vectordotdev/go-datemath"
 	_ "golang.org/x/time/rate"
 	_ "gopkg.in/square/go-jose.v2"
 )

--- a/pkg/tsdb/legacydata/time_range.go
+++ b/pkg/tsdb/legacydata/time_range.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/timberio/go-datemath"
+	"github.com/vectordotdev/go-datemath"
 )
 
 type DataTimeRange struct {

--- a/pkg/tsdb/legacydata/time_range.go
+++ b/pkg/tsdb/legacydata/time_range.go
@@ -75,6 +75,14 @@ func (tr DataTimeRange) ParseTo(options ...TimeRangeOption) (time.Time, error) {
 	return pt.Parse()
 }
 
+func (tr DataTimeRange) ParseFromWithWeekStart(location *time.Location, weekstart time.Weekday) (time.Time, error) {
+	return tr.ParseFrom(WithLocation(location), WithWeekstart(weekstart))
+}
+
+func (tr DataTimeRange) ParseToWithWeekStart(location *time.Location, weekstart time.Weekday) (time.Time, error) {
+	return tr.ParseTo(WithLocation(location), WithWeekstart(weekstart))
+}
+
 func WithWeekstart(weekday time.Weekday) TimeRangeOption {
 	return func(timeRange parsableTime) parsableTime {
 		timeRange.weekstart = &weekday

--- a/pkg/tsdb/legacydata/time_range_test.go
+++ b/pkg/tsdb/legacydata/time_range_test.go
@@ -3,9 +3,9 @@ package legacydata
 import (
 	"strconv"
 	"testing"
-
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -115,6 +115,30 @@ func TestTimeRange(t *testing.T) {
 			require.Nil(t, err)
 			require.Equal(t, expected, res)
 		})
+	})
+
+	t.Run("Can parse now/fy, now/fQ for 1994-02-26T14:00:00.000Z with fiscal year starting in July", func(t *testing.T) {
+		tr := DataTimeRange{
+			From: "now/fy",
+			To:   "now/fQ",
+			Now:  time.Date(1994, time.February, 26, 14, 0, 0, 0, time.UTC),
+		}
+
+		start, err := tr.ParseFrom(WithFiscalStartMonth(time.July))
+		require.NoError(t, err)
+		assert.Equal(
+			t,
+			time.Date(1993, time.July, 1, 0, 0, 0, 0, time.UTC),
+			start,
+		)
+
+		end, err := tr.ParseTo(WithFiscalStartMonth(time.July))
+		require.NoError(t, err)
+		assert.Equal(
+			t,
+			time.Date(1994, time.April, 1, 0, 0, 0, 0, time.UTC).Add(-time.Millisecond),
+			end,
+		)
 	})
 
 	t.Run("Can parse 1960-02-01T07:00:00.000Z, 1965-02-03T08:00:00.000Z", func(t *testing.T) {

--- a/pkg/tsdb/legacydata/time_range_test.go
+++ b/pkg/tsdb/legacydata/time_range_test.go
@@ -205,7 +205,7 @@ func TestTimeRange(t *testing.T) {
 			expected, err := time.Parse(time.RFC3339Nano, "2020-06-01T00:00:00.000-05:00")
 			require.Nil(t, err)
 
-			res, err := tr.ParseFromWithLocation(location)
+			res, err := tr.ParseFrom(WithLocation(location))
 			require.Nil(t, err)
 			require.True(t, expected.Equal(res))
 		})
@@ -214,7 +214,7 @@ func TestTimeRange(t *testing.T) {
 			expected, err := time.Parse(time.RFC3339Nano, "2020-06-30T23:59:59.999-05:00")
 			require.Nil(t, err)
 
-			res, err := tr.ParseToWithLocation(location)
+			res, err := tr.ParseTo(WithLocation(location))
 			require.Nil(t, err)
 			require.True(t, expected.Equal(res))
 		})
@@ -233,7 +233,7 @@ func TestTimeRange(t *testing.T) {
 			expected, err := time.Parse(time.RFC3339Nano, "2020-07-26T07:12:56.000-05:00")
 			require.Nil(t, err)
 
-			res, err := tr.ParseFromWithLocation(location)
+			res, err := tr.ParseFrom(WithLocation(location))
 			require.Nil(t, err)
 			require.True(t, expected.Equal(res))
 		})
@@ -242,7 +242,7 @@ func TestTimeRange(t *testing.T) {
 			expected, err := time.Parse(time.RFC3339Nano, "2020-07-26T12:12:56.000-05:00")
 			require.Nil(t, err)
 
-			res, err := tr.ParseToWithLocation(location)
+			res, err := tr.ParseTo(WithLocation(location))
 			require.Nil(t, err)
 			require.True(t, expected.Equal(res))
 		})
@@ -261,7 +261,7 @@ func TestTimeRange(t *testing.T) {
 			expected, err := time.Parse(time.RFC3339Nano, "2020-07-13T00:00:00.000Z")
 			require.Nil(t, err)
 
-			res, err := tr.ParseFromWithWeekStart(nil, weekstart)
+			res, err := tr.ParseFrom(WithWeekstart(weekstart))
 			require.Nil(t, err)
 			require.True(t, expected.Equal(res))
 		})
@@ -270,7 +270,7 @@ func TestTimeRange(t *testing.T) {
 			expected, err := time.Parse(time.RFC3339Nano, "2020-07-19T23:59:59.999Z")
 			require.Nil(t, err)
 
-			res, err := tr.ParseToWithWeekStart(nil, weekstart)
+			res, err := tr.ParseTo(WithWeekstart(weekstart))
 			require.Nil(t, err)
 			require.True(t, expected.Equal(res))
 		})
@@ -290,7 +290,7 @@ func TestTimeRange(t *testing.T) {
 			expected, err := time.Parse(time.RFC3339Nano, "2020-07-13T00:00:00.000-05:00")
 			require.Nil(t, err)
 
-			res, err := tr.ParseFromWithWeekStart(location, weekstart)
+			res, err := tr.ParseFrom(WithLocation(location), WithWeekstart(weekstart))
 			require.Nil(t, err)
 			require.True(t, expected.Equal(res))
 		})
@@ -299,7 +299,7 @@ func TestTimeRange(t *testing.T) {
 			expected, err := time.Parse(time.RFC3339Nano, "2020-07-19T23:59:59.999-05:00")
 			require.Nil(t, err)
 
-			res, err := tr.ParseToWithWeekStart(location, weekstart)
+			res, err := tr.ParseTo(WithLocation(location), WithWeekstart(weekstart))
 			require.Nil(t, err)
 			require.True(t, expected.Equal(res))
 		})
@@ -319,7 +319,7 @@ func TestTimeRange(t *testing.T) {
 			expected, err := time.Parse(time.RFC3339Nano, "2020-07-19T00:00:00.000-05:00")
 			require.Nil(t, err)
 
-			res, err := tr.ParseFromWithWeekStart(location, weekstart)
+			res, err := tr.ParseFrom(WithLocation(location), WithWeekstart(weekstart))
 			require.Nil(t, err)
 			require.True(t, expected.Equal(res))
 		})
@@ -328,7 +328,7 @@ func TestTimeRange(t *testing.T) {
 			expected, err := time.Parse(time.RFC3339Nano, "2020-07-25T23:59:59.999-05:00")
 			require.Nil(t, err)
 
-			res, err := tr.ParseToWithWeekStart(location, weekstart)
+			res, err := tr.ParseTo(WithLocation(location), WithWeekstart(weekstart))
 			require.Nil(t, err)
 			require.True(t, expected.Equal(res))
 		})
@@ -348,7 +348,7 @@ func TestTimeRange(t *testing.T) {
 			expected, err := time.Parse(time.RFC3339Nano, "2020-07-18T00:00:00.000-05:00")
 			require.Nil(t, err)
 
-			res, err := tr.ParseFromWithWeekStart(location, weekstart)
+			res, err := tr.ParseFrom(WithLocation(location), WithWeekstart(weekstart))
 			require.Nil(t, err)
 			require.True(t, expected.Equal(res))
 		})
@@ -357,7 +357,7 @@ func TestTimeRange(t *testing.T) {
 			expected, err := time.Parse(time.RFC3339Nano, "2020-07-24T23:59:59.999-05:00")
 			require.Nil(t, err)
 
-			res, err := tr.ParseToWithWeekStart(location, weekstart)
+			res, err := tr.ParseTo(WithLocation(location), WithWeekstart(weekstart))
 			require.Nil(t, err)
 			require.True(t, expected.Equal(res))
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:

Time range parsing in the Grafana backend currently doesn't support fiscal years and quarters which the frontend supports.

I also refactored the time range parsing to use a functional options style instead of adding yet another `ParseXWithY` family of methods.

**Which issue(s) this PR fixes**:

Partially fixing support for quarters and financial quarters for reporting.

- https://github.com/grafana/grafana-enterprise/issues/2062

**Special notes for your reviewer**:

I noted that this package is marked as deprecated in favor of [grafana/grafana-plugin-sdk-go](https://github.com/grafana/grafana-plugin-sdk-go/tree/main/backend), but that doesn't seem to contain the time range logic, so it's not a useful replacement for this particular structure.

I've specifically not refactored this part of this package away from the deprecated package (where it doesn't seem to belong) because I'm unsure where to put it.