### PR TITLE
Data Links: Fix DataLink "__all_variables" on Repeat Panels

### DIFF
--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -568,7 +568,9 @@ export class PanelModel implements DataConfigSource, IPanelModel {
     const vars: ScopedVars = Object.assign({}, this.scopedVars, lastRequest?.scopedVars, extraVars);
 
     const allVariablesParams = getVariablesUrlParams(vars);
-    const variablesQuery = urlUtil.toUrlParams(allVariablesParams);
+    const variablesQuery = vars?.__all_variables
+      ? vars?.__all_variables.value
+      : urlUtil.toUrlParams(allVariablesParams);
     const timeRangeUrl = urlUtil.toUrlParams(getTimeSrv().timeRangeForUrl());
 
     vars[DataLinkBuiltInVars.keepTime] = {


### PR DESCRIPTION
**What this PR does / why we need it**:

When using Data Links within a Repeated Panel, it is not possible to access the currently selected value of the template variable that is being repeated.

"__all_variables" should be the solution for this. As it is meant to always reflect what template values are currented selected. A link to your current dashboard with nothing but "__all_variables" should be a "noop". However, logic in "replaceVariables" is incorrectly overwriting that logic so that "__all_variables" uses your current panel's scoped variable values. The end result is that a Data Link within a repeated panel will always either force the repeated variable back to default values, or it will force it to single selection based on which repeated panel the link is on.

My fix for this is very simple. Basically, in "replaceVariables" I check to see if an "__all_variables" value was passed in (which, at that point, already has all of the variables formatted for the URL, since it was passed in by getLinkSupplier). If it was, then I use that rather than trying to recreate it locally. The logic to create the URL formatted "all variables" is actually being run twice in a row. Once in getLinkSupplier (done correctly) and once in replaceVariables (incorrect because it considers the panel's scopeVars).

For everything but "__all_variables", of course, we want the panel's scopeVars to continue to be used.


Fixes #37282
