### PR TITLE
Fix: Prevent automatic parsing of string data types to numbers

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -6,11 +6,11 @@ import { MappingType, ValueMapping } from '../types/valueMapping';
 
 import { getDisplayProcessor, getRawDisplayProcessor } from './displayProcessor';
 
-function getDisplayProcessorFromConfig(config: FieldConfig) {
+function getDisplayProcessorFromConfig(config: FieldConfig, fieldType: FieldType = FieldType.number) {
   return getDisplayProcessor({
     field: {
       config,
-      type: FieldType.number,
+      type: fieldType,
     },
     theme: createTheme(),
   });
@@ -456,31 +456,31 @@ describe('Date display options', () => {
   });
 
   describe('number formatting for string values', () => {
-    it('should preserve string unchanged if unit is strings', () => {
-      const processor = getDisplayProcessor({
-        field: {
-          type: FieldType.string,
-          config: { unit: 'string' },
-        },
-        theme: createTheme(),
-      });
+    it('should preserve string unchanged if unit is string', () => {
+      const processor = getDisplayProcessorFromConfig({ unit: 'string' }, FieldType.string);
       expect(processor('22.1122334455').text).toEqual('22.1122334455');
     });
 
-    it('should format string as number if no unit', () => {
-      const processor = getDisplayProcessor({
-        field: {
-          type: FieldType.string,
-          config: { decimals: 2 },
-        },
-        theme: createTheme(),
-      });
-      expect(processor('22.1122334455').text).toEqual('22.11');
+    it('should preserve string unchanged if no unit is specified', () => {
+      const processor = getDisplayProcessorFromConfig({}, FieldType.string);
+      expect(processor('22.1122334455').text).toEqual('22.1122334455');
 
       // Support empty/missing strings
       expect(processor(undefined).text).toEqual('');
       expect(processor(null).text).toEqual('');
       expect(processor('').text).toEqual('');
+    });
+
+    it('should format string as number if unit is `none`', () => {
+      const processor = getDisplayProcessorFromConfig({ unit: 'none' }, FieldType.string);
+      expect(processor('0x10').text).toEqual('16');
+    });
+
+    it('should not parse a 64 bit number when the data type is string', () => {
+      const value = '2882377905688543293';
+      const instance = getDisplayProcessorFromConfig({}, FieldType.string);
+      const disp = instance(value);
+      expect(disp.text).toEqual(value);
     });
   });
 });

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -68,6 +68,8 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
     if (!isBooleanUnit(unit)) {
       unit = 'bool';
     }
+  } else if (!unit && field.type === FieldType.string) {
+    unit = 'string';
   }
 
   const formatFunc = getValueFormat(unit || 'none');

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -38,7 +38,7 @@ export const getCategories = (): ValueFormatCategory[] => [
   {
     name: 'Misc',
     formats: [
-      { name: 'none', id: 'none', fn: toFixedUnit('') },
+      { name: 'Automatic', id: 'none', fn: toFixedUnit('') },
       { name: 'String', id: 'string', fn: stringFormater },
       {
         name: 'short',

--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -38,7 +38,7 @@ export const getCategories = (): ValueFormatCategory[] => [
   {
     name: 'Misc',
     formats: [
-      { name: 'Automatic', id: 'none', fn: toFixedUnit('') },
+      { name: 'Number', id: 'none', fn: toFixedUnit('') },
       { name: 'String', id: 'string', fn: stringFormater },
       {
         name: 'short',


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes the displayProcessor to prevent parsing `FieldType.string` fields as numbers, to fix a bunch of cases where that's not desired (leading zeroes being dropped, [very big numbers being truncated](https://github.com/grafana/grafana/issues/36149), etc) by setting the `unit` to `string` if a `FieldType.string` field doesn't have an explicitly set `unit`.

You can opt into the previous automatic parsing behaviour by setting the unit to `none` (which I have renamed to "Automatic")

**Which issue(s) this PR fixes**:

Fixes #36149

**Special notes for your reviewer**:

 - Should we migrating existing panels with no selected unit to the Automatic/none unit?
 - Do we want to change what the Automatic/none unit does?
 - Is this actually a breaking change? Would migrating existing panels change whether its breaking or not?
 
# Release notice breaking change

Panels will no longer automatically try to parse fields with data type `string` to numbers to prevent issues where values that _looked_ like numbers could be changed inadvertently (for example, leading zeroes getting dropped). Any panels that relied on this old behaviour should update to explicitly add an appropriate unit, or use the "Misc / none" unit.