### PR TITLE
CloudWatch: List all metrics properly in SQL autocomplete

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -249,6 +249,26 @@ describe('datasource', () => {
       });
     });
   });
+  describe('resource requests', () => {
+    it('should map resource response to metric response', async () => {
+      const datasource = setupMockedDataSource().datasource;
+      datasource.doMetricResourceRequest = jest.fn().mockResolvedValue([
+        {
+          text: 'AWS/EC2',
+          value: 'CPUUtilization',
+        },
+        {
+          text: 'AWS/Redshift',
+          value: 'CPUPercentage',
+        },
+      ]);
+      const allMetrics = await datasource.getAllMetrics('us-east-2');
+      expect(allMetrics[0].metricName).toEqual('CPUUtilization');
+      expect(allMetrics[0].namespace).toEqual('AWS/EC2');
+      expect(allMetrics[1].metricName).toEqual('CPUPercentage');
+      expect(allMetrics[1].namespace).toEqual('AWS/Redshift');
+    });
+  });
 
   describe('performTimeSeriesQuery', () => {
     it('should return the same length of data as result', async () => {

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -670,7 +670,7 @@ export class CloudWatchDatasource
       region: this.templateSrv.replace(this.getActualRegion(region)),
     });
 
-    return values.map((v) => ({ metricName: v.label, namespace: v.text }));
+    return values.map((v) => ({ metricName: v.value, namespace: v.text }));
   }
 
   async getDimensionKeys(


### PR DESCRIPTION
**What this PR does / why we need it**:
The call to fetch all metrics from the list metrics api somehow mapped the wrong values, possibly introduced in [this](https://github.com/grafana/grafana/pull/41571/files) pr. This PR makes sure the metric is passed to the autocompleter for Metric Query SQL. 

Before:
![Screenshot from 2022-02-25 11-28-11](https://user-images.githubusercontent.com/2388950/155699559-3e40de6a-7251-4a8e-a8f3-a1f4b1578e52.png)

After:
![Screenshot from 2022-02-25 11-29-25](https://user-images.githubusercontent.com/2388950/155699660-b3ea7c44-01d1-467d-ac05-27c752341ef1.png)


**Which issue(s) this PR fixes**:

Fixes #45894

**Special notes for your reviewer**:
Also correcting order of imports in datasource.ts

