### PR TITLE
[POC] PublicDashboards 

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -492,6 +492,7 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   timeInfo?: string; // The query time description (blue text in the upper right)
   panelId?: number;
   dashboardId?: number;
+  dashboardUid?: string;
 
   // Request Timing
   startTime: number;

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
@@ -30,7 +30,14 @@ export function PanelEditorTableView({ width, height, panel, dashboard }: Props)
     const timeData = applyPanelTimeOverrides(panel, timeSrv.timeRange());
 
     const sub = panel.events.subscribe(RefreshEvent, () => {
-      panel.runAllPanelQueries(dashboard.id, dashboard.getTimezone(), timeData, width);
+      panel.runAllPanelQueries(
+        dashboard.id,
+        dashboard.uid,
+        dashboard.meta.isPublic,
+        dashboard.getTimezone(),
+        timeData,
+        width
+      );
     });
     return () => {
       sub.unsubscribe();

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -45,6 +45,7 @@ type DashboardPageRouteSearchParams = {
   viewPanel?: string;
   editview?: string;
   inspect?: string;
+  public?: string;
   from?: string;
   to?: string;
   refresh?: string;
@@ -122,6 +123,9 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
       urlUid: match.params.uid,
       urlType: match.params.type,
       urlFolderId: queryParams.folderId,
+      // this is just to test, a public dashboard needs a unique URL & route
+      // But for now we can just test with a &public URL query param
+      isPublic: queryParams.public != null,
       routeName: this.props.route.routeName,
       fixUrl: true,
     });

--- a/public/app/features/dashboard/containers/SoloPanelPage.tsx
+++ b/public/app/features/dashboard/containers/SoloPanelPage.tsx
@@ -46,6 +46,8 @@ export class SoloPanelPage extends Component<Props, State> {
       urlType: match.params.type,
       routeName: route.routeName,
       fixUrl: false,
+      // this is just temp test
+      isPublic: false,
     });
   }
 

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -297,7 +297,7 @@ export class PanelChrome extends PureComponent<Props, State> {
   }
 
   onRefresh = () => {
-    const { panel, isInView, width } = this.props;
+    const { panel, isInView, width, dashboard } = this.props;
 
     if (!isInView) {
       this.setState({ refreshWhenInView: true });
@@ -315,7 +315,14 @@ export class PanelChrome extends PureComponent<Props, State> {
       if (this.state.refreshWhenInView) {
         this.setState({ refreshWhenInView: false });
       }
-      panel.runAllPanelQueries(this.props.dashboard.id, this.props.dashboard.getTimezone(), timeData, width);
+      panel.runAllPanelQueries(
+        dashboard.id,
+        dashboard.uid,
+        dashboard.meta.isPublic,
+        dashboard.getTimezone(),
+        timeData,
+        width
+      );
     } else {
       // The panel should render on refresh as well if it doesn't have a query, like clock panel
       this.setState({

--- a/public/app/features/dashboard/services/PublicDashboardDataSource.ts
+++ b/public/app/features/dashboard/services/PublicDashboardDataSource.ts
@@ -19,7 +19,7 @@ export class PublicDashboardDataSource extends DataSourceApi<any> {
    * Ideally final -- any other implementation may not work as expected
    */
   query(request: DataQueryRequest<any>): Observable<DataQueryResponse> {
-    const { intervalMs, maxDataPoints, range, requestId, dashboardUid } = request;
+    const { intervalMs, maxDataPoints, range, requestId, dashboardUid, panelId } = request;
     let targets = request.targets;
 
     if (this.filterQuery) {
@@ -40,7 +40,7 @@ export class PublicDashboardDataSource extends DataSourceApi<any> {
       return of({ data: [] });
     }
 
-    const body: any = { queries };
+    const body: any = { queries, dashboardUid, panelId };
 
     if (range) {
       body.range = range;

--- a/public/app/features/dashboard/services/PublicDashboardDataSource.ts
+++ b/public/app/features/dashboard/services/PublicDashboardDataSource.ts
@@ -1,0 +1,71 @@
+import { DataQuery, DataQueryRequest, DataQueryResponse, DataSourceApi, PluginMeta } from '@grafana/data';
+import { BackendDataSourceResponse, getBackendSrv, toDataQueryResponse } from '@grafana/runtime';
+import { catchError, Observable, of, switchMap } from 'rxjs';
+
+export class PublicDashboardDataSource extends DataSourceApi<any> {
+  constructor() {
+    super({
+      name: 'public-ds',
+      id: 1,
+      type: 'public-ds',
+      meta: {} as PluginMeta,
+      uid: '1',
+      jsonData: {},
+      access: 'proxy',
+    });
+  }
+
+  /**
+   * Ideally final -- any other implementation may not work as expected
+   */
+  query(request: DataQueryRequest<any>): Observable<DataQueryResponse> {
+    const { intervalMs, maxDataPoints, range, requestId, dashboardUid } = request;
+    let targets = request.targets;
+
+    if (this.filterQuery) {
+      targets = targets.filter((q) => this.filterQuery!(q));
+    }
+
+    const queries = targets.map((q) => {
+      return {
+        ...q,
+        dashboardUid,
+        intervalMs,
+        maxDataPoints,
+      };
+    });
+
+    // Return early if no queries exist
+    if (!queries.length) {
+      return of({ data: [] });
+    }
+
+    const body: any = { queries };
+
+    if (range) {
+      body.range = range;
+      body.from = range.from.valueOf().toString();
+      body.to = range.to.valueOf().toString();
+    }
+
+    return getBackendSrv()
+      .fetch<BackendDataSourceResponse>({
+        url: '/api/ds/public-query',
+        method: 'POST',
+        data: body,
+        requestId,
+      })
+      .pipe(
+        switchMap((raw) => {
+          return of(toDataQueryResponse(raw, queries as DataQuery[]));
+        }),
+        catchError((err) => {
+          return of(toDataQueryResponse(err));
+        })
+      );
+  }
+
+  testDatasource(): Promise<any> {
+    return Promise.resolve(null);
+  }
+}

--- a/public/app/features/dashboard/services/PublicDashboardDataSource.ts
+++ b/public/app/features/dashboard/services/PublicDashboardDataSource.ts
@@ -22,10 +22,6 @@ export class PublicDashboardDataSource extends DataSourceApi<any> {
     const { intervalMs, maxDataPoints, range, requestId, dashboardUid, panelId } = request;
     let targets = request.targets;
 
-    if (this.filterQuery) {
-      targets = targets.filter((q) => this.filterQuery!(q));
-    }
-
     const queries = targets.map((q) => {
       return {
         ...q,

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -304,13 +304,22 @@ export class PanelModel implements DataConfigSource, IPanelModel {
     this.gridPos.h = newPos.h;
   }
 
-  runAllPanelQueries(dashboardId: number, dashboardTimezone: string, timeData: TimeOverrideResult, width: number) {
+  runAllPanelQueries(
+    dashboardId: number,
+    dashboardUid: string,
+    isPublic: boolean | undefined,
+    timezone: string,
+    timeData: TimeOverrideResult,
+    width: number
+  ) {
     this.getQueryRunner().run({
       datasource: this.datasource,
       queries: this.targets,
       panelId: this.id,
-      dashboardId: dashboardId,
-      timezone: dashboardTimezone,
+      dashboardId,
+      dashboardUid,
+      timezone,
+      isPublic,
       timeRange: timeData.timeRange,
       timeInfo: timeData.timeInfo,
       maxDataPoints: this.maxDataPoints || Math.floor(width),

--- a/public/app/features/dashboard/state/initDashboard.test.ts
+++ b/public/app/features/dashboard/state/initDashboard.test.ts
@@ -102,6 +102,7 @@ function describeInitScenario(description: string, scenarioFn: ScenarioFn) {
       args: {
         urlUid: 'DGmvKKxZz',
         fixUrl: false,
+        isPublic: false,
         routeName: DashboardRoutes.Normal,
       },
       backendSrv: getBackendSrv(),

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -31,6 +31,7 @@ export interface InitDashboardArgs {
   urlFolderId?: string | null;
   routeName?: string;
   fixUrl: boolean;
+  isPublic: boolean;
 }
 
 async function fetchDashboard(
@@ -59,6 +60,7 @@ async function fetchDashboard(
       }
       case DashboardRoutes.Normal: {
         const dashDTO: DashboardDTO = await dashboardLoaderSrv.loadDashboard(args.urlType, args.urlSlug, args.urlUid);
+        dashDTO.meta.isPublic = args.isPublic;
 
         if (args.fixUrl && dashDTO.meta.url) {
           // check if the current url is correct (might be old slug)

--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -34,6 +34,7 @@ export interface DashboardMeta {
   updatedBy?: string;
   fromScript?: boolean;
   fromFile?: boolean;
+  isPublic?: boolean;
   hasUnsavedFolderChange?: boolean;
 }
 


### PR DESCRIPTION
This is just a very early exploration of the frontend changes needed to route all panel requests to a new `/api/ds/public-query` API where the frontend will pass panelId and dashboardUid. 

A public dashboard "mode" can be faked by adding `&public` url param. But when doing this for real I imagine that a user creates a public URL for the dashboard (with a unique key) and some constraints for the template variables. The URL will be a specific url route for public dashboards (so we can have exceptions in the backend for anonymous access to this URL). This URL can then be revoked at will as well.  (Just general spitballing of how public dashboards can work). 

I actually think public dashboards should be must easier to get to a useful state than validated queries. Specifically in how we solve template variables. When the user creates the public dashboard URL they can define static variable value constraints that we can more easily enforce.
