### PR TITLE
QueryEditor: Fix setting panel state to done if query had no error

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.test.ts
+++ b/public/app/features/query/components/QueryEditorRow.test.ts
@@ -74,4 +74,21 @@ describe('filterPanelDataToQuery', () => {
     expect(panelDataA?.series[0].refId).toBe('A');
     expect(panelDataA?.state).toBe(LoadingState.Done);
   });
+
+  it('should not set the state to done if the frame is loading and has no errors', () => {
+    const loadingData: PanelData = {
+      state: LoadingState.Loading,
+      series: [
+        toDataFrame({ refId: 'A', fields: [{ name: 'AAA' }], meta: {} }),
+        toDataFrame({ refId: 'B', fields: [{ name: 'B111' }], meta: {} }),
+      ],
+      timeRange: { from: dateTime(), to: dateTime(), raw: { from: 'now-1d', to: 'now' } },
+    };
+
+    const panelDataB = filterPanelDataToQuery(loadingData, 'B');
+    expect(panelDataB?.state).toBe(LoadingState.Loading);
+
+    const panelDataA = filterPanelDataToQuery(loadingData, 'A');
+    expect(panelDataA?.state).toBe(LoadingState.Loading);
+  });
 });

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -480,7 +480,7 @@ export function filterPanelDataToQuery(data: PanelData, refId: string): PanelDat
   const error = data.error && data.error.refId === refId ? data.error : undefined;
   if (error) {
     state = LoadingState.Error;
-  } else {
+  } else if (!error && data.state === LoadingState.Error) {
     state = LoadingState.Done;
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix of a fix 😅  Make sure not to change loading state to done.

