### PR TITLE
Live: centrifuge error when navigating to d-solo link with queryOverLive feature flag

### DIFF
--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -209,6 +209,9 @@ export class CentrifugeService implements CentrifugeSrv {
    * Since the initial request and subscription are on the same socket, this will support HA setups
    */
   getQueryData: CentrifugeSrv['getQueryData'] = async (options) => {
+    if (!this.centrifuge.isConnected()) {
+      await this.connectionBlocker;
+    }
     return this.centrifuge.namedRPC('grafana.query', options.body);
   };
 

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -143,7 +143,8 @@ export function runRequest(
     }),
     // handle errors
     catchError((err) => {
-      console.error('runRequest.catchError', err);
+      const errLog = typeof err === 'string' ? err : JSON.stringify(err);
+      console.error('runRequest.catchError', errLog);
       return of({
         ...state.panelData,
         state: LoadingState.Error,


### PR DESCRIPTION
to reproduce:

1. setup https://github.com/grafana/grafana-image-renderer in `headed` mode
    - use `scaled-thumb-result` branch and add `headed: true` to `<root>/dev.json` file
2. enable `queryOverLive` feature flag
3. try to share a screen of a panel

![queryOverLiveError](https://user-images.githubusercontent.com/23451458/148881549-5367b1f7-666c-4f35-9abd-631bd7697b95.gif)



error from centrifuge:
```
"{\"message\":\"connection closed\",\"code\":0}"}
```


example `d-solo` link http://localhost:3000/d-solo/zNigXIonz/heatmap-yoyo?orgId=1&from=1641873928547&to=1641874828547&panelId=2&width=1000&height=500&tz=Asia%2FDubai&render=1