### PR TITLE
API: Fix storing dashboard with static UID

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -323,13 +323,13 @@ func (hs *HTTPServer) postDashboard(c *models.ReqContext, cmd models.SaveDashboa
 	if dash.Id != 0 {
 		data, err := svc.GetProvisionedDashboardDataByDashboardID(dash.Id)
 		if err != nil {
-			return response.Error(500, "Error while checking if dashboard is provisioned", err)
+			return response.Error(500, "Error while checking if dashboard is provisioned using ID", err)
 		}
 		provisioningData = data
 	} else if dash.Uid != "" {
 		data, err := svc.GetProvisionedDashboardDataByDashboardUID(dash.OrgId, dash.Uid)
-		if err != nil && !errors.Is(err, models.ErrProvisionedDashboardNotFound) {
-			return response.Error(500, "Error while checking if dashboard is provisioned", err)
+		if err != nil && (!errors.Is(err, models.ErrProvisionedDashboardNotFound) && !errors.Is(err, models.ErrDashboardNotFound)) {
+			return response.Error(500, "Error while checking if dashboard is provisioned using UID", err)
 		}
 		provisioningData = data
 	}

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -97,7 +97,7 @@ func createUser(t *testing.T, store *sqlstore.SQLStore, cmd models.CreateUserCom
 	return u.Id
 }
 
-func TestProvisionioningDashboards(t *testing.T) {
+func TestUpdatingProvisionionedDashboards(t *testing.T) {
 	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableAnonymous: true,
@@ -161,14 +161,31 @@ providers:
 		testCases := []struct {
 			desc          string
 			dashboardData string
+			expStatus     int
+			expErrReason  string
 		}{
 			{
 				desc:          "when updating provisioned dashboard using ID it should fail",
 				dashboardData: fmt.Sprintf(`{"title":"just testing", "id": %d, "version": 1}`, dashboardID),
+				expStatus:     http.StatusBadRequest,
+				expErrReason:  models.ErrDashboardCannotSaveProvisionedDashboard.Reason,
 			},
 			{
-				desc:          "when updating provisioned dashboard using UID is should fail",
+				desc:          "when updating provisioned dashboard using UID it should fail",
 				dashboardData: fmt.Sprintf(`{"title":"just testing", "uid": %q, "version": 1}`, dashboardUID),
+				expStatus:     http.StatusBadRequest,
+				expErrReason:  models.ErrDashboardCannotSaveProvisionedDashboard.Reason,
+			},
+			{
+				desc:          "when updating dashboard using unknown ID, it should succeed",
+				dashboardData: `{"title":"just testing", "id": 42, "version": 1}`,
+				expStatus:     http.StatusNotFound,
+				expErrReason:  models.ErrDashboardNotFound.Reason,
+			},
+			{
+				desc:          "when updating dashboard using unknown UID, it should succeed",
+				dashboardData: `{"title":"just testing", "uid": "unknown", "version": 1}`,
+				expStatus:     http.StatusOK,
 			},
 		}
 		for _, tc := range testCases {
@@ -186,17 +203,20 @@ providers:
 				// nolint:gosec
 				resp, err := http.Post(u, "application/json", buf)
 				require.NoError(t, err)
-				assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+				assert.Equal(t, tc.expStatus, resp.StatusCode)
 				t.Cleanup(func() {
 					err := resp.Body.Close()
 					require.NoError(t, err)
 				})
+				if tc.expErrReason == "" {
+					return
+				}
 				b, err := ioutil.ReadAll(resp.Body)
 				require.NoError(t, err)
 				dashboardErr := &errorResponseBody{}
 				err = json.Unmarshal(b, dashboardErr)
 				require.NoError(t, err)
-				assert.Equal(t, models.ErrDashboardCannotSaveProvisionedDashboard.Reason, dashboardErr.Message)
+				assert.Equal(t, tc.expErrReason, dashboardErr.Message)
 			})
 		}
 

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -177,7 +177,7 @@ providers:
 				expErrReason:  models.ErrDashboardCannotSaveProvisionedDashboard.Reason,
 			},
 			{
-				desc:          "when updating dashboard using unknown ID, it should succeed",
+				desc:          "when updating dashboard using unknown ID, it should fail",
 				dashboardData: `{"title":"just testing", "id": 42, "version": 1}`,
 				expStatus:     http.StatusNotFound,
 				expErrReason:  models.ErrDashboardNotFound.Reason,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The bug was introduced in #41894. `GetProvisionedDashboardDataByDashboardUID()` can return either `ErrProvisionedDashboardNotFound` or `ErrDashboardNotFound` error but I [checked](https://github.com/grafana/grafana/blob/d350ed0f35b6ebaf7caf6169d70b2436e9947f31/pkg/api/dashboard.go#L331) only for the former. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #43857

**Special notes for your reviewer**:
This bug affects also some cloud instances running `8.4.x` version