### PR TITLE
Chore: Remove duplication in npm script

### DIFF
--- a/scripts/build/release-npm-packages.sh
+++ b/scripts/build/release-npm-packages.sh
@@ -51,13 +51,3 @@ if [ $RELEASE_CHANNEL == "latest" ]; then
     npm dist-tag add "$i"@"$PACKAGE_VERSION" next
   done
 fi
-
-# When releasing stable(latest) version of packages we are updating previously published next tag(beta) to be the same version as latest
-if [ $RELEASE_CHANNEL == "latest" ]; then
-  for i in "${PACKAGES[@]}"
-  do
-    :
-    npm dist-tag add "$i"@"$PACKAGE_VERSION" next
-  done
-fi
-


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes duplicated loop to tag `next` npm packages.