### PR TITLE
Rendering: increase request timeout multiplier

### DIFF
--- a/pkg/services/rendering/interface.go
+++ b/pkg/services/rendering/interface.go
@@ -32,7 +32,7 @@ type AuthOpts struct {
 
 func getRequestTimeout(opt TimeoutOpts) time.Duration {
 	if opt.RequestTimeoutMultiplier == 0 {
-		return opt.Timeout * 2 // default
+		return opt.Timeout * 3 // default
 	}
 
 	return opt.Timeout * opt.RequestTimeoutMultiplier


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The Image Renderer plugin uses the configurable _timeout_ value in two different places within a single rendering request:
first during the initial dashboard navigation, and then when waiting for all the panels to load. 
Currently, we set the context timeout to `2 * image_renderer_timeout`, which is not enough in scenarios in which both operations (the dashboard navigation and panel loading wait) time out.

This PR increases the multiplier to 3 so that we hopefully avoid all `context deadline exceeded` errors. 


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

