### PR TITLE
Logs Panel: fix timestamp parsing for string dates without timezone

### DIFF
--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -9,7 +9,6 @@ import {
   DataQueryRequest,
   DataQueryResponse,
   DataSourceApi,
-  dateTime,
   dateTimeFormat,
   dateTimeFormatTimeAgo,
   FieldCache,
@@ -36,6 +35,7 @@ import {
   textUtil,
   TimeRange,
   toDataFrame,
+  toUtc,
 } from '@grafana/data';
 import { getThemeColor } from 'app/core/utils/colors';
 import { SIPrefix } from '@grafana/data/src/valueFormats/symbolFormatters';
@@ -367,7 +367,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
 
     for (let j = 0; j < series.length; j++) {
       const ts = timeField.values.get(j);
-      const time = dateTime(ts);
+      const time = toUtc(ts);
       const tsNs = timeNanosecondField ? timeNanosecondField.values.get(j) : undefined;
       const timeEpochNs = tsNs ? tsNs : time.valueOf() + '000000';
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When visualizing logs, dates are currently parsed using the `dateTime` function that accepts numbers or strings.
When passing date numbers the get parsed assuming UTC, otherwise the timezone is extracted from the string itself when available. When not available though (ie. for formats like `YYYY-MM-DD HH:mm:ss`) the user's browser locale/timezone is assumed which, in the context of Grafana, is less than ideal as people looking at the same dashboards (with the same data) but being in different timezones would see different results.

This PR replaces `dateTime` with `toUtc`, which instead of assuming local time, assumes the input is in UTC when not explicitly defined.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->
Part of https://github.com/grafana/support-escalations/issues/1629

**Special notes for your reviewer**:

This is a bit tricky to reproduce. Using elasticsearch77, create an index and insert a document having a date without timezone info:

```
curl -XPUT http://localhost:13200/without-tz -H "Content-Type: application/json" -d '{"mappings": {"properties": {"@timestamp": {"type": "date", "format": "yyyy-MM-dd HH:mm:ss"}}}}'

curl -XPUT http://localhost:13200/without-tz/_doc/example -H "Content-Type: application/json" -d '{ "@timestamp": "2022-01-31 13:30:00", "foo": "bar" }'
```

then configure the datasource to use that index (`without-tx`) and create a dashboard with 2 panels:
- count group by date histogram (timeseries panel)
- logs or raw data (logs panel).

now, depending on the timezone you live in (if you are in a UTC-like timezone then go in another country. changing your computer timezone manually works as well) you'll see that the logs panel time is not aligned with the one from the timeseries panel.

with this changes applied, all timestamps should be aligned.

I don't know of a proper way to add unit tests for this, as AFAIK it's not possible to change jest's timezone for a single test. happy to get some suggestions here if you can think of a good way to do it.