### PR TITLE
Chore: Add dependabot to the ignore list

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -183,7 +183,7 @@
     "type": "author",
     "name": "pr/external",
     "notMemberOf": { "org": "grafana" },
-    "ignoreList": ["renovate[bot]"],
+    "ignoreList": ["renovate[bot]","dependabot[bot]"],
     "action": "updateLabel",
     "addLabel": "pr/external"
   }


### PR DESCRIPTION
for external label so @daniellee doesn't have to manually remove that label 😄

