### PR TITLE
Settings: Fix subsection overwrites

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -696,7 +696,7 @@ func (cfg *Cfg) loadSpecifiedConfigFile(configFile string, masterFile *ini.File)
 				defaultSec, _ = masterFile.NewSection(section.Name())
 			}
 			defaultKey, err := defaultSec.GetKey(key.Name())
-			if err != nil {
+			if _, exists := defaultSec.KeysHash()[key.Name()]; !exists || err != nil {
 				defaultKey, _ = defaultSec.NewKey(key.Name(), key.Value())
 			}
 			defaultKey.SetValue(key.Value())


### PR DESCRIPTION
_(Note: Do not consider the proposal as final. I'm more interested on an open discussion & feedback)_

<br/>
<br/>

**What this PR does / why we need it**:

Consider we have two sections on the settings file like:

```
[caching]
enabled = true
...
[caching.encryption]
enabled = false
```

which would express the user's desire to "enable caching" but "do not enable it with encryption".

Then, the problem is that `caching.encryption.enabled` value overwrites the `caching.enabled` value.

That happens because at time of reading the configuration file,  we call the `GetKey` method of the current section (i.e. `caching.encryption`) which, in case the key (i.e. `enabled`) does not exist yet, it initializes a new key. But, the library considers that, [if the section is a "child section" (contains a dot `.`), then the new key's section should be the parent](https://github.com/go-ini/ini/blob/main/section.go#L124). So, at time of initializing the `enabled` key for the `caching.encryption` section, it initializes a new one that points to `caching` section, therefore the value configured for `caching.enabled` gets overwritten with the value configured for `caching.encryption.enabled`.

So, in order to prevent this issue, my naive proposal is to add an extra check that verifies if the current section contains the key we're looking for (we could also add an if..else statement or similar, but as I mentioned I'm more interested on the discussion than the final code lines to deal with it) -- note there are multiple checks that are hard to perform because most of them rely on `GetKey` behavior mentioned above.

**Which issue(s) this PR fixes**:

_No issue created, directly jumped into this pull request / discussion._

**Special notes for your reviewer**:

Beyond the final way to handle this edge case (there's probably a nicer way to code it), what's suggested on this pull request represents a behavior change which could break other things. So, I'm especially interested in knowing if there are other parts that rely on the current behavior (not the suggested one but the opposite) and, if so, how we could solve this issue considering a change on the section/key name would represent a breaking change as well (if I'm not wrong).

Thanks! 🙌🏻 
