### PR TITLE
Provisioning: Ensure that the default value for orgID is set when provisioning datasources to be deleted

### DIFF
--- a/pkg/services/provisioning/datasources/config_reader.go
+++ b/pkg/services/provisioning/datasources/config_reader.go
@@ -93,11 +93,11 @@ func (cr *configReader) parseDatasourceConfig(path string, file os.FileInfo) (*c
 func (cr *configReader) validateDefaultUniqueness(ctx context.Context, datasources []*configs) error {
 	defaultCount := map[int64]int{}
 	for i := range datasources {
-		if datasources[i].Datasources == nil {
-			continue
-		}
-
 		for _, ds := range datasources[i].Datasources {
+			if ds == nil {
+				continue
+			}
+
 			if ds.OrgID == 0 {
 				ds.OrgID = 1
 			}
@@ -115,6 +115,10 @@ func (cr *configReader) validateDefaultUniqueness(ctx context.Context, datasourc
 		}
 
 		for _, ds := range datasources[i].DeleteDatasources {
+			if ds == nil {
+				continue
+			}
+
 			if ds.OrgID == 0 {
 				ds.OrgID = 1
 			}

--- a/pkg/services/provisioning/datasources/config_reader_test.go
+++ b/pkg/services/provisioning/datasources/config_reader_test.go
@@ -18,6 +18,7 @@ var (
 
 	twoDatasourcesConfig            = "testdata/two-datasources"
 	twoDatasourcesConfigPurgeOthers = "testdata/insert-two-delete-two"
+	deleteOneDatasource             = "testdata/delete-one"
 	doubleDatasourcesConfig         = "testdata/double-default"
 	allProperties                   = "testdata/all-properties"
 	versionZero                     = "testdata/version-0"
@@ -126,6 +127,27 @@ func TestDatasourceAsConfig(t *testing.T) {
 			require.Equal(t, fakeRepo.inserted[0].OrgId, int64(1))
 			require.True(t, fakeRepo.inserted[2].IsDefault)
 			require.Equal(t, fakeRepo.inserted[2].OrgId, int64(2))
+		})
+	})
+
+	t.Run("Remove one datasource", func(t *testing.T) {
+		setup()
+		t.Run("Remove one datasource", func(t *testing.T) {
+			fakeRepo.loadAll = []*models.DataSource{}
+
+			t.Run("should have removed old datasource", func(t *testing.T) {
+				dc := newDatasourceProvisioner(logger)
+				err := dc.applyChanges(context.Background(), deleteOneDatasource)
+				if err != nil {
+					t.Fatalf("applyChanges return an error %v", err)
+				}
+
+				require.Equal(t, 1, len(fakeRepo.deleted))
+				// should have set OrgID to 1
+				require.Equal(t, fakeRepo.deleted[0].OrgID, int64(1))
+				require.Equal(t, 0, len(fakeRepo.inserted))
+				require.Equal(t, len(fakeRepo.updated), 0)
+			})
 		})
 	})
 

--- a/pkg/services/provisioning/datasources/testdata/delete-one/one-datasource.yaml
+++ b/pkg/services/provisioning/datasources/testdata/delete-one/one-datasource.yaml
@@ -1,0 +1,3 @@
+datasources: []
+delete_datasources:
+  - name: old-data-source


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR fixes a bug in where the provisioning of a file containing the delete of a single datasource would fail if there were no datasources to be created.

With current implementation, the operation fails because the default `orgID` is not set, due to a condition in where the `deleteDatasources` field won't be parsed (and therefore orgId wont be set to default) if the `datasources` array is `nil` .

For example, if one tries to start Grafana, provisioning the following datasource file:

```
datasources: []
delete_datasources:
  - name: old-data-source
```


Grafana will fail with the following error:

```
logger=provisioning t=2022-01-20T03:42:04.34-0300 lvl=eror msg="Failed to provision data sources" error="Datasource provisioning error: unique identifier and org id are needed to be able to get or delete a datasource"
Failed to start grafana. error: Datasource provisioning error: unique identifier and org id are needed to be able to get or delete a datasource
Datasource provisioning error: unique identifier and org id are needed to be able to get or delete a datasource
```

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/44243

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


Signed-off-by: Maicon Costa <maiconscosta@gmail.com>


