### PR TITLE
Azure Monitor Logs: Order subscriptions in resource picker by name

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
@@ -42,7 +42,7 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
                 | project subscriptionName=name, subscriptionURI=id, subscriptionId
               ) on subscriptionId
     | summarize count() by subscriptionName, subscriptionURI, subscriptionId
-    | order by subscriptionURI asc
+    | order by subscriptionName desc
   `;
 
     let resources: RawAzureSubscriptionItem[] = [];


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that subscriptions in the resource picker are being displayed in alphabetical order. 

**Which issue(s) this PR fixes**:

Fixes #45066 

