### PR TITLE
OAuth: Sync GitHub OAuth user name to Grafana if it's set

### DIFF
--- a/pkg/login/social/github_oauth.go
+++ b/pkg/login/social/github_oauth.go
@@ -182,6 +182,7 @@ func (s *SocialGithub) UserInfo(client *http.Client, token *oauth2.Token) (*Basi
 		Id    int    `json:"id"`
 		Login string `json:"login"`
 		Email string `json:"email"`
+		Name  string `json:"name"`
 	}
 
 	response, err := s.httpGet(client, s.apiUrl)
@@ -207,6 +208,9 @@ func (s *SocialGithub) UserInfo(client *http.Client, token *oauth2.Token) (*Basi
 		Id:     fmt.Sprintf("%d", data.Id),
 		Email:  data.Email,
 		Groups: teams,
+	}
+	if data.Name != "" {
+		userInfo.Name = data.Name
 	}
 
 	organizationsUrl := fmt.Sprintf(s.apiUrl + "/orgs")


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Currently GitHub OAuth always uses user's GitHub *login* as Grafana *login* and *name*, but a name should be a name and GitHub user can have a name.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #45437

**Special notes for your reviewer**:

### Release notice breaking change

When user is using Github OAuth, GitHub login is showed as both Grafana login and name. Now the GitHub name is showed as Grafana name, and GitHub login is showed as Grafana Login.