### PR TITLE
Layout: New layout component FlexBox

### DIFF
--- a/packages/grafana-ui/src/components/FlexBox/FlexBox.mdx
+++ b/packages/grafana-ui/src/components/FlexBox/FlexBox.mdx
@@ -1,0 +1,19 @@
+import { Props } from '@storybook/addon-docs/blocks';
+import { FlexBox } from './FlexBox';
+
+# FlexBox
+
+Simple util component for flex box layouts.
+
+### Usage
+
+```jsx
+<FlexBox gap={4} direction="column">
+  <div>hello</div>
+  <div>hello2</div>
+</FlexBox>
+```
+
+### Props
+
+<Props of={FlexBox} />

--- a/packages/grafana-ui/src/components/FlexBox/FlexBox.story.tsx
+++ b/packages/grafana-ui/src/components/FlexBox/FlexBox.story.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { FlexBox } from './FlexBox';
+import { withCenteredStory } from '@grafana/ui/src/utils/storybook/withCenteredStory';
+import mdx from './FlexBox.mdx';
+import { useTheme2 } from '../../themes/ThemeContext';
+
+export default {
+  title: 'Layout/FlexBox',
+  component: FlexBox,
+  decorators: [withCenteredStory],
+  parameters: {
+    docs: {
+      page: mdx,
+    },
+  },
+};
+
+export const Examples = () => {
+  const theme = useTheme2();
+
+  function RedBox({ children, minHeight = 50 }: any) {
+    return <div style={{ background: theme.colors.error.main, minWidth: 50, minHeight }}>{children}</div>;
+  }
+
+  return (
+    <FlexBox direction="column">
+      <span>Defaults</span>
+      <FlexBox>
+        <RedBox />
+        <RedBox />
+        <RedBox />
+      </FlexBox>
+      <span>Direction = column, gap=0.5</span>
+      <FlexBox direction="column" gap={0.5}>
+        <RedBox />
+        <RedBox />
+        <RedBox />
+      </FlexBox>
+      <span>alignItems=center</span>
+      <FlexBox alignItems="center">
+        <RedBox />
+        <RedBox minHeight={10} />
+        <RedBox minHeight={20} />
+      </FlexBox>
+      <span>justifyContent=flex-end</span>
+      <FlexBox justifyContent="flex-end">
+        <RedBox />
+      </FlexBox>
+    </FlexBox>
+  );
+};

--- a/packages/grafana-ui/src/components/FlexBox/FlexBox.tsx
+++ b/packages/grafana-ui/src/components/FlexBox/FlexBox.tsx
@@ -1,0 +1,40 @@
+import React, { CSSProperties, HTMLAttributes } from 'react';
+import { css, cx } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { useTheme2 } from '../../themes/ThemeContext';
+import { stylesFactory } from '../../themes/stylesFactory';
+
+export interface Props extends HTMLAttributes<HTMLDivElement> {
+  direction?: CSSProperties['flexDirection'];
+  alignItems?: CSSProperties['alignItems'];
+  justifyContent?: CSSProperties['justifyContent'];
+  wrap?: boolean;
+  padding?: number;
+  gap?: number;
+}
+
+export const FlexBox = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
+  const { alignItems, direction, justifyContent, wrap, gap, className, padding, children, ...otherProps } = props;
+  const theme = useTheme2();
+  const styles = useStyles(theme, props);
+
+  return (
+    <div ref={ref} className={cx(styles.root, className)} {...otherProps}>
+      {children}
+    </div>
+  );
+});
+
+FlexBox.displayName = 'FlexBox';
+
+const useStyles = stylesFactory((theme: GrafanaTheme2, props: Props) => ({
+  root: css({
+    display: 'flex',
+    flexDirection: props.direction ?? 'row',
+    flexWrap: props.wrap ?? true ? 'wrap' : undefined,
+    alignItems: props.alignItems,
+    justifyContent: props.justifyContent,
+    padding: props.padding ? theme.spacing(props.padding) : undefined,
+    gap: theme.spacing(props.gap ?? 2),
+  }),
+}));

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -205,6 +205,7 @@ export { getSelectStyles } from './Select/getSelectStyles';
 export * from './Select/types';
 
 export { HorizontalGroup, VerticalGroup, Container } from './Layout/Layout';
+export { FlexBox } from './FlexBox/FlexBox';
 export { Badge, BadgeColor, BadgeProps } from './Badge/Badge';
 export { RadioButtonGroup } from './Forms/RadioButtonGroup/RadioButtonGroup';
 

--- a/public/app/features/dashboard/components/PanelEditor/PanelNotSupported.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelNotSupported.tsx
@@ -1,7 +1,5 @@
 import React, { useCallback } from 'react';
-import { Button, VerticalGroup } from '@grafana/ui';
-
-import { Layout } from '@grafana/ui/src/components/Layout/Layout';
+import { Alert, Button, FlexBox } from '@grafana/ui';
 import { PanelEditorTabId } from './types';
 import { locationService } from '@grafana/runtime';
 
@@ -15,15 +13,13 @@ export function PanelNotSupported({ message }: Props): JSX.Element {
   }, []);
 
   return (
-    <Layout justify="center" style={{ marginTop: '100px' }}>
-      <VerticalGroup spacing="md">
-        <h2>{message}</h2>
-        <div>
-          <Button size="md" variant="secondary" icon="arrow-left" onClick={onBackToQueries}>
-            Go back to Queries
-          </Button>
-        </div>
-      </VerticalGroup>
-    </Layout>
+    <FlexBox justifyContent="center" padding={2}>
+      <Alert title={message}>
+        <br />
+        <Button size="md" variant="secondary" fill="outline" onClick={onBackToQueries}>
+          Go back to Query tab
+        </Button>
+      </Alert>
+    </FlexBox>
   );
 }


### PR DESCRIPTION
Exploring a component that should replace Layout, HorizontalLayout and VerticalLayout. The main issue I have found with those components is that it does a foreach on child and injects it's own children so you do not have control over the direct flexbox child, this has many times caused issues for me so I have stopped using these components in almost all cases. The reason for this child as far as I can see it to control spacing between children. 

When working on the new Query builders someone created a new generic layout component Stack , https://github.com/grafana/grafana-experimental/blob/main/src/query-builder/Stack.tsx  that used the gap css property instead to control child spacing. This new component is a lot more generically useful and predictable / more control, as it does not inject new divs into the dom tree the behavior of children and flex grow handling etc is easy. 

This is a draft as I am not sure about 
* Name for component?
* Should we instead just change the internals of Layout so it uses gap instead? 
* Should this also try to handle all the properties of Container? 

A few properties I am not 100% sure it should have
* width & height? 

