### PR TITLE
CloudWatch: Use single timeout for log queries

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -192,9 +192,7 @@ export class CloudWatchDatasource
         });
       },
       queryParams,
-      {
-        timeoutFunc: timeoutFunc,
-      }
+      timeoutFunc
     ).pipe(
       mergeMap(({ frames, error }: { frames: DataFrame[]; error?: DataQueryError }) =>
         // This queries for the results

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -81,8 +81,6 @@ const displayAlert = (datasourceName: string, region: string) =>
 const displayCustomError = (title: string, message: string) =>
   store.dispatch(notifyApp(createErrorNotification(title, message)));
 
-export const MAX_ATTEMPTS = 5;
-
 export class CloudWatchDatasource
   extends DataSourceWithBackend<CloudWatchQuery, CloudWatchJsonData>
   implements DataSourceWithLogsContextSupport
@@ -180,6 +178,11 @@ export class CloudWatchDatasource
       region: this.replace(this.getActualRegion(target.region), options.scopedVars, true, 'region'),
     }));
 
+    const startTime = new Date();
+    const timeoutFunc = () => {
+      return Date.now() >= startTime.valueOf() + rangeUtil.intervalToMs(this.logsTimeout);
+    };
+
     return runWithRetry(
       (targets: StartQueryRequest[]) => {
         return this.makeLogActionRequest('StartQuery', targets, {
@@ -190,7 +193,7 @@ export class CloudWatchDatasource
       },
       queryParams,
       {
-        timeout: rangeUtil.intervalToMs(this.logsTimeout),
+        timeoutFunc: timeoutFunc,
       }
     ).pipe(
       mergeMap(({ frames, error }: { frames: DataFrame[]; error?: DataQueryError }) =>
@@ -202,7 +205,8 @@ export class CloudWatchDatasource
             refId: dataFrame.refId!,
             statsGroups: (logQueries.find((target) => target.refId === dataFrame.refId)! as CloudWatchLogsQuery)
               .statsGroups,
-          }))
+          })),
+          timeoutFunc
         ).pipe(
           map((response: DataQueryResponse) => {
             if (!response.error && error) {
@@ -310,7 +314,8 @@ export class CloudWatchDatasource
       limit?: number;
       region: string;
       statsGroups?: string[];
-    }>
+    }>,
+    timeoutFunc: () => boolean
   ): Observable<DataQueryResponse> {
     this.logQueries = {};
     queryParams.forEach((param) => {
@@ -363,7 +368,7 @@ export class CloudWatchDatasource
         }
       }),
       map(([dataFrames, failedAttempts]) => {
-        if (failedAttempts >= MAX_ATTEMPTS) {
+        if (timeoutFunc()) {
           for (const frame of dataFrames) {
             set(frame, 'meta.custom.Status', CloudWatchLogsQueryStatus.Cancelled);
           }
@@ -381,13 +386,12 @@ export class CloudWatchDatasource
           )
             ? LoadingState.Done
             : LoadingState.Loading,
-          error:
-            failedAttempts >= MAX_ATTEMPTS
-              ? {
-                  message: `error: query timed out after ${MAX_ATTEMPTS} attempts`,
-                  type: DataQueryErrorType.Timeout,
-                }
-              : undefined,
+          error: timeoutFunc()
+            ? {
+                message: `error: query timed out after ${failedAttempts} attempts`,
+                type: DataQueryErrorType.Timeout,
+              }
+            : undefined,
         };
       }),
       takeWhile(({ state }) => state !== LoadingState.Error && state !== LoadingState.Done, true)

--- a/public/app/plugins/datasource/cloudwatch/utils/logsRetry.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/logsRetry.test.ts
@@ -4,17 +4,16 @@ import { lastValueFrom, of, throwError } from 'rxjs';
 import { dataFrameToJSON, MutableDataFrame } from '@grafana/data';
 import { DataResponse, FetchError } from '@grafana/runtime';
 import { StartQueryRequest } from '../types';
+import { log } from 'console';
 
 describe('runWithRetry', () => {
+  const timeoutPass = () => false;
+  const timeoutFail = () => true;
   it('returns results if no retry is needed', async () => {
     const queryFunc = jest.fn();
     queryFunc.mockReturnValueOnce(of([createResponseFrame('A')]));
     const targets = [targetA];
-    const startTime = new Date();
-    const timeoutFunc = () => {
-      return Date.now() >= startTime.valueOf() + 30000;
-    };
-    const values = await lastValueFrom(runWithRetry(queryFunc, targets, timeoutFunc).pipe(toArray()));
+    const values = await lastValueFrom(runWithRetry(queryFunc, targets, timeoutPass).pipe(toArray()));
     expect(queryFunc).toBeCalledTimes(1);
     expect(queryFunc).toBeCalledWith(targets);
     expect(values).toEqual([{ frames: [createResponseFrame('A')] }]);
@@ -27,11 +26,7 @@ describe('runWithRetry', () => {
     queryFunc.mockReturnValueOnce(throwError(() => createErrorResponse(targets)));
     queryFunc.mockReturnValueOnce(of([createResponseFrame('A')]));
 
-    const startTime = new Date();
-    const timeoutFunc = () => {
-      return Date.now() >= startTime.valueOf() + 30000;
-    };
-    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutFunc).pipe(toArray()));
+    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutPass).pipe(toArray()));
     jest.runAllTimers();
     const values = await valuesPromise;
 
@@ -41,7 +36,7 @@ describe('runWithRetry', () => {
     expect(values).toEqual([{ frames: [createResponseFrame('A')] }]);
   });
 
-  it('fails if reaching timoeut and no data was retrieved', async () => {
+  it('fails if reaching timeout and no data was retrieved', async () => {
     jest.useFakeTimers();
     const targets = [targetA];
     const queryFunc = jest.fn();
@@ -49,10 +44,7 @@ describe('runWithRetry', () => {
     queryFunc.mockReturnValueOnce(of([createResponseFrame('A')]));
 
     const startTime = new Date();
-    const timeoutFunc = () => {
-      return Date.now() >= startTime.valueOf() + 0;
-    };
-    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutFunc).pipe(toArray()));
+    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutFail).pipe(toArray()));
     jest.runAllTimers();
     let error;
     try {
@@ -72,11 +64,7 @@ describe('runWithRetry', () => {
     const queryFunc = jest.fn();
     queryFunc.mockReturnValueOnce(throwError(() => 'random error'));
 
-    const startTime = new Date();
-    const timeoutFunc = () => {
-      return Date.now() >= startTime.valueOf() + 30000;
-    };
-    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutFunc).pipe(toArray()));
+    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutPass).pipe(toArray()));
     jest.runAllTimers();
     let error;
     try {
@@ -95,11 +83,7 @@ describe('runWithRetry', () => {
     const queryFunc = jest.fn();
     queryFunc.mockReturnValueOnce(of([createResponseFrame('A'), createResponseFrame('B')]));
 
-    const startTime = new Date();
-    const timeoutFunc = () => {
-      return Date.now() >= startTime.valueOf() + 30000;
-    };
-    const values = await lastValueFrom(runWithRetry(queryFunc, targets, timeoutFunc).pipe(toArray()));
+    const values = await lastValueFrom(runWithRetry(queryFunc, targets, timeoutPass).pipe(toArray()));
 
     expect(queryFunc).toBeCalledTimes(1);
     expect(queryFunc).nthCalledWith(1, targets);
@@ -121,11 +105,7 @@ describe('runWithRetry', () => {
 
     queryFunc.mockReturnValueOnce(of([createResponseFrame('B')]));
 
-    const startTime = new Date();
-    const timeoutFunc = () => {
-      return Date.now() >= startTime.valueOf() + 30000;
-    };
-    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutFunc).pipe(toArray()));
+    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutPass).pipe(toArray()));
     jest.runAllTimers();
     const values = await valuesPromise;
 
@@ -153,11 +133,7 @@ describe('runWithRetry', () => {
       )
     );
 
-    const startTime = new Date();
-    const timeoutFunc = () => {
-      return Date.now() >= startTime.valueOf() + 0;
-    };
-    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutFunc).pipe(toArray()));
+    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutFail).pipe(toArray()));
     jest.runAllTimers();
     const values = await valuesPromise;
 

--- a/public/app/plugins/datasource/cloudwatch/utils/logsRetry.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/logsRetry.test.ts
@@ -10,7 +10,11 @@ describe('runWithRetry', () => {
     const queryFunc = jest.fn();
     queryFunc.mockReturnValueOnce(of([createResponseFrame('A')]));
     const targets = [targetA];
-    const values = await lastValueFrom(runWithRetry(queryFunc, targets).pipe(toArray()));
+    const startTime = new Date();
+    const timeoutFunc = () => {
+      return Date.now() >= startTime.valueOf() + 30000;
+    };
+    const values = await lastValueFrom(runWithRetry(queryFunc, targets, timeoutFunc).pipe(toArray()));
     expect(queryFunc).toBeCalledTimes(1);
     expect(queryFunc).toBeCalledWith(targets);
     expect(values).toEqual([{ frames: [createResponseFrame('A')] }]);
@@ -23,7 +27,11 @@ describe('runWithRetry', () => {
     queryFunc.mockReturnValueOnce(throwError(() => createErrorResponse(targets)));
     queryFunc.mockReturnValueOnce(of([createResponseFrame('A')]));
 
-    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets).pipe(toArray()));
+    const startTime = new Date();
+    const timeoutFunc = () => {
+      return Date.now() >= startTime.valueOf() + 30000;
+    };
+    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutFunc).pipe(toArray()));
     jest.runAllTimers();
     const values = await valuesPromise;
 
@@ -40,7 +48,11 @@ describe('runWithRetry', () => {
     queryFunc.mockReturnValueOnce(throwError(() => createErrorResponse(targets)));
     queryFunc.mockReturnValueOnce(of([createResponseFrame('A')]));
 
-    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, { timeout: 0 }).pipe(toArray()));
+    const startTime = new Date();
+    const timeoutFunc = () => {
+      return Date.now() >= startTime.valueOf() + 0;
+    };
+    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutFunc).pipe(toArray()));
     jest.runAllTimers();
     let error;
     try {
@@ -60,7 +72,11 @@ describe('runWithRetry', () => {
     const queryFunc = jest.fn();
     queryFunc.mockReturnValueOnce(throwError(() => 'random error'));
 
-    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets).pipe(toArray()));
+    const startTime = new Date();
+    const timeoutFunc = () => {
+      return Date.now() >= startTime.valueOf() + 30000;
+    };
+    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutFunc).pipe(toArray()));
     jest.runAllTimers();
     let error;
     try {
@@ -79,7 +95,11 @@ describe('runWithRetry', () => {
     const queryFunc = jest.fn();
     queryFunc.mockReturnValueOnce(of([createResponseFrame('A'), createResponseFrame('B')]));
 
-    const values = await lastValueFrom(runWithRetry(queryFunc, targets).pipe(toArray()));
+    const startTime = new Date();
+    const timeoutFunc = () => {
+      return Date.now() >= startTime.valueOf() + 30000;
+    };
+    const values = await lastValueFrom(runWithRetry(queryFunc, targets, timeoutFunc).pipe(toArray()));
 
     expect(queryFunc).toBeCalledTimes(1);
     expect(queryFunc).nthCalledWith(1, targets);
@@ -101,7 +121,11 @@ describe('runWithRetry', () => {
 
     queryFunc.mockReturnValueOnce(of([createResponseFrame('B')]));
 
-    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets).pipe(toArray()));
+    const startTime = new Date();
+    const timeoutFunc = () => {
+      return Date.now() >= startTime.valueOf() + 30000;
+    };
+    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutFunc).pipe(toArray()));
     jest.runAllTimers();
     const values = await valuesPromise;
 
@@ -129,7 +153,11 @@ describe('runWithRetry', () => {
       )
     );
 
-    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, { timeout: 0 }).pipe(toArray()));
+    const startTime = new Date();
+    const timeoutFunc = () => {
+      return Date.now() >= startTime.valueOf() + 0;
+    };
+    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutFunc).pipe(toArray()));
     jest.runAllTimers();
     const values = await valuesPromise;
 
@@ -172,9 +200,7 @@ describe('runWithRetry', () => {
       )
     );
 
-    const valuesPromise = lastValueFrom(
-      runWithRetry(queryFunc, targets, { timeoutFunc: (retry) => retry >= 2 }).pipe(toArray())
-    );
+    const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, (retry) => retry >= 2).pipe(toArray()));
     jest.runAllTimers();
     const values = await valuesPromise;
 

--- a/public/app/plugins/datasource/cloudwatch/utils/logsRetry.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/logsRetry.test.ts
@@ -4,7 +4,6 @@ import { lastValueFrom, of, throwError } from 'rxjs';
 import { dataFrameToJSON, MutableDataFrame } from '@grafana/data';
 import { DataResponse, FetchError } from '@grafana/runtime';
 import { StartQueryRequest } from '../types';
-import { log } from 'console';
 
 describe('runWithRetry', () => {
   const timeoutPass = () => false;
@@ -43,7 +42,6 @@ describe('runWithRetry', () => {
     queryFunc.mockReturnValueOnce(throwError(() => createErrorResponse(targets)));
     queryFunc.mockReturnValueOnce(of([createResponseFrame('A')]));
 
-    const startTime = new Date();
     const valuesPromise = lastValueFrom(runWithRetry(queryFunc, targets, timeoutFail).pipe(toArray()));
     jest.runAllTimers();
     let error;

--- a/public/app/plugins/datasource/cloudwatch/utils/logsRetry.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/logsRetry.ts
@@ -5,8 +5,6 @@ import { DataFrame, DataFrameJSON, DataQueryError } from '@grafana/data';
 
 type Result = { frames: DataFrameJSON[]; error?: string };
 
-const defaultTimeout = 30_000;
-
 /**
  * A retry strategy specifically for cloud watch logs query. Cloud watch logs queries need first starting the query
  * and the polling for the results. The start query can fail because of the concurrent queries rate limit,
@@ -23,11 +21,7 @@ const defaultTimeout = 30_000;
 export function runWithRetry(
   queryFun: (targets: StartQueryRequest[]) => Observable<DataFrame[]>,
   targets: StartQueryRequest[],
-  options: {
-    timeout?: number;
-    timeoutFunc?: (retry: number, startTime: number) => boolean;
-    retryWaitFunc?: (retry: number) => number;
-  } = {}
+  timeoutFunc: (retry: number, startTime: number) => boolean
 ): Observable<{ frames: DataFrame[]; error?: DataQueryError }> {
   const startTime = new Date();
   let retries = 0;
@@ -35,17 +29,9 @@ export function runWithRetry(
   let subscription: Subscription;
   let collected = {};
 
-  const timeoutFunction = options.timeoutFunc
-    ? options.timeoutFunc
-    : (retry: number, startTime: number) => {
-        return Date.now() >= startTime + (options.timeout === undefined ? defaultTimeout : options.timeout);
-      };
-
-  const retryWaitFunction = options.retryWaitFunc
-    ? options.retryWaitFunc
-    : (retry: number) => {
-        return Math.pow(2, retry) * 1000 + Math.random() * 100;
-      };
+  const retryWaitFunction = (retry: number) => {
+    return Math.pow(2, retry) * 1000 + Math.random() * 100;
+  };
 
   return new Observable((observer) => {
     // Run function is where the logic takes place. We have it in a function so we can call it recursively.
@@ -82,7 +68,7 @@ export function runWithRetry(
             return;
           }
 
-          if (timeoutFunction(retries, startTime.valueOf())) {
+          if (timeoutFunc(retries, startTime.valueOf())) {
             // We timed out but we could have started some queries
             if (Object.keys(collected).length || Object.keys(errorData.good).length) {
               const dataResponse = toDataQueryResponse({


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Uses the log timeout for log queries instead of failing after 5 responses without new info.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #44074

**Special notes for your reviewer**:

