### PR TITLE
DataSourcePlugin: Add possibility to update queries when changing data source type

### DIFF
--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -113,7 +113,7 @@ export class QueryGroup extends PureComponent<Props, State> {
 
   onChangeDataSource = async (newSettings: DataSourceInstanceSettings) => {
     const { dsSettings } = this.state;
-    const queries = updateQueries(newSettings, this.state.queries, dsSettings);
+    const queries = await updateQueries(newSettings, this.state.queries, dsSettings);
 
     const dataSource = await this.dataSourceSrv.get(newSettings.name);
     this.onChange({

--- a/public/app/features/query/state/updateQueries.test.ts
+++ b/public/app/features/query/state/updateQueries.test.ts
@@ -1,9 +1,45 @@
+import {
+  DataQuery,
+  DataSourceApi,
+  DataSourceInstanceSettings,
+  DataSourcePlugin,
+  DataSourcePluginMeta,
+} from '@grafana/data';
+import { DataSourceSrv, setDataSourceSrv } from '@grafana/runtime';
 import { ExpressionDatasourceRef } from '@grafana/runtime/src/utils/DataSourceWithBackend';
 import { updateQueries } from './updateQueries';
 
+class TestDataSource {
+  constructor(public instanceSettings: DataSourceInstanceSettings) {}
+}
+
+const datasourcePluginMock = new DataSourcePlugin(TestDataSource as any);
+jest.mock('app/features/plugins/plugin_loader', () => ({
+  importDataSourcePlugin: (meta: DataSourcePluginMeta) => {
+    return Promise.resolve(datasourcePluginMock);
+  },
+}));
+
 describe('updateQueries', () => {
-  it('Should update all queries except expression query when changing data source with same type', () => {
-    const updated = updateQueries(
+  beforeEach(() => {
+    setDataSourceSrv({
+      get: (uid: string) => {
+        if (uid === 'new-uid') {
+          return Promise.resolve({
+            uid,
+            type: 'new-type',
+          } as DataSourceApi);
+        }
+
+        return Promise.resolve({
+          uid,
+        } as DataSourceApi);
+      },
+    } as DataSourceSrv);
+  });
+
+  it('Should update all queries except expression query when changing data source with same type', async () => {
+    const updated = await updateQueries(
       {
         uid: 'new-uid',
         type: 'same-type',
@@ -32,8 +68,8 @@ describe('updateQueries', () => {
     expect(updated[1].datasource).toEqual(ExpressionDatasourceRef);
   });
 
-  it('Should clear queries when changing type', () => {
-    const updated = updateQueries(
+  it('Should clear queries when changing type', async () => {
+    const updated = await updateQueries(
       {
         uid: 'new-uid',
         type: 'new-type',
@@ -65,8 +101,8 @@ describe('updateQueries', () => {
     expect(updated[0].datasource).toEqual({ type: 'new-type', uid: 'new-uid' });
   });
 
-  it('Should preserve query data source when changing to mixed', () => {
-    const updated = updateQueries(
+  it('Should preserve query data source when changing to mixed', async () => {
+    const updated = await updateQueries(
       {
         uid: 'mixed',
         type: 'mixed',
@@ -98,5 +134,88 @@ describe('updateQueries', () => {
 
     expect(updated[0].datasource).toEqual({ type: 'old-type', uid: 'old-uid' });
     expect(updated[1].datasource).toEqual({ type: 'other-type', uid: 'other-uid' });
+  });
+
+  describe('migrating queries when changing data source', () => {
+    beforeEach(() => {
+      datasourcePluginMock.setDataSourceChangeHandler(
+        (prev: DataSourceInstanceSettings, __: DataSourceInstanceSettings, qs: DataQuery[]) => {
+          if (prev.uid === 'old-uid-skip') {
+            return false;
+          }
+          return Promise.resolve(qs.map((q) => ({ ...q, addedProp: 'prop' }))) as any;
+        }
+      );
+    });
+
+    it('Should migrate queries when changing type and change handler defined', async () => {
+      const updated = await updateQueries(
+        {
+          uid: 'new-uid',
+          type: 'new-type',
+          meta: {},
+        } as any,
+        [
+          {
+            refId: 'A',
+            datasource: {
+              uid: 'old-uid',
+              type: 'old-type',
+            },
+          },
+          {
+            refId: 'B',
+            datasource: {
+              uid: 'old-uid',
+              type: 'old-type',
+            },
+          },
+        ],
+        {
+          uid: 'old-uid',
+          type: 'old-type',
+        } as any
+      );
+
+      expect(updated.length).toEqual(2);
+      expect(updated[0].datasource).toEqual({ type: 'new-type', uid: 'new-uid' });
+      expect(updated[1].datasource).toEqual({ type: 'new-type', uid: 'new-uid' });
+      expect(updated[0]).toHaveProperty('addedProp');
+      expect(updated[1]).toHaveProperty('addedProp');
+    });
+
+    it('Should clear queries when handler returns false', async () => {
+      const updated = await updateQueries(
+        {
+          uid: 'new-uid',
+          type: 'new-type',
+          meta: {},
+        } as any,
+        [
+          {
+            refId: 'A',
+            datasource: {
+              uid: 'old-uid-skip',
+              type: 'old-type',
+            },
+          },
+          {
+            refId: 'B',
+            datasource: {
+              uid: 'old-uid-skip',
+              type: 'old-type',
+            },
+          },
+        ],
+        {
+          uid: 'old-uid-skip',
+          type: 'old-type',
+        } as any
+      );
+
+      expect(updated.length).toEqual(1);
+      expect(updated[0].datasource).toEqual({ type: 'new-type', uid: 'new-uid' });
+      expect(updated[0]).not.toHaveProperty('addedProp');
+    });
   });
 });

--- a/public/app/features/query/state/updateQueries.ts
+++ b/public/app/features/query/state/updateQueries.ts
@@ -1,19 +1,49 @@
-import { DataQuery, DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
+import { AppEvents, DataQuery, DataSourceApi, DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
 import { isExpressionReference } from '@grafana/runtime/src/utils/DataSourceWithBackend';
+import appEvents from 'app/core/app_events';
+import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
+import { importDataSourcePlugin } from 'app/features/plugins/plugin_loader';
 
-export function updateQueries(
+export async function updateQueries(
   newSettings: DataSourceInstanceSettings,
   queries: DataQuery[],
   dsSettings?: DataSourceInstanceSettings
-): DataQuery[] {
+): Promise<DataQuery[]> {
   const datasource = getDataSourceRef(newSettings);
-
   // we are changing data source type
   if (dsSettings?.type !== newSettings.type) {
     // If changing to mixed do nothing
     if (newSettings.meta.mixed) {
       return queries;
     } else {
+      const dataSourceSrv = getDatasourceSrv();
+      let datasource: DataSourceApi;
+
+      try {
+        datasource = await dataSourceSrv.get(newSettings.uid);
+      } catch (error) {
+        datasource = await dataSourceSrv.get();
+      }
+
+      let migratedQueries: DataQuery[] | false = false;
+      try {
+        const dsPlugin = await importDataSourcePlugin(datasource.meta);
+        if (dsPlugin.onDatasourceChange) {
+          migratedQueries = await dsPlugin.onDatasourceChange(
+            dsSettings!,
+            newSettings,
+            queries.map((q) => ({
+              ...q,
+              datasource,
+            }))
+          );
+        }
+      } catch (err) {
+        appEvents.emit(AppEvents.alertError, [datasource.name, ' plugin failed', err.toString()]);
+      }
+
+      return migratedQueries || [{ refId: 'A', datasource }];
+
       // Changing to another datasource type clear queries
       return [{ refId: 'A', datasource }];
     }


### PR DESCRIPTION
This PR bring a new method to `DataSourcePlugin` API that will allow migrating queries when the user changes the data source type in the panel editor.

Proposed method, `setDataSourceChangeHandler` takes the previous and next data source's settings as well as an array of panel queries. It can modify the queries based on the existing ones to allow queries migration from one DS to another. To opt-out from the migration one can return `false` from the handler and the current default behavior (clearing the queries) will be applied.

An example implementation of the handler:

```ts
plugin.setDataSourceChangeHandler(
    (
      prev: DataSourceInstanceSettings,
      next: DataSourceInstanceSettings,
      queries: DataQuery[]
    ): BigQueryQueryNG[] | false => {
      if (prev.type !== 'doitintl-bigquery-datasource') {
        // preserve current, default behavior - clear the queries
        return false;
      }

      return queries.map((q) => {
        return {
          // DataQuery
          refId: q.refId,
          queryType: q.queryType,
          hide: q.hide,
          key: q.key,
          datasource: q.datasource,

          // BigQuery query
          format: (q as any).format === 'time_series' ? QueryFormat.Timeseries : QueryFormat.Table,
          location: (q as any).location,
          rawSql: (q as any).rawSql,
          rawQuery: (q as any).rawQuery,
        };
      });
    }
  );
```

UI behavior before this change:

https://user-images.githubusercontent.com/2376619/148953490-659d99a6-acd9-4e10-89d8-1eb4c101ac82.mov



UI behavior after this change:

https://user-images.githubusercontent.com/2376619/148953421-fe1bf0c2-759f-43a8-b10d-b2426773d638.mov


Background: We are implementing a new version of the BigQuery data source and we want to have an easy migration path for the users that want to switch from the current to the updated version of the data source. Thanks to this proposal, changing the data source type will preserve the BigQuery queries created with the doit BigQuery plugin.