### PR TITLE
DashboardSrv: add saveDashboard method

### DIFF
--- a/public/app/features/dashboard/services/DashboardSrv.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.ts
@@ -23,6 +23,7 @@ export interface SaveDashboardOptions {
    *  If this is lower than the minimum refresh interval, Grafana will ignore it and will enforce the minimum refresh interval. */
   refresh?: string;
 }
+
 export class DashboardSrv {
   dashboard?: DashboardModel;
 

--- a/public/app/features/dashboard/services/DashboardSrv.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.ts
@@ -70,7 +70,10 @@ export class DashboardSrv {
       getBackendSrv().fetch({
         url: '/api/dashboards/db/',
         method: 'POST',
-        data,
+        data: {
+          ...data,
+          dashboard: data.dashboard.getSaveModelClone(),
+        },
         ...requestOptions,
       })
     );

--- a/public/app/features/dashboard/services/DashboardSrv.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.ts
@@ -6,6 +6,7 @@ import { getBackendSrv } from 'app/core/services/backend_srv';
 import { saveDashboard } from 'app/features/manage-dashboards/state/actions';
 import { RemovePanelEvent } from '../../../types/events';
 import { BackendSrvRequest } from '@grafana/runtime';
+import { lastValueFrom } from 'rxjs';
 
 export interface SaveDashboardOptions {
   /** The complete dashboard model. If `dashboard.id` is not set a new dashboard will be created. */
@@ -65,12 +66,14 @@ export class DashboardSrv {
     data: SaveDashboardOptions,
     requestOptions?: Pick<BackendSrvRequest, 'showErrorAlert' | 'showSuccessAlert'>
   ) {
-    return getBackendSrv().request({
-      url: '/api/dashboards/db/',
-      method: 'POST',
-      data,
-      ...requestOptions,
-    });
+    return lastValueFrom(
+      getBackendSrv().fetch({
+        url: '/api/dashboards/db/',
+        method: 'POST',
+        data,
+        ...requestOptions,
+      })
+    );
   }
 
   starDashboard(dashboardId: string, isStarred: any) {

--- a/public/app/features/dashboard/services/DashboardSrv.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.ts
@@ -1,7 +1,7 @@
 import { appEvents } from 'app/core/app_events';
 import { DashboardModel } from '../state/DashboardModel';
 import { removePanel } from '../utils/panel';
-import { DashboardDataDTO, DashboardMeta } from 'app/types';
+import { DashboardMeta } from 'app/types';
 import { getBackendSrv } from 'app/core/services/backend_srv';
 import { saveDashboard } from 'app/features/manage-dashboards/state/actions';
 import { RemovePanelEvent } from '../../../types/events';
@@ -9,7 +9,7 @@ import { BackendSrvRequest } from '@grafana/runtime';
 
 export interface SaveDashboardOptions {
   /** The complete dashboard model. If `dashboard.id` is not set a new dashboard will be created. */
-  dashboard: DashboardDataDTO;
+  dashboard: DashboardModel;
   /** Set a commit message for the version history. */
   message?: string;
   /** The id of the folder to save the dashboard in. */

--- a/public/app/features/dashboard/services/DashboardSrv.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.ts
@@ -1,11 +1,28 @@
 import { appEvents } from 'app/core/app_events';
 import { DashboardModel } from '../state/DashboardModel';
 import { removePanel } from '../utils/panel';
-import { DashboardMeta } from 'app/types';
+import { DashboardDataDTO, DashboardMeta } from 'app/types';
 import { getBackendSrv } from 'app/core/services/backend_srv';
 import { saveDashboard } from 'app/features/manage-dashboards/state/actions';
 import { RemovePanelEvent } from '../../../types/events';
+import { BackendSrvRequest } from '@grafana/runtime';
 
+export interface SaveDashboardOptions {
+  /** The complete dashboard model. If `dashboard.id` is not set a new dashboard will be created. */
+  dashboard: DashboardDataDTO;
+  /** Set a commit message for the version history. */
+  message?: string;
+  /** The id of the folder to save the dashboard in. */
+  folderId?: number;
+  /** The UID of the folder to save the dashboard in. Overrides `folderId`. */
+  folderUid?: string;
+  /** Set to `true` if you want to overwrite existing dashboard with newer version,
+   *  same dashboard title in folder or same dashboard uid. */
+  overwrite?: boolean;
+  /** Set the dashboard refresh interval.
+   *  If this is lower than the minimum refresh interval, Grafana will ignore it and will enforce the minimum refresh interval. */
+  refresh?: string;
+}
 export class DashboardSrv {
   dashboard?: DashboardModel;
 
@@ -40,6 +57,18 @@ export class DashboardSrv {
     return saveDashboard({
       dashboard: parsedJson,
       folderId: this.dashboard?.meta.folderId || parsedJson.folderId,
+    });
+  }
+
+  saveDashboard(
+    data: SaveDashboardOptions,
+    requestOptions?: Pick<BackendSrvRequest, 'showErrorAlert' | 'showSuccessAlert'>
+  ) {
+    return getBackendSrv().request({
+      url: '/api/dashboards/db/',
+      method: 'POST',
+      data,
+      ...requestOptions,
     });
   }
 

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -12,7 +12,7 @@ import {
   setJsonDashboard,
   setLibraryPanelInputs,
 } from './reducers';
-import { DashboardDataDTO, DashboardDTO, FolderInfo, PermissionLevelString, ThunkResult } from 'app/types';
+import { DashboardDTO, FolderInfo, PermissionLevelString, ThunkResult } from 'app/types';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/actions';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
@@ -21,6 +21,7 @@ import { DashboardSearchHit } from '../../search/types';
 import { getLibraryPanel } from '../../library-panels/state/api';
 import { LibraryElementDTO, LibraryElementKind } from '../../library-panels/types';
 import { LibraryElementExport } from '../../dashboard/components/DashExportModal/DashboardExporter';
+import { DashboardSrv, getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 
 export function fetchGcomDashboard(id: string): ThunkResult<void> {
   return async (dispatch) => {
@@ -256,22 +257,10 @@ export function deleteFoldersAndDashboards(folderUids: string[], dashboardUids: 
   return executeInOrder(tasks);
 }
 
-export interface SaveDashboardOptions {
-  dashboard: DashboardDataDTO;
-  message?: string;
-  folderId?: number;
-  overwrite?: boolean;
-}
-
-export function saveDashboard(options: SaveDashboardOptions) {
+export function saveDashboard(options: Parameters<DashboardSrv['saveDashboard']>[0]) {
   dashboardWatcher.ignoreNextSave();
 
-  return getBackendSrv().post('/api/dashboards/db/', {
-    dashboard: options.dashboard,
-    message: options.message ?? '',
-    overwrite: options.overwrite ?? false,
-    folderId: options.folderId,
-  });
+  return getDashboardSrv().saveDashboard(options);
 }
 
 function deleteFolder(uid: string, showSuccessAlert: boolean) {

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -12,7 +12,7 @@ import {
   setJsonDashboard,
   setLibraryPanelInputs,
 } from './reducers';
-import { DashboardDTO, FolderInfo, PermissionLevelString, ThunkResult } from 'app/types';
+import { DashboardDataDTO, DashboardDTO, FolderInfo, PermissionLevelString, ThunkResult } from 'app/types';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/actions';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
@@ -21,7 +21,6 @@ import { DashboardSearchHit } from '../../search/types';
 import { getLibraryPanel } from '../../library-panels/state/api';
 import { LibraryElementDTO, LibraryElementKind } from '../../library-panels/types';
 import { LibraryElementExport } from '../../dashboard/components/DashExportModal/DashboardExporter';
-import { DashboardSrv, getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 
 export function fetchGcomDashboard(id: string): ThunkResult<void> {
   return async (dispatch) => {
@@ -257,10 +256,22 @@ export function deleteFoldersAndDashboards(folderUids: string[], dashboardUids: 
   return executeInOrder(tasks);
 }
 
-export function saveDashboard(options: Parameters<DashboardSrv['saveDashboard']>[0]) {
+export interface SaveDashboardOptions {
+  dashboard: DashboardDataDTO;
+  message?: string;
+  folderId?: number;
+  overwrite?: boolean;
+}
+
+export function saveDashboard(options: SaveDashboardOptions) {
   dashboardWatcher.ignoreNextSave();
 
-  return getDashboardSrv().saveDashboard(options);
+  return getBackendSrv().post('/api/dashboards/db/', {
+    dashboard: options.dashboard,
+    message: options.message ?? '',
+    overwrite: options.overwrite ?? false,
+    folderId: options.folderId,
+  });
 }
 
 function deleteFolder(uid: string, showSuccessAlert: boolean) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Adds a `saveDashboard` to `DashboardSrv` allowing consumers to save dashboards via said service class.


**Special notes for your reviewer**:

instead of using `DahsboardDataDTO` as discussed offline i changed it to use `DashboardModel` is it is the same type returned by `getSaveModelClone` in `DashboardModel` itself, so i'm assuming it should be the correct type.

