### PR TITLE
[v8.3.x] CI: Release automations fixes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2638,7 +2638,8 @@ volumes:
     path: /var/run/docker.sock
   name: docker
 ---
-depends_on: []
+depends_on:
+- publish-artifacts-public
 kind: pipeline
 name: publish-packages
 node:
@@ -5148,6 +5149,6 @@ kind: secret
 name: prerelease_bucket
 ---
 kind: signature
-hmac: 22628a3937dc59d00cc04d5c01c3fd2e309bb6295d7564b8badce6b0dcf6fcfd
+hmac: e1bc6f40f569d2e7adfff147328f6d494486988e8fd063374394bfd0c692d62b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2656,7 +2656,8 @@ steps:
   name: grabpl
 - commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
-  - ./bin/grabpl store-packages --edition oss --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
+  - ./bin/grabpl store-packages --edition oss --packages-bucket grafana-downloads
+    --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
   depends_on:
   - grabpl
   environment:
@@ -2674,7 +2675,8 @@ steps:
   name: store-packages-oss
 - commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
-  - ./bin/grabpl store-packages --edition enterprise --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
+  - ./bin/grabpl store-packages --edition enterprise --packages-bucket grafana-downloads
+    --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
   depends_on:
   - grabpl
   environment:
@@ -5146,6 +5148,6 @@ kind: secret
 name: prerelease_bucket
 ---
 kind: signature
-hmac: c405c799db7cac8262e1ffba013983f9ca3ce0b074767c088988ca774e6f5cab
+hmac: 22628a3937dc59d00cc04d5c01c3fd2e309bb6295d7564b8badce6b0dcf6fcfd
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1514,8 +1514,8 @@ steps:
   - .\grabpl.exe gen-version ${DRONE_TAG}
   - .\grabpl.exe windows-installer --edition oss ${DRONE_TAG}
   - $$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]
-  - gsutil cp $$fname gs://%PRERELEASE_BUCKET%/artifacts/downloads/oss/release/
-  - gsutil cp "$$fname.sha256" gs://%PRERELEASE_BUCKET%/artifacts/downloads/oss/release/
+  - gsutil cp $$fname gs://%PRERELEASE_BUCKET%/artifacts/downloads/${DRONE_TAG}/oss/release/
+  - gsutil cp "$$fname.sha256" gs://%PRERELEASE_BUCKET%/artifacts/downloads/${DRONE_TAG}/oss/release/
   depends_on:
   - initialize
   environment:
@@ -2201,8 +2201,8 @@ steps:
   - .\grabpl.exe gen-version ${DRONE_TAG}
   - .\grabpl.exe windows-installer --edition enterprise ${DRONE_TAG}
   - $$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]
-  - gsutil cp $$fname gs://%PRERELEASE_BUCKET%/artifacts/downloads/enterprise/release/
-  - gsutil cp "$$fname.sha256" gs://%PRERELEASE_BUCKET%/artifacts/downloads/enterprise/release/
+  - gsutil cp $$fname gs://%PRERELEASE_BUCKET%/artifacts/downloads/${DRONE_TAG}/enterprise/release/
+  - gsutil cp "$$fname.sha256" gs://%PRERELEASE_BUCKET%/artifacts/downloads/${DRONE_TAG}/enterprise/release/
   depends_on:
   - initialize
   environment:
@@ -3170,8 +3170,8 @@ steps:
   - .\grabpl.exe windows-installer --edition oss --packages-bucket grafana-downloads-test
     v7.3.0-test
   - $$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]
-  - gsutil cp $$fname gs://grafana-downloads-test/oss/release/
-  - gsutil cp "$$fname.sha256" gs://grafana-downloads-test/oss/release/
+  - gsutil cp $$fname gs://grafana-downloads-test/v7.3.0-test/oss/release/
+  - gsutil cp "$$fname.sha256" gs://grafana-downloads-test/v7.3.0-test/oss/release/
   depends_on:
   - initialize
   environment:
@@ -3831,8 +3831,8 @@ steps:
   - .\grabpl.exe windows-installer --edition enterprise --packages-bucket grafana-downloads-test
     v7.3.0-test
   - $$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]
-  - gsutil cp $$fname gs://grafana-downloads-test/enterprise/release/
-  - gsutil cp "$$fname.sha256" gs://grafana-downloads-test/enterprise/release/
+  - gsutil cp $$fname gs://grafana-downloads-test/v7.3.0-test/enterprise/release/
+  - gsutil cp "$$fname.sha256" gs://grafana-downloads-test/v7.3.0-test/enterprise/release/
   depends_on:
   - initialize
   environment:
@@ -5149,6 +5149,6 @@ kind: secret
 name: prerelease_bucket
 ---
 kind: signature
-hmac: e1bc6f40f569d2e7adfff147328f6d494486988e8fd063374394bfd0c692d62b
+hmac: d1445d0c5b25b96a69776e6df2e9711ab25b7bc8080358a11f25ee386e30ad3d
 
 ...

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -413,7 +413,7 @@ def publish_packages_pipeline():
     ]
 
     return [pipeline(
-        name='publish-packages', trigger=trigger, steps=steps, edition="all"
+        name='publish-packages', trigger=trigger, steps=steps, edition="all", depends_on=['publish-artifacts-public']
     )]
 
 def publish_npm_pipelines(mode):

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -937,7 +937,7 @@ def store_packages_step(edition, ver_mode, is_downstream=False):
                   test_release_ver,
               )
     elif ver_mode == 'release':
-        cmd = './bin/grabpl store-packages --edition {} --gcp-key /tmp/gcpkey.json ${{DRONE_TAG}}'.format(
+        cmd = './bin/grabpl store-packages --edition {} --packages-bucket grafana-downloads --gcp-key /tmp/gcpkey.json ${{DRONE_TAG}}'.format(
             edition,
         )
     elif ver_mode == 'main':

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1030,9 +1030,17 @@ def get_windows_steps(edition, ver_mode, is_downstream=False):
                 '.\\grabpl.exe gen-version {}'.format(ver_part),
                 '.\\grabpl.exe windows-installer --edition {}{} {}'.format(edition, bucket_part, ver_part),
                 '$$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]',
-                'gsutil cp $$fname gs://{}/{}/{}/'.format(bucket, edition, dir),
-                'gsutil cp "$$fname.sha256" gs://{}/{}/{}/'.format(bucket, edition, dir),
             ])
+            if ver_mode == 'main':
+                installer_commands.extend([
+                    'gsutil cp $$fname gs://{}/{}/{}/'.format(bucket, edition, dir),
+                    'gsutil cp "$$fname.sha256" gs://{}/{}/{}/'.format(bucket, edition, dir),
+                ])
+            else:
+                installer_commands.extend([
+                    'gsutil cp $$fname gs://{}/{}/{}/{}/'.format(bucket, ver_part, edition, dir),
+                    'gsutil cp "$$fname.sha256" gs://{}/{}/{}/{}/'.format(bucket, ver_part, edition, dir),
+                ])
         steps.append({
             'name': 'build-windows-installer',
             'image': wix_image,


### PR DESCRIPTION
**What this PR does / why we need it**:

After testing new release automations, some small tweaks were needed in order for them to work properly.
Those are:

* Download files from the correct bucket upon publishing.
* Make publish depend on artifacts publish.
* Make sure all `*.msi` files are stored to the correct path.
