### PR TITLE
feature-flags: enable fullRangeLogsVolume by default

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1094,6 +1094,7 @@ enable =
 
 # feature1 = true
 # feature2 = false
+fullRangeLogsVolume = true
 
 [date_formats]
 # For information on what formatting patterns that are supported https://momentjs.com/docs/#/displaying/


### PR DESCRIPTION
the plan is to have this feature-flag enabled-by-default for one minor release (so that users can disable it if they want to), and then the feature-flag will be removed (so there will be no way to disable it).

the code works, but i'm not 100% sure if adding to `defaults.ini` is the best approach here.

NOTE: @bergquist @marefr i added you as reviewers to review if this is the right way to do a by-default-enabled feature-flag, there's no need to review the functionality itself. (i'll add other reviewers for that).thanks!