### PR TITLE
Alerting: Minor tweak/fix to step number style

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/RuleEditorSection.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleEditorSection.tsx
@@ -54,7 +54,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     text-align: center;
     color: ${theme.colors.text.maxContrast};
     background-color: ${theme.colors.background.secondary};
-    border: 1px solid ${theme.colors.border.weak};
     font-size: ${theme.typography.size.lg};
     margin-right: ${theme.spacing(2)};
   `,

--- a/public/app/features/alerting/unified/components/rule-editor/RuleEditorSection.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleEditorSection.tsx
@@ -53,7 +53,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
     border-radius: ${theme.spacing(4)};
     text-align: center;
     color: ${theme.colors.text.maxContrast};
-    background-color: ${theme.colors.background.canvas};
+    background-color: ${theme.colors.background.secondary};
+    border: 1px solid ${theme.colors.border.weak};
     font-size: ${theme.typography.size.lg};
     margin-right: ${theme.spacing(2)};
   `,


### PR DESCRIPTION
Super nitpick / tweak 

The alert number background in dark theme looked off to me. Using the input background/inset color (or canvas color). 

![Screenshot from 2022-02-08 08-25-14](https://user-images.githubusercontent.com/10999/152938237-fa6a9ebf-3b24-4ad3-bc87-62e35602c4b7.png)

In light theme it looks better like this: 
![Screenshot from 2022-02-08 08-25-04](https://user-images.githubusercontent.com/10999/152938406-3945ff42-4936-43cc-bdfe-3c1f08501418.png)

Propose instead to use the secondary background so the dark & light themes are more consistent and the dark theme looks better (will be no change to the light theme). 

![Screenshot from 2022-02-08 08-29-13](https://user-images.githubusercontent.com/10999/152938821-dc077d33-e0ec-4c77-954b-64ad91da8e82.png)

Another idea would be to add the weak border to the circle, but not sure? 
![Screenshot from 2022-02-08 08-30-03](https://user-images.githubusercontent.com/10999/152938936-7ab545e4-7343-407a-be21-bba9828b1e72.png)

