### PR TITLE
Docs: Remove dependency between `build-frontend` and `build-frontend-docs`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -433,16 +433,9 @@ steps:
   image: grafana/build-container:1.4.9
   name: initialize
 - commands:
-  - ./bin/grabpl build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
-    --no-pull-enterprise
-  depends_on:
-  - initialize
-  environment:
-    NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.4.9
-  name: build-frontend
-- commands:
+  - yarn packages:build
   - yarn packages:docsExtract
+  - yarn packages:docsToMarkdown
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - initialize
@@ -810,7 +803,9 @@ steps:
   image: grafana/build-container:1.4.9
   name: publish-frontend-metrics
 - commands:
+  - yarn packages:build
   - yarn packages:docsExtract
+  - yarn packages:docsToMarkdown
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - initialize
@@ -4266,6 +4261,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 497f1f29968fdbbe53927d06e12e68c1203049618f6a578418b6685fab545c18
+hmac: f209cfff82a4817d7bae67872ce1a34a4a26915451ae35b4f8c9848003b18b91
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -442,9 +442,10 @@ steps:
   image: grafana/build-container:1.4.9
   name: build-frontend
 - commands:
+  - yarn packages:docsExtract
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
-  - build-frontend
+  - initialize
   image: grafana/build-container:1.4.9
   name: build-frontend-docs
 - commands:
@@ -599,7 +600,7 @@ steps:
   name: trigger-enterprise-downstream
   settings:
     params:
-    - SOURCE_BUILD_NUMBER=${DRONE_BUILD_NUMBER}
+    - SOURCE_BUILD_NUMBER=${DRONE_COMMIT}
     - SOURCE_COMMIT=${DRONE_COMMIT}
     repositories:
     - grafana/grafana-enterprise@main
@@ -809,9 +810,10 @@ steps:
   image: grafana/build-container:1.4.9
   name: publish-frontend-metrics
 - commands:
+  - yarn packages:docsExtract
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
-  - build-frontend
+  - initialize
   image: grafana/build-container:1.4.9
   name: build-frontend-docs
 - commands:
@@ -4264,6 +4266,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: b02f6b686b120ff88a1f412a9cab4b3d295783f3e8cabde336b446083fe6433c
+hmac: 497f1f29968fdbbe53927d06e12e68c1203049618f6a578418b6685fab545c18
 
 ...

--- a/scripts/drone/pipelines/docs.star
+++ b/scripts/drone/pipelines/docs.star
@@ -27,9 +27,6 @@ ver_mode = 'pr'
 
 def docs_pipelines(edition):
     steps = [download_grabpl_step()] + initialize_step(edition, platform='linux', ver_mode=ver_mode)
-    steps.extend([
-        build_frontend_step(edition=edition, ver_mode=ver_mode),
-    ])
 
     # Insert remaining steps
     steps.extend([

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -189,7 +189,7 @@ def enterprise_downstream_step(edition):
                 'grafana/grafana-enterprise@main',
             ],
             'params': [
-                'SOURCE_BUILD_NUMBER=${DRONE_BUILD_NUMBER}',
+                'SOURCE_BUILD_NUMBER=${DRONE_COMMIT}',
                 'SOURCE_COMMIT=${DRONE_COMMIT}',
             ],
         },
@@ -427,9 +427,10 @@ def build_frontend_docs_step(edition):
         'name': 'build-frontend-docs',
         'image': build_image,
         'depends_on': [
-            'build-frontend'
+            'initialize'
         ],
         'commands': [
+            'yarn packages:docsExtract',
             './scripts/ci-reference-docs-lint.sh ci',
         ]
     }

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -430,7 +430,9 @@ def build_frontend_docs_step(edition):
             'initialize'
         ],
         'commands': [
+            'yarn packages:build',
             'yarn packages:docsExtract',
+            'yarn packages:docsToMarkdown',
             './scripts/ci-reference-docs-lint.sh ci',
         ]
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Removes time-consuming `build-frontend` dependency for docs/website build. Replaces the dependency with yarn commands.

Related to: #40703