### PR TITLE
refactor promethueus package into sub packages

### DIFF
--- a/pkg/tsdb/prometheus/client/provider.go
+++ b/pkg/tsdb/prometheus/client/provider.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"strings"
+
+	"github.com/grafana/grafana/pkg/tsdb/prometheus/middleware"
+
+	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana/pkg/infra/httpclient"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/prometheus/client_golang/api"
+	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+func Create(url string, httpOpts sdkhttpclient.Options, clientProvider httpclient.Provider, jsonData map[string]interface{}, plog log.Logger) (apiv1.API, error) {
+	customParamsMiddleware := middleware.CustomQueryParameters(plog)
+	middlewares := []sdkhttpclient.Middleware{customParamsMiddleware}
+	if shouldForceGet(jsonData) {
+		middlewares = append(middlewares, middleware.ForceHttpGet(plog))
+	}
+	httpOpts.Middlewares = middlewares
+
+	roundTripper, err := clientProvider.GetTransport(httpOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := api.Config{
+		Address:      url,
+		RoundTripper: roundTripper,
+	}
+
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return apiv1.NewAPI(client), nil
+}
+
+func shouldForceGet(settingsJson map[string]interface{}) bool {
+	methodInterface, exists := settingsJson["httpMethod"]
+	if !exists {
+		return false
+	}
+
+	method, ok := methodInterface.(string)
+	if !ok {
+		return false
+	}
+
+	return strings.ToLower(method) == "get"
+}

--- a/pkg/tsdb/prometheus/client/provider_test.go
+++ b/pkg/tsdb/prometheus/client/provider_test.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestForceGet(t *testing.T) {
+	t.Run("With nil jsonOpts, should not force get-method", func(t *testing.T) {
+		var jsonOpts map[string]interface{}
+		require.False(t, shouldForceGet(jsonOpts))
+	})
+
+	t.Run("With empty jsonOpts, should not force get-method", func(t *testing.T) {
+		jsonOpts := make(map[string]interface{})
+		require.False(t, shouldForceGet(jsonOpts))
+	})
+
+	t.Run("With httpMethod=nil, should not not force get-method", func(t *testing.T) {
+		jsonOpts := map[string]interface{}{
+			"httpMethod": nil,
+		}
+		require.False(t, shouldForceGet(jsonOpts))
+	})
+
+	t.Run("With httpMethod=post, should not force get-method", func(t *testing.T) {
+		jsonOpts := map[string]interface{}{
+			"httpMethod": "POST",
+		}
+		require.False(t, shouldForceGet(jsonOpts))
+	})
+
+	t.Run("With httpMethod=get, should force get-method", func(t *testing.T) {
+		jsonOpts := map[string]interface{}{
+			"httpMethod": "get",
+		}
+		require.True(t, shouldForceGet(jsonOpts))
+	})
+
+	t.Run("With httpMethod=GET, should force get-method", func(t *testing.T) {
+		jsonOpts := map[string]interface{}{
+			"httpMethod": "GET",
+		}
+		require.True(t, shouldForceGet(jsonOpts))
+	})
+}

--- a/pkg/tsdb/prometheus/middleware/custom_query_params.go
+++ b/pkg/tsdb/prometheus/middleware/custom_query_params.go
@@ -1,4 +1,4 @@
-package prometheus
+package middleware
 
 import (
 	"net/http"
@@ -14,7 +14,7 @@ const (
 	grafanaDataKey                      = "grafanaData"
 )
 
-func customQueryParametersMiddleware(logger log.Logger) sdkhttpclient.Middleware {
+func CustomQueryParameters(logger log.Logger) sdkhttpclient.Middleware {
 	return sdkhttpclient.NamedMiddlewareFunc(customQueryParametersMiddlewareName, func(opts sdkhttpclient.Options, next http.RoundTripper) http.RoundTripper {
 		grafanaData, exists := opts.CustomOptions[grafanaDataKey]
 		if !exists {

--- a/pkg/tsdb/prometheus/middleware/custom_query_params_test.go
+++ b/pkg/tsdb/prometheus/middleware/custom_query_params_test.go
@@ -1,4 +1,4 @@
-package prometheus
+package middleware
 
 import (
 	"net/http"
@@ -19,7 +19,7 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 	})
 
 	t.Run("Without custom query parameters set should not apply middleware", func(t *testing.T) {
-		mw := customQueryParametersMiddleware(log.New("test"))
+		mw := CustomQueryParameters(log.New("test"))
 		rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
 		require.NotNil(t, rt)
 		middlewareName, ok := mw.(httpclient.MiddlewareName)
@@ -39,7 +39,7 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 	})
 
 	t.Run("Without custom query parameters set as string should not apply middleware", func(t *testing.T) {
-		mw := customQueryParametersMiddleware(log.New("test"))
+		mw := CustomQueryParameters(log.New("test"))
 		rt := mw.CreateMiddleware(httpclient.Options{
 			CustomOptions: map[string]interface{}{
 				customQueryParametersKey: 64,
@@ -63,7 +63,7 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 	})
 
 	t.Run("With custom query parameters set as empty string should not apply middleware", func(t *testing.T) {
-		mw := customQueryParametersMiddleware(log.New("test"))
+		mw := CustomQueryParameters(log.New("test"))
 		rt := mw.CreateMiddleware(httpclient.Options{
 			CustomOptions: map[string]interface{}{
 				customQueryParametersKey: "",
@@ -87,7 +87,7 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 	})
 
 	t.Run("With custom query parameters set as invalid query string should not apply middleware", func(t *testing.T) {
-		mw := customQueryParametersMiddleware(log.New("test"))
+		mw := CustomQueryParameters(log.New("test"))
 		rt := mw.CreateMiddleware(httpclient.Options{
 			CustomOptions: map[string]interface{}{
 				customQueryParametersKey: "custom=%%abc&test=abc",
@@ -111,7 +111,7 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 	})
 
 	t.Run("With custom query parameters set should apply middleware for request URL containing query parameters ", func(t *testing.T) {
-		mw := customQueryParametersMiddleware(log.New("test"))
+		mw := CustomQueryParameters(log.New("test"))
 		rt := mw.CreateMiddleware(httpclient.Options{
 			CustomOptions: map[string]interface{}{
 				grafanaDataKey: map[string]interface{}{
@@ -143,7 +143,7 @@ func TestCustomQueryParametersMiddleware(t *testing.T) {
 	})
 
 	t.Run("With custom query parameters set should apply middleware for request URL not containing query parameters", func(t *testing.T) {
-		mw := customQueryParametersMiddleware(log.New("test"))
+		mw := CustomQueryParameters(log.New("test"))
 		rt := mw.CreateMiddleware(httpclient.Options{
 			CustomOptions: map[string]interface{}{
 				grafanaDataKey: map[string]interface{}{

--- a/pkg/tsdb/prometheus/middleware/force_http_get.go
+++ b/pkg/tsdb/prometheus/middleware/force_http_get.go
@@ -1,4 +1,4 @@
-package prometheus
+package middleware
 
 import (
 	"net/http"
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 )
 
-func forceHttpGetMiddleware(logger log.Logger) sdkhttpclient.Middleware {
+func ForceHttpGet(logger log.Logger) sdkhttpclient.Middleware {
 	return sdkhttpclient.NamedMiddlewareFunc("force-http-get", func(opts sdkhttpclient.Options, next http.RoundTripper) http.RoundTripper {
 		// the prometheus library we use does not allow us to set the http method.
 		// it's behavior is to first try POST, and if it fails in certain ways

--- a/pkg/tsdb/prometheus/middleware/force_http_get_test.go
+++ b/pkg/tsdb/prometheus/middleware/force_http_get_test.go
@@ -1,4 +1,4 @@
-package prometheus
+package middleware
 
 import (
 	"net/http"
@@ -9,52 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestForceGet(t *testing.T) {
-	t.Run("With nil jsonOpts, should not force get-method", func(t *testing.T) {
-		var jsonOpts map[string]interface{}
-		require.False(t, forceHttpGet(jsonOpts))
-	})
-
-	t.Run("With empty jsonOpts, should not force get-method", func(t *testing.T) {
-		jsonOpts := make(map[string]interface{})
-		require.False(t, forceHttpGet(jsonOpts))
-	})
-
-	t.Run("With httpMethod=nil, should not not force get-method", func(t *testing.T) {
-		jsonOpts := map[string]interface{}{
-			"httpMethod": nil,
-		}
-		require.False(t, forceHttpGet(jsonOpts))
-	})
-
-	t.Run("With httpMethod=post, should not force get-method", func(t *testing.T) {
-		jsonOpts := map[string]interface{}{
-			"httpMethod": "POST",
-		}
-		require.False(t, forceHttpGet(jsonOpts))
-	})
-
-	t.Run("With httpMethod=get, should force get-method", func(t *testing.T) {
-		jsonOpts := map[string]interface{}{
-			"httpMethod": "get",
-		}
-		require.True(t, forceHttpGet(jsonOpts))
-	})
-
-	t.Run("With httpMethod=GET, should force get-method", func(t *testing.T) {
-		jsonOpts := map[string]interface{}{
-			"httpMethod": "GET",
-		}
-		require.True(t, forceHttpGet(jsonOpts))
-	})
-}
-
 func TestEnsureHttpMethodMiddleware(t *testing.T) {
 	t.Run("Name should be correct", func(t *testing.T) {
 		finalRoundTripper := httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			return &http.Response{StatusCode: http.StatusOK}, nil
 		})
-		mw := forceHttpGetMiddleware(log.New("test"))
+		mw := ForceHttpGet(log.New("test"))
 		rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
 		require.NotNil(t, rt)
 		middlewareName, ok := mw.(httpclient.MiddlewareName)
@@ -67,7 +27,7 @@ func TestEnsureHttpMethodMiddleware(t *testing.T) {
 			return &http.Response{StatusCode: http.StatusOK}, nil
 		})
 
-		mw := forceHttpGetMiddleware(log.New("test"))
+		mw := ForceHttpGet(log.New("test"))
 		rt := mw.CreateMiddleware(httpclient.Options{}, finalRoundTripper)
 		require.NotNil(t, rt)
 


### PR DESCRIPTION
This is a prefactor to some work to making a caching client provider. This work pulls the existing pieces into packages to organize the prometheus package into functionality

This is intended to make the next PR more readable