### PR TITLE
BugFix: Remove root/scripts directory from Jest root

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
     'node_modules/(?!(ol)/)', // <- exclude the open layers library
   ],
   moduleDirectories: ['node_modules', 'public'],
-  roots: ['<rootDir>/public/app', '<rootDir>/public/test', '<rootDir>/packages', '<rootDir>/scripts'],
+  roots: ['<rootDir>/public/app', '<rootDir>/public/test', '<rootDir>/packages'],
   testRegex: '(\\.|/)(test)\\.(jsx?|tsx?)$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   setupFiles: ['jest-canvas-mock', './public/test/jest-shim.ts', './public/test/jest-setup.ts'],


### PR DESCRIPTION
**What this PR does / why we need it**:
Replication Steps: 
1. Run `yarn e2e` to run the end to end tests. This creates a folder called `scripts/grafana-server/tmp` as of #44249 
2. Run `yarn test` to run integration tests. It will pick up tests in the tmp directory and they will fail

**Which issue(s) this PR fixes**: No ticket.

**Special notes for your reviewer**:
The scripts folder doesn't seem to be a valid place for jest tests, so I think we can remove this safely.

