### PR TITLE
BarGuage: Fixes vertical view flip and bar misalignment when used with datalinks

### DIFF
--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
@@ -170,6 +170,18 @@ describe('BarGauge', () => {
     });
   });
 
+  describe('Vertical bar', () => {
+    it('should adjust empty region to always have same width as colored bar', () => {
+      const props = getProps({
+        width: 150,
+        value: getValue(100),
+        orientation: VizOrientation.Vertical,
+      });
+      const styles = getBasicAndGradientStyles(props);
+      expect(styles.emptyBar.width).toBe('150px');
+    });
+  });
+
   describe('Vertical bar without title', () => {
     it('should not include title height in height', () => {
       const props = getProps({
@@ -272,6 +284,16 @@ describe('BarGauge', () => {
       });
       const styles = getTitleStyles(props);
       expect(styles.title.width).toBe('37px');
+    });
+
+    it('should adjust empty region to always have same height as colored bar', () => {
+      const props = getProps({
+        height: 150,
+        value: getValue(100),
+        orientation: VizOrientation.Horizontal,
+      });
+      const styles = getBasicAndGradientStyles(props);
+      expect(styles.emptyBar.height).toBe('150px');
     });
   });
 

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -486,6 +486,9 @@ export function getBasicAndGradientStyles(props: Props): BasicAndGradientStyles 
     // adjust so that filled in bar is at the bottom
     emptyBar.bottom = '-3px';
 
+    //adjust empty region to always have same width as colored bar
+    emptyBar.width = `${valueWidth}px`;
+
     if (isBasic) {
       // Basic styles
       barStyles.background = `${tinycolor(valueColor).setAlpha(0.35).toRgbString()}`;
@@ -508,6 +511,9 @@ export function getBasicAndGradientStyles(props: Props): BasicAndGradientStyles 
 
     // shift empty region back to fill gaps due to border radius
     emptyBar.left = '-3px';
+
+    //adjust empty region to always have same height as colored bar
+    emptyBar.height = `${valueHeight}px`;
 
     if (isBasic) {
       // Basic styles

--- a/packages/grafana-ui/src/components/BarGauge/__snapshots__/BarGauge.test.tsx.snap
+++ b/packages/grafana-ui/src/components/BarGauge/__snapshots__/BarGauge.test.tsx.snap
@@ -56,6 +56,7 @@ exports[`BarGauge Render with basic options should render 1`] = `
           "borderRadius": "3px",
           "display": "flex",
           "flexGrow": 1,
+          "height": "300px",
           "left": "-3px",
           "position": "relative",
         }

--- a/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
@@ -8,6 +8,7 @@ import {
   FieldConfig,
   DisplayProcessor,
   DisplayValue,
+  VizOrientation,
 } from '@grafana/data';
 import { BarGauge, DataLinksContextMenu, VizRepeater, VizRepeaterRenderValueProps } from '@grafana/ui';
 
@@ -52,12 +53,12 @@ export class BarGaugePanel extends PureComponent<PanelProps<BarGaugeOptions>> {
   };
 
   renderValue = (valueProps: VizRepeaterRenderValueProps<FieldDisplay, DisplayValueAlignmentFactors>): JSX.Element => {
-    const { value } = valueProps;
+    const { value, orientation } = valueProps;
     const { hasLinks, getLinks } = value;
 
     if (hasLinks && getLinks) {
       return (
-        <div style={{ width: '100%' }}>
+        <div style={{ width: '100%', display: orientation === VizOrientation.Vertical ? 'flex' : 'initial' }}>
           <DataLinksContextMenu links={getLinks} config={value.field}>
             {(api) => this.renderComponent(valueProps, api)}
           </DataLinksContextMenu>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR fixes vertical view flip and bar misalignment when used with datalinks.

**_Show unfilled area_ checkbox to enable/disable settings in vertical orientations**
| Before | After |
| --- | --- |
|<img width="1178" alt="bargauge-vertical-show-unfilled-before" src="https://user-images.githubusercontent.com/29557702/148056336-c319c4ab-86cd-41ad-9b60-2ecbfcc472cb.png">|<img width="1199" alt="barguage-vertical-show-unfilled-after" src="https://user-images.githubusercontent.com/29557702/148063076-357940a5-6359-4a2d-afd7-fbd55315cdfe.png">|

**Vertical view flip when used with datalinks**
| Before | After |
| --- | --- |
|<img width="681" alt="barguage-vertical-view-with-datalink-before" src="https://user-images.githubusercontent.com/29557702/148065003-88097d2f-0e4e-4e61-9203-3ea790c4ba7b.png">|<img width="521" alt="barguage-vertical-view-with-datalink-after" src="https://user-images.githubusercontent.com/29557702/148065054-fa8098ae-dc46-4596-8532-ba95a656e105.png">|

**Bar misalignment in vertical and horizontal orientations when used with datalinks**
| Before | After |
| --- | --- |
|<img width="1228" alt="barguage-misalignment-with-datalink-before" src="https://user-images.githubusercontent.com/29557702/148065202-8954d17d-0a8e-4df9-bb50-c29c18a1a043.png">|<img width="1198" alt="barguage-misalignment-with-datalink-after" src="https://user-images.githubusercontent.com/29557702/148065261-6dd299b6-0425-4df8-888d-8019939e2bbc.png">|

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #43306

**Todo**:

- [x] Fix vertical view flip issue when used with datalinks
- [x] Fix _Show unfilled area_ checkbox to enable/disable settings in vertical orientations
- [x] Fix bar misalignment in vertical and horizontal orientations when used with datalinks
- [x] Write test to prevent bar misalignment in the future

