### PR TITLE
Cloud Monitoring: set missing meta data for distribution type metrics

### DIFF
--- a/pkg/tsdb/cloudmonitoring/test-data/9-series-response-distribution-without-points.json
+++ b/pkg/tsdb/cloudmonitoring/test-data/9-series-response-distribution-without-points.json
@@ -1,0 +1,17 @@
+{
+  "timeSeries": [
+    {
+      "metric": {
+        "type": "loadbalancing.googleapis.com\/https\/backend_latencies"
+      },
+      "resource": {
+        "type": "https_lb_rule",
+        "labels": {
+          "project_id": "grafana-prod"
+        }
+      },
+      "metricKind": "DELTA",
+      "valueType": "DISTRIBUTION"
+    }
+  ]
+}

--- a/pkg/tsdb/cloudmonitoring/time_series_filter.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter.go
@@ -193,6 +193,9 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) parseResponse(queryRes 
 							valueField,
 						},
 						RefID: timeSeriesFilter.RefID,
+						Meta: &data.FrameMeta{
+							ExecutedQueryString: executedQueryString,
+						},
 					}
 
 					if maxKey < i {
@@ -220,12 +223,23 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) parseResponse(queryRes 
 							timeField,
 							valueField,
 						},
+						Meta: &data.FrameMeta{
+							ExecutedQueryString: executedQueryString,
+						},
 					}
 				}
 			}
 		}
 		for i := 0; i < len(buckets); i++ {
+			if buckets[i].Meta != nil {
+				buckets[i].Meta.Custom = customFrameMeta
+			} else {
+				buckets[i].SetMeta(&data.FrameMeta{Custom: customFrameMeta})
+			}
 			frames = append(frames, buckets[i])
+		}
+		if len(buckets) == 0 {
+			frames = append(frames, frame)
 		}
 	}
 	if len(response.TimeSeries) > 0 {

--- a/pkg/tsdb/cloudmonitoring/time_series_filter.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter.go
@@ -231,11 +231,7 @@ func (timeSeriesFilter *cloudMonitoringTimeSeriesFilter) parseResponse(queryRes 
 			}
 		}
 		for i := 0; i < len(buckets); i++ {
-			if buckets[i].Meta != nil {
-				buckets[i].Meta.Custom = customFrameMeta
-			} else {
-				buckets[i].SetMeta(&data.FrameMeta{Custom: customFrameMeta})
-			}
+			buckets[i].Meta.Custom = customFrameMeta
 			frames = append(frames, buckets[i])
 		}
 		if len(buckets) == 0 {

--- a/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
@@ -402,6 +402,23 @@ func TestTimeSeriesFilter(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "grafana-prod", labels["resource.label.project_id"])
 	})
+
+	t.Run("Parse labels for distribution without points", func(t *testing.T) {
+		data, err := loadTestFile("./test-data/9-series-response-distribution-without-points.json")
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(data.TimeSeries))
+		res := &backend.DataResponse{}
+		query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}}
+		err = query.parseResponse(res, data, "")
+		require.NoError(t, err)
+		frames := res.Frames
+		assert.Equal(t, 1, len(frames))
+		custom, ok := frames[0].Meta.Custom.(map[string]interface{})
+		require.True(t, ok)
+		labels, ok := custom["labels"].(map[string]string)
+		require.True(t, ok)
+		assert.Equal(t, "grafana-prod", labels["resource.label.project_id"])
+	})
 }
 
 func loadTestFile(path string) (cloudMonitoringResponse, error) {

--- a/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	sdkdata "github.com/grafana/grafana-plugin-sdk-go/data"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -387,39 +389,75 @@ func TestTimeSeriesFilter(t *testing.T) {
 		assert.Equal(t, "114250375703598695", labels["resource.label.instance_id"])
 	})
 
-	t.Run("Parse labels for distribution", func(t *testing.T) {
-		data, err := loadTestFile("./test-data/3-series-response-distribution-exponential.json")
-		require.NoError(t, err)
-		assert.Equal(t, 1, len(data.TimeSeries))
-		res := &backend.DataResponse{}
-		query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}}
-		err = query.parseResponse(res, data, "test_query")
-		require.NoError(t, err)
-		frames := res.Frames
-		assert.Equal(t, "test_query", frames[0].Meta.ExecutedQueryString)
-		custom, ok := frames[0].Meta.Custom.(map[string]interface{})
-		require.True(t, ok)
-		labels, ok := custom["labels"].(map[string]string)
-		require.True(t, ok)
-		assert.Equal(t, "grafana-prod", labels["resource.label.project_id"])
-	})
+	t.Run("parseResponse successfully parses metadata for distribution valueType", func(t *testing.T) {
+		t.Run("exponential bounds", func(t *testing.T) {
+			data, err := loadTestFile("./test-data/3-series-response-distribution-exponential.json")
+			require.NoError(t, err)
+			assert.Equal(t, 1, len(data.TimeSeries))
 
-	t.Run("Parse labels for distribution without points", func(t *testing.T) {
-		data, err := loadTestFile("./test-data/9-series-response-distribution-without-points.json")
-		require.NoError(t, err)
-		assert.Equal(t, 1, len(data.TimeSeries))
-		res := &backend.DataResponse{}
-		query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}}
-		err = query.parseResponse(res, data, "test_query")
-		require.NoError(t, err)
-		frames := res.Frames
-		assert.Equal(t, 1, len(frames))
-		assert.Equal(t, "test_query", frames[0].Meta.ExecutedQueryString)
-		custom, ok := frames[0].Meta.Custom.(map[string]interface{})
-		require.True(t, ok)
-		labels, ok := custom["labels"].(map[string]string)
-		require.True(t, ok)
-		assert.Equal(t, "grafana-prod", labels["resource.label.project_id"])
+			res := &backend.DataResponse{}
+			require.NoError(t, (&cloudMonitoringTimeSeriesFilter{}).parseResponse(res, data, "test_query"))
+
+			require.NotNil(t, res.Frames[0].Meta)
+			assert.Equal(t, sdkdata.FrameMeta{
+				ExecutedQueryString: "test_query",
+				Custom: map[string]interface{}{
+					"groupBys":        []string(nil),
+					"alignmentPeriod": "",
+					"labels": map[string]string{
+						"resource.label.project_id": "grafana-prod",
+						"resource.type":             "https_lb_rule",
+					},
+					"perSeriesAligner": "",
+				},
+			}, *res.Frames[0].Meta)
+		})
+
+		t.Run("explicit bounds", func(t *testing.T) {
+			data, err := loadTestFile("./test-data/4-series-response-distribution-explicit.json")
+			require.NoError(t, err)
+			assert.Equal(t, 1, len(data.TimeSeries))
+
+			res := &backend.DataResponse{}
+			require.NoError(t, (&cloudMonitoringTimeSeriesFilter{}).parseResponse(res, data, "test_query"))
+
+			require.NotNil(t, res.Frames[0].Meta)
+			assert.Equal(t, sdkdata.FrameMeta{
+				ExecutedQueryString: "test_query",
+				Custom: map[string]interface{}{
+					"groupBys":        []string(nil),
+					"alignmentPeriod": "",
+					"labels": map[string]string{
+						"resource.label.project_id": "grafana-demo",
+						"resource.type":             "global",
+					},
+					"perSeriesAligner": "",
+				},
+			}, *res.Frames[0].Meta)
+		})
+
+		t.Run("without series points", func(t *testing.T) {
+			data, err := loadTestFile("./test-data/3-series-response-distribution-exponential.json")
+			require.NoError(t, err)
+			assert.Equal(t, 1, len(data.TimeSeries))
+
+			res := &backend.DataResponse{}
+			require.NoError(t, (&cloudMonitoringTimeSeriesFilter{}).parseResponse(res, data, "test_query"))
+
+			require.NotNil(t, res.Frames[0].Meta)
+			assert.Equal(t, sdkdata.FrameMeta{
+				ExecutedQueryString: "test_query",
+				Custom: map[string]interface{}{
+					"groupBys":        []string(nil),
+					"alignmentPeriod": "",
+					"labels": map[string]string{
+						"resource.label.project_id": "grafana-prod",
+						"resource.type":             "https_lb_rule",
+					},
+					"perSeriesAligner": "",
+				},
+			}, *res.Frames[0].Meta)
+		})
 	})
 }
 

--- a/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
@@ -396,13 +396,13 @@ func TestTimeSeriesFilter(t *testing.T) {
 			assert.Equal(t, 1, len(data.TimeSeries))
 
 			res := &backend.DataResponse{}
-			require.NoError(t, (&cloudMonitoringTimeSeriesFilter{}).parseResponse(res, data, "test_query"))
+			require.NoError(t, (&cloudMonitoringTimeSeriesFilter{GroupBys: []string{"test_group_by"}}).parseResponse(res, data, "test_query"))
 
 			require.NotNil(t, res.Frames[0].Meta)
 			assert.Equal(t, sdkdata.FrameMeta{
 				ExecutedQueryString: "test_query",
 				Custom: map[string]interface{}{
-					"groupBys":        []string(nil),
+					"groupBys":        []string{"test_group_by"},
 					"alignmentPeriod": "",
 					"labels": map[string]string{
 						"resource.label.project_id": "grafana-prod",
@@ -419,13 +419,13 @@ func TestTimeSeriesFilter(t *testing.T) {
 			assert.Equal(t, 1, len(data.TimeSeries))
 
 			res := &backend.DataResponse{}
-			require.NoError(t, (&cloudMonitoringTimeSeriesFilter{}).parseResponse(res, data, "test_query"))
+			require.NoError(t, (&cloudMonitoringTimeSeriesFilter{GroupBys: []string{"test_group_by"}}).parseResponse(res, data, "test_query"))
 
 			require.NotNil(t, res.Frames[0].Meta)
 			assert.Equal(t, sdkdata.FrameMeta{
 				ExecutedQueryString: "test_query",
 				Custom: map[string]interface{}{
-					"groupBys":        []string(nil),
+					"groupBys":        []string{"test_group_by"},
 					"alignmentPeriod": "",
 					"labels": map[string]string{
 						"resource.label.project_id": "grafana-demo",
@@ -442,13 +442,13 @@ func TestTimeSeriesFilter(t *testing.T) {
 			assert.Equal(t, 1, len(data.TimeSeries))
 
 			res := &backend.DataResponse{}
-			require.NoError(t, (&cloudMonitoringTimeSeriesFilter{}).parseResponse(res, data, "test_query"))
+			require.NoError(t, (&cloudMonitoringTimeSeriesFilter{GroupBys: []string{"test_group_by"}}).parseResponse(res, data, "test_query"))
 
 			require.NotNil(t, res.Frames[0].Meta)
 			assert.Equal(t, sdkdata.FrameMeta{
 				ExecutedQueryString: "test_query",
 				Custom: map[string]interface{}{
-					"groupBys":        []string(nil),
+					"groupBys":        []string{"test_group_by"},
 					"alignmentPeriod": "",
 					"labels": map[string]string{
 						"resource.label.project_id": "grafana-prod",

--- a/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
@@ -386,6 +386,22 @@ func TestTimeSeriesFilter(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "114250375703598695", labels["resource.label.instance_id"])
 	})
+
+	t.Run("Parse labels for distribution", func(t *testing.T) {
+		data, err := loadTestFile("./test-data/3-series-response-distribution-exponential.json")
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(data.TimeSeries))
+		res := &backend.DataResponse{}
+		query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}}
+		err = query.parseResponse(res, data, "")
+		require.NoError(t, err)
+		frames := res.Frames
+		custom, ok := frames[0].Meta.Custom.(map[string]interface{})
+		require.True(t, ok)
+		labels, ok := custom["labels"].(map[string]string)
+		require.True(t, ok)
+		assert.Equal(t, "grafana-prod", labels["resource.label.project_id"])
+	})
 }
 
 func loadTestFile(path string) (cloudMonitoringResponse, error) {

--- a/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
@@ -393,9 +393,10 @@ func TestTimeSeriesFilter(t *testing.T) {
 		assert.Equal(t, 1, len(data.TimeSeries))
 		res := &backend.DataResponse{}
 		query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}}
-		err = query.parseResponse(res, data, "")
+		err = query.parseResponse(res, data, "test_query")
 		require.NoError(t, err)
 		frames := res.Frames
+		assert.Equal(t, "test_query", frames[0].Meta.ExecutedQueryString)
 		custom, ok := frames[0].Meta.Custom.(map[string]interface{})
 		require.True(t, ok)
 		labels, ok := custom["labels"].(map[string]string)
@@ -409,10 +410,11 @@ func TestTimeSeriesFilter(t *testing.T) {
 		assert.Equal(t, 1, len(data.TimeSeries))
 		res := &backend.DataResponse{}
 		query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}}
-		err = query.parseResponse(res, data, "")
+		err = query.parseResponse(res, data, "test_query")
 		require.NoError(t, err)
 		frames := res.Frames
 		assert.Equal(t, 1, len(frames))
+		assert.Equal(t, "test_query", frames[0].Meta.ExecutedQueryString)
 		custom, ok := frames[0].Meta.Custom.(map[string]interface{})
 		require.True(t, ok)
 		labels, ok := custom["labels"].(map[string]string)


### PR DESCRIPTION
**What this PR does / why we need it**:
Set metadata for distribution type metrics.

**Which issue(s) this PR fixes**:
Fixes #45347

**Special notes for your reviewer**:

