### PR TITLE
Auth: support AWS ALB JWT

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -564,6 +564,7 @@ jwk_set_file =
 cache_ttl = 60m
 expected_claims = {}
 key_file =
+key_url =
 auto_sign_up = false
 
 #################################### Auth LDAP ###########################

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -318,6 +318,7 @@ type Cfg struct {
 	JWTAuthJWKSetURL     string
 	JWTAuthCacheTTL      time.Duration
 	JWTAuthKeyFile       string
+	JWTAuthKeyURL        string
 	JWTAuthJWKSetFile    string
 	JWTAuthAutoSignUp    bool
 
@@ -1275,6 +1276,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	cfg.JWTAuthJWKSetURL = valueAsString(authJWT, "jwk_set_url", "")
 	cfg.JWTAuthCacheTTL = authJWT.Key("cache_ttl").MustDuration(time.Minute * 60)
 	cfg.JWTAuthKeyFile = valueAsString(authJWT, "key_file", "")
+	cfg.JWTAuthKeyURL = valueAsString(authJWT, "key_url", "")
 	cfg.JWTAuthJWKSetFile = valueAsString(authJWT, "jwk_set_file", "")
 	cfg.JWTAuthAutoSignUp = authJWT.Key("auto_sign_up").MustBool(false)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for AWS ALB JWT authentication.

AWS ALB is popular service, and it provides authentication feature.
If authentication is enabled, ALB pass header which includes JWT to backend instance.

AWS doesn't provides public key as JWK, and key URL contain key id.
Current Grafana implementation doesn't support it.

There is sample code how to verify JWT in official doc.
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/listener-authenticate-users.html#user-claims-encoding

**Which issue(s) this PR fixes**:
related to https://github.com/grafana/grafana/issues/44261

**Special notes for your reviewer**:
There is a pitfall. If JWT contain extra padding, go-jose return `error in cryptographic primitive` error.

AWS JWT does not conform to standard.
https://github.com/auth0/node-jws/pull/84#issuecomment-733045578
https://github.com/golang-jwt/jwt/issues/92

go-jose generate data to be signed from parsed JWT data.
https://github.com/square/go-jose/blob/v2.5.1/jws.go#L105-L138

The computed sign doesn't match to JWT embedded sign.

Currently, I don't have idea to fix this without forking go-jose or switching other library.