### PR TITLE
Access Control: handle case when scope is wildcard in SQL filter

### DIFF
--- a/pkg/services/accesscontrol/filter.go
+++ b/pkg/services/accesscontrol/filter.go
@@ -30,8 +30,8 @@ func Filter(ctx context.Context, sqlID, prefix, action string, user *models.Sign
 	var hasWildcard bool
 	var ids []interface{}
 	for _, scope := range user.Permissions[user.OrgId][action] {
-		if strings.HasPrefix(scope, prefix) {
-			if id := strings.TrimPrefix(scope, prefix); id == ":*" || id == ":id:*" {
+		if strings.HasPrefix(scope, prefix) || scope == "*" {
+			if id := strings.TrimPrefix(scope, prefix); id == "*" || id == ":*" || id == ":id:*" {
 				hasWildcard = true
 				break
 			}

--- a/pkg/services/accesscontrol/filter_test.go
+++ b/pkg/services/accesscontrol/filter_test.go
@@ -32,6 +32,22 @@ func TestFilter_Datasources(t *testing.T) {
 			expectedDataSources: []string{"ds:1", "ds:2", "ds:3", "ds:4", "ds:5", "ds:6", "ds:7", "ds:8", "ds:9", "ds:10"},
 		},
 		{
+			desc:  "expect all data sources for wildcard id scope to be returned",
+			sqlID: "data_source.id",
+			permissions: []*accesscontrol.Permission{
+				{Action: "datasources:read", Scope: "datasources:id:*"},
+			},
+			expectedDataSources: []string{"ds:1", "ds:2", "ds:3", "ds:4", "ds:5", "ds:6", "ds:7", "ds:8", "ds:9", "ds:10"},
+		},
+		{
+			desc:  "expect all data sources for wildcard scope to be returned",
+			sqlID: "data_source.id",
+			permissions: []*accesscontrol.Permission{
+				{Action: "datasources:read", Scope: "*"},
+			},
+			expectedDataSources: []string{"ds:1", "ds:2", "ds:3", "ds:4", "ds:5", "ds:6", "ds:7", "ds:8", "ds:9", "ds:10"},
+		},
+		{
 			desc:                "expect no data sources to be returned",
 			sqlID:               "data_source.id",
 			permissions:         []*accesscontrol.Permission{},
@@ -46,6 +62,14 @@ func TestFilter_Datasources(t *testing.T) {
 				{Action: "datasources:read", Scope: "datasources:id:8"},
 			},
 			expectedDataSources: []string{"ds:3", "ds:7", "ds:8"},
+		},
+		{
+			desc:  "expect no data sources to be returned for malformed scope",
+			sqlID: "data_source.id",
+			permissions: []*accesscontrol.Permission{
+				{Action: "datasources:read", Scope: "datasources:id:1*"},
+			},
+			expectedDataSources: []string{},
 		},
 		{
 			desc:  "expect error if sqlID is not in the accept list",


### PR DESCRIPTION
**What this PR does / why we need it**:
Handle the case when  user have `*` as scope for an action
