### PR TITLE
Docs: Update Add support for annotations for backend data sources

### DIFF
--- a/docs/sources/developers/plugins/add-support-for-annotations.md
+++ b/docs/sources/developers/plugins/add-support-for-annotations.md
@@ -24,7 +24,7 @@ To enable annotation support for your data source, add the following two lines o
    }
    ```
 
-2. In `datasource.ts`, override the `annotations` property from `DataSourceApi`. For the default behavior, you can set `annotations` to an empty object.
+2. In `datasource.ts`, override the `annotations` property from `DataSourceApi` (or `DataSourceWithBackend` for backend data sources). For the default behavior, you can set `annotations` to an empty object.
 
    **datasource.ts**
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Although `DataSourceWithBackend` inherits `DataSourceApi` we should make it clear where to add the annotation support for backend data sources.