### PR TITLE
CI: Make e2e tests depend on binary builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -189,7 +189,9 @@ steps:
 - commands:
   - ./scripts/grafana-server/start-server
   depends_on:
-  - package
+  - build-plugins
+  - build-backend
+  - build-frontend
   detach: true
   environment:
     PORT: 3001
@@ -199,7 +201,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -208,7 +210,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -217,7 +219,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -226,7 +228,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -619,7 +621,9 @@ steps:
 - commands:
   - ./scripts/grafana-server/start-server
   depends_on:
-  - package
+  - build-plugins
+  - build-backend
+  - build-frontend
   detach: true
   environment:
     PORT: 3001
@@ -629,7 +633,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -638,7 +642,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -647,7 +651,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -656,7 +660,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -1226,7 +1230,9 @@ steps:
 - commands:
   - ./scripts/grafana-server/start-server
   depends_on:
-  - package
+  - build-plugins
+  - build-backend
+  - build-frontend
   detach: true
   environment:
     PORT: 3001
@@ -1236,7 +1242,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -1245,7 +1251,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -1254,7 +1260,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -1263,7 +1269,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -1828,7 +1834,9 @@ steps:
 - commands:
   - ./scripts/grafana-server/start-server
   depends_on:
-  - package
+  - build-plugins
+  - build-backend
+  - build-frontend
   detach: true
   environment:
     PACKAGE_FILE: dist/grafana-enterprise-*linux-amd64.tar.gz
@@ -1840,7 +1848,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -1849,7 +1857,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -1858,7 +1866,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -1867,7 +1875,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -2982,7 +2990,9 @@ steps:
 - commands:
   - ./scripts/grafana-server/start-server
   depends_on:
-  - package
+  - build-plugins
+  - build-backend
+  - build-frontend
   detach: true
   environment:
     PORT: 3001
@@ -2992,7 +3002,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -3001,7 +3011,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -3010,7 +3020,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -3019,7 +3029,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -3512,7 +3522,9 @@ steps:
 - commands:
   - ./scripts/grafana-server/start-server
   depends_on:
-  - package
+  - build-plugins
+  - build-backend
+  - build-frontend
   detach: true
   environment:
     PACKAGE_FILE: dist/grafana-enterprise-*linux-amd64.tar.gz
@@ -3524,7 +3536,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -3533,7 +3545,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -3542,7 +3554,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -3551,7 +3563,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:9.3.1
@@ -4175,6 +4187,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 19229313440a0d96416f34c4c7ac5d8d00f30478e71a0a6072ae106145e1794c
+hmac: 1bec42327418f8b41fb63e12c7fbad397dc37418ee07fcbd0751cbc45a3122a3
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -194,6 +194,7 @@ steps:
   - build-frontend
   detach: true
   environment:
+    ARCH: linux-amd64
     PORT: 3001
   image: grafana/build-container:1.4.9
   name: grafana-server
@@ -626,6 +627,7 @@ steps:
   - build-frontend
   detach: true
   environment:
+    ARCH: linux-amd64
     PORT: 3001
   image: grafana/build-container:1.4.9
   name: grafana-server
@@ -1235,6 +1237,7 @@ steps:
   - build-frontend
   detach: true
   environment:
+    ARCH: linux-amd64
     PORT: 3001
   image: grafana/build-container:1.4.9
   name: grafana-server
@@ -1839,7 +1842,7 @@ steps:
   - build-frontend
   detach: true
   environment:
-    PACKAGE_FILE: dist/grafana-enterprise-*linux-amd64.tar.gz
+    ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
   image: grafana/build-container:1.4.9
@@ -2995,6 +2998,7 @@ steps:
   - build-frontend
   detach: true
   environment:
+    ARCH: linux-amd64
     PORT: 3001
   image: grafana/build-container:1.4.9
   name: grafana-server
@@ -3527,7 +3531,7 @@ steps:
   - build-frontend
   detach: true
   environment:
-    PACKAGE_FILE: dist/grafana-enterprise-*linux-amd64.tar.gz
+    ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
   image: grafana/build-container:1.4.9
@@ -4187,6 +4191,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 1bec42327418f8b41fb63e12c7fbad397dc37418ee07fcbd0751cbc45a3122a3
+hmac: 4d1a5696bf1e510fb51a021c07e240c50cb913724ce08ed52cce037ff02dd8de
 
 ...

--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -14,7 +14,7 @@ load(
     'build_frontend_step',
     'build_plugins_step',
     'package_step',
-    'e2e_tests_server_step',
+    'grafana_server_step',
     'e2e_tests_step',
     'e2e_tests_artifacts',
     'build_storybook_step',
@@ -99,7 +99,7 @@ def get_steps(edition, is_downstream=False):
     # Insert remaining steps
     build_steps.extend([
         package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2, is_downstream=is_downstream),
-        e2e_tests_server_step(edition=edition),
+        grafana_server_step(edition=edition),
         e2e_tests_step('dashboards-suite', edition=edition),
         e2e_tests_step('smoke-tests-suite', edition=edition),
         e2e_tests_step('panels-suite', edition=edition),

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -14,7 +14,7 @@ load(
     'test_backend_integration_step',
     'test_frontend_step',
     'package_step',
-    'e2e_tests_server_step',
+    'grafana_server_step',
     'e2e_tests_step',
     'e2e_tests_artifacts',
     'build_storybook_step',
@@ -92,7 +92,7 @@ def pr_pipelines(edition):
     # Insert remaining build_steps
     build_steps.extend([
         package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2, variants=variants),
-        e2e_tests_server_step(edition=edition),
+        grafana_server_step(edition=edition),
         e2e_tests_step('dashboards-suite', edition=edition),
         e2e_tests_step('smoke-tests-suite', edition=edition),
         e2e_tests_step('panels-suite', edition=edition),

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -18,7 +18,7 @@ load(
     'build_frontend_step',
     'build_plugins_step',
     'package_step',
-    'e2e_tests_server_step',
+    'grafana_server_step',
     'e2e_tests_step',
     'e2e_tests_artifacts',
     'build_storybook_step',
@@ -226,7 +226,7 @@ def get_steps(edition, ver_mode):
         copy_packages_for_docker_step(),
         package_docker_images_step(edition=edition, ver_mode=ver_mode, publish=should_publish),
         package_docker_images_step(edition=edition, ver_mode=ver_mode, ubuntu=True, publish=should_publish),
-        e2e_tests_server_step(edition=edition),
+        grafana_server_step(edition=edition),
     ])
 
     if not disable_tests:

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -659,9 +659,9 @@ def grafana_server_step(edition, port=3001):
 
     environment = {
         'PORT': port,
+        'ARCH': 'linux-amd64'
     }
     if package_file_pfx:
-        environment['PACKAGE_FILE'] = 'dist/{}-*linux-amd64.tar.gz'.format(package_file_pfx)
         environment['RUNDIR'] = 'scripts/grafana-server/tmp-{}'.format(package_file_pfx)
 
     return {

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -650,7 +650,7 @@ def package_step(edition, ver_mode, include_enterprise2=False, variants=None, is
     }
 
 
-def e2e_tests_server_step(edition, port=3001):
+def grafana_server_step(edition, port=3001):
     package_file_pfx = ''
     if edition == 'enterprise2':
         package_file_pfx = 'grafana' + enterprise2_suffix(edition)
@@ -669,7 +669,9 @@ def e2e_tests_server_step(edition, port=3001):
         'image': build_image,
         'detach': True,
         'depends_on': [
-            'package' + enterprise2_suffix(edition),
+            'build-plugins',
+            'build-backend',
+            'build-frontend',
         ],
         'environment': environment,
         'commands': [
@@ -685,7 +687,7 @@ def e2e_tests_step(suite, edition, port=3001, tries=None):
         'name': 'end-to-end-tests-{}'.format(suite) + enterprise2_suffix(edition),
         'image': 'cypress/included:9.3.1',
         'depends_on': [
-            'package',
+            'grafana-server',
         ],
         'environment': {
             'HOST': 'grafana-server' + enterprise2_suffix(edition),

--- a/scripts/grafana-server/start-server
+++ b/scripts/grafana-server/start-server
@@ -12,33 +12,24 @@ mkdir $RUNDIR
 
 echo -e "Copying grafana backend files to temp dir..."
 
-# Expand any wildcards
-pkgs=(${PACKAGE_FILE})
-pkg=${pkgs[0]}
-if [[ -f ${pkg} ]]; then
-  echo "Found package tar file ${pkg}, extracting..."
-  tar zxf ${pkg} -C $RUNDIR
-  mv $RUNDIR/grafana-*/* $RUNDIR
-else
-  echo "Couldn't find package ${PACKAGE_FILE} - copying local dev files"
+echo "Couldn't find package ${PACKAGE_FILE} - copying local dev files"
 
-  if [[ ! -f bin/grafana-server ]]; then
-    echo bin/grafana-server missing
-    exit 1
-  fi
-
-  cp -r ./bin $RUNDIR
-  cp -r ./public $RUNDIR
-  cp -r ./tools $RUNDIR
-
-  mkdir $RUNDIR/conf
-  mkdir $PROV_DIR
-  mkdir $PROV_DIR/datasources
-  mkdir $PROV_DIR/dashboards
-
-  cp ./scripts/grafana-server/custom.ini $RUNDIR/conf/custom.ini
-  cp ./conf/defaults.ini $RUNDIR/conf/defaults.ini
+if [[ ! -f bin/grafana-server ]]; then
+  echo bin/grafana-server missing
+  exit 1
 fi
+
+cp -r ./bin $RUNDIR
+cp -r ./public $RUNDIR
+cp -r ./tools $RUNDIR
+
+mkdir $RUNDIR/conf
+mkdir $PROV_DIR
+mkdir $PROV_DIR/datasources
+mkdir $PROV_DIR/dashboards
+
+cp ./scripts/grafana-server/custom.ini $RUNDIR/conf/custom.ini
+cp ./conf/defaults.ini $RUNDIR/conf/defaults.ini
 
 echo -e "Copy provisioning setup from devenv"
 

--- a/scripts/grafana-server/start-server
+++ b/scripts/grafana-server/start-server
@@ -4,7 +4,6 @@ set -eo pipefail
 . scripts/grafana-server/variables
 
 PORT=${PORT:-$DEFAULT_PORT}
-PACKAGE_FILE=${PACKAGE_FILE:-$DEFAULT_PACKAGE_FILE}
 
 ./scripts/grafana-server/kill-server
 
@@ -12,9 +11,9 @@ mkdir $RUNDIR
 
 echo -e "Copying grafana backend files to temp dir..."
 
-echo "Couldn't find package ${PACKAGE_FILE} - copying local dev files"
-
-if [[ ! -f bin/grafana-server ]]; then
+if [[ ! -f bin/linux-amd64/grafana-server ]]; then
+  echo "bin/linux-amd64/grafana-server missing, trying local grafana-server binary"
+elif [[ ! -f bin/grafana-server ]] ; then
   echo bin/grafana-server missing
   exit 1
 fi

--- a/scripts/grafana-server/start-server
+++ b/scripts/grafana-server/start-server
@@ -4,6 +4,11 @@ set -eo pipefail
 . scripts/grafana-server/variables
 
 PORT=${PORT:-$DEFAULT_PORT}
+ARCH=${ARCH:-$DEFAULT_ARCH}
+
+if [ "$ARCH" ]; then
+    ARCH+="/"
+fi
 
 ./scripts/grafana-server/kill-server
 
@@ -11,12 +16,11 @@ mkdir $RUNDIR
 
 echo -e "Copying grafana backend files to temp dir..."
 
-if [[ ! -f bin/linux-amd64/grafana-server ]]; then
+if [[ ! -f bin/"$ARCH"grafana-server ]]; then
   echo "bin/linux-amd64/grafana-server missing, trying local grafana-server binary"
-elif [[ ! -f bin/grafana-server ]] ; then
-  echo bin/grafana-server missing
-  exit 1
 fi
+
+echo starting server
 
 cp -r ./bin $RUNDIR
 cp -r ./public $RUNDIR
@@ -39,7 +43,7 @@ cp -r devenv $RUNDIR
 
 echo -e "Starting Grafana Server port $PORT"
 
-$RUNDIR/bin/grafana-server \
+$RUNDIR/bin/"$ARCH"grafana-server \
   --homepath=$HOME_PATH \
   --pidfile=$RUNDIR/pid \
   cfg:server.http_port=$PORT \

--- a/scripts/grafana-server/variables
+++ b/scripts/grafana-server/variables
@@ -2,6 +2,7 @@
 
 DEFAULT_RUNDIR=scripts/grafana-server/tmp
 RUNDIR=${RUNDIR:-$DEFAULT_RUNDIR}
+DEFAULT_ARCH=
 HOME_PATH=$PWD/$RUNDIR
 PIDFILE=$RUNDIR/pid
 PROV_DIR=$RUNDIR/conf/provisioning

--- a/scripts/grafana-server/variables
+++ b/scripts/grafana-server/variables
@@ -4,7 +4,6 @@ DEFAULT_RUNDIR=scripts/grafana-server/tmp
 RUNDIR=${RUNDIR:-$DEFAULT_RUNDIR}
 HOME_PATH=$PWD/$RUNDIR
 PIDFILE=$RUNDIR/pid
-DEFAULT_PACKAGE_FILE=dist/grafana-*linux-amd64.tar.gz
 PROV_DIR=$RUNDIR/conf/provisioning
 DEFAULT_HOST=localhost
 DEFAULT_PORT=3001


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR is responsible for making e2e tests depend on binary, instead of packages. 
This can help us speed the process, since package step takes ~2mins.

