### PR TITLE
Packaging: remove ncurses upgrade in docker image

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -31,9 +31,6 @@ RUN apk add --no-cache ca-certificates bash tzdata && \
 
 RUN apk add --no-cache openssl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 
-# Update out of date ncurses dependency which can stack overflow. This should be removed when alpine has released the 3.14.3 docker image.
-RUN apk upgrade ncurses-libs ncurses-terminfo-base --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
-
 # Oracle Support for x86_64 only
 RUN if [ `arch` = "x86_64" ]; then \
       apk add --no-cache libaio libnsl && \


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

reverts: #41002

removes the `apk upgrade` command added in 2021/10, in response to this vulnerability (I believe?):

https://security.alpinelinux.org/vuln/CVE-2021-39537

The dockerfile now uses Alpine 3.15 which uses the newer, unaffected `ncurses` 6.3 packages:

https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/

**Which issue(s) this PR fixes**:

reverts: #41002
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

