### PR TITLE
Explore: Fix closing split pane when logs panel is used

### DIFF
--- a/public/app/features/explore/LogsNavigation.tsx
+++ b/public/app/features/explore/LogsNavigation.tsx
@@ -82,7 +82,7 @@ function LogsNavigation({
 
   useEffect(() => {
     clearCache();
-    // We can't enforce the eslint rule here because we only want to run when component unmounts.
+    // We can't enforce the eslint rule here because we only want to run when component is mounted.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/public/app/features/explore/LogsNavigation.tsx
+++ b/public/app/features/explore/LogsNavigation.tsx
@@ -81,7 +81,7 @@ function LogsNavigation({
   }, [visibleRange, absoluteRange, logsSortOrder, queries, clearCache, addResultsToCache]);
 
   useEffect(() => {
-    return () => clearCache();
+    clearCache();
     // We can't enforce the eslint rule here because we only want to run when component unmounts.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

LogsNavigation component caches result pages in Explore pane state to avoid re-requesting logs for the same page when the user uses navigation. 

The cache is cleared when the component was unmounted. It causes problems when closing split pane because, for example when closing the right pane following actions are invoked:
* splitClose action cleans `ExploreState.right = undefined`
* saveState action is called that updates URL cleaning `right` param
* the change in state causes unmounting the right pane that contains LogsNavigation component
* LogsNavigation when unmounted calls clearCacheAction for `exploreId="right"`
* clearCacheAction is provided with *default state* because the current state of `exploreId="right"` is undefined -> that causes adding default right pane back to the state
* in this case saveState is not called meaning the URL is not updated
* the reason why we don't see that default right pane from the state right away after BUT the close button is visible is because:
  * the button is shown based on the store state (which contains the default right pane created after clearCacheAction), 
  * but Explore Wrapper shows only the left pane because it's the logic is based on the current URL params 

The fix is to clear the cache when the component is mounted. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #44429

**Special notes for your reviewer**:

To test it follow instructions in #44429.

The side effect to the fix is that we won't re-use the cache for the pagination after splitting.
