### PR TITLE
Backport a9399ab to v8.4.x

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -101,7 +101,7 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 		DashboardUID:  dashboardUID,
 		PanelID:       panelID,
 	}
-	if err := srv.store.GetOrgRuleGroups(&ruleGroupQuery); err != nil {
+	if err := srv.store.GetOrgRuleGroups(c.Req.Context(), &ruleGroupQuery); err != nil {
 		ruleResponse.DiscoveryBase.Status = "error"
 		ruleResponse.DiscoveryBase.Error = fmt.Sprintf("failure getting rule groups: %s", err.Error())
 		ruleResponse.DiscoveryBase.ErrorType = apiv1.ErrServer
@@ -113,7 +113,7 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 		DashboardUID: dashboardUID,
 		PanelID:      panelID,
 	}
-	if err := srv.store.GetOrgAlertRules(&alertRuleQuery); err != nil {
+	if err := srv.store.GetOrgAlertRules(c.Req.Context(), &alertRuleQuery); err != nil {
 		ruleResponse.DiscoveryBase.Status = "error"
 		ruleResponse.DiscoveryBase.Error = fmt.Sprintf("failure getting rules: %s", err.Error())
 		ruleResponse.DiscoveryBase.ErrorType = apiv1.ErrServer

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -38,7 +38,7 @@ func (srv RulerSrv) RouteDeleteNamespaceRulesConfig(c *models.ReqContext) respon
 		return toNamespaceErrorResponse(err)
 	}
 
-	uids, err := srv.store.DeleteNamespaceAlertRules(c.SignedInUser.OrgId, namespace.Uid)
+	uids, err := srv.store.DeleteNamespaceAlertRules(c.Req.Context(), c.SignedInUser.OrgId, namespace.Uid)
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "failed to delete namespace alert rules")
 	}
@@ -60,7 +60,7 @@ func (srv RulerSrv) RouteDeleteRuleGroupConfig(c *models.ReqContext) response.Re
 		return toNamespaceErrorResponse(err)
 	}
 	ruleGroup := web.Params(c.Req)[":Groupname"]
-	uids, err := srv.store.DeleteRuleGroupAlertRules(c.SignedInUser.OrgId, namespace.Uid, ruleGroup)
+	uids, err := srv.store.DeleteRuleGroupAlertRules(c.Req.Context(), c.SignedInUser.OrgId, namespace.Uid, ruleGroup)
 
 	if err != nil {
 		if errors.Is(err, ngmodels.ErrRuleGroupNamespaceNotFound) {
@@ -90,7 +90,7 @@ func (srv RulerSrv) RouteGetNamespaceRulesConfig(c *models.ReqContext) response.
 		OrgID:        c.SignedInUser.OrgId,
 		NamespaceUID: namespace.Uid,
 	}
-	if err := srv.store.GetNamespaceAlertRules(&q); err != nil {
+	if err := srv.store.GetNamespaceAlertRules(c.Req.Context(), &q); err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "failed to update rule group")
 	}
 
@@ -133,7 +133,7 @@ func (srv RulerSrv) RouteGetRulegGroupConfig(c *models.ReqContext) response.Resp
 		NamespaceUID: namespace.Uid,
 		RuleGroup:    ruleGroup,
 	}
-	if err := srv.store.GetRuleGroupAlertRules(&q); err != nil {
+	if err := srv.store.GetRuleGroupAlertRules(c.Req.Context(), &q); err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "failed to get group alert rules")
 	}
 
@@ -187,7 +187,7 @@ func (srv RulerSrv) RouteGetRulesConfig(c *models.ReqContext) response.Response 
 		PanelID:       panelID,
 	}
 
-	if err := srv.store.GetOrgAlertRules(&q); err != nil {
+	if err := srv.store.GetOrgAlertRules(c.Req.Context(), &q); err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "failed to get alert rules")
 	}
 
@@ -282,7 +282,7 @@ func (srv RulerSrv) RoutePostNameRulesConfig(c *models.ReqContext, ruleGroupConf
 		}
 	}
 
-	if err := srv.store.UpdateRuleGroup(store.UpdateRuleGroupCmd{
+	if err := srv.store.UpdateRuleGroup(c.Req.Context(), store.UpdateRuleGroupCmd{
 		OrgID:           c.SignedInUser.OrgId,
 		NamespaceUID:    namespace.Uid,
 		RuleGroupConfig: ruleGroupConfig,

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -169,7 +169,7 @@ func (ng *AlertNG) init() error {
 // Run starts the scheduler and Alertmanager.
 func (ng *AlertNG) Run(ctx context.Context) error {
 	ng.Log.Debug("ngalert starting")
-	ng.stateManager.Warm()
+	ng.stateManager.Warm(ctx)
 
 	children, subCtx := errgroup.WithContext(ctx)
 

--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -1,12 +1,13 @@
 package schedule
 
 import (
+	"context"
 	"time"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-func (sch *schedule) getAlertRules(disabledOrgs []int64) []*models.AlertRule {
+func (sch *schedule) getAlertRules(ctx context.Context, disabledOrgs []int64) []*models.AlertRule {
 	start := time.Now()
 	defer func() {
 		sch.metrics.GetAlertRulesDuration.Observe(time.Since(start).Seconds())
@@ -15,7 +16,7 @@ func (sch *schedule) getAlertRules(disabledOrgs []int64) []*models.AlertRule {
 	q := models.ListAlertRulesQuery{
 		ExcludeOrgs: disabledOrgs,
 	}
-	err := sch.ruleStore.GetAlertRulesForScheduling(&q)
+	err := sch.ruleStore.GetAlertRulesForScheduling(ctx, &q)
 	if err != nil {
 		sch.log.Error("failed to fetch alert definitions", "err", err)
 		return nil

--- a/pkg/services/ngalert/schedule/schedule_test.go
+++ b/pkg/services/ngalert/schedule/schedule_test.go
@@ -36,10 +36,12 @@ type evalAppliedInfo struct {
 func TestWarmStateCache(t *testing.T) {
 	evaluationTime, err := time.Parse("2006-01-02", "2021-03-25")
 	require.NoError(t, err)
+
+	ctx := context.Background()
 	_, dbstore := tests.SetupTestEnv(t, 1)
 
 	const mainOrgID int64 = 1
-	rule := tests.CreateTestAlertRule(t, dbstore, 600, mainOrgID)
+	rule := tests.CreateTestAlertRule(t, ctx, dbstore, 600, mainOrgID)
 
 	expectedEntries := []*state.State{
 		{
@@ -104,8 +106,9 @@ func TestWarmStateCache(t *testing.T) {
 		Metrics:                 testMetrics.GetSchedulerMetrics(),
 		AdminConfigPollInterval: 10 * time.Minute, // do not poll in unit tests.
 	}
+
 	st := state.NewManager(schedCfg.Logger, testMetrics.GetStateMetrics(), nil, dbstore, dbstore)
-	st.Warm()
+	st.Warm(ctx)
 
 	t.Run("instance cache has expected entries", func(t *testing.T) {
 		for _, entry := range expectedEntries {
@@ -121,13 +124,14 @@ func TestWarmStateCache(t *testing.T) {
 }
 
 func TestAlertingTicker(t *testing.T) {
+	ctx := context.Background()
 	_, dbstore := tests.SetupTestEnv(t, 1)
 
 	alerts := make([]*models.AlertRule, 0)
 
 	const mainOrgID int64 = 1
 	// create alert rule under main org with one second interval
-	alerts = append(alerts, tests.CreateTestAlertRule(t, dbstore, 1, mainOrgID))
+	alerts = append(alerts, tests.CreateTestAlertRule(t, ctx, dbstore, 1, mainOrgID))
 
 	const disabledOrgID int64 = 3
 
@@ -162,8 +166,6 @@ func TestAlertingTicker(t *testing.T) {
 	}
 	sched := schedule.NewScheduler(schedCfg, nil, appUrl, st)
 
-	ctx := context.Background()
-
 	go func() {
 		err := sched.Run(ctx)
 		require.NoError(t, err)
@@ -178,7 +180,7 @@ func TestAlertingTicker(t *testing.T) {
 
 	// add alert rule under main org with three seconds interval
 	var threeSecInterval int64 = 3
-	alerts = append(alerts, tests.CreateTestAlertRule(t, dbstore, threeSecInterval, mainOrgID))
+	alerts = append(alerts, tests.CreateTestAlertRule(t, ctx, dbstore, threeSecInterval, mainOrgID))
 	t.Logf("alert rule: %v added with interval: %d", alerts[1].GetKey(), threeSecInterval)
 
 	expectedAlertRulesEvaluated = []models.AlertRuleKey{alerts[0].GetKey()}
@@ -200,7 +202,7 @@ func TestAlertingTicker(t *testing.T) {
 	})
 
 	key := alerts[0].GetKey()
-	err := dbstore.DeleteAlertRuleByUID(alerts[0].OrgID, alerts[0].UID)
+	err := dbstore.DeleteAlertRuleByUID(ctx, alerts[0].OrgID, alerts[0].UID)
 	require.NoError(t, err)
 	t.Logf("alert rule: %v deleted", key)
 
@@ -221,7 +223,7 @@ func TestAlertingTicker(t *testing.T) {
 	})
 
 	// create alert rule with one second interval
-	alerts = append(alerts, tests.CreateTestAlertRule(t, dbstore, 1, mainOrgID))
+	alerts = append(alerts, tests.CreateTestAlertRule(t, ctx, dbstore, 1, mainOrgID))
 
 	expectedAlertRulesEvaluated = []models.AlertRuleKey{alerts[2].GetKey()}
 	t.Run(fmt.Sprintf("on 7th tick alert rules: %s should be evaluated", concatenate(expectedAlertRulesEvaluated)), func(t *testing.T) {
@@ -230,7 +232,7 @@ func TestAlertingTicker(t *testing.T) {
 	})
 
 	// create alert rule with one second interval under disabled org
-	alerts = append(alerts, tests.CreateTestAlertRule(t, dbstore, 1, disabledOrgID))
+	alerts = append(alerts, tests.CreateTestAlertRule(t, ctx, dbstore, 1, disabledOrgID))
 
 	expectedAlertRulesEvaluated = []models.AlertRuleKey{alerts[2].GetKey()}
 	t.Run(fmt.Sprintf("on 8th tick alert rules: %s should be evaluated", concatenate(expectedAlertRulesEvaluated)), func(t *testing.T) {

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -481,6 +481,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 		evalChan := make(chan *evalContext)
 		evalAppliedChan := make(chan time.Time)
 
+		ctx := context.Background()
 		sch, ruleStore, _, _, _ := createSchedule(evalAppliedChan)
 
 		rule := CreateTestAlertRule(t, ruleStore, 10, rand.Int63(), randomNormalState())
@@ -503,7 +504,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 		// Now update the rule
 		newRule := *rule
 		newRule.Version++
-		ruleStore.putRule(&newRule)
+		ruleStore.putRule(ctx, &newRule)
 
 		// and call with new version
 		expectedTime = expectedTime.Add(time.Duration(rand.Intn(10)) * time.Second)
@@ -680,6 +681,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 			evalAppliedChan := make(chan time.Time)
 			updateChan := make(chan struct{})
 
+			ctx := context.Background()
 			sch, ruleStore, _, _, _ := createSchedule(evalAppliedChan)
 			sch.senders[orgID] = s
 
@@ -727,7 +729,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 			wg.Wait()
 			newRule := rule
 			newRule.Version++
-			ruleStore.putRule(&newRule)
+			ruleStore.putRule(ctx, &newRule)
 			wg.Add(1)
 			updateChan <- struct{}{}
 			wg.Wait()
@@ -1040,6 +1042,8 @@ func setupScheduler(t *testing.T, rs store.RuleStore, is store.InstanceStore, ac
 
 // createTestAlertRule creates a dummy alert definition to be used by the tests.
 func CreateTestAlertRule(t *testing.T, dbstore *fakeRuleStore, intervalSeconds int64, orgID int64, evalResult eval.State) *models.AlertRule {
+	ctx := context.Background()
+
 	t.Helper()
 	records := make([]interface{}, 0, len(dbstore.recordedOps))
 	copy(records, dbstore.recordedOps)
@@ -1079,7 +1083,7 @@ func CreateTestAlertRule(t *testing.T, dbstore *fakeRuleStore, intervalSeconds i
 		require.Fail(t, "Alert rule with desired evaluation result NoData is not supported yet")
 	}
 
-	err := dbstore.UpdateRuleGroup(store.UpdateRuleGroupCmd{
+	err := dbstore.UpdateRuleGroup(ctx, store.UpdateRuleGroupCmd{
 		OrgID:        orgID,
 		NamespaceUID: "namespace",
 		RuleGroupConfig: apimodels.PostableRuleGroupConfig{
@@ -1117,7 +1121,7 @@ func CreateTestAlertRule(t *testing.T, dbstore *fakeRuleStore, intervalSeconds i
 		NamespaceUID: "namespace",
 		RuleGroup:    ruleGroup,
 	}
-	err = dbstore.GetRuleGroupAlertRules(&q)
+	err = dbstore.GetRuleGroupAlertRules(ctx, &q)
 	require.NoError(t, err)
 	require.NotEmpty(t, q.Result)
 

--- a/pkg/services/ngalert/schedule/testing.go
+++ b/pkg/services/ngalert/schedule/testing.go
@@ -70,7 +70,7 @@ type fakeRuleStore struct {
 }
 
 // putRule puts the rule in the rules map. If there are existing rule in the same namespace, they will be overwritten
-func (f *fakeRuleStore) putRule(r *models.AlertRule) {
+func (f *fakeRuleStore) putRule(_ context.Context, r *models.AlertRule) {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.rules[r.OrgID][r.RuleGroup][r.NamespaceUID] = []*models.AlertRule{
@@ -94,15 +94,17 @@ func (f *fakeRuleStore) getRecordedCommands(predicate func(cmd interface{}) (int
 	return result
 }
 
-func (f *fakeRuleStore) DeleteAlertRuleByUID(_ int64, _ string) error { return nil }
-func (f *fakeRuleStore) DeleteNamespaceAlertRules(_ int64, _ string) ([]string, error) {
+func (f *fakeRuleStore) DeleteAlertRuleByUID(_ context.Context, _ int64, _ string) error { return nil }
+func (f *fakeRuleStore) DeleteNamespaceAlertRules(_ context.Context, _ int64, _ string) ([]string, error) {
 	return []string{}, nil
 }
-func (f *fakeRuleStore) DeleteRuleGroupAlertRules(_ int64, _ string, _ string) ([]string, error) {
+func (f *fakeRuleStore) DeleteRuleGroupAlertRules(_ context.Context, _ int64, _ string, _ string) ([]string, error) {
 	return []string{}, nil
 }
-func (f *fakeRuleStore) DeleteAlertInstancesByRuleUID(_ int64, _ string) error { return nil }
-func (f *fakeRuleStore) GetAlertRuleByUID(q *models.GetAlertRuleByUIDQuery) error {
+func (f *fakeRuleStore) DeleteAlertInstancesByRuleUID(_ context.Context, _ int64, _ string) error {
+	return nil
+}
+func (f *fakeRuleStore) GetAlertRuleByUID(_ context.Context, q *models.GetAlertRuleByUIDQuery) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = append(f.recordedOps, *q)
@@ -129,7 +131,7 @@ func (f *fakeRuleStore) GetAlertRuleByUID(q *models.GetAlertRuleByUIDQuery) erro
 }
 
 // For now, we're not implementing namespace filtering.
-func (f *fakeRuleStore) GetAlertRulesForScheduling(q *models.ListAlertRulesQuery) error {
+func (f *fakeRuleStore) GetAlertRulesForScheduling(_ context.Context, q *models.ListAlertRulesQuery) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = append(f.recordedOps, *q)
@@ -146,19 +148,19 @@ func (f *fakeRuleStore) GetAlertRulesForScheduling(q *models.ListAlertRulesQuery
 
 	return nil
 }
-func (f *fakeRuleStore) GetOrgAlertRules(q *models.ListAlertRulesQuery) error {
+func (f *fakeRuleStore) GetOrgAlertRules(_ context.Context, q *models.ListAlertRulesQuery) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = append(f.recordedOps, *q)
 	return nil
 }
-func (f *fakeRuleStore) GetNamespaceAlertRules(q *models.ListNamespaceAlertRulesQuery) error {
+func (f *fakeRuleStore) GetNamespaceAlertRules(_ context.Context, q *models.ListNamespaceAlertRulesQuery) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = append(f.recordedOps, *q)
 	return nil
 }
-func (f *fakeRuleStore) GetRuleGroupAlertRules(q *models.ListRuleGroupAlertRulesQuery) error {
+func (f *fakeRuleStore) GetRuleGroupAlertRules(_ context.Context, q *models.ListRuleGroupAlertRulesQuery) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = append(f.recordedOps, *q)
@@ -196,7 +198,7 @@ func (f *fakeRuleStore) GetNamespaces(_ context.Context, _ int64, _ *models2.Sig
 func (f *fakeRuleStore) GetNamespaceByTitle(_ context.Context, _ string, _ int64, _ *models2.SignedInUser, _ bool) (*models2.Folder, error) {
 	return nil, nil
 }
-func (f *fakeRuleStore) GetOrgRuleGroups(q *models.ListOrgRuleGroupsQuery) error {
+func (f *fakeRuleStore) GetOrgRuleGroups(_ context.Context, q *models.ListOrgRuleGroupsQuery) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = append(f.recordedOps, *q)
@@ -206,7 +208,7 @@ func (f *fakeRuleStore) GetOrgRuleGroups(q *models.ListOrgRuleGroupsQuery) error
 	return nil
 }
 
-func (f *fakeRuleStore) UpsertAlertRules(q []store.UpsertRule) error {
+func (f *fakeRuleStore) UpsertAlertRules(_ context.Context, q []store.UpsertRule) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = append(f.recordedOps, q)
@@ -215,7 +217,7 @@ func (f *fakeRuleStore) UpsertAlertRules(q []store.UpsertRule) error {
 	}
 	return nil
 }
-func (f *fakeRuleStore) UpdateRuleGroup(cmd store.UpdateRuleGroupCmd) error {
+func (f *fakeRuleStore) UpdateRuleGroup(_ context.Context, cmd store.UpdateRuleGroupCmd) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = append(f.recordedOps, cmd)

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -51,7 +51,7 @@ func (st *Manager) Close() {
 	st.quit <- struct{}{}
 }
 
-func (st *Manager) Warm() {
+func (st *Manager) Warm(ctx context.Context) {
 	st.log.Info("warming cache for startup")
 	st.ResetCache()
 
@@ -66,7 +66,7 @@ func (st *Manager) Warm() {
 		ruleCmd := ngModels.ListAlertRulesQuery{
 			OrgID: orgId,
 		}
-		if err := st.ruleStore.GetOrgAlertRules(&ruleCmd); err != nil {
+		if err := st.ruleStore.GetOrgAlertRules(ctx, &ruleCmd); err != nil {
 			st.log.Error("unable to fetch previous state", "msg", err.Error())
 		}
 

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -1511,10 +1511,11 @@ func TestStaleResultsHandler(t *testing.T) {
 		t.Fatalf("error parsing date format: %s", err.Error())
 	}
 
+	ctx := context.Background()
 	_, dbstore := tests.SetupTestEnv(t, 1)
 
 	const mainOrgID int64 = 1
-	rule := tests.CreateTestAlertRule(t, dbstore, 600, mainOrgID)
+	rule := tests.CreateTestAlertRule(t, ctx, dbstore, 600, mainOrgID)
 
 	saveCmd1 := &models.SaveAlertInstanceCommand{
 		RuleOrgID:         rule.OrgID,
@@ -1587,8 +1588,10 @@ func TestStaleResultsHandler(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		ctx := context.Background()
 		st := state.NewManager(log.New("test_stale_results_handler"), testMetrics.GetStateMetrics(), nil, dbstore, dbstore)
-		st.Warm()
+		st.Warm(ctx)
+
 		existingStatesForRule := st.GetStatesForRuleUID(rule.OrgID, rule.UID)
 
 		// We have loaded the expected number of entries from the db

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -4,6 +4,7 @@
 package store_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -26,20 +27,21 @@ func mockTimeNow() {
 }
 
 func TestAlertInstanceOperations(t *testing.T) {
+	ctx := context.Background()
 	_, dbstore := tests.SetupTestEnv(t, baseIntervalSeconds)
 
 	const mainOrgID int64 = 1
 
-	alertRule1 := tests.CreateTestAlertRule(t, dbstore, 60, mainOrgID)
+	alertRule1 := tests.CreateTestAlertRule(t, ctx, dbstore, 60, mainOrgID)
 	orgID := alertRule1.OrgID
 
-	alertRule2 := tests.CreateTestAlertRule(t, dbstore, 60, mainOrgID)
+	alertRule2 := tests.CreateTestAlertRule(t, ctx, dbstore, 60, mainOrgID)
 	require.Equal(t, orgID, alertRule2.OrgID)
 
-	alertRule3 := tests.CreateTestAlertRule(t, dbstore, 60, mainOrgID)
+	alertRule3 := tests.CreateTestAlertRule(t, ctx, dbstore, 60, mainOrgID)
 	require.Equal(t, orgID, alertRule3.OrgID)
 
-	alertRule4 := tests.CreateTestAlertRule(t, dbstore, 60, mainOrgID)
+	alertRule4 := tests.CreateTestAlertRule(t, ctx, dbstore, 60, mainOrgID)
 	require.Equal(t, orgID, alertRule4.OrgID)
 
 	t.Run("can save and read new alert instance", func(t *testing.T) {

--- a/pkg/services/ngalert/tests/util.go
+++ b/pkg/services/ngalert/tests/util.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -50,9 +51,9 @@ func SetupTestEnv(t *testing.T, baseInterval time.Duration) (*ngalert.AlertNG, *
 }
 
 // CreateTestAlertRule creates a dummy alert definition to be used by the tests.
-func CreateTestAlertRule(t *testing.T, dbstore *store.DBstore, intervalSeconds int64, orgID int64) *models.AlertRule {
+func CreateTestAlertRule(t *testing.T, ctx context.Context, dbstore *store.DBstore, intervalSeconds int64, orgID int64) *models.AlertRule {
 	ruleGroup := fmt.Sprintf("ruleGroup-%s", util.GenerateShortUID())
-	err := dbstore.UpdateRuleGroup(store.UpdateRuleGroupCmd{
+	err := dbstore.UpdateRuleGroup(ctx, store.UpdateRuleGroupCmd{
 		OrgID:        orgID,
 		NamespaceUID: "namespace",
 		RuleGroupConfig: apimodels.PostableRuleGroupConfig{
@@ -92,7 +93,7 @@ func CreateTestAlertRule(t *testing.T, dbstore *store.DBstore, intervalSeconds i
 		NamespaceUID: "namespace",
 		RuleGroup:    ruleGroup,
 	}
-	err = dbstore.GetRuleGroupAlertRules(&q)
+	err = dbstore.GetRuleGroupAlertRules(ctx, &q)
 	require.NoError(t, err)
 	require.NotEmpty(t, q.Result)
 
@@ -102,7 +103,7 @@ func CreateTestAlertRule(t *testing.T, dbstore *store.DBstore, intervalSeconds i
 }
 
 // updateTestAlertRule update a dummy alert definition to be used by the tests.
-func UpdateTestAlertRuleIntervalSeconds(t *testing.T, dbstore *store.DBstore, existingRule *models.AlertRule, intervalSeconds int64) *models.AlertRule {
+func UpdateTestAlertRuleIntervalSeconds(t *testing.T, ctx context.Context, dbstore *store.DBstore, existingRule *models.AlertRule, intervalSeconds int64) *models.AlertRule {
 	cmd := store.UpdateRuleGroupCmd{
 		OrgID:        1,
 		NamespaceUID: "namespace",
@@ -119,7 +120,7 @@ func UpdateTestAlertRuleIntervalSeconds(t *testing.T, dbstore *store.DBstore, ex
 		},
 	}
 
-	err := dbstore.UpdateRuleGroup(cmd)
+	err := dbstore.UpdateRuleGroup(ctx, cmd)
 	require.NoError(t, err)
 
 	q := models.ListRuleGroupAlertRulesQuery{
@@ -127,7 +128,7 @@ func UpdateTestAlertRuleIntervalSeconds(t *testing.T, dbstore *store.DBstore, ex
 		NamespaceUID: "namespace",
 		RuleGroup:    existingRule.RuleGroup,
 	}
-	err = dbstore.GetRuleGroupAlertRules(&q)
+	err = dbstore.GetRuleGroupAlertRules(ctx, &q)
 	require.NoError(t, err)
 	require.NotEmpty(t, q.Result)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport `a9399ab` from https://github.com/grafana/grafana/pull/45004
