### PR TITLE
NewNavigation: Fix failing e2e test

### DIFF
--- a/public/app/core/reducers/navBarTree.ts
+++ b/public/app/core/reducers/navBarTree.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { NavModelItem } from '@grafana/data';
 import config from 'app/core/config';
 
-const defaultPins = (config.bootData.navTree as NavModelItem[]).map((n) => n.id).join(',');
+const defaultPins = ((config.bootData?.navTree as NavModelItem[]) ?? []).map((n) => n.id).join(',');
 const storedPins = (window.localStorage.getItem('pinnedNavItems') ?? defaultPins).split(',');
 
 export const initialState: NavModelItem[] = ((config.bootData?.navTree ?? []) as NavModelItem[]).map(


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix failing e2e test caused by trying to access property on undefined variable.

