### PR TITLE
Alerting: Fix use of > instead of >= when checking the For duration

### DIFF
--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -552,7 +552,7 @@ func TestProcessEvalResults(t *testing.T) {
 					},
 				},
 			},
-			expectedAnnotations: 2,
+			expectedAnnotations: 3,
 			expectedStates: map[string]*state.State{
 				`[["__alert_rule_namespace_uid__","test_namespace_uid"],["__alert_rule_uid__","test_alert_rule_uid_2"],["alertname","test_title"],["instance_label","test"],["label","test"]]`: {
 					AlertRuleUID: "test_alert_rule_uid_2",
@@ -578,7 +578,7 @@ func TestProcessEvalResults(t *testing.T) {
 							Values:          make(map[string]*float64),
 						},
 					},
-					StartsAt:           evaluationTime,
+					StartsAt:           evaluationTime.Add(20 * time.Second),
 					EndsAt:             evaluationTime.Add(30 * time.Second).Add(state.ResendDelay * 3),
 					LastEvaluationTime: evaluationTime.Add(30 * time.Second),
 					EvaluationDuration: evaluationDuration,

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -64,7 +64,7 @@ func (a *State) resultAlerting(alertRule *ngModels.AlertRule, result eval.Result
 	case eval.Alerting:
 		a.setEndsAt(alertRule, result)
 	case eval.Pending:
-		if result.EvaluatedAt.Sub(a.StartsAt) > alertRule.For {
+		if result.EvaluatedAt.Sub(a.StartsAt) >= alertRule.For {
 			a.State = eval.Alerting
 			a.StartsAt = result.EvaluatedAt
 			a.setEndsAt(alertRule, result)


### PR DESCRIPTION
**What this PR does / why we need it**:

Grafana uses `>` instead of `>=` when checking the `For` duration of an alert rule. This means that, for example, an alert rule that is configured to evaluate once per minute for two minutes will not move from **pending** to **firing** until the third evaluation (3 minutes after the first evaluation). However, changing the condition from `>` to `>=` fixes this issue such that the alert rule moves from **pending** to **firing** after just two evaluations (2 minutes after the first evaluation as expected).

**Which issue(s) this PR fixes**:

Fixes #46010

**Special notes for your reviewer**:

