### PR TITLE
[v8.3.x] Alerting: Migration to create only one folder per dashboard with custom ACL

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -89,10 +89,6 @@ func addMigrationInfo(da *dashAlert) (map[string]string, map[string]string) {
 	return lbls, annotations
 }
 
-func getMigrationString(da dashAlert) string {
-	return fmt.Sprintf(`{"dashboardUid": "%v", "panelId": %v, "alertId": %v}`, da.DashboardUID, da.PanelId, da.Id)
-}
-
 func (m *migration) makeAlertRule(cond condition, da dashAlert, folderUID string) (*alertRule, error) {
 	lbls, annotations := addMigrationInfo(&da)
 	lbls["alertname"] = da.Name

--- a/pkg/services/sqlstore/migrations/ualert/ualert_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert_test.go
@@ -184,3 +184,33 @@ func configFromReceivers(t *testing.T, receivers []*PostableGrafanaReceiver) *Po
 }
 
 const invalidUri = "�6�M��)uk譹1(�h`$�o�N>mĕ����cS2�dh![ę�	���`csB�!��OSxP�{�"
+
+func Test_getAlertFolderNameFromDashboard(t *testing.T) {
+	t.Run("should include full title", func(t *testing.T) {
+		dash := &dashboard{
+			Uid:   util.GenerateShortUID(),
+			Title: "TEST",
+		}
+		folder := getAlertFolderNameFromDashboard(dash)
+		require.Contains(t, folder, dash.Title)
+		require.Contains(t, folder, dash.Uid)
+	})
+	t.Run("should cut title to the length", func(t *testing.T) {
+		title := ""
+		for {
+			title += util.GenerateShortUID()
+			if len(title) > MaxFolderName {
+				title = title[:MaxFolderName]
+				break
+			}
+		}
+
+		dash := &dashboard{
+			Uid:   util.GenerateShortUID(),
+			Title: title,
+		}
+		folder := getAlertFolderNameFromDashboard(dash)
+		require.Len(t, folder, MaxFolderName)
+		require.Contains(t, folder, dash.Uid)
+	})
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Manual backport of https://github.com/grafana/grafana/pull/44283 that needs to be rebased.

Currently, during the migration from legacy alerting, Grafana creates folders for a dashboard that have custom permissions and assigns the dashboard's permissions to the new folder. However, it creates a folder per panel, which basically leads to the situation that there is a folder per alert. This is not effective.

This PR changes this behavior and updates Grafana to create only one folder per dashboard. Also, this PR changes the format of the folder name from `Migrated {"dashboardUid": "<UID>", "panelId": <ID>, "alertId": <ID>}` to `<dashboard_name> Alerts (<UID>)` the UID part is necessary to avoid collisions when two dashboards have same name.


**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/43934

