### PR TITLE
Fix incorrect metric values for scheduler_behind_seconds

### DIFF
--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -368,7 +368,11 @@ func (sch *schedule) schedulePeriodic(ctx context.Context) error {
 	for {
 		select {
 		case tick := <-sch.ticker.C:
-			start := time.Now()
+			// We use Round(0) on the start time to remove the monotonic clock.
+			// This is required as late ticks from the ticker have current monotonic
+			// timestamps such that start.Sub(tick) does not return the expected
+			// delta.
+			start := time.Now().Round(0)
 			sch.metrics.BehindSeconds.Set(start.Sub(tick).Seconds())
 
 			tickNum := tick.Unix() / int64(sch.baseInterval.Seconds())


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes a bug where `scheduler_behind_seconds` had incorrect values due to the tick having current monotonic timestamps.

**Which issue(s) this PR fixes**:

Fixes #43031

**Special notes for your reviewer**:

