### PR TITLE
CI: Release automation fixes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2797,7 +2797,8 @@ steps:
   name: grabpl
 - commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
-  - ./bin/grabpl store-packages --edition oss --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
+  - ./bin/grabpl store-packages --edition oss --packages-bucket grafana-downloads
+    --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
   depends_on:
   - grabpl
   environment:
@@ -2815,7 +2816,8 @@ steps:
   name: store-packages-oss
 - commands:
   - printenv GCP_KEY | base64 -d > /tmp/gcpkey.json
-  - ./bin/grabpl store-packages --edition enterprise --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
+  - ./bin/grabpl store-packages --edition enterprise --packages-bucket grafana-downloads
+    --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
   depends_on:
   - grabpl
   environment:
@@ -5504,6 +5506,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 9df8ada188b84934ba449a62dbea9eb81f2ba8feff2d5a04a7ec94a718d8cd74
+hmac: 298beeb11ac1f4f050efd457efe02da407b28abc71b89c08f5c4ec279b7e2bdb
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -2779,7 +2779,8 @@ volumes:
     path: /var/run/docker.sock
   name: docker
 ---
-depends_on: []
+depends_on:
+- publish-artifacts-public
 kind: pipeline
 name: publish-packages
 node:
@@ -5506,6 +5507,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 298beeb11ac1f4f050efd457efe02da407b28abc71b89c08f5c4ec279b7e2bdb
+hmac: f41aecf39aca36a15ad9c7d28e188f15922a29cac12249c683feaa81c305571e
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1622,8 +1622,8 @@ steps:
   - .\grabpl.exe gen-version ${DRONE_TAG}
   - .\grabpl.exe windows-installer --edition oss ${DRONE_TAG}
   - $$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]
-  - gsutil cp $$fname gs://%PRERELEASE_BUCKET%/artifacts/downloads/oss/release/
-  - gsutil cp "$$fname.sha256" gs://%PRERELEASE_BUCKET%/artifacts/downloads/oss/release/
+  - gsutil cp $$fname gs://%PRERELEASE_BUCKET%/artifacts/downloads/${DRONE_TAG}/oss/release/
+  - gsutil cp "$$fname.sha256" gs://%PRERELEASE_BUCKET%/artifacts/downloads/${DRONE_TAG}/oss/release/
   depends_on:
   - initialize
   environment:
@@ -2342,8 +2342,8 @@ steps:
   - .\grabpl.exe gen-version ${DRONE_TAG}
   - .\grabpl.exe windows-installer --edition enterprise ${DRONE_TAG}
   - $$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]
-  - gsutil cp $$fname gs://%PRERELEASE_BUCKET%/artifacts/downloads/enterprise/release/
-  - gsutil cp "$$fname.sha256" gs://%PRERELEASE_BUCKET%/artifacts/downloads/enterprise/release/
+  - gsutil cp $$fname gs://%PRERELEASE_BUCKET%/artifacts/downloads/${DRONE_TAG}/enterprise/release/
+  - gsutil cp "$$fname.sha256" gs://%PRERELEASE_BUCKET%/artifacts/downloads/${DRONE_TAG}/enterprise/release/
   depends_on:
   - initialize
   environment:
@@ -3344,8 +3344,8 @@ steps:
   - .\grabpl.exe windows-installer --edition oss --packages-bucket grafana-downloads-test
     v7.3.0-test
   - $$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]
-  - gsutil cp $$fname gs://grafana-downloads-test/oss/release/
-  - gsutil cp "$$fname.sha256" gs://grafana-downloads-test/oss/release/
+  - gsutil cp $$fname gs://grafana-downloads-test/v7.3.0-test/oss/release/
+  - gsutil cp "$$fname.sha256" gs://grafana-downloads-test/v7.3.0-test/oss/release/
   depends_on:
   - initialize
   environment:
@@ -4038,8 +4038,8 @@ steps:
   - .\grabpl.exe windows-installer --edition enterprise --packages-bucket grafana-downloads-test
     v7.3.0-test
   - $$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]
-  - gsutil cp $$fname gs://grafana-downloads-test/enterprise/release/
-  - gsutil cp "$$fname.sha256" gs://grafana-downloads-test/enterprise/release/
+  - gsutil cp $$fname gs://grafana-downloads-test/v7.3.0-test/enterprise/release/
+  - gsutil cp "$$fname.sha256" gs://grafana-downloads-test/v7.3.0-test/enterprise/release/
   depends_on:
   - initialize
   environment:
@@ -5507,6 +5507,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: f41aecf39aca36a15ad9c7d28e188f15922a29cac12249c683feaa81c305571e
+hmac: 01bbd575b573f01011e7e7b291f1b23c57542b942a8214f3292f9093a829e4c3
 
 ...

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -417,7 +417,7 @@ def publish_packages_pipeline():
     ]
 
     return [pipeline(
-        name='publish-packages', trigger=trigger, steps=steps, edition="all"
+        name='publish-packages', trigger=trigger, steps=steps, edition="all", depends_on=['publish-artifacts-public']
     )]
 
 def publish_npm_pipelines(mode):

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -975,7 +975,7 @@ def store_packages_step(edition, ver_mode, is_downstream=False):
                   test_release_ver,
               )
     elif ver_mode == 'release':
-        cmd = './bin/grabpl store-packages --edition {} --gcp-key /tmp/gcpkey.json ${{DRONE_TAG}}'.format(
+        cmd = './bin/grabpl store-packages --edition {} --packages-bucket grafana-downloads --gcp-key /tmp/gcpkey.json ${{DRONE_TAG}}'.format(
             edition,
         )
     elif ver_mode == 'main':

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1070,9 +1070,17 @@ def get_windows_steps(edition, ver_mode, is_downstream=False):
                 '.\\grabpl.exe gen-version {}'.format(ver_part),
                 '.\\grabpl.exe windows-installer --edition {}{} {}'.format(edition, bucket_part, ver_part),
                 '$$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]',
-                'gsutil cp $$fname gs://{}/{}/{}/'.format(bucket, edition, dir),
-                'gsutil cp "$$fname.sha256" gs://{}/{}/{}/'.format(bucket, edition, dir),
             ])
+            if ver_mode == 'main':
+                installer_commands.extend([
+                    'gsutil cp $$fname gs://{}/{}/{}/'.format(bucket, edition, dir),
+                    'gsutil cp "$$fname.sha256" gs://{}/{}/{}/'.format(bucket, edition, dir),
+                ])
+            else:
+                installer_commands.extend([
+                    'gsutil cp $$fname gs://{}/{}/{}/{}/'.format(bucket, ver_part, edition, dir),
+                    'gsutil cp "$$fname.sha256" gs://{}/{}/{}/{}/'.format(bucket, ver_part, edition, dir),
+                ])
         steps.append({
             'name': 'build-windows-installer',
             'image': wix_image,


### PR DESCRIPTION
**What this PR does / why we need it**:

After testing new release automations, some small tweaks were needed in order for them to work properly.
Those are:

* Download files from the correct bucket upon publishing.
* Make publish depend on artifacts publish.
* Make sure all `*.msi` files are stored to the correct path.
