### PR TITLE
Alerting: Create basic storage layer for provisioning

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -105,6 +105,14 @@ func (alertRule *AlertRule) PreSave(timeNow func() time.Time) error {
 	return nil
 }
 
+func (alertRule *AlertRule) GetResourceTypeIdentifier() string {
+	return "alertRule"
+}
+
+func (alertRule *AlertRule) GetResourceUniqueIdentifier() string {
+	return alertRule.UID
+}
+
 // AlertRuleVersion is the model for alert rule versions in unified alerting.
 type AlertRuleVersion struct {
 	ID               int64  `xorm:"pk autoincr 'id'"`

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -105,7 +105,7 @@ func (alertRule *AlertRule) PreSave(timeNow func() time.Time) error {
 	return nil
 }
 
-func (alertRule *AlertRule) ResourceTypeID() string {
+func (alertRule *AlertRule) ResourceType() string {
 	return "alertRule"
 }
 

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -105,11 +105,11 @@ func (alertRule *AlertRule) PreSave(timeNow func() time.Time) error {
 	return nil
 }
 
-func (alertRule *AlertRule) GetResourceTypeIdentifier() string {
+func (alertRule *AlertRule) ResourceTypeID() string {
 	return "alertRule"
 }
 
-func (alertRule *AlertRule) GetResourceUniqueIdentifier() string {
+func (alertRule *AlertRule) ResourceID() string {
 	return alertRule.UID
 }
 

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -113,6 +113,10 @@ func (alertRule *AlertRule) ResourceID() string {
 	return alertRule.UID
 }
 
+func (alertRule *AlertRule) ResourceOrgID() int64 {
+	return alertRule.OrgID
+}
+
 // AlertRuleVersion is the model for alert rule versions in unified alerting.
 type AlertRuleVersion struct {
 	ID               int64  `xorm:"pk autoincr 'id'"`

--- a/pkg/services/ngalert/models/provisioning.go
+++ b/pkg/services/ngalert/models/provisioning.go
@@ -10,7 +10,7 @@ const (
 
 // Provisionable represents a resource that can be created through a provisioning mechanism, such as Terraform or config file.
 type Provisionable interface {
-	ResourceTypeID() string
+	ResourceType() string
 	ResourceID() string
 	ResourceOrgID() int64
 }

--- a/pkg/services/ngalert/models/provisioning.go
+++ b/pkg/services/ngalert/models/provisioning.go
@@ -8,7 +8,20 @@ const (
 	File Provenance = "file"
 )
 
-func GetResourceTypeIdentifier(o interface{}) string {
+type ProvisionedObject interface {
+	GetResourceTypeIdentifier() string
+	GetResourceUniqueIdentifier() string
+}
+
+func (ar *AlertRule) GetResourceTypeIdentifier() string {
+	return "alertRule"
+}
+
+func (ar *AlertRule) GetResourceUniqueIdentifier() string {
+	return ar.UID
+}
+
+/*func GetResourceTypeIdentifier(o interface{}) string {
 	switch o.(type) {
 	case AlertRule:
 		return "alertRule"
@@ -24,4 +37,4 @@ func GetResourceUniqueIdentifier(o interface{}) string {
 	default:
 		return ""
 	}
-}
+}*/

--- a/pkg/services/ngalert/models/provisioning.go
+++ b/pkg/services/ngalert/models/provisioning.go
@@ -1,0 +1,27 @@
+package models
+
+type Provenance string
+
+const (
+	None Provenance = ""
+	Api  Provenance = "api"
+	File Provenance = "file"
+)
+
+func GetResourceTypeIdentifier(o interface{}) string {
+	switch o.(type) {
+	case AlertRule:
+		return "alertRule"
+	default:
+		return ""
+	}
+}
+
+func GetResourceUniqueIdentifier(o interface{}) string {
+	switch o.(type) {
+	case AlertRule:
+		return o.(AlertRule).UID
+	default:
+		return ""
+	}
+}

--- a/pkg/services/ngalert/models/provisioning.go
+++ b/pkg/services/ngalert/models/provisioning.go
@@ -13,10 +13,10 @@ type ProvisionedObject interface {
 	GetResourceUniqueIdentifier() string
 }
 
-func (ar *AlertRule) GetResourceTypeIdentifier() string {
+func (alertRule *AlertRule) GetResourceTypeIdentifier() string {
 	return "alertRule"
 }
 
-func (ar *AlertRule) GetResourceUniqueIdentifier() string {
-	return ar.UID
+func (alertRule *AlertRule) GetResourceUniqueIdentifier() string {
+	return alertRule.UID
 }

--- a/pkg/services/ngalert/models/provisioning.go
+++ b/pkg/services/ngalert/models/provisioning.go
@@ -12,4 +12,5 @@ const (
 type Provisionable interface {
 	ResourceTypeID() string
 	ResourceID() string
+	ResourceOrgID() int64
 }

--- a/pkg/services/ngalert/models/provisioning.go
+++ b/pkg/services/ngalert/models/provisioning.go
@@ -8,7 +8,7 @@ const (
 	ProvenanceFile Provenance = "file"
 )
 
-type ProvisionedObject interface {
+type Provisionable interface {
 	GetResourceTypeIdentifier() string
 	GetResourceUniqueIdentifier() string
 }

--- a/pkg/services/ngalert/models/provisioning.go
+++ b/pkg/services/ngalert/models/provisioning.go
@@ -3,9 +3,9 @@ package models
 type Provenance string
 
 const (
-	None Provenance = ""
-	Api  Provenance = "api"
-	File Provenance = "file"
+	ProvenanceNone Provenance = ""
+	ProvenanceApi  Provenance = "api"
+	ProvenanceFile Provenance = "file"
 )
 
 type ProvisionedObject interface {
@@ -20,21 +20,3 @@ func (ar *AlertRule) GetResourceTypeIdentifier() string {
 func (ar *AlertRule) GetResourceUniqueIdentifier() string {
 	return ar.UID
 }
-
-/*func GetResourceTypeIdentifier(o interface{}) string {
-	switch o.(type) {
-	case AlertRule:
-		return "alertRule"
-	default:
-		return ""
-	}
-}
-
-func GetResourceUniqueIdentifier(o interface{}) string {
-	switch o.(type) {
-	case AlertRule:
-		return o.(AlertRule).UID
-	default:
-		return ""
-	}
-}*/

--- a/pkg/services/ngalert/models/provisioning.go
+++ b/pkg/services/ngalert/models/provisioning.go
@@ -9,6 +9,6 @@ const (
 )
 
 type Provisionable interface {
-	GetResourceTypeIdentifier() string
-	GetResourceUniqueIdentifier() string
+	ResourceTypeID() string
+	ResourceID() string
 }

--- a/pkg/services/ngalert/models/provisioning.go
+++ b/pkg/services/ngalert/models/provisioning.go
@@ -8,6 +8,7 @@ const (
 	ProvenanceFile Provenance = "file"
 )
 
+// Provisionable represents a resource that can be created through a provisioning mechanism, such as Terraform or config file.
 type Provisionable interface {
 	ResourceTypeID() string
 	ResourceID() string

--- a/pkg/services/ngalert/models/provisioning.go
+++ b/pkg/services/ngalert/models/provisioning.go
@@ -12,11 +12,3 @@ type ProvisionedObject interface {
 	GetResourceTypeIdentifier() string
 	GetResourceUniqueIdentifier() string
 }
-
-func (alertRule *AlertRule) GetResourceTypeIdentifier() string {
-	return "alertRule"
-}
-
-func (alertRule *AlertRule) GetResourceUniqueIdentifier() string {
-	return alertRule.UID
-}

--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -21,12 +21,12 @@ func (pr provenanceRecord) TableName() string {
 }
 
 type ProvisioningStore interface {
-	GetProvenance(o models.ProvisionedObject) (models.Provenance, error)
+	GetProvenance(o models.Provisionable) (models.Provenance, error)
 	// TODO: API to query all provenances for a specific type?
-	SetProvenance(o models.ProvisionedObject, p models.Provenance) error
+	SetProvenance(o models.Provisionable, p models.Provenance) error
 }
 
-func (st DBstore) GetProvenance(o models.ProvisionedObject) (models.Provenance, error) {
+func (st DBstore) GetProvenance(o models.Provisionable) (models.Provenance, error) {
 	recordType := o.GetResourceTypeIdentifier()
 	recordKey := o.GetResourceUniqueIdentifier()
 
@@ -52,7 +52,7 @@ func (st DBstore) GetProvenance(o models.ProvisionedObject) (models.Provenance, 
 	return provenance, nil
 }
 
-func (st DBstore) SetProvenance(o models.ProvisionedObject, p models.Provenance) error {
+func (st DBstore) SetProvenance(o models.Provisionable, p models.Provenance) error {
 	recordType := o.GetResourceTypeIdentifier()
 	recordKey := o.GetResourceUniqueIdentifier()
 

--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -22,6 +22,7 @@ func (pr provenanceRecord) TableName() string {
 
 type ProvisioningStore interface {
 	GetProvenance(o interface{}) (models.Provenance, error)
+	// TODO: API to query all provenances for a specific type
 	SetProvenance(o interface{}, p models.Provenance) error
 }
 
@@ -67,11 +68,33 @@ func (st DBstore) SetProvenance(o interface{}, p models.Provenance) error {
 		return nil
 	}
 
+	/*
+	   NOTES:
+	   BEGIN TRANSACTION
+	   SELECT * FROM ..... WHERE id = 'blah'
+	   UPDATE .... WHERE id = 'blah'
+	   UPDATE .... WHERE foreignId = 'blah'
+	   EXECUTE
+
+
+
+
+	   Begin transaction
+	   update....... WHERE token = 'last_known_token'
+	   CREATE new provenance record....
+	   Execute
+
+	   in memory:
+	   >0 records updated! successful transaction
+
+	   reacquire token, reapply, or reject request....*/
+
 	return st.SQLStore.WithTransactionalDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 		// TODO: this is gonna slap the database. Is in-memory caching of provenance status possible? does this break HA?
 		// TODO: either way, this is a really naive way of doing this.
 		// TODO: this also totally won't slap the database if we use a unit of work pattern. This solves other problems too.
 		// TODO: Need to make sure that writing a record where our concurrency key fails will also fail the whole transaction. That way, this gets rolled back too. can't just check that 0 updates happened inmemory. Check with jp. If not possible, we need our own concurrency key.
+		// TODO: clean up provenance records periodically
 		q := "DELETE FROM provenance_type WHERE record_key = ? AND record_type = ?"
 		_, err := sess.Exec(q, recordKey, recordType)
 		if err != nil {

--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -34,18 +34,14 @@ func (st DBstore) GetProvenance(ctx context.Context, o models.Provisionable) (mo
 
 	provenance := models.ProvenanceNone
 	err := st.SQLStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		result := make([]*provenanceRecord, 0)
-		q := "SELECT * FROM provenance_type WHERE record_key = ? AND record_type = ? ORDER BY id ASC LIMIT 1"
-		params := []interface{}{recordKey, recordType}
-
-		if err := sess.SQL(q, params...).Find(&result); err != nil {
+		var result models.Provenance
+		has, err := sess.Table(provenanceRecord{}).Where("record_key = ? AND record_type = ?", recordKey, recordType).Desc("id").Cols("provenance").Get(&result)
+		if err != nil {
 			return fmt.Errorf("failed to query for existing provenance status: %w", err)
 		}
-		if len(result) < 1 {
-			return nil
+		if has {
+			provenance = result
 		}
-
-		provenance = result[0].Provenance
 		return nil
 	})
 	if err != nil {
@@ -63,8 +59,8 @@ func (st DBstore) SetProvenance(ctx context.Context, o models.Provisionable, p m
 		// TODO: Add a unit-of-work pattern, so updating objects + provenance will happen consistently with rollbacks across stores.
 		// TODO: Need to make sure that writing a record where our concurrency key fails will also fail the whole transaction. That way, this gets rolled back too. can't just check that 0 updates happened inmemory. Check with jp. If not possible, we need our own concurrency key.
 		// TODO: Clean up stale provenance records periodically.
-		q := "DELETE FROM provenance_type WHERE record_key = ? AND record_type = ?"
-		_, err := sess.Exec(q, recordKey, recordType)
+		_, err := sess.Table(provenanceRecord{}).Where("record_key = ? AND record_type = ?", recordKey, recordType).Delete(provenanceRecord{})
+
 		if err != nil {
 			return fmt.Errorf("failed to delete pre-existing provisioning status: %w", err)
 		}

--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -22,7 +22,7 @@ func (pr provenanceRecord) TableName() string {
 
 type ProvisioningStore interface {
 	GetProvenance(o interface{}) (models.Provenance, error)
-	// TODO: API to query all provenances for a specific type
+	// TODO: API to query all provenances for a specific type?
 	SetProvenance(o interface{}, p models.Provenance) error
 }
 
@@ -30,7 +30,7 @@ func (st DBstore) GetProvenance(o models.ProvisionedObject) (models.Provenance, 
 	recordType := o.GetResourceTypeIdentifier()
 	recordKey := o.GetResourceUniqueIdentifier()
 
-	provenance := models.None
+	provenance := models.ProvenanceNone
 	err := st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 		result := make([]*provenanceRecord, 0)
 		q := "SELECT * FROM provenance_type WHERE record_key = ? AND record_type = ? ORDER BY id ASC LIMIT 1"
@@ -47,7 +47,7 @@ func (st DBstore) GetProvenance(o models.ProvisionedObject) (models.Provenance, 
 		return nil
 	})
 	if err != nil {
-		return models.None, err
+		return models.ProvenanceNone, err
 	}
 	return provenance, nil
 }

--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -37,7 +37,7 @@ func (st DBstore) GetProvenance(ctx context.Context, o models.Provisionable) (mo
 		params := []interface{}{recordKey, recordType}
 
 		if err := sess.SQL(q, params...).Find(&result); err != nil {
-			return err
+			return fmt.Errorf("failed to query for existing provenance status: %w", err)
 		}
 		if len(result) < 1 {
 			return nil

--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -1,0 +1,93 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+)
+
+type provenanceRecord struct {
+	Id         int `xorm:"pk autoincr 'id'"`
+	OrgId      int
+	RecordKey  string
+	RecordType string
+	Provenance models.Provenance
+}
+
+func (pr provenanceRecord) TableName() string {
+	return "provenance_type"
+}
+
+type ProvisioningStore interface {
+	GetProvenance(o interface{}) (models.Provenance, error)
+	SetProvenance(o interface{}, p models.Provenance) error
+}
+
+func (st DBstore) GetProvenance(o interface{}) (models.Provenance, error) {
+	recordType := models.GetResourceTypeIdentifier(o)
+	if recordType == "" {
+		return models.None, nil
+	}
+	recordKey := models.GetResourceUniqueIdentifier(o)
+	if recordKey == "" {
+		return models.None, nil
+	}
+
+	provenance := models.None
+	err := st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		result := make([]*provenanceRecord, 0)
+		q := "SELECT * FROM provenance_type WHERE record_key = ? AND record_type = ? ORDER BY id ASC LIMIT 1"
+		params := []interface{}{recordKey, recordType}
+
+		if err := sess.SQL(q, params...).Find(&result); err != nil {
+			return err
+		}
+		if len(result) < 1 {
+			return nil
+		}
+
+		provenance = result[0].Provenance
+		return nil
+	})
+	if err != nil {
+		return models.None, err
+	}
+	return provenance, nil
+}
+
+func (st DBstore) SetProvenance(o interface{}, p models.Provenance) error {
+	recordType := models.GetResourceTypeIdentifier(o)
+	if recordType == "" {
+		return nil
+	}
+	recordKey := models.GetResourceUniqueIdentifier(o)
+	if recordKey == "" {
+		return nil
+	}
+
+	return st.SQLStore.WithTransactionalDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		// TODO: this is gonna slap the database. Is in-memory caching of provenance status possible? does this break HA?
+		// TODO: either way, this is a really naive way of doing this.
+		// TODO: this also totally won't slap the database if we use a unit of work pattern. This solves other problems too.
+		// TODO: Need to make sure that writing a record where our concurrency key fails will also fail the whole transaction. That way, this gets rolled back too. can't just check that 0 updates happened inmemory. Check with jp. If not possible, we need our own concurrency key.
+		q := "DELETE FROM provenance_type WHERE record_key = ? AND record_type = ?"
+		_, err := sess.Exec(q, recordKey, recordType)
+		if err != nil {
+			return fmt.Errorf("failed to delete pre-existing provisioning status: %w", err)
+		}
+
+		record := provenanceRecord{
+			RecordKey:  recordKey,
+			RecordType: recordType,
+			Provenance: p,
+		}
+
+		if _, err := sess.Insert(record); err != nil {
+			return fmt.Errorf("failed to store provisioning status: %w", err)
+		}
+
+		return nil
+	})
+}

--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -29,7 +29,7 @@ type ProvisioningStore interface {
 
 // GetProvenance gets the provenance status for a provisionable object.
 func (st DBstore) GetProvenance(ctx context.Context, o models.Provisionable) (models.Provenance, error) {
-	recordType := o.ResourceTypeID()
+	recordType := o.ResourceType()
 	recordKey := o.ResourceID()
 	orgID := o.ResourceOrgID()
 
@@ -54,7 +54,7 @@ func (st DBstore) GetProvenance(ctx context.Context, o models.Provisionable) (mo
 
 // SetProvenance changes the provenance status for a provisionable object.
 func (st DBstore) SetProvenance(ctx context.Context, o models.Provisionable, p models.Provenance) error {
-	recordType := o.ResourceTypeID()
+	recordType := o.ResourceType()
 	recordKey := o.ResourceID()
 	orgID := o.ResourceOrgID()
 

--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -26,15 +26,9 @@ type ProvisioningStore interface {
 	SetProvenance(o interface{}, p models.Provenance) error
 }
 
-func (st DBstore) GetProvenance(o interface{}) (models.Provenance, error) {
-	recordType := models.GetResourceTypeIdentifier(o)
-	if recordType == "" {
-		return models.None, nil
-	}
-	recordKey := models.GetResourceUniqueIdentifier(o)
-	if recordKey == "" {
-		return models.None, nil
-	}
+func (st DBstore) GetProvenance(o models.ProvisionedObject) (models.Provenance, error) {
+	recordType := o.GetResourceTypeIdentifier()
+	recordKey := o.GetResourceUniqueIdentifier()
 
 	provenance := models.None
 	err := st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
@@ -58,15 +52,9 @@ func (st DBstore) GetProvenance(o interface{}) (models.Provenance, error) {
 	return provenance, nil
 }
 
-func (st DBstore) SetProvenance(o interface{}, p models.Provenance) error {
-	recordType := models.GetResourceTypeIdentifier(o)
-	if recordType == "" {
-		return nil
-	}
-	recordKey := models.GetResourceUniqueIdentifier(o)
-	if recordKey == "" {
-		return nil
-	}
+func (st DBstore) SetProvenance(o models.ProvisionedObject, p models.Provenance) error {
+	recordType := o.GetResourceTypeIdentifier()
+	recordKey := o.GetResourceUniqueIdentifier()
 
 	/*
 	   NOTES:

--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -21,9 +21,9 @@ func (pr provenanceRecord) TableName() string {
 }
 
 type ProvisioningStore interface {
-	GetProvenance(o interface{}) (models.Provenance, error)
+	GetProvenance(o models.ProvisionedObject) (models.Provenance, error)
 	// TODO: API to query all provenances for a specific type?
-	SetProvenance(o interface{}, p models.Provenance) error
+	SetProvenance(o models.ProvisionedObject, p models.Provenance) error
 }
 
 func (st DBstore) GetProvenance(o models.ProvisionedObject) (models.Provenance, error) {

--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -20,12 +20,14 @@ func (pr provenanceRecord) TableName() string {
 	return "provenance_type"
 }
 
+// ProvisioningStore is a store of provisioning data for arbitrary objects.
 type ProvisioningStore interface {
 	GetProvenance(ctx context.Context, o models.Provisionable) (models.Provenance, error)
 	// TODO: API to query all provenances for a specific type?
 	SetProvenance(ctx context.Context, o models.Provisionable, p models.Provenance) error
 }
 
+// GetProvenance gets the provenance status for a provisionable object.
 func (st DBstore) GetProvenance(ctx context.Context, o models.Provisionable) (models.Provenance, error) {
 	recordType := o.ResourceTypeID()
 	recordKey := o.ResourceID()
@@ -52,6 +54,7 @@ func (st DBstore) GetProvenance(ctx context.Context, o models.Provisionable) (mo
 	return provenance, nil
 }
 
+// SetProvenance changes the provenance status for a provisionable object.
 func (st DBstore) SetProvenance(ctx context.Context, o models.Provisionable, p models.Provenance) error {
 	recordType := o.ResourceTypeID()
 	recordKey := o.ResourceID()

--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -21,12 +21,12 @@ func (pr provenanceRecord) TableName() string {
 }
 
 type ProvisioningStore interface {
-	GetProvenance(o models.Provisionable) (models.Provenance, error)
+	GetProvenance(ctx context.Context, o models.Provisionable) (models.Provenance, error)
 	// TODO: API to query all provenances for a specific type?
-	SetProvenance(o models.Provisionable, p models.Provenance) error
+	SetProvenance(ctx context.Context, o models.Provisionable, p models.Provenance) error
 }
 
-func (st DBstore) GetProvenance(o models.Provisionable) (models.Provenance, error) {
+func (st DBstore) GetProvenance(ctx context.Context, o models.Provisionable) (models.Provenance, error) {
 	recordType := o.GetResourceTypeIdentifier()
 	recordKey := o.GetResourceUniqueIdentifier()
 
@@ -52,11 +52,11 @@ func (st DBstore) GetProvenance(o models.Provisionable) (models.Provenance, erro
 	return provenance, nil
 }
 
-func (st DBstore) SetProvenance(o models.Provisionable, p models.Provenance) error {
+func (st DBstore) SetProvenance(ctx context.Context, o models.Provisionable, p models.Provenance) error {
 	recordType := o.GetResourceTypeIdentifier()
 	recordKey := o.GetResourceUniqueIdentifier()
 
-	return st.SQLStore.WithTransactionalDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+	return st.SQLStore.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		// TODO: Add a unit-of-work pattern, so updating objects + provenance will happen consistently with rollbacks across stores.
 		// TODO: Need to make sure that writing a record where our concurrency key fails will also fail the whole transaction. That way, this gets rolled back too. can't just check that 0 updates happened inmemory. Check with jp. If not possible, we need our own concurrency key.
 		// TODO: Clean up stale provenance records periodically.

--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -27,11 +27,11 @@ type ProvisioningStore interface {
 }
 
 func (st DBstore) GetProvenance(ctx context.Context, o models.Provisionable) (models.Provenance, error) {
-	recordType := o.GetResourceTypeIdentifier()
-	recordKey := o.GetResourceUniqueIdentifier()
+	recordType := o.ResourceTypeID()
+	recordKey := o.ResourceID()
 
 	provenance := models.ProvenanceNone
-	err := st.SQLStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+	err := st.SQLStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		result := make([]*provenanceRecord, 0)
 		q := "SELECT * FROM provenance_type WHERE record_key = ? AND record_type = ? ORDER BY id ASC LIMIT 1"
 		params := []interface{}{recordKey, recordType}
@@ -53,8 +53,8 @@ func (st DBstore) GetProvenance(ctx context.Context, o models.Provisionable) (mo
 }
 
 func (st DBstore) SetProvenance(ctx context.Context, o models.Provisionable, p models.Provenance) error {
-	recordType := o.GetResourceTypeIdentifier()
-	recordKey := o.GetResourceUniqueIdentifier()
+	recordType := o.ResourceTypeID()
+	recordKey := o.ResourceID()
 
 	return st.SQLStore.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		// TODO: Add a unit-of-work pattern, so updating objects + provenance will happen consistently with rollbacks across stores.

--- a/pkg/services/ngalert/store/provisioning_store_test.go
+++ b/pkg/services/ngalert/store/provisioning_store_test.go
@@ -37,5 +37,3 @@ func TestProvisioningStore(t *testing.T) {
 		require.Equal(t, models.ProvenanceFile, p)
 	})
 }
-
-type randomStruct struct{}

--- a/pkg/services/ngalert/store/provisioning_store_test.go
+++ b/pkg/services/ngalert/store/provisioning_store_test.go
@@ -1,6 +1,7 @@
 package store_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -18,7 +19,7 @@ func TestProvisioningStore(t *testing.T) {
 			UID: "asdf",
 		}
 
-		provenance, err := dbstore.GetProvenance(&rule)
+		provenance, err := dbstore.GetProvenance(context.Background(), &rule)
 
 		require.NoError(t, err)
 		require.Equal(t, models.ProvenanceNone, provenance)
@@ -28,10 +29,10 @@ func TestProvisioningStore(t *testing.T) {
 		rule := models.AlertRule{
 			UID: "123",
 		}
-		err := dbstore.SetProvenance(&rule, models.ProvenanceFile)
+		err := dbstore.SetProvenance(context.Background(), &rule, models.ProvenanceFile)
 		require.NoError(t, err)
 
-		p, err := dbstore.GetProvenance(&rule)
+		p, err := dbstore.GetProvenance(context.Background(), &rule)
 
 		require.NoError(t, err)
 		require.Equal(t, models.ProvenanceFile, p)

--- a/pkg/services/ngalert/store/provisioning_store_test.go
+++ b/pkg/services/ngalert/store/provisioning_store_test.go
@@ -21,20 +21,20 @@ func TestProvisioningStore(t *testing.T) {
 		provenance, err := dbstore.GetProvenance(&rule)
 
 		require.NoError(t, err)
-		require.Equal(t, models.None, provenance)
+		require.Equal(t, models.ProvenanceNone, provenance)
 	})
 
 	t.Run("Store returns saved provenance type", func(t *testing.T) {
 		rule := models.AlertRule{
 			UID: "123",
 		}
-		err := dbstore.SetProvenance(&rule, models.File)
+		err := dbstore.SetProvenance(&rule, models.ProvenanceFile)
 		require.NoError(t, err)
 
 		p, err := dbstore.GetProvenance(&rule)
 
 		require.NoError(t, err)
-		require.Equal(t, models.File, p)
+		require.Equal(t, models.ProvenanceFile, p)
 	})
 }
 

--- a/pkg/services/ngalert/store/provisioning_store_test.go
+++ b/pkg/services/ngalert/store/provisioning_store_test.go
@@ -13,19 +13,12 @@ const testAlertingIntervalSeconds = 10
 func TestProvisioningStore(t *testing.T) {
 	_, dbstore := tests.SetupTestEnv(t, testAlertingIntervalSeconds)
 
-	t.Run("Provenance of an unknown type is always None", func(t *testing.T) {
-		provenance, err := dbstore.GetProvenance(randomStruct{})
-
-		require.NoError(t, err)
-		require.Equal(t, models.None, provenance)
-	})
-
 	t.Run("Default provenance of a known type is None", func(t *testing.T) {
 		rule := models.AlertRule{
 			UID: "asdf",
 		}
 
-		provenance, err := dbstore.GetProvenance(rule)
+		provenance, err := dbstore.GetProvenance(&rule)
 
 		require.NoError(t, err)
 		require.Equal(t, models.None, provenance)
@@ -35,10 +28,10 @@ func TestProvisioningStore(t *testing.T) {
 		rule := models.AlertRule{
 			UID: "123",
 		}
-		err := dbstore.SetProvenance(rule, models.File)
+		err := dbstore.SetProvenance(&rule, models.File)
 		require.NoError(t, err)
 
-		p, err := dbstore.GetProvenance(rule)
+		p, err := dbstore.GetProvenance(&rule)
 
 		require.NoError(t, err)
 		require.Equal(t, models.File, p)

--- a/pkg/services/ngalert/store/provisioning_store_test.go
+++ b/pkg/services/ngalert/store/provisioning_store_test.go
@@ -1,0 +1,48 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/tests"
+	"github.com/stretchr/testify/require"
+)
+
+const testAlertingIntervalSeconds = 10
+
+func TestProvisioningStore(t *testing.T) {
+	_, dbstore := tests.SetupTestEnv(t, testAlertingIntervalSeconds)
+
+	t.Run("Provenance of an unknown type is always None", func(t *testing.T) {
+		provenance, err := dbstore.GetProvenance(randomStruct{})
+
+		require.NoError(t, err)
+		require.Equal(t, models.None, provenance)
+	})
+
+	t.Run("Default provenance of a known type is None", func(t *testing.T) {
+		rule := models.AlertRule{
+			UID: "asdf",
+		}
+
+		provenance, err := dbstore.GetProvenance(rule)
+
+		require.NoError(t, err)
+		require.Equal(t, models.None, provenance)
+	})
+
+	t.Run("Store returns saved provenance type", func(t *testing.T) {
+		rule := models.AlertRule{
+			UID: "123",
+		}
+		err := dbstore.SetProvenance(rule, models.File)
+		require.NoError(t, err)
+
+		p, err := dbstore.GetProvenance(rule)
+
+		require.NoError(t, err)
+		require.Equal(t, models.File, p)
+	})
+}
+
+type randomStruct struct{}

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -22,6 +22,9 @@ func AddTablesMigrations(mg *migrator.Migrator) {
 
 	// Create Admin Configuration
 	AddAlertAdminConfigMigrations(mg)
+
+	// Create provisioning data table
+	AddProvisioningMigrations(mg)
 }
 
 // AddAlertDefinitionMigrations should not be modified.
@@ -326,4 +329,23 @@ func AddAlertAdminConfigMigrations(mg *migrator.Migrator) {
 	mg.AddMigration("add column send_alerts_to in ngalert_configuration", migrator.NewAddColumnMigration(adminConfiguration, &migrator.Column{
 		Name: "send_alerts_to", Type: migrator.DB_SmallInt, Nullable: false,
 	}))
+}
+
+func AddProvisioningMigrations(mg *migrator.Migrator) {
+	provisioningTable := migrator.Table{
+		Name: "provenance_type",
+		Columns: []*migrator.Column{
+			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
+			{Name: "org_id", Type: migrator.DB_BigInt, Nullable: false},
+			{Name: "record_key", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "record_type", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "provenance", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+		},
+		Indices: []*migrator.Index{
+			{Cols: []string{"record_type", "record_key"}, Type: migrator.UniqueIndex},
+		},
+	}
+
+	mg.AddMigration("create provenance_type table", migrator.NewAddTableMigration(provisioningTable))
+	mg.AddMigration("add index to uniquify (record_key, record_type) columns", migrator.NewAddIndexMigration(provisioningTable, provisioningTable.Indices[0]))
 }

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -342,10 +342,10 @@ func AddProvisioningMigrations(mg *migrator.Migrator) {
 			{Name: "provenance", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 		},
 		Indices: []*migrator.Index{
-			{Cols: []string{"record_type", "record_key"}, Type: migrator.UniqueIndex},
+			{Cols: []string{"record_type", "record_key", "org_id"}, Type: migrator.UniqueIndex},
 		},
 	}
 
 	mg.AddMigration("create provenance_type table", migrator.NewAddTableMigration(provisioningTable))
-	mg.AddMigration("add index to uniquify (record_key, record_type) columns", migrator.NewAddIndexMigration(provisioningTable, provisioningTable.Indices[0]))
+	mg.AddMigration("add index to uniquify (record_key, record_type, org_id) columns", migrator.NewAddIndexMigration(provisioningTable, provisioningTable.Indices[0]))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a basic storage layer for tracking provisioning status of objects.

The purpose of this PR is to add a base-line approach that satisfies a few simple behavioral tests. More complex behavior will build off of this base in future changes. For the sake of easier review, the goal is to keep things small for now.

Future PRs are in-work to add the following properties:
- Transaction support across stores - ability to update a record and its provisioning status atomically.
- Linearizable writes - prevent concurrent reads/updates from conflicting with each other.
- Cleaning up of dead records.