### PR TITLE
Alerting: Use time.Ticker instead of alerting.Ticker in ngalert

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -137,7 +137,7 @@ func (ng *AlertNG) init() error {
 		appUrl = nil
 	}
 	stateManager := state.NewManager(ng.Log, ng.Metrics.GetStateMetrics(), appUrl, store, store)
-	scheduler := schedule.NewScheduler(schedCfg, ng.ExpressionService, appUrl, stateManager)
+	scheduler := schedule.NewScheduler(schedCfg, ng.ExpressionService, appUrl, stateManager, nil)
 
 	ng.stateManager = stateManager
 	ng.schedule = scheduler

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -353,11 +353,12 @@ func (sch *schedule) adminConfigSync(ctx context.Context) error {
 }
 
 func (sch *schedule) ruleEvaluationLoop(ctx context.Context) error {
+	var tickNum int64
 	dispatcherGroup, ctx := errgroup.WithContext(ctx)
 	for {
 		select {
 		case tick := <-sch.ticker.C():
-			tickNum := tick.Unix() / int64(sch.baseInterval.Seconds())
+			tickNum += 1
 			disabledOrgs := make([]int64, 0, len(sch.disabledOrgs))
 			for disabledOrg := range sch.disabledOrgs {
 				disabledOrgs = append(disabledOrgs, disabledOrg)

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -944,7 +944,8 @@ func setupScheduler(t *testing.T, rs store.RuleStore, is store.InstanceStore, ac
 		Scheme: "http",
 		Host:   "localhost",
 	}
-	return NewScheduler(schedCfg, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil), appUrl, st), mockedClock
+	ticker := NewDefaultTicker(schedCfg.BaseInterval)
+	return NewScheduler(schedCfg, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil), appUrl, st, ticker), mockedClock
 }
 
 // createTestAlertRule creates a dummy alert definition to be used by the tests.

--- a/pkg/services/ngalert/schedule/tick.go
+++ b/pkg/services/ngalert/schedule/tick.go
@@ -1,0 +1,73 @@
+package schedule
+
+import (
+	"time"
+)
+
+// Ticker is an interface for time.Ticker and similar tickers.
+type Ticker interface {
+	// C returns the chan on which ticks are received.
+	C() <-chan time.Time
+
+	// Reset stops the ticker and resets its interval to the
+	// specified duration.
+	Reset(time.Duration)
+
+	// Stop stops the ticker.
+	Stop()
+}
+
+// DefaultTicker is a time.Ticker.
+type DefaultTicker struct {
+	Ticker *time.Ticker
+}
+
+func (t *DefaultTicker) C() <-chan time.Time {
+	return t.Ticker.C
+}
+
+func (t *DefaultTicker) Reset(d time.Duration) {
+	t.Ticker.Reset(d)
+}
+
+func (t *DefaultTicker) Stop() {
+	t.Ticker.Stop()
+}
+
+func NewDefaultTicker(d time.Duration) Ticker {
+	return &DefaultTicker{Ticker: time.NewTicker(d)}
+}
+
+// TestTicker is a ticker where the next tick is sent on each
+// call to Tick.
+type TestTicker struct {
+	interval time.Duration
+	last     time.Time
+	ticks    chan time.Time
+}
+
+// Tick sends the next tick with the time interval seconds
+// after the last tick. Tick will block if no receivers are
+// waiting to receive the next tick.
+func (t *TestTicker) Tick() time.Time {
+	next := t.last.Add(t.interval)
+	t.ticks <- next
+	t.last = next
+	return next
+}
+
+func (t *TestTicker) C() <-chan time.Time {
+	return t.ticks
+}
+
+func (t *TestTicker) Reset(_ time.Duration) {}
+func (t *TestTicker) Stop()                 {}
+
+// NewTestTicker returns a new test ticker for the interval.
+func NewTestTicker(interval time.Duration) *TestTicker {
+	return &TestTicker{
+		interval: interval,
+		last:     time.Now(),
+		ticks:    make(chan time.Time),
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit changes the ticker in the ngalert scheduler from one that does not drop ticks for slow receivers to one that will drop ticks.

The motivation for making this change is that we have observed situations where the timestamps of firing alerts are not the real time that the alert fired, but instead some time in the past. This happens when the scheduler cannot schedule the evaluation of all alert rules before the next tick arrives and as such, when using a ticker that doesn't drop ticks, will start to receive ticks late. However, changing the ticker to one that will drop ticks will mean that, even for slow schedulers, the timestamps for firing alerts will have the real time that the alert fired.

**Which issue(s) this PR fixes**:

#43031 

