### PR TITLE
Chore: Add function documentation for new functions (Prometheus visual query editor)

### DIFF
--- a/public/app/plugins/datasource/prometheus/promql.ts
+++ b/public/app/plugins/datasource/prometheus/promql.ts
@@ -143,6 +143,12 @@ export const FUNCTIONS = [
       'Returns the number of elements in a time series vector as a scalar. This is in contrast to the `count()` aggregation operator, which always returns a vector (an empty one if the input vector is empty) and allows grouping by labels via a `by` clause.',
   },
   {
+    insertText: 'deg',
+    label: 'deg',
+    detail: 'deg(v instant-vector)',
+    documentation: 'Converts radians to degrees for all elements in v',
+  },
+  {
     insertText: 'day_of_month',
     label: 'day_of_month',
     detail: 'day_of_month(v=vector(time()) instant-vector)',
@@ -287,11 +293,23 @@ export const FUNCTIONS = [
       'Returns the month of the year for each of the given times in UTC. Returned values are from 1 to 12, where 1 means January etc.',
   },
   {
+    insertText: 'pi',
+    label: 'pi',
+    detail: 'pi()',
+    documentation: 'Returns pi',
+  },
+  {
     insertText: 'predict_linear',
     label: 'predict_linear',
     detail: 'predict_linear(v range-vector, t scalar)',
     documentation:
       'Predicts the value of time series `t` seconds from now, based on the range vector `v`, using simple linear regression.',
+  },
+  {
+    insertText: 'rad',
+    label: 'rad',
+    detail: 'rad(v instant-vector)',
+    documentation: 'Converts degrees to radians for all elements in v',
   },
   {
     insertText: 'rate',

--- a/public/app/plugins/datasource/prometheus/promql.ts
+++ b/public/app/plugins/datasource/prometheus/promql.ts
@@ -18,6 +18,81 @@ export const RATE_RANGES: CompletionItem[] = [
 export const OPERATORS = ['by', 'group_left', 'group_right', 'ignoring', 'on', 'offset', 'without'];
 export const LOGICAL_OPERATORS = ['or', 'and', 'unless'];
 
+const TRIGONOMETRIC_FUNCTIONS: CompletionItem[] = [
+  {
+    label: 'acos',
+    insertText: 'acos',
+    detail: 'acos(v instant-vector)',
+    documentation: 'calculates the arccosine of all elements in v',
+  },
+  {
+    label: 'acosh',
+    insertText: 'acosh',
+    detail: 'acosh(v instant-vector)',
+    documentation: 'calculates the inverse hyperbolic cosine of all elements in v',
+  },
+  {
+    label: 'asin',
+    insertText: 'asin',
+    detail: 'asin(v instant-vector)',
+    documentation: 'calculates the arcsine of all elements in v',
+  },
+  {
+    label: 'asinh',
+    insertText: 'asinh',
+    detail: 'asinh(v instant-vector)',
+    documentation: 'calculates the inverse hyperbolic sine of all elements in v',
+  },
+  {
+    label: 'atan',
+    insertText: 'atan',
+    detail: 'atan(v instant-vector)',
+    documentation: 'calculates the arctangent of all elements in v',
+  },
+  {
+    label: 'atanh',
+    insertText: 'atanh',
+    detail: 'atanh(v instant-vector)',
+    documentation: 'calculates the inverse hyperbolic tangent of all elements in v',
+  },
+  {
+    label: 'cos',
+    insertText: 'cos',
+    detail: 'cos(v instant-vector)',
+    documentation: 'calculates the cosine of all elements in v',
+  },
+  {
+    label: 'cosh',
+    insertText: 'cosh',
+    detail: 'cosh(v instant-vector)',
+    documentation: 'calculates the hyperbolic cosine of all elements in v',
+  },
+  {
+    label: 'sin',
+    insertText: 'sin',
+    detail: 'sin(v instant-vector)',
+    documentation: 'calculates the sine of all elements in v',
+  },
+  {
+    label: 'sinh',
+    insertText: 'sinh',
+    detail: 'sinh(v instant-vector)',
+    documentation: 'calculates the hyperbolic sine of all elements in v',
+  },
+  {
+    label: 'tan',
+    insertText: 'tan',
+    detail: 'tan(v instant-vector)',
+    documentation: 'calculates the tangent of all elements in v',
+  },
+  {
+    label: 'tanh',
+    insertText: 'tanh',
+    detail: 'tanh(v instant-vector)',
+    documentation: 'calculates the hyperbolic tangent of all elements in v',
+  },
+];
+
 const AGGREGATION_OPERATORS: CompletionItem[] = [
   {
     label: 'sum',
@@ -83,6 +158,7 @@ const AGGREGATION_OPERATORS: CompletionItem[] = [
 
 export const FUNCTIONS = [
   ...AGGREGATION_OPERATORS,
+  ...TRIGONOMETRIC_FUNCTIONS,
   {
     insertText: 'abs',
     label: 'abs',


### PR DESCRIPTION
**What this PR does / why we need it**: https://github.com/grafana/grafana/issues/44253

This adds documentation so that all of the functions in the prometheus query editor are documented when the user clicks on the info icon

**Which issue(s) this PR fixes**: https://github.com/grafana/grafana/issues/44253



Fixes #44253 (at least a part of it)

![image](https://user-images.githubusercontent.com/7053010/155196493-d212fc8a-f96e-4e74-964a-9bb2a972f63c.png)

