### PR TITLE
Loki: do not convert NaN to null

### DIFF
--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -306,7 +306,7 @@ describe('enhanceDataFrame', () => {
         [1, 1000],
         [0, 2000],
         [1, 4000],
-        [null, 7000],
+        [NaN, 7000],
         [Infinity, 8000],
         [-Infinity, 9000],
       ]);

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -209,10 +209,6 @@ export function lokiPointsToTimeseriesPoints(data: Array<[number, string]>): Tim
   for (const [time, value] of data) {
     let datapointValue: TimeSeriesValue = parsePrometheusFormatSampleValue(value);
 
-    if (isNaN(datapointValue)) {
-      datapointValue = null;
-    }
-
     const timestamp = time * 1000;
 
     datapoints.push([datapointValue, timestamp]);


### PR DESCRIPTION
when Loki returns metric data to Grafana, the numeric value can be the `NaN` (not a number) value. in the alerting-backend-code we keep the value as `NaN`, but in the frontend (i assume for historical reasons), we convert it to `null`. to keep both modes (backend-alerting & frontend) work the same way, we will stop converting `NaN` to `null`. i did some tests, and while this is technically a breaking-change, the timeSeries panel behaves the same way for both `NaN` and `null`, so most of times this change will not be visible to the end user.
this will also help having simpler loki-backend-mode code.

how to test:
- we need test-data that contains both numbers and `NaN`. this is hard to find, so i have a nodejs-script that generates it:
    ````
    now = new Date();
    nowNs = now.getTime() * 1000 * 1000;
    minNs = 60 * 1000 * 1000 * 1000;
    
    DATA = `
    {
      "streams": [
        {
          "stream": {
            "nantest": "yes"
          },
          "values": [
            ["${nowNs - 0 * minNs}", "num=41"],
            ["${nowNs - 1 * minNs}", "num=42"],
            ["${nowNs - 2 * minNs}", "num=43"],
            ["${nowNs - 3 * minNs}", "num=NaN"],
            ["${nowNs - 4 * minNs}", "num=45"],
            ["${nowNs - 5 * minNs}", "num=46"],
            ["${nowNs - 6 * minNs}", "num=47"]
          ]
        }
      ]
    }
    `;
    
    console.log(DATA);
    ````
- save the script, run it, it will output to the console some loki-logs-data, 7 log lines for the last 7 minutes.
- we can send this to loki using this line (we assume loki is running on `http://localhost:3100`):
    - `node make_nan_data.js | curl -X POST -H 'Content-Type: application/json' -d '@-' 'http://localhost:9999/loki/api/v1/push'`
        - (it tells `curl` to send json-data that it reads from standard-input to localhost-3100)
- now go to grafana dashboards and:
    - create a new timeseries panel
    - set the time-range to last-15-minutes
    - in query-options set min_interval to `1m`
    - use this query:  `avg_over_time({nantest="yes"} | logfmt | unwrap num [$__interval])`
    - now you should see a graph, verify in the `query inspector / data` that you are seeing 7 values: `47, 46, 45, NaN, 43, 42, 41`
- at this point you can compare the behavior of the main-branch code and this code. it should be the same
- try changing the `connect null values` setting, the behavior should be the same on main-branch as here


# Release notice breaking change

In the Loki data source, for consistency and performance reasons, we changed how we represent `NaN` (not a number) values received from Loki. In the past versions, we converted these to `null` in the frontend (for dashboard and explore), and kept as `NaN` in the alerting path. Starting with this version, we will always keep it as `NaN`. This change should be mostly invisible for the users.