### PR TITLE
Alerting: fix notification channel test

### DIFF
--- a/pkg/services/alerting/test_notification.go
+++ b/pkg/services/alerting/test_notification.go
@@ -33,6 +33,7 @@ func (s *AlertNotificationService) HandleNotificationTestCommand(ctx context.Con
 
 	model := models.AlertNotification{
 		Id:       cmd.ID,
+		OrgId:    cmd.OrgID,
 		Name:     cmd.Name,
 		Type:     cmd.Type,
 		Settings: cmd.Settings,


### PR DESCRIPTION
**What this PR does / why we need it**:

Testing a saved notification channel with secure settings would fail, a detailed breakdown can be read here 👉  https://github.com/grafana/grafana/issues/43214#issuecomment-1004853428

**Which issue(s) this PR fixes**:

Fixes #43214

**Special notes for your reviewer**:

