### PR TITLE
Renovate: Separate storybook deps from monthly patches

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,8 +31,14 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],
+      "excludePackagePatterns": ["@storybook"],
       "extends": ["schedule:monthly"],
       "groupName": "Monthly patch updates"
+    },
+    {
+      "matchPackagePatterns": ["@storybook"],
+      "extends": ["schedule:monthly"],
+      "groupName": "Storybook updates"
     }
   ],
   "pin": {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Storybook is an amazing tool that helps both devs and consumers of our component library however bumping it isn't always the easiest of tasks. To try to reduce the impact this can have on renovates monthly patches this PR splits out the storybook dependencies into their own monthly patch update.
