### PR TITLE
Fix change to mixed bahavior

### DIFF
--- a/public/app/features/query/state/updateQueries.test.ts
+++ b/public/app/features/query/state/updateQueries.test.ts
@@ -99,4 +99,42 @@ describe('updateQueries', () => {
     expect(updated[0].datasource).toEqual({ type: 'old-type', uid: 'old-uid' });
     expect(updated[1].datasource).toEqual({ type: 'other-type', uid: 'other-uid' });
   });
+
+  it('should change nothing mixed updated to mixed', () => {
+    const updated = updateQueries(
+      {
+        uid: 'mixed',
+        type: 'mixed',
+        meta: {
+          mixed: true,
+        },
+      } as any,
+      [
+        {
+          refId: 'A',
+          datasource: {
+            uid: 'old-uid',
+            type: 'old-type',
+          },
+        },
+        {
+          refId: 'B',
+          datasource: {
+            uid: 'other-uid',
+            type: 'other-type',
+          },
+        },
+      ],
+      {
+        uid: 'mixed',
+        type: 'mixed',
+        meta: {
+          mixed: true,
+        },
+      } as any
+    );
+
+    expect(updated[0].datasource).toEqual({ type: 'old-type', uid: 'old-uid' });
+    expect(updated[1].datasource).toEqual({ type: 'other-type', uid: 'other-uid' });
+  });
 });

--- a/public/app/features/query/state/updateQueries.ts
+++ b/public/app/features/query/state/updateQueries.ts
@@ -21,7 +21,7 @@ export function updateQueries(
 
   // Set data source on all queries except expression queries
   return queries.map((query) => {
-    if (!isExpressionReference(query.datasource)) {
+    if (!isExpressionReference(query.datasource) && !newSettings.meta.mixed) {
       query.datasource = datasource;
     }
     return query;


### PR DESCRIPTION
- If the datasource is already set to mixed, don't change any queries in the editor

When the datasource was already set to `mixed`, setting it again caused all child queries to take the type `mixed` and fail. 

In particular, this was causing the Recorded Queries feature to break the query editor. Recorded Queries doesn't know the state of the query editor when a query is added so it tries to set the datasource type to mixed. 

