### PR TITLE
ContextMenu: make focus on open optional

### DIFF
--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
@@ -11,6 +11,8 @@ export interface ContextMenuProps {
   y: number;
   /** Callback for closing the menu */
   onClose?: () => void;
+  /** Enable focus on first Menu element on openning the menu */
+  focusOnOpen?: boolean;
   /** RenderProp function that returns menu items to display */
   renderMenuItems?: () => React.ReactNode;
   /** A function that returns header element */
@@ -18,7 +20,7 @@ export interface ContextMenuProps {
 }
 
 export const ContextMenu: React.FC<ContextMenuProps> = React.memo(
-  ({ x, y, onClose, renderMenuItems, renderHeader }) => {
+  ({ x, y, onClose, focusOnOpen = true, renderMenuItems, renderHeader }) => {
     const menuRef = useRef<HTMLDivElement>(null);
     const [positionStyles, setPositionStyles] = useState({});
 
@@ -46,7 +48,9 @@ export const ContextMenu: React.FC<ContextMenuProps> = React.memo(
     const header = renderHeader?.();
     const menuItems = renderMenuItems?.();
     const onOpen = (setFocusedItem: (a: number) => void) => {
-      setFocusedItem(0);
+      if (focusOnOpen) {
+        setFocusedItem(0);
+      }
     };
     const onKeyDown = (e: React.KeyboardEvent) => {
       if (e.key === 'Escape') {

--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenu.tsx
@@ -11,7 +11,7 @@ export interface ContextMenuProps {
   y: number;
   /** Callback for closing the menu */
   onClose?: () => void;
-  /** Enable focus on first Menu element on openning the menu */
+  /** On menu open focus the first element */
   focusOnOpen?: boolean;
   /** RenderProp function that returns menu items to display */
   renderMenuItems?: () => React.ReactNode;

--- a/packages/grafana-ui/src/components/ContextMenu/WithContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/WithContextMenu.tsx
@@ -6,9 +6,11 @@ interface WithContextMenuProps {
   children: (props: { openMenu: React.MouseEventHandler<HTMLElement> }) => JSX.Element;
   /** A function that returns an array of menu items */
   renderMenuItems: () => React.ReactNode;
+  /** Enable focus on first Menu element on openning the menu */
+  focusOnOpen?: boolean;
 }
 
-export const WithContextMenu: React.FC<WithContextMenuProps> = ({ children, renderMenuItems }) => {
+export const WithContextMenu: React.FC<WithContextMenuProps> = ({ children, renderMenuItems, focusOnOpen = true }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 });
   return (
@@ -29,6 +31,7 @@ export const WithContextMenu: React.FC<WithContextMenuProps> = ({ children, rend
           x={menuPosition.x}
           y={menuPosition.y}
           renderMenuItems={renderMenuItems}
+          focusOnOpen={focusOnOpen}
         />
       )}
     </>

--- a/packages/grafana-ui/src/components/ContextMenu/WithContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/WithContextMenu.tsx
@@ -6,7 +6,7 @@ interface WithContextMenuProps {
   children: (props: { openMenu: React.MouseEventHandler<HTMLElement> }) => JSX.Element;
   /** A function that returns an array of menu items */
   renderMenuItems: () => React.ReactNode;
-  /** Enable focus on first Menu element on openning the menu */
+  /** On menu open focus the first element */
   focusOnOpen?: boolean;
 }
 


### PR DESCRIPTION
This is extracted from https://github.com/grafana/grafana/pull/44980

In that UI, we need to avoid setting(changing!) focus when the context opens.  This adds a simple flag to avoid the default behavior
