### PR TITLE
Variables: Handle variable cancellations better

### DIFF
--- a/public/app/features/variables/query/VariableQueryRunner.ts
+++ b/public/app/features/variables/query/VariableQueryRunner.ts
@@ -1,5 +1,5 @@
 import { merge, Observable, of, Subject, throwError, Unsubscribable } from 'rxjs';
-import { catchError, filter, finalize, first, mergeMap, takeUntil } from 'rxjs/operators';
+import { catchError, filter, finalize, mergeMap, take, takeUntil } from 'rxjs/operators';
 import {
   CoreApp,
   DataQuery,
@@ -7,6 +7,7 @@ import {
   DataSourceApi,
   getDefaultTimeRange,
   LoadingState,
+  PanelData,
   ScopedVars,
 } from '@grafana/data';
 
@@ -115,12 +116,14 @@ export class VariableQueryRunner {
           filter(() => {
             // Lets check if we started another batch during the execution of the observable. If so we just want to abort the rest.
             const afterUid = getState().templating.transaction.uid;
+
             return beforeUid === afterUid;
           }),
-          first((data) => data.state === LoadingState.Done || data.state === LoadingState.Error),
-          mergeMap((data) => {
+          filter((data) => data.state === LoadingState.Done || data.state === LoadingState.Error), // we only care about done or error for now
+          take(1), // take the first result, using first caused a bug where it in some situations throw an uncaught error because of no results had been received yet
+          mergeMap((data: PanelData) => {
             if (data.state === LoadingState.Error) {
-              return throwError(data.error);
+              return throwError(() => data.error);
             }
 
             return of(data);
@@ -148,7 +151,7 @@ export class VariableQueryRunner {
             }
 
             this.updateOptionsResults.next({ identifier, state: LoadingState.Error, error });
-            return throwError(error);
+            return throwError(() => error);
           }),
           finalize(() => {
             this.updateOptionsResults.next({ identifier, state: LoadingState.Done });

--- a/public/app/features/variables/query/actions.test.ts
+++ b/public/app/features/variables/query/actions.test.ts
@@ -37,6 +37,7 @@ import { silenceConsoleOutput } from '../../../../test/core/utils/silenceConsole
 import { getTimeSrv, setTimeSrv, TimeSrv } from '../../dashboard/services/TimeSrv';
 import { setVariableQueryRunner, VariableQueryRunner } from './VariableQueryRunner';
 import { setDataSourceSrv } from '@grafana/runtime';
+import { variablesInitTransaction } from '../state/transactionReducer';
 
 const mocks: Record<string, any> = {
   datasource: {
@@ -78,6 +79,22 @@ describe('query actions', () => {
 
   variableAdapters.setInit(() => [createQueryVariableAdapter()]);
 
+  describe('when updateQueryVariableOptions is dispatched but there is no ongoing transaction', () => {
+    it('then correct actions are dispatched', async () => {
+      const variable = createVariable({ includeAll: false });
+      const optionsMetrics = [createMetric('A'), createMetric('B')];
+
+      mockDatasourceMetrics(variable, optionsMetrics);
+
+      const tester = await reduxTester<RootReducerType>()
+        .givenRootReducer(getRootReducer())
+        .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenAsyncActionIsDispatched(updateQueryVariableOptions(toVariablePayload(variable)), true);
+
+      tester.thenNoActionsWhereDispatched();
+    });
+  });
+
   describe('when updateQueryVariableOptions is dispatched for variable without both tags and includeAll', () => {
     it('then correct actions are dispatched', async () => {
       const variable = createVariable({ includeAll: false });
@@ -88,6 +105,7 @@ describe('query actions', () => {
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
         .whenAsyncActionIsDispatched(updateQueryVariableOptions(toVariablePayload(variable)), true);
 
       const option = createOption('A');
@@ -110,6 +128,7 @@ describe('query actions', () => {
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
         .whenAsyncActionIsDispatched(updateQueryVariableOptions(toVariablePayload(variable)), true);
 
       const option = createOption(ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE);
@@ -136,6 +155,7 @@ describe('query actions', () => {
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
         .whenActionIsDispatched(setIdInEditor({ id: variable.id }))
         .whenAsyncActionIsDispatched(updateQueryVariableOptions(toVariablePayload(variable)), true);
 
@@ -164,6 +184,7 @@ describe('query actions', () => {
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
         .whenActionIsDispatched(setIdInEditor({ id: variable.id }))
         .whenAsyncActionIsDispatched(updateQueryVariableOptions(toVariablePayload(variable), 'search'), true);
 
@@ -191,6 +212,7 @@ describe('query actions', () => {
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
         .whenActionIsDispatched(setIdInEditor({ id: variable.id }))
         .whenAsyncActionIsDispatched(updateOptions(toVariablePayload(variable)), true);
 
@@ -227,6 +249,7 @@ describe('query actions', () => {
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
         .whenAsyncActionIsDispatched(initQueryVariableEditor(toVariablePayload(variable)), true);
 
       tester.thenDispatchedActionsPredicateShouldEqual((actions) => {
@@ -256,6 +279,7 @@ describe('query actions', () => {
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
         .whenAsyncActionIsDispatched(initQueryVariableEditor(toVariablePayload(variable)), true);
 
       tester.thenDispatchedActionsPredicateShouldEqual((actions) => {
@@ -284,6 +308,7 @@ describe('query actions', () => {
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
         .whenAsyncActionIsDispatched(initQueryVariableEditor(toVariablePayload(variable)), true);
 
       tester.thenDispatchedActionsPredicateShouldEqual((actions) => {
@@ -306,6 +331,7 @@ describe('query actions', () => {
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
         .whenAsyncActionIsDispatched(initQueryVariableEditor(toVariablePayload(variable)), true);
 
       tester.thenDispatchedActionsPredicateShouldEqual((actions) => {
@@ -330,6 +356,7 @@ describe('query actions', () => {
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
         .whenAsyncActionIsDispatched(
           changeQueryVariableDataSource(toVariablePayload(variable), { uid: 'datasource' }),
           true
@@ -365,6 +392,7 @@ describe('query actions', () => {
           .whenActionIsDispatched(
             addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable }))
           )
+          .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
           .whenAsyncActionIsDispatched(
             changeQueryVariableDataSource(toVariablePayload(variable), { uid: 'datasource' }),
             true
@@ -402,6 +430,7 @@ describe('query actions', () => {
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
         .whenAsyncActionIsDispatched(
           changeQueryVariableDataSource(toVariablePayload(variable), { uid: 'datasource' }),
           true
@@ -436,6 +465,7 @@ describe('query actions', () => {
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
         .whenAsyncActionIsDispatched(changeQueryVariableQuery(toVariablePayload(variable), query, definition), true);
 
       const option = createOption(ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE);
@@ -466,6 +496,7 @@ describe('query actions', () => {
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
         .whenAsyncActionIsDispatched(changeQueryVariableQuery(toVariablePayload(variable), query, definition), true);
 
       const option = createOption(ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE);
@@ -495,6 +526,7 @@ describe('query actions', () => {
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
         .whenAsyncActionIsDispatched(changeQueryVariableQuery(toVariablePayload(variable), query, definition), true);
 
       const option = createOption('A');
@@ -521,6 +553,7 @@ describe('query actions', () => {
       const tester = await reduxTester<RootReducerType>()
         .givenRootReducer(getRootReducer())
         .whenActionIsDispatched(addVariable(toVariablePayload(variable, { global: false, index: 0, model: variable })))
+        .whenActionIsDispatched(variablesInitTransaction({ uid: 'a uid' }))
         .whenAsyncActionIsDispatched(changeQueryVariableQuery(toVariablePayload(variable), query, definition), true);
 
       const errorText = 'Query cannot contain a reference to itself. Variable: $' + variable.name;

--- a/public/app/features/variables/state/upgradeLegacyQueries.test.ts
+++ b/public/app/features/variables/state/upgradeLegacyQueries.test.ts
@@ -5,13 +5,20 @@ import { upgradeLegacyQueries } from './actions';
 import { changeVariableProp } from './sharedReducer';
 import { thunkTester } from '../../../../test/core/thunk/thunkTester';
 import { VariableModel } from '../types';
+import { TransactionStatus } from './transactionReducer';
 
 interface Args {
   query?: any;
   variable?: VariableModel;
   datasource?: any;
+  transactionStatus?: TransactionStatus;
 }
-function getTestContext({ query = '', variable, datasource }: Args = {}) {
+function getTestContext({
+  query = '',
+  variable,
+  datasource,
+  transactionStatus = TransactionStatus.Fetching,
+}: Args = {}) {
   variable =
     variable ??
     queryBuilder()
@@ -22,6 +29,7 @@ function getTestContext({ query = '', variable, datasource }: Args = {}) {
       .build();
   const state = {
     templating: {
+      transaction: { status: transactionStatus },
       variables: {
         [variable.id]: variable,
       },
@@ -63,6 +71,22 @@ describe('upgradeLegacyQueries', () => {
       ]);
       expect(get).toHaveBeenCalledTimes(1);
       expect(get).toHaveBeenCalledWith({ uid: 'test-data', type: 'test-data' });
+    });
+
+    describe('but there is no ongoing transaction', () => {
+      it('then it should not dispatch changeVariableProp', async () => {
+        const { state, identifier, get, getDatasourceSrv } = getTestContext({
+          query: '*',
+          transactionStatus: TransactionStatus.NotStarted,
+        });
+
+        const dispatchedActions = await thunkTester(state)
+          .givenThunk(upgradeLegacyQueries)
+          .whenThunkIsDispatched(identifier, getDatasourceSrv);
+
+        expect(dispatchedActions).toEqual([]);
+        expect(get).toHaveBeenCalledTimes(0);
+      });
     });
   });
 

--- a/public/app/features/variables/utils.ts
+++ b/public/app/features/variables/utils.ts
@@ -7,6 +7,9 @@ import { QueryVariableModel, VariableModel, VariableRefresh } from './types';
 import { getTimeSrv } from '../dashboard/services/TimeSrv';
 import { variableAdapters } from './adapters';
 import { safeStringifyValue } from 'app/core/utils/explore';
+import { StoreState } from '../../types';
+import { getState } from '../../store/store';
+import { TransactionStatus } from './state/transactionReducer';
 
 /*
  * This regex matches 3 types of variable reference with an optional format specifier
@@ -252,4 +255,8 @@ export function ensureStringValues(value: any | any[]): string | string[] {
   }
 
   return '';
+}
+
+export function hasOngoingTransaction(state: StoreState = getState()): boolean {
+  return state.templating.transaction.status !== TransactionStatus.NotStarted;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We learned (spending a lot of time) that calling `first` here https://github.com/grafana/grafana/blob/e01ac44cfae7d724daa89a916882fd08cc023de0/public/app/features/variables/query/VariableQueryRunner.ts#L120 without specifying a default value will throw an unhandled exception if the observable is completed and no value has been emitted. Was really hard to debug this error but we finally managed to figure it out.

Instead we changed to a `filter` combined with a `take(1)`, should be the same 🤞 .

Because we can't control at what specific point when the user navigates away from a ongoing loading of a dashboard, we also created the utility function `hasOngoingTransaction` as a safe guard to make sure we don't try to access variable state when there is no state. Not super happy with this, but necessary because everything is async and we really don't know at which point the state is cleared. An alternative would be to show the errors.

**Which issue(s) this PR fixes**:
Fixes #43585

**Special notes for your reviewer**:
Realised that I'd created a completely new branch instead of reusing the mob branch so I added everyone involved in the commit as co-authors.
