### PR TITLE
OAuth: Fix parsing of ID token if header contains non-string value

### DIFF
--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -231,13 +231,19 @@ func (s *SocialGenericOAuth) extractFromToken(token *oauth2.Token) *UserInfoJson
 		return nil
 	}
 
-	var header map[string]string
+	var header map[string]interface{}
 	if err := json.Unmarshal(headerBytes, &header); err != nil {
 		s.log.Error("Error deserializing header", "error", err)
 		return nil
 	}
 
-	if compression, ok := header["zip"]; ok {
+	if compressionVal, exists := header["zip"]; exists {
+		compression, ok := compressionVal.(string)
+		if !ok {
+			s.log.Warn("Unknown compression algorithm")
+			return nil
+		}
+
 		if compression != "DEF" {
 			s.log.Warn("Unknown compression algorithm", "algorithm", compression)
 			return nil

--- a/pkg/login/social/generic_oauth_test.go
+++ b/pkg/login/social/generic_oauth_test.go
@@ -728,6 +728,14 @@ func TestPayloadCompression(t *testing.T) {
 			ExpectedEmail: "john.doe@example.com",
 		},
 		{
+			Name: "Given a valid DEFLATE compressed id_token with numeric header, return userInfo",
+			OAuth2Extra: map[string]interface{}{
+				// Generated from https://token.dev/
+				"id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsInZlciI6NH0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTY0MjUxNjYwNSwiZXhwIjoxNjQyNTIwMjA1LCJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIn0.ANndoPWIHNjKPG8na7UUq7nan1RgF8-ze8STU31RXcA",
+			},
+			ExpectedEmail: "john.doe@example.com",
+		},
+		{
 			Name: "Given an invalid DEFLATE compressed id_token, return nil",
 			OAuth2Extra: map[string]interface{}{
 				// { "role": "Admin", "email": "john.doe@example.com" }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix parsing of ID token that contains non-string value in header: https://jwt.io/#debugger-io?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsInZlciI6NH0.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTY0MjUxNjYwNSwiZXhwIjoxNjQyNTIwMjA1LCJlbWFpbCI6ImpvaG4uZG9lQGV4YW1wbGUuY29tIn0.wPtNEJRISwWftaVjVflMRNS-4izq4Q6yt3JgZgtpAd4

**Which issue(s) this PR fixes**:
Fixes #41111

**Special notes for your reviewer**:

