### PR TITLE
Prometheus: Create name fields based on targets length

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.test.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.test.ts
@@ -141,7 +141,7 @@ describe('Prometheus Result Transformer', () => {
       expect(series.data[0].fields[2].name).toEqual('label2');
       expect(series.data[0].fields[3].name).toEqual('label3');
       expect(series.data[0].fields[4].name).toEqual('label4');
-      expect(series.data[0].fields[5].name).toEqual('Value #A');
+      expect(series.data[0].fields[5].name).toEqual('Value');
       expect(series.data[0].meta?.preferredVisualisationType).toEqual('table');
     });
 

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -122,10 +122,11 @@ export function transformDFToTable(dfs: DataFrame[]): DataFrame[] {
 
   // Group results by refId and process dataFrames with the same refId as 1 dataFrame
   const dataFramesByRefId = groupBy(dfs, 'refId');
+  const refIds = Object.keys(dataFramesByRefId);
 
-  const frames = Object.keys(dataFramesByRefId).map((refId) => {
+  const frames = refIds.map((refId) => {
     // Create timeField, valueField and labelFields
-    const valueText = getValueText(dfs.length, refId);
+    const valueText = getValueText(refIds.length, refId);
     const valueField = getValueField({ data: [], valueName: valueText });
     const timeField = getTimeField([]);
     const labelFields: MutableField[] = [];


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the fields name was created based on number of dataframes, but it should be created based on number of targets (refIds)
