### PR TITLE
Instrumentation: consider http.handlers not setting status code success

### DIFF
--- a/pkg/middleware/request_metrics.go
+++ b/pkg/middleware/request_metrics.go
@@ -68,7 +68,7 @@ func RequestMetrics(features featuremgmt.FeatureToggles) func(handler string) we
 				// avoiding the sanitize functions for in the new instrumentation
 				// since they dont make much sense. We should remove them later.
 				histogram := httpRequestDurationHistogram.
-					WithLabelValues(handler, strconv.Itoa(rw.Status()), req.Method)
+					WithLabelValues(handler, sanitizeCode(rw.Status()), req.Method)
 				if traceID, ok := cw.ExtractSampledTraceID(c.Req.Context()); ok {
 					// Need to type-convert the Observer to an
 					// ExemplarObserver. This will always work for a


### PR DESCRIPTION
While debugging an escalation I found that a bunch of requests was instrumentation with `status = 0`. I think this due to how we manage http.Handlers so not setting a status could should be considered a 200.