### PR TITLE
 Github Actions: another fix for the levitate workflow

### DIFF
--- a/.github/workflows/detect-breaking-changes-report.yml
+++ b/.github/workflows/detect-breaking-changes-report.yml
@@ -14,6 +14,8 @@ jobs:
       ARTIFACT_NAME: 'levitate'
 
     steps:
+    - uses: actions/checkout@v2
+    
     - name: 'Download artifact'
       uses: actions/github-script@v5
       env:


### PR DESCRIPTION
**Previous PRs:** 
- https://github.com/grafana/grafana/pull/43188
- https://github.com/grafana/grafana/pull/43621
 
### What changed?
Checking out the repo so we access the helper scripts 🤦‍♂️  

### Why this was needed?
A mistake I somehow didn't realise. Unfortunately the only real way to test these is by merging them to main.
[Example error](https://github.com/grafana/grafana/runs/4700254890?check_suite_focus=true#step:4:17)