### PR TITLE
Chore: Reorder babel plugins into correct order

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -26,9 +26,6 @@
     ]
   ],
   "plugins": [
-    // added to mitigate https://github.com/babel/babel/issues/14289
-    // package (and following line) can be removed once the issue is fixed and released
-    "@babel/plugin-proposal-class-properties",
     [
       "@babel/plugin-transform-typescript",
       {
@@ -36,6 +33,9 @@
         "allowDeclareFields": true
       }
     ],
+    // added to mitigate https://github.com/babel/babel/issues/14289
+    // package (and following line) can be removed once the issue is fixed and released
+    "@babel/plugin-proposal-class-properties",
     ["@babel/plugin-proposal-object-rest-spread", { "loose": true }],
     "@babel/plugin-transform-react-constant-elements",
     "@babel/plugin-proposal-nullish-coalescing-operator",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- https://github.com/grafana/grafana/pull/45664 introduced a new babel plugin
- when backporting, this fix didn't work due to being in the wrong order (see https://github.com/grafana/grafana/pull/45667)
- `yarn start` now shows an error for me locally, so let's make the same change in main as i did in the backport branch

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

Not sure why the CI didn't fail on main for the first PR... 😕 

