### PR TITLE
Alerting: load correct unified alerting tab

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
@@ -86,9 +86,9 @@ function renderAlertTab(
   dashboard: DashboardModel,
   onChangeTab: (tab: PanelEditorTab) => void
 ) {
-  const alertingNotEnabled = !config.alertingEnabled && !config.unifiedAlertingEnabled;
+  const alertingDisabled = !config.alertingEnabled && !config.unifiedAlertingEnabled;
 
-  if (alertingNotEnabled) {
+  if (alertingDisabled) {
     return null;
   }
 

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTabs.tsx
@@ -41,7 +41,7 @@ export const PanelEditorTabs: FC<PanelEditorTabsProps> = React.memo(({ panel, da
       <TabsBar className={styles.tabBar} hideBorder>
         {tabs.map((tab) => {
           if (tab.id === PanelEditorTabId.Alert) {
-            renderAlertTab(tab, panel, dashboard, onChangeTab);
+            return renderAlertTab(tab, panel, dashboard, onChangeTab);
           }
           return (
             <Tab
@@ -86,9 +86,13 @@ function renderAlertTab(
   dashboard: DashboardModel,
   onChangeTab: (tab: PanelEditorTab) => void
 ) {
-  if (!config.alertingEnabled || !config.unifiedAlertingEnabled) {
+  const alertingNotEnabled = !config.alertingEnabled && !config.unifiedAlertingEnabled;
+
+  if (alertingNotEnabled) {
     return null;
-  } else if (config.unifiedAlertingEnabled) {
+  }
+
+  if (config.unifiedAlertingEnabled) {
     return (
       <PanelAlertTab
         key={tab.id}
@@ -100,7 +104,9 @@ function renderAlertTab(
         dashboard={dashboard}
       />
     );
-  } else if (config.alertingEnabled) {
+  }
+
+  if (config.alertingEnabled) {
     return (
       <Tab
         key={tab.id}


### PR DESCRIPTION
**What this PR does / why we need it**:

A small regression in https://github.com/grafana/grafana/pull/43339 was preventing the correct tab component from being loaded when `unified_alerting` was enabled.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

I've tested it with all possible combinations of
```
[unified_alerting]
enabled = 

[alerting]
enabled = 
```

