### PR TITLE
AccessControl: Trigger permission reload with team removal

### DIFF
--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -42,10 +42,7 @@ export class TeamList extends PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    // Don't fetch teams if the user cannot see any
-    if (contextSrv.hasAccess(AccessControlAction.ActionTeamsRead, true)) {
-      this.fetchTeams();
-    }
+    this.fetchTeams();
     if (contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
       this.fetchRoleOptions();
     }
@@ -198,10 +195,8 @@ export class TeamList extends PureComponent<Props, State> {
 
   renderList() {
     const { teamsCount, hasFetched } = this.props;
-    // If the user cannot read any team, we didn't fetch them
-    let isLoading = !hasFetched && contextSrv.hasAccess(AccessControlAction.ActionTeamsRead, true);
 
-    if (isLoading) {
+    if (!hasFetched) {
       return null;
     }
 
@@ -214,12 +209,10 @@ export class TeamList extends PureComponent<Props, State> {
 
   render() {
     const { hasFetched, navModel } = this.props;
-    // If the user cannot read any team, we didn't fetch them
-    let isLoading = !hasFetched && contextSrv.hasAccess(AccessControlAction.ActionTeamsRead, true);
 
     return (
       <Page navModel={navModel}>
-        <Page.Contents isLoading={isLoading}>{this.renderList()}</Page.Contents>
+        <Page.Contents isLoading={!hasFetched}>{this.renderList()}</Page.Contents>
       </Page>
     );
   }

--- a/public/app/features/teams/state/actions.ts
+++ b/public/app/features/teams/state/actions.ts
@@ -1,13 +1,20 @@
 import { getBackendSrv } from '@grafana/runtime';
 
-import { TeamMember, ThunkResult } from 'app/types';
+import { AccessControlAction, TeamMember, ThunkResult } from 'app/types';
 import { updateNavIndex } from 'app/core/actions';
 import { buildNavModel } from './navModel';
 import { teamGroupsLoaded, teamLoaded, teamMembersLoaded, teamsLoaded } from './reducers';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
+import { contextSrv } from 'app/core/core';
 
 export function loadTeams(): ThunkResult<void> {
   return async (dispatch) => {
+    // Early return if the user cannot list teams
+    if (!contextSrv.hasPermission(AccessControlAction.ActionTeamsRead)) {
+      dispatch(teamsLoaded([]));
+      return;
+    }
+
     const response = await getBackendSrv().get(
       '/api/teams/search',
       accessControlQueryParam({ perpage: 1000, page: 1 })
@@ -83,6 +90,8 @@ export function removeTeamGroup(groupId: string): ThunkResult<void> {
 export function deleteTeam(id: number): ThunkResult<void> {
   return async (dispatch) => {
     await getBackendSrv().delete(`/api/teams/${id}`);
+    // Update users permissions in case they lost teams.read with the deletion
+    await contextSrv.fetchUserPermissions();
     dispatch(loadTeams());
   };
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When team admins remove a team they are admin of, they loose the `teams:read` associated to this team. Hence the teams listing that comes straight after a removal can result in a `403`. This PR intends to fix this issue.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

