### PR TITLE
Chore: Correctly escape strings in JSONFormatter

### DIFF
--- a/packages/grafana-ui/src/components/JSONFormatter/json_explorer/helpers.test.ts
+++ b/packages/grafana-ui/src/components/JSONFormatter/json_explorer/helpers.test.ts
@@ -1,4 +1,4 @@
-import { escapeString } from './helpers';
+import { formatString } from './helpers';
 
 describe('JSONFormatter helpers', () => {
   describe('escapeString', () => {
@@ -6,7 +6,7 @@ describe('JSONFormatter helpers', () => {
       const input = 'hello world';
       const expected = 'hello world';
 
-      const result = escapeString(input);
+      const result = formatString(input);
       expect(result).toEqual(expected);
     });
 
@@ -14,7 +14,7 @@ describe('JSONFormatter helpers', () => {
       const input = `'hello world'`;
       const expected = `'hello world'`;
 
-      const result = escapeString(input);
+      const result = formatString(input);
       expect(result).toEqual(expected);
     });
 
@@ -22,7 +22,7 @@ describe('JSONFormatter helpers', () => {
       const input = `"hello world`;
       const expected = `\\"hello world`;
 
-      const result = escapeString(input);
+      const result = formatString(input);
       expect(result).toEqual(expected);
     });
 
@@ -30,7 +30,7 @@ describe('JSONFormatter helpers', () => {
       const input = `"hello world"`;
       const expected = `\\"hello world\\"`;
 
-      const result = escapeString(input);
+      const result = formatString(input);
       expect(result).toEqual(expected);
     });
 
@@ -38,7 +38,7 @@ describe('JSONFormatter helpers', () => {
       const input = `{"hello": "world"}`;
       const expected = `{\\"hello\\": \\"world\\"}`;
 
-      const result = escapeString(input);
+      const result = formatString(input);
       expect(result).toEqual(expected);
     });
   });

--- a/packages/grafana-ui/src/components/JSONFormatter/json_explorer/helpers.test.ts
+++ b/packages/grafana-ui/src/components/JSONFormatter/json_explorer/helpers.test.ts
@@ -1,0 +1,45 @@
+import { escapeString } from './helpers';
+
+describe('JSONFormatter helpers', () => {
+  describe('escapeString', () => {
+    it("does not escape strings that don't contain quotes", () => {
+      const input = 'hello world';
+      const expected = 'hello world';
+
+      const result = escapeString(input);
+      expect(result).toEqual(expected);
+    });
+
+    it('does not escape strings that contain single quotes', () => {
+      const input = `'hello world'`;
+      const expected = `'hello world'`;
+
+      const result = escapeString(input);
+      expect(result).toEqual(expected);
+    });
+
+    it('does escapes strings that contain one double quote', () => {
+      const input = `"hello world`;
+      const expected = `\\"hello world`;
+
+      const result = escapeString(input);
+      expect(result).toEqual(expected);
+    });
+
+    it('does escapes strings that contain two double quotes', () => {
+      const input = `"hello world"`;
+      const expected = `\\"hello world\\"`;
+
+      const result = escapeString(input);
+      expect(result).toEqual(expected);
+    });
+
+    it('does escapes a string that looks like JSON', () => {
+      const input = `{"hello": "world"}`;
+      const expected = `{\\"hello\\": \\"world\\"}`;
+
+      const result = escapeString(input);
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/packages/grafana-ui/src/components/JSONFormatter/json_explorer/helpers.ts
+++ b/packages/grafana-ui/src/components/JSONFormatter/json_explorer/helpers.ts
@@ -2,10 +2,10 @@
 // License MIT, Copyright (c) 2015 Mohsen Azimi
 
 /*
- * Escapes `"` characters from string
+ * Escapes `"` characters from string for formatting
  */
-function escapeString(str: string): string {
-  return str.replace('"', '"');
+export function escapeString(str: string): string {
+  return str.replace(/"/g, '\\"');
 }
 
 /*

--- a/packages/grafana-ui/src/components/JSONFormatter/json_explorer/helpers.ts
+++ b/packages/grafana-ui/src/components/JSONFormatter/json_explorer/helpers.ts
@@ -2,10 +2,10 @@
 // License MIT, Copyright (c) 2015 Mohsen Azimi
 
 /*
- * Escapes `"` characters from string for formatting
+ * Escapes `"` characters from string
  */
-export function escapeString(str: string): string {
-  return str.replace(/"/g, '\\"');
+export function formatString(str: string): string {
+  return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 /*
@@ -62,7 +62,7 @@ export function getValuePreview(object: object, value: string): string {
   }
 
   if (type === 'string') {
-    value = '"' + escapeString(value) + '"';
+    value = '"' + formatString(value) + '"';
   }
   if (type === 'function') {
     // Remove content of the function


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a "Incomplete string escaping or encoding" warning from code scanning. The warning itself is pretty benign as this function is only used for display formatting, and only in the Table panel I think?

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/security/code-scanning/9?query=ref%3Arefs%2Fheads%2Fmain

Relates to #43080

Before: 
![image](https://user-images.githubusercontent.com/46142/149762086-2be8f698-a911-4da1-9aed-ce2063cfc0a5.png)


After:
![image](https://user-images.githubusercontent.com/46142/149762164-0e9767a9-1ee2-42e0-b3f8-049d2bcc6dce.png)

The new value is correct because when i copy-paste it into the JSON console, the string is logged as expected 

![image](https://user-images.githubusercontent.com/46142/149762237-abe90baf-63e1-4b8c-8b92-c85c351c087a.png)
