### PR TITLE
TestDS: Use code editor for CSV input

### DIFF
--- a/public/app/plugins/datasource/testdata/components/CSVContentEditor.tsx
+++ b/public/app/plugins/datasource/testdata/components/CSVContentEditor.tsx
@@ -1,20 +1,21 @@
-import React, { ChangeEvent } from 'react';
-import { InlineField, TextArea } from '@grafana/ui';
+import React from 'react';
+import { CodeEditor, InlineField } from '@grafana/ui';
 import { EditorProps } from '../QueryEditor';
 
 export const CSVContentEditor = ({ onChange, query }: EditorProps) => {
-  const onContent = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    onChange({ ...query, csvContent: e.currentTarget.value });
+  const onContent = (v: string) => {
+    onChange({ ...query, csvContent: v });
   };
 
   return (
-    <InlineField label="CSV" labelWidth={14}>
-      <TextArea
-        width="100%"
-        rows={10}
+    <InlineField label="CSV" labelWidth={14} grow>
+      <CodeEditor
+        language="csv"
+        value={query.csvContent ?? ''}
         onBlur={onContent}
-        placeholder="CSV content"
-        defaultValue={query.csvContent ?? ''}
+        width="100%"
+        height="200px"
+        showMiniMap={false}
       />
     </InlineField>
   );


### PR DESCRIPTION
Seems like the csv editor for test data source has been broken for couple of days. This PR resurects it and replaces text area with code editor:

before:
<img width="857" alt="Screen Shot 2022-01-20 at 16 55 24" src="https://user-images.githubusercontent.com/2376619/150377846-683f1c45-2eed-421c-aac5-c5b0053461bd.png">

after:
<img width="857" alt="Screen Shot 2022-01-20 at 17 17 07" src="https://user-images.githubusercontent.com/2376619/150378275-d2c25fb0-d874-4381-b904-6b5e1d79889e.png">


