### PR TITLE
Elastic: Allow using long/int as date field for alerts

### DIFF
--- a/pkg/tsdb/elasticsearch/client/models.go
+++ b/pkg/tsdb/elasticsearch/client/models.go
@@ -136,8 +136,8 @@ func (f *QueryStringFilter) MarshalJSON() ([]byte, error) {
 type RangeFilter struct {
 	Filter
 	Key    string
-	Gte    string
-	Lte    string
+	Gte    int64
+	Lte    int64
 	Format string
 }
 
@@ -264,8 +264,8 @@ type TermsAggregation struct {
 
 // ExtendedBounds represents extended bounds
 type ExtendedBounds struct {
-	Min string `json:"min"`
-	Max string `json:"max"`
+	Min int64 `json:"min"`
+	Max int64 `json:"max"`
 }
 
 // GeoHashGridAggregation represents a geo hash grid aggregation

--- a/pkg/tsdb/elasticsearch/client/search_request.go
+++ b/pkg/tsdb/elasticsearch/client/search_request.go
@@ -235,7 +235,7 @@ func (b *FilterQueryBuilder) Build() ([]Filter, error) {
 }
 
 // AddDateRangeFilter adds a new time range filter
-func (b *FilterQueryBuilder) AddDateRangeFilter(timeField, lte, gte, format string) *FilterQueryBuilder {
+func (b *FilterQueryBuilder) AddDateRangeFilter(timeField string, lte, gte int64, format string) *FilterQueryBuilder {
 	b.filters = append(b.filters, &RangeFilter{
 		Key:    timeField,
 		Lte:    lte,

--- a/pkg/tsdb/elasticsearch/client/search_request_test.go
+++ b/pkg/tsdb/elasticsearch/client/search_request_test.go
@@ -50,7 +50,7 @@ func TestSearchRequest(t *testing.T) {
 		b.Size(200)
 		b.SortDesc(timeField, "boolean")
 		filters := b.Query().Bool().Filter()
-		filters.AddDateRangeFilter(timeField, "$timeTo", "$timeFrom", DateFormatEpochMS)
+		filters.AddDateRangeFilter(timeField, 10, 5, DateFormatEpochMS)
 		filters.AddQueryStringFilter("test", true)
 
 		t.Run("When building search request", func(t *testing.T) {
@@ -71,8 +71,8 @@ func TestSearchRequest(t *testing.T) {
 			t.Run("Should have range filter", func(t *testing.T) {
 				f, ok := sr.Query.Bool.Filters[0].(*RangeFilter)
 				require.True(t, ok)
-				require.Equal(t, "$timeFrom", f.Gte)
-				require.Equal(t, "$timeTo", f.Lte)
+				require.Equal(t, int64(5), f.Gte)
+				require.Equal(t, int64(10), f.Lte)
 				require.Equal(t, "epoch_millis", f.Format)
 			})
 
@@ -95,8 +95,8 @@ func TestSearchRequest(t *testing.T) {
 				require.Equal(t, "boolean", sort.Get("unmapped_type").MustString())
 
 				timeRangeFilter := json.GetPath("query", "bool", "filter").GetIndex(0).Get("range").Get(timeField)
-				require.Equal(t, "$timeFrom", timeRangeFilter.Get("gte").MustString(""))
-				require.Equal(t, "$timeTo", timeRangeFilter.Get("lte").MustString(""))
+				require.Equal(t, int64(5), timeRangeFilter.Get("gte").MustInt64())
+				require.Equal(t, int64(10), timeRangeFilter.Get("lte").MustInt64())
 				require.Equal(t, DateFormatEpochMS, timeRangeFilter.Get("format").MustString(""))
 
 				queryStringFilter := json.GetPath("query", "bool", "filter").GetIndex(1).Get("query_string")

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -37,8 +37,8 @@ func (e *timeSeriesQuery) execute() (*backend.QueryDataResponse, error) {
 
 	ms := e.client.MultiSearch()
 
-	from := fmt.Sprintf("%d", e.dataQueries[0].TimeRange.From.UnixNano()/int64(time.Millisecond))
-	to := fmt.Sprintf("%d", e.dataQueries[0].TimeRange.To.UnixNano()/int64(time.Millisecond))
+	from := e.dataQueries[0].TimeRange.From.UnixNano() / int64(time.Millisecond)
+	to := e.dataQueries[0].TimeRange.To.UnixNano() / int64(time.Millisecond)
 	result := backend.QueryDataResponse{
 		Responses: backend.Responses{},
 	}
@@ -62,7 +62,7 @@ func (e *timeSeriesQuery) execute() (*backend.QueryDataResponse, error) {
 	return rp.getTimeSeries()
 }
 
-func (e *timeSeriesQuery) processQuery(q *Query, ms *es.MultiSearchRequestBuilder, from, to string,
+func (e *timeSeriesQuery) processQuery(q *Query, ms *es.MultiSearchRequestBuilder, from, to int64,
 	result backend.QueryDataResponse) error {
 	minInterval, err := e.client.GetMinInterval(q.Interval)
 	if err != nil {
@@ -243,7 +243,7 @@ func (bucketAgg BucketAgg) generateSettingsForDSL() map[string]interface{} {
 	return bucketAgg.Settings.MustMap()
 }
 
-func addDateHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, timeFrom, timeTo string) es.AggBuilder {
+func addDateHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, timeFrom, timeTo int64) es.AggBuilder {
 	aggBuilder.DateHistogram(bucketAgg.ID, bucketAgg.Field, func(a *es.DateHistogramAgg, b es.AggBuilder) {
 		a.Interval = bucketAgg.Settings.Get("interval").MustString("auto")
 		a.MinDocCount = bucketAgg.Settings.Get("min_doc_count").MustInt(0)

--- a/pkg/tsdb/elasticsearch/time_series_query_test.go
+++ b/pkg/tsdb/elasticsearch/time_series_query_test.go
@@ -2,7 +2,6 @@ package elasticsearch
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
 	"time"
 
@@ -17,8 +16,8 @@ import (
 func TestExecuteTimeSeriesQuery(t *testing.T) {
 	from := time.Date(2018, 5, 15, 17, 50, 0, 0, time.UTC)
 	to := time.Date(2018, 5, 15, 17, 55, 0, 0, time.UTC)
-	fromStr := fmt.Sprintf("%d", from.UnixNano()/int64(time.Millisecond))
-	toStr := fmt.Sprintf("%d", to.UnixNano()/int64(time.Millisecond))
+	fromMs := from.UnixNano() / int64(time.Millisecond)
+	toMs := to.UnixNano() / int64(time.Millisecond)
 
 	t.Run("Test execute time series query", func(t *testing.T) {
 		t.Run("With defaults on es 2", func(t *testing.T) {
@@ -32,14 +31,14 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			sr := c.multisearchRequests[0].Requests[0]
 			rangeFilter := sr.Query.Bool.Filters[0].(*es.RangeFilter)
 			require.Equal(t, rangeFilter.Key, c.timeField)
-			require.Equal(t, rangeFilter.Lte, toStr)
-			require.Equal(t, rangeFilter.Gte, fromStr)
+			require.Equal(t, rangeFilter.Lte, toMs)
+			require.Equal(t, rangeFilter.Gte, fromMs)
 			require.Equal(t, rangeFilter.Format, es.DateFormatEpochMS)
 			require.Equal(t, sr.Aggs[0].Key, "2")
 			dateHistogramAgg := sr.Aggs[0].Aggregation.Aggregation.(*es.DateHistogramAgg)
 			require.Equal(t, dateHistogramAgg.Field, "@timestamp")
-			require.Equal(t, dateHistogramAgg.ExtendedBounds.Min, fromStr)
-			require.Equal(t, dateHistogramAgg.ExtendedBounds.Max, toStr)
+			require.Equal(t, dateHistogramAgg.ExtendedBounds.Min, fromMs)
+			require.Equal(t, dateHistogramAgg.ExtendedBounds.Max, toMs)
 		})
 
 		t.Run("With defaults on es 5", func(t *testing.T) {
@@ -53,8 +52,8 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			sr := c.multisearchRequests[0].Requests[0]
 			require.Equal(t, sr.Query.Bool.Filters[0].(*es.RangeFilter).Key, c.timeField)
 			require.Equal(t, sr.Aggs[0].Key, "2")
-			require.Equal(t, sr.Aggs[0].Aggregation.Aggregation.(*es.DateHistogramAgg).ExtendedBounds.Min, fromStr)
-			require.Equal(t, sr.Aggs[0].Aggregation.Aggregation.(*es.DateHistogramAgg).ExtendedBounds.Max, toStr)
+			require.Equal(t, sr.Aggs[0].Aggregation.Aggregation.(*es.DateHistogramAgg).ExtendedBounds.Min, fromMs)
+			require.Equal(t, sr.Aggs[0].Aggregation.Aggregation.(*es.DateHistogramAgg).ExtendedBounds.Max, toMs)
 		})
 
 		t.Run("With multiple bucket aggs", func(t *testing.T) {
@@ -1061,7 +1060,7 @@ func TestSettingsCasting(t *testing.T) {
 							"field": "@timestamp",
 							"id": "2",
 							"settings": {
-								"interval": "1d"							
+								"interval": "1d"
 							}
 						}
 					],
@@ -1088,7 +1087,7 @@ func TestSettingsCasting(t *testing.T) {
 							"field": "@timestamp",
 							"id": "2",
 							"settings": {
-								"interval": "1d"							
+								"interval": "1d"
 							}
 						}
 					],


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

When doing Data Histogram aggregation `from` and `to` dates are sent as strings. When selected aggregation field has `date` type in Elastic it's automatically converted by Elastic from a string to a number. However, if the aggregation field has a numeric type, such conversion doesn't happen. 

This automatic type conversion happens inside Elastic because `date` can be represented as [a formatted string or a timestamp in milliseconds or seconds](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html). We always pass both values as timestamps in milliseconds anyway so there's no need to use strings, because it's not needed to be converted. This way fields with non-date type will also work fine for Date Histograms.

A similar fix was applied some time ago in frontend code #22173.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #29826

**Special notes for your reviewer**:

<details>
<summary>How to test it?</summary>

* run `make devenv sources=elastic77`
* create an Elastic data source:
 * URL: http://localhost:13200
 * set index-name to test-index
 * set time field name to `time`

![Elasticsearch details](https://user-images.githubusercontent.com/745532/149495883-75fd0623-cdcc-4fc5-8c92-0d7406acff8d.jpg)

Create a document with number field called `time` that will be used for time aggregation by running:
`curl -XPOST http://localhost:13200/test-index/doc -H "Content-Type: application/json" -d '{ "time": 10000, "foo": "bar" }'`

Create a dashboard with a query: 
* `_index: "test-index"`
* Group by / Date Histogram: time

![Elastic query](https://user-images.githubusercontent.com/745532/149495833-031f85da-bb1a-45ea-8584-4275d7207204.jpg)

Save dashboard and test the alert.

In `main` you should see an error: `request handler response error {java.text.ParseException: Unparseable number`. In this branch it should show the alert evaluation results.

To test if alerts are run correctly you can replace `time: 10000` in curl  command above with some recent time in milliseconds.

</summary>
