### PR TITLE
Package: Add `packages:publishPrevious` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "packages:publishLatest": "lerna publish from-package --contents dist --yes",
     "packages:publishNext": "lerna publish from-package --contents dist --dist-tag next --yes",
     "packages:publishTest": "lerna publish from-package --contents dist --dist-tag test --yes",
+    "packages:publishPrevious": "lerna publish from-package --contents dist --dist-tag previous --yes",
     "packages:publishDev": "lerna publish from-package --contents dist --dist-tag dev --yes --registry http://grafana-npm.local:4873 --force-publish=*",
     "packages:typecheck": "lerna run typecheck",
     "packages:clean": "lerna run clean",


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `packages:publishPrevious`, so npm packages can be tagged as `previous`, for releases that are not latest.
