### PR TITLE
CloudWatch: Fix MetricName resetting on Namespace change

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
@@ -129,7 +129,7 @@ describe('MetricStatEditor', () => {
 
       fireEvent.keyDown(namespaceSelect, keyDownEvent);
       await waitFor(() => screen.getByText('n1'));
-      fireEvent.click(screen.getByText('n1'));
+      await waitFor(() => fireEvent.click(screen.getByText('n1')));
 
       fireEvent.keyDown(metricsSelect, keyDownEvent);
       await waitFor(() => screen.getByText('m1'));
@@ -156,11 +156,9 @@ describe('MetricStatEditor', () => {
 
       fireEvent.keyDown(namespaceSelect, keyDownEvent);
       await waitFor(() => screen.getByText('n1'));
-      fireEvent.click(screen.getByText('n1'));
+      await waitFor(() => fireEvent.click(screen.getByText('n1')));
 
-      expect(onChange.mock.calls).toEqual([
-        [{ ...props.query, metricName: '', namespace: 'n1' }], // namespace select, metricName should have been removed
-      ]);
+      expect(onChange.mock.calls).toEqual([[{ ...props.query, metricName: '', namespace: 'n1' }]]);
     });
 
     it('should not remove metricName from query if it does exist in new namespace', async () => {
@@ -178,11 +176,9 @@ describe('MetricStatEditor', () => {
 
       fireEvent.keyDown(namespaceSelect, keyDownEvent);
       await waitFor(() => screen.getByText('n2'));
-      fireEvent.click(screen.getByText('n2'));
+      await waitFor(() => fireEvent.click(screen.getByText('n2')));
 
-      expect(onChange.mock.calls).toEqual([
-        [{ ...props.query, metricName: 'm1', namespace: 'n2' }], // namespace select, metricName should stay the same
-      ]);
+      expect(onChange.mock.calls).toEqual([[{ ...props.query, metricName: 'm1', namespace: 'n2' }]]);
     });
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
@@ -163,8 +163,6 @@ describe('MetricStatEditor', () => {
       expect(onChange.mock.calls).toEqual([[{ ...props.query, metricName: '', namespace: 'n1' }]]);
     });
 
-    // Todo test re-render or at least prop metricName='' -> select value = null
-
     it('should not remove metricName from query if it does exist in new namespace', async () => {
       const onChange = jest.fn();
 

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
@@ -141,7 +141,6 @@ describe('MetricStatEditor', () => {
       const onChange = jest.fn();
 
       props.datasource.getNamespaces = jest.fn().mockResolvedValue(namespaces);
-      // props.datasource.getMetrics = jest.fn().mockImplementation(() => Promise.resolve(metrics));
       props.datasource.getMetrics = jest.fn().mockImplementation((namespace: string, region: string) => {
         let mockMetrics =
           namespace === 'n1' && region === props.query.region
@@ -162,10 +161,9 @@ describe('MetricStatEditor', () => {
       await selectEvent.select(namespaceSelect, 'n1');
 
       expect(onChange.mock.calls).toEqual([[{ ...props.query, metricName: '', namespace: 'n1' }]]);
-
-      // todo: we should test component re-renders when sent different metricname (i.e. shallow comparison = false negative :( )
-      // and check   expect(screen.getByText('oldNamespaceMetric')).not.toBeInTheDocument();
     });
+
+    // Todo test re-render or at least prop metricName='' -> select value = null
 
     it('should not remove metricName from query if it does exist in new namespace', async () => {
       const onChange = jest.fn();

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
@@ -5,7 +5,6 @@ import '@testing-library/jest-dom';
 import { CloudWatchMetricsQuery } from '../../types';
 import userEvent from '@testing-library/user-event';
 import { MetricStatEditor } from '..';
-import { MetricName } from 'lezer-promql';
 
 const ds = setupMockedDataSource({
   variables: [],

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { cleanup, fireEvent, render, screen, act, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, act } from '@testing-library/react';
 import { setupMockedDataSource } from '../../__mocks__/CloudWatchDataSource';
 import '@testing-library/jest-dom';
 import { CloudWatchMetricsQuery } from '../../types';
@@ -163,7 +163,7 @@ describe('MetricStatEditor', () => {
 
       expect(onChange.mock.calls).toEqual([[{ ...props.query, metricName: '', namespace: 'n1' }]]);
 
-      // todo: should we test component re-renders when sent different metricname (i.e. shallow comparison = false negative :( )
+      // todo: we should test component re-renders when sent different metricname (i.e. shallow comparison = false negative :( )
       // and check   expect(screen.getByText('oldNamespaceMetric')).not.toBeInTheDocument();
     });
 

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { cleanup, fireEvent, render, screen, act } from '@testing-library/react';
+import selectEvent from 'react-select-event';
 import { setupMockedDataSource } from '../../__mocks__/CloudWatchDataSource';
 import '@testing-library/jest-dom';
 import { CloudWatchMetricsQuery } from '../../types';
 import userEvent from '@testing-library/user-event';
 import { MetricStatEditor } from '..';
-import selectEvent from 'react-select-event';
 
 const ds = setupMockedDataSource({
   variables: [],

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
@@ -70,7 +70,7 @@ export function MetricStatEditor({
           <EditorField label="Metric name" width={16}>
             <Select
               aria-label="Metric name"
-              value={query.metricName}
+              value={query.metricName || null}
               allowCustomValue
               options={metrics}
               onChange={({ value: metricName }) => {

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
@@ -41,6 +41,10 @@ export function MetricStatEditor({
   const validateMetricName = async (query: CloudWatchMetricsQuery) => {
     let { metricName, namespace, region } = query;
 
+    if (!metricName) {
+      return query;
+    }
+
     await datasource.getMetrics(namespace, region).then((result: Array<SelectableValue<string>>) => {
       if (!result.find((metric) => metric.value === metricName)) {
         metricName = '';

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
@@ -6,6 +6,7 @@ import { CloudWatchDatasource } from '../../datasource';
 import { useDimensionKeys, useMetrics, useNamespaces } from '../../hooks';
 import { CloudWatchMetricsQuery } from '../../types';
 import { appendTemplateVariables, toOption } from '../../utils/utils';
+import { SelectableValue } from '@grafana/data';
 
 export type Props = {
   query: CloudWatchMetricsQuery;
@@ -32,6 +33,23 @@ export function MetricStatEditor({
     onRunQuery();
   };
 
+  const onNamespaceChange = async (query: CloudWatchMetricsQuery) => {
+    const validatedQuery = await validateMetricName(query);
+    onQueryChange(validatedQuery);
+  };
+
+  const validateMetricName = async (query: CloudWatchMetricsQuery) => {
+    let { metricName, namespace, region } = query;
+
+    await datasource.getMetrics(namespace, region).then((result: Array<SelectableValue<string>>) => {
+      if (!result.find((metric) => metric.value === metricName)) {
+        metricName = '';
+      }
+    });
+
+    return { ...query, metricName };
+  };
+
   return (
     <EditorRows>
       <EditorRow>
@@ -44,7 +62,7 @@ export function MetricStatEditor({
               options={namespaces}
               onChange={({ value: namespace }) => {
                 if (namespace) {
-                  onQueryChange({ ...query, namespace });
+                  onNamespaceChange({ ...query, namespace });
                 }
               }}
             />

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
@@ -40,17 +40,14 @@ export function MetricStatEditor({
 
   const validateMetricName = async (query: CloudWatchMetricsQuery) => {
     let { metricName, namespace, region } = query;
-
     if (!metricName) {
       return query;
     }
-
     await datasource.getMetrics(namespace, region).then((result: Array<SelectableValue<string>>) => {
       if (!result.find((metric) => metric.value === metricName)) {
         metricName = '';
       }
     });
-
     return { ...query, metricName };
   };
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

## What this PR does / why we need it
In the Cloudwatch Metric Search editor, there is a MetricName select component whose values are dependent on a Namespace select component's value.
Currently, if we select a namespace, a metric name for it and then change namespace, the metric value will not be reset even though it does not exist in the dropdown.

This PR fixes this bug, resetting the metricName if it does not exist in new dropdown. 
N.B. If a metricName is shared between old and new namespace, it will not be reset.

### Screenshots
*Before* 


https://user-images.githubusercontent.com/42030685/149966945-61ddffac-5104-4db9-b4a0-6ad558db48b9.mov



*After*


https://user-images.githubusercontent.com/42030685/149966979-dd29fb26-13f2-4690-8acd-a9f5546a3fa2.mov




### Test coverage
Output from 
```
yarn test public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx --coverage --collectCoverageFrom=public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx 

----------------------|---------|----------|---------|---------|-------------------
File                  | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------------------|---------|----------|---------|---------|-------------------
All files             |   95.91 |    91.66 |   85.71 |   95.45 |                   
 MetricStatEditor.tsx |   95.91 |    91.66 |   85.71 |   95.45 | 115-133           
----------------------|---------|----------|---------|---------|-------------------
```


## Which issue(s) this PR fixes
Fixes https://github.com/grafana/cloudwatch-private/issues/68

## Special notes for your reviewer
https://github.com/grafana/grafana/tree/cwp_68_2 (WIP) is a branch of this one and adds the same logic to SQLBuilderSelectRow.tsx to fix the bug there too.