### PR TITLE
Query history: Add search functionality

### DIFF
--- a/docs/sources/http_api/query_history.md
+++ b/docs/sources/http_api/query_history.md
@@ -81,7 +81,8 @@ Status codes:
 
 `GET /api/query-history`
 
-Returns a list of queries in query history that match search parameters. Query history search supports pagination. Use the `limit` query parameter to control the maximum number of queries returned; the default limit is 100. You can also use the `page` query parameter to fetch queries from any page other than the first one.
+Returns a list of queries in the query history that matches the search criteria. Query history search supports pagination. Use the `limit` parameter to control the maximum number of queries returned; the default limit is 100. You can also use the `page` query parameter to fetch queries from any page other than the first one.
+		
 
 Query parameters:
 

--- a/docs/sources/http_api/query_history.md
+++ b/docs/sources/http_api/query_history.md
@@ -88,7 +88,7 @@ Query parameters:
 
 - **datasourceUid** - Filter the query history for selected data sources. You must specify at least one data source UID. To perform an "AND" filtering with multiple data sources, specify the data source parameter using the following format: `datasourceUid=uid1&datasourceUid=uid2`.
 - **searchString** – Use searchString parameter for filtering query history items based on the content of queries.
-- **sort** - Sorting order. Can be `time-asc` or `time-desc`. Defaults to `time-desc`.
+- **sort** - Specify the sorting order. Sorting can be `time-asc` or `time-desc`. The default is `time-desc`.
 - **onlyStarred** - Search for queries that are starred. Defaults to `false`.
 - **page** - Number of page you would like to to get. Search supports pagination and it is limits results to 100 queries per page.
 - **limit** - Limits the number of returned query history items per page. Defaults to 100.

--- a/docs/sources/http_api/query_history.md
+++ b/docs/sources/http_api/query_history.md
@@ -23,7 +23,7 @@ Accept: application/json
 Content-Type: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 {
-  "dataSourceUid": "PE1C5CBDA0504A6A3",
+  "datasourceUid": "PE1C5CBDA0504A6A3",
   "queries": [
     {
         "refId": "A",
@@ -93,7 +93,7 @@ Query parameters:
   **Example request for query history search**:
 
 ```http
-GET /api/query-history?dataSourceUid="PE1C5CBDA0504A6A3"&dataSourceUid="FG1C1CBDA0504A6EL"&searchString="ALERTS"&sort="time-asc" HTTP/1.1
+GET /api/query-history?datasourceUid="PE1C5CBDA0504A6A3"&datasourceUid="FG1C1CBDA0504A6EL"&searchString="ALERTS"&sort="time-asc" HTTP/1.1
 Accept: application/json
 Content-Type: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk

--- a/docs/sources/http_api/query_history.md
+++ b/docs/sources/http_api/query_history.md
@@ -89,7 +89,7 @@ Query parameters:
 - **searchString** – Filter the query history based on the content.
 - **sort** - Specify the sorting order. Sorting can be `time-asc` or `time-desc`. The default is `time-desc`.
 - **onlyStarred** - Search for queries that are starred. Defaults to `false`.
-- **page** - Number of page you would like to to get. Search supports pagination and it is limits results to 100 queries per page.
+- **page** - Search supports pagination. Specify which page number to return. Use the limit parameter to specify the number of queries per page.
 - **limit** - Limits the number of returned query history items per page. The default is 100 queries per page.
 
 **Example request for query history search**:

--- a/docs/sources/http_api/query_history.md
+++ b/docs/sources/http_api/query_history.md
@@ -107,7 +107,11 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 HTTP/1.1 200
 Content-Type: application/json
 {
-  "result": [{
+  "result": {
+    "totalCount": 150,
+    "page": 1,
+    "perPage": 100
+    "queryHistory":[{
     "uid": "Ahg678z",
     "datasourceUid": "PE1C5CBDA0504A6A3",
     "createdBy": 1,

--- a/docs/sources/http_api/query_history.md
+++ b/docs/sources/http_api/query_history.md
@@ -90,6 +90,7 @@ Query parameters:
 - **sort** - Sorting order. Can be `time-asc` or `time-desc`. Defaults to `time-desc`.
 - **onlyStarred** - Search for queries that are starred. Defaults to `false`.
 - **page** - Number of page you would like to to get. Search supports pagination and it is limits results to 100 queries per page.
+- **limit** - Limits the number of returned query history items per page. Defaults to 100.
 
 **Example request for query history search**:
 

--- a/docs/sources/http_api/query_history.md
+++ b/docs/sources/http_api/query_history.md
@@ -90,7 +90,8 @@ Query parameters:
 - **sort** - Sorting order. Can be `time-asc` or `time desc`. Defaults to `time-desc`.
 - **onlyStarred** - Search for queries that are starred. Defaults to `false`.
 - **page** - Number of page you would like to to get. Search supports pagination and it is limits results to 100 queries per page.
-  **Example request for query history search**:
+
+**Example request for query history search**:
 
 ```http
 GET /api/query-history?datasourceUid="PE1C5CBDA0504A6A3"&datasourceUid="FG1C1CBDA0504A6EL"&searchString="ALERTS"&sort="time-asc" HTTP/1.1

--- a/docs/sources/http_api/query_history.md
+++ b/docs/sources/http_api/query_history.md
@@ -87,7 +87,7 @@ Returns a list of queries in the query history that matches the search criteria.
 Query parameters:
 
 - **datasourceUid** - Filter the query history for selected data sources. You must specify at least one data source UID. To perform an "AND" filtering with multiple data sources, specify the data source parameter using the following format: `datasourceUid=uid1&datasourceUid=uid2`.
-- **searchString** – Use searchString parameter for filtering query history items based on the content of queries.
+- **searchString** – Filter the query history based on the content.
 - **sort** - Specify the sorting order. Sorting can be `time-asc` or `time-desc`. The default is `time-desc`.
 - **onlyStarred** - Search for queries that are starred. Defaults to `false`.
 - **page** - Number of page you would like to to get. Search supports pagination and it is limits results to 100 queries per page.

--- a/docs/sources/http_api/query_history.md
+++ b/docs/sources/http_api/query_history.md
@@ -87,7 +87,7 @@ Query parameters:
 
 - **datasourceUid** - Use this parameter to filter query history items for selected data source. At least 1 data source uid needs to be specified. To do an "AND" filtering with multiple data sources, specify the data source parameter multiple times e.g. `datasourceUid=uid1&datasourceUid=uid2`.
 - **searchString** – Use searchString parameter for filtering query history items based on the content of queries.
-- **sort** - Sorting order. Can be `time-asc` or `time desc`. Defaults to `time-desc`.
+- **sort** - Sorting order. Can be `time-asc` or `time-desc`. Defaults to `time-desc`.
 - **onlyStarred** - Search for queries that are starred. Defaults to `false`.
 - **page** - Number of page you would like to to get. Search supports pagination and it is limits results to 100 queries per page.
 

--- a/docs/sources/http_api/query_history.md
+++ b/docs/sources/http_api/query_history.md
@@ -91,7 +91,7 @@ Query parameters:
 - **sort** - Specify the sorting order. Sorting can be `time-asc` or `time-desc`. The default is `time-desc`.
 - **onlyStarred** - Search for queries that are starred. Defaults to `false`.
 - **page** - Number of page you would like to to get. Search supports pagination and it is limits results to 100 queries per page.
-- **limit** - Limits the number of returned query history items per page. Defaults to 100.
+- **limit** - Limits the number of returned query history items per page. The default is 100 queries per page.
 
 **Example request for query history search**:
 

--- a/docs/sources/http_api/query_history.md
+++ b/docs/sources/http_api/query_history.md
@@ -127,6 +127,11 @@ Content-Type: application/json
 }
 ```
 
+Status codes:
+
+- **200** – OK
+- **500** – Unable to add query to the database
+
 ## Delete query from Query history by UID
 
 `DELETE /api/query-history/:uid`

--- a/docs/sources/http_api/query_history.md
+++ b/docs/sources/http_api/query_history.md
@@ -82,7 +82,6 @@ Status codes:
 `GET /api/query-history`
 
 Returns a list of queries in the query history that matches the search criteria. Query history search supports pagination. Use the `limit` parameter to control the maximum number of queries returned; the default limit is 100. You can also use the `page` query parameter to fetch queries from any page other than the first one.
-		
 
 Query parameters:
 

--- a/docs/sources/http_api/query_history.md
+++ b/docs/sources/http_api/query_history.md
@@ -86,7 +86,7 @@ Returns a list of queries in the query history that matches the search criteria.
 
 Query parameters:
 
-- **datasourceUid** - Use this parameter to filter query history items for selected data source. At least 1 data source uid needs to be specified. To do an "AND" filtering with multiple data sources, specify the data source parameter multiple times e.g. `datasourceUid=uid1&datasourceUid=uid2`.
+- **datasourceUid** - Filter the query history for selected data sources. You must specify at least one data source UID. To perform an "AND" filtering with multiple data sources, specify the data source parameter using the following format: `datasourceUid=uid1&datasourceUid=uid2`.
 - **searchString** – Use searchString parameter for filtering query history items based on the content of queries.
 - **sort** - Sorting order. Can be `time-asc` or `time-desc`. Defaults to `time-desc`.
 - **onlyStarred** - Search for queries that are starred. Defaults to `false`.

--- a/docs/sources/http_api/query_history.md
+++ b/docs/sources/http_api/query_history.md
@@ -77,6 +77,56 @@ Status codes:
 - **400** - Errors (invalid JSON, missing or invalid fields)
 - **500** – Unable to add query to the database
 
+## Query history search
+
+`GET /api/query-history`
+
+Returns a list of queries in query history that match search parameters. Query history search supports pagination. Use the `limit` query parameter to control the maximum number of queries returned; the default limit is 100. You can also use the `page` query parameter to fetch queries from any page other than the first one.
+
+Query parameters:
+
+- **datasourceUid** - Use this parameter to filter query history items for selected data source. At least 1 data source uid needs to be specified. To do an "AND" filtering with multiple data sources, specify the data source parameter multiple times e.g. `datasourceUid=uid1&datasourceUid=uid2`.
+- **searchString** – Use searchString parameter for filtering query history items based on the content of queries.
+- **sort** - Sorting order. Can be `time-asc` or `time desc`. Defaults to `time-desc`.
+- **onlyStarred** - Search for queries that are starred. Defaults to `false`.
+- **page** - Number of page you would like to to get. Search supports pagination and it is limits results to 100 queries per page.
+  **Example request for query history search**:
+
+```http
+GET /api/query-history?dataSourceUid="PE1C5CBDA0504A6A3"&dataSourceUid="FG1C1CBDA0504A6EL"&searchString="ALERTS"&sort="time-asc" HTTP/1.1
+Accept: application/json
+Content-Type: application/json
+Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
+```
+
+**Example response for query history search**:
+
+```http
+HTTP/1.1 200
+Content-Type: application/json
+{
+  "result": [{
+    "uid": "Ahg678z",
+    "datasourceUid": "PE1C5CBDA0504A6A3",
+    "createdBy": 1,
+    "createdAt": 1643630762,
+    "starred": false,
+    "comment": "",
+    "queries": [
+      {
+        "refId": "A",
+        "key": "Q-87fed8e3-62ba-4eb2-8d2a-4129979bb4de-0",
+        "scenarioId": "csv_content",
+        "datasource": {
+            "type": "testdata",
+            "uid": "PE1C5CBDA0504A6A3"
+        }
+      }
+    ]
+  }]
+}
+```
+
 ## Delete query from Query history by UID
 
 `DELETE /api/query-history/:uid`

--- a/pkg/services/queryhistory/api.go
+++ b/pkg/services/queryhistory/api.go
@@ -46,12 +46,12 @@ func (s *QueryHistoryService) searchHandler(c *models.ReqContext) response.Respo
 		Limit:          c.QueryInt("limit"),
 	}
 
-	queries, err := s.SearchInQueryHistory(c.Req.Context(), c.SignedInUser, query)
+	result, err := s.SearchInQueryHistory(c.Req.Context(), c.SignedInUser, query)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to get query history", err)
 	}
 
-	return response.JSON(http.StatusOK, QueryHistorySearchResponse{Result: queries})
+	return response.JSON(http.StatusOK, QueryHistorySearchResponse{Result: result})
 }
 
 func (s *QueryHistoryService) deleteHandler(c *models.ReqContext) response.Response {

--- a/pkg/services/queryhistory/api.go
+++ b/pkg/services/queryhistory/api.go
@@ -14,6 +14,7 @@ import (
 func (s *QueryHistoryService) registerAPIEndpoints() {
 	s.RouteRegister.Group("/api/query-history", func(entities routing.RouteRegister) {
 		entities.Post("/", middleware.ReqSignedIn, routing.Wrap(s.createHandler))
+		entities.Get("/", middleware.ReqSignedIn, routing.Wrap(s.searchHandler))
 		entities.Delete("/:uid", middleware.ReqSignedIn, routing.Wrap(s.deleteHandler))
 		entities.Post("/star/:uid", middleware.ReqSignedIn, routing.Wrap(s.starHandler))
 		entities.Delete("/star/:uid", middleware.ReqSignedIn, routing.Wrap(s.unstarHandler))
@@ -33,6 +34,24 @@ func (s *QueryHistoryService) createHandler(c *models.ReqContext) response.Respo
 	}
 
 	return response.JSON(http.StatusOK, QueryHistoryResponse{Result: query})
+}
+
+func (s *QueryHistoryService) searchHandler(c *models.ReqContext) response.Response {
+	query := SearchInQueryHistoryQuery{
+		DatasourceUIDs: c.QueryStrings("datasourceUid"),
+		SearchString:   c.Query("searchString"),
+		OnlyStarred:    c.QueryBoolWithDefault("onlyStarred", false),
+		Sort:           c.Query("sort"),
+		Page:           c.QueryInt("page"),
+		Limit:          c.QueryInt("limit"),
+	}
+
+	queries, err := s.SearchInQueryHistory(c.Req.Context(), c.SignedInUser, query)
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, "Failed to get query history", err)
+	}
+
+	return response.JSON(http.StatusOK, QueryHistorySearchResponse{Result: queries})
 }
 
 func (s *QueryHistoryService) deleteHandler(c *models.ReqContext) response.Response {

--- a/pkg/services/queryhistory/database.go
+++ b/pkg/services/queryhistory/database.go
@@ -78,7 +78,7 @@ func (s QueryHistoryService) searchQueries(ctx context.Context, user *models.Sig
 				INNER JOIN query_history_star ON query_history_star.query_uid = query_history.uid
 			`
 		} else {
-			sql = sql + `IIF(query_history_star.query_uid IS NULL, false, true) AS starred
+			sql = sql + `CASE WHEN query_history_star.query_uid IS NULL THEN false ELSE true END AS starred
 				FROM query_history
 				LEFT JOIN query_history_star ON query_history_star.query_uid = query_history.uid
 			`

--- a/pkg/services/queryhistory/database.go
+++ b/pkg/services/queryhistory/database.go
@@ -73,7 +73,7 @@ func (s QueryHistoryService) searchQueries(ctx context.Context, user *models.Sig
 		`
 
 		if query.OnlyStarred {
-			sql = sql + `1 as "starred"
+			sql = sql + `? as "starred"
 				FROM query_history
 				INNER JOIN query_history_star ON query_history_star.query_uid = query_history.uid
 			`
@@ -98,7 +98,11 @@ func (s QueryHistoryService) searchQueries(ctx context.Context, user *models.Sig
 		sql = sql + `LIMIT ? OFFSET ?
 		`
 
-		params := []interface{}{user.OrgId, user.UserId, "%" + query.SearchString + "%"}
+		params := make([]interface{}, 0)
+		if query.OnlyStarred {
+			params = append(params, s.SQLStore.Dialect.BooleanStr(true))
+		}
+		params = append(params, user.OrgId, user.UserId, "%"+query.SearchString+"%")
 		for _, uid := range query.DatasourceUIDs {
 			params = append(params, uid)
 		}

--- a/pkg/services/queryhistory/database.go
+++ b/pkg/services/queryhistory/database.go
@@ -73,7 +73,7 @@ func (s QueryHistoryService) searchQueries(ctx context.Context, user *models.Sig
 		`
 
 		if query.OnlyStarred {
-			sql = sql + `? as "starred"
+			sql = sql + ` ` + s.SQLStore.Dialect.BooleanStr(true) + ` as "starred"
 				FROM query_history
 				INNER JOIN query_history_star ON query_history_star.query_uid = query_history.uid
 			`
@@ -84,7 +84,7 @@ func (s QueryHistoryService) searchQueries(ctx context.Context, user *models.Sig
 			`
 		}
 
-		sql = sql + `WHERE query_history.org_id = ? AND query_history.created_by = ? AND query_history.queries LIKE ? AND query_history.datasource_uid IN (?` + strings.Repeat(",?", len(query.DatasourceUIDs)-1) + `)
+		sql = sql + `WHERE query_history.org_id = ? AND query_history.created_by = ? AND query_history.queries ` + s.SQLStore.Dialect.LikeStr() + ` ? AND query_history.datasource_uid IN (?` + strings.Repeat(",?", len(query.DatasourceUIDs)-1) + `)
 		`
 
 		if query.Sort == "time-asc" {
@@ -98,11 +98,7 @@ func (s QueryHistoryService) searchQueries(ctx context.Context, user *models.Sig
 		sql = sql + `LIMIT ? OFFSET ?
 		`
 
-		params := make([]interface{}, 0)
-		if query.OnlyStarred {
-			params = append(params, s.SQLStore.Dialect.BooleanStr(true))
-		}
-		params = append(params, user.OrgId, user.UserId, "%"+query.SearchString+"%")
+		params := []interface{}{user.OrgId, user.UserId, "%" + query.SearchString + "%"}
 		for _, uid := range query.DatasourceUIDs {
 			params = append(params, uid)
 		}

--- a/pkg/services/queryhistory/database.go
+++ b/pkg/services/queryhistory/database.go
@@ -67,18 +67,18 @@ func (s QueryHistoryService) searchQueries(ctx context.Context, user *models.Sig
 			query_history.uid,
 			query_history.datasource_uid,
 			query_history.created_by,
-			query_history.created_at as "created_at",
+			query_history.created_at AS created_at,
 			query_history.comment,
 			query_history.queries,
 		`
 
 		if query.OnlyStarred {
-			sql = sql + ` ` + s.SQLStore.Dialect.BooleanStr(true) + ` as "starred"
+			sql = sql + s.SQLStore.Dialect.BooleanStr(true) + ` AS starred
 				FROM query_history
 				INNER JOIN query_history_star ON query_history_star.query_uid = query_history.uid
 			`
 		} else {
-			sql = sql + `CASE WHEN query_history_star.query_uid IS NULL THEN false ELSE true END AS starred
+			sql = sql + `CASE WHEN query_history_star.query_uid IS NULL THEN ` + s.SQLStore.Dialect.BooleanStr(false) + ` ELSE ` + s.SQLStore.Dialect.BooleanStr(true) + ` END AS starred
 				FROM query_history
 				LEFT JOIN query_history_star ON query_history_star.query_uid = query_history.uid
 			`

--- a/pkg/services/queryhistory/models.go
+++ b/pkg/services/queryhistory/models.go
@@ -34,13 +34,22 @@ type CreateQueryInQueryHistoryCommand struct {
 	Queries       *simplejson.Json `json:"queries"`
 }
 
+type SearchInQueryHistoryQuery struct {
+	DatasourceUIDs []string `json:"datasourceUids"`
+	SearchString   string   `json:"searchString"`
+	OnlyStarred    bool     `json:"onlyStarred"`
+	Sort           string   `json:"sort"`
+	Page           int      `json:"page"`
+	Limit          int      `json:"limit"`
+}
+
 type PatchQueryCommentInQueryHistoryCommand struct {
 	Comment string `json:"comment"`
 }
 
 type QueryHistoryDTO struct {
-	UID           string           `json:"uid"`
-	DatasourceUID string           `json:"datasourceUid"`
+	UID           string           `json:"uid" xorm:"uid"`
+	DatasourceUID string           `json:"datasourceUid" xorm:"datasource_uid"`
 	CreatedBy     int64            `json:"createdBy"`
 	CreatedAt     int64            `json:"createdAt"`
 	Comment       string           `json:"comment"`
@@ -51,6 +60,10 @@ type QueryHistoryDTO struct {
 // QueryHistoryResponse is a response struct for QueryHistoryDTO
 type QueryHistoryResponse struct {
 	Result QueryHistoryDTO `json:"result"`
+}
+
+type QueryHistorySearchResponse struct {
+	Result []QueryHistoryDTO `json:"result"`
 }
 
 // DeleteQueryFromQueryHistoryResponse is the response struct for deleting a query from query history

--- a/pkg/services/queryhistory/models.go
+++ b/pkg/services/queryhistory/models.go
@@ -62,8 +62,15 @@ type QueryHistoryResponse struct {
 	Result QueryHistoryDTO `json:"result"`
 }
 
+type QueryHistorySearchResult struct {
+	TotalCount   int               `json:"totalCount"`
+	QueryHistory []QueryHistoryDTO `json:"queryHistory"`
+	Page         int               `json:"page"`
+	PerPage      int               `json:"perPage"`
+}
+
 type QueryHistorySearchResponse struct {
-	Result []QueryHistoryDTO `json:"result"`
+	Result QueryHistorySearchResult `json:"result"`
 }
 
 // DeleteQueryFromQueryHistoryResponse is the response struct for deleting a query from query history

--- a/pkg/services/queryhistory/queryhistory.go
+++ b/pkg/services/queryhistory/queryhistory.go
@@ -28,7 +28,7 @@ func ProvideService(cfg *setting.Cfg, sqlStore *sqlstore.SQLStore, routeRegister
 
 type Service interface {
 	CreateQueryInQueryHistory(ctx context.Context, user *models.SignedInUser, cmd CreateQueryInQueryHistoryCommand) (QueryHistoryDTO, error)
-	SearchInQueryHistory(ctx context.Context, user *models.SignedInUser, query SearchInQueryHistoryQuery) ([]QueryHistoryDTO, error)
+	SearchInQueryHistory(ctx context.Context, user *models.SignedInUser, query SearchInQueryHistoryQuery) (QueryHistorySearchResult, error)
 	DeleteQueryFromQueryHistory(ctx context.Context, user *models.SignedInUser, UID string) (int64, error)
 	PatchQueryCommentInQueryHistory(ctx context.Context, user *models.SignedInUser, UID string, cmd PatchQueryCommentInQueryHistoryCommand) (QueryHistoryDTO, error)
 	StarQueryInQueryHistory(ctx context.Context, user *models.SignedInUser, UID string) (QueryHistoryDTO, error)
@@ -46,7 +46,7 @@ func (s QueryHistoryService) CreateQueryInQueryHistory(ctx context.Context, user
 	return s.createQuery(ctx, user, cmd)
 }
 
-func (s QueryHistoryService) SearchInQueryHistory(ctx context.Context, user *models.SignedInUser, query SearchInQueryHistoryQuery) ([]QueryHistoryDTO, error) {
+func (s QueryHistoryService) SearchInQueryHistory(ctx context.Context, user *models.SignedInUser, query SearchInQueryHistoryQuery) (QueryHistorySearchResult, error) {
 	return s.searchQueries(ctx, user, query)
 }
 

--- a/pkg/services/queryhistory/queryhistory.go
+++ b/pkg/services/queryhistory/queryhistory.go
@@ -28,6 +28,7 @@ func ProvideService(cfg *setting.Cfg, sqlStore *sqlstore.SQLStore, routeRegister
 
 type Service interface {
 	CreateQueryInQueryHistory(ctx context.Context, user *models.SignedInUser, cmd CreateQueryInQueryHistoryCommand) (QueryHistoryDTO, error)
+	SearchInQueryHistory(ctx context.Context, user *models.SignedInUser, query SearchInQueryHistoryQuery) ([]QueryHistoryDTO, error)
 	DeleteQueryFromQueryHistory(ctx context.Context, user *models.SignedInUser, UID string) (int64, error)
 	PatchQueryCommentInQueryHistory(ctx context.Context, user *models.SignedInUser, UID string, cmd PatchQueryCommentInQueryHistoryCommand) (QueryHistoryDTO, error)
 	StarQueryInQueryHistory(ctx context.Context, user *models.SignedInUser, UID string) (QueryHistoryDTO, error)
@@ -43,6 +44,10 @@ type QueryHistoryService struct {
 
 func (s QueryHistoryService) CreateQueryInQueryHistory(ctx context.Context, user *models.SignedInUser, cmd CreateQueryInQueryHistoryCommand) (QueryHistoryDTO, error) {
 	return s.createQuery(ctx, user, cmd)
+}
+
+func (s QueryHistoryService) SearchInQueryHistory(ctx context.Context, user *models.SignedInUser, query SearchInQueryHistoryQuery) ([]QueryHistoryDTO, error) {
+	return s.searchQueries(ctx, user, query)
 }
 
 func (s QueryHistoryService) DeleteQueryFromQueryHistory(ctx context.Context, user *models.SignedInUser, UID string) (int64, error) {

--- a/pkg/services/queryhistory/queryhistory_create_test.go
+++ b/pkg/services/queryhistory/queryhistory_create_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_delete_test.go
+++ b/pkg/services/queryhistory/queryhistory_delete_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_patch_test.go
+++ b/pkg/services/queryhistory/queryhistory_patch_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -25,7 +25,7 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			err := json.Unmarshal(resp.Body(), &response)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
-			require.Equal(t, 0, len(response.Result))
+			require.Equal(t, 0, response.Result.TotalCount)
 		})
 
 	testScenarioWithQueryInQueryHistory(t, "When users tries to get query with valid datasourceUid, it should succeed",
@@ -36,7 +36,7 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			err := json.Unmarshal(resp.Body(), &response)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
-			require.Equal(t, 1, len(response.Result))
+			require.Equal(t, 1, response.Result.TotalCount)
 		})
 
 	testScenarioWithMultipleQueriesInQueryHistory(t, "When users tries to get queries with datasourceUid, it should return correct queries",
@@ -47,9 +47,9 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			err := json.Unmarshal(resp.Body(), &response)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
-			require.Equal(t, 2, len(response.Result))
-			require.Equal(t, true, response.Result[0].Starred)
-			require.Equal(t, false, response.Result[1].Starred)
+			require.Equal(t, 2, response.Result.TotalCount)
+			require.Equal(t, true, response.Result.QueryHistory[0].Starred)
+			require.Equal(t, false, response.Result.QueryHistory[1].Starred)
 		})
 
 	testScenarioWithMultipleQueriesInQueryHistory(t, "When users tries to get queries with datasourceUid and sort, it should return correct queries",
@@ -61,9 +61,9 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			err := json.Unmarshal(resp.Body(), &response)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
-			require.Equal(t, 2, len(response.Result))
-			require.Equal(t, false, response.Result[0].Starred)
-			require.Equal(t, true, response.Result[1].Starred)
+			require.Equal(t, 2, response.Result.TotalCount)
+			require.Equal(t, false, response.Result.QueryHistory[0].Starred)
+			require.Equal(t, true, response.Result.QueryHistory[1].Starred)
 		})
 
 	testScenarioWithMultipleQueriesInQueryHistory(t, "When users tries to get queries with invalid datasourceUid, it should return empty result",
@@ -74,10 +74,10 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			err := json.Unmarshal(resp.Body(), &response)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
-			require.Equal(t, 0, len(response.Result))
+			require.Equal(t, 0, response.Result.TotalCount)
 		})
 
-	testScenarioWithMultipleQueriesInQueryHistory(t, "When users tries to get queries with multiple datasourceUid, it should return empty result",
+	testScenarioWithMultipleQueriesInQueryHistory(t, "When users tries to get queries with multiple datasourceUid,  it should return correct queries",
 		func(t *testing.T, sc scenarioContext) {
 			sc.reqContext.Req.Form.Add("datasourceUid", testDsUID1)
 			sc.reqContext.Req.Form.Add("datasourceUid", testDsUID2)
@@ -86,7 +86,7 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			err := json.Unmarshal(resp.Body(), &response)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
-			require.Equal(t, 3, len(response.Result))
+			require.Equal(t, 3, response.Result.TotalCount)
 		})
 
 	testScenarioWithMultipleQueriesInQueryHistory(t, "When users tries to get starred queries, it should return correct queries",
@@ -98,8 +98,8 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			err := json.Unmarshal(resp.Body(), &response)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
-			require.Equal(t, 1, len(response.Result))
-			require.Equal(t, true, response.Result[0].Starred)
+			require.Equal(t, 1, response.Result.TotalCount)
+			require.Equal(t, true, response.Result.QueryHistory[0].Starred)
 		})
 
 	testScenarioWithMultipleQueriesInQueryHistory(t, "When users tries to get queries including search string, it should return correct queries",
@@ -111,7 +111,7 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			err := json.Unmarshal(resp.Body(), &response)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
-			require.Equal(t, 1, len(response.Result))
-			require.Equal(t, true, response.Result[0].Starred)
+			require.Equal(t, 1, response.Result.TotalCount)
+			require.Equal(t, true, response.Result.QueryHistory[0].Starred)
 		})
 }

--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -8,6 +8,12 @@ import (
 )
 
 func TestGetQueriesFromQueryHistory(t *testing.T) {
+	testScenario(t, "When users tries to get query without datasourceUid, it should fail",
+		func(t *testing.T, sc scenarioContext) {
+			resp := sc.service.searchHandler(sc.reqContext)
+			require.Equal(t, 500, resp.Status())
+		})
+
 	testScenario(t, "When users tries to get query in empty query history, it should return empty result",
 		func(t *testing.T, sc scenarioContext) {
 			sc.reqContext.Req.Form.Add("datasourceUid", "test")
@@ -18,12 +24,6 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			require.Equal(t, 0, len(queryHistory))
 		})
 
-	testScenarioWithQueryInQueryHistory(t, "When users tries to get query without datasourceUid, it should fail",
-		func(t *testing.T, sc scenarioContext) {
-			resp := sc.service.searchHandler(sc.reqContext)
-			require.Equal(t, 500, resp.Status())
-		})
-
 	testScenarioWithQueryInQueryHistory(t, "When users tries to get query with valid datasourceUid, it should succeed",
 		func(t *testing.T, sc scenarioContext) {
 			sc.reqContext.Req.Form.Add("datasourceUid", sc.initialResult.Result.DatasourceUID)
@@ -32,5 +32,62 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			json.Unmarshal(resp.Body(), &response)
 			require.Equal(t, 200, resp.Status())
 			require.Equal(t, 1, len(response.Result))
+		})
+
+	testScenarioWithMultipleQueriesInQueryHistory(t, "When users tries to get queries with datasourceUid, it should return correct queries",
+		func(t *testing.T, sc scenarioContext) {
+			sc.reqContext.Req.Form.Add("datasourceUid", sc.initialResult.Result.DatasourceUID)
+			resp := sc.service.searchHandler(sc.reqContext)
+			var response QueryHistorySearchResponse
+			json.Unmarshal(resp.Body(), &response)
+			require.Equal(t, 200, resp.Status())
+			require.Equal(t, 2, len(response.Result))
+			require.Equal(t, false, response.Result[0].Starred)
+			require.Equal(t, true, response.Result[1].Starred)
+		})
+
+	testScenarioWithMultipleQueriesInQueryHistory(t, "When users tries to get queries with invalid datasourceUid, it should return empty result",
+		func(t *testing.T, sc scenarioContext) {
+			sc.reqContext.Req.Form.Add("datasourceUid", "non-existent")
+			resp := sc.service.searchHandler(sc.reqContext)
+			var response QueryHistorySearchResponse
+			json.Unmarshal(resp.Body(), &response)
+			require.Equal(t, 200, resp.Status())
+			require.Equal(t, 0, len(response.Result))
+		})
+
+	testScenarioWithMultipleQueriesInQueryHistory(t, "When users tries to get queries with multiple datasourceUid, it should return empty result",
+		func(t *testing.T, sc scenarioContext) {
+			sc.reqContext.Req.Form.Add("datasourceUid", testDsUID1)
+			sc.reqContext.Req.Form.Add("datasourceUid", testDsUID2)
+			resp := sc.service.searchHandler(sc.reqContext)
+			var response QueryHistorySearchResponse
+			json.Unmarshal(resp.Body(), &response)
+			require.Equal(t, 200, resp.Status())
+			require.Equal(t, 3, len(response.Result))
+		})
+
+	testScenarioWithMultipleQueriesInQueryHistory(t, "When users tries to get starred queries, it should return correct queries",
+		func(t *testing.T, sc scenarioContext) {
+			sc.reqContext.Req.Form.Add("datasourceUid", testDsUID1)
+			sc.reqContext.Req.Form.Add("onlyStarred", "true")
+			resp := sc.service.searchHandler(sc.reqContext)
+			var response QueryHistorySearchResponse
+			json.Unmarshal(resp.Body(), &response)
+			require.Equal(t, 200, resp.Status())
+			require.Equal(t, 1, len(response.Result))
+			require.Equal(t, true, response.Result[0].Starred)
+		})
+
+	testScenarioWithMultipleQueriesInQueryHistory(t, "When users tries to get queries including search string, it should return correct queries",
+		func(t *testing.T, sc scenarioContext) {
+			sc.reqContext.Req.Form.Add("datasourceUid", testDsUID1)
+			sc.reqContext.Req.Form.Add("searchString", "2")
+			resp := sc.service.searchHandler(sc.reqContext)
+			var response QueryHistorySearchResponse
+			json.Unmarshal(resp.Body(), &response)
+			require.Equal(t, 200, resp.Status())
+			require.Equal(t, 1, len(response.Result))
+			require.Equal(t, true, response.Result[0].Starred)
 		})
 }

--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -48,6 +48,20 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
 			require.Equal(t, 2, len(response.Result))
+			require.Equal(t, true, response.Result[0].Starred)
+			require.Equal(t, false, response.Result[1].Starred)
+		})
+
+	testScenarioWithMultipleQueriesInQueryHistory(t, "When users tries to get queries with datasourceUid and sort, it should return correct queries",
+		func(t *testing.T, sc scenarioContext) {
+			sc.reqContext.Req.Form.Add("datasourceUid", sc.initialResult.Result.DatasourceUID)
+			sc.reqContext.Req.Form.Add("sort", "time-asc")
+			resp := sc.service.searchHandler(sc.reqContext)
+			var response QueryHistorySearchResponse
+			err := json.Unmarshal(resp.Body(), &response)
+			require.NoError(t, err)
+			require.Equal(t, 200, resp.Status())
+			require.Equal(t, 2, len(response.Result))
 			require.Equal(t, false, response.Result[0].Starred)
 			require.Equal(t, true, response.Result[1].Starred)
 		})

--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -18,10 +18,11 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 		func(t *testing.T, sc scenarioContext) {
 			sc.reqContext.Req.Form.Add("datasourceUid", "test")
 			resp := sc.service.searchHandler(sc.reqContext)
-			var queryHistory []QueryHistoryDTO
-			json.Unmarshal(resp.Body(), &queryHistory)
+			var response QueryHistorySearchResponse
+			err := json.Unmarshal(resp.Body(), &response)
+			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
-			require.Equal(t, 0, len(queryHistory))
+			require.Equal(t, 0, len(response.Result))
 		})
 
 	testScenarioWithQueryInQueryHistory(t, "When users tries to get query with valid datasourceUid, it should succeed",
@@ -29,7 +30,8 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			sc.reqContext.Req.Form.Add("datasourceUid", sc.initialResult.Result.DatasourceUID)
 			resp := sc.service.searchHandler(sc.reqContext)
 			var response QueryHistorySearchResponse
-			json.Unmarshal(resp.Body(), &response)
+			err := json.Unmarshal(resp.Body(), &response)
+			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
 			require.Equal(t, 1, len(response.Result))
 		})
@@ -39,7 +41,8 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			sc.reqContext.Req.Form.Add("datasourceUid", sc.initialResult.Result.DatasourceUID)
 			resp := sc.service.searchHandler(sc.reqContext)
 			var response QueryHistorySearchResponse
-			json.Unmarshal(resp.Body(), &response)
+			err := json.Unmarshal(resp.Body(), &response)
+			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
 			require.Equal(t, 2, len(response.Result))
 			require.Equal(t, false, response.Result[0].Starred)
@@ -51,7 +54,8 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			sc.reqContext.Req.Form.Add("datasourceUid", "non-existent")
 			resp := sc.service.searchHandler(sc.reqContext)
 			var response QueryHistorySearchResponse
-			json.Unmarshal(resp.Body(), &response)
+			err := json.Unmarshal(resp.Body(), &response)
+			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
 			require.Equal(t, 0, len(response.Result))
 		})
@@ -62,7 +66,8 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			sc.reqContext.Req.Form.Add("datasourceUid", testDsUID2)
 			resp := sc.service.searchHandler(sc.reqContext)
 			var response QueryHistorySearchResponse
-			json.Unmarshal(resp.Body(), &response)
+			err := json.Unmarshal(resp.Body(), &response)
+			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
 			require.Equal(t, 3, len(response.Result))
 		})
@@ -73,7 +78,8 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			sc.reqContext.Req.Form.Add("onlyStarred", "true")
 			resp := sc.service.searchHandler(sc.reqContext)
 			var response QueryHistorySearchResponse
-			json.Unmarshal(resp.Body(), &response)
+			err := json.Unmarshal(resp.Body(), &response)
+			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
 			require.Equal(t, 1, len(response.Result))
 			require.Equal(t, true, response.Result[0].Starred)
@@ -85,7 +91,8 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			sc.reqContext.Req.Form.Add("searchString", "2")
 			resp := sc.service.searchHandler(sc.reqContext)
 			var response QueryHistorySearchResponse
-			json.Unmarshal(resp.Body(), &response)
+			err := json.Unmarshal(resp.Body(), &response)
+			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
 			require.Equal(t, 1, len(response.Result))
 			require.Equal(t, true, response.Result[0].Starred)

--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -1,0 +1,36 @@
+package queryhistory
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetQueriesFromQueryHistory(t *testing.T) {
+	testScenario(t, "When users tries to get query in empty query history, it should return empty result",
+		func(t *testing.T, sc scenarioContext) {
+			sc.reqContext.Req.Form.Add("datasourceUid", "test")
+			resp := sc.service.searchHandler(sc.reqContext)
+			var queryHistory []QueryHistoryDTO
+			json.Unmarshal(resp.Body(), &queryHistory)
+			require.Equal(t, 200, resp.Status())
+			require.Equal(t, 0, len(queryHistory))
+		})
+
+	testScenarioWithQueryInQueryHistory(t, "When users tries to get query without datasourceUid, it should fail",
+		func(t *testing.T, sc scenarioContext) {
+			resp := sc.service.searchHandler(sc.reqContext)
+			require.Equal(t, 500, resp.Status())
+		})
+
+	testScenarioWithQueryInQueryHistory(t, "When users tries to get query with valid datasourceUid, it should succeed",
+		func(t *testing.T, sc scenarioContext) {
+			sc.reqContext.Req.Form.Add("datasourceUid", sc.initialResult.Result.DatasourceUID)
+			resp := sc.service.searchHandler(sc.reqContext)
+			var response QueryHistorySearchResponse
+			json.Unmarshal(resp.Body(), &response)
+			require.Equal(t, 200, resp.Status())
+			require.Equal(t, 1, len(response.Result))
+		})
+}

--- a/pkg/services/queryhistory/queryhistory_star_test.go
+++ b/pkg/services/queryhistory/queryhistory_star_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_test.go
+++ b/pkg/services/queryhistory/queryhistory_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_test.go
+++ b/pkg/services/queryhistory/queryhistory_test.go
@@ -115,6 +115,7 @@ func testScenarioWithMultipleQueriesInQueryHistory(t *testing.T, desc string, fn
 		resp1 := sc.service.createHandler(sc.reqContext)
 		sc.initialResult = validateAndUnMarshalResponse(t, resp1)
 
+		time.Sleep(1 * time.Second)
 		command2 := CreateQueryInQueryHistoryCommand{
 			DatasourceUID: testDsUID1,
 			Queries: simplejson.NewFromAny(map[string]interface{}{
@@ -127,6 +128,7 @@ func testScenarioWithMultipleQueriesInQueryHistory(t *testing.T, desc string, fn
 		sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result2.Result.UID})
 		sc.service.starHandler(sc.reqContext)
 
+		time.Sleep(1 * time.Second)
 		command3 := CreateQueryInQueryHistoryCommand{
 			DatasourceUID: testDsUID2,
 			Queries: simplejson.NewFromAny(map[string]interface{}{

--- a/pkg/services/queryhistory/queryhistory_test.go
+++ b/pkg/services/queryhistory/queryhistory_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -37,6 +38,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 	t.Run(desc, func(t *testing.T) {
 		ctx := web.Context{Req: &http.Request{
 			Header: http.Header{},
+			Form:   url.Values{},
 		}}
 		ctx.Req.Header.Add("Content-Type", "application/json")
 		sqlStore := sqlstore.InitTestDB(t)

--- a/pkg/services/queryhistory/queryhistory_test.go
+++ b/pkg/services/queryhistory/queryhistory_test.go
@@ -22,6 +22,8 @@ import (
 var (
 	testOrgID  = int64(1)
 	testUserID = int64(1)
+	testDsUID1 = "NCzh67i"
+	testDsUID2 = "ABch1a1"
 )
 
 type scenarioContext struct {
@@ -84,7 +86,7 @@ func testScenarioWithQueryInQueryHistory(t *testing.T, desc string, fn func(t *t
 
 	testScenario(t, desc, func(t *testing.T, sc scenarioContext) {
 		command := CreateQueryInQueryHistoryCommand{
-			DatasourceUID: "NCzh67i",
+			DatasourceUID: testDsUID1,
 			Queries: simplejson.NewFromAny(map[string]interface{}{
 				"expr": "test",
 			}),
@@ -92,6 +94,48 @@ func testScenarioWithQueryInQueryHistory(t *testing.T, desc string, fn func(t *t
 		sc.reqContext.Req.Body = mockRequestBody(command)
 		resp := sc.service.createHandler(sc.reqContext)
 		sc.initialResult = validateAndUnMarshalResponse(t, resp)
+		fn(t, sc)
+	})
+}
+
+func testScenarioWithMultipleQueriesInQueryHistory(t *testing.T, desc string, fn func(t *testing.T, sc scenarioContext)) {
+	t.Helper()
+
+	testScenario(t, desc, func(t *testing.T, sc scenarioContext) {
+		command1 := CreateQueryInQueryHistoryCommand{
+			DatasourceUID: testDsUID1,
+			Queries: simplejson.NewFromAny(map[string]interface{}{
+				"expr": "test",
+			}),
+		}
+		sc.reqContext.Req.Body = mockRequestBody(command1)
+		resp1 := sc.service.createHandler(sc.reqContext)
+		sc.initialResult = validateAndUnMarshalResponse(t, resp1)
+
+		command2 := CreateQueryInQueryHistoryCommand{
+			DatasourceUID: testDsUID1,
+			Queries: simplejson.NewFromAny(map[string]interface{}{
+				"expr": "test2",
+			}),
+		}
+		sc.reqContext.Req.Body = mockRequestBody(command2)
+		resp2 := sc.service.createHandler(sc.reqContext)
+		result2 := validateAndUnMarshalResponse(t, resp2)
+		sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result2.Result.UID})
+		sc.service.starHandler(sc.reqContext)
+
+		command3 := CreateQueryInQueryHistoryCommand{
+			DatasourceUID: testDsUID2,
+			Queries: simplejson.NewFromAny(map[string]interface{}{
+				"expr": "test2",
+			}),
+		}
+		sc.reqContext.Req.Body = mockRequestBody(command3)
+		resp3 := sc.service.createHandler(sc.reqContext)
+		result3 := validateAndUnMarshalResponse(t, resp3)
+		sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": result3.Result.UID})
+		sc.service.starHandler(sc.reqContext)
+
 		fn(t, sc)
 	})
 }

--- a/pkg/services/queryhistory/queryhistory_unstar_test.go
+++ b/pkg/services/queryhistory/queryhistory_unstar_test.go
@@ -1,7 +1,9 @@
+//go:build integration
+// +build integration
+
 package queryhistory
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/web"
@@ -20,7 +22,6 @@ func TestUnstarQueryInQueryHistory(t *testing.T) {
 			sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
 			sc.service.starHandler(sc.reqContext)
 			resp := sc.service.unstarHandler(sc.reqContext)
-			fmt.Println(resp)
 			require.Equal(t, 200, resp.Status())
 		})
 

--- a/pkg/services/queryhistory/writers.go
+++ b/pkg/services/queryhistory/writers.go
@@ -1,0 +1,49 @@
+package queryhistory
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+)
+
+func writeStarredSQL(query SearchInQueryHistoryQuery, sqlStore *sqlstore.SQLStore, builder *sqlstore.SQLBuilder) {
+	if query.OnlyStarred {
+		builder.Write(sqlStore.Dialect.BooleanStr(true) + ` AS starred
+				FROM query_history
+				INNER JOIN query_history_star ON query_history_star.query_uid = query_history.uid 
+				`)
+	} else {
+		builder.Write(` CASE WHEN query_history_star.query_uid IS NULL THEN ` + sqlStore.Dialect.BooleanStr(false) + ` ELSE ` + sqlStore.Dialect.BooleanStr(true) + ` END AS starred
+				FROM query_history
+				LEFT JOIN query_history_star ON query_history_star.query_uid = query_history.uid 
+				`)
+	}
+}
+
+func writeFiltersSQL(query SearchInQueryHistoryQuery, user *models.SignedInUser, sqlStore *sqlstore.SQLStore, builder *sqlstore.SQLBuilder) {
+	params := []interface{}{user.OrgId, user.UserId, "%" + query.SearchString + "%"}
+	for _, uid := range query.DatasourceUIDs {
+		params = append(params, uid)
+	}
+	var sql bytes.Buffer
+	sql.WriteString(" WHERE query_history.org_id = ? AND query_history.created_by = ? AND query_history.queries " + sqlStore.Dialect.LikeStr() + " ? AND query_history.datasource_uid IN (? " + strings.Repeat(",?", len(query.DatasourceUIDs)-1) + ") ")
+	builder.Write(sql.String(), params...)
+}
+
+func writeSortSQL(query SearchInQueryHistoryQuery, sqlStore *sqlstore.SQLStore, builder *sqlstore.SQLBuilder) {
+	if query.Sort == "time-asc" {
+		builder.Write(" ORDER BY created_at ASC ")
+	} else {
+		builder.Write(" ORDER BY created_at DESC ")
+	}
+}
+
+func writeLimitSQL(query SearchInQueryHistoryQuery, sqlStore *sqlstore.SQLStore, builder *sqlstore.SQLBuilder) {
+	builder.Write(" LIMIT ? ", query.Limit)
+}
+
+func writeOffsetSQL(query SearchInQueryHistoryQuery, sqlStore *sqlstore.SQLStore, builder *sqlstore.SQLBuilder) {
+	builder.Write(" OFFSET ? ", query.Limit*(query.Page-1))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is part of f https://github.com/grafana/grafana/issues/44327. The design document is [here](https://docs.google.com/document/d/1BdVtoXCxhH0Q6C-O_Z7jKi-u1m5pDoS9_HQKhYu_hEE/edit#)

This PR adds **search for query history**. I have added documentation and tests for it. 

Part of https://github.com/grafana/grafana/issues/44327

**Special notes for your reviewer**:
1. Enable query history `enabled = true` flag in custom.ini
2. Add testing functions to frontend:

In https://github.com/grafana/grafana/blob/main/public/app/features/explore/state/query.ts#L322 add following code snippet In the snippet we are:
- adding every new query to history
- randomly starring some
- searching queries using `createParams` function where you can pass/test different props

 ` import { getBackendSrv } from '@grafana/runtime`
 
```
  //To test query history search
  const dataSourceUid = queries[0]?.datasource?.uid;
  if (dataSourceUid) {
    const { result } = await getBackendSrv().post(`/api/query-history`, {
      dataSourceUid,
      queries,
    });

    // Randomly star queries
    if (Math.random() * 10 < 3) {
      getBackendSrv().post(`/api/query-history/star/${result.uid}`);
    }

    // Function to add/remove params for testing
    const createParams = (p: {
      datasourceUids: string[];
      searchString?: string;
      sort?: string;
      limit?: number;
      page?: number;
      onlyStarred?: boolean;
    }) => {
      let params = `${p.datasourceUids.map((uid) => `datasourceUid=${encodeURIComponent(uid)}`).join('&')}`;
      if (p.searchString) {
        params = params + `&searchString=${p.searchString}`;
      }
      if (p.sort) {
        params = params + `&sort=${p.sort}`;
      }
      if (p.limit) {
        params = params + `&limit=${p.limit}`;
      }
      if (p.page) {
        params = params + `&page=${p.page}`;
      }
      if (p.onlyStarred) {
        params = params + `&onlyStarred=${p.onlyStarred}`;
      }
      return params;
    };

    // Here you can add/change params you want!
    const params = createParams({ datasourceUids: [dataSourceUid], onlyStarred: true });

    const queryHistory = await getBackendSrv().get(`/api/query-history?${params}`);
    // Show query history in console
    console.log(queryHistory);
  }
  // End of test
```

If the feature is enabled, it should be able to star/unstar/delete queries.

This PR is missing adding of API endpoints to the the OpenAPI spec. But after this PR there is only 'getQueryHistory` PR left and I was thinking about adding query history API then. If it is okay with reviewer. 
