### PR TITLE
Input: Fix margins when not using prefix/suffix

### DIFF
--- a/packages/grafana-ui/src/components/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Input/Input.tsx
@@ -58,8 +58,8 @@ export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
           className={styles.input}
           {...restProps}
           style={{
-            paddingLeft: prefixRect ? prefixRect.width + 12 : undefined,
-            paddingRight: suffixRect && (suffix || loading) ? suffixRect.width + 12 : undefined,
+            paddingLeft: prefix ? prefixRect.width + 12 : undefined,
+            paddingRight: suffix || loading ? suffixRect.width + 12 : undefined,
           }}
         />
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
I think https://github.com/grafana/grafana/pull/39746/files introduced a visual bug for which a padding in the `Input` component gets rendered regardless of It having any suffix/prefix:
<img width="366" alt="Screenshot 2022-01-05 at 17 52 53" src="https://user-images.githubusercontent.com/1170767/148258701-5d782f56-c6c7-4532-b2d0-2a7e863d5b03.png">
instead of:
<img width="353" alt="Screenshot 2022-01-05 at 17 53 15" src="https://user-images.githubusercontent.com/1170767/148258806-08cf7e6c-3991-402a-a8b8-b869b87cddca.png">

As you can see in the following screenshot, the content of the inputs compared to the select is a bit off:
<img width="457" alt="Screenshot 2022-01-05 at 17 42 56" src="https://user-images.githubusercontent.com/1170767/148255910-36b0cd9d-ffcb-44bb-8c4c-0b107b727254.png">

This PR changes it so that the padding is only added where prefix or suffix are set:
<img width="432" alt="Screenshot 2022-01-05 at 17 43 08" src="https://user-images.githubusercontent.com/1170767/148256064-bfdea913-4177-4250-b22e-8a12abd22daf.png">


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

N/A

**Special notes for your reviewer**:

currently in storybook it's not possible to render suffix/prefix via controls, I didn't check why this is happening, pinging @thisisobate as i think you recently implemented them.

