### PR TITLE
AzureMonitor: Request multiple pages of resource names

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.test.ts
@@ -308,20 +308,16 @@ describe('AzureMonitorDatasource', () => {
       beforeEach(() => {
         const fn = jest.fn();
         ctx.ds.azureMonitorDatasource.getResource = fn;
+        const basePath = `azuremonitor/subscriptions/${subscription}/resourceGroups`;
+        const expectedPath = `${basePath}/${resourceGroup}/resources?$filter=resourceType eq '${metricDefinition}'&api-version=2021-04-01`;
         // first page
         fn.mockImplementationOnce((path: string) => {
-          const basePath = `azuremonitor/subscriptions/${subscription}/resourceGroups`;
-          expect(path).toBe(
-            `${basePath}/${resourceGroup}/resources?$filter=resourceType eq '${metricDefinition}'&api-version=2021-04-01`
-          );
+          expect(path).toBe(expectedPath);
           return Promise.resolve(response1);
         });
         // second page
         fn.mockImplementationOnce((path: string) => {
-          const basePath = `azuremonitor/subscriptions/${subscription}/resourceGroups`;
-          expect(path).toBe(
-            `${basePath}/${resourceGroup}/resources?$filter=resourceType eq '${metricDefinition}'&api-version=2021-04-01&$skiptoken=${skipToken}`
-          );
+          expect(path).toBe(`${expectedPath}&$skiptoken=${skipToken}`);
           return Promise.resolve(response2);
         });
       });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.test.ts
@@ -284,6 +284,58 @@ describe('AzureMonitorDatasource', () => {
           });
       });
     });
+
+    describe('and there are several pages', () => {
+      const skipToken = 'token';
+      const response1 = {
+        value: [
+          {
+            name: `${resourceGroup}1`,
+            type: metricDefinition,
+          },
+        ],
+        nextLink: `https://management.azure.com/resourceuri?$skiptoken=${skipToken}`,
+      };
+      const response2 = {
+        value: [
+          {
+            name: `${resourceGroup}2`,
+            type: metricDefinition,
+          },
+        ],
+      };
+
+      beforeEach(() => {
+        const fn = jest.fn();
+        ctx.ds.azureMonitorDatasource.getResource = fn;
+        // first page
+        fn.mockImplementationOnce((path: string) => {
+          const basePath = `azuremonitor/subscriptions/${subscription}/resourceGroups`;
+          expect(path).toBe(
+            `${basePath}/${resourceGroup}/resources?$filter=resourceType eq '${metricDefinition}'&api-version=2021-04-01`
+          );
+          return Promise.resolve(response1);
+        });
+        // second page
+        fn.mockImplementationOnce((path: string) => {
+          const basePath = `azuremonitor/subscriptions/${subscription}/resourceGroups`;
+          expect(path).toBe(
+            `${basePath}/${resourceGroup}/resources?$filter=resourceType eq '${metricDefinition}'&api-version=2021-04-01&$skiptoken=${skipToken}`
+          );
+          return Promise.resolve(response2);
+        });
+      });
+
+      it('should return list of Resource Names', () => {
+        return ctx.ds
+          .getResourceNames(subscription, resourceGroup, metricDefinition)
+          .then((results: Array<{ text: string; value: string }>) => {
+            expect(results.length).toEqual(2);
+            expect(results[0].value).toEqual(`${resourceGroup}1`);
+            expect(results[1].value).toEqual(`${resourceGroup}2`);
+          });
+      });
+    });
   });
 
   describe('When performing getMetricNames', () => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

When there is more than 1000 entries in a result, Azure Monitor API returns a `nextLink` that should be used to retrieve the next page of values. This PR implements this behavior for resource names (which is the only one likely to go over 1k values). 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #42937

**Special notes for your reviewer**:

I tested this IRL setting the parameter `$top=1` so only one resource is returned per page.
