### PR TITLE
QueryOperations: Box border and symetric 8px padding

### DIFF
--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -72,6 +72,7 @@ export const QueryOperationRow: React.FC<QueryOperationRowProps> = ({
   const titleElement = title && ReactUtils.renderOrCallToRender(title, renderPropArgs);
   const actionsElement = actions && ReactUtils.renderOrCallToRender(actions, renderPropArgs);
   const headerElementRendered = headerElement && ReactUtils.renderOrCallToRender(headerElement, renderPropArgs);
+  const wrapperStyle = cx(styles.wrapper, isContentVisible && styles.wrapperExpanded);
 
   const rowHeader = (
     <div className={styles.header}>
@@ -105,7 +106,7 @@ export const QueryOperationRow: React.FC<QueryOperationRowProps> = ({
           const dragHandleProps = { ...provided.dragHandleProps, role: 'group' }; // replace the role="button" because it causes https://dequeuniversity.com/rules/axe/4.3/nested-interactive?application=msftAI
           return (
             <>
-              <div ref={provided.innerRef} className={styles.wrapper} {...provided.draggableProps}>
+              <div ref={provided.innerRef} className={wrapperStyle} {...provided.draggableProps}>
                 <div {...dragHandleProps}>{rowHeader}</div>
                 {isContentVisible && <div className={styles.content}>{children}</div>}
               </div>
@@ -117,7 +118,7 @@ export const QueryOperationRow: React.FC<QueryOperationRowProps> = ({
   }
 
   return (
-    <div className={styles.wrapper}>
+    <div className={wrapperStyle}>
       {rowHeader}
       {isContentVisible && <div className={styles.content}>{children}</div>}
     </div>
@@ -128,6 +129,10 @@ const getQueryOperationRowStyles = stylesFactory((theme: GrafanaTheme) => {
   return {
     wrapper: css`
       margin-bottom: ${theme.spacing.md};
+    `,
+    wrapperExpanded: css`
+      border: 1px solid ${theme.colors.border2};
+      border-radius: ${theme.border.radius.sm};
     `,
     header: css`
       label: Header;
@@ -180,8 +185,7 @@ const getQueryOperationRowStyles = stylesFactory((theme: GrafanaTheme) => {
       text-overflow: ellipsis;
     `,
     content: css`
-      margin-top: ${theme.spacing.inlineFormMargin};
-      margin-left: ${theme.spacing.lg};
+      padding: ${theme.spacing.sm};
     `,
     disabled: css`
       color: ${theme.colors.textWeak};

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -111,8 +111,6 @@ export const EmptyQueryWrapper: FC<{}> = ({ children }) => {
 const getStyles = (theme: GrafanaTheme2) => ({
   wrapper: css`
     label: AlertingQueryWrapper;
-    margin-bottom: ${theme.spacing(1)};
-    border: 1px solid ${theme.colors.border.medium};
-    border-radius: ${theme.shape.borderRadius(1)};
+    margin-bottom: ${theme.spacing(2)};
   `,
 });


### PR DESCRIPTION
Trying to improve UX for query editors
* Clearer separation between queries 
* Consistency in design between queries in dashboard, explore and alerting
* The new padding now makes the editor box look better in alerting (that previously had a query box border)

I am not 100% happy with the design but I think it's an improvment overall

Cons: 
* More busy & complex, less elegant 
* The white theme medium border feels to strong 

Figma explorations: https://www.figma.com/file/YeTF07V4TUNydMJMD1DYBd/Query-builder-improvements?node-id=1689%3A13863 

![Screenshot from 2022-02-07 15-07-00](https://user-images.githubusercontent.com/10999/152803289-b86fdf62-e6b4-4612-969d-a2cc2d6d996b.png)
![Screenshot from 2022-02-07 15-03-59](https://user-images.githubusercontent.com/10999/152803429-3abe34c0-79ac-4cb0-a8c7-3b9074a1a41d.png)

Transformations: 
![Screenshot from 2022-02-07 14-39-29](https://user-images.githubusercontent.com/10999/152802547-fe7d55eb-87f4-48dc-9c41-b7a7520cf9a4.png)

