### PR TITLE
Formatters: speed up toDuration()

### DIFF
--- a/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
@@ -20,6 +20,17 @@ export enum Interval {
   Millisecond = 'millisecond',
 }
 
+const UNITS = [
+  Interval.Year,
+  Interval.Month,
+  Interval.Week,
+  Interval.Day,
+  Interval.Hour,
+  Interval.Minute,
+  Interval.Second,
+  Interval.Millisecond,
+];
+
 const INTERVALS_IN_SECONDS: IntervalsInSeconds = {
   [Interval.Year]: 31536000,
   [Interval.Month]: 2592000,
@@ -188,17 +199,6 @@ export function toDays(size: number, decimals?: DecimalCount): FormattedValue {
   }
 }
 
-const units = [
-  Interval.Year,
-  Interval.Month,
-  Interval.Week,
-  Interval.Day,
-  Interval.Hour,
-  Interval.Minute,
-  Interval.Second,
-  Interval.Millisecond,
-];
-
 export function toDuration(size: number, decimals: DecimalCount, timeScale: Interval): FormattedValue {
   if (size === null) {
     return { text: '' };
@@ -231,13 +231,13 @@ export function toDuration(size: number, decimals: DecimalCount, timeScale: Inte
     decimalsCount = decimals as number;
   }
 
-  for (let i = 0; i < units.length && decimalsCount >= 0; i++) {
-    const interval = INTERVALS_IN_SECONDS[units[i]] * 1000;
+  for (let i = 0; i < UNITS.length && decimalsCount >= 0; i++) {
+    const interval = INTERVALS_IN_SECONDS[UNITS[i]] * 1000;
     const value = size / interval;
     if (value >= 1 || decrementDecimals) {
       decrementDecimals = true;
       const floor = Math.floor(value);
-      const unit = units[i] + (floor !== 1 ? 's' : '');
+      const unit = UNITS[i] + (floor !== 1 ? 's' : '');
       strings.push(floor + ' ' + unit);
       size = size % interval;
       decimalsCount--;

--- a/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/dateTimeFormatters.ts
@@ -188,6 +188,17 @@ export function toDays(size: number, decimals?: DecimalCount): FormattedValue {
   }
 }
 
+const units = [
+  Interval.Year,
+  Interval.Month,
+  Interval.Week,
+  Interval.Day,
+  Interval.Hour,
+  Interval.Minute,
+  Interval.Second,
+  Interval.Millisecond,
+];
+
 export function toDuration(size: number, decimals: DecimalCount, timeScale: Interval): FormattedValue {
   if (size === null) {
     return { text: '' };
@@ -206,17 +217,6 @@ export function toDuration(size: number, decimals: DecimalCount, timeScale: Inte
     return v;
   }
 
-  const units = [
-    { long: Interval.Year },
-    { long: Interval.Month },
-    { long: Interval.Week },
-    { long: Interval.Day },
-    { long: Interval.Hour },
-    { long: Interval.Minute },
-    { long: Interval.Second },
-    { long: Interval.Millisecond },
-  ];
-
   // convert $size to milliseconds
   // intervals_in_seconds uses seconds (duh), convert them to milliseconds here to minimize floating point errors
   size *= INTERVALS_IN_SECONDS[timeScale] * 1000;
@@ -232,12 +232,12 @@ export function toDuration(size: number, decimals: DecimalCount, timeScale: Inte
   }
 
   for (let i = 0; i < units.length && decimalsCount >= 0; i++) {
-    const interval = INTERVALS_IN_SECONDS[units[i].long] * 1000;
+    const interval = INTERVALS_IN_SECONDS[units[i]] * 1000;
     const value = size / interval;
     if (value >= 1 || decrementDecimals) {
       decrementDecimals = true;
       const floor = Math.floor(value);
-      const unit = units[i].long + (floor !== 1 ? 's' : '');
+      const unit = units[i] + (floor !== 1 ? 's' : '');
       strings.push(floor + ' ' + unit);
       size = size % interval;
       decimalsCount--;


### PR DESCRIPTION
noticed this while reviewing the first iteration of https://github.com/grafana/grafana/pull/44046

not a major improvement, but worthwhile for something that can potentially run on every mousemove, and on thousands of datapoints if some form of https://github.com/grafana/grafana-plugin-sdk-go/pull/449 lands in the future.

this date/time formatting fn (and many others in the codebase) should probably get a thorough/consistent refactoring, but i didnt want this simple thing getting lost to time.