### PR TITLE
AccessControl: SQL filters for team search

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -198,8 +198,8 @@ func (hs *HTTPServer) registerRoutes() {
 
 		// team without requirement of user to be org admin
 		apiRoute.Group("/teams", func(teamsRoute routing.RouteRegister) {
-			teamsRoute.Get("/:teamId", routing.Wrap(hs.GetTeamByID))
-			teamsRoute.Get("/search", routing.Wrap(hs.SearchTeams))
+			teamsRoute.Get("/:teamId", authorize(reqSignedIn, ac.EvalPermission(ac.ActionTeamsRead, ac.ScopeTeamsID)), routing.Wrap(hs.GetTeamByID))
+			teamsRoute.Get("/search", authorize(reqSignedIn, ac.EvalPermission(ac.ActionTeamsRead)), routing.Wrap(hs.SearchTeams))
 		})
 
 		// org information available to all users.

--- a/pkg/api/team.go
+++ b/pkg/api/team.go
@@ -130,12 +130,10 @@ func (hs *HTTPServer) SearchTeams(c *models.ReqContext) response.Response {
 		page = 1
 	}
 
-	var userIdFilter int64
 	// Using accesscontrol the filtering is done based on user permissions
+	userIdFilter := models.FilterIgnoreUser
 	if !hs.Features.IsEnabled(featuremgmt.FlagAccesscontrol) {
-		if hs.Cfg.EditorsCanAdmin && c.OrgRole != models.ROLE_ADMIN {
-			userIdFilter = userFilter(hs.Cfg.EditorsCanAdmin, c)
-		}
+		userIdFilter = userFilter(hs.Cfg.EditorsCanAdmin, c)
 	}
 
 	query := models.SearchTeamsQuery{
@@ -209,12 +207,18 @@ func (hs *HTTPServer) GetTeamByID(c *models.ReqContext) response.Response {
 		return response.Error(http.StatusBadRequest, "teamId is invalid", err)
 	}
 
+	// Using accesscontrol the filtering has already been performed at middleware layer
+	userIdFilter := models.FilterIgnoreUser
+	if !hs.Features.IsEnabled(featuremgmt.FlagAccesscontrol) {
+		userIdFilter = userFilter(hs.Cfg.EditorsCanAdmin, c)
+	}
+
 	query := models.GetTeamByIdQuery{
 		OrgId:        c.OrgId,
 		Id:           teamId,
 		SignedInUser: c.SignedInUser,
 		HiddenUsers:  hs.Cfg.HiddenUsers,
-		UserIdFilter: userFilter(hs.Cfg.EditorsCanAdmin, c),
+		UserIdFilter: userIdFilter,
 	}
 
 	if err := hs.SQLStore.GetTeamById(c.Req.Context(), &query); err != nil {

--- a/pkg/api/team.go
+++ b/pkg/api/team.go
@@ -130,11 +130,19 @@ func (hs *HTTPServer) SearchTeams(c *models.ReqContext) response.Response {
 		page = 1
 	}
 
+	var userIdFilter int64
+	// Using accesscontrol the filtering is done based on user permissions
+	if !hs.Features.IsEnabled(featuremgmt.FlagAccesscontrol) {
+		if hs.Cfg.EditorsCanAdmin && c.OrgRole != models.ROLE_ADMIN {
+			userIdFilter = userFilter(hs.Cfg.EditorsCanAdmin, c)
+		}
+	}
+
 	query := models.SearchTeamsQuery{
 		OrgId:        c.OrgId,
 		Query:        c.Query("query"),
 		Name:         c.Query("name"),
-		UserIdFilter: userFilter(hs.Cfg.EditorsCanAdmin, c),
+		UserIdFilter: userIdFilter,
 		Page:         page,
 		Limit:        perPage,
 		SignedInUser: c.SignedInUser,

--- a/pkg/api/team_test.go
+++ b/pkg/api/team_test.go
@@ -255,7 +255,7 @@ func TestTeamAPIEndpoint_GetTeamByID_FGAC(t *testing.T) {
 		res := &models.TeamDTO{}
 		err := json.Unmarshal(response.Body.Bytes(), res)
 		require.NoError(t, err)
-		assert.Equal(t, res.Name, "team1")
+		assert.Equal(t, "team1", res.Name)
 	})
 }
 

--- a/pkg/api/team_test.go
+++ b/pkg/api/team_test.go
@@ -34,9 +34,12 @@ func (stub *testLogger) Warn(testMessage string, ctx ...interface{}) {
 func TestTeamAPIEndpoint(t *testing.T) {
 	t.Run("Given two teams", func(t *testing.T) {
 		hs := setupSimpleHTTPServer(nil)
-		hs.SQLStore = sqlstore.InitTestDB(t)
-		mock := &mockstore.SQLStoreMock{}
 		hs.Cfg.EditorsCanAdmin = true
+		store := sqlstore.InitTestDB(t)
+		store.Cfg = hs.Cfg
+		hs.SQLStore = store
+		mock := &mockstore.SQLStoreMock{}
+
 		loggedInUserScenario(t, "When calling GET on", "/api/teams/search", "/api/teams/search", func(sc *scenarioContext) {
 			_, err := hs.SQLStore.CreateTeam("team1", "", 1)
 			require.NoError(t, err)
@@ -123,6 +126,7 @@ func TestTeamAPIEndpoint(t *testing.T) {
 }
 
 const (
+	searchTeamsURL          = "/api/teams/search"
 	createTeamURL           = "/api/teams/"
 	detailTeamURL           = "/api/teams/%d"
 	detailTeamPreferenceURL = "/api/teams/%d/preferences"
@@ -179,6 +183,79 @@ func TestTeamAPIEndpoint_CreateTeam_FGAC(t *testing.T) {
 		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: "teams:invalid"}}, accesscontrol.GlobalOrgID)
 		response := callAPI(sc.server, http.MethodPost, createTeamURL, input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+}
+
+func TestTeamAPIEndpoint_SearchTeams_FGAC(t *testing.T) {
+	sc := setupHTTPServer(t, true, true)
+	sc.db = sqlstore.InitTestDB(t)
+
+	// Seed three teams
+	for i := 1; i <= 3; i++ {
+		_, err := sc.db.CreateTeam(fmt.Sprintf("team%d", i), fmt.Sprintf("team%d@example.org", i), 1)
+		require.NoError(t, err)
+	}
+
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	t.Run("Access control prevents searching for teams with the incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: accesscontrol.ActionTeamsDelete, Scope: "teams:id:*"}}, 1)
+		response := callAPI(sc.server, http.MethodGet, searchTeamsURL, http.NoBody, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	t.Run("Access control allows searching for teams with the correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:*"}}, 1)
+		response := callAPI(sc.server, http.MethodGet, searchTeamsURL, http.NoBody, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+
+		res := &models.SearchTeamQueryResult{}
+		err := json.Unmarshal(response.Body.Bytes(), res)
+		require.NoError(t, err)
+		require.Len(t, res.Teams, 3, "expected all teams to have been returned")
+		require.Equal(t, res.TotalCount, int64(3), "expected count to match teams length")
+	})
+
+	t.Run("Access control filters teams based on user permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:1"}, {Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:3"}}, 1)
+		response := callAPI(sc.server, http.MethodGet, searchTeamsURL, http.NoBody, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+
+		res := &models.SearchTeamQueryResult{}
+		err := json.Unmarshal(response.Body.Bytes(), res)
+		require.NoError(t, err)
+		require.Len(t, res.Teams, 2, "expected a subset of teams to have been returned")
+		require.Equal(t, res.TotalCount, int64(2), "expected count to match teams length")
+		for _, team := range res.Teams {
+			require.NotEqual(t, team.Name, "team2", "expected team2 to have been filtered")
+		}
+	})
+}
+
+func TestTeamAPIEndpoint_GetTeamByID_FGAC(t *testing.T) {
+	sc := setupHTTPServer(t, true, true)
+	sc.db = sqlstore.InitTestDB(t)
+
+	_, err := sc.db.CreateTeam("team1", "team1@example.org", 1)
+	require.NoError(t, err)
+
+	setInitCtxSignedInViewer(sc.initCtx)
+
+	t.Run("Access control prevents getting a team with the incorrect permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:2"}}, 1)
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(detailTeamURL, 1), http.NoBody, t)
+		assert.Equal(t, http.StatusForbidden, response.Code)
+	})
+
+	t.Run("Access control allows getting a team with the correct permissions", func(t *testing.T) {
+		setAccessControlPermissions(sc.acmock, []*accesscontrol.Permission{{Action: accesscontrol.ActionTeamsRead, Scope: "teams:id:1"}}, 1)
+		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(detailTeamURL, 1), http.NoBody, t)
+		assert.Equal(t, http.StatusOK, response.Code)
+
+		res := &models.TeamDTO{}
+		err := json.Unmarshal(response.Body.Bytes(), res)
+		require.NoError(t, err)
+		assert.Equal(t, res.Name, "team1")
 	})
 }
 

--- a/pkg/services/accesscontrol/filter.go
+++ b/pkg/services/accesscontrol/filter.go
@@ -12,6 +12,7 @@ import (
 var sqlIDAcceptList = map[string]struct{}{
 	"org_user.user_id": {},
 	"role.id":          {},
+	"team.id":          {},
 }
 
 var (


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR brings accesscontrol to the GET endpoints for teams. It also filters out teams at SQL level for the search endpoint.

For example, if we have 5 teams:
![image](https://user-images.githubusercontent.com/5232696/151549801-29d18623-2268-45d2-9740-af57689ca9ee.png)

And allow members of the "team admins" teams to see three teams only:
```yaml
  - name: "custom:teams:123:writer"
    description: "Read and Write a subset (id: 1, 2, 3) of teams"
    version: 1
    global: true
    permissions:
      - action: "teams:read"
        scope: "teams:id:1"
      - action: "teams:write"
        scope: "teams:id:1"
      - action: "teams.permissions:read"
        scope: "teams:id:1"
      - action: "teams.permissions:write"
        scope: "teams:id:1"
      - action: "teams:read"
        scope: "teams:id:2"
      - action: "teams:write"
        scope: "teams:id:2"
      - action: "teams.permissions:read"
        scope: "teams:id:2"
      - action: "teams.permissions:write"
        scope: "teams:id:2"
      - action: "teams:read"
        scope: "teams:id:3"
      - action: "teams:write"
        scope: "teams:id:3"
      - action: "teams.permissions:read"
        scope: "teams:id:3"
      - action: "teams.permissions:write"
        scope: "teams:id:3"
    teams:
      - name: "team admins"
        global: true
```

The end result for a member of the "team admins" team will be:
![image](https://user-images.githubusercontent.com/5232696/151550144-791fac28-e58f-4500-91db-2ab311e773ee.png)

Thus filtering out the teams "hidden to others" and "hidden too".

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/2605
Fixes https://github.com/grafana/grafana-enterprise/issues/2668

**Special notes for your reviewer**:

