### PR TITLE
Alerting: Add Alerting Squad as codeowner of legacy alerting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,6 +59,7 @@ go.sum @grafana/backend-platform
 # Unified Alerting
 /pkg/services/ngalert @grafana/alerting-squad
 /pkg/services/sqlstore/migrations/ualert @grafana/alerting-squad
+/pkg/services/alerting @grafana/alerting-squad
 
 # Library Services
 /pkg/services/libraryelements @grafana/user-essentials

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,10 +56,11 @@ go.sum @grafana/backend-platform
 # Grafana live
 /pkg/services/live/ @grafana/grafana-edge-squad
 
-# Unified Alerting
-/pkg/services/ngalert @grafana/alerting-squad
-/pkg/services/sqlstore/migrations/ualert @grafana/alerting-squad
-/pkg/services/alerting @grafana/alerting-squad
+# Alerting
+/pkg/services/ngalert @grafana/alerting-squad-backend
+/pkg/services/sqlstore/migrations/ualert @grafana/alerting-squad-backend
+/pkg/services/alerting @grafana/alerting-squad-backend
+/public/app/features/alerting/ @grafana/alerting-squad-frontend
 
 # Library Services
 /pkg/services/libraryelements @grafana/user-essentials

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,7 +60,7 @@ go.sum @grafana/backend-platform
 /pkg/services/ngalert @grafana/alerting-squad-backend
 /pkg/services/sqlstore/migrations/ualert @grafana/alerting-squad-backend
 /pkg/services/alerting @grafana/alerting-squad-backend
-/public/app/features/alerting/ @grafana/alerting-squad-frontend
+/public/app/features/alerting @grafana/alerting-squad-frontend
 
 # Library Services
 /pkg/services/libraryelements @grafana/user-essentials


### PR DESCRIPTION
Exactly what it says in the tin.