### PR TITLE
Fetch: parse JSON off-main-thread (async) based on response Content-Type

### DIFF
--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -192,7 +192,7 @@ export class BackendSrv implements BackendService {
       mergeMap(async (response) => {
         const { status, statusText, ok, headers, url, type, redirected } = response;
 
-        let responseType = options.responseType ?? (isContentTypeApplicationJson(headers) ? 'json' : undefined);
+        const responseType = options.responseType ?? (isContentTypeApplicationJson(headers) ? 'json' : undefined);
 
         const data = await parseResponseBody<T>(response, responseType);
         const fetchResponse: FetchResponse<T> = {

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -20,7 +20,12 @@ import { getConfig } from 'app/core/config';
 import { DashboardSearchHit } from 'app/features/search/types';
 import { FolderDTO } from 'app/types';
 import { ContextSrv, contextSrv } from './context_srv';
-import { parseInitFromOptions, parseResponseBody, parseUrlFromOptions } from '../utils/fetch';
+import {
+  isContentTypeApplicationJson,
+  parseInitFromOptions,
+  parseResponseBody,
+  parseUrlFromOptions,
+} from '../utils/fetch';
 import { isDataQuery, isLocalUrl } from '../utils/query';
 import { FetchQueue } from './FetchQueue';
 import { ResponseQueue } from './ResponseQueue';
@@ -187,7 +192,9 @@ export class BackendSrv implements BackendService {
       mergeMap(async (response) => {
         const { status, statusText, ok, headers, url, type, redirected } = response;
 
-        const data = await parseResponseBody<T>(response, options.responseType);
+        let responseType = options.responseType ?? (isContentTypeApplicationJson(headers) ? 'json' : undefined);
+
+        const data = await parseResponseBody<T>(response, responseType);
         const fetchResponse: FetchResponse<T> = {
           status,
           statusText,


### PR DESCRIPTION
not sure this is the correct place to fix it, or why `parseResponseBody<T>(response, options.responseType)` has not been using the response's content type headers. `options.responseType` seems to always be `undefined` which then ends up using the blocking/synchronous `JSON.parse()`.

https://github.com/grafana/grafana/blob/c7a5d2c5c7ab81357466b9630b098f4e02d394e4/public/app/core/utils/fetch.ts#L115-L119

i suspect this happens on the main thread. when testing a heavy heatmap response, this turned up as the top profile item. after this change, it gets absorbed into the `program` bucket.

10x random-data refreshes (45k points per refresh):

before:

![image](https://user-images.githubusercontent.com/43234/153319604-3c9ec17a-9a23-4fd3-bcc5-39fc7126addd.png)

after:

![image](https://user-images.githubusercontent.com/43234/153319714-6db14679-9bcb-4a9d-b107-38788b551548.png)
