### PR TITLE
Alerting: Display query from grafana-managed alert rules on `/api/v1/rules`

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -224,7 +224,7 @@ func ruleToQuery(logger log.Logger, rule *ngmodels.AlertRule) string {
 		if err != nil {
 			// If we can't find the query simply omit it, and try the rest.
 			// Even single query alerts would have 2 `AlertQuery`, one for the query and one for the condition.
-			if err == ngmodels.ErrNoQuery {
+			if errors.Is(err, ngmodels.ErrNoQuery) {
 				continue
 			}
 

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -1,13 +1,21 @@
 package api
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
+	"github.com/grafana/grafana/pkg/util"
+	"github.com/grafana/grafana/pkg/web"
 
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,7 +24,7 @@ func TestRouteGetAlertStatuses(t *testing.T) {
 	fakeAlertInstanceManager := NewFakeAlertInstanceManager(t)
 	orgID := int64(1)
 
-	server := PrometheusSrv{
+	api := PrometheusSrv{
 		log:     log.NewNopLogger(),
 		manager: fakeAlertInstanceManager,
 		store:   fakeStore,
@@ -25,7 +33,7 @@ func TestRouteGetAlertStatuses(t *testing.T) {
 	c := &models.ReqContext{SignedInUser: &models.SignedInUser{OrgId: orgID}}
 
 	t.Run("with no alerts", func(t *testing.T) {
-		r := server.RouteGetAlertStatuses(c)
+		r := api.RouteGetAlertStatuses(c)
 		require.Equal(t, http.StatusOK, r.Status())
 		require.JSONEq(t, `
 {
@@ -38,8 +46,8 @@ func TestRouteGetAlertStatuses(t *testing.T) {
 	})
 
 	t.Run("with two alerts", func(t *testing.T) {
-		fakeAlertInstanceManager.GenerateAlertInstances(1, 2)
-		r := server.RouteGetAlertStatuses(c)
+		fakeAlertInstanceManager.GenerateAlertInstances(1, util.GenerateShortUID(), 2)
+		r := api.RouteGetAlertStatuses(c)
 		require.Equal(t, http.StatusOK, r.Status())
 		require.JSONEq(t, `
 {
@@ -78,3 +86,214 @@ func TestRouteGetAlertStatuses(t *testing.T) {
 }`, string(r.Body()))
 	})
 }
+
+func TestRouteGetRuleStatuses(t *testing.T) {
+	timeNow = func() time.Time { return time.Date(2022, 3, 10, 14, 0, 0, 0, time.UTC) }
+	fakeStore := store.NewFakeRuleStore(t)
+	fakeAIM := NewFakeAlertInstanceManager(t)
+	orgID := int64(1)
+	api := PrometheusSrv{
+		log:     log.NewNopLogger(),
+		manager: fakeAIM,
+		store:   fakeStore,
+	}
+
+	req, err := http.NewRequest("GET", "/api/v1/rules", nil)
+	require.NoError(t, err)
+	c := &models.ReqContext{Context: &web.Context{Req: req}, SignedInUser: &models.SignedInUser{OrgId: orgID}}
+
+	t.Run("with no rules", func(t *testing.T) {
+		r := api.RouteGetRuleStatuses(c)
+		require.JSONEq(t, `
+{
+	"status": "success",
+	"data": {
+		"groups": []
+	}
+}
+`, string(r.Body()))
+	})
+
+	t.Run("with some rules", func(t *testing.T) {
+		generateRuleAndInstanceWithQuery(t, orgID, fakeAIM, fakeStore, withSingleQuery())
+
+		r := api.RouteGetRuleStatuses(c)
+		require.Equal(t, http.StatusOK, r.Status())
+		require.JSONEq(t, `
+{
+	"status": "success",
+	"data": {
+		"groups": [{
+			"name": "rule-group",
+			"file": "namespaceUID",
+			"rules": [{
+				"state": "inactive",
+				"name": "AlwaysFiring",
+				"query": "[{\"refId\":\"QueryRefID\",\"queryType\":\"prometheus\",\"relativeTimeRange\":{\"from\":3e-7,\"to\":0},\"datasourceUid\":\"QueryDatasourceUID\",\"model\":[{\"refId\":\"A\",\"queryType\":\"\",\"relativeTimeRange\":{\"from\":300,\"to\":0},\"datasourceUid\":\"P17AB2139481E68BC\",\"model\":{\"expr\":\"go_goroutines\",\"format\":\"time_series\",\"intervalFactor\":1,\"refId\":\"A\"}},{\"refId\":\"B\",\"queryType\":\"\",\"relativeTimeRange\":{\"from\":0,\"to\":0},\"datasourceUid\":\"-100\",\"model\":{\"type\":\"classic_conditions\",\"refId\":\"B\",\"conditions\":[{\"evaluator\":{\"params\":[65],\"type\":\"gt\"},\"operator\":{\"type\":\"and\"},\"query\":{\"params\":[\"A\"]},\"reducer\":{\"type\":\"avg\"}}]}}]}]",
+				"alerts": [{
+					"labels": {
+						"job": "prometheus"
+					},
+					"annotations": {
+						"severity": "critical"
+					},
+					"state": "Normal",
+					"activeAt": "0001-01-01T00:00:00Z",
+					"value": ""
+				}],
+				"labels": null,
+				"health": "ok",
+				"lastError": "",
+				"type": "alerting",
+				"lastEvaluation": "2022-03-10T14:01:00Z",
+				"duration": 180,
+				"evaluationTime": 60
+			}],
+			"interval": 60,
+			"lastEvaluation": "2022-03-10T14:01:00Z",
+			"evaluationTime": 0
+		}]
+	}
+}
+`, string(r.Body()))
+	})
+}
+
+func generateRuleAndInstanceWithQuery(t *testing.T, orgID int64, fakeAIM *fakeAlertInstanceManager, fakeStore *store.FakeRuleStore, query func(r *ngmodels.AlertRule)) {
+	t.Helper()
+
+	rules := ngmodels.GenerateAlertRules(1, ngmodels.AlertRuleGen(withOrgID(orgID), asAFixture(), query))
+
+	fakeAIM.GenerateAlertInstances(orgID, rules[0].UID, 1, func(s *state.State) *state.State {
+		s.Labels = data.Labels{"job": "prometheus"}
+		s.Annotations = data.Labels{"severity": "critical"}
+		return s
+	})
+
+	for _, r := range rules {
+		fakeStore.PutRule(context.Background(), r)
+	}
+}
+
+// asAFixture removes variable values of the alert rule.
+// we're not too interested in variability of the rule in this scenario.
+func asAFixture() func(r *ngmodels.AlertRule) {
+	return func(r *ngmodels.AlertRule) {
+		r.Title = "AlwaysFiring"
+		r.NamespaceUID = "namespaceUID"
+		r.RuleGroup = "rule-group"
+		r.UID = "RuleUID"
+		r.Labels = nil
+		r.Annotations = nil
+		r.IntervalSeconds = 60
+		r.For = 180 * time.Second
+	}
+}
+
+func withSingleQuery() func(r *ngmodels.AlertRule) {
+	return func(r *ngmodels.AlertRule) {
+		queries := []ngmodels.AlertQuery{
+			{
+				DatasourceUID: "QueryDatasourceUID",
+				Model:         json.RawMessage(PrometheusModelQueryFixture),
+				RelativeTimeRange: ngmodels.RelativeTimeRange{
+					From: ngmodels.Duration(300),
+					To:   ngmodels.Duration(0),
+				},
+				RefID:     "QueryRefID",
+				QueryType: "prometheus",
+			},
+		}
+
+		r.Data = queries
+	}
+}
+
+const randomWalkQueryFixture = `
+[{
+	"refId": "A",
+	"queryType": "",
+	"relativeTimeRange": {
+		"from": 300,
+		"to": 0
+	},
+	"datasourceUid": "ehkoACGnz",
+	"model": {
+		"refId": "A",
+		"scenarioId": "slow_query",
+		"stringInput": "5s"
+	}
+}, {
+	"refId": "B",
+	"queryType": "",
+	"relativeTimeRange": {
+		"from": 0,
+		"to": 0
+	},
+	"datasourceUid": "-100",
+	"model": {
+		"type": "classic_conditions",
+		"refId": "B",
+		"conditions": [{
+			"evaluator": {
+				"params": [20],
+				"type": "gt"
+			},
+			"operator": {
+				"type": "and"
+			},
+			"query": {
+				"params": ["A"]
+			},
+			"reducer": {
+				"type": "avg"
+			}
+		}]
+	}
+}]
+`
+
+const PrometheusModelQueryFixture = `
+[{
+	"refId": "A",
+	"queryType": "",
+	"relativeTimeRange": {
+		"from": 300,
+		"to": 0
+	},
+	"datasourceUid": "P17AB2139481E68BC",
+	"model": {
+		"expr": "go_goroutines",
+		"format": "time_series",
+		"intervalFactor": 1,
+		"refId": "A"
+	}
+}, {
+	"refId": "B",
+	"queryType": "",
+	"relativeTimeRange": {
+		"from": 0,
+		"to": 0
+	},
+	"datasourceUid": "-100",
+	"model": {
+		"type": "classic_conditions",
+		"refId": "B",
+		"conditions": [{
+			"evaluator": {
+				"params": [65],
+				"type": "gt"
+			},
+			"operator": {
+				"type": "and"
+			},
+			"query": {
+				"params": ["A"]
+			},
+			"reducer": {
+				"type": "avg"
+			}
+		}]
+	}
+}]
+`

--- a/pkg/services/ngalert/api/api_prometheus_test_fixtures.go
+++ b/pkg/services/ngalert/api/api_prometheus_test_fixtures.go
@@ -1,0 +1,118 @@
+package api
+
+// prometheusQueryModel represents the way we express a prometheus query as part of an alert query.
+// It supports formatting for the refID of the query.
+const prometheusQueryModel = `
+{
+	"exemplar": false,
+	"expr": "vector(1)",
+	"hide": false,
+	"interval": "",
+	"intervalMs": 1000,
+	"legendFormat": "",
+	"maxDataPoints": 43200,
+	"refId": "%s"
+}
+`
+
+// classicConditionsModel represents the way we express a classic condition as part of an alert query.
+// It supports formatting for 1) the refID of the query and 2) the refID of the condition.
+const classicConditionsModel = `
+{
+	"conditions": [{
+		"evaluator": {
+			"params": [0.5],
+			"type": "gt"
+		},
+		"operator": {
+			"type": "and"
+		},
+		"query": {
+			"params": ["%s"]
+		},
+		"reducer": {
+			"params": [],
+			"type": "last"
+		},
+		"type": "query"
+	}],
+	"datasource": {
+		"type": "__expr__",
+		"uid": "-100"
+	},
+	"hide": false,
+	"intervalMs": 1000,
+	"maxDataPoints": 43200,
+	"refId": "%s",
+	"type": "classic_conditions"
+}
+`
+
+// reduceLastExpressionModel represents the way we express reduce to last data point as part of an alert query.
+// It supports formatting for 1) the refID of the query to target and 2) the refID of the condition.
+const reduceLastExpressionModel = `
+{
+	"conditions": [{
+		"evaluator": {
+			"params": [0,0],
+			"type": "gt"
+		},
+		"operator": {
+			"type": "and"
+		},
+		"query": {
+			"params": []
+		},
+		"reducer": {
+			"params": [],
+			"type": "last"
+		},
+		"type": "query"
+	}],
+	"datasource": {
+		"type": "__expr__",
+		"uid": "__expr__"
+	},
+	"expression": "%s",
+	"hide": false,
+	"intervalMs": 1000,
+	"maxDataPoints": 43200,
+	"reducer": "last",
+	"refId": "%s",
+	"type": "reduce"
+}
+`
+
+// reduceLastExpressionModel represents the way we express a math (sum of two refIDs greater than 1) operation of an alert query.
+// It supports formatting for 1) refID of the first operand, 2) refID of the second operand and 3) the refID of the math operation.
+const mathExpressionModel = `
+{
+	"conditions": [{
+		"evaluator": {
+			"params": [0, 0],
+			"type": "gt"
+		},
+		"operator": {
+			"type": "and"
+		},
+		"query": {
+			"params": []
+		},
+		"reducer": {
+			"params": [],
+			"type": "avg"
+		},
+		"type": "query"
+	}],
+	"datasource": {
+		"type": "__expr__",
+		"uid": "__expr__"
+	},
+	"expression": "$%s + $%s \u003e 1",
+	"hide": false,
+	"intervalMs": 1000,
+	"maxDataPoints": 43200,
+	"refId": "%s",
+	"type": "math"
+}
+`

--- a/pkg/services/ngalert/api/testing.go
+++ b/pkg/services/ngalert/api/testing.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
-	"github.com/grafana/grafana/pkg/util"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
@@ -73,13 +72,15 @@ func (f *fakeAlertInstanceManager) GetStatesForRuleUID(orgID int64, alertRuleUID
 	return f.states[orgID][alertRuleUID]
 }
 
-func (f *fakeAlertInstanceManager) GenerateAlertInstances(orgID int64, count int) {
+// forEachState represents the callback used when generating alert instances that allows us to modify the generated result
+type forEachState func(s *state.State) *state.State
+
+func (f *fakeAlertInstanceManager) GenerateAlertInstances(orgID int64, alertRuleUID string, count int, callbacks ...forEachState) {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 
-	evaluationTime := time.Now()
+	evaluationTime := timeNow()
 	evaluationDuration := 1 * time.Minute
-	alertRuleUID := util.GenerateShortUID()
 
 	for i := 0; i < count; i++ {
 		_, ok := f.states[orgID]
@@ -91,8 +92,8 @@ func (f *fakeAlertInstanceManager) GenerateAlertInstances(orgID int64, count int
 			f.states[orgID][alertRuleUID] = []*state.State{}
 		}
 
-		f.states[orgID][alertRuleUID] = append(f.states[orgID][alertRuleUID], &state.State{
-			AlertRuleUID: fmt.Sprintf("alert_rule_%v", i),
+		newState := &state.State{
+			AlertRuleUID: alertRuleUID,
 			OrgID:        1,
 			Labels: data.Labels{
 				"__alert_rule_namespace_uid__": "test_namespace_uid",
@@ -117,6 +118,14 @@ func (f *fakeAlertInstanceManager) GenerateAlertInstances(orgID int64, count int
 			LastEvaluationTime: evaluationTime.Add(1 * time.Minute),
 			EvaluationDuration: evaluationDuration,
 			Annotations:        map[string]string{"annotation": "test"},
-		})
+		}
+
+		if len(callbacks) != 0 {
+			for _, cb := range callbacks {
+				newState = cb(newState)
+			}
+		}
+
+		f.states[orgID][alertRuleUID] = append(f.states[orgID][alertRuleUID], newState)
 	}
 }

--- a/pkg/services/ngalert/models/alert_query.go
+++ b/pkg/services/ngalert/models/alert_query.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -11,6 +12,8 @@ import (
 
 const defaultMaxDataPoints float64 = 43200 // 12 hours at 1sec interval
 const defaultIntervalMS float64 = 1000
+
+var ErrNoQuery = errors.New("no `expr` property in the query model")
 
 // Duration is a type used for marshalling durations.
 type Duration time.Duration
@@ -172,6 +175,28 @@ func (aq *AlertQuery) GetIntervalDuration() (time.Duration, error) {
 // GetDatasource returns the query datasource identifier.
 func (aq *AlertQuery) GetDatasource() (string, error) {
 	return aq.DatasourceUID, nil
+}
+
+// GetQuery returns the query defined by `expr` within the model.
+// Returns an ErrNoQuery if it is unable to find the query.
+// Returns an error if it is not able to cast the query to a string.
+func (aq *AlertQuery) GetQuery() (string, error) {
+	if aq.modelProps == nil {
+		err := aq.setModelProps()
+		if err != nil {
+			return "", err
+		}
+	}
+	query, ok := aq.modelProps["expr"]
+	if !ok {
+		return "", ErrNoQuery
+	}
+
+	q, ok := query.(string)
+	if !ok {
+		return "", fmt.Errorf("failed to cast query to string: %v", aq.modelProps["expr"])
+	}
+	return q, nil
 }
 
 func (aq *AlertQuery) GetModel() ([]byte, error) {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/45882

On `api/v1/rules` which is one of the prometheus-compatible routes, we want to be able to visualize the query.  However, Grafana's multi-query model makes this a bit tricky.

For Prometheus compliance reasons, we must display _just_ the query. In the case of for example - most Prometheus expressions this is very valid as grafana managed alerts would only have 1 query.

My proposal as part of this pull request is that:

- ~~For single query expressions (`len(rule.Data) == 1`) attempt to extract the query and use that.~~ Doesn't work, even single query expressions have two queries.
- For multi query expressions (`len(rule.Data) > 1`) attempt to extract _all_ the queries and concatenate them using `|` for example: `"count(up) | sum by (job) (up) | vector(4)"`
- If the above fails for any reason (e.g. because the query was not stored in `expr` within the model  - because this is datasource dependant) fallback to rendering the whole of `rule.Data` as `JSON` and use that - which is the behaviour before this pull request.

TODO

- [x] check API specs
- [x] tests
- [x] documentation that might need updating