### PR TITLE
fix(40639): datasource should not be visible after uninstall

### DIFF
--- a/public/app/features/plugins/pluginCacheBuster.ts
+++ b/public/app/features/plugins/pluginCacheBuster.ts
@@ -1,3 +1,5 @@
+import { clearPluginSettingsCache } from './pluginSettings';
+
 const cache: Record<string, string> = {};
 const initializedAt: number = Date.now();
 
@@ -17,6 +19,7 @@ export function invalidatePluginInCache(pluginId: string): void {
   if (cache[path]) {
     delete cache[path];
   }
+  clearPluginSettingsCache(pluginId);
 }
 
 export function locateWithCache(load: { address: string }, defaultBust = initializedAt): string {

--- a/public/app/features/plugins/pluginSettings.test.ts
+++ b/public/app/features/plugins/pluginSettings.test.ts
@@ -14,93 +14,73 @@ describe('PluginSettings', () => {
   });
 
   it('should fetch settings when cache is empty', async () => {
-    // assign
-    getBackendSrv().get = jest.fn().mockResolvedValue({
+    // arrange
+    const testPluginResponse = {
       name: 'TestPlugin',
       type: 'datasource',
       id: 'test-plugin',
       enabled: true,
-    });
+    };
+    getBackendSrv().get = jest.fn().mockResolvedValue(testPluginResponse);
     const getRequestSpy = jest.spyOn(getBackendSrv(), 'get');
     // act
     const response = await getPluginSettings('test');
     // assert
-    expect(response).toEqual({
-      name: 'TestPlugin',
-      type: 'datasource',
-      id: 'test-plugin',
-      enabled: true,
-    });
+    expect(response).toEqual(testPluginResponse);
     expect(getRequestSpy).toHaveBeenCalledTimes(1);
     expect(getRequestSpy).toHaveBeenCalledWith('/api/plugins/test/settings');
   });
 
   it('should fetch settings from cache when it has a hit', async () => {
-    // assign
-    getBackendSrv().get = jest.fn().mockResolvedValue({
+    // arrange
+    const testPluginResponse = {
       name: 'TestPlugin',
       type: 'datasource',
       id: 'test-plugin',
       enabled: true,
-    });
+    };
+    getBackendSrv().get = jest.fn().mockResolvedValue(testPluginResponse);
     const getRequestSpy = jest.spyOn(getBackendSrv(), 'get');
     // act
     const response1 = await getPluginSettings('test');
     const response2 = await getPluginSettings('test');
 
     // assert
-    expect(response1).toEqual({
-      name: 'TestPlugin',
-      type: 'datasource',
-      id: 'test-plugin',
-      enabled: true,
-    });
-    expect(response2).toEqual({
-      name: 'TestPlugin',
-      type: 'datasource',
-      id: 'test-plugin',
-      enabled: true,
-    });
+    expect(response1).toEqual(testPluginResponse);
+    expect(response2).toEqual(testPluginResponse);
     expect(getRequestSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should refetch from backend when cache is cleared', async () => {
-    // assign
-    getBackendSrv().get = jest.fn().mockResolvedValue({
+    // arrange
+    const testPluginResponse = {
       name: 'TestPlugin',
       type: 'datasource',
       id: 'test-plugin',
       enabled: true,
-    });
+    };
+    getBackendSrv().get = jest.fn().mockResolvedValue(testPluginResponse);
     const getRequestSpy = jest.spyOn(getBackendSrv(), 'get');
+
     // act
     const response1 = await getPluginSettings('test');
     await clearPluginSettingsCache('test');
     const response2 = await getPluginSettings('test');
 
     // assert
-    expect(response1).toEqual({
-      name: 'TestPlugin',
-      type: 'datasource',
-      id: 'test-plugin',
-      enabled: true,
-    });
-    expect(response2).toEqual({
-      name: 'TestPlugin',
-      type: 'datasource',
-      id: 'test-plugin',
-      enabled: true,
-    });
+    expect(response1).toEqual(testPluginResponse);
+    expect(response2).toEqual(testPluginResponse);
     expect(getRequestSpy).toHaveBeenCalledTimes(2);
   });
   it('should fetch from cache when it is cleared for another plugin setting', async () => {
-    // assign
-    getBackendSrv().get = jest.fn().mockResolvedValue({
+    // arrange
+    const testPluginResponse = {
       name: 'TestPlugin',
       type: 'datasource',
       id: 'test-plugin',
       enabled: true,
-    });
+    };
+    getBackendSrv().get = jest.fn().mockResolvedValue(testPluginResponse);
     const getRequestSpy = jest.spyOn(getBackendSrv(), 'get');
     // act
     const response1 = await getPluginSettings('test');
@@ -108,47 +88,29 @@ describe('PluginSettings', () => {
     const response2 = await getPluginSettings('test');
 
     // assert
-    expect(response1).toEqual({
-      name: 'TestPlugin',
-      type: 'datasource',
-      id: 'test-plugin',
-      enabled: true,
-    });
-    expect(response2).toEqual({
-      name: 'TestPlugin',
-      type: 'datasource',
-      id: 'test-plugin',
-      enabled: true,
-    });
+    expect(response1).toEqual(testPluginResponse);
+    expect(response2).toEqual(testPluginResponse);
     expect(getRequestSpy).toHaveBeenCalledTimes(1);
   });
   it('should clear all cache when no plugin id is provided to the clear function', async () => {
-    // assign
-    getBackendSrv().get = jest.fn().mockResolvedValue({
+    // arrange
+    const testPluginResponse = {
       name: 'TestPlugin',
       type: 'datasource',
       id: 'test-plugin',
       enabled: true,
-    });
+    };
+    getBackendSrv().get = jest.fn().mockResolvedValue(testPluginResponse);
     const getRequestSpy = jest.spyOn(getBackendSrv(), 'get');
+
     // act
     const response1 = await getPluginSettings('test');
     await clearPluginSettingsCache();
     const response2 = await getPluginSettings('test');
 
     // assert
-    expect(response1).toEqual({
-      name: 'TestPlugin',
-      type: 'datasource',
-      id: 'test-plugin',
-      enabled: true,
-    });
-    expect(response2).toEqual({
-      name: 'TestPlugin',
-      type: 'datasource',
-      id: 'test-plugin',
-      enabled: true,
-    });
+    expect(response1).toEqual(testPluginResponse);
+    expect(response2).toEqual(testPluginResponse);
     expect(getRequestSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/public/app/features/plugins/pluginSettings.test.ts
+++ b/public/app/features/plugins/pluginSettings.test.ts
@@ -1,0 +1,154 @@
+import { getPluginSettings, clearPluginSettingsCache } from './pluginSettings';
+import { getBackendSrv } from '@grafana/runtime';
+
+jest.mock('@grafana/runtime', () => ({
+  getBackendSrv: jest.fn().mockReturnValue({
+    get: jest.fn(),
+  }),
+}));
+
+describe('PluginSettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearPluginSettingsCache();
+  });
+
+  it('should fetch settings when cache is empty', async () => {
+    // assign
+    getBackendSrv().get = jest.fn().mockResolvedValue({
+      name: 'TestPlugin',
+      type: 'datasource',
+      id: 'test-plugin',
+      enabled: true,
+    });
+    const getRequestSpy = jest.spyOn(getBackendSrv(), 'get');
+    // act
+    const response = await getPluginSettings('test');
+    // assert
+    expect(response).toEqual({
+      name: 'TestPlugin',
+      type: 'datasource',
+      id: 'test-plugin',
+      enabled: true,
+    });
+    expect(getRequestSpy).toHaveBeenCalledTimes(1);
+    expect(getRequestSpy).toHaveBeenCalledWith('/api/plugins/test/settings');
+  });
+
+  it('should fetch settings from cache when it has a hit', async () => {
+    // assign
+    getBackendSrv().get = jest.fn().mockResolvedValue({
+      name: 'TestPlugin',
+      type: 'datasource',
+      id: 'test-plugin',
+      enabled: true,
+    });
+    const getRequestSpy = jest.spyOn(getBackendSrv(), 'get');
+    // act
+    const response1 = await getPluginSettings('test');
+    const response2 = await getPluginSettings('test');
+
+    // assert
+    expect(response1).toEqual({
+      name: 'TestPlugin',
+      type: 'datasource',
+      id: 'test-plugin',
+      enabled: true,
+    });
+    expect(response2).toEqual({
+      name: 'TestPlugin',
+      type: 'datasource',
+      id: 'test-plugin',
+      enabled: true,
+    });
+    expect(getRequestSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should refetch from backend when cache is cleared', async () => {
+    // assign
+    getBackendSrv().get = jest.fn().mockResolvedValue({
+      name: 'TestPlugin',
+      type: 'datasource',
+      id: 'test-plugin',
+      enabled: true,
+    });
+    const getRequestSpy = jest.spyOn(getBackendSrv(), 'get');
+    // act
+    const response1 = await getPluginSettings('test');
+    await clearPluginSettingsCache('test');
+    const response2 = await getPluginSettings('test');
+
+    // assert
+    expect(response1).toEqual({
+      name: 'TestPlugin',
+      type: 'datasource',
+      id: 'test-plugin',
+      enabled: true,
+    });
+    expect(response2).toEqual({
+      name: 'TestPlugin',
+      type: 'datasource',
+      id: 'test-plugin',
+      enabled: true,
+    });
+    expect(getRequestSpy).toHaveBeenCalledTimes(2);
+  });
+  it('should fetch from cache when it is cleared for another plugin setting', async () => {
+    // assign
+    getBackendSrv().get = jest.fn().mockResolvedValue({
+      name: 'TestPlugin',
+      type: 'datasource',
+      id: 'test-plugin',
+      enabled: true,
+    });
+    const getRequestSpy = jest.spyOn(getBackendSrv(), 'get');
+    // act
+    const response1 = await getPluginSettings('test');
+    await clearPluginSettingsCache('another-test');
+    const response2 = await getPluginSettings('test');
+
+    // assert
+    expect(response1).toEqual({
+      name: 'TestPlugin',
+      type: 'datasource',
+      id: 'test-plugin',
+      enabled: true,
+    });
+    expect(response2).toEqual({
+      name: 'TestPlugin',
+      type: 'datasource',
+      id: 'test-plugin',
+      enabled: true,
+    });
+    expect(getRequestSpy).toHaveBeenCalledTimes(1);
+  });
+  it('should clear all cache when no plugin id is provided to the clear function', async () => {
+    // assign
+    getBackendSrv().get = jest.fn().mockResolvedValue({
+      name: 'TestPlugin',
+      type: 'datasource',
+      id: 'test-plugin',
+      enabled: true,
+    });
+    const getRequestSpy = jest.spyOn(getBackendSrv(), 'get');
+    // act
+    const response1 = await getPluginSettings('test');
+    await clearPluginSettingsCache();
+    const response2 = await getPluginSettings('test');
+
+    // assert
+    expect(response1).toEqual({
+      name: 'TestPlugin',
+      type: 'datasource',
+      id: 'test-plugin',
+      enabled: true,
+    });
+    expect(response2).toEqual({
+      name: 'TestPlugin',
+      type: 'datasource',
+      id: 'test-plugin',
+      enabled: true,
+    });
+    expect(getRequestSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/public/app/features/plugins/pluginSettings.ts
+++ b/public/app/features/plugins/pluginSettings.ts
@@ -22,3 +22,11 @@ export function getPluginSettings(pluginId: string): Promise<PluginMeta> {
       return Promise.reject(new Error('Unknown Plugin'));
     });
 }
+
+export const clearPluginSettingsCache = (pluginId?: string) => {
+  if (pluginId) {
+    return delete pluginInfoCache[pluginId];
+  }
+  // clear all
+  return Object.keys(pluginInfoCache).forEach((key) => delete pluginInfoCache[key]);
+};

--- a/public/app/features/plugins/tests/pluginCacheBuster.test.ts
+++ b/public/app/features/plugins/tests/pluginCacheBuster.test.ts
@@ -1,4 +1,5 @@
 import { invalidatePluginInCache, locateWithCache, registerPluginInCache } from '../pluginCacheBuster';
+import * as pluginSettings from '../pluginSettings';
 
 describe('PluginCacheBuster', () => {
   const now = 12345;
@@ -34,6 +35,20 @@ describe('PluginCacheBuster', () => {
 
     const url = `${address}?_cache=${encodeURI(String(now))}`;
     expect(locateWithCache({ address }, now)).toBe(url);
+  });
+
+  it('should also clear plugin settings cache', () => {
+    const slug = 'bubble-chart-3';
+    const version = 'v1.0.0';
+    const path = resolvePath(slug);
+
+    const clearPluginSettingsCacheSpy = jest.spyOn(pluginSettings, 'clearPluginSettingsCache');
+
+    registerPluginInCache({ path, version });
+    invalidatePluginInCache(slug);
+
+    expect(clearPluginSettingsCacheSpy).toBeCalledTimes(1);
+    expect(clearPluginSettingsCacheSpy).toBeCalledWith('bubble-chart-3');
   });
 });
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Currently datasource settings are shown even when plugin is uninstalled, this is happening because plugin settings are cached but never invalidated. This PR fixes it.

- Clear plugin settings cache when it's uninstalled or cache is invalidated


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #40639

**Special notes for your reviewer**:
This is how it looks after the fix.

https://user-images.githubusercontent.com/580672/147970130-c59031e2-6c96-478e-a8c9-84042c4a1b9f.mp4


