### PR TITLE
Team access changes for editors when editorsCanAdmin is enabled

### DIFF
--- a/docs/sources/http_api/team.md
+++ b/docs/sources/http_api/team.md
@@ -13,7 +13,8 @@ Access to these API endpoints is restricted as follows:
 
 - All authenticated users are able to view details of teams they are a member of.
 - Organization Admins are able to manage all teams and team members.
-- If the `editors_can_admin` configuration flag is enabled, Organization Editors are able to view details of all teams and to manage teams that they are Admin members of.
+- If the `editors_can_admin` configuration flag is enabled, Organization Editors are able to create teams and manage teams that they are Admin members of.
+  - Note that editors could find the names of teams that they are not members of by attempting to create a team with the same name.
 
 > If you are running Grafana Enterprise and have [Fine-grained access control]({{< relref "../enterprise/access-control/_index.md" >}}) enabled, access to endpoints will be controlled by Fine-grained access control permissions.
 > Refer to specific endpoints to understand what permissions are required.

--- a/docs/sources/http_api/team.md
+++ b/docs/sources/http_api/team.md
@@ -13,8 +13,8 @@ Access to these API endpoints is restricted as follows:
 
 - All authenticated users are able to view details of teams they are a member of.
 - Organization Admins are able to manage all teams and team members.
-- If the `editors_can_admin` configuration flag is enabled, Organization Editors are able to create teams and manage teams that they are Admin members of.
-  - Note that when the `editors_can_admin` configuration flag is enabled, Organization Editors could find out whether a team that they are not members of exists by attempting to create a team with the same name.
+- If you enable `editors_can_admin` configuration flag, then Organization Editors can create teams and manage teams where they are Admin.
+  - If you enable `editors_can_admin` configuration flag, Editors can find out whether a team that they are not members of exists by trying to create a team with the same name.
 
 > If you are running Grafana Enterprise and have [Fine-grained access control]({{< relref "../enterprise/access-control/_index.md" >}}) enabled, access to endpoints will be controlled by Fine-grained access control permissions.
 > Refer to specific endpoints to understand what permissions are required.

--- a/docs/sources/http_api/team.md
+++ b/docs/sources/http_api/team.md
@@ -14,7 +14,6 @@ Access to these API endpoints is restricted as follows:
 - All authenticated users are able to view details of teams they are a member of.
 - Organization Admins are able to manage all teams and team members.
 - If the `editors_can_admin` configuration flag is enabled, Organization Editors are able to create teams and manage teams that they are Admin members of.
-  - Note that when the `editors_can_admin` configuration flag is enabled, Organizations Editors could find the name of a team that they are not members of by attempting to create a team with the same name.
 
 > If you are running Grafana Enterprise and have [Fine-grained access control]({{< relref "../enterprise/access-control/_index.md" >}}) enabled, access to endpoints will be controlled by Fine-grained access control permissions.
 > Refer to specific endpoints to understand what permissions are required.

--- a/docs/sources/http_api/team.md
+++ b/docs/sources/http_api/team.md
@@ -14,6 +14,7 @@ Access to these API endpoints is restricted as follows:
 - All authenticated users are able to view details of teams they are a member of.
 - Organization Admins are able to manage all teams and team members.
 - If the `editors_can_admin` configuration flag is enabled, Organization Editors are able to create teams and manage teams that they are Admin members of.
+  - Note that when the `editors_can_admin` configuration flag is enabled, Organization Editors could find out whether a team that they are not members of exists by attempting to create a team with the same name.
 
 > If you are running Grafana Enterprise and have [Fine-grained access control]({{< relref "../enterprise/access-control/_index.md" >}}) enabled, access to endpoints will be controlled by Fine-grained access control permissions.
 > Refer to specific endpoints to understand what permissions are required.

--- a/docs/sources/http_api/team.md
+++ b/docs/sources/http_api/team.md
@@ -14,7 +14,7 @@ Access to these API endpoints is restricted as follows:
 - All authenticated users are able to view details of teams they are a member of.
 - Organization Admins are able to manage all teams and team members.
 - If the `editors_can_admin` configuration flag is enabled, Organization Editors are able to create teams and manage teams that they are Admin members of.
-  - Note that editors could find the names of teams that they are not members of by attempting to create a team with the same name.
+  - Note that when the `editors_can_admin` configuration flag is enabled, Organizations Editors could find the name of a team that they are not members of by attempting to create a team with the same name.
 
 > If you are running Grafana Enterprise and have [Fine-grained access control]({{< relref "../enterprise/access-control/_index.md" >}}) enabled, access to endpoints will be controlled by Fine-grained access control permissions.
 > Refer to specific endpoints to understand what permissions are required.

--- a/pkg/api/team.go
+++ b/pkg/api/team.go
@@ -133,7 +133,7 @@ func (hs *HTTPServer) SearchTeams(c *models.ReqContext) response.Response {
 	// Using accesscontrol the filtering is done based on user permissions
 	userIdFilter := models.FilterIgnoreUser
 	if !hs.Features.IsEnabled(featuremgmt.FlagAccesscontrol) {
-		userIdFilter = userFilter(hs.Cfg.EditorsCanAdmin, c)
+		userIdFilter = userFilter(c)
 	}
 
 	query := models.SearchTeamsQuery{
@@ -189,14 +189,12 @@ func (hs *HTTPServer) getTeamAccessControlMetadata(c *models.ReqContext, teamID 
 
 // UserFilter returns the user ID used in a filter when querying a team
 // 1. If the user is a viewer or editor, this will return the user's ID.
-// 2. If EditorsCanAdmin is enabled and the user is an editor, this will return models.FilterIgnoreUser (0)
-// 3. If the user is an admin, this will return models.FilterIgnoreUser (0)
-func userFilter(editorsCanAdmin bool, c *models.ReqContext) int64 {
+// 2. If the user is an admin, this will return models.FilterIgnoreUser (0)
+func userFilter(c *models.ReqContext) int64 {
 	userIdFilter := c.SignedInUser.UserId
-	if (editorsCanAdmin && c.OrgRole == models.ROLE_EDITOR) || c.OrgRole == models.ROLE_ADMIN {
+	if c.OrgRole == models.ROLE_ADMIN {
 		userIdFilter = models.FilterIgnoreUser
 	}
-
 	return userIdFilter
 }
 
@@ -210,7 +208,7 @@ func (hs *HTTPServer) GetTeamByID(c *models.ReqContext) response.Response {
 	// Using accesscontrol the filtering has already been performed at middleware layer
 	userIdFilter := models.FilterIgnoreUser
 	if !hs.Features.IsEnabled(featuremgmt.FlagAccesscontrol) {
-		userIdFilter = userFilter(hs.Cfg.EditorsCanAdmin, c)
+		userIdFilter = userFilter(c)
 	}
 
 	query := models.GetTeamByIdQuery{

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -72,11 +72,9 @@ export class TeamList extends PureComponent<Props, State> {
     const { editorsCanAdmin, signedInUser } = this.props;
     const permission = team.permission;
     const teamUrl = `org/teams/edit/${team.id}`;
-    const canDelete = contextSrv.hasAccessInMetadata(
-      AccessControlAction.ActionTeamsDelete,
-      team,
-      isPermissionTeamAdmin({ permission, editorsCanAdmin, signedInUser })
-    );
+    const isTeamAdmin = isPermissionTeamAdmin({ permission, editorsCanAdmin, signedInUser });
+    const canDelete = contextSrv.hasAccessInMetadata(AccessControlAction.ActionTeamsDelete, team, isTeamAdmin);
+    const canReadTeam = contextSrv.hasAccessInMetadata(AccessControlAction.ActionTeamsRead, team, isTeamAdmin);
     const canSeeTeamRoles = contextSrv.hasAccessInMetadata(AccessControlAction.ActionTeamsRolesList, team, false);
     const canUpdateTeamRoles =
       contextSrv.hasAccess(AccessControlAction.ActionTeamsRolesAdd, false) ||
@@ -89,20 +87,34 @@ export class TeamList extends PureComponent<Props, State> {
     return (
       <tr key={team.id}>
         <td className="width-4 text-center link-td">
-          <a href={teamUrl}>
+          {canReadTeam ? (
+            <a href={teamUrl}>
+              <img className="filter-table__avatar" src={team.avatarUrl} alt="Team avatar" />
+            </a>
+          ) : (
             <img className="filter-table__avatar" src={team.avatarUrl} alt="Team avatar" />
-          </a>
+          )}
         </td>
         <td className="link-td">
-          <a href={teamUrl}>{team.name}</a>
+          {canReadTeam ? <a href={teamUrl}>{team.name}</a> : <div style={{ padding: '0px 8px' }}>{team.name}</div>}
         </td>
         <td className="link-td">
-          <a href={teamUrl} aria-label={team.email?.length > 0 ? undefined : 'Empty email cell'}>
-            {team.email}
-          </a>
+          {canReadTeam ? (
+            <a href={teamUrl} aria-label={team.email?.length > 0 ? undefined : 'Empty email cell'}>
+              {team.email}
+            </a>
+          ) : (
+            <div style={{ padding: '0px 8px' }} aria-label={team.email?.length > 0 ? undefined : 'Empty email cell'}>
+              {team.email}
+            </div>
+          )}
         </td>
         <td className="link-td">
-          <a href={teamUrl}>{team.memberCount}</a>
+          {canReadTeam ? (
+            <a href={teamUrl}>{team.memberCount}</a>
+          ) : (
+            <div style={{ padding: '0px 8px' }}>{team.memberCount}</div>
+          )}
         </td>
         {displayRolePicker && (
           <td>

--- a/public/app/features/teams/__snapshots__/TeamList.test.tsx.snap
+++ b/public/app/features/teams/__snapshots__/TeamList.test.tsx.snap
@@ -445,42 +445,50 @@ exports[`Render when feature toggle editorsCanAdmin is turned on and signedin us
               <td
                 className="width-4 text-center link-td"
               >
-                <a
-                  href="org/teams/edit/1"
-                >
-                  <img
-                    alt="Team avatar"
-                    className="filter-table__avatar"
-                    src="some/url/"
-                  />
-                </a>
+                <img
+                  alt="Team avatar"
+                  className="filter-table__avatar"
+                  src="some/url/"
+                />
               </td>
               <td
                 className="link-td"
               >
-                <a
-                  href="org/teams/edit/1"
+                <div
+                  style={
+                    Object {
+                      "padding": "0px 8px",
+                    }
+                  }
                 >
                   test-1
-                </a>
+                </div>
               </td>
               <td
                 className="link-td"
               >
-                <a
-                  href="org/teams/edit/1"
+                <div
+                  style={
+                    Object {
+                      "padding": "0px 8px",
+                    }
+                  }
                 >
                   test-1@test.com
-                </a>
+                </div>
               </td>
               <td
                 className="link-td"
               >
-                <a
-                  href="org/teams/edit/1"
+                <div
+                  style={
+                    Object {
+                      "padding": "0px 8px",
+                    }
+                  }
                 >
                   1
-                </a>
+                </div>
               </td>
               <td
                 className="text-right"
@@ -583,42 +591,50 @@ exports[`Render when feature toggle editorsCanAdmin is turned on and signedin us
               <td
                 className="width-4 text-center link-td"
               >
-                <a
-                  href="org/teams/edit/1"
-                >
-                  <img
-                    alt="Team avatar"
-                    className="filter-table__avatar"
-                    src="some/url/"
-                  />
-                </a>
+                <img
+                  alt="Team avatar"
+                  className="filter-table__avatar"
+                  src="some/url/"
+                />
               </td>
               <td
                 className="link-td"
               >
-                <a
-                  href="org/teams/edit/1"
+                <div
+                  style={
+                    Object {
+                      "padding": "0px 8px",
+                    }
+                  }
                 >
                   test-1
-                </a>
+                </div>
               </td>
               <td
                 className="link-td"
               >
-                <a
-                  href="org/teams/edit/1"
+                <div
+                  style={
+                    Object {
+                      "padding": "0px 8px",
+                    }
+                  }
                 >
                   test-1@test.com
-                </a>
+                </div>
               </td>
               <td
                 className="link-td"
               >
-                <a
-                  href="org/teams/edit/1"
+                <div
+                  style={
+                    Object {
+                      "padding": "0px 8px",
+                    }
+                  }
                 >
                   1
-                </a>
+                </div>
               </td>
               <td
                 className="text-right"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Changes some backend and frontend behaviours related to teams for organisation editors when `editorsCanAdmin` setting is enabled:
* restricts team editors to only be able to list the teams that they are members of - this was the case previously, and was changed as part of https://github.com/grafana/grafana/pull/45083;
* adds information about user's permissions in the team context (as in, whether the user is a member or an admin of a team) to data returned when listing teams (again, this was changed in https://github.com/grafana/grafana/pull/45083) - these permissions are checked by frontend to determine what to display (for instance, whether team deletion button should be enabled);
* restricts the frontend for teams to only allow clicking on teams that the user is an admin of - otherwise the user was running into an error message, as they're not allowed to list team members and team preferences.


Videos to showcase behaviour before and after:
* setup for both videos has `editorsCanAdmin` setting set to true and the user is an organisation editor.

Before the changes:

https://user-images.githubusercontent.com/9482349/154098251-38569954-0a42-4b73-aec8-3275b5d5435f.mp4


After the changes:


https://user-images.githubusercontent.com/9482349/154098378-dbd85ac2-ebe2-487a-92c1-d7b6d94088fa.mp4


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

The biggest change introduced by this PR is that Organization Editors can now only list the teams that they are members of, rather than being able to list all teams. However, they could still find the name of a team that they are not members of by attempting to create a team with the same name.
