### PR TITLE
Chore: fix Levitate reporting issues with missing PR numbers

### DIFF
--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Persisting the check output
         run: |
             mkdir -p ./levitate
-            echo "{ \"exit_code\": ${{ steps.breaking-changes.outputs.is_breaking }}, \"message\": \"${{ steps.breaking-changes.outputs.message }}\", \"job_link\": \"${{ steps.job.outputs.link }}#step:${GITHUB_STEP_NUMBER}:1\" }" > ./levitate/result.json
+            echo "{ \"exit_code\": ${{ steps.breaking-changes.outputs.is_breaking }}, \"message\": \"${{ steps.breaking-changes.outputs.message }}\", \"job_link\": \"${{ steps.job.outputs.link }}#step:${GITHUB_STEP_NUMBER}:1\", \"pr_number\": \"${{ github.event.pull_request.number }}\" }" > ./levitate/result.json
 
       - name: Upload check output as artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/detect-breaking-changes-report.yml
+++ b/.github/workflows/detect-breaking-changes-report.yml
@@ -82,7 +82,7 @@ jobs:
       if: ${{ steps.levitate-run.outputs.exit_code == 1 }}
       uses: marocchino/sticky-pull-request-comment@v2
       with:
-        number: ${{ github.event.workflow_run.pull_requests[0].number }}
+        number: ${{ steps.levitate-run.outputs.pr_number }}
         message: |
           ⚠️ &nbsp;&nbsp;**Possible breaking changes**
 
@@ -97,7 +97,7 @@ jobs:
       if: ${{ steps.levitate-run.outputs.exit_code == 0 }}
       uses: marocchino/sticky-pull-request-comment@v2
       with:
-        number: ${{ github.event.workflow_run.pull_requests[0].number }}
+        number: ${{ steps.levitate-run.outputs.pr_number }}
         delete: true
 
     # Posts a notification to Slack if a PR has a breaking change and it did not have a breaking change before
@@ -108,8 +108,8 @@ jobs:
       with:
         payload: |
           {
-            "pr_link": "${{ github.event.workflow_run.pull_requests[0].html_url }}",
-            "pr_number": "${{ github.event.workflow_run.pull_requests[0].number }}",
+            "pr_link": "https://github.com/grafana/grafana/pull/${{ steps.levitate-run.outputs.pr_number }}",
+            "pr_number": "${{ steps.levitate-run.outputs.pr_number }}",
             "job_link": "${{ steps.levitate-run.outputs.job_link }}",
             "reporting_job_link": "${{ github.event.workflow_run.html_url }}",
             "message": "${{ steps.levitate-run.outputs.message }}"
@@ -121,7 +121,7 @@ jobs:
       if: ${{ steps.levitate-run.outputs.exit_code == 1 && steps.does-label-exist.outputs.result == 0 }}
       uses: actions/github-script@v5
       env:
-        PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
       with:
         script: |
           await github.rest.issues.addLabels({
@@ -135,7 +135,7 @@ jobs:
       if: ${{ steps.levitate-run.outputs.exit_code == 0 && steps.does-label-exist.outputs.result == 1 }}
       uses: actions/github-script@v5
       env:
-        PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
       with:
         script: |
           await github.rest.issues.removeLabel({
@@ -151,7 +151,7 @@ jobs:
       if: ${{ steps.levitate-run.outputs.exit_code == 1 }}
       uses: actions/github-script@v5
       env:
-        PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
       with:
         script: |
           await github.rest.pulls.requestReviewers({
@@ -166,7 +166,7 @@ jobs:
       if: ${{ steps.levitate-run.outputs.exit_code == 0 }}
       uses: actions/github-script@v5
       env:
-        PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
       with:
         script: |
           await github.rest.pulls.removeRequestedReviewers({


### PR DESCRIPTION
### What is the problem?
Unfortunately whenever the `workflow_run` reporting workflow is triggered via a 3rd party (from a fork) pull request then the event context `github.event.workflow_run.pull_requests` is not populated correctly, it's empty. 

![Screenshot 2022-02-15 at 9 26 15](https://user-images.githubusercontent.com/9974811/154022251-389559e0-36f6-4a32-a5f4-4c8a15c3cecd.png)

([Issue on Github's community forum](https://github.community/t/pull-request-attribute-empty-in-workflow-run-event-object-for-pr-from-forked-repo/154682)) 
[Example error](https://github.com/grafana/grafana/runs/5194440824?check_suite_focus=true)


### What changed?
A workaround that should work in all scenarios is to persist the PR number in the artifact from the original `pull_request` workflow where this information is always available, and use this in the reporting workflow.