### PR TITLE
Prometheus: Fill missing steps with null values

### DIFF
--- a/pkg/tsdb/prometheus/time_series_query.go
+++ b/pkg/tsdb/prometheus/time_series_query.go
@@ -73,8 +73,8 @@ func (s *Service) executeTimeSeriesQuery(ctx context.Context, req *backend.Query
 		timeRange := apiv1.Range{
 			Step: query.Step,
 			// Align query range to step. It rounds start and end down to a multiple of step.
-			Start: time.Unix(int64(math.Floor((float64(query.Start.Unix()+query.UtcOffsetSec)/query.Step.Seconds()))*query.Step.Seconds()-float64(query.UtcOffsetSec)), 0),
-			End:   time.Unix(int64(math.Floor((float64(query.End.Unix()+query.UtcOffsetSec)/query.Step.Seconds()))*query.Step.Seconds()-float64(query.UtcOffsetSec)), 0),
+			Start: alignTimeRange(query.Start, query.Step, query.UtcOffsetSec),
+			End:   alignTimeRange(query.End, query.Step, query.UtcOffsetSec),
 		}
 
 		if query.RangeQuery {
@@ -299,15 +299,28 @@ func matrixToDataFrames(matrix model.Matrix, query *PrometheusQuery, frames data
 			tags[string(k)] = string(v)
 		}
 
-		timeField := data.NewFieldFromFieldType(data.FieldTypeTime, len(v.Values))
-		valueField := data.NewFieldFromFieldType(data.FieldTypeNullableFloat64, len(v.Values))
+		baseTimestamp := alignTimeRange(query.Start, query.Step, query.UtcOffsetSec).UnixMilli()
+		datapointsCount := int((query.End.UnixMilli()-query.Start.UnixMilli())/query.Step.Milliseconds()) + 1
 
-		for i, k := range v.Values {
-			timeField.Set(i, time.Unix(k.Timestamp.Unix(), 0).UTC())
-			value := float64(k.Value)
-			if !math.IsNaN(value) {
-				valueField.Set(i, &value)
+		timeField := data.NewFieldFromFieldType(data.FieldTypeTime, datapointsCount)
+		valueField := data.NewFieldFromFieldType(data.FieldTypeNullableFloat64, datapointsCount)
+		idx := 0
+
+		for _, pair := range v.Values {
+			timestamp := int64(pair.Timestamp)
+			value := float64(pair.Value)
+
+			for t := baseTimestamp; t < timestamp; t += query.Step.Milliseconds() {
+				timeField.Set(idx, time.Unix(0, t*1000000).UTC())
+				idx++
 			}
+
+			timeField.Set(idx, time.Unix(pair.Timestamp.Unix(), 0).UTC())
+			if !math.IsNaN(value) {
+				valueField.Set(idx, &value)
+			}
+			baseTimestamp = timestamp + query.Step.Milliseconds()
+			idx++
 		}
 
 		name := formatLegend(v.Metric, query)
@@ -502,4 +515,8 @@ func newDataFrame(name string, typ string, fields ...*data.Field) *data.Frame {
 	}
 
 	return frame
+}
+
+func alignTimeRange(t time.Time, step time.Duration, offset int64) time.Time {
+	return time.Unix(int64(math.Floor((float64(t.Unix()+offset)/step.Seconds()))*step.Seconds()-float64(offset)), 0)
 }

--- a/pkg/tsdb/prometheus/time_series_query.go
+++ b/pkg/tsdb/prometheus/time_series_query.go
@@ -300,7 +300,9 @@ func matrixToDataFrames(matrix model.Matrix, query *PrometheusQuery, frames data
 		}
 
 		baseTimestamp := alignTimeRange(query.Start, query.Step, query.UtcOffsetSec).UnixMilli()
-		datapointsCount := int((query.End.UnixMilli()-query.Start.UnixMilli())/query.Step.Milliseconds()) + 1
+		endTimestamp := alignTimeRange(query.End, query.Step, query.UtcOffsetSec).UnixMilli()
+		// For each step we create 1 data point. This results in range / step + 1 data points.
+		datapointsCount := int((endTimestamp-baseTimestamp)/query.Step.Milliseconds()) + 1
 
 		timeField := data.NewFieldFromFieldType(data.FieldTypeTime, datapointsCount)
 		valueField := data.NewFieldFromFieldType(data.FieldTypeNullableFloat64, datapointsCount)

--- a/pkg/tsdb/prometheus/time_series_query_test.go
+++ b/pkg/tsdb/prometheus/time_series_query_test.go
@@ -567,6 +567,10 @@ func TestPrometheus_parseTimeSeriesResponse(t *testing.T) {
 		}
 		query := &PrometheusQuery{
 			LegendFormat: "legend {{app}}",
+			Step:         1 * time.Second,
+			Start:        time.Unix(1, 0).UTC(),
+			End:          time.Unix(5, 0).UTC(),
+			UtcOffsetSec: 0,
 		}
 		res, err := parseTimeSeriesResponse(value, query)
 		require.NoError(t, err)
@@ -586,6 +590,39 @@ func TestPrometheus_parseTimeSeriesResponse(t *testing.T) {
 		require.Equal(t, "UTC", testValue.(time.Time).Location().String())
 	})
 
+	t.Run("matrix response with missed data points should be parsed correctly", func(t *testing.T) {
+		values := []p.SamplePair{
+			{Value: 1, Timestamp: 1000},
+			{Value: 4, Timestamp: 4000},
+		}
+		value := make(map[TimeSeriesQueryType]interface{})
+		value[RangeQueryType] = p.Matrix{
+			&p.SampleStream{
+				Metric: p.Metric{"app": "Application", "tag2": "tag2"},
+				Values: values,
+			},
+		}
+		query := &PrometheusQuery{
+			LegendFormat: "",
+			Step:         1 * time.Second,
+			Start:        time.Unix(1, 0).UTC(),
+			End:          time.Unix(4, 0).UTC(),
+			UtcOffsetSec: 0,
+		}
+		res, err := parseTimeSeriesResponse(value, query)
+		var nilPointer *float64
+
+		require.NoError(t, err)
+		require.Len(t, res, 1)
+		require.Equal(t, res[0].Fields[0].Len(), 4)
+		require.Equal(t, res[0].Fields[0].At(1), time.Unix(2, 0).UTC())
+		require.Equal(t, res[0].Fields[0].At(2), time.Unix(3, 0).UTC())
+		require.Equal(t, res[0].Fields[1].Len(), 4)
+		require.Equal(t, res[0].Fields[1].At(1), nilPointer)
+		require.Equal(t, res[0].Fields[1].At(2), nilPointer)
+
+	})
+
 	t.Run("matrix response with NaN value should be changed to null", func(t *testing.T) {
 		value := make(map[TimeSeriesQueryType]interface{})
 		value[RangeQueryType] = p.Matrix{
@@ -598,6 +635,10 @@ func TestPrometheus_parseTimeSeriesResponse(t *testing.T) {
 		}
 		query := &PrometheusQuery{
 			LegendFormat: "",
+			Step:         1 * time.Second,
+			Start:        time.Unix(1, 0).UTC(),
+			End:          time.Unix(4, 0).UTC(),
+			UtcOffsetSec: 0,
 		}
 		res, err := parseTimeSeriesResponse(value, query)
 		require.NoError(t, err)

--- a/pkg/tsdb/prometheus/time_series_query_test.go
+++ b/pkg/tsdb/prometheus/time_series_query_test.go
@@ -620,7 +620,6 @@ func TestPrometheus_parseTimeSeriesResponse(t *testing.T) {
 		require.Equal(t, res[0].Fields[1].Len(), 4)
 		require.Equal(t, res[0].Fields[1].At(1), nilPointer)
 		require.Equal(t, res[0].Fields[1].At(2), nilPointer)
-
 	})
 
 	t.Run("matrix response with NaN value should be changed to null", func(t *testing.T) {

--- a/pkg/tsdb/prometheus/time_series_query_test.go
+++ b/pkg/tsdb/prometheus/time_series_query_test.go
@@ -610,7 +610,6 @@ func TestPrometheus_parseTimeSeriesResponse(t *testing.T) {
 			UtcOffsetSec: 0,
 		}
 		res, err := parseTimeSeriesResponse(value, query)
-		var nilPointer *float64
 
 		require.NoError(t, err)
 		require.Len(t, res, 1)

--- a/pkg/tsdb/prometheus/time_series_query_test.go
+++ b/pkg/tsdb/prometheus/time_series_query_test.go
@@ -618,8 +618,8 @@ func TestPrometheus_parseTimeSeriesResponse(t *testing.T) {
 		require.Equal(t, res[0].Fields[0].At(1), time.Unix(2, 0).UTC())
 		require.Equal(t, res[0].Fields[0].At(2), time.Unix(3, 0).UTC())
 		require.Equal(t, res[0].Fields[1].Len(), 4)
-		require.Equal(t, res[0].Fields[1].At(1), nilPointer)
-		require.Equal(t, res[0].Fields[1].At(2), nilPointer)
+		require.Nil(t, res[0].Fields[1].At(1))
+		require.Nil(t, res[0].Fields[1].At(2))
 	})
 
 	t.Run("matrix response with NaN value should be changed to null", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously (before backend migration) on [frontend we filled out missing steps with null values](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/prometheus/result_transformer.ts#L383-L389). This PR implements this missing functionality. I've decided to implement this on backend so the results of prometheus queries are same everywhere (Dashboard, Explore, Alerting) and we don't have to rely o frontend implementation. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/42993

**How to test:**
1. Run make `devenv sources=prometheus`
2. Create dashboard with query `counters_logins{server="backend-01"}` and time range `Last 5 min` and step `10s`
3. Stop `devenv_fake-prometheus-data_1` in docker and wait ~1 min. Then start it again
4. Where data points are missing, you should see empty/non-connected space:
![image](https://user-images.githubusercontent.com/30407135/147964631-26c94ce3-2aa2-4160-af3f-647b2d4745f4.png)

On current main, the lines are connected (incorrect behaviour/bug):
![image](https://user-images.githubusercontent.com/30407135/147964699-c458ce4b-be32-44ff-adc3-a09f4a2f3791.png)

