### PR TITLE
ServiceAccounts: Add access control metadata to service accounts

### DIFF
--- a/pkg/services/serviceaccounts/database/database.go
+++ b/pkg/services/serviceaccounts/database/database.go
@@ -143,10 +143,11 @@ func (s *ServiceAccountsStoreImpl) ListServiceAccounts(ctx context.Context, orgI
 	if serviceAccountID > 0 {
 		query.UserID = serviceAccountID
 	}
-	err := s.sqlStore.GetOrgUsers(ctx, &query)
-	if err != nil {
+
+	if err := s.sqlStore.GetOrgUsers(ctx, &query); err != nil {
 		return nil, err
 	}
+
 	saDTOs := make([]*serviceaccounts.ServiceAccountDTO, len(query.Result))
 	for i, user := range query.Result {
 		saDTOs[i] = &serviceaccounts.ServiceAccountDTO{
@@ -154,6 +155,7 @@ func (s *ServiceAccountsStoreImpl) ListServiceAccounts(ctx context.Context, orgI
 			OrgId: user.OrgId,
 			Name:  user.Name,
 			Login: user.Login,
+			Role:  user.Role,
 		}
 		tokens, err := s.ListTokens(ctx, user.OrgId, user.UserId)
 		if err != nil {
@@ -161,7 +163,8 @@ func (s *ServiceAccountsStoreImpl) ListServiceAccounts(ctx context.Context, orgI
 		}
 		saDTOs[i].Tokens = int64(len(tokens))
 	}
-	return saDTOs, err
+
+	return saDTOs, nil
 }
 
 // RetrieveServiceAccountByID returns a service account by its ID

--- a/pkg/services/serviceaccounts/models.go
+++ b/pkg/services/serviceaccounts/models.go
@@ -33,6 +33,7 @@ type ServiceAccountDTO struct {
 	Login  string `json:"login"`
 	OrgId  int64  `json:"orgId"`
 	Tokens int64  `json:"tokens"`
+	Role   string `json:"role"`
 }
 
 type ServiceAccountProfileDTO struct {

--- a/pkg/services/serviceaccounts/models.go
+++ b/pkg/services/serviceaccounts/models.go
@@ -28,12 +28,14 @@ type CreateServiceaccountForm struct {
 }
 
 type ServiceAccountDTO struct {
-	Id     int64  `json:"id"`
-	Name   string `json:"name"`
-	Login  string `json:"login"`
-	OrgId  int64  `json:"orgId"`
-	Tokens int64  `json:"tokens"`
-	Role   string `json:"role"`
+	Id            int64           `json:"id"`
+	Name          string          `json:"name"`
+	Login         string          `json:"login"`
+	OrgId         int64           `json:"orgId"`
+	Tokens        int64           `json:"tokens"`
+	Role          string          `json:"role"`
+	AvatarUrl     string          `json:"avatarUrl"`
+	AccessControl map[string]bool `json:"accessControl,omitempty"`
 }
 
 type ServiceAccountProfileDTO struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add access control metadata to service accounts
  - Allows implementing role picker and permissions in UI
  
- Add avatars to service accounts

![image](https://user-images.githubusercontent.com/8071073/153040207-e536d8e5-20ec-4876-a9a5-b906f4e0f076.png)

