### PR TITLE
Logs: Fix LogDetailsRow tests that produced console errors

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogDetailsRow.test.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetailsRow.test.tsx
@@ -20,7 +20,13 @@ const setup = (propOverrides?: Partial<Props>) => {
 
   Object.assign(props, propOverrides);
 
-  return render(<LogDetailsRow {...props} />);
+  return render(
+    <table>
+      <tbody>
+        <LogDetailsRow {...props} />
+      </tbody>
+    </table>
+  );
 };
 
 describe('LogDetailsRow', () => {

--- a/packages/grafana-ui/src/components/Logs/LogLabelStats.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogLabelStats.tsx
@@ -18,6 +18,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       background: inherit;
       color: ${theme.colors.text};
       word-break: break-all;
+      width: fit-content;
     `,
     logsStatsHeader: css`
       label: logs-stats__header;
@@ -73,28 +74,22 @@ class UnThemedLogLabelStats extends PureComponent<Props> {
     const otherProportion = otherCount / total;
 
     return (
-      <table>
-        <tbody>
-          <tr>
-            <td className={style.logsStats} data-testid="logLabelStats">
-              <div className={style.logsStatsHeader}>
-                <div className={style.logsStatsTitle}>
-                  {label}: {total} of {rowCount} rows have that {isLabel ? 'label' : 'field'}
-                </div>
-              </div>
-              <div className={style.logsStatsBody}>
-                {topRows.map((stat) => (
-                  <LogLabelStatsRow key={stat.value} {...stat} active={stat.value === value} />
-                ))}
-                {insertActiveRow && activeRow && <LogLabelStatsRow key={activeRow.value} {...activeRow} active />}
-                {otherCount > 0 && (
-                  <LogLabelStatsRow key="__OTHERS__" count={otherCount} value="Other" proportion={otherProportion} />
-                )}
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <div className={style.logsStats} data-testid="logLabelStats">
+        <div className={style.logsStatsHeader}>
+          <div className={style.logsStatsTitle}>
+            {label}: {total} of {rowCount} rows have that {isLabel ? 'label' : 'field'}
+          </div>
+        </div>
+        <div className={style.logsStatsBody}>
+          {topRows.map((stat) => (
+            <LogLabelStatsRow key={stat.value} {...stat} active={stat.value === value} />
+          ))}
+          {insertActiveRow && activeRow && <LogLabelStatsRow key={activeRow.value} {...activeRow} active />}
+          {otherCount > 0 && (
+            <LogLabelStatsRow key="__OTHERS__" count={otherCount} value="Other" proportion={otherProportion} />
+          )}
+        </div>
+      </div>
     );
   }
 }

--- a/packages/grafana-ui/src/components/Logs/LogLabelStats.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogLabelStats.tsx
@@ -19,6 +19,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       color: ${theme.colors.text};
       word-break: break-all;
       width: fit-content;
+      max-width: 100%;
     `,
     logsStatsHeader: css`
       label: logs-stats__header;

--- a/packages/grafana-ui/src/components/Logs/LogLabelStats.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogLabelStats.tsx
@@ -15,7 +15,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
   return {
     logsStats: css`
       label: logs-stats;
-      column-span: 2;
       background: inherit;
       color: ${theme.colors.text};
       word-break: break-all;
@@ -74,22 +73,28 @@ class UnThemedLogLabelStats extends PureComponent<Props> {
     const otherProportion = otherCount / total;
 
     return (
-      <td className={style.logsStats} data-testid="logLabelStats">
-        <div className={style.logsStatsHeader}>
-          <div className={style.logsStatsTitle}>
-            {label}: {total} of {rowCount} rows have that {isLabel ? 'label' : 'field'}
-          </div>
-        </div>
-        <div className={style.logsStatsBody}>
-          {topRows.map((stat) => (
-            <LogLabelStatsRow key={stat.value} {...stat} active={stat.value === value} />
-          ))}
-          {insertActiveRow && activeRow && <LogLabelStatsRow key={activeRow.value} {...activeRow} active />}
-          {otherCount > 0 && (
-            <LogLabelStatsRow key="__OTHERS__" count={otherCount} value="Other" proportion={otherProportion} />
-          )}
-        </div>
-      </td>
+      <table>
+        <tbody>
+          <tr>
+            <td className={style.logsStats} data-testid="logLabelStats">
+              <div className={style.logsStatsHeader}>
+                <div className={style.logsStatsTitle}>
+                  {label}: {total} of {rowCount} rows have that {isLabel ? 'label' : 'field'}
+                </div>
+              </div>
+              <div className={style.logsStatsBody}>
+                {topRows.map((stat) => (
+                  <LogLabelStatsRow key={stat.value} {...stat} active={stat.value === value} />
+                ))}
+                {insertActiveRow && activeRow && <LogLabelStatsRow key={activeRow.value} {...activeRow} active />}
+                {otherCount > 0 && (
+                  <LogLabelStatsRow key="__OTHERS__" count={otherCount} value="Other" proportion={otherProportion} />
+                )}
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     );
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
There were 2 issues producing console.errors in tests:
1. ` Warning: validateDOMNesting(...): <tr> cannot appear as a child of <div>.`
<img width="1047" alt="image" src="https://user-images.githubusercontent.com/30407135/154044873-0dfa45ce-9f7a-4f20-baa5-6b630ccdb4a1.png">

  This was because we have `<table><tbody>` in LogDetails component and in tests we were rendering `LogDetailsRow` that starts with `<tr>`. This issue is only in tests. We are fixing it by wrapping `LogDetails` in tests in  `<table><tbody>`.



2. `Warning: validateDOMNesting(...): <td> cannot appear as a child of <td>.`
<img width="999" alt="image" src="https://user-images.githubusercontent.com/30407135/154045369-2ac9d14b-ef0a-43f5-a533-8b017c65bee4.png">

This is an actual issue. We use <td> element inside <td>.  To fix this, we are changing `<td>` to `<div>` and updating styling so it looks the same as currently. The short stats take short space and long stats take long space. 
<img width="1318" alt="image" src="https://user-images.githubusercontent.com/30407135/154048603-b679fdf4-59d0-4ff2-a4f9-78d0319c1544.png">

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/45194
