### PR TITLE
Access control: Grant viewers `fixed:datasources:explorer` role when viewer_can_edit is enabled

### DIFF
--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 // API related actions
@@ -59,6 +60,26 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			},
 		},
 		Grants: []string{accesscontrol.RoleGrafanaAdmin},
+	}
+
+	datasourcesExplorerRole := accesscontrol.RoleRegistration{
+		Role: accesscontrol.RoleDTO{
+			Version:     4,
+			Name:        "fixed:datasources:explorer",
+			DisplayName: "Data source explorer",
+			Description: "Enable the Explore feature. Data source permissions still apply; you can only query data sources for which you have query permissions.",
+			Group:       "Data sources",
+			Permissions: []accesscontrol.Permission{
+				{
+					Action: accesscontrol.ActionDatasourcesExplore,
+				},
+			},
+		},
+		Grants: []string{string(models.ROLE_EDITOR)},
+	}
+
+	if setting.ViewersCanEdit {
+		datasourcesExplorerRole.Grants = append(datasourcesExplorerRole.Grants, string(models.ROLE_VIEWER))
 	}
 
 	datasourcesReaderRole := accesscontrol.RoleRegistration{
@@ -226,7 +247,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 	return hs.AccessControl.DeclareFixedRoles(
 		provisioningWriterRole, datasourcesReaderRole, datasourcesWriterRole, datasourcesIdReaderRole,
 		datasourcesCompatibilityReaderRole, orgReaderRole, orgWriterRole,
-		orgMaintainerRole, teamsCreatorRole, teamsWriterRole,
+		orgMaintainerRole, teamsCreatorRole, teamsWriterRole, datasourcesExplorerRole,
 	)
 }
 

--- a/pkg/services/accesscontrol/roles.go
+++ b/pkg/services/accesscontrol/roles.go
@@ -15,19 +15,6 @@ type RoleRegistry interface {
 
 // Roles definition
 var (
-	datasourcesExplorerRole = RoleDTO{
-		Version:     3,
-		Name:        datasourcesExplorer,
-		DisplayName: "Data source explorer",
-		Description: "Enable the Explore feature. Data source permissions still apply; you can only query data sources for which you have query permissions.",
-		Group:       "Data sources",
-		Permissions: []Permission{
-			{
-				Action: ActionDatasourcesExplore,
-			},
-		},
-	}
-
 	ldapReaderRole = RoleDTO{
 		Name:        ldapReader,
 		DisplayName: "LDAP reader",
@@ -201,15 +188,14 @@ var (
 
 // Role names definitions
 const (
-	datasourcesExplorer = "fixed:datasources:explorer"
-	ldapReader          = "fixed:ldap:reader"
-	ldapWriter          = "fixed:ldap:writer"
-	orgUsersReader      = "fixed:org.users:reader"
-	orgUsersWriter      = "fixed:org.users:writer"
-	settingsReader      = "fixed:settings:reader"
-	statsReader         = "fixed:stats:reader"
-	usersReader         = "fixed:users:reader"
-	usersWriter         = "fixed:users:writer"
+	ldapReader     = "fixed:ldap:reader"
+	ldapWriter     = "fixed:ldap:writer"
+	orgUsersReader = "fixed:org.users:reader"
+	orgUsersWriter = "fixed:org.users:writer"
+	settingsReader = "fixed:settings:reader"
+	statsReader    = "fixed:stats:reader"
+	usersReader    = "fixed:users:reader"
+	usersWriter    = "fixed:users:writer"
 )
 
 var (
@@ -220,15 +206,14 @@ var (
 	// resource. FixedRoleGrants lists which built-in roles are
 	// assigned which fixed roles in this list.
 	FixedRoles = map[string]RoleDTO{
-		datasourcesExplorer: datasourcesExplorerRole,
-		ldapReader:          ldapReaderRole,
-		ldapWriter:          ldapWriterRole,
-		orgUsersReader:      orgUsersReaderRole,
-		orgUsersWriter:      orgUsersWriterRole,
-		settingsReader:      settingsReaderRole,
-		statsReader:         statsReaderRole,
-		usersReader:         usersReaderRole,
-		usersWriter:         usersWriterRole,
+		ldapReader:     ldapReaderRole,
+		ldapWriter:     ldapWriterRole,
+		orgUsersReader: orgUsersReaderRole,
+		orgUsersWriter: orgUsersWriterRole,
+		settingsReader: settingsReaderRole,
+		statsReader:    statsReaderRole,
+		usersReader:    usersReaderRole,
+		usersWriter:    usersWriterRole,
 	}
 
 	// FixedRoleGrants specifies which built-in roles are assigned
@@ -247,9 +232,6 @@ var (
 		string(models.ROLE_ADMIN): {
 			orgUsersReader,
 			orgUsersWriter,
-		},
-		string(models.ROLE_EDITOR): {
-			datasourcesExplorer,
 		},
 	}
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
To replicate the behaviour of viewer_can_edit flag we need to grant viewers the `fixed:datasources:explorer` role if the flag is set to true.

One thing to keep in mind is if the role is granted and we turn of the viewers_can_edit flag the grant wont disappear. Then we need to manually remove the grant 


