### PR TITLE
SQLStore: Fix migrator locking test for SQLite

### DIFF
--- a/pkg/services/sqlstore/migrations/migrations_test.go
+++ b/pkg/services/sqlstore/migrations/migrations_test.go
@@ -291,7 +291,8 @@ func getTestDB(t *testing.T, dbType string) sqlutil.TestDB {
 		f, err := os.CreateTemp(".", "grafana-test-db-")
 		require.NoError(t, err)
 		t.Cleanup(func() {
-			os.Remove(f.Name())
+			err := os.Remove(f.Name())
+			require.NoError(t, err)
 		})
 
 		return sqlutil.TestDB{

--- a/pkg/services/sqlstore/migrations/migrations_test.go
+++ b/pkg/services/sqlstore/migrations/migrations_test.go
@@ -65,7 +65,7 @@ func TestMigrationLock(t *testing.T) {
 		t.Skip()
 	}
 
-	testDB := getTestDB(dbType)
+	testDB := getTestDB(t, dbType)
 
 	x, err := xorm.NewEngine(testDB.DriverName, testDB.ConnStr)
 	require.NoError(t, err)
@@ -154,7 +154,7 @@ func TestMigrationLock(t *testing.T) {
 
 func TestMigratorLocking(t *testing.T) {
 	dbType := getDBType()
-	testDB := getTestDB(dbType)
+	testDB := getTestDB(t, dbType)
 
 	x, err := xorm.NewEngine(testDB.DriverName, testDB.ConnStr)
 	require.NoError(t, err)
@@ -172,7 +172,7 @@ func TestMigratorLocking(t *testing.T) {
 			i := i // capture i variable
 			t.Run(fmt.Sprintf("run migration %d", i), func(t *testing.T) {
 				t.Parallel()
-				err = mg.Start(true, 0)
+				err := mg.Start(true, 0)
 				if err != nil {
 					if errors.Is(err, ErrMigratorIsLocked) {
 						atomic.AddInt64(&errorNum, 1)
@@ -191,7 +191,7 @@ func TestDatabaseLocking(t *testing.T) {
 		t.Skip()
 	}
 
-	testDB := getTestDB(dbType)
+	testDB := getTestDB(t, dbType)
 
 	x, err := xorm.NewEngine(testDB.DriverName, testDB.ConnStr)
 	require.NoError(t, err)
@@ -281,14 +281,23 @@ func getDBType() string {
 	return dbType
 }
 
-func getTestDB(dbType string) sqlutil.TestDB {
+func getTestDB(t *testing.T, dbType string) sqlutil.TestDB {
 	switch dbType {
 	case "mysql":
 		return sqlutil.MySQLTestDB()
 	case "postgres":
 		return sqlutil.PostgresTestDB()
 	default:
-		return sqlutil.SQLite3TestDB()
+		f, err := os.CreateTemp(".", "grafana-test-db-")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			os.Remove(f.Name())
+		})
+
+		return sqlutil.TestDB{
+			DriverName: "sqlite3",
+			ConnStr:    f.Name(),
+		}
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fix occasionally [failing test](https://drone.grafana.net/grafana/grafana/52018/1/10). This test verifies migrator locking by starting running migrations for the same migrator in parallel and expects the second one to fail [here](https://github.com/grafana/grafana/blob/123f095536c5cf721ef21f2d54f53d2c8918acc2/pkg/services/sqlstore/migrator/migrator.go#L249)
However, in `SQLite` the in-memory database [was shared among connections](https://github.com/grafana/grafana/blob/815ccb1a039141413552b3bbc5de6c672a7d1765/pkg/services/sqlstore/sqlutil/sqlutil.go#L18) and the [CleanDB()](https://github.com/grafana/grafana/blob/8835020457d277c3dcfc395ecec2cb7b7ba884d3/pkg/services/sqlstore/migrations/migrations_test.go#L162) [is not implemented](https://github.com/grafana/grafana/blob/af1691dbfb1fa060d44cce1163d7fccd5fc271fb/pkg/services/sqlstore/migrator/sqlite_dialect.go#L88). So if migrations have already run for a previous test then there are no migrations to run so there was a possibility that the first thread would release the lock before the second thread try to get it. In that case the test would fail.
This fix uses a temporary file database that it's deleted when the test is completed.

<details>
<summary>Before:</summary>

```
logger=migrator t=2022-02-16T16:38:38.77+0000 lvl=info msg="Locking database"
logger=migrator t=2022-02-16T16:38:38.77+0000 lvl=info msg="Starting DB migrations"
logger=migrator t=2022-02-16T16:38:38.79+0000 lvl=info msg="migrations completed" performed=0 skipped=383 duration=1.311283ms
logger=migrator t=2022-02-16T16:38:38.79+0000 lvl=info msg="Unlocking database"
logger=migrator t=2022-02-16T16:38:38.8+0000 lvl=info msg="Locking database"
logger=migrator t=2022-02-16T16:38:38.8+0000 lvl=info msg="Starting DB migrations"
logger=migrator t=2022-02-16T16:38:38.81+0000 lvl=info msg="migrations completed" performed=0 skipped=383 duration=1.086623ms
logger=migrator t=2022-02-16T16:38:38.81+0000 lvl=info msg="Unlocking database"
--- FAIL: TestMigratorLocking (0.06s)
    migrations_test.go:184: 
        	Error Trace:	migrations_test.go:184
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 0
        	Test:       	TestMigratorLocking
FAIL
```
</details>

<details>
<summary>After:</summary>

```
logger=migrator t=2022-02-17T15:27:23.79+0200 lvl=info msg="Locking database"
logger=migrator t=2022-02-17T15:27:23.79+0200 lvl=info msg="Starting DB migrations"
logger=migrator t=2022-02-17T15:27:23.79+0200 lvl=info msg="Locking database"
logger=migrator t=2022-02-17T15:27:23.79+0200 lvl=eror msg="Failed to lock database" error="migrator is locked"
logger=migrator t=2022-02-17T15:27:23.79+0200 lvl=info msg="Executing migration" id="create migration_log table"
logger=migrator t=2022-02-17T15:27:23.79+0200 lvl=info msg="Executing migration" id="create user table"
logger=migrator t=2022-02-17T15:27:23.79+0200 lvl=info msg="Executing migration" id="add unique index user.login"
logger=migrator t=2022-02-17T15:27:23.8+0200 lvl=info msg="Executing migration" id="add unique index user.email"
logger=migrator t=2022-02-17T15:27:23.8+0200 lvl=info msg="Executing migration" id="drop index UQE_user_login - v1"
logger=migrator t=2022-02-17T15:27:23.8+0200 lvl=info msg="Executing migration" id="drop index UQE_user_email - v1"
logger=migrator t=2022-02-17T15:27:23.8+0200 lvl=info msg="Executing migration" id="Rename table user to user_v1 - v1"
logger=migrator t=2022-02-17T15:27:23.8+0200 lvl=info msg="Executing migration" id="create user table v2"
logger=migrator t=2022-02-17T15:27:23.81+0200 lvl=info msg="Executing migration" id="create index UQE_user_login - v2"
logger=migrator t=2022-02-17T15:27:23.81+0200 lvl=info msg="Executing migration" id="create index UQE_user_email - v2"
logger=migrator t=2022-02-17T15:27:23.81+0200 lvl=info msg="Executing migration" id="copy data_source v1 to v2"
logger=migrator t=2022-02-17T15:27:23.81+0200 lvl=info msg="Executing migration" id="Drop old table user_v1"
logger=migrator t=2022-02-17T15:27:23.81+0200 lvl=info msg="Executing migration" id="Add column help_flags1 to user table"
logger=migrator t=2022-02-17T15:27:23.81+0200 lvl=info msg="Executing migration" id="Update user table charset"
logger=migrator t=2022-02-17T15:27:23.81+0200 lvl=info msg="Executing migration" id="Add last_seen_at column to user"
logger=migrator t=2022-02-17T15:27:23.82+0200 lvl=info msg="Executing migration" id="Add missing user data"
logger=migrator t=2022-02-17T15:27:23.82+0200 lvl=info msg="Executing migration" id="Add is_disabled column to user"
logger=migrator t=2022-02-17T15:27:23.82+0200 lvl=info msg="Executing migration" id="Add index user.login/user.email"
logger=migrator t=2022-02-17T15:27:23.82+0200 lvl=info msg="Executing migration" id="Add is_service_account column to user"
logger=migrator t=2022-02-17T15:27:23.82+0200 lvl=info msg="Executing migration" id="create temp user table v1-7"
logger=migrator t=2022-02-17T15:27:23.83+0200 lvl=info msg="Executing migration" id="create index IDX_temp_user_email - v1-7"
logger=migrator t=2022-02-17T15:27:23.83+0200 lvl=info msg="Executing migration" id="create index IDX_temp_user_org_id - v1-7"
logger=migrator t=2022-02-17T15:27:23.83+0200 lvl=info msg="Executing migration" id="create index IDX_temp_user_code - v1-7"
logger=migrator t=2022-02-17T15:27:23.83+0200 lvl=info msg="Executing migration" id="create index IDX_temp_user_status - v1-7"
logger=migrator t=2022-02-17T15:27:23.83+0200 lvl=info msg="Executing migration" id="Update temp_user table charset"
logger=migrator t=2022-02-17T15:27:23.84+0200 lvl=info msg="Executing migration" id="drop index IDX_temp_user_email - v1"
logger=migrator t=2022-02-17T15:27:23.84+0200 lvl=info msg="Executing migration" id="drop index IDX_temp_user_org_id - v1"
logger=migrator t=2022-02-17T15:27:23.84+0200 lvl=info msg="Executing migration" id="drop index IDX_temp_user_code - v1"
logger=migrator t=2022-02-17T15:27:23.84+0200 lvl=info msg="Executing migration" id="drop index IDX_temp_user_status - v1"
logger=migrator t=2022-02-17T15:27:23.84+0200 lvl=info msg="Executing migration" id="Rename table temp_user to temp_user_tmp_qwerty - v1"
logger=migrator t=2022-02-17T15:27:23.84+0200 lvl=info msg="Executing migration" id="create temp_user v2"
logger=migrator t=2022-02-17T15:27:23.85+0200 lvl=info msg="Executing migration" id="create index IDX_temp_user_email - v2"
logger=migrator t=2022-02-17T15:27:23.85+0200 lvl=info msg="Executing migration" id="create index IDX_temp_user_org_id - v2"
logger=migrator t=2022-02-17T15:27:23.85+0200 lvl=info msg="Executing migration" id="create index IDX_temp_user_code - v2"
logger=migrator t=2022-02-17T15:27:23.85+0200 lvl=info msg="Executing migration" id="create index IDX_temp_user_status - v2"
logger=migrator t=2022-02-17T15:27:23.85+0200 lvl=info msg="Executing migration" id="copy temp_user v1 to v2"
logger=migrator t=2022-02-17T15:27:23.85+0200 lvl=info msg="Executing migration" id="drop temp_user_tmp_qwerty"
logger=migrator t=2022-02-17T15:27:23.86+0200 lvl=info msg="Executing migration" id="Set created for temp users that will otherwise prematurely expire"
logger=migrator t=2022-02-17T15:27:23.86+0200 lvl=info msg="Executing migration" id="create star table"
logger=migrator t=2022-02-17T15:27:23.86+0200 lvl=info msg="Executing migration" id="add unique index star.user_id_dashboard_id"
logger=migrator t=2022-02-17T15:27:23.86+0200 lvl=info msg="Executing migration" id="create org table v1"
logger=migrator t=2022-02-17T15:27:23.86+0200 lvl=info msg="Executing migration" id="create index UQE_org_name - v1"
logger=migrator t=2022-02-17T15:27:23.87+0200 lvl=info msg="Executing migration" id="create org_user table v1"
logger=migrator t=2022-02-17T15:27:23.87+0200 lvl=info msg="Executing migration" id="create index IDX_org_user_org_id - v1"
logger=migrator t=2022-02-17T15:27:23.87+0200 lvl=info msg="Executing migration" id="create index UQE_org_user_org_id_user_id - v1"
logger=migrator t=2022-02-17T15:27:23.87+0200 lvl=info msg="Executing migration" id="create index IDX_org_user_user_id - v1"
logger=migrator t=2022-02-17T15:27:23.87+0200 lvl=info msg="Executing migration" id="Update org table charset"
logger=migrator t=2022-02-17T15:27:23.88+0200 lvl=info msg="Executing migration" id="Update org_user table charset"
logger=migrator t=2022-02-17T15:27:23.88+0200 lvl=info msg="Executing migration" id="Migrate all Read Only Viewers to Viewers"
logger=migrator t=2022-02-17T15:27:23.88+0200 lvl=info msg="Executing migration" id="create dashboard table"
logger=migrator t=2022-02-17T15:27:23.88+0200 lvl=info msg="Executing migration" id="add index dashboard.account_id"
logger=migrator t=2022-02-17T15:27:23.88+0200 lvl=info msg="Executing migration" id="add unique index dashboard_account_id_slug"
logger=migrator t=2022-02-17T15:27:23.89+0200 lvl=info msg="Executing migration" id="create dashboard_tag table"
logger=migrator t=2022-02-17T15:27:23.89+0200 lvl=info msg="Executing migration" id="add unique index dashboard_tag.dasboard_id_term"
logger=migrator t=2022-02-17T15:27:23.89+0200 lvl=info msg="Executing migration" id="drop index UQE_dashboard_tag_dashboard_id_term - v1"
logger=migrator t=2022-02-17T15:27:23.89+0200 lvl=info msg="Executing migration" id="Rename table dashboard to dashboard_v1 - v1"
logger=migrator t=2022-02-17T15:27:23.89+0200 lvl=info msg="Executing migration" id="create dashboard v2"
logger=migrator t=2022-02-17T15:27:23.9+0200 lvl=info msg="Executing migration" id="create index IDX_dashboard_org_id - v2"
logger=migrator t=2022-02-17T15:27:23.9+0200 lvl=info msg="Executing migration" id="create index UQE_dashboard_org_id_slug - v2"
logger=migrator t=2022-02-17T15:27:23.9+0200 lvl=info msg="Executing migration" id="copy dashboard v1 to v2"
logger=migrator t=2022-02-17T15:27:23.9+0200 lvl=info msg="Executing migration" id="drop table dashboard_v1"
logger=migrator t=2022-02-17T15:27:23.9+0200 lvl=info msg="Executing migration" id="alter dashboard.data to mediumtext v1"
logger=migrator t=2022-02-17T15:27:23.91+0200 lvl=info msg="Executing migration" id="Add column updated_by in dashboard - v2"
logger=migrator t=2022-02-17T15:27:23.91+0200 lvl=info msg="Executing migration" id="Add column created_by in dashboard - v2"
logger=migrator t=2022-02-17T15:27:23.91+0200 lvl=info msg="Executing migration" id="Add column gnetId in dashboard"
logger=migrator t=2022-02-17T15:27:23.91+0200 lvl=info msg="Executing migration" id="Add index for gnetId in dashboard"
logger=migrator t=2022-02-17T15:27:23.92+0200 lvl=info msg="Executing migration" id="Add column plugin_id in dashboard"
logger=migrator t=2022-02-17T15:27:23.92+0200 lvl=info msg="Executing migration" id="Add index for plugin_id in dashboard"
logger=migrator t=2022-02-17T15:27:23.92+0200 lvl=info msg="Executing migration" id="Add index for dashboard_id in dashboard_tag"
logger=migrator t=2022-02-17T15:27:23.92+0200 lvl=info msg="Executing migration" id="Update dashboard table charset"
logger=migrator t=2022-02-17T15:27:23.92+0200 lvl=info msg="Executing migration" id="Update dashboard_tag table charset"
logger=migrator t=2022-02-17T15:27:23.93+0200 lvl=info msg="Executing migration" id="Add column folder_id in dashboard"
logger=migrator t=2022-02-17T15:27:23.93+0200 lvl=info msg="Executing migration" id="Add column isFolder in dashboard"
logger=migrator t=2022-02-17T15:27:23.93+0200 lvl=info msg="Executing migration" id="Add column has_acl in dashboard"
logger=migrator t=2022-02-17T15:27:23.93+0200 lvl=info msg="Executing migration" id="Add column uid in dashboard"
logger=migrator t=2022-02-17T15:27:23.93+0200 lvl=info msg="Executing migration" id="Update uid column values in dashboard"
logger=migrator t=2022-02-17T15:27:23.94+0200 lvl=info msg="Executing migration" id="Add unique index dashboard_org_id_uid"
logger=migrator t=2022-02-17T15:27:23.94+0200 lvl=info msg="Executing migration" id="Remove unique index org_id_slug"
logger=migrator t=2022-02-17T15:27:23.94+0200 lvl=info msg="Executing migration" id="Update dashboard title length"
logger=migrator t=2022-02-17T15:27:23.94+0200 lvl=info msg="Executing migration" id="Add unique index for dashboard_org_id_title_folder_id"
logger=migrator t=2022-02-17T15:27:23.94+0200 lvl=info msg="Executing migration" id="create dashboard_provisioning"
logger=migrator t=2022-02-17T15:27:23.95+0200 lvl=info msg="Executing migration" id="Rename table dashboard_provisioning to dashboard_provisioning_tmp_qwerty - v1"
logger=migrator t=2022-02-17T15:27:23.95+0200 lvl=info msg="Executing migration" id="create dashboard_provisioning v2"
logger=migrator t=2022-02-17T15:27:23.95+0200 lvl=info msg="Executing migration" id="create index IDX_dashboard_provisioning_dashboard_id - v2"
logger=migrator t=2022-02-17T15:27:23.95+0200 lvl=info msg="Executing migration" id="create index IDX_dashboard_provisioning_dashboard_id_name - v2"
logger=migrator t=2022-02-17T15:27:23.96+0200 lvl=info msg="Executing migration" id="copy dashboard_provisioning v1 to v2"
logger=migrator t=2022-02-17T15:27:23.96+0200 lvl=info msg="Executing migration" id="drop dashboard_provisioning_tmp_qwerty"
logger=migrator t=2022-02-17T15:27:23.97+0200 lvl=info msg="Executing migration" id="Add check_sum column"
logger=migrator t=2022-02-17T15:27:23.97+0200 lvl=info msg="Executing migration" id="Add index for dashboard_title"
logger=migrator t=2022-02-17T15:27:23.97+0200 lvl=info msg="Executing migration" id="delete tags for deleted dashboards"
logger=migrator t=2022-02-17T15:27:23.98+0200 lvl=info msg="Executing migration" id="delete stars for deleted dashboards"
logger=migrator t=2022-02-17T15:27:23.98+0200 lvl=info msg="Executing migration" id="Add index for dashboard_is_folder"
logger=migrator t=2022-02-17T15:27:23.98+0200 lvl=info msg="Executing migration" id="create data_source table"
logger=migrator t=2022-02-17T15:27:23.98+0200 lvl=info msg="Executing migration" id="add index data_source.account_id"
logger=migrator t=2022-02-17T15:27:23.98+0200 lvl=info msg="Executing migration" id="add unique index data_source.account_id_name"
logger=migrator t=2022-02-17T15:27:23.99+0200 lvl=info msg="Executing migration" id="drop index IDX_data_source_account_id - v1"
logger=migrator t=2022-02-17T15:27:23.99+0200 lvl=info msg="Executing migration" id="drop index UQE_data_source_account_id_name - v1"
logger=migrator t=2022-02-17T15:27:23.99+0200 lvl=info msg="Executing migration" id="Rename table data_source to data_source_v1 - v1"
logger=migrator t=2022-02-17T15:27:24+0200 lvl=info msg="Executing migration" id="create data_source table v2"
logger=migrator t=2022-02-17T15:27:24+0200 lvl=info msg="Executing migration" id="create index IDX_data_source_org_id - v2"
logger=migrator t=2022-02-17T15:27:24+0200 lvl=info msg="Executing migration" id="create index UQE_data_source_org_id_name - v2"
logger=migrator t=2022-02-17T15:27:24+0200 lvl=info msg="Executing migration" id="copy data_source v1 to v2"
logger=migrator t=2022-02-17T15:27:24.01+0200 lvl=info msg="Executing migration" id="Drop old table data_source_v1 #2"
logger=migrator t=2022-02-17T15:27:24.01+0200 lvl=info msg="Executing migration" id="Add column with_credentials"
logger=migrator t=2022-02-17T15:27:24.01+0200 lvl=info msg="Executing migration" id="Add secure json data column"
logger=migrator t=2022-02-17T15:27:24.01+0200 lvl=info msg="Executing migration" id="Update data_source table charset"
logger=migrator t=2022-02-17T15:27:24.02+0200 lvl=info msg="Executing migration" id="Update initial version to 1"
logger=migrator t=2022-02-17T15:27:24.02+0200 lvl=info msg="Executing migration" id="Add read_only data column"
logger=migrator t=2022-02-17T15:27:24.02+0200 lvl=info msg="Executing migration" id="Migrate logging ds to loki ds"
logger=migrator t=2022-02-17T15:27:24.02+0200 lvl=info msg="Executing migration" id="Update json_data with nulls"
logger=migrator t=2022-02-17T15:27:24.03+0200 lvl=info msg="Executing migration" id="Add uid column"
logger=migrator t=2022-02-17T15:27:24.03+0200 lvl=info msg="Executing migration" id="Update uid value"
logger=migrator t=2022-02-17T15:27:24.03+0200 lvl=info msg="Executing migration" id="Add unique index datasource_org_id_uid"
logger=migrator t=2022-02-17T15:27:24.04+0200 lvl=info msg="Executing migration" id="add unique index datasource_org_id_is_default"
logger=migrator t=2022-02-17T15:27:24.04+0200 lvl=info msg="Executing migration" id="create api_key table"
logger=migrator t=2022-02-17T15:27:24.04+0200 lvl=info msg="Executing migration" id="add index api_key.account_id"
logger=migrator t=2022-02-17T15:27:24.04+0200 lvl=info msg="Executing migration" id="add index api_key.key"
logger=migrator t=2022-02-17T15:27:24.05+0200 lvl=info msg="Executing migration" id="add index api_key.account_id_name"
logger=migrator t=2022-02-17T15:27:24.05+0200 lvl=info msg="Executing migration" id="drop index IDX_api_key_account_id - v1"
logger=migrator t=2022-02-17T15:27:24.05+0200 lvl=info msg="Executing migration" id="drop index UQE_api_key_key - v1"
logger=migrator t=2022-02-17T15:27:24.05+0200 lvl=info msg="Executing migration" id="drop index UQE_api_key_account_id_name - v1"
logger=migrator t=2022-02-17T15:27:24.06+0200 lvl=info msg="Executing migration" id="Rename table api_key to api_key_v1 - v1"
logger=migrator t=2022-02-17T15:27:24.06+0200 lvl=info msg="Executing migration" id="create api_key table v2"
logger=migrator t=2022-02-17T15:27:24.06+0200 lvl=info msg="Executing migration" id="create index IDX_api_key_org_id - v2"
logger=migrator t=2022-02-17T15:27:24.06+0200 lvl=info msg="Executing migration" id="create index UQE_api_key_key - v2"
logger=migrator t=2022-02-17T15:27:24.07+0200 lvl=info msg="Executing migration" id="create index UQE_api_key_org_id_name - v2"
logger=migrator t=2022-02-17T15:27:24.07+0200 lvl=info msg="Executing migration" id="copy api_key v1 to v2"
logger=migrator t=2022-02-17T15:27:24.07+0200 lvl=info msg="Executing migration" id="Drop old table api_key_v1"
logger=migrator t=2022-02-17T15:27:24.07+0200 lvl=info msg="Executing migration" id="Update api_key table charset"
logger=migrator t=2022-02-17T15:27:24.08+0200 lvl=info msg="Executing migration" id="Add expires to api_key table"
logger=migrator t=2022-02-17T15:27:24.08+0200 lvl=info msg="Executing migration" id="Add service account foreign key"
logger=migrator t=2022-02-17T15:27:24.08+0200 lvl=info msg="Executing migration" id="create dashboard_snapshot table v4"
logger=migrator t=2022-02-17T15:27:24.08+0200 lvl=info msg="Executing migration" id="drop table dashboard_snapshot_v4 #1"
logger=migrator t=2022-02-17T15:27:24.08+0200 lvl=info msg="Executing migration" id="create dashboard_snapshot table v5 #2"
logger=migrator t=2022-02-17T15:27:24.09+0200 lvl=info msg="Executing migration" id="create index UQE_dashboard_snapshot_key - v5"
logger=migrator t=2022-02-17T15:27:24.09+0200 lvl=info msg="Executing migration" id="create index UQE_dashboard_snapshot_delete_key - v5"
logger=migrator t=2022-02-17T15:27:24.09+0200 lvl=info msg="Executing migration" id="create index IDX_dashboard_snapshot_user_id - v5"
logger=migrator t=2022-02-17T15:27:24.09+0200 lvl=info msg="Executing migration" id="alter dashboard_snapshot to mediumtext v2"
logger=migrator t=2022-02-17T15:27:24.1+0200 lvl=info msg="Executing migration" id="Update dashboard_snapshot table charset"
logger=migrator t=2022-02-17T15:27:24.1+0200 lvl=info msg="Executing migration" id="Add column external_delete_url to dashboard_snapshots table"
logger=migrator t=2022-02-17T15:27:24.1+0200 lvl=info msg="Executing migration" id="Add encrypted dashboard json column"
logger=migrator t=2022-02-17T15:27:24.1+0200 lvl=info msg="Executing migration" id="Change dashboard_encrypted column to MEDIUMBLOB"
logger=migrator t=2022-02-17T15:27:24.1+0200 lvl=info msg="Executing migration" id="create quota table v1"
logger=migrator t=2022-02-17T15:27:24.11+0200 lvl=info msg="Executing migration" id="create index UQE_quota_org_id_user_id_target - v1"
logger=migrator t=2022-02-17T15:27:24.11+0200 lvl=info msg="Executing migration" id="Update quota table charset"
logger=migrator t=2022-02-17T15:27:24.11+0200 lvl=info msg="Executing migration" id="create plugin_setting table"
logger=migrator t=2022-02-17T15:27:24.11+0200 lvl=info msg="Executing migration" id="create index UQE_plugin_setting_org_id_plugin_id - v1"
logger=migrator t=2022-02-17T15:27:24.12+0200 lvl=info msg="Executing migration" id="Add column plugin_version to plugin_settings"
logger=migrator t=2022-02-17T15:27:24.12+0200 lvl=info msg="Executing migration" id="Update plugin_setting table charset"
logger=migrator t=2022-02-17T15:27:24.12+0200 lvl=info msg="Executing migration" id="create session table"
logger=migrator t=2022-02-17T15:27:24.12+0200 lvl=info msg="Executing migration" id="Drop old table playlist table"
logger=migrator t=2022-02-17T15:27:24.13+0200 lvl=info msg="Executing migration" id="Drop old table playlist_item table"
logger=migrator t=2022-02-17T15:27:24.13+0200 lvl=info msg="Executing migration" id="create playlist table v2"
logger=migrator t=2022-02-17T15:27:24.13+0200 lvl=info msg="Executing migration" id="create playlist item table v2"
logger=migrator t=2022-02-17T15:27:24.13+0200 lvl=info msg="Executing migration" id="Update playlist table charset"
logger=migrator t=2022-02-17T15:27:24.13+0200 lvl=info msg="Executing migration" id="Update playlist_item table charset"
logger=migrator t=2022-02-17T15:27:24.13+0200 lvl=info msg="Executing migration" id="drop preferences table v2"
logger=migrator t=2022-02-17T15:27:24.14+0200 lvl=info msg="Executing migration" id="drop preferences table v3"
logger=migrator t=2022-02-17T15:27:24.14+0200 lvl=info msg="Executing migration" id="create preferences table v3"
logger=migrator t=2022-02-17T15:27:24.14+0200 lvl=info msg="Executing migration" id="Update preferences table charset"
logger=migrator t=2022-02-17T15:27:24.14+0200 lvl=info msg="Executing migration" id="Add column team_id in preferences"
logger=migrator t=2022-02-17T15:27:24.14+0200 lvl=info msg="Executing migration" id="Update team_id column values in preferences"
logger=migrator t=2022-02-17T15:27:24.15+0200 lvl=info msg="Executing migration" id="Add column week_start in preferences"
logger=migrator t=2022-02-17T15:27:24.15+0200 lvl=info msg="Executing migration" id="create alert table v1"
logger=migrator t=2022-02-17T15:27:24.15+0200 lvl=info msg="Executing migration" id="add index alert org_id & id "
logger=migrator t=2022-02-17T15:27:24.16+0200 lvl=info msg="Executing migration" id="add index alert state"
logger=migrator t=2022-02-17T15:27:24.16+0200 lvl=info msg="Executing migration" id="add index alert dashboard_id"
logger=migrator t=2022-02-17T15:27:24.16+0200 lvl=info msg="Executing migration" id="Create alert_rule_tag table v1"
logger=migrator t=2022-02-17T15:27:24.17+0200 lvl=info msg="Executing migration" id="Add unique index alert_rule_tag.alert_id_tag_id"
logger=migrator t=2022-02-17T15:27:24.17+0200 lvl=info msg="Executing migration" id="drop index UQE_alert_rule_tag_alert_id_tag_id - v1"
logger=migrator t=2022-02-17T15:27:24.17+0200 lvl=info msg="Executing migration" id="Rename table alert_rule_tag to alert_rule_tag_v1 - v1"
logger=migrator t=2022-02-17T15:27:24.18+0200 lvl=info msg="Executing migration" id="Create alert_rule_tag table v2"
logger=migrator t=2022-02-17T15:27:24.18+0200 lvl=info msg="Executing migration" id="create index UQE_alert_rule_tag_alert_id_tag_id - Add unique index alert_rule_tag.alert_id_tag_id V2"
logger=migrator t=2022-02-17T15:27:24.18+0200 lvl=info msg="Executing migration" id="copy alert_rule_tag v1 to v2"
logger=migrator t=2022-02-17T15:27:24.19+0200 lvl=info msg="Executing migration" id="drop table alert_rule_tag_v1"
logger=migrator t=2022-02-17T15:27:24.19+0200 lvl=info msg="Executing migration" id="create alert_notification table v1"
logger=migrator t=2022-02-17T15:27:24.19+0200 lvl=info msg="Executing migration" id="Add column is_default"
logger=migrator t=2022-02-17T15:27:24.2+0200 lvl=info msg="Executing migration" id="Add column frequency"
logger=migrator t=2022-02-17T15:27:24.2+0200 lvl=info msg="Executing migration" id="Add column send_reminder"
logger=migrator t=2022-02-17T15:27:24.2+0200 lvl=info msg="Executing migration" id="Add column disable_resolve_message"
logger=migrator t=2022-02-17T15:27:24.2+0200 lvl=info msg="Executing migration" id="add index alert_notification org_id & name"
logger=migrator t=2022-02-17T15:27:24.21+0200 lvl=info msg="Executing migration" id="Update alert table charset"
logger=migrator t=2022-02-17T15:27:24.21+0200 lvl=info msg="Executing migration" id="Update alert_notification table charset"
logger=migrator t=2022-02-17T15:27:24.21+0200 lvl=info msg="Executing migration" id="create notification_journal table v1"
logger=migrator t=2022-02-17T15:27:24.21+0200 lvl=info msg="Executing migration" id="add index notification_journal org_id & alert_id & notifier_id"
logger=migrator t=2022-02-17T15:27:24.21+0200 lvl=info msg="Executing migration" id="drop alert_notification_journal"
logger=migrator t=2022-02-17T15:27:24.22+0200 lvl=info msg="Executing migration" id="create alert_notification_state table v1"
logger=migrator t=2022-02-17T15:27:24.22+0200 lvl=info msg="Executing migration" id="add index alert_notification_state org_id & alert_id & notifier_id"
logger=migrator t=2022-02-17T15:27:24.22+0200 lvl=info msg="Executing migration" id="Add for to alert table"
logger=migrator t=2022-02-17T15:27:24.22+0200 lvl=info msg="Executing migration" id="Add column uid in alert_notification"
logger=migrator t=2022-02-17T15:27:24.23+0200 lvl=info msg="Executing migration" id="Update uid column values in alert_notification"
logger=migrator t=2022-02-17T15:27:24.23+0200 lvl=info msg="Executing migration" id="Add unique index alert_notification_org_id_uid"
logger=migrator t=2022-02-17T15:27:24.23+0200 lvl=info msg="Executing migration" id="Remove unique index org_id_name"
logger=migrator t=2022-02-17T15:27:24.23+0200 lvl=info msg="Executing migration" id="Add column secure_settings in alert_notification"
logger=migrator t=2022-02-17T15:27:24.23+0200 lvl=info msg="Executing migration" id="alter alert.settings to mediumtext"
logger=migrator t=2022-02-17T15:27:24.24+0200 lvl=info msg="Executing migration" id="Add non-unique index alert_notification_state_alert_id"
logger=migrator t=2022-02-17T15:27:24.24+0200 lvl=info msg="Executing migration" id="Add non-unique index alert_rule_tag_alert_id"
logger=migrator t=2022-02-17T15:27:24.24+0200 lvl=info msg="Executing migration" id="Drop old annotation table v4"
logger=migrator t=2022-02-17T15:27:24.24+0200 lvl=info msg="Executing migration" id="create annotation table v5"
logger=migrator t=2022-02-17T15:27:24.24+0200 lvl=info msg="Executing migration" id="add index annotation 0 v3"
logger=migrator t=2022-02-17T15:27:24.25+0200 lvl=info msg="Executing migration" id="add index annotation 1 v3"
logger=migrator t=2022-02-17T15:27:24.25+0200 lvl=info msg="Executing migration" id="add index annotation 2 v3"
logger=migrator t=2022-02-17T15:27:24.25+0200 lvl=info msg="Executing migration" id="add index annotation 3 v3"
logger=migrator t=2022-02-17T15:27:24.25+0200 lvl=info msg="Executing migration" id="add index annotation 4 v3"
logger=migrator t=2022-02-17T15:27:24.26+0200 lvl=info msg="Executing migration" id="Update annotation table charset"
logger=migrator t=2022-02-17T15:27:24.26+0200 lvl=info msg="Executing migration" id="Add column region_id to annotation table"
logger=migrator t=2022-02-17T15:27:24.26+0200 lvl=info msg="Executing migration" id="Drop category_id index"
logger=migrator t=2022-02-17T15:27:24.26+0200 lvl=info msg="Executing migration" id="Add column tags to annotation table"
logger=migrator t=2022-02-17T15:27:24.27+0200 lvl=info msg="Executing migration" id="Create annotation_tag table v2"
logger=migrator t=2022-02-17T15:27:24.27+0200 lvl=info msg="Executing migration" id="Add unique index annotation_tag.annotation_id_tag_id"
logger=migrator t=2022-02-17T15:27:24.27+0200 lvl=info msg="Executing migration" id="drop index UQE_annotation_tag_annotation_id_tag_id - v2"
logger=migrator t=2022-02-17T15:27:24.27+0200 lvl=info msg="Executing migration" id="Rename table annotation_tag to annotation_tag_v2 - v2"
logger=migrator t=2022-02-17T15:27:24.28+0200 lvl=info msg="Executing migration" id="Create annotation_tag table v3"
logger=migrator t=2022-02-17T15:27:24.28+0200 lvl=info msg="Executing migration" id="create index UQE_annotation_tag_annotation_id_tag_id - Add unique index annotation_tag.annotation_id_tag_id V3"
logger=migrator t=2022-02-17T15:27:24.28+0200 lvl=info msg="Executing migration" id="copy annotation_tag v2 to v3"
logger=migrator t=2022-02-17T15:27:24.28+0200 lvl=info msg="Executing migration" id="drop table annotation_tag_v2"
logger=migrator t=2022-02-17T15:27:24.29+0200 lvl=info msg="Executing migration" id="Update alert annotations and set TEXT to empty"
logger=migrator t=2022-02-17T15:27:24.29+0200 lvl=info msg="Executing migration" id="Add created time to annotation table"
logger=migrator t=2022-02-17T15:27:24.29+0200 lvl=info msg="Executing migration" id="Add updated time to annotation table"
logger=migrator t=2022-02-17T15:27:24.29+0200 lvl=info msg="Executing migration" id="Add index for created in annotation table"
logger=migrator t=2022-02-17T15:27:24.3+0200 lvl=info msg="Executing migration" id="Add index for updated in annotation table"
logger=migrator t=2022-02-17T15:27:24.3+0200 lvl=info msg="Executing migration" id="Convert existing annotations from seconds to milliseconds"
logger=migrator t=2022-02-17T15:27:24.3+0200 lvl=info msg="Executing migration" id="Add epoch_end column"
logger=migrator t=2022-02-17T15:27:24.3+0200 lvl=info msg="Executing migration" id="Add index for epoch_end"
logger=migrator t=2022-02-17T15:27:24.3+0200 lvl=info msg="Executing migration" id="Make epoch_end the same as epoch"
logger=migrator t=2022-02-17T15:27:24.31+0200 lvl=info msg="Executing migration" id="Move region to single row"
logger=migrator t=2022-02-17T15:27:24.31+0200 lvl=info msg="Executing migration" id="Remove index org_id_epoch from annotation table"
logger=migrator t=2022-02-17T15:27:24.31+0200 lvl=info msg="Executing migration" id="Remove index org_id_dashboard_id_panel_id_epoch from annotation table"
logger=migrator t=2022-02-17T15:27:24.31+0200 lvl=info msg="Executing migration" id="Add index for org_id_dashboard_id_epoch_end_epoch on annotation table"
logger=migrator t=2022-02-17T15:27:24.31+0200 lvl=info msg="Executing migration" id="Add index for org_id_epoch_end_epoch on annotation table"
logger=migrator t=2022-02-17T15:27:24.32+0200 lvl=info msg="Executing migration" id="Remove index org_id_epoch_epoch_end from annotation table"
logger=migrator t=2022-02-17T15:27:24.32+0200 lvl=info msg="Executing migration" id="Add index for alert_id on annotation table"
logger=migrator t=2022-02-17T15:27:24.32+0200 lvl=info msg="Executing migration" id="create test_data table"
logger=migrator t=2022-02-17T15:27:24.32+0200 lvl=info msg="Executing migration" id="create dashboard_version table v1"
logger=migrator t=2022-02-17T15:27:24.33+0200 lvl=info msg="Executing migration" id="add index dashboard_version.dashboard_id"
logger=migrator t=2022-02-17T15:27:24.33+0200 lvl=info msg="Executing migration" id="add unique index dashboard_version.dashboard_id and dashboard_version.version"
logger=migrator t=2022-02-17T15:27:24.33+0200 lvl=info msg="Executing migration" id="Set dashboard version to 1 where 0"
logger=migrator t=2022-02-17T15:27:24.33+0200 lvl=info msg="Executing migration" id="save existing dashboard data in dashboard_version table v1"
logger=migrator t=2022-02-17T15:27:24.33+0200 lvl=info msg="Executing migration" id="alter dashboard_version.data to mediumtext v1"
logger=migrator t=2022-02-17T15:27:24.34+0200 lvl=info msg="Executing migration" id="create team table"
logger=migrator t=2022-02-17T15:27:24.34+0200 lvl=info msg="Executing migration" id="add index team.org_id"
logger=migrator t=2022-02-17T15:27:24.34+0200 lvl=info msg="Executing migration" id="add unique index team_org_id_name"
logger=migrator t=2022-02-17T15:27:24.34+0200 lvl=info msg="Executing migration" id="create team member table"
logger=migrator t=2022-02-17T15:27:24.35+0200 lvl=info msg="Executing migration" id="add index team_member.org_id"
logger=migrator t=2022-02-17T15:27:24.35+0200 lvl=info msg="Executing migration" id="add unique index team_member_org_id_team_id_user_id"
logger=migrator t=2022-02-17T15:27:24.35+0200 lvl=info msg="Executing migration" id="add index team_member.team_id"
logger=migrator t=2022-02-17T15:27:24.35+0200 lvl=info msg="Executing migration" id="Add column email to team table"
logger=migrator t=2022-02-17T15:27:24.36+0200 lvl=info msg="Executing migration" id="Add column external to team_member table"
logger=migrator t=2022-02-17T15:27:24.36+0200 lvl=info msg="Executing migration" id="Add column permission to team_member table"
logger=migrator t=2022-02-17T15:27:24.36+0200 lvl=info msg="Executing migration" id="create dashboard acl table"
logger=migrator t=2022-02-17T15:27:24.36+0200 lvl=info msg="Executing migration" id="add index dashboard_acl_dashboard_id"
logger=migrator t=2022-02-17T15:27:24.37+0200 lvl=info msg="Executing migration" id="add unique index dashboard_acl_dashboard_id_user_id"
logger=migrator t=2022-02-17T15:27:24.37+0200 lvl=info msg="Executing migration" id="add unique index dashboard_acl_dashboard_id_team_id"
logger=migrator t=2022-02-17T15:27:24.37+0200 lvl=info msg="Executing migration" id="add index dashboard_acl_user_id"
logger=migrator t=2022-02-17T15:27:24.38+0200 lvl=info msg="Executing migration" id="add index dashboard_acl_team_id"
logger=migrator t=2022-02-17T15:27:24.38+0200 lvl=info msg="Executing migration" id="add index dashboard_acl_org_id_role"
logger=migrator t=2022-02-17T15:27:24.38+0200 lvl=info msg="Executing migration" id="add index dashboard_permission"
logger=migrator t=2022-02-17T15:27:24.38+0200 lvl=info msg="Executing migration" id="save default acl rules in dashboard_acl table"
logger=migrator t=2022-02-17T15:27:24.39+0200 lvl=info msg="Executing migration" id="delete acl rules for deleted dashboards and folders"
logger=migrator t=2022-02-17T15:27:24.39+0200 lvl=info msg="Executing migration" id="create tag table"
logger=migrator t=2022-02-17T15:27:24.39+0200 lvl=info msg="Executing migration" id="add index tag.key_value"
logger=migrator t=2022-02-17T15:27:24.39+0200 lvl=info msg="Executing migration" id="create login attempt table"
logger=migrator t=2022-02-17T15:27:24.39+0200 lvl=info msg="Executing migration" id="add index login_attempt.username"
logger=migrator t=2022-02-17T15:27:24.4+0200 lvl=info msg="Executing migration" id="drop index IDX_login_attempt_username - v1"
logger=migrator t=2022-02-17T15:27:24.4+0200 lvl=info msg="Executing migration" id="Rename table login_attempt to login_attempt_tmp_qwerty - v1"
logger=migrator t=2022-02-17T15:27:24.41+0200 lvl=info msg="Executing migration" id="create login_attempt v2"
logger=migrator t=2022-02-17T15:27:24.41+0200 lvl=info msg="Executing migration" id="create index IDX_login_attempt_username - v2"
logger=migrator t=2022-02-17T15:27:24.41+0200 lvl=info msg="Executing migration" id="copy login_attempt v1 to v2"
logger=migrator t=2022-02-17T15:27:24.41+0200 lvl=info msg="Executing migration" id="drop login_attempt_tmp_qwerty"
logger=migrator t=2022-02-17T15:27:24.42+0200 lvl=info msg="Executing migration" id="create user auth table"
logger=migrator t=2022-02-17T15:27:24.42+0200 lvl=info msg="Executing migration" id="create index IDX_user_auth_auth_module_auth_id - v1"
logger=migrator t=2022-02-17T15:27:24.42+0200 lvl=info msg="Executing migration" id="alter user_auth.auth_id to length 190"
logger=migrator t=2022-02-17T15:27:24.43+0200 lvl=info msg="Executing migration" id="Add OAuth access token to user_auth"
logger=migrator t=2022-02-17T15:27:24.43+0200 lvl=info msg="Executing migration" id="Add OAuth refresh token to user_auth"
logger=migrator t=2022-02-17T15:27:24.43+0200 lvl=info msg="Executing migration" id="Add OAuth token type to user_auth"
logger=migrator t=2022-02-17T15:27:24.44+0200 lvl=info msg="Executing migration" id="Add OAuth expiry to user_auth"
logger=migrator t=2022-02-17T15:27:24.44+0200 lvl=info msg="Executing migration" id="Add index to user_id column in user_auth"
logger=migrator t=2022-02-17T15:27:24.44+0200 lvl=info msg="Executing migration" id="Add OAuth ID token to user_auth"
logger=migrator t=2022-02-17T15:27:24.45+0200 lvl=info msg="Executing migration" id="create server_lock table"
logger=migrator t=2022-02-17T15:27:24.45+0200 lvl=info msg="Executing migration" id="add index server_lock.operation_uid"
logger=migrator t=2022-02-17T15:27:24.45+0200 lvl=info msg="Executing migration" id="create user auth token table"
logger=migrator t=2022-02-17T15:27:24.46+0200 lvl=info msg="Executing migration" id="add unique index user_auth_token.auth_token"
logger=migrator t=2022-02-17T15:27:24.46+0200 lvl=info msg="Executing migration" id="add unique index user_auth_token.prev_auth_token"
logger=migrator t=2022-02-17T15:27:24.47+0200 lvl=info msg="Executing migration" id="add index user_auth_token.user_id"
logger=migrator t=2022-02-17T15:27:24.47+0200 lvl=info msg="Executing migration" id="Add revoked_at to the user auth token"
logger=migrator t=2022-02-17T15:27:24.47+0200 lvl=info msg="Executing migration" id="create cache_data table"
logger=migrator t=2022-02-17T15:27:24.48+0200 lvl=info msg="Executing migration" id="add unique index cache_data.cache_key"
logger=migrator t=2022-02-17T15:27:24.48+0200 lvl=info msg="Executing migration" id="create short_url table v1"
logger=migrator t=2022-02-17T15:27:24.48+0200 lvl=info msg="Executing migration" id="add index short_url.org_id-uid"
logger=migrator t=2022-02-17T15:27:24.49+0200 lvl=info msg="Executing migration" id="delete alert_definition table"
logger=migrator t=2022-02-17T15:27:24.49+0200 lvl=info msg="Executing migration" id="recreate alert_definition table"
logger=migrator t=2022-02-17T15:27:24.49+0200 lvl=info msg="Executing migration" id="add index in alert_definition on org_id and title columns"
logger=migrator t=2022-02-17T15:27:24.5+0200 lvl=info msg="Executing migration" id="add index in alert_definition on org_id and uid columns"
logger=migrator t=2022-02-17T15:27:24.5+0200 lvl=info msg="Executing migration" id="alter alert_definition table data column to mediumtext in mysql"
logger=migrator t=2022-02-17T15:27:24.5+0200 lvl=info msg="Executing migration" id="drop index in alert_definition on org_id and title columns"
logger=migrator t=2022-02-17T15:27:24.5+0200 lvl=info msg="Executing migration" id="drop index in alert_definition on org_id and uid columns"
logger=migrator t=2022-02-17T15:27:24.51+0200 lvl=info msg="Executing migration" id="add unique index in alert_definition on org_id and title columns"
logger=migrator t=2022-02-17T15:27:24.51+0200 lvl=info msg="Executing migration" id="add unique index in alert_definition on org_id and uid columns"
logger=migrator t=2022-02-17T15:27:24.51+0200 lvl=info msg="Executing migration" id="Add column paused in alert_definition"
logger=migrator t=2022-02-17T15:27:24.51+0200 lvl=info msg="Executing migration" id="drop alert_definition table"
logger=migrator t=2022-02-17T15:27:24.52+0200 lvl=info msg="Executing migration" id="delete alert_definition_version table"
logger=migrator t=2022-02-17T15:27:24.52+0200 lvl=info msg="Executing migration" id="recreate alert_definition_version table"
logger=migrator t=2022-02-17T15:27:24.52+0200 lvl=info msg="Executing migration" id="add index in alert_definition_version table on alert_definition_id and version columns"
logger=migrator t=2022-02-17T15:27:24.52+0200 lvl=info msg="Executing migration" id="add index in alert_definition_version table on alert_definition_uid and version columns"
logger=migrator t=2022-02-17T15:27:24.52+0200 lvl=info msg="Executing migration" id="alter alert_definition_version table data column to mediumtext in mysql"
logger=migrator t=2022-02-17T15:27:24.53+0200 lvl=info msg="Executing migration" id="drop alert_definition_version table"
logger=migrator t=2022-02-17T15:27:24.53+0200 lvl=info msg="Executing migration" id="create alert_instance table"
logger=migrator t=2022-02-17T15:27:24.53+0200 lvl=info msg="Executing migration" id="add index in alert_instance table on def_org_id, def_uid and current_state columns"
logger=migrator t=2022-02-17T15:27:24.53+0200 lvl=info msg="Executing migration" id="add index in alert_instance table on def_org_id, current_state columns"
logger=migrator t=2022-02-17T15:27:24.54+0200 lvl=info msg="Executing migration" id="add column current_state_end to alert_instance"
logger=migrator t=2022-02-17T15:27:24.54+0200 lvl=info msg="Executing migration" id="remove index def_org_id, def_uid, current_state on alert_instance"
logger=migrator t=2022-02-17T15:27:24.54+0200 lvl=info msg="Executing migration" id="remove index def_org_id, current_state on alert_instance"
logger=migrator t=2022-02-17T15:27:24.54+0200 lvl=info msg="Executing migration" id="rename def_org_id to rule_org_id in alert_instance"
logger=migrator t=2022-02-17T15:27:24.55+0200 lvl=info msg="Executing migration" id="rename def_uid to rule_uid in alert_instance"
logger=migrator t=2022-02-17T15:27:24.55+0200 lvl=info msg="Executing migration" id="add index rule_org_id, rule_uid, current_state on alert_instance"
logger=migrator t=2022-02-17T15:27:24.56+0200 lvl=info msg="Executing migration" id="add index rule_org_id, current_state on alert_instance"
logger=migrator t=2022-02-17T15:27:24.56+0200 lvl=info msg="Executing migration" id="create alert_rule table"
logger=migrator t=2022-02-17T15:27:24.56+0200 lvl=info msg="Executing migration" id="add index in alert_rule on org_id and title columns"
logger=migrator t=2022-02-17T15:27:24.56+0200 lvl=info msg="Executing migration" id="add index in alert_rule on org_id and uid columns"
logger=migrator t=2022-02-17T15:27:24.57+0200 lvl=info msg="Executing migration" id="add index in alert_rule on org_id, namespace_uid, group_uid columns"
logger=migrator t=2022-02-17T15:27:24.57+0200 lvl=info msg="Executing migration" id="alter alert_rule table data column to mediumtext in mysql"
logger=migrator t=2022-02-17T15:27:24.57+0200 lvl=info msg="Executing migration" id="add column for to alert_rule"
logger=migrator t=2022-02-17T15:27:24.58+0200 lvl=info msg="Executing migration" id="add column annotations to alert_rule"
logger=migrator t=2022-02-17T15:27:24.58+0200 lvl=info msg="Executing migration" id="add column labels to alert_rule"
logger=migrator t=2022-02-17T15:27:24.58+0200 lvl=info msg="Executing migration" id="remove unique index from alert_rule on org_id, title columns"
logger=migrator t=2022-02-17T15:27:24.58+0200 lvl=info msg="Executing migration" id="add index in alert_rule on org_id, namespase_uid and title columns"
logger=migrator t=2022-02-17T15:27:24.59+0200 lvl=info msg="Executing migration" id="add dashboard_uid column to alert_rule"
logger=migrator t=2022-02-17T15:27:24.59+0200 lvl=info msg="Executing migration" id="add panel_id column to alert_rule"
logger=migrator t=2022-02-17T15:27:24.59+0200 lvl=info msg="Executing migration" id="add index in alert_rule on org_id, dashboard_uid and panel_id columns"
logger=migrator t=2022-02-17T15:27:24.59+0200 lvl=info msg="Executing migration" id="create alert_rule_version table"
logger=migrator t=2022-02-17T15:27:24.6+0200 lvl=info msg="Executing migration" id="add index in alert_rule_version table on rule_org_id, rule_uid and version columns"
logger=migrator t=2022-02-17T15:27:24.6+0200 lvl=info msg="Executing migration" id="add index in alert_rule_version table on rule_org_id, rule_namespace_uid and rule_group columns"
logger=migrator t=2022-02-17T15:27:24.6+0200 lvl=info msg="Executing migration" id="alter alert_rule_version table data column to mediumtext in mysql"
logger=migrator t=2022-02-17T15:27:24.6+0200 lvl=info msg="Executing migration" id="add column for to alert_rule_version"
logger=migrator t=2022-02-17T15:27:24.61+0200 lvl=info msg="Executing migration" id="add column annotations to alert_rule_version"
logger=migrator t=2022-02-17T15:27:24.61+0200 lvl=info msg="Executing migration" id="add column labels to alert_rule_version"
logger=migrator t=2022-02-17T15:27:24.61+0200 lvl=info msg="Executing migration" id=create_alert_configuration_table
logger=migrator t=2022-02-17T15:27:24.62+0200 lvl=info msg="Executing migration" id="Add column default in alert_configuration"
logger=migrator t=2022-02-17T15:27:24.62+0200 lvl=info msg="Executing migration" id="alert alert_configuration alertmanager_configuration column from TEXT to MEDIUMTEXT if mysql"
logger=migrator t=2022-02-17T15:27:24.62+0200 lvl=info msg="Executing migration" id="add column org_id in alert_configuration"
logger=migrator t=2022-02-17T15:27:24.62+0200 lvl=info msg="Executing migration" id="add index in alert_configuration table on org_id column"
logger=migrator t=2022-02-17T15:27:24.63+0200 lvl=info msg="Executing migration" id=create_ngalert_configuration_table
logger=migrator t=2022-02-17T15:27:24.63+0200 lvl=info msg="Executing migration" id="add index in ngalert_configuration on org_id column"
logger=migrator t=2022-02-17T15:27:24.63+0200 lvl=info msg="Executing migration" id="add column send_alerts_to in ngalert_configuration"
logger=migrator t=2022-02-17T15:27:24.63+0200 lvl=info msg="Executing migration" id="create provenance_type table"
logger=migrator t=2022-02-17T15:27:24.64+0200 lvl=info msg="Executing migration" id="add index to uniquify (record_key, record_type, org_id) columns"
logger=migrator t=2022-02-17T15:27:24.64+0200 lvl=info msg="Executing migration" id="clear migration entry \"remove unified alerting data\""
logger=migrator t=2022-02-17T15:27:24.64+0200 lvl=info msg="Executing migration" id="move dashboard alerts to unified alerting"
logger=migrator t=2022-02-17T15:27:24.64+0200 lvl=info msg="alerts found to migrate" alerts=0
logger=migrator t=2022-02-17T15:27:24.64+0200 lvl=info msg="Executing migration" id="create library_element table v1"
logger=migrator t=2022-02-17T15:27:24.65+0200 lvl=info msg="Executing migration" id="add index library_element org_id-folder_id-name-kind"
logger=migrator t=2022-02-17T15:27:24.65+0200 lvl=info msg="Executing migration" id="create library_element_connection table v1"
logger=migrator t=2022-02-17T15:27:24.65+0200 lvl=info msg="Executing migration" id="add index library_element_connection element_id-kind-connection_id"
logger=migrator t=2022-02-17T15:27:24.65+0200 lvl=info msg="Executing migration" id="add unique index library_element org_id_uid"
logger=migrator t=2022-02-17T15:27:24.66+0200 lvl=info msg="Executing migration" id="clone move dashboard alerts to unified alerting"
logger=migrator t=2022-02-17T15:27:24.66+0200 lvl=info msg="Executing migration" id="create data_keys table"
logger=migrator t=2022-02-17T15:27:24.66+0200 lvl=info msg="Executing migration" id="create kv_store table v1"
logger=migrator t=2022-02-17T15:27:24.66+0200 lvl=info msg="Executing migration" id="add index kv_store.org_id-namespace-key"
logger=migrator t=2022-02-17T15:27:24.67+0200 lvl=info msg="Executing migration" id="update dashboard_uid and panel_id from existing annotations"
logger=migrator t=2022-02-17T15:27:24.67+0200 lvl=info msg="Executing migration" id="create permission table"
logger=migrator t=2022-02-17T15:27:24.67+0200 lvl=info msg="Executing migration" id="add unique index permission.role_id"
logger=migrator t=2022-02-17T15:27:24.68+0200 lvl=info msg="Executing migration" id="add unique index role_id_action_scope"
logger=migrator t=2022-02-17T15:27:24.68+0200 lvl=info msg="Executing migration" id="create role table"
logger=migrator t=2022-02-17T15:27:24.68+0200 lvl=info msg="Executing migration" id="add column display_name"
logger=migrator t=2022-02-17T15:27:24.69+0200 lvl=info msg="Executing migration" id="add column group_name"
logger=migrator t=2022-02-17T15:27:24.69+0200 lvl=info msg="Executing migration" id="add index role.org_id"
logger=migrator t=2022-02-17T15:27:24.69+0200 lvl=info msg="Executing migration" id="add unique index role_org_id_name"
logger=migrator t=2022-02-17T15:27:24.69+0200 lvl=info msg="Executing migration" id="add index role_org_id_uid"
logger=migrator t=2022-02-17T15:27:24.7+0200 lvl=info msg="Executing migration" id="create team role table"
logger=migrator t=2022-02-17T15:27:24.7+0200 lvl=info msg="Executing migration" id="add index team_role.org_id"
logger=migrator t=2022-02-17T15:27:24.7+0200 lvl=info msg="Executing migration" id="add unique index team_role_org_id_team_id_role_id"
logger=migrator t=2022-02-17T15:27:24.7+0200 lvl=info msg="Executing migration" id="add index team_role.team_id"
logger=migrator t=2022-02-17T15:27:24.71+0200 lvl=info msg="Executing migration" id="create user role table"
logger=migrator t=2022-02-17T15:27:24.71+0200 lvl=info msg="Executing migration" id="add index user_role.org_id"
logger=migrator t=2022-02-17T15:27:24.71+0200 lvl=info msg="Executing migration" id="add unique index user_role_org_id_user_id_role_id"
logger=migrator t=2022-02-17T15:27:24.71+0200 lvl=info msg="Executing migration" id="add index user_role.user_id"
logger=migrator t=2022-02-17T15:27:24.72+0200 lvl=info msg="Executing migration" id="create builtin role table"
logger=migrator t=2022-02-17T15:27:24.72+0200 lvl=info msg="Executing migration" id="add index builtin_role.role_id"
logger=migrator t=2022-02-17T15:27:24.72+0200 lvl=info msg="Executing migration" id="add index builtin_role.name"
logger=migrator t=2022-02-17T15:27:24.73+0200 lvl=info msg="Executing migration" id="Add column org_id to builtin_role table"
logger=migrator t=2022-02-17T15:27:24.73+0200 lvl=info msg="Executing migration" id="add index builtin_role.org_id"
logger=migrator t=2022-02-17T15:27:24.73+0200 lvl=info msg="Executing migration" id="add unique index builtin_role_org_id_role_id_role"
logger=migrator t=2022-02-17T15:27:24.73+0200 lvl=info msg="Executing migration" id="Remove unique index role_org_id_uid"
logger=migrator t=2022-02-17T15:27:24.74+0200 lvl=info msg="Executing migration" id="add unique index role.uid"
logger=migrator t=2022-02-17T15:27:24.74+0200 lvl=info msg="Executing migration" id="create seed assignment table"
logger=migrator t=2022-02-17T15:27:24.74+0200 lvl=info msg="Executing migration" id="add unique index builtin_role_role_name"
logger=migrator t=2022-02-17T15:27:24.74+0200 lvl=info msg="Executing migration" id="create query_history table v1"
logger=migrator t=2022-02-17T15:27:24.75+0200 lvl=info msg="Executing migration" id="add index query_history.org_id-created_by-datasource_uid"
logger=migrator t=2022-02-17T15:27:24.75+0200 lvl=info msg="migrations completed" performed=387 skipped=0 duration=957.774712ms
logger=migrator t=2022-02-17T15:27:24.75+0200 lvl=info msg="Unlocking database"
--- PASS: TestMigratorLocking (0.96s)
    --- PASS: TestMigratorLocking/when_concurrent_migrations_for_the_same_migrator_occur,_the_second_one_should_fail (0.00s)
        --- PASS: TestMigratorLocking/when_concurrent_migrations_for_the_same_migrator_occur,_the_second_one_should_fail/run_migration_0 (0.00s)
        --- PASS: TestMigratorLocking/when_concurrent_migrations_for_the_same_migrator_occur,_the_second_one_should_fail/run_migration_1 (0.96s)
```
<details>

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**: