### PR TITLE
TimeSeries/BarChart: Add support for sorting series in the tooltip

### DIFF
--- a/devenv/dev-dashboards/all-panels.json
+++ b/devenv/dev-dashboards/all-panels.json
@@ -162,7 +162,7 @@
           "showValue": "auto",
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "targets": [
@@ -547,7 +547,7 @@
           },
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "targets": [
@@ -795,7 +795,7 @@
           },
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "targets": [
@@ -865,7 +865,7 @@
           "text": {},
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "targets": [

--- a/devenv/dev-dashboards/all-panels.json
+++ b/devenv/dev-dashboards/all-panels.json
@@ -161,7 +161,8 @@
           "rowHeight": 0.99,
           "showValue": "auto",
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "targets": [
@@ -545,7 +546,8 @@
             "values": false
           },
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "targets": [
@@ -792,7 +794,8 @@
             "placement": "bottom"
           },
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "targets": [
@@ -861,7 +864,8 @@
           "stacking": "none",
           "text": {},
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "targets": [

--- a/devenv/dev-dashboards/datasource-elasticsearch/elasticsearch_compare.json
+++ b/devenv/dev-dashboards/datasource-elasticsearch/elasticsearch_compare.json
@@ -10536,7 +10536,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -10665,7 +10665,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [

--- a/devenv/dev-dashboards/datasource-elasticsearch/elasticsearch_compare.json
+++ b/devenv/dev-dashboards/datasource-elasticsearch/elasticsearch_compare.json
@@ -10535,7 +10535,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -10663,7 +10664,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [

--- a/devenv/dev-dashboards/datasource-testdata/new_features_in_v8.json
+++ b/devenv/dev-dashboards/datasource-testdata/new_features_in_v8.json
@@ -319,7 +319,8 @@
             "placement": "bottom"
           },
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "pluginVersion": "8.0.0-beta2",
@@ -605,7 +606,8 @@
           "showValue": "auto",
           "text": {},
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "targets": [
@@ -726,7 +728,8 @@
           "showValue": "auto",
           "text": {},
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "targets": [
@@ -872,7 +875,8 @@
             "placement": "bottom"
           },
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -990,7 +994,8 @@
             "placement": "bottom"
           },
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -1108,7 +1113,8 @@
             "placement": "bottom"
           },
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -1235,7 +1241,8 @@
             "placement": "bottom"
           },
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -1339,7 +1346,8 @@
             "placement": "bottom"
           },
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -1443,7 +1451,8 @@
             "placement": "bottom"
           },
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -1623,7 +1632,8 @@
             "placement": "bottom"
           },
           "tooltip": {
-            "mode": "multi"
+            "mode": "multi",
+            "sortOrder": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -1899,7 +1909,8 @@
             "placement": "bottom"
           },
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -2221,7 +2232,8 @@
             "placement": "bottom"
           },
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -2475,7 +2487,8 @@
             "placement": "bottom"
           },
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",

--- a/devenv/dev-dashboards/datasource-testdata/new_features_in_v8.json
+++ b/devenv/dev-dashboards/datasource-testdata/new_features_in_v8.json
@@ -320,7 +320,7 @@
           },
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "pluginVersion": "8.0.0-beta2",
@@ -607,7 +607,7 @@
           "text": {},
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "targets": [
@@ -729,7 +729,7 @@
           "text": {},
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "targets": [
@@ -876,7 +876,7 @@
           },
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -995,7 +995,7 @@
           },
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -1114,7 +1114,7 @@
           },
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -1242,7 +1242,7 @@
           },
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -1347,7 +1347,7 @@
           },
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -1452,7 +1452,7 @@
           },
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -1633,7 +1633,7 @@
           },
           "tooltip": {
             "mode": "multi",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -1910,7 +1910,7 @@
           },
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -2233,7 +2233,7 @@
           },
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",
@@ -2488,7 +2488,7 @@
           },
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "pluginVersion": "7.4.0-beta1",

--- a/devenv/dev-dashboards/panel-barchart/barchart-autosizing.json
+++ b/devenv/dev-dashboards/panel-barchart/barchart-autosizing.json
@@ -79,7 +79,8 @@
         "stacking": "none",
         "text": {},
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -151,7 +152,8 @@
         "stacking": "none",
         "text": {},
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -221,7 +223,8 @@
         "stacking": "none",
         "text": {},
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -291,7 +294,8 @@
         "stacking": "none",
         "text": {},
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -363,7 +367,8 @@
           "valueSize": 25
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -433,7 +438,8 @@
         "stacking": "none",
         "text": {},
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -504,7 +510,8 @@
         "stacking": "none",
         "text": {},
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [

--- a/devenv/dev-dashboards/panel-barchart/barchart-autosizing.json
+++ b/devenv/dev-dashboards/panel-barchart/barchart-autosizing.json
@@ -80,7 +80,7 @@
         "text": {},
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -153,7 +153,7 @@
         "text": {},
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -224,7 +224,7 @@
         "text": {},
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -295,7 +295,7 @@
         "text": {},
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -368,7 +368,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -439,7 +439,7 @@
         "text": {},
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -511,7 +511,7 @@
         "text": {},
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [

--- a/devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json
+++ b/devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json
@@ -95,7 +95,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -181,7 +182,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -266,7 +268,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -352,7 +355,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -437,7 +441,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -531,7 +536,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -620,7 +626,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -709,7 +716,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -797,7 +805,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [

--- a/devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json
+++ b/devenv/dev-dashboards/panel-graph/graph-ng-by-value-color-schemes.json
@@ -96,7 +96,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -183,7 +183,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -269,7 +269,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -356,7 +356,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -442,7 +442,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -537,7 +537,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -627,7 +627,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -717,7 +717,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -806,7 +806,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [

--- a/devenv/dev-dashboards/panel-graph/graph-ng-nulls.json
+++ b/devenv/dev-dashboards/panel-graph/graph-ng-nulls.json
@@ -100,7 +100,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "pluginVersion": "7.4.0-pre",
@@ -206,7 +207,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "pluginVersion": "7.4.0-pre",
@@ -320,7 +322,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "pluginVersion": "7.4.0-pre",
@@ -452,7 +455,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "pluginVersion": "7.4.0-pre",
@@ -558,7 +562,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "pluginVersion": "7.4.0-pre",
@@ -672,7 +677,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "pluginVersion": "7.4.0-pre",
@@ -836,7 +842,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "pluginVersion": "7.2.0-pre",
@@ -976,7 +983,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "pluginVersion": "7.2.0-pre",
@@ -1082,7 +1090,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "pluginVersion": "7.5.0-pre",
@@ -1184,7 +1193,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [

--- a/devenv/dev-dashboards/panel-graph/graph-ng-nulls.json
+++ b/devenv/dev-dashboards/panel-graph/graph-ng-nulls.json
@@ -101,7 +101,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "pluginVersion": "7.4.0-pre",
@@ -208,7 +208,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "pluginVersion": "7.4.0-pre",
@@ -323,7 +323,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "pluginVersion": "7.4.0-pre",
@@ -456,7 +456,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "pluginVersion": "7.4.0-pre",
@@ -563,7 +563,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "pluginVersion": "7.4.0-pre",
@@ -678,7 +678,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "pluginVersion": "7.4.0-pre",
@@ -843,7 +843,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "pluginVersion": "7.2.0-pre",
@@ -984,7 +984,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "pluginVersion": "7.2.0-pre",
@@ -1091,7 +1091,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "pluginVersion": "7.5.0-pre",
@@ -1194,7 +1194,7 @@
         },
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [

--- a/devenv/dev-dashboards/panel-timeline/timeline-demo.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-demo.json
@@ -89,7 +89,8 @@
         "rowHeight": 0.98,
         "showValue": "always",
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "pluginVersion": "7.5.0-pre",
@@ -186,7 +187,8 @@
         "rowHeight": 0.98,
         "showValue": "always",
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -287,7 +289,8 @@
         "rowHeight": 0.98,
         "showValue": "always",
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "targets": [
@@ -367,7 +370,8 @@
         "rowHeight": 0.98,
         "showValue": "always",
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "asc"
         }
       },
       "pluginVersion": "7.5.0-pre",

--- a/devenv/dev-dashboards/panel-timeline/timeline-demo.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-demo.json
@@ -90,7 +90,7 @@
         "showValue": "always",
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "pluginVersion": "7.5.0-pre",
@@ -188,7 +188,7 @@
         "showValue": "always",
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -290,7 +290,7 @@
         "showValue": "always",
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "targets": [
@@ -371,7 +371,7 @@
         "showValue": "always",
         "tooltip": {
           "mode": "single",
-          "sortOrder": "asc"
+          "sort": "asc"
         }
       },
       "pluginVersion": "7.5.0-pre",

--- a/devenv/dev-dashboards/panel-timeline/timeline-modes.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-modes.json
@@ -69,7 +69,7 @@
         "showValue": "always",
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "pluginVersion": "7.5.0-pre",
@@ -246,7 +246,7 @@
         "showValue": "always",
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "pluginVersion": "7.5.0-pre",
@@ -322,7 +322,7 @@
         "showValue": "always",
         "tooltip": {
           "mode": "single",
-          "sortOrder": "none"
+          "sort": "none"
         }
       },
       "pluginVersion": "7.5.0-pre",

--- a/devenv/dev-dashboards/panel-timeline/timeline-modes.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-modes.json
@@ -68,7 +68,8 @@
         "rowHeight": 0.9,
         "showValue": "always",
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "pluginVersion": "7.5.0-pre",
@@ -244,7 +245,8 @@
         "rowHeight": 0.9,
         "showValue": "always",
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "pluginVersion": "7.5.0-pre",
@@ -319,7 +321,8 @@
         "rowHeight": 0.9,
         "showValue": "always",
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sortOrder": "none"
         }
       },
       "pluginVersion": "7.5.0-pre",

--- a/devenv/dev-dashboards/transforms/config-from-query.json
+++ b/devenv/dev-dashboards/transforms/config-from-query.json
@@ -83,7 +83,8 @@
             "placement": "bottom"
           },
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "targets": [
@@ -484,7 +485,8 @@
           "showValue": "auto",
           "text": {},
           "tooltip": {
-            "mode": "single"
+            "mode": "single",
+            "sortOrder": "none"
           }
         },
         "pluginVersion": "8.1.0-pre",

--- a/devenv/dev-dashboards/transforms/config-from-query.json
+++ b/devenv/dev-dashboards/transforms/config-from-query.json
@@ -84,7 +84,7 @@
           },
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "targets": [
@@ -486,7 +486,7 @@
           "text": {},
           "tooltip": {
             "mode": "single",
-            "sortOrder": "none"
+            "sort": "none"
           }
         },
         "pluginVersion": "8.1.0-pre",

--- a/packages/grafana-data/src/utils/arrayUtils.test.ts
+++ b/packages/grafana-data/src/utils/arrayUtils.test.ts
@@ -1,0 +1,28 @@
+import { SortOrder } from '@grafana/schema';
+import { sortValues } from './arrayUtils';
+
+describe('arrayUtils', () => {
+  describe('sortValues', () => {
+    const testArrayNumeric = [1, 10, null, 2, undefined, 5, 6, 7, 9, 8, 3, 4];
+    const testArrayString = ['1', '10', null, '2', undefined, '5', '6', '7', '9', '8', '3', '4'];
+    const testArrayFloatingPoint = ['1.0', '2.7', '0.5', null, '2', undefined];
+    const testArrayText = ['baz', 'foo', null, 'bar', undefined];
+    const testArrayMixed = ['baz', 1, 'foo', '1.5', '0.5', null, 'bar', undefined];
+    it.each`
+      order                   | testArray                 | expected
+      ${SortOrder.Ascending}  | ${testArrayNumeric}       | ${[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, null, undefined]}
+      ${SortOrder.Descending} | ${testArrayNumeric}       | ${[10, 9, 8, 7, 6, 5, 4, 3, 2, 1, null, undefined]}
+      ${SortOrder.Ascending}  | ${testArrayString}        | ${['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', null, undefined]}
+      ${SortOrder.Descending} | ${testArrayString}        | ${['10', '9', '8', '7', '6', '5', '4', '3', '2', '1', null, undefined]}
+      ${SortOrder.Ascending}  | ${testArrayFloatingPoint} | ${['0.5', '1.0', '2', '2.7', null, undefined]}
+      ${SortOrder.Descending} | ${testArrayFloatingPoint} | ${['2.7', '2', '1.0', '0.5', null, undefined]}
+      ${SortOrder.Ascending}  | ${testArrayText}          | ${['bar', 'baz', 'foo', null, undefined]}
+      ${SortOrder.Descending} | ${testArrayText}          | ${['foo', 'baz', 'bar', null, undefined]}
+      ${SortOrder.Ascending}  | ${testArrayMixed}         | ${['0.5', 1, '1.5', 'bar', 'baz', 'foo', null, undefined]}
+      ${SortOrder.Descending} | ${testArrayMixed}         | ${['foo', 'baz', 'bar', '1.5', 1, '0.5', null, undefined]}
+    `('$order', ({ order, testArray, expected }) => {
+      const sorted = [...testArray].sort(sortValues(order));
+      expect(sorted).toEqual(expected);
+    });
+  });
+});

--- a/packages/grafana-data/src/utils/arrayUtils.test.ts
+++ b/packages/grafana-data/src/utils/arrayUtils.test.ts
@@ -3,23 +3,24 @@ import { sortValues } from './arrayUtils';
 
 describe('arrayUtils', () => {
   describe('sortValues', () => {
-    const testArrayNumeric = [1, 10, null, 2, undefined, 5, 6, 7, 9, 8, 3, 4];
-    const testArrayString = ['1', '10', null, '2', undefined, '5', '6', '7', '9', '8', '3', '4'];
-    const testArrayFloatingPoint = ['1.0', '2.7', '0.5', null, '2', undefined];
-    const testArrayText = ['baz', 'foo', null, 'bar', undefined];
-    const testArrayMixed = ['baz', 1, 'foo', '1.5', '0.5', null, 'bar', undefined];
+    const testArrayNumeric = [1, 10, null, 2, undefined, 5, 6, ' ', 7, 9, 8, 3, 4];
+    const testArrayString = ['1', '10', null, '2', undefined, '5', '6', ' ', '7', '9', '8', '3', '4'];
+    const testArrayFloatingPoint = ['1.0', '2.7', '0.5', ' ', null, '2', undefined];
+    const testArrayText = ['baz', ' ', 'foo', null, 'bar', undefined];
+    const testArrayMixed = ['baz', ' ', 1, 'foo', '1.5', '0.5', null, 'bar', undefined];
+
     it.each`
       order                   | testArray                 | expected
-      ${SortOrder.Ascending}  | ${testArrayNumeric}       | ${[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, null, undefined]}
-      ${SortOrder.Descending} | ${testArrayNumeric}       | ${[10, 9, 8, 7, 6, 5, 4, 3, 2, 1, null, undefined]}
-      ${SortOrder.Ascending}  | ${testArrayString}        | ${['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', null, undefined]}
-      ${SortOrder.Descending} | ${testArrayString}        | ${['10', '9', '8', '7', '6', '5', '4', '3', '2', '1', null, undefined]}
-      ${SortOrder.Ascending}  | ${testArrayFloatingPoint} | ${['0.5', '1.0', '2', '2.7', null, undefined]}
-      ${SortOrder.Descending} | ${testArrayFloatingPoint} | ${['2.7', '2', '1.0', '0.5', null, undefined]}
-      ${SortOrder.Ascending}  | ${testArrayText}          | ${['bar', 'baz', 'foo', null, undefined]}
-      ${SortOrder.Descending} | ${testArrayText}          | ${['foo', 'baz', 'bar', null, undefined]}
-      ${SortOrder.Ascending}  | ${testArrayMixed}         | ${['0.5', 1, '1.5', 'bar', 'baz', 'foo', null, undefined]}
-      ${SortOrder.Descending} | ${testArrayMixed}         | ${['foo', 'baz', 'bar', '1.5', 1, '0.5', null, undefined]}
+      ${SortOrder.Ascending}  | ${testArrayNumeric}       | ${[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ' ', null, undefined]}
+      ${SortOrder.Descending} | ${testArrayNumeric}       | ${[10, 9, 8, 7, 6, 5, 4, 3, 2, 1, ' ', null, undefined]}
+      ${SortOrder.Ascending}  | ${testArrayString}        | ${['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', ' ', null, undefined]}
+      ${SortOrder.Descending} | ${testArrayString}        | ${['10', '9', '8', '7', '6', '5', '4', '3', '2', '1', ' ', null, undefined]}
+      ${SortOrder.Ascending}  | ${testArrayFloatingPoint} | ${['0.5', '1.0', '2', '2.7', null, ' ', undefined]}
+      ${SortOrder.Descending} | ${testArrayFloatingPoint} | ${['2.7', '2', '1.0', '0.5', null, ' ', undefined]}
+      ${SortOrder.Ascending}  | ${testArrayText}          | ${['bar', 'baz', 'foo', null, ' ', undefined]}
+      ${SortOrder.Descending} | ${testArrayText}          | ${['foo', 'baz', 'bar', null, ' ', undefined]}
+      ${SortOrder.Ascending}  | ${testArrayMixed}         | ${['0.5', 1, '1.5', 'bar', 'baz', 'foo', null, ' ', undefined]}
+      ${SortOrder.Descending} | ${testArrayMixed}         | ${['foo', 'baz', 'bar', '1.5', 1, '0.5', null, ' ', undefined]}
     `('$order', ({ order, testArray, expected }) => {
       const sorted = [...testArray].sort(sortValues(order));
       expect(sorted).toEqual(expected);

--- a/packages/grafana-data/src/utils/arrayUtils.ts
+++ b/packages/grafana-data/src/utils/arrayUtils.ts
@@ -9,7 +9,7 @@ export function moveItemImmutably<T>(arr: T[], from: number, to: number) {
 
 /**
  * Given a sort order and a value, return a function that can be used to sort values
- * Null values are always sorted to the end regardless of the sort order
+ * Null/undefined/empty string values are always sorted to the end regardless of the sort order provided
  */
 const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 export function sortValues(sort: SortOrder.Ascending | SortOrder.Descending) {
@@ -18,10 +18,10 @@ export function sortValues(sort: SortOrder.Ascending | SortOrder.Descending) {
       return 0;
     }
 
-    if (b == null) {
+    if (b == null || (typeof b === 'string' && b.trim() === '')) {
       return -1;
     }
-    if (a == null) {
+    if (a == null || (typeof a === 'string' && a?.trim() === '')) {
       return 1;
     }
 

--- a/packages/grafana-data/src/utils/arrayUtils.ts
+++ b/packages/grafana-data/src/utils/arrayUtils.ts
@@ -1,6 +1,33 @@
+import { SortOrder } from '@grafana/schema';
+
 /** @internal */
 export function moveItemImmutably<T>(arr: T[], from: number, to: number) {
   const clone = [...arr];
   Array.prototype.splice.call(clone, to, 0, Array.prototype.splice.call(clone, from, 1)[0]);
   return clone;
+}
+
+/**
+ * Given a sort order and a value, return a function that can be used to sort values
+ * Null values are always sorted to the end regardless of the sort order
+ */
+const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+export function sortValues(sort: SortOrder.Ascending | SortOrder.Descending) {
+  return (a: any, b: any) => {
+    if (a === b) {
+      return 0;
+    }
+
+    if (b == null) {
+      return -1;
+    }
+    if (a == null) {
+      return 1;
+    }
+
+    if (sort === SortOrder.Descending) {
+      return collator.compare(b, a);
+    }
+    return collator.compare(a, b);
+  };
 }

--- a/packages/grafana-schema/src/schema/graph.gen.ts
+++ b/packages/grafana-schema/src/schema/graph.gen.ts
@@ -290,5 +290,5 @@ export const defaultTableFieldOptions: TableFieldOptions = {
 
 export interface VizTooltipOptions {
   mode: TooltipDisplayMode;
-  sortOrder: SortOrder;
+  sort: SortOrder;
 }

--- a/packages/grafana-schema/src/schema/graph.gen.ts
+++ b/packages/grafana-schema/src/schema/graph.gen.ts
@@ -239,6 +239,12 @@ export enum TooltipDisplayMode {
   Single = 'single',
 }
 
+export enum TooltipSortOrder {
+  Ascending = 'asc',
+  Descending = 'desc',
+  None = 'none',
+}
+
 export interface GraphFieldConfig
   extends LineConfig,
     FillConfig,
@@ -284,4 +290,5 @@ export const defaultTableFieldOptions: TableFieldOptions = {
 
 export interface VizTooltipOptions {
   mode: TooltipDisplayMode;
+  sortOrder: TooltipSortOrder;
 }

--- a/packages/grafana-schema/src/schema/graph.gen.ts
+++ b/packages/grafana-schema/src/schema/graph.gen.ts
@@ -239,7 +239,7 @@ export enum TooltipDisplayMode {
   Single = 'single',
 }
 
-export enum TooltipSortOrder {
+export enum SortOrder {
   Ascending = 'asc',
   Descending = 'desc',
   None = 'none',
@@ -290,5 +290,5 @@ export const defaultTableFieldOptions: TableFieldOptions = {
 
 export interface VizTooltipOptions {
   mode: TooltipDisplayMode;
-  sortOrder: TooltipSortOrder;
+  sortOrder: SortOrder;
 }

--- a/packages/grafana-schema/src/schema/tooltip.cue
+++ b/packages/grafana-schema/src/schema/tooltip.cue
@@ -1,9 +1,9 @@
 package schema
 
 TooltipDisplayMode: "single" | "multi" | "none" @cuetsy(kind="enum")
-TooltipSortOrder: "asc" | "desc" | "none" @cuetsy(kind="enum")
+SortOrder: "asc" | "desc" | "none" @cuetsy(kind="enum")
 
 VizTooltipOptions: {
 	mode: TooltipDisplayMode
-	sortOrder: TooltipSortOrder
+	sortOrder: SortOrder
 } @cuetsy(kind="interface")

--- a/packages/grafana-schema/src/schema/tooltip.cue
+++ b/packages/grafana-schema/src/schema/tooltip.cue
@@ -5,5 +5,5 @@ SortOrder: "asc" | "desc" | "none" @cuetsy(kind="enum")
 
 VizTooltipOptions: {
 	mode: TooltipDisplayMode
-	sortOrder: SortOrder
+	sort: SortOrder
 } @cuetsy(kind="interface")

--- a/packages/grafana-schema/src/schema/tooltip.cue
+++ b/packages/grafana-schema/src/schema/tooltip.cue
@@ -1,7 +1,9 @@
 package schema
 
 TooltipDisplayMode: "single" | "multi" | "none" @cuetsy(kind="enum")
+TooltipSortOrder: "asc" | "desc" | "none" @cuetsy(kind="enum")
 
 VizTooltipOptions: {
 	mode: TooltipDisplayMode
+	sortOrder: TooltipSortOrder
 } @cuetsy(kind="interface")

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -235,18 +235,11 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
         });
       }
 
-      let result = new Array(series.length);
-
       if (sortOrder !== SortOrder.None) {
-        sortIdx.sort((a, b) => arrayUtils.sortValues(sortOrder)(a[1], b[1]));
-        for (let i = 0; i < sortIdx.length; i++) {
-          result[i] = series[sortIdx[i][0]];
-        }
-      } else {
-        result = series;
+        series.sort((a, b) => arrayUtils.sortValues(sortOrder)(a.value, b.value));
       }
 
-      tooltip = <SeriesTable series={result} timestamp={xVal} />;
+      tooltip = <SeriesTable series={series} timestamp={xVal} />;
     }
   } else {
     tooltip = renderTooltip(otherProps.data, focusedSeriesIdx, focusedPointIdx);

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useMountedState } from 'react-use';
 import uPlot from 'uplot';
 import {
+  arrayUtils,
   CartesianCoords2D,
   DashboardCursorSync,
   DataFrame,
@@ -12,7 +13,7 @@ import {
   getFieldDisplayName,
   TimeZone,
 } from '@grafana/data';
-import { TooltipDisplayMode, TooltipSortOrder } from '@grafana/schema';
+import { TooltipDisplayMode, SortOrder } from '@grafana/schema';
 import { useTheme2 } from '../../../themes/ThemeContext';
 import { Portal } from '../../Portal/Portal';
 import { SeriesTable, SeriesTableRowProps, VizTooltipContainer } from '../../VizTooltip';
@@ -24,7 +25,7 @@ interface TooltipPluginProps {
   data: DataFrame;
   config: UPlotConfigBuilder;
   mode?: TooltipDisplayMode;
-  sortOrder?: TooltipSortOrder;
+  sortOrder?: SortOrder;
   sync?: DashboardCursorSync;
   // Allows custom tooltip content rendering. Exposes aligned data frame with relevant indexes for data inspection
   // Use field.state.origin indexes from alignedData frame field to get access to original data frame and field index.
@@ -38,7 +39,7 @@ const TOOLTIP_OFFSET = 10;
  */
 export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
   mode = TooltipDisplayMode.Single,
-  sortOrder = TooltipSortOrder.None,
+  sortOrder = SortOrder.None,
   sync,
   timeZone,
   config,
@@ -236,8 +237,8 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
 
       let result = new Array(series.length);
 
-      if (sortOrder !== TooltipSortOrder.None) {
-        sortIdx.sort((a, b) => sortValues(sortOrder)(a[1], b[1]));
+      if (sortOrder !== SortOrder.None) {
+        sortIdx.sort((a, b) => arrayUtils.sortValues(sortOrder)(a[1], b[1]));
         for (let i = 0; i < sortIdx.length; i++) {
           result[i] = series[sortIdx[i][0]];
         }
@@ -299,28 +300,4 @@ export function positionTooltip(u: uPlot, bbox: DOMRect) {
   }
 
   return { x, y };
-}
-
-/**
- * Given a sort order and a value, return a function that can be used to sort values
- * Null values are always sorted to the end regardless of the sort order
- */
-function sortValues(sort: TooltipSortOrder) {
-  return (a: number | null | undefined, b: number | null | undefined) => {
-    if (a === b) {
-      return 0;
-    }
-
-    if (b == null) {
-      return -1;
-    }
-    if (a == null) {
-      return 1;
-    }
-
-    if (sort === TooltipSortOrder.Descending) {
-      return b - a;
-    }
-    return a - b;
-  };
 }

--- a/packages/grafana-ui/src/options/builder/tooltip.tsx
+++ b/packages/grafana-ui/src/options/builder/tooltip.tsx
@@ -1,4 +1,4 @@
-import { OptionsWithTooltip, TooltipDisplayMode, TooltipSortOrder } from '@grafana/schema';
+import { OptionsWithTooltip, TooltipDisplayMode, SortOrder } from '@grafana/schema';
 import { PanelOptionsEditorBuilder } from '@grafana/data';
 
 export function addTooltipOptions<T extends OptionsWithTooltip>(
@@ -18,9 +18,9 @@ export function addTooltipOptions<T extends OptionsWithTooltip>(
       ];
 
   const sortOptions = [
-    { value: TooltipSortOrder.None, label: 'None' },
-    { value: TooltipSortOrder.Ascending, label: 'Ascending' },
-    { value: TooltipSortOrder.Descending, label: 'Descending' },
+    { value: SortOrder.None, label: 'None' },
+    { value: SortOrder.Ascending, label: 'Ascending' },
+    { value: SortOrder.Descending, label: 'Descending' },
   ];
 
   builder
@@ -37,7 +37,7 @@ export function addTooltipOptions<T extends OptionsWithTooltip>(
       path: 'tooltip.sortOrder',
       name: 'Values sort order',
       category,
-      defaultValue: TooltipSortOrder.None,
+      defaultValue: SortOrder.None,
       showIf: (options: T) => options.tooltip.mode === TooltipDisplayMode.Multi,
       settings: {
         options: sortOptions,

--- a/packages/grafana-ui/src/options/builder/tooltip.tsx
+++ b/packages/grafana-ui/src/options/builder/tooltip.tsx
@@ -1,29 +1,46 @@
-import { OptionsWithTooltip } from '@grafana/schema';
+import { OptionsWithTooltip, TooltipDisplayMode, TooltipSortOrder } from '@grafana/schema';
 import { PanelOptionsEditorBuilder } from '@grafana/data';
 
 export function addTooltipOptions<T extends OptionsWithTooltip>(
   builder: PanelOptionsEditorBuilder<T>,
   singleOnly = false
 ) {
-  const options = singleOnly
+  const category = ['Tooltip'];
+  const modeOptions = singleOnly
     ? [
-        { value: 'single', label: 'Single' },
-        { value: 'none', label: 'Hidden' },
+        { value: TooltipDisplayMode.Single, label: 'Single' },
+        { value: TooltipDisplayMode.None, label: 'Hidden' },
       ]
     : [
-        { value: 'single', label: 'Single' },
-        { value: 'multi', label: 'All' },
-        { value: 'none', label: 'Hidden' },
+        { value: TooltipDisplayMode.Single, label: 'Single' },
+        { value: TooltipDisplayMode.Multi, label: 'All' },
+        { value: TooltipDisplayMode.None, label: 'Hidden' },
       ];
 
-  builder.addRadio({
-    path: 'tooltip.mode',
-    name: 'Tooltip mode',
-    category: ['Tooltip'],
-    description: '',
-    defaultValue: 'single',
-    settings: {
-      options,
-    },
-  });
+  const sortOptions = [
+    { value: TooltipSortOrder.None, label: 'None' },
+    { value: TooltipSortOrder.Ascending, label: 'Ascending' },
+    { value: TooltipSortOrder.Descending, label: 'Descending' },
+  ];
+
+  builder
+    .addRadio({
+      path: 'tooltip.mode',
+      name: 'Tooltip mode',
+      category,
+      defaultValue: 'single',
+      settings: {
+        options: modeOptions,
+      },
+    })
+    .addRadio({
+      path: 'tooltip.sortOrder',
+      name: 'Values sort order',
+      category,
+      defaultValue: TooltipSortOrder.None,
+      showIf: (options: T) => options.tooltip.mode === TooltipDisplayMode.Multi,
+      settings: {
+        options: sortOptions,
+      },
+    });
 }

--- a/packages/grafana-ui/src/options/builder/tooltip.tsx
+++ b/packages/grafana-ui/src/options/builder/tooltip.tsx
@@ -34,7 +34,7 @@ export function addTooltipOptions<T extends OptionsWithTooltip>(
       },
     })
     .addRadio({
-      path: 'tooltip.sortOrder',
+      path: 'tooltip.sort',
       name: 'Values sort order',
       category,
       defaultValue: SortOrder.None,

--- a/pkg/schema/testdata/devenvgoldenfiles/all-panels.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/all-panels.json
@@ -189,7 +189,8 @@
 				"rowHeight": 0.99,
 				"showValue": "auto",
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -651,7 +652,8 @@
 					"values": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -937,7 +939,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -1015,7 +1018,8 @@
 				"stacking": "none",
 				"text": {},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [

--- a/pkg/schema/testdata/devenvgoldenfiles/all-panels.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/all-panels.json
@@ -190,7 +190,7 @@
 				"showValue": "auto",
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -389,7 +389,7 @@
 				"showCommonLabels": false,
 				"showLabels": false,
 				"showTime": false,
-				"sortOrder": "Descending",
+				"sort": "Descending",
 				"wrapLogMessage": false
 			},
 			"targets": [
@@ -478,7 +478,7 @@
 				"dashboardAlerts": false,
 				"maxItems": 20,
 				"showInstances": false,
-				"sortOrder": 1,
+				"sort": 1,
 				"stateFilter": {
 					"firing": true,
 					"inactive": false,
@@ -653,7 +653,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -940,7 +940,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -1019,7 +1019,7 @@
 				"text": {},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [

--- a/pkg/schema/testdata/devenvgoldenfiles/barchart-autosizing.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/barchart-autosizing.json
@@ -82,7 +82,8 @@
 				"stacking": "none",
 				"text": {},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -163,7 +164,8 @@
 				"stacking": "none",
 				"text": {},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -242,7 +244,8 @@
 				"stacking": "none",
 				"text": {},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -321,7 +324,8 @@
 				"stacking": "none",
 				"text": {},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -402,7 +406,8 @@
 					"valueSize": 25
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -481,7 +486,8 @@
 				"stacking": "none",
 				"text": {},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -561,7 +567,8 @@
 				"stacking": "none",
 				"text": {},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [

--- a/pkg/schema/testdata/devenvgoldenfiles/barchart-autosizing.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/barchart-autosizing.json
@@ -83,7 +83,7 @@
 				"text": {},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -165,7 +165,7 @@
 				"text": {},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -245,7 +245,7 @@
 				"text": {},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -325,7 +325,7 @@
 				"text": {},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -407,7 +407,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -487,7 +487,7 @@
 				"text": {},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -568,7 +568,7 @@
 				"text": {},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [

--- a/pkg/schema/testdata/devenvgoldenfiles/config-from-query.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/config-from-query.json
@@ -86,7 +86,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -528,7 +529,8 @@
 				"showValue": "auto",
 				"text": {},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "8.1.0-pre",

--- a/pkg/schema/testdata/devenvgoldenfiles/config-from-query.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/config-from-query.json
@@ -87,7 +87,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -530,7 +530,7 @@
 				"text": {},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "8.1.0-pre",

--- a/pkg/schema/testdata/devenvgoldenfiles/elasticsearch_compare.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/elasticsearch_compare.json
@@ -10533,7 +10533,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -10670,7 +10671,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [

--- a/pkg/schema/testdata/devenvgoldenfiles/elasticsearch_compare.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/elasticsearch_compare.json
@@ -10534,7 +10534,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -10672,7 +10672,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [

--- a/pkg/schema/testdata/devenvgoldenfiles/graph-ng-by-value-color-schemes.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/graph-ng-by-value-color-schemes.json
@@ -98,7 +98,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -193,7 +194,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -287,7 +289,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -382,7 +385,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -476,7 +480,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -579,7 +584,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -677,7 +683,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -775,7 +782,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -872,7 +880,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [

--- a/pkg/schema/testdata/devenvgoldenfiles/graph-ng-by-value-color-schemes.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/graph-ng-by-value-color-schemes.json
@@ -99,7 +99,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -195,7 +195,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -290,7 +290,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -386,7 +386,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -481,7 +481,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -585,7 +585,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -684,7 +684,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -783,7 +783,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -881,7 +881,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [

--- a/pkg/schema/testdata/devenvgoldenfiles/graph-ng-nulls.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/graph-ng-nulls.json
@@ -103,7 +103,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-pre",
@@ -218,7 +219,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-pre",
@@ -341,7 +343,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-pre",
@@ -482,7 +485,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-pre",
@@ -597,7 +601,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-pre",
@@ -720,7 +725,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-pre",
@@ -891,7 +897,8 @@
 					"placement": "bottom"
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.2.0-pre",
@@ -1037,7 +1044,8 @@
 					"placement": "bottom"
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.2.0-pre",
@@ -1151,7 +1159,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.5.0-pre",
@@ -1262,7 +1271,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [

--- a/pkg/schema/testdata/devenvgoldenfiles/graph-ng-nulls.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/graph-ng-nulls.json
@@ -104,7 +104,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-pre",
@@ -220,7 +220,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-pre",
@@ -344,7 +344,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-pre",
@@ -486,7 +486,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-pre",
@@ -602,7 +602,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-pre",
@@ -726,7 +726,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-pre",
@@ -898,7 +898,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.2.0-pre",
@@ -1045,7 +1045,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.2.0-pre",
@@ -1160,7 +1160,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.5.0-pre",
@@ -1272,7 +1272,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [

--- a/pkg/schema/testdata/devenvgoldenfiles/new_features_in_v8.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/new_features_in_v8.json
@@ -379,7 +379,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "8.0.0-beta2",
@@ -723,7 +724,8 @@
 				"showValue": "auto",
 				"text": {},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -853,7 +855,8 @@
 				"showValue": "auto",
 				"text": {},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -1034,7 +1037,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -1161,7 +1165,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -1288,7 +1293,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -1437,7 +1443,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -1550,7 +1557,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -1663,7 +1671,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -1865,7 +1874,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "multi"
+					"mode": "multi",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -2163,7 +2173,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -2494,7 +2505,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -2757,7 +2769,8 @@
 					"isVisible": false
 				},
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",

--- a/pkg/schema/testdata/devenvgoldenfiles/new_features_in_v8.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/new_features_in_v8.json
@@ -380,7 +380,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "8.0.0-beta2",
@@ -725,7 +725,7 @@
 				"text": {},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -856,7 +856,7 @@
 				"text": {},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -1038,7 +1038,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -1166,7 +1166,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -1294,7 +1294,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -1444,7 +1444,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -1558,7 +1558,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -1672,7 +1672,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -1875,7 +1875,7 @@
 				},
 				"tooltip": {
 					"mode": "multi",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -2174,7 +2174,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -2506,7 +2506,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",
@@ -2770,7 +2770,7 @@
 				},
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.4.0-beta1",

--- a/pkg/schema/testdata/devenvgoldenfiles/timeline-demo.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/timeline-demo.json
@@ -93,7 +93,7 @@
 				"showValue": "always",
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.5.0-pre",
@@ -201,7 +201,7 @@
 				"showValue": "always",
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -313,7 +313,7 @@
 				"showValue": "always",
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"targets": [
@@ -403,7 +403,7 @@
 				"showValue": "always",
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.5.0-pre",

--- a/pkg/schema/testdata/devenvgoldenfiles/timeline-demo.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/timeline-demo.json
@@ -92,7 +92,8 @@
 				"rowHeight": 0.98,
 				"showValue": "always",
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.5.0-pre",
@@ -199,7 +200,8 @@
 				"rowHeight": 0.98,
 				"showValue": "always",
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -310,7 +312,8 @@
 				"rowHeight": 0.98,
 				"showValue": "always",
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"targets": [
@@ -399,7 +402,8 @@
 				"rowHeight": 0.98,
 				"showValue": "always",
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.5.0-pre",

--- a/pkg/schema/testdata/devenvgoldenfiles/timeline-modes.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/timeline-modes.json
@@ -71,7 +71,8 @@
 				"rowHeight": 0.9,
 				"showValue": "always",
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.5.0-pre",
@@ -256,7 +257,8 @@
 				"rowHeight": 0.9,
 				"showValue": "always",
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				}
 			},
 			"pluginVersion": "7.5.0-pre",
@@ -340,7 +342,8 @@
 				"rowHeight": 0.9,
 				"showValue": "always",
 				"tooltip": {
-					"mode": "single"
+					"mode": "single",
+					"sortOrder": "none"
 				},
 				"alignValue": "left"
 			},

--- a/pkg/schema/testdata/devenvgoldenfiles/timeline-modes.json
+++ b/pkg/schema/testdata/devenvgoldenfiles/timeline-modes.json
@@ -72,7 +72,7 @@
 				"showValue": "always",
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.5.0-pre",
@@ -258,7 +258,7 @@
 				"showValue": "always",
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				}
 			},
 			"pluginVersion": "7.5.0-pre",
@@ -343,7 +343,7 @@
 				"showValue": "always",
 				"tooltip": {
 					"mode": "single",
-					"sortOrder": "none"
+					"sort": "none"
 				},
 				"alignValue": "left"
 			},

--- a/public/app/features/explore/ExploreGraph.tsx
+++ b/public/app/features/explore/ExploreGraph.tsx
@@ -165,7 +165,7 @@ export function ExploreGraph({
         timeZone={timeZone}
         options={
           {
-            tooltip: { mode: tooltipDisplayMode, sortOrder: SortOrder.None },
+            tooltip: { mode: tooltipDisplayMode, sort: SortOrder.None },
             legend: { displayMode: LegendDisplayMode.List, placement: 'bottom', calcs: [] },
           } as TimeSeriesOptions
         }

--- a/public/app/features/explore/ExploreGraph.tsx
+++ b/public/app/features/explore/ExploreGraph.tsx
@@ -16,7 +16,7 @@ import {
   TimeZone,
 } from '@grafana/data';
 import { PanelRenderer } from '@grafana/runtime';
-import { GraphDrawStyle, LegendDisplayMode, TooltipDisplayMode } from '@grafana/schema';
+import { GraphDrawStyle, LegendDisplayMode, TooltipDisplayMode, TooltipSortOrder } from '@grafana/schema';
 import {
   Icon,
   PanelContext,
@@ -165,7 +165,7 @@ export function ExploreGraph({
         timeZone={timeZone}
         options={
           {
-            tooltip: { mode: tooltipDisplayMode },
+            tooltip: { mode: tooltipDisplayMode, sortOrder: TooltipSortOrder.None },
             legend: { displayMode: LegendDisplayMode.List, placement: 'bottom', calcs: [] },
           } as TimeSeriesOptions
         }

--- a/public/app/features/explore/ExploreGraph.tsx
+++ b/public/app/features/explore/ExploreGraph.tsx
@@ -16,7 +16,7 @@ import {
   TimeZone,
 } from '@grafana/data';
 import { PanelRenderer } from '@grafana/runtime';
-import { GraphDrawStyle, LegendDisplayMode, TooltipDisplayMode, TooltipSortOrder } from '@grafana/schema';
+import { GraphDrawStyle, LegendDisplayMode, TooltipDisplayMode, SortOrder } from '@grafana/schema';
 import {
   Icon,
   PanelContext,
@@ -165,7 +165,7 @@ export function ExploreGraph({
         timeZone={timeZone}
         options={
           {
-            tooltip: { mode: tooltipDisplayMode, sortOrder: TooltipSortOrder.None },
+            tooltip: { mode: tooltipDisplayMode, sortOrder: SortOrder.None },
             legend: { displayMode: LegendDisplayMode.List, placement: 'bottom', calcs: [] },
           } as TimeSeriesOptions
         }

--- a/public/app/plugins/panel/barchart/BarChartPanel.tsx
+++ b/public/app/plugins/panel/barchart/BarChartPanel.tsx
@@ -123,7 +123,7 @@ export const BarChartPanel: React.FunctionComponent<Props> = ({ data, options, w
         data={info.aligned}
         rowIndex={datapointIdx}
         columnIndex={seriesIdx}
-        sortOrder={options.tooltip.sortOrder}
+        sortOrder={options.tooltip.sort}
       />
     );
   };

--- a/public/app/plugins/panel/barchart/BarChartPanel.tsx
+++ b/public/app/plugins/panel/barchart/BarChartPanel.tsx
@@ -118,7 +118,14 @@ export const BarChartPanel: React.FunctionComponent<Props> = ({ data, options, w
       seriesIdx = info.aligned.fields.findIndex((f) => disp === getFieldDisplayName(f, info.aligned));
     }
 
-    return <DataHoverView data={info.aligned} rowIndex={datapointIdx} columnIndex={seriesIdx} />;
+    return (
+      <DataHoverView
+        data={info.aligned}
+        rowIndex={datapointIdx}
+        columnIndex={seriesIdx}
+        sortOrder={options.tooltip.sortOrder}
+      />
+    );
   };
 
   const renderLegend = (config: UPlotConfigBuilder) => {

--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -5,6 +5,7 @@ import {
   VisibilityMode,
   GraphGradientMode,
   StackingMode,
+  TooltipSortOrder,
 } from '@grafana/schema';
 import {
   createTheme,
@@ -92,6 +93,7 @@ describe('BarChart utils', () => {
       stacking: StackingMode.None,
       tooltip: {
         mode: TooltipDisplayMode.None,
+        sortOrder: TooltipSortOrder.None,
       },
       text: {
         valueSize: 10,

--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -5,7 +5,7 @@ import {
   VisibilityMode,
   GraphGradientMode,
   StackingMode,
-  TooltipSortOrder,
+  SortOrder,
 } from '@grafana/schema';
 import {
   createTheme,
@@ -93,7 +93,7 @@ describe('BarChart utils', () => {
       stacking: StackingMode.None,
       tooltip: {
         mode: TooltipDisplayMode.None,
-        sortOrder: TooltipSortOrder.None,
+        sortOrder: SortOrder.None,
       },
       text: {
         valueSize: 10,

--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -93,7 +93,7 @@ describe('BarChart utils', () => {
       stacking: StackingMode.None,
       tooltip: {
         mode: TooltipDisplayMode.None,
-        sortOrder: SortOrder.None,
+        sort: SortOrder.None,
       },
       text: {
         valueSize: 10,

--- a/public/app/plugins/panel/geomap/components/DataHoverView.tsx
+++ b/public/app/plugins/panel/geomap/components/DataHoverView.tsx
@@ -38,14 +38,18 @@ export class DataHoverView extends PureComponent<Props> {
       return null;
     }
 
-    const displayValues: Array<[string, string]> = [];
+    const displayValues: Array<[string, any, string]> = [];
     const visibleFields = data.fields.filter((f) => !Boolean(f.config.custom?.hideFrom?.tooltip));
 
     if (visibleFields.length === 0) {
       return null;
     }
     for (let i = 0; i < visibleFields.length; i++) {
-      displayValues.push([getFieldDisplayName(visibleFields[i], data), fmt(visibleFields[i], rowIndex!)]);
+      displayValues.push([
+        getFieldDisplayName(visibleFields[i], data),
+        visibleFields[i].values.get(rowIndex!),
+        fmt(visibleFields[i], rowIndex),
+      ]);
     }
 
     if (sortOrder && sortOrder !== SortOrder.None) {
@@ -58,7 +62,7 @@ export class DataHoverView extends PureComponent<Props> {
           {displayValues.map((v, i) => (
             <tr key={`${i}/${rowIndex}`} className={i === columnIndex ? this.style.highlight : ''}>
               <th>{v[0]}:</th>
-              <td>{v[1]}</td>
+              <td>{v[2]}</td>
             </tr>
           ))}
         </tbody>

--- a/public/app/plugins/panel/geomap/components/DataHoverView.tsx
+++ b/public/app/plugins/panel/geomap/components/DataHoverView.tsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 import { stylesFactory } from '@grafana/ui';
 import {
   ArrayDataFrame,
+  arrayUtils,
   DataFrame,
   Field,
   formattedValueToString,
@@ -11,19 +12,21 @@ import {
 import { css } from '@emotion/css';
 import { config } from 'app/core/config';
 import { FeatureLike } from 'ol/Feature';
+import { SortOrder } from '@grafana/schema';
 
 export interface Props {
   data?: DataFrame; // source data
   feature?: FeatureLike;
   rowIndex?: number | null; // the hover row
   columnIndex?: number | null; // the hover column
+  sortOrder?: SortOrder;
 }
 
 export class DataHoverView extends PureComponent<Props> {
   style = getStyles(config.theme2);
 
   render() {
-    const { feature, columnIndex } = this.props;
+    const { feature, columnIndex, sortOrder } = this.props;
     let { data, rowIndex } = this.props;
     if (feature) {
       const { geometry, ...properties } = feature.getProperties();
@@ -35,17 +38,29 @@ export class DataHoverView extends PureComponent<Props> {
       return null;
     }
 
+    const displayValues: Array<[string, string]> = [];
+    const visibleFields = data.fields.filter((f) => !Boolean(f.config.custom?.hideFrom?.tooltip));
+
+    if (visibleFields.length === 0) {
+      return null;
+    }
+    for (let i = 0; i < visibleFields.length; i++) {
+      displayValues.push([getFieldDisplayName(visibleFields[i], data), fmt(visibleFields[i], rowIndex!)]);
+    }
+
+    if (sortOrder && sortOrder !== SortOrder.None) {
+      displayValues.sort((a, b) => arrayUtils.sortValues(sortOrder)(a[1], b[1]));
+    }
+
     return (
       <table className={this.style.infoWrap}>
         <tbody>
-          {data.fields
-            .filter((f) => !Boolean(f.config.custom?.hideFrom?.tooltip))
-            .map((f, i) => (
-              <tr key={`${i}/${rowIndex}`} className={i === columnIndex ? this.style.highlight : ''}>
-                <th>{getFieldDisplayName(f, data)}:</th>
-                <td>{fmt(f, rowIndex!)}</td>
-              </tr>
-            ))}
+          {displayValues.map((v, i) => (
+            <tr key={`${i}/${rowIndex}`} className={i === columnIndex ? this.style.highlight : ''}>
+              <th>{v[0]}:</th>
+              <td>{v[1]}</td>
+            </tr>
+          ))}
         </tbody>
       </table>
     );

--- a/public/app/plugins/panel/histogram/models.gen.ts
+++ b/public/app/plugins/panel/histogram/models.gen.ts
@@ -10,6 +10,7 @@ import {
   TooltipDisplayMode,
   GraphGradientMode,
   HideableFieldConfig,
+  TooltipSortOrder,
 } from '@grafana/schema';
 
 export const modelVersion = Object.freeze([1, 0]);
@@ -29,6 +30,7 @@ export const defaultPanelOptions: PanelOptions = {
   },
   tooltip: {
     mode: TooltipDisplayMode.Multi,
+    sortOrder: TooltipSortOrder.None,
   },
 };
 

--- a/public/app/plugins/panel/histogram/models.gen.ts
+++ b/public/app/plugins/panel/histogram/models.gen.ts
@@ -10,7 +10,7 @@ import {
   TooltipDisplayMode,
   GraphGradientMode,
   HideableFieldConfig,
-  TooltipSortOrder,
+  SortOrder,
 } from '@grafana/schema';
 
 export const modelVersion = Object.freeze([1, 0]);
@@ -30,7 +30,7 @@ export const defaultPanelOptions: PanelOptions = {
   },
   tooltip: {
     mode: TooltipDisplayMode.Multi,
-    sortOrder: TooltipSortOrder.None,
+    sortOrder: SortOrder.None,
   },
 };
 

--- a/public/app/plugins/panel/histogram/models.gen.ts
+++ b/public/app/plugins/panel/histogram/models.gen.ts
@@ -30,7 +30,7 @@ export const defaultPanelOptions: PanelOptions = {
   },
   tooltip: {
     mode: TooltipDisplayMode.Multi,
-    sortOrder: SortOrder.None,
+    sort: SortOrder.None,
   },
 };
 

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -60,7 +60,7 @@ export const TimeSeriesPanel: React.FC<TimeSeriesPanelProps> = ({
                 data={alignedDataFrame}
                 config={config}
                 mode={options.tooltip.mode}
-                sortOrder={options.tooltip.sortOrder}
+                sortOrder={options.tooltip.sort}
                 sync={sync}
                 timeZone={timeZone}
               />

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -60,6 +60,7 @@ export const TimeSeriesPanel: React.FC<TimeSeriesPanelProps> = ({
                 data={alignedDataFrame}
                 config={config}
                 mode={options.tooltip.mode}
+                sortOrder={options.tooltip.sortOrder}
                 sync={sync}
                 timeZone={timeZone}
               />

--- a/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
+++ b/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
@@ -46,7 +46,8 @@ Object {
       "placement": "bottom",
     },
     "tooltip": Object {
-      "mode": "single",
+      "mode": "multi",
+      "sortOrder": "none",
     },
   },
 }
@@ -74,6 +75,7 @@ Object {
     },
     "tooltip": Object {
       "mode": "single",
+      "sortOrder": "none",
     },
   },
 }
@@ -99,6 +101,7 @@ Object {
     },
     "tooltip": Object {
       "mode": "single",
+      "sortOrder": "none",
     },
   },
 }
@@ -153,7 +156,8 @@ Object {
       "placement": "bottom",
     },
     "tooltip": Object {
-      "mode": "single",
+      "mode": "multi",
+      "sortOrder": "none",
     },
   },
 }
@@ -208,7 +212,8 @@ Object {
       "placement": "bottom",
     },
     "tooltip": Object {
-      "mode": "single",
+      "mode": "multi",
+      "sortOrder": "none",
     },
   },
 }
@@ -236,6 +241,7 @@ Object {
     },
     "tooltip": Object {
       "mode": "single",
+      "sortOrder": "none",
     },
   },
 }
@@ -321,7 +327,8 @@ Object {
       "placement": "bottom",
     },
     "tooltip": Object {
-      "mode": "single",
+      "mode": "multi",
+      "sortOrder": "none",
     },
   },
 }
@@ -377,7 +384,8 @@ Object {
       "placement": "bottom",
     },
     "tooltip": Object {
-      "mode": "single",
+      "mode": "multi",
+      "sortOrder": "none",
     },
   },
 }
@@ -417,7 +425,8 @@ Object {
       "placement": "bottom",
     },
     "tooltip": Object {
-      "mode": "single",
+      "mode": "multi",
+      "sortOrder": "none",
     },
   },
 }
@@ -465,7 +474,8 @@ Object {
       "placement": "bottom",
     },
     "tooltip": Object {
-      "mode": "single",
+      "mode": "multi",
+      "sortOrder": "none",
     },
   },
 }
@@ -550,7 +560,8 @@ Object {
       "placement": "bottom",
     },
     "tooltip": Object {
-      "mode": "single",
+      "mode": "multi",
+      "sortOrder": "none",
     },
   },
 }

--- a/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
+++ b/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
@@ -47,7 +47,7 @@ Object {
     },
     "tooltip": Object {
       "mode": "multi",
-      "sortOrder": "none",
+      "sort": "none",
     },
   },
 }
@@ -75,7 +75,7 @@ Object {
     },
     "tooltip": Object {
       "mode": "single",
-      "sortOrder": "none",
+      "sort": "none",
     },
   },
 }
@@ -101,7 +101,7 @@ Object {
     },
     "tooltip": Object {
       "mode": "single",
-      "sortOrder": "none",
+      "sort": "none",
     },
   },
 }
@@ -157,7 +157,7 @@ Object {
     },
     "tooltip": Object {
       "mode": "multi",
-      "sortOrder": "none",
+      "sort": "none",
     },
   },
 }
@@ -213,7 +213,7 @@ Object {
     },
     "tooltip": Object {
       "mode": "multi",
-      "sortOrder": "none",
+      "sort": "none",
     },
   },
 }
@@ -241,7 +241,7 @@ Object {
     },
     "tooltip": Object {
       "mode": "single",
-      "sortOrder": "none",
+      "sort": "none",
     },
   },
 }
@@ -328,7 +328,7 @@ Object {
     },
     "tooltip": Object {
       "mode": "multi",
-      "sortOrder": "none",
+      "sort": "none",
     },
   },
 }
@@ -385,7 +385,7 @@ Object {
     },
     "tooltip": Object {
       "mode": "multi",
-      "sortOrder": "none",
+      "sort": "none",
     },
   },
 }
@@ -426,7 +426,7 @@ Object {
     },
     "tooltip": Object {
       "mode": "multi",
-      "sortOrder": "none",
+      "sort": "none",
     },
   },
 }
@@ -475,7 +475,7 @@ Object {
     },
     "tooltip": Object {
       "mode": "multi",
-      "sortOrder": "none",
+      "sort": "none",
     },
   },
 }
@@ -561,7 +561,7 @@ Object {
     },
     "tooltip": Object {
       "mode": "multi",
-      "sortOrder": "none",
+      "sort": "none",
     },
   },
 }

--- a/public/app/plugins/panel/timeseries/migrations.test.ts
+++ b/public/app/plugins/panel/timeseries/migrations.test.ts
@@ -1,7 +1,7 @@
 import { PanelModel, FieldConfigSource } from '@grafana/data';
 import { graphPanelChangedHandler } from './migrations';
 import { cloneDeep } from 'lodash';
-import { TooltipDisplayMode, TooltipSortOrder } from '@grafana/schema';
+import { TooltipDisplayMode, SortOrder } from '@grafana/schema';
 
 describe('Graph Migrations', () => {
   let prevFieldConfig: FieldConfigSource;
@@ -384,10 +384,10 @@ describe('Graph Migrations', () => {
       panel3.options = graphPanelChangedHandler(panel3, 'graph', desc, prevFieldConfig);
       panel4.options = graphPanelChangedHandler(panel4, 'graph', singleModeWithUnnecessaryOption, prevFieldConfig);
 
-      expect(panel1.options.tooltip.sortOrder).toBe(TooltipSortOrder.None);
-      expect(panel2.options.tooltip.sortOrder).toBe(TooltipSortOrder.Ascending);
-      expect(panel3.options.tooltip.sortOrder).toBe(TooltipSortOrder.Descending);
-      expect(panel4.options.tooltip.sortOrder).toBe(TooltipSortOrder.None);
+      expect(panel1.options.tooltip.sortOrder).toBe(SortOrder.None);
+      expect(panel2.options.tooltip.sortOrder).toBe(SortOrder.Ascending);
+      expect(panel3.options.tooltip.sortOrder).toBe(SortOrder.Descending);
+      expect(panel4.options.tooltip.sortOrder).toBe(SortOrder.None);
     });
   });
 });

--- a/public/app/plugins/panel/timeseries/migrations.test.ts
+++ b/public/app/plugins/panel/timeseries/migrations.test.ts
@@ -384,10 +384,10 @@ describe('Graph Migrations', () => {
       panel3.options = graphPanelChangedHandler(panel3, 'graph', desc, prevFieldConfig);
       panel4.options = graphPanelChangedHandler(panel4, 'graph', singleModeWithUnnecessaryOption, prevFieldConfig);
 
-      expect(panel1.options.tooltip.sortOrder).toBe(SortOrder.None);
-      expect(panel2.options.tooltip.sortOrder).toBe(SortOrder.Ascending);
-      expect(panel3.options.tooltip.sortOrder).toBe(SortOrder.Descending);
-      expect(panel4.options.tooltip.sortOrder).toBe(SortOrder.None);
+      expect(panel1.options.tooltip.sort).toBe(SortOrder.None);
+      expect(panel2.options.tooltip.sort).toBe(SortOrder.Ascending);
+      expect(panel3.options.tooltip.sort).toBe(SortOrder.Descending);
+      expect(panel4.options.tooltip.sort).toBe(SortOrder.None);
     });
   });
 });

--- a/public/app/plugins/panel/timeseries/migrations.test.ts
+++ b/public/app/plugins/panel/timeseries/migrations.test.ts
@@ -1,6 +1,7 @@
 import { PanelModel, FieldConfigSource } from '@grafana/data';
 import { graphPanelChangedHandler } from './migrations';
 import { cloneDeep } from 'lodash';
+import { TooltipDisplayMode, TooltipSortOrder } from '@grafana/schema';
 
 describe('Graph Migrations', () => {
   let prevFieldConfig: FieldConfigSource;
@@ -306,6 +307,87 @@ describe('Graph Migrations', () => {
       panel.options = graphPanelChangedHandler(panel, 'graph', {}, prevFieldConfig);
       expect(panel.fieldConfig.defaults.custom.hideFrom).toEqual({ viz: false, legend: false, tooltip: false });
       expect(panel.fieldConfig.overrides[0].properties[0].value).toEqual({ viz: true, legend: false, tooltip: false });
+    });
+  });
+
+  describe('tooltip', () => {
+    test('tooltip mode', () => {
+      const single: any = {
+        angular: {
+          tooltip: {
+            shared: false,
+          },
+        },
+      };
+      const multi: any = {
+        angular: {
+          tooltip: {
+            shared: true,
+          },
+        },
+      };
+
+      const panel1 = {} as PanelModel;
+      const panel2 = {} as PanelModel;
+
+      panel1.options = graphPanelChangedHandler(panel1, 'graph', single, prevFieldConfig);
+      panel2.options = graphPanelChangedHandler(panel2, 'graph', multi, prevFieldConfig);
+
+      expect(panel1.options.tooltip.mode).toBe(TooltipDisplayMode.Single);
+      expect(panel2.options.tooltip.mode).toBe(TooltipDisplayMode.Multi);
+    });
+
+    test('sort order', () => {
+      const none: any = {
+        angular: {
+          tooltip: {
+            shared: true,
+            sort: 0,
+          },
+        },
+      };
+
+      const asc: any = {
+        angular: {
+          tooltip: {
+            shared: true,
+            sort: 1,
+          },
+        },
+      };
+
+      const desc: any = {
+        angular: {
+          tooltip: {
+            shared: true,
+            sort: 2,
+          },
+        },
+      };
+
+      const singleModeWithUnnecessaryOption: any = {
+        angular: {
+          tooltip: {
+            shared: false,
+            sort: 2,
+          },
+        },
+      };
+
+      const panel1 = {} as PanelModel;
+      const panel2 = {} as PanelModel;
+      const panel3 = {} as PanelModel;
+      const panel4 = {} as PanelModel;
+
+      panel1.options = graphPanelChangedHandler(panel1, 'graph', none, prevFieldConfig);
+      panel2.options = graphPanelChangedHandler(panel2, 'graph', asc, prevFieldConfig);
+      panel3.options = graphPanelChangedHandler(panel3, 'graph', desc, prevFieldConfig);
+      panel4.options = graphPanelChangedHandler(panel4, 'graph', singleModeWithUnnecessaryOption, prevFieldConfig);
+
+      expect(panel1.options.tooltip.sortOrder).toBe(TooltipSortOrder.None);
+      expect(panel2.options.tooltip.sortOrder).toBe(TooltipSortOrder.Ascending);
+      expect(panel3.options.tooltip.sortOrder).toBe(TooltipSortOrder.Descending);
+      expect(panel4.options.tooltip.sortOrder).toBe(TooltipSortOrder.None);
     });
   });
 });

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -25,7 +25,7 @@ import {
   VisibilityMode,
   ScaleDistribution,
   StackingMode,
-  TooltipSortOrder,
+  SortOrder,
 } from '@grafana/schema';
 import { TimeSeriesOptions } from './types';
 import { omitBy, pickBy, isNil, isNumber, isString } from 'lodash';
@@ -314,7 +314,7 @@ export function flotToGraphOptions(angular: any): { fieldConfig: FieldConfigSour
     },
     tooltip: {
       mode: TooltipDisplayMode.Single,
-      sortOrder: TooltipSortOrder.None,
+      sortOrder: SortOrder.None,
     },
   };
 
@@ -346,13 +346,13 @@ export function flotToGraphOptions(angular: any): { fieldConfig: FieldConfigSour
     if (tooltipConfig.sort !== undefined && tooltipConfig.shared) {
       switch (tooltipConfig.sort) {
         case 1:
-          options.tooltip.sortOrder = TooltipSortOrder.Ascending;
+          options.tooltip.sortOrder = SortOrder.Ascending;
           break;
         case 2:
-          options.tooltip.sortOrder = TooltipSortOrder.Descending;
+          options.tooltip.sortOrder = SortOrder.Descending;
           break;
         default:
-          options.tooltip.sortOrder = TooltipSortOrder.None;
+          options.tooltip.sortOrder = SortOrder.None;
       }
     }
   }

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -25,6 +25,7 @@ import {
   VisibilityMode,
   ScaleDistribution,
   StackingMode,
+  TooltipSortOrder,
 } from '@grafana/schema';
 import { TimeSeriesOptions } from './types';
 import { omitBy, pickBy, isNil, isNumber, isString } from 'lodash';
@@ -313,6 +314,7 @@ export function flotToGraphOptions(angular: any): { fieldConfig: FieldConfigSour
     },
     tooltip: {
       mode: TooltipDisplayMode.Single,
+      sortOrder: TooltipSortOrder.None,
     },
   };
 
@@ -332,6 +334,26 @@ export function flotToGraphOptions(angular: any): { fieldConfig: FieldConfigSour
     if (angular.legend.values) {
       const enabledLegendValues = pickBy(angular.legend);
       options.legend.calcs = getReducersFromLegend(enabledLegendValues);
+    }
+  }
+
+  const tooltipConfig = angular.tooltip;
+  if (tooltipConfig) {
+    if (tooltipConfig.shared !== undefined) {
+      options.tooltip.mode = tooltipConfig.shared ? TooltipDisplayMode.Multi : TooltipDisplayMode.Single;
+    }
+
+    if (tooltipConfig.sort !== undefined && tooltipConfig.shared) {
+      switch (tooltipConfig.sort) {
+        case 1:
+          options.tooltip.sortOrder = TooltipSortOrder.Ascending;
+          break;
+        case 2:
+          options.tooltip.sortOrder = TooltipSortOrder.Descending;
+          break;
+        default:
+          options.tooltip.sortOrder = TooltipSortOrder.None;
+      }
     }
   }
 

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -314,7 +314,7 @@ export function flotToGraphOptions(angular: any): { fieldConfig: FieldConfigSour
     },
     tooltip: {
       mode: TooltipDisplayMode.Single,
-      sortOrder: SortOrder.None,
+      sort: SortOrder.None,
     },
   };
 
@@ -346,13 +346,13 @@ export function flotToGraphOptions(angular: any): { fieldConfig: FieldConfigSour
     if (tooltipConfig.sort !== undefined && tooltipConfig.shared) {
       switch (tooltipConfig.sort) {
         case 1:
-          options.tooltip.sortOrder = SortOrder.Ascending;
+          options.tooltip.sort = SortOrder.Ascending;
           break;
         case 2:
-          options.tooltip.sortOrder = SortOrder.Descending;
+          options.tooltip.sort = SortOrder.Descending;
           break;
         default:
-          options.tooltip.sortOrder = SortOrder.None;
+          options.tooltip.sort = SortOrder.None;
       }
     }
   }


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/discussions/38861

This PR brings ability to sort series in the Timeseries panel's tooltip as it was possible with the old graph panel. Additionally, a migration for legacy tooltip options is added.

Note that the `null`/`undefined` values are sorted at the end of the tooltip regardless the sort order configured.

https://user-images.githubusercontent.com/2376619/147934261-925762d8-2708-4ebc-803e-70a3fbb7f51f.mov


