### PR TITLE
Chore: Suppress messages and logs from tests

### DIFF
--- a/public/app/core/components/Select/UserPicker.test.tsx
+++ b/public/app/core/components/Select/UserPicker.test.tsx
@@ -7,8 +7,9 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 describe('UserPicker', () => {
-  it('renders correctly', () => {
+  it('renders correctly', async () => {
     render(<UserPicker onSelected={() => {}} />);
-    expect(screen.getByTestId('userPicker')).toBeInTheDocument();
+
+    expect(await screen.findByTestId('userPicker')).toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/unified/components/alert-groups/GroupBy.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/GroupBy.tsx
@@ -31,6 +31,7 @@ export const GroupBy = ({ className, groups, groupBy, onGroupingChange }: Props)
           onGroupingChange(items.map(({ value }) => value as string));
         }}
         options={labelKeyOptions}
+        menuShouldPortal
       />
     </div>
   );

--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesExpandedForm.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesExpandedForm.tsx
@@ -82,6 +82,7 @@ export const AmRoutesExpandedForm: FC<AmRoutesExpandedFormProps> = ({ onCancel, 
                                 onChange={(value) => onChange(value?.value)}
                                 options={matcherFieldOptions}
                                 aria-label="Operator"
+                                menuShouldPortal
                               />
                             )}
                             defaultValue={field.operator}

--- a/public/app/features/alerting/unified/components/rules/ActionIcon.tsx
+++ b/public/app/features/alerting/unified/components/rules/ActionIcon.tsx
@@ -56,21 +56,24 @@ interface GoToProps {
   url: string;
   label?: string;
   target?: string;
+  children?: React.ReactNode;
 }
 
-const GoTo: FC<GoToProps> = ({ url, label, target, children }) => {
+const GoTo = React.forwardRef<HTMLAnchorElement, GoToProps>(({ url, label, target, children }, ref) => {
   const absoluteUrl = url?.startsWith('http');
 
   return absoluteUrl ? (
-    <a aria-label={label} href={url} target={target}>
+    <a ref={ref} aria-label={label} href={url} target={target}>
       {children}
     </a>
   ) : (
-    <Link aria-label={label} to={url} target={target}>
+    <Link ref={ref} aria-label={label} to={url} target={target}>
       {children}
     </Link>
   );
-};
+});
+
+GoTo.displayName = 'GoTo';
 
 export const getStyle = () => css`
   cursor: pointer;


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes various tests and components to stop their error messages/warnings from spamming the console when running unit tests:

 - `act()` in UserPicker test to fix warning about uncaught component changes.
 - `menuShouldPortal` to AmRoutesExpandedForm to suppress deprecation message in AmRoutes tests.
 - `forwardRef` to alerting ActionIcon to suppress error warning about refs on function components
 - `menuShouldPortal` to alerting GroupBy to suppress deprecation message in AlertGroups tests.

**Which issue(s) this PR fixes**:

Part of #42359