### PR TITLE
PieChart: Respect percent labels and legends decimal setting

### DIFF
--- a/public/app/plugins/panel/piechart/PieChart.tsx
+++ b/public/app/plugins/panel/piechart/PieChart.tsx
@@ -299,7 +299,7 @@ function PieLabel({ arc, outerRadius, innerRadius, displayLabels, total, color, 
         )}
         {displayLabels.includes(PieChartLabels.Percent) && (
           <tspan x={labelX} dy="1.2em">
-            {((arc.data.display.numeric / total) * 100).toFixed(0) + '%'}
+            {((arc.data.display.numeric / total) * 100).toFixed(arc.data.field.decimals ?? 0) + '%'}
           </tspan>
         )}
       </text>

--- a/public/app/plugins/panel/piechart/PieChartPanel.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.tsx
@@ -123,7 +123,7 @@ function getLegend(props: Props, displayValues: FieldDisplay[]) {
               text:
                 hidden || isNaN(fractionOfTotal)
                   ? props.fieldConfig.defaults.noValue ?? '-'
-                  : percentOfTotal.toFixed(0) + '%',
+                  : percentOfTotal.toFixed(value.field.decimals ?? 0) + '%',
               title: valuesToShow.length > 1 ? 'Percent' : '',
             });
           }


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows the user to display decimals for labels and legends percentage values.

**Which issue(s) this PR fixes**:
Fixes #31991