### PR TITLE
Postgres: Fix aggregate dropdown when TimescaleDB is enabled 

### DIFF
--- a/public/app/plugins/datasource/postgres/query_ctrl.ts
+++ b/public/app/plugins/datasource/postgres/query_ctrl.ts
@@ -127,7 +127,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
     });
     const aggIndex = this.findAggregateIndex(this.selectParts[0]);
 
-    // add/remove TimescaleDB aggregate functions as needed
+    // add or remove TimescaleDB aggregate functions as needed
     if (aggIndex !== -1) {
       this.selectParts[0][aggIndex].def.params[0].options = this.timescaleAggCheck(aggIndex);
     }

--- a/public/app/plugins/datasource/postgres/query_ctrl.ts
+++ b/public/app/plugins/datasource/postgres/query_ctrl.ts
@@ -111,13 +111,19 @@ export class PostgresQueryCtrl extends QueryCtrl {
     this.panelCtrl.refresh();
   }
 
-  timescaleAggCheck(aggIndex: number) {
-    const baseOpts = this.selectParts[0][aggIndex].def.params[0].baseOptions;
-    const timescaleOpts = baseOpts.concat(this.selectParts[0][aggIndex].def.params[0].timescaleOptions);
-    if (this.datasource.jsonData.timescaledb === true) {
-      return timescaleOpts;
-    } else {
-      return baseOpts;
+  timescaleAggCheck() {
+    const aggIndex = this.findAggregateIndex(this.selectParts[0]);
+
+    // add or remove TimescaleDB aggregate functions as needed
+    if (aggIndex !== -1) {
+      const baseOpts = this.selectParts[0][aggIndex].def.params[0].baseOptions;
+      const timescaleOpts = baseOpts.concat(this.selectParts[0][aggIndex].def.params[0].timescaleOptions);
+
+      if (this.datasource.jsonData.timescaledb === true) {
+        this.selectParts[0][aggIndex].def.params[0].options = timescaleOpts;
+      } else {
+        this.selectParts[0][aggIndex].def.params[0].options = baseOpts;
+      }
     }
   }
 
@@ -125,12 +131,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
     this.selectParts = map(this.target.select, (parts: any) => {
       return map(parts, sqlPart.create).filter((n) => n);
     });
-    const aggIndex = this.findAggregateIndex(this.selectParts[0]);
-
-    // add or remove TimescaleDB aggregate functions as needed
-    if (aggIndex !== -1) {
-      this.selectParts[0][aggIndex].def.params[0].options = this.timescaleAggCheck(aggIndex);
-    }
+    this.timescaleAggCheck();
 
     this.whereParts = map(this.target.where, sqlPart.create).filter((n) => n);
     this.groupParts = map(this.target.group, sqlPart.create).filter((n) => n);
@@ -142,6 +143,7 @@ export class PostgresQueryCtrl extends QueryCtrl {
         return { type: part.def.type, datatype: part.datatype, params: part.params };
       });
     });
+    this.timescaleAggCheck();
     this.target.where = map(this.whereParts, (part: any) => {
       return { type: part.def.type, datatype: part.datatype, name: part.name, params: part.params };
     });

--- a/public/app/plugins/datasource/postgres/query_ctrl.ts
+++ b/public/app/plugins/datasource/postgres/query_ctrl.ts
@@ -111,10 +111,26 @@ export class PostgresQueryCtrl extends QueryCtrl {
     this.panelCtrl.refresh();
   }
 
+  timescaleAggCheck() {
+    const baseOpts = this.selectParts[0][1].def.params[0].baseOptions;
+    const timescaleOpts = baseOpts.concat(this.selectParts[0][1].def.params[0].timescaleOptions);
+    if (this.datasource.jsonData.timescaledb === true) {
+      return timescaleOpts;
+    } else {
+      return baseOpts;
+    }
+  }
+
   updateProjection() {
     this.selectParts = map(this.target.select, (parts: any) => {
       return map(parts, sqlPart.create).filter((n) => n);
     });
+
+    // add/remove TimescaleDB aggregate functions as needed
+    if (this.selectParts[0][1].def.type === 'aggregate') {
+      this.selectParts[0][1].def.params[0].options = this.timescaleAggCheck();
+    }
+
     this.whereParts = map(this.target.where, sqlPart.create).filter((n) => n);
     this.groupParts = map(this.target.group, sqlPart.create).filter((n) => n);
   }

--- a/public/app/plugins/datasource/postgres/query_ctrl.ts
+++ b/public/app/plugins/datasource/postgres/query_ctrl.ts
@@ -132,7 +132,6 @@ export class PostgresQueryCtrl extends QueryCtrl {
       return map(parts, sqlPart.create).filter((n) => n);
     });
     this.timescaleAggCheck();
-
     this.whereParts = map(this.target.where, sqlPart.create).filter((n) => n);
     this.groupParts = map(this.target.group, sqlPart.create).filter((n) => n);
   }

--- a/public/app/plugins/datasource/postgres/query_ctrl.ts
+++ b/public/app/plugins/datasource/postgres/query_ctrl.ts
@@ -111,9 +111,9 @@ export class PostgresQueryCtrl extends QueryCtrl {
     this.panelCtrl.refresh();
   }
 
-  timescaleAggCheck() {
-    const baseOpts = this.selectParts[0][1].def.params[0].baseOptions;
-    const timescaleOpts = baseOpts.concat(this.selectParts[0][1].def.params[0].timescaleOptions);
+  timescaleAggCheck(aggIndex: number) {
+    const baseOpts = this.selectParts[0][aggIndex].def.params[0].baseOptions;
+    const timescaleOpts = baseOpts.concat(this.selectParts[0][aggIndex].def.params[0].timescaleOptions);
     if (this.datasource.jsonData.timescaledb === true) {
       return timescaleOpts;
     } else {
@@ -125,10 +125,11 @@ export class PostgresQueryCtrl extends QueryCtrl {
     this.selectParts = map(this.target.select, (parts: any) => {
       return map(parts, sqlPart.create).filter((n) => n);
     });
+    const aggIndex = this.findAggregateIndex(this.selectParts[0]);
 
     // add/remove TimescaleDB aggregate functions as needed
-    if (this.selectParts[0][1].def.type === 'aggregate') {
-      this.selectParts[0][1].def.params[0].options = this.timescaleAggCheck();
+    if (aggIndex !== -1) {
+      this.selectParts[0][aggIndex].def.params[0].options = this.timescaleAggCheck(aggIndex);
     }
 
     this.whereParts = map(this.target.where, sqlPart.create).filter((n) => n);

--- a/public/app/plugins/datasource/postgres/sql_part.ts
+++ b/public/app/plugins/datasource/postgres/sql_part.ts
@@ -50,6 +50,8 @@ register({
       name: 'name',
       type: 'string',
       options: ['avg', 'count', 'min', 'max', 'sum', 'stddev', 'variance'],
+      baseOptions: ['avg', 'count', 'min', 'max', 'sum', 'stddev', 'variance'],
+      timescaleOptions: ['first', 'last'],
     },
   ],
   defaultParams: ['avg'],

--- a/public/app/plugins/datasource/postgres/sql_part.ts
+++ b/public/app/plugins/datasource/postgres/sql_part.ts
@@ -49,7 +49,7 @@ register({
     {
       name: 'name',
       type: 'string',
-      options: ['avg', 'count', 'min', 'max', 'sum', 'stddev', 'variance'],
+      options: [],
       baseOptions: ['avg', 'count', 'min', 'max', 'sum', 'stddev', 'variance'],
       timescaleOptions: ['first', 'last'],
     },


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an edge case with the Postgres query builder: 

There are two aggregate functions that are specific to TimescalDB, and they should be visible when the `timescaledb` toggle option is chosen in the configeditor. While there is some logic to add them to the primary select menu, this in turn creates a sqlPart, which has its own dropdown list. That list is hardcoded to show the base options, and there is no mechanism to add the extra functions as needed:


https://user-images.githubusercontent.com/37156449/156063324-b83eae90-00fc-479d-9fa1-d6148e049a4e.mp4



Here is the new behavior:


https://user-images.githubusercontent.com/37156449/156063434-00e50230-4fff-42f1-8309-362f863c2f16.mp4



This PR adds a function to check the datasource's timescaledb status and then update this secondary list accordingly.

It also refactors the `aggregate` object to reflect these extra options

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #24906

**Special notes for your reviewer**:

still trying to get in the habit of a TDD workflow. If a test is desired, maybe someone could pair with me?