### PR TITLE
Fix Discord Webhook URL for invalid template

### DIFF
--- a/pkg/services/ngalert/notifier/channels/discord.go
+++ b/pkg/services/ngalert/notifier/channels/discord.go
@@ -103,6 +103,7 @@ func (d DiscordNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 	u := tmpl(d.WebhookURL)
 	if tmplErr != nil {
 		d.log.Warn("failed to template Discord message", "err", tmplErr.Error())
+		return false, tmplErr
 	}
 
 	body, err := json.Marshal(bodyJSON)

--- a/pkg/services/ngalert/notifier/channels/discord_test.go
+++ b/pkg/services/ngalert/notifier/channels/discord_test.go
@@ -3,6 +3,7 @@ package channels
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/url"
 	"testing"
 
@@ -98,6 +99,14 @@ func TestDiscordNotifier(t *testing.T) {
 			name:         "Error in initialization",
 			settings:     `{}`,
 			expInitError: `failed to validate receiver "discord_testing" of type "discord": could not find webhook url property in settings`,
+		},
+		{
+			name: "Invalid template returns error",
+			settings: `{
+				"url": "http://localhost",
+				"message": "{{ template \"invalid.template\" }}"
+			}`,
+			expMsgError: errors.New("template: :1:12: executing \"\" at <{{template \"invalid.template\"}}>: template \"invalid.template\" not defined"),
 		},
 		{
 			name: "Default config with one alert, use default discord username",


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes an issue where an invalid template for Discord would change the Webhook URL to "" and cause "unsupported protocol scheme" errors.

**Which issue(s) this PR fixes**:

https://github.com/grafana/grafana/issues/43826