### PR TITLE
Alerting: Fixing minor styling issues

### DIFF
--- a/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
@@ -2,6 +2,7 @@ import React, { FormEvent } from 'react';
 import { Label, Tooltip, Input, Icon, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css } from '@emotion/css';
+import { Stack } from '@grafana/experimental';
 
 interface Props {
   className?: string;
@@ -20,17 +21,19 @@ export const MatcherFilter = ({ className, onFilterChange, defaultQueryString, q
   return (
     <div className={className}>
       <Label>
-        <Tooltip
-          content={
-            <div>
-              Filter alerts using label querying, ex:
-              <pre>{`{severity="critical", instance=~"cluster-us-.+"}`}</pre>
-            </div>
-          }
-        >
-          <Icon className={styles.icon} name="info-circle" size="xs" />
-        </Tooltip>
-        Search by label
+        <Stack gap={0.5}>
+          <span>Search by label</span>
+          <Tooltip
+            content={
+              <div>
+                Filter alerts using label querying, ex:
+                <pre>{`{severity="critical", instance=~"cluster-us-.+"}`}</pre>
+              </div>
+            }
+          >
+            <Icon className={styles.icon} name="info-circle" size="sm" />
+          </Tooltip>
+        </Stack>
       </Label>
       <Input
         placeholder="Search"

--- a/public/app/features/alerting/unified/components/rules/RulesFilter.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesFilter.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, useState } from 'react';
-import { Button, Icon, Input, Label, RadioButtonGroup, Tooltip, useStyles } from '@grafana/ui';
+import { Button, Field, Icon, Input, Label, RadioButtonGroup, Tooltip, useStyles } from '@grafana/ui';
 import { DataSourceInstanceSettings, GrafanaTheme, SelectableValue } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import { debounce } from 'lodash';
@@ -9,6 +9,7 @@ import { useQueryParams } from 'app/core/hooks/useQueryParams';
 import { getFiltersFromUrlParams } from '../../utils/misc';
 import { DataSourcePicker } from '@grafana/runtime';
 import { alertStateToReadable } from '../../utils/rules';
+import { Stack } from '@grafana/experimental';
 
 const ViewOptions: SelectableValue[] = [
   {
@@ -87,8 +88,7 @@ const RulesFilter = () => {
   const searchIcon = <Icon name={'search'} />;
   return (
     <div className={styles.container}>
-      <div className={styles.inputWidth}>
-        <Label>Search by data source</Label>
+      <Field className={styles.inputWidth} label="Search by data source">
         <DataSourcePicker
           key={dataSourceKey}
           alerting
@@ -98,23 +98,29 @@ const RulesFilter = () => {
           onChange={handleDataSourceChange}
           onClear={clearDataSource}
         />
-      </div>
+      </Field>
       <div className={cx(styles.flexRow, styles.spaceBetween)}>
         <div className={styles.flexRow}>
-          <div className={styles.rowChild}>
-            <Label>
-              <Tooltip
-                content={
-                  <div>
-                    Filter rules and alerts using label querying, ex:
-                    <pre>{`{severity="critical", instance=~"cluster-us-.+"}`}</pre>
-                  </div>
-                }
-              >
-                <Icon name="info-circle" className={styles.tooltip} />
-              </Tooltip>
-              Search by label
-            </Label>
+          <Field
+            className={styles.rowChild}
+            label={
+              <Label>
+                <Stack gap={0.5}>
+                  <span>Search by label</span>
+                  <Tooltip
+                    content={
+                      <div>
+                        Filter rules and alerts using label querying, ex:
+                        <code>{`{severity="critical", instance=~"cluster-us-.+"}`}</code>
+                      </div>
+                    }
+                  >
+                    <Icon name="info-circle" size="sm" />
+                  </Tooltip>
+                </Stack>
+              </Label>
+            }
+          >
             <Input
               key={queryStringKey}
               className={styles.inputWidth}
@@ -124,7 +130,7 @@ const RulesFilter = () => {
               placeholder="Search"
               data-testid="search-query-input"
             />
-          </div>
+          </Field>
           <div className={styles.rowChild}>
             <Label>State</Label>
             <RadioButtonGroup options={stateOptions} value={alertState} onChange={handleAlertStateChange} />
@@ -169,12 +175,8 @@ const getStyles = (theme: GrafanaTheme) => {
     container: css`
       display: flex;
       flex-direction: column;
-      border-bottom: 1px solid ${theme.colors.border1};
       padding-bottom: ${theme.spacing.sm};
-
-      & > div {
-        margin-bottom: ${theme.spacing.sm};
-      }
+      margin-bottom: ${theme.spacing.sm};
     `,
     inputWidth: css`
       width: 340px;
@@ -191,11 +193,7 @@ const getStyles = (theme: GrafanaTheme) => {
       justify-content: space-between;
     `,
     rowChild: css`
-      margin-right: ${theme.spacing.sm};
-      margin-top: ${theme.spacing.sm};
-    `,
-    tooltip: css`
-      margin: 0 ${theme.spacing.xs};
+      margin: 0 ${theme.spacing.sm} 0 0;
     `,
     clearButton: css`
       margin-top: ${theme.spacing.sm};

--- a/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
@@ -7,6 +7,7 @@ import { getSilenceFiltersFromUrlParams } from '../../utils/misc';
 import { SilenceState } from 'app/plugins/datasource/alertmanager/types';
 import { parseMatchers } from '../../utils/alertmanager';
 import { debounce, uniqueId } from 'lodash';
+import { Stack } from '@grafana/experimental';
 
 const stateOptions: SelectableValue[] = Object.entries(SilenceState).map(([key, value]) => ({
   label: key,
@@ -45,19 +46,21 @@ export const SilencesFilter = () => {
       <Field
         className={styles.rowChild}
         label={
-          <span className={styles.fieldLabel}>
-            <Tooltip
-              content={
-                <div>
-                  Filter silences by matchers using a comma separated list of matchers, ie:
-                  <pre>{`severity=critical, instance=~cluster-us-.+`}</pre>
-                </div>
-              }
-            >
-              <Icon name="info-circle" />
-            </Tooltip>{' '}
-            Search by matchers
-          </span>
+          <Label>
+            <Stack gap={0.5}>
+              <span>Search by matchers</span>
+              <Tooltip
+                content={
+                  <div>
+                    Filter silences by matchers using a comma separated list of matchers, ie:
+                    <pre>{`severity=critical, instance=~cluster-us-.+`}</pre>
+                  </div>
+                }
+              >
+                <Icon name="info-circle" size="sm" />
+              </Tooltip>
+            </Stack>
+          </Label>
         }
         invalid={inputInvalid}
         error={inputInvalid ? 'Query must use valid matcher syntax' : null}
@@ -72,11 +75,9 @@ export const SilencesFilter = () => {
           data-testid="search-query-input"
         />
       </Field>
-
-      <div className={styles.rowChild}>
-        <Label>State</Label>
+      <Field className={styles.rowChild} label="State">
         <RadioButtonGroup options={stateOptions} value={silenceState} onChange={handleSilenceStateChange} />
-      </div>
+      </Field>
       {(queryString || silenceState) && (
         <div className={styles.rowChild}>
           <Button variant="secondary" icon="times" onClick={clearFilters}>

--- a/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
@@ -17,6 +17,7 @@ import { ActionIcon } from '../rules/ActionIcon';
 import { useDispatch } from 'react-redux';
 import { expireSilenceAction } from '../../state/actions';
 import { SilenceDetails } from './SilenceDetails';
+import { Stack } from '@grafana/experimental';
 
 export interface SilenceTableItem extends Silence {
   silencedAlerts: AlertmanagerAlert[];
@@ -221,7 +222,7 @@ function useColumns(alertManagerSourceName: string) {
         label: 'Actions',
         renderCell: function renderActions({ data: silence }) {
           return (
-            <>
+            <Stack gap={0.5}>
               {silence.status.state === 'expired' ? (
                 <Link href={makeAMLink(`/alerting/silence/${silence.id}/edit`, alertManagerSourceName)}>
                   <ActionButton icon="sync">Recreate</ActionButton>
@@ -239,10 +240,10 @@ function useColumns(alertManagerSourceName: string) {
                   tooltip="edit"
                 />
               )}
-            </>
+            </Stack>
           );
         },
-        size: '140px',
+        size: '147px',
       });
     }
     return columns;


### PR DESCRIPTION
When clicking around alerting I found a number of small style issues, inconsistent paddings. button rows break 

Examples: Missing label bottom margin (due to custom Label style instead of using Label component). Tooltip before label instead of after like elsewhere:
![Screenshot from 2022-02-10 14-31-16](https://user-images.githubusercontent.com/10999/153418283-28b7b22e-fea2-4fbf-b7aa-6a085d8589e7.png)

The silence table looks pretty bad with actions wrapping and schedule wrapping when there is plenty of space. This PR only addresses the actions, to get schedule to only wrap when needed looks like a bigger refactoring. The table grid template looks very hard coded right now, think using more dynamic content based fit logic would be be better. 

![Screenshot from 2022-02-10 14-32-21](https://user-images.githubusercontent.com/10999/153418396-e6b128a2-f008-4efe-91ef-feb970049b0d.png)

We are using Labels with info icon in a lot of places (not just here in Alerting). Think we should probably make that into a component or extend Label to support a "info" property that renders an info icon and tooltip. 