### PR TITLE
Add metrics to ngalert scheduler

### DIFF
--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -1,8 +1,9 @@
 package schedule
 
 import (
-	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"time"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
 func (sch *schedule) getAlertRules(disabledOrgs []int64) []*models.AlertRule {

--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -2,9 +2,15 @@ package schedule
 
 import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"time"
 )
 
-func (sch *schedule) fetchAllDetails(disabledOrgs []int64) []*models.AlertRule {
+func (sch *schedule) getAlertRules(disabledOrgs []int64) []*models.AlertRule {
+	start := time.Now()
+	defer func() {
+		sch.metrics.GetAlertRulesDuration.Observe(time.Since(start).Seconds())
+	}()
+
 	q := models.ListAlertRulesQuery{
 		ExcludeOrgs: disabledOrgs,
 	}

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -79,7 +79,7 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					LastEvaluationTime: evaluationTime,
@@ -133,7 +133,7 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					LastEvaluationTime: evaluationTime,
@@ -156,7 +156,7 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime,
@@ -213,12 +213,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(1 * time.Minute),
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					LastEvaluationTime: evaluationTime.Add(1 * time.Minute),
@@ -274,12 +274,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(1 * time.Minute),
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime.Add(1 * time.Minute),
@@ -346,17 +346,17 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(80 * time.Second),
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime.Add(80 * time.Second),
@@ -440,22 +440,22 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(20 * time.Second),
 							EvaluationState: eval.NoData,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(30 * time.Second),
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(40 * time.Second),
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime.Add(30 * time.Second),
@@ -531,22 +531,22 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(20 * time.Second),
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(30 * time.Second),
 							EvaluationState: eval.NoData,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime,
@@ -605,12 +605,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),
@@ -669,12 +669,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime,
@@ -733,12 +733,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.NoData,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),
@@ -797,12 +797,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.NoData,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),
@@ -860,7 +860,7 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.NoData,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),
@@ -924,7 +924,7 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.NoData,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),
@@ -991,7 +991,7 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime.Add(20 * time.Second),
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           time.Time{},
@@ -1049,12 +1049,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.NoData,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),
@@ -1114,12 +1114,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.NoData,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),
@@ -1179,12 +1179,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.Error,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),
@@ -1258,12 +1258,12 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(10 * time.Second),
 							EvaluationState: eval.Error,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime.Add(10 * time.Second),
@@ -1339,22 +1339,22 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(30 * time.Second),
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(40 * time.Second),
 							EvaluationState: eval.Error,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(70 * time.Second),
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime.Add(70 * time.Second),
@@ -1431,22 +1431,22 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(30 * time.Second),
 							EvaluationState: eval.Alerting,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(40 * time.Second),
 							EvaluationState: eval.Error,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 						{
 							EvaluationTime:  evaluationTime.Add(50 * time.Second),
 							EvaluationState: eval.NoData,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					StartsAt:           evaluationTime.Add(30 * time.Second),
@@ -1498,7 +1498,7 @@ func TestProcessEvalResults(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime,
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					LastEvaluationTime: evaluationTime,
@@ -1603,7 +1603,7 @@ func TestStaleResultsHandler(t *testing.T) {
 						{
 							EvaluationTime:  evaluationTime.Add(3 * time.Minute),
 							EvaluationState: eval.Normal,
-							Values:          make(map[string]state.EvaluationValue),
+							Values:          make(map[string]*float64),
 						},
 					},
 					LastEvaluationTime: evaluationTime.Add(3 * time.Minute),

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -35,23 +35,14 @@ type Evaluation struct {
 	// Values contains the RefID and value of reduce and math expressions.
 	// It does not contain values for classic conditions as the values
 	// in classic conditions do not have a RefID.
-	Values map[string]EvaluationValue
-}
-
-// EvaluationValue contains the labels and value for a RefID in an evaluation.
-type EvaluationValue struct {
-	Labels data.Labels
-	Value  *float64
+	Values map[string]*float64
 }
 
 // NewEvaluationValues returns the labels and values for each RefID in the capture.
-func NewEvaluationValues(m map[string]eval.NumberValueCapture) map[string]EvaluationValue {
-	result := make(map[string]EvaluationValue, len(m))
+func NewEvaluationValues(m map[string]eval.NumberValueCapture) map[string]*float64 {
+	result := make(map[string]*float64, len(m))
 	for k, v := range m {
-		result[k] = EvaluationValue{
-			Labels: v.Labels,
-			Value:  v.Value,
-		}
+		result[k] = v.Value
 	}
 	return result
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request adds metrics to the ngalert scheduler so we can see how long it takes to evaluate a tick.

**Which issue(s) this PR fixes**:

#43031 