### PR TITLE
Azure Monitor: Remove valid aggregation type check in metrics query editor

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.ts
@@ -257,9 +257,7 @@ export const useMetricMetadata = (query: AzureMonitorQuery, datasource: Datasour
 
   // Update the query state in response to the meta data changing
   useEffect(() => {
-    const aggregationIsValid = aggregation && metricMetadata.supportedAggTypes.includes(aggregation);
-
-    const newAggregation = aggregationIsValid ? aggregation : metricMetadata.primaryAggType;
+    const newAggregation = aggregation || metricMetadata.primaryAggType;
     const newTimeGrain = timeGrain || 'auto';
 
     if (newAggregation !== aggregation || newTimeGrain !== timeGrain) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The array of supported aggregation types is empty at this point and causes the aggregation to be reassigned to undefined followed later by a default aggregation type of Average. This overwrites whatever type the user originally chose when editing a metrics query. (#43402)

Template variables are not considered valid, so this check was also causing #43950.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #43402 and fixes #43950

**Special notes for your reviewer**:
Thanks for the help @andresmgot 
