### PR TITLE
CI: Update breaking changes workflow to compare against main

### DIFF
--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -3,27 +3,23 @@ name: Levitate / Detect breaking changes
 on: pull_request
 
 jobs:
-  build:
-    name: Detect
+  buildPR:
+    name: Build PR
     runs-on: ubuntu-latest
-    env:
-      GITHUB_STEP_NUMBER: 7
+    defaults:
+      run:
+        working-directory: './pr'
 
     steps:
     - uses: actions/checkout@v2
+      with: 
+        path: './pr'
 
     - name: Setup environment
       uses: actions/setup-node@v2.5.1
       with:
         node-version: '16'
-
-    - name: Get link for the Github Action job
-      id: job
-      uses: actions/github-script@v5
-      with:
-        script: |
-            const script = require('./.github/workflows/scripts/pr-get-job-link.js')
-            await script({github, context, core})
+        cache: 'yarn'
       
     - name: Install dependencies
       run: yarn install --immutable
@@ -31,24 +27,98 @@ jobs:
     - name: Build packages
       run: yarn packages:build
 
-    - name: Detect breaking changes
-      id: breaking-changes
-      run: ./scripts/check-breaking-changes.sh 
-      env:
-        FORCE_COLOR: 3
-        GITHUB_JOB_LINK: ${{ steps.job.outputs.link }}
-
-    - name: Persisting the check output
-      run: |
-          mkdir -p ./levitate
-          echo "{ \"exit_code\": ${{ steps.breaking-changes.outputs.is_breaking }}, \"message\": \"${{ steps.breaking-changes.outputs.message }}\", \"job_link\": \"${{ steps.job.outputs.link }}#step:${GITHUB_STEP_NUMBER}:1\" }" > ./levitate/result.json
-
     - name: Upload check output as artifact
       uses: actions/upload-artifact@v2
       with:
-        name: levitate
-        path: levitate/
+        name: buildPr
+        path: './pr'
+
+  buildMain:
+    name: Build Main
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: './main'
+
+    steps:
+    - uses: actions/checkout@v2
+      with: 
+        path: './main'
+        ref: 'main'
+
+    - name: Setup environment
+      uses: actions/setup-node@v2.5.1
+      with:
+        node-version: '16'
+        cache: 'yarn'
       
-    - name: Exit
-      run: exit ${{ steps.breaking-changes.outputs.is_breaking }}
-      shell: bash
+    - name: Install dependencies
+      run: yarn install --immutable
+
+    - name: Build packages
+      run: yarn packages:build
+  
+    - name: Upload check output as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: buildMain
+        path: './main'
+
+  Detect:
+    name: Detect breaking changes
+    runs-on: ubuntu-latest
+    needs: ['buildPR', 'buildMain']
+    env:
+      GITHUB_STEP_NUMBER: 7
+
+    steps:
+      - name: Get output from pr
+        uses: actions/download-artifact@v2
+        with:
+          name: buildPr
+          path: './pr'
+
+      - name: Get output from main
+        uses: actions/download-artifact@v2
+        with:
+          name: buildMain
+          path: './main'
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: './pr'
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: './main'
+
+
+    # - name: Get link for the Github Action job
+    #   id: job
+    #   uses: actions/github-script@v5
+    #   with:
+    #     script: |
+    #         const script = require('./.github/workflows/scripts/pr-get-job-link.js')
+    #         await script({github, context, core})
+
+    # - name: Detect breaking changes
+    #   id: breaking-changes
+    #   run: ./scripts/check-breaking-changes.sh 
+    #   env:
+    #     FORCE_COLOR: 3
+    #     GITHUB_JOB_LINK: ${{ steps.job.outputs.link }}
+
+    # - name: Persisting the check output
+    #   run: |
+    #       mkdir -p ./levitate
+    #       echo "{ \"exit_code\": ${{ steps.breaking-changes.outputs.is_breaking }}, \"message\": \"${{ steps.breaking-changes.outputs.message }}\", \"job_link\": \"${{ steps.job.outputs.link }}#step:${GITHUB_STEP_NUMBER}:1\" }" > ./levitate/result.json
+
+    # - name: Upload check output as artifact
+    #   uses: actions/upload-artifact@v2
+    #   with:
+    #     name: levitate
+    #     path: levitate/
+      
+    # - name: Exit
+    #   run: exit ${{ steps.breaking-changes.outputs.is_breaking }}
+    #   shell: bash

--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -15,12 +15,18 @@ jobs:
       with: 
         path: './pr'
 
-    - name: Setup environment
-      uses: actions/setup-node@v2.5.1
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+    
+    - name: Restore yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache
       with:
-        node-version: '16'
-        cache: 'yarn'
-        path: './pr'
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: yarn-cache-folder-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
+        restore-keys: |
+          yarn-cache-folder-
       
     - name: Install dependencies
       run: yarn install --immutable
@@ -28,11 +34,14 @@ jobs:
     - name: Build packages
       run: yarn packages:build
 
-    - name: Upload check output as artifact
+    - name: Zip built packages
+      run: zip -r ./pr_built_packages.zip ./packages/**/dist
+
+    - name: Upload build output as artifact
       uses: actions/upload-artifact@v2
       with:
         name: buildPr
-        path: './pr'
+        path: './pr/pr_built_packages.zip'
 
   buildMain:
     name: Build Main
@@ -47,24 +56,33 @@ jobs:
         path: './main'
         ref: 'main'
 
-    - name: Setup environment
-      uses: actions/setup-node@v2.5.1
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+    
+    - name: Restore yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache
       with:
-        node-version: '16'
-        cache: 'yarn'
-        path: './main'
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: yarn-cache-folder-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
+        restore-keys: |
+          yarn-cache-folder-
       
     - name: Install dependencies
       run: yarn install --immutable
 
     - name: Build packages
       run: yarn packages:build
-  
-    - name: Upload check output as artifact
+
+    - name: Zip built packages
+      run: zip -r ./main_built_packages.zip ./packages/**/dist
+
+    - name: Upload build output as artifact
       uses: actions/upload-artifact@v2
       with:
         name: buildMain
-        path: './main'
+        path: './main/main_built_packages.zip'
 
   Detect:
     name: Detect breaking changes
@@ -74,53 +92,50 @@ jobs:
       GITHUB_STEP_NUMBER: 7
 
     steps:
-      - name: Get output from pr
+      - uses: actions/checkout@v2
+
+      - name: Get built packages from pr
         uses: actions/download-artifact@v2
         with:
           name: buildPr
-          path: './pr'
 
-      - name: Get output from main
+      - name: Get built packages from main
         uses: actions/download-artifact@v2
         with:
           name: buildMain
-          path: './main'
-
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: './pr'
-
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: './main'
-
-
-    # - name: Get link for the Github Action job
-    #   id: job
-    #   uses: actions/github-script@v5
-    #   with:
-    #     script: |
-    #         const script = require('./.github/workflows/scripts/pr-get-job-link.js')
-    #         await script({github, context, core})
-
-    # - name: Detect breaking changes
-    #   id: breaking-changes
-    #   run: ./scripts/check-breaking-changes.sh 
-    #   env:
-    #     FORCE_COLOR: 3
-    #     GITHUB_JOB_LINK: ${{ steps.job.outputs.link }}
-
-    # - name: Persisting the check output
-    #   run: |
-    #       mkdir -p ./levitate
-    #       echo "{ \"exit_code\": ${{ steps.breaking-changes.outputs.is_breaking }}, \"message\": \"${{ steps.breaking-changes.outputs.message }}\", \"job_link\": \"${{ steps.job.outputs.link }}#step:${GITHUB_STEP_NUMBER}:1\" }" > ./levitate/result.json
-
-    # - name: Upload check output as artifact
-    #   uses: actions/upload-artifact@v2
-    #   with:
-    #     name: levitate
-    #     path: levitate/
       
-    # - name: Exit
-    #   run: exit ${{ steps.breaking-changes.outputs.is_breaking }}
-    #   shell: bash
+      - name: Unzip artifact from pr
+        run: unzip pr_built_packages.zip -d ./pr && rm pr_built_packages.zip
+
+      - name: Unzip artifact from main
+        run: unzip main_built_packages.zip -d ./main && rm main_built_packages.zip
+
+      - name: Get link for the Github Action job
+        id: job
+        uses: actions/github-script@v5
+        with:
+          script: |
+              const script = require('./.github/workflows/scripts/pr-get-job-link.js')
+              await script({github, context, core})
+
+      - name: Detect breaking changes
+        id: breaking-changes
+        run: ./scripts/check-breaking-changes.sh 
+        env:
+          FORCE_COLOR: 3
+          GITHUB_JOB_LINK: ${{ steps.job.outputs.link }}
+
+      - name: Persisting the check output
+        run: |
+            mkdir -p ./levitate
+            echo "{ \"exit_code\": ${{ steps.breaking-changes.outputs.is_breaking }}, \"message\": \"${{ steps.breaking-changes.outputs.message }}\", \"job_link\": \"${{ steps.job.outputs.link }}#step:${GITHUB_STEP_NUMBER}:1\" }" > ./levitate/result.json
+
+      - name: Upload check output as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: levitate
+          path: levitate/
+        
+      - name: Exit
+        run: exit ${{ steps.breaking-changes.outputs.is_breaking }}
+        shell: bash

--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -20,6 +20,7 @@ jobs:
       with:
         node-version: '16'
         cache: 'yarn'
+        path: './pr'
       
     - name: Install dependencies
       run: yarn install --immutable
@@ -51,6 +52,7 @@ jobs:
       with:
         node-version: '16'
         cache: 'yarn'
+        path: './main'
       
     - name: Install dependencies
       run: yarn install --immutable


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Currently we compare changes in a PR against the latest canary npm package however there is a period of time where PRs build against an outdated canary package (due to merge to main and waiting for that to build and publish) which results in breaking changes being incorrectly labelled in PRs.

- [x] build packages for a PR branch and main
- [x] parallelise package building
- [x] use built package artifacts to compare changes
- [x] cache dependency installation

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #44102

**Special notes for your reviewer**:

