### PR TITLE
Access control: Delete user permissions when a user is deleted

### DIFF
--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -2,6 +2,7 @@ package accesscontrol
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/models"
@@ -179,4 +180,16 @@ func GetResourcesMetadata(ctx context.Context, permissions map[string][]string, 
 	}
 
 	return result
+}
+
+func ManagedUserRoleName(userID int64) string {
+	return fmt.Sprintf("managed:users:%d:permissions", userID)
+}
+
+func ManagedTeamRoleName(teamID int64) string {
+	return fmt.Sprintf("managed:teams:%d:permissions", teamID)
+}
+
+func ManagedBuiltInRoleName(builtInRole string) string {
+	return fmt.Sprintf("managed:builtins:%s:permissions", strings.ToLower(builtInRole))
 }

--- a/pkg/services/accesscontrol/database/resource_permissions.go
+++ b/pkg/services/accesscontrol/database/resource_permissions.go
@@ -56,7 +56,7 @@ func (s *AccessControlStore) setUserResourcePermission(
 	cmd types.SetResourcePermissionCommand,
 	hook types.UserResourceHookFunc,
 ) (*accesscontrol.ResourcePermission, error) {
-	permission, err := s.setResourcePermission(sess, orgID, managedUserRoleName(user.ID), s.userAdder(sess, orgID, user.ID), cmd)
+	permission, err := s.setResourcePermission(sess, orgID, accesscontrol.ManagedUserRoleName(user.ID), s.userAdder(sess, orgID, user.ID), cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (s *AccessControlStore) setTeamResourcePermission(
 	cmd types.SetResourcePermissionCommand,
 	hook types.TeamResourceHookFunc,
 ) (*accesscontrol.ResourcePermission, error) {
-	permission, err := s.setResourcePermission(sess, orgID, managedTeamRoleName(teamID), s.teamAdder(sess, orgID, teamID), cmd)
+	permission, err := s.setResourcePermission(sess, orgID, accesscontrol.ManagedTeamRoleName(teamID), s.teamAdder(sess, orgID, teamID), cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (s *AccessControlStore) setBuiltInResourcePermission(
 	cmd types.SetResourcePermissionCommand,
 	hook types.BuiltinResourceHookFunc,
 ) (*accesscontrol.ResourcePermission, error) {
-	permission, err := s.setResourcePermission(sess, orgID, managedBuiltInRoleName(builtInRole), s.builtInRoleAdder(sess, orgID, builtInRole), cmd)
+	permission, err := s.setResourcePermission(sess, orgID, accesscontrol.ManagedBuiltInRoleName(builtInRole), s.builtInRoleAdder(sess, orgID, builtInRole), cmd)
 	if err != nil {
 		return nil, err
 	}
@@ -627,16 +627,4 @@ func managedPermission(action, resource string, resourceID string) accesscontrol
 		Action: action,
 		Scope:  accesscontrol.GetResourceScope(resource, resourceID),
 	}
-}
-
-func managedUserRoleName(userID int64) string {
-	return fmt.Sprintf("managed:users:%d:permissions", userID)
-}
-
-func managedTeamRoleName(teamID int64) string {
-	return fmt.Sprintf("managed:teams:%d:permissions", teamID)
-}
-
-func managedBuiltInRoleName(builtInRole string) string {
-	return fmt.Sprintf("managed:builtins:%s:permissions", strings.ToLower(builtInRole))
 }

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/events"
 	"github.com/grafana/grafana/pkg/models"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -791,6 +792,47 @@ func deleteUserInTransaction(sess *DBSession, cmd *models.DeleteUserCommand) err
 			return err
 		}
 	}
+
+	return deleteUserAccessControl(sess, cmd.UserId)
+}
+
+func deleteUserAccessControl(sess *DBSession, userID int64) error {
+	// Delete user role assignments
+	if _, err := sess.Exec("DELETE FROM user_role WHERE user_id = ?", userID); err != nil {
+		return err
+	}
+
+	// Delete permissions that are scoped to user
+	if _, err := sess.Exec("DELETE FROM permission WHERE scope = ?", ac.Scope("users", "id", strconv.FormatInt(userID, 10))); err != nil {
+		return err
+	}
+
+	var roleIDs []int64
+	if err := sess.SQL("SELECT id FROM role WHERE name = ?", ac.ManagedUserRoleName(userID)).Find(&roleIDs); err != nil {
+		return err
+	}
+
+	if len(roleIDs) == 0 {
+		return nil
+	}
+
+	query := "DELETE FROM permission WHERE role_id IN(? " + strings.Repeat(",?", len(roleIDs)-1) + ")"
+	args := make([]interface{}, 0, len(roleIDs)+1)
+	args = append(args, query)
+	for _, id := range roleIDs {
+		args = append(args, id)
+	}
+
+	// Delete managed user permissions
+	if _, err := sess.Exec(args...); err != nil {
+		return err
+	}
+
+	// Delete managed user roles
+	if _, err := sess.Exec("DELETE FROM role WHERE name = ?", ac.ManagedUserRoleName(userID)); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When a user is deleted everything related to that user in access control should be deleted as well.
This includes:
* User role assignments
* Managed roles for user and all permissions for those roles
* Permissions scoped to user

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana-enterprise/issues/2824

**Special notes for your reviewer**:

