### PR TITLE
Dashboard Extractor: Don't fail when using default OSS implementation

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -9,11 +9,12 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/grafana/grafana/pkg/services/datasources/permissions"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/api/datasource"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
-	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins/adapters"
@@ -577,7 +578,7 @@ func (hs *HTTPServer) filterDatasourcesByQueryPermission(ctx context.Context, us
 	query.Result = datasources
 
 	if err := hs.DatasourcePermissionsService.FilterDatasourcesBasedOnQueryPermissions(ctx, &query); err != nil {
-		if !errors.Is(err, bus.ErrHandlerNotFound) {
+		if !errors.Is(err, permissions.ErrNotImplemented) {
 			return nil, err
 		}
 		return datasources, nil

--- a/pkg/services/alerting/extractor.go
+++ b/pkg/services/alerting/extractor.go
@@ -212,9 +212,10 @@ func (e *DashAlertExtractorService) getAlertFromPanels(ctx context.Context, json
 			}
 
 			if err := e.datasourcePermissionsService.FilterDatasourcesBasedOnQueryPermissions(ctx, &dsFilterQuery); err != nil {
-				return nil, err
-			}
-			if len(dsFilterQuery.Result) == 0 {
+				if !errors.Is(err, permissions.ErrNotImplemented) {
+					return nil, err
+				}
+			} else if len(dsFilterQuery.Result) == 0 {
 				return nil, models.ErrDataSourceAccessDenied
 			}
 

--- a/pkg/services/datasources/permissions/datasource_permissions.go
+++ b/pkg/services/datasources/permissions/datasource_permissions.go
@@ -2,9 +2,12 @@ package permissions
 
 import (
 	"context"
+	"errors"
 
 	"github.com/grafana/grafana/pkg/models"
 )
+
+var ErrNotImplemented = errors.New("not implemented")
 
 type DatasourcePermissionsService interface {
 	FilterDatasourcesBasedOnQueryPermissions(ctx context.Context, cmd *models.DatasourcesPermissionFilterQuery) error
@@ -12,7 +15,7 @@ type DatasourcePermissionsService interface {
 
 // dummy method
 func (hs *OSSDatasourcePermissionsService) FilterDatasourcesBasedOnQueryPermissions(ctx context.Context, cmd *models.DatasourcesPermissionFilterQuery) error {
-	return nil
+	return ErrNotImplemented
 }
 
 type OSSDatasourcePermissionsService struct{}

--- a/pkg/services/datasources/permissions/datasource_permissions_mocks.go
+++ b/pkg/services/datasources/permissions/datasource_permissions_mocks.go
@@ -7,12 +7,13 @@ import (
 )
 
 type mockDatasourcePermissionService struct {
-	DsResult []*models.DataSource
+	DsResult  []*models.DataSource
+	ErrResult error
 }
 
 func (m *mockDatasourcePermissionService) FilterDatasourcesBasedOnQueryPermissions(ctx context.Context, cmd *models.DatasourcesPermissionFilterQuery) error {
 	cmd.Result = m.DsResult
-	return nil
+	return m.ErrResult
 }
 
 func NewMockDatasourcePermissionService() *mockDatasourcePermissionService {


### PR DESCRIPTION
I refactored this service wrong 😞.

When we are using the OSS implementation the number of filtered datasource permission are always 0 and we need to skip this check. 

To fix it, OSS implementation returns a known error to be able to skip this check (as was done before) and continue with the code.