### PR TITLE
Chore: Remove `menuShouldPortal` deprecation warning

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -20,7 +20,6 @@ import { useTheme2 } from '../../themes';
 import { getSelectStyles } from './getSelectStyles';
 import { cleanValue, findSelectedValue } from './utils';
 import { ActionMeta, SelectBaseProps, SelectValue } from './types';
-import { deprecationWarning } from '@grafana/data';
 
 interface ExtraValuesIndicatorProps {
   maxVisibleValues?: number | undefined;

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -119,6 +119,7 @@ export function SelectBase<T>({
   maxVisibleValues,
   menuPlacement = 'auto',
   menuPosition,
+  // TODO change this to default to true for Grafana 9
   menuShouldPortal = false,
   noOptionsMessage = 'No options found',
   onBlur,
@@ -140,9 +141,6 @@ export function SelectBase<T>({
   isValidNewOption,
   formatOptionLabel,
 }: SelectBaseProps<T>) {
-  if (menuShouldPortal === false) {
-    deprecationWarning('SelectBase', 'menuShouldPortal={false}', 'menuShouldPortal={true}');
-  }
   const theme = useTheme2();
   const styles = getSelectStyles(theme);
 

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -47,9 +47,8 @@ export interface SelectCommonProps<T> {
   menuPlacement?: 'auto' | 'bottom' | 'top';
   menuPosition?: 'fixed' | 'absolute';
   /**
-   * @deprecated
    * Setting to true will portal the menu to `document.body`.
-   * This property will soon be removed and portalling will be the default behavior.
+   * This property will soon default to true and portalling will be the default behavior.
    */
   menuShouldPortal?: boolean;
   /** The message to display when no options could be found */

--- a/yarn.lock
+++ b/yarn.lock
@@ -29082,7 +29082,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.6, postcss@npm:^8.4.6":
+"postcss@npm:8.4.6, postcss@npm:^8.4.5, postcss@npm:^8.4.6":
   version: 8.4.6
   resolution: "postcss@npm:8.4.6"
   dependencies:


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- `menuShouldPortal` isn't really deprecated, we just intend to switch the behaviour to default to true in Grafana 9
- had feedback that this warning is confusing, so let's remove it and just flip the switch in Grafana 9.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

