### PR TITLE
Plugins: Add ability to enable debug logging per plugin

### DIFF
--- a/pkg/plugins/manager/loader/loader.go
+++ b/pkg/plugins/manager/loader/loader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"path"
@@ -240,7 +241,7 @@ func createPluginBase(pluginJSON plugins.JSONData, class plugins.Class, pluginDi
 		Class:     class,
 	}
 
-	plugin.SetLogger(logger.New("pluginID", plugin.ID))
+	plugin.SetLogger(log.New(fmt.Sprintf("plugin.%s", plugin.ID)))
 	setImages(plugin)
 
 	return plugin


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Previously in order to enable debug logging for a plugin, we would have to enable it for all plugins:

```ini
[log]
filters = plugin-loader:debug
```

It was also not very clear that it was a plugin logger:
```
INFO[02-16|16:03:51] Creating new instance                logger=plugin.loader pluginID=grafana-timestream-datasource 
DBUG[02-16|16:03:51] Successfully created AWS session     logger=plugin.loader pluginID=grafana-timestream-datasource
```

With this change:
```ini
filters = plugin.grafana-timestream-datasource:debug
```

```
INFO[02-16|16:03:51] Creating new instance                logger=plugin.grafana-timestream-datasource 
DBUG[02-16|16:03:51] Successfully created AWS session     logger=plugin.grafana-timestream-datasource
```