### PR TITLE
Logger: avoid panic when time is a string (not fmt.Stringer)

### DIFF
--- a/pkg/infra/log/term/terminal_logger.go
+++ b/pkg/infra/log/term/terminal_logger.go
@@ -91,12 +91,36 @@ func getRecord(keyvals ...interface{}) *record {
 		k, v := keyvals[i], keyvals[i+1]
 
 		if k == "t" {
-			t := v.(fmt.Stringer)
-			time, err := time.Parse("2006-01-02T15:04:05.999999999-0700", t.String())
-			if err == nil {
-				r.time = time
+			t, ok := v.(fmt.Stringer)
+			if ok {
+				time, err := time.Parse("2006-01-02T15:04:05.999999999-0700", t.String())
+				if err == nil {
+					r.time = time
+					continue
+				}
 			}
-			continue
+
+			// t2, ok := v.(time.Time)
+			// if ok {
+			// 	r.time = t2
+			// 	continue
+			// }
+
+			fmt.Printf("XXXXXXXXXXXXXXXXXXXXXX\n")
+			fmt.Printf("XXXXXXXXXXXXXXXXXXXXXX\n")
+			fmt.Printf("XXXXXXXXXXXXXXXXXXXXXX BAD LINE: %v (%T)\n", v, v)
+			fmt.Printf("XXXXXXXXXXXXXXXXXXXXXX\n")
+			fmt.Printf("XXXXXXXXXXXXXXXXXXXXXX\n")
+
+			t3, ok := v.(string)
+			if ok {
+				// from alerting:        2022-01-26T12:03:41.655107858-08:00
+				time, err := time.Parse("2006-01-02T15:04:05.999999999-07:00", t3)
+				if err == nil {
+					r.time = time
+					continue
+				}
+			}
 		}
 
 		if keyvals[i] == "msg" {

--- a/pkg/infra/log/term/terminal_logger.go
+++ b/pkg/infra/log/term/terminal_logger.go
@@ -100,18 +100,6 @@ func getRecord(keyvals ...interface{}) *record {
 				}
 			}
 
-			// t2, ok := v.(time.Time)
-			// if ok {
-			// 	r.time = t2
-			// 	continue
-			// }
-
-			fmt.Printf("XXXXXXXXXXXXXXXXXXXXXX\n")
-			fmt.Printf("XXXXXXXXXXXXXXXXXXXXXX\n")
-			fmt.Printf("XXXXXXXXXXXXXXXXXXXXXX BAD LINE: %v (%T)\n", v, v)
-			fmt.Printf("XXXXXXXXXXXXXXXXXXXXXX\n")
-			fmt.Printf("XXXXXXXXXXXXXXXXXXXXXX\n")
-
 			t3, ok := v.(string)
 			if ok {
 				// from alerting:        2022-01-26T12:03:41.655107858-08:00


### PR DESCRIPTION
This PR fixes a panic I now see periodically:
![image](https://user-images.githubusercontent.com/705951/151244014-ca9f03b9-7781-477f-8a38-86264a1df78b.png)
