### PR TITLE
Tempo: Show error if transformTrace() is passed bad data to parse to JSON

### DIFF
--- a/public/app/plugins/datasource/tempo/resultTransformer.test.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.test.ts
@@ -129,7 +129,7 @@ describe('transformFromOTLP()', () => {
     );
 
     expect(res.data[0]).toBeFalsy();
-    expect(res?.error?.message).toContain('JSON is not valid OpenTelemetry format');
+    expect(res.error?.message).toBeTruthy();
     // if it does have resources, no error will be thrown
     expect({
       ...res.data[0],
@@ -175,9 +175,13 @@ describe('transformTrace()', () => {
   test('if passed bad data, will surface an error', () => {
     const response = transformTrace({ data: [badFrame] }, false);
     expect(response.data[0]).toBeFalsy();
-    expect(response?.error?.message).toContain('JSON is not valid OpenTelemetry format');
+    expect(response.error?.message).toBeTruthy();
+  });
 
+  test('if passed good data, will parse successfully', () => {
     const response2 = transformTrace({ data: [goodFrame] }, false);
-    expect(response2.data[0]).not.toBeFalsy();
+    expect(response2.data[0]).toBeTruthy();
+    expect(response2.data[0]).toMatchObject(goodFrame);
+    expect(response2.error).toBeFalsy();
   });
 });

--- a/public/app/plugins/datasource/tempo/resultTransformer.test.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.test.ts
@@ -1,13 +1,44 @@
-import { FieldType, MutableDataFrame, PluginType, DataSourceInstanceSettings, dateTime } from '@grafana/data';
+import {
+  ArrayVector,
+  FieldType,
+  MutableDataFrame,
+  PluginType,
+  DataSourceInstanceSettings,
+  dateTime,
+} from '@grafana/data';
 import {
   SearchResponse,
   createTableFrame,
   transformToOTLP,
   transformFromOTLP,
+  transformTrace,
   createTableFrameFromSearch,
 } from './resultTransformer';
-import { otlpDataFrameToResponse, otlpDataFrameFromResponse, otlpResponse, tempoSearchResponse } from './testResponse';
+import {
+  badOTLPResponse,
+  otlpDataFrameToResponse,
+  otlpDataFrameFromResponse,
+  otlpResponse,
+  tempoSearchResponse,
+} from './testResponse';
 import { collectorTypes } from '@opentelemetry/exporter-collector';
+
+const defaultSettings: DataSourceInstanceSettings = {
+  id: 0,
+  uid: '0',
+  type: 'tracing',
+  name: 'tempo',
+  access: 'proxy',
+  meta: {
+    id: 'tempo',
+    name: 'tempo',
+    type: PluginType.datasource,
+    info: {} as any,
+    module: '',
+    baseUrl: '',
+  },
+  jsonData: {},
+};
 
 describe('transformTraceList()', () => {
   const lokiDataFrame = new MutableDataFrame({
@@ -84,19 +115,69 @@ describe('createTableFrameFromSearch()', () => {
   });
 });
 
-const defaultSettings: DataSourceInstanceSettings = {
-  id: 0,
-  uid: '0',
-  type: 'tracing',
-  name: 'tempo',
-  access: 'proxy',
-  meta: {
-    id: 'tempo',
-    name: 'tempo',
-    type: PluginType.datasource,
-    info: {} as any,
-    module: '',
-    baseUrl: '',
-  },
-  jsonData: {},
-};
+describe('transformFromOTLP()', () => {
+  // Mock the console error so that running the test suite doesnt throw the error
+  const origError = console.error;
+  const consoleErrorMock = jest.fn();
+  afterEach(() => (console.error = origError));
+  beforeEach(() => (console.error = consoleErrorMock));
+
+  test('if passed bad data, will surface an error', () => {
+    const res = transformFromOTLP(
+      (badOTLPResponse.batches as unknown) as collectorTypes.opentelemetryProto.trace.v1.ResourceSpans[],
+      false
+    );
+
+    expect(res.data[0]).toBeFalsy();
+    expect(res?.error?.message).toContain('JSON is not valid OpenTelemetry format');
+    // if it does have resources, no error will be thrown
+    expect({
+      ...res.data[0],
+      resources: {
+        attributes: [
+          { key: 'service.name', value: { stringValue: 'db' } },
+          { key: 'job', value: { stringValue: 'tns/db' } },
+          { key: 'opencensus.exporterversion', value: { stringValue: 'Jaeger-Go-2.22.1' } },
+          { key: 'host.name', value: { stringValue: '63d16772b4a2' } },
+          { key: 'ip', value: { stringValue: '0.0.0.0' } },
+          { key: 'client-uuid', value: { stringValue: '39fb01637a579639' } },
+        ],
+      },
+    }).not.toBeFalsy();
+  });
+});
+
+describe('transformTrace()', () => {
+  // Mock the console error so that running the test suite doesnt throw the error
+  const origError = console.error;
+  const consoleErrorMock = jest.fn();
+  afterEach(() => (console.error = origError));
+  beforeEach(() => (console.error = consoleErrorMock));
+
+  const badFrame = new MutableDataFrame({
+    fields: [
+      {
+        name: 'serviceTags',
+        values: new ArrayVector([undefined]),
+      },
+    ],
+  });
+
+  const goodFrame = new MutableDataFrame({
+    fields: [
+      {
+        name: 'serviceTags',
+        values: new ArrayVector(),
+      },
+    ],
+  });
+
+  test('if passed bad data, will surface an error', () => {
+    const response = transformTrace({ data: [badFrame] }, false);
+    expect(response.data[0]).toBeFalsy();
+    expect(response?.error?.message).toContain('JSON is not valid OpenTelemetry format');
+
+    const response2 = transformTrace({ data: [goodFrame] }, false);
+    expect(response2.data[0]).not.toBeFalsy();
+  });
+});

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -491,7 +491,12 @@ export function transformTrace(response: DataQueryResponse, nodeGraph = false): 
     return emptyDataQueryResponse;
   }
 
-  parseJsonFields(frame);
+  try {
+    parseJsonFields(frame);
+  } catch (error) {
+    console.error(error);
+    return { error: { message: 'JSON is not valid OpenTelemetry format: ' + error }, data: [] };
+  }
 
   let data = [...response.data];
   if (nodeGraph) {

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -495,7 +495,7 @@ export function transformTrace(response: DataQueryResponse, nodeGraph = false): 
     parseJsonFields(frame);
   } catch (error) {
     console.error(error);
-    return { error: { message: 'JSON is not valid OpenTelemetry format: ' + error }, data: [] };
+    return { error: { message: 'Unable to parse trace response: ' + error }, data: [] };
   }
 
   let data = [...response.data];

--- a/public/app/plugins/datasource/tempo/testResponse.ts
+++ b/public/app/plugins/datasource/tempo/testResponse.ts
@@ -2223,3 +2223,32 @@ export const tempoSearchResponse = {
     inspectedBytes: '83720',
   },
 };
+
+export const badOTLPResponse = {
+  batches: [
+    {
+      resource: {},
+      instrumentationLibrarySpans: [
+        {
+          spans: [
+            {
+              traceId: 'AAAAAAAAAABguiq7RPE+rg==',
+              spanId: 'cmteMBAvwNA=',
+              parentSpanId: 'OY8PIaPbma4=',
+              name: 'HTTP GET - root',
+              kind: 'SPAN_KIND_CLIENT',
+              startTimeUnixNano: 1627471657255809000,
+              endTimeUnixNano: 1627471657256268000,
+              attributes: [
+                { key: 'http.status_code', value: { intValue: 200 } },
+                { key: 'http.method', value: { stringValue: 'GET' } },
+                { key: 'http.url', value: { stringValue: '/' } },
+                { key: 'component', value: { stringValue: 'net/http' } },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
**What this PR does / why we need it**:
- This PR fixes the issue where, the function `parseJsonData` is passed bad data and fails silently. We need to surface an error so that the frontend notifies the user.
- This PR also adds a test for the a function written by @connorlindsey in the same file `transformFromOTLP()` that also surfaces an error if it receives bad data. I was just testing my own and was doing so by adding a test to his, so just thought I'd leave that test. LMK if it's wrong!

**Which issue(s) this PR fixes**:
Closes [Tempo: Show some error message when we could not transform response](https://github.com/grafana/grafana/issues/42131) 

**Special notes for your reviewer**:
I did not put bad data into the UI to trigger this, instead, by @connorlindsey suggestion, I used TDD. So attached you'll see the tests returning the correct `console.error`. Then I mocked those console errors, so that you dont actually see them when running the test suite. 

***Test of bad data, returns a console error and surfaces the error to Grafana global alerting `JSON is not valid OpenTelemetry format`***

<img width="418" alt="Screen Shot 2022-01-31 at 3 31 55 PM" src="https://user-images.githubusercontent.com/27353719/151890267-8723ac9c-db33-410e-bd10-662e16020ba3.png">

<img width="412" alt="Screen Shot 2022-01-31 at 3 32 06 PM" src="https://user-images.githubusercontent.com/27353719/151890294-18ea72bb-f3e4-4ef3-8285-e1234c9cd1d8.png">

***With mocking of console.error and passing tests***
<img width="412" alt="Screen Shot 2022-01-31 at 3 32 21 PM" src="https://user-images.githubusercontent.com/27353719/151890303-0b4ec5e2-71dc-477d-8e46-267f398825bc.png">

