### PR TITLE
Chore: Replace ts-jest mocked with jest.mocked

### DIFF
--- a/public/app/features/plugins/admin/__mocks__/mockHelpers.ts
+++ b/public/app/features/plugins/admin/__mocks__/mockHelpers.ts
@@ -1,4 +1,3 @@
-import { mocked } from 'ts-jest/utils';
 import { setBackendSrv } from '@grafana/runtime';
 import { API_ROOT, GCOM_API_ROOT } from '../constants';
 import {
@@ -110,7 +109,7 @@ type UserAccessTestContext = {
 jest.mock('../permissions');
 
 export function mockUserPermissions(options: UserAccessTestContext): void {
-  const mock = mocked(permissions);
+  const mock = jest.mocked(permissions);
   mock.isDataSourceEditor.mockReturnValue(options.isDataSourceEditor);
   mock.isOrgAdmin.mockReturnValue(options.isOrgAdmin);
   mock.isGrafanaAdmin.mockReturnValue(options.isAdmin);

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/datasource.ts
@@ -1,5 +1,4 @@
 import Datasource from '../datasource';
-import { mocked } from 'ts-jest/utils';
 
 type DeepPartial<T> = {
   [P in keyof T]?: DeepPartial<T[P]>;
@@ -47,5 +46,5 @@ export default function createMockDatasource(overrides?: DeepPartial<Datasource>
 
   const mockDatasource = _mockDatasource as Datasource;
 
-  return mocked(mockDatasource, true);
+  return jest.mocked(mockDatasource, true);
 }

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.test.ts
@@ -1,5 +1,4 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { MockedObjectDeep } from 'ts-jest/dist/utils/testing';
 
 import createMockDatasource from '../../__mocks__/datasource';
 import Datasource from '../../datasource';
@@ -282,7 +281,7 @@ describe('AzureMonitor: metrics dataHooks', () => {
     },
   ];
 
-  let datasource: MockedObjectDeep<Datasource>;
+  let datasource: Datasource;
   let onChange: jest.Mock<any, any>;
   let setError: jest.Mock<any, any>;
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The `mocked` function from `ts-jest/utils` was moved into Jest core https://github.com/facebook/jest/pull/12089#issuecomment-1005572903

This PR removed about 1,103 lines of deprecation warnings from the tests 🤯

**Which issue(s) this PR fixes**:

Part of #42359
