### PR TITLE
Cloudwatch : Fixed reseting metric name when changing namespace in Metric Query

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.test.tsx
@@ -7,10 +7,6 @@ import { QueryEditorExpressionType, QueryEditorPropertyType } from '../../expres
 import SQLBuilderSelectRow from './SQLBuilderSelectRow';
 
 const { datasource } = setupMockedDataSource();
-datasource.getDimensionKeys = jest.fn().mockResolvedValue([]);
-datasource.getDimensionValues = jest.fn().mockResolvedValue([]);
-datasource.getNamespaces = jest.fn().mockResolvedValue([]);
-datasource.getMetrics = jest.fn().mockResolvedValue([]);
 
 const makeSQLQuery = (sql?: SQLExpression): CloudWatchMetricsQuery => ({
   queryMode: 'Metrics',
@@ -44,10 +40,11 @@ const query = makeSQLQuery({
   },
 });
 
+const onQueryChange = jest.fn();
 const baseProps = {
   query,
   datasource,
-  onQueryChange: () => {},
+  onQueryChange,
 };
 
 const namespaces = [
@@ -63,14 +60,16 @@ describe('Cloudwatch SQLBuilderSelectRow', () => {
   beforeEach(() => {
     datasource.getNamespaces = jest.fn().mockResolvedValue(namespaces);
     datasource.getMetrics = jest.fn().mockResolvedValue([]);
+    datasource.getDimensionKeys = jest.fn().mockResolvedValue([]);
+    datasource.getDimensionValues = jest.fn().mockResolvedValue([]);
+    onQueryChange.mockReset();
   });
 
   it('Selecting a namespace should not reset metricName if it exist in new namespace', async () => {
     datasource.getMetrics = jest.fn().mockResolvedValue(metrics);
-    const onQueryChange = jest.fn();
 
     await act(async () => {
-      render(<SQLBuilderSelectRow {...baseProps} query={query} onQueryChange={onQueryChange} />);
+      render(<SQLBuilderSelectRow {...baseProps} />);
     });
 
     expect(screen.getByText('n1')).toBeInTheDocument();
@@ -109,10 +108,9 @@ describe('Cloudwatch SQLBuilderSelectRow', () => {
           : [{ value: 'newNamespaceMetric', label: 'newNamespaceMetric', text: 'newNamespaceMetric' }];
       return Promise.resolve(mockMetrics);
     });
-    const onQueryChange = jest.fn();
 
     await act(async () => {
-      render(<SQLBuilderSelectRow {...baseProps} query={query} onQueryChange={onQueryChange} />);
+      render(<SQLBuilderSelectRow {...baseProps} />);
     });
 
     expect(screen.getByText('n1')).toBeInTheDocument();

--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.test.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import SQLBuilderSelectRow from './SQLBuilderSelectRow';
+import { act, render, screen } from '@testing-library/react';
+import { CloudWatchMetricsQuery, MetricEditorMode, MetricQueryType, SQLExpression } from '../../types';
+import { setupMockedDataSource } from '../../__mocks__/CloudWatchDataSource';
+import { QueryEditorExpressionType, QueryEditorPropertyType } from '../../expressions';
+// import selectEvent from 'react-select-event';
+import { selectOptionInTest } from '@grafana/ui';
+
+const { datasource } = setupMockedDataSource();
+datasource.getDimensionKeys = jest.fn().mockResolvedValue([]);
+datasource.getDimensionValues = jest.fn().mockResolvedValue([]);
+datasource.getNamespaces = jest.fn().mockResolvedValue([]);
+datasource.getMetrics = jest.fn().mockResolvedValue([]);
+
+const makeSQLQuery = (sql?: SQLExpression): CloudWatchMetricsQuery => ({
+  queryMode: 'Metrics',
+  refId: '',
+  id: '',
+  region: 'us-east-1',
+  namespace: 'ec2',
+  dimensions: { somekey: 'somevalue' },
+  metricQueryType: MetricQueryType.Query,
+  metricEditorMode: MetricEditorMode.Builder,
+  sql: sql,
+});
+
+describe('Cloudwatch SQLBuilderSelectRow', () => {
+  const query = makeSQLQuery({
+    select: {
+      type: QueryEditorExpressionType.Function,
+      name: 'AVERAGE',
+      parameters: [
+        {
+          type: QueryEditorExpressionType.FunctionParameter,
+          name: 'm1',
+        },
+      ],
+    },
+    from: {
+      type: QueryEditorExpressionType.Property,
+      property: {
+        type: QueryEditorPropertyType.String,
+        name: 'n1',
+      },
+    },
+  });
+
+  const baseProps = {
+    query,
+    datasource,
+    onQueryChange: () => {},
+  };
+
+  const namespaces = [
+    { value: 'n1', label: 'n1', text: 'n1' },
+    { value: 'n2', label: 'n2', text: 'n2' },
+  ];
+  const metrics = [
+    { value: 'm1', label: 'm1', text: 'm1' },
+    { value: 'm2', label: 'm2', text: 'm2' },
+  ];
+
+  beforeEach(() => {
+    datasource.getNamespaces = jest.fn().mockResolvedValue(namespaces);
+    datasource.getMetrics = jest.fn().mockResolvedValue([]);
+  });
+
+  it('Selecting a namespace should not reset metricName if it exist in new namespace', async () => {
+    datasource.getMetrics = jest.fn().mockResolvedValue(metrics);
+    const onQueryChange = jest.fn();
+
+    await act(async () => {
+      render(<SQLBuilderSelectRow {...baseProps} query={query} onQueryChange={onQueryChange} />);
+    });
+
+    expect(screen.getByText('n1')).toBeInTheDocument();
+    expect(screen.getByText('m1')).toBeInTheDocument();
+
+    const namespaceSelect = screen.getByLabelText('Namespace');
+
+    await act(async () => {
+      await selectOptionInTest(namespaceSelect, 'n2');
+    });
+
+    const expectedQuery = makeSQLQuery({
+      select: {
+        type: QueryEditorExpressionType.Function,
+        name: 'AVERAGE',
+        parameters: [
+          {
+            type: QueryEditorExpressionType.FunctionParameter,
+            name: 'm1',
+          },
+        ],
+      },
+      from: {
+        type: QueryEditorExpressionType.Property,
+        property: {
+          type: QueryEditorPropertyType.String,
+          name: 'n2',
+        },
+      },
+    });
+    expect(onQueryChange).toHaveBeenCalledTimes(1);
+    expect(onQueryChange.mock.calls).toEqual([[{ ...expectedQuery, namespace: 'n2' }]]);
+  });
+
+  it('Selecting a namespace should reset metricName if it does not exist in new namespace', async () => {
+    datasource.getMetrics = jest.fn().mockImplementation((namespace: string, region: string) => {
+      let mockMetrics =
+        namespace === 'n1' && region === baseProps.query.region
+          ? metrics
+          : [{ value: 'oldNamespaceMetric', label: 'oldNamespaceMetric', text: 'oldNamespaceMetric' }];
+      return Promise.resolve(mockMetrics);
+    });
+    const onQueryChange = jest.fn();
+
+    await act(async () => {
+      render(<SQLBuilderSelectRow {...baseProps} query={query} onQueryChange={onQueryChange} />);
+    });
+
+    expect(screen.getByText('n1')).toBeInTheDocument();
+    expect(screen.getByText('m1')).toBeInTheDocument();
+
+    const namespaceSelect = screen.getByLabelText('Namespace');
+
+    await act(async () => {
+      await selectOptionInTest(namespaceSelect, 'n2');
+    });
+
+    const expectedQuery = makeSQLQuery({
+      select: {
+        type: QueryEditorExpressionType.Function,
+        name: 'AVERAGE',
+      },
+      from: {
+        type: QueryEditorExpressionType.Property,
+        property: {
+          type: QueryEditorPropertyType.String,
+          name: 'n2',
+        },
+      },
+    });
+    expect(onQueryChange).toHaveBeenCalledTimes(1);
+    expect(onQueryChange.mock.calls).toEqual([[{ ...expectedQuery, namespace: 'n2' }]]);
+  });
+});

--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import SQLBuilderSelectRow from './SQLBuilderSelectRow';
+import { selectOptionInTest } from '@grafana/ui';
 import { act, render, screen } from '@testing-library/react';
 import { CloudWatchMetricsQuery, MetricEditorMode, MetricQueryType, SQLExpression } from '../../types';
 import { setupMockedDataSource } from '../../__mocks__/CloudWatchDataSource';
 import { QueryEditorExpressionType, QueryEditorPropertyType } from '../../expressions';
-import { selectOptionInTest } from '@grafana/ui';
+import SQLBuilderSelectRow from './SQLBuilderSelectRow';
 
 const { datasource } = setupMockedDataSource();
 datasource.getDimensionKeys = jest.fn().mockResolvedValue([]);
@@ -24,42 +24,42 @@ const makeSQLQuery = (sql?: SQLExpression): CloudWatchMetricsQuery => ({
   sql: sql,
 });
 
-describe('Cloudwatch SQLBuilderSelectRow', () => {
-  const query = makeSQLQuery({
-    select: {
-      type: QueryEditorExpressionType.Function,
-      name: 'AVERAGE',
-      parameters: [
-        {
-          type: QueryEditorExpressionType.FunctionParameter,
-          name: 'm1',
-        },
-      ],
-    },
-    from: {
-      type: QueryEditorExpressionType.Property,
-      property: {
-        type: QueryEditorPropertyType.String,
-        name: 'n1',
+const query = makeSQLQuery({
+  select: {
+    type: QueryEditorExpressionType.Function,
+    name: 'AVERAGE',
+    parameters: [
+      {
+        type: QueryEditorExpressionType.FunctionParameter,
+        name: 'm1',
       },
+    ],
+  },
+  from: {
+    type: QueryEditorExpressionType.Property,
+    property: {
+      type: QueryEditorPropertyType.String,
+      name: 'n1',
     },
-  });
+  },
+});
 
-  const baseProps = {
-    query,
-    datasource,
-    onQueryChange: () => {},
-  };
+const baseProps = {
+  query,
+  datasource,
+  onQueryChange: () => {},
+};
 
-  const namespaces = [
-    { value: 'n1', label: 'n1', text: 'n1' },
-    { value: 'n2', label: 'n2', text: 'n2' },
-  ];
-  const metrics = [
-    { value: 'm1', label: 'm1', text: 'm1' },
-    { value: 'm2', label: 'm2', text: 'm2' },
-  ];
+const namespaces = [
+  { value: 'n1', label: 'n1', text: 'n1' },
+  { value: 'n2', label: 'n2', text: 'n2' },
+];
+const metrics = [
+  { value: 'm1', label: 'm1', text: 'm1' },
+  { value: 'm2', label: 'm2', text: 'm2' },
+];
 
+describe('Cloudwatch SQLBuilderSelectRow', () => {
   beforeEach(() => {
     datasource.getNamespaces = jest.fn().mockResolvedValue(namespaces);
     datasource.getMetrics = jest.fn().mockResolvedValue([]);
@@ -75,12 +75,8 @@ describe('Cloudwatch SQLBuilderSelectRow', () => {
 
     expect(screen.getByText('n1')).toBeInTheDocument();
     expect(screen.getByText('m1')).toBeInTheDocument();
-
     const namespaceSelect = screen.getByLabelText('Namespace');
-
-    await act(async () => {
-      await selectOptionInTest(namespaceSelect, 'n2');
-    });
+    await selectOptionInTest(namespaceSelect, 'n2');
 
     const expectedQuery = makeSQLQuery({
       select: {
@@ -110,7 +106,7 @@ describe('Cloudwatch SQLBuilderSelectRow', () => {
       let mockMetrics =
         namespace === 'n1' && region === baseProps.query.region
           ? metrics
-          : [{ value: 'oldNamespaceMetric', label: 'oldNamespaceMetric', text: 'oldNamespaceMetric' }];
+          : [{ value: 'newNamespaceMetric', label: 'newNamespaceMetric', text: 'newNamespaceMetric' }];
       return Promise.resolve(mockMetrics);
     });
     const onQueryChange = jest.fn();
@@ -121,12 +117,8 @@ describe('Cloudwatch SQLBuilderSelectRow', () => {
 
     expect(screen.getByText('n1')).toBeInTheDocument();
     expect(screen.getByText('m1')).toBeInTheDocument();
-
     const namespaceSelect = screen.getByLabelText('Namespace');
-
-    await act(async () => {
-      await selectOptionInTest(namespaceSelect, 'n2');
-    });
+    await selectOptionInTest(namespaceSelect, 'n2');
 
     const expectedQuery = makeSQLQuery({
       select: {

--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.test.tsx
@@ -65,7 +65,7 @@ describe('Cloudwatch SQLBuilderSelectRow', () => {
     onQueryChange.mockReset();
   });
 
-  it('Selecting a namespace should not reset metricName if it exist in new namespace', async () => {
+  it('Should not reset metricName when selecting a namespace if metric exist in new namespace', async () => {
     datasource.getMetrics = jest.fn().mockResolvedValue(metrics);
 
     await act(async () => {
@@ -100,7 +100,7 @@ describe('Cloudwatch SQLBuilderSelectRow', () => {
     expect(onQueryChange.mock.calls).toEqual([[{ ...expectedQuery, namespace: 'n2' }]]);
   });
 
-  it('Selecting a namespace should reset metricName if it does not exist in new namespace', async () => {
+  it('Should reset metricName when selecting a namespace if metric does not exist in new namespace', async () => {
     datasource.getMetrics = jest.fn().mockImplementation((namespace: string, region: string) => {
       let mockMetrics =
         namespace === 'n1' && region === baseProps.query.region

--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.test.tsx
@@ -4,7 +4,6 @@ import { act, render, screen } from '@testing-library/react';
 import { CloudWatchMetricsQuery, MetricEditorMode, MetricQueryType, SQLExpression } from '../../types';
 import { setupMockedDataSource } from '../../__mocks__/CloudWatchDataSource';
 import { QueryEditorExpressionType, QueryEditorPropertyType } from '../../expressions';
-// import selectEvent from 'react-select-event';
 import { selectOptionInTest } from '@grafana/ui';
 
 const { datasource } = setupMockedDataSource();

--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.tsx
@@ -53,19 +53,19 @@ const SQLBuilderSelectRow: React.FC<SQLBuilderSelectRowProps> = ({ datasource, q
     [unusedDimensionKeys, schemaLabels]
   );
 
-  const onNamespaceChange = async (query: CloudWatchMetricsQuery, namespace: string) => {
-    const validatedQuery = await validateMetricName(setNamespace(query, namespace), namespace);
+  const onNamespaceChange = async (query: CloudWatchMetricsQuery) => {
+    const validatedQuery = await validateMetricName(query);
     onQueryChange(validatedQuery);
   };
 
-  const validateMetricName = async (query: CloudWatchMetricsQuery, namespace: string) => {
+  const validateMetricName = async (query: CloudWatchMetricsQuery) => {
     let { region, sql } = query;
-    await datasource.getMetrics(namespace, region).then((result: Array<SelectableValue<string>>) => {
+    await datasource.getMetrics(query.namespace, region).then((result: Array<SelectableValue<string>>) => {
       if (!result.find((metric) => metric.value === metricName)) {
         sql = removeMetricName(query).sql;
       }
     });
-    return { ...query, namespace, sql };
+    return { ...query, sql };
   };
 
   return (
@@ -78,7 +78,7 @@ const SQLBuilderSelectRow: React.FC<SQLBuilderSelectRowProps> = ({ datasource, q
             inputId={`${query.refId}-cloudwatch-sql-namespace`}
             options={namespaceOptions}
             allowCustomValue
-            onChange={({ value }) => value && onNamespaceChange(query, value)}
+            onChange={({ value }) => value && onNamespaceChange(setNamespace(query, value))}
             menuShouldPortal
           />
         </EditorField>

--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.tsx
@@ -61,7 +61,7 @@ const SQLBuilderSelectRow: React.FC<SQLBuilderSelectRowProps> = ({ datasource, q
   const validateMetricName = async (query: CloudWatchMetricsQuery) => {
     let { region, sql } = query;
     await datasource.getMetrics(query.namespace, region).then((result: Array<SelectableValue<string>>) => {
-      if (!result.find((metric) => metric.value === metricName)) {
+      if (!result.some((metric) => metric.value === metricName)) {
         sql = removeMetricName(query).sql;
       }
     });

--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.tsx
@@ -53,20 +53,19 @@ const SQLBuilderSelectRow: React.FC<SQLBuilderSelectRowProps> = ({ datasource, q
     [unusedDimensionKeys, schemaLabels]
   );
 
-  const onNamespaceChange = async (query: CloudWatchMetricsQuery) => {
-    const validatedQuery = await validateMetricName(query);
+  const onNamespaceChange = async (query: CloudWatchMetricsQuery, namespace: string) => {
+    const validatedQuery = await validateMetricName(setNamespace(query, namespace), namespace);
     onQueryChange(validatedQuery);
   };
 
-  const validateMetricName = async (query: CloudWatchMetricsQuery) => {
-    let { metricName, namespace, region, sql } = query;
+  const validateMetricName = async (query: CloudWatchMetricsQuery, namespace: string) => {
+    let { region, sql } = query;
     await datasource.getMetrics(namespace, region).then((result: Array<SelectableValue<string>>) => {
       if (!result.find((metric) => metric.value === metricName)) {
-        metricName = '';
         sql = removeMetricName(query).sql;
       }
     });
-    return { ...query, metricName, sql };
+    return { ...query, namespace, sql };
   };
 
   return (
@@ -79,7 +78,7 @@ const SQLBuilderSelectRow: React.FC<SQLBuilderSelectRowProps> = ({ datasource, q
             inputId={`${query.refId}-cloudwatch-sql-namespace`}
             options={namespaceOptions}
             allowCustomValue
-            onChange={({ value }) => value && onNamespaceChange(setNamespace(query, value))}
+            onChange={({ value }) => value && onNamespaceChange(query, value)}
             menuShouldPortal
           />
         </EditorField>

--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
-import { toOption } from '@grafana/data';
+import { SelectableValue, toOption } from '@grafana/data';
 import { EditorField, EditorFieldGroup } from '@grafana/experimental';
 import { Select, Switch } from '@grafana/ui';
 import { STATISTICS } from '../../cloudwatch-sql/language';
@@ -12,6 +12,7 @@ import {
   getNamespaceFromExpression,
   getSchemaLabelKeys as getSchemaLabels,
   isUsingWithSchema,
+  removeMetricName,
   setAggregation,
   setMetricName,
   setNamespace,
@@ -52,16 +53,33 @@ const SQLBuilderSelectRow: React.FC<SQLBuilderSelectRowProps> = ({ datasource, q
     [unusedDimensionKeys, schemaLabels]
   );
 
+  const onNamespaceChange = async (query: CloudWatchMetricsQuery) => {
+    const validatedQuery = await validateMetricName(query);
+    onQueryChange(validatedQuery);
+  };
+
+  const validateMetricName = async (query: CloudWatchMetricsQuery) => {
+    let { metricName, namespace, region, sql } = query;
+    await datasource.getMetrics(namespace, region).then((result: Array<SelectableValue<string>>) => {
+      if (!result.find((metric) => metric.value === metricName)) {
+        metricName = '';
+        sql = removeMetricName(query).sql;
+      }
+    });
+    return { ...query, metricName, sql };
+  };
+
   return (
     <>
       <EditorFieldGroup>
         <EditorField label="Namespace" width={16}>
           <Select
+            aria-label="Namespace"
             value={namespace ? toOption(namespace) : null}
             inputId={`${query.refId}-cloudwatch-sql-namespace`}
             options={namespaceOptions}
             allowCustomValue
-            onChange={({ value }) => value && onQueryChange(setNamespace(query, value))}
+            onChange={({ value }) => value && onNamespaceChange(setNamespace(query, value))}
             menuShouldPortal
           />
         </EditorField>

--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/utils.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/utils.ts
@@ -146,6 +146,8 @@ export function setSql(query: CloudWatchMetricsQuery, sql: SQLExpression): Cloud
 
 export function setNamespace(query: CloudWatchMetricsQuery, namespace: string | undefined): CloudWatchMetricsQuery {
   const sql = query.sql ?? {};
+  //updating `namespace` props for CloudWatchMetricsQuery
+  query.namespace = namespace ? namespace : '';
 
   if (namespace === undefined) {
     return setSql(query, {

--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/utils.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/utils.ts
@@ -230,6 +230,13 @@ export function setMetricName(query: CloudWatchMetricsQuery, metricName: string)
   });
 }
 
+export function removeMetricName(query: CloudWatchMetricsQuery): CloudWatchMetricsQuery {
+  const queryWithNoParams = { ...query };
+  delete queryWithNoParams.sql?.select?.parameters;
+
+  return queryWithNoParams;
+}
+
 export function setAggregation(query: CloudWatchMetricsQuery, aggregation: string): CloudWatchMetricsQuery {
   return setSql(query, {
     select: {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

## What this PR does / why we need it: 
In the Cloudwatch Metric Query editor, there is a MetricName select component whose values are dependent on a Namespace select component's value.
Currently, if we select a namespace, a metric name for it and then change namespace, the metric value will not be reset even though it does not exist in the dropdown.

This PR fixes this bug, resetting the metricName if it does not exist in new dropdown. 
N.B. If a metricName is shared between old and new namespace, it will not be reset.

### Screenshots
*Before* 


https://user-images.githubusercontent.com/42030685/151616998-8111760e-c7ca-46b3-9efd-8704ddcf69d7.mov



*After*

https://user-images.githubusercontent.com/42030685/151617016-1c25c4be-6307-4143-8958-0188a44c7ef3.mov



## Which issue(s) this PR fixes: 
Fixes #44290 

### Test coverage
Output from 
```
yarn test public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/ --coverage --collectCoverageFrom="public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/*.{ts,tsx}"
```

```
-------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------
File                     | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                           
-------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------
All files                |   68.42 |    43.13 |   56.57 |   68.23 |                                                                             
 SQLBuilderSelectRow.tsx |   88.46 |     75.6 |   73.33 |   90.24 | 91-130                                                                      
 utils.ts                |   58.33 |    49.16 |   57.14 |   59.13 | 55-73,83-92,116,133,151,170-188,195-215,219-224,251,260-277,295,312,331,346 
-------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------
```
_The uncovered lines are not part of this PR - all modified/added lines are covered_ 

## Special notes for your reviewer:
Similar issue for Metric Search fixed by #44165 

Tests use new Select testing lib discussed in: https://github.com/grafana/grafana/pull/36398 (as I had an issue with the `menuShouldPortal` property on the Select)

