### PR TITLE
GetUserInfo: Return an error if no user was found

### DIFF
--- a/pkg/services/login/authinfoservice/database.go
+++ b/pkg/services/login/authinfoservice/database.go
@@ -38,7 +38,7 @@ func (s *Implementation) GetExternalUserInfoByLogin(ctx context.Context, query *
 }
 
 func (s *Implementation) GetAuthInfo(ctx context.Context, query *models.GetAuthInfoQuery) error {
-	if query.UserId == 0 {
+	if query.UserId == 0 && query.AuthId == "" {
 		return models.ErrUserNotFound
 	}
 

--- a/pkg/services/login/authinfoservice/database.go
+++ b/pkg/services/login/authinfoservice/database.go
@@ -38,6 +38,10 @@ func (s *Implementation) GetExternalUserInfoByLogin(ctx context.Context, query *
 }
 
 func (s *Implementation) GetAuthInfo(ctx context.Context, query *models.GetAuthInfoQuery) error {
+	if query.UserId == 0 {
+		return models.ErrUserNotFound
+	}
+
 	userAuth := &models.UserAuth{
 		UserId:     query.UserId,
 		AuthModule: query.AuthModule,


### PR DESCRIPTION
**What this PR does / why we need it**:

Checks for `UserId` and `AuthId`, and returns `ErrNotFound` if empty.