### PR TITLE
Chore: Move variable field selectors to data-testid

### DIFF
--- a/e2e/dashboards-suite/new-constant-variable.spec.ts
+++ b/e2e/dashboards-suite/new-constant-variable.spec.ts
@@ -10,10 +10,10 @@ describe('Variables - Constant', () => {
     // Create a new "Constant" variable
     e2e.components.CallToActionCard.buttonV2('Add variable').click();
 
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelect().type('Constant{enter}');
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalNameInput().clear().type('VariableUnderTest').blur();
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInput().type('Variable under test').blur();
-    e2e.pages.Dashboard.Settings.Variables.Edit.ConstantVariable.constantOptionsQueryInput().type('pesto').blur();
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelectV2().type('Constant{enter}');
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalNameInputV2().clear().type('VariableUnderTest').blur();
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInputV2().type('Variable under test').blur();
+    e2e.pages.Dashboard.Settings.Variables.Edit.ConstantVariable.constantOptionsQueryInputV2().type('pesto').blur();
 
     e2e.pages.Dashboard.Settings.Variables.Edit.General.previewOfValuesOption().eq(0).should('have.text', 'pesto');
 

--- a/e2e/dashboards-suite/new-custom-variable.spec.ts
+++ b/e2e/dashboards-suite/new-custom-variable.spec.ts
@@ -3,9 +3,9 @@ import { e2e } from '@grafana/e2e';
 const PAGE_UNDER_TEST = 'kVi2Gex7z/test-variable-output';
 
 function fillInCustomVariable(name: string, label: string, value: string) {
-  e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelect().type('Custom{enter}');
-  e2e.pages.Dashboard.Settings.Variables.Edit.General.generalNameInput().clear().type(name).blur();
-  e2e.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInput().type(label).blur();
+  e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelectV2().type('Custom{enter}');
+  e2e.pages.Dashboard.Settings.Variables.Edit.General.generalNameInputV2().clear().type(name).blur();
+  e2e.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInputV2().type(label).blur();
   e2e.pages.Dashboard.Settings.Variables.Edit.CustomVariable.customValueInput().type(value).blur();
 }
 
@@ -42,7 +42,7 @@ describe('Variables - Custom', () => {
 
     // Create a new "Custom" variable
     e2e.components.CallToActionCard.buttonV2('Add variable').click();
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelect().type('Custom{enter}');
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelectV2().type('Custom{enter}');
 
     // Set it's name, label, and content
     fillInCustomVariable('VariableUnderTest', 'Variable under test', 'One : 1,Two : 2, Three : 3');

--- a/e2e/dashboards-suite/new-query-variable.spec.ts
+++ b/e2e/dashboards-suite/new-query-variable.spec.ts
@@ -9,18 +9,18 @@ describe('Variables - Query - Add variable', () => {
 
     e2e.pages.Dashboard.Settings.Variables.List.newButton().should('be.visible').click();
 
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalNameInput()
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalNameInputV2()
       .should('be.visible')
       .within((input) => {
         expect(input.attr('placeholder')).equals('name');
         expect(input.val()).equals('query0');
       });
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelect()
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelectV2()
       .should('be.visible')
       .within((select) => {
         e2e.components.Select.singleValue().should('have.text', 'Query');
       });
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInput()
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInputV2()
       .should('be.visible')
       .within((input) => {
         expect(input.attr('placeholder')).equals('optional display name');
@@ -33,7 +33,7 @@ describe('Variables - Query - Add variable', () => {
         expect(input.attr('placeholder')).equals('descriptive text');
         expect(input.val()).equals('');
       });
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalHideSelect()
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalHideSelectV2()
       .should('be.visible')
       .within((select) => {
         e2e.components.Select.singleValue().should('have.text', '');
@@ -45,19 +45,19 @@ describe('Variables - Query - Add variable', () => {
         e2e.components.Select.singleValue().should('have.text', 'gdev-testdata');
       });
 
-    e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsRefreshSelect()
+    e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsRefreshSelectV2()
       .should('be.visible')
       .within((select) => {
         e2e.components.Select.singleValue().should('have.text', 'On dashboard load');
       });
-    e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsRegExInput()
+    e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsRegExInputV2()
       .should('be.visible')
       .within((input) => {
         const placeholder = '/.*-(?<text>.*)-(?<value>.*)-.*/';
         expect(input.attr('placeholder')).equals(placeholder);
         expect(input.val()).equals('');
       });
-    e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsSortSelect()
+    e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsSortSelectV2()
       .should('be.visible')
       .within((select) => {
         e2e.components.Select.singleValue().should('have.text', 'Disabled');
@@ -66,7 +66,7 @@ describe('Variables - Query - Add variable', () => {
     e2e.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsIncludeAllSwitch().should('not.be.checked');
 
     e2e.pages.Dashboard.Settings.Variables.Edit.General.previewOfValuesOption().should('not.exist');
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsCustomAllInput().should('not.exist');
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsCustomAllInputV2().should('not.exist');
   });
 
   it('adding a single value query variable', () => {
@@ -75,7 +75,7 @@ describe('Variables - Query - Add variable', () => {
 
     e2e.pages.Dashboard.Settings.Variables.List.newButton().should('be.visible').click();
 
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInput()
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInputV2()
       .should('be.visible')
       .clear()
       .type('a label');
@@ -89,7 +89,7 @@ describe('Variables - Query - Add variable', () => {
       .type('*')
       .blur();
 
-    e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsRegExInput()
+    e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsRegExInputV2()
       .should('be.visible')
       .type('/.*C.*/')
       .blur();
@@ -125,7 +125,7 @@ describe('Variables - Query - Add variable', () => {
 
     e2e.pages.Dashboard.Settings.Variables.List.newButton().should('be.visible').click();
 
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInput()
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInputV2()
       .should('be.visible')
       .clear()
       .type('a label');
@@ -139,7 +139,7 @@ describe('Variables - Query - Add variable', () => {
       .type('*')
       .blur();
 
-    e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsRegExInput()
+    e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsRegExInputV2()
       .should('be.visible')
       .type('/.*C.*/')
       .blur();
@@ -152,7 +152,7 @@ describe('Variables - Query - Add variable', () => {
       .click({ force: true })
       .should('be.checked');
 
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsCustomAllInput().within((input) => {
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsCustomAllInputV2().within((input) => {
       expect(input.attr('placeholder')).equals('blank = auto');
       expect(input.val()).equals('');
     });

--- a/e2e/dashboards-suite/new-text-box-variable.spec.ts
+++ b/e2e/dashboards-suite/new-text-box-variable.spec.ts
@@ -10,10 +10,10 @@ describe('Variables - Text box', () => {
     // Create a new "Custom" variable
     e2e.components.CallToActionCard.buttonV2('Add variable').click();
 
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelect().type('Text box{enter}');
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalNameInput().clear().type('VariableUnderTest').blur();
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInput().type('Variable under test').blur();
-    e2e.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInput().type('cat-dog').blur();
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelectV2().type('Text box{enter}');
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalNameInputV2().clear().type('VariableUnderTest').blur();
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInputV2().type('Variable under test').blur();
+    e2e.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInputV2().type('cat-dog').blur();
 
     e2e.pages.Dashboard.Settings.Variables.Edit.General.previewOfValuesOption().eq(0).should('have.text', 'cat-dog');
 

--- a/e2e/dashboards-suite/textbox-variables.spec.ts
+++ b/e2e/dashboards-suite/textbox-variables.spec.ts
@@ -201,7 +201,7 @@ function validateVariable(value: string) {
 
   e2e.pages.Dashboard.Settings.Variables.List.tableRowNameFields('text').should('be.visible').click();
 
-  e2e.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInput()
+  e2e.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInputV2()
     .should('be.visible')
     .should('have.value', value);
 }
@@ -234,7 +234,7 @@ function changeQueryInput() {
 
   e2e.pages.Dashboard.Settings.Variables.List.tableRowNameFields('text').should('be.visible').click();
 
-  e2e.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInput()
+  e2e.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInputV2()
     .should('be.visible')
     .clear()
     .type('changed value')

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -110,20 +110,28 @@ export const Pages = {
              */
             modeLabelEdit: 'Variable editor Header mode Edit',
             generalNameInput: 'Variable editor Form Name field',
+            generalNameInputV2: 'data-testid Variable editor Form Name field',
             generalTypeSelect: 'Variable editor Form Type select',
+            generalTypeSelectV2: 'data-testid Variable editor Form Type select',
             generalLabelInput: 'Variable editor Form Label field',
+            generalLabelInputV2: 'data-testid Variable editor Form Label field',
             generalHideSelect: 'Variable editor Form Hide select',
+            generalHideSelectV2: 'data-testid Variable editor Form Hide select',
             selectionOptionsMultiSwitch: 'Variable editor Form Multi switch',
             selectionOptionsIncludeAllSwitch: 'Variable editor Form IncludeAll switch',
             selectionOptionsCustomAllInput: 'Variable editor Form IncludeAll field',
+            selectionOptionsCustomAllInputV2: 'data-testid Variable editor Form IncludeAll field',
             previewOfValuesOption: 'Variable editor Preview of Values option',
             submitButton: 'Variable editor Submit button',
           },
           QueryVariable: {
             queryOptionsDataSourceSelect: Components.DataSourcePicker.container,
             queryOptionsRefreshSelect: 'Variable editor Form Query Refresh select',
+            queryOptionsRefreshSelectV2: 'data-testid Variable editor Form Query Refresh select',
             queryOptionsRegExInput: 'Variable editor Form Query RegEx field',
+            queryOptionsRegExInputV2: 'data-testid Variable editor Form Query RegEx field',
             queryOptionsSortSelect: 'Variable editor Form Query Sort select',
+            queryOptionsSortSelectV2: 'data-testid Variable editor Form Query Sort select',
             queryOptionsQueryInput: 'Variable editor Form Default Variable Query Editor textarea',
             valueGroupsTagsEnabledSwitch: 'Variable editor Form Query UseTags switch',
             valueGroupsTagsTagsQueryInput: 'Variable editor Form Query TagsQuery field',
@@ -131,9 +139,14 @@ export const Pages = {
           },
           ConstantVariable: {
             constantOptionsQueryInput: 'Variable editor Form Constant Query field',
+            constantOptionsQueryInputV2: 'data-testid Variable editor Form Constant Query field',
+          },
+          DatasourceVariable: {
+            datasourceSelect: 'Variable editor',
           },
           TextBoxVariable: {
             textBoxOptionsQueryInput: 'Variable editor Form TextBox Query field',
+            textBoxOptionsQueryInputV2: 'data-testid Variable editor Form TextBox Query field',
           },
           CustomVariable: {
             customValueInput: 'data-testid custom-variable-input',

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -142,7 +142,7 @@ export const Pages = {
             constantOptionsQueryInputV2: 'data-testid Variable editor Form Constant Query field',
           },
           DatasourceVariable: {
-            datasourceSelect: 'Variable editor',
+            datasourceSelect: 'data-testid Variable editor',
           },
           TextBoxVariable: {
             textBoxOptionsQueryInput: 'Variable editor Form TextBox Query field',

--- a/packages/grafana-e2e/src/flows/addDashboard.ts
+++ b/packages/grafana-e2e/src/flows/addDashboard.ts
@@ -162,7 +162,7 @@ const addVariable = (config: PartialAddVariableConfig, isFirst: boolean): AddVar
 
   // This field is key to many reactive changes
   if (type !== VARIABLE_TYPE_QUERY) {
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelect()
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelectV2()
       .should('be.visible')
       .within(() => {
         e2e.components.Select.singleValue().should('have.text', 'Query').click();
@@ -171,10 +171,10 @@ const addVariable = (config: PartialAddVariableConfig, isFirst: boolean): AddVar
   }
 
   if (label) {
-    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInput().type(label);
+    e2e.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInputV2().type(label);
   }
 
-  e2e.pages.Dashboard.Settings.Variables.Edit.General.generalNameInput().clear().type(name);
+  e2e.pages.Dashboard.Settings.Variables.Edit.General.generalNameInputV2().clear().type(name);
 
   if (
     dataSource &&
@@ -188,7 +188,7 @@ const addVariable = (config: PartialAddVariableConfig, isFirst: boolean): AddVar
   }
 
   if (constantValue && type === VARIABLE_TYPE_CONSTANT) {
-    e2e.pages.Dashboard.Settings.Variables.Edit.ConstantVariable.constantOptionsQueryInput().type(constantValue);
+    e2e.pages.Dashboard.Settings.Variables.Edit.ConstantVariable.constantOptionsQueryInputV2().type(constantValue);
   }
 
   if (type === VARIABLE_TYPE_QUERY) {
@@ -197,7 +197,7 @@ const addVariable = (config: PartialAddVariableConfig, isFirst: boolean): AddVar
     }
 
     if (regex) {
-      e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsRegExInput().type(regex);
+      e2e.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsRegExInputV2().type(regex);
     }
   }
 

--- a/public/app/features/variables/constant/ConstantVariableEditor.tsx
+++ b/public/app/features/variables/constant/ConstantVariableEditor.tsx
@@ -36,7 +36,7 @@ export class ConstantVariableEditor extends PureComponent<Props> {
           onChange={this.onChange}
           onBlur={this.onBlur}
           labelWidth={20}
-          ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.ConstantVariable.constantOptionsQueryInput}
+          testId={selectors.pages.Dashboard.Settings.Variables.Edit.ConstantVariable.constantOptionsQueryInputV2}
           grow
         />
       </VerticalGroup>

--- a/public/app/features/variables/datasource/DataSourceVariableEditor.tsx
+++ b/public/app/features/variables/datasource/DataSourceVariableEditor.tsx
@@ -15,6 +15,7 @@ import { VariableSectionHeader } from '../editor/VariableSectionHeader';
 import { VariableSelectField } from '../editor/VariableSelectField';
 import { SelectableValue } from '@grafana/data';
 import { VariableTextField } from '../editor/VariableTextField';
+import { selectors } from '@grafana/e2e-selectors';
 
 export interface OwnProps extends VariableEditorProps<DataSourceVariableModel> {}
 
@@ -84,6 +85,7 @@ export class DataSourceVariableEditorUnConnected extends PureComponent<Props> {
                 options={typeOptions}
                 onChange={this.onDataSourceTypeChanged}
                 labelWidth={10}
+                testId={selectors.pages.Dashboard.Settings.Variables.Edit.ConstantVariable.constantOptionsQueryInputV2}
               />
             </InlineFieldRow>
             <InlineFieldRow>

--- a/public/app/features/variables/datasource/DataSourceVariableEditor.tsx
+++ b/public/app/features/variables/datasource/DataSourceVariableEditor.tsx
@@ -85,7 +85,7 @@ export class DataSourceVariableEditorUnConnected extends PureComponent<Props> {
                 options={typeOptions}
                 onChange={this.onDataSourceTypeChanged}
                 labelWidth={10}
-                testId={selectors.pages.Dashboard.Settings.Variables.Edit.ConstantVariable.constantOptionsQueryInputV2}
+                testId={selectors.pages.Dashboard.Settings.Variables.Edit.DatasourceVariable.datasourceSelect}
               />
             </InlineFieldRow>
             <InlineFieldRow>

--- a/public/app/features/variables/editor/SelectionOptionsEditor.tsx
+++ b/public/app/features/variables/editor/SelectionOptionsEditor.tsx
@@ -68,7 +68,7 @@ export const SelectionOptionsEditor: FunctionComponent<SelectionOptionsEditorPro
             onChange={onAllValueChanged}
             name="Custom all value"
             placeholder="blank = auto"
-            ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsCustomAllInput}
+            testId={selectors.pages.Dashboard.Settings.Variables.Edit.General.selectionOptionsCustomAllInputV2}
             labelWidth={20}
           />
         </InlineFieldRow>

--- a/public/app/features/variables/editor/VariableEditorEditor.tsx
+++ b/public/app/features/variables/editor/VariableEditorEditor.tsx
@@ -133,7 +133,7 @@ export class VariableEditorEditorUnConnected extends PureComponent<Props> {
                   name="Name"
                   placeholder="name"
                   required
-                  ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.General.generalNameInput}
+                  testId={selectors.pages.Dashboard.Settings.Variables.Edit.General.generalNameInputV2}
                 />
                 <VariableTypeSelect onChange={this.onTypeChange} type={this.props.variable.type} />
               </InlineFieldRow>
@@ -150,7 +150,7 @@ export class VariableEditorEditorUnConnected extends PureComponent<Props> {
                   onChange={this.onLabelChange}
                   name="Label"
                   placeholder="optional display name"
-                  ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInput}
+                  testId={selectors.pages.Dashboard.Settings.Variables.Edit.General.generalLabelInputV2}
                 />
                 <VariableHideSelect
                   onChange={this.onHideChange}

--- a/public/app/features/variables/editor/VariableHideSelect.tsx
+++ b/public/app/features/variables/editor/VariableHideSelect.tsx
@@ -30,7 +30,7 @@ export function VariableHideSelect({ onChange, hide, type }: PropsWithChildren<P
       value={value}
       options={HIDE_OPTIONS}
       onChange={onChange}
-      ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.General.generalHideSelect}
+      testId={selectors.pages.Dashboard.Settings.Variables.Edit.General.generalHideSelectV2}
     />
   );
 }

--- a/public/app/features/variables/editor/VariableSelectField.tsx
+++ b/public/app/features/variables/editor/VariableSelectField.tsx
@@ -10,7 +10,7 @@ interface VariableSelectFieldProps<T> {
   options: Array<SelectableValue<T>>;
   onChange: (option: SelectableValue<T>) => void;
   tooltip?: string;
-  ariaLabel?: string;
+  testId?: string;
   width?: number;
   labelWidth?: number;
 }
@@ -21,7 +21,7 @@ export function VariableSelectField({
   options,
   tooltip,
   onChange,
-  ariaLabel,
+  testId,
   width,
   labelWidth,
 }: PropsWithChildren<VariableSelectFieldProps<any>>): ReactElement {
@@ -34,7 +34,7 @@ export function VariableSelectField({
       <InlineFormLabel width={labelWidth ?? 6} tooltip={tooltip} htmlFor={inputId}>
         {name}
       </InlineFormLabel>
-      <div aria-label={ariaLabel}>
+      <div data-testid={testId}>
         <Select
           inputId={inputId}
           menuShouldPortal

--- a/public/app/features/variables/editor/VariableTextField.tsx
+++ b/public/app/features/variables/editor/VariableTextField.tsx
@@ -6,7 +6,7 @@ interface VariableTextFieldProps {
   name: string;
   placeholder: string;
   onChange: (event: FormEvent<HTMLInputElement>) => void;
-  ariaLabel?: string;
+  testId?: string;
   tooltip?: PopoverContent;
   required?: boolean;
   width?: number;
@@ -20,7 +20,7 @@ export function VariableTextField({
   name,
   placeholder,
   onChange,
-  ariaLabel,
+  testId,
   width,
   labelWidth,
   required,
@@ -39,7 +39,7 @@ export function VariableTextField({
         onChange={onChange}
         onBlur={onBlur}
         width={grow ? undefined : width ?? 25}
-        aria-label={ariaLabel}
+        data-testid={testId}
         required={required}
       />
     </InlineField>

--- a/public/app/features/variables/editor/VariableTypeSelect.tsx
+++ b/public/app/features/variables/editor/VariableTypeSelect.tsx
@@ -22,7 +22,7 @@ export function VariableTypeSelect({ onChange, type }: PropsWithChildren<Props>)
       options={options}
       onChange={onChange}
       tooltip={variableAdapters.get(type).description}
-      ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelect}
+      testId={selectors.pages.Dashboard.Settings.Variables.Edit.General.generalTypeSelectV2}
     />
   );
 }

--- a/public/app/features/variables/query/QueryVariableEditor.test.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.test.tsx
@@ -106,7 +106,7 @@ describe('QueryVariableEditor', () => {
 const getQueryField = () =>
   screen.getByRole('textbox', { name: /variable editor form default variable query editor textarea/i });
 
-const getRegExField = () => screen.getByRole('textbox', { name: /variable editor form query regex field/i });
+const getRegExField = () => screen.getByLabelText('Regex');
 
 const fieldAccessors: Record<string, () => HTMLElement> = {
   query: getQueryField,

--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -199,7 +199,7 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
                   ).
                 </div>
               }
-              ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsRegExInput}
+              testId={selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsRegExInputV2}
               grow
             />
             <QueryVariableSortSelect onChange={this.onSortChange} sort={this.props.variable.sort} />

--- a/public/app/features/variables/query/QueryVariableRefreshSelect.tsx
+++ b/public/app/features/variables/query/QueryVariableRefreshSelect.tsx
@@ -24,7 +24,7 @@ export function QueryVariableRefreshSelect({ onChange, refresh }: PropsWithChild
       options={REFRESH_OPTIONS}
       onChange={onChange}
       labelWidth={10}
-      ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsRefreshSelect}
+      testId={selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsRefreshSelectV2}
       tooltip="When to update the values of this variable."
     />
   );

--- a/public/app/features/variables/query/QueryVariableSortSelect.tsx
+++ b/public/app/features/variables/query/QueryVariableSortSelect.tsx
@@ -29,7 +29,7 @@ export function QueryVariableSortSelect({ onChange, sort }: PropsWithChildren<Pr
       options={SORT_OPTIONS}
       onChange={onChange}
       labelWidth={10}
-      ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsSortSelect}
+      testId={selectors.pages.Dashboard.Settings.Variables.Edit.QueryVariable.queryOptionsSortSelectV2}
       tooltip="How to sort the values of this variable."
     />
   );

--- a/public/app/features/variables/textbox/TextBoxVariableEditor.tsx
+++ b/public/app/features/variables/textbox/TextBoxVariableEditor.tsx
@@ -33,7 +33,7 @@ export function TextBoxVariableEditor({ onPropChange, variable: { query } }: Pro
         onBlur={onBlur}
         labelWidth={20}
         grow
-        ariaLabel={selectors.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInput}
+        testId={selectors.pages.Dashboard.Settings.Variables.Edit.TextBoxVariable.textBoxOptionsQueryInputV2}
       />
     </VerticalGroup>
   );


### PR DESCRIPTION
**What this PR does / why we need it**:

Just some aria-label -> data-testid changes I'm pulling out into a seperate PR for ease-of-reviewing 😌 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates to https://github.com/grafana/grafana/issues/43803