### PR TITLE
Query history: Store preferences in database

### DIFF
--- a/docs/sources/http_api/preferences.md
+++ b/docs/sources/http_api/preferences.md
@@ -12,6 +12,7 @@ Keys:
 - **theme** - One of: `light`, `dark`, or an empty string for the default theme
 - **homeDashboardId** - The numerical `:id` of a favorited dashboard, default: `0`
 - **timezone** - One of: `utc`, `browser`, or an empty string for the default
+- **queryHistory** - JSON with preferences for query history. Supported preferences: showOnlyCurrentDs, starredTabFirst
 
 Omitting a key will cause the current value to be replaced with the
 system default value.
@@ -53,7 +54,11 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 {
   "theme": "",
   "homeDashboardId":0,
-  "timezone":"utc"
+  "timezone":"utc",
+  "queryHistory": {
+    "showOnlyCurrentDs": true,
+    "starredTabFirst": true
+  }
 }
 ```
 

--- a/pkg/api/dtos/prefs.go
+++ b/pkg/api/dtos/prefs.go
@@ -1,10 +1,13 @@
 package dtos
 
+import "github.com/grafana/grafana/pkg/components/simplejson"
+
 type Prefs struct {
-	Theme           string `json:"theme"`
-	HomeDashboardID int64  `json:"homeDashboardId"`
-	Timezone        string `json:"timezone"`
-	WeekStart       string `json:"weekStart"`
+	Theme           string           `json:"theme"`
+	HomeDashboardID int64            `json:"homeDashboardId"`
+	Timezone        string           `json:"timezone"`
+	WeekStart       string           `json:"weekStart"`
+	QueryHistory    *simplejson.Json `json:"queryHistory"`
 }
 
 // swagger:model
@@ -15,6 +18,7 @@ type UpdatePrefsCmd struct {
 	// Default:0
 	HomeDashboardID int64 `json:"homeDashboardId"`
 	// Enum: utc,browser
-	Timezone  string `json:"timezone"`
-	WeekStart string `json:"weekStart"`
+	Timezone     string           `json:"timezone"`
+	WeekStart    string           `json:"weekStart"`
+	QueryHistory *simplejson.Json `json:"queryHistory"`
 }

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -49,6 +49,7 @@ func (hs *HTTPServer) getPreferencesFor(ctx context.Context, orgID, userID, team
 		HomeDashboardID: prefsQuery.Result.HomeDashboardId,
 		Timezone:        prefsQuery.Result.Timezone,
 		WeekStart:       prefsQuery.Result.WeekStart,
+		QueryHistory:    prefsQuery.Result.QueryHistory,
 	}
 
 	return response.JSON(200, &dto)
@@ -75,6 +76,7 @@ func (hs *HTTPServer) updatePreferencesFor(ctx context.Context, orgID, userID, t
 		Timezone:        dtoCmd.Timezone,
 		WeekStart:       dtoCmd.WeekStart,
 		HomeDashboardId: dtoCmd.HomeDashboardID,
+		QueryHistory:    dtoCmd.QueryHistory,
 	}
 
 	if err := hs.SQLStore.SavePreferences(ctx, &saveCmd); err != nil {

--- a/pkg/models/preferences.go
+++ b/pkg/models/preferences.go
@@ -2,6 +2,8 @@ package models
 
 import (
 	"time"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
 )
 
 type Preferences struct {
@@ -14,6 +16,7 @@ type Preferences struct {
 	Timezone        string
 	WeekStart       string
 	Theme           string
+	QueryHistory    *simplejson.Json
 	Created         time.Time
 	Updated         time.Time
 }
@@ -43,8 +46,9 @@ type SavePreferencesCommand struct {
 	OrgId  int64
 	TeamId int64
 
-	HomeDashboardId int64  `json:"homeDashboardId"`
-	Timezone        string `json:"timezone"`
-	WeekStart       string `json:"weekStart"`
-	Theme           string `json:"theme"`
+	HomeDashboardId int64            `json:"homeDashboardId"`
+	Timezone        string           `json:"timezone"`
+	WeekStart       string           `json:"weekStart"`
+	Theme           string           `json:"theme"`
+	QueryHistory    *simplejson.Json `json:"queryHistory"`
 }

--- a/pkg/services/sqlstore/migrations/preferences_mig.go
+++ b/pkg/services/sqlstore/migrations/preferences_mig.go
@@ -46,4 +46,8 @@ func addPreferencesMigrations(mg *Migrator) {
 	mg.AddMigration("Add column week_start in preferences", NewAddColumnMigration(preferencesV2, &Column{
 		Name: "week_start", Type: DB_NVarchar, Length: 10, Nullable: true,
 	}))
+
+	mg.AddMigration("Add query_history settings in preferences", NewAddColumnMigration(preferencesV2, &Column{
+		Name: "query_history", Type: DB_Text, Nullable: true,
+	}))
 }

--- a/pkg/services/sqlstore/preferences.go
+++ b/pkg/services/sqlstore/preferences.go
@@ -104,6 +104,7 @@ func (ss *SQLStore) SavePreferences(ctx context.Context, cmd *models.SavePrefere
 				Timezone:        cmd.Timezone,
 				WeekStart:       cmd.WeekStart,
 				Theme:           cmd.Theme,
+				QueryHistory:    cmd.QueryHistory,
 				Created:         time.Now(),
 				Updated:         time.Now(),
 			}
@@ -114,6 +115,7 @@ func (ss *SQLStore) SavePreferences(ctx context.Context, cmd *models.SavePrefere
 		prefs.Timezone = cmd.Timezone
 		prefs.WeekStart = cmd.WeekStart
 		prefs.Theme = cmd.Theme
+		prefs.QueryHistory = cmd.QueryHistory
 		prefs.Updated = time.Now()
 		prefs.Version += 1
 		_, err = sess.ID(prefs.Id).AllCols().Update(&prefs)

--- a/pkg/services/sqlstore/preferences_test.go
+++ b/pkg/services/sqlstore/preferences_test.go
@@ -24,7 +24,7 @@ func TestPreferencesDataAccess(t *testing.T) {
 		err := ss.GetPreferencesWithDefaults(context.Background(), query)
 		require.NoError(t, err)
 		require.Equal(t, "light", query.Result.Theme)
-		require.Equal(t, "V", query.Result.Timezone)
+		require.Equal(t, "UTC", query.Result.Timezone)
 		require.Equal(t, int64(0), query.Result.HomeDashboardId)
 	})
 

--- a/pkg/services/sqlstore/preferences_test.go
+++ b/pkg/services/sqlstore/preferences_test.go
@@ -24,7 +24,7 @@ func TestPreferencesDataAccess(t *testing.T) {
 		err := ss.GetPreferencesWithDefaults(context.Background(), query)
 		require.NoError(t, err)
 		require.Equal(t, "light", query.Result.Theme)
-		require.Equal(t, "UTC", query.Result.Timezone)
+		require.Equal(t, "V", query.Result.Timezone)
 		require.Equal(t, int64(0), query.Result.HomeDashboardId)
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is the first part of moving query history to be stored in database instead of browser's local storage. The design document is [here](https://docs.google.com/document/d/1BdVtoXCxhH0Q6C-O_Z7jKi-u1m5pDoS9_HQKhYu_hEE/edit#)

To make PRs smaller and easier to review, I am splitting it into chunks. Here is the issue with steps: https://github.com/grafana/grafana/issues/44327

This PR adds user's query history preferences to preferences table. Query history preferences are json, so in the future we can store all preferences here.

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/grafana/issues/44327

**Special notes for your reviewer**:
1. enable query history `enabled = true` flag in custom.ini

 In https://github.com/grafana/grafana/blob/main/public/app/features/explore/state/query.ts#L324 add:
 ` import { getBackendSrv } from '@grafana/runtime`
 
```
  //To test changing preferences
  getBackendSrv().put(`/api/user/preferences`, { queryHistoryJSON: {showOnlyCurrentDs: true} });
  // End of test
```
