### PR TITLE
Variables: Fix so data source variables are added to adhoc configuration

### DIFF
--- a/public/app/features/variables/adhoc/actions.ts
+++ b/public/app/features/variables/adhoc/actions.ts
@@ -110,7 +110,7 @@ export const changeVariableDatasource = (datasource?: DataSourceRef): ThunkResul
 };
 
 export const initAdHocVariableEditor = (): ThunkResult<void> => (dispatch) => {
-  const dataSources = getDatasourceSrv().getList({ metrics: true, variables: false });
+  const dataSources = getDatasourceSrv().getList({ metrics: true, variables: true });
   const selectable = dataSources.reduce(
     (all: Array<{ text: string; value: DataSourceRef | null }>, ds) => {
       if (ds.meta.mixed) {


### PR DESCRIPTION
**What this PR does / why we need it**:
When I fixed a DataSource ref  related issue in #41232 I read the original deprecated function wrong. The function `getMetricSources` has an optional parameter but it's a falsy param: 

```ts
getMetricSources(options?: { skipVariables?: boolean }): DataSourceSelectItem[] {
```

This PR changes the call to the `getList` function to be correct.

**Which issue(s) this PR fixes**:
Fixes #43472

**Special notes for your reviewer**:

