### PR TITLE
Rendering: periodically refresh remote plugin version

### DIFF
--- a/pkg/services/rendering/http_mode.go
+++ b/pkg/services/rendering/http_mode.go
@@ -267,7 +267,7 @@ func (rs *RenderingService) refreshRemotePluginVersion() {
 	}
 
 	currentVersion := rs.Version()
-	if newVersion != "" && currentVersion != newVersion {
+	if currentVersion != newVersion {
 		rs.versionMutex.Lock()
 		defer rs.versionMutex.Unlock()
 

--- a/pkg/services/rendering/http_mode.go
+++ b/pkg/services/rendering/http_mode.go
@@ -29,8 +29,9 @@ var netClient = &http.Client{
 }
 
 var (
-	remoteVersionFetchInterval time.Duration = time.Second * 15
-	remoteVersionFetchRetries  uint          = 4
+	remoteVersionFetchInterval   time.Duration = time.Second * 15
+	remoteVersionFetchRetries    uint          = 4
+	remoteVersionRefreshInterval               = time.Minute * 15
 )
 
 func (rs *RenderingService) renderViaHTTP(ctx context.Context, renderKey string, opts Opts) (*RenderResult, error) {
@@ -250,4 +251,27 @@ func (rs *RenderingService) getRemotePluginVersion() (string, error) {
 		return "", err
 	}
 	return info.Version, nil
+}
+
+func (rs *RenderingService) refreshRemotePluginVersion() {
+	newVersion, err := rs.getRemotePluginVersion()
+	if err != nil {
+		rs.log.Info("Failed to refresh remote plugin version", "err", err)
+		return
+	}
+
+	if newVersion == "" {
+		// the image-renderer could have been temporary unavailable - skip updating the version
+		rs.log.Debug("Received empty version when trying to refresh remote plugin version")
+		return
+	}
+
+	currentVersion := rs.Version()
+	if newVersion != "" && currentVersion != newVersion {
+		rs.versionMutex.Lock()
+		defer rs.versionMutex.Unlock()
+
+		rs.log.Info("Updating remote plugin version", "currentVersion", currentVersion, "newVersion", newVersion)
+		rs.version = newVersion
+	}
 }


### PR DESCRIPTION
**Why we need it**:

Follow up on https://github.com/grafana/grafana/pull/45259

Quick fix to periodically refresh the remote plugin version. It will prevent issues with starting the dashboard previews crawler process in the following scenarios:

1. Image renderer process is started > 5 minutes after the grafana process
   - the `version` of plugin in `grafana-core/rendering` remains empty until the grafana process is restarted
2. We have a working Grafana+Image Renderer setup. Image renderer is updated from version `3.3` to `3.4`
   - the `version` of plugin in `grafana-core/rendering` stays at `3.3` until grafana process is restarted


**What this PR does**

I have added a ticker which tries to refresh the plugin version every 15 minutes. The ticker...

- runs _only_ when http mode is enabled
- runs on all nodes in HA env
- updates the version only if the new one is non-empty

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/grafana/issues/44449

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:


