### PR TITLE
Loki: Uppercase autocomplete

### DIFF
--- a/public/app/plugins/datasource/loki/syntax.test.ts
+++ b/public/app/plugins/datasource/loki/syntax.test.ts
@@ -21,6 +21,9 @@ describe('Loki syntax', () => {
     expect(Prism.highlight('{key="value"', syntax, 'loki')).toBe(
       '<span class="token context-labels"><span class="token punctuation">{</span><span class="token label-key attr-name">key</span>=<span class="token label-value attr-value">"value"</span></span>'
     );
+    expect(Prism.highlight('{Key="value"', syntax, 'loki')).toBe(
+      '<span class="token context-labels"><span class="token punctuation">{</span><span class="token label-key attr-name">Key</span>=<span class="token label-value attr-value">"value"</span></span>'
+    );
   });
   it('should highlight functions in Loki query correctly', () => {
     expect(Prism.highlight('rate({key="value"}[5m])', syntax, 'loki')).toContain(

--- a/public/app/plugins/datasource/loki/syntax.ts
+++ b/public/app/plugins/datasource/loki/syntax.ts
@@ -192,7 +192,7 @@ export const lokiGrammar: Grammar = {
         pattern: /#.*/,
       },
       'label-key': {
-        pattern: /[a-z_]\w*(?=\s*(=|!=|=~|!~))/,
+        pattern: /[a-z_,A-Z_]\w*(?=\s*(=|!=|=~|!~))/,
         alias: 'attr-name',
         greedy: true,
       },

--- a/public/app/plugins/datasource/loki/syntax.ts
+++ b/public/app/plugins/datasource/loki/syntax.ts
@@ -192,7 +192,7 @@ export const lokiGrammar: Grammar = {
         pattern: /#.*/,
       },
       'label-key': {
-        pattern: /[a-z_,A-Z_]\w*(?=\s*(=|!=|=~|!~))/,
+        pattern: /[a-zA-Z_]\w*(?=\s*(=|!=|=~|!~))/,
         alias: 'attr-name',
         greedy: true,
       },


### PR DESCRIPTION
**What this PR does / why we need it**:
To allow Loki queries with labels that have an uppercase char for the first letter. 
To also allow syntax highlighting for the above.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/42573

**Special notes for your reviewer**:
Before
![Before](https://user-images.githubusercontent.com/90795735/153170595-1509e045-56b9-49d2-abf4-8f33118f0217.png)
After
![After](https://user-images.githubusercontent.com/90795735/153170610-65d62d5d-4f48-47f0-a752-9bf8a42ff615.png)

