### PR TITLE
Alerting: run validation before testing contact point

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
@@ -37,7 +37,7 @@ export function ChannelSubForm<R extends ChannelValues>({
 }: Props<R>): JSX.Element {
   const styles = useStyles2(getStyles);
   const name = (fieldName: string) => `${pathPrefix}${fieldName}`;
-  const { control, watch, register } = useFormContext();
+  const { control, watch, register, trigger, formState } = useFormContext();
   const selectedType = watch(name('type')) ?? defaultValues.type; // nope, setting "default" does not work at all.
   const { loading: testingReceiver } = useUnifiedAlertingSelector((state) => state.testReceivers);
 
@@ -65,6 +65,15 @@ export function ChannelSubForm<R extends ChannelValues>({
         .sort((a, b) => a.label.localeCompare(b.label)),
     [notifiers]
   );
+
+  const handleTest = async () => {
+    await trigger();
+    const isValid = Object.keys(formState.errors).length === 0;
+
+    if (isValid && onTest) {
+      onTest();
+    }
+  };
 
   const notifier = notifiers.find(({ type }) => type === selectedType);
   // if there are mandatory options defined, optional options will be hidden by a collapse
@@ -105,7 +114,7 @@ export function ChannelSubForm<R extends ChannelValues>({
                 size="xs"
                 variant="secondary"
                 type="button"
-                onClick={() => onTest()}
+                onClick={() => handleTest()}
                 icon={testingReceiver ? 'fa fa-spinner' : 'message'}
               >
                 Test


### PR DESCRIPTION
**What this PR does / why we need it**:

The current "Test" button for contact points does not validate the input form before sending API requests; since we're also not handling the error response gracefully I've opted to run a manual front-end form validation before presenting the test modal.

https://user-images.githubusercontent.com/868844/148243823-204c5931-570b-4480-b3da-ce3b52b6966f.mov

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

