### PR TITLE
Azure Monitor: Fixes broken log queries that use workspace

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.test.ts
@@ -1,11 +1,12 @@
-import AzureMonitorDatasource from '../datasource';
-import AzureLogAnalyticsDatasource from './azure_log_analytics_datasource';
-import FakeSchemaData from './__mocks__/schema';
-import { TemplateSrv } from 'app/features/templating/template_srv';
-import { AzureMonitorQuery, AzureQueryType, DatasourceValidationResult } from '../types';
 import { toUtc } from '@grafana/data';
+import { TemplateSrv } from 'app/features/templating/template_srv';
+
 import createMockQuery from '../__mocks__/query';
 import { singleVariable } from '../__mocks__/variables';
+import AzureMonitorDatasource from '../datasource';
+import { AzureMonitorQuery, AzureQueryType, DatasourceValidationResult } from '../types';
+import FakeSchemaData from './__mocks__/schema';
+import AzureLogAnalyticsDatasource from './azure_log_analytics_datasource';
 
 const templateSrv = new TemplateSrv();
 
@@ -273,12 +274,24 @@ describe('AzureLogAnalyticsDatasource', () => {
       laDatasource = new AzureLogAnalyticsDatasource(ctx.instanceSettings);
     });
 
-    it('should run complete queries', () => {
+    it('should run queries with a resource', () => {
       const query: AzureMonitorQuery = {
         refId: 'A',
         azureLogAnalytics: {
           resource: '/sub/124/rg/cloud/vm/server',
           query: 'perf | take 100',
+        },
+      };
+
+      expect(laDatasource.filterQuery(query)).toBeTruthy();
+    });
+
+    it('should run queries with a workspace', () => {
+      const query: AzureMonitorQuery = {
+        refId: 'A',
+        azureLogAnalytics: {
+          query: 'perf | take 100',
+          workspace: 'abc1b44e-3e57-4410-b027-6cc0ae6dee67',
         },
       };
 
@@ -317,7 +330,7 @@ describe('AzureLogAnalyticsDatasource', () => {
       expect(laDatasource.filterQuery(query)).toBeFalsy();
     });
 
-    it('should not run queries missing a resource', () => {
+    it('should not run queries missing a resource and a missing workspace', () => {
       const query: AzureMonitorQuery = {
         refId: 'A',
         azureLogAnalytics: {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.ts
@@ -1,26 +1,27 @@
-import { map } from 'lodash';
-import LogAnalyticsQuerystringBuilder from '../log_analytics/querystring_builder';
-import ResponseParser, { transformMetadataToKustoSchema } from './response_parser';
-import {
-  AzureMonitorQuery,
-  AzureDataSourceJsonData,
-  AzureLogsVariable,
-  AzureQueryType,
-  DatasourceValidationResult,
-} from '../types';
 import {
   DataQueryRequest,
   DataQueryResponse,
-  ScopedVars,
   DataSourceInstanceSettings,
   DataSourceRef,
+  ScopedVars,
 } from '@grafana/data';
-import { getTemplateSrv, DataSourceWithBackend } from '@grafana/runtime';
-import { Observable, from } from 'rxjs';
+import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
+import { map } from 'lodash';
+import { from, Observable } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
-import { getAuthType, getAzureCloud, getAzurePortalUrl } from '../credentials';
+
 import { isGUIDish } from '../components/ResourcePicker/utils';
+import { getAuthType, getAzureCloud, getAzurePortalUrl } from '../credentials';
+import LogAnalyticsQuerystringBuilder from '../log_analytics/querystring_builder';
+import {
+  AzureDataSourceJsonData,
+  AzureLogsVariable,
+  AzureMonitorQuery,
+  AzureQueryType,
+  DatasourceValidationResult,
+} from '../types';
 import { interpolateVariable, routeNames } from '../utils/common';
+import ResponseParser, { transformMetadataToKustoSchema } from './response_parser';
 
 interface AdhocQuery {
   datasource: DataSourceRef;
@@ -60,7 +61,11 @@ export default class AzureLogAnalyticsDatasource extends DataSourceWithBackend<
   }
 
   filterQuery(item: AzureMonitorQuery): boolean {
-    return item.hide !== true && !!item.azureLogAnalytics?.query && !!item.azureLogAnalytics.resource;
+    return (
+      item.hide !== true &&
+      !!item.azureLogAnalytics?.query &&
+      (!!item.azureLogAnalytics.resource || !!item.azureLogAnalytics.workspace)
+    );
   }
 
   async getSubscriptions(): Promise<Array<{ text: string; value: string }>> {


### PR DESCRIPTION
**What this PR does / why we need it**:
Before the resource picker was introduced in 8.0, scope for Logs queries were defined by a workspace. Since 8.0, Azure Monitor Logs queries that use `workspace` are being migrated to use `resource` instead. This migration takes place once the Logs editor is opened. Immediately after opening a dashboard, the datasource.query method is invoked before the migration takes place. That should be fined because both the resource and the workspace path is being handled correctly in the [backend](https://github.com/grafana/grafana/blob/main/pkg/tsdb/azuremonitor/azure-log-analytics-datasource.go#L82-L86). However, queries that did not have a `resource` prop on the query object would not be executed at all due to a bug in the frontend. This PR makes sure queries that **only** has a workspace are being executed properly. 

See issue for details on how to reproduce. 

**Which issue(s) this PR fixes**:
First reported in https://github.com/grafana/support-escalations/issues/1966
Fixes #45833


