### PR TITLE
Fixed broken links in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,4 +82,4 @@ Before we can accept your pull request, you need to [sign our CLA](https://grafa
 - Set up your [development environment](contribute/developer-guide.md).
 - Learn how to [contribute documentation](contribute/README.md).
 - Get started [developing plugins](https://grafana.com/docs/grafana/latest/developers/plugins/) for Grafana.
-- Look through the resources in the [contribute](https://github.com/grafana/grafana/tree/main/contribute) folder.
+- Look through the resources in the [contribute](contribute) folder.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,6 @@ Before we can accept your pull request, you need to [sign our CLA](https://grafa
 ## Where do I go from here?
 
 - Set up your [development environment](contribute/developer-guide.md).
-- Learn how to [contribute documentation](contribute/documentation.md).
+- Learn how to [contribute documentation](contribute/README.md).
 - Get started [developing plugins](https://grafana.com/docs/grafana/latest/developers/plugins/) for Grafana.
 - Look through the resources in the [contribute](https://github.com/grafana/grafana/tree/main/contribute) folder.

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -631,7 +631,7 @@ Path to the default home dashboard. If this value is empty, then Grafana uses St
 
 Set to `false` to prohibit users from being able to sign up / create
 user accounts. Default is `false`. The admin user can still create
-users from the [Grafana Admin Pages](/reference/admin).
+users from the [Grafana Admin Pages]({{< relref "../manage-users/server-admin/server-admin-manage-users.md" >}}).
 
 ### allow_org_create
 


### PR DESCRIPTION
What this PR does / why we need it:
- Fixes broken link `Grafana Admin Pages` in [documentation page](https://grafana.com/docs/grafana/latest/administration/configuration/#allow_sign_up)
- Fixes broken link `contribute documentation` in [CONTRIBUTION.md](https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md#where-do-i-go-from-here)
- Also changed `contribute` github url to relative path for consistency