### PR TITLE
Access control: Use role picker for add user to org modal

### DIFF
--- a/public/app/core/components/RolePicker/RolePicker.tsx
+++ b/public/app/core/components/RolePicker/RolePicker.tsx
@@ -35,8 +35,9 @@ export const RolePicker = ({
   const [query, setQuery] = useState('');
 
   useEffect(() => {
+    setSelectedBuiltInRole(builtInRole);
     setSelectedRoles(appliedRoles);
-  }, [appliedRoles]);
+  }, [appliedRoles, builtInRole]);
 
   const onOpen = useCallback(
     (event: FormEvent<HTMLElement>) => {


### PR DESCRIPTION
This PR adds role picker to the "Add user to organization" modal if access control enabled (instead of default picker).