### PR TITLE
ServiceAccounts: allow deleting from service account list

### DIFF
--- a/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
@@ -121,7 +121,7 @@ const ServiceAccountsListPage = ({
         )}
         {Boolean(toRemove) && (
           <ConfirmModal
-            body={`Are you sure you want to delete user ${toRemove?.name}?`}
+            body={`Are you sure you want to delete ${toRemove?.name}?`}
             confirmText="Delete"
             title="Delete"
             onDismiss={() => {
@@ -234,7 +234,7 @@ const ServiceAccountListItem = memo(
                 onSetToRemove(serviceAccount);
               }}
               icon="times"
-              aria-label="Delete user"
+              aria-label="Delete service account"
             />
           </td>
         )}

--- a/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
@@ -5,7 +5,13 @@ import { css, cx } from '@emotion/css';
 
 import Page from 'app/core/components/Page/Page';
 import { StoreState, ServiceAccountDTO, AccessControlAction, Role } from 'app/types';
-import { fetchACOptions, loadServiceAccounts, removeServiceAccount, updateServiceAccount } from './state/actions';
+import {
+  fetchACOptions,
+  loadServiceAccounts,
+  removeServiceAccount,
+  updateServiceAccount,
+  setServiceAccountToRemove,
+} from './state/actions';
 import { getNavModel } from 'app/core/selectors/navModel';
 import { getServiceAccounts, getServiceAccountsSearchPage, getServiceAccountsSearchQuery } from './state/selectors';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
@@ -24,6 +30,7 @@ function mapStateToProps(state: StoreState) {
     isLoading: state.serviceAccounts.isLoading,
     roleOptions: state.serviceAccounts.roleOptions,
     builtInRoles: state.serviceAccounts.builtInRoles,
+    toRemove: state.serviceAccounts.serviceAccountToRemove,
   };
 }
 
@@ -32,6 +39,7 @@ const mapDispatchToProps = {
   fetchACOptions,
   updateServiceAccount,
   removeServiceAccount,
+  setServiceAccountToRemove,
 };
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
@@ -41,14 +49,15 @@ const ServiceAccountsListPage = ({
   removeServiceAccount,
   fetchACOptions,
   updateServiceAccount,
+  setServiceAccountToRemove,
   navModel,
   serviceAccounts,
   isLoading,
   roleOptions,
   builtInRoles,
+  toRemove,
 }: Props) => {
   const styles = useStyles2(getStyles);
-  let toRemove: ServiceAccountDTO | null | undefined;
 
   useEffect(() => {
     loadServiceAccounts();
@@ -61,10 +70,6 @@ const ServiceAccountsListPage = ({
     const updatedServiceAccount = { ...serviceAccount, role: role };
 
     updateServiceAccount(updatedServiceAccount);
-  };
-
-  const onSetToRemove = (serviceAccount: ServiceAccountDTO) => {
-    toRemove = serviceAccount;
   };
 
   const onRemoveServiceAccount = (serviceAccount: ServiceAccountDTO) => {
@@ -106,7 +111,7 @@ const ServiceAccountsListPage = ({
                       builtInRoles={builtInRoles}
                       roleOptions={roleOptions}
                       onRoleChange={onRoleChange}
-                      onSetToRemove={onSetToRemove}
+                      onSetToRemove={setServiceAccountToRemove}
                     />
                   ))}
                 </tbody>
@@ -120,7 +125,7 @@ const ServiceAccountsListPage = ({
             confirmText="Delete"
             title="Delete"
             onDismiss={() => {
-              toRemove = null;
+              setServiceAccountToRemove(null);
             }}
             isOpen={true}
             onConfirm={() => {
@@ -128,7 +133,7 @@ const ServiceAccountsListPage = ({
                 return;
               }
               onRemoveServiceAccount(toRemove);
-              toRemove = null;
+              setServiceAccountToRemove(null);
             }}
           />
         )}

--- a/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
@@ -19,6 +19,7 @@ import { GrafanaTheme2, OrgRole } from '@grafana/data';
 import { contextSrv } from 'app/core/core';
 import { UserRolePicker } from 'app/core/components/RolePicker/UserRolePicker';
 import { OrgRolePicker } from '../admin/OrgRolePicker';
+import pluralize from 'pluralize';
 export type Props = ConnectedProps<typeof connector>;
 
 function mapStateToProps(state: StoreState) {
@@ -117,7 +118,14 @@ const ServiceAccountsListPage = ({
         )}
         {toRemove && (
           <ConfirmModal
-            body={`Are you sure you want to delete ${toRemove?.name}?`}
+            body={
+              <div>
+                Are you sure you want to delete &apos;{toRemove.name}&apos;
+                {Boolean(toRemove.tokens) &&
+                  ` and ${toRemove.tokens} accompanying ${pluralize('token', toRemove.tokens)}`}
+                ?
+              </div>
+            }
             confirmText="Delete"
             title="Delete service account"
             onDismiss={() => {

--- a/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
@@ -72,10 +72,6 @@ const ServiceAccountsListPage = ({
     updateServiceAccount(updatedServiceAccount);
   };
 
-  const onRemoveServiceAccount = (serviceAccount: ServiceAccountDTO) => {
-    removeServiceAccount(serviceAccount.id);
-  };
-
   return (
     <Page navModel={navModel}>
       <Page.Contents>
@@ -119,20 +115,17 @@ const ServiceAccountsListPage = ({
             </div>
           </>
         )}
-        {Boolean(toRemove) && (
+        {toRemove && (
           <ConfirmModal
             body={`Are you sure you want to delete ${toRemove?.name}?`}
             confirmText="Delete"
-            title="Delete"
+            title="Delete service account"
             onDismiss={() => {
               setServiceAccountToRemove(null);
             }}
             isOpen={true}
             onConfirm={() => {
-              if (!toRemove) {
-                return;
-              }
-              onRemoveServiceAccount(toRemove);
+              removeServiceAccount(toRemove.id);
               setServiceAccountToRemove(null);
             }}
           />

--- a/public/app/features/serviceaccounts/state/actions.ts
+++ b/public/app/features/serviceaccounts/state/actions.ts
@@ -6,6 +6,7 @@ import {
   serviceAccountLoaded,
   serviceAccountsLoaded,
   serviceAccountTokensLoaded,
+  serviceAccountToRemoveLoaded,
 } from './reducers';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
 import { fetchBuiltinRoles, fetchRoleOptions } from 'app/core/components/RolePicker/api';
@@ -19,6 +20,16 @@ export function fetchACOptions(): ThunkResult<void> {
       dispatch(acOptionsLoaded(options));
       const builtInRoles = await fetchBuiltinRoles();
       dispatch(builtInRolesLoaded(builtInRoles));
+    } catch (error) {
+      console.error(error);
+    }
+  };
+}
+
+export function setServiceAccountToRemove(serviceAccount: ServiceAccountDTO | null): ThunkResult<void> {
+  return async (dispatch) => {
+    try {
+      dispatch(serviceAccountToRemoveLoaded(serviceAccount));
     } catch (error) {
       console.error(error);
     }

--- a/public/app/features/serviceaccounts/state/reducers.ts
+++ b/public/app/features/serviceaccounts/state/reducers.ts
@@ -9,6 +9,7 @@ export const initialState: ServiceAccountsState = {
   isLoading: true,
   builtInRoles: {},
   roleOptions: [],
+  serviceAccountToRemove: null,
 };
 
 export const initialStateProfile: ServiceAccountProfileState = {
@@ -50,6 +51,9 @@ const serviceAccountsSlice = createSlice({
     builtInRolesLoaded: (state, action: PayloadAction<Record<string, Role[]>>): ServiceAccountsState => {
       return { ...state, builtInRoles: action.payload };
     },
+    serviceAccountToRemoveLoaded: (state, action: PayloadAction<ServiceAccountDTO | null>): ServiceAccountsState => {
+      return { ...state, serviceAccountToRemove: action.payload };
+    },
   },
 });
 
@@ -59,6 +63,7 @@ export const {
   serviceAccountsLoaded,
   acOptionsLoaded,
   builtInRolesLoaded,
+  serviceAccountToRemoveLoaded,
 } = serviceAccountsSlice.actions;
 
 export const { serviceAccountLoaded, serviceAccountTokensLoaded } = serviceAccountProfileSlice.actions;

--- a/public/app/types/serviceaccount.ts
+++ b/public/app/types/serviceaccount.ts
@@ -46,5 +46,6 @@ export interface ServiceAccountsState {
   searchPage: number;
   isLoading: boolean;
   roleOptions: Role[];
+  serviceAccountToRemove: ServiceAccountDTO | null;
   builtInRoles: Record<string, Role[]>;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Allow deleting a service account from the service account list

![image](https://user-images.githubusercontent.com/8071073/153420400-034c25be-2645-437b-ae3a-0e430eade986.png)|

![image](https://user-images.githubusercontent.com/8071073/153420771-69427da2-4644-4843-bc0a-16023bfce218.png)

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-enterprise/issues/2566
