### PR TITLE
Rendering: fix `IsAvailable()`

### DIFF
--- a/pkg/services/rendering/capabilities_test.go
+++ b/pkg/services/rendering/capabilities_test.go
@@ -57,10 +57,10 @@ func TestCapabilities(t *testing.T) {
 			rendererUrl:     dummyRendererUrl,
 			rendererVersion: "",
 			capabilityName:  testCapabilityName,
-			expectedError:   ErrInvalidPluginVersion,
+			expectedError:   ErrRenderUnavailable,
 			expectedResult: CapabilitySupportRequestResult{
 				IsSupported:      false,
-				SemverConstraint: testCapabilitySemverConstraint,
+				SemverConstraint: "",
 			},
 		},
 		{

--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -167,7 +167,7 @@ func (rs *RenderingService) remoteAvailable() bool {
 }
 
 func (rs *RenderingService) IsAvailable() bool {
-	return rs.remoteAvailable() || rs.pluginAvailable()
+	return (rs.remoteAvailable() && rs.Version() != "") || rs.pluginAvailable()
 }
 
 func (rs *RenderingService) Version() string {

--- a/pkg/services/rendering/rendering_test.go
+++ b/pkg/services/rendering/rendering_test.go
@@ -149,9 +149,22 @@ func TestRenderLimitImage(t *testing.T) {
 func TestRenderingServiceGetRemotePluginVersion(t *testing.T) {
 	cfg := setting.NewCfg()
 	rs := &RenderingService{
-		Cfg: cfg,
-		log: log.New("rendering-test"),
+		Cfg:                   cfg,
+		RendererPluginManager: &dummyPluginManager{},
+		log:                   log.New("rendering-test"),
 	}
+
+	t.Run("When renderer url is set but version is missing", func(t *testing.T) {
+		rs.Cfg.RendererUrl = "http://localhost:8081/render"
+		rs.version = ""
+		require.Equal(t, false, rs.IsAvailable())
+	})
+
+	t.Run("When renderer url is set and version is present", func(t *testing.T) {
+		rs.Cfg.RendererUrl = "http://localhost:8081/render"
+		rs.version = "1.0.0"
+		require.Equal(t, true, rs.IsAvailable())
+	})
 
 	t.Run("When renderer responds with correct version should return that version", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Currently, if `renderer_url` is present, `IsAvailable()` will always return true, but the sole presence of `renderer_url` does not mean that the HTTP server is actually running/is available. 

<img width="384" alt="image" src="https://user-images.githubusercontent.com/23451458/153466418-72ebe46b-ded4-45ea-acb3-fb7f93970364.png">

With this PR, `IsAvailable()` will return false if `renderer_url` is present but we failed to retrieve the plugin version from the HTTP server

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

