### PR TITLE
fix issue where unify alerting UI was displaying 404 banner when Prometheus-compatible backend doesn't support ruler API

### DIFF
--- a/public/app/features/alerting/unified/api/ruler.ts
+++ b/public/app/features/alerting/unified/api/ruler.ts
@@ -107,15 +107,8 @@ async function rulerGetRequest<T>(url: string, empty: T, params?: Record<string,
       throw error;
     }
 
-    const notFoundError = error.status === 404;
-
-    if (notFoundError) {
-      // the endpoint will return 404 but confirm that it's a Cortex endpoint
-      if (isCortexErrorResponse(error)) {
-        return empty;
-      }
-      // any other 404 should throw an exception
-      throw new Error('404 from rules config endpoint. Perhaps ruler API is not enabled?');
+    if (isCortexErrorResponse(error)) {
+      return empty;
     } else if (isRulerNotSupported(error)) {
       // assert if the endoint is not supported at all
       throw {
@@ -138,13 +131,17 @@ function isResponseError(error: unknown): error is FetchResponse<ErrorResponseMe
 
 function isRulerNotSupported(error: FetchResponse<ErrorResponseMessage>) {
   return (
-    error.status === 500 &&
-    error.data.message?.includes('unexpected content type from upstream. expected YAML, got text/html')
+    error.status === 404 ||
+    (error.status === 500 &&
+      error.data.message?.includes('unexpected content type from upstream. expected YAML, got text/html'))
   );
 }
 
 function isCortexErrorResponse(error: FetchResponse<ErrorResponseMessage>) {
-  return error.data.message?.includes('group does not exist') || error.data.message?.includes('no rule groups found');
+  return (
+    error.status === 404 &&
+    (error.data.message?.includes('group does not exist') || error.data.message?.includes('no rule groups found'))
+  );
 }
 
 export async function deleteNamespace(dataSourceName: string, namespace: string): Promise<void> {

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -66,6 +66,7 @@ import { addDefaultsToAlertmanagerConfig, removeMuteTimingFromRoute, isFetchErro
 import * as ruleId from '../utils/rule-id';
 import { isEmpty } from 'lodash';
 import messageFromError from 'app/plugins/datasource/grafana-azure-monitor-datasource/utils/messageFromError';
+import { RULER_NOT_SUPPORTED_MSG } from '../utils/constants';
 
 const FETCH_CONFIG_RETRY_TIMEOUT = 30 * 1000;
 
@@ -636,7 +637,8 @@ export const checkIfLotexSupportsEditingRulesAction = createAsyncThunk<boolean, 
             (isFetchError(e) &&
               (e.data.message?.includes('GetRuleGroup unsupported in rule local store') || // "local" rule storage
                 e.data.message?.includes('page not found'))) || // ruler api disabled
-            e.message?.includes('404 from rules config endpoint') // ruler api disabled
+            e.message?.includes('404 from rules config endpoint') || // ruler api disabled
+            e.data.message?.includes(RULER_NOT_SUPPORTED_MSG) // ruler api not supported
           ) {
             return false;
           }

--- a/public/app/features/alerting/unified/utils/rules.ts
+++ b/public/app/features/alerting/unified/utils/rules.ts
@@ -50,7 +50,7 @@ export function alertInstanceKey(alert: Alert): string {
 }
 
 export function isRulerNotSupportedResponse(resp: AsyncRequestState<any>) {
-  return resp.error && resp.error?.message === RULER_NOT_SUPPORTED_MSG;
+  return resp.error && resp.error?.message?.includes(RULER_NOT_SUPPORTED_MSG);
 }
 
 export function isGrafanaRuleIdentifier(identifier: RuleIdentifier): identifier is GrafanaRuleIdentifier {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Currently Grafana relies on the backend to return a 500 to see whether or not ruler is supported. The `/rules` endpoint is also not listed on https://prometheus.io/docs/prometheus/latest/querying/api/#rules. The `/rules` page on Prometheus is actually a HTML page, and it is possible for a Prometheus-compatible backend to return 404. 

Hence, I propose that we drop the 404 banner if the service returns 404, instead of only relying on a parsing error.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #43301

**Special notes for your reviewer**:

