### PR TITLE
MySQL: Prevent pre-epoch timestamps from breaking `__timeFilter`

### DIFF
--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -68,7 +68,9 @@ func (m *mySQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *bac
 		if len(args) == 0 {
 			return "", fmt.Errorf("missing time column argument for macro %v", name)
 		}
-
+		if timeRange.From.UTC().Unix() < 0 {
+			return fmt.Sprintf("%s BETWEEN DATE_ADD(FROM_UNIXTIME(0), INTERVAL %d SECOND) AND FROM_UNIXTIME(%d)", args[0], timeRange.From.UTC().Unix(), timeRange.To.UTC().Unix()), nil
+		}
 		return fmt.Sprintf("%s BETWEEN FROM_UNIXTIME(%d) AND FROM_UNIXTIME(%d)", args[0], timeRange.From.UTC().Unix(), timeRange.To.UTC().Unix()), nil
 	case "__timeFrom":
 		return fmt.Sprintf("FROM_UNIXTIME(%d)", timeRange.From.UTC().Unix()), nil

--- a/pkg/tsdb/mysql/macros_test.go
+++ b/pkg/tsdb/mysql/macros_test.go
@@ -129,7 +129,7 @@ func TestMacroEngine(t *testing.T) {
 			sql, err := engine.Interpolate(query, timeRange, "WHERE $__timeFilter(time_column)")
 			require.Nil(t, err)
 
-			require.Equal(t, fmt.Sprintf("WHERE time_column BETWEEN FROM_UNIXTIME(%d) AND FROM_UNIXTIME(%d)", from.Unix(), to.Unix()), sql)
+			require.Equal(t, fmt.Sprintf("WHERE time_column BETWEEN DATE_ADD(FROM_UNIXTIME(0), INTERVAL %d SECOND) AND FROM_UNIXTIME(%d)", from.Unix(), to.Unix()), sql)
 		})
 
 		t.Run("interpolate __unixEpochFilter function", func(t *testing.T) {
@@ -152,7 +152,7 @@ func TestMacroEngine(t *testing.T) {
 			sql, err := engine.Interpolate(query, timeRange, "WHERE $__timeFilter(time_column)")
 			require.Nil(t, err)
 
-			require.Equal(t, fmt.Sprintf("WHERE time_column BETWEEN FROM_UNIXTIME(%d) AND FROM_UNIXTIME(%d)", from.Unix(), to.Unix()), sql)
+			require.Equal(t, fmt.Sprintf("WHERE time_column BETWEEN DATE_ADD(FROM_UNIXTIME(0), INTERVAL %d SECOND) AND FROM_UNIXTIME(%d)", from.Unix(), to.Unix()), sql)
 		})
 
 		t.Run("interpolate __unixEpochFilter function", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Using the `__timeFilter` macro with a `FROM` time that is pre Unix Epoch will not return any results. As [the linked issue describes](https://github.com/grafana/grafana/issues/22453), this passes a negative integer to the `FROM_UNIXTIME()` function, which it cannot handle. This means no results are returned.

this limits the macro's usability on historical datasets

To test this:

if you dumped this table into mysql/mariadb:

```
#
# TABLE STRUCTURE FOR: timestamps
#

DROP TABLE IF EXISTS `timestamps`;

CREATE TABLE IF NOT EXISTS `timestamps` (
  `timestamp` datetime NOT NULL,
  `rev` int(3) unsigned NOT NULL,
  `content` varchar(200) NOT NULL,
  PRIMARY KEY (`timestamp`,`rev`)
) DEFAULT CHARSET=utf8;
INSERT INTO `timestamps` (`timestamp`, `rev`, `content`) VALUES
  ('1953-02-08 00:01:12', '1', 'The earth is flat'),
  ('1963-02-08 00:01:12', '1', 'One hundred angels can dance on the head of a pin'),
  ('1973-02-08 00:01:12', '2', 'The earth is flat and rests on a bull\'s horn'),
  ('2013-02-08 00:01:12', '3', 'The earth is like a ball.');
```

and then made a query in a panel like:
```
SELECT
  timestamp AS "time"
FROM timestamps
WHERE
  $__timeFilter(timestamp)
ORDER BY timestamp
```

And set the time-picker ~1940 to today:

`from=-944091001000&to=1644487199000`

without this fix, the panel will generate this query and the response will ~~error out~~ return no data:

```
SELECT
  timestamp AS "time"
FROM timestamps
WHERE
  timestamp BETWEEN FROM_UNIXTIME(-944091001) AND FROM_UNIXTIME(1644487199)
ORDER BY timestamp
```

with the fix, the panel generates this query:

```
SELECT
  timestamp AS "time"
FROM timestamps
WHERE
  timestamp BETWEEN DATE_ADD(FROM_UNIXTIME(0), INTERVAL -944091001 SECOND) AND FROM_UNIXTIME(1644487199)
ORDER BY timestamp
```

and all four timestamps are now returned, from 1953 to 2013


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #22453

**Special notes for your reviewer**:

