### PR TITLE
Alerting: Move slow queries in the scheduler to another goroutine

### DIFF
--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -554,7 +554,7 @@ func TestAlertAndGroupsQuery(t *testing.T) {
 			}
 
 			return false
-		}, 18*time.Second, 2*time.Second)
+		}, 30*time.Second, 2*time.Second)
 	}
 }
 

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -829,7 +829,7 @@ func TestNotificationChannels(t *testing.T) {
 	// nolint:gosec
 	require.Eventually(t, func() bool {
 		return mockChannel.totalNotifications() >= len(nonEmailAlertNames) && len(mockEmail.emails) >= 1
-	}, 30*time.Second, 1*time.Second)
+	}, 60*time.Second, 1*time.Second)
 
 	mockChannel.matchesExpNotifications(t, expNonEmailNotifications)
 	require.Equal(t, expEmailNotifications, mockEmail.emails)


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit moves retrieving alert rules from the database out of `ruleEvaluationLoop` and to another goroutine. This fixes an issue where querying 100s or more alert rules can cause each tick in `ruleEvaluationLoop` to take longer than the tick interval, such that the scheduler cannot keep up with the rate of ticks.

**Which issue(s) this PR fixes**:

#43031 