### PR TITLE
Plugins: Add notices to docs to prevent NPX commands from hanging

### DIFF
--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -17,6 +17,8 @@ Open the terminal, and run the following command in your [plugin directory]({{< 
 npx @grafana/toolkit plugin:create my-grafana-plugin
 ```
 
+> **Note:** If running NPM 7+ the `npx` commands mentioned in this article may hang. If so use `npx --legacy-peer-deps <command to run>`.
+
 If you want a more guided introduction to plugin development, check out our tutorials:
 
 - [Build a panel plugin]({{< relref "/tutorials/build-a-panel-plugin.md" >}})

--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -17,7 +17,7 @@ Open the terminal, and run the following command in your [plugin directory]({{< 
 npx @grafana/toolkit plugin:create my-grafana-plugin
 ```
 
-> **Note:** If running NPM 7+ the `npx` commands mentioned in this article may hang. If so use `npx --legacy-peer-deps <command to run>`.
+> **Note:** If running NPM 7+ the `npx` commands mentioned in this article may hang. The workaround is to use `npx --legacy-peer-deps <command to run>`.
 
 If you want a more guided introduction to plugin development, check out our tutorials:
 

--- a/docs/sources/developers/plugins/sign-a-plugin.md
+++ b/docs/sources/developers/plugins/sign-a-plugin.md
@@ -41,7 +41,7 @@ Public plugins need to be reviewed by the Grafana team before you can sign them.
    npx @grafana/toolkit plugin:sign
    ```
 
-> **Note:** If running NPM 7+ the `npx` commands mentioned in this article may hang. If so use `npx --legacy-peer-deps <command to run>`.
+> **Note:** If running NPM 7+ the `npx` commands mentioned in this article may hang. The workaround is to use `npx --legacy-peer-deps <command to run>`.
 
 ## Sign a private plugin
 

--- a/docs/sources/developers/plugins/sign-a-plugin.md
+++ b/docs/sources/developers/plugins/sign-a-plugin.md
@@ -41,6 +41,8 @@ Public plugins need to be reviewed by the Grafana team before you can sign them.
    npx @grafana/toolkit plugin:sign
    ```
 
+> **Note:** If running NPM 7+ the `npx` commands mentioned in this article may hang. If so use `npx --legacy-peer-deps <command to run>`.
+
 ## Sign a private plugin
 
 1. In your plugin directory, sign the plugin with the API key you just created. Grafana Toolkit creates a [MANIFEST.txt](#plugin-manifest) file in the `dist` directory of your plugin.

--- a/packages/grafana-toolkit/README.md
+++ b/packages/grafana-toolkit/README.md
@@ -15,6 +15,8 @@ yarn install
 yarn dev
 ```
 
+> **Note:** If running NPM 7+ the `npx` commands mentioned in this article may hang. If so use `npx --legacy-peer-deps <command to run>`.
+
 ## Update your plugin to use grafana-toolkit
 
 Follow the steps below to start using grafana-toolkit in your existing plugin.

--- a/packages/grafana-toolkit/README.md
+++ b/packages/grafana-toolkit/README.md
@@ -15,7 +15,7 @@ yarn install
 yarn dev
 ```
 
-> **Note:** If running NPM 7+ the `npx` commands mentioned in this article may hang. If so use `npx --legacy-peer-deps <command to run>`.
+> **Note:** If running NPM 7+ the `npx` commands mentioned in this article may hang. The workaround is to use `npx --legacy-peer-deps <command to run>`.
 
 ## Update your plugin to use grafana-toolkit
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR adds a notice box below shell code examples that mention `npx @grafana/toolkit` with a workaround for peer dependency issues with NPM 7+ that cause the commands to hang in terminal.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related #34807

**Special notes for your reviewer**:

