### PR TITLE
Docs: Add info about yarn pnp to developer guide

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -39,6 +39,14 @@ For alternative ways of cloning the Grafana repository, please refer to [GitHub'
 
 **Warning:** Do not use `go get` to download Grafana. Recent versions of Go have added behavior which isn't compatible with the way the Grafana repository is structured.
 
+### Configure Editors
+
+For some IDEs, additional configuration may be needed for Typescript to work with [Yarn plug'n'play](https://yarnpkg.com/features/pnp).
+For [VSCode](https://yarnpkg.com/getting-started/editor-sdks#vscode) and [Vim](https://yarnpkg.com/getting-started/editor-sdks#vim),
+it's as easy as running `yarn dlx @yarnpkg/sdks vscode` or `yarn dlx@yarnpkg/sdks vim`, respectively.
+
+More information can be found [here](https://yarnpkg.com/getting-started/editor-sdks).
+
 ## Build Grafana
 
 Grafana consists of two components; the _frontend_, and the _backend_.

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -43,7 +43,7 @@ For alternative ways of cloning the Grafana repository, please refer to [GitHub'
 
 For some IDEs, additional configuration may be needed for Typescript to work with [Yarn plug'n'play](https://yarnpkg.com/features/pnp).
 For [VSCode](https://yarnpkg.com/getting-started/editor-sdks#vscode) and [Vim](https://yarnpkg.com/getting-started/editor-sdks#vim),
-it's as easy as running `yarn dlx @yarnpkg/sdks vscode` or `yarn dlx@yarnpkg/sdks vim`, respectively.
+it's as easy as running `yarn dlx @yarnpkg/sdks vscode` or `yarn dlx @yarnpkg/sdks vim`, respectively.
 
 More information can be found [here](https://yarnpkg.com/getting-started/editor-sdks).
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds information about additional configuration that may be needed to get yarn pnp working with various editors to the developer guide.
