### PR TITLE
Plugins: Make plugin loading for nested plugins more deterministic

### DIFF
--- a/pkg/plugins/manager/loader/finder/finder.go
+++ b/pkg/plugins/manager/loader/finder/finder.go
@@ -19,20 +19,20 @@ func New() Finder {
 	return Finder{log: log.New("plugin.finder")}
 }
 
-func (f *Finder) Find(pluginDirs []string) ([]string, error) {
+func (f *Finder) Find(pluginPaths []string) ([]string, error) {
 	var pluginJSONPaths []string
 
-	for _, dir := range pluginDirs {
-		exists, err := fs.Exists(dir)
+	for _, path := range pluginPaths {
+		exists, err := fs.Exists(path)
 		if err != nil {
-			f.log.Warn("Error occurred when checking if plugin directory exists", "dir", dir, "err", err)
+			f.log.Warn("Error occurred when checking if plugin directory exists", "path", path, "err", err)
 		}
 		if !exists {
-			f.log.Warn("Skipping finding plugins as directory does not exist", "dir", dir)
+			f.log.Warn("Skipping finding plugins as directory does not exist", "path", path)
 			continue
 		}
 
-		paths, err := f.getPluginJSONPaths(dir)
+		paths, err := f.getAbsPluginJSONPaths(path)
 		if err != nil {
 			return nil, err
 		}
@@ -42,16 +42,16 @@ func (f *Finder) Find(pluginDirs []string) ([]string, error) {
 	return pluginJSONPaths, nil
 }
 
-func (f *Finder) getPluginJSONPaths(dir string) ([]string, error) {
+func (f *Finder) getAbsPluginJSONPaths(path string) ([]string, error) {
 	var pluginJSONPaths []string
 
 	var err error
-	dir, err = filepath.Abs(dir)
+	path, err = filepath.Abs(path)
 	if err != nil {
 		return []string{}, err
 	}
 
-	if err := util.Walk(dir, true, true,
+	if err := util.Walk(path, true, true,
 		func(currentPath string, fi os.FileInfo, err error) error {
 			if err != nil {
 				return fmt.Errorf("filepath.Walk reported an error for %q: %w", currentPath, err)
@@ -73,11 +73,11 @@ func (f *Finder) getPluginJSONPaths(dir string) ([]string, error) {
 			return nil
 		}); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			f.log.Debug("Couldn't scan directory since it doesn't exist", "pluginDir", dir, "err", err)
+			f.log.Debug("Couldn't scan directory since it doesn't exist", "pluginDir", path, "err", err)
 			return []string{}, nil
 		}
 		if errors.Is(err, os.ErrPermission) {
-			f.log.Debug("Couldn't scan directory due to lack of permissions", "pluginDir", dir, "err", err)
+			f.log.Debug("Couldn't scan directory due to lack of permissions", "pluginDir", path, "err", err)
 			return []string{}, nil
 		}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Sometimes, depending on the order of file paths that are fed into the plugin loader component, we can get different results. This created issues for app plugins that have children, as it would use incorrect data to set certain fields. A test has been added to help prevent issues like this in the future.

[Here's an example in CI that highlights the issue](https://drone.grafana.net/grafana/grafana/48578/1/10)

