### PR TITLE
Postgres: Fix test datasource always returns success

### DIFF
--- a/public/app/plugins/datasource/postgres/datasource.test.ts
+++ b/public/app/plugins/datasource/postgres/datasource.test.ts
@@ -1,0 +1,66 @@
+import { backendSrv } from 'app/core/services/backend_srv';
+import { of, throwError } from 'rxjs';
+import { createFetchResponse } from 'test/helpers/createFetchResponse';
+import { PostgresDatasource } from './datasource';
+
+jest.mock('@grafana/runtime', () => ({
+  ...(jest.requireActual('@grafana/runtime') as any),
+  getBackendSrv: () => backendSrv,
+  getTemplateSrv: () => ({
+    replace: (val: string): string => {
+      return val;
+    },
+  }),
+}));
+
+describe('Postgres datasource', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when performing testDatasource call', () => {
+    it('should return the error from the server', async () => {
+      setupFetchMock(
+        undefined,
+        throwError(() => ({
+          status: 400,
+          statusText: 'Bad Request',
+          data: {
+            results: {
+              meta: {
+                error: 'db query error: pq: password authentication failed for user "postgres"',
+                frames: [
+                  {
+                    schema: {
+                      refId: 'meta',
+                      meta: {
+                        executedQueryString: 'SELECT 1',
+                      },
+                      fields: [],
+                    },
+                    data: {
+                      values: [],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        }))
+      );
+
+      const ds = new PostgresDatasource({ name: '', id: 0, jsonData: {} } as any);
+      const result = await ds.testDatasource();
+      expect(result.status).toEqual('error');
+      expect(result.message).toEqual('db query error: pq: password authentication failed for user "postgres"');
+    });
+  });
+});
+
+function setupFetchMock(response: any, mock?: any) {
+  const defaultMock = () => mock ?? of(createFetchResponse(response));
+
+  const fetchMock = jest.spyOn(backendSrv, 'fetch');
+  fetchMock.mockImplementation(defaultMock);
+  return fetchMock;
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr fixes the test datasource issue that it returned success always.

**Which issue(s) this PR fixes**:

Fixes #43638
Fixes https://github.com/grafana/support-escalations/issues/1641

**Special notes for your reviewer**:

