### PR TITLE
CloudWatch: Add test to executeStartQuery

### DIFF
--- a/pkg/tsdb/cloudwatch/annotation_query_test.go
+++ b/pkg/tsdb/cloudwatch/annotation_query_test.go
@@ -97,10 +97,3 @@ func TestQuery_AnnotationQuery(t *testing.T) {
 		}, client.calls.describeAlarms[0])
 	})
 }
-
-func pointerString(s string) *string {
-	return &s
-}
-func pointerInt64(i int64) *int64 {
-	return &i
-}

--- a/pkg/tsdb/cloudwatch/log_actions_test.go
+++ b/pkg/tsdb/cloudwatch/log_actions_test.go
@@ -428,14 +428,8 @@ func Test_executeStartQuery(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.Equal(t, []*cloudwatchlogs.StartQueryInput{
-			{
-				StartTime:     pointerInt64(0),
-				EndTime:       pointerInt64(1),
-				QueryString:   pointerString("fields @timestamp,ltrim(@log) as __log__grafana_internal__,ltrim(@logStream) as __logstream__grafana_internal__|"),
-				LogGroupNames: []*string{},
-			},
-		}, cli.calls.startQueryWithContext)
+		require.Len(t, cli.calls.startQueryWithContext, 1)
+		assert.Nil(t, cli.calls.startQueryWithContext[0].Limit)
 	})
 
 	t.Run("does not populate StartQueryInput.limit when no limit provided", func(t *testing.T) {
@@ -460,14 +454,8 @@ func Test_executeStartQuery(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-		assert.Equal(t, []*cloudwatchlogs.StartQueryInput{
-			{
-				StartTime:     pointerInt64(0),
-				EndTime:       pointerInt64(1),
-				QueryString:   pointerString("fields @timestamp,ltrim(@log) as __log__grafana_internal__,ltrim(@logStream) as __logstream__grafana_internal__|"),
-				LogGroupNames: []*string{},
-			},
-		}, cli.calls.startQueryWithContext)
+		require.Len(t, cli.calls.startQueryWithContext, 1)
+		assert.Nil(t, cli.calls.startQueryWithContext[0].Limit)
 	})
 }
 

--- a/pkg/tsdb/cloudwatch/log_actions_test.go
+++ b/pkg/tsdb/cloudwatch/log_actions_test.go
@@ -28,7 +28,7 @@ func TestQuery_DescribeLogGroups(t *testing.T) {
 	var cli FakeCWLogsClient
 
 	NewCWLogsClient = func(sess *session.Session) cloudwatchlogsiface.CloudWatchLogsAPI {
-		return cli
+		return &cli
 	}
 
 	t.Run("Empty log group name prefix", func(t *testing.T) {
@@ -155,7 +155,7 @@ func TestQuery_GetLogGroupFields(t *testing.T) {
 	var cli FakeCWLogsClient
 
 	NewCWLogsClient = func(sess *session.Session) cloudwatchlogsiface.CloudWatchLogsAPI {
-		return cli
+		return &cli
 	}
 
 	cli = FakeCWLogsClient{
@@ -232,7 +232,7 @@ func TestQuery_StartQuery(t *testing.T) {
 	var cli FakeCWLogsClient
 
 	NewCWLogsClient = func(sess *session.Session) cloudwatchlogsiface.CloudWatchLogsAPI {
-		return cli
+		return &cli
 	}
 
 	t.Run("invalid time range", func(t *testing.T) {
@@ -357,6 +357,88 @@ func TestQuery_StartQuery(t *testing.T) {
 	})
 }
 
+func Test_executeStartQuery(t *testing.T) {
+	origNewCWLogsClient := NewCWLogsClient
+	t.Cleanup(func() {
+		NewCWLogsClient = origNewCWLogsClient
+	})
+
+	var cli FakeCWLogsClient
+
+	NewCWLogsClient = func(sess *session.Session) cloudwatchlogsiface.CloudWatchLogsAPI {
+		return &cli
+	}
+
+	t.Run("successfully parses information from JSON to StartQueryWithContext", func(t *testing.T) {
+		cli = FakeCWLogsClient{}
+		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return datasourceInfo{}, nil
+		})
+		executor := newExecutor(im, newTestConfig(), fakeSessionCache{})
+
+		_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+			Queries: []backend.DataQuery{
+				{
+					RefID:     "A",
+					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
+					JSON: json.RawMessage(`{
+						"type":    "logAction",
+						"subtype": "StartQuery",
+						"limit":   12,
+						"queryString":"fields @message",
+						"logGroupNames":["some name","another name"]
+					}`),
+				},
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, []*cloudwatchlogs.StartQueryInput{
+			{
+				StartTime:     pointerInt64(0),
+				EndTime:       pointerInt64(1),
+				Limit:         pointerInt64(12),
+				QueryString:   pointerString("fields @timestamp,ltrim(@log) as __log__grafana_internal__,ltrim(@logStream) as __logstream__grafana_internal__|fields @message"),
+				LogGroupNames: []*string{pointerString("some name"), pointerString("another name")},
+			},
+		}, cli.calls.startQueryWithContext)
+	})
+
+	t.Run("cannot parse limit as float", func(t *testing.T) {
+		cli = FakeCWLogsClient{}
+		im := datasource.NewInstanceManager(func(s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return datasourceInfo{}, nil
+		})
+		executor := newExecutor(im, newTestConfig(), fakeSessionCache{})
+
+		_, err := executor.QueryData(context.Background(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{}},
+			Queries: []backend.DataQuery{
+				{
+					RefID:     "A",
+					TimeRange: backend.TimeRange{From: time.Unix(0, 0), To: time.Unix(1, 0)},
+					JSON: json.RawMessage(`{
+						"type":    "logAction",
+						"subtype": "StartQuery",
+						"limit":   12.0
+					}`),
+				},
+			},
+		})
+
+		assert.NoError(t, err)
+		assert.Equal(t, []*cloudwatchlogs.StartQueryInput{
+			{
+				StartTime:     pointerInt64(0),
+				EndTime:       pointerInt64(1),
+				QueryString:   pointerString("fields @timestamp,ltrim(@log) as __log__grafana_internal__,ltrim(@logStream) as __logstream__grafana_internal__|"),
+				LogGroupNames: []*string{},
+			},
+		}, cli.calls.startQueryWithContext)
+	})
+}
+
 func TestQuery_StopQuery(t *testing.T) {
 	origNewCWLogsClient := NewCWLogsClient
 	t.Cleanup(func() {
@@ -366,7 +448,7 @@ func TestQuery_StopQuery(t *testing.T) {
 	var cli FakeCWLogsClient
 
 	NewCWLogsClient = func(sess *session.Session) cloudwatchlogsiface.CloudWatchLogsAPI {
-		return cli
+		return &cli
 	}
 
 	cli = FakeCWLogsClient{
@@ -438,7 +520,7 @@ func TestQuery_GetQueryResults(t *testing.T) {
 	var cli FakeCWLogsClient
 
 	NewCWLogsClient = func(sess *session.Session) cloudwatchlogsiface.CloudWatchLogsAPI {
-		return cli
+		return &cli
 	}
 
 	const refID = "A"

--- a/pkg/tsdb/cloudwatch/test_utils.go
+++ b/pkg/tsdb/cloudwatch/test_utils.go
@@ -20,32 +20,41 @@ import (
 
 type FakeCWLogsClient struct {
 	cloudwatchlogsiface.CloudWatchLogsAPI
+
+	calls logsQueryCalls
+
 	logGroups      cloudwatchlogs.DescribeLogGroupsOutput
 	logGroupFields cloudwatchlogs.GetLogGroupFieldsOutput
 	queryResults   cloudwatchlogs.GetQueryResultsOutput
 }
 
-func (m FakeCWLogsClient) GetQueryResultsWithContext(ctx context.Context, input *cloudwatchlogs.GetQueryResultsInput, option ...request.Option) (*cloudwatchlogs.GetQueryResultsOutput, error) {
+type logsQueryCalls struct {
+	startQueryWithContext []*cloudwatchlogs.StartQueryInput
+}
+
+func (m *FakeCWLogsClient) GetQueryResultsWithContext(ctx context.Context, input *cloudwatchlogs.GetQueryResultsInput, option ...request.Option) (*cloudwatchlogs.GetQueryResultsOutput, error) {
 	return &m.queryResults, nil
 }
 
-func (m FakeCWLogsClient) StartQueryWithContext(ctx context.Context, input *cloudwatchlogs.StartQueryInput, option ...request.Option) (*cloudwatchlogs.StartQueryOutput, error) {
+func (m *FakeCWLogsClient) StartQueryWithContext(ctx context.Context, input *cloudwatchlogs.StartQueryInput, option ...request.Option) (*cloudwatchlogs.StartQueryOutput, error) {
+	m.calls.startQueryWithContext = append(m.calls.startQueryWithContext, input)
+
 	return &cloudwatchlogs.StartQueryOutput{
 		QueryId: aws.String("abcd-efgh-ijkl-mnop"),
 	}, nil
 }
 
-func (m FakeCWLogsClient) StopQueryWithContext(ctx context.Context, input *cloudwatchlogs.StopQueryInput, option ...request.Option) (*cloudwatchlogs.StopQueryOutput, error) {
+func (m *FakeCWLogsClient) StopQueryWithContext(ctx context.Context, input *cloudwatchlogs.StopQueryInput, option ...request.Option) (*cloudwatchlogs.StopQueryOutput, error) {
 	return &cloudwatchlogs.StopQueryOutput{
 		Success: aws.Bool(true),
 	}, nil
 }
 
-func (m FakeCWLogsClient) DescribeLogGroupsWithContext(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput, option ...request.Option) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
+func (m *FakeCWLogsClient) DescribeLogGroupsWithContext(ctx context.Context, input *cloudwatchlogs.DescribeLogGroupsInput, option ...request.Option) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
 	return &m.logGroups, nil
 }
 
-func (m FakeCWLogsClient) GetLogGroupFieldsWithContext(ctx context.Context, input *cloudwatchlogs.GetLogGroupFieldsInput, option ...request.Option) (*cloudwatchlogs.GetLogGroupFieldsOutput, error) {
+func (m *FakeCWLogsClient) GetLogGroupFieldsWithContext(ctx context.Context, input *cloudwatchlogs.GetLogGroupFieldsInput, option ...request.Option) (*cloudwatchlogs.GetLogGroupFieldsOutput, error) {
 	return &m.logGroupFields, nil
 }
 
@@ -191,4 +200,11 @@ func (s fakeSessionCache) GetSession(c awsds.SessionConfig) (*session.Session, e
 	return &session.Session{
 		Config: &aws.Config{},
 	}, nil
+}
+
+func pointerString(s string) *string {
+	return &s
+}
+func pointerInt64(i int64) *int64 {
+	return &i
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This adds tests which document the json parsing of all fields in executeStartQuery.
Contributes to the goal of json deserialization: #45417

**Special notes for your reviewer**:
The receiver on the mock StartQueryWithContext needed to be changed to a pointer to record the calls on it. For uniformity I've changed all methods on the mock to have pointer receivers.
