### PR TITLE
SSE: Remove beta tooltip

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryEditor.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryEditor.tsx
@@ -9,7 +9,7 @@ import {
   RelativeTimeRange,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Button, HorizontalGroup, Icon, stylesFactory, Tooltip } from '@grafana/ui';
+import { Button, HorizontalGroup, stylesFactory } from '@grafana/ui';
 import { config } from '@grafana/runtime';
 import { QueryRows } from './QueryRows';
 import {
@@ -121,18 +121,15 @@ export class QueryEditor extends PureComponent<Props, State> {
           Query
         </Button>
         {config.expressionsEnabled && (
-          <Tooltip content="Beta feature: queries could stop working in next version" placement="right">
-            <Button
-              type="button"
-              icon="plus"
-              onClick={this.onNewExpressionQuery}
-              variant="secondary"
-              className={styles.expressionButton}
-            >
-              <span>Expression&nbsp;</span>
-              <Icon name="exclamation-triangle" className="muted" size="sm" />
-            </Button>
-          </Tooltip>
+          <Button
+            type="button"
+            icon="plus"
+            onClick={this.onNewExpressionQuery}
+            variant="secondary"
+            className={styles.expressionButton}
+          >
+            <span>Expression&nbsp;</span>
+          </Button>
         )}
       </HorizontalGroup>
     );

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -5,12 +5,10 @@ import {
   Button,
   CustomScrollbar,
   HorizontalGroup,
-  Icon,
   InlineFormLabel,
   Modal,
   ScrollbarPosition,
   stylesFactory,
-  Tooltip,
 } from '@grafana/ui';
 import { DataSourcePicker, getDataSourceSrv } from '@grafana/runtime';
 import { QueryEditorRows } from './QueryEditorRows';
@@ -334,17 +332,14 @@ export class QueryGroup extends PureComponent<Props, State> {
           </Button>
         )}
         {config.expressionsEnabled && this.isExpressionsSupported(dsSettings) && (
-          <Tooltip content="Beta feature: queries could stop working in next version" placement="right">
-            <Button
-              icon="plus"
-              onClick={this.onAddExpressionClick}
-              variant="secondary"
-              className={styles.expressionButton}
-            >
-              <span>Expression&nbsp;</span>
-              <Icon name="exclamation-triangle" className="muted" size="sm" />
-            </Button>
-          </Tooltip>
+          <Button
+            icon="plus"
+            onClick={this.onAddExpressionClick}
+            variant="secondary"
+            className={styles.expressionButton}
+          >
+            <span>Expression&nbsp;</span>
+          </Button>
         )}
         {this.renderExtraActions()}
       </HorizontalGroup>


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove beta / queries could break indicator on Expression button.

![image](https://user-images.githubusercontent.com/1692624/148983530-ea1832f4-0523-4225-879b-d0d79f4e3c56.png)

Ping'd by Petros on it, and don't think we can really break existing functionality in it at this point anyways.

