### PR TITLE
loki: run some queries through backend

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -29,6 +29,7 @@ export interface FeatureToggles {
   tempoSearch?: boolean;
   tempoBackendSearch?: boolean;
   tempoServiceGraph?: boolean;
+  lokiBackendMode?: boolean;
   fullRangeLogsVolume?: boolean;
   accesscontrol?: boolean;
   prometheus_azure_auth?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -73,6 +73,12 @@ var (
 			FrontendOnly: true,
 		},
 		{
+			Name:         "lokiBackendMode",
+			Description:  "Loki datasource works as backend datasource",
+			State:        FeatureStateAlpha,
+			FrontendOnly: true,
+		},
+		{
 			Name:         "fullRangeLogsVolume",
 			Description:  "Show full range logs volume in explore",
 			State:        FeatureStateBeta,

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -55,6 +55,10 @@ const (
 	// show service
 	FlagTempoServiceGraph = "tempoServiceGraph"
 
+	// FlagLokiBackendMode
+	// Loki datasource works as backend datasource
+	FlagLokiBackendMode = "lokiBackendMode"
+
 	// FlagFullRangeLogsVolume
 	// Show full range logs volume in explore
 	FlagFullRangeLogsVolume = "fullRangeLogsVolume"


### PR DESCRIPTION
this is the initial commit that starts sending some loki queries through the backend. it is intentionally kept small, and only sends some frontend-queries to backend,  not all:

- it adds a new feature-flag `lokiBackendMode`
- when certain conditions are true, it sends the query through the backend. conditions:
    - feature-flag enabled
    - AND in explore
    - AND every query is a range-query and a metric-query and not a log-volume-query

how to test:
- enable the feature flag. have this in your `conf/custom.ini`:
    ```
    [feature_toggles]
    enable = lokiBackendMode
    ```
- have a running loki database & datasource
- go to explore-mode
- open in your browser the network tab, to be able to see the AJAX requests
- enter a query that is not a metric query, like `{level="info"}`, run it, check the AJAX request. it should go to `/api/datasources/proxy/...` . this means it was a frontend-query
- enter a metric query, like `count_over_time({level="info"}[10s])`, run it, check the AJAX request. it should go to `/api/ds/query` . this means it was a backend-query 🎆 
- go to dashboards, create a new dashboard, add a single panel (now we repeat the test from explore, but it should never go backend-mode):
- enter a query that is not a metric query, like `{level="info"}`, run it, check the AJAX request. it should go to `/api/datasources/proxy/...` . this means it was a frontend-query
- enter a metric query, like `count_over_time({level="info"}[10s])`, run it, check the AJAX request. it should go to `/api/datasources/proxy/...` . this means it was a frontend-query
