### PR TITLE
Dashboards: Improve query time

### DIFF
--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -32,17 +32,15 @@ func (d DashboardPermissionFilter) Where() (string, []interface{}) {
 			SELECT distinct DashboardId from (
 				SELECT d.id AS DashboardId
 					FROM dashboard AS d
-					LEFT JOIN dashboard AS folder on folder.id = d.folder_id
 					LEFT JOIN dashboard_acl AS da ON
 						da.dashboard_id = d.id OR
 						da.dashboard_id = d.folder_id
-					LEFT JOIN team_member as ugm on ugm.team_id = da.team_id
 					WHERE
 						d.org_id = ? AND
 						da.permission >= ? AND
 						(
 							da.user_id = ? OR
-							ugm.user_id = ? OR
+							da.team_id IN (SELECT team_id from team_member AS tm WHERE tm.user_id = ?) OR
 							da.role IN (?` + strings.Repeat(",?", len(okRoles)-1) + `)
 						)
 				UNION
@@ -54,7 +52,7 @@ func (d DashboardPermissionFilter) Where() (string, []interface{}) {
 							-- include default permissions -->
 							da.org_id = -1 AND (
 							  (folder.id IS NOT NULL AND folder.has_acl = ` + falseStr + `) OR
-							  (folder.id IS NULL AND d.has_acl = ` + falseStr + `)
+							  (folder.id IS NULL AND d.has_acl = ` + falseStr + `) 
 							)
 						)
 					WHERE

--- a/pkg/services/sqlstore/sqlbuilder.go
+++ b/pkg/services/sqlstore/sqlbuilder.go
@@ -51,17 +51,15 @@ func (sb *SQLBuilder) WriteDashboardPermissionFilter(user *models.SignedInUser, 
 			SELECT distinct DashboardId from (
 				SELECT d.id AS DashboardId
 					FROM dashboard AS d
-					LEFT JOIN dashboard AS folder on folder.id = d.folder_id
 					LEFT JOIN dashboard_acl AS da ON
 						da.dashboard_id = d.id OR
 						da.dashboard_id = d.folder_id
-					LEFT JOIN team_member as ugm on ugm.team_id = da.team_id
 					WHERE
 						d.org_id = ? AND
 						da.permission >= ? AND
 						(
 							da.user_id = ? OR
-							ugm.user_id = ? OR
+							da.team_id IN (SELECT team_id from team_member AS tm WHERE tm.user_id = ?) OR
 							da.role IN (?` + strings.Repeat(",?", len(okRoles)-1) + `)
 						)
 				UNION


### PR DESCRIPTION
**What this PR does / why we need it**:
It removes two joins, one is not used and the other one can be replaced with a simple subquery.

Tested with with 13k dashboards + 2k users + 300 teams + ~130k of dashboard/folder permissions using Mac in localhost.

**Improvements**
* **Postgres**: From ~4 seconds to ~2 seconds (No much improvement)
* **SQLite3**: From ~4 seconds to ~300ms 
* **MySQL**: From ~3 minutes to ~40 seconds
