### PR TITLE
Cloudwatch: Use ids instead of aria-labels

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.tsx
@@ -144,7 +144,7 @@ export class MetricsQueryEditor extends PureComponent<Props, State> {
             tooltip="ID can be used to reference other queries in math expressions. The ID can include numbers, letters, and underscore, and must start with a lowercase letter."
           >
             <Input
-              aria-label="Optional ID"
+              id={`${query.refId}-cloudwatch-metric-query-editor-id`}
               onBlur={onRunQuery}
               onChange={(event: ChangeEvent<HTMLInputElement>) =>
                 this.onChange({ ...metricsQuery, id: event.target.value })
@@ -157,7 +157,7 @@ export class MetricsQueryEditor extends PureComponent<Props, State> {
 
           <EditorField label="Period" width={26} tooltip="Minimum interval between points in seconds.">
             <Input
-              aria-label="Period"
+              id={`${query.refId}-cloudwatch-metric-query-editor-period`}
               value={query.period || ''}
               placeholder="auto"
               onBlur={onRunQuery}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The `EditorField`'s label will be associated for `Input` elements with an `id` and make it accessible, so an aria-label isn't needed here


