### PR TITLE
LibraryPanels: Prevent long descriptions and names from obscuring the delete button

### DIFF
--- a/public/app/features/panel/components/VizTypePicker/PanelTypeCard.tsx
+++ b/public/app/features/panel/components/VizTypePicker/PanelTypeCard.tsx
@@ -120,7 +120,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     description: css`
       text-overflow: ellipsis;
       overflow: hidden;
-      white-space: nowrap;
       color: ${theme.colors.text.secondary};
       font-size: ${theme.typography.bodySmall.fontSize};
       font-weight: ${theme.typography.fontWeightLight};

--- a/public/app/features/panel/components/VizTypePicker/PanelTypeCard.tsx
+++ b/public/app/features/panel/components/VizTypePicker/PanelTypeCard.tsx
@@ -112,7 +112,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     name: css`
       text-overflow: ellipsis;
       overflow: hidden;
-      white-space: nowrap;
       font-size: ${theme.typography.size.sm};
       font-weight: ${theme.typography.fontWeightMedium};
       width: 100%;


### PR DESCRIPTION
**What this PR does / why we need it**:

Extremely long library panel descriptions will not wrap. This blocks the Trash Can icon and makes deletion impossible from the dashboard manager. This fixes the descriptions so the text wraps.

Before:

![CleanShot 2022-02-09 at 15 46 32@2x](https://user-images.githubusercontent.com/37156449/153323052-791b20ec-7b39-4d88-8985-3ae631e2ddad.png)

After:

![CleanShot 2022-02-09 at 15 46 44@2x](https://user-images.githubusercontent.com/37156449/153323017-c9e33258-cf17-4af4-8c85-d43b409e3bd5.png)

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/45090

**Special notes for your reviewer**:

