### PR TITLE
Loki: Update syntax highlighting to colorize strings

### DIFF
--- a/public/app/plugins/datasource/loki/syntax.ts
+++ b/public/app/plugins/datasource/loki/syntax.ts
@@ -240,12 +240,12 @@ export const lokiGrammar: Grammar = {
     },
   ],
   quote: {
-    pattern: /".*?"/,
+    pattern: /"(?:\\.|[^\\"])*"/,
     alias: 'string',
     greedy: true,
   },
   backticks: {
-    pattern: /`.*?`/,
+    pattern: /`(?:\\.|[^\\`])*`/,
     alias: 'string',
     greedy: true,
   },

--- a/public/app/plugins/datasource/loki/syntax.ts
+++ b/public/app/plugins/datasource/loki/syntax.ts
@@ -239,9 +239,19 @@ export const lokiGrammar: Grammar = {
       },
     },
   ],
+  quote: {
+    pattern: /".*?"/,
+    alias: 'string',
+    greedy: true,
+  },
+  backticks: {
+    pattern: /`.*?`/,
+    alias: 'string',
+    greedy: true,
+  },
   number: /\b-?\d+((\.\d*)?([eE][+-]?\d+)?)?\b/,
   operator: /\s?(\|[=~]?|!=?|<(?:=>?|<|>)?|>[>=]?)\s?/i,
-  punctuation: /[{}()`,.]/,
+  punctuation: /[{}(),.]/,
 };
 
 export default lokiGrammar;


### PR DESCRIPTION
Just a proposal, not sure what is best here, so feedback is appreciated. 

I noticed that strings (both double quotes, and tick versions), are colored differently. Label filters strings where green but line filter string where not. 

Before: 
![Screenshot from 2022-02-28 11-23-41](https://user-images.githubusercontent.com/10999/155966669-8391e094-d4ac-43cf-a783-886460c329a5.png)
![Screenshot from 2022-02-28 11-25-33](https://user-images.githubusercontent.com/10999/155967167-3d49e024-7af7-4fc1-b41c-d5c446873750.png)


After:
![Screenshot from 2022-02-28 11-23-11](https://user-images.githubusercontent.com/10999/155966684-120013f7-166e-4cdb-995a-04c84af7c88b.png)
![Screenshot from 2022-02-28 11-26-13](https://user-images.githubusercontent.com/10999/155967178-d15b4c8a-c1d2-44c8-8f2f-51278c4f999e.png)


The same is true for double quotes `"asdas"`  (this PR makes both be colored as strings, same as label values) 