### PR TITLE
Github Actions: another fix for the levitate workflow

### DIFF
--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Persisting the check output
       run: |
           mkdir -p ./levitate
-          echo "{ \"exit_code\": ${{ steps.breaking-changes.outputs.is_breaking }}, \"message\": \"${{ steps.breaking-changes.outputs.mesage }}\", \"job_link\": \"${{ steps.job.outputs.link }}#step:${GITHUB_STEP_NUMBER}\" }" > ./levitate/result.json
+          echo "{ \"exit_code\": ${{ steps.breaking-changes.outputs.is_breaking }}, \"message\": \"${{ steps.breaking-changes.outputs.message }}\", \"job_link\": \"${{ steps.job.outputs.link }}#step:${GITHUB_STEP_NUMBER}\" }" > ./levitate/result.json
 
     - name: Upload check output as artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -6,6 +6,8 @@ jobs:
   build:
     name: Detect
     runs-on: ubuntu-latest
+    env:
+      GITHUB_STEP_NUMBER: 7
 
     steps:
     - uses: actions/checkout@v2
@@ -35,12 +37,11 @@ jobs:
       env:
         FORCE_COLOR: 3
         GITHUB_JOB_LINK: ${{ steps.job.outputs.link }}
-        GITHUB_STEP_NUMBER: 7
 
     - name: Persisting the check output
       run: |
           mkdir -p ./levitate
-          echo "{ \"exit_code\": ${{ steps.breaking-changes.outputs.is_breaking }}, \"message\": \"${{ steps.breaking-changes.outputs.mesage }}\", \"job_link\": \"${{ steps.job.outputs.link }}\" }" > ./levitate/result.json
+          echo "{ \"exit_code\": ${{ steps.breaking-changes.outputs.is_breaking }}, \"message\": \"${{ steps.breaking-changes.outputs.mesage }}\", \"job_link\": \"${{ steps.job.outputs.link }}#step:${GITHUB_STEP_NUMBER}\" }" > ./levitate/result.json
 
     - name: Upload check output as artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -48,3 +48,7 @@ jobs:
       with:
         name: levitate
         path: levitate/
+      
+    - name: Exit
+      run: exit ${{ steps.breaking-changes.outputs.is_breaking }}
+      shell: bash

--- a/.github/workflows/detect-breaking-changes-report.yml
+++ b/.github/workflows/detect-breaking-changes-report.yml
@@ -160,7 +160,4 @@ jobs:
             team_reviewers: ['grafana/plugins-platform-frontend']
           });
 
-    - name: Exit
-      run: exit ${{ steps.levitate-run.outputs.exit_code }}
-      shell: bash
 


### PR DESCRIPTION
**Previous PRs:** 
- https://github.com/grafana/grafana/pull/43188
- https://github.com/grafana/grafana/pull/43621
- https://github.com/grafana/grafana/pull/43646
 
### What changed?
- fixed a typo (caused not having a full comment message)
- failing the detect workflow on a breaking change
- stop failing the reporting workflow on a breaking change (the reporting can still happen "successfully")
- add the workflow step number to the "view console output" link