### PR TITLE
Access control: add the permission to read org users to team creator

### DIFF
--- a/pkg/api/roles.go
+++ b/pkg/api/roles.go
@@ -215,11 +215,12 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		Role: accesscontrol.RoleDTO{
 			Name:        "fixed:teams:creator",
 			DisplayName: "Team creator",
-			Description: "Create teams.",
+			Description: "Create teams and read organisation users (required to manage the created teams).",
 			Group:       "Teams",
-			Version:     1,
+			Version:     2,
 			Permissions: []accesscontrol.Permission{
 				{Action: accesscontrol.ActionTeamsCreate},
+				{Action: accesscontrol.ActionOrgUsersRead, Scope: accesscontrol.ScopeUsersAll},
 			},
 		},
 		Grants: teamCreatorGrants,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
With legacy access control, editors can create and manage teams when `editorsCanAdmin` setting is enabled. With FGAC editors are granted the rights to create teams when `editorsCanAdmin` is set, but they cannot fully managed the teams that they have created, because adding new team members requires `org.users:read` permission. This PR adds this permission to organisation editors when `editorsCanAdmin` setting is enabled.

Benefits:
* behaviour with FGAC is consistent with the legacy behaviour;

Drawbacks:
* `fixed:teams:creator` role includes a permission that is not directly related to teams;
* organisation Viewers who are team admins still won't be able to list users by default (however, this behaviour is consistent with the legacy behaviour).

Other approaches considered:
* adding the `org.users:read` permission to a user when they get added as a team admin. However, this is technically much more difficult.
