### PR TITLE
Rename build-e2e-publish pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1094,7 +1094,7 @@ type: docker
 ---
 depends_on: []
 kind: pipeline
-name: oss-build-publish-e2e-release
+name: oss-build-e2e-publish-release
 node:
   type: no-parallel
 platform:
@@ -1599,7 +1599,7 @@ volumes:
     medium: memory
 ---
 depends_on:
-- oss-build-publish-e2e-release
+- oss-build-e2e-publish-release
 - oss-test-release
 - oss-integration-tests-release
 kind: pipeline
@@ -2858,7 +2858,7 @@ volumes:
 ---
 depends_on: []
 kind: pipeline
-name: oss-build-publish-e2e-release-branch
+name: oss-build-e2e-publish-release-branch
 node:
   type: no-parallel
 platform:
@@ -3305,7 +3305,7 @@ volumes:
     medium: memory
 ---
 depends_on:
-- oss-build-publish-e2e-release-branch
+- oss-build-e2e-publish-release-branch
 - oss-test-release-branch
 - oss-integration-tests-release-branch
 kind: pipeline
@@ -4191,6 +4191,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 4d1a5696bf1e510fb51a021c07e240c50cb913724ce08ed52cce037ff02dd8de
+hmac: f26fc6de1d7ec3cf5608b70c851c8cf2b998e07abad8c52714e72ad072492387
 
 ...

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -285,7 +285,7 @@ def get_oss_pipelines(trigger, ver_mode):
     )
     pipelines = [
         pipeline(
-            name='oss-build-publish{}-{}'.format(get_e2e_suffix(), ver_mode), edition=edition, trigger=trigger, services=[],
+            name='oss-build{}-publish-{}'.format(get_e2e_suffix(), ver_mode), edition=edition, trigger=trigger, services=[],
             steps=[download_grabpl_step()] + initialize_step(edition, platform='linux', ver_mode=ver_mode) +
                   build_steps + package_steps + publish_steps,
             volumes=volumes,
@@ -308,7 +308,7 @@ def get_oss_pipelines(trigger, ver_mode):
         ])
         deps = {
             'depends_on': [
-                'oss-build-publish{}-{}'.format(get_e2e_suffix(), ver_mode),
+                'oss-build{}-publish-{}'.format(get_e2e_suffix(), ver_mode),
                 'oss-test-{}'.format(ver_mode),
                 'oss-integration-tests-{}'.format(ver_mode)
             ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Renames build-e2e-publish pipelines