### PR TITLE
Deprecation: use locationService in favor of getLocationSrv

### DIFF
--- a/docs/sources/developers/plugins/add-support-for-variables.md
+++ b/docs/sources/developers/plugins/add-support-for-variables.md
@@ -80,13 +80,11 @@ For more information on the available variable formats, refer to [Advanced varia
 
 ## Set a variable from your plugin
 
-Not only can you read the value of a variable, you can also update the variable from your plugin. Use LocationSrv.update()
+Not only can you read the value of a variable, you can also update the variable from your plugin. Use `locationService.replacePartial(query)`.
 
 The following example shows how to update a variable called `service`.
 
 - `query` contains the query parameters you want to update. Query parameters controlling variables are prefixed with `var-`.
-- `partial: true` makes the update only affect the query parameters listed in `query`, and leaves the other query parameters unchanged.
-- `replace: true` tells Grafana to update the current URL state, rather than creating a new history entry.
 
 ```ts
 import { getLocationSrv } from '@grafana/runtime';

--- a/docs/sources/developers/plugins/add-support-for-variables.md
+++ b/docs/sources/developers/plugins/add-support-for-variables.md
@@ -80,24 +80,19 @@ For more information on the available variable formats, refer to [Advanced varia
 
 ## Set a variable from your plugin
 
-Not only can you read the value of a variable, you can also update the variable from your plugin. Use `locationService.replacePartial(query)`.
+Not only can you read the value of a variable, you can also update the variable from your plugin. Use `locationService.partial(query, replace)`.
 
 The following example shows how to update a variable called `service`.
 
 - `query` contains the query parameters you want to update. Query parameters controlling variables are prefixed with `var-`.
+- `replace: true` tells Grafana to update the current URL state, rather than creating a new history entry.
 
 ```ts
-import { getLocationSrv } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 ```
 
 ```ts
-getLocationSrv().update({
-  query: {
-    'var-service': 'billing',
-  },
-  partial: true,
-  replace: true,
-});
+locationService.partial({ 'var-service': 'billing' }, true);
 ```
 
 > **Note:** Grafana queries your data source whenever you update a variable. Excessive updates to variables can slow down Grafana and lead to a poor user experience.

--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -66,7 +66,7 @@ import { getLocationSrv } from '@grafana/runtime';
 import { locationService } from '@grafana/runtime';
 ```
 
-**Example:** How to navigate to a path and add a new record in the navigation history so you can navigate back to the previous one.
+**Example:** Navigate to a path and add a new record in the navigation history so that you can navigate back to the previous one.
 
 ```ts
 // before

--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -15,7 +15,7 @@ This guide helps you identify the steps you need to take based on the Grafana ve
 - [From version 8.3.x to 8.4.x](#from-version-83x-to-84x)
   - [Value Mapping Editor has been removed from @grafana-ui library](#value-mapping-editor-has-been-removed-from-grafana-ui-library)
   - [Thresholds Editor has been removed from @grafana-ui library](#thresholds-editor-has-been-removed-from-grafana-ui-library)
-  - [8.3 Deprecations](#83-deprecations)
+  - [8.4 Deprecations](#84-deprecations)
     - [LocationService replaces getLocationSrv](#locationservice-replaces-getlocationsrv)
 - [From version 7.x.x to 8.x.x](#from-version-7xx-to-8xx)
   - [Backend plugin v1 support has been dropped](#backend-plugin-v1-support-has-been-dropped)
@@ -50,11 +50,11 @@ Removed due to being an internal component.
 
 Removed due to being an internal component.
 
-### 8.3 deprecations
+### 8.4 deprecations
 
 #### LocationService replaces getLocationSrv
 
-IIn a previous release, we migrated to use a new routing system and introduced a new service for managing locations, navigation, and related information. In this release, we are making that new service the primary service.  
+In a previous release, we migrated to use a new routing system and introduced a new service for managing locations, navigation, and related information. In this release, we are making that new service the primary service.
 
 **Example:** Import the service.
 

--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -109,7 +109,7 @@ getLocationSrv.update({
 locationService.partial({ value: 1 });
 ```
 
-**Example:** How to update the search/query parameter for the current route and add replacing it in the navigation history.
+**Example:** Update the search or query parameter for the current route and add replacing it in the navigation history.
 
 ```ts
 // before

--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -56,7 +56,7 @@ Removed due to being an internal component.
 
 IIn a previous release, we migrated to use a new routing system and introduced a new service for managing locations, navigation, and related information. In this release, we are making that new service the primary service.  
 
-**Example:** How to import the service.
+**Example:** Import the service.
 
 ```ts
 // before

--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -15,6 +15,8 @@ This guide helps you identify the steps you need to take based on the Grafana ve
 - [From version 8.3.x to 8.4.x](#from-version-83x-to-84x)
   - [Value Mapping Editor has been removed from @grafana-ui library](#value-mapping-editor-has-been-removed-from-grafana-ui-library)
   - [Thresholds Editor has been removed from @grafana-ui library](#thresholds-editor-has-been-removed-from-grafana-ui-library)
+  - [8.3 Deprecations](#83-deprecations)
+    - [LocationService replaces getLocationSrv](#locationservice-replaces-getlocationsrv)
 - [From version 7.x.x to 8.x.x](#from-version-7xx-to-8xx)
   - [Backend plugin v1 support has been dropped](#backend-plugin-v1-support-has-been-dropped)
     - [1. Add dependency on grafana-plugin-sdk-go](#1-add-dependency-on-grafana-plugin-sdk-go)
@@ -47,6 +49,85 @@ Removed due to being an internal component.
 ### Thresholds Editor has been removed from @grafana-ui library
 
 Removed due to being an internal component.
+
+### 8.3 deprecations
+
+#### LocationService replaces getLocationSrv
+
+A while back we migrated to use a new routing system. At the same time we introduced a new service for managing locations, navigation etc. and we are now making that service the primary one to use.
+
+**Example:** How to import the service.
+
+```ts
+// before
+import { getLocationSrv } from '@grafana/runtime';
+
+// after
+import { locationService } from '@grafana/runtime';
+```
+
+**Example:** How to navigate to a path and add a new record in the navigation history so you can navigate back to the previous one.
+
+```ts
+// before
+getLocationSrv.update({
+  path: '/route-to-navigate-to',
+  replace: false,
+});
+
+// after
+locationService.push('/route-to-navigate-to');
+```
+
+**Example:** How to navigate to a path and replacing the current record in the navigation history.
+
+```ts
+// before
+getLocationSrv.update({
+  path: '/route-to-navigate-to',
+  replace: true,
+});
+
+// after
+locationService.replace('/route-to-navigate-to');
+```
+
+**Example:** How to update the search/query parameter for the current route and add a new record in the navigation history so you can navigate back to the previous one.
+
+```ts
+// How to navigate to a new path
+// before
+getLocationSrv.update({
+  query: {
+    value: 1,
+  },
+  partial: true,
+  replace: false,
+});
+
+// after
+locationService.pushPartial({
+  value: 1,
+});
+```
+
+**Example:** How to update the search/query parameter for the current route and add replacing it in the navigation history.
+
+```ts
+// before
+getLocationSrv.update({
+  query: {
+    'var-variable': 1,
+  },
+  partial: true,
+  replace: true,
+});
+
+// after
+locationService.replacePartial({
+  'var-variable': 1,
+});
+```
 
 ## From version 7.x.x to 8.x.x
 

--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -92,7 +92,7 @@ getLocationSrv.update({
 locationService.replace('/route-to-navigate-to');
 ```
 
-**Example:** How to update the search/query parameter for the current route and add a new record in the navigation history so you can navigate back to the previous one.
+**Example:** Update the search or query parameter for the current route and add a new record in the navigation history so that you can navigate back to the previous one.
 
 ```ts
 // How to navigate to a new path

--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -79,7 +79,7 @@ getLocationSrv.update({
 locationService.push('/route-to-navigate-to');
 ```
 
-**Example:** How to navigate to a path and replacing the current record in the navigation history.
+**Example:** Navigate to a path and replace the current record in the navigation history.
 
 ```ts
 // before

--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -54,7 +54,7 @@ Removed due to being an internal component.
 
 #### LocationService replaces getLocationSrv
 
-A while back we migrated to use a new routing system. At the same time we introduced a new service for managing locations, navigation etc. and we are now making that service the primary one to use.
+IIn a previous release, we migrated to use a new routing system and introduced a new service for managing locations, navigation, and related information. In this release, we are making that new service the primary service.  
 
 **Example:** How to import the service.
 

--- a/docs/sources/developers/plugins/migration-guide.md
+++ b/docs/sources/developers/plugins/migration-guide.md
@@ -106,9 +106,7 @@ getLocationSrv.update({
 });
 
 // after
-locationService.pushPartial({
-  value: 1,
-});
+locationService.partial({ value: 1 });
 ```
 
 **Example:** How to update the search/query parameter for the current route and add replacing it in the navigation history.
@@ -124,9 +122,7 @@ getLocationSrv.update({
 });
 
 // after
-locationService.replacePartial({
-  'var-variable': 1,
-});
+locationService.partial({ 'var-variable': 1 }, true);
 ```
 
 ## From version 7.x.x to 8.x.x

--- a/packages/grafana-runtime/src/services/LocationService.ts
+++ b/packages/grafana-runtime/src/services/LocationService.ts
@@ -141,8 +141,9 @@ export function locationSearchToObject(search: string | number): UrlQueryMap {
  */
 export let locationService: LocationService = new HistoryWrapper();
 
-/** @internal
+/**
  * Used for tests only
+ * @internal
  */
 export const setLocationService = (location: LocationService) => {
   if (process.env.NODE_ENV !== 'test') {

--- a/packages/grafana-runtime/src/services/LocationService.ts
+++ b/packages/grafana-runtime/src/services/LocationService.ts
@@ -5,7 +5,7 @@ import { attachDebugger, createLogger } from '@grafana/ui';
 import { config } from '../config';
 
 /**
- * @alpha
+ * @public
  * A wrapper to help work with browser location and history
  */
 export interface LocationService {
@@ -120,7 +120,7 @@ export class HistoryWrapper implements LocationService {
 }
 
 /**
- * @alpha
+ * @public
  * Parses a location search string to an object
  * */
 export function locationSearchToObject(search: string | number): UrlQueryMap {
@@ -137,7 +137,7 @@ export function locationSearchToObject(search: string | number): UrlQueryMap {
 }
 
 /**
- * @alpha
+ * @public
  */
 export let locationService: LocationService = new HistoryWrapper();
 

--- a/packages/grafana-runtime/src/services/LocationSrv.ts
+++ b/packages/grafana-runtime/src/services/LocationSrv.ts
@@ -1,13 +1,8 @@
-/**
- * Passed as options to the {@link LocationSrv} to describe how the automatically navigation
- * should be performed.
- *
- * @public
- */
 import { UrlQueryMap } from '@grafana/data';
 
 /**
  * @public
+ * @deprecated in favor of {@link locationService} and will be removed in Grafana 9
  */
 export interface LocationUpdate {
   /**
@@ -47,6 +42,7 @@ export interface LocationUpdate {
  * be done via the LocationSrv and it will make sure to update the application state accordingly.
  *
  * @public
+ * @deprecated in favor of {@link locationService} and will be removed in Grafana 9
  */
 export interface LocationSrv {
   update(options: LocationUpdate): void;
@@ -69,6 +65,7 @@ export function setLocationSrv(instance: LocationSrv) {
  * the user to a new place in Grafana.
  *
  * @public
+ * @deprecated in favor of {@link locationService} and will be removed in Grafana 9
  */
 export function getLocationSrv(): LocationSrv {
   return singletonInstance;

--- a/packages/grafana-runtime/src/services/appEvents.ts
+++ b/packages/grafana-runtime/src/services/appEvents.ts
@@ -40,8 +40,8 @@ export class CopyPanelEvent extends BusEventWithPayload<PanelModel> {
 let singletonInstance: EventBus;
 
 /**
- * Used during startup by Grafana to set the LocationSrv so it is available
- * via the {@link getLocationSrv} to the rest of the application.
+ * Used during startup by Grafana to set the setAppEvents so it is available
+ * via the {@link setAppEvents} to the rest of the application.
  *
  * @internal
  */

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorQueries.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorQueries.tsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { QueryGroup } from 'app/features/query/components/QueryGroup';
 import { PanelModel } from '../../state';
-import { getLocationSrv } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import { QueryGroupDataSource, QueryGroupOptions } from 'app/types';
 import { DataQuery } from '@grafana/data';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
@@ -47,9 +47,9 @@ export class PanelEditorQueries extends PureComponent<Props> {
   };
 
   onOpenQueryInspector = () => {
-    getLocationSrv().update({
-      query: { inspect: this.props.panel.id, inspectTab: 'query' },
-      partial: true,
+    locationService.partial({
+      inspect: this.props.panel.id,
+      inspectTab: 'query',
     });
   };
 

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderCorner.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderCorner.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 
 import { renderMarkdown, LinkModelSupplier, ScopedVars } from '@grafana/data';
 import { Tooltip, PopoverContent } from '@grafana/ui';
-import { getLocationSrv, getTemplateSrv } from '@grafana/runtime';
+import { locationService, getTemplateSrv } from '@grafana/runtime';
 
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
@@ -74,7 +74,10 @@ export class PanelHeaderCorner extends Component<Props> {
    * Open the Panel Inspector when we click on an error
    */
   onClickError = () => {
-    getLocationSrv().update({ partial: true, query: { inspect: this.props.panel.id, inspectTab: InspectTab.Error } });
+    locationService.partial({
+      inspect: this.props.panel.id,
+      inspectTab: InspectTab.Error,
+    });
   };
 
   renderCornerType(infoMode: InfoMode, content: PopoverContent, onClick?: () => void) {

--- a/public/app/features/plugins/admin/hooks/useHistory.tsx
+++ b/public/app/features/plugins/admin/hooks/useHistory.tsx
@@ -1,13 +1,9 @@
-import { getLocationSrv } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 
 export const useHistory = () => {
   return {
     push: ({ query }: any) => {
-      getLocationSrv().update({
-        partial: true,
-        replace: false,
-        query,
-      });
+      locationService.partial(query);
     },
   };
 };

--- a/public/app/features/search/components/ConfirmDeleteModal.tsx
+++ b/public/app/features/search/components/ConfirmDeleteModal.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { css } from '@emotion/css';
 import { GrafanaTheme } from '@grafana/data';
 import { ConfirmModal, stylesFactory, useTheme } from '@grafana/ui';
-import { getLocationSrv } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import { DashboardSection, OnDeleteItems } from '../types';
 import { getCheckedUids } from '../utils';
 import { deleteFoldersAndDashboards } from 'app/features/manage-dashboards/state/actions';
@@ -41,7 +41,7 @@ export const ConfirmDeleteModal: FC<Props> = ({ results, onDeleteItems, isOpen, 
     deleteFoldersAndDashboards(folders, dashboards).then(() => {
       onDismiss();
       // Redirect to /dashboard in case folder was deleted from f/:folder.uid
-      getLocationSrv().update({ path: '/dashboards' });
+      locationService.push('/dashboards');
       onDeleteItems(folders, dashboards);
     });
   };

--- a/public/app/features/search/hooks/useDashboardSearch.ts
+++ b/public/app/features/search/hooks/useDashboardSearch.ts
@@ -1,5 +1,5 @@
 import { KeyboardEvent, useReducer } from 'react';
-import { getLocationSrv } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import { DashboardQuery, DashboardSearchItemType, DashboardSection } from '../types';
 import { MOVE_SELECTION_DOWN, MOVE_SELECTION_UP } from '../reducers/actionTypes';
 import { dashboardsSearchState, DashboardsSearchState, searchReducer } from '../reducers/dashboardSearch';
@@ -58,9 +58,7 @@ export const useDashboardSearch = (query: DashboardQuery, onCloseSearch: () => v
           if (selectedItem.type === DashboardSearchItemType.DashFolder) {
             onToggleSection(selectedItem as DashboardSection);
           } else {
-            getLocationSrv().update({
-              path: locationUtil.stripBaseFromUrl(selectedItem.url),
-            });
+            locationService.push(locationUtil.stripBaseFromUrl(selectedItem.url));
             // Delay closing to prevent current page flicker
             setTimeout(onCloseSearch, 0);
           }

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -19,7 +19,7 @@ import { graphPanelMigrationHandler } from './GraphMigrations';
 import { DataWarning, GraphFieldConfig, GraphPanelOptions } from './types';
 
 import { auto } from 'angular';
-import { getLocationSrv } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import { getDataTimeRange } from './utils';
 import { changePanelPlugin } from 'app/features/panel/state/actions';
 import { dispatch } from 'app/store/store';
@@ -266,12 +266,9 @@ export class GraphCtrl extends MetricsPanelCtrl {
     if (range) {
       dataWarning.actionText = 'Zoom to data';
       dataWarning.action = () => {
-        getLocationSrv().update({
-          partial: true,
-          query: {
-            from: range.from,
-            to: range.to,
-          },
+        locationService.partial({
+          from: range.from,
+          to: range.to,
         });
       };
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently our documentation states that you should use `getLocationSrv` to perform navigation actions via `locationSrv.update`. When you use the `locationSrv.update` function a deprecation warning will be printed in the console stating that you should use `push, partial, replace` in favor of `update`. However there are no `push`, `partial`, `replace` functions exposed via the  `LocationSrv` interface.

This PR will deprecate the whole `LocationSrc` in favor of `LocationService`. I will investigate if we can minimize the `LocationService` interface in follow up PRs to create a more clear and easy to use interface towards external consumers.

**Which issue(s) this PR fixes**:
Fixes #44572

**Special notes for your reviewer**:

> I also introduce two new functions in favor of the `partial` on the `LocationService` interface. The idea is that you probably know what action you want to take when calling the `partial` function and it makes it more clear what the intention are compared to passing a `true/false` value.
> 
> My thinking is that if plugin developers need to migrate to the locationService interface it might be better to do this change now instead of letting them migrate again in a near future. But I'm not sure this is worth all the work. WDYT, should I revert this change and keep partial?

I basically decided to revert this change due to failing tests and a lot of mocks that I didn't manage to change quickly. So I didn't feel like it is worth the time.