### PR TITLE
CI: Replace `hugohaggmark/docker-puppeteer` with `grafana/docker-puppeteer`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -283,7 +283,7 @@ steps:
     HOST: end-to-end-tests-server
     PORT: 3001
   failure: always
-  image: hugohaggmark/docker-puppeteer
+  image: grafana/docker-puppeteer:1.0.0
   name: test-a11y-frontend
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
@@ -730,7 +730,7 @@ steps:
     HOST: end-to-end-tests-server
     PORT: 3001
   failure: ignore
-  image: hugohaggmark/docker-puppeteer
+  image: grafana/docker-puppeteer:1.0.0
   name: test-a11y-frontend
 - commands:
   - ./scripts/ci-frontend-metrics.sh | ./bin/grabpl publish-metrics $${GRAFANA_MISC_STATS_API_KEY}
@@ -5504,6 +5504,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: dbd70fd70a25696521e6b0005d2aebcc03e05cc504f34055bfdccf9868b64a68
+hmac: 9df8ada188b84934ba449a62dbea9eb81f2ba8feff2d5a04a7ec94a718d8cd74
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -552,7 +552,7 @@ def test_a11y_frontend_step(ver_mode, edition, port=3001):
 
     return {
         'name': 'test-a11y-frontend' + enterprise2_suffix(edition),
-        'image': 'hugohaggmark/docker-puppeteer',
+        'image': 'grafana/docker-puppeteer:1.0.0',
         'depends_on': [
             'end-to-end-tests-server' + enterprise2_suffix(edition),
         ],


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces `hugohaggmark/docker-puppeteer` with `grafana/docker-puppeteer`, so we can keep all images under grafana org.
