### PR TITLE
WIP: loki-json-iterative-parsing PoC

### DIFF
--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -1,0 +1,92 @@
+package loki
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	parsers "github.com/grafana/grafana/pkg/tsdb/prometheus/parser"
+	"github.com/grafana/loki/pkg/loghttp"
+	jsoniter "github.com/json-iterator/go"
+)
+
+type LokiAPI struct {
+	client *http.Client
+	url    string
+}
+
+func NewLokiAPI(client *http.Client, url string) *LokiAPI {
+	return &LokiAPI{client: client, url: url}
+}
+
+func makeRequest(ctx context.Context, lokiDsUrl string, query lokiQuery) (*http.Request, error) {
+	qs := url.Values{}
+	qs.Set("query", query.Expr)
+	qs.Set("step", query.Step.String())
+	qs.Set("start", strconv.FormatInt(query.Start.UnixNano(), 10))
+	qs.Set("end", strconv.FormatInt(query.End.UnixNano(), 10))
+
+	lokiUrl, err := url.Parse(lokiDsUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	lokiUrl.Path = "/loki/api/v1/query_range"
+	lokiUrl.RawQuery = qs.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", lokiUrl.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// if query.VolumeQuery {
+	// 	req.Header.Set("X-Query-Tags", "Source=logvolhist")
+	// }
+
+	return req, nil
+}
+
+func (api *LokiAPI) QueryRangeUsingLokiStructures(ctx context.Context, query lokiQuery) (*loghttp.QueryResponse, error) {
+	req, err := makeRequest(ctx, api.url, query)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := api.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	var response loghttp.QueryResponse
+	err = jsoniter.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+func (api *LokiAPI) QueryRangeIter(ctx context.Context, query lokiQuery) (*backend.DataResponse, error) {
+	req, err := makeRequest(ctx, api.url, query)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := api.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	iter := jsoniter.Parse(jsoniter.ConfigDefault, resp.Body, 1024)
+	fmt.Println("iter-parsing started")
+	res := parsers.ReadPrometheusStyleResult(iter)
+	fmt.Println("iter-parsing ended")
+	return res, nil
+}

--- a/pkg/tsdb/loki/loki_bench_test.go
+++ b/pkg/tsdb/loki/loki_bench_test.go
@@ -1,0 +1,59 @@
+package loki
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// when memory-profiling these benchmarks these commands are recommended
+// - go test -benchmem -run=^$ -benchtime 1x -memprofile memprofile.out -memprofilerate 1 -bench ^BenchmarkMatrixJson$ github.com/grafana/grafana/pkg/tsdb/loki
+// - go tool pprof -http=localhost:6061 memprofile.out
+func BenchmarkMatrixJson(b *testing.B) {
+	bytes := createJsonTestData(1642000000, 1, 300, 400)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, _ = runQuery(context.Background(), makeMockedAPI(200, "application/json", bytes), &lokiQuery{})
+	}
+}
+
+const nanRate = 0.002
+
+// we build the JSON file from strings,
+// it was easier to write it this way.
+func makeJsonTestMetric(index int) string {
+	return fmt.Sprintf(`{"server":"main","category":"maintenance","case":"%v"}`, index)
+}
+
+// return a value between -100 and +100, sometimes NaN, in string
+func makeJsonTestValue(r *rand.Rand) string {
+	if r.Float64() < nanRate {
+		return "NaN"
+	} else {
+		return fmt.Sprintf("%f", (r.Float64()*200)-100)
+	}
+}
+
+// create one time-series
+func makeJsonTestSeries(start int64, step int64, timestampCount int, r *rand.Rand, seriesIndex int) string {
+	var values []string
+	for i := 0; i < timestampCount; i++ {
+		value := fmt.Sprintf(`[%d,"%v"]`, start+(int64(i)*step), makeJsonTestValue(r))
+		values = append(values, value)
+	}
+	return fmt.Sprintf(`{"metric":%v,"values":[%v]}`, makeJsonTestMetric(seriesIndex), strings.Join(values, ","))
+}
+
+func createJsonTestData(start int64, step int64, timestampCount int, seriesCount int) []byte {
+	// we use random numbers as values, but they have to be the same numbers
+	// every time we call this, so we create a random source.
+	r := rand.New(rand.NewSource(42))
+	var allSeries []string
+	for i := 0; i < seriesCount; i++ {
+		allSeries = append(allSeries, makeJsonTestSeries(start, step, timestampCount, r, i))
+	}
+	return []byte(fmt.Sprintf(`{"data":{"resultType":"matrix","result":[%v]},"status":"success"}`, strings.Join(allSeries, ",")))
+}


### PR DESCRIPTION
this uses https://github.com/grafana/grafana/pull/44520 as it's base, seems to work 👍 
notes:

this code-path is only used by the alerting-code-path, not dashboard/explore. but, you can force the dashboard to use it this way:
1. create a dashboard panel with the loki metric query (at this point this does not run through the backend code)
2. add an `Expression`, set it's value to `$A` (this means, just return the value of the query from above)
3. save the panel&dashboard&whatever
4. click the refresh-button
5. now the code goes through this backend-code
6. (you can even hide the original query, to not get double-results)

unit tests in loki are failing, you can (probably) see the errors in the CI output, if not, tests are in [pkg/tsdb/loki/framing_test.go](https://github.com/grafana/grafana/blob/gabor/hackday-json/pkg/tsdb/loki/framing_test.go), there are two reasons for failing for success-matrix-responses:
- timestamps went from UTC to local-timezone
- labels are not extracted

you can run the benchmark to profile the used memory in https://github.com/grafana/grafana/blob/gabor/hackday-json/pkg/tsdb/loki/loki_bench_test.go , some rough numbers:
- in main-branch: memory-used 70MB, from that grafana-code 9MB
- in this-branch: memory-used 20MB
- (note, these are rough numbers, reading the memory-profile graphs is .. confusing 😄 )
- if you want to run them yourself, these two commands:
        - `go test -benchmem -run=^$ -benchtime 1x -memprofile memprofile.out -memprofilerate 1 -bench ^BenchmarkMatrixJson$ github.com/grafana/grafana/pkg/tsdb/loki`
            - this will itself report some numbers, you are interested in the *** B/op, this should be the memory-bytes-used
        - `go tool pprof -http=localhost:6061 memprofile.out`
            - this will show in your web-browsers a detailed memory-profile, this number differs from the one above, it seems to contain two runs... anyway, it's hard to now 100% sure what's going on, but it allows you to see at least proportionally where the memory is used