### PR TITLE
Alerting: fix tooltip placement

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleListErrors.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListErrors.tsx
@@ -107,7 +107,7 @@ const ErrorSummaryButton: FC<ErrorSummaryProps> = ({ count, onClick }) => {
 
   return (
     <div className={styles.floatRight}>
-      <Tooltip content="Show all errors">
+      <Tooltip content="Show all errors" placement="bottom">
         <Button fill="text" variant="destructive" icon="exclamation-triangle" onClick={onClick}>
           {count > 1 ? <>{count} errors</> : <>1 error</>}
         </Button>


### PR DESCRIPTION
**What this PR does / why we need it**:

Initially introduced in https://github.com/grafana/grafana/pull/43406 – if the window is too wide the tooltip will be displayed on the left-hand side and includes a visual bug.

<img width="265" alt="Screenshot 2022-01-03 at 15 07 08" src="https://user-images.githubusercontent.com/868844/147940633-2958c46b-d1a7-4e33-a002-3d22c032387d.png">

The current proposed solution is to fix the placement to the bottom.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

