### PR TITLE
[v7.5.x] Alerting: Fix NoDataFound for alert rules using AND operator (#41305)

### DIFF
--- a/pkg/services/alerting/eval_handler.go
+++ b/pkg/services/alerting/eval_handler.go
@@ -48,7 +48,7 @@ func (e *DefaultEvalHandler) Eval(context *EvalContext) {
 
 		// calculating Firing based on operator
 		if cr.Operator == "or" {
-			firing = firing || cr.Firingimport
+			firing = firing || cr.Firing
 		} else {
 			firing = firing && cr.Firing
 		}

--- a/pkg/services/alerting/eval_handler.go
+++ b/pkg/services/alerting/eval_handler.go
@@ -48,12 +48,15 @@ func (e *DefaultEvalHandler) Eval(context *EvalContext) {
 
 		// calculating Firing based on operator
 		if cr.Operator == "or" {
-			firing = firing || cr.Firing
-			noDataFound = noDataFound || cr.NoDataFound
+			firing = firing || cr.Firingimport
 		} else {
 			firing = firing && cr.Firing
-			noDataFound = noDataFound && cr.NoDataFound
 		}
+
+		// We cannot evaluate the expression when one or more conditions are missing data
+		// and so noDataFound should be true if at least one condition returns no data,
+		// irrespective of the operator.
+		noDataFound = noDataFound || cr.NoDataFound
 
 		if i > 0 {
 			conditionEvals = "[" + conditionEvals + " " + strings.ToUpper(cr.Operator) + " " + strconv.FormatBool(cr.Firing) + "]"

--- a/pkg/services/alerting/eval_handler_test.go
+++ b/pkg/services/alerting/eval_handler_test.go
@@ -181,7 +181,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 			So(context.NoDataFound, ShouldBeTrue)
 		})
 
-		Convey("Should not return no data if at least one condition has no data and using AND", func() {
+		Convey("Should return no data if at least one condition has no data and using AND", func() {
 			context := NewEvalContext(context.TODO(), &Rule{
 				Conditions: []Condition{
 					&conditionStub{operator: "and", noData: true},
@@ -190,7 +190,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 			}, &validations.OSSPluginRequestValidator{})
 
 			handler.Eval(context)
-			So(context.NoDataFound, ShouldBeFalse)
+			So(context.NoDataFound, ShouldBeTrue)
 		})
 
 		Convey("Should return no data if at least one condition has no data and using OR", func() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9567,19 +9567,19 @@ caniuse-db@1.0.30000772:
   integrity sha1-UarokXaChureSj2DGep21qAbUSs=
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001173:
-  version "1.0.30001178"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001178.tgz#3ad813b2b2c7d585b0be0a2440e1e233c6eabdbc"
-  integrity sha512-VtdZLC0vsXykKni8Uztx45xynytOi71Ufx9T8kHptSw9AL4dpqailUJJHavttuzUe1KYuBYtChiWv+BAb7mPmQ==
+  version "1.0.30001299"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz"
+  integrity sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==
 
 caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001093:
-  version "1.0.30001104"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001104.tgz#4e3d5b3b1dd3c3529f10cb7f519c62ba3e579f5d"
-  integrity sha512-pkpCg7dmI/a7WcqM2yfdOiT4Xx5tzyoHAXWsX5/HxZ3TemwDZs0QXdqbE0UPLPVy/7BeK7693YfzfRYfu1YVpg==
+  version "1.0.30001299"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz"
+  integrity sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==
 
 caniuse-lite@^1.0.30001109:
-  version "1.0.30001179"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz#b0803883b4471a6c62066fb1752756f8afc699c8"
-  integrity sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==
+  version "1.0.30001299"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz"
+  integrity sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This commit fixes an issue in alerting where NoDataFound is false when using the AND operator to compare two conditions in an alert rule and one of the conditions has no data.

Backport of https://github.com/grafana/grafana/pull/41305
