### PR TITLE
Cursor sync: Apply the settings without saving the dashboard

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/GraphNG/utils.test.ts
@@ -197,7 +197,7 @@ describe('GraphNG utils', () => {
       timeZone: DefaultTimeZone,
       getTimeRange: getDefaultTimeRange,
       eventBus: new EventBusSrv(),
-      sync: DashboardCursorSync.Tooltip,
+      sync: () => DashboardCursorSync.Tooltip,
       allFrames: [frame!],
     }).getConfig();
     expect(result).toMatchSnapshot();

--- a/packages/grafana-ui/src/components/PanelChrome/PanelContext.ts
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelContext.ts
@@ -15,7 +15,7 @@ export interface PanelContext {
   eventBus: EventBus;
 
   /** Dashboard panels sync */
-  sync?: DashboardCursorSync;
+  sync?: () => DashboardCursorSync;
 
   /** Information on what the outer container is */
   app?: CoreApp | 'string';

--- a/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
@@ -18,7 +18,7 @@ export class UnthemedTimeSeries extends React.Component<TimeSeriesProps> {
   panelContext: PanelContext = {} as PanelContext;
 
   prepConfig = (alignedFrame: DataFrame, allFrames: DataFrame[], getTimeRange: () => TimeRange) => {
-    const { eventBus, sync } = this.context;
+    const { eventBus, sync } = this.context as PanelContext;
     const { theme, timeZone, legend, renderers, tweakAxis, tweakScale } = this.props;
 
     return preparePlotConfigBuilder({

--- a/packages/grafana-ui/src/components/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/components/TimeSeries/utils.ts
@@ -39,7 +39,7 @@ const defaultConfig: GraphFieldConfig = {
 };
 
 export const preparePlotConfigBuilder: UPlotConfigPrepFn<{
-  sync: () => DashboardCursorSync;
+  sync?: () => DashboardCursorSync;
   legend?: VizLegendOptions;
 }> = ({
   frame,
@@ -408,7 +408,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{
     },
   };
 
-  if (sync() !== DashboardCursorSync.Off) {
+  if (sync && sync() !== DashboardCursorSync.Off) {
     const payload: DataHoverPayload = {
       point: {
         [xScaleKey]: null,
@@ -421,7 +421,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{
       key: '__global_',
       filters: {
         pub: (type: string, src: uPlot, x: number, y: number, w: number, h: number, dataIdx: number) => {
-          if (sync() === DashboardCursorSync.Off) {
+          if (sync && sync() === DashboardCursorSync.Off) {
             return false;
           }
 

--- a/packages/grafana-ui/src/components/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/components/TimeSeries/utils.ts
@@ -38,7 +38,10 @@ const defaultConfig: GraphFieldConfig = {
   axisPlacement: AxisPlacement.Auto,
 };
 
-export const preparePlotConfigBuilder: UPlotConfigPrepFn<{ sync: DashboardCursorSync; legend?: VizLegendOptions }> = ({
+export const preparePlotConfigBuilder: UPlotConfigPrepFn<{
+  sync: () => DashboardCursorSync;
+  legend?: VizLegendOptions;
+}> = ({
   frame,
   theme,
   timeZone,
@@ -405,7 +408,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{ sync: DashboardCursor
     },
   };
 
-  if (sync !== DashboardCursorSync.Off) {
+  if (sync() !== DashboardCursorSync.Off) {
     const payload: DataHoverPayload = {
       point: {
         [xScaleKey]: null,
@@ -418,6 +421,10 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{ sync: DashboardCursor
       key: '__global_',
       filters: {
         pub: (type: string, src: uPlot, x: number, y: number, w: number, h: number, dataIdx: number) => {
+          if (sync() === DashboardCursorSync.Off) {
+            return false;
+          }
+
           payload.rowIndex = dataIdx;
           if (x < 0 && y < 0) {
             payload.point[xScaleUnit] = null;

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -26,7 +26,7 @@ interface TooltipPluginProps {
   config: UPlotConfigBuilder;
   mode?: TooltipDisplayMode;
   sortOrder?: SortOrder;
-  sync?: DashboardCursorSync;
+  sync?: () => DashboardCursorSync;
   // Allows custom tooltip content rendering. Exposes aligned data frame with relevant indexes for data inspection
   // Use field.state.origin indexes from alignedData frame field to get access to original data frame and field index.
   renderTooltip?: (alignedFrame: DataFrame, seriesIdx: number | null, datapointIdx: number | null) => React.ReactNode;
@@ -95,7 +95,7 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
       u.root.parentElement?.addEventListener('blur', plotLeave);
       u.over.addEventListener('mouseleave', plotLeave);
 
-      if (sync === DashboardCursorSync.Crosshair) {
+      if (sync && sync() === DashboardCursorSync.Crosshair) {
         u.root.classList.add('shared-crosshair');
       }
     });
@@ -168,7 +168,7 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
     };
   }, [config, setCoords, setIsActive, setFocusedPointIdx, setFocusedPointIdxs]);
 
-  if (focusedPointIdx === null || (!isActive && sync === DashboardCursorSync.Crosshair)) {
+  if (focusedPointIdx === null || (!isActive && sync && sync() === DashboardCursorSync.Crosshair)) {
     return null;
   }
 

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -80,8 +80,8 @@ export class PanelChrome extends PureComponent<Props, State> {
       refreshWhenInView: false,
       context: {
         eventBus,
-        sync: props.isEditing ? DashboardCursorSync.Off : props.dashboard.graphTooltip,
         app: this.getPanelContextApp(),
+        sync: this.getSync,
         onSeriesColorChange: this.onSeriesColorChange,
         onToggleSeriesVisibility: this.onSeriesVisibilityChange,
         onAnnotationCreate: this.onAnnotationCreate,
@@ -94,6 +94,9 @@ export class PanelChrome extends PureComponent<Props, State> {
       data: this.getInitialPanelDataState(),
     };
   }
+
+  // Due to a mutable panel model we get the sync settings via function that proactively reads from the model
+  getSync = () => (this.props.isEditing ? DashboardCursorSync.Off : this.props.dashboard.graphTooltip);
 
   onInstanceStateChange = (value: any) => {
     this.props.onInstanceStateChange(value);
@@ -224,11 +227,12 @@ export class PanelChrome extends PureComponent<Props, State> {
     const app = this.getPanelContextApp();
     const sync = isEditing ? DashboardCursorSync.Off : this.props.dashboard.graphTooltip;
 
-    if (context.sync !== sync || context.app !== app) {
+    if ((context.sync && context.sync() !== sync) || context.app !== app) {
+      // console.log('sync updaye');
       this.setState({
         context: {
           ...context,
-          sync,
+          sync: () => sync,
           app,
         },
       });

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -221,18 +221,15 @@ export class PanelChrome extends PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    const { isInView, isEditing, width } = this.props;
+    const { isInView, width } = this.props;
     const { context } = this.state;
 
     const app = this.getPanelContextApp();
-    const sync = isEditing ? DashboardCursorSync.Off : this.props.dashboard.graphTooltip;
 
-    if ((context.sync && context.sync() !== sync) || context.app !== app) {
-      // console.log('sync updaye');
+    if (context.app !== app) {
       this.setState({
         context: {
           ...context,
-          sync: () => sync,
           app,
         },
       });

--- a/public/app/plugins/panel/state-timeline/types.ts
+++ b/public/app/plugins/panel/state-timeline/types.ts
@@ -17,7 +17,7 @@ export interface TimelineOptions extends OptionsWithLegend, OptionsWithTooltip {
   // only used in "changes" mode (state-timeline)
   alignValue?: TimelineValueAlignment;
 
-  sync?: DashboardCursorSync;
+  sync?: () => DashboardCursorSync;
 }
 
 export type TimelineValueAlignment = 'center' | 'left' | 'right';

--- a/public/app/plugins/panel/state-timeline/utils.ts
+++ b/public/app/plugins/panel/state-timeline/utils.ts
@@ -236,14 +236,14 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<TimelineOptions> = ({
     });
   }
 
-  if (sync) {
+  if (sync && sync() !== DashboardCursorSync.Off) {
     let cursor: Partial<uPlot.Cursor> = {};
 
     cursor.sync = {
       key: '__global_',
       filters: {
         pub: (type: string, src: uPlot, x: number, y: number, w: number, h: number, dataIdx: number) => {
-          if (sync() === DashboardCursorSync.Off) {
+          if (sync && sync() === DashboardCursorSync.Off) {
             return false;
           }
           payload.rowIndex = dataIdx;

--- a/public/app/plugins/panel/state-timeline/utils.ts
+++ b/public/app/plugins/panel/state-timeline/utils.ts
@@ -236,13 +236,16 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<TimelineOptions> = ({
     });
   }
 
-  if (sync !== DashboardCursorSync.Off) {
+  if (sync) {
     let cursor: Partial<uPlot.Cursor> = {};
 
     cursor.sync = {
       key: '__global_',
       filters: {
         pub: (type: string, src: uPlot, x: number, y: number, w: number, h: number, dataIdx: number) => {
+          if (sync() === DashboardCursorSync.Off) {
+            return false;
+          }
           payload.rowIndex = dataIdx;
           if (x < 0 && y < 0) {
             payload.point[xScaleUnit] = null;


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/44187

The reported issue was caused by the fact that the dashboard model passed down to the dashboard components is mutable and does not cause components re-render when the properties of the model change. The proposed fix changes the way we retrieve the sync config for the visualizations- instead of passing the config as a property, I'm passing a function that reads from the current dashboard model when needed.