### PR TITLE
packages: disable auto-updating of slate-related package

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,10 +4,12 @@
   ],
   "enabledManagers": ["npm"],
   "ignoreDeps": [
+    "@grafana/slate-react", // should be updated when the `slate` package is updated
     "@types/systemjs",
     "@types/d3-force", // we should bump this once we move to esm modules
     "@types/d3-interpolate", // we should bump this once we move to esm modules
     "@types/d3-scale-chromatic", // we should bump this once we move to esm modules
+    "@types/grafana__slate-react", // should be updated when the `slate` package is updated
     "@types/react-icons", // jaeger-ui-components is being refactored to use @grafana/ui icons instead
     "d3",
     "d3-force", // we should bump this once we move to esm modules


### PR DESCRIPTION
we are already blocked the auto-update of the `slate` by renovate, this pull request adds slate-related packages to the blocklist (i think it does not make sense to update slate-related packages when we do not update `slate` itself)