### PR TITLE
TestData: use CodeEditor for csv content

### DIFF
--- a/public/app/plugins/datasource/testdata/components/CSVContentEditor.tsx
+++ b/public/app/plugins/datasource/testdata/components/CSVContentEditor.tsx
@@ -1,21 +1,21 @@
-import React, { ChangeEvent } from 'react';
-import { InlineField, TextArea } from '@grafana/ui';
+import React from 'react';
+import { CodeEditor } from '@grafana/ui';
 import { EditorProps } from '../QueryEditor';
 
 export const CSVContentEditor = ({ onChange, query }: EditorProps) => {
-  const onContent = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    onChange({ ...query, csvContent: e.currentTarget.value });
+  const onSaveCSV = (csvContent: string) => {
+    onChange({ ...query, csvContent });
   };
 
   return (
-    <InlineField label="CSV" labelWidth={14}>
-      <TextArea
-        width="100%"
-        rows={10}
-        onBlur={onContent}
-        placeholder="CSV content"
-        defaultValue={query.csvContent ?? ''}
-      />
-    </InlineField>
+    <CodeEditor
+      height={300}
+      language="csv"
+      value={query.csvContent ?? ''}
+      onBlur={onSaveCSV}
+      onSave={onSaveCSV}
+      showMiniMap={false}
+      showLineNumbers={true}
+    />
   );
 };


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/705951/150249530-d53cea88-88ed-4a32-9516-112eab4afd9f.png)

After:
![image](https://user-images.githubusercontent.com/705951/150248817-1cb203c4-5214-454f-9439-e7ee25afa64f.png)

monaco is not strictly necessary, but looks a bit nicer :)