### PR TITLE
Access control: Enable data source view for partial permissions

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -608,5 +608,5 @@ func filterDatasourcesByQueryPermission(ctx context.Context, user *models.Signed
 		return datasources, nil
 	}
 
-	return query.Datasources, nil
+	return query.Result, nil
 }

--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -235,7 +235,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 // dataSourcesConfigurationAccessEvaluator is used to protect the "Configure > Data sources" tab access
 var dataSourcesConfigurationAccessEvaluator = accesscontrol.EvalAll(
-	accesscontrol.EvalPermission(ActionDatasourcesRead, ScopeDatasourcesAll),
+	accesscontrol.EvalPermission(ActionDatasourcesRead),
 	accesscontrol.EvalAny(
 		accesscontrol.EvalPermission(ActionDatasourcesCreate),
 		accesscontrol.EvalPermission(ActionDatasourcesDelete),
@@ -245,14 +245,14 @@ var dataSourcesConfigurationAccessEvaluator = accesscontrol.EvalAll(
 
 // dataSourcesNewAccessEvaluator is used to protect the "Configure > Data sources > New" page access
 var dataSourcesNewAccessEvaluator = accesscontrol.EvalAll(
-	accesscontrol.EvalPermission(ActionDatasourcesRead, ScopeDatasourcesAll),
+	accesscontrol.EvalPermission(ActionDatasourcesRead),
 	accesscontrol.EvalPermission(ActionDatasourcesCreate),
 	accesscontrol.EvalPermission(ActionDatasourcesWrite),
 )
 
 // dataSourcesEditAccessEvaluator is used to protect the "Configure > Data sources > Edit" page access
 var dataSourcesEditAccessEvaluator = accesscontrol.EvalAll(
-	accesscontrol.EvalPermission(ActionDatasourcesRead, ScopeDatasourcesAll),
+	accesscontrol.EvalPermission(ActionDatasourcesRead),
 	accesscontrol.EvalPermission(ActionDatasourcesWrite),
 )
 

--- a/public/app/features/datasources/state/navModel.ts
+++ b/public/app/features/datasources/state/navModel.ts
@@ -39,7 +39,7 @@ export function buildNavModel(dataSource: DataSourceSettings, plugin: GenericDat
     }
   }
 
-  if (pluginMeta.includes && hasDashboards(pluginMeta.includes)) {
+  if (pluginMeta.includes && hasDashboards(pluginMeta.includes) && contextSrv.hasRole('Admin')) {
     navModel.children!.push({
       active: false,
       icon: 'apps',


### PR DESCRIPTION
**What this PR does / why we need it**:
When a user has access to read and edit at least one data source display the view.

All data sources are filtered by data source permissions. By removing the "ScopeDatasourcesAll" requirement users with read and update permissions for at least one data source can access this view