### PR TITLE
[v8.3.x] Chore: Revert externalization of the tslib so it gets bundled with plugins

### DIFF
--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
@@ -171,7 +171,6 @@ const getBaseWebpackConfig: WebpackConfigurationGetter = async (options) => {
 
     performance: { hints: false },
     externals: [
-      'tslib',
       'lodash',
       'jquery',
       'moment',

--- a/plugins-bundled/internal/input-datasource/package.json
+++ b/plugins-bundled/internal/input-datasource/package.json
@@ -16,7 +16,10 @@
   "author": "Grafana Labs",
   "devDependencies": {
     "@types/jest": "26.0.15",
+    "@types/lodash": "4.14.149",
     "@types/react": "17.0.30",
+    "lodash": "4.17.21",
+    "pnp-webpack-plugin": "^1.7.0",
     "ts-loader": "8.0.11",
     "webpack": "5.58.1"
   },

--- a/plugins-bundled/internal/input-datasource/webpack.config.js
+++ b/plugins-bundled/internal/input-datasource/webpack.config.js
@@ -1,0 +1,15 @@
+const { merge } = require('lodash');
+const PnpWebpackPlugin = require('pnp-webpack-plugin');
+
+module.exports = {
+  getWebpackConfig: (baseConfig) => {
+    return merge(baseConfig, {
+      resolve: {
+        plugins: [PnpWebpackPlugin],
+      },
+      resolveLoader: {
+        plugins: [PnpWebpackPlugin.moduleLoader(module)],
+      },
+    });
+  },
+};

--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -5,7 +5,6 @@ import kbn from 'app/core/utils/kbn';
 import moment from 'moment'; // eslint-disable-line no-restricted-imports
 import angular from 'angular';
 import jquery from 'jquery';
-import * as tslib from 'tslib';
 
 // Experimental module exports
 import prismjs from 'prismjs';
@@ -82,7 +81,6 @@ function exposeToPlugin(name: string, component: any) {
   });
 }
 
-exposeToPlugin('tslib', tslib);
 exposeToPlugin('@grafana/data', grafanaData);
 exposeToPlugin('@grafana/ui', grafanaUI);
 exposeToPlugin('@grafana/runtime', grafanaRuntime);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2333,8 +2333,11 @@ __metadata:
     "@grafana/toolkit": 8.3.3
     "@grafana/ui": 8.3.3
     "@types/jest": 26.0.15
+    "@types/lodash": 4.14.149
     "@types/react": 17.0.30
     jquery: 3.5.1
+    lodash: 4.17.21
+    pnp-webpack-plugin: ^1.7.0
     react: 17.0.1
     react-dom: 17.0.1
     react-hook-form: 7.5.3
@@ -24969,6 +24972,15 @@ __metadata:
   dependencies:
     ts-pnp: ^1.1.6
   checksum: 0606a63db96400b07f182300168298da9518727a843f9e10cf5045d2a102a4be06bb18c73dc481281e3e0f1ed8d04ef0d285a342b6dcd0eff1340e28e5d2328d
+  languageName: node
+  linkType: hard
+
+"pnp-webpack-plugin@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "pnp-webpack-plugin@npm:1.7.0"
+  dependencies:
+    ts-pnp: ^1.1.6
+  checksum: a41716d13607be5a3e06ba58b17e9e619cf07da3a0a7b10bd41cd89362873041054fd2b7966ad30a1b26b826cfb8fecc0469a95902d5b1b8ba8f591e2fe6b96d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backport efd7a12686a642fc1da912ed911403b4a6ab888e from https://github.com/grafana/grafana/pull/43556