### PR TITLE
Tempo: Update service graph linked queries

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -347,7 +347,7 @@ const serviceGraphLinks = [
     title: 'Request rate',
     internal: {
       query: {
-        expr: 'rate(traces_service_graph_request_total{server="${__data.fields.id}"}[$__interval])',
+        expr: 'rate(traces_service_graph_request_total{server="${__data.fields.id}"}[$__rate_interval])',
       },
       datasourceUid: 'prom',
       datasourceName: 'Prometheus',
@@ -358,7 +358,7 @@ const serviceGraphLinks = [
     title: 'Request histogram',
     internal: {
       query: {
-        expr: 'histogram_quantile(0.9, rate(traces_service_graph_request_server_seconds_bucket{server="${__data.fields.id}"}[$__interval]))',
+        expr: 'histogram_quantile(0.9, sum(rate(traces_service_graph_request_server_seconds_bucket{server="${__data.fields.id}"}[$__rate_interval])) by (le, client, server))',
       },
       datasourceUid: 'prom',
       datasourceName: 'Prometheus',
@@ -369,7 +369,7 @@ const serviceGraphLinks = [
     title: 'Failed request rate',
     internal: {
       query: {
-        expr: 'rate(traces_service_graph_request_failed_total{server="${__data.fields.id}"}[$__interval])',
+        expr: 'rate(traces_service_graph_request_failed_total{server="${__data.fields.id}"}[$__rate_interval])',
       },
       datasourceUid: 'prom',
       datasourceName: 'Prometheus',

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -325,17 +325,17 @@ function serviceMapQuery(request: DataQueryRequest<TempoQuery>, datasourceUid: s
         links: [
           makePromLink(
             'Request rate',
-            `rate(${totalsMetric}{server="\${__data.fields.id}"}[$__interval])`,
+            `rate(${totalsMetric}{server="\${__data.fields.id}"}[$__rate_interval])`,
             datasourceUid
           ),
           makePromLink(
             'Request histogram',
-            `histogram_quantile(0.9, rate(${histogramMetric}{server="\${__data.fields.id}"}[$__interval]))`,
+            `histogram_quantile(0.9, sum(rate(${histogramMetric}{server="\${__data.fields.id}"}[$__rate_interval])) by (le, client, server))`,
             datasourceUid
           ),
           makePromLink(
             'Failed request rate',
-            `rate(${failedMetric}{server="\${__data.fields.id}"}[$__interval])`,
+            `rate(${failedMetric}{server="\${__data.fields.id}"}[$__rate_interval])`,
             datasourceUid
           ),
         ],


### PR DESCRIPTION
**What this PR does / why we need it**:
Use `__rate_interval` which works better, especially in short time windows. Also group the histogram query by server and client to return cleaner results. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

