### PR TITLE
Variables: Change datasource and query editor in the same action

### DIFF
--- a/public/app/features/variables/editor/reducer.ts
+++ b/public/app/features/variables/editor/reducer.ts
@@ -13,12 +13,12 @@ export interface VariableEditorState<ExtendedProps extends {} = {}> {
   extended: VariableEditorExtension<ExtendedProps> | null;
 }
 
-interface VariableEditorExtendedProps {
-  dataSource?: DataSourceApi;
+export interface QueryVariableEditorState {
+  dataSource?: DataSourceApi | null;
   VariableQueryEditor?: VariableQueryEditorType;
 }
 
-export const initialVariableEditorState: VariableEditorState<VariableEditorExtendedProps> = {
+export const initialVariableEditorState: VariableEditorState<QueryVariableEditorState> = {
   id: '',
   isValid: true,
   errors: {},
@@ -30,26 +30,26 @@ const variableEditorReducerSlice = createSlice({
   name: 'templating/editor',
   initialState: initialVariableEditorState,
   reducers: {
-    setIdInEditor: (state: VariableEditorState<VariableEditorExtendedProps>, action: PayloadAction<{ id: string }>) => {
+    setIdInEditor: (state: VariableEditorState<QueryVariableEditorState>, action: PayloadAction<{ id: string }>) => {
       state.id = action.payload.id;
     },
-    clearIdInEditor: (state: VariableEditorState<VariableEditorExtendedProps>, action: PayloadAction<undefined>) => {
+    clearIdInEditor: (state: VariableEditorState<QueryVariableEditorState>, action: PayloadAction<undefined>) => {
       state.id = '';
     },
     variableEditorMounted: (
-      state: VariableEditorState<VariableEditorExtendedProps>,
+      state: VariableEditorState<QueryVariableEditorState>,
       action: PayloadAction<{ name: string }>
     ) => {
       state.name = action.payload.name;
     },
     variableEditorUnMounted: (
-      state: VariableEditorState<VariableEditorExtendedProps>,
+      state: VariableEditorState<QueryVariableEditorState>,
       action: PayloadAction<VariablePayload>
     ) => {
       return initialVariableEditorState;
     },
     changeVariableNameSucceeded: (
-      state: VariableEditorState<VariableEditorExtendedProps>,
+      state: VariableEditorState<QueryVariableEditorState>,
       action: PayloadAction<VariablePayload<{ newName: string }>>
     ) => {
       state.name = action.payload.data.newName;
@@ -57,7 +57,7 @@ const variableEditorReducerSlice = createSlice({
       state.isValid = Object.keys(state.errors).length === 0;
     },
     changeVariableNameFailed: (
-      state: VariableEditorState<VariableEditorExtendedProps>,
+      state: VariableEditorState<QueryVariableEditorState>,
       action: PayloadAction<{ newName: string; errorText: string }>
     ) => {
       state.name = action.payload.newName;
@@ -65,21 +65,21 @@ const variableEditorReducerSlice = createSlice({
       state.isValid = Object.keys(state.errors).length === 0;
     },
     addVariableEditorError: (
-      state: VariableEditorState<VariableEditorExtendedProps>,
+      state: VariableEditorState<QueryVariableEditorState>,
       action: PayloadAction<{ errorProp: string; errorText: any }>
     ) => {
       state.errors[action.payload.errorProp] = action.payload.errorText;
       state.isValid = Object.keys(state.errors).length === 0;
     },
     removeVariableEditorError: (
-      state: VariableEditorState<VariableEditorExtendedProps>,
+      state: VariableEditorState<QueryVariableEditorState>,
       action: PayloadAction<{ errorProp: string }>
     ) => {
       delete state.errors[action.payload.errorProp];
       state.isValid = Object.keys(state.errors).length === 0;
     },
     changeVariableEditorExtended: (
-      state: VariableEditorState<VariableEditorExtendedProps>,
+      state: VariableEditorState<QueryVariableEditorState>,
       action: PayloadAction<{ propName: string; propValue: any }>
     ) => {
       state.extended = {
@@ -88,7 +88,7 @@ const variableEditorReducerSlice = createSlice({
       };
     },
     updateQueryVariableDatasource: (
-      state: VariableEditorState<VariableEditorExtendedProps>,
+      state: VariableEditorState<QueryVariableEditorState>,
       action: PayloadAction<{ datasource: DataSourceApi; queryEditor: VariableQueryEditorType; variable: unknown }>
     ) => {
       if (!state.extended) {

--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -8,9 +8,8 @@ import { DataSourceInstanceSettings, getDataSourceRef, LoadingState, SelectableV
 
 import { SelectionOptionsEditor } from '../editor/SelectionOptionsEditor';
 import { QueryVariableModel, VariableRefresh, VariableSort, VariableWithMultiSupport } from '../types';
-import { QueryVariableEditorState } from './reducer';
 import { changeQueryVariableDataSource, changeQueryVariableQuery, initQueryVariableEditor } from './actions';
-import { VariableEditorState } from '../editor/reducer';
+import { QueryVariableEditorState, VariableEditorState } from '../editor/reducer';
 import { OnPropChangeArguments, VariableEditorProps } from '../editor/types';
 import { StoreState } from '../../../types';
 import { toVariableIdentifier } from '../state/types';

--- a/public/app/features/variables/query/actions.ts
+++ b/public/app/features/variables/query/actions.ts
@@ -8,9 +8,9 @@ import { ThunkResult } from '../../../types';
 import { getVariable } from '../state/selectors';
 import {
   addVariableEditorError,
-  changeVariableEditorExtended,
   removeVariableEditorError,
   VariableEditorState,
+  updateQueryVariableDatasource,
 } from '../editor/reducer';
 import { changeVariableProp } from '../state/sharedReducer';
 import { toVariableIdentifier, toVariablePayload, VariableIdentifier } from '../state/types';
@@ -75,13 +75,19 @@ export const changeQueryVariableDataSource = (
       const editorState = getState().templating.editor as VariableEditorState<QueryVariableEditorState>;
       const previousDatasource = editorState.extended?.dataSource;
       const dataSource = await getDataSourceSrv().get(name ?? '');
+      const VariableQueryEditor = await getVariableQueryEditor(dataSource);
+
       if (previousDatasource && previousDatasource.type !== dataSource?.type) {
         dispatch(changeVariableProp(toVariablePayload(identifier, { propName: 'query', propValue: '' })));
       }
-      dispatch(changeVariableEditorExtended({ propName: 'dataSource', propValue: dataSource }));
 
-      const VariableQueryEditor = await getVariableQueryEditor(dataSource);
-      dispatch(changeVariableEditorExtended({ propName: 'VariableQueryEditor', propValue: VariableQueryEditor }));
+      dispatch(
+        updateQueryVariableDatasource({
+          datasource: dataSource,
+          queryEditor: VariableQueryEditor,
+          variable: null,
+        })
+      );
     } catch (err) {
       console.error(err);
     }

--- a/public/app/features/variables/query/actions.ts
+++ b/public/app/features/variables/query/actions.ts
@@ -11,13 +11,13 @@ import {
   removeVariableEditorError,
   VariableEditorState,
   updateQueryVariableDatasource,
+  QueryVariableEditorState,
 } from '../editor/reducer';
 import { changeVariableProp } from '../state/sharedReducer';
 import { toVariableIdentifier, toVariablePayload, VariableIdentifier } from '../state/types';
 import { getVariableQueryEditor } from '../editor/getVariableQueryEditor';
 import { getVariableQueryRunner } from './VariableQueryRunner';
 import { variableQueryObserver } from './variableQueryObserver';
-import { QueryVariableEditorState } from './reducer';
 import { hasOngoingTransaction } from '../utils';
 
 export const updateQueryVariableOptions = (

--- a/public/app/features/variables/query/reducer.ts
+++ b/public/app/features/variables/query/reducer.ts
@@ -1,15 +1,8 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { isNumber, sortBy, toLower, uniqBy } from 'lodash';
-import { DataSourceApi, MetricFindValue, stringToJsRegex } from '@grafana/data';
+import { MetricFindValue, stringToJsRegex } from '@grafana/data';
 
-import {
-  initialVariableModelState,
-  QueryVariableModel,
-  VariableOption,
-  VariableQueryEditorType,
-  VariableRefresh,
-  VariableSort,
-} from '../types';
+import { initialVariableModelState, QueryVariableModel, VariableOption, VariableRefresh, VariableSort } from '../types';
 
 import { getInstanceState, initialVariablesState, VariablePayload, VariablesState } from '../state/types';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE, NONE_VARIABLE_TEXT, NONE_VARIABLE_VALUE } from '../constants';
@@ -17,11 +10,6 @@ import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE, NONE_VARIABLE_TEXT, NONE_VARIABL
 interface VariableOptionsUpdate {
   templatedRegex: string;
   results: MetricFindValue[];
-}
-
-export interface QueryVariableEditorState {
-  VariableQueryEditor: VariableQueryEditorType;
-  dataSource: DataSourceApi | null;
 }
 
 export const initialQueryVariableModelState: QueryVariableModel = {


### PR DESCRIPTION
**What this PR does / why we need it**:

Creates a new action to change the datasource and variable query editor in the same update to keep them in sync.

_I think_ this is sufficient to resolve the bug reported?

**Which issue(s) this PR fixes**:

Fixes #43803

**Special notes for your reviewer**:

This was easier than I expected, but I'm still digging around to see if there's other refactors/changes needed to be made in sync.

Also will try for 8.4.0, but only if it makes beta 1. Otherwise happy for it to go into 8.5.0
