### PR TITLE
Alerting: Improve Contact Points error handling (#44888)

### DIFF
--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -53,7 +53,7 @@ import {
   isVanillaPrometheusAlertManagerDataSource,
 } from '../utils/datasource';
 import { makeAMLink, retryWhile } from '../utils/misc';
-import { isFetchError, withAppEvents, withSerializedError } from '../utils/redux';
+import { withAppEvents, withSerializedError } from '../utils/redux';
 import { formValuesToRulerRuleDTO, formValuesToRulerGrafanaRuleDTO } from '../utils/rule-form';
 import {
   isCloudRuleIdentifier,
@@ -62,7 +62,7 @@ import {
   isPrometheusRuleIdentifier,
   isRulerNotSupportedResponse,
 } from '../utils/rules';
-import { addDefaultsToAlertmanagerConfig } from '../utils/alertmanager';
+import { addDefaultsToAlertmanagerConfig, isFetchError } from '../utils/alertmanager';
 import * as ruleId from '../utils/rule-id';
 import { isEmpty } from 'lodash';
 import messageFromError from 'app/plugins/datasource/grafana-azure-monitor-datasource/utils/messageFromError';

--- a/public/app/features/alerting/unified/utils/alertmanager.ts
+++ b/public/app/features/alerting/unified/utils/alertmanager.ts
@@ -4,6 +4,7 @@ import { MatcherFieldValue } from '../types/silence-form';
 import { SelectableValue } from '@grafana/data';
 import { getAllDataSources } from './config';
 import { DataSourceType } from './datasource';
+import { FetchError } from '@grafana/runtime';
 
 export function addDefaultsToAlertmanagerConfig(config: AlertManagerCortexConfig): AlertManagerCortexConfig {
   // add default receiver if it does not exist
@@ -175,4 +176,8 @@ export function getAllAlertmanagerDataSources() {
 
 export function getAlertmanagerByUid(uid?: string) {
   return getAllAlertmanagerDataSources().find((ds) => uid === ds.uid);
+}
+
+export function isFetchError(e: unknown): e is FetchError {
+  return typeof e === 'object' && e !== null && 'status' in e && 'data' in e;
 }

--- a/public/app/features/alerting/unified/utils/redux.ts
+++ b/public/app/features/alerting/unified/utils/redux.ts
@@ -4,6 +4,7 @@ import { FetchError } from '@grafana/runtime';
 import { AppEvents } from '@grafana/data';
 
 import { appEvents } from 'app/core/core';
+import { isFetchError } from './alertmanager';
 
 export interface AsyncRequestState<T> {
   result?: T;
@@ -136,10 +137,6 @@ export function withAppEvents<T>(
       appEvents.emit(AppEvents.alertError, [`${options.errorMessage ?? 'Error'}: ${msg}`]);
       throw e;
     });
-}
-
-export function isFetchError(e: unknown): e is FetchError {
-  return typeof e === 'object' && e !== null && 'status' in e && 'data' in e;
 }
 
 export function messageFromError(e: Error | FetchError | SerializedError): string {

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -245,7 +245,7 @@ interface TestReceiversResultGrafanaReceiverConfig {
   name: string;
   uid?: string;
   error?: string;
-  status: 'failed';
+  status: 'ok' | 'failed';
 }
 
 interface TestReceiversResultReceiver {


### PR DESCRIPTION
Manual backport of 1cf48618dee807d3b93ac54f53dc76632e14c892 from https://github.com/grafana/grafana/pull/44888

* Add 400 and 408 errors handling to display useful error message

* Add generic error handling

* Improve type guard

(cherry picked from commit 1cf48618dee807d3b93ac54f53dc76632e14c892)


