### PR TITLE
DataFrame: Add cached response notice for X-Cache: HIT header

### DIFF
--- a/packages/grafana-runtime/src/utils/queryResponse.test.ts
+++ b/packages/grafana-runtime/src/utils/queryResponse.test.ts
@@ -1,7 +1,6 @@
 import { DataQuery, toDataFrameDTO, DataFrame } from '@grafana/data';
-import { DataResponse } from 'src';
 import { FetchError, FetchResponse } from 'src/services';
-import { BackendDataSourceResponse, toDataQueryResponse, toTestingStatus } from './queryResponse';
+import { BackendDataSourceResponse, cachedResponseNotice, toDataQueryResponse, toTestingStatus } from './queryResponse';
 
 const resp = {
   data: {
@@ -302,9 +301,7 @@ describe('Query Response parser', () => {
     test('adds notice for responses with X-Cache: HIT header', () => {
       const queries: DataQuery[] = [{ refId: 'A' }];
       resp.headers.set('X-Cache', 'HIT');
-      expect(toDataQueryResponse(resp, queries).data[0].meta.notices).toStrictEqual([
-        { severity: 'info', text: 'Cached response' },
-      ]);
+      expect(toDataQueryResponse(resp, queries).data[0].meta.notices).toStrictEqual([cachedResponseNotice]);
     });
 
     test('does not remove existing notices', () => {
@@ -313,7 +310,7 @@ describe('Query Response parser', () => {
       resp.data.results.A.frames[0].schema.meta = { notices: [{ severity: 'info', text: 'Example' }] };
       expect(toDataQueryResponse(resp, queries).data[0].meta.notices).toStrictEqual([
         { severity: 'info', text: 'Example' },
-        { severity: 'info', text: 'Cached response' },
+        cachedResponseNotice,
       ]);
     });
 

--- a/packages/grafana-runtime/src/utils/queryResponse.test.ts
+++ b/packages/grafana-runtime/src/utils/queryResponse.test.ts
@@ -1,4 +1,5 @@
 import { DataQuery, toDataFrameDTO, DataFrame } from '@grafana/data';
+import { DataResponse } from 'src';
 import { FetchError, FetchResponse } from 'src/services';
 import { BackendDataSourceResponse, toDataQueryResponse, toTestingStatus } from './queryResponse';
 
@@ -275,6 +276,57 @@ describe('Query Response parser', () => {
 
     const ids = (toDataQueryResponse(resp, queries).data as DataFrame[]).map((f) => f.refId);
     expect(ids).toEqual(['A', 'B']);
+  });
+
+  describe('Cache notice', () => {
+    let resp: any;
+
+    beforeEach(() => {
+      resp = {
+        url: '',
+        type: 'basic',
+        config: { url: '' },
+        status: 200,
+        statusText: 'OK',
+        ok: true,
+        redirected: false,
+        headers: new Headers(),
+        data: {
+          results: {
+            A: { frames: [{ schema: { fields: [] } }] },
+          },
+        },
+      };
+    });
+
+    test('adds notice for responses with X-Cache: HIT header', () => {
+      const queries: DataQuery[] = [{ refId: 'A' }];
+      resp.headers.set('X-Cache', 'HIT');
+      expect(toDataQueryResponse(resp, queries).data[0].meta.notices).toStrictEqual([
+        { severity: 'info', text: 'Cached response' },
+      ]);
+    });
+
+    test('does not remove existing notices', () => {
+      const queries: DataQuery[] = [{ refId: 'A' }];
+      resp.headers.set('X-Cache', 'HIT');
+      resp.data.results.A.frames[0].schema.meta = { notices: [{ severity: 'info', text: 'Example' }] };
+      expect(toDataQueryResponse(resp, queries).data[0].meta.notices).toStrictEqual([
+        { severity: 'info', text: 'Example' },
+        { severity: 'info', text: 'Cached response' },
+      ]);
+    });
+
+    test('does not add notice for responses with X-Cache: MISS header', () => {
+      const queries: DataQuery[] = [{ refId: 'A' }];
+      resp.headers.set('X-Cache', 'MISS');
+      expect(toDataQueryResponse(resp, queries).data[0].meta?.notices).toBeUndefined();
+    });
+
+    test('does not add notice for responses without X-Cache header', () => {
+      const queries: DataQuery[] = [{ refId: 'A' }];
+      expect(toDataQueryResponse(resp, queries).data[0].meta?.notices).toBeUndefined();
+    });
   });
 
   test('resultWithError', () => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Query caching will be using the `X-Cache` header to mark responses as cached. The current approach uses frame meta notices to mark individual frames as cached, and that info is displayed in the panel's tooltip.

![image](https://user-images.githubusercontent.com/360020/154557504-7c4a5ce4-69cf-497f-be5c-2fc908fc428f.png)

In order to maintain backward compatibility, we will need to display the tooltip for any query response with a header value of `X-Cache: HIT`.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
See https://github.com/grafana/grafana-enterprise/pull/2830#discussion_r802782183
