### PR TITLE
Alerting: support fine-grained access control in ruler API

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -104,7 +104,10 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 			scheduleService: api.Schedule,
 			store:           api.RuleStore,
 			xactManager:     api.TransactionManager,
-			log:             logger, cfg: &api.Cfg.UnifiedAlerting},
+			log:             logger,
+			cfg:             &api.Cfg.UnifiedAlerting,
+			ac:              api.AccessControl,
+		},
 	), m)
 	api.RegisterTestingApiEndpoints(NewForkedTestingApi(
 		&TestingApiSrv{

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/quota"
@@ -34,6 +35,7 @@ type RulerSrv struct {
 	scheduleService schedule.ScheduleService
 	log             log.Logger
 	cfg             *setting.UnifiedAlertingSettings
+	ac              accesscontrol.AccessControl
 }
 
 var (

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -278,6 +278,13 @@ func (srv RulerSrv) updateAlertRulesInGroup(c *models.ReqContext, namespace *mod
 			return nil
 		}
 
+		err = authorizeRuleChanges(namespace, groupChanges, func(evaluator accesscontrol.Evaluator) (bool, error) {
+			return srv.ac.Evaluate(c.Req.Context(), c.SignedInUser, evaluator) // use request context instead of transaction context to make sure that nothing authz related is locked on db side
+		})
+		if err != nil {
+			return err
+		}
+
 		if len(groupChanges.Update) > 0 || len(groupChanges.New) > 0 {
 			upsert := make([]store.UpsertRule, 0, len(groupChanges.Update)+len(groupChanges.New))
 			for _, update := range groupChanges.Update {

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -221,7 +221,7 @@ func authorizeRuleChanges(namespace *models.Folder, changes *changes, evaluator 
 			}
 		}
 
-		// Check if the rule is moved from one folder to the current. If yes, then user must have authorization to delete rules from source folder and add rules to the target folder
+		// Check if the rule is moved from one folder to the current. If yes, then the user must have the authorization to delete rules from the source folder and add rules to the target folder.
 		if rule.Existing.NamespaceUID != rule.New.NamespaceUID {
 			allowed := evaluator(ac.EvalAll(ac.EvalPermission(ac.ActionAlertingRuleDelete, dashboards.ScopeFoldersProvider.GetResourceScopeUID(rule.Existing.NamespaceUID))))
 			if !allowed {

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -211,14 +211,9 @@ func authorizeRuleChanges(namespace *models.Folder, changes *changes, evaluator 
 	}
 
 	for _, rule := range changes.Update {
-		// If data is not changed, skip authorization. Effectively, this give users
-		// that do not have access to query data sources used by the rule
-		// limited access to some of the rule's settings like the interval, for, labels, annotations.
-		if len(rule.Diff.GetDiffsForField("Data")) > 0 {
-			dsAllowed := evaluator(getEvaluatorForAlertRule(rule.New))
-			if !dsAllowed {
-				return fmt.Errorf("%w to update alert rule '%s' (UID: %s) because the user does not have read permissions for one or many datasources the rule uses", ErrAuthorization, rule.Existing.Title, rule.Existing.UID)
-			}
+		dsAllowed := evaluator(getEvaluatorForAlertRule(rule.New))
+		if !dsAllowed {
+			return fmt.Errorf("%w to update alert rule '%s' (UID: %s) because the user does not have read permissions for one or many datasources the rule uses", ErrAuthorization, rule.Existing.Title, rule.Existing.UID)
 		}
 
 		// Check if the rule is moved from one folder to the current. If yes, then the user must have the authorization to delete rules from the source folder and add rules to the target folder.

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -185,7 +185,7 @@ func getEvaluatorForAlertRule(rule *ngmodels.AlertRule) ac.Evaluator {
 }
 
 // authorizeRuleChanges analyzes changes in the rule group, determines what actions the user is trying to perform and check whether those actions are authorized.
-// If the user is not authorized to perform the changes the function returns ErrAuthorization with description of what action is not authorized. If evaluator function returns error, the function returns it
+// If the user is not authorized to perform the changes the function returns ErrAuthorization with a description of what action is not authorized. If the evaluator function returns an error, the function returns it.
 func authorizeRuleChanges(namespace *models.Folder, changes *changes, evaluator func(evaluator ac.Evaluator) bool) error {
 	namespaceScope := dashboards.ScopeFoldersProvider.GetResourceScope(strconv.FormatInt(namespace.Id, 10))
 	if len(changes.Delete) > 0 {

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -1,15 +1,24 @@
 package api
 
 import (
+	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/go-openapi/loads"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/expr"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util/cmputil"
 )
 
 func TestAuthorize(t *testing.T) {
@@ -59,5 +68,225 @@ func TestAuthorize(t *testing.T) {
 		require.Panics(t, func() {
 			api.authorize("test", "test")
 		})
+	})
+}
+
+func TestAuthorizeRuleChanges(t *testing.T) {
+	namespace := randFolder()
+	namespaceIdScope := dashboards.ScopeFoldersProvider.GetResourceScope(strconv.FormatInt(namespace.Id, 10))
+
+	testCases := []struct {
+		name        string
+		changes     func() *changes
+		permissions func(c *changes) map[string][]string
+	}{
+		{
+			name: "if there are rules to delete it should check delete action",
+			changes: func() *changes {
+				return &changes{
+					New:    nil,
+					Update: nil,
+					Delete: models.GenerateAlertRules(rand.Intn(4)+1, models.AlertRuleGen(withNamespace(namespace))),
+				}
+			},
+			permissions: func(c *changes) map[string][]string {
+				return map[string][]string{
+					ac.ActionAlertingRuleDelete: {
+						namespaceIdScope,
+					},
+				}
+			},
+		},
+		{
+			name: "if there are rules to add it should check create action ",
+			changes: func() *changes {
+				return &changes{
+					New:    models.GenerateAlertRules(rand.Intn(4)+1, models.AlertRuleGen(withNamespace(namespace))),
+					Update: nil,
+					Delete: nil,
+				}
+			},
+			permissions: func(c *changes) map[string][]string {
+				return map[string][]string{
+					ac.ActionAlertingRuleCreate: {
+						namespaceIdScope,
+					},
+				}
+			},
+		},
+		{
+			name: "if there are rules to update within the same namespace it should check update action ",
+			changes: func() *changes {
+				rules := models.GenerateAlertRules(rand.Intn(4)+1, models.AlertRuleGen(withNamespace(namespace)))
+				updates := make([]ruleUpdate, 0, len(rules))
+
+				for _, rule := range rules {
+					updates = append(updates, ruleUpdate{
+						Existing: rule,
+						New:      models.CopyRule(rule),
+						Diff:     nil,
+					})
+				}
+
+				return &changes{
+					New:    nil,
+					Update: updates,
+					Delete: nil,
+				}
+			},
+			permissions: func(c *changes) map[string][]string {
+				return map[string][]string{
+					ac.ActionAlertingRuleUpdate: {
+						namespaceIdScope,
+					},
+				}
+			},
+		},
+		{
+			name: "if there are rules that are moved between namespaces it should check update action ",
+			changes: func() *changes {
+				rules := models.GenerateAlertRules(rand.Intn(4)+1, models.AlertRuleGen(withNamespace(namespace)))
+				updates := make([]ruleUpdate, 0, len(rules))
+
+				for _, rule := range rules {
+					cp := models.CopyRule(rule)
+					cp.NamespaceUID = rule.NamespaceUID + "other"
+					updates = append(updates, ruleUpdate{
+						Existing: cp,
+						New:      rule,
+						Diff:     nil,
+					})
+				}
+
+				return &changes{
+					New:    nil,
+					Update: updates,
+					Delete: nil,
+				}
+			},
+			permissions: func(c *changes) map[string][]string {
+				return map[string][]string{
+					ac.ActionAlertingRuleDelete: {
+						dashboards.ScopeFoldersProvider.GetResourceScopeUID(namespace.Uid + "other"),
+					},
+					ac.ActionAlertingRuleCreate: {
+						namespaceIdScope,
+					},
+				}
+			},
+		},
+		{
+			name: "should check access to datasource if Data is updated",
+			changes: func() *changes {
+				rules := models.GenerateAlertRules(rand.Intn(4)+1, models.AlertRuleGen(withNamespace(namespace), func(rule *models.AlertRule) {
+					rule.Data = nil
+				}))
+				updates := make([]ruleUpdate, 0, len(rules))
+
+				for _, rule := range rules {
+					newRule := models.CopyRule(rule)
+					newRule.Data = []models.AlertQuery{
+						models.GenerateAlertQuery(),
+					}
+					updates = append(updates, ruleUpdate{
+						Existing: rule,
+						New:      rule,
+						Diff: []cmputil.Diff{
+							{
+								Path:  "Data",
+								Left:  reflect.ValueOf(nil), // these fields are ignored for now. only path matters
+								Right: reflect.ValueOf(nil),
+							},
+						},
+					})
+				}
+
+				return &changes{
+					New:    nil,
+					Update: updates,
+					Delete: nil,
+				}
+			},
+			permissions: func(c *changes) map[string][]string {
+				p := map[string][]string{
+					ac.ActionAlertingRuleUpdate: {
+						namespaceIdScope,
+					},
+				}
+				var ds []string
+				for _, update := range c.Update {
+					for _, query := range update.New.Data {
+						ds = append(ds, dashboards.ScopeFoldersProvider.GetResourceScopeUID(query.DatasourceUID))
+					}
+				}
+				p[datasources.ActionQuery] = ds
+				return p
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			executed := false
+
+			groupChanges := testCase.changes()
+
+			err := authorizeRuleChanges(namespace, groupChanges, func(evaluator ac.Evaluator) (bool, error) {
+				response, err := evaluator.Evaluate(make(map[string][]string))
+				require.False(t, response)
+				require.NoError(t, err)
+				executed = true
+				return false, nil
+			})
+			require.Error(t, err)
+			require.Truef(t, executed, "evaluation function is expected to be called but it was not.")
+
+			permissions := testCase.permissions(groupChanges)
+			executed = false
+			err = authorizeRuleChanges(namespace, groupChanges, func(evaluator ac.Evaluator) (bool, error) {
+				response, err := evaluator.Evaluate(permissions)
+				require.Truef(t, response, "provided permissions [%v] is not enough for requested permissions [%s]", testCase.permissions, evaluator.GoString())
+				require.NoError(t, err)
+				executed = true
+				return true, nil
+			})
+			require.NoError(t, err)
+			require.Truef(t, executed, "evaluation function is expected to be called but it was not.")
+		})
+	}
+}
+
+func TestGetEvaluatorForAlertRule(t *testing.T) {
+	t.Run("should not consider expressions", func(t *testing.T) {
+		rule := models.AlertRuleGen()()
+
+		expressionByType := models.GenerateAlertQuery()
+		expressionByType.QueryType = expr.DatasourceType
+		expressionByUID := models.GenerateAlertQuery()
+		expressionByUID.DatasourceUID = expr.OldDatasourceUID
+
+		var data []models.AlertQuery
+		var scopes []string
+		for i := 0; i < rand.Intn(3)+2; i++ {
+			q := models.GenerateAlertQuery()
+			scopes = append(scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(q.DatasourceUID))
+			data = append(data, q)
+		}
+
+		data = append(data, expressionByType, expressionByUID)
+		rand.Shuffle(len(data), func(i, j int) {
+			data[j], data[i] = data[i], data[j]
+		})
+
+		rule.Data = data
+
+		eval := getEvaluatorForAlertRule(rule)
+
+		allowed, err := eval.Evaluate(map[string][]string{
+			datasources.ActionQuery: scopes,
+		})
+
+		require.NoError(t, err)
+		require.True(t, allowed)
 	})
 }

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -238,24 +238,24 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 
 			groupChanges := testCase.changes()
 
-			err := authorizeRuleChanges(namespace, groupChanges, func(evaluator ac.Evaluator) (bool, error) {
+			err := authorizeRuleChanges(namespace, groupChanges, func(evaluator ac.Evaluator) bool {
 				response, err := evaluator.Evaluate(make(map[string][]string))
 				require.False(t, response)
 				require.NoError(t, err)
 				executed = true
-				return false, nil
+				return false
 			})
 			require.Error(t, err)
 			require.Truef(t, executed, "evaluation function is expected to be called but it was not.")
 
 			permissions := testCase.permissions(groupChanges)
 			executed = false
-			err = authorizeRuleChanges(namespace, groupChanges, func(evaluator ac.Evaluator) (bool, error) {
+			err = authorizeRuleChanges(namespace, groupChanges, func(evaluator ac.Evaluator) bool {
 				response, err := evaluator.Evaluate(permissions)
 				require.Truef(t, response, "provided permissions [%v] is not enough for requested permissions [%s]", testCase.permissions, evaluator.GoString())
 				require.NoError(t, err)
 				executed = true
-				return true, nil
+				return true
 			})
 			require.NoError(t, err)
 			require.Truef(t, executed, "evaluation function is expected to be called but it was not.")


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
PR https://github.com/grafana/grafana/pull/46561 added support for fine-grained access to API routes. However, it is not possible to provide the desired level of granularity for some API on the router level, and therefore, we need to update request handlers to do the final validation. 

This PR updates Grafana Rule API request handlers to:
- rule update API is updated to perform additional authorization based on the changes in the payload. PR https://github.com/grafana/grafana/pull/45980/files and https://github.com/grafana/grafana/pull/45877 introduced support for calculating Diff. This PR  uses the calculated diff to determine what the user is trying to accomplish: add a new rule, update or delete an existing rule from the group, and then verify that the user has permissions to execute the actions.
    - In order to create a new or update existing rule, user must have `datasources:query` permission to all data sources the rule uses.