### PR TITLE
CodeQL: Ignore go/log-injection for terminal logger

### DIFF
--- a/pkg/infra/log/term/terminal_logger.go
+++ b/pkg/infra/log/term/terminal_logger.go
@@ -47,9 +47,9 @@ func (l terminalLogger) Log(keyvals ...interface{}) error {
 	b := &bytes.Buffer{}
 	lvl := strings.ToUpper(r.level.String())
 	if r.color > 0 {
-		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %s ", r.color, lvl, r.time.Format(termTimeFormat), r.msg)
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %s ", r.color, lvl, r.time.Format(termTimeFormat), r.msg) // lgtm[go/log-injection
 	} else {
-		fmt.Fprintf(b, "[%s] [%s] %s ", lvl, r.time.Format(termTimeFormat), r.msg)
+		fmt.Fprintf(b, "[%s] [%s] %s ", lvl, r.time.Format(termTimeFormat), r.msg) // lgtm[go/log-injection
 	}
 
 	// try to justify the log output for short messages
@@ -148,7 +148,7 @@ func logfmt(buf *bytes.Buffer, ctx []interface{}, color int) {
 
 		// XXX: we should probably check that all of your key bytes aren't invalid
 		if color > 0 {
-			fmt.Fprintf(buf, "\x1b[%dm%s\x1b[0m=%s", color, k, v)
+			fmt.Fprintf(buf, "\x1b[%dm%s\x1b[0m=%s", color, k, v) // lgtm[go/log-injection
 		} else {
 			buf.WriteString(k)
 			buf.WriteByte('=')

--- a/pkg/infra/log/term/terminal_logger.go
+++ b/pkg/infra/log/term/terminal_logger.go
@@ -47,9 +47,9 @@ func (l terminalLogger) Log(keyvals ...interface{}) error {
 	b := &bytes.Buffer{}
 	lvl := strings.ToUpper(r.level.String())
 	if r.color > 0 {
-		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %s ", r.color, lvl, r.time.Format(termTimeFormat), r.msg) // lgtm[go/log-injection
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%s] %s ", r.color, lvl, r.time.Format(termTimeFormat), r.msg) // lgtm[go/log-injection]
 	} else {
-		fmt.Fprintf(b, "[%s] [%s] %s ", lvl, r.time.Format(termTimeFormat), r.msg) // lgtm[go/log-injection
+		fmt.Fprintf(b, "[%s] [%s] %s ", lvl, r.time.Format(termTimeFormat), r.msg) // lgtm[go/log-injection]
 	}
 
 	// try to justify the log output for short messages
@@ -148,7 +148,7 @@ func logfmt(buf *bytes.Buffer, ctx []interface{}, color int) {
 
 		// XXX: we should probably check that all of your key bytes aren't invalid
 		if color > 0 {
-			fmt.Fprintf(buf, "\x1b[%dm%s\x1b[0m=%s", color, k, v) // lgtm[go/log-injection
+			fmt.Fprintf(buf, "\x1b[%dm%s\x1b[0m=%s", color, k, v) // lgtm[go/log-injection]
 		} else {
 			buf.WriteString(k)
 			buf.WriteByte('=')


### PR DESCRIPTION
**What this PR does / why we need it**:
Suppresses a couple of code scanning errors in the terminal logger.

https://github.com/grafana/grafana/security/code-scanning/223?query=ref%3Arefs%2Fheads%2Fmain
https://github.com/grafana/grafana/security/code-scanning/222?query=ref%3Arefs%2Fheads%2Fmain
https://github.com/grafana/grafana/security/code-scanning/221?query=ref%3Arefs%2Fheads%2Fmain

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
As noted [here](https://help.semmle.com/lgtm-enterprise/user/help/alert-suppression.html) this might not resolve until the PR has been merged:
> If you've enabled automated code review of pull requests for your projects, it's important to note that alert suppression changes made in a pull request are only applied when that pull request is merged. So, if you suppress an alert in a pull request, LGTM will continue to report the related alert for as long as the pull request is open. For more information, see Automated code review FAQs.
