### PR TITLE
Improve prettier:check output

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "packages:typecheck": "lerna run typecheck",
     "packages:clean": "lerna run clean",
     "precommit": "yarn run lint-staged",
-    "prettier:check": "prettier --list-different \"**/*.{scss,md,mdx}\"",
+    "prettier:check": "prettier --check --list-different=false --loglevel=warn \"**/*.{scss,md,mdx}\"",
     "prettier:write": "prettier --list-different \"**/*.{scss,md,mdx}\" --write",
     "start": "yarn themes:generate && yarn dev --watch",
     "start:noTsCheck": "yarn start --env noTsCheck=1",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Before:
```
➜ grafana (armandgrillet/legacy-alerting-deprecation-notice) ✔ yarn run prettier:check
docs/sources/alerting/_index.md
```

After: 
```
➜ grafana (armandgrillet/legacy-alerting-deprecation-notice) ✔ yarn run prettier:check
[warn] docs/sources/alerting/_index.md
[warn] Code style issues found in the above file(s). Forgot to run Prettier?
```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

No issue, just a bad experience not understanding the CI output of https://drone.grafana.net/grafana/grafana/49884/1/9 yesterday. This is the same fix as in https://github.com/sourcegraph/sourcegraph/pull/29684.

**Special notes for your reviewer**:

