### PR TITLE
CloudWatch: Fix running go test with count

### DIFF
--- a/pkg/tsdb/cloudwatch/get_metric_data_executor_test.go
+++ b/pkg/tsdb/cloudwatch/get_metric_data_executor_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var counter = 1
-
 type cloudWatchFakeClient struct {
 	cloudwatchiface.CloudWatchAPI
+
+	counterForGetMetricDataWithContext int
 }
 
 func (client *cloudWatchFakeClient) GetMetricDataWithContext(ctx aws.Context, input *cloudwatch.GetMetricDataInput, opts ...request.Option) (*cloudwatch.GetMetricDataOutput, error) {
@@ -23,13 +23,13 @@ func (client *cloudWatchFakeClient) GetMetricDataWithContext(ctx aws.Context, in
 	res := []*cloudwatch.MetricDataResult{{
 		Values: []*float64{aws.Float64(12.3), aws.Float64(23.5)},
 	}}
-	if counter == 0 {
+	if client.counterForGetMetricDataWithContext == 0 {
 		nextToken = ""
 		res = []*cloudwatch.MetricDataResult{{
 			Values: []*float64{aws.Float64(100)},
 		}}
 	}
-	counter--
+	client.counterForGetMetricDataWithContext--
 	return &cloudwatch.GetMetricDataOutput{
 		MetricDataResults: res,
 		NextToken:         aws.String(nextToken),
@@ -39,7 +39,7 @@ func (client *cloudWatchFakeClient) GetMetricDataWithContext(ctx aws.Context, in
 func TestGetMetricDataExecutorTest(t *testing.T) {
 	executor := &cloudWatchExecutor{}
 	inputs := &cloudwatch.GetMetricDataInput{MetricDataQueries: []*cloudwatch.MetricDataQuery{}}
-	res, err := executor.executeRequest(context.Background(), &cloudWatchFakeClient{}, inputs)
+	res, err := executor.executeRequest(context.Background(), &cloudWatchFakeClient{counterForGetMetricDataWithContext: 1}, inputs)
 	require.NoError(t, err)
 	require.Len(t, res, 2)
 	require.Len(t, res[0].MetricDataResults[0].Values, 2)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
A mocked method used a global counter to control its iterations. 
This was creating some infinite loop which preventing running `go test -count` : #45717

Thanks @iwysiu!

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #45717

**Special notes for your reviewer**:
A bit uncomfortable with the counter behavior, but not changing the way this test works for now. Gave it a really long name to discourage its use elsewhere hopefully. Or at least make it obvious it's for that mock method.
