### PR TITLE
Alerting: Split legacy and unified routing configuration

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -491,7 +491,7 @@ func (hs *HTTPServer) buildCreateNavLinks(c *models.ReqContext) []*dtos.NavLink 
 	_, uaIsDisabledForOrg := hs.Cfg.UnifiedAlerting.DisabledOrgs[c.OrgId]
 	uaVisibleForOrg := hs.Cfg.UnifiedAlerting.IsEnabled() && !uaIsDisabledForOrg
 
-	if setting.AlertingEnabled != nil && *setting.AlertingEnabled || uaVisibleForOrg {
+	if uaVisibleForOrg {
 		children = append(children, &dtos.NavLink{
 			Text: "Alert rule", SubTitle: "Create an alert rule", Id: "alert",
 			Icon: "bell", Url: hs.Cfg.AppSubURL + "/alerting/new",

--- a/public/app/features/alerting/AlertRuleListIndex.tsx
+++ b/public/app/features/alerting/AlertRuleListIndex.tsx
@@ -1,7 +1,0 @@
-import { config } from '@grafana/runtime';
-import { RuleList } from './unified/RuleList';
-import AlertRuleList from './AlertRuleList';
-
-// route between unified and "old" alerting pages based on feature flag
-
-export default config.unifiedAlertingEnabled ? RuleList : AlertRuleList;

--- a/public/app/features/alerting/NotificationsIndex.tsx
+++ b/public/app/features/alerting/NotificationsIndex.tsx
@@ -1,7 +1,0 @@
-import { config } from '@grafana/runtime';
-import NotificationsListPage from './NotificationsListPage';
-import Receivers from './unified/Receivers';
-
-// route between unified and "old" alerting pages based on feature flag
-
-export default config.unifiedAlertingEnabled ? Receivers : NotificationsListPage;

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -224,7 +224,7 @@ export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
     return legacyRoutes;
   }
 
-  const uniquePaths = uniq([...legacyRoutes, ...commonRoutes].map((route) => route.path));
+  const uniquePaths = uniq([...legacyRoutes, ...unifiedRoutes].map((route) => route.path));
   return uniquePaths.map((path) => ({
     path,
     component: SafeDynamicImport(

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -3,23 +3,92 @@ import { Redirect } from 'react-router-dom';
 import { SafeDynamicImport } from 'app/core/components/DynamicImports/SafeDynamicImport';
 import { config } from 'app/core/config';
 import { RouteDescriptor } from 'app/core/navigation/types';
+import { uniq } from 'lodash';
 
-const alertingRoutes: RouteDescriptor[] = [
+const commonRoutes: RouteDescriptor[] = [
   {
     path: '/alerting',
     // eslint-disable-next-line react/display-name
     component: () => <Redirect to="/alerting/list" />,
   },
+];
+
+const legacyRoutes: RouteDescriptor[] = [
+  ...commonRoutes,
   {
     path: '/alerting/list',
     component: SafeDynamicImport(
-      () => import(/* webpackChunkName: "AlertRuleListIndex" */ 'app/features/alerting/AlertRuleListIndex')
+      () => import(/* webpackChunkName: "AlertRuleListIndex" */ 'app/features/alerting/AlertRuleList')
     ),
   },
   {
     path: '/alerting/ng/list',
     component: SafeDynamicImport(
       () => import(/* webpackChunkName: "AlertRuleList" */ 'app/features/alerting/AlertRuleList')
+    ),
+  },
+  {
+    path: '/alerting/notifications',
+    roles: config.unifiedAlertingEnabled ? () => ['Editor', 'Admin'] : undefined,
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsListPage')
+    ),
+  },
+  {
+    path: '/alerting/notifications/templates/new',
+    roles: () => ['Editor', 'Admin'],
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsListPage')
+    ),
+  },
+  {
+    path: '/alerting/notifications/templates/:id/edit',
+    roles: () => ['Editor', 'Admin'],
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsListPage')
+    ),
+  },
+  {
+    path: '/alerting/notifications/receivers/new',
+    roles: () => ['Editor', 'Admin'],
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsListPage')
+    ),
+  },
+  {
+    path: '/alerting/notifications/receivers/:id/edit',
+    roles: () => ['Editor', 'Admin'],
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsListPage')
+    ),
+  },
+  {
+    path: '/alerting/notifications/global-config',
+    roles: () => ['Admin', 'Editor'],
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsListPage')
+    ),
+  },
+  {
+    path: '/alerting/notification/new',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "NewNotificationChannel" */ 'app/features/alerting/NewNotificationChannelPage')
+    ),
+  },
+  {
+    path: '/alerting/notification/:id/edit',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "EditNotificationChannel"*/ 'app/features/alerting/EditNotificationChannelPage')
+    ),
+  },
+];
+
+const unifiedRoutes: RouteDescriptor[] = [
+  ...commonRoutes,
+  {
+    path: '/alerting/list',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "AlertRuleListIndex" */ 'app/features/alerting/unified/RuleList')
     ),
   },
   {
@@ -67,54 +136,42 @@ const alertingRoutes: RouteDescriptor[] = [
     path: '/alerting/notifications',
     roles: config.unifiedAlertingEnabled ? () => ['Editor', 'Admin'] : undefined,
     component: SafeDynamicImport(
-      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/unified/Receivers')
     ),
   },
   {
     path: '/alerting/notifications/templates/new',
     roles: () => ['Editor', 'Admin'],
     component: SafeDynamicImport(
-      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/unified/Receivers')
     ),
   },
   {
     path: '/alerting/notifications/templates/:id/edit',
     roles: () => ['Editor', 'Admin'],
     component: SafeDynamicImport(
-      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/unified/Receivers')
     ),
   },
   {
     path: '/alerting/notifications/receivers/new',
     roles: () => ['Editor', 'Admin'],
     component: SafeDynamicImport(
-      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/unified/Receivers')
     ),
   },
   {
     path: '/alerting/notifications/receivers/:id/edit',
     roles: () => ['Editor', 'Admin'],
     component: SafeDynamicImport(
-      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/unified/Receivers')
     ),
   },
   {
     path: '/alerting/notifications/global-config',
     roles: () => ['Admin', 'Editor'],
     component: SafeDynamicImport(
-      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/NotificationsIndex')
-    ),
-  },
-  {
-    path: '/alerting/notification/new',
-    component: SafeDynamicImport(
-      () => import(/* webpackChunkName: "NewNotificationChannel" */ 'app/features/alerting/NewNotificationChannelPage')
-    ),
-  },
-  {
-    path: '/alerting/notification/:id/edit',
-    component: SafeDynamicImport(
-      () => import(/* webpackChunkName: "EditNotificationChannel"*/ 'app/features/alerting/EditNotificationChannelPage')
+      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/unified/Receivers')
     ),
   },
   {
@@ -161,12 +218,15 @@ const alertingRoutes: RouteDescriptor[] = [
 ];
 
 export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
-  if (cfg.alertingEnabled || cfg.unifiedAlertingEnabled) {
-    return alertingRoutes;
+  if (cfg.unifiedAlertingEnabled) {
+    return unifiedRoutes;
+  } else if (cfg.alertingEnabled) {
+    return legacyRoutes;
   }
 
-  return alertingRoutes.map((route) => ({
-    ...route,
+  const uniquePaths = uniq([...legacyRoutes, ...commonRoutes].map((route) => route.path));
+  return uniquePaths.map((path) => ({
+    path,
     component: SafeDynamicImport(
       () => import(/* webpackChunkName: "Alerting feature toggle page"*/ 'app/features/alerting/FeatureTogglePage')
     ),

--- a/public/app/features/alerting/unified/RuleList.test.tsx
+++ b/public/app/features/alerting/unified/RuleList.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { configureStore } from 'app/store/configureStore';
 import { Provider } from 'react-redux';
-import { RuleList } from './RuleList';
+import RuleList from './RuleList';
 import { byLabelText, byRole, byTestId, byText } from 'testing-library-selector';
 import { typeAsJestMock } from 'test/helpers/typeAsJestMock';
 import { getAllDataSources } from './utils/config';

--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -26,7 +26,7 @@ const VIEWS = {
   state: RuleListStateView,
 };
 
-export const RuleList = withErrorBoundary(
+const RuleList = withErrorBoundary(
   () => {
     const dispatch = useDispatch();
     const styles = useStyles2(getStyles);
@@ -133,3 +133,5 @@ const getStyles = (theme: GrafanaTheme2) => ({
     margin-right: ${theme.spacing(1)};
   `,
 });
+
+export default RuleList;


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Removes the `Alert rule` from the `Create` menu when the legacy alerting is enabled
2. Splits the legacy and unified routing configuration so legacy routes are not enabled when unified alerting is in use and vice versa

**Which issue(s) this PR fixes**:
Fixes #43335

**Special notes for your reviewer**:
The change in the `Create` menu is handled in the backend code

