### PR TITLE
Angular: Add AngularJS plugin support deprecation plan to docs site

### DIFF
--- a/docs/sources/developers/angular_deprecation.md
+++ b/docs/sources/developers/angular_deprecation.md
@@ -5,7 +5,7 @@ keywords = ["grafana", "documentation", "developers", "resources"]
 
 # Angular support deprecation
 
-Angular plugin support is deprecated, meaning it will be removed in a future release. There are still many community plugins that depend on Grafana’s angular plugin support for them to work. The same is true for many internal (private) plugins that have been developed over the years by Grafana users. Grafana version 9 will have a server configuration option, global for the whole instance, that will control if angular plugin support is available or not. By default angular plugin support will be disabled.
+Angular plugin support is deprecated, and it will be removed in a future release. There are still many community plugins that depend on Grafana’s angular plugin support for them to work. The same is true for many internal (private) plugins developed over the years by Grafana users. Grafana version 9 will have a server configuration option, global for the whole instance, that will control if angular plugin support is available or not. By default, angular plugin support will be disabled.
 
 ## Why are we deprecating angular support?
 

--- a/docs/sources/developers/angular_deprecation.md
+++ b/docs/sources/developers/angular_deprecation.md
@@ -17,7 +17,7 @@ In Grafana version 9 coming in June 2022, all angular plugins will stop working 
 
 This is a good time to start working on migrating plugins to React.
 
-The plan is to fully remove angular plugin support in version 10 released in 2023. Meaning all plugins that do depend on angular will stop working and this temporary option to enable it introduced in v9 will be removed.
+Our plan is to fully remove angular plugin support in version 10 released in 2023. Meaning all plugins that do depend on angular will stop working and this temporary option to enable it introduced in v9 will be removed.
 
 ## How do I migrate an angular plugin to React?
 

--- a/docs/sources/developers/angular_deprecation.md
+++ b/docs/sources/developers/angular_deprecation.md
@@ -5,7 +5,7 @@ keywords = ["grafana", "documentation", "developers", "resources"]
 
 # Angular support deprecation
 
-Angular plugin support is to viewed as deprecated, meaning it will be removed in a future release. There are still many community plugins that depend on Grafana’s angular plugin support for them to work. The same is true for many internal (private) plugins that have been developed over the years by Grafana users. Grafana version 9 will have a server configuration option, global for the whole instance, that will control if angular plugin support is available or not. By default angular plugin support will be disabled.
+Angular plugin support is deprecated, meaning it will be removed in a future release. There are still many community plugins that depend on Grafana’s angular plugin support for them to work. The same is true for many internal (private) plugins that have been developed over the years by Grafana users. Grafana version 9 will have a server configuration option, global for the whole instance, that will control if angular plugin support is available or not. By default angular plugin support will be disabled.
 
 ## Why are we deprecating angular support?
 
@@ -15,7 +15,7 @@ AngularJS is an old frontend framework that stopped active development many year
 
 In Grafana version 9 coming in June 2022 all angular plugins will stop working unless a new server configuration option is turned on. So if you still depend on community or internally developed plugins that require AngularJS then you will have to turn this option on.
 
-This will flag the start of the depreciation period and a good time to start working on migrating plugins to React.
+This is a good time to start working on migrating plugins to React.
 
 The plan is to fully remove angular plugin support in version 10 released in 2023. Meaning all plugins that do depend on angular will stop working and this temporary option to enable it introduced in v9 will be removed.
 

--- a/docs/sources/developers/angular_deprecation.md
+++ b/docs/sources/developers/angular_deprecation.md
@@ -23,7 +23,7 @@ Our plan is to fully remove angular plugin support in version 10 released in 202
 
 Depending on if it’s a data source plugin, panel plugin, or app plugin the process will differ.
 
-For panels the rendering logic could in some cases be easily preserved but all options need to be redone to use the declarative options framework. For data source plugins the query editor and config options will likely need a total rewrite.
+For panels, the rendering logic could in some cases be easily preserved but all options need to be redone to use the declarative options framework. For data source plugins the query editor and config options will likely need a total rewrite.
 
 ### Links
 

--- a/docs/sources/developers/angular_deprecation.md
+++ b/docs/sources/developers/angular_deprecation.md
@@ -9,7 +9,7 @@ Angular plugin support is deprecated, meaning it will be removed in a future rel
 
 ## Why are we deprecating angular support?
 
-AngularJS is an old frontend framework that stopped active development many years ago. Because of that it is a security risk. AngularJS also requires unsafe-eval in the CSP (Content Security Policy) settings which also reduces the security level of how javascript is executed in the browser.
+AngularJS is an old frontend framework that stopped active development many years ago. As a result, it is a security risk. AngularJS also requires unsafe-eval in the CSP (Content Security Policy) settings which also reduces the security level of how javascript is executed in the browser.
 
 ## When will angular plugins stop working?
 

--- a/docs/sources/developers/angular_deprecation.md
+++ b/docs/sources/developers/angular_deprecation.md
@@ -13,7 +13,7 @@ AngularJS is an old frontend framework that stopped active development many year
 
 ## When will angular plugins stop working?
 
-In Grafana version 9 coming in June 2022 all angular plugins will stop working unless a new server configuration option is turned on. So if you still depend on community or internally developed plugins that require AngularJS then you will have to turn this option on.
+In Grafana version 9 coming in June 2022, all angular plugins will stop working unless a new server configuration option is turned on. If you still depend on community or internally developed plugins that require AngularJS then you will have to turn this option on.
 
 This is a good time to start working on migrating plugins to React.
 

--- a/docs/sources/developers/angular_deprecation.md
+++ b/docs/sources/developers/angular_deprecation.md
@@ -21,7 +21,7 @@ Our plan is to fully remove angular plugin support in version 10 released in 202
 
 ## How do I migrate an angular plugin to React?
 
-Depending on if it’s a data source plugin, panel plugin or app plugin the process will be a bit different.
+Depending on if it’s a data source plugin, panel plugin, or app plugin the process will differ.
 
 For panels the rendering logic could in some cases be easily preserved but all options need to be redone to use the declarative options framework. For data source plugins the query editor and config options will likely need a total rewrite.
 

--- a/docs/sources/developers/angular_deprecation.md
+++ b/docs/sources/developers/angular_deprecation.md
@@ -5,13 +5,13 @@ keywords = ["grafana", "documentation", "developers", "resources"]
 
 # Angular support deprecation
 
-In Grafana version 9 angular plugin support will be deprecated. By that point all core functionality will be written in React. There are still many community plugins that depend on Grafana’s angular plugin support for them to work. The same is true for many internal (private) plugins that have been developed over the years by Grafana users. Grafana version 9 will have a server configuration option, global for the whole instance, that will control if angular plugin support is available or not. By default angular plugin support will be disabled.
+Angular plugin support is to viewed as deprecated, meaning it will be removed in a future release. There are still many community plugins that depend on Grafana’s angular plugin support for them to work. The same is true for many internal (private) plugins that have been developed over the years by Grafana users. Grafana version 9 will have a server configuration option, global for the whole instance, that will control if angular plugin support is available or not. By default angular plugin support will be disabled.
 
 ## Why are we deprecating angular support?
 
 AngularJS is an old frontend framework that stopped active development many years ago. Because of that it is a security risk. AngularJS also requires unsafe-eval in the CSP (Content Security Policy) settings which also reduces the security level of how javascript is executed in the browser.
 
-## When is this deprecation happening?
+## When will angular plugins stop working?
 
 In Grafana version 9 coming in June 2022 all angular plugins will stop working unless a new server configuration option is turned on. So if you still depend on community or internally developed plugins that require AngularJS then you will have to turn this option on.
 

--- a/docs/sources/developers/angular_deprecation.md
+++ b/docs/sources/developers/angular_deprecation.md
@@ -1,0 +1,32 @@
++++
+title = "Angular support deprecation"
+keywords = ["grafana", "documentation", "developers", "resources"]
++++
+
+# Angular support deprecation
+
+In Grafana version 9 angular plugin support will be deprecated. By that point all core functionality will be written in React. There are still many community plugins that depend on Grafana’s angular plugin support for them to work. The same is true for many internal (private) plugins that have been developed over the years by Grafana users. Grafana version 9 will have a server configuration option, global for the whole instance, that will control if angular plugin support is available or not. By default angular plugin support will be disabled.
+
+## Why are we deprecating angular support?
+
+AngularJS is an old frontend framework that stopped active development many years ago. Because of that it is a security risk. AngularJS also requires unsafe-eval in the CSP (Content Security Policy) settings which also reduces the security level of how javascript is executed in the browser.
+
+## When is this deprecation happening?
+
+In Grafana version 9 coming in June 2022 all angular plugins will stop working unless a new server configuration option is turned on. So if you still depend on community or internally developed plugins that require AngularJS then you will have to turn this option on.
+
+This will flag the start of the depreciation period and a good time to start working on migrating plugins to React.
+
+The plan is to fully remove angular plugin support in version 10 released in 2023. Meaning all plugins that do depend on angular will stop working and this temporary option to enable it introduced in v9 will be removed.
+
+## How do I migrate an angular plugin to React?
+
+Depending on if it’s a data source plugin, panel plugin or app plugin the process will be a bit different.
+
+For panels the rendering logic could in some cases be easily preserved but all options need to be redone to use the declarative options framework. For data source plugins the query editor and config options will likely need a total rewrite.
+
+### Links
+
+- [Migrate Angular to React](https://grafana.com/docs/grafana/latest/developers/plugins/migration-guide/#migrate-a-plugin-from-angular-to-react)
+- [Build a panel plugin](https://grafana.com/tutorials/build-a-panel-plugin/)
+- [Build a data source plugin](https://grafana.com/tutorials/build-a-data-source-plugin/)


### PR DESCRIPTION

# Deprecation notice

AngularJS plugin support is now in a deprecated state, meaning it will be removed in a future release. Currently, that is planned for version 10 (in 2023). The documentation site has an [article](https://grafana.com/docs/grafana/next/developers/angular_deprecation/) with more details on why, when, and how. 