### PR TITLE
Fix: JSON parsing in backend_srv

### DIFF
--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -105,7 +105,12 @@ export async function parseResponseBody<T>(
         return response.blob() as any;
 
       case 'json':
-        return response.json();
+        try {
+          return await response.json();
+        } catch (err) {
+          console.warn(`${response.url} returned an invalid JSON -`, err);
+          return {} as unknown as T;
+        }
 
       case 'text':
         return response.text() as any;

--- a/public/app/features/plugins/admin/state/actions.ts
+++ b/public/app/features/plugins/admin/state/actions.ts
@@ -73,6 +73,8 @@ export const install = createAsyncThunk(
 
       return { id, changes } as Update<CatalogPlugin>;
     } catch (e) {
+      console.error(e);
+
       return thunkApi.rejectWithValue('Unknown error.');
     }
   }
@@ -90,6 +92,8 @@ export const uninstall = createAsyncThunk(`${STATE_PREFIX}/uninstall`, async (id
       changes: { isInstalled: false, installedVersion: undefined },
     } as Update<CatalogPlugin>;
   } catch (e) {
+    console.error(e);
+
     return thunkApi.rejectWithValue('Unknown error.');
   }
 });


### PR DESCRIPTION
**More context:** https://github.com/grafana/grafana/pull/45188
**Slack threads:** 
- https://raintank-corp.slack.com/archives/C024NL6AEJH/p1645176639622769 
- https://raintank-corp.slack.com/archives/C01C4K8DETW/p1645119983230489

# What is the problem?
While https://github.com/grafana/grafana/pull/45188 truly brought performance benefits, it also highlighted issues that we have in some of our APIs. There are API endpoints that use the `Content-Type: application/json` header but are returning an invalid JSON, e.g. an empty body. An example to this is the `/api/plugins/<plugin-id>/install` endpoint.

Although this is actually an error in the APIs - and we are planning to fix them - we don't want other parts of the UI to fall over until we find and fix these endpoints, and also to be a bit more resilient to these kind of errors.

It probably would be good to somehow record these warnings in Sentry, so we can see what other API endpoints would need a fix. @bfmatei / @domasx2 can you help with how the best to approach that would be?

@leeoniya for visibility.

Big thanks to @jackw for helping debugging this. 🙏 