### PR TITLE
cue: Add central context and Thema library pkg

### DIFF
--- a/internal/cuectx/ctx.go
+++ b/internal/cuectx/ctx.go
@@ -1,0 +1,23 @@
+// Package cuectx provides a single, central CUE context (runtime) and Thema
+// library that can be used uniformly across Grafana.
+
+package cuectx
+
+import (
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/grafana/thema"
+)
+
+var ctx *cue.Context = cuecontext.New()
+var lib thema.Library = thema.NewLibrary(ctx)
+
+// ProvideCUEContext is a wire service provider of a central cue.Context.
+func ProvideCUEContext() *cue.Context {
+	return ctx
+}
+
+// ProvideThemaLibrary is a wire service provider of a central thema.Library.
+func ProvideThemaLibrary() thema.Library {
+	return lib
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

To avoid CUE-related operations becoming unintentionally non-interoperable, they all have to descend from the same `cue.Context`. This introduces a simple central package that can either be used via dependency injection, or just with direct calls (with both resulting in the same context or Thema library)
