### PR TITLE
Github Actions: another fix for the levitate workflow

### DIFF
--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Persisting the check output
       run: |
           mkdir -p ./levitate
-          echo "{ \"exit_code\": ${{ steps.breaking-changes.outputs.is_breaking }}, \"message\": \"${{ steps.breaking-changes.outputs.message }}\", \"job_link\": \"${{ steps.job.outputs.link }}#step:${GITHUB_STEP_NUMBER}\" }" > ./levitate/result.json
+          echo "{ \"exit_code\": ${{ steps.breaking-changes.outputs.is_breaking }}, \"message\": \"${{ steps.breaking-changes.outputs.message }}\", \"job_link\": \"${{ steps.job.outputs.link }}#step:${GITHUB_STEP_NUMBER}:1\" }" > ./levitate/result.json
 
     - name: Upload check output as artifact
       uses: actions/upload-artifact@v2

--- a/scripts/check-breaking-changes.sh
+++ b/scripts/check-breaking-changes.sh
@@ -39,7 +39,7 @@ while IFS= read -r line; do
     if [ $STATUS -gt 0 ]
     then
         EXIT_CODE=1
-        GITHUB_MESSAGE="${GITHUB_MESSAGE}**\`${PACKAGE_NAME}\`** has possible breaking changes ([more info](${GITHUB_JOB_LINK}#step:${GITHUB_STEP_NUMBER}:1))<br />"    
+        GITHUB_MESSAGE="${GITHUB_MESSAGE}**\\\`${PACKAGE_NAME}\\\`** has possible breaking changes ([more info](${GITHUB_JOB_LINK}#step:${GITHUB_STEP_NUMBER}:1))<br />"    
     fi    
 
 done <<< "$PACKAGES"


### PR DESCRIPTION
### What changed?
- fixed a link to the console messages (missed the column number and Github couldn't handle it)
- fixed an escaping issue for showing the affected package name

|  **Before**  |    **After**    |
|--------------|-----------------|
| ![Screenshot 2022-01-06 at 11 29 55](https://user-images.githubusercontent.com/9974811/148369197-6f2805c0-73a8-483d-ab06-09c415e3ceb2.png) | ![Screenshot 2022-01-06 at 11 30 51](https://user-images.githubusercontent.com/9974811/148369209-f41d8b3c-999f-4ef8-ac66-ad5fd7850fbc.png) |

**Previous PRs:** 
- https://github.com/grafana/grafana/pull/43188
- https://github.com/grafana/grafana/pull/43621
- https://github.com/grafana/grafana/pull/43646
- https://github.com/grafana/grafana/pull/43659
