### PR TITLE
Alerting: show deleted datasource

### DIFF
--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -180,8 +180,7 @@ const getQueryOperationRowStyles = stylesFactory((theme: GrafanaTheme) => {
       text-overflow: ellipsis;
     `,
     content: css`
-      margin-top: ${theme.spacing.inlineFormMargin};
-      margin-left: ${theme.spacing.lg};
+      margin: ${theme.spacing.md};
     `,
     disabled: css`
       color: ${theme.colors.textWeak};

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -5,7 +5,6 @@ import {
   DataSourceInstanceSettings,
   LoadingState,
   PanelData,
-  PluginType,
   RelativeTimeRange,
   ThresholdsConfig,
   ThresholdsMode,
@@ -17,6 +16,7 @@ import { isExpressionQuery } from 'app/features/expressions/guards';
 import { queriesWithUpdatedReferences } from './util';
 import { Button, Card, Icon } from '@grafana/ui';
 import { QueryOperationRow } from 'app/core/components/QueryOperationRow/QueryOperationRow';
+import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 
 interface Props {
   // The query configuration
@@ -241,7 +241,10 @@ export class QueryRows extends PureComponent<Props, State> {
                         index={index}
                         model={query.model}
                         onUpdateDatasource={() => {
-                          this.onChangeDataSource(createDummyDatasource(), index);
+                          const defaultDataSource = getDatasourceSrv().getInstanceSettings(null);
+                          if (defaultDataSource) {
+                            this.onChangeDataSource(defaultDataSource, index);
+                          }
                         }}
                         onRemoveQuery={() => {
                           this.onRemoveQuery(query);
@@ -342,36 +345,3 @@ const DatasourceNotFound = ({ index, onUpdateDatasource, onRemoveQuery, model }:
     </EmptyQueryWrapper>
   );
 };
-
-function createDummyDatasource(): DataSourceInstanceSettings {
-  return {
-    id: -1,
-    uid: 'unknown',
-    name: 'unknown',
-    type: '',
-    meta: {
-      builtIn: true,
-      id: '',
-      name: 'unknown',
-      type: PluginType.datasource,
-      info: {
-        author: {
-          name: '',
-        },
-        description: '',
-        links: [],
-        logos: {
-          large: '',
-          small: '',
-        },
-        screenshots: [],
-        updated: '',
-        version: '',
-      },
-      module: '',
-      baseUrl: '',
-    },
-    jsonData: {},
-    access: 'direct',
-  };
-}

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -108,6 +108,15 @@ export class QueryRows extends PureComponent<Props, State> {
         return item;
       }
 
+      const previous = getDataSourceSrv().getInstanceSettings(item.datasourceUid);
+
+      if (previous?.type === settings.uid) {
+        return {
+          ...item,
+          datasourceUid: settings.uid,
+        };
+      }
+
       return {
         ...item,
         datasourceUid: settings.uid,

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -1,19 +1,22 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, useState } from 'react';
 import { DragDropContext, Droppable, DropResult } from 'react-beautiful-dnd';
 import {
   DataQuery,
   DataSourceInstanceSettings,
   LoadingState,
   PanelData,
+  PluginType,
   RelativeTimeRange,
   ThresholdsConfig,
   ThresholdsMode,
 } from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
-import { QueryWrapper } from './QueryWrapper';
-import { AlertQuery } from 'app/types/unified-alerting-dto';
+import { EmptyQueryWrapper, QueryWrapper } from './QueryWrapper';
+import { AlertDataQuery, AlertQuery } from 'app/types/unified-alerting-dto';
 import { isExpressionQuery } from 'app/features/expressions/guards';
 import { queriesWithUpdatedReferences } from './util';
+import { Button, Card, Icon } from '@grafana/ui';
+import { QueryOperationRow } from 'app/core/components/QueryOperationRow/QueryOperationRow';
 
 interface Props {
   // The query configuration
@@ -100,30 +103,17 @@ export class QueryRows extends PureComponent<Props, State> {
   onChangeDataSource = (settings: DataSourceInstanceSettings, index: number) => {
     const { queries, onQueriesChange } = this.props;
 
-    onQueriesChange(
-      queries.map((item, itemIndex) => {
-        if (itemIndex !== index) {
-          return item;
-        }
+    const updatedQueries = queries.map((item, itemIndex) => {
+      if (itemIndex !== index) {
+        return item;
+      }
 
-        const previous = getDataSourceSrv().getInstanceSettings(item.datasourceUid);
-
-        if (previous?.type === settings.uid) {
-          return {
-            ...item,
-            datasourceUid: settings.uid,
-          };
-        }
-
-        const { refId, hide } = item.model;
-
-        return {
-          ...item,
-          datasourceUid: settings.uid,
-          model: { refId, hide },
-        };
-      })
-    );
+      return {
+        ...item,
+        datasourceUid: settings.uid,
+      };
+    });
+    onQueriesChange(updatedQueries);
   };
 
   onChangeQuery = (query: DataQuery, index: number) => {
@@ -245,8 +235,21 @@ export class QueryRows extends PureComponent<Props, State> {
                   const dsSettings = this.getDataSourceSettings(query);
 
                   if (!dsSettings) {
-                    return null;
+                    return (
+                      <DatasourceNotFound
+                        key={`${query.refId}-${index}`}
+                        index={index}
+                        model={query.model}
+                        onUpdateDatasource={() => {
+                          this.onChangeDataSource(createDummyDatasource(), index);
+                        }}
+                        onRemoveQuery={() => {
+                          this.onRemoveQuery(query);
+                        }}
+                      />
+                    );
                   }
+
                   return (
                     <QueryWrapper
                       index={index}
@@ -274,4 +277,101 @@ export class QueryRows extends PureComponent<Props, State> {
       </DragDropContext>
     );
   }
+}
+
+interface DatasourceNotFoundProps {
+  index: number;
+  model: AlertDataQuery;
+  onUpdateDatasource: () => void;
+  onRemoveQuery: () => void;
+}
+
+const DatasourceNotFound = ({ index, onUpdateDatasource, onRemoveQuery, model }: DatasourceNotFoundProps) => {
+  const refId = model.refId;
+
+  const [showDetails, setShowDetails] = useState<boolean>(false);
+
+  const toggleDetails = () => {
+    setShowDetails((show) => !show);
+  };
+
+  const handleUpdateDatasource = () => {
+    onUpdateDatasource();
+  };
+
+  return (
+    <EmptyQueryWrapper>
+      <QueryOperationRow title={refId} draggable index={index} id={refId} isOpen>
+        <Card
+          heading="This datasource has been removed"
+          description={
+            'The datasource for this query was not found, it was either removed or is not installed correctly.'
+          }
+        >
+          <Card.Figure>
+            <Icon name="question-circle" />
+          </Card.Figure>
+          <Card.Actions>
+            <Button key="update" variant="secondary" onClick={handleUpdateDatasource}>
+              Update datasource
+            </Button>
+            <Button key="remove" variant="destructive" onClick={onRemoveQuery}>
+              Remove query
+            </Button>
+          </Card.Actions>
+          <Card.SecondaryActions>
+            <Button
+              key="details"
+              onClick={toggleDetails}
+              icon={showDetails ? 'angle-up' : 'angle-down'}
+              fill="text"
+              size="sm"
+            >
+              Show details
+            </Button>
+          </Card.SecondaryActions>
+        </Card>
+        {showDetails && (
+          <div>
+            <pre>
+              <code>{JSON.stringify(model, null, 2)}</code>
+            </pre>
+          </div>
+        )}
+      </QueryOperationRow>
+    </EmptyQueryWrapper>
+  );
+};
+
+function createDummyDatasource(): DataSourceInstanceSettings {
+  return {
+    id: -1,
+    uid: 'unknown',
+    name: 'unknown',
+    type: '',
+    meta: {
+      builtIn: true,
+      id: '',
+      name: 'unknown',
+      type: PluginType.datasource,
+      info: {
+        author: {
+          name: '',
+        },
+        description: '',
+        links: [],
+        logos: {
+          large: '',
+          small: '',
+        },
+        screenshots: [],
+        updated: '',
+        version: '',
+      },
+      module: '',
+      baseUrl: '',
+    },
+    jsonData: {},
+    access: 'direct',
+  };
 }

--- a/public/app/features/alerting/unified/components/rule-editor/QueryStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryStep.tsx
@@ -14,6 +14,7 @@ export const QueryStep: FC = () => {
   } = useFormContext<RuleFormValues>();
   const type = watch('type');
   const dataSourceName = watch('dataSourceName');
+
   return (
     <RuleEditorSection
       stepNo={2}

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -102,12 +102,16 @@ export const QueryWrapper: FC<Props> = ({
   );
 };
 
+export const EmptyQueryWrapper: FC<{}> = ({ children }) => {
+  const styles = useStyles2(getStyles);
+  return <div className={styles.wrapper}>{children}</div>;
+};
+
 const getStyles = (theme: GrafanaTheme2) => ({
   wrapper: css`
     label: AlertingQueryWrapper;
     margin-bottom: ${theme.spacing(1)};
     border: 1px solid ${theme.colors.border.medium};
     border-radius: ${theme.shape.borderRadius(1)};
-    padding-bottom: ${theme.spacing(1)};
   `,
 });

--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -102,7 +102,7 @@ export enum GrafanaAlertStateDecision {
   Error = 'Error',
 }
 
-interface AlertDataQuery extends DataQuery {
+export interface AlertDataQuery extends DataQuery {
   maxDataPoints?: number;
   intervalMs?: number;
 }


### PR DESCRIPTION
This change informs the user that a datasource might have been removed in the alert rule. 

It also allows the user to inspect the details of the alert model and switching to a new compatible datasource preserves the previous settings.

https://user-images.githubusercontent.com/868844/148925611-668f3679-8050-42f0-be25-f152f952cffb.mov

**What this PR does / why we need it**:

Previously query editor rows with missing datasources were not rendered at all, see #42629

**Which issue(s) this PR fixes**:

Fixes #42629

**Special notes for your reviewer**:

I still need to figure out if we need to keep the previous logic in `onChangeDataSource`, it prevents us from preserving the query settings but perhaps they were necessary for backwards compatibility reasons.
