### PR TITLE
Chore: Move Typescript cache file to root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ awsconfig
 /.awcache
 /dist
 /public/build
-public/dist/tsconfig.tsbuildinfo
 /public/views/index.html
 /public/views/error.html
 /emails/dist
@@ -17,6 +16,7 @@ public/dist/tsconfig.tsbuildinfo
 vendor/
 /docs/menu.yaml
 /requests
+tsconfig.tsbuildinfo
 
 # Yarn
 .yarn/*

--- a/packages/grafana-data/tsconfig.json
+++ b/packages/grafana-data/tsconfig.json
@@ -5,7 +5,9 @@
     "rootDirs": ["."],
     "paths": {
       "@grafana/data": ["."]
-    }
+    },
+    "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "exclude": ["dist", "node_modules"],
   "extends": "@grafana/tsconfig",

--- a/packages/grafana-e2e-selectors/tsconfig.json
+++ b/packages/grafana-e2e-selectors/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "declarationDir": "dist",
     "outDir": "compiled",
-    "rootDirs": ["."]
+    "rootDirs": ["."],
+    "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "exclude": ["dist", "node_modules"],
   "extends": "@grafana/tsconfig",

--- a/packages/grafana-e2e/tsconfig.json
+++ b/packages/grafana-e2e/tsconfig.json
@@ -3,7 +3,9 @@
     "declarationDir": "dist",
     "outDir": "compiled",
     "rootDirs": ["."],
-    "types": ["cypress"]
+    "types": ["cypress"],
+    "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "exclude": ["dist", "node_modules"],
   "extends": "@grafana/tsconfig",

--- a/packages/grafana-runtime/tsconfig.json
+++ b/packages/grafana-runtime/tsconfig.json
@@ -3,7 +3,9 @@
     "baseUrl": ".",
     "declarationDir": "dist",
     "outDir": "compiled",
-    "rootDirs": ["."]
+    "rootDirs": ["."],
+    "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "exclude": ["dist", "node_modules"],
   "extends": "@grafana/tsconfig",

--- a/packages/grafana-schema/tsconfig.json
+++ b/packages/grafana-schema/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "declarationDir": "dist",
     "outDir": "compiled",
-    "rootDirs": ["."]
+    "rootDirs": ["."],
+    "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "exclude": ["dist", "node_modules"],
   "extends": "@grafana/tsconfig",

--- a/packages/grafana-ui/tsconfig.json
+++ b/packages/grafana-ui/tsconfig.json
@@ -3,7 +3,9 @@
     "baseUrl": "./",
     "declarationDir": "dist",
     "outDir": "compiled",
-    "rootDirs": [".", "stories"]
+    "rootDirs": [".", "stories"],
+    "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "exclude": ["dist", "node_modules"],
   "extends": "@grafana/tsconfig",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "strict": true,
     "resolveJsonModule": true,
     "useUnknownInCatchVariables": false,
-    "incremental": true
+    "incremental": true,
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "extends": "@grafana/tsconfig/base.json",
   "include": [


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR moves the TS cache file to the root of the repo to make it easier for devs to delete it if need be.

It also and adds `incremental` flag to packages to speed up subsequent `yarn typecheck` runs:

### Cold start
```
yarn typecheck     
lerna notice cli v4.0.0
lerna info Executing command in 8 packages: "yarn run typecheck"
lerna info run Ran npm script 'typecheck' in '@grafana/schema' in 2.8s:

lerna info run Ran npm script 'typecheck' in '@grafana/e2e-selectors' in 3.2s:

lerna info run Ran npm script 'typecheck' in '@grafana/e2e' in 4.6s:

lerna info run Ran npm script 'typecheck' in '@grafana/data' in 9.1s:

lerna info run Ran npm script 'typecheck' in '@grafana/ui' in 18.8s:

lerna info run Ran npm script 'typecheck' in '@grafana/toolkit' in 11.7s:

lerna info run Ran npm script 'typecheck' in '@grafana/runtime' in 21.0s:

lerna info run Ran npm script 'typecheck' in '@jaegertracing/jaeger-ui-components' in 21.6s:

lerna success run Ran npm script 'typecheck' in 8 packages in 52.3s:
```

### Populated Cache

```
yarn typecheck
lerna notice cli v4.0.0
lerna info Executing command in 8 packages: "yarn run typecheck"
lerna info run Ran npm script 'typecheck' in '@grafana/schema' in 2.7s:

lerna info run Ran npm script 'typecheck' in '@grafana/e2e-selectors' in 3.2s:

lerna info run Ran npm script 'typecheck' in '@grafana/e2e' in 4.2s:

lerna info run Ran npm script 'typecheck' in '@grafana/data' in 6.1s:

lerna info run Ran npm script 'typecheck' in '@grafana/ui' in 7.2s:

lerna info run Ran npm script 'typecheck' in '@grafana/runtime' in 9.1s:

lerna info run Ran npm script 'typecheck' in '@grafana/toolkit' in 10.2s:

lerna info run Ran npm script 'typecheck' in '@jaegertracing/jaeger-ui-components' in 17.7s:

lerna success run Ran npm script 'typecheck' in 8 packages in 33.7s:
```


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #45965

**Special notes for your reviewer**:

