### PR TITLE
log-volume: adjust request-id to avoid conflicts

### DIFF
--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -112,10 +112,12 @@ describe('runQueries', () => {
 
     const state = getState().explore[ExploreId.left];
     expect(state.queryResponse.request?.requestId).toBe('explore_left');
-    // need to cast to `any` to get through with typescript
-    const provider = (state.datasourceInstance as any).getLogsVolumeDataProvider;
-    const lastCall = provider.mock.calls[provider.mock.calls.length - 1];
-    expect(lastCall[0].requestId).toBe('explore_left_log_volume');
+    const datasource = state.datasourceInstance as any as DataSourceWithLogsVolumeSupport<DataQuery>;
+    expect(datasource.getLogsVolumeDataProvider).toBeCalledWith(
+      expect.objectContaining({
+        requestId: 'explore_left_log_volume',
+      })
+    );
   });
 
   it('should set state to done if query completes without emitting', async () => {

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -21,6 +21,7 @@ import {
   DataQueryResponse,
   DataSourceApi,
   DataSourceJsonData,
+  DataSourceWithLogsVolumeSupport,
   DefaultTimeZone,
   LoadingState,
   MutableDataFrame,

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -54,6 +54,7 @@ const defaultInitialState = {
       datasourceInstance: {
         query: jest.fn(),
         getRef: jest.fn(),
+        getLogsVolumeDataProvider: jest.fn(),
         meta: {
           id: 'something',
         },
@@ -99,6 +100,22 @@ describe('runQueries', () => {
     await dispatch(runQueries(ExploreId.left));
     expect(getState().explore[ExploreId.left].showMetrics).toBeTruthy();
     expect(getState().explore[ExploreId.left].graphResult).toBeDefined();
+  });
+
+  it('should modify the request-id for log-volume queries', async () => {
+    setTimeSrv({ init() {} } as any);
+    const { dispatch, getState } = configureStore({
+      ...(defaultInitialState as any),
+    });
+    setupQueryResponse(getState());
+    await dispatch(runQueries(ExploreId.left));
+
+    const state = getState().explore[ExploreId.left];
+    expect(state.queryResponse.request?.requestId).toBe('explore_left');
+    // need to cast to `any` to get through with typescript
+    const provider = (state.datasourceInstance as any).getLogsVolumeDataProvider;
+    const lastCall = provider.mock.calls[provider.mock.calls.length - 1];
+    expect(lastCall[0].requestId).toBe('explore_left_log_volume');
   });
 
   it('should set state to done if query completes without emitting', async () => {

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -497,7 +497,11 @@ export const runQueries = (
         );
         dispatch(cleanLogsVolumeAction({ exploreId }));
       } else if (hasLogsVolumeSupport(datasourceInstance)) {
-        const logsVolumeDataProvider = datasourceInstance.getLogsVolumeDataProvider(transaction.request);
+        const sourceRequest = {
+          ...transaction.request,
+          requestId: transaction.request.requestId + '_log_volume',
+        };
+        const logsVolumeDataProvider = datasourceInstance.getLogsVolumeDataProvider(sourceRequest);
         dispatch(
           storeLogsVolumeDataProviderAction({
             exploreId,


### PR DESCRIPTION
when creating the log-volume-request, we have to change the request-id, otherwise there can be two requests with the same request-id.

this is not a problem currently, but as datasources migrate to backend-mode, this causes problems (the log-volume request gets cancelled)