### PR TITLE
Analytics: Collect information about queries reordering

### DIFF
--- a/public/app/features/query/components/QueryEditorRows.tsx
+++ b/public/app/features/query/components/QueryEditorRows.tsx
@@ -11,8 +11,8 @@ import {
   PanelData,
 } from '@grafana/data';
 import { QueryEditorRow } from './QueryEditorRow';
-import { DragDropContext, Droppable, DropResult } from 'react-beautiful-dnd';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { DragDropContext, DragStart, Droppable, DropResult } from 'react-beautiful-dnd';
+import { getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 
 interface Props {
   // The query configuration
@@ -81,8 +81,18 @@ export class QueryEditorRows extends PureComponent<Props> {
     );
   }
 
+  onDragStart = (result: DragStart) => {
+    const { queries, dsSettings } = this.props;
+
+    reportInteraction('query_row_reorder_started', {
+      startIndex: result.source.index,
+      numberOfQueries: queries.length,
+      datasourceType: dsSettings.type,
+    });
+  };
+
   onDragEnd = (result: DropResult) => {
-    const { queries, onQueriesChange } = this.props;
+    const { queries, onQueriesChange, dsSettings } = this.props;
 
     if (!result || !result.destination) {
       return;
@@ -91,6 +101,12 @@ export class QueryEditorRows extends PureComponent<Props> {
     const startIndex = result.source.index;
     const endIndex = result.destination.index;
     if (startIndex === endIndex) {
+      reportInteraction('query_row_reorder_canceled', {
+        startIndex,
+        endIndex,
+        numberOfQueries: queries.length,
+        datasourceType: dsSettings.type,
+      });
       return;
     }
 
@@ -98,13 +114,20 @@ export class QueryEditorRows extends PureComponent<Props> {
     const [removed] = update.splice(startIndex, 1);
     update.splice(endIndex, 0, removed);
     onQueriesChange(update);
+
+    reportInteraction('query_row_reorder_ended', {
+      startIndex,
+      endIndex,
+      numberOfQueries: queries.length,
+      datasourceType: dsSettings.type,
+    });
   };
 
   render() {
     const { dsSettings, data, queries, app, history, eventBus } = this.props;
 
     return (
-      <DragDropContext onDragEnd={this.onDragEnd}>
+      <DragDropContext onDragStart={this.onDragStart} onDragEnd={this.onDragEnd}>
         <Droppable droppableId="transformations-list" direction="vertical">
           {(provided) => {
             return (


### PR DESCRIPTION
Added interaction reporting for query drag-and-drop UI.

Four new event types are added:
- `query_row_reorder_started`
- `query_row_reorder_ended`
- `query_row_reorder_canceled`
- `query_row_reorder_drag_position` - represents relative mouse positinion within Query header element (x/y, 0-1)