### PR TITLE
Access control: Reduce number of API calls for role picker

### DIFF
--- a/public/app/core/components/RolePicker/TeamRolePicker.tsx
+++ b/public/app/core/components/RolePicker/TeamRolePicker.tsx
@@ -1,38 +1,29 @@
 import React, { FC, useState } from 'react';
 import { useAsync } from 'react-use';
-import { contextSrv } from 'app/core/core';
-import { AccessControlAction, Role } from 'app/types';
+import { Role } from 'app/types';
 import { RolePicker } from './RolePicker';
-import { fetchRoleOptions, fetchTeamRoles, updateTeamRoles } from './api';
+import { fetchTeamRoles, updateTeamRoles } from './api';
 
 export interface Props {
   teamId: number;
   orgId?: number;
-  getRoleOptions?: () => Promise<Role[]>;
+  roleOptions: Role[];
   disabled?: boolean;
   builtinRolesDisabled?: boolean;
 }
 
-export const TeamRolePicker: FC<Props> = ({ teamId, orgId, getRoleOptions, disabled, builtinRolesDisabled }) => {
-  const [roleOptions, setRoleOptions] = useState<Role[]>([]);
+export const TeamRolePicker: FC<Props> = ({ teamId, orgId, roleOptions, disabled, builtinRolesDisabled }) => {
   const [appliedRoles, setAppliedRoles] = useState<Role[]>([]);
 
   const { loading } = useAsync(async () => {
     try {
-      if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
-        let options = await (getRoleOptions ? getRoleOptions() : fetchRoleOptions(orgId));
-        setRoleOptions(options.filter((option) => !option.name?.startsWith('managed:')));
-      } else {
-        setRoleOptions([]);
-      }
-
       const teamRoles = await fetchTeamRoles(teamId, orgId);
       setAppliedRoles(teamRoles);
     } catch (e) {
       // TODO handle error
       console.error('Error loading options');
     }
-  }, [getRoleOptions, orgId, teamId]);
+  }, [orgId, teamId]);
 
   return (
     <RolePicker

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -3,15 +3,15 @@ import { useAsync } from 'react-use';
 import { contextSrv } from 'app/core/core';
 import { Role, OrgRole, AccessControlAction } from 'app/types';
 import { RolePicker } from './RolePicker';
-import { fetchBuiltinRoles, fetchRoleOptions, fetchUserRoles, updateUserRoles } from './api';
+import { fetchUserRoles, updateUserRoles } from './api';
 
 export interface Props {
   builtInRole: OrgRole;
   userId: number;
   orgId?: number;
   onBuiltinRoleChange: (newRole: OrgRole) => void;
-  getRoleOptions?: () => Promise<Role[]>;
-  getBuiltinRoles?: () => Promise<{ [key: string]: Role[] }>;
+  roleOptions: Role[];
+  builtInRoles?: { [key: string]: Role[] };
   disabled?: boolean;
   builtinRolesDisabled?: boolean;
 }
@@ -21,31 +21,15 @@ export const UserRolePicker: FC<Props> = ({
   userId,
   orgId,
   onBuiltinRoleChange,
-  getRoleOptions,
-  getBuiltinRoles,
+  roleOptions,
+  builtInRoles,
   disabled,
   builtinRolesDisabled,
 }) => {
-  const [roleOptions, setRoleOptions] = useState<Role[]>([]);
   const [appliedRoles, setAppliedRoles] = useState<Role[]>([]);
-  const [builtInRoles, setBuiltinRoles] = useState<Record<string, Role[]>>({});
 
   const { loading } = useAsync(async () => {
     try {
-      if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
-        let options = await (getRoleOptions ? getRoleOptions() : fetchRoleOptions(orgId));
-        setRoleOptions(options.filter((option) => !option.name?.startsWith('managed:')));
-      } else {
-        setRoleOptions([]);
-      }
-
-      if (contextSrv.hasPermission(AccessControlAction.ActionBuiltinRolesList)) {
-        const builtInRoles = await (getBuiltinRoles ? getBuiltinRoles() : fetchBuiltinRoles(orgId));
-        setBuiltinRoles(builtInRoles);
-      } else {
-        setBuiltinRoles({});
-      }
-
       if (contextSrv.hasPermission(AccessControlAction.ActionUserRolesList)) {
         const userRoles = await fetchUserRoles(userId, orgId);
         setAppliedRoles(userRoles);
@@ -56,7 +40,7 @@ export const UserRolePicker: FC<Props> = ({
       // TODO handle error
       console.error('Error loading options');
     }
-  }, [getBuiltinRoles, getRoleOptions, orgId, userId]);
+  }, [orgId, userId]);
 
   return (
     <RolePicker

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -141,10 +141,14 @@ class UnThemedOrgRow extends PureComponent<OrgRowProps> {
   componentDidMount() {
     if (contextSrv.licensedAccessControlEnabled()) {
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
-        fetchRoleOptions(this.props.org.orgId).then((roles) => this.setState({ roleOptions: roles })).catch(err => console.error(err));
+        fetchRoleOptions(this.props.org.orgId)
+          .then((roles) => this.setState({ roleOptions: roles }))
+          .catch((e) => console.error(e));
       }
       if (contextSrv.hasPermission(AccessControlAction.ActionBuiltinRolesList)) {
-        fetchRoleOptions(this.props.org.orgId).then((roles) => this.setState({ builtInRoles: roles })).catch(err => console.error(err));
+        fetchRoleOptions(this.props.org.orgId)
+          .then((roles) => this.setState({ builtInRoles: roles }))
+          .catch((e) => console.error(e));
       }
     }
   }

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -141,7 +141,7 @@ class UnThemedOrgRow extends PureComponent<OrgRowProps> {
   componentDidMount() {
     if (contextSrv.licensedAccessControlEnabled()) {
       if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
-        fetchRoleOptions(this.props.org.orgId).then((roles) => this.setState({ roleOptions: roles }));
+        fetchRoleOptions(this.props.org.orgId).then((roles) => this.setState({ roleOptions: roles })).catch(err => console.error(err));
       }
       if (contextSrv.hasPermission(AccessControlAction.ActionBuiltinRolesList)) {
         fetchRoleOptions(this.props.org.orgId).then((roles) => this.setState({ builtInRoles: roles }));

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -20,6 +20,7 @@ import { OrgPicker, OrgSelectItem } from 'app/core/components/Select/OrgPicker';
 import { OrgRolePicker } from './OrgRolePicker';
 import { contextSrv } from 'app/core/core';
 import { UserRolePicker } from 'app/core/components/RolePicker/UserRolePicker';
+import { fetchRoleOptions } from 'app/core/components/RolePicker/api';
 
 interface Props {
   orgs: UserOrg[];
@@ -133,7 +134,20 @@ class UnThemedOrgRow extends PureComponent<OrgRowProps> {
   state = {
     currentRole: this.props.org.role,
     isChangingRole: false,
+    roleOptions: [],
+    builtInRoles: {},
   };
+
+  componentDidMount() {
+    if (contextSrv.licensedAccessControlEnabled()) {
+      if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
+        fetchRoleOptions(this.props.org.orgId).then((roles) => this.setState({ roleOptions: roles }));
+      }
+      if (contextSrv.hasPermission(AccessControlAction.ActionBuiltinRolesList)) {
+        fetchRoleOptions(this.props.org.orgId).then((roles) => this.setState({ builtInRoles: roles }));
+      }
+    }
+  }
 
   onOrgRemove = () => {
     const { org } = this.props;
@@ -184,6 +198,8 @@ class UnThemedOrgRow extends PureComponent<OrgRowProps> {
                   userId={user?.id || 0}
                   orgId={org.orgId}
                   builtInRole={org.role}
+                  roleOptions={this.state.roleOptions}
+                  builtInRoles={this.state.builtInRoles}
                   onBuiltinRoleChange={this.onBuiltinRoleChange}
                   builtinRolesDisabled={rolePickerDisabled}
                 />

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -144,7 +144,7 @@ class UnThemedOrgRow extends PureComponent<OrgRowProps> {
         fetchRoleOptions(this.props.org.orgId).then((roles) => this.setState({ roleOptions: roles })).catch(err => console.error(err));
       }
       if (contextSrv.hasPermission(AccessControlAction.ActionBuiltinRolesList)) {
-        fetchRoleOptions(this.props.org.orgId).then((roles) => this.setState({ builtInRoles: roles }));
+        fetchRoleOptions(this.props.org.orgId).then((roles) => this.setState({ builtInRoles: roles })).catch(err => console.error(err));
       }
     }
   }

--- a/public/app/features/serviceaccounts/ServiceAccountsTable.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsTable.tsx
@@ -28,10 +28,15 @@ const ServiceAccountsTable: FC<Props> = (props) => {
   useEffect(() => {
     async function fetchOptions() {
       try {
-        let options = await fetchRoleOptions(orgId);
-        setRoleOptions(options);
-        const builtInRoles = await fetchBuiltinRoles(orgId);
-        setBuiltinRoles(builtInRoles);
+        if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
+          let options = await fetchRoleOptions(orgId);
+          setRoleOptions(options);
+        }
+
+        if (contextSrv.hasPermission(AccessControlAction.ActionBuiltinRolesList)) {
+          const builtInRoles = await fetchBuiltinRoles(orgId);
+          setBuiltinRoles(builtInRoles);
+        }
       } catch (e) {
         console.error('Error loading options');
       }
@@ -40,9 +45,6 @@ const ServiceAccountsTable: FC<Props> = (props) => {
       fetchOptions();
     }
   }, [orgId]);
-
-  const getRoleOptions = async () => roleOptions;
-  const getBuiltinRoles = async () => builtinRoles;
 
   return (
     <>
@@ -89,8 +91,8 @@ const ServiceAccountsTable: FC<Props> = (props) => {
                       orgId={orgId}
                       builtInRole={serviceAccount.role}
                       onBuiltinRoleChange={(newRole) => onRoleChange(newRole, serviceAccount)}
-                      getRoleOptions={getRoleOptions}
-                      getBuiltinRoles={getBuiltinRoles}
+                      roleOptions={roleOptions}
+                      builtInRoles={builtinRoles}
                       disabled={rolePickerDisabled}
                     />
                   ) : (

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -43,7 +43,7 @@ export class TeamList extends PureComponent<Props, State> {
 
   componentDidMount() {
     this.fetchTeams();
-    if (contextSrv.licensedAccessControlEnabled()) {
+    if (contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
       this.fetchRoleOptions();
     }
   }
@@ -63,6 +63,10 @@ export class TeamList extends PureComponent<Props, State> {
 
   onSearchQueryChange = (value: string) => {
     this.props.setSearchQuery(value);
+  };
+
+  getRoleOptions = () => {
+    return Promise.resolve(this.state.roleOptions);
   };
 
   renderTeam(team: Team) {
@@ -95,7 +99,7 @@ export class TeamList extends PureComponent<Props, State> {
         </td>
         {contextSrv.licensedAccessControlEnabled() && (
           <td>
-            <TeamRolePicker teamId={team.id} getRoleOptions={async () => this.state.roleOptions} />
+            <TeamRolePicker teamId={team.id} roleOptions={this.state.roleOptions} />
           </td>
         )}
         <td className="text-right">

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -65,10 +65,6 @@ export class TeamList extends PureComponent<Props, State> {
     this.props.setSearchQuery(value);
   };
 
-  getRoleOptions = () => {
-    return Promise.resolve(this.state.roleOptions);
-  };
-
   renderTeam(team: Team) {
     const { editorsCanAdmin, signedInUser } = this.props;
     const permission = team.permission;

--- a/public/app/features/users/UsersTable.tsx
+++ b/public/app/features/users/UsersTable.tsx
@@ -26,15 +26,11 @@ const UsersTable: FC<Props> = (props) => {
         if (contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
           let options = await fetchRoleOptions(orgId);
           setRoleOptions(options);
-        } else {
-          setRoleOptions([]);
         }
 
         if (contextSrv.hasPermission(AccessControlAction.ActionBuiltinRolesList)) {
           const builtInRoles = await fetchBuiltinRoles(orgId);
           setBuiltinRoles(builtInRoles);
-        } else {
-          setBuiltinRoles({});
         }
       } catch (e) {
         console.error('Error loading options');
@@ -44,9 +40,6 @@ const UsersTable: FC<Props> = (props) => {
       fetchOptions();
     }
   }, [orgId]);
-
-  const getRoleOptions = async () => roleOptions;
-  const getBuiltinRoles = async () => builtinRoles;
 
   return (
     <>
@@ -94,8 +87,8 @@ const UsersTable: FC<Props> = (props) => {
                       orgId={orgId}
                       builtInRole={user.role}
                       onBuiltinRoleChange={(newRole) => onRoleChange(newRole, user)}
-                      getRoleOptions={getRoleOptions}
-                      getBuiltinRoles={getBuiltinRoles}
+                      roleOptions={roleOptions}
+                      builtInRoles={builtinRoles}
                       disabled={!contextSrv.hasPermissionInMetadata(AccessControlAction.OrgUsersRoleUpdate, user)}
                     />
                   ) : (


### PR DESCRIPTION
**What this PR does / why we need it**:
Due to the way the state of UserRolePicker and TeamRolePicker was structured, roles for users and teams was fetched several times. four times for each user and two times for each team.

By moving the state of roleOptions and builtInRoles up one component we can get the expected behaviour of 1 call for each user/team
