### PR TITLE
Chore: Make detect breaking changes workflow backport compatible 

### DIFF
--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -43,18 +43,18 @@ jobs:
         name: buildPr
         path: './pr/pr_built_packages.zip'
 
-  buildMain:
-    name: Build Main
+  buildBase:
+    name: Build Base
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: './main'
+        working-directory: './base'
 
     steps:
     - uses: actions/checkout@v2
       with: 
-        path: './main'
-        ref: 'main'
+        path: './base'
+        ref: ${{ github.event.pull_request.base.ref }}
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
@@ -76,18 +76,18 @@ jobs:
       run: yarn packages:build
 
     - name: Zip built packages
-      run: zip -r ./main_built_packages.zip ./packages/**/dist
+      run: zip -r ./base_built_packages.zip ./packages/**/dist
 
     - name: Upload build output as artifact
       uses: actions/upload-artifact@v2
       with:
-        name: buildMain
-        path: './main/main_built_packages.zip'
+        name: buildBase
+        path: './base/base_built_packages.zip'
 
   Detect:
     name: Detect breaking changes
     runs-on: ubuntu-latest
-    needs: ['buildPR', 'buildMain']
+    needs: ['buildPR', 'buildBase']
     env:
       GITHUB_STEP_NUMBER: 7
 
@@ -99,16 +99,16 @@ jobs:
         with:
           name: buildPr
 
-      - name: Get built packages from main
+      - name: Get built packages from base
         uses: actions/download-artifact@v2
         with:
-          name: buildMain
+          name: buildBase
       
       - name: Unzip artifact from pr
         run: unzip pr_built_packages.zip -d ./pr && rm pr_built_packages.zip
 
-      - name: Unzip artifact from main
-        run: unzip main_built_packages.zip -d ./main && rm main_built_packages.zip
+      - name: Unzip artifact from base
+        run: unzip base_built_packages.zip -d ./base && rm base_built_packages.zip
 
       - name: Get link for the Github Action job
         id: job

--- a/scripts/check-breaking-changes.sh
+++ b/scripts/check-breaking-changes.sh
@@ -12,7 +12,7 @@ while IFS=" " read -r -a package; do
     PACKAGE_PATH=$(basename "$package")
 
     # Calculate current and previous package paths / names
-    PREV="./main/packages/$PACKAGE_PATH/dist/"
+    PREV="./base/packages/$PACKAGE_PATH/dist/"
     CURRENT="./pr/packages/$PACKAGE_PATH/dist/"
 
     # Temporarily skipping these packages as they don't have any exposed static typing


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This [PR](https://github.com/grafana/grafana/pull/44996#issuecomment-1031573343) has highlighted that always comparing against main for breaking changes won't work for backports as the PR target branch will be different.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

