### PR TITLE
Devenv: fix permission failures for SQL docker blocks used for testing

### DIFF
--- a/devenv/docker/blocks/mysql_tests/Dockerfile
+++ b/devenv/docker/blocks/mysql_tests/Dockerfile
@@ -1,4 +1,5 @@
 ARG mysql_version=5.6
 FROM mysql:${mysql_version}
 ADD setup.sql /docker-entrypoint-initdb.d
+RUN chown -R mysql:mysql /docker-entrypoint-initdb.d/
 CMD ["mysqld"]

--- a/devenv/docker/blocks/postgres_tests/Dockerfile
+++ b/devenv/docker/blocks/postgres_tests/Dockerfile
@@ -1,4 +1,5 @@
 ARG postgres_version=9.3
 FROM postgres:${postgres_version}
 ADD setup.sql /docker-entrypoint-initdb.d
+RUN chown -R postgres:postgres /docker-entrypoint-initdb.d/
 CMD ["postgres"]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The `mysql_tests` and `postgres_tests` containers failed to start due to `permission denied` accessing `setup.sql` file during initialisation:
`
/usr/local/bin/docker-entrypoint.sh: line 75: /docker-entrypoint-initdb.d/setup.sql: Permission denied
`

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
For starting the containers:
`make devenv sources=mysql_tests,postgres_tests`