### PR TITLE
Alerting: Allow custom prefixes for OpsGenie notifications

### DIFF
--- a/docs/sources/old-alerting/notifications.md
+++ b/docs/sources/old-alerting/notifications.md
@@ -128,6 +128,7 @@ To setup Opsgenie you will need an API Key and the Alert API Url. These can be o
 | API Key                   | The API Key as provided by Opsgenie for your configured Grafana integration.                                                                                                                                                            |
 | Override priority         | Configures the alert priority using the `og_priority` tag. The `og_priority` tag must have one of the following values: `P1`, `P2`, `P3`, `P4`, or `P5`. Default is `False`.                                                            |
 | Send notification tags as | Specify how you would like [Notification Tags]({{< relref "create-alerts/#notifications" >}}) delivered to Opsgenie. They can be delivered as `Tags`, `Extra Properties` or both. Default is Tags. See note below for more information. |
+| Override alias prefix     | In case multiple instances of grafana are connected to a single OpsGenie account, the alias prefix is a unique identifier for each instance (a-zA-Z0-9).                                                                                |
 
 > **Note:** When notification tags are sent as `Tags` they are concatenated into a string with a `key:value` format. If you prefer to receive the notifications tags as key/values under Extra Properties in Opsgenie then change the `Send notification tags as` to either `Extra Properties` or `Tags & Extra Properties`.
 

--- a/docs/sources/old-alerting/notifications.md
+++ b/docs/sources/old-alerting/notifications.md
@@ -128,7 +128,7 @@ To setup Opsgenie you will need an API Key and the Alert API Url. These can be o
 | API Key                   | The API Key as provided by Opsgenie for your configured Grafana integration.                                                                                                                                                            |
 | Override priority         | Configures the alert priority using the `og_priority` tag. The `og_priority` tag must have one of the following values: `P1`, `P2`, `P3`, `P4`, or `P5`. Default is `False`.                                                            |
 | Send notification tags as | Specify how you would like [Notification Tags]({{< relref "create-alerts/#notifications" >}}) delivered to Opsgenie. They can be delivered as `Tags`, `Extra Properties` or both. Default is Tags. See note below for more information. |
-| Override alias prefix     | In case multiple instances of grafana are connected to a single OpsGenie account, the alias prefix is a unique identifier for each instance (a-zA-Z0-9).                                                                                |
+| Override alias prefix     | If multiple instances of Grafana are connected to a single OpsGenie account, the alias prefix is a unique identifier for each instance (a-zA-Z0-9).                                                                                     |
 
 > **Note:** When notification tags are sent as `Tags` they are concatenated into a string with a `key:value` format. If you prefer to receive the notifications tags as key/values under Extra Properties in Opsgenie then change the `Send notification tags as` to either `Extra Properties` or `Tags & Extra Properties`.
 

--- a/pkg/services/alerting/notifiers/opsgenie.go
+++ b/pkg/services/alerting/notifiers/opsgenie.go
@@ -80,7 +80,7 @@ func init() {
 				Element:      alerting.ElementTypeInput,
 				InputType:    alerting.InputTypeText,
 				Placeholder:  "AlertId",
-				Description:  "In case multiple instances of grafana are connected to a single OpsGenie account, the alias prefix is a unique identifier for each instance (a-zA-Z0-9).",
+				Description:  "If multiple instances of Grafana are connected to a single OpsGenie account, the alias prefix is a unique identifier for each instance (a-zA-Z0-9).",
 				PropertyName: "aliasPrefix",
 			},
 		},


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

When the OpsGenie notification plugin creates an alert in opsgenie, it sets an alias filed, for example "alertID-1".
This alias is used in opsgenie for [deduplicating the alerts](https://support.atlassian.com/opsgenie/docs/what-is-alert-de-duplication/).  

The "alertID" part is hardcoded and the number at the end increments. However, this leads to inconsistent deduplications if there are multiple instances of grafana connected to a single opsgenie.  Very different alerts will be grouped, even if they are very different in nature.  

This PR proposes a setting "Override alias prefix" with a default value of 'alertID', to allow configuring a prefix for this alias field.  

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #30080
Fixes #31295

**Special notes for your reviewer**:

Thanks for reviewing this PR !