### PR TITLE
Cloudwatch: Fix bug with onblur in Metric Search 

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/MathExpressionQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MathExpressionQueryField.tsx
@@ -72,6 +72,7 @@ export function MathExpressionQueryField({
         onBlur={(value) => {
           if (value !== query) {
             onChange(value);
+            onRunQuery();
           }
         }}
         onBeforeEditorMount={(monaco: Monaco) =>


### PR DESCRIPTION
**What this PR does / why we need it**:
To reproduce:
- go to cloudwatch
- make sure you have Metric Search selected and then select Code
- start adding or editing a search expression and notice that the query does not run again until you click the refresh button. 

This was an oversight of mine when we upgraded the new metric math search field. The query should re-run on blur. 

**Which issue(s) this PR fixes**:
Fixes #45489

**Special notes for your reviewer**:

