### PR TITLE
Tempo: Add time range to tempo search query behind a feature flag

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -49,6 +49,7 @@ export interface FeatureToggles {
   accesscontrol: boolean;
   tempoServiceGraph: boolean;
   tempoSearch: boolean;
+  tempoBackendSearch: boolean;
   recordedQueries: boolean;
   newNavigation: boolean;
   fullRangeLogsVolume: boolean;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -66,6 +66,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
     trimDefaults: false,
     tempoServiceGraph: false,
     tempoSearch: false,
+    tempoBackendSearch: false,
     recordedQueries: false,
     newNavigation: false,
     fullRangeLogsVolume: false,

--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -136,8 +136,15 @@ class TempoQueryFieldComponent extends React.PureComponent<Props, State> {
         {query.queryType === 'nativeSearch' && (
           <p style={{ maxWidth: '65ch' }}>
             <Badge icon="rocket" text="Beta" color="blue" />
-            &nbsp;Tempo search is currently in beta and is designed to return recent traces only. It ignores the time
-            range picker. We are actively working on full backend search. Look for improvements in the near future!
+            {config.featureToggles.tempoBackendSearch ? (
+              <>&nbsp;Tempo search is currently in beta.</>
+            ) : (
+              <>
+                &nbsp;Tempo search is currently in beta and is designed to return recent traces only. It ignores the
+                time range picker. We are actively working on full backend search. Look for improvements in the near
+                future!
+              </>
+            )}
           </p>
         )}
         {query.queryType === 'search' && (

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -178,6 +178,24 @@ describe('Tempo data source', () => {
     });
   });
 
+  it('should include time range if provided', () => {
+    const ds = new TempoDatasource(defaultSettings);
+    const tempoQuery: TempoQuery = {
+      queryType: 'search',
+      refId: 'A',
+      query: '',
+      search: '',
+    };
+    const timeRange = { startTime: 0, endTime: 1000 };
+    const builtQuery = ds.buildSearchQuery(tempoQuery, timeRange);
+    expect(builtQuery).toStrictEqual({
+      tags: '',
+      limit: DEFAULT_LIMIT,
+      start: timeRange.startTime,
+      end: timeRange.endTime,
+    });
+  });
+
   it('formats native search query history correctly', () => {
     const ds = new TempoDatasource(defaultSettings);
     const tempoQuery: TempoQuery = {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds time range to the tempo search query which is required to start testing full backend search. Should be in unix seconds. endTime may be undefined.

**Which issue(s) this PR fixes**:
Fixes #

Here's an example query. Notice the corresponding time range in the url in milliseconds. 
![Screen Shot 2022-01-07 at 9 16 48 AM](https://user-images.githubusercontent.com/12838032/148573818-b6898322-92f7-4748-afb3-2d7e66785594.png)

