### PR TITLE
Tempo: Provide tag value completion items while typing value

### DIFF
--- a/public/app/plugins/datasource/tempo/language_provider.ts
+++ b/public/app/plugins/datasource/tempo/language_provider.ts
@@ -37,7 +37,10 @@ export default class TempoLanguageProvider extends LanguageProvider {
     if (!value) {
       return emptyResult;
     }
-    if (text === '=') {
+
+    const query = value.endText.getText();
+    const isValue = query[query.indexOf(text) - 1] === '=';
+    if (isValue || text === '=') {
       return this.getTagValueCompletionItems(value);
     }
     return this.getTagsCompletionItems();
@@ -58,19 +61,17 @@ export default class TempoLanguageProvider extends LanguageProvider {
   };
 
   async getTagValueCompletionItems(value: Value) {
-    const tagNames = value.endText.getText().split(' ');
-    let tagName = tagNames[0];
-    // Get last item if multiple tags
-    if (tagNames.length > 1) {
-      tagName = tagNames[tagNames.length - 1];
-    }
-    tagName = tagName.slice(0, -1);
+    const tags = value.endText.getText().split(' ');
+
+    let tagName = tags[tags.length - 1] ?? '';
+    tagName = tagName.split('=')[0];
+
     const response = await this.request(`/api/search/tag/${tagName}/values`, []);
     const suggestions: CompletionItemGroup[] = [];
 
     if (response && response.tagValues) {
       suggestions.push({
-        label: `TagValues`,
+        label: `Tag Values`,
         items: response.tagValues.map((tagValue: string) => ({ label: tagValue })),
       });
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Originally, tempo search provided tag values only after entering an '=', so when the user kept typing the value, it would revert to showing tag options for the autocomplete. Now, it more accurately checks whether the user it typing a value (after an =, before another space). 

**Which issue(s) this PR fixes**:
Fixes #43715

**Special notes for your reviewer**:

