### PR TITLE
Azure Monitor: Do not assign aggregation type until supported types retrieved

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.ts
@@ -257,6 +257,9 @@ export const useMetricMetadata = (query: AzureMonitorQuery, datasource: Datasour
 
   // Update the query state in response to the meta data changing
   useEffect(() => {
+    if (!metricMetadata.supportedAggTypes.length) {
+      return;
+    }
     const aggregationIsValid = aggregation && metricMetadata.supportedAggTypes.includes(aggregation);
 
     const newAggregation = aggregationIsValid ? aggregation : metricMetadata.primaryAggType;


### PR DESCRIPTION
**What this PR does / why we need it**:
The array of supported aggregation types is empty at this point and causes the aggregation to be reassigned to `undefined` followed later by a default aggregation type of `Average`. This overwrites whatever type the user originally chose when editing a metrics query 

**Which issue(s) this PR fixes**:

Fixes #43402

**Special notes for your reviewer**:
Hi @joshhunt would you give your feedback on this one? Thanks :)