### PR TITLE
Alerting: Fix updating notification channels in legacy

### DIFF
--- a/pkg/services/alerting/service.go
+++ b/pkg/services/alerting/service.go
@@ -2,6 +2,7 @@ package alerting
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/models"
@@ -77,6 +78,7 @@ func (s *AlertNotificationService) UpdateAlertNotification(ctx context.Context, 
 
 	model := models.AlertNotification{
 		Id:       cmd.Id,
+		OrgId:    cmd.OrgId,
 		Name:     cmd.Name,
 		Type:     cmd.Type,
 		Settings: cmd.Settings,
@@ -137,7 +139,11 @@ func (s *AlertNotificationService) createNotifier(ctx context.Context, model *mo
 			return nil, err
 		}
 
-		if query.Result != nil && query.Result.SecureSettings != nil {
+		if query.Result == nil {
+			return nil, fmt.Errorf("unable to find the alert notification")
+		}
+
+		if query.Result.SecureSettings != nil {
 			var err error
 			secureSettingsMap, err = s.EncryptionService.DecryptJsonData(ctx, query.Result.SecureSettings, setting.SecretKey)
 			if err != nil {


### PR DESCRIPTION
The problem here is that without the orgID we ignore the lookup of the existing notification channel just before updating and end up failing the update because there is no channel available.

I'm surprised this has not been reported before as it affect _all_ contact points if you're reviewing this and have any context on open issues that report this please let me know that we can close them.

Edit: Seems like Github took an important line away from my commit message. This is very similar to https://github.com/grafana/grafana/pull/43695 and the contact point validation was first introduced as part of https://github.com/grafana/grafana/pull/41062