### PR TITLE
Select: Show keyboard indicator icon when custom values can be entered

### DIFF
--- a/packages/grafana-ui/src/components/Select/IndicatorsContainer.tsx
+++ b/packages/grafana-ui/src/components/Select/IndicatorsContainer.tsx
@@ -14,6 +14,9 @@ export const IndicatorsContainer = React.forwardRef<HTMLDivElement, React.PropsW
         styles.suffix,
         css`
           position: relative;
+          & > * {
+            margin-left: 2px;
+          }
         `
       )}
       ref={ref}

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -290,7 +290,12 @@ export function SelectBase<T>({
               );
             }
 
-            if (allowCustomValue && (creatableProps.allowCreateWhileLoading || !isLoading)) {
+            if (
+              allowCustomValue &&
+              // Currently cannot enter new values if this `isSearchable` false!
+              isSearchable &&
+              (creatableProps.allowCreateWhileLoading || !isLoading)
+            ) {
               additionalIndicators.push(<Icon name="keyboard" />);
             }
 

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -276,13 +276,11 @@ export function SelectBase<T>({
           IndicatorsContainer(props: any) {
             const { selectProps } = props;
             const { value, showAllSelectedWhenOpen, maxVisibleValues, menuIsOpen } = selectProps;
+            const additionalIndicators = [];
 
             if (maxVisibleValues !== undefined) {
               const selectedValuesCount = value.length;
-              const indicatorChildren = [...props.children];
-              indicatorChildren.splice(
-                -1,
-                0,
+              additionalIndicators.push(
                 renderExtraValuesIndicator({
                   maxVisibleValues,
                   selectedValuesCount,
@@ -290,13 +288,22 @@ export function SelectBase<T>({
                   menuIsOpen,
                 })
               );
-              return <IndicatorsContainer {...props}>{indicatorChildren}</IndicatorsContainer>;
             }
 
-            return <IndicatorsContainer {...props} />;
+            if (allowCustomValue && (creatableProps.allowCreateWhileLoading || !isLoading)) {
+              additionalIndicators.push(<Icon name="keyboard" />);
+            }
+
+            const indicatorChildren = [...props.children];
+            // Any additional indicators inserted before last
+            if (indicatorChildren.length > 0) {
+              indicatorChildren.splice(-1, 0, additionalIndicators);
+            }
+
+            return <IndicatorsContainer {...props}>{indicatorChildren}</IndicatorsContainer>;
           },
           IndicatorSeparator() {
-            return <></>;
+            return null;
           },
           Control: CustomControl,
           Option: SelectMenuOptions,


### PR DESCRIPTION
**What this PR does / why we need it**:
Gives the user an extra hint that the keyboard can be used here.

`allowCustomValue=true`
![image](https://user-images.githubusercontent.com/38694490/152170655-9304f827-f255-44a5-8298-07fc4746aaee.png)

`allowCustomValue=true`, `allowCreateWhileLoading=true`, `isLoading=true`
![image](https://user-images.githubusercontent.com/38694490/152171052-0e9c0e97-4981-4f64-b8a6-8fcfef408a78.png)

**Special notes for your reviewer**:
When `isSearchable=false`, the keyboard entry is disabled. This appears to be an issue on the react-select library. In the future, I will investigate if something can be done over there to enhance this further.
