### PR TITLE
Plugins: Adding support for traceID field to accept variables.

### DIFF
--- a/public/app/plugins/datasource/jaeger/datasource.test.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.test.ts
@@ -159,6 +159,32 @@ describe('JaegerDatasource', () => {
     });
   });
 
+  it('should resolve templates in traceID', async () => {
+    const mock = setupFetchMock({ data: [testResponse] });
+    const ds = new JaegerDatasource(defaultSettings, timeSrvStub);
+
+    await lastValueFrom(
+      ds.query({
+        ...defaultQuery,
+        scopedVars: {
+          $traceid: {
+            text: 'traceid',
+            value: '5311b0dd0ca8df3463df93c99cb805a6',
+          },
+        },
+        targets: [
+          {
+            query: '$traceid',
+            refId: '1',
+          },
+        ],
+      })
+    );
+    expect(mock).toBeCalledWith({
+      url: `${defaultSettings.url}/api/traces/5311b0dd0ca8df3463df93c99cb805a6`,
+    });
+  });
+
   it('should resolve templates in tags', async () => {
     const mock = setupFetchMock({ data: [testResponse] });
     const ds = new JaegerDatasource(defaultSettings, timeSrvStub);

--- a/public/app/plugins/datasource/jaeger/datasource.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.ts
@@ -52,7 +52,9 @@ export class JaegerDatasource extends DataSourceApi<JaegerQuery, JaegerJsonData>
     }
 
     if (target.queryType !== 'search' && target.query) {
-      return this._request(`/api/traces/${encodeURIComponent(target.query)}`).pipe(
+      return this._request(
+        `/api/traces/${encodeURIComponent(getTemplateSrv().replace(target.query, options.scopedVars))}`
+      ).pipe(
         map((response) => {
           const traceData = response?.data?.data?.[0];
           if (!traceData) {


### PR DESCRIPTION
# Adding support for traceID field to accept variables.

What this PR does / why we need it:
Enable source jaeger to accept variables in the traceID field 