### PR TITLE
Jaeger: Show loader when search options havent yet loaded

### DIFF
--- a/public/app/plugins/datasource/jaeger/components/SearchForm.test.tsx
+++ b/public/app/plugins/datasource/jaeger/components/SearchForm.test.tsx
@@ -1,0 +1,154 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { backendSrv } from 'app/core/services/backend_srv';
+import { createFetchResponse } from 'test/helpers/createFetchResponse';
+import { DataQueryRequest, DataSourceInstanceSettings, dateTime, PluginType } from '@grafana/data';
+import { of } from 'rxjs';
+import { JaegerDatasource, JaegerJsonData } from '../datasource';
+import { JaegerQuery } from '../types';
+import React from 'react';
+import SearchForm from './SearchForm';
+import { testResponse } from '../testResponse';
+import userEvent from '@testing-library/user-event';
+
+describe('SearchForm', () => {
+  it('should call the `onChange` function on click of the Input', async () => {
+    const promise = Promise.resolve();
+    const handleOnChange = jest.fn(() => promise);
+    const query = {
+      ...defaultQuery,
+      targets: [
+        {
+          query: 'a/b',
+          refId: '1',
+        },
+      ],
+      refId: '121314',
+    };
+    const ds = {
+      async metadataRequest(url: string, params?: Record<string, any>): Promise<any> {
+        if (url === '/api/services') {
+          return Promise.resolve(['jaeger-query', 'service2', 'service3']);
+        }
+      },
+    } as JaegerDatasource;
+    setupFetchMock({ data: [testResponse] });
+
+    render(<SearchForm datasource={ds} query={query} onChange={handleOnChange} />);
+
+    const asyncServiceSelect = await waitFor(() => screen.getByRole('combobox', { name: 'select-service-name' }));
+    expect(asyncServiceSelect).toBeInTheDocument();
+
+    userEvent.click(asyncServiceSelect);
+
+    const jaegerService = await screen.findByText('jaeger-query');
+    expect(jaegerService).toBeInTheDocument();
+  });
+
+  it('should be able to select operation name if query.service exists', async () => {
+    const promise = Promise.resolve();
+    const handleOnChange = jest.fn(() => promise);
+    const query2 = {
+      ...defaultQuery,
+      targets: [
+        {
+          query: 'a/b',
+          refId: '1',
+        },
+      ],
+      refId: '121314',
+      service: 'jaeger-query',
+    };
+    setupFetchMock({ data: [testResponse] });
+
+    render(<SearchForm datasource={{} as JaegerDatasource} query={query2} onChange={handleOnChange} />);
+
+    const asyncOperationSelect2 = await waitFor(() => screen.getByRole('combobox', { name: 'select-operation-name' }));
+    expect(asyncOperationSelect2).toBeInTheDocument();
+  });
+});
+
+describe('If JaegerQuery has a delay fetching options', () => {
+  it('should show loader', async () => {
+    const promise = Promise.resolve();
+    const handleOnChange = jest.fn(() => {
+      setTimeout(() => {
+        return promise;
+      }, 3000);
+    });
+    const query = {
+      ...defaultQuery,
+      targets: [
+        {
+          query: 'a/b',
+          refId: '1',
+        },
+      ],
+      refId: '121314',
+      service: 'jaeger-query',
+    };
+    const ds = new JaegerDatasource(defaultSettings);
+    setupFetchMock({ data: [testResponse] });
+
+    render(<SearchForm datasource={ds} query={query} onChange={handleOnChange} />);
+
+    const asyncServiceSelect = screen.getByRole('combobox', { name: 'select-service-name' });
+    userEvent.click(asyncServiceSelect);
+    const loader = screen.getByText('Loading options...');
+
+    expect(loader).toBeInTheDocument();
+    await act(() => promise);
+  });
+});
+
+function setupFetchMock(response: any, mock?: any) {
+  const defaultMock = () => mock ?? of(createFetchResponse(response));
+
+  const fetchMock = jest.spyOn(backendSrv, 'fetch');
+  fetchMock.mockImplementation(defaultMock);
+  return fetchMock;
+}
+
+const defaultSettings: DataSourceInstanceSettings<JaegerJsonData> = {
+  id: 0,
+  uid: '0',
+  type: 'tracing',
+  name: 'jaeger',
+  url: 'http://grafana.com',
+  access: 'proxy',
+  meta: {
+    id: 'jaeger',
+    name: 'jaeger',
+    type: PluginType.datasource,
+    info: {} as any,
+    module: '',
+    baseUrl: '',
+  },
+  jsonData: {
+    nodeGraph: {
+      enabled: true,
+    },
+  },
+};
+
+const defaultQuery: DataQueryRequest<JaegerQuery> = {
+  requestId: '1',
+  dashboardId: 0,
+  interval: '0',
+  intervalMs: 10,
+  panelId: 0,
+  scopedVars: {},
+  range: {
+    from: dateTime().subtract(1, 'h'),
+    to: dateTime(),
+    raw: { from: '1h', to: 'now' },
+  },
+  timezone: 'browser',
+  app: 'explore',
+  startTime: 0,
+  targets: [
+    {
+      query: '12345',
+      refId: '1',
+    },
+  ],
+};

--- a/public/app/plugins/datasource/jaeger/components/SearchForm.test.tsx
+++ b/public/app/plugins/datasource/jaeger/components/SearchForm.test.tsx
@@ -67,8 +67,8 @@ describe('SearchForm', () => {
   });
 });
 
-describe('If JaegerQuery has a delay fetching options', () => {
-  it('should show loader', async () => {
+describe('SearchForm', () => {
+  it('should show loader if there is a delay fetching options', async () => {
     const promise = Promise.resolve();
     const handleOnChange = jest.fn(() => {
       setTimeout(() => {

--- a/public/app/plugins/datasource/jaeger/components/SearchForm.tsx
+++ b/public/app/plugins/datasource/jaeger/components/SearchForm.tsx
@@ -141,6 +141,7 @@ export function SearchForm({ datasource, query, onChange }: Props) {
           <AsyncSelect
             inputId="operation"
             menuShouldPortal
+            cacheOptions={false}
             loadOptions={() =>
               loadServices(
                 {
@@ -195,3 +196,5 @@ export function SearchForm({ datasource, query, onChange }: Props) {
     </div>
   );
 }
+
+export default SearchForm;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

When using the Tracing Explorer panel and opening the service or operation dropdown, a loading indicator to let users know that something is happening and they should wait.

Why is this needed:
The current implementation can result in users believing that there are not values available for selection, when there is an active query processing to build the values. Users may close the menu before the response has been received and processed to fill in the values.

**Which issue(s) this PR fixes**:

Fixes #[35523](https://github.com/grafana/grafana/issues/35523)

**Special notes for your reviewer**:

