### PR TITLE
Service Accounts: Fix issue in UserTable and ServiceAccountsTable

### DIFF
--- a/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
@@ -45,7 +45,7 @@ export class ServiceAccountsListPage extends PureComponent<Props, State> {
         <ServiceAccountsTable
           serviceAccounts={paginatedServiceAccounts}
           onRoleChange={(role, serviceAccount) => this.onRoleChange(role, serviceAccount)}
-          onRemoveServiceaccount={(serviceAccount) => this.props.removeServiceAccount(serviceAccount.serviceAccountId)}
+          onRemoveServiceAccount={(serviceAccount) => this.props.removeServiceAccount(serviceAccount.serviceAccountId)}
         />
         <HorizontalGroup justify="flex-end">
           <Pagination

--- a/public/app/features/serviceaccounts/ServiceAccountsTable.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsTable.tsx
@@ -19,7 +19,7 @@ const ServiceaccountsTable: FC<Props> = (props) => {
   const canRemoveFromOrg = contextSrv.hasPermission(AccessControlAction.OrgUsersRemove);
   const rolePickerDisabled = !canUpdateRole;
 
-  const [showRemoveModal, setShowRemoveModal] = useState(false);
+  const [showRemoveModal, setShowRemoveModal] = useState<boolean | string>(false);
   const [roleOptions, setRoleOptions] = useState<Role[]>([]);
   const [builtinRoles, setBuiltinRoles] = useState<Record<string, Role[]>>({});
 
@@ -106,7 +106,7 @@ const ServiceaccountsTable: FC<Props> = (props) => {
                   <Button
                     size="sm"
                     variant="destructive"
-                    onClick={() => setShowRemoveModal(Boolean(serviceAccount.login))}
+                    onClick={() => setShowRemoveModal(serviceAccount.login)}
                     icon="times"
                     aria-label="Delete serviceaccount"
                   />
@@ -115,7 +115,7 @@ const ServiceaccountsTable: FC<Props> = (props) => {
                     confirmText="Delete"
                     title="Delete"
                     onDismiss={() => setShowRemoveModal(false)}
-                    isOpen={Boolean(serviceAccount.login) === showRemoveModal}
+                    isOpen={serviceAccount.login === showRemoveModal}
                     onConfirm={() => {
                       onRemoveserviceaccount(serviceAccount);
                     }}

--- a/public/app/features/serviceaccounts/ServiceAccountsTable.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsTable.tsx
@@ -120,7 +120,7 @@ const ServiceAccountsTable: FC<Props> = (props) => {
       </table>
       {toRemove !== null && (
         <ConfirmModal
-          body={`Are you sure you want to delete serviceaccount ${toRemove.login}?`}
+          body={`Are you sure you want to delete ${toRemove.login} service account?`}
           confirmText="Delete"
           title="Delete"
           onDismiss={() => setToRemove(null)}

--- a/public/app/features/serviceaccounts/ServiceAccountsTable.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsTable.tsx
@@ -9,19 +9,20 @@ import { fetchBuiltinRoles, fetchRoleOptions, UserRolePicker } from 'app/core/co
 export interface Props {
   serviceAccounts: OrgServiceAccount[];
   orgId?: number;
-  onRoleChange: (role: OrgRole, serviceaccount: OrgServiceAccount) => void;
-  onRemoveServiceaccount: (serviceaccount: OrgServiceAccount) => void;
+  onRoleChange: (role: OrgRole, serviceAccount: OrgServiceAccount) => void;
+  onRemoveServiceAccount: (serviceAccount: OrgServiceAccount) => void;
 }
 
-const ServiceaccountsTable: FC<Props> = (props) => {
-  const { serviceAccounts, orgId, onRoleChange, onRemoveServiceaccount: onRemoveserviceaccount } = props;
+const ServiceAccountsTable: FC<Props> = (props) => {
+  const { serviceAccounts, orgId, onRoleChange, onRemoveServiceAccount } = props;
   const canUpdateRole = contextSrv.hasPermission(AccessControlAction.OrgUsersRoleUpdate);
   const canRemoveFromOrg = contextSrv.hasPermission(AccessControlAction.OrgUsersRemove);
   const rolePickerDisabled = !canUpdateRole;
 
-  const [showRemoveModal, setShowRemoveModal] = useState<boolean | string>(false);
   const [roleOptions, setRoleOptions] = useState<Role[]>([]);
+  const [toRemove, setToRemove] = useState<OrgServiceAccount | null>(null);
   const [builtinRoles, setBuiltinRoles] = useState<Record<string, Role[]>>({});
+  const [showRemoveModal, setShowRemoveModal] = useState<boolean | string>(false);
 
   useEffect(() => {
     async function fetchOptions() {
@@ -43,91 +44,92 @@ const ServiceaccountsTable: FC<Props> = (props) => {
   const getBuiltinRoles = async () => builtinRoles;
 
   return (
-    <table className="filter-table form-inline">
-      <thead>
-        <tr>
-          <th />
-          <th>Login</th>
-          <th>Email</th>
-          <th>Name</th>
-          <th>Seen</th>
-          <th>Role</th>
-          <th style={{ width: '34px' }} />
-        </tr>
-      </thead>
-      <tbody>
-        {serviceAccounts.map((serviceAccount, index) => {
-          return (
-            <tr key={`${serviceAccount.serviceAccountId}-${index}`}>
-              <td className="width-2 text-center">
-                <img className="filter-table__avatar" src={serviceAccount.avatarUrl} alt="serviceaccount avatar" />
-              </td>
-              <td className="max-width-6">
-                <span className="ellipsis" title={serviceAccount.login}>
-                  {serviceAccount.login}
-                </span>
-              </td>
-
-              <td className="max-width-5">
-                <span className="ellipsis" title={serviceAccount.email}>
-                  {serviceAccount.email}
-                </span>
-              </td>
-              <td className="max-width-5">
-                <span className="ellipsis" title={serviceAccount.name}>
-                  {serviceAccount.name}
-                </span>
-              </td>
-              <td className="width-1">{serviceAccount.lastSeenAtAge}</td>
-
-              <td className="width-8">
-                {contextSrv.accessControlEnabled() ? (
-                  <UserRolePicker
-                    userId={serviceAccount.serviceAccountId}
-                    orgId={orgId}
-                    builtInRole={serviceAccount.role}
-                    onBuiltinRoleChange={(newRole) => onRoleChange(newRole, serviceAccount)}
-                    getRoleOptions={getRoleOptions}
-                    getBuiltinRoles={getBuiltinRoles}
-                    disabled={rolePickerDisabled}
-                  />
-                ) : (
-                  <OrgRolePicker
-                    aria-label="Role"
-                    value={serviceAccount.role}
-                    disabled={!canUpdateRole}
-                    onChange={(newRole) => onRoleChange(newRole, serviceAccount)}
-                  />
-                )}
-              </td>
-
-              {canRemoveFromOrg && (
-                <td>
-                  <Button
-                    size="sm"
-                    variant="destructive"
-                    onClick={() => setShowRemoveModal(serviceAccount.login)}
-                    icon="times"
-                    aria-label="Delete serviceaccount"
-                  />
-                  <ConfirmModal
-                    body={`Are you sure you want to delete serviceaccount ${serviceAccount.login}?`}
-                    confirmText="Delete"
-                    title="Delete"
-                    onDismiss={() => setShowRemoveModal(false)}
-                    isOpen={serviceAccount.login === showRemoveModal}
-                    onConfirm={() => {
-                      onRemoveserviceaccount(serviceAccount);
-                    }}
-                  />
+    <>
+      <table className="filter-table form-inline">
+        <thead>
+          <tr>
+            <th />
+            <th>Login</th>
+            <th>Email</th>
+            <th>Name</th>
+            <th>Seen</th>
+            <th>Role</th>
+            <th style={{ width: '34px' }} />
+          </tr>
+        </thead>
+        <tbody>
+          {serviceAccounts.map((serviceAccount, index) => {
+            return (
+              <tr key={`${serviceAccount.serviceAccountId}-${index}`}>
+                <td className="width-2 text-center">
+                  <img className="filter-table__avatar" src={serviceAccount.avatarUrl} alt="serviceaccount avatar" />
                 </td>
-              )}
-            </tr>
-          );
-        })}
-      </tbody>
-    </table>
+                <td className="max-width-6">
+                  <span className="ellipsis" title={serviceAccount.login}>
+                    {serviceAccount.login}
+                  </span>
+                </td>
+
+                <td className="max-width-5">
+                  <span className="ellipsis" title={serviceAccount.email}>
+                    {serviceAccount.email}
+                  </span>
+                </td>
+                <td className="max-width-5">
+                  <span className="ellipsis" title={serviceAccount.name}>
+                    {serviceAccount.name}
+                  </span>
+                </td>
+                <td className="width-1">{serviceAccount.lastSeenAtAge}</td>
+
+                <td className="width-8">
+                  {contextSrv.accessControlEnabled() ? (
+                    <UserRolePicker
+                      userId={serviceAccount.serviceAccountId}
+                      orgId={orgId}
+                      builtInRole={serviceAccount.role}
+                      onBuiltinRoleChange={(newRole) => onRoleChange(newRole, serviceAccount)}
+                      getRoleOptions={getRoleOptions}
+                      getBuiltinRoles={getBuiltinRoles}
+                      disabled={rolePickerDisabled}
+                    />
+                  ) : (
+                    <OrgRolePicker
+                      aria-label="Role"
+                      value={serviceAccount.role}
+                      disabled={!canUpdateRole}
+                      onChange={(newRole) => onRoleChange(newRole, serviceAccount)}
+                    />
+                  )}
+                </td>
+                {canRemoveFromOrg && (
+                  <td>
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      onClick={() => setShowRemoveModal(serviceAccount.login)}
+                      icon="times"
+                      aria-label="Delete serviceaccount"
+                    />
+                  </td>
+                )}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {toRemove !== null && (
+        <ConfirmModal
+          body={`Are you sure you want to delete serviceaccount ${toRemove.login}?`}
+          confirmText="Delete"
+          title="Delete"
+          onDismiss={() => setToRemove(null)}
+          isOpen={toRemove.login === showRemoveModal}
+          onConfirm={() => onRemoveServiceAccount(toRemove)}
+        />
+      )}
+    </>
   );
 };
 
-export default ServiceaccountsTable;
+export default ServiceAccountsTable;

--- a/public/app/features/users/UsersTable.tsx
+++ b/public/app/features/users/UsersTable.tsx
@@ -16,7 +16,7 @@ export interface Props {
 const UsersTable: FC<Props> = (props) => {
   const { users, orgId, onRoleChange, onRemoveUser } = props;
 
-  const [showRemoveModal, setShowRemoveModal] = useState<boolean | string>(false);
+  const [showRemoveModal, setShowRemoveModal] = useState(false);
   const [roleOptions, setRoleOptions] = useState<Role[]>([]);
   const [builtinRoles, setBuiltinRoles] = useState<{ [key: string]: Role[] }>({});
 
@@ -103,7 +103,7 @@ const UsersTable: FC<Props> = (props) => {
                   <Button
                     size="sm"
                     variant="destructive"
-                    onClick={() => setShowRemoveModal(user.login)}
+                    onClick={() => setShowRemoveModal(Boolean(user.login))}
                     icon="times"
                     aria-label="Delete user"
                   />
@@ -112,7 +112,7 @@ const UsersTable: FC<Props> = (props) => {
                     confirmText="Delete"
                     title="Delete"
                     onDismiss={() => setShowRemoveModal(false)}
-                    isOpen={user.login === showRemoveModal}
+                    isOpen={Boolean(user.login) === showRemoveModal}
                     onConfirm={() => {
                       onRemoveUser(user);
                     }}

--- a/public/app/features/users/UsersTable.tsx
+++ b/public/app/features/users/UsersTable.tsx
@@ -16,7 +16,7 @@ export interface Props {
 const UsersTable: FC<Props> = (props) => {
   const { users, orgId, onRoleChange, onRemoveUser } = props;
 
-  const [showRemoveModal, setShowRemoveModal] = useState(false);
+  const [showRemoveModal, setShowRemoveModal] = useState<boolean | string>(false);
   const [roleOptions, setRoleOptions] = useState<Role[]>([]);
   const [builtinRoles, setBuiltinRoles] = useState<{ [key: string]: Role[] }>({});
 
@@ -103,7 +103,7 @@ const UsersTable: FC<Props> = (props) => {
                   <Button
                     size="sm"
                     variant="destructive"
-                    onClick={() => setShowRemoveModal(Boolean(user.login))}
+                    onClick={() => setShowRemoveModal(user.login)}
                     icon="times"
                     aria-label="Delete user"
                   />
@@ -112,7 +112,7 @@ const UsersTable: FC<Props> = (props) => {
                     confirmText="Delete"
                     title="Delete"
                     onDismiss={() => setShowRemoveModal(false)}
-                    isOpen={Boolean(user.login) === showRemoveModal}
+                    isOpen={user.login === showRemoveModal}
                     onConfirm={() => {
                       onRemoveUser(user);
                     }}


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/grafana/grafana/pull/43573 changes to how showRemoveModal property is set in UserTable causes a bug where a confirmation modal is rendered for every item in the list with the last one on top.

This happens because the ConfirmModal is rendered in a loop and if we use true as value then every item will render the modal.

Changes to UserTable - https://github.com/grafana/grafana/pull/43885
