### PR TITLE
Stacking: Ignore null/undefined-only stacks instead of assuming 0 value

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/utils.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.test.ts
@@ -296,6 +296,132 @@ describe('preparePlotData', () => {
       `);
     });
 
+    describe('ignores nullish-only stacks', () => {
+      test('single stacking group', () => {
+        const df = new MutableDataFrame({
+          fields: [
+            { name: 'time', type: FieldType.time, values: [9997, 9998, 9999] },
+            {
+              name: 'a',
+              values: [-10, null, 10],
+              config: { custom: { stacking: { mode: StackingMode.Normal, group: 'stackA' } } },
+            },
+            {
+              name: 'b',
+              values: [10, null, null],
+              config: { custom: { stacking: { mode: StackingMode.Normal, group: 'stackA' } } },
+            },
+            {
+              name: 'c',
+              values: [20, undefined, 20],
+              config: { custom: { stacking: { mode: StackingMode.Normal, group: 'stackA' } } },
+            },
+          ],
+        });
+
+        expect(preparePlotData([df])).toMatchInlineSnapshot(`
+          Array [
+            Array [
+              9997,
+              9998,
+              9999,
+            ],
+            Array [
+              -10,
+              null,
+              10,
+            ],
+            Array [
+              0,
+              null,
+              10,
+            ],
+            Array [
+              20,
+              null,
+              30,
+            ],
+          ]
+        `);
+      });
+      test('multiple stacking groups', () => {
+        const df = new MutableDataFrame({
+          fields: [
+            { name: 'time', type: FieldType.time, values: [9997, 9998, 9999] },
+            {
+              name: 'a',
+              values: [-10, undefined, 10],
+              config: { custom: { stacking: { mode: StackingMode.Normal, group: 'stackA' } } },
+            },
+            {
+              name: 'b',
+              values: [10, undefined, 10],
+              config: { custom: { stacking: { mode: StackingMode.Normal, group: 'stackA' } } },
+            },
+            {
+              name: 'c',
+              values: [20, undefined, 20],
+              config: { custom: { stacking: { mode: StackingMode.Normal, group: 'stackA' } } },
+            },
+            {
+              name: 'd',
+              values: [1, 2, null],
+              config: { custom: { stacking: { mode: StackingMode.Normal, group: 'stackB' } } },
+            },
+            {
+              name: 'e',
+              values: [1, 2, null],
+              config: { custom: { stacking: { mode: StackingMode.Normal, group: 'stackB' } } },
+            },
+            {
+              name: 'f',
+              values: [1, 2, null],
+              config: { custom: { stacking: { mode: StackingMode.Normal, group: 'stackB' } } },
+            },
+          ],
+        });
+
+        expect(preparePlotData([df])).toMatchInlineSnapshot(`
+          Array [
+            Array [
+              9997,
+              9998,
+              9999,
+            ],
+            Array [
+              -10,
+              null,
+              10,
+            ],
+            Array [
+              0,
+              null,
+              20,
+            ],
+            Array [
+              20,
+              null,
+              40,
+            ],
+            Array [
+              1,
+              2,
+              null,
+            ],
+            Array [
+              2,
+              4,
+              null,
+            ],
+            Array [
+              3,
+              6,
+              null,
+            ],
+          ]
+        `);
+      });
+    });
     describe('with legend sorted', () => {
       it('should affect when single group', () => {
         const df = new MutableDataFrame({
@@ -323,53 +449,53 @@ describe('preparePlotData', () => {
         });
 
         expect(preparePlotData([df], undefined, { sortBy: 'Max', sortDesc: false } as any)).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            9997,
-            9998,
-            9999,
-          ],
-          Array [
-            0,
-            30,
-            20,
-          ],
-          Array [
-            10,
-            10,
-            10,
-          ],
-          Array [
-            20,
-            50,
-            40,
-          ],
-        ]
-      `);
+                  Array [
+                    Array [
+                      9997,
+                      9998,
+                      9999,
+                    ],
+                    Array [
+                      0,
+                      30,
+                      20,
+                    ],
+                    Array [
+                      10,
+                      10,
+                      10,
+                    ],
+                    Array [
+                      20,
+                      50,
+                      40,
+                    ],
+                  ]
+              `);
         expect(preparePlotData([df], undefined, { sortBy: 'Max', sortDesc: true } as any)).toMatchInlineSnapshot(`
-        Array [
-          Array [
-            9997,
-            9998,
-            9999,
-          ],
-          Array [
-            -10,
-            20,
-            10,
-          ],
-          Array [
-            20,
-            50,
-            40,
-          ],
-          Array [
-            10,
-            40,
-            30,
-          ],
-        ]
-      `);
+                  Array [
+                    Array [
+                      9997,
+                      9998,
+                      9999,
+                    ],
+                    Array [
+                      -10,
+                      20,
+                      10,
+                    ],
+                    Array [
+                      20,
+                      50,
+                      40,
+                    ],
+                    Array [
+                      10,
+                      40,
+                      30,
+                    ],
+                  ]
+              `);
       });
     });
   });

--- a/packages/grafana-ui/src/components/uPlot/utils.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.ts
@@ -74,7 +74,7 @@ export function preparePlotData(
     // array or stacking groups
     for (const [_, seriesIds] of stackingGroups.entries()) {
       const seriesIdxs = orderIdsByCalcs({ ids: seriesIds, legend, frame });
-
+      const noValueStack = Array(dataLength).fill(true);
       const groupTotals = byPct ? Array(dataLength).fill(0) : null;
 
       if (byPct) {
@@ -99,10 +99,13 @@ export function preparePlotData(
 
         for (let k = 0; k < dataLength; k++) {
           const v = currentlyStacking[k];
+          if (v != null && noValueStack[k]) {
+            noValueStack[k] = false;
+          }
           acc[k] += v == null ? 0 : v / (byPct ? groupTotals![k] : 1);
         }
 
-        result[seriesIdx] = acc.slice();
+        result[seriesIdx] = acc.slice().map((v, i) => (noValueStack[i] ? null : v));
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/43134

Instead of assuming null/undefined-only stacks to equal 0, we ignore those and not render on the visualization.

<details>
<summary>Test dashboard.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": "-- Grafana --",
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 668,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": [
          {
            "matcher": {
              "id": "byFrameRefID",
              "options": "B"
            },
            "properties": [
              {
                "id": "custom.drawStyle",
                "value": "bars"
              },
              {
                "id": "color",
                "value": {
                  "mode": "palette-classic"
                }
              },
              {
                "id": "custom.gradientMode",
                "value": "none"
              },
              {
                "id": "custom.barAlignment",
                "value": 1
              },
              {
                "id": "custom.stacking",
                "value": {
                  "group": "A",
                  "mode": "normal"
                }
              },
              {
                "id": "custom.spanNulls",
                "value": 3600000
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 8,
        "w": 8,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "hidden",
          "placement": "bottom"
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "csvContent": "\"Time\",\"Sum daily.cost_per_kwh\"\n1639612800000,\n1639872000000,0\n1639958400000,272\n1640044800000,272\n1640131200000,327\n1640217600000,290\n1640304000000,286\n1640390400000,256\n1640476800000,397\n1640563200000,295\n1640649600000,310\n1640736000000,224\n1640822400000,291\n1640908800000,265\n1640995200000,256\n1641081600000,399\n1641168000000,471\n1641254400000,325\n1641340800000,363\n1641427200000,375\n1641513600000,365\n1641600000000,492\n1641686400000,409\n1641772800000,371\n1641859200000,448\n1641945600000,372\n1642032000000,0\n1642118400000,0\n1642204800000,0\n1642291200000,0\n1642377600000,0\n1642464000000,0\n\n",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "hide": false,
          "refId": "A",
          "scenarioId": "csv_content"
        },
        {
          "csvContent": "\"Time\",\"Sum morning.cost_per_kwh\",\"Sum afternoon.cost_per_kwh\",\"Sum evening.cost_per_kwh\",\"Sum night.cost_per_kwh\",\"Sum late.cost_per_kwh\"\n1639612800000,0,0,0,0,0\n1639872000000,,,,,\n1639958400000,,,,,\n1640044800000,,,,,\n1640131200000,,,,,\n1640217600000,32,28,62,63,32\n1640304000000,,,,,\n1640390400000,,,,,\n1640476800000,,,,,\n1640563200000,,,,,\n1640649600000,,,,,\n1640736000000,,,,,\n1640822400000,47,53,68,96,45\n1640908800000,,,,,\n1640995200000,,,,,\n1641081600000,,,,,\n1641168000000,,,,,\n1641254400000,,,,,\n1641340800000,,,,,\n1641427200000,112,130,147,152,115\n1641513600000,,,,,\n1641600000000,,,,,\n1641686400000,,,,,\n1641772800000,,,,,\n1641859200000,,,,,\n1641945600000,,,,,\n1642032000000,0,0,0,0,0\n1642118400000,,,,,\n1642204800000,,,,,\n1642291200000,,,,,\n1642377600000,,,,,\n1642464000000,,,,,\n\n",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "hide": false,
          "refId": "B",
          "scenarioId": "csv_content"
        }
      ],
      "title": "Panel Title",
      "transformations": [],
      "type": "timeseries"
    },
    {
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": [
          {
            "matcher": {
              "id": "byFrameRefID",
              "options": "B"
            },
            "properties": [
              {
                "id": "custom.drawStyle",
                "value": "line"
              },
              {
                "id": "color",
                "value": {
                  "mode": "palette-classic"
                }
              },
              {
                "id": "custom.gradientMode",
                "value": "none"
              },
              {
                "id": "custom.barAlignment",
                "value": 1
              },
              {
                "id": "custom.stacking",
                "value": {
                  "group": "A",
                  "mode": "normal"
                }
              },
              {
                "id": "custom.spanNulls",
                "value": true
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 8,
        "w": 8,
        "x": 8,
        "y": 0
      },
      "id": 3,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "hidden",
          "placement": "bottom"
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "csvContent": "\"Time\",\"Sum daily.cost_per_kwh\"\n1639612800000,\n1639872000000,0\n1639958400000,272\n1640044800000,272\n1640131200000,327\n1640217600000,290\n1640304000000,286\n1640390400000,256\n1640476800000,397\n1640563200000,295\n1640649600000,310\n1640736000000,224\n1640822400000,291\n1640908800000,265\n1640995200000,256\n1641081600000,399\n1641168000000,471\n1641254400000,325\n1641340800000,363\n1641427200000,375\n1641513600000,365\n1641600000000,492\n1641686400000,409\n1641772800000,371\n1641859200000,448\n1641945600000,372\n1642032000000,0\n1642118400000,0\n1642204800000,0\n1642291200000,0\n1642377600000,0\n1642464000000,0\n\n",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "hide": false,
          "refId": "A",
          "scenarioId": "csv_content"
        },
        {
          "csvContent": "\"Time\",\"Sum morning.cost_per_kwh\",\"Sum afternoon.cost_per_kwh\",\"Sum evening.cost_per_kwh\",\"Sum night.cost_per_kwh\",\"Sum late.cost_per_kwh\"\n1639612800000,0,0,0,0,0\n1639872000000,,,,,\n1639958400000,,,,,\n1640044800000,,,,,\n1640131200000,,,,,\n1640217600000,32,28,62,63,32\n1640304000000,,,,,\n1640390400000,,,,,\n1640476800000,,,,,\n1640563200000,,,,,\n1640649600000,,,,,\n1640736000000,,,,,\n1640822400000,47,53,68,96,45\n1640908800000,,,,,\n1640995200000,,,,,\n1641081600000,,,,,\n1641168000000,,,,,\n1641254400000,,,,,\n1641340800000,,,,,\n1641427200000,112,130,147,152,115\n1641513600000,,,,,\n1641600000000,,,,,\n1641686400000,,,,,\n1641772800000,,,,,\n1641859200000,,,,,\n1641945600000,,,,,\n1642032000000,0,0,0,0,0\n1642118400000,,,,,\n1642204800000,,,,,\n1642291200000,,,,,\n1642377600000,,,,,\n1642464000000,,,,,\n\n",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "hide": false,
          "refId": "B",
          "scenarioId": "csv_content"
        }
      ],
      "title": "Connect null values = always",
      "transformations": [],
      "type": "timeseries"
    },
    {
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": [
          {
            "matcher": {
              "id": "byFrameRefID",
              "options": "B"
            },
            "properties": [
              {
                "id": "custom.drawStyle",
                "value": "line"
              },
              {
                "id": "color",
                "value": {
                  "mode": "palette-classic"
                }
              },
              {
                "id": "custom.gradientMode",
                "value": "none"
              },
              {
                "id": "custom.barAlignment",
                "value": 1
              },
              {
                "id": "custom.stacking",
                "value": {
                  "group": "A",
                  "mode": "normal"
                }
              },
              {
                "id": "custom.spanNulls",
                "value": false
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 8,
        "w": 8,
        "x": 16,
        "y": 0
      },
      "id": 4,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "hidden",
          "placement": "bottom"
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "csvContent": "\"Time\",\"Sum daily.cost_per_kwh\"\n1639612800000,\n1639872000000,0\n1639958400000,272\n1640044800000,272\n1640131200000,327\n1640217600000,290\n1640304000000,286\n1640390400000,256\n1640476800000,397\n1640563200000,295\n1640649600000,310\n1640736000000,224\n1640822400000,291\n1640908800000,265\n1640995200000,256\n1641081600000,399\n1641168000000,471\n1641254400000,325\n1641340800000,363\n1641427200000,375\n1641513600000,365\n1641600000000,492\n1641686400000,409\n1641772800000,371\n1641859200000,448\n1641945600000,372\n1642032000000,0\n1642118400000,0\n1642204800000,0\n1642291200000,0\n1642377600000,0\n1642464000000,0\n\n",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "hide": false,
          "refId": "A",
          "scenarioId": "csv_content"
        },
        {
          "csvContent": "\"Time\",\"Sum morning.cost_per_kwh\",\"Sum afternoon.cost_per_kwh\",\"Sum evening.cost_per_kwh\",\"Sum night.cost_per_kwh\",\"Sum late.cost_per_kwh\"\n1639612800000,0,0,0,0,0\n1639872000000,,,,,\n1639958400000,,,,,\n1640044800000,,,,,\n1640131200000,,,,,\n1640217600000,32,28,62,63,32\n1640304000000,,,,,\n1640390400000,,,,,\n1640476800000,,,,,\n1640563200000,,,,,\n1640649600000,,,,,\n1640736000000,,,,,\n1640822400000,47,53,68,96,45\n1640908800000,,,,,\n1640995200000,,,,,\n1641081600000,,,,,\n1641168000000,,,,,\n1641254400000,,,,,\n1641340800000,,,,,\n1641427200000,112,130,147,152,115\n1641513600000,,,,,\n1641600000000,,,,,\n1641686400000,,,,,\n1641772800000,,,,,\n1641859200000,,,,,\n1641945600000,,,,,\n1642032000000,0,0,0,0,0\n1642118400000,,,,,\n1642204800000,,,,,\n1642291200000,,,,,\n1642377600000,,,,,\n1642464000000,,,,,\n\n",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "hide": false,
          "refId": "B",
          "scenarioId": "csv_content"
        }
      ],
      "title": "Connect null values = never",
      "transformations": [],
      "type": "timeseries"
    }
  ],
  "refresh": false,
  "schemaVersion": 35,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "2021-12-14T04:26:06.328Z",
    "to": "2022-01-19T08:44:05.795Z"
  },
  "timepicker": {},
  "timezone": "",
  "title": "https://github.com/grafana/grafana/issues/43134",
  "uid": "YjRg3Rx7k",
  "version": 18,
  "weekStart": ""
}
```
</details>

|  BEFORE | AFTER  |
|---|---|
|<img width="1520" alt="Screen Shot 2022-01-21 at 15 05 03" src="https://user-images.githubusercontent.com/2376619/150543755-0585c135-e9b1-4a54-825f-fba755d42d9c.png">|<img width="1520" alt="Screen Shot 2022-01-21 at 15 22 28" src="https://user-images.githubusercontent.com/2376619/150543784-fb196f3d-dd93-41b4-8bc7-0fe79ed8435c.png">|


