### PR TITLE
Fix: update link pointing to breaking changes guideline

### DIFF
--- a/.github/workflows/detect-breaking-changes-report.yml
+++ b/.github/workflows/detect-breaking-changes-report.yml
@@ -91,7 +91,7 @@ jobs:
           ${{ steps.levitate-run.outputs.message }}
 
           [Console output](${{ steps.levitate-run.outputs.job_link }})
-          [Read our guideline](../../contribute/breaking-changes-guide.md)
+          [Read our guideline](https://github.com/grafana/grafana/blob/main/contribute/breaking-changes-guide.md)
 
     - name: Remove comment on PR
       if: ${{ steps.levitate-run.outputs.exit_code == 0 }}


### PR DESCRIPTION
### What changed?
The link that was pointing to the breaking changes guideline was broken, this PR is fixing it.