### PR TITLE
Enable setting SuperAdmin via Auth Proxy

### DIFF
--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -407,6 +407,62 @@ func TestMiddlewareContext(t *testing.T) {
 			cfg.AuthProxyAutoSignUp = false
 		})
 
+		middlewareScenario(t, "Should create a superadmin from headers", func(t *testing.T, sc *scenarioContext) {
+			bus.AddHandler("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+				if query.UserId > 0 {
+					query.Result = &models.SignedInUser{OrgId: query.OrgId, UserId: userID, IsGrafanaAdmin: true}
+					return nil
+				}
+				return models.ErrUserNotFound
+			})
+
+			bus.AddHandler("test", func(ctx context.Context, cmd *models.UpsertUserCommand) error {
+				cmd.Result = &models.User{Id: userID}
+				return nil
+			})
+
+			sc.fakeReq("GET", "/")
+			sc.req.Header.Set(sc.cfg.AuthProxyHeaderName, hdrName)
+			sc.req.Header.Set("X-WEBAUTH-ADMIN", "1")
+			sc.exec()
+
+			assert.True(t, sc.context.IsSignedIn)
+			assert.Equal(t, userID, sc.context.UserId)
+			assert.Equal(t, true, sc.context.SignedInUser.IsGrafanaAdmin)
+		}, func(cfg *setting.Cfg) {
+			configure(cfg)
+			cfg.LDAPEnabled = false
+			cfg.AuthProxyAutoSignUp = true
+		})
+
+		middlewareScenario(t, "Should revoke superadmin rights for user via headers", func(t *testing.T, sc *scenarioContext) {
+			bus.AddHandler("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+				if query.UserId > 0 {
+					query.Result = &models.SignedInUser{OrgId: query.OrgId, UserId: userID}
+					return nil
+				}
+				return models.ErrUserNotFound
+			})
+
+			bus.AddHandler("test", func(ctx context.Context, cmd *models.UpsertUserCommand) error {
+				cmd.Result = &models.User{Id: userID}
+				return nil
+			})
+
+			sc.fakeReq("GET", "/")
+			sc.req.Header.Set(sc.cfg.AuthProxyHeaderName, hdrName)
+			sc.req.Header.Set("X-WEBAUTH-ADMIN", "0")
+			sc.exec()
+
+			assert.True(t, sc.context.IsSignedIn)
+			assert.Equal(t, userID, sc.context.UserId)
+			assert.Equal(t, false, sc.context.IsGrafanaAdmin)
+		}, func(cfg *setting.Cfg) {
+			configure(cfg)
+			cfg.LDAPEnabled = false
+			cfg.AuthProxyAutoSignUp = true
+		})
+
 		middlewareScenario(t, "Should create an user from a header", func(t *testing.T, sc *scenarioContext) {
 			bus.AddHandler("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 				if query.UserId > 0 {

--- a/pkg/services/contexthandler/authproxy/authproxy.go
+++ b/pkg/services/contexthandler/authproxy/authproxy.go
@@ -45,7 +45,7 @@ var isLDAPEnabled = func(cfg *setting.Cfg) bool {
 var newLDAP = multildap.New
 
 // supportedHeaders states the supported headers configuration fields
-var supportedHeaderFields = []string{"Name", "Email", "Login", "Groups", "Role"}
+var supportedHeaderFields = []string{"Name", "Email", "Login", "Groups", "Role", "SuperAdmin"}
 
 // AuthProxy struct
 type AuthProxy struct {
@@ -293,6 +293,12 @@ func (auth *AuthProxy) LoginViaHeader() (int64, error) {
 					}
 					extUser.OrgRoles[orgID] = rt
 				}
+			}
+		case "SuperAdmin":
+			if header != "" {
+				var IsGrafanaAdmin = new(bool)
+				*IsGrafanaAdmin = (header == "1")
+				extUser.IsGrafanaAdmin = IsGrafanaAdmin
 			}
 		default:
 			reflect.ValueOf(extUser).Elem().FieldByName(field).SetString(header)


### PR DESCRIPTION
This PR adds the possibility to set superadmin rights via the auth proxy (as a header). This way, other means besides username/password can now be used to manage the overall aspects of grafana.

Fixes: https://github.com/grafana/grafana/discussions/44000