### PR TITLE
Elasticsearch: Fix QueryEditor styling issues

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/FiltersSettingsEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/SettingsEditor/FiltersSettingsEditor/index.tsx
@@ -47,12 +47,12 @@ export const FiltersSettingsEditor = ({ bucketAgg }: Props) => {
               display: flex;
             `}
           >
-            <div
-              className={css`
-                width: 250px;
-              `}
-            >
-              <InlineField label="Query" labelWidth={10}>
+            <InlineField label="Query" labelWidth={8}>
+              <div
+                className={css`
+                  width: 150px;
+                `}
+              >
                 <QueryField
                   placeholder="Lucene Query"
                   portalOrigin="elasticsearch"
@@ -60,10 +60,11 @@ export const FiltersSettingsEditor = ({ bucketAgg }: Props) => {
                   onChange={(query) => dispatch(changeFilter({ index, filter: { ...filter, query } }))}
                   query={filter.query}
                 />
-              </InlineField>
-            </div>
-            <InlineField label="Label" labelWidth={10}>
+              </div>
+            </InlineField>
+            <InlineField label="Label" labelWidth={8}>
               <Input
+                width={16}
                 id={`${baseId}-label-${index}`}
                 placeholder="Label"
                 onBlur={(e) => dispatch(changeFilter({ index, filter: { ...filter, label: e.target.value } }))}

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -32,7 +32,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   queryFieldWrapper: css`
     flex-grow: 1;
-    margin-right: ${theme.spacing(0.5)};
+    margin: 0 ${theme.spacing(0.5)} ${theme.spacing(0.5)} 0;
   `,
 });
 

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
-import { getDefaultTimeRange, QueryEditorProps } from '@grafana/data';
+import { getDefaultTimeRange, GrafanaTheme2, QueryEditorProps } from '@grafana/data';
 import { ElasticDatasource } from '../../datasource';
 import { ElasticsearchOptions, ElasticsearchQuery } from '../../types';
 import { ElasticsearchProvider } from './ElasticsearchQueryContext';
-import { InlineField, InlineFieldRow, Input, QueryField } from '@grafana/ui';
+import { InlineField, InlineLabel, Input, QueryField, useStyles2 } from '@grafana/ui';
 import { changeAliasPattern, changeQuery } from './state';
 import { MetricAggregationsEditor } from './MetricAggregationsEditor';
 import { BucketAggregationsEditor } from './BucketAggregationsEditor';
 import { useDispatch } from '../../hooks/useStatelessReducer';
 import { useNextId } from '../../hooks/useNextId';
 import { metricAggregationConfig } from './MetricAggregationsEditor/utils';
+import { css } from '@emotion/css';
 
 export type ElasticQueryEditorProps = QueryEditorProps<ElasticDatasource, ElasticsearchQuery, ElasticsearchOptions>;
 
@@ -25,6 +26,16 @@ export const QueryEditor = ({ query, onChange, onRunQuery, datasource, range }: 
   </ElasticsearchProvider>
 );
 
+const getStyles = (theme: GrafanaTheme2) => ({
+  root: css`
+    display: flex;
+  `,
+  queryFieldWrapper: css`
+    flex-grow: 1;
+    margin-right: ${theme.spacing(0.5)};
+  `,
+});
+
 interface Props {
   value: ElasticsearchQuery;
 }
@@ -32,6 +43,7 @@ interface Props {
 const QueryEditorForm = ({ value }: Props) => {
   const dispatch = useDispatch();
   const nextId = useNextId();
+  const styles = useStyles2(getStyles);
 
   // To be considered a time series query, the last bucked aggregation must be a Date Histogram
   const isTimeSeriesQuery = value.bucketAggs?.slice(-1)[0]?.type === 'date_histogram';
@@ -42,8 +54,9 @@ const QueryEditorForm = ({ value }: Props) => {
 
   return (
     <>
-      <InlineFieldRow>
-        <InlineField label="Query" labelWidth={17} grow>
+      <div className={styles.root}>
+        <InlineLabel width={17}>Query</InlineLabel>
+        <div className={styles.queryFieldWrapper}>
           <QueryField
             query={value.query}
             // By default QueryField calls onChange if onBlur is not defined, this will trigger a rerender
@@ -53,7 +66,7 @@ const QueryEditorForm = ({ value }: Props) => {
             placeholder="Lucene Query"
             portalOrigin="elasticsearch"
           />
-        </InlineField>
+        </div>
         <InlineField
           label="Alias"
           labelWidth={15}
@@ -67,7 +80,7 @@ const QueryEditorForm = ({ value }: Props) => {
             defaultValue={value.alias}
           />
         </InlineField>
-      </InlineFieldRow>
+      </div>
 
       <MetricAggregationsEditor nextId={nextId} />
       {showBucketAggregationsEditor && <BucketAggregationsEditor nextId={nextId} />}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The `QueryField` component doesn't play very nicely when used within `InlineField` and `InlineFieldRow`. especially after https://github.com/grafana/grafana/commit/b00b2bbc767aca0d6ede9d9cd1066a9210d6cff3 as it adds an extra div around the field (similarly to what happens in the `Field` component)
This PRs works around it by using some custom styling instead.

before:
![Screenshot 2022-01-14 at 12 35 24](https://user-images.githubusercontent.com/1170767/149516403-b2007b94-e1a4-4c1f-a1ea-3c11b03d6d54.png)


after:
![Screenshot 2022-01-14 at 12 30 52](https://user-images.githubusercontent.com/1170767/149516270-a1427465-f525-4bf1-8611-9ce9021d78c2.png)
![Screenshot 2022-01-14 at 12 31 09](https://user-images.githubusercontent.com/1170767/149516278-a96d4544-35f6-4abd-a070-1c26eaaa96ae.png)


