### PR TITLE
Use stack trace context in XORM trace logger

### DIFF
--- a/pkg/infra/log/log.go
+++ b/pkg/infra/log/log.go
@@ -29,9 +29,9 @@ var filters map[string]level.Option
 var Root MultiLoggers
 
 const (
+	// top 7 calls in the stack are within logger
 	DefaultCallerDepth = 7
 	CallerContextKey   = "caller"
-	StackContextKey    = "stack"
 )
 
 func init() {

--- a/pkg/infra/log/log.go
+++ b/pkg/infra/log/log.go
@@ -145,6 +145,28 @@ func New(ctx ...interface{}) MultiLoggers {
 	return newloger
 }
 
+func with(loggers MultiLoggers, withFunc func(gokitlog.Logger, ...interface{}) gokitlog.Logger, ctx []interface{}) MultiLoggers {
+	if len(ctx) == 0 {
+		return loggers
+	}
+	var newloger MultiLoggers
+	for _, l := range loggers.loggers {
+		l.val = withFunc(l.val, ctx...)
+		newloger.loggers = append(newloger.loggers, l)
+	}
+	return newloger
+}
+
+// WithPrefix adds context that will be added to the log message
+func WithPrefix(loggers MultiLoggers, ctx ...interface{}) MultiLoggers {
+	return with(loggers, gokitlog.WithPrefix, ctx)
+}
+
+// WithSuffix adds context that will be appended at the end of the log message
+func WithSuffix(loggers MultiLoggers, ctx ...interface{}) MultiLoggers {
+	return with(loggers, gokitlog.WithSuffix, ctx)
+}
+
 var logLevels = map[string]level.Option{
 	"trace":    level.AllowDebug(),
 	"debug":    level.AllowDebug(),

--- a/pkg/infra/log/log.go
+++ b/pkg/infra/log/log.go
@@ -106,22 +106,9 @@ func (ml MultiLoggers) Log(keyvals ...interface{}) error {
 	return nil
 }
 
-// we need to implement new function for multiloggers
+// New creates a new logger from the existing one with additional context
 func (ml MultiLoggers) New(ctx ...interface{}) MultiLoggers {
-	var newloger MultiLoggers
-	for _, logWithFilter := range ml.loggers {
-		logWithFilter.val = gokitlog.With(logWithFilter.val, ctx)
-		if len(ctx) > 0 {
-			v, ok := logWithFilter.filters[ctx[0].(string)]
-			if ok {
-				logWithFilter.val = level.NewFilter(logWithFilter.val, v)
-			} else {
-				logWithFilter.val = level.NewFilter(logWithFilter.val, logWithFilter.maxLevel)
-			}
-		}
-		newloger.loggers = append(newloger.loggers, logWithFilter)
-	}
-	return newloger
+	return with(ml, gokitlog.With, ctx)
 }
 
 // New creates MultiLoggers with the provided context and caller that is added as a suffix.

--- a/pkg/login/social/generic_oauth_test.go
+++ b/pkg/login/social/generic_oauth_test.go
@@ -7,15 +7,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/log/level"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/log/level"
 )
 
 func newLogger(name string, lev string) log.Logger {
-	logger := log.Root.New("logger", name)
+	logger := log.New(name)
 	logger.AddLogger(logger, lev, map[string]level.Option{})
 	return logger
 }

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -374,7 +374,7 @@ func (ss *SQLStore) initEngine(engine *xorm.Engine) error {
 		engine.SetLogger(&xorm.DiscardLogger{})
 	} else {
 		// add stack to database calls to be able to see what repository initiated queries. Top 7 items from the stack as they are likely in the xorm library.
-		engine.SetLogger(NewXormLogger(log.LvlInfo, log.WithSuffix(log.New("sqlstore.xorm"), log.StackContextKey, log.StackCaller(7))))
+		engine.SetLogger(NewXormLogger(log.LvlInfo, log.WithSuffix(log.New("sqlstore.xorm"), log.CallerContextKey, log.StackCaller(log.DefaultCallerDepth))))
 		engine.ShowSQL(true)
 		engine.ShowExecTime(true)
 	}

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -12,6 +12,9 @@ import (
 	"time"
 
 	"github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
+	"xorm.io/xorm"
+
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/fs"
 	"github.com/grafana/grafana/pkg/infra/localcache"
@@ -25,8 +28,6 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/errutil"
-	_ "github.com/lib/pq"
-	"xorm.io/xorm"
 )
 
 var (
@@ -372,7 +373,8 @@ func (ss *SQLStore) initEngine(engine *xorm.Engine) error {
 	if !debugSQL {
 		engine.SetLogger(&xorm.DiscardLogger{})
 	} else {
-		engine.SetLogger(NewXormLogger(log.LvlInfo, log.New("sqlstore.xorm")))
+		// add stack to database calls to be able to see what repository initiated queries. Top 7 items from the stack as they are likely in the xorm library.
+		engine.SetLogger(NewXormLogger(log.LvlInfo, log.WithSuffix(log.New("sqlstore.xorm"), log.StackContextKey, log.StackCaller(7))))
 		engine.ShowSQL(true)
 		engine.ShowExecTime(true)
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR adds a few improvements to the logger 
1. adds stack trace context to XORM logger. This can be useful to quickly identify the place where the log message comes from.  I set it to ignore top 7 calls as they are all in the logger.
```
logger=sqlstore.xorm t=2022-01-10T17:02:58.09-0500 lvl=info msg="[SQL] INSERT INTO `kv_store` (`org_id`,`namespace`,`key`,`value`,`created`,`updated`) VALUES (?, ?, ?, ?, ?, ?) []interface {}{1, \"alertmanager\", \"silences\", \"\", \"2022-01-10 17:02:58\", \"2022-01-10 17:02:58\"} - took: 1.1867ms" stack="[session_raw.go:180 session_insert.go:555 session_insert.go:93 sql.go:79 transactions.go:45 transactions.go:19 sql.go:47 kvstore.go:51 file_store.go:78 alertmanager.go:186 silence.go:389 silence.go:410 alertmanager.go:185]"
```

2. Adds WithPrefix and WithSuffix functions that do the same as the corresponding go-kit implementation.
3. Update function MultiLoggers.New to not add a filter on top of the existing one because that function is not used to produce logger with new `logger` in the context. Instead, it is used to create a logger with additional context.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**: