### PR TITLE
MixedDatasource: Fixes infinite loop with empty query panel

### DIFF
--- a/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.test.ts
@@ -2,6 +2,7 @@ import { LoadingState } from '@grafana/data';
 import { lastValueFrom } from 'rxjs';
 import { getQueryOptions } from 'test/helpers/getQueryOptions';
 import { DatasourceSrvMock, MockObservableDataSourceApi } from 'test/mocks/datasource_srv';
+import { MIXED_DATASOURCE_NAME } from './MixedDataSource';
 import { MixedDatasource } from './module';
 
 const defaultDS = new MockObservableDataSourceApi('DefaultDS', [{ data: ['DDD'] }]);
@@ -124,6 +125,19 @@ describe('MixedDatasource', () => {
       expect(results[0].key).toBe('mixed-0-');
       expect(results[1].key).toBe('mixed-1-');
       expect(results[1].state).toBe(LoadingState.Done);
+    });
+  });
+
+  it('should filter out MixedDataSource queries', async () => {
+    const ds = new MixedDatasource({} as any);
+
+    await expect(
+      ds.query({
+        targets: [{ refId: 'A', datasource: { uid: MIXED_DATASOURCE_NAME, id: 'datasource' } }],
+      } as any)
+    ).toEmitValuesWith((results) => {
+      expect(results).toHaveLength(1);
+      expect(results[0].data).toHaveLength(0);
     });
   });
 });

--- a/public/app/plugins/datasource/mixed/MixedDataSource.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.ts
@@ -26,7 +26,7 @@ export class MixedDatasource extends DataSourceApi<DataQuery> {
   query(request: DataQueryRequest<DataQuery>): Observable<DataQueryResponse> {
     // Remove any invalid queries
     const queries = request.targets.filter((t) => {
-      return t.datasource?.type !== MIXED_DATASOURCE_NAME;
+      return t.datasource?.uid !== MIXED_DATASOURCE_NAME;
     });
 
     if (!queries.length) {


### PR DESCRIPTION
**What this PR does / why we need it**:
If a dashboard was created where there is a panel with a mixed datasource and no queries, saving or reloading the dashboard would cause an infinite loop making the tab crash.
When the dashboard is loaded, despite there being no queries, a target with `refId` `A` is added by default in 
`PanelModel.ts`. In `PanelQueryRunner` then, the following is executed
```ts
      // Attach the data source name to each query
      request.targets = request.targets.map((query) => {
        if (!query.datasource) {
          query.datasource = ds.getRef();
        }
        return query;
      });
```

where `ds.getRef()` returns `{ type: 'datasource', uid: '-- Mixed --' }` for the mixed datasource.
Later, in the query method of `MixedDatasource`, we have the following
```ts
    // Remove any invalid queries
    const queries = request.targets.filter((t) => {
      return t.datasource?.type !== MIXED_DATASOURCE_NAME;
    });
```

which I've changed to check `uid` rather than `type` in this PR.
The problem occurs in the `batchQueries` method of MixedDatasource:
```ts
// ...
return from(api.query(dsRequest)).pipe(
// ...
```

Since the mixed datasource query didn't get filtered out, it calls its query method, which then calls its query method again, and so on.

**Which issue(s) this PR fixes**:
Closes #43998

**Special notes for your reviewer**:
The way we use the terms `id` and `type` to refer to the same or different things depending on the context is confusing and no doubt leads to issues like this one, and an effort should probably be made at some point to make the codebase more consistent in this regard.