### PR TITLE
Bug: Make `e2e artifacts upload` run at the end of the pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -258,7 +258,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
-  name: e2e_tests_artifacts_upload
+  name: e2e-tests-artifacts-upload
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -684,7 +684,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
-  name: e2e_tests_artifacts_upload
+  name: e2e-tests-artifacts-upload
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -1286,7 +1286,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
-  name: e2e_tests_artifacts_upload
+  name: e2e-tests-artifacts-upload
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -1885,7 +1885,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
-  name: e2e_tests_artifacts_upload
+  name: e2e-tests-artifacts-upload
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise --bucket "$${PRERELEASE_BUCKET}/artifacts/static-assets"
   depends_on:
@@ -3032,7 +3032,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
-  name: e2e_tests_artifacts_upload
+  name: e2e-tests-artifacts-upload
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -3587,7 +3587,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
-  name: e2e_tests_artifacts_upload
+  name: e2e-tests-artifacts-upload
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise --bucket "grafana-static-assets"
   depends_on:
@@ -4351,7 +4351,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
-  name: e2e_tests_artifacts_upload
+  name: e2e-tests-artifacts-upload
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -4879,7 +4879,7 @@ steps:
     GITHUB_TOKEN:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
-  name: e2e_tests_artifacts_upload
+  name: e2e-tests-artifacts-upload
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -5467,6 +5467,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: e990d6f5836b0a633877cf673e2e47e6d43443050d3fcae5e3a869fc00c62a0d
+hmac: fff4f33f3f6c6ec46c3dcbae5f5906129322400683f2bbf708c6cf4d7d5228c0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -259,6 +259,10 @@ steps:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
   name: e2e-tests-artifacts-upload
+  when:
+    status:
+    - success
+    - failure
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -685,6 +689,10 @@ steps:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
   name: e2e-tests-artifacts-upload
+  when:
+    status:
+    - success
+    - failure
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -1287,6 +1295,10 @@ steps:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
   name: e2e-tests-artifacts-upload
+  when:
+    status:
+    - success
+    - failure
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -1886,6 +1898,10 @@ steps:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
   name: e2e-tests-artifacts-upload
+  when:
+    status:
+    - success
+    - failure
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise --bucket "$${PRERELEASE_BUCKET}/artifacts/static-assets"
   depends_on:
@@ -3033,6 +3049,10 @@ steps:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
   name: e2e-tests-artifacts-upload
+  when:
+    status:
+    - success
+    - failure
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -3588,6 +3608,10 @@ steps:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
   name: e2e-tests-artifacts-upload
+  when:
+    status:
+    - success
+    - failure
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise --bucket "grafana-static-assets"
   depends_on:
@@ -4352,6 +4376,10 @@ steps:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
   name: e2e-tests-artifacts-upload
+  when:
+    status:
+    - success
+    - failure
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -4880,6 +4908,10 @@ steps:
       from_secret: github_token
   image: google/cloud-sdk:367.0.0
   name: e2e-tests-artifacts-upload
+  when:
+    status:
+    - success
+    - failure
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -5467,6 +5499,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: fff4f33f3f6c6ec46c3dcbae5f5906129322400683f2bbf708c6cf4d7d5228c0
+hmac: 81173294ad474a12cbb622d9e963e208ddd2a2ac42a30dde6396794923b158a0
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -296,6 +296,12 @@ def e2e_tests_artifacts(edition):
             'end-to-end-tests-smoke-tests-suite',
             'end-to-end-tests-various-suite',
         ],
+        'when': {
+            'status': [
+                'success',
+                'failure',
+            ]
+        },
         'environment': {
             'GCP_GRAFANA_UPLOAD_ARTIFACTS_KEY': from_secret('gcp_upload_artifacts_key'),
             'E2E_TEST_ARTIFACTS_BUCKET': 'releng-pipeline-artifacts-dev',

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -288,7 +288,7 @@ def store_storybook_step(edition, ver_mode):
 
 def e2e_tests_artifacts(edition):
     return {
-        'name': 'e2e_tests_artifacts_upload' + enterprise2_suffix(edition),
+        'name': 'e2e-tests-artifacts-upload' + enterprise2_suffix(edition),
         'image': 'google/cloud-sdk:367.0.0',
         'depends_on': [
             'end-to-end-tests-dashboards-suite',


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, e2e artifacts upload step, depends on all of our e2e tests suites, which means that if we have a suite failing, we won't be able to store failed e2e tests recordings.

This PR fixes this issue, by making this step run at the end, both if the e2e tests success or fail. If they fail, the step will still store the e2e tests recordings.

**Special notes for your reviewer:**

1. Case when e2e tests failed, but step ran and stored recordings: https://drone.grafana.net/grafana/grafana/47573
2. Case when e2e tests didn't run, so nothing uploaded to GCS: https://drone.grafana.net/grafana/grafana/47578
