### PR TITLE
CODEOWNERS: update based on o11y squad changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@ go.sum @grafana/backend-platform
 /scripts/drone/ @grafana/grafana-release-eng
 
 # Cloud Datasources backend code
+/pkg/tsdb/cloudwatch @grafana/cloud-datasources
 /pkg/tsdb/azuremonitor @grafana/cloud-datasources
 /pkg/tsdb/cloudmonitoring @grafana/cloud-datasources
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -106,6 +106,7 @@ go.sum @grafana/backend-platform
 /public/app/plugins/panel/barchart @grafana/grafana-bi-squad
 /public/app/plugins/panel/heatmap @grafana/grafana-bi-squad
 /public/app/plugins/panel/histogram @grafana/grafana-bi-squad
+/public/app/plugins/panel/logs @grafana/logs-traces-squad
 /public/app/plugins/panel/nodeGraph @grafana/logs-traces-squad
 /public/app/plugins/panel/piechart @grafana/grafana-bi-squad
 /public/app/plugins/panel/state-timeline @grafana/grafana-bi-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,18 +30,18 @@ go.sum @grafana/backend-platform
 /scripts/drone/ @grafana/grafana-release-eng
 
 # Cloud Datasources backend code
-/pkg/tsdb/cloudwatch @grafana/cloud-datasources @grafana/observability-squad
 /pkg/tsdb/azuremonitor @grafana/cloud-datasources
 /pkg/tsdb/cloudmonitoring @grafana/cloud-datasources
 
 # Observability backend code
-/pkg/tsdb/influxdb @grafana/observability-squad
-/pkg/tsdb/elasticsearch @grafana/observability-squad
-/pkg/tsdb/graphite @grafana/observability-squad
-/pkg/tsdb/jaeger @grafana/observability-squad
-/pkg/tsdb/loki @grafana/observability-squad
-/pkg/tsdb/zipkin @grafana/observability-squad
-/pkg/tsdb/tempo @grafana/observability-squad
+/pkg/tsdb/prometheus @grafana/observability-metrics
+/pkg/tsdb/influxdb @grafana/observability-metrics
+/pkg/tsdb/elasticsearch @grafana/logs-traces-squad
+/pkg/tsdb/graphite @grafana/observability-metrics
+/pkg/tsdb/jaeger @grafana/logs-traces-squad
+/pkg/tsdb/loki @grafana/logs-traces-squad
+/pkg/tsdb/zipkin @grafana/logs-traces-squad
+/pkg/tsdb/tempo @grafana/logs-traces-squad
 
 # BI backend code
 /pkg/tsdb/mysql @grafana/grafana-bi-squad
@@ -89,7 +89,7 @@ go.sum @grafana/backend-platform
 /packages/grafana-ui/src/components/TimeSeries @grafana/grafana-bi-squad
 /packages/grafana-ui/src/components/uPlot @grafana/grafana-bi-squad
 /packages/grafana-ui/src/utils/storybook @grafana/plugins-platform-frontend
-/packages/jaeger-ui-components/ @grafana/observability-squad
+/packages/jaeger-ui-components/ @grafana/logs-traces-squad
 /plugins-bundled @grafana/plugins-platform-frontend
 # public folder
 /public/app/core/components/TimePicker @grafana/grafana-bi-squad
@@ -98,14 +98,14 @@ go.sum @grafana/backend-platform
 /public/app/features/dimensions/ @grafana/grafana-edge-squad
 /public/app/features/geo/ @grafana/grafana-edge-squad
 /public/app/features/live/ @grafana/grafana-edge-squad
-/public/app/features/explore/ @grafana/observability-squad
+/public/app/features/explore/ @grafana/observability-experience-squad
 /public/app/features/plugins @grafana/plugins-platform-frontend
 /public/app/core/components/TransformersUI/spatial @grafana/grafana-edge-squad
 /public/app/plugins/panel/alertlist @grafana/alerting-squad
 /public/app/plugins/panel/barchart @grafana/grafana-bi-squad
 /public/app/plugins/panel/heatmap @grafana/grafana-bi-squad
 /public/app/plugins/panel/histogram @grafana/grafana-bi-squad
-/public/app/plugins/panel/nodeGraph @grafana/observability-squad
+/public/app/plugins/panel/nodeGraph @grafana/logs-traces-squad
 /public/app/plugins/panel/piechart @grafana/grafana-bi-squad
 /public/app/plugins/panel/state-timeline @grafana/grafana-bi-squad
 /public/app/plugins/panel/status-history @grafana/grafana-bi-squad
@@ -136,21 +136,21 @@ lerna.json @grafana/frontend-ops
 *.mdx @marcusolsson @jessover9000 @grafana/plugins-platform-frontend
 
 # Core datasources
-/public/app/plugins/datasource/cloudwatch @grafana/cloud-datasources @grafana/observability-squad
-/public/app/plugins/datasource/elasticsearch @grafana/observability-squad
+/public/app/plugins/datasource/cloudwatch @grafana/cloud-datasources
+/public/app/plugins/datasource/elasticsearch @grafana/logs-traces-squad
 /public/app/plugins/datasource/grafana-azure-monitor-datasource @grafana/cloud-datasources
-/public/app/plugins/datasource/graphite @grafana/observability-squad
-/public/app/plugins/datasource/influxdb @grafana/observability-squad
-/public/app/plugins/datasource/jaeger @grafana/observability-squad
-/public/app/plugins/datasource/loki @grafana/observability-squad
+/public/app/plugins/datasource/graphite @grafana/observability-metrics
+/public/app/plugins/datasource/influxdb @grafana/observability-metrics
+/public/app/plugins/datasource/jaeger @grafana/logs-traces-squad
+/public/app/plugins/datasource/loki @grafana/logs-traces-squad
 /public/app/plugins/datasource/mssql @grafana/grafana-bi-squad
 /public/app/plugins/datasource/mysql @grafana/grafana-bi-squad
 /public/app/plugins/datasource/opentsdb @grafana/backend-platform
 /public/app/plugins/datasource/postgres @grafana/grafana-bi-squad
-/public/app/plugins/datasource/prometheus @grafana/observability-squad
+/public/app/plugins/datasource/prometheus @grafana/observability-metrics
 /public/app/plugins/datasource/cloud-monitoring @grafana/cloud-datasources
-/public/app/plugins/datasource/zipkin @grafana/observability-squad
-/public/app/plugins/datasource/tempo @grafana/observability-squad
+/public/app/plugins/datasource/zipkin @grafana/logs-traces-squad
+/public/app/plugins/datasource/tempo @grafana/logs-traces-squad
 /public/app/plugins/datasource/alertmanager @grafana/alerting-squad
 
 # Cloud middleware


### PR DESCRIPTION
i did four things:
1. i added `/pkg/tsdb/prometheus @grafana/observability-metrics`
2. i added `/public/app/plugins/panel/logs @grafana/logs-traces-squad`
3. i removed `@grafana/observability-squad` from cloudwatch-related things
3. i searched for every instance of `@grafana/observability-squad` and replaced it with one of the three new squads