### PR TITLE
Tempo: Default search time range to 15 minutes

### DIFF
--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
@@ -23,6 +23,8 @@ import { debounce } from 'lodash';
 import { dispatch } from 'app/store/store';
 import { notifyApp } from 'app/core/actions';
 import { createErrorNotification } from 'app/core/copy/appNotification';
+import { updateTimeRange } from 'app/features/explore/state/time';
+import { ExploreId } from 'app/types';
 
 interface Props {
   datasource: TempoDatasource;
@@ -103,6 +105,16 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
     };
     fetchAutocomplete();
   }, [languageProvider, fetchServiceNameOptions, fetchSpanNameOptions]);
+
+  useEffect(() => {
+    // Default time picker to 15 minutes to reduce server load for search
+    dispatch(
+      updateTimeRange({
+        exploreId: ExploreId.left,
+        rawRange: { from: 'now-15m', to: 'now' },
+      })
+    );
+  }, []);
 
   const onTypeahead = async (typeahead: TypeaheadInput): Promise<TypeaheadOutput> => {
     return await languageProvider.provideCompletionItems(typeahead);

--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -133,20 +133,6 @@ class TempoQueryFieldComponent extends React.PureComponent<Props, State> {
             />
           </InlineField>
         </InlineFieldRow>
-        {query.queryType === 'nativeSearch' && (
-          <p style={{ maxWidth: '65ch' }}>
-            <Badge icon="rocket" text="Beta" color="blue" />
-            {config.featureToggles.tempoBackendSearch ? (
-              <>&nbsp;Tempo search is currently in beta.</>
-            ) : (
-              <>
-                &nbsp;Tempo search is currently in beta and is designed to return recent traces only. It ignores the
-                time range picker. We are actively working on full backend search. Look for improvements in the near
-                future!
-              </>
-            )}
-          </p>
-        )}
         {query.queryType === 'search' && (
           <SearchSection
             linkedDatasourceUid={logsDatasourceUid}
@@ -156,13 +142,27 @@ class TempoQueryFieldComponent extends React.PureComponent<Props, State> {
           />
         )}
         {query.queryType === 'nativeSearch' && (
-          <NativeSearch
-            datasource={this.props.datasource}
-            query={query}
-            onChange={onChange}
-            onBlur={this.props.onBlur}
-            onRunQuery={this.props.onRunQuery}
-          />
+          <>
+            <p style={{ maxWidth: '65ch' }}>
+              <Badge icon="rocket" text="Beta" color="blue" />
+              {config.featureToggles.tempoBackendSearch ? (
+                <>&nbsp;Tempo search is currently in beta.</>
+              ) : (
+                <>
+                  &nbsp;Tempo search is currently in beta and is designed to return recent traces only. It ignores the
+                  time range picker. We are actively working on full backend search. Look for improvements in the near
+                  future!
+                </>
+              )}
+            </p>
+            <NativeSearch
+              datasource={this.props.datasource}
+              query={query}
+              onChange={onChange}
+              onBlur={this.props.onBlur}
+              onRunQuery={this.props.onRunQuery}
+            />
+          </>
         )}
         {query.queryType === 'upload' && (
           <div className={css({ padding: this.props.theme.spacing(2) })}>


### PR DESCRIPTION
**What this PR does / why we need it**:
Default to 15 minutes to reduce load on search (for when full backend search is enabled)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #44008

**Special notes for your reviewer**:

