### PR TITLE
Explore: Reduce spacing for Logs switches

### DIFF
--- a/packages/grafana-ui/src/components/Switch/Switch.tsx
+++ b/packages/grafana-ui/src/components/Switch/Switch.tsx
@@ -47,12 +47,11 @@ export interface InlineSwitchProps extends Props {
 }
 
 export const InlineSwitch = React.forwardRef<HTMLInputElement, InlineSwitchProps>(
-  ({ transparent, showLabel, label, value, id, ...props }, ref) => {
+  ({ transparent, className, showLabel, label, value, id, ...props }, ref) => {
     const theme = useTheme2();
     const styles = getSwitchStyles(theme, transparent);
-
     return (
-      <div className={styles.inlineContainer}>
+      <div className={cx(styles.inlineContainer, className)}>
         {showLabel && (
           <label
             htmlFor={id}

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -316,24 +316,43 @@ class UnthemedLogs extends PureComponent<Props, State> {
         ) : undefined}
         <div className={styles.logOptions} ref={this.topLogsRef}>
           <InlineFieldRow>
-            <InlineField label="Time" transparent>
-              <InlineSwitch value={showTime} onChange={this.onChangeTime} transparent id="show-time" />
+            <InlineField label="Time" className={styles.horizontalInlineLabel} transparent>
+              <InlineSwitch
+                value={showTime}
+                onChange={this.onChangeTime}
+                className={styles.horizontalInlineSwitch}
+                transparent
+                id="show-time"
+              />
             </InlineField>
-            <InlineField label="Unique labels" transparent>
-              <InlineSwitch value={showLabels} onChange={this.onChangeLabels} transparent id="unique-labels" />
+            <InlineField label="Unique labels" className={styles.horizontalInlineLabel} transparent>
+              <InlineSwitch
+                value={showLabels}
+                onChange={this.onChangeLabels}
+                className={styles.horizontalInlineSwitch}
+                transparent
+                id="unique-labels"
+              />
             </InlineField>
-            <InlineField label="Wrap lines" transparent>
-              <InlineSwitch value={wrapLogMessage} onChange={this.onChangewrapLogMessage} transparent id="wrap-lines" />
+            <InlineField label="Wrap lines" className={styles.horizontalInlineLabel} transparent>
+              <InlineSwitch
+                value={wrapLogMessage}
+                onChange={this.onChangewrapLogMessage}
+                className={styles.horizontalInlineSwitch}
+                transparent
+                id="wrap-lines"
+              />
             </InlineField>
-            <InlineField label="Prettify JSON" transparent>
+            <InlineField label="Prettify JSON" className={styles.horizontalInlineLabel} transparent>
               <InlineSwitch
                 value={prettifyLogMessage}
                 onChange={this.onChangePrettifyLogMessage}
+                className={styles.horizontalInlineSwitch}
                 transparent
                 id="prettify"
               />
             </InlineField>
-            <InlineField label="Dedup" transparent>
+            <InlineField label="Dedup" className={styles.horizontalInlineLabel} transparent>
               <RadioButtonGroup
                 options={Object.values(LogsDedupStrategy).map((dedupType) => ({
                   label: capitalize(dedupType),
@@ -452,8 +471,16 @@ const getStyles = (theme: GrafanaTheme2, wrapLogMessage: boolean) => {
     headerButton: css`
       margin: ${theme.spacing(0.5, 0, 0, 1)};
     `,
+    horizontalInlineLabel: css`
+      > label {
+        margin-right: 0;
+      }
+    `,
+    horizontalInlineSwitch: css`
+      padding: 0 ${theme.spacing(1)} 0 0;
+    `,
     radioButtons: css`
-      margin: 0 ${theme.spacing(1)};
+      margin: 0;
     `,
     logsSection: css`
       display: flex;


### PR DESCRIPTION
**What this PR does / why we need it**:
There are multiple, horizontally inline switches as part of the Explore Logs panel. The spacing specified by the design system gives them as much space from each other as the label has with the switch, so it was difficult to see what label went with what switch. Some investigation showed that besides dynamically generated UI, only this panel displays multiple switches in this way. The only other area with multiple `InlineSwitch` components are for some elasticsearch settings, but they display the switches stacked vertically. After talking with UX, we decided that this area will probably undergo a design review sometime shortly, and doing a fix just for this panel instead of at the design system level makes more sense. 

Before:
![Screen Shot 2022-02-04 at 4 01 30 PM](https://user-images.githubusercontent.com/1533128/152609342-8912fa15-73c1-4993-b31c-d9dfc382c451.png)

After:
![Screen Shot 2022-02-04 at 4 00 04 PM](https://user-images.githubusercontent.com/1533128/152609356-c3728a5f-1e5a-4ae7-a4cf-2d856677b309.png)

**Which issue(s) this PR fixes**:
Fixes #36608 

**Special notes for your reviewer**:
The storybook documentation for switch is a little different - I added `className` to the `InlineSwitch` component, not the base `Switch` component. They don't have separate entries in storybook, so I didn't add anything to the documentation. Let me know if something should be done here.
