### PR TITLE
Access control: increment fixed role version

### DIFF
--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -231,7 +231,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			DisplayName: "Team writer",
 			Description: "Create, read, write, or delete a team as well as controlling team memberships.",
 			Group:       "Teams",
-			Version:     1,
+			Version:     2,
 			Permissions: []accesscontrol.Permission{
 				{Action: accesscontrol.ActionTeamsCreate},
 				{Action: accesscontrol.ActionTeamsDelete, Scope: accesscontrol.ScopeTeamsAll},


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
increments the version of `fixed:teams:writer`. We had this role previously, then removed it in [this PR](https://github.com/grafana/grafana/pull/43951/files#diff-c08021604e885c8394398f34a570f5ac10756c7992c357b07a1837e05cbd9f67L197) and re-added it in [this PR](https://github.com/grafana/grafana/pull/44524/files#diff-c08021604e885c8394398f34a570f5ac10756c7992c357b07a1837e05cbd9f67R209), but we didn't increment the team version. Therefore anyone who would have run Grafana in between the two PRs would still be using the fixed role as it was defined in the first PR.