### PR TITLE
Chore: update the variables sent to Slack for Levitate reporting

### DIFF
--- a/.github/workflows/detect-breaking-changes-report.yml
+++ b/.github/workflows/detect-breaking-changes-report.yml
@@ -107,9 +107,10 @@ jobs:
       with:
         payload: |
           {
-            "pr_link": "${{ github.event.workflow_run.pull_requests[0].url }}",
+            "pr_link": "${{ github.event.workflow_run.pull_requests[0].html_url }}",
             "pr_number": "${{ github.event.workflow_run.pull_requests[0].number }}",
             "job_link": "${{ steps.levitate-run.outputs.job_link }}",
+            "reporting_job_link": "${{ github.event.workflow_run.html_url }}",
             "message": "${{ steps.levitate-run.outputs.message }}"
           }
       env:


### PR DESCRIPTION
### What changed?
Changed to use the `.html_url` property instead of the previously used `.url` which turned out to give back an API link.
Also introduced a new variable which will point to the reporting workflow (we have different workflows for detecting the breaking changes and reporting them due to security reasons).