### PR TITLE
Dashboard ACL: Remove indexes that were created for license stuff

### DIFF
--- a/pkg/services/sqlstore/migrations/dashboard_acl.go
+++ b/pkg/services/sqlstore/migrations/dashboard_acl.go
@@ -38,6 +38,11 @@ func addDashboardAclMigrations(mg *Migrator) {
 	mg.AddMigration("add index dashboard_acl_org_id_role", NewAddIndexMigration(dashboardAclV1, dashboardAclV1.Indices[5]))
 	mg.AddMigration("add index dashboard_permission", NewAddIndexMigration(dashboardAclV1, dashboardAclV1.Indices[6]))
 
+	mg.AddMigration("remove index dashboard_acl_user_id from dashboard_acl table", NewDropIndexMigration(dashboardAclV1, dashboardAclV1.Indices[3]))
+	mg.AddMigration("remove index dashboard_acl_team_id from dashboard_acl table", NewDropIndexMigration(dashboardAclV1, dashboardAclV1.Indices[4]))
+	mg.AddMigration("remove index dashboard_acl_org_id_role from dashboard_acl table", NewDropIndexMigration(dashboardAclV1, dashboardAclV1.Indices[5]))
+	mg.AddMigration("remove index dashboard_permission from dashboard_acl table", NewDropIndexMigration(dashboardAclV1, dashboardAclV1.Indices[6]))
+
 	const rawSQL = `
 INSERT INTO dashboard_acl
 	(


### PR DESCRIPTION
**What this PR does / why we need it**:
We created some indexes in the 8.2.0 version because we needed them to license improvements but finally are not necessary and we can rid of them.

This decision was taken because one of our clients started to have lot of problems with those indexes and it cannot upgrade their Grafana version.

We prepared this PR for 8.4.0 but it can move to 8.5.0 if necessary.

**Special notes for your reviewer**:
PLEASE, DON'T MERGE UNTIL WE KNOW THE IMPLICATIONS OF REMOVE THESE INDEXES.
