### PR TITLE
Tooltip: Improve tooltip contrast

### DIFF
--- a/packages/grafana-data/src/themes/createComponents.ts
+++ b/packages/grafana-data/src/themes/createComponents.ts
@@ -69,7 +69,7 @@ export function createComponents(colors: ThemeColors, shadows: ThemeShadows): Th
       background: input.background,
     },
     tooltip: {
-      background: colors.mode === 'light' ? '#555' : colors.background.secondary,
+      background: colors.mode === 'light' ? '#555' : '#35383e',
       text: colors.mode === 'light' ? '#FFF' : colors.text.primary,
     },
     dashboard: {

--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -291,9 +291,9 @@ $tooltipLinkColor: $link-color;
 $tooltipExternalLinkColor: $external-link-color;
 $graph-tooltip-bg: $dark-1;
 
-$tooltipBackground: #22252b;
+$tooltipBackground: #35383e;
 $tooltipColor: rgb(204, 204, 220);
-$tooltipArrowColor: #22252b;
+$tooltipArrowColor: #35383e;
 $tooltipBackgroundError: #D10E5C;
 $tooltipShadow: 0px 4px 8px rgba(24, 26, 27, 0.75);
 


### PR DESCRIPTION
Our non native Tooltip style in dark theme is really bad, they sometimes blend into the background making them hard to read. This is due to the fact that they use the secondary background (same as cards & inline form labels) and have only shadow on the lower side. This makes them blend into other cards and secondary background-colored elements. 

Example (current state showing problem)
![Screenshot from 2022-02-08 08-57-14](https://user-images.githubusercontent.com/10999/152942853-deeee47c-5a9b-4598-a8d6-c5bd30180011.png)

This was an issue before but is becoming a bigger issue with new query editor styles that use secondary color more (and places form elements inside "cards" / secondary bg).

Proposal: Use our highest contrast gray (same as secondary button): 
![Screenshot from 2022-02-08 08-51-17](https://user-images.githubusercontent.com/10999/152942435-b0ef9c9a-ca66-4364-95d1-10caca20e7a7.png)

Alternative (that I don't think is as good), use input/canvas color: 
![Screenshot from 2022-02-08 08-50-09](https://user-images.githubusercontent.com/10999/152942511-1610ecc7-d352-4947-984f-c4f84349b0db.png)

The tooltip color in light theme is not an issue it's not using a theme color but a special gray (as the main theme colors do not have a suitable color). 
