### PR TITLE
Alerting: Support the For condition for DatasourceError alerts

### DIFF
--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -2,11 +2,11 @@ package state
 
 import (
 	"errors"
-	"github.com/grafana/grafana/pkg/expr"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 
+	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	ngModels "github.com/grafana/grafana/pkg/services/ngalert/models"
 )

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -93,31 +93,53 @@ func (a *State) resultAlerting(alertRule *ngModels.AlertRule, result eval.Result
 func (a *State) resultError(alertRule *ngModels.AlertRule, result eval.Result) {
 	a.Error = result.Error
 
-	if a.StartsAt.IsZero() {
-		a.StartsAt = result.EvaluatedAt
-	}
-	a.setEndsAt(alertRule, result)
-
-	if alertRule.ExecErrState == ngModels.AlertingErrState {
-		a.State = eval.Alerting
-	} else if alertRule.ExecErrState == ngModels.ErrorErrState {
-		a.State = eval.Error
-
-		// If the evaluation failed because a query returned an error then
-		// update the state with the Datasource UID as a label and the error
-		// message as an annotation so other code can use this metadata to
-		// add context to alerts
-		var queryError expr.QueryError
-		if errors.As(a.Error, &queryError) {
-			for _, next := range alertRule.Data {
-				if next.RefID == queryError.RefID {
-					a.Labels["ref_id"] = next.RefID
-					a.Labels["datasource_uid"] = next.DatasourceUID
-					break
-				}
+	// If the evaluation failed because a query returned an error then
+	// update the state with the Datasource UID as a label and the error
+	// message as an annotation so other code can use this metadata to
+	// add context to alerts
+	var queryError expr.QueryError
+	if errors.As(a.Error, &queryError) {
+		for _, next := range alertRule.Data {
+			if next.RefID == queryError.RefID {
+				a.Labels["ref_id"] = next.RefID
+				a.Labels["datasource_uid"] = next.DatasourceUID
+				break
 			}
-			a.Annotations["Error"] = queryError.Error()
 		}
+		a.Annotations["Error"] = queryError.Error()
+	}
+
+	// The state can be either alerting or error depending on the
+	// alert state if execution error or timeout
+	s := eval.Error
+	if alertRule.ExecErrState == ngModels.AlertingErrState {
+		s = eval.Alerting
+	}
+
+	if a.State == eval.Alerting || a.State == eval.Error {
+		a.setEndsAt(alertRule, result)
+	} else if a.State == eval.Pending {
+		// If the state is pending make sure at least `for` seconds
+		// have elapsed before moving it out of pending
+		if result.EvaluatedAt.Sub(a.StartsAt) > alertRule.For {
+			a.State = s
+			a.StartsAt = result.EvaluatedAt
+			a.setEndsAt(alertRule, result)
+		}
+	} else {
+		// If we should wait at least `for` seconds before changing the state
+		// then set the state to pending. We will change the state once `for`
+		// seconds has elapsed
+		if alertRule.For > 0 {
+			a.State = eval.Pending
+		} else {
+			a.State = s
+		}
+		// We don't want to change the start timestamp for subsequent results
+		if a.StartsAt.IsZero() {
+			a.StartsAt = result.EvaluatedAt
+		}
+		a.setEndsAt(alertRule, result)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds support for the `For` condition for `DatasourceError` alerts to prevent ephemeral and non-recurring errors from firing `DatasourceError` alerts.
