### PR TITLE
AccessControl: Hide server stats buttons when user doesn't have permissions to access those links

### DIFF
--- a/public/app/features/admin/ServerStats.test.tsx
+++ b/public/app/features/admin/ServerStats.test.tsx
@@ -41,5 +41,8 @@ describe('ServerStats', () => {
     expect(screen.getByText('Playlists')).toBeInTheDocument();
     expect(screen.getByText('Snapshots')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Manage dashboards' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Manage data sources' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Alerts' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Manage users' })).toBeInTheDocument();
   });
 });

--- a/public/app/features/admin/ServerStats.tsx
+++ b/public/app/features/admin/ServerStats.tsx
@@ -12,6 +12,9 @@ export const ServerStats = () => {
   const [isLoading, setIsLoading] = useState(false);
   const styles = useStyles2(getStyles);
 
+  const hasAccessToDataSources = contextSrv.hasAccess(AccessControlAction.DataSourcesRead, contextSrv.isGrafanaAdmin);
+  const hasAccessToAdminUsers = contextSrv.hasAccess(AccessControlAction.UsersRead, contextSrv.isGrafanaAdmin);
+
   useEffect(() => {
     if (contextSrv.hasAccess(AccessControlAction.ActionServerStatsRead, contextSrv.isGrafanaAdmin)) {
       setIsLoading(true);
@@ -53,9 +56,11 @@ export const ServerStats = () => {
             <StatCard
               content={[{ name: 'Data sources', value: stats.datasources }]}
               footer={
-                <LinkButton href={'/datasources'} variant={'secondary'}>
-                  Manage data sources
-                </LinkButton>
+                hasAccessToDataSources && (
+                  <LinkButton href={'/datasources'} variant={'secondary'}>
+                    Manage data sources
+                  </LinkButton>
+                )
               }
             />
             <StatCard
@@ -75,9 +80,11 @@ export const ServerStats = () => {
               { name: 'Active sessions', value: stats.activeSessions },
             ]}
             footer={
-              <LinkButton href={'/admin/users'} variant={'secondary'}>
-                Manage users
-              </LinkButton>
+              hasAccessToAdminUsers && (
+                <LinkButton href={'/admin/users'} variant={'secondary'}>
+                  Manage users
+                </LinkButton>
+              )
             }
           />
         </div>
@@ -129,7 +136,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 
 type StatCardProps = {
   content: Array<Record<string, number | string>>;
-  footer?: JSX.Element;
+  footer?: JSX.Element | boolean;
 };
 
 const StatCard = ({ content, footer }: StatCardProps) => {


### PR DESCRIPTION
**What this PR does / why we need it**:
`Instance Statistics` panel under `Stats & Licensing` has buttons to manage data sources, users, dashboards and alerts. These buttons link to data source, users, dashboard and alerts pages. 
With FGAC enabled, they are displayed for any user that has `server.stats:read` permission, regardless of whether they have `datasources:read` etc. If a user without access to those pages click one of those buttons we are showing an error.
With FGAC disabled, Only `Grafana Admins` can access to `Stats & Licensing` and all users have access to `Dashboards` and `Users` so changes were introduced only for `Manage Datasources` and `Manage users`

**With FGAC enabled**
**Manage Data sources**
- Only show the button when user has `datasources:read` permission which is the same that we are validating when any user wants to access `/datasources`

**Manage users**
- Only show the button when user has `users:read` permission which is the same that we are validating when any user wants to access `/admin/users`

**With FGAC disabled**
Only Grafana Admins can access to `/admin/licensing` so we hide the buttons if a user is not a Grafana Admin (at this moment a user without Grafana Admin permission can not access to `Stats & licensing` either)

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-enterprise/issues/2007
