### PR TITLE
Chore: Stub `console.warn` in CustomEndpointTransport test

### DIFF
--- a/public/app/core/services/echo/backends/sentry/transports/CustomEndpointTransport.test.ts
+++ b/public/app/core/services/echo/backends/sentry/transports/CustomEndpointTransport.test.ts
@@ -3,7 +3,18 @@ import { CustomEndpointTransport } from './CustomEndpointTransport';
 
 describe('CustomEndpointTransport', () => {
   const fetchSpy = (window.fetch = jest.fn());
-  beforeEach(() => jest.resetAllMocks());
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    // The code logs a warning to console
+    // Let's stub this out so we don't pollute the test output
+    consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
   const now = new Date();
 
   const event: Event = {
@@ -87,7 +98,7 @@ describe('CustomEndpointTransport', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
-  it('will drop events if max concurrency is reached', async () => {
+  it('will drop events and log a warning to console if max concurrency is reached', async () => {
     const calls: Array<(value: unknown) => void> = [];
     fetchSpy.mockImplementation(
       () =>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- Stubs `console.warn` to prevent this logging messages to the console when running unit tests

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/45031

**Special notes for your reviewer**:

