### PR TITLE
Prometheus: Add rest of prometheus operation ids

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/aggregations.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/aggregations.ts
@@ -7,25 +7,25 @@ import {
   getPromAndLokiOperationDisplayName,
 } from './shared/operationUtils';
 import { QueryBuilderOperation, QueryBuilderOperationDef, QueryBuilderOperationParamDef } from './shared/types';
-import { PromVisualQueryOperationCategory } from './types';
+import { PromVisualQueryOperationCategory, PromOperationId } from './types';
 
 export function getAggregationOperations(): QueryBuilderOperationDef[] {
   return [
-    ...createAggregationOperation('sum'),
-    ...createAggregationOperation('avg'),
-    ...createAggregationOperation('min'),
-    ...createAggregationOperation('max'),
-    ...createAggregationOperation('count'),
-    ...createAggregationOperation('topk'),
-    createAggregationOverTime('sum'),
-    createAggregationOverTime('avg'),
-    createAggregationOverTime('min'),
-    createAggregationOverTime('max'),
-    createAggregationOverTime('count'),
-    createAggregationOverTime('last'),
-    createAggregationOverTime('present'),
-    createAggregationOverTime('stddev'),
-    createAggregationOverTime('stdvar'),
+    ...createAggregationOperation(PromOperationId.Sum),
+    ...createAggregationOperation(PromOperationId.Avg),
+    ...createAggregationOperation(PromOperationId.Min),
+    ...createAggregationOperation(PromOperationId.Max),
+    ...createAggregationOperation(PromOperationId.Count),
+    ...createAggregationOperation(PromOperationId.Topk),
+    createAggregationOverTime(PromOperationId.SumOverTime),
+    createAggregationOverTime(PromOperationId.AvgOverTime),
+    createAggregationOverTime(PromOperationId.MinOverTime),
+    createAggregationOverTime(PromOperationId.MaxOverTime),
+    createAggregationOverTime(PromOperationId.CountOverTime),
+    createAggregationOverTime(PromOperationId.LastOverTime),
+    createAggregationOverTime(PromOperationId.PresentOverTime),
+    createAggregationOverTime(PromOperationId.StddevOverTime),
+    createAggregationOverTime(PromOperationId.StdvarOverTime),
   ];
 }
 
@@ -172,10 +172,9 @@ function getOnLabelAdddedHandler(changeToOperartionId: string) {
 }
 
 function createAggregationOverTime(name: string): QueryBuilderOperationDef {
-  const functionName = `${name}_over_time`;
   return {
-    id: functionName,
-    name: getPromAndLokiOperationDisplayName(functionName),
+    id: name,
+    name: getPromAndLokiOperationDisplayName(name),
     params: [getAggregationOverTimeRangeVector()],
     defaultParams: ['auto'],
     alternativesKey: 'overtime function',

--- a/public/app/plugins/datasource/prometheus/querybuilder/types.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/types.ts
@@ -32,6 +32,21 @@ export enum PromOperationId {
   MultiplyBy = '__multiply_by',
   DivideBy = '__divide_by',
   NestedQuery = '__nested_query',
+  Sum = 'sum',
+  Avg = 'avg',
+  Min = 'min',
+  Max = 'max',
+  Count = 'count',
+  Topk = 'topk',
+  SumOverTime = 'sum_over_time',
+  AvgOverTime = 'avg_over_time',
+  MinOverTime = 'min_over_time',
+  MaxOverTime = 'max_over_time',
+  CountOverTime = 'count_over_time',
+  LastOverTime = 'last_over_time',
+  PresentOverTime = 'present_over_time',
+  StddevOverTime = 'stddev_over_time',
+  StdvarOverTime = 'stdvar_over_time',
 }
 
 export interface PromQueryPattern {


### PR DESCRIPTION
Adds `PromOperationIds` for aggregation and aggregation over time operations. This is going to help with safety of hint fixes. 