### PR TITLE
loki: alerting: better error-handling

### DIFF
--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -99,7 +99,6 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 
 func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	result := backend.NewQueryDataResponse()
-	queryRes := backend.DataResponse{}
 
 	dsInfo, err := s.getDSInfo(req.PluginContext)
 	if err != nil {
@@ -132,10 +131,15 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		defer span.End()
 
 		frames, err := runQuery(client, query)
+
+		queryRes := backend.DataResponse{}
+
 		if err != nil {
-			return result, err
+			queryRes.Error = err
+		} else {
+			queryRes.Frames = frames
 		}
-		queryRes.Frames = frames
+
 		result.Responses[query.RefID] = queryRes
 	}
 	return result, nil


### PR DESCRIPTION
when the `QueryData()` function is called in the loki datasource, there are two ways to return errors:
1. in the second value of the returned `(*backend.QueryDataResponse, error)` pair
2. the `backend.QueryDataResponse` stores `DataResponse` objects, and those can store errors

currently Loki uses [1], i am switching it to [2].

[2] is better for the future, because for example, if 3 queries are send to be executed, with approach [1] you will not know which query failed, but with [2] you do know.

this will be more important with the eventual Loki backend datasource migration.

based on my tests this should be reasonably backward-compatible (the alerting engine reports error-state in both [1] and [2] approach, the string-error-message is not an exact-match, in case [2] it also says which query failed, i think that's ok)

how to test:
1. this test assumes "new alerting", if you need to test with old alerting, ping me 😄 
2. go to `Alerting` / `New alert rule`, choose a name, choose rule_type=grafana_managed_alert
3. choose a Loki datasource, enter a Loki metric query. for example `count_over_time({level="info"}[10s])`
4. try the [run queries] button, you should see a graph
5. try the [preview alerts] button, it should report 'normal'
6. now modify the query, for example remove the last character from it, to make it invalid
7. try the [preview alerts] button, it should report Error, the error-message should be something like "failed to execute query A: Run out of attempts while querying..."