### PR TITLE
Button: Only set pointer-events: none; on disabled LinkButtons

### DIFF
--- a/packages/grafana-ui/src/components/Button/Button.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.tsx
@@ -82,7 +82,15 @@ export const LinkButton = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
       iconOnly: !children,
     });
 
-    const linkButtonStyles = cx(styles.button, { [styles.disabled]: disabled }, className);
+    const linkButtonStyles = cx(
+      styles.button,
+      {
+        [css(styles.disabled, {
+          pointerEvents: 'none',
+        })]: disabled,
+      },
+      className
+    );
 
     deprecatedPropWarning(
       variant === 'link',
@@ -228,7 +236,6 @@ function getPropertiesForDisabled(theme: GrafanaTheme2, variant: ButtonVariant, 
   const disabledStyles: CSSObject = {
     cursor: 'not-allowed',
     boxShadow: 'none',
-    pointerEvents: 'none',
     color: theme.colors.text.disabled,
     transition: 'none',
   };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- setting `pointer-events: none;` on a `<button>` isn't needed, as the `disabled` attribute handles everything
  - it also stops the correct cursor from showing
- it **is** still needed for things that masquerade as a button (e.g. `LinkButton`, which is really an anchor)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

