### PR TITLE
TimeSeries/Barchart: Only show default label for y axis

### DIFF
--- a/docs/sources/visualizations/time-series/change-axis-display.md
+++ b/docs/sources/visualizations/time-series/change-axis-display.md
@@ -47,7 +47,7 @@ Set a Y-axis text label.
 
 ![Label example](/static/img/docs/time-series-panel/label-example-7-4.png)
 
-If you have more than one Y-axis, then you can give assign different labels in the Override tab.
+If you have more than one Y-axis, then you can give assign different labels in the Override tab. You can also set the X-axis label using an override.
 
 ## Width
 

--- a/packages/grafana-ui/src/options/builder/axis.tsx
+++ b/packages/grafana-ui/src/options/builder/axis.tsx
@@ -38,7 +38,7 @@ export function addAxisConfig(
       },
       showIf: (c) => c.axisPlacement !== AxisPlacement.Hidden,
       // no matter what the field type is
-      shouldApply: () => true,
+      shouldApply: (f) => f.type !== FieldType.time && f.type !== FieldType.string,
     })
     .addNumberInput({
       path: 'axisWidth',

--- a/packages/grafana-ui/src/options/builder/axis.tsx
+++ b/packages/grafana-ui/src/options/builder/axis.tsx
@@ -37,7 +37,7 @@ export function addAxisConfig(
         placeholder: 'Optional text',
       },
       showIf: (c) => c.axisPlacement !== AxisPlacement.Hidden,
-      // no matter what the field type is
+      // Do not apply default settings to time and string fields which are used as x-axis fields in Time series and Bar chart panels
       shouldApply: (f) => f.type !== FieldType.time && f.type !== FieldType.string,
     })
     .addNumberInput({


### PR DESCRIPTION
**What this PR does / why we need it**:
Only shows the label for the Y axis as it was before the change to allow X axis labels. X axis labels can still be set with overrides. XY chart is still a bit messy.

**Which issue(s) this PR fixes**:

Fixes #42966


