### PR TITLE
[v8.3.x] CI: Replace docker-puppeteer with the one in grafana dockerhub repo (#44145)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -250,7 +250,7 @@ steps:
     HOST: end-to-end-tests-server
     PORT: 3001
   failure: always
-  image: hugohaggmark/docker-puppeteer
+  image: grafana/docker-puppeteer:1.0.0
   name: test-a11y-frontend
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
@@ -674,7 +674,7 @@ steps:
     HOST: end-to-end-tests-server
     PORT: 3001
   failure: ignore
-  image: hugohaggmark/docker-puppeteer
+  image: grafana/docker-puppeteer:1.0.0
   name: test-a11y-frontend
 - commands:
   - ./scripts/ci-frontend-metrics.sh | ./bin/grabpl publish-metrics $${GRAFANA_MISC_STATS_API_KEY}
@@ -5146,6 +5146,6 @@ kind: secret
 name: prerelease_bucket
 ---
 kind: signature
-hmac: 390006ba60e87a26bcb898ff230a9218b0c954da09c44c7823cfc8aa0b82cb98
+hmac: c405c799db7cac8262e1ffba013983f9ca3ce0b074767c088988ca774e6f5cab
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -512,7 +512,7 @@ def test_a11y_frontend_step(ver_mode, edition, port=3001):
 
     return {
         'name': 'test-a11y-frontend' + enterprise2_suffix(edition),
-        'image': 'hugohaggmark/docker-puppeteer',
+        'image': 'grafana/docker-puppeteer:1.0.0',
         'depends_on': [
             'end-to-end-tests-server' + enterprise2_suffix(edition),
         ],


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport of #44145

(cherry picked from commit 118cc0d735a28235e12f5c86b89809acec4440f3)
