### PR TITLE
Fix notification routes editing when filters are applied

### DIFF
--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.test.ts
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.test.ts
@@ -1,7 +1,7 @@
 import { MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
 import { FormAmRoute } from '../../types/amroutes';
 import { MatcherFieldValue } from '../../types/silence-form';
-import { getFilteredRoutes } from './AmRoutesTable';
+import { deleteRoute, getFilteredRoutes, updatedRoute } from './AmRoutesTable';
 
 const defaultAmRoute: FormAmRoute = {
   id: '',
@@ -108,5 +108,81 @@ describe('getFilteredRoutes', () => {
     // Assert
     expect(filteredRoutes).toHaveLength(1);
     expect(filteredRoutes).toContain(routes[2]);
+  });
+});
+
+describe('updatedRoute', () => {
+  it('Should update an item of the same id', () => {
+    // Arrange
+    const routes: FormAmRoute[] = [buildAmRoute({ id: '1' }), buildAmRoute({ id: '2' }), buildAmRoute({ id: '3' })];
+
+    const routeUpdate: FormAmRoute = {
+      ...routes[1],
+      object_matchers: [buildMatcher('severity', 'critical', MatcherOperator.equal)],
+    };
+
+    // Act
+    const updatedRoutes = updatedRoute(routes, routeUpdate);
+
+    // Assert
+    expect(updatedRoutes).toHaveLength(3);
+    const changedRoute = updatedRoutes[1];
+
+    expect(changedRoute.object_matchers).toHaveLength(1);
+    expect(changedRoute.object_matchers[0].name).toBe('severity');
+    expect(changedRoute.object_matchers[0].value).toBe('critical');
+    expect(changedRoute.object_matchers[0].operator).toBe(MatcherOperator.equal);
+  });
+
+  it('Should not update any element when an element of matching id not found', () => {
+    // Arrange
+    const routes: FormAmRoute[] = [buildAmRoute({ id: '1' }), buildAmRoute({ id: '2' }), buildAmRoute({ id: '3' })];
+
+    const routeUpdate: FormAmRoute = {
+      ...routes[1],
+      id: '-1',
+      object_matchers: [buildMatcher('severity', 'critical', MatcherOperator.equal)],
+    };
+
+    // Act
+    const updatedRoutes = updatedRoute(routes, routeUpdate);
+
+    // Assert
+    expect(updatedRoutes).toHaveLength(3);
+
+    updatedRoutes.forEach((route) => {
+      expect(route.object_matchers).toHaveLength(0);
+    });
+  });
+});
+
+describe('deleteRoute', () => {
+  it('Should delete an element of the same id', () => {
+    // Arrange
+    const routes: FormAmRoute[] = [buildAmRoute({ id: '1' }), buildAmRoute({ id: '2' }), buildAmRoute({ id: '3' })];
+
+    const routeToDelete = routes[1];
+
+    // Act
+    const updatedRoutes = deleteRoute(routes, routeToDelete);
+
+    // Assert
+    expect(updatedRoutes).toHaveLength(2);
+    expect(updatedRoutes[0].id).toBe('1');
+    expect(updatedRoutes[1].id).toBe('3');
+  });
+
+  it('Should not delete anything when an element of matching id not found', () => {
+    // Arrange
+    const routes: FormAmRoute[] = [buildAmRoute({ id: '1' }), buildAmRoute({ id: '2' }), buildAmRoute({ id: '3' })];
+
+    // Act
+    const updatedRoutes = deleteRoute(routes, buildAmRoute({ id: '-1' }));
+
+    // Assert
+    expect(updatedRoutes).toHaveLength(3);
+    expect(updatedRoutes[0].id).toBe('1');
+    expect(updatedRoutes[1].id).toBe('2');
+    expect(updatedRoutes[2].id).toBe('3');
   });
 });

--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
@@ -44,6 +44,23 @@ export const getFilteredRoutes = (routes: FormAmRoute[], labelMatcherQuery?: str
   return filteredRoutes;
 };
 
+export const updatedRoute = (routes: FormAmRoute[], updatedRoute: FormAmRoute): FormAmRoute[] => {
+  const newRoutes = [...routes];
+  const editIndex = newRoutes.findIndex((route) => route.id === updatedRoute.id);
+
+  if (editIndex >= 0) {
+    newRoutes[editIndex] = {
+      ...newRoutes[editIndex],
+      ...updatedRoute,
+    };
+  }
+  return newRoutes;
+};
+
+export const deleteRoute = (routes: FormAmRoute[], routeToRemove: FormAmRoute): FormAmRoute[] => {
+  return routes.filter((route) => route.id !== routeToRemove.id);
+};
+
 export const AmRoutesTable: FC<AmRoutesTableProps> = ({
   isAddMode,
   onCancelAdd,
@@ -118,7 +135,7 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
                     aria-label="Delete route"
                     name="trash-alt"
                     onClick={() => {
-                      const newRoutes = routes.filter((route) => route.id !== item.data.id);
+                      const newRoutes = deleteRoute(routes, item.data);
                       onChange(newRoutes);
                     }}
                     type="button"
@@ -178,15 +195,7 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
               setEditMode(false);
             }}
             onSave={(data) => {
-              const newRoutes = [...routes];
-
-              const editIndex = newRoutes.findIndex((route) => route.id === data.id);
-              if (editIndex >= 0) {
-                newRoutes[editIndex] = {
-                  ...newRoutes[editIndex],
-                  ...data,
-                };
-              }
+              const newRoutes = updatedRoute(routes, data);
 
               setEditMode(false);
               onChange(newRoutes);
@@ -197,16 +206,7 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
         ) : (
           <AmRoutesExpandedRead
             onChange={(data) => {
-              const newRoutes = [...routes];
-
-              const editIndex = newRoutes.findIndex((route) => route.id === data.id);
-              if (editIndex >= 0) {
-                newRoutes[editIndex] = {
-                  ...item.data,
-                  ...data,
-                };
-              }
-
+              const newRoutes = updatedRoute(routes, data);
               onChange(newRoutes);
             }}
             receivers={receivers}

--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
@@ -180,10 +180,14 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
             onSave={(data) => {
               const newRoutes = [...routes];
 
-              newRoutes[index] = {
-                ...newRoutes[index],
-                ...data,
-              };
+              const editIndex = newRoutes.findIndex((route) => route.id === data.id);
+              if (editIndex >= 0) {
+                newRoutes[editIndex] = {
+                  ...newRoutes[editIndex],
+                  ...data,
+                };
+              }
+
               setEditMode(false);
               onChange(newRoutes);
             }}
@@ -195,10 +199,13 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
             onChange={(data) => {
               const newRoutes = [...routes];
 
-              newRoutes[index] = {
-                ...item.data,
-                ...data,
-              };
+              const editIndex = newRoutes.findIndex((route) => route.id === data.id);
+              if (editIndex >= 0) {
+                newRoutes[editIndex] = {
+                  ...item.data,
+                  ...data,
+                };
+              }
 
               onChange(newRoutes);
             }}

--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
@@ -158,7 +158,7 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
     [isAddMode, routes, filteredRoutes]
   );
 
-  // expand the last item when adding or rest when the lenght changed
+  // expand the last item when adding or reset when the length changed
   useEffect(() => {
     if (isAddMode && dynamicTableRoutes.length) {
       setExpandedId(dynamicTableRoutes[dynamicTableRoutes.length - 1].id);

--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
@@ -92,7 +92,7 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
             id: 'actions',
             label: 'Actions',
             // eslint-disable-next-line react/display-name
-            renderCell: (item, index) => {
+            renderCell: (item) => {
               if (item.renderExpandedContent) {
                 return null;
               }
@@ -118,10 +118,7 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
                     aria-label="Delete route"
                     name="trash-alt"
                     onClick={() => {
-                      const newRoutes = [...routes];
-
-                      newRoutes.splice(index, 1);
-
+                      const newRoutes = routes.filter((route) => route.id !== item.data.id);
                       onChange(newRoutes);
                     }}
                     type="button"
@@ -144,10 +141,13 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
     [isAddMode, routes, filteredRoutes]
   );
 
-  // expand the last item when adding
+  // expand the last item when adding or rest when the lenght changed
   useEffect(() => {
     if (isAddMode && dynamicTableRoutes.length) {
       setExpandedId(dynamicTableRoutes[dynamicTableRoutes.length - 1].id);
+    }
+    if (!isAddMode && dynamicTableRoutes.length) {
+      setExpandedId(undefined);
     }
   }, [isAddMode, dynamicTableRoutes]);
 
@@ -168,7 +168,7 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
       onCollapse={collapseItem}
       onExpand={expandItem}
       isExpanded={(item) => expandedId === item.id}
-      renderExpandedContent={(item: RouteTableItemProps, index) =>
+      renderExpandedContent={(item: RouteTableItemProps) =>
         isAddMode || editMode ? (
           <AmRoutesExpandedForm
             onCancel={() => {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes notification routes editing when there are any filters applied

**Which issue(s) this PR fixes**:
Fixes #45378

**Special notes for your reviewer**:

