### PR TITLE
Import: fix dashboard imports with expressions

### DIFF
--- a/pkg/plugins/manager/dashboard_import.go
+++ b/pkg/plugins/manager/dashboard_import.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/plugins"
 )
 
@@ -46,6 +47,13 @@ func (e *DashTemplateEvaluator) Eval() (*simplejson.Json, error) {
 		inputName := inputDefJson.Get("name").MustString()
 		inputType := inputDefJson.Get("type").MustString()
 		input := e.findInput(inputName, inputType)
+
+		// force expressions value to `__expr__`
+		if inputDefJson.Get("pluginId").MustString() == expr.DatasourceType {
+			input = &plugins.ImportDashboardInput{
+				Value: expr.DatasourceType,
+			}
+		}
 
 		if input == nil {
 			return nil, &DashboardInputMissingError{VariableName: inputName}

--- a/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
+++ b/public/app/features/manage-dashboards/components/ImportDashboardForm.tsx
@@ -11,6 +11,7 @@ import {
   Legend,
 } from '@grafana/ui';
 import { DataSourcePicker } from '@grafana/runtime';
+import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 import { selectors } from '@grafana/e2e-selectors';
 
 import { FolderPicker } from 'app/core/components/Select/FolderPicker';
@@ -107,6 +108,9 @@ export const ImportDashboardForm: FC<Props> = ({
       </Field>
       {inputs.dataSources &&
         inputs.dataSources.map((input: DataSourceInput, index: number) => {
+          if (input.pluginId === ExpressionDatasourceRef.type) {
+            return null;
+          }
           const dataSourceOption = `dataSources[${index}]`;
           const current = watchDataSources ?? [];
           return (


### PR DESCRIPTION
Fixes #43175

This PR will hide any options to change an expression datasource ref with variables, and will force `__expr__` as the value for any variable using expressions 