### PR TITLE
[v8.3.x] Propagate all headers (#43812)

### DIFF
--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -1,0 +1,237 @@
+package api_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"gopkg.in/macaron.v1"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+
+	"github.com/grafana/grafana/pkg/web"
+
+	"github.com/grafana/grafana/pkg/api/routing"
+
+	"github.com/grafana/grafana/pkg/services/quota"
+
+	"github.com/grafana/grafana/pkg/setting"
+
+	"golang.org/x/oauth2"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/api"
+	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/services/secrets"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryData(t *testing.T) {
+	t.Run("it attaches custom headers to the request", func(t *testing.T) {
+		tc := setup()
+		tc.dataSourceCache.ds.JsonData = simplejson.NewFromAny(map[string]interface{}{"httpHeaderName1": "foo", "httpHeaderName2": "bar"})
+		tc.secretService.decryptedJson = map[string]string{"httpHeaderValue1": "test-header", "httpHeaderValue2": "test-header2"}
+
+		_ = tc.httpServer.QueryMetricsV2(requestContext, metricRequest())
+
+		require.Equal(t, map[string]string{"foo": "test-header", "bar": "test-header2"}, tc.pluginContext.req.Headers)
+	})
+
+	t.Run("it attaches auth headers to the request", func(t *testing.T) {
+		token := &oauth2.Token{
+			TokenType:   "bearer",
+			AccessToken: "access-token",
+		}
+		token = token.WithExtra(map[string]interface{}{"id_token": "id-token"})
+
+		tc := setup()
+		tc.oauthTokenService.passThruEnabled = true
+		tc.oauthTokenService.token = token
+
+		_ = tc.httpServer.QueryMetricsV2(requestContext, metricRequest())
+
+		expected := map[string]string{
+			"Authorization": "Bearer access-token",
+			"X-ID-Token":    "id-token",
+		}
+		require.Equal(t, expected, tc.pluginContext.req.Headers)
+	})
+}
+
+func setup() *testContext {
+	pc := &fakePluginClient{}
+	sc := &fakeSecretsService{}
+	dc := &fakeDataSourceCache{ds: &models.DataSource{JsonData: simplejson.New()}}
+	tc := &fakeOAuthTokenService{}
+	rv := &fakePluginRequestValidator{}
+
+	server, err := api.ProvideHTTPServer(
+		api.ServerOptions{},
+		&setting.Cfg{},
+		&noOpRouteRegister{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		rv,
+		nil,
+		nil,
+		nil,
+		pc,
+		nil,
+		nil,
+		dc,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		&fakeAccessControl{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		&quota.QuotaService{},
+		nil,
+		tc,
+		nil,
+		nil,
+		nil,
+		nil,
+		sc,
+		nil,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	return &testContext{
+		pluginContext:          pc,
+		secretService:          sc,
+		dataSourceCache:        dc,
+		oauthTokenService:      tc,
+		pluginRequestValidator: rv,
+		httpServer:             server,
+	}
+}
+
+type testContext struct {
+	pluginContext          *fakePluginClient
+	secretService          *fakeSecretsService
+	dataSourceCache        *fakeDataSourceCache
+	oauthTokenService      *fakeOAuthTokenService
+	pluginRequestValidator *fakePluginRequestValidator
+	httpServer             *api.HTTPServer
+}
+
+func metricRequest() dtos.MetricRequest {
+	q, _ := simplejson.NewJson([]byte(`{"datasourceId":1}`))
+	return dtos.MetricRequest{
+		From:    "",
+		To:      "",
+		Queries: []*simplejson.Json{q},
+		Debug:   false,
+	}
+}
+
+var requestContext = &models.ReqContext{
+	Context: &macaron.Context{
+		Req: &http.Request{},
+	},
+}
+
+type fakeAccessControl struct {
+	accesscontrol.AccessControl
+}
+
+func (ac *fakeAccessControl) IsDisabled() bool {
+	return true
+}
+
+func (ac *fakeAccessControl) DeclareFixedRoles(...accesscontrol.RoleRegistration) error {
+	return nil
+}
+
+type noOpRouteRegister struct{}
+
+func (noOpRouteRegister) Get(string, ...web.Handler)                                 {}
+func (noOpRouteRegister) Post(string, ...web.Handler)                                {}
+func (noOpRouteRegister) Delete(string, ...web.Handler)                              {}
+func (noOpRouteRegister) Put(string, ...web.Handler)                                 {}
+func (noOpRouteRegister) Patch(string, ...web.Handler)                               {}
+func (noOpRouteRegister) Any(string, ...web.Handler)                                 {}
+func (noOpRouteRegister) Group(string, func(routing.RouteRegister), ...web.Handler)  {}
+func (noOpRouteRegister) Insert(string, func(routing.RouteRegister), ...web.Handler) {}
+func (noOpRouteRegister) Register(routing.Router)                                    {}
+func (noOpRouteRegister) Reset()                                                     {}
+
+type fakePluginRequestValidator struct {
+	err error
+}
+
+func (rv *fakePluginRequestValidator) Validate(dsURL string, req *http.Request) error {
+	return rv.err
+}
+
+type fakeOAuthTokenService struct {
+	passThruEnabled bool
+	token           *oauth2.Token
+}
+
+func (ts *fakeOAuthTokenService) GetCurrentOAuthToken(context.Context, *models.SignedInUser) *oauth2.Token {
+	return ts.token
+}
+
+func (ts *fakeOAuthTokenService) IsOAuthPassThruEnabled(*models.DataSource) bool {
+	return ts.passThruEnabled
+}
+
+type fakeSecretsService struct {
+	secrets.Service
+
+	decryptedJson map[string]string
+}
+
+func (s *fakeSecretsService) DecryptJsonData(ctx context.Context, sjd map[string][]byte) (map[string]string, error) {
+	return s.decryptedJson, nil
+}
+
+type fakeDataSourceCache struct {
+	ds *models.DataSource
+}
+
+func (c *fakeDataSourceCache) GetDatasource(datasourceID int64, user *models.SignedInUser, skipCache bool) (*models.DataSource, error) {
+	return c.ds, nil
+}
+
+func (c *fakeDataSourceCache) GetDatasourceByUID(datasourceUID string, user *models.SignedInUser, skipCache bool) (*models.DataSource, error) {
+	return c.ds, nil
+}
+
+type fakePluginClient struct {
+	plugins.Client
+
+	req *backend.QueryDataRequest
+}
+
+func (c *fakePluginClient) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	c.req = req
+	return &backend.QueryDataResponse{}, nil
+}

--- a/pkg/tsdb/prometheus/promclient/provider.go
+++ b/pkg/tsdb/prometheus/promclient/provider.go
@@ -14,11 +14,6 @@ import (
 	apiv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
-const (
-	authHeader    = "Authorization"
-	idTokenHeader = "X-ID-Token"
-)
-
 type Provider struct {
 	settings       backend.DataSourceInstanceSettings
 	jsonData       JsonData
@@ -41,9 +36,8 @@ func NewProvider(
 }
 
 type JsonData struct {
-	Method        string `json:"httpMethod"`
-	OauthPassThru bool   `json:"oauthPassThru"`
-	TimeInterval  string `json:"timeInterval"`
+	Method       string `json:"httpMethod"`
+	TimeInterval string `json:"timeInterval"`
 }
 
 func (p *Provider) GetClient(headers map[string]string) (apiv1.API, error) {
@@ -53,9 +47,7 @@ func (p *Provider) GetClient(headers map[string]string) (apiv1.API, error) {
 	}
 
 	opts.Middlewares = p.middlewares()
-	if p.jsonData.OauthPassThru {
-		opts.Headers = authHeaders(headers)
-	}
+	opts.Headers = reqHeaders(headers)
 
 	// Set SigV4 service namespace
 	if opts.SigV4 != nil {
@@ -92,15 +84,11 @@ func (p *Provider) middlewares() []sdkhttpclient.Middleware {
 	return middlewares
 }
 
-func authHeaders(headers map[string]string) map[string]string {
-	authHeaders := make(map[string]string)
-	if v, ok := headers[authHeader]; ok {
-		authHeaders[authHeader] = v
+func reqHeaders(headers map[string]string) map[string]string {
+	// copy to avoid changing the original map
+	h := make(map[string]string, len(headers))
+	for k, v := range headers {
+		h[k] = v
 	}
-
-	if v, ok := headers[idTokenHeader]; ok {
-		authHeaders[idTokenHeader] = v
-	}
-
-	return authHeaders
+	return h
 }

--- a/pkg/tsdb/prometheus/promclient/provider_test.go
+++ b/pkg/tsdb/prometheus/promclient/provider_test.go
@@ -43,7 +43,7 @@ func TestGetClient(t *testing.T) {
 		require.Contains(t, tc.httpProvider.middlewares(), "CustomHeaders")
 	})
 
-	t.Run("oauth pass through", func(t *testing.T) {
+	t.Run("extra headers", func(t *testing.T) {
 		t.Run("it sets the headers when 'oauthPassThru' is true and auth headers are passed", func(t *testing.T) {
 			tc := setup(`{"oauthPassThru":true}`)
 			_, err := tc.promClientProvider.GetClient(headers)
@@ -52,14 +52,14 @@ func TestGetClient(t *testing.T) {
 			require.Equal(t, headers, tc.httpProvider.opts.Headers)
 		})
 
-		t.Run("it only sets auth headers", func(t *testing.T) {
+		t.Run("it sets all headers", func(t *testing.T) {
 			withNonAuth := map[string]string{"X-Not-Auth": "stuff"}
 
 			tc := setup(`{"oauthPassThru":true}`)
 			_, err := tc.promClientProvider.GetClient(withNonAuth)
 			require.Nil(t, err)
 
-			require.Equal(t, map[string]string{}, tc.httpProvider.opts.Headers)
+			require.Equal(t, map[string]string{"X-Not-Auth": "stuff"}, tc.httpProvider.opts.Headers)
 		})
 
 		t.Run("it does not error when headers are nil", func(t *testing.T) {
@@ -67,14 +67,6 @@ func TestGetClient(t *testing.T) {
 
 			_, err := tc.promClientProvider.GetClient(nil)
 			require.Nil(t, err)
-		})
-
-		t.Run("it does not set the headers when 'oauthPassThru' is false", func(t *testing.T) {
-			tc := setup()
-			_, err := tc.promClientProvider.GetClient(headers)
-			require.Nil(t, err)
-
-			require.Len(t, tc.httpProvider.opts.Headers, 0)
 		})
 	})
 

--- a/pkg/tsdb/prometheus/prometheus.go
+++ b/pkg/tsdb/prometheus/prometheus.go
@@ -60,7 +60,7 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 		}
 
 		p := promclient.NewProvider(settings, jsonData, httpClientProvider, plog)
-		pc, err := promclient.NewProviderCache(p, jsonData)
+		pc, err := promclient.NewProviderCache(p)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Backport of https://github.com/grafana/grafana/pull/43812

There was a nice refactor in the original version so the test setup here is pretty gross.

