### PR TITLE
Chore: use the latest version of @grafana/levitate

### DIFF
--- a/scripts/check-breaking-changes.sh
+++ b/scripts/check-breaking-changes.sh
@@ -25,7 +25,7 @@ while IFS=" " read -r -a package; do
     echo ""
     echo "${PACKAGE_PATH}"
     echo "================================================="
-    npm exec -- @grafana/levitate@0.2.0 compare --prev "$PREV" --current "$CURRENT"
+    npm exec -- @grafana/levitate compare --prev "$PREV" --current "$CURRENT"
 
     # Check if the comparison returned with a non-zero exit code
     # Record the output, maybe with some additional information


### PR DESCRIPTION
**Why?**
After https://github.com/grafana/levitate/pull/36 was merged and the `0.3.1` version of the package was published the yargs commands are working again. (We fixed the package's version to `0.2.0` previously as there were some issues with the latest release).

**What changed?**
Removed the fixed version from the Levitate command so `npm exec` always fetches the latest version.
