### PR TITLE
Datasource API: #32556 resolve readonly datasources can be modified

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -320,7 +320,7 @@ func (hs *HTTPServer) UpdateDataSource(c *models.ReqContext) response.Response {
 	}
 
 	if ds.ReadOnly {
-		return response.Error(400, "Cannot update datasource", models.ErrDatasourceIsReadOnly)
+		return response.Error(403, "Cannot update read-only data source", nil)```
 	}
 
 	err = hs.fillWithSecureJSONData(c.Req.Context(), &cmd)

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -323,7 +323,7 @@ func (hs *HTTPServer) UpdateDataSource(c *models.ReqContext) response.Response {
 	}
 
 	if ds.ReadOnly {
-		return response.Error(403, "Cannot update read-only data source", nil)```
+		return response.Error(403, "Cannot update read-only data source", nil)
 	}
 
 	err = hs.fillWithSecureJSONData(c.Req.Context(), &cmd)

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -309,6 +309,15 @@ func (hs *HTTPServer) UpdateDataSource(c *models.ReqContext) response.Response {
 		return resp
 	}
 
+	ds, err := getRawDataSourceById(c.Req.Context(), cmd.Id, cmd.OrgId)
+	if err != nil {
+		return response.Error(409, "Datasource has already been updated by someone else. Please reload and try again", err)
+	}
+
+	if ds.ReadOnly {
+		return response.Error(400, "Cannot update datasource", models.ErrDatasourceIsReadOnly)
+	}
+
 	err = hs.fillWithSecureJSONData(c.Req.Context(), &cmd)
 	if err != nil {
 		return response.Error(500, "Failed to update datasource", err)

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -316,7 +316,10 @@ func (hs *HTTPServer) UpdateDataSource(c *models.ReqContext) response.Response {
 
 	ds, err := getRawDataSourceById(c.Req.Context(), cmd.Id, cmd.OrgId)
 	if err != nil {
-		return response.Error(409, "Datasource has already been updated by someone else. Please reload and try again", err)
+		if errors.Is(err, models.ErrDataSourceNotFound) {
+			return response.Error(404, "Data source not found", nil)
+		}
+		return response.Error(500, "Failed to update datasource", err)
 	}
 
 	if ds.ReadOnly {

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -87,6 +87,7 @@ func (hs *HTTPServer) getDataSourceAccessControlMetadata(c *models.ReqContext, d
 	return accesscontrol.GetResourcesMetadata(c.Req.Context(), userPermissions, "datasources", dsIDs)[key], nil
 }
 
+// GET /api/datasources/:id
 func (hs *HTTPServer) GetDataSourceById(c *models.ReqContext) response.Response {
 	id, err := strconv.ParseInt(web.Params(c.Req)[":id"], 10, 64)
 	if err != nil {
@@ -123,6 +124,7 @@ func (hs *HTTPServer) GetDataSourceById(c *models.ReqContext) response.Response 
 	return response.JSON(200, &dto)
 }
 
+// DELETE /api/datasources/:id
 func (hs *HTTPServer) DeleteDataSourceById(c *models.ReqContext) response.Response {
 	id, err := strconv.ParseInt(web.Params(c.Req)[":id"], 10, 64)
 	if err != nil {
@@ -220,6 +222,7 @@ func (hs *HTTPServer) DeleteDataSourceByUID(c *models.ReqContext) response.Respo
 	})
 }
 
+// DELETE /api/datasources/name/:name
 func (hs *HTTPServer) DeleteDataSourceByName(c *models.ReqContext) response.Response {
 	name := web.Params(c.Req)[":name"]
 
@@ -265,6 +268,7 @@ func validateURL(tp string, u string) response.Response {
 	return nil
 }
 
+// POST /api/datasources/
 func AddDataSource(c *models.ReqContext) response.Response {
 	cmd := models.AddDataSourceCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
@@ -293,6 +297,7 @@ func AddDataSource(c *models.ReqContext) response.Response {
 	})
 }
 
+// PUT /api/datasources/:id
 func (hs *HTTPServer) UpdateDataSource(c *models.ReqContext) response.Response {
 	cmd := models.UpdateDataSourceCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {

--- a/pkg/api/datasources_test.go
+++ b/pkg/api/datasources_test.go
@@ -15,14 +15,9 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/quota"
-	"github.com/grafana/grafana/pkg/services/searchusers"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
-	"github.com/grafana/grafana/pkg/services/searchusers/filters"
 )
 
 const (
@@ -196,6 +191,16 @@ func TestAPI_Datasources_AccessControl(t *testing.T) {
 		Type:   "postgresql",
 		Access: "Proxy",
 	}
+	testDatasourceReadOnly := models.DataSource{
+		Id:       4,
+		Uid:      "testUID",
+		OrgId:    testOrgID,
+		Name:     "test",
+		Url:      "http://localhost:5432",
+		Type:     "postgresql",
+		Access:   "Proxy",
+		ReadOnly: true,
+	}
 	getDatasourceStub := func(ctx context.Context, query *models.GetDataSourceQuery) error {
 		result := testDatasource
 		result.Id = query.Id
@@ -215,6 +220,16 @@ func TestAPI_Datasources_AccessControl(t *testing.T) {
 		cmd.Result = &testDatasource
 		return nil
 	}
+
+	updateDatasourceReadOnlyStub := func(ctx context.Context, cmd *models.UpdateDataSourceCommand) error {
+		cmd.Result = &testDatasourceReadOnly
+		return nil
+	}
+	getDatasourceReadOnlyStub := func(ctx context.Context, query *models.GetDataSourceQuery) error {
+		query.Result = &testDatasourceReadOnly
+		return nil
+	}
+
 	deleteDatasourceStub := func(ctx context.Context, cmd *models.DeleteDataSourceCommand) error {
 		cmd.DeletedDatasourcesCount = 1
 		return nil
@@ -306,6 +321,22 @@ func TestAPI_Datasources_AccessControl(t *testing.T) {
 				url:          fmt.Sprintf("/api/datasources/%v", testDatasource.Id),
 				method:       http.MethodPut,
 				permissions:  []*accesscontrol.Permission{{Action: "wrong"}},
+			},
+		},
+		{
+			busStubs: []bus.HandlerFunc{getDatasourceReadOnlyStub, updateDatasourceReadOnlyStub},
+			body:     updateDatasourceBody,
+			accessControlTestCase: accessControlTestCase{
+				expectedCode: http.StatusBadRequest,
+				desc:         "DatasourcesPut should return 400 for read only datasource",
+				url:          fmt.Sprintf("/api/datasources/%v", testDatasourceReadOnly.Id),
+				method:       http.MethodPut,
+				permissions: []*accesscontrol.Permission{
+					{
+						Action: ActionDatasourcesWrite,
+						Scope:  fmt.Sprintf("datasources:id:%v", testDatasourceReadOnly.Id),
+					},
+				},
 			},
 		},
 		{
@@ -515,66 +546,4 @@ func TestAPI_Datasources_AccessControl(t *testing.T) {
 			assert.Equal(t, test.expectedCode, sc.resp.Code)
 		})
 	}
-}
-
-func TestAPI_Datasources_ReadOnly(t *testing.T) {
-	testDatasource := models.DataSource{
-		Id:       3,
-		Uid:      "testUID",
-		OrgId:    testOrgID,
-		Name:     "test",
-		Url:      "http://localhost:5432",
-		Type:     "postgresql",
-		Access:   "Proxy",
-		ReadOnly: true,
-	}
-	getDatasourceStub := func(ctx context.Context, query *models.GetDataSourceQuery) error {
-		result := testDatasource
-		result.Id = query.Id
-		result.OrgId = query.OrgId
-		query.Result = &result
-		return nil
-	}
-	getDatasourcesStub := func(ctx context.Context, cmd *models.GetDataSourcesQuery) error {
-		cmd.Result = []*models.DataSource{}
-		return nil
-	}
-	updateDatasourceStub := func(ctx context.Context, cmd *models.UpdateDataSourceCommand) error {
-		cmd.Result = &testDatasource
-		return nil
-	}
-
-	bus.AddHandler("test_handler_1", getDatasourceStub)
-	bus.AddHandler("test_handler_2", getDatasourcesStub)
-	bus.AddHandler("test_handler_3", updateDatasourceStub)
-
-	cfg := setting.NewCfg()
-	hs := &HTTPServer{
-		Cfg:                cfg,
-		Bus:                bus.GetBus(),
-		Live:               newTestLive(t),
-		QuotaService:       &quota.QuotaService{Cfg: cfg},
-		RouteRegister:      routing.NewRouteRegister(),
-		AccessControl:      accesscontrolmock.New(),
-		searchUsersService: searchusers.ProvideUsersService(bus.GetBus(), filters.ProvideOSSSearchUserFilter()),
-	}
-
-	sc := setupScenarioContext(t, "/api/datasources/1234")
-
-	hs.registerRoutes()
-	hs.RouteRegister.Register(sc.m.Router)
-
-	sc.m.Put(sc.url, routing.Wrap(func(c *models.ReqContext) response.Response {
-		c.Req.Body = mockRequestBody(models.UpdateDataSourceCommand{
-			Name:   "Test",
-			Url:    "http://localhost:5432",
-			Access: "direct",
-			Type:   "test",
-		})
-		return hs.UpdateDataSource(c)
-	}))
-
-	sc.fakeReqWithParams("PUT", sc.url, map[string]string{}).exec()
-
-	assert.Equal(t, 400, sc.resp.Code)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, read only datasources can be modified through the api. This PR fixes this hole and adds tests for it.

**Which issue(s) this PR fixes**:
#32556 

Fixes #32556 

**Special notes for your reviewer**:

