### PR TITLE
Tempo: Update service graph linked queries from totals to rates

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -106,7 +106,10 @@ describe('Tempo data source', () => {
     expect(response.data).toHaveLength(2);
     expect(response.data[0].name).toBe('Nodes');
     expect(response.data[0].fields[0].values.length).toBe(3);
+
+    // Test Links
     expect(response.data[0].fields[0].config.links.length).toBeGreaterThan(0);
+    expect(response.data[0].fields[0].config.links).toEqual(serviceGraphLinks);
 
     expect(response.data[1].name).toBe('Edges');
     expect(response.data[1].fields[0].values.length).toBe(2);
@@ -337,3 +340,28 @@ const mockInvalidJson = {
     },
   ],
 };
+
+const serviceGraphLinks = [
+  {
+    url: '',
+    title: 'Request rate',
+    internal: {
+      query: {
+        expr: 'rate(traces_service_graph_request_total{server="${__data.fields.id}"}[$__interval])',
+      },
+      datasourceUid: 'prom',
+      datasourceName: 'Prometheus',
+    },
+  },
+  {
+    url: '',
+    title: 'Failed request rate',
+    internal: {
+      query: {
+        expr: 'rate(traces_service_graph_request_failed_total{server="${__data.fields.id}"}[$__interval])',
+      },
+      datasourceUid: 'prom',
+      datasourceName: 'Prometheus',
+    },
+  },
+];

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -313,8 +313,16 @@ function serviceMapQuery(request: DataQueryRequest<TempoQuery>, datasourceUid: s
       const { nodes, edges } = mapPromMetricsToServiceMap(responses, request.range);
       nodes.fields[0].config = {
         links: [
-          makePromLink('Request rate', `rate(${totalsMetric}[5m])`, datasourceUid),
-          makePromLink('Failed request rate', `rate(${failedMetric}[5m])`, datasourceUid),
+          makePromLink(
+            'Request rate',
+            `rate(${totalsMetric}{server="\${__data.fields.title}"}[$__interval])`,
+            datasourceUid
+          ),
+          makePromLink(
+            'Failed request rate',
+            `rate(${failedMetric}{server="\${__data.fields.title}"}[$__interval])`,
+            datasourceUid
+          ),
         ],
       };
 

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -315,12 +315,12 @@ function serviceMapQuery(request: DataQueryRequest<TempoQuery>, datasourceUid: s
         links: [
           makePromLink(
             'Request rate',
-            `rate(${totalsMetric}{server="\${__data.fields.title}"}[$__interval])`,
+            `rate(${totalsMetric}{server="\${__data.fields.id}"}[$__interval])`,
             datasourceUid
           ),
           makePromLink(
             'Failed request rate',
-            `rate(${failedMetric}{server="\${__data.fields.title}"}[$__interval])`,
+            `rate(${failedMetric}{server="\${__data.fields.id}"}[$__interval])`,
             datasourceUid
           ),
         ],

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -313,8 +313,8 @@ function serviceMapQuery(request: DataQueryRequest<TempoQuery>, datasourceUid: s
       const { nodes, edges } = mapPromMetricsToServiceMap(responses, request.range);
       nodes.fields[0].config = {
         links: [
-          makePromLink('Total requests', totalsMetric, datasourceUid),
-          makePromLink('Failed requests', failedMetric, datasourceUid),
+          makePromLink('Request rate', `rate(${totalsMetric}[5m])`, datasourceUid),
+          makePromLink('Failed request rate', `rate(${failedMetric}[5m])`, datasourceUid),
         ],
       };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Requested by Tempo team since rates are generally more informative than totals.

**Which issue(s) this PR fixes**:
Relates to #39879

**Special notes for your reviewer**:
Nice to have: add client and/or service filter based on the current node but that would require updates to the NodeGraph API. Waiting for now unless anyone objects.
