### PR TITLE
Chore: Stub deprecation warning in kbn unit tests

### DIFF
--- a/public/app/core/utils/kbn.test.ts
+++ b/public/app/core/utils/kbn.test.ts
@@ -1,6 +1,13 @@
 import kbn from './kbn';
 import { DecimalCount, TimeZone } from '@grafana/data';
 
+// Most of the methods in this file are deprecated
+// Stub the deprecation warning here to prevent polluting the test output
+jest.mock('@grafana/data', () => ({
+  ...jest.requireActual('@grafana/data'),
+  deprecationWarning: () => {},
+}));
+
 interface ValueFormatTest {
   id: string;
   decimals?: DecimalCount;

--- a/public/app/core/utils/kbn.ts
+++ b/public/app/core/utils/kbn.ts
@@ -50,7 +50,7 @@ const kbn = {
   addSlashes: (str: string) => str.replace(/[\'\"\\0]/g, '\\$&'),
   /** @deprecated since 7.2, use grafana/data */
   describeInterval: (str: string) => {
-    deprecationWarning('kbn.ts', 'kbn.stringToJsRegex()', '@grafana/data');
+    deprecationWarning('kbn.ts', 'kbn.describeInterval()', '@grafana/data');
     return rangeUtil.describeInterval(str);
   },
   /** @deprecated since 7.2, use grafana/data */


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- Stubs out the deprecation warning in the `kbn` unit tests since most of the methods in that file are deprecated
- Fixes a copy/paste error with a deprecation warning

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/45031

**Special notes for your reviewer**:

