### PR TITLE
[v8.3.x] CI: Make e2e tests depend on binary builds (#44647)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -188,9 +188,12 @@ steps:
 - commands:
   - ./scripts/grafana-server/start-server
   depends_on:
-  - package
+  - build-plugins
+  - build-backend
+  - build-frontend
   detach: true
   environment:
+    ARCH: linux-amd64
     PORT: 3001
   image: grafana/build-container:1.4.9
   name: grafana-server
@@ -198,7 +201,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -207,7 +210,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -216,7 +219,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -225,7 +228,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -595,9 +598,12 @@ steps:
 - commands:
   - ./scripts/grafana-server/start-server
   depends_on:
-  - package
+  - build-plugins
+  - build-backend
+  - build-frontend
   detach: true
   environment:
+    ARCH: linux-amd64
     PORT: 3001
   image: grafana/build-container:1.4.9
   name: grafana-server
@@ -605,7 +611,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -614,7 +620,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -623,7 +629,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -632,7 +638,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -1151,9 +1157,12 @@ steps:
 - commands:
   - ./scripts/grafana-server/start-server
   depends_on:
-  - package
+  - build-plugins
+  - build-backend
+  - build-frontend
   detach: true
   environment:
+    ARCH: linux-amd64
     PORT: 3001
   image: grafana/build-container:1.4.9
   name: grafana-server
@@ -1161,7 +1170,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -1170,7 +1179,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -1179,7 +1188,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -1188,7 +1197,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -1720,10 +1729,12 @@ steps:
 - commands:
   - ./scripts/grafana-server/start-server
   depends_on:
-  - package
+  - build-plugins
+  - build-backend
+  - build-frontend
   detach: true
   environment:
-    PACKAGE_FILE: dist/grafana-enterprise-*linux-amd64.tar.gz
+    ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
   image: grafana/build-container:1.4.9
@@ -1732,7 +1743,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -1741,7 +1752,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -1750,7 +1761,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -1759,7 +1770,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -2841,9 +2852,12 @@ steps:
 - commands:
   - ./scripts/grafana-server/start-server
   depends_on:
-  - package
+  - build-plugins
+  - build-backend
+  - build-frontend
   detach: true
   environment:
+    ARCH: linux-amd64
     PORT: 3001
   image: grafana/build-container:1.4.9
   name: grafana-server
@@ -2851,7 +2865,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -2860,7 +2874,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -2869,7 +2883,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -2878,7 +2892,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -3338,10 +3352,12 @@ steps:
 - commands:
   - ./scripts/grafana-server/start-server
   depends_on:
-  - package
+  - build-plugins
+  - build-backend
+  - build-frontend
   detach: true
   environment:
-    PACKAGE_FILE: dist/grafana-enterprise-*linux-amd64.tar.gz
+    ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
   image: grafana/build-container:1.4.9
@@ -3350,7 +3366,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite dashboards-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -3359,7 +3375,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite smoke-tests-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -3368,7 +3384,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite panels-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -3377,7 +3393,7 @@ steps:
   - apt-get install -y netcat
   - ./bin/grabpl e2e-tests --port 3001 --suite various-suite --tries 3
   depends_on:
-  - package
+  - grafana-server
   environment:
     HOST: grafana-server
   image: cypress/included:8.4.1
@@ -3883,6 +3899,6 @@ kind: secret
 name: prerelease_bucket
 ---
 kind: signature
-hmac: 771df38b5026fdb85630fdfda0e067df0403a8cd6d5a0bec376dffa8c36033f8
+hmac: 1c39a83bdf091e43a83d39be224283c10d9e5a47cde268a1c3c6fd1478531cb4
 
 ...

--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -14,7 +14,7 @@ load(
     'build_frontend_step',
     'build_plugins_step',
     'package_step',
-    'e2e_tests_server_step',
+    'grafana_server_step',
     'e2e_tests_step',
     'build_storybook_step',
     'build_frontend_docs_step',
@@ -95,8 +95,8 @@ def get_steps(edition, is_downstream=False):
 
     # Insert remaining steps
     build_steps.extend([
-        package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2, is_downstream=is_downstream),        
-        e2e_tests_server_step(edition=edition),
+        package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2, is_downstream=is_downstream),
+        grafana_server_step(edition=edition),
         e2e_tests_step('dashboards-suite', edition=edition),
         e2e_tests_step('smoke-tests-suite', edition=edition),
         e2e_tests_step('panels-suite', edition=edition),

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -14,7 +14,7 @@ load(
     'test_backend_integration_step',
     'test_frontend_step',
     'package_step',
-    'e2e_tests_server_step',
+    'grafana_server_step',
     'e2e_tests_step',
     'build_storybook_step',
     'build_frontend_docs_step',
@@ -89,7 +89,7 @@ def pr_pipelines(edition):
     # Insert remaining build_steps
     build_steps.extend([
         package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2, variants=variants),
-        e2e_tests_server_step(edition=edition),
+        grafana_server_step(edition=edition),
         e2e_tests_step('dashboards-suite', edition=edition),
         e2e_tests_step('smoke-tests-suite', edition=edition),
         e2e_tests_step('panels-suite', edition=edition),

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -17,7 +17,7 @@ load(
     'build_frontend_step',
     'build_plugins_step',
     'package_step',
-    'e2e_tests_server_step',
+    'grafana_server_step',
     'e2e_tests_step',
     'build_storybook_step',
     'copy_packages_for_docker_step',
@@ -222,7 +222,7 @@ def get_steps(edition, ver_mode):
         copy_packages_for_docker_step(),
         package_docker_images_step(edition=edition, ver_mode=ver_mode, publish=should_publish),
         package_docker_images_step(edition=edition, ver_mode=ver_mode, ubuntu=True, publish=should_publish),
-        e2e_tests_server_step(edition=edition),
+        grafana_server_step(edition=edition),
     ])
 
     if not disable_tests:

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -609,7 +609,7 @@ def package_step(edition, ver_mode, include_enterprise2=False, variants=None, is
     }
 
 
-def e2e_tests_server_step(edition, port=3001):
+def grafana_server_step(edition, port=3001):
     package_file_pfx = ''
     if edition == 'enterprise2':
         package_file_pfx = 'grafana' + enterprise2_suffix(edition)
@@ -618,9 +618,9 @@ def e2e_tests_server_step(edition, port=3001):
 
     environment = {
         'PORT': port,
+        'ARCH': 'linux-amd64'
     }
     if package_file_pfx:
-        environment['PACKAGE_FILE'] = 'dist/{}-*linux-amd64.tar.gz'.format(package_file_pfx)
         environment['RUNDIR'] = 'scripts/grafana-server/tmp-{}'.format(package_file_pfx)
 
     return {
@@ -628,7 +628,9 @@ def e2e_tests_server_step(edition, port=3001):
         'image': build_image,
         'detach': True,
         'depends_on': [
-            'package' + enterprise2_suffix(edition),
+            'build-plugins',
+            'build-backend',
+            'build-frontend',
         ],
         'environment': environment,
         'commands': [
@@ -644,7 +646,7 @@ def e2e_tests_step(suite, edition, port=3001, tries=None):
         'name': 'end-to-end-tests-{}'.format(suite) + enterprise2_suffix(edition),
         'image': 'cypress/included:8.4.1',
         'depends_on': [
-            'package',
+            'grafana-server',
         ],
         'environment': {
             'HOST': 'grafana-server' + enterprise2_suffix(edition),

--- a/scripts/grafana-server/start-server
+++ b/scripts/grafana-server/start-server
@@ -4,7 +4,11 @@ set -eo pipefail
 . scripts/grafana-server/variables
 
 PORT=${PORT:-$DEFAULT_PORT}
-PACKAGE_FILE=${PACKAGE_FILE:-$DEFAULT_PACKAGE_FILE}
+ARCH=${ARCH:-$DEFAULT_ARCH}
+
+if [ "$ARCH" ]; then
+    ARCH+="/"
+fi
 
 ./scripts/grafana-server/kill-server
 
@@ -12,32 +16,23 @@ mkdir $RUNDIR
 
 echo -e "Copying grafana backend files to temp dir..."
 
-# Expand any wildcards
-pkgs=(${PACKAGE_FILE})
-pkg=${pkgs[0]}
-if [[ -f ${pkg} ]]; then
-  echo "Found package tar file ${pkg}, extracting..."
-  tar zxf ${pkg} -C $RUNDIR
-  mv $RUNDIR/grafana-*/* $RUNDIR
-else
-  echo "Couldn't find package ${PACKAGE_FILE} - copying local dev files"
-
-  if [[ ! -f bin/grafana-server ]]; then
-    echo bin/grafana-server missing
-    exit 1
-  fi
-
-  cp -r ./bin $RUNDIR
-  cp -r ./public $RUNDIR
-  cp -r ./tools $RUNDIR
-
-  mkdir $RUNDIR/conf
-  mkdir $PROV_DIR
-  mkdir $PROV_DIR/datasources
-  mkdir $PROV_DIR/dashboards
-
-  cp ./conf/defaults.ini $RUNDIR/conf/defaults.ini
+if [[ ! -f bin/"$ARCH"grafana-server ]]; then
+  echo "bin/linux-amd64/grafana-server missing, trying local grafana-server binary"
 fi
+
+echo starting server
+
+cp -r ./bin $RUNDIR
+cp -r ./public $RUNDIR
+cp -r ./tools $RUNDIR
+
+mkdir $RUNDIR/conf
+mkdir $PROV_DIR
+mkdir $PROV_DIR/datasources
+mkdir $PROV_DIR/dashboards
+
+cp ./scripts/grafana-server/custom.ini $RUNDIR/conf/custom.ini
+cp ./conf/defaults.ini $RUNDIR/conf/defaults.ini
 
 echo -e "Copy provisioning setup from devenv"
 
@@ -48,7 +43,7 @@ cp -r devenv $RUNDIR
 
 echo -e "Starting Grafana Server port $PORT"
 
-$RUNDIR/bin/grafana-server \
+$RUNDIR/bin/"$ARCH"grafana-server \
   --homepath=$HOME_PATH \
   --pidfile=$RUNDIR/pid \
   cfg:server.http_port=$PORT \

--- a/scripts/grafana-server/variables
+++ b/scripts/grafana-server/variables
@@ -2,9 +2,9 @@
 
 DEFAULT_RUNDIR=scripts/grafana-server/tmp
 RUNDIR=${RUNDIR:-$DEFAULT_RUNDIR}
+DEFAULT_ARCH=
 HOME_PATH=$PWD/$RUNDIR
 PIDFILE=$RUNDIR/pid
-DEFAULT_PACKAGE_FILE=dist/grafana-*linux-amd64.tar.gz
 PROV_DIR=$RUNDIR/conf/provisioning
 DEFAULT_HOST=localhost
 DEFAULT_PORT=3001


### PR DESCRIPTION
Backport of #44647

* Make e2e test depend on binary builds

* Search for binary in the correct folders

* Remove package file var

* Add ARCH var

(cherry picked from commit 7bb5a5b3188004b14c67cef671662052b8fbe1d4)
