### PR TITLE
AccessControl: Account for AllowUserOrgCreate setting

### DIFF
--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 // API related actions
@@ -152,6 +153,22 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		Grants: []string{string(models.ROLE_VIEWER), accesscontrol.RoleGrafanaAdmin},
 	}
 
+	var orgCreatorGrants []string
+	if setting.AllowUserOrgCreate {
+		orgCreatorGrants = []string{string(models.ROLE_VIEWER)}
+	}
+	orgCreatorRole := accesscontrol.RoleRegistration{
+		Role: accesscontrol.RoleDTO{
+			Version:     1,
+			Name:        "fixed:organization:creator",
+			DisplayName: "Organization creator",
+			Description: "Create an organization.",
+			Group:       "Organizations",
+			Permissions: []accesscontrol.Permission{{Action: ActionOrgsCreate}},
+		},
+		Grants: orgCreatorGrants,
+	}
+
 	orgWriterRole := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
 			Version:     5,
@@ -187,7 +204,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	return hs.AccessControl.DeclareFixedRoles(
 		provisioningWriterRole, datasourcesReaderRole, datasourcesWriterRole, datasourcesIdReaderRole,
-		datasourcesCompatibilityReaderRole, orgReaderRole, orgWriterRole, orgMaintainerRole,
+		datasourcesCompatibilityReaderRole, orgReaderRole, orgCreatorRole, orgWriterRole, orgMaintainerRole,
 	)
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
We are leveraging RoleRegistration to account for config options. When we created org roles, we didn't account for AllowOrgUserCreate, this PR intends to fix this.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Partially fixes https://github.com/grafana/grafana-enterprise/issues/2154
Fixes https://github.com/grafana/grafana-enterprise/issues/2637

**Special notes for your reviewer**:
This is blocked while we haven't figured out a way to globally assign `orgs:create`
