### PR TITLE
loki: added benchmark for metric-response processing

### DIFF
--- a/pkg/tsdb/loki/loki_bench_test.go
+++ b/pkg/tsdb/loki/loki_bench_test.go
@@ -1,0 +1,58 @@
+package loki
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// when memory-profiling these benchmarks these commands are recommended
+// - go test -benchmem -run=^$ -benchtime 1x -memprofile memprofile.out -memprofilerate 1 -bench ^BenchmarkMatrixJson$ github.com/grafana/grafana/pkg/tsdb/loki
+// - go tool pprof -http=localhost:6061 memprofile.out
+func BenchmarkMatrixJson(b *testing.B) {
+	bytes := createJsonTestData(1642000000, 1, 300, 400)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, _ = runQuery(makeMockedClient(200, "application/json", bytes), &lokiQuery{})
+	}
+}
+
+const nanRate = 0.002
+
+// we build the JSON file from strings,
+// it was easier to write it this way.
+func makeJsonTestMetric(index int) string {
+	return fmt.Sprintf(`{"server":"main","category":"maintenance","case":"%v"}`, index)
+}
+
+// return a value between -100 and +100, sometimes NaN, in string
+func makeJsonTestValue(r *rand.Rand) string {
+	if r.Float64() < nanRate {
+		return "NaN"
+	} else {
+		return fmt.Sprintf("%f", (r.Float64()*200)-100)
+	}
+}
+
+// create one time-series
+func makeJsonTestSeries(start int64, step int64, timestampCount int, r *rand.Rand, seriesIndex int) string {
+	var values []string
+	for i := 0; i < timestampCount; i++ {
+		value := fmt.Sprintf(`[%d,"%v"]`, start+(int64(i)*step), makeJsonTestValue(r))
+		values = append(values, value)
+	}
+	return fmt.Sprintf(`{"metric":%v,"values":[%v]}`, makeJsonTestMetric(seriesIndex), strings.Join(values, ","))
+}
+
+func createJsonTestData(start int64, step int64, timestampCount int, seriesCount int) []byte {
+	// we use random numbers as values, but they have to be the same numbers
+	// every time we call this, so we create a random source.
+	r := rand.New(rand.NewSource(42))
+	var allSeries []string
+	for i := 0; i < seriesCount; i++ {
+		allSeries = append(allSeries, makeJsonTestSeries(start, step, timestampCount, r, i))
+	}
+	return []byte(fmt.Sprintf(`{"data":{"resultType":"matrix","result":[%v]},"status":"success"}`, strings.Join(allSeries, ",")))
+}


### PR DESCRIPTION
(NOTE: this is the same benchmark that we added to prometheus too, in https://github.com/grafana/grafana/pull/44309)

this pull request adds a benchmark for processing a large JSON matrix response file in the loki grafana backend:
- we generate the JSON file, filled with random numbers (they are always the same random numbers, so it is fixed)
- and benchmark it using the standard go benchmark approach

how to test:
1. you will need the `graphviz` tools installed (for example using `brew` on Mac, or by your package manager)
2. in the git project root folder
3. run `go test -benchmem -run=^$ -benchtime 1x -memprofile memprofile.out -memprofilerate 1 -bench ^BenchmarkMatrixJson$ github.com/grafana/grafana/pkg/tsdb/loki`
4. the command should end without errors, it should print out information about the run, the interesting number is the one by the `B/op`, for example `55000000 B/op` would mean the benchmark used 55MB of memory
    - it also writes out some debug-info, i think that's written out by the loki-client-library, ignore those lines
5. the command also produced a file called `memprofile.out`, which contain detailed memory profiling info
6. run `go tool pprof -http=localhost:6061 memprofile.out`
    - it might complain that you do not have some tools installed, you need the `graphviz` tools
7. this will run a small webserver on `localhost:6061`, and should also open a browser-window on your computer showing a webpage with a graph-representation of the memory used