### PR TITLE
Fix: a11y: Add aria-label on refresh button

### DIFF
--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -75,6 +75,7 @@ export class RefreshPicker extends PureComponent<Props> {
           icon={isLoading ? 'fa fa-spinner' : 'sync'}
           style={width ? { width } : undefined}
           data-testid={selectors.components.RefreshPicker.runButtonV2}
+          aria-label="Refresh"
         >
           {text}
         </ToolbarButton>


### PR DESCRIPTION
**What this PR does / why we need it**:
One of the fastpass issues on the explore query editor page was a label on this refresh button.
See the main PR #43580

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Contributes to #42705

**Special notes for your reviewer**:
@sarahzinger Could I use your help here? 
Since this is a shared component (?), I just want to tread carefully.
The test [here](https://github.com/grafana/grafana/blob/main/public/app/features/dashboard/components/DashNav/DashNavTimeControls.test.tsx#L64) seems to be testing this button, but when I add an aria-label that is not identical, it fails. I guess it needs a priority label to assert...?

