### PR TITLE
Hotkeys: Make time range absolute/permanent

### DIFF
--- a/public/app/core/components/help/HelpModal.tsx
+++ b/public/app/core/components/help/HelpModal.tsx
@@ -40,6 +40,10 @@ const shortcuts = {
       keys: ['t', '→'],
       description: 'Move time range forward',
     },
+    {
+      keys: ['t', 'a'],
+      description: 'Make time range absolute/permanent',
+    },
   ],
 };
 

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -14,6 +14,7 @@ import {
   ShiftTimeEventPayload,
   ShowModalReactEvent,
   ZoomOutEvent,
+  AbsoluteTimeEvent,
 } from '../../types/events';
 import { contextSrv } from '../core';
 import { getDatasourceSrv } from '../../features/plugins/datasource_srv';
@@ -34,6 +35,7 @@ export class KeybindingSrv {
       this.bind('g a', this.openAlerting);
       this.bind('g p', this.goToProfile);
       this.bind('s o', this.openSearch);
+      this.bind('t a', this.makeAbsoluteTime);
       this.bind('f', this.openSearch);
       this.bind('esc', this.exit);
       this.bindGlobal('esc', this.globalEsc);
@@ -87,6 +89,10 @@ export class KeybindingSrv {
 
   private goToProfile() {
     locationService.push('/profile');
+  }
+
+  private makeAbsoluteTime() {
+    appEvents.publish(new AbsoluteTimeEvent());
   }
 
   private showHelpModal() {

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -14,7 +14,7 @@ import { getShiftedTimeRange, getZoomedTimeRange } from 'app/core/utils/timePick
 import { config } from 'app/core/config';
 import { getRefreshFromUrl } from '../utils/getRefreshFromUrl';
 import { locationService } from '@grafana/runtime';
-import { ShiftTimeEvent, ShiftTimeEventPayload, ZoomOutEvent } from '../../../types/events';
+import { AbsoluteTimeEvent, ShiftTimeEvent, ShiftTimeEventPayload, ZoomOutEvent } from '../../../types/events';
 import { contextSrv, ContextSrv } from 'app/core/services/context_srv';
 import appEvents from 'app/core/app_events';
 
@@ -39,6 +39,10 @@ export class TimeSrv {
 
     appEvents.subscribe(ShiftTimeEvent, (e) => {
       this.shiftTime(e.payload);
+    });
+
+    appEvents.subscribe(AbsoluteTimeEvent, () => {
+      this.makeAbsoluteTime();
     });
 
     document.addEventListener('visibilitychange', () => {
@@ -346,6 +350,16 @@ export class TimeSrv {
       from: toUtc(from),
       to: toUtc(to),
     });
+  }
+
+  makeAbsoluteTime() {
+    const params = locationService.getSearch();
+    if (params.get('left')) {
+      return; // explore handles this;
+    }
+
+    const { from, to } = this.timeRange();
+    this.setTime({ from, to });
   }
 
   // isRefreshOutsideThreshold function calculates the difference between last refresh and now

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -37,6 +37,7 @@ const dummyProps: Props = {
   isLive: false,
   syncedTimes: false,
   updateTimeRange: jest.fn(),
+  makeAbsoluteTime: jest.fn(),
   graphResult: [],
   absoluteRange: {
     from: 0,

--- a/public/app/features/explore/state/time.ts
+++ b/public/app/features/explore/state/time.ts
@@ -128,6 +128,29 @@ export function syncTimes(exploreId: ExploreId): ThunkResult<void> {
 }
 
 /**
+ * Forces the timepicker's time into absolute time.
+ * The conversion is applied to all Explore panes.
+ * Useful to produce a bookmarkable URL that points to the same data.
+ */
+export function makeAbsoluteTime(): ThunkResult<void> {
+  return (dispatch, getState) => {
+    const timeZone = getTimeZone(getState().user);
+    const fiscalYearStartMonth = getFiscalYearStartMonth(getState().user);
+    const leftState = getState().explore.left;
+    const leftRange = getTimeRange(timeZone, leftState.range.raw, fiscalYearStartMonth);
+    const leftAbsoluteRange: AbsoluteTimeRange = { from: leftRange.from.valueOf(), to: leftRange.to.valueOf() };
+    dispatch(updateTime({ exploreId: ExploreId.left, absoluteRange: leftAbsoluteRange }));
+    const rightState = getState().explore.right!;
+    if (rightState) {
+      const rightRange = getTimeRange(timeZone, rightState.range.raw, fiscalYearStartMonth);
+      const rightAbsoluteRange: AbsoluteTimeRange = { from: rightRange.from.valueOf(), to: rightRange.to.valueOf() };
+      dispatch(updateTime({ exploreId: ExploreId.right, absoluteRange: rightAbsoluteRange }));
+    }
+    dispatch(stateSave());
+  };
+}
+
+/**
  * Reducer for an Explore area, to be used by the global Explore reducer.
  */
 // Redux Toolkit uses ImmerJs as part of their solution to ensure that state objects are not mutated.

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -144,6 +144,10 @@ export class ShiftTimeEvent extends BusEventWithPayload<ShiftTimeEventPayload> {
   static type = 'shift-time';
 }
 
+export class AbsoluteTimeEvent extends BusEventBase {
+  static type = 'absolute-time';
+}
+
 export class RemovePanelEvent extends BusEventWithPayload<number> {
   static type = 'remove-panel';
 }


### PR DESCRIPTION
Typing `t a` in Explore or Dashboards will turn a relative time like "Last 1 hour"
into an absolute range to make the URL permanent, so that when sharing it others
will see the same data.

- registered `t a` in key service
- new `AbsoluteTimeEvent` dispatch via global event bus
- dashboard times handled in TimeSrv
- Explore times handled in Explore.tsx and Explore's time reducer
- added `t a` to help screen

I could not find an easy way to combine time handling for Exlore and Dashboard in one place.

Fixes #37893
Supersedes #37899

CC @owen-d 
