### PR TITLE
QueryEditor: Fix crash in angular panels when query have error

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.test.ts
+++ b/public/app/features/query/components/QueryEditorRow.test.ts
@@ -54,10 +54,24 @@ describe('filterPanelDataToQuery', () => {
 
     const panelData = filterPanelDataToQuery(withError, 'B');
     expect(panelData).toBeDefined();
+    expect(panelData?.state).toBe(LoadingState.Error);
+    expect(panelData?.error).toBe(withError.error);
+  });
 
-    // @ts-ignore typescript doesn't understand that panelData can't be undefined here
-    expect(panelData.state).toBe(LoadingState.Error);
-    // @ts-ignore typescript doesn't understand that panelData can't be undefined here
-    expect(panelData.error).toBe(withError.error);
+  it('should set the state to done if the frame has no errors', () => {
+    const withError = {
+      ...data,
+    };
+    withError.state = LoadingState.Error;
+
+    const panelDataB = filterPanelDataToQuery(withError, 'B');
+    expect(panelDataB?.series.length).toBe(3);
+    expect(panelDataB?.series[0].refId).toBe('B');
+    expect(panelDataB?.state).toBe(LoadingState.Error);
+
+    const panelDataA = filterPanelDataToQuery(withError, 'A');
+    expect(panelDataA?.series.length).toBe(1);
+    expect(panelDataA?.series[0].refId).toBe('A');
+    expect(panelDataA?.state).toBe(LoadingState.Done);
   });
 });

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -480,6 +480,8 @@ export function filterPanelDataToQuery(data: PanelData, refId: string): PanelDat
   const error = data.error && data.error.refId === refId ? data.error : undefined;
   if (error) {
     state = LoadingState.Error;
+  } else {
+    state = LoadingState.Done;
   }
 
   const timeRange = data.timeRange;


### PR DESCRIPTION
**What this PR does / why we need it**:

Query editor row caused some crashes when a panel had error.

https://user-images.githubusercontent.com/13729989/154125645-2ff7464e-15e1-4164-aaf3-3708d229a6b2.mov


