### PR TITLE
LibraryPanels: Fix for Error while cleaning library panels

### DIFF
--- a/public/app/features/panel/state/actions.ts
+++ b/public/app/features/panel/state/actions.ts
@@ -93,7 +93,7 @@ export function changeToLibraryPanel(panel: PanelModel, libraryPanel: LibraryEle
       ...libraryPanel.model,
       gridPos: panel.gridPos,
       id: panel.id,
-      libraryPanel: toPanelModelLibraryPanel(libraryPanel.model),
+      libraryPanel: toPanelModelLibraryPanel(libraryPanel),
     });
 
     // a new library panel usually means new queries, clear any current result


### PR DESCRIPTION
**What this PR does / why we need it**:
Seem like `any` strikes again, I think we're accidentally passing `libraryPanel.model` instead of `libraryPanel` when replacing a "normal" panel with a library panels causing an `Error while cleaning library panels` when saving the dashboard.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Not sure how to add a test for this, so skipping it this time. Read escalation for more details.
