### PR TITLE
Annotations: Fixes issue with tags filter not showing in annotation query

### DIFF
--- a/public/app/plugins/datasource/grafana/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/AnnotationQueryEditor.tsx
@@ -88,7 +88,7 @@ export default function AnnotationQueryEditor({ query, onChange }: Props) {
           onChange={onMaxLimitChange}
         />
       </Field>
-      {type === GrafanaAnnotationType.Tags && tags && (
+      {type === GrafanaAnnotationType.Tags && (
         <>
           <Field label="Match any" description={matchTooltipContent}>
             <Switch id="grafana-annotations__match-any" value={matchAny} onChange={onMatchAnyChange} />
@@ -100,7 +100,7 @@ export default function AnnotationQueryEditor({ query, onChange }: Props) {
               inputId="grafana-annotations__tags"
               onChange={onTagsChange}
               tagOptions={getAnnotationTags}
-              tags={tags}
+              tags={tags ?? []}
             />
           </Field>
         </>


### PR DESCRIPTION
Fixes issue with tags options not showing when editing annotation query.

https://github.com/grafana/support-escalations/issues/1904
