### PR TITLE
Drop unused debian packages

### DIFF
--- a/docs/sources/setup-grafana/installation/debian.md
+++ b/docs/sources/setup-grafana/installation/debian.md
@@ -38,7 +38,6 @@ If you install from the APT repository, then Grafana is automatically updated ev
 #### To install the latest Enterprise edition:
 
 ```bash
-sudo apt-get install -y software-properties-common wget
 wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
 ```
 
@@ -64,7 +63,7 @@ sudo apt-get install grafana-enterprise
 #### To install the latest OSS release:
 
 ```bash
-sudo apt-get install -y software-properties-common wget
+sudo apt-get install -y wget
 wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
 ```
 

--- a/docs/sources/setup-grafana/installation/debian.md
+++ b/docs/sources/setup-grafana/installation/debian.md
@@ -38,7 +38,6 @@ If you install from the APT repository, then Grafana is automatically updated ev
 #### To install the latest Enterprise edition:
 
 ```bash
-sudo apt-get install -y apt-transport-https
 sudo apt-get install -y software-properties-common wget
 wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
 ```
@@ -65,7 +64,6 @@ sudo apt-get install grafana-enterprise
 #### To install the latest OSS release:
 
 ```bash
-sudo apt-get install -y apt-transport-https
 sudo apt-get install -y software-properties-common wget
 wget -q -O - https://packages.grafana.com/gpg.key | sudo apt-key add -
 ```

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -119,7 +119,6 @@ COPY --from=toolchain /tmp/dockerize /usr/local/bin/
 RUN apt-get update && \
     apt-get install -yq  \
         build-essential netcat-traditional clang gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf gcc-mingw-w64-x86-64 \
-        apt-transport-https \
         python-pip      \
         ca-certificates \
         curl            \

--- a/scripts/verify-repo-update/Dockerfile.deb
+++ b/scripts/verify-repo-update/Dockerfile.deb
@@ -5,7 +5,6 @@ ARG PACKAGE=grafana
 
 RUN apt update && \
     apt install -y curl                \
-                   apt-transport-https \
                    ca-certificates     \
                    gnupg               && \
     curl https://packages.grafana.com/gpg.key | apt-key add -


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove now unneeded apt packages (apt-transport-https and software-properties-common) from install instructions.

*apt-transport-https* is a virtual package since Ubuntu Bionic as apt
natively supports HTTPS repos since then, see:
https://packages.ubuntu.com/bionic/apt-transport-https

*software-properties-common* was used for the add-apt-repository command
that is no longer used since commit 26cf3d9

**Which issue(s) this PR fixes**:

n/a as it's a drive-by PR.