### PR TITLE
StateTimeline: Add flag to force panel config recreation

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -38,6 +38,7 @@ export type PropDiffFn<T extends any = any> = (prev: T, next: T) => boolean;
 export interface GraphNGProps extends Themeable2 {
   frames: DataFrame[];
   structureRev?: number; // a number that will change when the frames[] structure changes
+  alwaysPrepStateWithConfig?: boolean;
   width: number;
   height: number;
   timeRange: TimeRange;
@@ -216,7 +217,7 @@ export class GraphNG extends React.Component<GraphNGProps, GraphNGState> {
     const propsChanged = !sameProps(prevProps, this.props, propsToDiff);
 
     if (frames !== prevProps.frames || propsChanged) {
-      let newState = this.prepState(this.props, false);
+      let newState = this.prepState(this.props, this.props.alwaysPrepStateWithConfig ?? false);
 
       if (newState) {
         const shouldReconfig =

--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
@@ -101,6 +101,7 @@ export const StateTimelinePanel: React.FC<TimelinePanelProps> = ({
       legendItems={legendItems}
       {...options}
       mode={TimelineMode.Changes}
+      alwaysPrepStateWithConfig={true}
     >
       {(config, alignedFrame) => {
         return (

--- a/public/app/plugins/panel/state-timeline/TimelineChart.tsx
+++ b/public/app/plugins/panel/state-timeline/TimelineChart.tsx
@@ -26,6 +26,7 @@ export interface TimelineProps
   alignValue?: TimelineValueAlignment;
   colWidth?: number;
   legendItems?: VizLegendItem[];
+  alwaysPrepStateWithConfig?: boolean;
 }
 
 const propsToDiff = ['rowHeight', 'colWidth', 'showValue', 'mergeValues', 'alignValue'];
@@ -76,6 +77,7 @@ export class TimelineChart extends React.Component<TimelineProps> {
         prepConfig={this.prepConfig}
         propsToDiff={propsToDiff}
         renderLegend={this.renderLegend}
+        alwaysPrepStateWithConfig={this.props.alwaysPrepStateWithConfig}
       />
     );
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR adds a flag that will signal to always recreate the State Timeline config when data changes.

**Which issue(s) this PR fixes**:
It will fix an issue where changing data points in the State Timeline would not update the visualisation color scheme correctly.
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/44648

**Special notes for your reviewer**:
Not sure if this is the best approach (adding a flag just for the StateTimeline) or if it would be better to always recreate the config for all GraphNG children. I would assume the reason why the config doesn't recreate on component update is for performance reasons.
