### PR TITLE
Middleware: Fix IPv6 host parsing in CSRF check

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -466,7 +466,7 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 	}
 
 	m.Use(middleware.Recovery(hs.Cfg))
-	m.UseMiddleware(middleware.CSRF(hs.Cfg.LoginCookieName, hs.Cfg.HTTPPort))
+	m.UseMiddleware(middleware.CSRF(hs.Cfg.LoginCookieName, hs.Cfg.HTTPPort, hs.log))
 
 	hs.mapStatic(m, hs.Cfg.StaticRootPath, "build", "public/build")
 	hs.mapStatic(m, hs.Cfg.StaticRootPath, "", "public", "/public/views/swagger.html")

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -466,7 +466,7 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 	}
 
 	m.Use(middleware.Recovery(hs.Cfg))
-	m.UseMiddleware(middleware.CSRF(hs.Cfg.LoginCookieName))
+	m.UseMiddleware(middleware.CSRF(hs.Cfg.LoginCookieName, hs.Cfg.HTTPPort))
 
 	hs.mapStatic(m, hs.Cfg.StaticRootPath, "build", "public/build")
 	hs.mapStatic(m, hs.Cfg.StaticRootPath, "", "public", "/public/views/swagger.html")

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -466,7 +466,7 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 	}
 
 	m.Use(middleware.Recovery(hs.Cfg))
-	m.UseMiddleware(middleware.CSRF(hs.Cfg.LoginCookieName, hs.Cfg.HTTPPort, hs.log))
+	m.UseMiddleware(middleware.CSRF(hs.Cfg.LoginCookieName, hs.log))
 
 	hs.mapStatic(m, hs.Cfg.StaticRootPath, "build", "public/build")
 	hs.mapStatic(m, hs.Cfg.StaticRootPath, "", "public", "/public/views/swagger.html")

--- a/pkg/middleware/csrf.go
+++ b/pkg/middleware/csrf.go
@@ -34,6 +34,10 @@ func CSRF(loginCookieName, defaultPort string) func(http.Handler) http.Handler {
 			}
 
 			origin, err := url.Parse(r.Header.Get("Origin"))
+			// Possible TODO: If Origin, but malformed, error?
+			// Per url.Parse: The url may be relative (a path, without a host) or absolute (starting with
+			// a scheme). Trying to parse a hostname and path without a scheme is invalid but may not
+			//  necessarily return an error, due to parsing ambiguities.
 			if err != nil || netAddr.Host == "" || (origin.String() != "" && origin.Hostname() != netAddr.Host) {
 				http.Error(w, "origin not allowed", http.StatusForbidden)
 				return

--- a/pkg/middleware/csrf.go
+++ b/pkg/middleware/csrf.go
@@ -38,7 +38,8 @@ func CSRF(loginCookieName string, logger log.Logger) func(http.Handler) http.Han
 			origin, err := url.Parse(r.Header.Get("Origin"))
 			if err != nil {
 				logger.Error("error parsing Origin header", "err", err)
-			} else if netAddr.Host == "" || (origin.String() != "" && origin.Hostname() != netAddr.Host) {
+			}
+			if err != nil || netAddr.Host == "" || (origin.String() != "" && origin.Hostname() != netAddr.Host) {
 				http.Error(w, "origin not allowed", http.StatusForbidden)
 				return
 			}

--- a/pkg/middleware/csrf.go
+++ b/pkg/middleware/csrf.go
@@ -5,10 +5,11 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/util"
 )
 
-func CSRF(loginCookieName, defaultPort string) func(http.Handler) http.Handler {
+func CSRF(loginCookieName, defaultPort string, logger log.Logger) func(http.Handler) http.Handler {
 	// As per RFC 7231/4.2.2 these methods are idempotent:
 	// (GET is excluded because it may have side effects in some APIs)
 	safeMethods := []string{"HEAD", "OPTIONS", "TRACE"}
@@ -31,6 +32,7 @@ func CSRF(loginCookieName, defaultPort string) func(http.Handler) http.Handler {
 			netAddr, err := util.SplitHostPortDefault(r.Host, "", defaultPort)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
 			}
 
 			origin, err := url.Parse(r.Header.Get("Origin"))
@@ -38,7 +40,9 @@ func CSRF(loginCookieName, defaultPort string) func(http.Handler) http.Handler {
 			// Per url.Parse: The url may be relative (a path, without a host) or absolute (starting with
 			// a scheme). Trying to parse a hostname and path without a scheme is invalid but may not
 			//  necessarily return an error, due to parsing ambiguities.
-			if err != nil || netAddr.Host == "" || (origin.String() != "" && origin.Hostname() != netAddr.Host) {
+			if err != nil {
+				logger.Error("error parsing Origin header", "err", err)
+			} else if netAddr.Host == "" || (origin.String() != "" && origin.Hostname() != netAddr.Host) {
 				http.Error(w, "origin not allowed", http.StatusForbidden)
 				return
 			}

--- a/pkg/middleware/csrf_test.go
+++ b/pkg/middleware/csrf_test.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiddlewareCSRF(t *testing.T) {
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.AddCookie(&http.Cookie{
+		Name: "foo",
+	})
+
+	req.Header.Add("ORIGIN", "localhost")
+	req.Header.Add("HOST", "notLocalhost")
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+	})
+
+	rr := httptest.NewRecorder()
+	handler := CSRF("foo")(testHandler)
+	handler.ServeHTTP(rr, req)
+	spew.Dump(rr.Body)
+	require.Equal(t, rr.Code, http.StatusForbidden)
+}

--- a/pkg/middleware/csrf_test.go
+++ b/pkg/middleware/csrf_test.go
@@ -10,24 +10,29 @@ import (
 )
 
 func TestMiddlewareCSRF(t *testing.T) {
+	rr := csrfScenario(t, "foo", "localhost", "notLocalhost")
+	spew.Dump(rr.Body)
+	require.Equal(t, rr.Code, http.StatusForbidden)
+}
+
+func csrfScenario(t *testing.T, cookieName, origin string, host string) *httptest.ResponseRecorder {
 	req, err := http.NewRequest("GET", "/", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	req.AddCookie(&http.Cookie{
-		Name: "foo",
+		Name: cookieName,
 	})
 
-	req.Header.Add("ORIGIN", "localhost")
-	req.Header.Add("HOST", "notLocalhost")
+	req.Header.Add("ORIGIN", origin)
+	req.Header.Add("HOST", host)
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 	})
 
 	rr := httptest.NewRecorder()
-	handler := CSRF("foo")(testHandler)
+	handler := CSRF(cookieName)(testHandler)
 	handler.ServeHTTP(rr, req)
-	spew.Dump(rr.Body)
-	require.Equal(t, rr.Code, http.StatusForbidden)
+	return rr
 }

--- a/pkg/middleware/csrf_test.go
+++ b/pkg/middleware/csrf_test.go
@@ -86,7 +86,6 @@ func TestMiddlewareCSRF(t *testing.T) {
 			require.Equal(t, tt.code, rr.Code)
 		})
 	}
-
 }
 
 func csrfScenario(t *testing.T, cookieName, method, origin, host, defaultPort string) *httptest.ResponseRecorder {

--- a/pkg/middleware/csrf_test.go
+++ b/pkg/middleware/csrf_test.go
@@ -5,17 +5,15 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMiddlewareCSRF(t *testing.T) {
-	rr := csrfScenario(t, "foo", "localhost", "notLocalhost")
-	spew.Dump(rr.Body)
+	rr := csrfScenario(t, "foo", "localhost", "notLocalhost", "80")
 	require.Equal(t, rr.Code, http.StatusForbidden)
 }
 
-func csrfScenario(t *testing.T, cookieName, origin string, host string) *httptest.ResponseRecorder {
+func csrfScenario(t *testing.T, cookieName, origin, host, defaultPort string) *httptest.ResponseRecorder {
 	req, err := http.NewRequest("GET", "/", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -32,7 +30,7 @@ func csrfScenario(t *testing.T, cookieName, origin string, host string) *httptes
 	})
 
 	rr := httptest.NewRecorder()
-	handler := CSRF(cookieName)(testHandler)
+	handler := CSRF(cookieName, defaultPort)(testHandler)
 	handler.ServeHTTP(rr, req)
 	return rr
 }

--- a/pkg/middleware/csrf_test.go
+++ b/pkg/middleware/csrf_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,7 +55,7 @@ func TestMiddlewareCSRF(t *testing.T) {
 			code:        http.StatusBadRequest,
 		},
 		{
-			name:        "should work without port",
+			name:        "should works without port",
 			cookieName:  "foo",
 			method:      "GET",
 			host:        "localhost",
@@ -63,7 +64,7 @@ func TestMiddlewareCSRF(t *testing.T) {
 			code:        http.StatusOK,
 		},
 		{
-			name:       "IPv6 host work with port",
+			name:       "IPv6 host works with port",
 			cookieName: "foo",
 			method:     "GET",
 			host:       "[::1]:3000",
@@ -71,11 +72,19 @@ func TestMiddlewareCSRF(t *testing.T) {
 			code:       http.StatusOK,
 		},
 		{
-			name:        "IPv6 host should get default port",
+			name:       "IPv6 host (with longer address) works with port",
+			cookieName: "foo",
+			method:     "GET",
+			host:       "[2001:db8::1]:3000",
+			origin:     "http://[2001:db8::1]:3000",
+			code:       http.StatusOK,
+		},
+		{
+			name:        "IPv6 host (with longer address) should get default port",
 			cookieName:  "foo",
 			method:      "GET",
-			host:        "[::1]",
-			origin:      "http://[::1]",
+			host:        "[2001:db8::1]",
+			origin:      "http://[2001:db8::1]",
 			defaultPort: "3000",
 			code:        http.StatusOK,
 		},
@@ -108,7 +117,7 @@ func csrfScenario(t *testing.T, cookieName, method, origin, host, defaultPort st
 	})
 
 	rr := httptest.NewRecorder()
-	handler := CSRF(cookieName, defaultPort)(testHandler)
+	handler := CSRF(cookieName, defaultPort, log.New())(testHandler)
 	handler.ServeHTTP(rr, req)
 	return rr
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the CSRF middleware to work with IPv6.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #45115

**Special notes for your reviewer**:

