### PR TITLE
Alerting: make send_alerts_to field nullable

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -327,7 +327,7 @@ func AddAlertAdminConfigMigrations(mg *migrator.Migrator) {
 	mg.AddMigration("create_ngalert_configuration_table", migrator.NewAddTableMigration(adminConfiguration))
 	mg.AddMigration("add index in ngalert_configuration on org_id column", migrator.NewAddIndexMigration(adminConfiguration, adminConfiguration.Indices[0]))
 	mg.AddMigration("add column send_alerts_to in ngalert_configuration", migrator.NewAddColumnMigration(adminConfiguration, &migrator.Column{
-		Name: "send_alerts_to", Type: migrator.DB_SmallInt, Nullable: true, Default: "0",
+		Name: "send_alerts_to", Type: migrator.DB_SmallInt, Nullable: false, Default: "0",
 	}))
 }
 

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -327,7 +327,7 @@ func AddAlertAdminConfigMigrations(mg *migrator.Migrator) {
 	mg.AddMigration("create_ngalert_configuration_table", migrator.NewAddTableMigration(adminConfiguration))
 	mg.AddMigration("add index in ngalert_configuration on org_id column", migrator.NewAddIndexMigration(adminConfiguration, adminConfiguration.Indices[0]))
 	mg.AddMigration("add column send_alerts_to in ngalert_configuration", migrator.NewAddColumnMigration(adminConfiguration, &migrator.Column{
-		Name: "send_alerts_to", Type: migrator.DB_SmallInt, Nullable: false,
+		Name: "send_alerts_to", Type: migrator.DB_SmallInt, Nullable: true, Default: "0",
 	}))
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The field `send_alerts_to` is non-nullable. This makes it impossible to migrate to 8.4 since that field was introduced in that version.
