### PR TITLE
Content Security Policy: Update default Content Security Policy to be more restrictive on images

### DIFF
--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -287,7 +287,7 @@
 # Set Content Security Policy template used when adding the Content-Security-Policy header to your requests.
 # $NONCE in the template includes a random nonce.
 # $ROOT_PATH is server.root_url without the protocol.
-;content_security_policy_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
+;content_security_policy_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src 'self' data: https://grafana.com;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
 
 #################################### Snapshots ###########################
 [snapshots]


### PR DESCRIPTION
**What this PR does / why we need it**:

The default Content Security Policy template uses wildcard on img-src, this is potentially too open and could be abused. I have tested `img-src 'self' https://grafana.com data: ;` which works fine on Grafana 8.3.6.

