### PR TITLE
NodeGraph: Fix empty state to display 'No Data' message

### DIFF
--- a/public/app/plugins/panel/nodeGraph/NodeGraph.test.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.test.tsx
@@ -14,12 +14,14 @@ jest.mock('react-use/lib/useMeasure', () => {
 });
 
 describe('NodeGraph', () => {
-  it('doesnt fail without any data', async () => {
+  it('shows no data message without any data', async () => {
     render(<NodeGraph dataFrames={[]} getLinks={() => []} />);
+
+    await screen.findByText('No data');
   });
 
   it('can zoom in and out', async () => {
-    render(<NodeGraph dataFrames={[]} getLinks={() => []} />);
+    render(<NodeGraph dataFrames={[makeNodesDataFrame(2), makeEdgesDataFrame([[0, 1]])]} getLinks={() => []} />);
     const zoomIn = await screen.findByTitle(/Zoom in/);
     const zoomOut = await screen.findByTitle(/Zoom out/);
 

--- a/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
@@ -67,6 +67,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     padding-bottom: 5px;
     margin-right: 10px;
   `,
+  viewControlsWrapper: css`
+    margin-left: auto;
+  `,
   alert: css`
     label: alert;
     padding: 5px 8px;
@@ -212,7 +215,7 @@ export function NodeGraph({ getLinks, dataFrames, nodeLimit }: Props) {
       </svg>
 
       <div className={styles.viewControls}>
-        {nodes.length && (
+        {nodes.length ? (
           <div className={styles.legend}>
             <Legend
               sortable={config.gridLayout}
@@ -226,22 +229,24 @@ export function NodeGraph({ getLinks, dataFrames, nodeLimit }: Props) {
               }}
             />
           </div>
-        )}
+        ) : null}
 
-        <ViewControls<Config>
-          config={config}
-          onConfigChange={(cfg) => {
-            if (cfg.gridLayout !== config.gridLayout) {
-              setFocusedNodeId(undefined);
-            }
-            setConfig(cfg);
-          }}
-          onMinus={onStepDown}
-          onPlus={onStepUp}
-          scale={scale}
-          disableZoomIn={isMaxZoom}
-          disableZoomOut={isMinZoom}
-        />
+        <div className={styles.viewControlsWrapper}>
+          <ViewControls<Config>
+            config={config}
+            onConfigChange={(cfg) => {
+              if (cfg.gridLayout !== config.gridLayout) {
+                setFocusedNodeId(undefined);
+              }
+              setConfig(cfg);
+            }}
+            onMinus={onStepDown}
+            onPlus={onStepUp}
+            scale={scale}
+            disableZoomIn={isMaxZoom}
+            disableZoomOut={isMinZoom}
+          />
+        </div>
       </div>
 
       {hiddenNodesCount > 0 && (

--- a/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
@@ -44,6 +44,15 @@ const getStyles = (theme: GrafanaTheme2) => ({
     user-select: none;
   `,
 
+  noDataMsg: css`
+    height: 100%;
+    width: 100%;
+    display: grid;
+    place-items: center;
+    font-size: ${theme.typography.h4.fontSize};
+    color: ${theme.colors.text.secondary};
+  `,
+
   mainGroup: css`
     label: mainGroup;
     will-change: transform;
@@ -180,39 +189,43 @@ export function NodeGraph({ getLinks, dataFrames, nodeLimit }: Props) {
         </div>
       ) : null}
 
-      <svg
-        ref={panRef}
-        viewBox={`${-(width / 2)} ${-(height / 2)} ${width} ${height}`}
-        className={cx(styles.svg, isPanning && styles.svgPanning)}
-      >
-        <g
-          className={styles.mainGroup}
-          style={{ transform: `scale(${scale}) translate(${Math.floor(position.x)}px, ${Math.floor(position.y)}px)` }}
+      {nodes.length ? (
+        <svg
+          ref={panRef}
+          viewBox={`${-(width / 2)} ${-(height / 2)} ${width} ${height}`}
+          className={cx(styles.svg, isPanning && styles.svgPanning)}
         >
-          <EdgeArrowMarker />
-          {!config.gridLayout && (
-            <Edges
-              edges={edges}
-              nodeHoveringId={nodeHover}
-              edgeHoveringId={edgeHover}
-              onClick={onEdgeOpen}
-              onMouseEnter={setEdgeHover}
-              onMouseLeave={clearEdgeHover}
+          <g
+            className={styles.mainGroup}
+            style={{ transform: `scale(${scale}) translate(${Math.floor(position.x)}px, ${Math.floor(position.y)}px)` }}
+          >
+            <EdgeArrowMarker />
+            {!config.gridLayout && (
+              <Edges
+                edges={edges}
+                nodeHoveringId={nodeHover}
+                edgeHoveringId={edgeHover}
+                onClick={onEdgeOpen}
+                onMouseEnter={setEdgeHover}
+                onMouseLeave={clearEdgeHover}
+              />
+            )}
+            <Nodes
+              nodes={nodes}
+              onMouseEnter={setNodeHover}
+              onMouseLeave={clearNodeHover}
+              onClick={onNodeOpen}
+              hoveringId={nodeHover || highlightId}
             />
-          )}
-          <Nodes
-            nodes={nodes}
-            onMouseEnter={setNodeHover}
-            onMouseLeave={clearNodeHover}
-            onClick={onNodeOpen}
-            hoveringId={nodeHover || highlightId}
-          />
 
-          <Markers markers={markers || []} onClick={setFocused} />
-          {/*We split the labels from edges so that they are shown on top of everything else*/}
-          {!config.gridLayout && <EdgeLabels edges={edges} nodeHoveringId={nodeHover} edgeHoveringId={edgeHover} />}
-        </g>
-      </svg>
+            <Markers markers={markers || []} onClick={setFocused} />
+            {/*We split the labels from edges so that they are shown on top of everything else*/}
+            {!config.gridLayout && <EdgeLabels edges={edges} nodeHoveringId={nodeHover} edgeHoveringId={edgeHover} />}
+          </g>
+        </svg>
+      ) : (
+        <div className={styles.noDataMsg}>No data</div>
+      )}
 
       <div className={styles.viewControls}>
         {nodes.length ? (

--- a/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
@@ -189,7 +189,7 @@ export function NodeGraph({ getLinks, dataFrames, nodeLimit }: Props) {
         </div>
       ) : null}
 
-      {nodes.length ? (
+      {dataFrames.length ? (
         <svg
           ref={panRef}
           viewBox={`${-(width / 2)} ${-(height / 2)} ${width} ${height}`}


### PR DESCRIPTION
**What this PR does / why we need it**:
Show 'No data' when the Node Graph doesn't receive any nodes. Also removes an extra "0" that was present in the ViewControls because we were using `&&` instead of a ternary which will occasionally still render something if the condition is false. 

Before/after screenshots:
![Screen Shot 2022-01-03 at 1 57 27 PM](https://user-images.githubusercontent.com/12838032/147981714-9bc5c48c-33b2-4784-8820-215144eb4aff.png)
![Screen Shot 2022-01-03 at 2 20 40 PM](https://user-images.githubusercontent.com/12838032/147981710-59e36c0a-b101-4310-8764-c982421db4ad.png)

**Which issue(s) this PR fixes**:
Fixes #41475

**Special notes for your reviewer**:

