### PR TITLE
change dashboard version example to use `version` instead of `id`

### DIFF
--- a/docs/sources/http_api/dashboard_versions.md
+++ b/docs/sources/http_api/dashboard_versions.md
@@ -67,7 +67,7 @@ Status Codes:
 
 ## Get dashboard version
 
-`GET /api/dashboards/id/:dashboardId/versions/:id`
+`GET /api/dashboards/id/:dashboardId/versions/:version`
 
 Get the dashboard version with the given version, for the dashboard with the given id.
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/45866, change dashboard version example to use `version` instead of `id`

`api/dashboards/id/24/versions/1`

**What this PR does / why we need it**:
Fix to API endpoint

**Which issue(s) this PR fixes**:

Fixes [45866](https://github.com/grafana/grafana/issues/45866)

**Special notes for your reviewer**:



