### PR TITLE
Thresholds: fix crash when trying to render zero-height base thresholds

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/gradientFills.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/gradientFills.ts
@@ -134,6 +134,10 @@ export function scaleGradient(u: uPlot, scaleKey: string, scaleStops: ScaleValue
 
   let range = minStopPos - maxStopPos;
 
+  if (range === 0) {
+    return scaleStops[maxStopIdx!][1];
+  }
+
   let x0, y0, x1, y1;
 
   if (u.scales.x!.ori === ScaleOrientation.Horizontal) {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/45235

(you may need to play with panel resize to trigger the original issue)

<details><summary>Dashboard</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": "-- Grafana --",
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 110,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "area"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "#EAB839",
                "value": 0.1
              },
              {
                "color": "red",
                "value": 0.25
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 9,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom"
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_metric_values",
          "stringInput": "0,10000,0"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "refresh": "",
  "schemaVersion": 35,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "threshold-limit",
  "uid": "mLYvQBa7z",
  "version": 1,
  "weekStart": ""
}
```
</details>