### PR TITLE
Chore: fix permission issues in the Levitate reporting workflow

### DIFF
--- a/.github/workflows/detect-breaking-changes-report.yml
+++ b/.github/workflows/detect-breaking-changes-report.yml
@@ -123,6 +123,7 @@ jobs:
       env:
         PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
       with:
+        github-token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
         script: |
           await github.rest.issues.addLabels({
             issue_number: process.env.PR_NUMBER,
@@ -137,6 +138,7 @@ jobs:
       env:
         PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
       with:
+        github-token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
         script: |
           await github.rest.issues.removeLabel({
             issue_number: process.env.PR_NUMBER,
@@ -153,6 +155,7 @@ jobs:
       env:
         PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
       with:
+        github-token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
         script: |
           await github.rest.pulls.requestReviewers({
             pull_number: process.env.PR_NUMBER,
@@ -168,6 +171,7 @@ jobs:
       env:
         PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
       with:
+        github-token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
         script: |
           await github.rest.pulls.removeRequestedReviewers({
             pull_number: process.env.PR_NUMBER,


### PR DESCRIPTION
### What is the problem?
In some cases the reporting workflow was failing due to permission issues with the provided `GITHUB_TOKEN`.
This seems to be a bug in the Github API, but a possible workaround is to use a PAT (Personal Access Token) instead.

![Screenshot 2022-02-15 at 8 55 07](https://user-images.githubusercontent.com/9974811/154017404-3e0f1954-ad2d-4bf1-9732-7bd7e6253417.png)

[Issue describing a similar problem](https://github.com/peter-evans/create-pull-request/issues/155#issuecomment-611904487)
[Example error](https://github.com/grafana/grafana/runs/5186027360?check_suite_focus=true)

### What changed?
Started using the `GH_BOT_ACCESS_TOKEN` PAT from the secrets instead of the default `GITHUB_TOKEN`.