### PR TITLE
[v8.3.x] Cursor sync: Apply the settings without saving the dashboard (#44270)

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/GraphNG/utils.test.ts
@@ -197,7 +197,7 @@ describe('GraphNG utils', () => {
       timeZone: DefaultTimeZone,
       getTimeRange: getDefaultTimeRange,
       eventBus: new EventBusSrv(),
-      sync: DashboardCursorSync.Tooltip,
+      sync: () => DashboardCursorSync.Tooltip,
       allFrames: [frame!],
     }).getConfig();
     expect(result).toMatchSnapshot();

--- a/packages/grafana-ui/src/components/PanelChrome/PanelContext.ts
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelContext.ts
@@ -15,7 +15,7 @@ export interface PanelContext {
   eventBus: EventBus;
 
   /** Dashboard panels sync */
-  sync?: DashboardCursorSync;
+  sync?: () => DashboardCursorSync;
 
   /** Information on what the outer container is */
   app?: CoreApp | 'string';

--- a/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
@@ -18,7 +18,7 @@ export class UnthemedTimeSeries extends React.Component<TimeSeriesProps> {
   panelContext: PanelContext = {} as PanelContext;
 
   prepConfig = (alignedFrame: DataFrame, allFrames: DataFrame[], getTimeRange: () => TimeRange) => {
-    const { eventBus, sync } = this.context;
+    const { eventBus, sync } = this.context as PanelContext;
     const { theme, timeZone, legend, renderers, tweakAxis, tweakScale } = this.props;
 
     return preparePlotConfigBuilder({

--- a/packages/grafana-ui/src/components/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/components/TimeSeries/utils.ts
@@ -36,7 +36,10 @@ const defaultConfig: GraphFieldConfig = {
   axisPlacement: AxisPlacement.Auto,
 };
 
-export const preparePlotConfigBuilder: UPlotConfigPrepFn<{ sync: DashboardCursorSync; legend?: VizLegendOptions }> = ({
+export const preparePlotConfigBuilder: UPlotConfigPrepFn<{
+  sync?: () => DashboardCursorSync;
+  legend?: VizLegendOptions;
+}> = ({
   frame,
   theme,
   timeZone,
@@ -386,7 +389,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{ sync: DashboardCursor
     },
   };
 
-  if (sync !== DashboardCursorSync.Off) {
+  if (sync && sync() !== DashboardCursorSync.Off) {
     const payload: DataHoverPayload = {
       point: {
         [xScaleKey]: null,
@@ -399,6 +402,10 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{ sync: DashboardCursor
       key: '__global_',
       filters: {
         pub: (type: string, src: uPlot, x: number, y: number, w: number, h: number, dataIdx: number) => {
+          if (sync && sync() === DashboardCursorSync.Off) {
+            return false;
+          }
+
           payload.rowIndex = dataIdx;
           if (x < 0 && y < 0) {
             payload.point[xScaleUnit] = null;

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin.tsx
@@ -24,7 +24,7 @@ interface TooltipPluginProps {
   data: DataFrame;
   config: UPlotConfigBuilder;
   mode?: TooltipDisplayMode;
-  sync?: DashboardCursorSync;
+  sync?: () => DashboardCursorSync;
   // Allows custom tooltip content rendering. Exposes aligned data frame with relevant indexes for data inspection
   // Use field.state.origin indexes from alignedData frame field to get access to original data frame and field index.
   renderTooltip?: (alignedFrame: DataFrame, seriesIdx: number | null, datapointIdx: number | null) => React.ReactNode;
@@ -91,7 +91,7 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
       u.over.addEventListener('mouseleave', plotMouseLeave);
       u.over.addEventListener('mouseenter', plotMouseEnter);
 
-      if (sync === DashboardCursorSync.Crosshair) {
+      if (sync && sync() === DashboardCursorSync.Crosshair) {
         u.root.classList.add('shared-crosshair');
       }
     });
@@ -162,7 +162,7 @@ export const TooltipPlugin: React.FC<TooltipPluginProps> = ({
     };
   }, [config, setCoords, setIsActive, setFocusedPointIdx, setFocusedPointIdxs]);
 
-  if (focusedPointIdx === null || (!isActive && sync === DashboardCursorSync.Crosshair)) {
+  if (focusedPointIdx === null || (!isActive && sync && sync() === DashboardCursorSync.Crosshair)) {
     return null;
   }
 

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -80,8 +80,8 @@ export class PanelChrome extends PureComponent<Props, State> {
       refreshWhenInView: false,
       context: {
         eventBus,
-        sync: props.isEditing ? DashboardCursorSync.Off : props.dashboard.graphTooltip,
         app: this.getPanelContextApp(),
+        sync: this.getSync,
         onSeriesColorChange: this.onSeriesColorChange,
         onToggleSeriesVisibility: this.onSeriesVisibilityChange,
         onAnnotationCreate: this.onAnnotationCreate,
@@ -94,6 +94,9 @@ export class PanelChrome extends PureComponent<Props, State> {
       data: this.getInitialPanelDataState(),
     };
   }
+
+  // Due to a mutable panel model we get the sync settings via function that proactively reads from the model
+  getSync = () => (this.props.isEditing ? DashboardCursorSync.Off : this.props.dashboard.graphTooltip);
 
   onInstanceStateChange = (value: any) => {
     this.props.onInstanceStateChange(value);
@@ -218,17 +221,15 @@ export class PanelChrome extends PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    const { isInView, isEditing, width } = this.props;
+    const { isInView, width } = this.props;
     const { context } = this.state;
 
     const app = this.getPanelContextApp();
-    const sync = isEditing ? DashboardCursorSync.Off : this.props.dashboard.graphTooltip;
 
-    if (context.sync !== sync || context.app !== app) {
+    if (context.app !== app) {
       this.setState({
         context: {
           ...context,
-          sync,
           app,
         },
       });

--- a/public/app/plugins/panel/state-timeline/types.ts
+++ b/public/app/plugins/panel/state-timeline/types.ts
@@ -17,7 +17,7 @@ export interface TimelineOptions extends OptionsWithLegend, OptionsWithTooltip {
   // only used in "changes" mode (state-timeline)
   alignValue?: TimelineValueAlignment;
 
-  sync?: DashboardCursorSync;
+  sync?: () => DashboardCursorSync;
 }
 
 export type TimelineValueAlignment = 'center' | 'left' | 'right';

--- a/public/app/plugins/panel/state-timeline/utils.ts
+++ b/public/app/plugins/panel/state-timeline/utils.ts
@@ -236,13 +236,16 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<TimelineOptions> = ({
     });
   }
 
-  if (sync !== DashboardCursorSync.Off) {
+  if (sync && sync() !== DashboardCursorSync.Off) {
     let cursor: Partial<uPlot.Cursor> = {};
 
     cursor.sync = {
       key: '__global_',
       filters: {
         pub: (type: string, src: uPlot, x: number, y: number, w: number, h: number, dataIdx: number) => {
+          if (sync && sync() === DashboardCursorSync.Off) {
+            return false;
+          }
           payload.rowIndex = dataIdx;
           if (x < 0 && y < 0) {
             payload.point[xScaleUnit] = null;


### PR DESCRIPTION
Manual backport https://github.com/grafana/grafana/pull/44270

* Cursor sync: Apply the settings without saving the dashboard

* Remove unnecessary code

* Lint god damn

(cherry picked from commit 7bf25f62e154886686b436b4201242f4ba7435c3)

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

