### PR TITLE
DashboardSettings: Prevent Dashboard permissions from linking to folder permissions when user does not have sufficient permissions

### DIFF
--- a/public/app/core/components/PermissionList/PermissionListItem.tsx
+++ b/public/app/core/components/PermissionList/PermissionListItem.tsx
@@ -65,7 +65,7 @@ export default class PermissionsListItem extends PureComponent<Props> {
           {item.inherited && folderInfo && (
             <em className="muted no-wrap">
               Inherited from folder{' '}
-              {folderInfo.hasFolderPermissions ? (
+              {folderInfo.canViewFolderPermissions ? (
                 <a className="text-link" href={`${folderInfo.url}/permissions`}>
                   {folderInfo.title}
                 </a>

--- a/public/app/core/components/PermissionList/PermissionListItem.tsx
+++ b/public/app/core/components/PermissionList/PermissionListItem.tsx
@@ -65,9 +65,13 @@ export default class PermissionsListItem extends PureComponent<Props> {
           {item.inherited && folderInfo && (
             <em className="muted no-wrap">
               Inherited from folder{' '}
-              <a className="text-link" href={`${folderInfo.url}/permissions`}>
-                {folderInfo.title}
-              </a>{' '}
+              {folderInfo.hasFolderPermissions ? (
+                <a className="text-link" href={`${folderInfo.url}/permissions`}>
+                  {folderInfo.title}
+                </a>
+              ) : (
+                folderInfo.title
+              )}
             </em>
           )}
           {inheritedFromRoot && <em className="muted no-wrap">Default Permission</em>}

--- a/public/app/features/dashboard/components/DashboardPermissions/DashboardPermissions.tsx
+++ b/public/app/features/dashboard/components/DashboardPermissions/DashboardPermissions.tsx
@@ -18,6 +18,7 @@ import PermissionsInfo from 'app/core/components/PermissionList/PermissionsInfo'
 
 const mapStateToProps = (state: StoreState) => ({
   permissions: state.dashboard.permissions,
+  hasFolderPermissions: state.folder.permissions.length > 0,
 });
 
 const mapDispatchToProps = {
@@ -77,12 +78,13 @@ export class DashboardPermissionsUnconnected extends PureComponent<Props, State>
   };
 
   getFolder() {
-    const { dashboard } = this.props;
+    const { dashboard, hasFolderPermissions } = this.props;
 
     return {
       id: dashboard.meta.folderId,
       title: dashboard.meta.folderTitle,
       url: dashboard.meta.folderUrl,
+      hasFolderPermissions,
     };
   }
 

--- a/public/app/features/dashboard/components/DashboardPermissions/DashboardPermissions.tsx
+++ b/public/app/features/dashboard/components/DashboardPermissions/DashboardPermissions.tsx
@@ -10,7 +10,7 @@ import {
   removeDashboardPermission,
   updateDashboardPermission,
 } from '../../state/actions';
-import { getFolderPermissions } from '../../../folders/state/actions';
+import { checkFolderPermissions } from '../../../folders/state/actions';
 import { DashboardModel } from '../../state/DashboardModel';
 import PermissionList from 'app/core/components/PermissionList/PermissionList';
 import AddPermission from 'app/core/components/PermissionList/AddPermission';
@@ -26,7 +26,7 @@ const mapDispatchToProps = {
   addDashboardPermission,
   removeDashboardPermission,
   updateDashboardPermission,
-  getFolderPermissions,
+  checkFolderPermissions,
 };
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
@@ -53,7 +53,7 @@ export class DashboardPermissionsUnconnected extends PureComponent<Props, State>
   componentDidMount() {
     this.props.getDashboardPermissions(this.props.dashboard.id);
     if (this.props.dashboard.meta.folderUid) {
-      this.props.getFolderPermissions(this.props.dashboard.meta.folderUid);
+      this.props.checkFolderPermissions(this.props.dashboard.meta.folderUid);
     }
   }
 

--- a/public/app/features/dashboard/components/DashboardPermissions/DashboardPermissions.tsx
+++ b/public/app/features/dashboard/components/DashboardPermissions/DashboardPermissions.tsx
@@ -10,6 +10,7 @@ import {
   removeDashboardPermission,
   updateDashboardPermission,
 } from '../../state/actions';
+import { getFolderPermissions } from '../../../folders/state/actions';
 import { DashboardModel } from '../../state/DashboardModel';
 import PermissionList from 'app/core/components/PermissionList/PermissionList';
 import AddPermission from 'app/core/components/PermissionList/AddPermission';
@@ -24,6 +25,7 @@ const mapDispatchToProps = {
   addDashboardPermission,
   removeDashboardPermission,
   updateDashboardPermission,
+  getFolderPermissions,
 };
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
@@ -49,6 +51,9 @@ export class DashboardPermissionsUnconnected extends PureComponent<Props, State>
 
   componentDidMount() {
     this.props.getDashboardPermissions(this.props.dashboard.id);
+    if (this.props.dashboard.meta.folderUid) {
+      this.props.getFolderPermissions(this.props.dashboard.meta.folderUid);
+    }
   }
 
   onOpenAddPermissions = () => {

--- a/public/app/features/dashboard/components/DashboardPermissions/DashboardPermissions.tsx
+++ b/public/app/features/dashboard/components/DashboardPermissions/DashboardPermissions.tsx
@@ -18,7 +18,7 @@ import PermissionsInfo from 'app/core/components/PermissionList/PermissionsInfo'
 
 const mapStateToProps = (state: StoreState) => ({
   permissions: state.dashboard.permissions,
-  hasFolderPermissions: state.folder.permissions.length > 0,
+  canViewFolderPermissions: state.folder.canViewFolderPermissions,
 });
 
 const mapDispatchToProps = {
@@ -78,13 +78,13 @@ export class DashboardPermissionsUnconnected extends PureComponent<Props, State>
   };
 
   getFolder() {
-    const { dashboard, hasFolderPermissions } = this.props;
+    const { dashboard, canViewFolderPermissions } = this.props;
 
     return {
       id: dashboard.meta.folderId,
       title: dashboard.meta.folderTitle,
       url: dashboard.meta.folderUrl,
-      hasFolderPermissions,
+      canViewFolderPermissions,
     };
   }
 

--- a/public/app/features/folders/FolderSettingsPage.test.tsx
+++ b/public/app/features/folders/FolderSettingsPage.test.tsx
@@ -20,6 +20,7 @@ const setup = (propOverrides?: object) => {
       hasChanged: false,
       version: 1,
       permissions: [],
+      canViewFolderPermissions: true,
     },
     getFolderByUid: jest.fn(),
     setFolderTitle: mockToolkitActionCreator(setFolderTitle),

--- a/public/app/features/folders/state/actions.test.ts
+++ b/public/app/features/folders/state/actions.test.ts
@@ -1,0 +1,63 @@
+import { getBackendSrv, setBackendSrv, BackendSrv, FetchResponse } from '@grafana/runtime';
+import { Observable, of, throwError } from 'rxjs';
+import { thunkTester } from 'test/core/thunk/thunkTester';
+import { checkFolderPermissions } from './actions';
+import { setCanViewFolderPermissions } from './reducers';
+import { backendSrv } from 'app/core/services/backend_srv';
+import { notifyApp } from 'app/core/actions';
+import { createWarningNotification } from 'app/core/copy/appNotification';
+
+describe('folder actions', () => {
+  // let originalBackendSrv: BackendSrv;
+  let fetchSpy = jest.spyOn(backendSrv, 'fetch');
+
+  afterAll(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function mockFetch(resp: Observable<any>) {
+    fetchSpy.mockReturnValueOnce(resp);
+  }
+
+  const folderUid = 'abc123';
+
+  describe('checkFolderPermissions', () => {
+    it('should dispatch true when the api call is successful', async () => {
+      mockFetch(of({}));
+
+      const dispatchedActions = await thunkTester({})
+        .givenThunk(checkFolderPermissions)
+        .whenThunkIsDispatched(folderUid);
+
+      expect(dispatchedActions).toEqual([setCanViewFolderPermissions(true)]);
+    });
+
+    it('should only dispatch false when the api call fails with 403', async () => {
+      mockFetch(throwError(() => ({ status: 403, data: { message: 'Access denied' } })));
+
+      const dispatchedActions = await thunkTester({})
+        .givenThunk(checkFolderPermissions)
+        .whenThunkIsDispatched(folderUid);
+
+      expect(dispatchedActions).toEqual([setCanViewFolderPermissions(false)]);
+    });
+
+    it('should also show a notification when the api call fails with an error other than 403', async () => {
+      mockFetch(throwError(() => ({ status: 500, data: { message: 'Server error' } })));
+
+      const dispatchedActions = await thunkTester({})
+        .givenThunk(checkFolderPermissions)
+        .whenThunkIsDispatched(folderUid);
+
+      const notificationAction = notifyApp(
+        createWarningNotification('Error checking folder permissions', 'Server error')
+      );
+      notificationAction.payload.id = expect.any(String);
+
+      expect(dispatchedActions).toEqual([
+        expect.objectContaining(notificationAction),
+        setCanViewFolderPermissions(false),
+      ]);
+    });
+  });
+});

--- a/public/app/features/folders/state/actions.test.ts
+++ b/public/app/features/folders/state/actions.test.ts
@@ -1,4 +1,3 @@
-import { getBackendSrv, setBackendSrv, BackendSrv, FetchResponse } from '@grafana/runtime';
 import { Observable, of, throwError } from 'rxjs';
 import { thunkTester } from 'test/core/thunk/thunkTester';
 import { checkFolderPermissions } from './actions';
@@ -6,11 +5,14 @@ import { setCanViewFolderPermissions } from './reducers';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { notifyApp } from 'app/core/actions';
 import { createWarningNotification } from 'app/core/copy/appNotification';
+import { FetchResponse } from '@grafana/runtime';
 
 describe('folder actions', () => {
-  // let originalBackendSrv: BackendSrv;
-  let fetchSpy = jest.spyOn(backendSrv, 'fetch');
+  let fetchSpy: jest.SpyInstance<Observable<FetchResponse<unknown>>>;
 
+  beforeAll(() => {
+    fetchSpy = jest.spyOn(backendSrv, 'fetch');
+  });
   afterAll(() => {
     fetchSpy.mockRestore();
   });
@@ -32,7 +34,7 @@ describe('folder actions', () => {
       expect(dispatchedActions).toEqual([setCanViewFolderPermissions(true)]);
     });
 
-    it('should only dispatch false when the api call fails with 403', async () => {
+    it('should dispatch just "false" when the api call fails with 403', async () => {
       mockFetch(throwError(() => ({ status: 403, data: { message: 'Access denied' } })));
 
       const dispatchedActions = await thunkTester({})
@@ -42,7 +44,7 @@ describe('folder actions', () => {
       expect(dispatchedActions).toEqual([setCanViewFolderPermissions(false)]);
     });
 
-    it('should also show a notification when the api call fails with an error other than 403', async () => {
+    it('should also dispatch a notification when the api call fails with an error other than 403', async () => {
       mockFetch(throwError(() => ({ status: 500, data: { message: 'Server error' } })));
 
       const dispatchedActions = await thunkTester({})

--- a/public/app/features/folders/state/actions.ts
+++ b/public/app/features/folders/state/actions.ts
@@ -36,7 +36,7 @@ export function deleteFolder(uid: string): ThunkResult<void> {
   };
 }
 
-export function getFolderPermissions(uid: string): ThunkResult<void> {
+export function getFolderPermissions(uid: string, requestOptions: { handleErrors: true }): ThunkResult<void> {
   return async (dispatch) => {
     const permissions = await backendSrv.get(`/api/folders/${uid}/permissions`);
     dispatch(loadFolderPermissions(permissions));

--- a/public/app/features/folders/state/actions.ts
+++ b/public/app/features/folders/state/actions.ts
@@ -61,6 +61,7 @@ export function checkFolderPermissions(uid: string): ThunkResult<void> {
       if (err.status !== 403) {
         dispatch(notifyApp(createWarningNotification('Error checking folder permissions', err.data?.message)));
       }
+
       dispatch(setCanViewFolderPermissions(false));
     }
   };

--- a/public/app/features/folders/state/actions.ts
+++ b/public/app/features/folders/state/actions.ts
@@ -36,10 +36,21 @@ export function deleteFolder(uid: string): ThunkResult<void> {
   };
 }
 
-export function getFolderPermissions(uid: string, requestOptions: { handleErrors: true }): ThunkResult<void> {
+export function getFolderPermissions(uid: string): ThunkResult<void> {
   return async (dispatch) => {
     const permissions = await backendSrv.get(`/api/folders/${uid}/permissions`);
     dispatch(loadFolderPermissions(permissions));
+  };
+}
+
+export function checkFolderPermissions(uid: string): ThunkResult<void> {
+  return async (dispatch) => {
+    try {
+      const permissions = await backendSrv.get(`/api/folders/${uid}/permissions`);
+      // dispatch(loadFolderPermissions(permissions));
+    }catch (error) {
+      console.error({ error }); 
+    }
   };
 }
 

--- a/public/app/features/folders/state/actions.ts
+++ b/public/app/features/folders/state/actions.ts
@@ -6,7 +6,7 @@ import { DashboardAcl, DashboardAclUpdateDTO, NewDashboardAclItem, PermissionLev
 import { notifyApp, updateNavIndex } from 'app/core/actions';
 import { buildNavModel } from './navModel';
 import appEvents from 'app/core/app_events';
-import { loadFolder, loadFolderPermissions } from './reducers';
+import { loadFolder, loadFolderPermissions, setCanViewFolderPermissions } from './reducers';
 import { lastValueFrom } from 'rxjs';
 import { createWarningNotification } from 'app/core/copy/appNotification';
 
@@ -56,10 +56,12 @@ export function checkFolderPermissions(uid: string): ThunkResult<void> {
           url: `/api/folders/${uid}/permissions`,
         })
       );
+      dispatch(setCanViewFolderPermissions(true));
     } catch (err) {
       if (err.status !== 403) {
         dispatch(notifyApp(createWarningNotification('Error checking folder permissions', err.data?.message)));
       }
+      dispatch(setCanViewFolderPermissions(false));
     }
   };
 }

--- a/public/app/features/folders/state/actions.ts
+++ b/public/app/features/folders/state/actions.ts
@@ -8,7 +8,7 @@ import { buildNavModel } from './navModel';
 import appEvents from 'app/core/app_events';
 import { loadFolder, loadFolderPermissions } from './reducers';
 import { lastValueFrom } from 'rxjs';
-import { createErrorNotification } from 'app/core/copy/appNotification';
+import { createWarningNotification } from 'app/core/copy/appNotification';
 
 export function getFolderByUid(uid: string): ThunkResult<void> {
   return async (dispatch) => {
@@ -57,10 +57,8 @@ export function checkFolderPermissions(uid: string): ThunkResult<void> {
         })
       );
     } catch (err) {
-      backendSrv.showErrorAlert({}, err);
-      console.error({ err });
       if (err.status !== 403) {
-        dispatch(notifyApp(createErrorNotification('Saving rich history failed', error.message)));
+        dispatch(notifyApp(createWarningNotification('Error checking folder permissions', err.data?.message)));
       }
     }
   };

--- a/public/app/features/folders/state/reducers.test.ts
+++ b/public/app/features/folders/state/reducers.test.ts
@@ -1,5 +1,12 @@
 import { FolderDTO, FolderState, OrgRole, PermissionLevel } from 'app/types';
-import { folderReducer, initialState, loadFolder, loadFolderPermissions, setFolderTitle } from './reducers';
+import {
+  folderReducer,
+  initialState,
+  loadFolder,
+  loadFolderPermissions,
+  setCanViewFolderPermissions,
+  setFolderTitle,
+} from './reducers';
 import { reducerTester } from '../../../../test/core/redux/reducerTester';
 
 function getTestFolder(): FolderDTO {
@@ -139,6 +146,18 @@ describe('folder reducer', () => {
               userLogin: 'MyTestUser',
             },
           ],
+        });
+    });
+  });
+
+  describe('setCanViewFolderPermissions', () => {
+    it('should set the canViewFolderPermissions value', () => {
+      reducerTester<FolderState>()
+        .givenReducer(folderReducer, { ...initialState })
+        .whenActionIsDispatched(setCanViewFolderPermissions(true))
+        .thenStateShouldEqual({
+          ...initialState,
+          canViewFolderPermissions: true,
         });
     });
   });

--- a/public/app/features/folders/state/reducers.ts
+++ b/public/app/features/folders/state/reducers.ts
@@ -12,6 +12,7 @@ export const initialState: FolderState = {
   hasChanged: false,
   version: 1,
   permissions: [],
+  canViewFolderPermissions: false,
 };
 
 const folderSlice = createSlice({
@@ -37,6 +38,10 @@ const folderSlice = createSlice({
         ...state,
         permissions: processAclItems(action.payload),
       };
+    },
+    setCanViewFolderPermissions: (state, action: PayloadAction<boolean>): FolderState => {
+      state.canViewFolderPermissions = action.payload;
+      return state;
     },
   },
 });

--- a/public/app/features/folders/state/reducers.ts
+++ b/public/app/features/folders/state/reducers.ts
@@ -46,7 +46,7 @@ const folderSlice = createSlice({
   },
 });
 
-export const { loadFolderPermissions, loadFolder, setFolderTitle } = folderSlice.actions;
+export const { loadFolderPermissions, loadFolder, setFolderTitle, setCanViewFolderPermissions } = folderSlice.actions;
 
 export const folderReducer = folderSlice.reducer;
 

--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -17,6 +17,7 @@ export interface DashboardMeta {
   canAdmin?: boolean;
   url?: string;
   folderId?: number;
+  folderUid?: string;
   fromExplore?: boolean;
   canMakeEditable?: boolean;
   submenuEnabled?: boolean;

--- a/public/app/types/folders.ts
+++ b/public/app/types/folders.ts
@@ -26,4 +26,5 @@ export interface FolderInfo {
   id?: number;
   title?: string;
   url?: string;
+  hasFolderPermissions?: boolean;
 }

--- a/public/app/types/folders.ts
+++ b/public/app/types/folders.ts
@@ -27,5 +27,5 @@ export interface FolderInfo {
   id?: number;
   title?: string;
   url?: string;
-  hasFolderPermissions?: boolean;
+  canViewFolderPermissions?: boolean;
 }

--- a/public/app/types/folders.ts
+++ b/public/app/types/folders.ts
@@ -20,6 +20,7 @@ export interface FolderState {
   hasChanged: boolean;
   version: number;
   permissions: DashboardAcl[];
+  canViewFolderPermissions: boolean;
 }
 
 export interface FolderInfo {


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevents the Dashboard permissions page from linking to a folder in the "Inherits permissions from" message when the user does not have permissions to view the linked page.

The backend was always enforcing the correct permissions, so there was no security concern here, but just a poor user experience from a useless link that left the page in a weird state.

**Which issue(s) this PR fixes**:

Fixes #43882

**Special notes for your reviewer**:

Would like a thumbs-up from @diegoadams here also for disabling the link when the user does not have permissions to click through it it.

Before:

![image](https://user-images.githubusercontent.com/46142/150133976-f5aa6c40-c85f-4b3e-9eb7-88e19f9d7fd4.png)


After:

![image](https://user-images.githubusercontent.com/46142/150133939-9f618668-be87-403d-bd8b-d543acc1bc9d.png)

Note "Issue Reproductions" is no longer a link.
