### PR TITLE
Loki: Use explore query field unless new query builder feature toggle is enabled 

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 import { act } from 'react-dom/test-utils';
-import LokiExploreQueryEditor from './LokiExploreQueryEditor';
+import { LokiExploreQueryEditor } from './LokiExploreQueryEditor';
 import { LokiOptionFields } from './LokiOptionFields';
 import { LokiDatasource } from '../datasource';
 import { LokiQuery } from '../types';

--- a/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
@@ -10,7 +10,7 @@ import { LokiOptionFields } from './LokiOptionFields';
 
 type Props = QueryEditorProps<LokiDatasource, LokiQuery, LokiOptions>;
 
-export function LokiExploreQueryEditor(props: Props) {
+export const LokiExploreQueryEditor = memo((props: Props) => {
   const { query, data, datasource, history, onChange, onRunQuery, range } = props;
 
   return (
@@ -23,6 +23,7 @@ export function LokiExploreQueryEditor(props: Props) {
       history={history}
       data={data}
       range={range}
+      data-testid={testIds.editor}
       ExtraFieldElement={
         <LokiOptionFields
           lineLimitValue={query?.maxLines?.toString() || ''}
@@ -34,6 +35,10 @@ export function LokiExploreQueryEditor(props: Props) {
       }
     />
   );
-}
+});
 
-export default memo(LokiExploreQueryEditor);
+LokiExploreQueryEditor.displayName = 'LokiExploreQueryEditor';
+
+export const testIds = {
+  editor: 'loki-editor-explore',
+};

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditorByApp.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditorByApp.test.tsx
@@ -5,7 +5,8 @@ import { noop } from 'lodash';
 import { LokiDatasource } from '../datasource';
 import { testIds as alertingTestIds } from './LokiQueryEditorForAlerting';
 import { testIds as regularTestIds } from './LokiQueryEditor';
-import LokiQueryEditorByApp from './LokiQueryEditorByApp';
+import { testIds as exploreTestIds } from './LokiExploreQueryEditor';
+import { LokiQueryEditorByApp } from './LokiQueryEditorByApp';
 
 function setup(app: CoreApp): RenderResult {
   const dataSource = {
@@ -43,10 +44,10 @@ describe('LokiQueryEditorByApp', () => {
     expect(queryByTestId(alertingTestIds.editor)).toBeNull();
   });
 
-  it('should render regular query editor for explore', () => {
+  it('should render expore query editor for explore', () => {
     const { getByTestId, queryByTestId } = setup(CoreApp.Explore);
 
-    expect(getByTestId(regularTestIds.editor)).toBeInTheDocument();
+    expect(getByTestId(exploreTestIds.editor)).toBeInTheDocument();
     expect(queryByTestId(alertingTestIds.editor)).toBeNull();
   });
 

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditorByApp.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditorByApp.tsx
@@ -3,9 +3,9 @@ import { CoreApp } from '@grafana/data';
 import { LokiQueryEditorProps } from './types';
 import { LokiQueryEditor } from './LokiQueryEditor';
 import { LokiQueryEditorForAlerting } from './LokiQueryEditorForAlerting';
+import { LokiExploreQueryEditor } from './LokiExploreQueryEditor';
 import { LokiQueryEditorSelector } from '../querybuilder/components/LokiQueryEditorSelector';
 import { config } from '@grafana/runtime';
-import LokiExploreQueryEditor from './LokiExploreQueryEditor';
 
 export function LokiQueryEditorByApp(props: LokiQueryEditorProps) {
   const { app } = props;

--- a/public/app/plugins/datasource/loki/components/LokiQueryEditorByApp.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryEditorByApp.tsx
@@ -5,6 +5,7 @@ import { LokiQueryEditor } from './LokiQueryEditor';
 import { LokiQueryEditorForAlerting } from './LokiQueryEditorForAlerting';
 import { LokiQueryEditorSelector } from '../querybuilder/components/LokiQueryEditorSelector';
 import { config } from '@grafana/runtime';
+import LokiExploreQueryEditor from './LokiExploreQueryEditor';
 
 export function LokiQueryEditorByApp(props: LokiQueryEditorProps) {
   const { app } = props;
@@ -12,6 +13,11 @@ export function LokiQueryEditorByApp(props: LokiQueryEditorProps) {
   switch (app) {
     case CoreApp.CloudAlerting:
       return <LokiQueryEditorForAlerting {...props} />;
+    case CoreApp.Explore:
+      if (config.featureToggles.lokiQueryBuilder) {
+        return <LokiQueryEditorSelector {...props} />;
+      }
+      return <LokiExploreQueryEditor {...props} />;
     default:
       if (config.featureToggles.lokiQueryBuilder) {
         return <LokiQueryEditorSelector {...props} />;

--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`LokiExploreQueryEditor should render component 1`] = `
       },
     }
   }
+  data-testid="loki-editor-explore"
   datasource={
     Object {
       "getTimeRangeParams": [Function],

--- a/public/app/plugins/datasource/loki/module.ts
+++ b/public/app/plugins/datasource/loki/module.ts
@@ -9,6 +9,5 @@ import { ConfigEditor } from './configuration/ConfigEditor';
 export const plugin = new DataSourcePlugin(Datasource)
   .setQueryEditor(LokiQueryEditorByApp)
   .setConfigEditor(ConfigEditor)
-  .setExploreQueryField(LokiQueryEditorByApp)
   .setQueryEditorHelp(LokiCheatSheet)
   .setAnnotationQueryCtrl(LokiAnnotationsQueryCtrl);

--- a/public/app/plugins/datasource/prometheus/module.test.ts
+++ b/public/app/plugins/datasource/prometheus/module.test.ts
@@ -3,7 +3,6 @@ import { ANNOTATION_QUERY_STEP_DEFAULT } from './datasource';
 
 describe('module', () => {
   it('should have metrics query field in panels and Explore', () => {
-    expect(PrometheusDatasourcePlugin.components.ExploreMetricsQueryField).toBeDefined();
     expect(PrometheusDatasourcePlugin.components.QueryEditor).toBeDefined();
   });
   it('should have stepDefaultValuePlaceholder set in annotations ctrl', () => {

--- a/public/app/plugins/datasource/prometheus/module.ts
+++ b/public/app/plugins/datasource/prometheus/module.ts
@@ -14,6 +14,5 @@ class PrometheusAnnotationsQueryCtrl {
 export const plugin = new DataSourcePlugin(PrometheusDatasource)
   .setQueryEditor(PromQueryEditorByApp)
   .setConfigEditor(ConfigEditor)
-  .setExploreMetricsQueryField(PromQueryEditorByApp)
   .setAnnotationQueryCtrl(PrometheusAnnotationsQueryCtrl)
   .setQueryEditorHelp(PromCheatSheet);


### PR DESCRIPTION
**What this PR does / why we need it**:
Same fix as https://github.com/grafana/grafana/pull/44650, but for Loki editor. 

I did in this PR 1 more thing. We've used to use `.setExploreQueryField` to set up Explore query editor, but this is not needed anymore as we are using `LokiQueryEditorByApp` for both - `QueryEditor` and `ExploreQueryField` and in  `LokiQueryEditorByApp` we select which editor we want to use. So I am proposing to remove `setExploreQueryField`  as it is not needed anymore and have single place where we are choosing the editor - in `LokiQueryEditorByApp`. 

This is not going to influence Explore's experience because if we don't have `ExploreMetricsQueryField`, `ExploreLogsQueryField` or `ExploreQueryField`, we just use `QueryEditor` https://github.com/grafana/grafana/blob/main/public/app/features/query/components/QueryEditorRow.tsx#L214. Let me know what do you think. 