### PR TITLE
Alerting: fix multiple queries in alerting regression

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -117,9 +117,11 @@ export class QueryRows extends PureComponent<Props, State> {
         };
       }
 
+      const { refId, hide } = item.model;
       return {
         ...item,
         datasourceUid: settings.uid,
+        model: { refId, hide },
       };
     });
     onQueriesChange(updatedQueries);

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -109,18 +109,6 @@ export class QueryRows extends PureComponent<Props, State> {
         return item;
       }
 
-      const previous = getDataSourceSrv().getInstanceSettings(item.datasourceUid);
-
-      // compatible datasource
-      if (previous?.type === settings.type) {
-        return copyModel(item, settings.uid);
-      }
-
-      // this does not make any sense, is this for backwards compat?
-      if (previous?.type === settings.uid) {
-        return copyModel(item, settings.uid);
-      }
-
       return copyModel(item, settings.uid);
     });
     onQueriesChange(updatedQueries);


### PR DESCRIPTION
**What this PR does / why we need it**:

Previous PR #43891 introduced a regression where you would no longer be able to configure multiple queries in a Grafana Managed alert.

![image](https://user-images.githubusercontent.com/868844/151532967-bc5b5015-1037-4ce1-a085-e53f4f85e3fb.png)

After investigating with @peterholmberg this regression occurred because:

1. We are passing both `dsSettings` and `query.model` to `QueryEditorRow`.
2. When figuring out which datasource to load in to the editor the following logic is applied

https://github.com/grafana/grafana/blob/ac84da4275aaf1f752e1110b643897b4765d317d/public/app/features/query/components/QueryEditorRow.tsx#L125

Meaning that it would give preference to the `query.datasource` instead of the `dsSettings`.

In the previous version of the `QueryRows` component we were only copying over `refId` and `hide`, not the `datasource` meaning it would load the correct datasource when changing between datasource in the unified alerting editor.

This change will omit the `model.datasource` entirely on each change so we use the `dsSettings` which would be the correct datasource type and uid.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

~Sadly this also removes the ability to remember the settings of the previously deleted datasource and apply them to a compatible datasource.~

~Since we have the `details` button the user can use to inspect the previous settings for the query I think it's an acceptable trade-off.~

Settings are still correctly copied over between compatible datasource 🎉 



