### PR TITLE
Prometheus: Fix some of the alerting queries that use reduce/math operation

### DIFF
--- a/pkg/tsdb/prometheus/json_to_dataframes_test.go
+++ b/pkg/tsdb/prometheus/json_to_dataframes_test.go
@@ -109,7 +109,7 @@ func testScenario(t *testing.T, name string) {
 	api, err := makeMockedApi(responseBytes)
 	require.NoError(t, err)
 
-	result, err := runQueries(context.Background(), api, []*PrometheusQuery{&query})
+	result, err := runQueries(context.Background(), api, []*PrometheusQuery{&query}, true)
 	require.NoError(t, err)
 	require.Len(t, result.Responses, 1)
 

--- a/pkg/tsdb/prometheus/time_series_query.go
+++ b/pkg/tsdb/prometheus/time_series_query.go
@@ -47,7 +47,7 @@ const (
 	ExemplarQueryType TimeSeriesQueryType = "exemplar"
 )
 
-func runQueries(ctx context.Context, client apiv1.API, queries []*PrometheusQuery) (*backend.QueryDataResponse, error) {
+func runQueries(ctx context.Context, client apiv1.API, queries []*PrometheusQuery, fillNulls bool) (*backend.QueryDataResponse, error) {
 	result := backend.QueryDataResponse{
 		Responses: backend.Responses{},
 	}
@@ -101,7 +101,7 @@ func runQueries(ctx context.Context, client apiv1.API, queries []*PrometheusQuer
 			}
 		}
 
-		frames, err := parseTimeSeriesResponse(response, query)
+		frames, err := parseTimeSeriesResponse(response, query, fillNulls)
 		if err != nil {
 			return &result, err
 		}
@@ -128,7 +128,12 @@ func (s *Service) executeTimeSeriesQuery(ctx context.Context, req *backend.Query
 		return &result, err
 	}
 
-	return runQueries(ctx, client, queries)
+	fillNulls := true
+	if req.Headers["FromAlert"] == "true" {
+		fillNulls = false
+	}
+
+	return runQueries(ctx, client, queries, fillNulls)
 }
 
 func formatLegend(metric model.Metric, query *PrometheusQuery) string {
@@ -202,7 +207,7 @@ func (s *Service) parseTimeSeriesQuery(queryContext *backend.QueryDataRequest, d
 	return qs, nil
 }
 
-func parseTimeSeriesResponse(value map[TimeSeriesQueryType]interface{}, query *PrometheusQuery) (data.Frames, error) {
+func parseTimeSeriesResponse(value map[TimeSeriesQueryType]interface{}, query *PrometheusQuery, fillNulls bool) (data.Frames, error) {
 	var (
 		frames     = data.Frames{}
 		nextFrames = data.Frames{}
@@ -214,7 +219,11 @@ func parseTimeSeriesResponse(value map[TimeSeriesQueryType]interface{}, query *P
 
 		switch v := value.(type) {
 		case model.Matrix:
-			nextFrames = matrixToDataFrames(v, query, nextFrames)
+			if fillNulls {
+				nextFrames = matrixToDataFramesWithNullFill(v, query, nextFrames)
+			} else {
+				nextFrames = matrixToDataFrames(v, query, nextFrames)
+			}
 		case model.Vector:
 			nextFrames = vectorToDataFrames(v, query, nextFrames)
 		case *model.Scalar:
@@ -308,7 +317,7 @@ func interpolateVariables(model *QueryModel, interval time.Duration, timeRange t
 	return expr
 }
 
-func matrixToDataFrames(matrix model.Matrix, query *PrometheusQuery, frames data.Frames) data.Frames {
+func matrixToDataFramesWithNullFill(matrix model.Matrix, query *PrometheusQuery, frames data.Frames) data.Frames {
 	for _, v := range matrix {
 		tags := make(map[string]string, len(v.Metric))
 		for k, v := range v.Metric {
@@ -352,6 +361,35 @@ func matrixToDataFrames(matrix model.Matrix, query *PrometheusQuery, frames data
 		valueField.Config = &data.FieldConfig{DisplayNameFromDS: name}
 		valueField.Labels = tags
 
+		frames = append(frames, newDataFrame(name, "matrix", timeField, valueField))
+	}
+
+	return frames
+}
+
+func matrixToDataFrames(matrix model.Matrix, query *PrometheusQuery, frames data.Frames) data.Frames {
+	for _, v := range matrix {
+		tags := make(map[string]string, len(v.Metric))
+		for k, v := range v.Metric {
+			tags[string(k)] = string(v)
+		}
+		timeField := data.NewFieldFromFieldType(data.FieldTypeTime, len(v.Values))
+		valueField := data.NewFieldFromFieldType(data.FieldTypeNullableFloat64, len(v.Values))
+
+		for i, k := range v.Values {
+			timeField.Set(i, time.Unix(k.Timestamp.Unix(), 0).UTC())
+			value := float64(k.Value)
+
+			if !math.IsNaN(value) {
+				valueField.Set(i, &value)
+			}
+		}
+
+		name := formatLegend(v.Metric, query)
+		timeField.Name = data.TimeSeriesTimeFieldName
+		valueField.Name = data.TimeSeriesValueFieldName
+		valueField.Config = &data.FieldConfig{DisplayNameFromDS: name}
+		valueField.Labels = tags
 		frames = append(frames, newDataFrame(name, "matrix", timeField, valueField))
 	}
 


### PR DESCRIPTION
Backport (#44380)

* Prometheus: Dont fill response with nulls for alerting queries

* Refactor based on reviews

(cherry picked from commit 780591cc1259684982de937766ab196820194f93)

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

