### PR TITLE
Provisioning: Allow dashboards with same uid/ title for different orgs

### DIFF
--- a/pkg/services/provisioning/dashboards/validator.go
+++ b/pkg/services/provisioning/dashboards/validator.go
@@ -17,8 +17,8 @@ func newDuplicate() *duplicate {
 }
 
 type duplicateEntries struct {
-	Titles map[dashboardIdentity]*duplicate
-	UIDs   map[string]*duplicate
+	Titles map[titleIdentity]*duplicate
+	UIDs   map[uidIdentity]*duplicate
 }
 
 func (d *duplicateEntries) InvolvedReaders() map[string]struct{} {
@@ -58,8 +58,8 @@ func newDuplicateValidator(logger log.Logger, readers []*FileReader) duplicateVa
 
 func (c *duplicateValidator) getDuplicates() *duplicateEntries {
 	duplicates := duplicateEntries{
-		Titles: make(map[dashboardIdentity]*duplicate),
-		UIDs:   make(map[string]*duplicate),
+		Titles: make(map[titleIdentity]*duplicate),
+		UIDs:   make(map[uidIdentity]*duplicate),
 	}
 
 	for _, reader := range c.readers {
@@ -89,15 +89,15 @@ func (c *duplicateValidator) getDuplicates() *duplicateEntries {
 func (c *duplicateValidator) logWarnings(duplicates *duplicateEntries) {
 	for uid, usage := range duplicates.UIDs {
 		if usage.Sum > 1 {
-			c.logger.Warn("the same UID is used more than once", "uid", uid, "times", usage.Sum, "providers",
-				keysToSlice(usage.InvolvedReaders))
+			c.logger.Warn("the same UID is used more than once", "uid", uid.uid, "times", usage.Sum,
+				"orgId", uid.orgId, "providers", keysToSlice(usage.InvolvedReaders))
 		}
 	}
 
 	for id, usage := range duplicates.Titles {
 		if usage.Sum > 1 {
-			c.logger.Warn("dashboard title is not unique in folder", "title", id.title, "folderID", id.folderID, "times",
-				usage.Sum, "providers", keysToSlice(usage.InvolvedReaders))
+			c.logger.Warn("dashboard title is not unique in folder", "title", id.title, "folderID", id.folderID, "times", usage.Sum,
+				"orgId", id.orgId, "providers", keysToSlice(usage.InvolvedReaders))
 		}
 	}
 }

--- a/pkg/services/provisioning/dashboards/validator_test.go
+++ b/pkg/services/provisioning/dashboards/validator_test.go
@@ -14,6 +14,7 @@ import (
 const (
 	dashboardContainingUID = "testdata/test-dashboards/dashboard-with-uid"
 	twoDashboardsWithUID   = "testdata/test-dashboards/two-dashboards-with-uid"
+	testDashboardUID       = "Z-phNqGmz"
 )
 
 func TestDuplicatesValidator(t *testing.T) {
@@ -35,7 +36,8 @@ func TestDuplicatesValidator(t *testing.T) {
 		folderID, err := getOrCreateFolderID(context.Background(), cfg, fakeService, folderName)
 		require.NoError(t, err)
 
-		identity := dashboardIdentity{folderID: folderID, title: "Grafana"}
+		uidIdt := uidIdentity{orgId: 1, uid: testDashboardUID}
+		titleIdt := titleIdentity{orgId: 1, folderID: folderID, title: "Grafana"}
 
 		cfg1 := &config{
 			Name: "first", Type: "file", OrgID: 1, Folder: folderName,
@@ -62,13 +64,13 @@ func TestDuplicatesValidator(t *testing.T) {
 
 		duplicates := duplicateValidator.getDuplicates()
 
-		require.Equal(t, uint8(2), duplicates.UIDs["Z-phNqGmz"].Sum)
-		uidUsageReaders := keysToSlice(duplicates.UIDs["Z-phNqGmz"].InvolvedReaders)
+		require.Equal(t, uint8(2), duplicates.UIDs[uidIdt].Sum)
+		uidUsageReaders := keysToSlice(duplicates.UIDs[uidIdt].InvolvedReaders)
 		sort.Strings(uidUsageReaders)
 		require.Equal(t, []string{"first", "second"}, uidUsageReaders)
 
-		require.Equal(t, uint8(2), duplicates.Titles[identity].Sum)
-		titleUsageReaders := keysToSlice(duplicates.Titles[identity].InvolvedReaders)
+		require.Equal(t, uint8(2), duplicates.Titles[titleIdt].Sum)
+		titleUsageReaders := keysToSlice(duplicates.Titles[titleIdt].InvolvedReaders)
 		sort.Strings(titleUsageReaders)
 		require.Equal(t, []string{"first", "second"}, titleUsageReaders)
 
@@ -106,20 +108,82 @@ func TestDuplicatesValidator(t *testing.T) {
 		folderID, err := getOrCreateFolderID(context.Background(), cfg, fakeService, cfg1.Folder)
 		require.NoError(t, err)
 
-		identity := dashboardIdentity{folderID: folderID, title: "Grafana"}
+		uidIdt := uidIdentity{orgId: 1, uid: testDashboardUID}
+		titleIdt := titleIdentity{orgId: 1, folderID: folderID, title: "Grafana"}
 
-		require.Equal(t, uint8(2), duplicates.UIDs["Z-phNqGmz"].Sum)
-		uidUsageReaders := keysToSlice(duplicates.UIDs["Z-phNqGmz"].InvolvedReaders)
+		require.Equal(t, uint8(2), duplicates.UIDs[uidIdt].Sum)
+		uidUsageReaders := keysToSlice(duplicates.UIDs[uidIdt].InvolvedReaders)
 		sort.Strings(uidUsageReaders)
 		require.Equal(t, []string{"first"}, uidUsageReaders)
 
-		require.Equal(t, uint8(2), duplicates.Titles[identity].Sum)
-		titleUsageReaders := keysToSlice(duplicates.Titles[identity].InvolvedReaders)
+		require.Equal(t, uint8(2), duplicates.Titles[titleIdt].Sum)
+		titleUsageReaders := keysToSlice(duplicates.Titles[titleIdt].InvolvedReaders)
 		sort.Strings(titleUsageReaders)
 		require.Equal(t, []string{"first"}, titleUsageReaders)
 
 		duplicateValidator.validate()
 		require.True(t, reader1.isDatabaseAccessRestricted())
+		require.False(t, reader2.isDatabaseAccessRestricted())
+	})
+
+	t.Run("Duplicates validator should not restrict write access for duplicate UIDs and titles for different OrgID", func(t *testing.T) {
+		const folderName = "duplicates-validator-folder"
+
+		cfg1 := &config{
+			Name: "first", Type: "file", OrgID: 1, Folder: folderName,
+			Options: map[string]interface{}{"path": dashboardContainingUID},
+		}
+		cfg2 := &config{
+			Name: "second", Type: "file", OrgID: 2, Folder: folderName,
+			Options: map[string]interface{}{"path": dashboardContainingUID},
+		}
+
+		reader1, err := NewDashboardFileReader(cfg1, logger, nil)
+		require.NoError(t, err)
+
+		reader2, err := NewDashboardFileReader(cfg2, logger, nil)
+		require.NoError(t, err)
+
+		duplicateValidator := newDuplicateValidator(logger, []*FileReader{reader1, reader2})
+
+		err = reader1.walkDisk(context.Background())
+		require.NoError(t, err)
+
+		err = reader2.walkDisk(context.Background())
+		require.NoError(t, err)
+
+		folderID, err := getOrCreateFolderID(context.Background(), cfg, fakeService, folderName)
+		require.NoError(t, err)
+
+		duplicates := duplicateValidator.getDuplicates()
+
+		uidIdt1 := uidIdentity{orgId: 1, uid: testDashboardUID}
+		uidIdt2 := uidIdentity{orgId: 2, uid: testDashboardUID}
+		titleIdt1 := titleIdentity{orgId: 1, folderID: folderID, title: "Grafana"}
+		titleIdt2 := titleIdentity{orgId: 2, folderID: folderID, title: "Grafana"}
+
+		require.Equal(t, uint8(1), duplicates.UIDs[uidIdt1].Sum)
+		uidUsageReaders1 := keysToSlice(duplicates.UIDs[uidIdt1].InvolvedReaders)
+		sort.Strings(uidUsageReaders1)
+		require.Equal(t, []string{"first"}, uidUsageReaders1)
+
+		require.Equal(t, uint8(1), duplicates.UIDs[uidIdt2].Sum)
+		uidUsageReaders2 := keysToSlice(duplicates.UIDs[uidIdt2].InvolvedReaders)
+		sort.Strings(uidUsageReaders2)
+		require.Equal(t, []string{"second"}, uidUsageReaders2)
+
+		require.Equal(t, uint8(1), duplicates.Titles[titleIdt1].Sum)
+		titleUsageReaders1 := keysToSlice(duplicates.Titles[titleIdt1].InvolvedReaders)
+		sort.Strings(titleUsageReaders1)
+		require.Equal(t, []string{"first"}, titleUsageReaders1)
+
+		require.Equal(t, uint8(1), duplicates.Titles[titleIdt2].Sum)
+		titleUsageReaders2 := keysToSlice(duplicates.Titles[titleIdt2].InvolvedReaders)
+		sort.Strings(titleUsageReaders2)
+		require.Equal(t, []string{"second"}, titleUsageReaders2)
+
+		duplicateValidator.validate()
+		require.False(t, reader1.isDatabaseAccessRestricted())
 		require.False(t, reader2.isDatabaseAccessRestricted())
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This MR adds validation for unique `OrgId` to Validation for Provisioning Dashboards that has been introduced in #26742
There was ignored `orgId`. Thus provisioning dashboards with the same title/ UID were failed to provision between different Grafana Organizations.

**Which issue(s) this PR fixes**:
Fixes #44126 

