### PR TITLE
Chore: Fix Debug Jest test command for vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,8 @@
       "name": "Debug Jest test",
       "type": "node",
       "request": "launch",
-      "runtimeArgs": ["--inspect-brk", "${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "${file}"],
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["run", "jest", "--runInBand", "${file}"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "port": 9229


### PR DESCRIPTION
**What this PR does / why we need it**:

After the yarn upgrade this was not updated and stopped working as we don't have a node_modules anymore.
