### PR TITLE
Routing: Fix links to different port from being treated as internal links

### DIFF
--- a/packages/grafana-data/src/utils/location.test.ts
+++ b/packages/grafana-data/src/utils/location.test.ts
@@ -3,7 +3,7 @@ import { locationUtil } from './location';
 describe('locationUtil', () => {
   const { location } = window;
 
-  beforeAll(() => {
+  beforeEach(() => {
     // @ts-ignore
     delete window.location;
 
@@ -21,63 +21,97 @@ describe('locationUtil', () => {
     };
   });
 
-  afterAll(() => {
+  afterEach(() => {
     window.location = location;
   });
 
-  describe('strip base when appSubUrl configured', () => {
-    beforeEach(() => {
-      locationUtil.initialize({
-        config: { appSubUrl: '/subUrl' } as any,
-        getVariablesUrlParams: (() => {}) as any,
-        getTimeRangeForUrl: (() => {}) as any,
+  describe('stripBaseFromUrl', () => {
+    describe('when appSubUrl configured', () => {
+      beforeEach(() => {
+        locationUtil.initialize({
+          config: { appSubUrl: '/subUrl' } as any,
+          getVariablesUrlParams: (() => {}) as any,
+          getTimeRangeForUrl: (() => {}) as any,
+        });
       });
-    });
-    test('relative url', () => {
-      const urlWithoutMaster = locationUtil.stripBaseFromUrl('/subUrl/thisShouldRemain/');
-      expect(urlWithoutMaster).toBe('/thisShouldRemain/');
-    });
-    test('relative url with multiple subUrl in path', () => {
-      const urlWithoutMaster = locationUtil.stripBaseFromUrl('/subUrl/thisShouldRemain/subUrl/');
-      expect(urlWithoutMaster).toBe('/thisShouldRemain/subUrl/');
-    });
-    test('relative url with subdirectory subUrl', () => {
-      const urlWithoutMaster = locationUtil.stripBaseFromUrl('/thisShouldRemain/subUrl/');
-      expect(urlWithoutMaster).toBe('/thisShouldRemain/subUrl/');
-    });
-    test('absolute url', () => {
-      const urlWithoutMaster = locationUtil.stripBaseFromUrl('http://www.domain.com:9877/subUrl/thisShouldRemain/');
-      expect(urlWithoutMaster).toBe('/thisShouldRemain/');
-    });
-    test('absolute url with multiple subUrl in path', () => {
-      const urlWithoutMaster = locationUtil.stripBaseFromUrl(
-        'http://www.domain.com:9877/subUrl/thisShouldRemain/subUrl/'
-      );
-      expect(urlWithoutMaster).toBe('/thisShouldRemain/subUrl/');
-    });
-    test('absolute url with subdirectory subUrl', () => {
-      const urlWithoutMaster = locationUtil.stripBaseFromUrl('http://www.domain.com:9877/thisShouldRemain/subUrl/');
-      expect(urlWithoutMaster).toBe('http://www.domain.com:9877/thisShouldRemain/subUrl/');
-    });
-  });
-
-  describe('strip base when appSubUrl not configured', () => {
-    beforeEach(() => {
-      locationUtil.initialize({
-        config: {} as any,
-        getVariablesUrlParams: (() => {}) as any,
-        getTimeRangeForUrl: (() => {}) as any,
+      test('relative url', () => {
+        const urlWithoutMaster = locationUtil.stripBaseFromUrl('/subUrl/thisShouldRemain/');
+        expect(urlWithoutMaster).toBe('/thisShouldRemain/');
+      });
+      test('relative url with multiple subUrl in path', () => {
+        const urlWithoutMaster = locationUtil.stripBaseFromUrl('/subUrl/thisShouldRemain/subUrl/');
+        expect(urlWithoutMaster).toBe('/thisShouldRemain/subUrl/');
+      });
+      test('relative url with subdirectory subUrl', () => {
+        const urlWithoutMaster = locationUtil.stripBaseFromUrl('/thisShouldRemain/subUrl/');
+        expect(urlWithoutMaster).toBe('/thisShouldRemain/subUrl/');
+      });
+      test('absolute url', () => {
+        const urlWithoutMaster = locationUtil.stripBaseFromUrl('http://www.domain.com:9877/subUrl/thisShouldRemain/');
+        expect(urlWithoutMaster).toBe('/thisShouldRemain/');
+      });
+      test('absolute url with multiple subUrl in path', () => {
+        const urlWithoutMaster = locationUtil.stripBaseFromUrl(
+          'http://www.domain.com:9877/subUrl/thisShouldRemain/subUrl/'
+        );
+        expect(urlWithoutMaster).toBe('/thisShouldRemain/subUrl/');
+      });
+      test('absolute url with subdirectory subUrl', () => {
+        const urlWithoutMaster = locationUtil.stripBaseFromUrl('http://www.domain.com:9877/thisShouldRemain/subUrl/');
+        expect(urlWithoutMaster).toBe('http://www.domain.com:9877/thisShouldRemain/subUrl/');
       });
     });
 
-    test('relative url', () => {
-      const urlWithoutMaster = locationUtil.stripBaseFromUrl('/subUrl/grafana/');
-      expect(urlWithoutMaster).toBe('/subUrl/grafana/');
+    describe('when appSubUrl not configured', () => {
+      beforeEach(() => {
+        locationUtil.initialize({
+          config: {} as any,
+          getVariablesUrlParams: (() => {}) as any,
+          getTimeRangeForUrl: (() => {}) as any,
+        });
+      });
+
+      test('relative url', () => {
+        const urlWithoutMaster = locationUtil.stripBaseFromUrl('/subUrl/grafana/');
+        expect(urlWithoutMaster).toBe('/subUrl/grafana/');
+      });
+
+      test('absolute url', () => {
+        const urlWithoutMaster = locationUtil.stripBaseFromUrl('http://www.domain.com:9877/subUrl/grafana/');
+        expect(urlWithoutMaster).toBe('/subUrl/grafana/');
+      });
     });
 
-    test('absolute url', () => {
-      const urlWithoutMaster = locationUtil.stripBaseFromUrl('http://www.domain.com:9877/subUrl/grafana/');
-      expect(urlWithoutMaster).toBe('/subUrl/grafana/');
+    describe('when origin does not have a port in it', () => {
+      beforeEach(() => {
+        window.location = {
+          ...location,
+          hash: '#hash',
+          host: 'www.domain.com',
+          hostname: 'www.domain.com',
+          href: 'http://www.domain.com/path/b?search=a&b=c&d#hash',
+          origin: 'http://www.domain.com',
+          pathname: '/path/b',
+          port: '',
+          protocol: 'http:',
+          search: '?search=a&b=c&d',
+        };
+      });
+
+      test('relative url', () => {
+        const urlWithoutMaster = locationUtil.stripBaseFromUrl('/subUrl/grafana/');
+        expect(urlWithoutMaster).toBe('/subUrl/grafana/');
+      });
+
+      test('URL with same host, different port', () => {
+        const urlWithoutMaster = locationUtil.stripBaseFromUrl('http://www.domain.com:9877/subUrl/grafana/');
+        expect(urlWithoutMaster).toBe('http://www.domain.com:9877/subUrl/grafana/');
+      });
+
+      test('URL of a completely different origin', () => {
+        const urlWithoutMaster = locationUtil.stripBaseFromUrl('http://www.another-domain.com/subUrl/grafana/');
+        expect(urlWithoutMaster).toBe('http://www.another-domain.com/subUrl/grafana/');
+      });
     });
   });
 


### PR DESCRIPTION
**What this PR does / why we need it**:

If you hosted Grafana on a "portless" origin (like port 80, https://mygrafana.com), and you linked to the same domain but different port (like https://mygrafana.com:3000), Grafana would think it's an internal link and try to do a react-router .push() on that.

This fixes that behaviour so they're properly treated as an external URL.

I would like to have refactored the `stripBaseFromUrl` function a bit more rather than adding extra code on top, but it's a bit too gnarly and every time I changed something tests broke. So here we are.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/44711

