### PR TITLE
Cloud Monitoring: Reduce request size when listing labels

### DIFF
--- a/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
@@ -370,6 +370,22 @@ func TestTimeSeriesFilter(t *testing.T) {
 			assert.Equal(t, "test-proj - asia-northeast1-c - 6724404429462225363 - 200", frames[0].Fields[1].Name)
 		})
 	})
+
+	t.Run("Parse labels", func(t *testing.T) {
+		data, err := loadTestFile("./test-data/5-series-response-meta-data.json")
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(data.TimeSeries))
+		res := &backend.DataResponse{}
+		query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}}
+		err = query.parseResponse(res, data, "")
+		require.NoError(t, err)
+		frames := res.Frames
+		custom, ok := frames[0].Meta.Custom.(map[string]interface{})
+		require.True(t, ok)
+		labels, ok := custom["labels"].(map[string]string)
+		require.True(t, ok)
+		assert.Equal(t, "114250375703598695", labels["resource.label.instance_id"])
+	})
 }
 
 func loadTestFile(path string) (cloudMonitoringResponse, error) {

--- a/pkg/tsdb/cloudmonitoring/time_series_query_test.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_query_test.go
@@ -77,4 +77,28 @@ func TestTimeSeriesQuery(t *testing.T) {
 			assert.Equal(t, "test-proj - asia-northeast1-c - 6724404429462225363 - 200", frames[0].Fields[1].Name)
 		})
 	})
+
+	t.Run("Parse labels", func(t *testing.T) {
+		data, err := loadTestFile("./test-data/7-series-response-mql.json")
+		require.NoError(t, err)
+
+		fromStart := time.Date(2018, 3, 15, 13, 0, 0, 0, time.UTC).In(time.Local)
+		res := &backend.DataResponse{}
+		query := &cloudMonitoringTimeSeriesQuery{
+			ProjectName: "test-proj",
+			Query:       "test-query",
+			timeRange: backend.TimeRange{
+				From: fromStart,
+				To:   fromStart.Add(34 * time.Minute),
+			},
+		}
+		err = query.parseResponse(res, data, "")
+		require.NoError(t, err)
+		frames := res.Frames
+		custom, ok := frames[0].Meta.Custom.(map[string]interface{})
+		require.True(t, ok)
+		labels, ok := custom["labels"].(map[string]string)
+		require.True(t, ok)
+		assert.Equal(t, "6724404429462225363", labels["resource.label.instance_id"])
+	})
 }

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -179,19 +179,24 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
           const dataQueryResponse = toDataQueryResponse({
             data: data,
           });
-          return dataQueryResponse?.data
+          const labels = dataQueryResponse?.data
             .map((f) => f.meta?.custom?.labels)
             .filter((p) => !!p)
             .reduce((acc, labels) => {
               for (let key in labels) {
-                if (acc[key]) {
-                  acc[key].push(...labels[key]);
-                } else {
-                  acc[key] = labels[key];
+                if (!acc[key]) {
+                  acc[key] = new Set<string>();
                 }
+                acc[key].add(labels[key]);
               }
               return acc;
             }, {});
+          return Object.fromEntries(
+            Object.entries(labels).map((l: any) => {
+              l[1] = Array.from(l[1]);
+              return l;
+            })
+          );
         })
       )
     );

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -1,4 +1,4 @@
-import { chunk, flatten, isString, isArray, map as _map } from 'lodash';
+import { chunk, flatten, isString, isArray } from 'lodash';
 import { from, lastValueFrom, Observable, of } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 import {
@@ -179,7 +179,8 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
           const dataQueryResponse = toDataQueryResponse({
             data: data,
           });
-          return _map(dataQueryResponse?.data, 'meta.custom.labels')
+          return dataQueryResponse?.data
+            .map((f) => f.meta?.custom?.labels)
             .filter((p) => !!p)
             .reduce((acc, labels) => {
               for (let key in labels) {

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -187,7 +187,9 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
                 if (!acc[key]) {
                   acc[key] = new Set<string>();
                 }
-                acc[key].add(labels[key]);
+                if (labels[key]) {
+                  acc[key].add(labels[key]);
+                }
               }
               return acc;
             }, {});

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -1,4 +1,4 @@
-import { chunk, flatten, isString, isArray } from 'lodash';
+import { chunk, flatten, isString, isArray, map as _map } from 'lodash';
 import { from, lastValueFrom, Observable, of } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 import {
@@ -179,7 +179,18 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
           const dataQueryResponse = toDataQueryResponse({
             data: data,
           });
-          return dataQueryResponse?.data[0]?.meta?.custom?.labels ?? {};
+          return _map(dataQueryResponse?.data, 'meta.custom.labels')
+            .filter((p) => !!p)
+            .reduce((acc, labels) => {
+              for (let key in labels) {
+                if (acc[key]) {
+                  acc[key].push(...labels[key]);
+                } else {
+                  acc[key] = labels[key];
+                }
+              }
+              return acc;
+            }, {});
         })
       )
     );


### PR DESCRIPTION
**What this PR does / why we need it**:
Cloud Monitoring amplify response size from v8.3.
It cause memory shortage and crash in some environment.

By splitting meta data and relocate it to each frames, the response size could be reduced.
I tested this change locally, and confirm that response size is significantly reduced. (63.06MB -> 3.60MB)

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/44190

**Special notes for your reviewer**:

