### PR TITLE
AccessControl: Remove unused error from `GetResourcesMetadata`

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -78,8 +78,7 @@ func (hs *HTTPServer) getDataSourceAccessControlMetadata(c *models.ReqContext, d
 	key := fmt.Sprintf("%d", dsID)
 	dsIDs := map[string]bool{key: true}
 
-	metadata := accesscontrol.GetResourcesMetadata(c.Req.Context(), userPermissions, "datasources", dsIDs)
-	return metadata[key], nil
+	return accesscontrol.GetResourcesMetadata(c.Req.Context(), userPermissions, "datasources", dsIDs)[key], nil
 }
 
 func (hs *HTTPServer) GetDataSourceById(c *models.ReqContext) response.Response {

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -78,12 +78,8 @@ func (hs *HTTPServer) getDataSourceAccessControlMetadata(c *models.ReqContext, d
 	key := fmt.Sprintf("%d", dsID)
 	dsIDs := map[string]bool{key: true}
 
-	metadata, err := accesscontrol.GetResourcesMetadata(c.Req.Context(), userPermissions, "datasources", dsIDs)
-	if err != nil {
-		return nil, err
-	}
-
-	return metadata[key], err
+	metadata := accesscontrol.GetResourcesMetadata(c.Req.Context(), userPermissions, "datasources", dsIDs)
+	return metadata[key], nil
 }
 
 func (hs *HTTPServer) GetDataSourceById(c *models.ReqContext) response.Response {

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -115,7 +115,7 @@ func (hs *HTTPServer) getUserAccessControlMetadata(c *models.ReqContext, resourc
 		return nil, err
 	}
 
-	return accesscontrol.GetResourcesMetadata(c.Req.Context(), userPermissions, "users", resourceIDs)
+	return accesscontrol.GetResourcesMetadata(c.Req.Context(), userPermissions, "users", resourceIDs), nil
 }
 
 // GET /api/orgs/:orgId/users

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -68,7 +68,6 @@ func (hs *HTTPServer) getGlobalUserAccessControlMetadata(c *models.ReqContext, u
 	key := fmt.Sprintf("%d", userID)
 	userIDs := map[string]bool{key: true}
 
-	metadata := accesscontrol.GetResourcesMetadata(c.Req.Context(), userPermissions, "global:users", userIDs)
 	return accesscontrol.GetResourcesMetadata(c.Req.Context(), userPermissions, "global:users", userIDs)[key], nil
 }
 

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -68,12 +68,8 @@ func (hs *HTTPServer) getGlobalUserAccessControlMetadata(c *models.ReqContext, u
 	key := fmt.Sprintf("%d", userID)
 	userIDs := map[string]bool{key: true}
 
-	metadata, err := accesscontrol.GetResourcesMetadata(c.Req.Context(), userPermissions, "global:users", userIDs)
-	if err != nil {
-		return nil, err
-	}
-
-	return metadata[key], err
+	metadata := accesscontrol.GetResourcesMetadata(c.Req.Context(), userPermissions, "global:users", userIDs)
+	return metadata[key], nil
 }
 
 // GET /api/users/lookup

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -69,7 +69,7 @@ func (hs *HTTPServer) getGlobalUserAccessControlMetadata(c *models.ReqContext, u
 	userIDs := map[string]bool{key: true}
 
 	metadata := accesscontrol.GetResourcesMetadata(c.Req.Context(), userPermissions, "global:users", userIDs)
-	return metadata[key], nil
+	return accesscontrol.GetResourcesMetadata(c.Req.Context(), userPermissions, "global:users", userIDs)[key], nil
 }
 
 // GET /api/users/lookup

--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -146,7 +146,7 @@ func addActionToMetadata(allMetadata map[string]Metadata, action, id string) map
 }
 
 // GetResourcesMetadata returns a map of accesscontrol metadata, listing for each resource, users available actions
-func GetResourcesMetadata(ctx context.Context, permissions []*Permission, resource string, resourceIDs map[string]bool) (map[string]Metadata, error) {
+func GetResourcesMetadata(ctx context.Context, permissions []*Permission, resource string, resourceIDs map[string]bool) map[string]Metadata {
 	allScope := GetResourceAllScope(resource)
 	allIDScope := GetResourceAllIDScope(resource)
 
@@ -171,5 +171,5 @@ func GetResourcesMetadata(ctx context.Context, permissions []*Permission, resour
 		}
 	}
 
-	return result, nil
+	return result
 }

--- a/pkg/services/accesscontrol/accesscontrol_bench_test.go
+++ b/pkg/services/accesscontrol/accesscontrol_bench_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func setupTestEnv(b *testing.B, resourceCount, permissionPerResource int) ([]*Permission, map[string]bool) {
@@ -31,10 +30,8 @@ func benchGetMetadata(b *testing.B, resourceCount, permissionPerResource int) {
 	b.ResetTimer()
 
 	var metadata map[string]Metadata
-	var err error
 	for n := 0; n < b.N; n++ {
-		metadata, err = GetResourcesMetadata(context.Background(), permissions, "resources", ids)
-		require.NoError(b, err)
+		metadata = GetResourcesMetadata(context.Background(), permissions, "resources", ids)
 		assert.Len(b, metadata, resourceCount)
 		for _, resourceMetadata := range metadata {
 			assert.Len(b, resourceMetadata, permissionPerResource)
@@ -53,7 +50,7 @@ func BenchmarkGetResourcesMetadata_10_1000000(b *testing.B) {
 	benchGetMetadata(b, 10, 1000000)
 } // ~3.89s/op
 
-// Lots of resources (worst case)
+// Lots of resources
 func BenchmarkGetResourcesMetadata_1000_10(b *testing.B)   { benchGetMetadata(b, 1000, 10) }   // ~0,0023s/op
 func BenchmarkGetResourcesMetadata_10000_10(b *testing.B)  { benchGetMetadata(b, 10000, 10) }  // ~0.021s/op
 func BenchmarkGetResourcesMetadata_100000_10(b *testing.B) { benchGetMetadata(b, 100000, 10) } // ~0.22s/op

--- a/pkg/services/accesscontrol/accesscontrol_test.go
+++ b/pkg/services/accesscontrol/accesscontrol_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGetResourcesMetadata(t *testing.T) {
@@ -95,9 +94,7 @@ func TestGetResourcesMetadata(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			metadata, err := GetResourcesMetadata(context.Background(), tt.permissions, tt.resource, tt.resourcesIDs)
-			require.NoError(t, err)
-
+			metadata := GetResourcesMetadata(context.Background(), tt.permissions, tt.resource, tt.resourcesIDs)
 			assert.EqualValues(t, tt.expected, metadata)
 		})
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Noticed that I returned an error for `GetResourcesMetadata` which is always `nil`. Hence this PR intends to remove it.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

