### PR TITLE
github: add issues to observability squad projects

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -100,18 +100,10 @@
   },
   {
     "type":"label",
-    "name":"oss-observability",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/54"
-    }
-  },
-  {
-    "type":"label",
     "name":"datasource/Prometheus",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/54"
+      "url":"https://github.com/orgs/grafana/projects/112"
     }
   },
   {
@@ -119,7 +111,7 @@
     "name":"datasource/InfluxDB",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/54"
+      "url":"https://github.com/orgs/grafana/projects/112"
     }
   },
   {
@@ -127,7 +119,7 @@
     "name":"datasource/OpenSearch",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/54"
+      "url":"https://github.com/orgs/grafana/projects/110"
     }
   },
   {
@@ -135,7 +127,7 @@
     "name":"datasource/Loki",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/54"
+      "url":"https://github.com/orgs/grafana/projects/110"
     }
   },
   {
@@ -143,7 +135,7 @@
     "name":"datasource/Tempo",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/54"
+      "url":"https://github.com/orgs/grafana/projects/110"
     }
   },
   {
@@ -151,7 +143,7 @@
     "name":"datasource/Elasticsearch",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/54"
+      "url":"https://github.com/orgs/grafana/projects/110"
     }
   },
   {
@@ -159,7 +151,7 @@
     "name":"area/explore",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/54"
+      "url":"https://github.com/orgs/grafana/projects/111"
     }
   },
   {

--- a/.github/commands.json
+++ b/.github/commands.json
@@ -116,6 +116,22 @@
   },
   {
     "type":"label",
+    "name":"datasource/Graphite",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/112"
+    }
+  },
+  {
+    "type":"label",
+    "name":"datasource/OpenTSDB",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/112"
+    }
+  },
+  {
+    "type":"label",
     "name":"datasource/OpenSearch",
     "action":"addToProject",
     "addToProject":{
@@ -141,6 +157,22 @@
   {
     "type":"label",
     "name":"datasource/Elasticsearch",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/110"
+    }
+  },
+  {
+    "type":"label",
+    "name":"datasource/Jaeger",
+    "action":"addToProject",
+    "addToProject":{
+      "url":"https://github.com/orgs/grafana/projects/110"
+    }
+  },
+  {
+    "type":"label",
+    "name":"datasource/Zipkin",
     "action":"addToProject",
     "addToProject":{
       "url":"https://github.com/orgs/grafana/projects/110"


### PR DESCRIPTION
the observability squad structure changed, now there are 3 separate squads, we adjusted the auto-assign config.