### PR TITLE
Fix typo in WebSockets configuration for Nginx

### DIFF
--- a/docs/sources/live/configure-grafana-live.md
+++ b/docs/sources/live/configure-grafana-live.md
@@ -92,8 +92,8 @@ http {
 
         location / {
             proxy_http_version 1.1;
-            proxy_set_header Upgrade $connection_upgrade;
-            proxy_set_header Connection "Upgrade";
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $http_host;
             proxy_pass http://grafana;
         }

--- a/docs/sources/live/configure-grafana-live.md
+++ b/docs/sources/live/configure-grafana-live.md
@@ -92,7 +92,7 @@ http {
 
         location / {
             proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Upgrade $connection_upgrade;
             proxy_set_header Connection "Upgrade";
             proxy_set_header Host $http_host;
             proxy_pass http://grafana;


### PR DESCRIPTION
**What this PR does / why we need it**:
I was looking for information about WebSockets configuration in Nginx for Grafana Live, and I found a possible typo in a [Configure Grafana Live](https://grafana.com/docs/grafana/latest/live/configure-grafana-live/#websocket-and-proxies) page. It seems that we should have used `$connection_upgrade` variable or got rid of unused `map` directive at all.

**Which issue(s) this PR fixes**:
I assume it would be better to use `$connection_upgrade` as it was supposed to.