### PR TITLE
CI: Remove `initialize` step from integration tests pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -373,16 +373,6 @@ steps:
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
 - commands:
-  - echo $DRONE_RUNNER_NAME
-  image: alpine:3.14.3
-  name: identify-runner
-- commands:
-  - make gen-go
-  - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
-  - yarn install --immutable
-  image: grafana/build-container:1.4.8
-  name: initialize
-- commands:
   - apt-get update
   - apt-get install -yq postgresql-client
   - dockerize -wait tcp://postgres:5432 -timeout 120s
@@ -4499,6 +4489,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 0140292b5e609a2db7f55c930a9072d5bd1afa92ebd6043ed10314119413c331
+hmac: b4299fa8508831f597ab67483a6fbf23f2371fa51aa5b1cb2d64bd8d9f7a7203
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -895,16 +895,6 @@ steps:
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
 - commands:
-  - echo $DRONE_RUNNER_NAME
-  image: alpine:3.14.3
-  name: identify-runner
-- commands:
-  - make gen-go
-  - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
-  - yarn install --immutable
-  image: grafana/build-container:1.4.8
-  name: initialize
-- commands:
   - apt-get update
   - apt-get install -yq postgresql-client
   - dockerize -wait tcp://postgres:5432 -timeout 120s
@@ -4489,6 +4479,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: b4299fa8508831f597ab67483a6fbf23f2371fa51aa5b1cb2d64bd8d9f7a7203
+hmac: 39bd9bda630c4071f354cb8f5192a84b37fadfd588fc13cc48bc5f0c036c163a
 
 ...

--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -98,7 +98,7 @@ def get_steps(edition, is_downstream=False):
 
     # Insert remaining steps
     build_steps.extend([
-        package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2, is_downstream=is_downstream),        
+        package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2, is_downstream=is_downstream),
         e2e_tests_server_step(edition=edition),
         e2e_tests_step('dashboards-suite', edition=edition),
         e2e_tests_step('smoke-tests-suite', edition=edition),
@@ -180,7 +180,7 @@ def main_pipelines(edition):
         ),
         pipeline(
             name='main-integration-tests', edition=edition, trigger=trigger, services=services,
-            steps=[download_grabpl_step()] + initialize_step(edition, platform='linux', ver_mode=ver_mode) + integration_test_steps,
+            steps=[download_grabpl_step()] + integration_test_steps,
             volumes=volumes,
         ),
         pipeline(

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -128,7 +128,7 @@ def pr_pipelines(edition):
                 + build_steps,
         ), pipeline(
             name='pr-integration-tests', edition=edition, trigger=trigger, services=services,
-            steps=[download_grabpl_step()] + initialize_step(edition, platform='linux', ver_mode=ver_mode) + integration_test_steps,
+            steps=[download_grabpl_step()] + integration_test_steps,
             volumes=volumes,
         ),
     ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes `initialize` step from integration tests pipeline, as only `grabpl` should be needed.
