### PR TITLE
Plugins: Fix importing panel modules

### DIFF
--- a/public/app/features/plugins/importPanelPlugin.ts
+++ b/public/app/features/plugins/importPanelPlugin.ts
@@ -28,22 +28,25 @@ export function importPanelPluginFromMeta(meta: grafanaData.PanelPluginMeta): Pr
   return getPanelPlugin(meta);
 }
 
-async function getPanelPlugin(meta: grafanaData.PanelPluginMeta): Promise<grafanaData.PanelPlugin> {
-  try {
-    const pluginExports = await importPluginModule(meta.module, meta.info?.version);
-    let plugin = pluginExports.plugin;
-
-    if (!plugin && pluginExports.PanelCtrl) {
-      plugin = new grafanaData.PanelPlugin(null);
-      plugin.angularPanelCtrl = pluginExports.PanelCtrl;
-    }
-
-    plugin.meta = meta;
-
-    return plugin;
-  } catch (err) {
-    // TODO, maybe a different error plugin
-    console.warn('Error loading panel plugin: ' + meta.id, err);
-    return getPanelPluginLoadError(meta, err);
-  }
+function getPanelPlugin(meta: grafanaData.PanelPluginMeta): Promise<grafanaData.PanelPlugin> {
+  return importPluginModule(meta.module, meta.info?.version)
+    .then((pluginExports) => {
+      if (pluginExports.plugin) {
+        return pluginExports.plugin as grafanaData.PanelPlugin;
+      } else if (pluginExports.PanelCtrl) {
+        const plugin = new grafanaData.PanelPlugin(null);
+        plugin.angularPanelCtrl = pluginExports.PanelCtrl;
+        return plugin;
+      }
+      throw new Error('missing export: plugin or PanelCtrl');
+    })
+    .then((plugin) => {
+      plugin.meta = meta;
+      return plugin;
+    })
+    .catch((err) => {
+      // TODO, maybe a different error plugin
+      console.warn('Error loading panel plugin: ' + meta.id, err);
+      return getPanelPluginLoadError(meta, err);
+    });
 }


### PR DESCRIPTION
Fixes issue importing external plugins in main introduced by #45421

In that PR I refactored a function from Promise.then to async await but apperently the Promise returned by SystemJS.import does not
work with async await keyword (you get back a Promise as the result of the await operation).



