### PR TITLE
Elastic Datasource: Forward headers to Elastic Search

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -247,6 +247,8 @@ func TestClient_ExecuteMultisearch(t *testing.T) {
 		require.Equal(t, map[string]string{"header-1": "header-value-1"}, opts.Headers)
 		require.Equal(t, sdkhttpclient.CustomHeadersMiddlewareName, (opts.Middlewares[0].(sdkhttpclient.MiddlewareName)).MiddlewareName())
 
+		require.Equal(t, "es", opts.SigV4.Service)
+
 		require.NotNil(t, sc.request)
 		assert.Equal(t, http.MethodPost, sc.request.Method)
 		assert.Equal(t, "/_msearch", sc.request.URL.Path)
@@ -350,6 +352,9 @@ func httpClientScenario(t *testing.T, desc string, ds *DatasourceInfo, fn scenar
 			rw.WriteHeader(sc.responseStatus)
 		}))
 		ds.URL = ts.URL
+		ds.Settings = backend.DataSourceInstanceSettings{
+			JSONData: []byte(`{"sigV4Auth":true}`),
+		}
 
 		from := time.Date(2018, 5, 15, 17, 50, 0, 0, time.UTC)
 		to := time.Date(2018, 5, 15, 17, 55, 0, 0, time.UTC)

--- a/pkg/tsdb/elasticsearch/client/index_pattern.go
+++ b/pkg/tsdb/elasticsearch/client/index_pattern.go
@@ -22,7 +22,7 @@ type indexPattern interface {
 	GetIndices(timeRange backend.TimeRange) ([]string, error)
 }
 
-var newIndexPattern = func(interval string, pattern string) (indexPattern, error) {
+func newIndexPattern(interval string, pattern string) (indexPattern, error) {
 	if interval == noInterval {
 		return &staticIndexPattern{indexName: pattern}, nil
 	}

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -67,7 +67,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		return &backend.QueryDataResponse{}, err
 	}
 
-	client, err := es.NewClient(ctx, s.HTTPClientProvider, dsInfo, req.Queries[0].TimeRange)
+	client, err := es.NewClient(ctx, s.HTTPClientProvider, dsInfo, req.Queries[0].TimeRange, req.Headers)
 	if err != nil {
 		return &backend.QueryDataResponse{}, err
 	}
@@ -82,15 +82,6 @@ func newInstanceSettings() datasource.InstanceFactoryFunc {
 		err := json.Unmarshal(settings.JSONData, &jsonData)
 		if err != nil {
 			return nil, fmt.Errorf("error reading settings: %w", err)
-		}
-		httpCliOpts, err := settings.HTTPClientOptions()
-		if err != nil {
-			return nil, fmt.Errorf("error getting http options: %w", err)
-		}
-
-		// Set SigV4 service namespace
-		if httpCliOpts.SigV4 != nil {
-			httpCliOpts.SigV4.Service = "es"
 		}
 
 		version, err := coerceVersion(jsonData["esVersion"])
@@ -136,7 +127,7 @@ func newInstanceSettings() datasource.InstanceFactoryFunc {
 		model := es.DatasourceInfo{
 			ID:                         settings.ID,
 			URL:                        settings.URL,
-			HTTPClientOpts:             httpCliOpts,
+			Settings:                   settings,
 			Database:                   settings.Database,
 			MaxConcurrentShardRequests: int64(maxConcurrentShardRequests),
 			ESVersion:                  version,


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/43311

How I tested:
- Configure an Elastic data source with custom/oauth headers
- Stop Elastic server and run the following go program that dumps request headers
- make an elastic query
- verify the headers exist on the incoming request

```go
package main

import (
	"fmt"
	"net/http"
)

func main() {
	http.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
		fmt.Println(r.Header)
	})

	http.ListenAndServe(":9200", nil)
}
```