### PR TITLE
Add Docker Compose dev environment for Intent API

### DIFF
--- a/devenv/docker/blocks/intentapi/.env
+++ b/devenv/docker/blocks/intentapi/.env
@@ -1,0 +1,2 @@
+kubeapi_version=1.23.3
+etcd_version=3.5.2

--- a/devenv/docker/blocks/intentapi/.gitignore
+++ b/devenv/docker/blocks/intentapi/.gitignore
@@ -1,0 +1,4 @@
+# Ignore X.509 keys, certs and certrequests
+*.pem
+*.csr
+*.kubeconfig

--- a/devenv/docker/blocks/intentapi/Makefile
+++ b/devenv/docker/blocks/intentapi/Makefile
@@ -65,6 +65,10 @@ $(KUBE_CONFIG):
 
 	@kubectl config use-context default --kubeconfig=$(KUBE_CONFIG)
 
+.PHONY: install-cfssl
+install-cfssl:
+	go get github.com/cloudflare/cfssl/cmd/cfssl
+
 .PHONY: clean
 clean:
 	@rm -f $(CERT_DIR)/*.pem $(CERT_DIR)/*.csr

--- a/devenv/docker/blocks/intentapi/Makefile
+++ b/devenv/docker/blocks/intentapi/Makefile
@@ -8,35 +8,35 @@ CERT_SA    := $(CERT_DIR)/service-account.pem $(CERT_DIR)/service-account-key.pe
 CERT_KUBE  := $(CERT_DIR)/kubernetes.pem $(CERT_DIR)/kubernetes-key.pem
 CERT_ADMIN := $(CERT_DIR)/admin.pem $(CERT_DIR)/admin-key.pem
 
-all: certs config
+all: clean install-tools certs config
 
 certs: $(CERT_CA) $(CERT_SA) $(CERT_KUBE) $(CERT_ADMIN)
 
 $(CERT_CA):
-	@cfssl gencert \
-		-initca $(CFG_DIR)/ca-csr.json | cfssljson -bare $(CERT_DIR)/ca
+	@$(CFSSL) gencert \
+		-initca $(CFG_DIR)/ca-csr.json | $(CFSSLJSON) -bare $(CERT_DIR)/ca
 
 $(CERT_SA):
-	@cfssl gencert -profile=kubernetes \
+	@$(CFSSL) gencert -profile=kubernetes \
 		-ca=$(CERT_DIR)/ca.pem \
 		-ca-key=$(CERT_DIR)/ca-key.pem \
 		-config=$(CFG_DIR)/ca-config.json \
-		$(CFG_DIR)/service-account-csr.json | cfssljson -bare $(CERT_DIR)/service-account
+		$(CFG_DIR)/service-account-csr.json | $(CFSSLJSON) -bare $(CERT_DIR)/service-account
 
 $(CERT_KUBE):
-	@cfssl gencert -profile=kubernetes \
+	@$(CFSSL) gencert -profile=kubernetes \
 		-ca=$(CERT_DIR)/ca.pem \
 		-ca-key=$(CERT_DIR)/ca-key.pem \
 		-config=$(CFG_DIR)/ca-config.json \
 		-hostname=$(KUBE_IPS),$(KUBE_HOSTNAMES) \
-		$(CFG_DIR)/kubernetes-csr.json | cfssljson -bare $(CERT_DIR)/kubernetes
+		$(CFG_DIR)/kubernetes-csr.json | $(CFSSLJSON) -bare $(CERT_DIR)/kubernetes
 
 $(CERT_ADMIN):
-	@cfssl gencert -profile=kubernetes \
+	@$(CFSSL) gencert -profile=kubernetes \
 		-ca=$(CERT_DIR)/ca.pem \
 		-ca-key=$(CERT_DIR)/ca-key.pem \
 		-config=$(CFG_DIR)/ca-config.json \
-		$(CFG_DIR)/admin-csr.json | cfssljson -bare $(CERT_DIR)/admin
+		$(CFG_DIR)/admin-csr.json | $(CFSSLJSON) -bare $(CERT_DIR)/admin
 
 KUBE_CONFIG  := admin.kubeconfig
 KUBE_CLUSTER := intentapi
@@ -65,9 +65,17 @@ $(KUBE_CONFIG):
 
 	@kubectl config use-context default --kubeconfig=$(KUBE_CONFIG)
 
-.PHONY: install-cfssl
-install-cfssl:
-	go get github.com/cloudflare/cfssl/cmd/cfssl
+CFSSL         := ${GOPATH}/bin/cfssl
+CFSSLJSON     := ${GOPATH}/bin/cfssljson
+CFSSL_VERSION := 1.6.1
+
+install-tools: $(CFSSL) $(CFSSLJSON)
+
+$(CFSSL):
+	@go install github.com/cloudflare/cfssl/cmd/cfssl@v$(CFSSL_VERSION)
+
+$(CFSSLJSON):
+	@go install github.com/cloudflare/cfssl/cmd/cfssljson@v$(CFSSL_VERSION)
 
 .PHONY: clean
 clean:

--- a/devenv/docker/blocks/intentapi/Makefile
+++ b/devenv/docker/blocks/intentapi/Makefile
@@ -1,0 +1,71 @@
+KUBE_IPS       := 10.32.0.1,10.240.0.10,10.240.0.11,10.240.0.12,127.0.0.1
+KUBE_HOSTNAMES := localhost,kubernetes,kubernetes.default,kubernetes.default.svc,kubernetes.default.svc.cluster,kubernetes.svc.cluster.local
+
+CFG_DIR    := pki
+CERT_DIR   := certs
+CERT_CA    := $(CERT_DIR)/ca.pem $(CERT_DIR)/ca-key.pem
+CERT_SA    := $(CERT_DIR)/service-account.pem $(CERT_DIR)/service-account-key.pem
+CERT_KUBE  := $(CERT_DIR)/kubernetes.pem $(CERT_DIR)/kubernetes-key.pem
+CERT_ADMIN := $(CERT_DIR)/admin.pem $(CERT_DIR)/admin-key.pem
+
+all: certs config
+
+certs: $(CERT_CA) $(CERT_SA) $(CERT_KUBE) $(CERT_ADMIN)
+
+$(CERT_CA):
+	@cfssl gencert \
+		-initca $(CFG_DIR)/ca-csr.json | cfssljson -bare $(CERT_DIR)/ca
+
+$(CERT_SA):
+	@cfssl gencert -profile=kubernetes \
+		-ca=$(CERT_DIR)/ca.pem \
+		-ca-key=$(CERT_DIR)/ca-key.pem \
+		-config=$(CFG_DIR)/ca-config.json \
+		$(CFG_DIR)/service-account-csr.json | cfssljson -bare $(CERT_DIR)/service-account
+
+$(CERT_KUBE):
+	@cfssl gencert -profile=kubernetes \
+		-ca=$(CERT_DIR)/ca.pem \
+		-ca-key=$(CERT_DIR)/ca-key.pem \
+		-config=$(CFG_DIR)/ca-config.json \
+		-hostname=$(KUBE_IPS),$(KUBE_HOSTNAMES) \
+		$(CFG_DIR)/kubernetes-csr.json | cfssljson -bare $(CERT_DIR)/kubernetes
+
+$(CERT_ADMIN):
+	@cfssl gencert -profile=kubernetes \
+		-ca=$(CERT_DIR)/ca.pem \
+		-ca-key=$(CERT_DIR)/ca-key.pem \
+		-config=$(CFG_DIR)/ca-config.json \
+		$(CFG_DIR)/admin-csr.json | cfssljson -bare $(CERT_DIR)/admin
+
+KUBE_CONFIG  := admin.kubeconfig
+KUBE_CLUSTER := intentapi
+KUBE_HOST    := localhost
+KUBE_PORT    := 6443
+KUBE_USER    := admin
+
+config: $(KUBE_CONFIG)
+$(KUBE_CONFIG):
+	@kubectl config set-cluster $(KUBE_CLUSTER) \
+		--embed-certs=true \
+		--certificate-authority=$(CERT_DIR)/ca.pem \
+		--server=https://$(KUBE_HOST):$(KUBE_PORT) \
+		--kubeconfig=$(KUBE_CONFIG)
+
+	@kubectl config set-credentials admin \
+		--embed-certs=true \
+		--client-certificate=$(CERT_DIR)/admin.pem \
+		--client-key=$(CERT_DIR)/admin-key.pem \
+		--kubeconfig=$(KUBE_CONFIG)
+
+	@kubectl config set-context default \
+		--cluster=$(KUBE_CLUSTER) \
+		--user=$(KUBE_USER) \
+		--kubeconfig=$(KUBE_CONFIG)
+
+	@kubectl config use-context default --kubeconfig=$(KUBE_CONFIG)
+
+.PHONY: clean
+clean:
+	@rm -f $(CERT_DIR)/*.pem $(CERT_DIR)/*.csr
+	@rm -f $(KUBE_CONFIG)

--- a/devenv/docker/blocks/intentapi/README.md
+++ b/devenv/docker/blocks/intentapi/README.md
@@ -11,20 +11,8 @@ You can switch to different kubeapi and etcd versions by changing the values in 
 In order to run and use `kube-apiserver` we need to setup PKI keys and certificates. This can be done with `make` - ensure that you do that before you boot up the environment, or re-create the environment after doing that in order for the changes to take effect:
 
 ```sh
-# Assuming you're in repo's root:
-$ cd devenv/docker/blocks/intentapi
-
-# Install cfsll (https://github.com/cloudflare/cfssl):
-$ make install-cfssl
-
 # Generate certs and kubeconfig:
-$ make
-```
-
-Once the certs are created, you can run the environment as a usual devenv Docker block:
-```sh
-# cd to repo's root:
-$ cd ../../../../
+$ make -C devenv/docker/blocks/intentapi
 
 # Spin up docker-compose env:
 $ make devenv sources=intentapi

--- a/devenv/docker/blocks/intentapi/README.md
+++ b/devenv/docker/blocks/intentapi/README.md
@@ -1,0 +1,31 @@
+# Intent API devenv
+
+This devenv stands up a `kube-apiserver` and a single-host `etcd` for local development / testing.
+
+## kubeapi and etcd versions
+
+You can switch to different kubeapi and etcd versions by changing the values in `.env`. Make sure that the images for those versions exist and can be pulled.
+
+## Preparing the environment
+
+In order to run and use `kube-apiserver` we need to setup PKI keys and certificates. This can be done with `make` - ensure that you do that before you boot up the environment, or re-create the environment after doing that in order for the changes to take effect:
+
+```sh
+# Install cfsll (https://github.com/cloudflare/cfssl):
+$ go get github.com/cloudflare/cfssl/cmd/cfssl
+
+# Or, with Homebrew:
+$ brew install cfssl
+
+# Generate certs and kubeconfig:
+$ make
+```
+
+Once the certs are created, you can run the environment as a usual devenv Docker block:
+```sh
+# Assuming that you're in repo's root:
+$ make devenv sources=intentapi
+
+# Test that the environment is working correctly:
+$ kubectl --kubeconfig=devenv/docker/blocks/intentapi/admin.kubeconfig api-resources
+```

--- a/devenv/docker/blocks/intentapi/README.md
+++ b/devenv/docker/blocks/intentapi/README.md
@@ -11,11 +11,11 @@ You can switch to different kubeapi and etcd versions by changing the values in 
 In order to run and use `kube-apiserver` we need to setup PKI keys and certificates. This can be done with `make` - ensure that you do that before you boot up the environment, or re-create the environment after doing that in order for the changes to take effect:
 
 ```sh
-# Install cfsll (https://github.com/cloudflare/cfssl):
-$ go get github.com/cloudflare/cfssl/cmd/cfssl
+# Assuming you're in repo's root:
+$ cd devenv/docker/blocks/intentapi
 
-# Or, with Homebrew:
-$ brew install cfssl
+# Install cfsll (https://github.com/cloudflare/cfssl):
+$ make install-cfssl
 
 # Generate certs and kubeconfig:
 $ make
@@ -23,7 +23,10 @@ $ make
 
 Once the certs are created, you can run the environment as a usual devenv Docker block:
 ```sh
-# Assuming that you're in repo's root:
+# cd to repo's root:
+$ cd ../../../../
+
+# Spin up docker-compose env:
 $ make devenv sources=intentapi
 
 # Test that the environment is working correctly:

--- a/devenv/docker/blocks/intentapi/docker-compose.yaml
+++ b/devenv/docker/blocks/intentapi/docker-compose.yaml
@@ -1,0 +1,35 @@
+  apiserver:
+    image: k8s.gcr.io/kube-apiserver:v${kubeapi_version}
+    restart: on-failure
+    ports:
+      - "6443:6443"
+    depends_on:
+      - etcd
+    volumes:
+      - ./docker/blocks/intentapi/certs:/var/lib/kubernetes
+    command:
+      - /usr/local/bin/kube-apiserver
+      - --bind-address=0.0.0.0
+      - --secure-port=6443
+      - --etcd-servers=http://etcd:2379
+      - --client-ca-file=/var/lib/kubernetes/ca.pem
+      - --tls-cert-file=/var/lib/kubernetes/kubernetes.pem
+      - --tls-private-key-file=/var/lib/kubernetes/kubernetes-key.pem
+      - --service-account-key-file=/var/lib/kubernetes/service-account.pem
+      - --service-account-signing-key-file=/var/lib/kubernetes/service-account-key.pem
+      - --service-account-issuer=https://localhost:6443
+
+  etcd:
+    image: quay.io/coreos/etcd:v${etcd_version}
+    restart: on-failure
+    ports:
+      - "2379:2379"
+      - "2380:2380"
+    command:
+      - /usr/local/bin/etcd
+      - -name=etcd-node-0
+      - -listen-client-urls=http://0.0.0.0:2379
+      - -advertise-client-urls=http://0.0.0.0:2379
+      - -initial-advertise-peer-urls=http://0.0.0.0:2380
+      - -listen-peer-urls=http://0.0.0.0:2380
+      - -initial-cluster=etcd-node-0=http://0.0.0.0:2380

--- a/devenv/docker/blocks/intentapi/pki/admin-csr.json
+++ b/devenv/docker/blocks/intentapi/pki/admin-csr.json
@@ -1,0 +1,16 @@
+{
+  "CN": "admin",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "CH",
+      "L": "Geneva",
+      "O": "Kubernetes",
+      "OU": "IntentAPI",
+      "ST": "Canton of Geneva"
+    }
+  ]
+}

--- a/devenv/docker/blocks/intentapi/pki/ca-config.json
+++ b/devenv/docker/blocks/intentapi/pki/ca-config.json
@@ -1,0 +1,13 @@
+{
+  "signing": {
+    "default": {
+      "expiry": "8760h"
+    },
+    "profiles": {
+      "kubernetes": {
+        "usages": ["signing", "key encipherment", "server auth", "client auth"],
+        "expiry": "8760h"
+      }
+    }
+  }
+}

--- a/devenv/docker/blocks/intentapi/pki/ca-csr.json
+++ b/devenv/docker/blocks/intentapi/pki/ca-csr.json
@@ -1,0 +1,17 @@
+{
+  "CN": "Kubernetes",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "CH",
+      "L": "Geneva",
+      "O": "Kubernetes",
+      "OU": "IntentAPI",
+      "ST": "Canton of Geneva"
+    }
+  ]
+}
+

--- a/devenv/docker/blocks/intentapi/pki/kubernetes-csr.json
+++ b/devenv/docker/blocks/intentapi/pki/kubernetes-csr.json
@@ -1,0 +1,16 @@
+{
+  "CN": "kubernetes",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "CH",
+      "L": "Geneva",
+      "O": "Kubernetes",
+      "OU": "IntentAPI",
+      "ST": "Canton of Geneva"
+    }
+  ]
+}

--- a/devenv/docker/blocks/intentapi/pki/service-account-csr.json
+++ b/devenv/docker/blocks/intentapi/pki/service-account-csr.json
@@ -1,0 +1,16 @@
+{
+  "CN": "service-accounts",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "CH",
+      "L": "Geneva",
+      "O": "Kubernetes",
+      "OU": "IntentAPI",
+      "ST": "Canton of Geneva"
+    }
+  ]
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR adds a new devenv block with local setup that contains kube-apiserver and etcd for testing Intent API functionality.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #44454

**Special notes for your reviewer**:

I've added a Makefile with targets for generating certs and kubectl config to the block directory. It's a bit inconvenient to use, since one has to cd into the directory to run `make` and then cd back to repo root to stand up the devenv, so I'm open to suggestions on how to improve it.