### PR TITLE
Explore: Don't change query status to Done if there was Error

### DIFF
--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -471,7 +471,12 @@ export const runQueries = (
             console.error(error);
           },
           complete() {
-            dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Done }));
+            // In case we don't get any response at all but the observable completed, make sure we stop loading state.
+            // This is for cases when some queries are noop like running first query after load but we don't have any
+            // actual query input.
+            if (getState().explore[exploreId]!.queryResponse.state === LoadingState.Loading) {
+              dispatch(changeLoadingStateAction({ exploreId, loadingState: LoadingState.Done }));
+            }
           },
         });
 


### PR DESCRIPTION
Because of this https://github.com/grafana/grafana/pull/43676, an error would not be visible as we would change Error status to Done after the query is finished. This changes it only when it was Loading so the user knows nothing more is coming.