### PR TITLE
Tabs: add suffix prop for the tab name

### DIFF
--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -106,6 +106,9 @@ export class GrafanaBootConfig implements GrafanaConfig {
   recordedQueries = {
     enabled: false,
   };
+  featureHighlights = {
+    enabled: false,
+  };
 
   constructor(options: GrafanaBootConfig) {
     const mode = options.bootData.user.lightTheme ? 'light' : 'dark';

--- a/packages/grafana-ui/src/components/Modal/ModalTabsHeader.tsx
+++ b/packages/grafana-ui/src/components/Modal/ModalTabsHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { IconName } from '../../types';
 import { TabsBar } from '../Tabs/TabsBar';
 import { Tab } from '../Tabs/Tab';
@@ -8,6 +8,7 @@ interface ModalTab {
   value: string;
   label: string;
   icon?: IconName;
+  labelSuffix?: FC;
 }
 
 interface Props {
@@ -28,6 +29,7 @@ export const ModalTabsHeader: React.FC<Props> = ({ icon, title, tabs, activeTab,
               key={`${t.value}-${index}`}
               label={t.label}
               icon={t.icon}
+              suffix={t.labelSuffix}
               active={t.value === activeTab}
               onChangeTab={() => onChangeTab(t)}
             />

--- a/packages/grafana-ui/src/components/Modal/ModalTabsHeader.tsx
+++ b/packages/grafana-ui/src/components/Modal/ModalTabsHeader.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React from 'react';
 import { IconName } from '../../types';
 import { TabsBar } from '../Tabs/TabsBar';
 import { Tab } from '../Tabs/Tab';
@@ -8,7 +8,7 @@ interface ModalTab {
   value: string;
   label: string;
   icon?: IconName;
-  labelSuffix?: FC;
+  labelSuffix?: () => JSX.Element;
 }
 
 interface Props {

--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -1,4 +1,4 @@
-import React, { FC, HTMLProps } from 'react';
+import React, { HTMLProps } from 'react';
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -18,7 +18,7 @@ export interface TabProps extends HTMLProps<HTMLAnchorElement> {
   onChangeTab?: (event?: React.MouseEvent<HTMLAnchorElement>) => void;
   /** A number rendered next to the text. Usually used to display the number of items in a tab's view. */
   counter?: number | null;
-  suffix?: FC;
+  suffix?: () => JSX.Element;
 }
 
 export const Tab = React.forwardRef<HTMLAnchorElement, TabProps>(
@@ -30,7 +30,7 @@ export const Tab = React.forwardRef<HTMLAnchorElement, TabProps>(
         {icon && <Icon name={icon} />}
         {label}
         {typeof counter === 'number' && <Counter value={counter} />}
-        {suffix && <span>{suffix({})}</span>}
+        {suffix && suffix()}
       </>
     );
 

--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps } from 'react';
+import React, { FC, HTMLProps } from 'react';
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -18,10 +18,11 @@ export interface TabProps extends HTMLProps<HTMLAnchorElement> {
   onChangeTab?: (event?: React.MouseEvent<HTMLAnchorElement>) => void;
   /** A number rendered next to the text. Usually used to display the number of items in a tab's view. */
   counter?: number | null;
+  suffix?: FC;
 }
 
 export const Tab = React.forwardRef<HTMLAnchorElement, TabProps>(
-  ({ label, active, icon, onChangeTab, counter, className, href, ...otherProps }, ref) => {
+  ({ label, active, icon, onChangeTab, counter, suffix, className, href, ...otherProps }, ref) => {
     const theme = useTheme2();
     const tabsStyles = getTabStyles(theme);
     const content = () => (
@@ -29,6 +30,7 @@ export const Tab = React.forwardRef<HTMLAnchorElement, TabProps>(
         {icon && <Icon name={icon} />}
         {label}
         {typeof counter === 'number' && <Counter value={counter} />}
+        {suffix && <span>{suffix({})}</span>}
       </>
     );
 

--- a/public/app/features/dashboard/components/ShareModal/types.ts
+++ b/public/app/features/dashboard/components/ShareModal/types.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FC } from 'react';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 
 export interface ShareModalTabProps {
@@ -10,5 +10,6 @@ export interface ShareModalTabProps {
 export interface ShareModalTabModel {
   label: string;
   value: string;
+  labelSuffix?: FC;
   component: React.ComponentType<ShareModalTabProps>;
 }

--- a/public/app/features/dashboard/components/ShareModal/types.ts
+++ b/public/app/features/dashboard/components/ShareModal/types.ts
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React from 'react';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 
 export interface ShareModalTabProps {
@@ -10,6 +10,6 @@ export interface ShareModalTabProps {
 export interface ShareModalTabModel {
   label: string;
   value: string;
-  labelSuffix?: FC;
+  labelSuffix?: () => JSX.Element;
   component: React.ComponentType<ShareModalTabProps>;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds the feature highlights feature toggles in the config file
- Adds a `suffix` prop to the `Tab` component to be able to add a `React.FC` component in a tab header (after the tab label) and uses it in the `ShareModal` component

