### PR TITLE
Plugins: Fix scanning plugins when permission is lacking

### DIFF
--- a/pkg/plugins/manager/loader/finder/finder_test.go
+++ b/pkg/plugins/manager/loader/finder/finder_test.go
@@ -2,12 +2,16 @@ package finder
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFinder_Find(t *testing.T) {
@@ -64,4 +68,60 @@ func TestFinder_Find(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFinder_getAbsPluginJSONPaths(t *testing.T) {
+	t.Run("When scanning a folder that doesn't exists shouldn't return an error", func(t *testing.T) {
+		origWalk := walk
+		walk = func(path string, followSymlinks, detectSymlinkInfiniteLoop bool, walkFn util.WalkFunc) error {
+			return walkFn(path, nil, os.ErrNotExist)
+		}
+		t.Cleanup(func() {
+			walk = origWalk
+		})
+
+		finder := &Finder{
+			log: log.New(),
+		}
+
+		paths, err := finder.getAbsPluginJSONPaths("test")
+		require.NoError(t, err)
+		require.Empty(t, paths)
+	})
+
+	t.Run("When scanning a folder that lacks permission shouldn't return an error", func(t *testing.T) {
+		origWalk := walk
+		walk = func(path string, followSymlinks, detectSymlinkInfiniteLoop bool, walkFn util.WalkFunc) error {
+			return walkFn(path, nil, os.ErrPermission)
+		}
+		t.Cleanup(func() {
+			walk = origWalk
+		})
+
+		finder := &Finder{
+			log: log.New(),
+		}
+
+		paths, err := finder.getAbsPluginJSONPaths("test")
+		require.NoError(t, err)
+		require.Empty(t, paths)
+	})
+
+	t.Run("When scanning a folder that returns a non-handled error should return that error", func(t *testing.T) {
+		origWalk := walk
+		walk = func(path string, followSymlinks, detectSymlinkInfiniteLoop bool, walkFn util.WalkFunc) error {
+			return walkFn(path, nil, fmt.Errorf("random error"))
+		}
+		t.Cleanup(func() {
+			walk = origWalk
+		})
+
+		finder := &Finder{
+			log: log.New(),
+		}
+
+		paths, err := finder.getAbsPluginJSONPaths("test")
+		require.Error(t, err)
+		require.Empty(t, paths)
+	})
 }

--- a/pkg/plugins/manager/loader/loader.go
+++ b/pkg/plugins/manager/loader/loader.go
@@ -62,7 +62,7 @@ func New(cfg *plugins.Cfg, license models.Licensing, authorizer plugins.PluginLo
 func (l *Loader) Load(ctx context.Context, class plugins.Class, paths []string, ignore map[string]struct{}) ([]*plugins.Plugin, error) {
 	pluginJSONPaths, err := l.pluginFinder.Find(paths)
 	if err != nil {
-		l.log.Error("plugin finder encountered an error", "err", err)
+		return nil, err
 	}
 
 	return l.loadPlugins(ctx, class, pluginJSONPaths, ignore)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes so that errors (directory not exists, no permission) when scanning plugins are logged as errors rather than with debug level. In addition, before the scanning would halt in case of referenced errors, but with these changes the scanning will continue. If any other error than the referenced error happens the scanning for specific directory would halt and return the error, e.g. stop Grafana from starting. 

**Which issue(s) this PR fixes**:
Fixes #43012 

**Special notes for your reviewer**:
Using the reproduction steps in the issue I got the following log message now, but Grafana continues to load rest of the plugins and starts:
INFO[01-28|12:31:04] Plugin registered                        logger=plugin.manager pluginId=input                                                             
EROR[01-28|12:31:04] Couldn't scan directory due to lack of permissions logger=plugin.finder pluginDir=/home/marcus/go/src/github.com/grafana/grafana/data/plug
ins err="open /home/marcus/go/src/github.com/grafana/grafana/data/plugins/test: permission denied"
