### PR TITLE
TemplateSrv: re-adding variableExists to prevent breaking angular plugins

### DIFF
--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -198,6 +198,11 @@ export class TemplateSrv implements BaseTemplateSrv {
     return variable !== null && variable !== undefined;
   }
 
+  variableExists(expression: string): boolean {
+    deprecationWarning('template_srv.ts', 'variableExists', 'containsTemplate');
+    return this.containsTemplate(expression);
+  }
+
   highlightVariablesAsHtml(str: string) {
     if (!str || !isString(str)) {
       return str;


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/grafana/grafana/pull/45214 I exposed the `containsTemplate` function via the `TemplateSrv` interface so it can be used from external plugins.

I added the `variableExists` back to decrease the risk of this change breaking older plugins. The plan is to remove the `variableExists` in Grafana 9.0.

