### PR TITLE
Access control: Add access control sql filter to org user queries

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -54,7 +54,7 @@ func (hs *HTTPServer) registerRoutes() {
 	r.Get("/datasources/", authorize(reqOrgAdmin, dataSourcesConfigurationAccessEvaluator), hs.Index)
 	r.Get("/datasources/new", authorize(reqOrgAdmin, dataSourcesNewAccessEvaluator), hs.Index)
 	r.Get("/datasources/edit/*", authorize(reqOrgAdmin, dataSourcesEditAccessEvaluator), hs.Index)
-	r.Get("/org/users", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), hs.Index)
+	r.Get("/org/users", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRead)), hs.Index)
 	r.Get("/org/users/new", reqOrgAdmin, hs.Index)
 	r.Get("/org/users/invite", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionUsersCreate)), hs.Index)
 	r.Get("/org/teams", reqCanAccessTeams, hs.Index)
@@ -206,8 +206,8 @@ func (hs *HTTPServer) registerRoutes() {
 			userIDScope := ac.Scope("users", "id", ac.Parameter(":userId"))
 			orgRoute.Put("/", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsWrite)), routing.Wrap(UpdateCurrentOrg))
 			orgRoute.Put("/address", authorize(reqOrgAdmin, ac.EvalPermission(ActionOrgsWrite)), routing.Wrap(UpdateCurrentOrgAddress))
-			orgRoute.Get("/users", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.GetOrgUsersForCurrentOrg))
-			orgRoute.Get("/users/search", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.SearchOrgUsersWithPaging))
+			orgRoute.Get("/users", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRead)), routing.Wrap(hs.GetOrgUsersForCurrentOrg))
+			orgRoute.Get("/users/search", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRead)), routing.Wrap(hs.SearchOrgUsersWithPaging))
 			orgRoute.Post("/users", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), quota("user"), routing.Wrap(hs.AddOrgUserToCurrentOrg))
 			orgRoute.Patch("/users/:userId", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRoleUpdate, userIDScope)), routing.Wrap(hs.UpdateOrgUserForCurrentOrg))
 			orgRoute.Delete("/users/:userId", authorize(reqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRemove, userIDScope)), routing.Wrap(hs.RemoveOrgUserForCurrentOrg))
@@ -224,7 +224,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 		// current org without requirement of user to be org admin
 		apiRoute.Group("/org", func(orgRoute routing.RouteRegister) {
-			orgRoute.Get("/users/lookup", authorize(reqOrgAdminFolderAdminOrTeamAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)), routing.Wrap(hs.GetOrgUsersForCurrentOrgLookup))
+			orgRoute.Get("/users/lookup", authorize(reqOrgAdminFolderAdminOrTeamAdmin, ac.EvalPermission(ac.ActionOrgUsersRead)), routing.Wrap(hs.GetOrgUsersForCurrentOrgLookup))
 		})
 
 		// create new org

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	acmiddleware "github.com/grafana/grafana/pkg/services/accesscontrol/middleware"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/auth"
@@ -354,6 +355,8 @@ func setupHTTPServerWithCfg(t *testing.T, useFakeAccessControl, enableAccessCont
 		initCtx.Logger = log.New("api-test")
 		c.Map(initCtx)
 	})
+
+	m.Use(acmiddleware.LoadPermissionsMiddleware(hs.AccessControl))
 
 	// Register all routes
 	hs.registerRoutes()

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -251,7 +251,7 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 		})
 	}
 
-	if hasAccess(ac.ReqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRead, ac.ScopeUsersAll)) {
+	if hasAccess(ac.ReqOrgAdmin, ac.EvalPermission(ac.ActionOrgUsersRead)) {
 		configNodes = append(configNodes, &dtos.NavLink{
 			Text:        "Users",
 			Id:          "users",

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -71,6 +71,7 @@ func (hs *HTTPServer) GetOrgUsersForCurrentOrg(c *models.ReqContext) response.Re
 		OrgId: c.OrgId,
 		Query: c.Query("query"),
 		Limit: c.QueryInt("limit"),
+		User:  c.SignedInUser,
 	}, c.SignedInUser)
 
 	if err != nil {
@@ -86,6 +87,7 @@ func (hs *HTTPServer) GetOrgUsersForCurrentOrgLookup(c *models.ReqContext) respo
 		OrgId: c.OrgId,
 		Query: c.Query("query"),
 		Limit: c.QueryInt("limit"),
+		User:  c.SignedInUser,
 	}, c.SignedInUser)
 
 	if err != nil {
@@ -124,6 +126,7 @@ func (hs *HTTPServer) GetOrgUsers(c *models.ReqContext) response.Response {
 		OrgId: c.ParamsInt64(":orgId"),
 		Query: "",
 		Limit: 0,
+		User:  c.SignedInUser,
 	}, c.SignedInUser)
 
 	if err != nil {
@@ -183,8 +186,9 @@ func (hs *HTTPServer) SearchOrgUsersWithPaging(c *models.ReqContext) response.Re
 	query := &models.SearchOrgUsersQuery{
 		OrgID: c.OrgId,
 		Query: c.Query("query"),
-		Limit: perPage,
 		Page:  page,
+		Limit: perPage,
+		User:  c.SignedInUser,
 	}
 
 	if err := hs.SQLStore.SearchOrgUsers(ctx, query); err != nil {

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -38,6 +38,7 @@ func TestOrgUsersAPIEndpoint_userLoggedIn(t *testing.T) {
 	hs := &HTTPServer{Cfg: settings}
 
 	sqlStore := sqlstore.InitTestDB(t)
+	sqlStore.Cfg = settings
 	hs.SQLStore = sqlStore
 
 	loggedInUserScenario(t, "When calling GET on", "api/org/users", func(sc *scenarioContext) {
@@ -802,7 +803,13 @@ func TestDeleteOrgUsersAPIEndpoint_AccessControl(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tc.expectedMessage, message)
 
-				getUsersQuery := models.GetOrgUsersQuery{OrgId: tc.targetOrg}
+				getUsersQuery := models.GetOrgUsersQuery{
+					OrgId: tc.targetOrg,
+					User: &models.SignedInUser{
+						OrgId:       tc.targetOrg,
+						Permissions: map[int64]map[string][]string{tc.targetOrg: {accesscontrol.ActionOrgUsersRead: {accesscontrol.ScopeUsersAll}}},
+					},
+				}
 				err = sc.db.GetOrgUsers(context.Background(), &getUsersQuery)
 				require.NoError(t, err)
 				assert.Len(t, getUsersQuery.Result, tc.expectedUserCount)

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -556,7 +556,10 @@ func TestPostOrgUsersAPIEndpoint_AccessControl(t *testing.T) {
 				require.NoError(t, err)
 				assert.EqualValuesf(t, tc.expectedMessage, message, "server did not answer expected message")
 
-				getUsersQuery := models.GetOrgUsersQuery{OrgId: tc.targetOrg}
+				getUsersQuery := models.GetOrgUsersQuery{OrgId: tc.targetOrg, User: &models.SignedInUser{
+					OrgId:       tc.targetOrg,
+					Permissions: map[int64]map[string][]string{tc.targetOrg: {"org.users:read": {"users:*"}}},
+				}}
 				err = sc.db.GetOrgUsers(context.Background(), &getUsersQuery)
 				require.NoError(t, err)
 				assert.Len(t, getUsersQuery.Result, tc.expectedUserCount)

--- a/pkg/models/org_user.go
+++ b/pkg/models/org_user.go
@@ -111,6 +111,7 @@ type GetOrgUsersQuery struct {
 	Query string
 	Limit int
 
+	User   *SignedInUser
 	Result []*OrgUserDTO
 }
 
@@ -120,6 +121,7 @@ type SearchOrgUsersQuery struct {
 	Page  int
 	Limit int
 
+	User   *SignedInUser
 	Result SearchOrgUsersQueryResult
 }
 

--- a/pkg/services/accesscontrol/filter.go
+++ b/pkg/services/accesscontrol/filter.go
@@ -10,7 +10,9 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 )
 
-var sqlIDAcceptList = map[string]struct{}{}
+var sqlIDAcceptList = map[string]struct{}{
+	"org_user.user_id": {},
+}
 
 type SQLDialect interface {
 	DriverName() string

--- a/pkg/services/accesscontrol/filter.go
+++ b/pkg/services/accesscontrol/filter.go
@@ -99,3 +99,12 @@ func postgresQuery(scopes []string, sqlID, prefix string) (string, []interface{}
 		)
 	`, sqlID, sqlID), args
 }
+
+// SetAcceptListForTest allow us to mutate the list for blackbox testing
+func SetAcceptListForTest(list map[string]struct{}) func() {
+	original := sqlIDAcceptList
+	sqlIDAcceptList = list
+	return func() {
+		sqlIDAcceptList = original
+	}
+}

--- a/pkg/services/sqlstore/org_users.go
+++ b/pkg/services/sqlstore/org_users.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -111,6 +112,15 @@ func (ss *SQLStore) GetOrgUsers(ctx context.Context, query *models.GetOrgUsersQu
 	// service accounts table in the modelling
 	whereConditions = append(whereConditions, fmt.Sprintf("%s.is_service_account = false", x.Dialect().Quote("user")))
 
+	if ss.Cfg.FeatureToggles["accesscontrol"] {
+		q, args, err := accesscontrol.Filter(ctx, ss.Dialect, "org_user.user_id", "users", "org.users:read", query.User)
+		if err != nil {
+			return err
+		}
+		whereConditions = append(whereConditions, q)
+		whereParams = append(whereParams, args...)
+	}
+
 	if query.Query != "" {
 		queryWithWildcards := "%" + query.Query + "%"
 		whereConditions = append(whereConditions, "(email "+dialect.LikeStr()+" ? OR name "+dialect.LikeStr()+" ? OR login "+dialect.LikeStr()+" ?)")
@@ -164,6 +174,15 @@ func (ss *SQLStore) SearchOrgUsers(ctx context.Context, query *models.SearchOrgU
 	// TODO: add to chore, for cleaning up after we have created
 	// service accounts table in the modelling
 	whereConditions = append(whereConditions, fmt.Sprintf("%s.is_service_account = false", x.Dialect().Quote("user")))
+
+	if ss.Cfg.FeatureToggles["accesscontrol"] {
+		q, args, err := accesscontrol.Filter(ctx, ss.Dialect, "org_user.user_id", "users", "org.users:read", query.User)
+		if err != nil {
+			return err
+		}
+		whereConditions = append(whereConditions, q)
+		whereParams = append(whereParams, args...)
+	}
 
 	if query.Query != "" {
 		queryWithWildcards := "%" + query.Query + "%"

--- a/pkg/services/sqlstore/org_users_test.go
+++ b/pkg/services/sqlstore/org_users_test.go
@@ -16,7 +16,6 @@ import (
 type getOrgUsersTestCase struct {
 	desc             string
 	query            *models.GetOrgUsersQuery
-	expectedErr      error
 	expectedNumUsers int
 }
 
@@ -67,7 +66,6 @@ func TestSQLStore_GetOrgUsers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-
 			err := store.GetOrgUsers(context.Background(), tt.query)
 			require.NoError(t, err)
 			require.Len(t, tt.query.Result, tt.expectedNumUsers)
@@ -84,7 +82,6 @@ func TestSQLStore_GetOrgUsers(t *testing.T) {
 type searchOrgUsersTestCase struct {
 	desc             string
 	query            *models.SearchOrgUsersQuery
-	expectedErr      error
 	expectedNumUsers int
 }
 
@@ -135,9 +132,9 @@ func TestSQLStore_SearchOrgUsers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-
 			err := store.SearchOrgUsers(context.Background(), tt.query)
 			require.NoError(t, err)
+			assert.Len(t, tt.query.Result.OrgUsers, tt.expectedNumUsers)
 
 			if !hasWildcardScope(tt.query.User, ac.ActionOrgUsersRead) {
 				for _, u := range tt.query.Result.OrgUsers {

--- a/pkg/services/sqlstore/org_users_test.go
+++ b/pkg/services/sqlstore/org_users_test.go
@@ -1,0 +1,176 @@
+package sqlstore
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/models"
+)
+
+type getOrgUsersTestCase struct {
+	desc             string
+	query            *models.GetOrgUsersQuery
+	expectedErr      error
+	expectedNumUsers int
+}
+
+func TestSQLStore_GetOrgUsers(t *testing.T) {
+	tests := []getOrgUsersTestCase{
+		{
+			desc: "should return all users",
+			query: &models.GetOrgUsersQuery{
+				OrgId: 1,
+				User: &models.SignedInUser{
+					OrgId:       1,
+					Permissions: map[int64]map[string][]string{1: {"org.users:read": {"users:*"}}},
+				},
+			},
+			expectedNumUsers: 10,
+		},
+		{
+			desc: "should return no users",
+			query: &models.GetOrgUsersQuery{
+				OrgId: 1,
+				User: &models.SignedInUser{
+					OrgId:       1,
+					Permissions: map[int64]map[string][]string{1: {"org.users:read": {""}}},
+				},
+			},
+			expectedNumUsers: 0,
+		},
+		{
+			desc: "should return some users",
+			query: &models.GetOrgUsersQuery{
+				OrgId: 1,
+				User: &models.SignedInUser{
+					OrgId: 1,
+					Permissions: map[int64]map[string][]string{1: {"org.users:read": {
+						"users:id:1",
+						"users:id:5",
+						"users:id:9",
+					}}},
+				},
+			},
+			expectedNumUsers: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			store := InitTestDB(t)
+			store.Cfg.FeatureToggles = map[string]bool{"accesscontrol": true}
+			seedOrgUsers(t, store, tt.query.OrgId)
+
+			err := store.GetOrgUsers(context.Background(), tt.query)
+			require.NoError(t, err)
+			require.Len(t, tt.query.Result, tt.expectedNumUsers)
+
+			if !hasWildcardScope(tt.query.User, "org.users:read") {
+				for _, u := range tt.query.Result {
+					assert.Contains(t, tt.query.User.Permissions[tt.query.User.OrgId]["org.users:read"], fmt.Sprintf("users:id:%d", u.UserId))
+				}
+			}
+		})
+	}
+}
+
+type searchOrgUsersTestCase struct {
+	desc             string
+	query            *models.SearchOrgUsersQuery
+	expectedErr      error
+	expectedNumUsers int
+}
+
+func TestSQLStore_SearchOrgUsers(t *testing.T) {
+	tests := []searchOrgUsersTestCase{
+		{
+			desc: "should return all users",
+			query: &models.SearchOrgUsersQuery{
+				OrgID: 1,
+				User: &models.SignedInUser{
+					OrgId:       1,
+					Permissions: map[int64]map[string][]string{1: {"org.users:read": {"users:*"}}},
+				},
+			},
+			expectedNumUsers: 10,
+		},
+		{
+			desc: "should return no users",
+			query: &models.SearchOrgUsersQuery{
+				OrgID: 1,
+				User: &models.SignedInUser{
+					OrgId:       1,
+					Permissions: map[int64]map[string][]string{1: {"org.users:read": {""}}},
+				},
+			},
+			expectedNumUsers: 0,
+		},
+		{
+			desc: "should return some users",
+			query: &models.SearchOrgUsersQuery{
+				OrgID: 1,
+				User: &models.SignedInUser{
+					OrgId: 1,
+					Permissions: map[int64]map[string][]string{1: {"org.users:read": {
+						"users:id:1",
+						"users:id:5",
+						"users:id:9",
+					}}},
+				},
+			},
+			expectedNumUsers: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			store := InitTestDB(t)
+			store.Cfg.FeatureToggles = map[string]bool{"accesscontrol": true}
+			seedOrgUsers(t, store, tt.query.OrgID)
+
+			err := store.SearchOrgUsers(context.Background(), tt.query)
+			require.NoError(t, err)
+
+			if !hasWildcardScope(tt.query.User, "org.users:read") {
+				for _, u := range tt.query.Result.OrgUsers {
+					assert.Contains(t, tt.query.User.Permissions[tt.query.User.OrgId]["org.users:read"], fmt.Sprintf("users:id:%d", u.UserId))
+				}
+			}
+		})
+	}
+}
+
+func seedOrgUsers(t *testing.T, store *SQLStore, orgID int64) {
+	t.Helper()
+	// Seed users
+	for i := 1; i <= 10; i++ {
+		user, err := store.CreateUser(context.Background(), models.CreateUserCommand{
+			Login: fmt.Sprintf("user-%d", i),
+			OrgId: orgID,
+		})
+		require.NoError(t, err)
+
+		if i != 1 {
+			err = store.AddOrgUser(context.Background(), &models.AddOrgUserCommand{
+				Role:   "Viewer",
+				OrgId:  1,
+				UserId: user.Id,
+			})
+			require.NoError(t, err)
+		}
+	}
+}
+
+func hasWildcardScope(user *models.SignedInUser, action string) bool {
+	for _, scope := range user.Permissions[user.OrgId][action] {
+		if strings.HasSuffix(scope, ":*") {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/services/sqlstore/org_users_test.go
+++ b/pkg/services/sqlstore/org_users_test.go
@@ -60,11 +60,12 @@ func TestSQLStore_GetOrgUsers(t *testing.T) {
 		},
 	}
 
+	store := InitTestDB(t)
+	store.Cfg.FeatureToggles = map[string]bool{"accesscontrol": true}
+	seedOrgUsers(t, store, 1)
+
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			store := InitTestDB(t)
-			store.Cfg.FeatureToggles = map[string]bool{"accesscontrol": true}
-			seedOrgUsers(t, store, tt.query.OrgId)
 
 			err := store.GetOrgUsers(context.Background(), tt.query)
 			require.NoError(t, err)
@@ -127,11 +128,12 @@ func TestSQLStore_SearchOrgUsers(t *testing.T) {
 		},
 	}
 
+	store := InitTestDB(t)
+	store.Cfg.FeatureToggles = map[string]bool{"accesscontrol": true}
+	seedOrgUsers(t, store, 10)
+
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			store := InitTestDB(t)
-			store.Cfg.FeatureToggles = map[string]bool{"accesscontrol": true}
-			seedOrgUsers(t, store, tt.query.OrgID)
 
 			err := store.SearchOrgUsers(context.Background(), tt.query)
 			require.NoError(t, err)
@@ -145,13 +147,13 @@ func TestSQLStore_SearchOrgUsers(t *testing.T) {
 	}
 }
 
-func seedOrgUsers(t *testing.T, store *SQLStore, orgID int64) {
+func seedOrgUsers(t *testing.T, store *SQLStore, numUsers int) {
 	t.Helper()
 	// Seed users
-	for i := 1; i <= 10; i++ {
+	for i := numUsers; i <= numUsers; i++ {
 		user, err := store.CreateUser(context.Background(), models.CreateUserCommand{
 			Login: fmt.Sprintf("user-%d", i),
-			OrgId: orgID,
+			OrgId: 1,
 		})
 		require.NoError(t, err)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
By using the access control filter we can return partial lists of entities. In this pr i have added it to the org users endpoints.

This is applied to:
* List users in a org
* Search users in a org
* And the users lookup function

User with action: `org.users:read` and scope `users:*`:
![2022-01-12-11:56:22](https://user-images.githubusercontent.com/23356117/149128412-a5132611-e9b4-4fcc-8cf2-4e1692003d7a.png)

User with action: `org.users:read` and scopes `users:id:1` `users:id:3`
![2022-01-12-11:57:06](https://user-images.githubusercontent.com/23356117/149128502-15a37612-f513-4579-838e-c14fc36dc282.png)
