### PR TITLE
Draft: Cloudwatch Search Bug Fixes

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/MathExpressionQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MathExpressionQueryField.tsx
@@ -72,6 +72,7 @@ export function MathExpressionQueryField({
         onBlur={(value) => {
           if (value !== query) {
             onChange(value);
+            onRunQuery();
           }
         }}
         onBeforeEditorMount={(monaco: Monaco) =>

--- a/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.tsx
@@ -101,7 +101,15 @@ export class MetricsQueryEditor extends PureComponent<Props, State> {
               <MathExpressionQueryField
                 onRunQuery={onRunQuery}
                 expression={query.expression ?? ''}
-                onChange={(expression) => this.props.onChange({ ...query, expression })}
+                onChange={(expression) =>
+                  this.props.onChange({
+                    ...query,
+                    namespace: '',
+                    metricName: '',
+                    dimensions: {},
+                    expression,
+                  })
+                }
                 datasource={datasource}
               ></MathExpressionQueryField>
             )}


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now we're experiencing some unexpected behavior with Cloudwatch Search when using Aliases in Code mode.

One way to see this is to use the EC2 curated dashboard and navigate to the network details panels such as "Inbound network packets per instance [IOPS]" you'll notice that the legend is not quite right and that if you switch to Builder mode it suddenly shows the right dimension and the Builder is populated with dimensions and other things that are independent of what's happening in the Code panel. 

If you switch back to the Code panel and add an alias of `{{InstanceId}}` you'll see the panel update properly with the right alias, but if you switch back to Builder and remove InstanceId as a dimension and then switch back to Code, you'll see the alias is now broken again and there's no way to fix it besides adding back a dimension on the builder page. 

It's not super clear the best solution for this but I'm proposing that we fix this maybe in a series of prs like so:
- [ ] parse search expressions written on the Code page for dimensions and then add label support for them (I believe this could happen on either the backend or frontend, my first impulse is to put this on the backend)
- [ ] we clear out all Builder fields when we enter an expression on the Code field and we clear out the Code field when we enter new info in the Builder. The idea that you can switch between the two panels and see different queries seems pretty confusing to me. 
- [ ] later on as a feature: When you create an expression in Builder and switch to Code, it should be able to copy it over to Code (we do this currently on the backend, in theory this is trivial to do on the frontend as well)
- [ ] later on: When you have a simple search expression in Code and switch to Builder, if it does translate well, we parse it and translate it.

This draft pr is exploring the first 2 bullet points. 

**Which issue(s) this PR fixes**:

Fixes #45471 and addresses #45189

**Special notes for your reviewer**:

I'm mainly focused here on adding support for `{{[DimensionName]}}` alias labels when using Code mode (this is currently stated as something we support in our documentation, but I do wonder if maybe we should just remove it?) 

The aws docs imply you can search across multiple dimensions, so I attempted to support that, but when I make such queries I seem to hit odd errors, so I'm not really as confident in this solution as I'd like to be. I'm not sure if I'm hitting a bug in our code, or if I'm just making bad queries. 

I know that this does seem to work for one dimension name like so:
`SEARCH('{AWS/EC2, AutoScalingGroupName} MetricName="CPUUtilization"', 'Average', 300)` with an alias of `{{AutoScalingGroupName}}` It also works for InstanceId. But I wonder can you pass a specific dimension name value, for example not just "instanceId" but also the id itself like "i-1234"? I also wonder if this only works for one dimension name, what is the point of using this as opposed to just `{{label}}`

Maybe parsing this string is not the best way to go this?

