### PR TITLE
Loki: Allow queries to be made either forward or backward

### DIFF
--- a/packages/grafana-data/src/types/query.ts
+++ b/packages/grafana-data/src/types/query.ts
@@ -1,3 +1,5 @@
+import { LogsSortOrder } from '.';
+
 /**
  * Attached to query results (not persisted)
  *
@@ -51,6 +53,11 @@ export interface DataQuery {
    * For non mixed scenarios this is undefined.
    */
   datasource?: DataSourceRef | null;
+
+  /**
+   * Specify the order in which the returned logs should be displayed initially
+   */
+  defaultLogsSortOrder?: LogsSortOrder;
 }
 
 /**

--- a/public/app/core/logs_model.test.ts
+++ b/public/app/core/logs_model.test.ts
@@ -941,10 +941,10 @@ describe('getSeriesProperties()', () => {
     ] as any;
     const range = { from: 0, to: 30 };
     const result = getSeriesProperties(rows, 3, range, 2, 1);
-    // Bucketsize 6 gets shortened to 4 because of new visible range is 20ms vs original range being 30ms
-    expect(result.bucketSize).toBe(4);
-    // From time is also aligned to bucketSize (divisible by 4)
-    expect(result.visibleRange).toMatchObject({ from: 8, to: 30 });
+    // Bucketsize 6 gets shortened to 2 because of new visible range is 10ms vs original range being 30ms
+    expect(result.bucketSize).toBe(2);
+    // From time is also aligned to bucketSize (divisible by 2)
+    expect(result.visibleRange).toMatchObject({ from: 10, to: 20 });
   });
 });
 

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -257,9 +257,10 @@ export function getSeriesProperties(
   // Clamp time range to visible logs otherwise big parts of the graph might look empty
   if (absoluteRange) {
     const earliestTsLogs = sortedRows[0].timeEpochMs;
+    const latestTsLogs = sortedRows[sortedRows.length - 1].timeEpochMs;
 
     requestedRangeMs = absoluteRange.to - absoluteRange.from;
-    visibleRangeMs = absoluteRange.to - earliestTsLogs;
+    visibleRangeMs = latestTsLogs - earliestTsLogs;
 
     if (visibleRangeMs > 0) {
       // Adjust interval bucket size for potentially shorter visible range
@@ -269,7 +270,8 @@ export function getSeriesProperties(
       bucketSize = Math.max(Math.ceil(resolutionIntervalMs * pxPerBar), minimumBucketSize);
       // makeSeriesForLogs() aligns dataspoints with time buckets, so we do the same here to not cut off data
       const adjustedEarliest = Math.floor(earliestTsLogs / bucketSize) * bucketSize;
-      visibleRange = { from: adjustedEarliest, to: absoluteRange.to };
+      const adjustedLatest = Math.ceil(latestTsLogs / bucketSize) * bucketSize;
+      visibleRange = { from: adjustedEarliest, to: adjustedLatest };
     } else {
       // We use visibleRangeMs to calculate range coverage of received logs. However, some data sources are rounding up range in requests. This means that received logs
       // can (in edge cases) be outside of the requested range and visibleRangeMs < 0. In that case, we want to change visibleRangeMs to be 1 so we can calculate coverage.

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -120,12 +120,16 @@ class UnthemedLogs extends PureComponent<Props, State> {
     }
   }
 
+  getDefaultLogsSortOrder() {
+    const { logsQueries } = this.props;
+    const query = logsQueries?.[0];
+
+    return query?.defaultLogsSortOrder ?? LogsSortOrder.Descending;
+  }
+
   resetLogsSortingOrder = () => {
     this.setState(() => {
-      const { logsQueries } = this.props;
-
-      const query = logsQueries?.[0];
-      return { logsSortOrder: query?.defaultLogsSortOrder ?? LogsSortOrder.Descending };
+      return { logsSortOrder: this.getDefaultLogsSortOrder() };
     });
   };
 
@@ -413,6 +417,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
           </div>
           <LogsNavigation
             logsSortOrder={logsSortOrder}
+            defaultLogsSortOrder={this.getDefaultLogsSortOrder()}
             visibleRange={visibleRange ?? absoluteRange}
             absoluteRange={absoluteRange}
             timeZone={timeZone}

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -112,6 +112,23 @@ class UnthemedLogs extends PureComponent<Props, State> {
     }
   }
 
+  componentDidUpdate(prevProps: Props) {
+    const prevDirection = prevProps.logsQueries?.[0]?.defaultLogsSortOrder;
+    const currentDirection = this.props.logsQueries?.[0]?.defaultLogsSortOrder;
+    if (this.state.logsSortOrder === null || prevDirection !== currentDirection) {
+      this.resetLogsSortingOrder();
+    }
+  }
+
+  resetLogsSortingOrder = () => {
+    this.setState(() => {
+      const { logsQueries } = this.props;
+
+      const query = logsQueries?.[0];
+      return { logsSortOrder: query?.defaultLogsSortOrder ?? LogsSortOrder.Descending };
+    });
+  };
+
   onChangeLogsSortOrder = () => {
     this.setState({ isFlipping: true });
     // we are using setTimeout here to make sure that disabled button is rendered before the rendering of reordered logs

--- a/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
@@ -1,13 +1,13 @@
 // Libraries
 import React, { memo } from 'react';
 // Types
-import { LokiQuery } from '../types';
+import { LokiDirectionType, LokiQuery } from '../types';
 import { LokiQueryField } from './LokiQueryField';
 import { LokiOptionFields } from './LokiOptionFields';
 import LokiDatasource from '../datasource';
 
 interface Props {
-  direction?: 'BACKWARD' | 'FORWARD';
+  direction?: LokiDirectionType;
   expr: string;
   maxLines?: number;
   instant?: boolean;

--- a/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
@@ -36,7 +36,7 @@ export const LokiAnnotationsQueryEditor = memo(function LokiAnnotationQueryEdito
         history={[]}
         ExtraFieldElement={
           <LokiOptionFields
-            queryDirection={queryWithRefId.direction ?? datasource.direction ?? 'BACKWARD'}
+            queryDirection={queryWithRefId.direction ?? datasource.direction}
             lineLimitValue={queryWithRefId?.maxLines?.toString() || ''}
             resolution={queryWithRefId.resolution || 1}
             query={queryWithRefId}

--- a/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
@@ -7,6 +7,7 @@ import { LokiOptionFields } from './LokiOptionFields';
 import LokiDatasource from '../datasource';
 
 interface Props {
+  direction?: 'BACKWARD' | 'FORWARD';
   expr: string;
   maxLines?: number;
   instant?: boolean;
@@ -15,10 +16,11 @@ interface Props {
 }
 
 export const LokiAnnotationsQueryEditor = memo(function LokiAnnotationQueryEditor(props: Props) {
-  const { expr, maxLines, instant, datasource, onChange } = props;
+  const { direction, expr, maxLines, instant, datasource, onChange } = props;
 
   const queryWithRefId: LokiQuery = {
     refId: '',
+    direction,
     expr,
     maxLines,
     instant,
@@ -34,6 +36,7 @@ export const LokiAnnotationsQueryEditor = memo(function LokiAnnotationQueryEdito
         history={[]}
         ExtraFieldElement={
           <LokiOptionFields
+            queryDirection={queryWithRefId.direction ?? datasource.direction ?? 'BACKWARD'}
             lineLimitValue={queryWithRefId?.maxLines?.toString() || ''}
             resolution={queryWithRefId.resolution || 1}
             query={queryWithRefId}

--- a/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
@@ -25,6 +25,7 @@ export function LokiExploreQueryEditor(props: Props) {
       range={range}
       ExtraFieldElement={
         <LokiOptionFields
+          queryDirection={ query.direction ?? datasource.direction ?? 'BACKWARD' }
           lineLimitValue={query?.maxLines?.toString() || ''}
           resolution={query.resolution || 1}
           query={query}

--- a/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
@@ -25,7 +25,7 @@ export function LokiExploreQueryEditor(props: Props) {
       range={range}
       ExtraFieldElement={
         <LokiOptionFields
-          queryDirection={ query.direction ?? datasource.direction ?? 'BACKWARD' }
+          queryDirection={query.direction ?? datasource.direction ?? 'BACKWARD'}
           lineLimitValue={query?.maxLines?.toString() || ''}
           resolution={query.resolution || 1}
           query={query}

--- a/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
@@ -25,7 +25,7 @@ export function LokiExploreQueryEditor(props: Props) {
       range={range}
       ExtraFieldElement={
         <LokiOptionFields
-          queryDirection={query.direction ?? datasource.direction ?? 'BACKWARD'}
+          queryDirection={query.direction ?? datasource.direction}
           lineLimitValue={query?.maxLines?.toString() || ''}
           resolution={query.resolution || 1}
           query={query}

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -65,8 +65,7 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
   }
 
   function onQueryDirectionChange(value: LokiDirectionType) {
-    let nextQuery;
-    nextQuery = { ...query, direction: value };
+    const nextQuery = { ...query, direction: value };
     onChange(nextQuery);
   }
 

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -11,11 +11,19 @@ import { LokiQuery, LokiQueryType } from '../types';
 export interface LokiOptionFieldsProps {
   lineLimitValue: string;
   resolution: number;
+  queryDirection: LokiDirectionType;
   query: LokiQuery;
   onChange: (value: LokiQuery) => void;
   onRunQuery: () => void;
   runOnBlur?: boolean;
 }
+
+type LokiDirectionType = 'FORWARD' | 'BACKWARD';
+
+const queryDirectionOptions = [
+  { value: 'FORWARD', label: 'Forward', description: 'Run query forward in time.' },
+  { value: 'BACKWARD', label: 'Backward', description: 'Run query backward in time.' },
+];
 
 const queryTypeOptions: Array<SelectableValue<LokiQueryType>> = [
   { value: LokiQueryType.Range, label: 'Range', description: 'Run query over a range of time.' },
@@ -44,7 +52,7 @@ const RESOLUTION_OPTIONS: Array<SelectableValue<number>> = [DEFAULT_RESOLUTION].
 );
 
 export function LokiOptionFields(props: LokiOptionFieldsProps) {
-  const { lineLimitValue, resolution, onRunQuery, runOnBlur, onChange } = props;
+  const { lineLimitValue, resolution, queryDirection, onRunQuery, runOnBlur, onChange } = props;
   const query = props.query ?? {};
   let queryType = query.queryType ?? (query.instant ? LokiQueryType.Instant : LokiQueryType.Range);
 
@@ -56,6 +64,12 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
   function onQueryTypeChange(queryType: LokiQueryType) {
     const { instant, range, ...rest } = query;
     onChange({ ...rest, queryType });
+  }
+
+  function onQueryDirectionChange(value: LokiDirectionType) {
+    let nextQuery;
+    nextQuery = { ...query, direction: value };
+    onChange(nextQuery);
   }
 
   function preprocessMaxLines(value: string): number {
@@ -157,6 +171,30 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
             menuShouldPortal
           />
         </InlineField>
+      </div>
+      {/*Query direction field*/}
+      <div
+        data-testid="queryDirectionField"
+        className={cx(
+          'gf-form explore-input-margin',
+          css`
+            flex-wrap: nowrap;
+          `
+        )}
+        aria-label="Query direction field"
+      >
+        <InlineFormLabel width="auto">Query direction</InlineFormLabel>
+
+        <RadioButtonGroup
+          options={queryDirectionOptions}
+          value={queryDirection}
+          onChange={(direction: LokiDirectionType) => {
+            onQueryDirectionChange(direction);
+            if (runOnBlur) {
+              onRunQuery();
+            }
+          }}
+        />
       </div>
     </div>
   );

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -5,7 +5,7 @@ import { map } from 'lodash';
 
 // Types
 import { InlineFormLabel, RadioButtonGroup, InlineField, Input, Select } from '@grafana/ui';
-import { SelectableValue } from '@grafana/data';
+import { LogsSortOrder, SelectableValue } from '@grafana/data';
 import { LokiDirectionType, LokiQuery, LokiQueryType } from '../types';
 
 export interface LokiOptionFieldsProps {
@@ -65,7 +65,11 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
   }
 
   function onQueryDirectionChange(value: LokiDirectionType) {
-    const nextQuery = { ...query, direction: value };
+    const nextQuery: LokiQuery = {
+      ...query,
+      direction: value,
+      defaultLogsSortOrder: value === 'FORWARD' ? LogsSortOrder.Ascending : LogsSortOrder.Descending,
+    };
     onChange(nextQuery);
   }
 

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -19,8 +19,8 @@ export interface LokiOptionFieldsProps {
 }
 
 const queryDirectionOptions: Array<SelectableValue<LokiDirectionType>> = [
-  { value: 'FORWARD', label: 'Forward', description: 'Run query forward in time.' },
-  { value: 'BACKWARD', label: 'Backward', description: 'Run query backward in time.' },
+  { value: LokiDirectionType.Forward, label: 'Forward', description: 'Run query forward in time.' },
+  { value: LokiDirectionType.Backward, label: 'Backward', description: 'Run query backward in time.' },
 ];
 
 const queryTypeOptions: Array<SelectableValue<LokiQueryType>> = [
@@ -68,7 +68,7 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
     const nextQuery: LokiQuery = {
       ...query,
       direction: value,
-      defaultLogsSortOrder: value === 'FORWARD' ? LogsSortOrder.Ascending : LogsSortOrder.Descending,
+      defaultLogsSortOrder: value === LokiDirectionType.Forward ? LogsSortOrder.Ascending : LogsSortOrder.Descending,
     };
     onChange(nextQuery);
   }

--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -6,7 +6,7 @@ import { map } from 'lodash';
 // Types
 import { InlineFormLabel, RadioButtonGroup, InlineField, Input, Select } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
-import { LokiQuery, LokiQueryType } from '../types';
+import { LokiDirectionType, LokiQuery, LokiQueryType } from '../types';
 
 export interface LokiOptionFieldsProps {
   lineLimitValue: string;
@@ -18,9 +18,7 @@ export interface LokiOptionFieldsProps {
   runOnBlur?: boolean;
 }
 
-type LokiDirectionType = 'FORWARD' | 'BACKWARD';
-
-const queryDirectionOptions = [
+const queryDirectionOptions: Array<SelectableValue<LokiDirectionType>> = [
   { value: 'FORWARD', label: 'Forward', description: 'Run query forward in time.' },
   { value: 'BACKWARD', label: 'Backward', description: 'Run query backward in time.' },
 ];

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -51,7 +51,7 @@ export function LokiQueryEditor(props: LokiQueryEditorProps) {
       ExtraFieldElement={
         <>
           <LokiOptionFields
-            queryDirection={ query.direction ?? datasource.direction ?? 'BACKWARD' }
+            queryDirection={query.direction ?? datasource.direction ?? 'BACKWARD'}
             lineLimitValue={query?.maxLines?.toString() || ''}
             resolution={query?.resolution || 1}
             query={query}

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -51,7 +51,7 @@ export function LokiQueryEditor(props: LokiQueryEditorProps) {
       ExtraFieldElement={
         <>
           <LokiOptionFields
-            queryDirection={query.direction ?? datasource.direction ?? 'BACKWARD'}
+            queryDirection={query.direction ?? datasource.direction}
             lineLimitValue={query?.maxLines?.toString() || ''}
             resolution={query?.resolution || 1}
             query={query}

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditor.tsx
@@ -51,6 +51,7 @@ export function LokiQueryEditor(props: LokiQueryEditorProps) {
       ExtraFieldElement={
         <>
           <LokiOptionFields
+            queryDirection={ query.direction ?? datasource.direction ?? 'BACKWARD' }
             lineLimitValue={query?.maxLines?.toString() || ''}
             resolution={query?.resolution || 1}
             query={query}

--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`LokiExploreQueryEditor should render component 1`] = `
         }
       }
       resolution={1}
+      queryDirection="BACKWARD"
     />
   }
   data={

--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
@@ -14,8 +14,8 @@ exports[`LokiExploreQueryEditor should render component 1`] = `
           "refId": "A",
         }
       }
-      resolution={1}
       queryDirection="BACKWARD"
+      resolution={1}
     />
   }
   data={

--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiQueryEditor.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`Render LokiQueryEditor with legend should render 1`] = `
           }
         }
         resolution={1}
+        queryDirection="BACKWARD"
         runOnBlur={true}
       />
       <div
@@ -81,6 +82,7 @@ exports[`Render LokiQueryEditor with legend should update timerange 1`] = `
           }
         }
         resolution={1}
+        queryDirection="BACKWARD"
         runOnBlur={true}
       />
       <div

--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiQueryEditor.test.tsx.snap
@@ -15,8 +15,8 @@ exports[`Render LokiQueryEditor with legend should render 1`] = `
             "refId": "A",
           }
         }
-        resolution={1}
         queryDirection="BACKWARD"
+        resolution={1}
         runOnBlur={true}
       />
       <div
@@ -81,8 +81,8 @@ exports[`Render LokiQueryEditor with legend should update timerange 1`] = `
             "refId": "A",
           }
         }
-        resolution={1}
         queryDirection="BACKWARD"
+        resolution={1}
         runOnBlur={true}
       />
       <div

--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { DataSourcePluginOptionsEditorProps, DataSourceSettings } from '@grafana/data';
 import { AlertingSettings, DataSourceHttpSettings } from '@grafana/ui';
-import { LokiOptions } from '../types';
+import { LokiDirectionType, LokiOptions } from '../types';
 import { MaxLinesField } from './MaxLinesField';
 import { DirectionField } from './DirectionField';
 import { DerivedFields } from './DerivedFields';
@@ -53,7 +53,7 @@ export const ConfigEditor = (props: Props) => {
               onChange={(value) => onOptionsChange(setMaxLines(options, value))}
             />
             <DirectionField
-              value={options.jsonData.direction || 'BACKWARD'}
+              value={options.jsonData.direction || LokiDirectionType.Backward}
               onChange={(value) => onOptionsChange(setDirection(options, value))}
             />
           </div>

--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx
@@ -3,6 +3,7 @@ import { DataSourcePluginOptionsEditorProps, DataSourceSettings } from '@grafana
 import { AlertingSettings, DataSourceHttpSettings } from '@grafana/ui';
 import { LokiOptions } from '../types';
 import { MaxLinesField } from './MaxLinesField';
+import { DirectionField } from './DirectionField';
 import { DerivedFields } from './DerivedFields';
 import { getAllAlertmanagerDataSources } from 'app/features/alerting/unified/utils/alertmanager';
 
@@ -22,6 +23,7 @@ const makeJsonUpdater = <T extends any>(field: keyof LokiOptions) => (
 };
 
 const setMaxLines = makeJsonUpdater('maxLines');
+const setDirection = makeJsonUpdater('direction');
 const setDerivedFields = makeJsonUpdater('derivedFields');
 
 export const ConfigEditor = (props: Props) => {
@@ -49,6 +51,10 @@ export const ConfigEditor = (props: Props) => {
             <MaxLinesField
               value={options.jsonData.maxLines || ''}
               onChange={(value) => onOptionsChange(setMaxLines(options, value))}
+            />
+            <DirectionField
+              value={options.jsonData.direction || 'BACKWARD'}
+              onChange={(value) => onOptionsChange(setDirection(options, value))}
             />
           </div>
         </div>

--- a/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
@@ -22,9 +22,9 @@ export const DirectionField = (props: Props) => {
       inputEl={<RadioButtonGroup options={queryDirectionOptions} value={value} onChange={onChange} />}
       tooltip={
         <>
-          Loki queries can be made in either 'FORWARD' or 'BACKWARD' directions. This configuration is the default for
-          the data source but can be changed on a per-query basis. 'FORWARD' queries are processed in chronological
-          order. 'BACKWARD' queries are processed in reverse chronological order.
+          Loki queries can be made in either FORWARD or BACKWARD directions. This configuration is the default for the
+          data source but can be changed on a per-query basis. FORWARD queries are processed in chronological order.
+          BACKWARD queries are processed in reverse chronological order.
         </>
       }
     />

--- a/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { LegacyForms, RadioButtonGroup } from '@grafana/ui';
+const { FormField } = LegacyForms;
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+
+const queryDirectionOptions = [
+  { value: 'FORWARD', label: 'Forward', description: 'By default, run queries forward in time.' },
+  { value: 'BACKWARD', label: 'Backward', description: 'By dfault, run queries backward in time.' },
+];
+
+export const DirectionField = (props: Props) => {
+  const { value, onChange } = props;
+  return (
+    <FormField
+      label="Direction"
+      labelWidth={11}
+      inputWidth={20}
+      inputEl={
+        <RadioButtonGroup
+          options={queryDirectionOptions}
+          value={value}
+          onChange={onChange}
+        />
+      }
+      tooltip={
+        <>
+          Loki queries can be made in either 'FORWARD' or 'BACKWARD' directions.
+          This configuration is the default for the data source but can be changed on a per-query basis.
+          'FORWARD' queries are processed in chronological order.
+          'BACKWARD' queries are processed in reverse chronological order.
+        </>
+      }
+    />
+  );
+};

--- a/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { LegacyForms, RadioButtonGroup } from '@grafana/ui';
+import { SelectableValue } from '@grafana/data';
+import { LokiDirectionType } from '../types';
 const { FormField } = LegacyForms;
 
 type Props = {
@@ -7,7 +9,7 @@ type Props = {
   onChange: (value: string) => void;
 };
 
-const queryDirectionOptions = [
+const queryDirectionOptions: Array<SelectableValue<LokiDirectionType>> = [
   { value: 'FORWARD', label: 'Forward', description: 'By default, run queries forward in time.' },
   { value: 'BACKWARD', label: 'Backward', description: 'By dfault, run queries backward in time.' },
 ];

--- a/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
@@ -7,7 +7,6 @@ type Props = {
   onChange: (value: string) => void;
 };
 
-
 const queryDirectionOptions = [
   { value: 'FORWARD', label: 'Forward', description: 'By default, run queries forward in time.' },
   { value: 'BACKWARD', label: 'Backward', description: 'By dfault, run queries backward in time.' },
@@ -20,19 +19,12 @@ export const DirectionField = (props: Props) => {
       label="Direction"
       labelWidth={11}
       inputWidth={20}
-      inputEl={
-        <RadioButtonGroup
-          options={queryDirectionOptions}
-          value={value}
-          onChange={onChange}
-        />
-      }
+      inputEl={<RadioButtonGroup options={queryDirectionOptions} value={value} onChange={onChange} />}
       tooltip={
         <>
-          Loki queries can be made in either 'FORWARD' or 'BACKWARD' directions.
-          This configuration is the default for the data source but can be changed on a per-query basis.
-          'FORWARD' queries are processed in chronological order.
-          'BACKWARD' queries are processed in reverse chronological order.
+          Loki queries can be made in either 'FORWARD' or 'BACKWARD' directions. This configuration is the default for
+          the data source but can be changed on a per-query basis. 'FORWARD' queries are processed in chronological
+          order. 'BACKWARD' queries are processed in reverse chronological order.
         </>
       }
     />

--- a/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DirectionField.tsx
@@ -10,8 +10,8 @@ type Props = {
 };
 
 const queryDirectionOptions: Array<SelectableValue<LokiDirectionType>> = [
-  { value: 'FORWARD', label: 'Forward', description: 'By default, run queries forward in time.' },
-  { value: 'BACKWARD', label: 'Backward', description: 'By dfault, run queries backward in time.' },
+  { value: LokiDirectionType.Forward, label: 'Forward', description: 'By default, run queries forward in time.' },
+  { value: LokiDirectionType.Backward, label: 'Backward', description: 'By dfault, run queries backward in time.' },
 ];
 
 export const DirectionField = (props: Props) => {

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -16,7 +16,7 @@ import {
 import { BackendSrvRequest, FetchResponse, config } from '@grafana/runtime';
 
 import LokiDatasource, { RangeQueryOptions } from './datasource';
-import { LokiQuery, LokiResponse, LokiResultType } from './types';
+import { LokiDirectionType, LokiQuery, LokiResponse, LokiResultType } from './types';
 import { getQueryOptions } from 'test/helpers/getQueryOptions';
 import { TemplateSrv } from 'app/features/templating/template_srv';
 import { TimeSrv } from 'app/features/dashboard/services/TimeSrv';
@@ -957,7 +957,7 @@ describe('LokiDatasource', () => {
 
       //Mock stored labels to only include "bar" label
       jest.spyOn(ds.languageProvider, 'getLabelKeys').mockImplementation(() => ['bar']);
-      const contextQuery = ds.prepareLogRowContextQueryTarget(row, 10, 'BACKWARD');
+      const contextQuery = ds.prepareLogRowContextQueryTarget(row, 10, LokiDirectionType.Backward);
 
       expect(contextQuery.expr).toContain('baz');
       expect(contextQuery.expr).not.toContain('uniqueParsedLabel');

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -47,6 +47,7 @@ import {
 import { addParsedLabelToQuery, queryHasPipeParser } from './query_utils';
 
 import {
+  LokiDirectionType,
   LokiOptions,
   LokiQuery,
   LokiQueryType,
@@ -95,7 +96,7 @@ export class LokiDatasource
   private streams = new LiveStreams();
   languageProvider: LanguageProvider;
   maxLines: number;
-  direction: 'BACKWARD' | 'FORWARD';
+  direction: LokiDirectionType;
 
   constructor(
     private instanceSettings: DataSourceInstanceSettings<LokiOptions>,
@@ -543,7 +544,7 @@ export class LokiDatasource
     );
   };
 
-  prepareLogRowContextQueryTarget = (row: LogRowModel, limit: number, direction: 'BACKWARD' | 'FORWARD') => {
+  prepareLogRowContextQueryTarget = (row: LogRowModel, limit: number, direction: LokiDirectionType) => {
     const labels = this.languageProvider.getLabelKeys();
     const query = Object.keys(row.labels)
       .map((label: string) => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -81,7 +81,7 @@ const RANGE_QUERY_ENDPOINT = `${LOKI_ENDPOINT}/query_range`;
 const INSTANT_QUERY_ENDPOINT = `${LOKI_ENDPOINT}/query`;
 
 const DEFAULT_QUERY_PARAMS: Partial<LokiRangeQueryRequest> = {
-  direction: 'BACKWARD',
+  direction: LokiDirectionType.Backward,
   limit: DEFAULT_MAX_LINES,
   query: '',
 };
@@ -108,7 +108,7 @@ export class LokiDatasource
     this.languageProvider = new LanguageProvider(this);
     const settingsData = instanceSettings.jsonData || {};
     this.maxLines = parseInt(settingsData.maxLines ?? '0', 10) || DEFAULT_MAX_LINES;
-    this.direction = settingsData.direction ?? 'BACKWARD';
+    this.direction = settingsData.direction ?? LokiDirectionType.Backward;
   }
 
   _request(apiUrl: string, data?: any, options?: Partial<BackendSrvRequest>): Observable<Record<string, any>> {
@@ -519,7 +519,9 @@ export class LokiDatasource
     const target = this.prepareLogRowContextQueryTarget(
       row,
       (options && options.limit) || 10,
-      (options && options.direction) || 'BACKWARD'
+      ((options && options.direction) || 'BACKWARD') === 'FORWARD'
+        ? LokiDirectionType.Forward
+        : LokiDirectionType.Backward
     );
 
     const reverse = options && options.direction === 'FORWARD';

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -203,7 +203,7 @@ export class LokiDatasource
     const queryLimit = isMetricsQuery(target.expr) ? options.maxDataPoints : target.maxLines;
     const query = {
       query: target.expr,
-      direction: target.direction,
+      direction: target.direction ?? DEFAULT_QUERY_PARAMS.direction,
       time: `${timeNs + (1e9 - (timeNs % 1e9))}`,
       limit: Math.min(queryLimit || Infinity, this.maxLines),
     };

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -95,6 +95,7 @@ export class LokiDatasource
   private streams = new LiveStreams();
   languageProvider: LanguageProvider;
   maxLines: number;
+  direction: 'BACKWARD' | 'FORWARD';
 
   constructor(
     private instanceSettings: DataSourceInstanceSettings<LokiOptions>,
@@ -106,6 +107,7 @@ export class LokiDatasource
     this.languageProvider = new LanguageProvider(this);
     const settingsData = instanceSettings.jsonData || {};
     this.maxLines = parseInt(settingsData.maxLines ?? '0', 10) || DEFAULT_MAX_LINES;
+    this.direction = settingsData.direction ?? 'BACKWARD';
   }
 
   _request(apiUrl: string, data?: any, options?: Partial<BackendSrvRequest>): Observable<Record<string, any>> {
@@ -200,6 +202,7 @@ export class LokiDatasource
     const queryLimit = isMetricsQuery(target.expr) ? options.maxDataPoints : target.maxLines;
     const query = {
       query: target.expr,
+      direction: target.direction,
       time: `${timeNs + (1e9 - (timeNs % 1e9))}`,
       limit: Math.min(queryLimit || Infinity, this.maxLines),
     };
@@ -236,6 +239,7 @@ export class LokiDatasource
 
   createRangeQuery(target: LokiQuery, options: RangeQueryOptions, limit: number): LokiRangeQueryRequest {
     const query = target.expr;
+    let direction = target.direction ?? DEFAULT_QUERY_PARAMS.direction;
     let range: { start?: number; end?: number; step?: number } = {};
     if (options.range) {
       const startNs = this.getTime(options.range.from, false);
@@ -259,6 +263,7 @@ export class LokiDatasource
     return {
       ...DEFAULT_QUERY_PARAMS,
       ...range,
+      direction: direction,
       query,
       limit,
     };

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -39,6 +39,7 @@ export interface LokiQuery extends DataQuery {
   maxLines?: number;
   resolution?: number;
   volumeQuery?: boolean; // Used in range queries
+  direction?: 'BACKWARD' | 'FORWARD';
 
   /* @deprecated now use queryType */
   range?: boolean;
@@ -49,6 +50,7 @@ export interface LokiQuery extends DataQuery {
 
 export interface LokiOptions extends DataSourceJsonData {
   maxLines?: string;
+  direction?: 'BACKWARD' | 'FORWARD';
   derivedFields?: DerivedFieldConfig[];
   alertmanager?: string;
 }

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -4,7 +4,7 @@ export interface LokiInstantQueryRequest {
   query: string;
   limit?: number;
   time?: string;
-  direction?: 'BACKWARD' | 'FORWARD';
+  direction?: LokiDirectionType;
 }
 
 export interface LokiRangeQueryRequest {
@@ -13,7 +13,7 @@ export interface LokiRangeQueryRequest {
   start?: number;
   end?: number;
   step?: number;
-  direction?: 'BACKWARD' | 'FORWARD';
+  direction?: LokiDirectionType;
 }
 
 export enum LokiResultType {
@@ -28,6 +28,8 @@ export enum LokiQueryType {
   // Stream = 'stream',
 }
 
+export type LokiDirectionType = 'FORWARD' | 'BACKWARD';
+
 export interface LokiQuery extends DataQuery {
   queryType?: LokiQueryType;
   expr: string;
@@ -39,7 +41,7 @@ export interface LokiQuery extends DataQuery {
   maxLines?: number;
   resolution?: number;
   volumeQuery?: boolean; // Used in range queries
-  direction?: 'BACKWARD' | 'FORWARD';
+  direction?: LokiDirectionType;
 
   /* @deprecated now use queryType */
   range?: boolean;
@@ -50,7 +52,7 @@ export interface LokiQuery extends DataQuery {
 
 export interface LokiOptions extends DataSourceJsonData {
   maxLines?: string;
-  direction?: 'BACKWARD' | 'FORWARD';
+  direction?: LokiDirectionType;
   derivedFields?: DerivedFieldConfig[];
   alertmanager?: string;
 }

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -28,7 +28,10 @@ export enum LokiQueryType {
   // Stream = 'stream',
 }
 
-export type LokiDirectionType = 'FORWARD' | 'BACKWARD';
+export enum LokiDirectionType {
+  Forward = 'FORWARD',
+  Backward = 'BACKWARD',
+}
 
 export interface LokiQuery extends DataQuery {
   queryType?: LokiQueryType;


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow Loki queries to be made either forward or backward.

This can be configured on a per query basis and on a per data source
basis where query configuration overrides data source configuration.
For backwards compatibility the default direction in the data source
configuration is 'BACKWARDS' which is the only direction previously
supported. The data source configuration becomes the default
configuration for new queries created in Explore or via a panel but
the user can change this with a toggle.

**Which issue(s) this PR fixes**:
Addresses the bulk of #20394 but does not touch add paging functionality.

Fixes #20394

**Special notes for your reviewer**:
Continuation of #36379 
