### PR TITLE
[v8.3.x] chore(drone): switch to using cypress built image for e2e tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -188,15 +188,6 @@ steps:
   image: grafana/build-container:1.4.9
   name: package
 - commands:
-  - yarn run cypress install
-  depends_on:
-  - package
-  image: grafana/ci-e2e:12.19.0-1
-  name: cypress
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
-- commands:
   - ./e2e/start-server
   depends_on:
   - package
@@ -206,45 +197,49 @@ steps:
   image: grafana/build-container:1.4.9
   name: end-to-end-tests-server
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-dashboards-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-smoke-tests-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-panels-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-various-suite
   volumes:
   - name: cypress_cache
@@ -618,15 +613,6 @@ steps:
   image: grafana/build-container:1.4.9
   name: package
 - commands:
-  - yarn run cypress install
-  depends_on:
-  - package
-  image: grafana/ci-e2e:12.19.0-1
-  name: cypress
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
-- commands:
   - ./e2e/start-server
   depends_on:
   - package
@@ -636,45 +622,49 @@ steps:
   image: grafana/build-container:1.4.9
   name: end-to-end-tests-server
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-dashboards-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-smoke-tests-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-panels-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-various-suite
   volumes:
   - name: cypress_cache
@@ -1207,54 +1197,49 @@ steps:
   image: grafana/build-container:1.4.9
   name: end-to-end-tests-server
 - commands:
-  - yarn run cypress install
-  depends_on:
-  - package
-  image: grafana/ci-e2e:12.19.0-1
-  name: cypress
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
-- commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-dashboards-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-smoke-tests-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-panels-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-various-suite
   volumes:
   - name: cypress_cache
@@ -1802,54 +1787,49 @@ steps:
   image: grafana/build-container:1.4.9
   name: end-to-end-tests-server
 - commands:
-  - yarn run cypress install
-  depends_on:
-  - package
-  image: grafana/ci-e2e:12.19.0-1
-  name: cypress
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
-- commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-dashboards-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-smoke-tests-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-panels-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-various-suite
   volumes:
   - name: cypress_cache
@@ -2961,54 +2941,49 @@ steps:
   image: grafana/build-container:1.4.9
   name: end-to-end-tests-server
 - commands:
-  - yarn run cypress install
-  depends_on:
-  - package
-  image: grafana/ci-e2e:12.19.0-1
-  name: cypress
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
-- commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-dashboards-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-smoke-tests-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-panels-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-various-suite
   volumes:
   - name: cypress_cache
@@ -3512,54 +3487,49 @@ steps:
   image: grafana/build-container:1.4.9
   name: end-to-end-tests-server
 - commands:
-  - yarn run cypress install
-  depends_on:
-  - package
-  image: grafana/ci-e2e:12.19.0-1
-  name: cypress
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
-- commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-dashboards-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-smoke-tests-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-panels-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-various-suite
   volumes:
   - name: cypress_cache
@@ -4274,54 +4244,49 @@ steps:
   image: grafana/build-container:1.4.9
   name: end-to-end-tests-server
 - commands:
-  - yarn run cypress install
-  depends_on:
-  - package
-  image: grafana/ci-e2e:12.19.0-1
-  name: cypress
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
-- commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-dashboards-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-smoke-tests-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-panels-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-various-suite
   volumes:
   - name: cypress_cache
@@ -4798,54 +4763,49 @@ steps:
   image: grafana/build-container:1.4.9
   name: end-to-end-tests-server
 - commands:
-  - yarn run cypress install
-  depends_on:
-  - package
-  image: grafana/ci-e2e:12.19.0-1
-  name: cypress
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
-- commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-dashboards-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-smoke-tests-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-panels-suite
   volumes:
   - name: cypress_cache
     path: /root/.cache/Cypress
 - commands:
+  - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
   depends_on:
-  - cypress
+  - package
   environment:
     HOST: end-to-end-tests-server
-  image: grafana/ci-e2e:12.19.0-1
+  image: cypress/included:9.2.0
   name: end-to-end-tests-various-suite
   volumes:
   - name: cypress_cache
@@ -5359,6 +5319,6 @@ kind: secret
 name: prerelease_bucket
 ---
 kind: signature
-hmac: c956acec95a1f87ba1f8b783af2ba35ca612ef35040506f18732365b2d0851c9
+hmac: 6ea7d50bb90a73595b25736b904c7073ece3a5427a9cedb7a7712eee25f9681d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -94,8 +94,6 @@ trigger:
   - pull_request
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -203,11 +201,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-dashboards-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite
@@ -215,11 +210,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-smoke-tests-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite
@@ -227,11 +219,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-panels-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite
@@ -239,11 +228,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-various-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -301,8 +287,6 @@ trigger:
   - pull_request
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -388,8 +372,6 @@ trigger:
   - pull_request
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -496,8 +478,6 @@ trigger:
   - push
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -628,11 +608,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-dashboards-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite
@@ -640,11 +617,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-smoke-tests-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite
@@ -652,11 +626,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-panels-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite
@@ -664,11 +635,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-various-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -798,8 +766,6 @@ trigger:
   - push
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -892,8 +858,6 @@ trigger:
   - push
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -955,8 +919,6 @@ trigger:
   - push
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -1014,8 +976,6 @@ trigger:
   - push
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -1203,11 +1163,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-dashboards-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
@@ -1215,11 +1172,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-smoke-tests-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
@@ -1227,11 +1181,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-panels-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
@@ -1239,11 +1190,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-various-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -1324,8 +1272,6 @@ trigger:
     - grafana/grafana
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -1432,8 +1378,6 @@ trigger:
     - grafana/grafana
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -1526,8 +1470,6 @@ trigger:
     - grafana/grafana
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -1594,8 +1536,6 @@ trigger:
     - grafana/grafana
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -1793,11 +1733,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-dashboards-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
@@ -1805,11 +1742,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-smoke-tests-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
@@ -1817,11 +1751,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-panels-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
@@ -1829,11 +1760,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-various-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise --bucket "$${PRERELEASE_BUCKET}/artifacts/static-assets"
   depends_on:
@@ -1910,8 +1838,6 @@ trigger:
     - grafana/grafana
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -2064,8 +1990,6 @@ trigger:
     - grafana/grafana
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -2208,8 +2132,6 @@ trigger:
     - grafana/grafana
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -2300,8 +2222,6 @@ trigger:
     - grafana/grafana
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -2380,8 +2300,6 @@ trigger:
   - public
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -2443,8 +2361,6 @@ trigger:
   - public
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -2523,8 +2439,6 @@ trigger:
   - security
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -2587,8 +2501,6 @@ trigger:
   - security
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -2625,8 +2537,6 @@ trigger:
   - security
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -2663,8 +2573,6 @@ trigger:
   - public
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -2723,8 +2631,6 @@ trigger:
   - public
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -2788,8 +2694,6 @@ trigger:
   - public
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -2947,11 +2851,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-dashboards-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
@@ -2959,11 +2860,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-smoke-tests-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
@@ -2971,11 +2869,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-panels-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
@@ -2983,11 +2878,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-various-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -3042,8 +2934,6 @@ trigger:
   - custom
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -3144,8 +3034,6 @@ trigger:
   - custom
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -3232,8 +3120,6 @@ trigger:
   - custom
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -3295,8 +3181,6 @@ trigger:
   - custom
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -3493,11 +3377,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-dashboards-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
@@ -3505,11 +3386,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-smoke-tests-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
@@ -3517,11 +3395,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-panels-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
@@ -3529,11 +3404,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-various-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise --bucket "grafana-static-assets"
   depends_on:
@@ -3604,8 +3476,6 @@ trigger:
   - custom
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -3751,8 +3621,6 @@ trigger:
   - custom
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -3888,8 +3756,6 @@ trigger:
   - custom
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -3975,8 +3841,6 @@ trigger:
   - custom
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -4061,8 +3925,6 @@ trigger:
   - custom
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -4250,11 +4112,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-dashboards-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
@@ -4262,11 +4121,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-smoke-tests-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
@@ -4274,11 +4130,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-panels-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
@@ -4286,11 +4139,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-various-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -4330,8 +4180,6 @@ trigger:
   - refs/heads/v[0-9]*
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -4431,8 +4279,6 @@ trigger:
   - refs/heads/v[0-9]*
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -4518,8 +4364,6 @@ trigger:
   - refs/heads/v[0-9]*
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -4576,8 +4420,6 @@ trigger:
   - refs/heads/v[0-9]*
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -4769,11 +4611,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-dashboards-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
@@ -4781,11 +4620,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-smoke-tests-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
@@ -4793,11 +4629,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-panels-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
@@ -4805,11 +4638,8 @@ steps:
   - package
   environment:
     HOST: end-to-end-tests-server
-  image: cypress/included:9.2.0
+  image: cypress/included:8.4.1
   name: end-to-end-tests-various-suite
-  volumes:
-  - name: cypress_cache
-    path: /root/.cache/Cypress
 - commands:
   - yarn storybook:build
   - ./bin/grabpl verify-storybook
@@ -4889,8 +4719,6 @@ trigger:
   - refs/heads/v[0-9]*
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -5035,8 +4863,6 @@ trigger:
   - refs/heads/v[0-9]*
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -5171,8 +4997,6 @@ trigger:
   - refs/heads/v[0-9]*
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -5253,8 +5077,6 @@ trigger:
   - refs/heads/v[0-9]*
 type: docker
 volumes:
-- name: cypress_cache
-  temp: {}
 - host:
     path: /var/run/docker.sock
   name: docker
@@ -5319,6 +5141,6 @@ kind: secret
 name: prerelease_bucket
 ---
 kind: signature
-hmac: 6ea7d50bb90a73595b25736b904c7073ece3a5427a9cedb7a7712eee25f9681d
+hmac: 35cc80f164e04c6ea4396395d9c719a44740804601e616a085f0b774d8aa61e7
 
 ...

--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -14,7 +14,6 @@ load(
     'build_frontend_step',
     'build_plugins_step',
     'package_step',
-    'install_cypress_step',
     'e2e_tests_server_step',
     'e2e_tests_step',
     'build_storybook_step',
@@ -96,8 +95,7 @@ def get_steps(edition, is_downstream=False):
 
     # Insert remaining steps
     build_steps.extend([
-        package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2, is_downstream=is_downstream),
-        install_cypress_step(),
+        package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2, is_downstream=is_downstream),        
         e2e_tests_server_step(edition=edition),
         e2e_tests_step('dashboards-suite', edition=edition),
         e2e_tests_step('smoke-tests-suite', edition=edition),

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -14,7 +14,6 @@ load(
     'test_backend_integration_step',
     'test_frontend_step',
     'package_step',
-    'install_cypress_step',
     'e2e_tests_server_step',
     'e2e_tests_step',
     'build_storybook_step',
@@ -90,7 +89,6 @@ def pr_pipelines(edition):
     # Insert remaining build_steps
     build_steps.extend([
         package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2, variants=variants),
-        install_cypress_step(),
         e2e_tests_server_step(edition=edition),
         e2e_tests_step('dashboards-suite', edition=edition),
         e2e_tests_step('smoke-tests-suite', edition=edition),

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -18,7 +18,6 @@ load(
     'build_frontend_step',
     'build_plugins_step',
     'package_step',
-    'install_cypress_step',
     'e2e_tests_server_step',
     'e2e_tests_step',
     'build_storybook_step',
@@ -229,7 +228,6 @@ def get_steps(edition, ver_mode):
 
     if not disable_tests:
         build_steps.extend([
-            install_cypress_step(),
             e2e_tests_step('dashboards-suite', edition=edition, tries=3),
             e2e_tests_step('smoke-tests-suite', edition=edition, tries=3),
             e2e_tests_step('panels-suite', edition=edition, tries=3),

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -673,17 +673,13 @@ def e2e_tests_step(suite, edition, port=3001, tries=None):
         cmd += ' --tries {}'.format(tries)
     return {
         'name': 'end-to-end-tests-{}'.format(suite) + enterprise2_suffix(edition),
-        'image': 'cypress/included:9.2.0',
+        'image': 'cypress/included:8.4.1',
         'depends_on': [
             'package',
         ],
         'environment': {
             'HOST': 'end-to-end-tests-server' + enterprise2_suffix(edition),
         },
-        'volumes': [{
-            'name': 'cypress_cache',
-            'path': '/root/.cache/Cypress'
-        }],
         'commands': [
             'apt-get install -y netcat',
             cmd,

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -667,31 +667,15 @@ def e2e_tests_server_step(edition, port=3001):
         ],
     }
 
-def install_cypress_step():
-    return {
-        'name': 'cypress',
-        'image': 'grafana/ci-e2e:12.19.0-1',
-        'depends_on': [
-            'package',
-            ],
-        'commands': [
-            'yarn run cypress install',
-        ],
-        'volumes': [{
-            'name': 'cypress_cache',
-            'path': '/root/.cache/Cypress'
-        }],
-    }
-
 def e2e_tests_step(suite, edition, port=3001, tries=None):
     cmd = './bin/grabpl e2e-tests --port {} --suite {}'.format(port, suite)
     if tries:
         cmd += ' --tries {}'.format(tries)
     return {
         'name': 'end-to-end-tests-{}'.format(suite) + enterprise2_suffix(edition),
-        'image': 'grafana/ci-e2e:12.19.0-1',
+        'image': 'cypress/included:9.2.0',
         'depends_on': [
-            'cypress',
+            'package',
         ],
         'environment': {
             'HOST': 'end-to-end-tests-server' + enterprise2_suffix(edition),
@@ -701,6 +685,7 @@ def e2e_tests_step(suite, edition, port=3001, tries=None):
             'path': '/root/.cache/Cypress'
         }],
         'commands': [
+            'apt-get install -y netcat',
             cmd,
         ],
     }

--- a/scripts/drone/utils/utils.star
+++ b/scripts/drone/utils/utils.star
@@ -38,9 +38,6 @@ def pipeline(
         'services': services,
         'steps': steps,
         'volumes': [{
-            'name': 'cypress_cache',
-            'temp': {},
-        },{
             'name': 'docker',
             'host': {
                 'path': '/var/run/docker.sock',


### PR DESCRIPTION
Backport of #43520 

(cherry picked from commit ec9d6b9ca96827297f2d009a0cb7389971baeab0)