### PR TITLE
Alerting: Improve Contact Points error handling

### DIFF
--- a/public/app/features/alerting/unified/api/alertmanager.ts
+++ b/public/app/features/alerting/unified/api/alertmanager.ts
@@ -1,22 +1,22 @@
-import { lastValueFrom } from 'rxjs';
 import { urlUtil } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
-
 import {
   AlertmanagerAlert,
   AlertManagerCortexConfig,
   AlertmanagerGroup,
+  AlertmanagerStatus,
+  ExternalAlertmanagersResponse,
+  Matcher,
+  Receiver,
   Silence,
   SilenceCreatePayload,
-  Matcher,
-  AlertmanagerStatus,
-  Receiver,
+  TestReceiversAlert,
   TestReceiversPayload,
   TestReceiversResult,
-  TestReceiversAlert,
-  ExternalAlertmanagersResponse,
 } from 'app/plugins/datasource/alertmanager/types';
+import { lastValueFrom } from 'rxjs';
 import { getDatasourceAPIId, GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
+import { isFetchError } from '../utils/alertmanager';
 
 // "grafana" for grafana-managed, otherwise a datasource name
 export async function fetchAlertManagerConfig(alertManagerSourceName: string): Promise<AlertManagerCortexConfig> {
@@ -171,28 +171,52 @@ export async function testReceivers(
     receivers,
     alert,
   };
-  const result = await lastValueFrom(
-    getBackendSrv().fetch<TestReceiversResult>({
-      method: 'POST',
-      data,
-      url: `/api/alertmanager/${getDatasourceAPIId(alertManagerSourceName)}/config/api/v1/receivers/test`,
-      showErrorAlert: false,
-      showSuccessAlert: false,
-    })
-  );
+  try {
+    const result = await lastValueFrom(
+      getBackendSrv().fetch<TestReceiversResult>({
+        method: 'POST',
+        data,
+        url: `/api/alertmanager/${getDatasourceAPIId(alertManagerSourceName)}/config/api/v1/receivers/test`,
+        showErrorAlert: false,
+        showSuccessAlert: false,
+      })
+    );
 
-  // api returns 207 if one or more receivers has failed test. Collect errors in this case
-  if (result.status === 207) {
-    throw new Error(
-      result.data.receivers
-        .flatMap((receiver) =>
-          receiver.grafana_managed_receiver_configs
-            .filter((receiver) => receiver.status === 'failed')
-            .map((receiver) => receiver.error ?? 'Unknown error.')
-        )
-        .join('; ')
+    // api returns 207 if one or more receivers has failed test. Collect errors in this case
+    if (result.status === 207) {
+      throw new Error(getReceiverResultError(result.data));
+    }
+  } catch (error) {
+    // api returns 400 if all receivers failed and 408 if all timed out
+    if (isFetchError(error) && (error.status === 400 || error.status === 408)) {
+      if (isTestReceiversResult(error.data)) {
+        throw new Error(getReceiverResultError(error.data));
+      }
+    }
+
+    throw error;
+  }
+}
+
+function isTestReceiversResult(data: any): data is TestReceiversResult {
+  if (typeof data.receivers === 'object' && Array.isArray(data.receivers)) {
+    return data.receivers.every(
+      (receiver: any) =>
+        typeof receiver.name === 'string' && typeof receiver.grafana_managed_receiver_configs === 'object'
     );
   }
+
+  return false;
+}
+
+function getReceiverResultError(receiversResult: TestReceiversResult) {
+  return receiversResult.receivers
+    .flatMap((receiver) =>
+      receiver.grafana_managed_receiver_configs
+        .filter((receiver) => receiver.status === 'failed')
+        .map((receiver) => receiver.error ?? 'Unknown error.')
+    )
+    .join('; ');
 }
 
 export async function addAlertManagers(alertManagers: string[]): Promise<void> {

--- a/public/app/features/alerting/unified/api/alertmanager.ts
+++ b/public/app/features/alerting/unified/api/alertmanager.ts
@@ -201,9 +201,9 @@ function receiversResponseContainsErrors(result: TestReceiversResult) {
 }
 
 function isTestReceiversResult(data: any): data is TestReceiversResult {
-  const { receivers } = data;
+  const receivers = data?.receivers;
 
-  if (Array.isArray(data.receivers)) {
+  if (Array.isArray(receivers)) {
     return receivers.every(
       (receiver: any) => typeof receiver.name === 'string' && Array.isArray(receiver.grafana_managed_receiver_configs)
     );

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -53,7 +53,7 @@ import {
   isVanillaPrometheusAlertManagerDataSource,
 } from '../utils/datasource';
 import { makeAMLink, retryWhile } from '../utils/misc';
-import { isFetchError, withAppEvents, withSerializedError } from '../utils/redux';
+import { withAppEvents, withSerializedError } from '../utils/redux';
 import { formValuesToRulerRuleDTO, formValuesToRulerGrafanaRuleDTO } from '../utils/rule-form';
 import {
   isCloudRuleIdentifier,
@@ -62,7 +62,7 @@ import {
   isPrometheusRuleIdentifier,
   isRulerNotSupportedResponse,
 } from '../utils/rules';
-import { addDefaultsToAlertmanagerConfig, removeMuteTimingFromRoute } from '../utils/alertmanager';
+import { addDefaultsToAlertmanagerConfig, removeMuteTimingFromRoute, isFetchError } from '../utils/alertmanager';
 import * as ruleId from '../utils/rule-id';
 import { isEmpty } from 'lodash';
 import messageFromError from 'app/plugins/datasource/grafana-azure-monitor-datasource/utils/messageFromError';

--- a/public/app/features/alerting/unified/utils/alertmanager.ts
+++ b/public/app/features/alerting/unified/utils/alertmanager.ts
@@ -11,6 +11,7 @@ import { MatcherFieldValue } from '../types/silence-form';
 import { SelectableValue } from '@grafana/data';
 import { getAllDataSources } from './config';
 import { DataSourceType } from './datasource';
+import { FetchError } from '@grafana/runtime';
 
 export function addDefaultsToAlertmanagerConfig(config: AlertManagerCortexConfig): AlertManagerCortexConfig {
   // add default receiver if it does not exist
@@ -253,4 +254,8 @@ export function getMonthsString(months?: string[]): string {
 
 export function getYearsString(years?: string[]): string {
   return 'Years: ' + (years?.join(', ') ?? 'All');
+}
+
+export function isFetchError(e: unknown): e is FetchError {
+  return typeof e === 'object' && e !== null && 'status' in e && 'data' in e;
 }

--- a/public/app/features/alerting/unified/utils/redux.ts
+++ b/public/app/features/alerting/unified/utils/redux.ts
@@ -4,6 +4,7 @@ import { FetchError } from '@grafana/runtime';
 import { AppEvents } from '@grafana/data';
 
 import { appEvents } from 'app/core/core';
+import { isFetchError } from './alertmanager';
 
 export interface AsyncRequestState<T> {
   result?: T;
@@ -136,10 +137,6 @@ export function withAppEvents<T>(
       appEvents.emit(AppEvents.alertError, [`${options.errorMessage ?? 'Error'}: ${msg}`]);
       throw e;
     });
-}
-
-export function isFetchError(e: unknown): e is FetchError {
-  return typeof e === 'object' && e !== null && 'status' in e && 'data' in e;
 }
 
 export function messageFromError(e: Error | FetchError | SerializedError): string {

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -247,7 +247,7 @@ interface TestReceiversResultGrafanaReceiverConfig {
   name: string;
   uid?: string;
   error?: string;
-  status: 'failed';
+  status: 'ok' | 'failed';
 }
 
 interface TestReceiversResultReceiver {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves error handling when testing contact points. This gives us the ability to display a specific error message instead of a generic error.

**Which issue(s) this PR fixes**:
Fixes #44238

