### PR TITLE
Accessibility Fixes for Several SQL Based Query Editors

### DIFF
--- a/public/app/angular/components/code_editor/code_editor.ts
+++ b/public/app/angular/components/code_editor/code_editor.ts
@@ -99,6 +99,9 @@ async function link(scope: any, elem: any, attrs: any) {
   const textarea = elem.find('textarea');
   textarea.addClass('gf-form-input');
 
+  // All aria-label to be set for accessibility
+  textarea.attr('aria-label', attrs.textareaLabel);
+
   if (scope.codeEditorFocus) {
     setTimeout(() => {
       textarea.focus();

--- a/public/app/plugins/datasource/mssql/partials/query.editor.html
+++ b/public/app/plugins/datasource/mssql/partials/query.editor.html
@@ -8,9 +8,9 @@
 
   <div class="gf-form-inline">
     <div class="gf-form">
-			<label class="gf-form-label query-keyword" id="format-label-{{ ctrl.target.refId }}">Format as</label>
+			<label class="gf-form-label query-keyword" for="format-select-{{ ctrl.target.refId }}">Format as</label>
 			<div class="gf-form-select-wrapper">
-				<select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()" aria-labelledby="format-label-{{ ctrl.target.refId }}"></select>
+				<select id="format-select-{{ ctrl.target.refId }}" class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()"></select>
 			</div>
 		</div>
 		<div class="gf-form">

--- a/public/app/plugins/datasource/mssql/partials/query.editor.html
+++ b/public/app/plugins/datasource/mssql/partials/query.editor.html
@@ -8,9 +8,9 @@
 
   <div class="gf-form-inline">
     <div class="gf-form">
-			<label class="gf-form-label query-keyword">Format as</label>
+			<label class="gf-form-label query-keyword" id="format-label-{{ ctrl.target.refId }}">Format as</label>
 			<div class="gf-form-select-wrapper">
-				<select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()" aria-label="Format as"></select>
+				<select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()" aria-labelledby="format-label-{{ ctrl.target.refId }}"></select>
 			</div>
 		</div>
 		<div class="gf-form">

--- a/public/app/plugins/datasource/mssql/partials/query.editor.html
+++ b/public/app/plugins/datasource/mssql/partials/query.editor.html
@@ -1,7 +1,7 @@
 <query-editor-row query-ctrl="ctrl" can-collapse="false">
 	<div class="gf-form-inline">
 		<div class="gf-form gf-form--grow">
-			<code-editor content="ctrl.target.rawSql" datasource="ctrl.datasource" on-change="ctrl.panelCtrl.refresh()" data-mode="sqlserver">
+			<code-editor content="ctrl.target.rawSql" datasource="ctrl.datasource" on-change="ctrl.panelCtrl.refresh()" data-mode="sqlserver" textarea-label="Query Editor">
 			</code-editor>
 		</div>
 	</div>
@@ -10,7 +10,7 @@
     <div class="gf-form">
 			<label class="gf-form-label query-keyword">Format as</label>
 			<div class="gf-form-select-wrapper">
-				<select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()"></select>
+				<select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()" aria-label="Format as"></select>
 			</div>
 		</div>
 		<div class="gf-form">

--- a/public/app/plugins/datasource/mysql/partials/query.editor.html
+++ b/public/app/plugins/datasource/mysql/partials/query.editor.html
@@ -102,9 +102,9 @@
 
   <div class="gf-form-inline">
     <div class="gf-form">
-      <label class="gf-form-label query-keyword">Format as</label>
+      <label class="gf-form-label query-keyword" id="format-label-{{ ctrl.target.refId }}">Format As</label>
       <div class="gf-form-select-wrapper">
-        <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()" aria-label="Format as"></select>
+        <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()" aria-labelledby="format-label-{{ ctrl.target.refId }}"></select>
       </div>
     </div>
     <div class="gf-form">

--- a/public/app/plugins/datasource/mysql/partials/query.editor.html
+++ b/public/app/plugins/datasource/mysql/partials/query.editor.html
@@ -3,7 +3,7 @@
   <div ng-if="ctrl.target.rawQuery">
     <div class="gf-form-inline">
       <div class="gf-form gf-form--grow">
-        <code-editor content="ctrl.target.rawSql" datasource="ctrl.datasource" on-change="ctrl.panelCtrl.refresh()" data-mode="sql">
+        <code-editor content="ctrl.target.rawSql" datasource="ctrl.datasource" on-change="ctrl.panelCtrl.refresh()" data-mode="sql" textarea-label="Query Editor">
         </code-editor>
       </div>
     </div>
@@ -104,7 +104,7 @@
     <div class="gf-form">
       <label class="gf-form-label query-keyword">Format as</label>
       <div class="gf-form-select-wrapper">
-        <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()"></select>
+        <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()" aria-label="Format as"></select>
       </div>
     </div>
     <div class="gf-form">

--- a/public/app/plugins/datasource/mysql/partials/query.editor.html
+++ b/public/app/plugins/datasource/mysql/partials/query.editor.html
@@ -102,9 +102,9 @@
 
   <div class="gf-form-inline">
     <div class="gf-form">
-      <label class="gf-form-label query-keyword" id="format-label-{{ ctrl.target.refId }}">Format As</label>
+      <label class="gf-form-label query-keyword" for="format-select-{{ ctrl.target.refId }}">Format As</label>
       <div class="gf-form-select-wrapper">
-        <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()" aria-labelledby="format-label-{{ ctrl.target.refId }}"></select>
+        <select id="format-select-{{ ctrl.target.refId }}" class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()"></select>
       </div>
     </div>
     <div class="gf-form">

--- a/public/app/plugins/datasource/postgres/partials/query.editor.html
+++ b/public/app/plugins/datasource/postgres/partials/query.editor.html
@@ -102,9 +102,9 @@
 
   <div class="gf-form-inline">
     <div class="gf-form">
-      <label class="gf-form-label query-keyword">Format as</label>
+      <label class="gf-form-label query-keyword" id="format-label-{{ ctrl.target.refId }}">Format as</label>
       <div class="gf-form-select-wrapper">
-        <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()" aria-label="Format as"></select>
+        <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()" aria-labelledby="format-label-{{ ctrl.target.refId }}"></select>
       </div>
     </div>
     <div class="gf-form">

--- a/public/app/plugins/datasource/postgres/partials/query.editor.html
+++ b/public/app/plugins/datasource/postgres/partials/query.editor.html
@@ -3,7 +3,7 @@
   <div ng-if="ctrl.target.rawQuery">
     <div class="gf-form-inline">
       <div class="gf-form gf-form--grow">
-        <code-editor content="ctrl.target.rawSql" datasource="ctrl.datasource" on-change="ctrl.panelCtrl.refresh()" data-mode="sql">
+        <code-editor content="ctrl.target.rawSql" datasource="ctrl.datasource" on-change="ctrl.panelCtrl.refresh()" data-mode="sql" textarea-label="Query Editor">
         </code-editor>
       </div>
     </div>
@@ -104,7 +104,7 @@
     <div class="gf-form">
       <label class="gf-form-label query-keyword" id="format-label">Format as</label>
       <div class="gf-form-select-wrapper">
-        <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()" aria-labelledby="format-label"></select>
+        <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()" aria-label="Format as"></select>
       </div>
     </div>
     <div class="gf-form">

--- a/public/app/plugins/datasource/postgres/partials/query.editor.html
+++ b/public/app/plugins/datasource/postgres/partials/query.editor.html
@@ -102,9 +102,9 @@
 
   <div class="gf-form-inline">
     <div class="gf-form">
-      <label class="gf-form-label query-keyword" id="format-label-{{ ctrl.target.refId }}">Format as</label>
+      <label class="gf-form-label query-keyword" for="format-select-{{ ctrl.target.refId }}">Format as</label>
       <div class="gf-form-select-wrapper">
-        <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()" aria-labelledby="format-label-{{ ctrl.target.refId }}"></select>
+        <select id="format-select-{{ ctrl.target.refId }}" class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()"></select>
       </div>
     </div>
     <div class="gf-form">

--- a/public/app/plugins/datasource/postgres/partials/query.editor.html
+++ b/public/app/plugins/datasource/postgres/partials/query.editor.html
@@ -102,9 +102,9 @@
 
   <div class="gf-form-inline">
     <div class="gf-form">
-      <label class="gf-form-label query-keyword">Format as</label>
+      <label class="gf-form-label query-keyword" id="format-label">Format as</label>
       <div class="gf-form-select-wrapper">
-        <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()"></select>
+        <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()" aria-labelledby="format-label"></select>
       </div>
     </div>
     <div class="gf-form">

--- a/public/app/plugins/datasource/postgres/partials/query.editor.html
+++ b/public/app/plugins/datasource/postgres/partials/query.editor.html
@@ -102,7 +102,7 @@
 
   <div class="gf-form-inline">
     <div class="gf-form">
-      <label class="gf-form-label query-keyword" id="format-label">Format as</label>
+      <label class="gf-form-label query-keyword">Format as</label>
       <div class="gf-form-select-wrapper">
         <select class="gf-form-input gf-size-auto" ng-model="ctrl.target.format" ng-options="f.value as f.text for f in ctrl.formats" ng-change="ctrl.refresh()" aria-label="Format as"></select>
       </div>


### PR DESCRIPTION
#### Overview

Contains updates for SQL based Query Editors (MySql, Postgres, MSSQL) uncovered with [Fastpass](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/). Main error being a missing label on a select field, as well as the raw query editor itself not being labeled. Fixes contained for both issues.

#### Fixes

#42716, #42718, #42722