### PR TITLE
CodeQL: avoid regexp in label format rendering

### DIFF
--- a/public/app/plugins/datasource/prometheus/legend.test.ts
+++ b/public/app/plugins/datasource/prometheus/legend.test.ts
@@ -23,8 +23,8 @@ describe('renderLegendFormat()', () => {
   it('Bad syntax', () => {
     expect(renderLegendFormat('value: {{a}', labels)).toEqual('value: {{a}');
     expect(renderLegendFormat('value: {a}}}', labels)).toEqual('value: {a}}}');
-
-    // Current behavior -- not sure if expected or not
-    expect(renderLegendFormat('value: {{{a}}}', labels)).toEqual('value: {a}');
+    expect(renderLegendFormat('{{}}', labels)).toEqual('{{}}');
+    expect(renderLegendFormat('{{{{a', labels)).toEqual('{{{{a');
+    expect(renderLegendFormat('value: {{{a}}}', labels)).toEqual('value: {{{a}}}');
   });
 });

--- a/public/app/plugins/datasource/prometheus/legend.test.ts
+++ b/public/app/plugins/datasource/prometheus/legend.test.ts
@@ -1,3 +1,4 @@
+import { Labels } from '@grafana/data';
 import { renderLegendFormat } from './legend';
 
 describe('renderLegendFormat()', () => {
@@ -27,4 +28,48 @@ describe('renderLegendFormat()', () => {
     expect(renderLegendFormat('{{{{a', labels)).toEqual('{{{{a');
     expect(renderLegendFormat('value: {{{a}}}', labels)).toEqual('value: {{{a}}}');
   });
+
+  // Same behavior as regexp
+  describe('check beavior vs long time regexp version', () => {
+    test.each([
+      [
+        '{{a}}',
+        '{{a}} {{a}}',
+        '{{a}} {{a',
+        '{{with space}}',
+        '{{$a}}',
+        '{{nope}}',
+        '{{xx}}',
+
+        // Questionable, but consistent
+        '{{ a }}',
+      ],
+    ])('should behave like original regexp version', (pattern) => {
+      let now = renderLegendFormat(pattern, labels);
+      let old = originalLegendRenderer(pattern, labels);
+      expect(now).toEqual(old);
+
+      // When labels are empty the behavior is slightly different
+      now = renderLegendFormat(pattern, {});
+      old = originalLegendRenderer(pattern, {});
+      expect(now).toEqual(old);
+    });
+
+    // Changed, but OK
+    test.each([
+      [
+        // Before, it became `{a}`, now `{{{a}}}`
+        'value: {{{a}}}',
+      ],
+    ])('should behave like original regexp version', (pattern) => {
+      const now = renderLegendFormat(pattern, labels);
+      const old = originalLegendRenderer(pattern, labels);
+      expect(now).not.toEqual(old);
+    });
+  });
 });
+
+function originalLegendRenderer(aliasPattern: string, aliasData: Labels): string {
+  const aliasRegex = /\{\{\s*(.+?)\s*\}\}/g;
+  return aliasPattern.replace(aliasRegex, (_, g1) => (aliasData[g1] ? aliasData[g1] : g1));
+}

--- a/public/app/plugins/datasource/prometheus/legend.ts
+++ b/public/app/plugins/datasource/prometheus/legend.ts
@@ -15,7 +15,10 @@ export function renderLegendFormat(aliasPattern: string, aliasData: Labels): str
     }
 
     const key = aliasPattern.substring(idx + 2, edx).trim();
-    const val = aliasData[key];
+    let val = aliasData[key];
+    if (val == null && Object.keys(aliasData).length === 0) {
+      val = key; // legacy behavior
+    }
     if (val != null) {
       aliasPattern = aliasPattern.substring(0, idx) + val + aliasPattern.substring(edx + 2);
     }


### PR DESCRIPTION
The new code scanning is complaining about:
![image](https://user-images.githubusercontent.com/705951/147962750-4158441a-3641-4f6a-99a1-9050015bf2ea.png)

This is for a function that has existed in grafana since prometheus was added.  

In #43054, we tried a few other regexp options, but all have slightly different behavior than the current behavior.

I am +0 on this approach, but figure we should consider it. 

Weirdly the existing code has different behavior when labels exist, but do not match vs not matching at all.  In partculat:

```
renderLegend( '{{x}}', {} ) !== renderLegend( '{{x}}', {a:'a'} ) 
```
 
Ref #43080