### PR TITLE
Access control: fetch role options only if user has permissions

### DIFF
--- a/public/app/core/components/RolePicker/TeamRolePicker.tsx
+++ b/public/app/core/components/RolePicker/TeamRolePicker.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState } from 'react';
 import { useAsync } from 'react-use';
-import { Role } from 'app/types';
+import { contextSrv } from 'app/core/core';
+import { AccessControlAction, Role } from 'app/types';
 import { RolePicker } from './RolePicker';
 import { fetchRoleOptions, fetchTeamRoles, updateTeamRoles } from './api';
 
@@ -18,8 +19,12 @@ export const TeamRolePicker: FC<Props> = ({ teamId, orgId, getRoleOptions, disab
 
   const { loading } = useAsync(async () => {
     try {
-      let options = await (getRoleOptions ? getRoleOptions() : fetchRoleOptions(orgId));
-      setRoleOptions(options.filter((option) => !option.name?.startsWith('managed:')));
+      if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
+        let options = await (getRoleOptions ? getRoleOptions() : fetchRoleOptions(orgId));
+        setRoleOptions(options.filter((option) => !option.name?.startsWith('managed:')));
+      } else {
+        setRoleOptions([]);
+      }
 
       const teamRoles = await fetchTeamRoles(teamId, orgId);
       setAppliedRoles(teamRoles);

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useState } from 'react';
 import { useAsync } from 'react-use';
-import { Role, OrgRole } from 'app/types';
+import { contextSrv } from 'app/core/core';
+import { Role, OrgRole, AccessControlAction } from 'app/types';
 import { RolePicker } from './RolePicker';
 import { fetchBuiltinRoles, fetchRoleOptions, fetchUserRoles, updateUserRoles } from './api';
 
@@ -31,11 +32,19 @@ export const UserRolePicker: FC<Props> = ({
 
   const { loading } = useAsync(async () => {
     try {
-      let options = await (getRoleOptions ? getRoleOptions() : fetchRoleOptions(orgId));
-      setRoleOptions(options.filter((option) => !option.name?.startsWith('managed:')));
+      if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
+        let options = await (getRoleOptions ? getRoleOptions() : fetchRoleOptions(orgId));
+        setRoleOptions(options.filter((option) => !option.name?.startsWith('managed:')));
+      } else {
+        setRoleOptions([]);
+      }
 
-      const builtInRoles = await (getBuiltinRoles ? getBuiltinRoles() : fetchBuiltinRoles(orgId));
-      setBuiltinRoles(builtInRoles);
+      if (contextSrv.hasPermission(AccessControlAction.ActionBuiltinRolesList)) {
+        const builtInRoles = await (getBuiltinRoles ? getBuiltinRoles() : fetchBuiltinRoles(orgId));
+        setBuiltinRoles(builtInRoles);
+      } else {
+        setBuiltinRoles({});
+      }
 
       const userRoles = await fetchUserRoles(userId, orgId);
       setAppliedRoles(userRoles);

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -46,8 +46,12 @@ export const UserRolePicker: FC<Props> = ({
         setBuiltinRoles({});
       }
 
-      const userRoles = await fetchUserRoles(userId, orgId);
-      setAppliedRoles(userRoles);
+      if (contextSrv.hasPermission(AccessControlAction.ActionUserRolesList)) {
+        const userRoles = await fetchUserRoles(userId, orgId);
+        setAppliedRoles(userRoles);
+      } else {
+        setAppliedRoles([]);
+      }
     } catch (e) {
       // TODO handle error
       console.error('Error loading options');

--- a/public/app/features/users/UsersTable.tsx
+++ b/public/app/features/users/UsersTable.tsx
@@ -23,10 +23,19 @@ const UsersTable: FC<Props> = (props) => {
   useEffect(() => {
     async function fetchOptions() {
       try {
-        let options = await fetchRoleOptions(orgId);
-        setRoleOptions(options);
-        const builtInRoles = await fetchBuiltinRoles(orgId);
-        setBuiltinRoles(builtInRoles);
+        if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
+          let options = await fetchRoleOptions(orgId);
+          setRoleOptions(options);
+        } else {
+          setRoleOptions([]);
+        }
+
+        if (contextSrv.hasPermission(AccessControlAction.ActionBuiltinRolesList)) {
+          const builtInRoles = await fetchBuiltinRoles(orgId);
+          setBuiltinRoles(builtInRoles);
+        } else {
+          setBuiltinRoles({});
+        }
       } catch (e) {
         console.error('Error loading options');
       }

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -50,6 +50,10 @@ export enum AccessControlAction {
   ActionServerStatsRead = 'server.stats:read',
 
   ActionTeamsCreate = 'teams:create',
+
+  ActionRolesList = 'roles:list',
+  ActionBuiltinRolesList = 'roles.builtin:list',
+  ActionUserRolesList = 'users.roles:list',
 }
 
 export interface Role {


### PR DESCRIPTION
This PR fixes access control error when user has no permissions for listing roles (happened in a role picker). PR adds permission check before calling API.