### PR TITLE
Logging: Fix so that filters can contain commented lines 

### DIFF
--- a/pkg/infra/log/log.go
+++ b/pkg/infra/log/log.go
@@ -251,7 +251,14 @@ func getLogLevelFromString(levelName string) level.Option {
 func getFilters(filterStrArray []string) map[string]level.Option {
 	filterMap := make(map[string]level.Option)
 
-	for _, filterStr := range filterStrArray {
+	for i := 0; i < len(filterStrArray); i++ {
+		filterStr := strings.TrimSpace(filterStrArray[i])
+
+		if filterStr == ";" || filterStr == "#" {
+			i++
+			continue
+		}
+
 		parts := strings.Split(filterStr, ":")
 		if len(parts) > 1 {
 			filterMap[parts[0]] = getLogLevelFromString(parts[1])

--- a/pkg/infra/log/log.go
+++ b/pkg/infra/log/log.go
@@ -254,8 +254,10 @@ func getFilters(filterStrArray []string) map[string]level.Option {
 	for i := 0; i < len(filterStrArray); i++ {
 		filterStr := strings.TrimSpace(filterStrArray[i])
 
-		if filterStr == ";" || filterStr == "#" {
-			i++
+		if strings.HasPrefix(filterStr, ";") || strings.HasPrefix(filterStr, "#") {
+			if len(filterStr) == 1 {
+				i++
+			}
 			continue
 		}
 

--- a/pkg/infra/log/log_test.go
+++ b/pkg/infra/log/log_test.go
@@ -137,11 +137,11 @@ func TestGetFilters(t *testing.T) {
           oauth.generic_oauth:debug \
           ; oauth.okta:debug \
           ; tsdb.postgres:debug \
-          ; tsdb.mssql:debug \
-          ; provisioning.plugins:debug \
+          ;tsdb.mssql:debug \
+          #provisioning.plugins:debug \
           provisioning.dashboard:debug \
           data-proxy-log:debug \
-          ; oauthtoken:debug \
+          ;oauthtoken:debug \
           plugins.backend:debug \
           tsdb.elasticsearch.client:debug \
           server:debug \

--- a/pkg/infra/log/log_test.go
+++ b/pkg/infra/log/log_test.go
@@ -7,6 +7,7 @@ import (
 
 	gokitlog "github.com/go-kit/log"
 	"github.com/grafana/grafana/pkg/infra/log/level"
+	"github.com/grafana/grafana/pkg/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -105,5 +106,75 @@ func TestLogger(t *testing.T) {
 			require.Len(t, loggedArgs, 4)
 			require.Len(t, swappedLoggedArgs, 7, "expected 4 messages for AllowAll logger and 3 messages for AllowInfo logger")
 		})
+	})
+}
+
+func TestGetFilters(t *testing.T) {
+	t.Run("Parsing filters on single line with only space should return expected result", func(t *testing.T) {
+		filter := `   `
+		filters := getFilters(util.SplitString(filter))
+		require.Len(t, filters, 0)
+	})
+
+	t.Run("Parsing filters on single line with should return expected result", func(t *testing.T) {
+		filter := `rendering:debug oauth.generic_oauth:debug testwithoutlevel provisioning.dashboard:debug`
+		filters := getFilters(util.SplitString(filter))
+		keys := []string{}
+		for k := range filters {
+			keys = append(keys, k)
+		}
+
+		require.ElementsMatch(t, []string{
+			"rendering",
+			"oauth.generic_oauth",
+			"provisioning.dashboard",
+		}, keys)
+	})
+
+	t.Run("Parsing filters spread over multiple lines with comments should return expected result", func(t *testing.T) {
+		filter := `rendering:debug \
+          ; alerting.notifier:debug \
+          oauth.generic_oauth:debug \
+          ; oauth.okta:debug \
+          ; tsdb.postgres:debug \
+          ; tsdb.mssql:debug \
+          ; provisioning.plugins:debug \
+          provisioning.dashboard:debug \
+          data-proxy-log:debug \
+          ; oauthtoken:debug \
+          plugins.backend:debug \
+          tsdb.elasticsearch.client:debug \
+          server:debug \
+          tsdb.graphite:debug \
+          auth:debug \
+          plugin.manager:debug \
+          plugin.initializer:debug \
+          plugin.loader:debug \
+          plugin.finder:debug \
+          plugin.installer:debug \
+          plugin.signature.validator:debug`
+		filters := getFilters(util.SplitString(filter))
+		keys := []string{}
+		for k := range filters {
+			keys = append(keys, k)
+		}
+
+		require.ElementsMatch(t, []string{
+			"rendering",
+			"oauth.generic_oauth",
+			"provisioning.dashboard",
+			"data-proxy-log",
+			"plugins.backend",
+			"tsdb.elasticsearch.client",
+			"server",
+			"tsdb.graphite",
+			"auth",
+			"plugin.manager",
+			"plugin.initializer",
+			"plugin.loader",
+			"plugin.finder",
+			"plugin.installer",
+			"plugin.signature.validator",
+		}, keys)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes log filters that contains comments should not be enabled:
```
filters = rendering:debug \
          ; alerting.notifier:debug \
          oauth.generic_oauth:debug \
          ; oauth.okta:debug \
          ; tsdb.postgres:debug \
          ; tsdb.mssql:debug \
          ; provisioning.plugins:debug \
          ; provisioning:debug \
          ; provisioning.dashboard:debug \
          # provisioning.datasources:debug \
          data-proxy-log:debug \
          ; oauthtoken:debug \
          plugins.backend:debug \
          tsdb.elasticsearch.client:debug \
          server:debug \
          tsdb.graphite:debug \
          auth:debug \
          plugin.manager:debug \
          plugin.initializer:debug \
          plugin.loader:debug \
          plugin.finder:debug \
          plugin.installer:debug \
          plugin.signature.validator:debug
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

