### PR TITLE
fix(40590): bundle the readme files of datasources inside app plugins

### DIFF
--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
@@ -99,6 +99,7 @@ const getCommonPlugins = (options: WebpackConfigurationOptions) => {
         // If src/README.md exists use it; otherwise the root README
         { from: hasREADME ? 'README.md' : '../README.md', to: '.', force: true },
         { from: 'plugin.json', to: '.' },
+        { from: '**/README.md', to: '[path]README.md' },
         { from: '../LICENSE', to: '.' },
         { from: '../CHANGELOG.md', to: '.', force: true },
         { from: '**/*.json', to: '.' },

--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
@@ -97,9 +97,9 @@ const getCommonPlugins = (options: WebpackConfigurationOptions) => {
     new CopyWebpackPlugin(
       [
         // If src/README.md exists use it; otherwise the root README
-        { from: hasREADME ? 'README.md' : '../README.md', to: '.', force: true },
+        { from: hasREADME ? 'README.md' : '../README.md', to: '.', force: true, prority: 1 },
         { from: 'plugin.json', to: '.' },
-        { from: '**/README.md', to: '[path]README.md' },
+        { from: '**/README.md', to: '[path]README.md', priority: 0 },
         { from: '../LICENSE', to: '.' },
         { from: '../CHANGELOG.md', to: '.', force: true },
         { from: '**/*.json', to: '.' },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Currently we only bundle the root README.md file into the build of a plugin. This PR also bundles all the README files in subfolders.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #40590

**Motivation behind this PR**
- Mostly this one is a discussion point for us to figure out if we want to keep the readme's in the plugin package, not necessary something to merge
- It seems that current version of Grafana does not care about the nested Readme's so there might be no benefit in doing so from the displaying perspective at the moment, the question is more - why strip it away from the datasources when it's nested inside of an app?
- Relevant code is [here](https://github.com/grafana/grafana/blob/main/public/app/features/plugins/admin/api.ts#L74) and the backend side is [here](https://github.com/grafana/grafana/blob/main/pkg/api/plugins.go#L209)
- It also seems that older version included the nested readmes in the Tab called '`README`' (see screenshots, but not 100% sure about it)
![image (1)](https://user-images.githubusercontent.com/580672/149735031-f4ac76bb-a051-46d5-9fff-e067ff0776cb.png)
![image](https://user-images.githubusercontent.com/580672/149735038-ebd23cb3-cfff-445d-9f06-0dcee8b4afb5.png)

