### PR TITLE
Tempo: Don't show error when running query without traceId

### DIFF
--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -13,7 +13,7 @@ import {
   storeLogsVolumeDataProviderAction,
 } from './query';
 import { ExploreId, ExploreItemState, StoreState, ThunkDispatch } from 'app/types';
-import { interval, Observable, of } from 'rxjs';
+import { EMPTY, interval, lastValueFrom, Observable, of } from 'rxjs';
 import {
   ArrayVector,
   DataFrame,
@@ -91,16 +91,25 @@ function setupQueryResponse(state: StoreState) {
 
 describe('runQueries', () => {
   it('should pass dataFrames to state even if there is error in response', async () => {
-    setTimeSrv({
-      init() {},
-    } as any);
-    const { dispatch, getState }: { dispatch: ThunkDispatch; getState: () => StoreState } = configureStore({
+    setTimeSrv({ init() {} } as any);
+    const { dispatch, getState } = configureStore({
       ...(defaultInitialState as any),
     });
     setupQueryResponse(getState());
     await dispatch(runQueries(ExploreId.left));
     expect(getState().explore[ExploreId.left].showMetrics).toBeTruthy();
     expect(getState().explore[ExploreId.left].graphResult).toBeDefined();
+  });
+
+  it('should set state to done if query completes without emitting', async () => {
+    setTimeSrv({ init() {} } as any);
+    const { dispatch, getState } = configureStore({
+      ...(defaultInitialState as any),
+    });
+    (getState().explore[ExploreId.left].datasourceInstance?.query as Mock).mockReturnValueOnce(EMPTY);
+    await dispatch(runQueries(ExploreId.left));
+    await new Promise((resolve) => setTimeout(() => resolve(''), 500));
+    expect(getState().explore[ExploreId.left].queryResponse.state).toBe(LoadingState.Done);
   });
 });
 

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -13,7 +13,7 @@ import {
   storeLogsVolumeDataProviderAction,
 } from './query';
 import { ExploreId, ExploreItemState, StoreState, ThunkDispatch } from 'app/types';
-import { EMPTY, interval, lastValueFrom, Observable, of } from 'rxjs';
+import { EMPTY, interval, Observable, of } from 'rxjs';
 import {
   ArrayVector,
   DataFrame,

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -449,8 +449,8 @@ export const runQueries = (
             )
           )
         )
-        .subscribe(
-          (data) => {
+        .subscribe({
+          next(data) {
             dispatch(queryStreamUpdatedAction({ exploreId, response: data }));
 
             // Keep scanning for results if this was the last scanning transaction
@@ -465,12 +465,15 @@ export const runQueries = (
               }
             }
           },
-          (error) => {
+          error(error) {
             dispatch(notifyApp(createErrorNotification('Query processing error', error)));
             dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Error }));
             console.error(error);
-          }
-        );
+          },
+          complete() {
+            dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Done }));
+          },
+        });
 
       if (live) {
         dispatch(

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -43,7 +43,7 @@ describe('Tempo data source', () => {
       })
     );
     const ds = new TempoDatasource(defaultSettings);
-    const response = await lastValueFrom(ds.query({ targets: [{ refId: 'refid1' }] } as any));
+    const response = await lastValueFrom(ds.query({ targets: [{ refId: 'refid1', query: '12345' }] } as any));
 
     expect(
       (response.data[0] as DataFrame).fields.map((f) => ({

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -16,6 +16,15 @@ import { DEFAULT_LIMIT, TempoJsonData, TempoDatasource, TempoQuery } from './dat
 import mockJson from './mockJsonResponse.json';
 
 describe('Tempo data source', () => {
+  it('returns empty response when traceId is empty', async () => {
+    const ds = new TempoDatasource(defaultSettings);
+    const response = await lastValueFrom(
+      ds.query({ targets: [{ refId: 'refid1', queryType: 'traceId', query: '' } as Partial<TempoQuery>] } as any),
+      { defaultValue: 'empty' }
+    );
+    expect(response).toBe('empty');
+  });
+
   it('parses json fields from backend', async () => {
     setupBackendSrv(
       new MutableDataFrame({


### PR DESCRIPTION
fixes: #43675

Adds code to check if query contains traceID, returns empty observable if not.

Also listen on query complete and changes status of the query so we are not stuck on loading state in such cases.