### PR TITLE
Revert "[v.8.0.x] Chore: Backport for missing tslib import"

### DIFF
--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -5,7 +5,6 @@ import kbn from 'app/core/utils/kbn';
 import moment from 'moment'; // eslint-disable-line no-restricted-imports
 import angular from 'angular';
 import jquery from 'jquery';
-import * as tslib from 'tslib';
 
 // Experimental module exports
 import prismjs from 'prismjs';
@@ -85,7 +84,6 @@ function exposeToPlugin(name: string, component: any) {
   });
 }
 
-exposeToPlugin('tslib', tslib);
 exposeToPlugin('@grafana/data', grafanaData);
 exposeToPlugin('@grafana/ui', grafanaUI);
 exposeToPlugin('@grafana/runtime', grafanaRuntime);


### PR DESCRIPTION
Reverts grafana/grafana#43497 in favor of https://github.com/grafana/grafana/pull/43556 , because we could get a version missmatch between the typescript version used to build the plugin and the one used to build Grafana.

