### PR TITLE
fix(github_actions): workflow execution concurrency is now limited to 1

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -4,7 +4,8 @@ on:
     types: [labeled, unlabeled]
   issue_comment:
     types: [created]
-
+concurrency:
+  group: issue-commands
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -5,7 +5,7 @@ on:
   issue_comment:
     types: [created]
 concurrency:
-  group: issue-commands
+  group: issue-commands-${{ github.event.issue.number }}
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,7 +13,7 @@ on:
       - milestoned
       - demilestoned
 concurrency:
-  group: pr-checks
+  group: pr-checks-${{ github.event.issue.number }}
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,7 +12,8 @@ on:
     types:
       - milestoned
       - demilestoned
-
+concurrency:
+  group: pr-checks
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-commands-closed.yml
+++ b/.github/workflows/pr-commands-closed.yml
@@ -4,7 +4,7 @@ on:
     types:
       - closed      
 concurrency:
-  group: pr-commands-closed
+  group: pr-commands-closed-${{ github.event.issue.number }}
 jobs:
   close_job:
     # this job will only run if the PR has been closed without being merged

--- a/.github/workflows/pr-commands-closed.yml
+++ b/.github/workflows/pr-commands-closed.yml
@@ -3,7 +3,8 @@ on:
   pull_request:
     types:
       - closed      
-
+concurrency:
+  group: pr-commands-closed
 jobs:
   close_job:
     # this job will only run if the PR has been closed without being merged

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -4,7 +4,8 @@ on:
     types:
       - opened
       - synchronize
-
+concurrency:
+  group: pr-commands
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -5,7 +5,7 @@ on:
       - opened
       - synchronize
 concurrency:
-  group: pr-commands
+  group: pr-commands-${{ github.event.issue.number }}
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR limits concurrent runs on the following github action workflows:
- pr-checks
- pr-commands
- issue-commands
- pr-commands-closed

Limiting concurrency should help with flakiness of milestone and backport checks

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-github-actions/issues/76

**Special notes for your reviewer**:

