### PR TITLE
Tempo: Auto-clear results when changing query type

### DIFF
--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -86,6 +86,16 @@ class TempoQueryFieldComponent extends React.PureComponent<Props, State> {
     this.props.onRunQuery();
   };
 
+  onClearResults = () => {
+    // Run clear query to clear results
+    const { onChange, query, onRunQuery } = this.props;
+    onChange({
+      ...query,
+      queryType: 'clear',
+    });
+    onRunQuery();
+  };
+
   render() {
     const { query, onChange, datasource } = this.props;
     // Find query field from linked datasource
@@ -124,14 +134,8 @@ class TempoQueryFieldComponent extends React.PureComponent<Props, State> {
               options={queryTypeOptions}
               value={query.queryType}
               onChange={(v) => {
-                // Run clear query to clear results
-                onChange({
-                  ...query,
-                  queryType: 'clear',
-                });
-                this.props.onRunQuery();
+                this.onClearResults();
 
-                // Update to actual query type
                 onChange({
                   ...query,
                   queryType: v,

--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -123,12 +123,20 @@ class TempoQueryFieldComponent extends React.PureComponent<Props, State> {
             <RadioButtonGroup<TempoQueryType>
               options={queryTypeOptions}
               value={query.queryType}
-              onChange={(v) =>
+              onChange={(v) => {
+                // Run clear query to clear results
+                onChange({
+                  ...query,
+                  queryType: 'clear',
+                });
+                this.props.onRunQuery();
+
+                // Update to actual query type
                 onChange({
                   ...query,
                   queryType: v,
-                })
-              }
+                });
+              }}
               size="md"
             />
           </InlineField>

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -28,7 +28,7 @@ import {
 import { NodeGraphOptions } from 'app/core/components/NodeGraphSettings';
 
 // search = Loki search, nativeSearch = Tempo search for backwards compatibility
-export type TempoQueryType = 'search' | 'traceId' | 'serviceMap' | 'upload' | 'nativeSearch';
+export type TempoQueryType = 'search' | 'traceId' | 'serviceMap' | 'upload' | 'nativeSearch' | 'clear';
 
 export interface TempoJsonData extends DataSourceJsonData {
   tracesToLogs?: TraceToLogsOptions;
@@ -89,6 +89,10 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     const subQueries: Array<Observable<DataQueryResponse>> = [];
     const filteredTargets = options.targets.filter((target) => !target.hide);
     const targets: { [type: string]: TempoQuery[] } = groupBy(filteredTargets, (t) => t.queryType || 'traceId');
+
+    if (targets.clear) {
+      return of({ data: [], state: LoadingState.Done });
+    }
 
     // Run search queries on linked datasource
     if (this.tracesToLogs?.datasourceUid && targets.search?.length > 0) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Automatically clears results in Tempo when changing query types. Users have reported its confusing to have old results especially when first using the service graph query type. 

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
https://user-images.githubusercontent.com/12838032/150826443-2e7f26c2-42df-4b0d-817f-1ca4fe6152d6.mov


