### PR TITLE
Prometheus/QueryBuilder: Fix parsing of functions without args

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/parsing.test.ts
@@ -365,6 +365,17 @@ describe('buildVisualQueryFromString', () => {
       },
     });
   });
+
+  it('lone aggregation without params', () => {
+    expect(buildVisualQueryFromString('sum()')).toEqual({
+      errors: [],
+      query: {
+        metric: '',
+        labels: [],
+        operations: [{ id: 'sum', params: [] }],
+      },
+    });
+  });
 });
 
 function noErrors(query: PromVisualQuery) {


### PR DESCRIPTION
Before an expression like `sum()` would throw.
- For one we don't catch that so would just bubble up so this adds try catch for the parsing so also unexpected errors are returned in the result.
- Also adds proper handling for such situation so it is not an error anymore.