### PR TITLE
Snapshots: Updates the default external snapshot server URL

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -294,8 +294,8 @@ content_security_policy_template = """script-src 'self' 'unsafe-eval' 'unsafe-in
 [snapshots]
 # snapshot sharing options
 external_enabled = true
-external_snapshot_url = https://snapshots-origin.raintank.io
-external_snapshot_name = Publish to snapshot.raintank.io
+external_snapshot_url = https://snapshots.raintank.io
+external_snapshot_name = Publish to snapshots.raintank.io
 
 # Set to true to enable this Grafana instance act as an external snapshot server and allow unauthenticated requests for
 # creating and deleting snapshots.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -294,8 +294,8 @@
 [snapshots]
 # snapshot sharing options
 ;external_enabled = true
-;external_snapshot_url = https://snapshots-origin.raintank.io
-;external_snapshot_name = Publish to snapshot.raintank.io
+;external_snapshot_url = https://snapshots.raintank.io
+;external_snapshot_name = Publish to snapshots.raintank.io
 
 # Set to true to enable this Grafana instance act as an external snapshot server and allow unauthenticated requests for
 # creating and deleting snapshots.

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -586,11 +586,11 @@ Set to `false` to disable external snapshot publish endpoint (default `true`).
 
 ### external_snapshot_url
 
-Set root URL to a Grafana instance where you want to publish external snapshots (defaults to https://snapshots-origin.raintank.io).
+Set root URL to a Grafana instance where you want to publish external snapshots (defaults to https://snapshots.raintank.io).
 
 ### external_snapshot_name
 
-Set name for external snapshot button. Defaults to `Publish to snapshot.raintank.io`.
+Set name for external snapshot button. Defaults to `Publish to snapshots.raintank.io`.
 
 ### public_mode
 

--- a/docs/sources/developers/plugins/legacy/snapshot-mode.md
+++ b/docs/sources/developers/plugins/legacy/snapshot-mode.md
@@ -7,7 +7,7 @@ aliases = ["/docs/grafana/latest/plugins/developing/snapshot-mode/"]
 
 {{< figure class="float-right"  src="/static/img/docs/Grafana-snapshot-example.png" caption="A dashboard using snapshot data and not live data." >}}
 
-Grafana has this great feature where you can [save a snapshot of your dashboard]({{< relref "../../../dashboards/json-model.md" >}}). Instead of sending a screenshot of a dashboard to someone, you can send them a working, interactive Grafana dashboard with the snapshot data embedded inside it. The snapshot can be saved on your Grafana server and is available to all your co-workers. Raintank also hosts a [snapshot server](http://snapshot.raintank.io/) if you want to send the snapshot to someone who does not have access to your Grafana server.
+Grafana has this great feature where you can [save a snapshot of your dashboard]({{< relref "../../../dashboards/json-model.md" >}}). Instead of sending a screenshot of a dashboard to someone, you can send them a working, interactive Grafana dashboard with the snapshot data embedded inside it. The snapshot can be saved on your Grafana server and is available to all your co-workers. Raintank also hosts a [snapshot server](https://snapshots.raintank.io) if you want to send the snapshot to someone who does not have access to your Grafana server.
 
 {{< figure class="float-right"  src="/static/img/docs/animated_gifs/snapshots.gif" caption="Selecting a snapshot" >}}
 
@@ -72,4 +72,4 @@ loadLocationDataFromFile(reload) {
 
 It is really easy to forget to add this support but it enables a great feature and can be used to demo your panel.
 
-If there is a panel plugin that you would like to be installed on the Raintank Snapshot server then please contact us via [Slack](https://raintank.slack.com) or [GitHub](https://github.com/grafana/grafana).
+If there is a panel plugin that you would like to be installed on the Raintank Snapshot server then please contact us via [Slack](https://slack.grafana.com) or [GitHub](https://github.com/grafana/grafana).

--- a/docs/sources/sharing/share-dashboard.md
+++ b/docs/sources/sharing/share-dashboard.md
@@ -30,14 +30,14 @@ To share a direct link:
 A dashboard snapshot shares an interactive dashboard publicly. Grafana strips sensitive data like queries
 (metric, template and annotation) and panel links, leaving only the visible metric data and series names embedded into your dashboard. Dashboard snapshots can be accessed by anyone with the link.
 
-You can publish snapshots to your local instance or to [snapshot.raintank.io](http://snapshot.raintank.io). The latter is a free service
+You can publish snapshots to your local instance or to [snapshots.raintank.io](http://snapshots.raintank.io). The latter is a free service
 provided by Grafana Labs that allows you to publish dashboard snapshots to an external Grafana instance. The same rules still apply: anyone with the link can view it. You can set an expiration time if you want the snapshot removed after a certain time period.
 
 ![Dashboard share snapshot](/static/img/docs/sharing/share-dashboard-snapshot-7-3.png)
 
 To publish a snapshot:
 
-1. Click on **Local Snapshot** or **Publish to snapshot.raintank.io**. This generates the link of the snapshot.
+1. Click on **Local Snapshot** or **Publish to snapshots.raintank.io**. This generates the link of the snapshot.
 1. Copy the snapshot link, and share it either within your organization or publicly on the web.
 
 In case you created a snapshot by mistake, click **delete snapshot** to remove the snapshot from your Grafana instance.

--- a/docs/sources/sharing/share-panel.md
+++ b/docs/sources/sharing/share-panel.md
@@ -46,14 +46,14 @@ https://play.grafana.org/d/000000012/grafana-play-home?orgId=1&from=156871968017
 
 A panel snapshot shares an interactive panel publicly. Grafana strips sensitive data leaving only the visible metric data and series names embedded into your dashboard. Panel snapshots can be accessed by anyone with the link.
 
-You can publish snapshots to your local instance or to [snapshot.raintank.io](http://snapshot.raintank.io). The latter is a free service provided by [Raintank](http://raintank.io), that allows you to publish dashboard snapshots to an external Grafana instance. You can optionally set an expiration time if you want the snapshot to be removed after a certain time period.
+You can publish snapshots to your local instance or to [snapshots.raintank.io](http://snapshots.raintank.io). The latter is a free service provided by [Grafana Labs](https://grafana.com), that allows you to publish dashboard snapshots to an external Grafana instance. You can optionally set an expiration time if you want the snapshot to be removed after a certain time period.
 
 ![Panel share snapshot](/static/img/docs/sharing/share-panel-snapshot-8-0.png)
 
 To publish a snapshot:
 
 1. In the Share Panel dialog, click **Snapshot** to open the tab.
-1. Click on **Local Snapshot** or **Publish to snapshot.raintank.io**. This generates the link of the snapshot.
+1. Click on **Local Snapshot** or **Publish to snapshots.raintank.io**. This generates the link of the snapshot.
 1. Copy the snapshot link, and share it either within your organization or publicly on the web.
 
 If you created a snapshot by mistake, click **delete snapshot** to remove the snapshot from your Grafana instance.
@@ -70,7 +70,7 @@ Here is an example of the HTML code:
 
 ```html
 <iframe
-  src="https://snapshot.raintank.io/dashboard-solo/snapshot/y7zwi2bZ7FcoTlB93WN7yWO4aMiz3pZb?from=1493369923321&to=1493377123321&panelId=4"
+  src="https://snapshots.raintank.io/dashboard-solo/snapshot/y7zwi2bZ7FcoTlB93WN7yWO4aMiz3pZb?from=1493369923321&to=1493377123321&panelId=4"
   width="650"
   height="300"
   frameborder="0"
@@ -79,7 +79,7 @@ Here is an example of the HTML code:
 
 The result is an interactive Grafana graph embedded in an iframe:
 
-<iframe src="https://snapshot.raintank.io/dashboard-solo/snapshot/y7zwi2bZ7FcoTlB93WN7yWO4aMiz3pZb?from=1493369923321&to=1493377123321&panelId=4" width="650" height="300" frameborder="0"></iframe>
+<iframe src="https://snapshots.raintank.io/dashboard-solo/snapshot/y7zwi2bZ7FcoTlB93WN7yWO4aMiz3pZb?from=1493369923321&to=1493377123321&panelId=4" width="650" height="300" frameborder="0"></iframe>
 
 ## Library panel
 

--- a/docs/sources/whatsnew/whats-new-in-v2-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v2-0.md
@@ -57,7 +57,7 @@ They're a great way to communicate about a particular incident with specific peo
 
 ### Publish snapshots
 
-You can publish snapshots locally or to [snapshot.raintank.io](http://snapshot.raintank.io). snapshot.raintank is a free service provided by [raintank](http://raintank.io) for hosting external Grafana snapshots.
+You can publish snapshots locally or to [snapshots.raintank.io](https://snapshots.raintank.io). snapshots.raintank.io is a free service provided by [Grafana Labs](https://grafana.com) for hosting external Grafana snapshots.
 
 Either way, anyone with the link (and access to your Grafana instance for local snapshots) can view it.
 
@@ -82,11 +82,11 @@ Currently you can only override the dashboard time with relative time ranges, no
 
 You can embed a single panel on another web page or your own application using the panel share dialog.
 
-Below you should see an iframe with a graph panel (taken from a Dashboard snapshot at [snapshot.raintank.io](http://snapshot.raintank.io).
+Below you should see an iframe with a graph panel (taken from a Dashboard snapshot at [snapshots.raintank.io](http://snapshots.raintank.io).
 
 Try hovering or zooming on the panel below!
 
-<iframe src="https://snapshot.raintank.io/dashboard-solo/snapshot/4IKyWYNEQll1B9FXcN3RIgx4M2VGgU8d?panelId=4&fullscreen" width="650" height="300" frameborder="0"></iframe>
+<iframe src="https://snapshots.raintank.io/dashboard-solo/snapshot/4IKyWYNEQll1B9FXcN3RIgx4M2VGgU8d?panelId=4&fullscreen" width="650" height="300" frameborder="0"></iframe>
 
 This feature makes it easy to include interactive visualizations from your Grafana instance anywhere you want.
 


### PR DESCRIPTION
This PR updates the default snapshot publication endpoints to the correct URLs.  Old URLs will still work but are deprecated.