### PR TITLE
package.json: remove unused @types/slate-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "@types/semver": "7.3.9",
     "@types/slate": "0.47.2",
     "@types/slate-plain-serializer": "0.7.2",
-    "@types/slate-react": "0.22.5",
     "@types/testing-library__jest-dom": "5.14.2",
     "@types/testing-library__react-hooks": "^3.2.0",
     "@types/tinycolor2": "1.4.3",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -144,7 +144,6 @@
     "@types/react-window": "1.8.5",
     "@types/slate": "0.47.2",
     "@types/slate-plain-serializer": "0.7.2",
-    "@types/slate-react": "0.22.5",
     "@types/testing-library__jest-dom": "5.14.2",
     "@types/testing-library__react-hooks": "^3.2.0",
     "@types/tinycolor2": "1.4.3",

--- a/packages/jaeger-ui-components/package.json
+++ b/packages/jaeger-ui-components/package.json
@@ -20,7 +20,6 @@
     "@types/react-icons": "2.2.7",
     "@types/recompose": "0.30.10",
     "@types/reselect": "2.2.0",
-    "@types/slate-react": "0.22.5",
     "@types/tinycolor2": "1.4.3",
     "enzyme": "3.11.0",
     "sinon": "12.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4107,7 +4107,6 @@ __metadata:
     "@types/react-window": 1.8.5
     "@types/slate": 0.47.2
     "@types/slate-plain-serializer": 0.7.2
-    "@types/slate-react": 0.22.5
     "@types/testing-library__jest-dom": 5.14.2
     "@types/testing-library__react-hooks": ^3.2.0
     "@types/tinycolor2": 1.4.3
@@ -4276,7 +4275,6 @@ __metadata:
     "@types/react-icons": 2.2.7
     "@types/recompose": 0.30.10
     "@types/reselect": 2.2.0
-    "@types/slate-react": 0.22.5
     "@types/tinycolor2": 1.4.3
     chance: ^1.0.10
     classnames: ^2.2.5
@@ -9537,7 +9535,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/grafana__slate-react@npm:@types/slate-react@0.22.5, @types/slate-react@npm:0.22.5":
+"@types/grafana__slate-react@npm:@types/slate-react@0.22.5":
   version: 0.22.5
   resolution: "@types/slate-react@npm:0.22.5"
   dependencies:
@@ -19864,7 +19862,6 @@ __metadata:
     "@types/semver": 7.3.9
     "@types/slate": 0.47.2
     "@types/slate-plain-serializer": 0.7.2
-    "@types/slate-react": 0.22.5
     "@types/testing-library__jest-dom": 5.14.2
     "@types/testing-library__react-hooks": ^3.2.0
     "@types/tinycolor2": 1.4.3


### PR DESCRIPTION
(assuming the CI goes through)

we got some auto-update pull-requests for `@types/slate-react`.

so i went to check. if i delete it from our package.jsons, `yarn run typecheck` still works.. so i deleted them 😁 

NOTE: we still have some magic there in the form of `"@types/grafana__slate-react": "npm:@types/slate-react@0.22.5"`, that i'll try to handle somehow next.