### PR TITLE
Previews: increase crawler timeout

### DIFF
--- a/pkg/services/thumbs/crawler.go
+++ b/pkg/services/thumbs/crawler.go
@@ -120,7 +120,7 @@ func (r *simpleCrawler) Run(ctx context.Context, authOpts rendering.AuthOpts, mo
 	r.opts = rendering.Opts{
 		AuthOpts: authOpts,
 		TimeoutOpts: rendering.TimeoutOpts{
-			Timeout:                  10 * time.Second,
+			Timeout:                  20 * time.Second,
 			RequestTimeoutMultiplier: 3,
 		},
 		Theme:           theme,


### PR DESCRIPTION
Unfortunately the existing timeout is not enough even for the simplest dashboards after testing it out on HG dev:

![image](https://user-images.githubusercontent.com/23451458/155554432-33359950-e704-49d8-8a11-8045e7b565bf.png)
 