### PR TITLE
FeatureToggls: remove IsFeatureToggleEnabled from SettingsProvider

### DIFF
--- a/pkg/cmd/grafana-cli/commands/secretsmigrations/reencrypt_secrets.go
+++ b/pkg/cmd/grafana-cli/commands/secretsmigrations/reencrypt_secrets.go
@@ -179,7 +179,7 @@ func (s alertingSecret) reencrypt(secretsSrv *manager.SecretsService, sess *xorm
 }
 
 func ReEncryptSecrets(_ utils.CommandLine, runner runner.Runner) error {
-	if !runner.SettingsProvider.IsFeatureToggleEnabled(featuremgmt.FlagEnvelopeEncryption) {
+	if !runner.Features.IsEnabled(featuremgmt.FlagEnvelopeEncryption) {
 		logger.Warn("Envelope encryption is not enabled, quitting...")
 		return nil
 	}

--- a/pkg/cmd/grafana-cli/runner/runner.go
+++ b/pkg/cmd/grafana-cli/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"github.com/grafana/grafana/pkg/services/encryption"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/secrets/manager"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
@@ -11,17 +12,19 @@ type Runner struct {
 	Cfg               *setting.Cfg
 	SQLStore          *sqlstore.SQLStore
 	SettingsProvider  setting.Provider
+	Features          featuremgmt.FeatureToggles
 	EncryptionService encryption.Internal
 	SecretsService    *manager.SecretsService
 }
 
 func New(cfg *setting.Cfg, sqlStore *sqlstore.SQLStore, settingsProvider setting.Provider,
-	encryptionService encryption.Internal, secretsService *manager.SecretsService) Runner {
+	encryptionService encryption.Internal, features featuremgmt.FeatureToggles, secretsService *manager.SecretsService) Runner {
 	return Runner{
 		Cfg:               cfg,
 		SQLStore:          sqlStore,
 		SettingsProvider:  settingsProvider,
 		EncryptionService: encryptionService,
 		SecretsService:    secretsService,
+		Features:          features,
 	}
 }

--- a/pkg/cmd/grafana-cli/runner/wire.go
+++ b/pkg/cmd/grafana-cli/runner/wire.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	secretsDatabase "github.com/grafana/grafana/pkg/services/secrets/database"
 	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
@@ -36,6 +37,7 @@ var wireSet = wire.NewSet(
 	wire.Bind(new(secrets.Store), new(*secretsDatabase.SecretsStoreImpl)),
 	secretsManager.ProvideSecretsService,
 	wire.Bind(new(secrets.Service), new(*secretsManager.SecretsService)),
+	hooks.ProvideService,
 )
 
 func Initialize(cfg *setting.Cfg) (Runner, error) {

--- a/pkg/cmd/grafana-cli/runner/wireexts_oss.go
+++ b/pkg/cmd/grafana-cli/runner/wireexts_oss.go
@@ -5,11 +5,13 @@ package runner
 
 import (
 	"github.com/google/wire"
+	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/encryption"
 	"github.com/grafana/grafana/pkg/services/encryption/ossencryption"
 	"github.com/grafana/grafana/pkg/services/kmsproviders"
 	"github.com/grafana/grafana/pkg/services/kmsproviders/osskmsproviders"
+	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -17,6 +19,8 @@ import (
 var wireExtsSet = wire.NewSet(
 	wireSet,
 	migrations.ProvideOSSMigrations,
+	licensing.ProvideService,
+	wire.Bind(new(models.Licensing), new(*licensing.OSSLicensingService)),
 	wire.Bind(new(registry.DatabaseMigrator), new(*migrations.OSSMigrations)),
 	setting.ProvideProvider,
 	wire.Bind(new(setting.Provider), new(*setting.OSSImpl)),

--- a/pkg/services/kmsproviders/osskmsproviders/osskmsproviders.go
+++ b/pkg/services/kmsproviders/osskmsproviders/osskmsproviders.go
@@ -12,17 +12,19 @@ import (
 type Service struct {
 	enc      encryption.Internal
 	settings setting.Provider
+	features featuremgmt.FeatureToggles
 }
 
-func ProvideService(enc encryption.Internal, settings setting.Provider) Service {
+func ProvideService(enc encryption.Internal, settings setting.Provider, features featuremgmt.FeatureToggles) Service {
 	return Service{
 		enc:      enc,
 		settings: settings,
+		features: features,
 	}
 }
 
 func (s Service) Provide() (map[secrets.ProviderID]secrets.Provider, error) {
-	if !s.settings.IsFeatureToggleEnabled(featuremgmt.FlagEnvelopeEncryption) {
+	if !s.features.IsEnabled(featuremgmt.FlagEnvelopeEncryption) {
 		return nil, nil
 	}
 

--- a/pkg/services/secrets/manager/helpers.go
+++ b/pkg/services/secrets/manager/helpers.go
@@ -37,9 +37,10 @@ func SetupTestService(tb testing.TB, store secrets.Store) *SecretsService {
 	encryption := ossencryption.ProvideService()
 	secretsService, err := ProvideSecretsService(
 		store,
-		osskmsproviders.ProvideService(encryption, settings),
+		osskmsproviders.ProvideService(encryption, settings, features),
 		encryption,
 		settings,
+		features,
 		&usagestats.UsageStatsMock{T: tb},
 	)
 	require.NoError(tb, err)

--- a/pkg/services/secrets/manager/manager_test.go
+++ b/pkg/services/secrets/manager/manager_test.go
@@ -178,15 +178,16 @@ func TestSecretsService_UseCurrentProvider(t *testing.T) {
 		raw, err := ini.Load([]byte(rawCfg))
 		require.NoError(t, err)
 
+		features := featuremgmt.WithFeatures(featuremgmt.FlagEnvelopeEncryption)
 		providerID := secrets.ProviderID("fakeProvider.v1")
 		settings := &setting.OSSImpl{
 			Cfg: &setting.Cfg{
 				Raw:                    raw,
-				IsFeatureToggleEnabled: featuremgmt.WithFeatures(featuremgmt.FlagEnvelopeEncryption).IsEnabled,
+				IsFeatureToggleEnabled: features.IsEnabled,
 			},
 		}
 		encr := ossencryption.ProvideService()
-		kms := newFakeKMS(osskmsproviders.ProvideService(encr, settings))
+		kms := newFakeKMS(osskmsproviders.ProvideService(encr, settings, features))
 		secretStore := database.ProvideSecretsStore(sqlstore.InitTestDB(t))
 
 		svcEncrypt, err := ProvideSecretsService(
@@ -194,6 +195,7 @@ func TestSecretsService_UseCurrentProvider(t *testing.T) {
 			&kms,
 			encr,
 			settings,
+			features,
 			&usagestats.UsageStatsMock{T: t},
 		)
 		require.NoError(t, err)
@@ -211,6 +213,7 @@ func TestSecretsService_UseCurrentProvider(t *testing.T) {
 			&kms,
 			encr,
 			settings,
+			features,
 			&usagestats.UsageStatsMock{T: t},
 		)
 		require.NoError(t, err)

--- a/pkg/setting/provider.go
+++ b/pkg/setting/provider.go
@@ -49,8 +49,6 @@ type Provider interface {
 	// RegisterReloadHandler registers a handler for validation and reload
 	// of configuration updates tied to a specific section
 	RegisterReloadHandler(section string, handler ReloadHandler)
-	// IsFeatureToggleEnabled checks if the feature's toggle is enabled
-	IsFeatureToggleEnabled(name string) bool
 }
 
 // Section is a settings section copy


### PR DESCRIPTION
This is a small cleanup after #44443 -- it removes `IsFeatureToggleEnabled` from settings provider *but* it still exists on settings.

Removing it from settings will require some more involved rejiggering because it is used within the settings package too.

