### PR TITLE
Access control: Disable select for non managed permissions

### DIFF
--- a/public/app/core/components/AccessControl/PermissionList.tsx
+++ b/public/app/core/components/AccessControl/PermissionList.tsx
@@ -6,12 +6,12 @@ interface Props {
   title: string;
   items: ResourcePermission[];
   permissionLevels: string[];
-  canRemove: boolean;
+  canSet: boolean;
   onRemove: (item: ResourcePermission) => void;
   onChange: (resourcePermission: ResourcePermission, permission: string) => void;
 }
 
-export const PermissionList = ({ title, items, permissionLevels, canRemove, onRemove, onChange }: Props) => {
+export const PermissionList = ({ title, items, permissionLevels, canSet, onRemove, onChange }: Props) => {
   if (items.length === 0) {
     return null;
   }
@@ -26,7 +26,7 @@ export const PermissionList = ({ title, items, permissionLevels, canRemove, onRe
               item={item}
               onRemove={onRemove}
               onChange={onChange}
-              canRemove={canRemove}
+              canSet={canSet}
               key={`${index}-${item.userId}`}
               permissionLevels={permissionLevels}
             />

--- a/public/app/core/components/AccessControl/PermissionListItem.tsx
+++ b/public/app/core/components/AccessControl/PermissionListItem.tsx
@@ -5,12 +5,12 @@ import { Button, Icon, Select, Tooltip } from '@grafana/ui';
 interface Props {
   item: ResourcePermission;
   permissionLevels: string[];
-  canRemove: boolean;
+  canSet: boolean;
   onRemove: (item: ResourcePermission) => void;
   onChange: (item: ResourcePermission, permission: string) => void;
 }
 
-export const PermissionListItem = ({ item, permissionLevels, canRemove, onRemove, onChange }: Props) => (
+export const PermissionListItem = ({ item, permissionLevels, canSet, onRemove, onChange }: Props) => (
   <tr>
     <td style={{ width: '1%' }}>{getAvatar(item)}</td>
     <td style={{ width: '90%' }}>{getDescription(item)}</td>
@@ -21,6 +21,7 @@ export const PermissionListItem = ({ item, permissionLevels, canRemove, onRemove
         <Select
           className="width-20"
           menuShouldPortal
+          disabled={!canSet || !item.isManaged}
           onChange={(p) => onChange(item, p.value!)}
           value={permissionLevels.find((p) => p === item.permission)}
           options={permissionLevels.map((p) => ({ value: p, label: p }))}
@@ -38,7 +39,7 @@ export const PermissionListItem = ({ item, permissionLevels, canRemove, onRemove
           size="sm"
           icon="times"
           variant="destructive"
-          disabled={!canRemove}
+          disabled={!canSet}
           onClick={() => onRemove(item)}
           aria-label={`Remove permission for ${getName(item)}`}
         />

--- a/public/app/core/components/AccessControl/Permissions.tsx
+++ b/public/app/core/components/AccessControl/Permissions.tsx
@@ -139,7 +139,7 @@ export const Permissions = ({ resource, resourceId, canListUsers, canSetPermissi
           permissionLevels={desc.permissions}
           onChange={onChange}
           onRemove={onRemove}
-          canRemove={canSetPermissions}
+          canSet={canSetPermissions}
         />
         <PermissionList
           title="Users"
@@ -147,7 +147,7 @@ export const Permissions = ({ resource, resourceId, canListUsers, canSetPermissi
           permissionLevels={desc.permissions}
           onChange={onChange}
           onRemove={onRemove}
-          canRemove={canSetPermissions}
+          canSet={canSetPermissions}
         />
         <PermissionList
           title="Teams"
@@ -155,7 +155,7 @@ export const Permissions = ({ resource, resourceId, canListUsers, canSetPermissi
           permissionLevels={desc.permissions}
           onChange={onChange}
           onRemove={onRemove}
-          canRemove={canSetPermissions}
+          canSet={canSetPermissions}
         />
       </div>
     </div>


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable permission select when a user don't have permissions to change it or if a permission is provisioned (fixed-roles/provisioning/api)

![2022-01-18-11:46:47](https://user-images.githubusercontent.com/23356117/149922901-9afa66ee-46f6-4aec-8b4e-46b22c641964.png)

