### PR TITLE
Testdata: use alias in streaming example

### DIFF
--- a/public/app/plugins/datasource/testdata/runStreams.ts
+++ b/public/app/plugins/datasource/testdata/runStreams.ts
@@ -51,10 +51,9 @@ export function runSignalStream(
 
     const schema: DataFrameSchema = {
       refId: target.refId,
-      name: target.alias || 'Signal ' + target.refId,
       fields: [
         { name: 'time', type: FieldType.time },
-        { name: 'value', type: FieldType.number },
+        { name: target.alias ?? 'value', type: FieldType.number },
       ],
     };
 


### PR DESCRIPTION
The current streaming testdata sets the alias in a place that does not get used in display.  This PR moves the alias to the name field when it exists:

![image](https://user-images.githubusercontent.com/705951/154752533-64441865-3b66-41f7-b560-3f00845a8bb0.png)

before:
![image](https://user-images.githubusercontent.com/705951/154752649-db271c3a-47b7-4d97-951d-922086ee5fb4.png)
