### PR TITLE
Tempo: Switch out Select with AsyncSelect component to get loading state in Tempo Search

### DIFF
--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.test.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.test.tsx
@@ -1,0 +1,109 @@
+import NativeSearch from './NativeSearch';
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { TempoDatasource, TempoQuery } from '../datasource';
+import userEvent from '@testing-library/user-event';
+
+const getOptions = jest.fn().mockImplementation(() => {
+  return Promise.resolve([
+    {
+      value: 'customer',
+      label: 'customer',
+    },
+    {
+      value: 'driver',
+      label: 'driver',
+    },
+  ]);
+});
+
+jest.mock('../language_provider', () => {
+  return jest.fn().mockImplementation(() => {
+    return { getOptions };
+  });
+});
+
+const mockQuery = {
+  refId: 'A',
+  queryType: 'nativeSearch',
+  key: 'Q-595a9bbc-2a25-49a7-9249-a52a0a475d83-0',
+  serviceName: 'driver',
+} as TempoQuery;
+
+describe('NativeSearch', () => {
+  it('should call the `onChange` function on click of the Input', async () => {
+    const promise = Promise.resolve();
+    const handleOnChange = jest.fn(() => promise);
+    const fakeOptionChoice = {
+      key: 'Q-595a9bbc-2a25-49a7-9249-a52a0a475d83-0',
+      queryType: 'nativeSearch',
+      refId: 'A',
+      serviceName: 'driver',
+      spanName: 'driver',
+    };
+
+    render(
+      <NativeSearch
+        datasource={{} as TempoDatasource}
+        query={mockQuery}
+        onChange={handleOnChange}
+        onRunQuery={() => {}}
+      />
+    );
+
+    const asyncServiceSelect = await screen.findByRole('combobox', { name: 'select-span-name' });
+
+    expect(asyncServiceSelect).toBeInTheDocument();
+    userEvent.click(asyncServiceSelect);
+
+    const driverOption = await screen.findByText('driver');
+    userEvent.click(driverOption);
+
+    expect(handleOnChange).toHaveBeenCalledWith(fakeOptionChoice);
+  });
+});
+
+describe('TempoLanguageProvider with delay', () => {
+  const getOptions2 = jest.fn().mockImplementation(() => {
+    return Promise.resolve([
+      {
+        value: 'customer',
+        label: 'customer',
+      },
+      {
+        value: 'driver',
+        label: 'driver',
+      },
+    ]);
+  });
+
+  jest.mock('../language_provider', () => {
+    return jest.fn().mockImplementation(() => {
+      setTimeout(() => {
+        return { getOptions2 };
+      }, 3000);
+    });
+  });
+
+  it('should show loader', async () => {
+    const promise = Promise.resolve();
+    const handleOnChange = jest.fn(() => promise);
+
+    render(
+      <NativeSearch
+        datasource={{} as TempoDatasource}
+        query={mockQuery}
+        onChange={handleOnChange}
+        onRunQuery={() => {}}
+      />
+    );
+
+    const asyncServiceSelect = screen.getByRole('combobox', { name: 'select-span-name' });
+
+    userEvent.click(asyncServiceSelect);
+    const loader = screen.getByText('Loading options...');
+
+    expect(loader).toBeInTheDocument();
+    await act(() => promise);
+  });
+});

--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
@@ -56,20 +56,29 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
   });
   const [error, setError] = useState(null);
   const [inputErrors, setInputErrors] = useState<{ [key: string]: boolean }>({});
-  const [isLoadingService, setIsLoadingService] = useState<{ optionType: string; loading: boolean }>({
-    optionType: '',
-    loading: false,
+  const [isLoading, setIsLoading] = useState<{
+    serviceName: boolean;
+    operationName: boolean;
+  }>({
+    serviceName: false,
+    operationName: false,
   });
 
   async function loadOptionsAsync(nameType: string, lp: TempoLanguageProvider) {
     const res = await lp.getOptions(nameType === 'serviceName' ? 'service.name' : 'name');
-    setIsLoadingService({ optionType: nameType, loading: false });
+    setIsLoading({
+      serviceName: nameType === 'serviceName' && false,
+      operationName: nameType === 'spanName' && false, // The terms 'span' and 'operation' are interchangeable
+    });
     return res;
   }
 
   const loadOptions = useCallback(
     (nameType: string) => {
-      setIsLoadingService({ optionType: nameType, loading: true });
+      setIsLoading({
+        serviceName: nameType === 'serviceName' && true,
+        operationName: nameType === 'spanName' && true,
+      });
       return loadOptionsAsync(nameType, languageProvider);
     },
     [languageProvider]
@@ -132,7 +141,7 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
               inputId="service"
               menuShouldPortal
               loadOptions={fetchServiceNameOptions}
-              isLoading={isLoadingService.optionType === 'serviceName' && isLoadingService.loading}
+              isLoading={isLoading.serviceName}
               value={asyncServiceNameValue.value}
               onChange={(v) => {
                 setAsyncServiceNameValue({
@@ -157,7 +166,7 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
               inputId="spanName"
               menuShouldPortal
               loadOptions={fetchSpanNameOptions}
-              isLoading={isLoadingService.optionType === 'spanName' && isLoadingService.loading}
+              isLoading={isLoading.operationName}
               value={asyncSpanNameValue.value}
               onChange={(v) => {
                 setAsyncSpanNameValue({ value: v });

--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
@@ -144,10 +144,10 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
                 });
               }}
               placeholder="Select a service"
-              onOpenMenu={fetchServiceNameOptions}
               isClearable
               defaultOptions
               onKeyDown={onKeyDown}
+              aria-label={'select-service-name'}
             />
           </InlineField>
         </InlineFieldRow>
@@ -167,10 +167,10 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
                 });
               }}
               placeholder="Select a span"
-              onOpenMenu={fetchSpanNameOptions}
               isClearable
               defaultOptions
               onKeyDown={onKeyDown}
+              aria-label={'select-span-name'}
             />
           </InlineField>
         </InlineFieldRow>

--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
@@ -133,7 +133,7 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
               menuShouldPortal
               loadOptions={fetchServiceNameOptions}
               isLoading={isLoadingService.optionType === 'serviceName' && isLoadingService.loading}
-              value={asyncServiceNameValue.value} //{(query.serviceName as SelectableValue) || asyncServiceNameValue}
+              value={asyncServiceNameValue.value}
               onChange={(v) => {
                 setAsyncServiceNameValue({
                   value: v,

--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
@@ -48,10 +48,12 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
   const styles = useStyles2(getStyles);
   const languageProvider = useMemo(() => new TempoLanguageProvider(datasource), [datasource]);
   const [hasSyntaxLoaded, setHasSyntaxLoaded] = useState(false);
-  const [asyncServiceNameValue, setAsyncServiceNameValue] = useState<SelectableValue<any>>(
-    query.serviceName as SelectableValue
-  );
-  const [asyncSpanNameValue, setAsyncSpanNameValue] = useState<SelectableValue<any>>(query.spanName as SelectableValue);
+  const [asyncServiceNameValue, setAsyncServiceNameValue] = useState<SelectableValue<any>>({
+    value: '',
+  });
+  const [asyncSpanNameValue, setAsyncSpanNameValue] = useState<SelectableValue<any>>({
+    value: '',
+  });
   const [error, setError] = useState(null);
   const [inputErrors, setInputErrors] = useState<{ [key: string]: boolean }>({});
   const [isLoadingService, setIsLoadingService] = useState<{ optionType: string; loading: boolean }>({
@@ -131,9 +133,11 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
               menuShouldPortal
               loadOptions={fetchServiceNameOptions}
               isLoading={isLoadingService.optionType === 'serviceName' && isLoadingService.loading}
-              value={(query.serviceName as SelectableValue) || asyncServiceNameValue}
+              value={asyncServiceNameValue.value} //{(query.serviceName as SelectableValue) || asyncServiceNameValue}
               onChange={(v) => {
-                setAsyncServiceNameValue(v);
+                setAsyncServiceNameValue({
+                  value: v,
+                });
                 onChange({
                   ...query,
                   serviceName: v?.value || undefined,
@@ -154,9 +158,9 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
               menuShouldPortal
               loadOptions={fetchSpanNameOptions}
               isLoading={isLoadingService.optionType === 'spanName' && isLoadingService.loading}
-              value={(query.spanName as SelectableValue) || asyncSpanNameValue}
+              value={asyncSpanNameValue.value}
               onChange={(v) => {
-                setAsyncSpanNameValue(v);
+                setAsyncSpanNameValue({ value: v });
                 onChange({
                   ...query,
                   spanName: v?.value || undefined,

--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
@@ -65,9 +65,20 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
   });
 
   async function fetchOptionsCallback(nameType: string, lp: TempoLanguageProvider) {
-    const res = await lp.getOptions(nameType === 'serviceName' ? 'service.name' : 'name');
-    setIsLoading((prevValue) => ({ ...prevValue, [nameType]: false }));
-    return res;
+    try {
+      const res = await lp.getOptions(nameType === 'serviceName' ? 'service.name' : 'name');
+      setIsLoading((prevValue) => ({ ...prevValue, [nameType]: false }));
+      return res;
+    } catch (error) {
+      if (error?.status === 404) {
+        setIsLoading((prevValue) => ({ ...prevValue, [nameType]: false }));
+      } else {
+        dispatch(notifyApp(createErrorNotification('Error', error)));
+        setIsLoading((prevValue) => ({ ...prevValue, [nameType]: false }));
+      }
+      setError(error);
+      return [];
+    }
   }
 
   const loadOptionsOfType = useCallback(
@@ -129,7 +140,9 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
             <AsyncSelect
               inputId="service"
               menuShouldPortal
+              cacheOptions={false}
               loadOptions={fetchOptionsOfType('serviceName')}
+              onOpenMenu={fetchOptionsOfType('serviceName')}
               isLoading={isLoading.serviceName}
               value={asyncServiceNameValue.value}
               onChange={(v) => {
@@ -154,7 +167,9 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
             <AsyncSelect
               inputId="spanName"
               menuShouldPortal
+              cacheOptions={false}
               loadOptions={fetchOptionsOfType('spanName')}
+              onOpenMenu={fetchOptionsOfType('spanName')}
               isLoading={isLoading.spanName}
               value={asyncSpanNameValue.value}
               onChange={(v) => {

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -9,7 +9,6 @@ import {
   DataSourceJsonData,
   isValidGoDuration,
   LoadingState,
-  SelectableValue,
 } from '@grafana/data';
 import { TraceToLogsOptions } from 'app/core/components/TraceToLogsSettings';
 import { config, BackendSrvRequest, DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
@@ -54,8 +53,8 @@ export interface TempoQuery extends DataQuery {
   linkedQuery?: LokiQuery;
   search: string;
   queryType: TempoQueryType;
-  serviceName?: string | SelectableValue;
-  spanName?: string | SelectableValue;
+  serviceName?: string;
+  spanName?: string;
   minDuration?: string;
   maxDuration?: string;
   limit?: number;

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -9,6 +9,7 @@ import {
   DataSourceJsonData,
   isValidGoDuration,
   LoadingState,
+  SelectableValue,
 } from '@grafana/data';
 import { TraceToLogsOptions } from 'app/core/components/TraceToLogsSettings';
 import { config, BackendSrvRequest, DataSourceWithBackend, getBackendSrv } from '@grafana/runtime';
@@ -53,8 +54,8 @@ export interface TempoQuery extends DataQuery {
   linkedQuery?: LokiQuery;
   search: string;
   queryType: TempoQueryType;
-  serviceName?: string;
-  spanName?: string;
+  serviceName?: string | SelectableValue;
+  spanName?: string | SelectableValue;
   minDuration?: string;
   maxDuration?: string;
   limit?: number;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
What would you like to be added:
Add a loading indicator to the service name and span name dropdowns. Fetching results may take a while and we should indicate to the user this is happening. Currently, it shows 'No options' while loading.

**Which issue(s) this PR fixes**:
Fixes: https://github.com/grafana/grafana/issues/44723

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

I'm not 100% sure the `onLoad` behavior is desirable, so LMK and if not then I'll update it, but here's a screenshot indicating that because the `loadOptionsAsync` happens on load, you'll see the spinner for a split second on load. 

<img width="1017" alt="Screen Shot 2022-02-10 at 3 14 43 PM" src="https://user-images.githubusercontent.com/27353719/153512786-711d9b37-161c-4fea-9ac0-fa9aa6e4af8d.png">

And each input will show a loader (and the text `Loading options...`) individually if `onClick` the list is still loading. (This loader is hard to capture a screenshot of; I will update this if I can before your review! But there's a test for this scenario as well.) And then when the promise resolves it'll either show `No options` (see screenshot below) or the options themselves.

<img width="1247" alt="Screen Shot 2022-02-10 at 3 07 54 PM" src="https://user-images.githubusercontent.com/27353719/153512132-7890af4b-22aa-4c80-bd47-61f5e78ef5f0.png">
 