### PR TITLE
renovate: stop updating "@mdx-js/react"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,6 +18,7 @@
     "d3-scale-chromatic", // we should bump this once we move to esm modules
     "execa", // we should bump this once we move to esm modules
     "history", // we should bump this together with react-router-dom
+    "@mdx-js/react", // storybook peer-depends on it's 1.x version, we should upgrade this when we upgrade storybook
     "monaco-editor", // due to us exposing this via @grafana/ui/CodeEditor's props bumping can break plugins
     "react-hook-form", // due to us exposing these hooks via @grafana/ui form components bumping can break plugins
     "react-icons", // jaeger-ui-components is being refactored to use @grafana/ui icons instead


### PR DESCRIPTION
it is a peer-dependency of "@storybook/addon-docs" with version 1.x, the new version is 2.x. we should update them together.
