### PR TITLE
Prometheus: Offer hint for metrics with labels

### DIFF
--- a/public/app/plugins/datasource/prometheus/query_hints.test.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.test.ts
@@ -88,6 +88,21 @@ describe('getQueryHints()', () => {
     expect(hints).toEqual([]);
   });
 
+  it('returns a rate hint with action for a counter metric with labels', () => {
+    const series = [
+      {
+        datapoints: [
+          [23, 1000],
+          [24, 1001],
+        ],
+      },
+    ];
+    const hints = getQueryHints('metric_total{job="grafana"}', series);
+    expect(hints!.length).toBe(1);
+    expect(hints![0].label).toContain('Selected metric looks like a counter');
+    expect(hints![0].fix).toBeDefined();
+  });
+
   it('returns a rate hint w/o action for a complex counter metric', () => {
     const series = [
       {

--- a/public/app/plugins/datasource/prometheus/query_hints.test.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.test.ts
@@ -133,6 +133,21 @@ describe('getQueryHints()', () => {
     });
   });
 
+  it('returns a histogram hint with action for a bucket with labels', () => {
+    const series = [
+      {
+        datapoints: [
+          [23, 1000],
+          [24, 1001],
+        ],
+      },
+    ];
+    const hints = getQueryHints('metric_bucket{job="grafana"}', series);
+    expect(hints!.length).toBe(1);
+    expect(hints![0].label).toContain('Selected metric has buckets.');
+    expect(hints![0].fix).toBeDefined();
+  });
+
   it('returns a sum hint when many time series results are returned for a simple metric', () => {
     const seriesCount = SUM_HINT_THRESHOLD_COUNT;
     const series = Array.from({ length: seriesCount }, (_) => ({

--- a/public/app/plugins/datasource/prometheus/query_hints.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.ts
@@ -53,12 +53,13 @@ export function getQueryHints(query: string, series?: any[], datasource?: Promet
     }
 
     if (counterNameMetric) {
-      const simpleMetric = query.trim().match(/^\w+$/);
+      // FixableQuery includes metric name and it can include label-value pairs. We are not offering fix for complex queries yet.
+      const fixableQuery = query.trim().match(/^\w+$|^\w+{.*}$/);
       const verb = certain ? 'is' : 'looks like';
       let label = `Selected metric ${verb} a counter.`;
       let fix: QueryFix | undefined;
 
-      if (simpleMetric) {
+      if (fixableQuery) {
         fix = {
           label: 'Consider calculating rate of counter by adding rate().',
           action: {

--- a/public/app/plugins/datasource/prometheus/query_hints.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.ts
@@ -11,7 +11,7 @@ export function getQueryHints(query: string, series?: any[], datasource?: Promet
   const hints = [];
 
   // ..._bucket metric needs a histogram_quantile()
-  const histogramMetric = query.trim().match(/^\w+_bucket$/);
+  const histogramMetric = query.trim().match(/^\w+_bucket$|^\w+_bucket{.*}$/);
   if (histogramMetric) {
     const label = 'Selected metric has buckets.';
     hints.push({

--- a/public/app/plugins/datasource/prometheus/query_hints.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.ts
@@ -53,7 +53,7 @@ export function getQueryHints(query: string, series?: any[], datasource?: Promet
     }
 
     if (counterNameMetric) {
-      // FixableQuery includes metric name and it can include label-value pairs. We are not offering fix for complex queries yet.
+      // FixableQuery consists of metric name and optionally label-value pairs. We are not offering fix for complex queries yet.
       const fixableQuery = query.trim().match(/^\w+$|^\w+{.*}$/);
       const verb = certain ? 'is' : 'looks like';
       let label = `Selected metric ${verb} a counter.`;


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow up on https://github.com/grafana/grafana/pull/45288. We want to offer hint for query that includes counter metric + optionally label-value pairs. This PR fixes it. 

**Now:** 
<img width="828" alt="image" src="https://user-images.githubusercontent.com/30407135/154068286-31d5f31d-2303-4038-8118-f2e7d267f2f2.png">

**Before:**
<img width="879" alt="image" src="https://user-images.githubusercontent.com/30407135/154068466-4b6b2bc5-7324-4b9d-8360-6ce84a5134a5.png">

