### PR TITLE
TablePanel: Make column headers more keyboard-friendly

### DIFF
--- a/packages/grafana-ui/src/components/Table/HeaderRow.tsx
+++ b/packages/grafana-ui/src/components/Table/HeaderRow.tsx
@@ -55,11 +55,7 @@ function renderHeaderCell(column: any, tableStyles: TableStyles, field?: Field, 
     <div className={tableStyles.headerCell} {...headerProps} role="columnheader">
       {column.canSort && (
         <>
-          <div
-            {...column.getSortByToggleProps()}
-            className={tableStyles.headerCellLabel}
-            title={column.render('Header')}
-          >
+          <button {...column.getSortByToggleProps()} className={tableStyles.headerCellLabel}>
             {showTypeIcons && (
               <Icon name={getFieldTypeIcon(field)} title={field?.type} size="sm" className={tableStyles.typeIcon} />
             )}
@@ -67,7 +63,7 @@ function renderHeaderCell(column: any, tableStyles: TableStyles, field?: Field, 
             <div>
               {column.isSorted && (column.isSortedDesc ? <Icon name="arrow-down" /> : <Icon name="arrow-up" />)}
             </div>
-          </div>
+          </button>
           {column.canFilter && <Filter column={column} tableStyles={tableStyles} field={field} />}
         </>
       )}

--- a/packages/grafana-ui/src/components/Table/styles.ts
+++ b/packages/grafana-ui/src/components/Table/styles.ts
@@ -92,6 +92,9 @@ export const getTableStyles = (theme: GrafanaTheme2) => {
       }
     `,
     headerCellLabel: css`
+      border: none;
+      padding: 0;
+      background: inherit;
       cursor: pointer;
       white-space: nowrap;
       overflow: hidden;


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes `HeaderRow`'s markup to use buttons instead of divs for keyboard accessibility.
Also removed `title` attribute from wrapper div as it was redundant.
