### PR TITLE
Transformations: groupBy transformation now preserves data order

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
@@ -260,4 +260,50 @@ describe('GroupBy transformer', () => {
       expect(result[1].fields).toEqual(expectedB);
     });
   });
+
+  it('should group values and keep the order of the fields', async () => {
+    const testSeries = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'message', type: FieldType.string, values: ['500', '404', '404', 'one', 'one', 'two', '200'] },
+        { name: 'values', type: FieldType.number, values: [1, 2, 2, 3, 3, 3, 4] },
+      ],
+    });
+
+    const cfg: DataTransformerConfig<GroupByTransformerOptions> = {
+      id: DataTransformerID.groupBy,
+      options: {
+        fields: {
+          message: {
+            operation: GroupByOperationID.groupBy,
+            aggregations: [],
+          },
+          values: {
+            operation: GroupByOperationID.aggregate,
+            aggregations: [ReducerID.sum],
+          },
+        },
+      },
+    };
+
+    await expect(transformDataFrame([cfg], [testSeries])).toEmitValuesWith((received) => {
+      const result = received[0];
+      const expected: Field[] = [
+        {
+          name: 'message',
+          type: FieldType.string,
+          values: new ArrayVector(['500', '404', 'one', 'two', '200']),
+          config: {},
+        },
+        {
+          name: 'values (sum)',
+          type: FieldType.number,
+          values: new ArrayVector([1, 4, 6, 3, 4]),
+          config: {},
+        },
+      ];
+
+      expect(result[0].fields).toEqual(expected);
+    });
+  });
 });

--- a/packages/grafana-data/src/transformations/transformers/groupBy.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.ts
@@ -89,16 +89,14 @@ export const groupByTransformer: DataTransformerInfo<GroupByTransformerOptions> 
           }
 
           const fields: Field[] = [];
-          const groupKeys = Array.from(valuesByGroupKey.keys());
 
           for (const field of groupByFields) {
             const values = new ArrayVector();
             const fieldName = getFieldDisplayName(field);
 
-            for (let key of groupKeys) {
-              const valuesByField = valuesByGroupKey.get(key);
-              values.add(valuesByField![fieldName].values.get(0));
-            }
+            valuesByGroupKey.forEach((value) => {
+              values.add(value[fieldName].values.get(0));
+            });
 
             fields.push({
               name: field.name,
@@ -120,8 +118,8 @@ export const groupByTransformer: DataTransformerInfo<GroupByTransformerOptions> 
             const aggregations = options.fields[fieldName].aggregations;
             const valuesByAggregation: Record<string, any[]> = {};
 
-            for (const groupKey of groupKeys) {
-              const fieldWithValuesForGroup = valuesByGroupKey.get(groupKey)![fieldName];
+            valuesByGroupKey.forEach((value) => {
+              const fieldWithValuesForGroup = value[fieldName];
               const results = reduceField({
                 field: fieldWithValuesForGroup,
                 reducers: aggregations,
@@ -133,7 +131,7 @@ export const groupByTransformer: DataTransformerInfo<GroupByTransformerOptions> 
                 }
                 valuesByAggregation[aggregation].push(results[aggregation]);
               }
-            }
+            });
 
             for (const aggregation of aggregations) {
               const aggregationField: Field = {
@@ -150,7 +148,7 @@ export const groupByTransformer: DataTransformerInfo<GroupByTransformerOptions> 
 
           processed.push({
             fields,
-            length: groupKeys.length,
+            length: valuesByGroupKey.size,
           });
         }
 

--- a/packages/grafana-data/src/transformations/transformers/groupBy.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.ts
@@ -63,13 +63,13 @@ export const groupByTransformer: DataTransformerInfo<GroupByTransformerOptions> 
 
           // Group the values by fields and groups so we can get all values for a
           // group for a given field.
-          const valuesByGroupKey: Record<string, Record<string, MutableField>> = {};
+          const valuesByGroupKey = new Map<string, Record<string, MutableField>>();
           for (let rowIndex = 0; rowIndex < frame.length; rowIndex++) {
             const groupKey = String(groupByFields.map((field) => field.values.get(rowIndex)));
-            const valuesByField = valuesByGroupKey[groupKey] ?? {};
+            const valuesByField = valuesByGroupKey.get(groupKey) ?? {};
 
-            if (!valuesByGroupKey[groupKey]) {
-              valuesByGroupKey[groupKey] = valuesByField;
+            if (!valuesByGroupKey.has(groupKey)) {
+              valuesByGroupKey.set(groupKey, valuesByField);
             }
 
             for (let field of frame.fields) {
@@ -89,15 +89,15 @@ export const groupByTransformer: DataTransformerInfo<GroupByTransformerOptions> 
           }
 
           const fields: Field[] = [];
-          const groupKeys = Object.keys(valuesByGroupKey);
+          const groupKeys = Array.from(valuesByGroupKey.keys());
 
           for (const field of groupByFields) {
             const values = new ArrayVector();
             const fieldName = getFieldDisplayName(field);
 
             for (let key of groupKeys) {
-              const valuesByField = valuesByGroupKey[key];
-              values.add(valuesByField[fieldName].values.get(0));
+              const valuesByField = valuesByGroupKey.get(key);
+              values.add(valuesByField![fieldName].values.get(0));
             }
 
             fields.push({
@@ -121,7 +121,7 @@ export const groupByTransformer: DataTransformerInfo<GroupByTransformerOptions> 
             const valuesByAggregation: Record<string, any[]> = {};
 
             for (const groupKey of groupKeys) {
-              const fieldWithValuesForGroup = valuesByGroupKey[groupKey][fieldName];
+              const fieldWithValuesForGroup = valuesByGroupKey.get(groupKey)![fieldName];
               const results = reduceField({
                 field: fieldWithValuesForGroup,
                 reducers: aggregations,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

groupBy transformer changed the order of numeric keys

See: https://github.com/grafana/grafana/issues/43545

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/43545

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer**:

My local environment get this https://github.com/facebook/jest/issues/9021 when running `yarn jest`, maybe you need to run the test yourself