### PR TITLE
Loki: use generic grafana null-insertion mechanism

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -10,7 +10,6 @@ import {
   FieldType,
   LogRowModel,
   MutableDataFrame,
-  TimeSeries,
   toUtc,
 } from '@grafana/data';
 import { BackendSrvRequest, FetchResponse, config } from '@grafana/runtime';

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -334,7 +334,7 @@ describe('LokiDatasource', () => {
       expect(ds.runRangeQuery).toBeCalled();
     });
 
-    it('should return series data for metrics range queries', async () => {
+    it('should return dataframe data for metrics range queries', async () => {
       const ds = createLokiDSForTests();
       const options = getQueryOptions<LokiQuery>({
         targets: [{ expr: metricsQuery, refId: 'B', range: true }],
@@ -345,11 +345,19 @@ describe('LokiDatasource', () => {
 
       await expect(ds.query(options)).toEmitValuesWith((received) => {
         const result = received[0];
-        const timeSeries = result.data[0] as TimeSeries;
+        const frame = result.data[0] as DataFrame;
 
-        expect(timeSeries.meta?.preferredVisualisationType).toBe('graph');
-        expect(timeSeries.refId).toBe('B');
-        expect(timeSeries.datapoints[0]).toEqual([1.1, 1605715380000]);
+        expect(frame.meta?.preferredVisualisationType).toBe('graph');
+        expect(frame.refId).toBe('B');
+        frame.fields.forEach((field) => {
+          const value = field.values.get(0);
+
+          if (field.type === FieldType.time) {
+            expect(value).toBe(1605715380000);
+          } else {
+            expect(value).toBe(1.1);
+          }
+        });
       });
     });
 

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -290,8 +290,6 @@ describe('enhanceDataFrame', () => {
      * NOTE on time parameters:
      * - Input time series data has timestamps in sec (like Prometheus)
      * - Output time series has timestamps in ms (as expected for the chart lib)
-     * - Start/end parameters are in ns (as expected for Loki)
-     * - Step is in sec (like in Prometheus)
      */
     const data: Array<[number, string]> = [
       [1, '1'],
@@ -300,12 +298,10 @@ describe('enhanceDataFrame', () => {
     ];
 
     it('returns data as is if step, start, and end align', () => {
-      const options: Partial<TransformerOptions> = { start: 1 * 1e9, end: 4 * 1e9, step: 1 };
-      const result = ResultTransformer.lokiPointsToTimeseriesPoints(data, options as TransformerOptions);
+      const result = ResultTransformer.lokiPointsToTimeseriesPoints(data);
       expect(result).toEqual([
         [1, 1000],
         [0, 2000],
-        [null, 3000],
         [1, 4000],
       ]);
     });

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -17,6 +17,7 @@ import {
   QueryResultMeta,
   TimeSeriesValue,
   ScopedVars,
+  toDataFrame,
 } from '@grafana/data';
 
 import { getTemplateSrv, getDataSourceSrv } from '@grafana/runtime';
@@ -184,21 +185,16 @@ function lokiMatrixToTimeSeries(matrixResult: LokiMatrixResult, options: Transfo
   return {
     target: name,
     title: name,
-    datapoints: lokiPointsToTimeseriesPoints(matrixResult.values, options),
+    datapoints: lokiPointsToTimeseriesPoints(matrixResult.values),
     tags: matrixResult.metric,
     meta: options.meta,
     refId: options.refId,
   };
 }
 
-export function lokiPointsToTimeseriesPoints(
-  data: Array<[number, string]>,
-  options: TransformerOptions
-): TimeSeriesValue[][] {
-  const stepMs = options.step * 1000;
+export function lokiPointsToTimeseriesPoints(data: Array<[number, string]>): TimeSeriesValue[][] {
   const datapoints: TimeSeriesValue[][] = [];
 
-  let baseTimestampMs = options.start / 1e6;
   for (const [time, value] of data) {
     let datapointValue: TimeSeriesValue = parseFloat(value);
 
@@ -207,17 +203,8 @@ export function lokiPointsToTimeseriesPoints(
     }
 
     const timestamp = time * 1000;
-    for (let t = baseTimestampMs; t < timestamp; t += stepMs) {
-      datapoints.push([null, t]);
-    }
 
-    baseTimestampMs = timestamp + stepMs;
     datapoints.push([datapointValue, timestamp]);
-  }
-
-  const endTimestamp = options.end / 1e6;
-  for (let t = baseTimestampMs; t <= endTimestamp; t += stepMs) {
-    datapoints.push([null, t]);
   }
 
   return datapoints;
@@ -454,7 +441,7 @@ function fieldFromDerivedFieldConfig(derivedFieldConfigs: DerivedFieldConfig[]):
   };
 }
 
-export function rangeQueryResponseToTimeSeries(
+function rangeQueryResponseToTimeSeries(
   response: LokiResponse,
   query: LokiRangeQueryRequest,
   target: LokiQuery,
@@ -491,6 +478,33 @@ export function rangeQueryResponseToTimeSeries(
   }
 }
 
+export function rangeQueryResponseToDataFrames(
+  response: LokiResponse,
+  query: LokiRangeQueryRequest,
+  target: LokiQuery,
+  responseListLength: number,
+  scopedVars: ScopedVars
+): DataFrame[] {
+  const series = rangeQueryResponseToTimeSeries(response, query, target, responseListLength, scopedVars);
+  const frames = series.map((s) => toDataFrame(s));
+
+  const { step } = query;
+
+  if (step != null) {
+    const intervalMs = step * 1000;
+
+    frames.forEach((frame) => {
+      frame.fields.forEach((field) => {
+        if (field.type === FieldType.time) {
+          field.config.interval = intervalMs;
+        }
+      });
+    });
+  }
+
+  return frames;
+}
+
 export function processRangeQueryResponse(
   response: LokiResponse,
   target: LokiQuery,
@@ -511,7 +525,7 @@ export function processRangeQueryResponse(
     case LokiResultType.Vector:
     case LokiResultType.Matrix:
       return of({
-        data: rangeQueryResponseToTimeSeries(
+        data: rangeQueryResponseToDataFrames(
           response,
           query,
           {


### PR DESCRIPTION
when a Loki metric query returns graph-data, if there are gaps in that data, for those gaps we simply receive no datapoints.
if we just feed this into a time-series graph, the graph will be connected through the gap.

currently, we solve this by adding new timestamps with `value=null` at the points where "should be data but is not". we do this in the loki datasource, and we know where those points are, because we can calculate it from the `step` value. but, this is very fragile, we get bugs like https://github.com/grafana/grafana/issues/44515

with https://github.com/grafana/grafana/pull/44622 merged, there is now a way to tell Grafana about this situation. we simply fill out in the dataframe the `field.config.interval` value, and Grafana does the rest automatically.

this pull requests adjusts the loki datasource to work with this new functionality:
- we stop inserting `value=null` timestamps
- for metric-queries currently we return `TimeSeries` structures. we have to switch to returning `DataFrame` structures. i do this by calling `@grafana/data/toDataFrame`
- we set the `field.config.interval` value in the dataframes


how to test:
- you need a loki database with data so that you can generate a metric query with a gap in it (ping me if this is a problem)
- go to explore-mode
- enter a loki metric query that produces a graph with a gap in it
     - if you have log-data with a large enough gap in it, something like `count_over_time({level="info"}[10s])` should work
- verify that in the graph the gap exists, the data before-gap and after-gap are not connected