### PR TITLE
Elasticsearch: Fix handling multiple datalinks for a single field

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -956,27 +956,52 @@ describe('enhanceDataFrame', () => {
         url: 'someUrl',
       },
       {
+        field: 'urlField',
+        url: 'someOtherUrl',
+      },
+      {
         field: 'traceField',
         url: 'query',
-        datasourceUid: 'dsUid',
+        datasourceUid: 'ds1',
+      },
+      {
+        field: 'traceField',
+        url: 'otherQuery',
+        datasourceUid: 'ds2',
       },
     ]);
 
-    expect(df.fields[0].config.links!.length).toBe(1);
-    expect(df.fields[0].config.links![0]).toEqual({
+    expect(df.fields[0].config.links).toHaveLength(2);
+    expect(df.fields[0].config.links).toContainEqual({
       title: '',
       url: 'someUrl',
     });
-    expect(df.fields[1].config.links!.length).toBe(1);
-    expect(df.fields[1].config.links![0]).toEqual({
+    expect(df.fields[0].config.links).toContainEqual({
       title: '',
-      url: '',
-      internal: {
-        query: { query: 'query' },
-        datasourceName: 'elastic25',
-        datasourceUid: 'dsUid',
-      },
+      url: 'someOtherUrl',
     });
+
+    expect(df.fields[1].config.links).toHaveLength(2);
+    expect(df.fields[1].config.links).toContainEqual(
+      expect.objectContaining({
+        title: '',
+        url: '',
+        internal: expect.objectContaining({
+          query: { query: 'query' },
+          datasourceUid: 'ds1',
+        }),
+      })
+    );
+    expect(df.fields[1].config.links).toContainEqual(
+      expect.objectContaining({
+        title: '',
+        url: '',
+        internal: expect.objectContaining({
+          query: { query: 'otherQuery' },
+          datasourceUid: 'ds2',
+        }),
+      })
+    );
   });
 
   it('adds limit to dataframe', () => {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -943,7 +943,7 @@ export function enhanceDataFrame(dataFrame: DataFrame, dataLinks: DataLinkConfig
     };
   }
 
-  if (!dataLinks.length || !dataLinks) {
+  if (!dataLinks.length) {
     return;
   }
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -936,8 +936,6 @@ export class ElasticDatasource
  * Exported for tests.
  */
 export function enhanceDataFrame(dataFrame: DataFrame, dataLinks: DataLinkConfig[], limit?: number) {
-  const dataSourceSrv = getDataSourceSrv();
-
   if (limit) {
     dataFrame.meta = {
       ...dataFrame.meta,
@@ -945,40 +943,42 @@ export function enhanceDataFrame(dataFrame: DataFrame, dataLinks: DataLinkConfig
     };
   }
 
-  if (!dataLinks.length) {
+  if (!dataLinks.length || !dataLinks) {
     return;
   }
 
   for (const field of dataFrame.fields) {
-    const dataLinkConfig = dataLinks.find((dataLink) => field.name && field.name.match(dataLink.field));
+    const linksToApply = dataLinks.filter((dataLink) => new RegExp(dataLink.field).test(field.name));
 
-    if (!dataLinkConfig) {
+    if (linksToApply.length === 0) {
       continue;
     }
 
-    let link: DataLink;
-
-    if (dataLinkConfig.datasourceUid) {
-      const dsSettings = dataSourceSrv.getInstanceSettings(dataLinkConfig.datasourceUid);
-
-      link = {
-        title: dataLinkConfig.urlDisplayLabel || '',
-        url: '',
-        internal: {
-          query: { query: dataLinkConfig.url },
-          datasourceUid: dataLinkConfig.datasourceUid,
-          datasourceName: dsSettings?.name ?? 'Data source not found',
-        },
-      };
-    } else {
-      link = {
-        title: dataLinkConfig.urlDisplayLabel || '',
-        url: dataLinkConfig.url,
-      };
-    }
-
     field.config = field.config || {};
-    field.config.links = [...(field.config.links || []), link];
+    field.config.links = [...(field.config.links || [], linksToApply.map(generateDataLink))];
+  }
+}
+
+function generateDataLink(linkConfig: DataLinkConfig): DataLink {
+  const dataSourceSrv = getDataSourceSrv();
+
+  if (linkConfig.datasourceUid) {
+    const dsSettings = dataSourceSrv.getInstanceSettings(linkConfig.datasourceUid);
+
+    return {
+      title: linkConfig.urlDisplayLabel || '',
+      url: '',
+      internal: {
+        query: { query: linkConfig.url },
+        datasourceUid: linkConfig.datasourceUid,
+        datasourceName: dsSettings?.name ?? 'Data source not found',
+      },
+    };
+  } else {
+    return {
+      title: linkConfig.urlDisplayLabel || '',
+      url: linkConfig.url,
+    };
   }
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
As described in the linked issue, when adding multiple datalinks for a single field in Elasticsearch, only the first one was being shown. This PR changes this behavior by ensuring all configured links are added for each field.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #43521


**How to test this:**

Using elastic77 devenv (or any other ES version) create a new datasource and configure as this:
![Screenshot 2022-01-14 at 10 08 11](https://user-images.githubusercontent.com/1170767/149497961-8d62331d-4ba4-45fa-9ffe-d6e79989e6dd.png)


then create multiple datalinks for the same field, they can be both external, internal or a mix of both:
![Screenshot 2022-01-14 at 10 10 14](https://user-images.githubusercontent.com/1170767/149498263-f9dfed6f-eb8b-48d2-ac8c-124d646795f2.png)

when then visualizing logs in explore, both links should show up next to the matching field:
![Screenshot 2022-01-14 at 10 10 51](https://user-images.githubusercontent.com/1170767/149498364-e46b01ab-1e73-487e-9920-bac8ada103d7.png)

