### PR TITLE
Chore: Add PR Check action enforcing backport decision

### DIFF
--- a/.github/pr-checks.json
+++ b/.github/pr-checks.json
@@ -5,5 +5,14 @@
     "targetUrl": "https://github.com/grafana/grafana/blob/main/contribute/merge-pull-request.md#assign-a-milestone",
     "success": "Milestone set",
     "failure": "Milestone not set"
+  },
+  {
+    "type": "check-backport",
+    "title": "Backport Check",
+    "backportEnabled": "Backport enabled",
+    "backportSkipped": "Backport skipped",
+    "failure": "Backport decision needed",
+    "targetUrl": "https://github.com/grafana/grafana/blob/main/contribute/merge-pull-request.md#should-the-pull-request-be-backported",
+    "skipLabels": [ "backport", "no-backport"]
   }
 ]

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -4,6 +4,8 @@ on:
     types:
       - opened
       - synchronize
+      - labeled
+      - unlabeled
   issues:
     types:
       - milestoned

--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -85,7 +85,20 @@ In case the pull request introduces a breaking change you should document this. 
 
 ### Should the pull request be backported?
 
+An active decision of backporting needs to be taken for every pull request. There's a pull request check named **Backport Check** that will enforce this. By adding/removing labels on the pull request the check will be re-evaluated.
+
+#### No backport
+
+If you don't want to backport you need to add a label named **no-backport** to the pull request.
+
+#### Backport
+
 If your pull request has changes that need to go into one or several existing release branches you need to backport the changes. Please refer to [Backport PR](.github/bot.md#backport-pr) for detailed instructions.
+
+The general rule of thumb regarding what changes goes into what release is:
+
+- bug fixes should be released in patch releases, e.g. v8.1.3, if the bug was introduced in the same major/minor or lower patch version.
+- new features should go into the next major/minor version, e.g. v8.0.0, v8.2.0.
 
 Some examples when backport is required:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an additional PR Check that enforces an active decision whether to backport or not. We can make this check required for PR's to be merged (when we've verified it works as expected).

You can test it out [here](https://github.com/grafana/github-actions-testrepo/pull/62) by assigning/removing labels (note it takes some time for the action to run). 

Labels named 
- `backport vX.Y.X` should trigger the check to succeed with _Backport enabled_ message.
- `backport` or `no-backport` should trigger the check to succeed with _Backport skipped_ message.

**Backport decision needed (no labels added):**
![image](https://user-images.githubusercontent.com/1668778/149000715-be82bfa6-3684-4e70-b4da-b8d00042d5cb.png)

**No backport:**
![image](https://user-images.githubusercontent.com/1668778/149000747-05d70ccf-5266-43c7-a80a-4c9cc47c83f3.png)

**Backport:**
![image](https://user-images.githubusercontent.com/1668778/149000795-019ea757-ccc2-4ede-8b08-af96dbf13a0d.png)

**Which issue(s) this PR fixes**:
Ref https://github.com/grafana/grafana-github-actions/pull/53
Ref https://github.com/grafana/grafana-release/issues/60

**Special notes for your reviewer**:
I've created the _no-backport_ [label](https://github.com/grafana/grafana/labels/no-backport)
