### PR TITLE
Docs: Fix typo in Forward OAuth identity for the logged-in user section

### DIFF
--- a/docs/sources/developers/plugins/add-authentication-for-data-source-plugins.md
+++ b/docs/sources/developers/plugins/add-authentication-for-data-source-plugins.md
@@ -291,16 +291,15 @@ When configured, Grafana will pass the user's token to the plugin in an Authoriz
 
 ```go
 func (ds *dataSource) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
-    for _, q := range req.Queries {
-        token := strings.Fields(q.Headers.Get("Authorization"))
+  token := strings.Fields(req.Headers["Authorization"])
+	var (
+		tokenType   = token[0]
+		accessToken = token[1]
+	)
 
-        var (
-          tokenType = token[0]
-          accessToken = token[1]
-        )
-
-        // ...
-    }
+	for _, q := range req.Queries {
+		// ...
+	}
 }
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes typo in the Go code example at https://grafana.com/docs/grafana/latest/developers/plugins/add-authentication-for-data-source-plugins/#forward-oauth-identity-for-the-logged-in-user.

**Which issue(s) this PR fixes**:
Fixes #45938 

**Special notes for your reviewer**:

