### PR TITLE
Package: Add `packages:publishTest` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "packages:publishCanary": "lerna publish from-package --contents dist --dist-tag canary --yes",
     "packages:publishLatest": "lerna publish from-package --contents dist --yes",
     "packages:publishNext": "lerna publish from-package --contents dist --dist-tag next --yes",
+    "packages:publishTest": "lerna publish from-package --contents dist --dist-tag test --yes",
     "packages:publishDev": "lerna publish from-package --contents dist --dist-tag dev --yes --registry http://grafana-npm.local:4873 --force-publish=*",
     "packages:typecheck": "lerna run typecheck",
     "packages:clean": "lerna run clean",

--- a/packages/README.md
+++ b/packages/README.md
@@ -47,6 +47,7 @@ Every commit to main that has changes within the `packages` directory is a subje
 
    - When releasing a prerelease run `packages:publishNext` to publish new versions.
    - When releasing a stable version run `packages:publishLatest` to publish new versions.
+   - When releasing a test version run `packages:publishTest` to publish test versions.
 
 5. Push version commit to the release branch.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `packages:publishTest` lerna command, so we can test npm uploads without breaking latest/next tags.