### PR TITLE
TablePanel: Fix ad-hoc variabes not working on default datasources

### DIFF
--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -73,7 +73,7 @@ export class TablePanel extends Component<Props> {
     this.forceUpdate();
   };
 
-  onCellFilterAdded = async (filter: FilterItem) => {
+  onCellFilterAdded = (filter: FilterItem) => {
     const { key, value, operator } = filter;
     const panelModel = getDashboardSrv().getCurrent()?.getPanelById(this.props.id);
 

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -76,12 +76,14 @@ export class TablePanel extends Component<Props> {
   onCellFilterAdded = (filter: FilterItem) => {
     const { key, value, operator } = filter;
     const panelModel = getDashboardSrv().getCurrent()?.getPanelById(this.props.id);
+    if (!panelModel) {
+      return;
+    }
 
-    // The datasource ref from the panel model can be null/undefined if a panel uses a default datasource
-    // so we need to resolve it to the real final datasource.
-    const datasourceInstance = getDatasourceSrv().getInstanceSettings(panelModel?.datasource);
+    // When the datasource is null/undefined (for a default datasource), we use getInstanceSettings
+    // to find the real datasource ref for the default datasource.
+    const datasourceInstance = getDatasourceSrv().getInstanceSettings(panelModel.datasource);
     const datasourceRef = datasourceInstance && getDataSourceRef(datasourceInstance);
-
     if (!datasourceRef) {
       return;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes TablePanel so ad-hoc filters work when the panel is configured with a default datasource.

**Which issue(s) this PR fixes**:

Fixes #43975