### PR TITLE
Docs: fix spelling error in trace to logs settings

### DIFF
--- a/public/app/core/components/TraceToLogsSettings.tsx
+++ b/public/app/core/components/TraceToLogsSettings.tsx
@@ -33,7 +33,7 @@ export function TraceToLogsSettings({ options, onOptionsChange }: Props) {
       <h3 className="page-heading">Trace to logs</h3>
 
       <div className={styles.infoText}>
-        Trace to logs let&apos;s you navigate from a trace span to the selected data source&apos;s log.
+        Trace to logs lets you navigate from a trace span to the selected data source&apos;s log.
       </div>
 
       <InlineFieldRow>


### PR DESCRIPTION
"Let's" is an abbreviation of "let us", which is not the right use in
this sentence on the settings page.


**What this PR does / why we need it**:

Fixes a spelling error.

**Which issue(s) this PR fixes**:

Did not create an issue for this issue.

**Special notes for your reviewer**: I'm not sure any are necessary.