### PR TITLE
FeatureToggles: register all enterprise feature toggles

### DIFF
--- a/pkg/models/licensing.go
+++ b/pkg/models/licensing.go
@@ -14,6 +14,9 @@ type Licensing interface {
 
 	StateInfo() string
 
+	// List the enabled features
+	EnabledFeatures() map[string]bool
+
 	FeatureEnabled(feature string) bool
 }
 

--- a/pkg/services/featuremgmt/service.go
+++ b/pkg/services/featuremgmt/service.go
@@ -51,6 +51,23 @@ func ProvideManagerService(cfg *setting.Cfg, licensing models.Licensing) (*Featu
 		flag.Expression = fmt.Sprintf("%t", val) // true | false
 	}
 
+	// Make sure enterprise features are registered
+	for key, val := range licensing.EnabledFeatures() {
+		f, ok := mgmt.flags[key]
+		if ok {
+			f.RequiresLicense = true
+			if f.Expression == "" {
+				f.Expression = "true"
+			}
+		} else if val {
+			mgmt.registerFlags(FeatureFlag{
+				Name:            key,
+				RequiresLicense: true,
+				Expression:      "true",
+			})
+		}
+	}
+
 	// Load config settings
 	configfile := filepath.Join(cfg.HomePath, "conf", "features.yaml")
 	if _, err := os.Stat(configfile); err == nil {

--- a/pkg/services/featuremgmt/service_test.go
+++ b/pkg/services/featuremgmt/service_test.go
@@ -1,0 +1,62 @@
+package featuremgmt
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeatureService(t *testing.T) {
+	license := stubLicenseServier{
+		flags: map[string]bool{
+			"some.feature": true,
+			"another":      true,
+		},
+	}
+	cfg := setting.NewCfg()
+	mgmt, err := ProvideManagerService(cfg, license)
+	require.NoError(t, err)
+	require.NotNil(t, mgmt)
+
+	require.False(t, license.FeatureEnabled("test"))
+	require.True(t, license.FeatureEnabled("some.feature"))
+	require.True(t, mgmt.IsEnabled("some.feature"))
+}
+
+var (
+	_ models.Licensing = (*stubLicenseServier)(nil)
+)
+
+type stubLicenseServier struct {
+	flags map[string]bool
+}
+
+func (s stubLicenseServier) Expiry() int64 {
+	return 100
+}
+
+func (s stubLicenseServier) Edition() string {
+	return "test"
+}
+
+func (s stubLicenseServier) ContentDeliveryPrefix() string {
+	return ""
+}
+
+func (s stubLicenseServier) LicenseURL(showAdminLicensingPage bool) string {
+	return "http://??"
+}
+
+func (s stubLicenseServier) StateInfo() string {
+	return "ok"
+}
+
+func (s stubLicenseServier) EnabledFeatures() map[string]bool {
+	return s.flags
+}
+
+func (s stubLicenseServier) FeatureEnabled(feature string) bool {
+	return s.flags[feature]
+}


### PR DESCRIPTION
This is a simple solution to make sure all enterprise features are registered.

I think a better solution would be to let the enterprise license manager register features directly -- but that will require a bit more orchestration and coordination
