### PR TITLE
NodeGraph: Include frames with name edges or nodes in node graph

### DIFF
--- a/docs/sources/visualizations/node-graph.md
+++ b/docs/sources/visualizations/node-graph.md
@@ -76,7 +76,7 @@ Click on the node and select "Show in Graph layout" option to switch back to gra
 
 This visualization needs a specific shape of the data to be returned from the data source in order to correctly display it.
 
-Data source needs to return two data frames, one for nodes and one for edges, and you also have to set `frame.meta.preferredVisualisationType = 'nodeGraph'` on both data frames if you want them to be automatically shown in node graph in Explore.
+Data source needs to return two data frames, one for nodes and one for edges. You have to set `frame.meta.preferredVisualisationType = 'nodeGraph'` on both data frames or name them `nodes` and `edges` respectively for the node graph to render.
 
 ### Node parameters
 

--- a/public/app/plugins/panel/nodeGraph/utils.ts
+++ b/public/app/plugins/panel/nodeGraph/utils.ts
@@ -323,5 +323,14 @@ export function getNodeGraphDataFrames(frames: DataFrame[]) {
   //  processing pipeline which ends up populating redux state with proper data. As we move towards more dataFrame
   //  oriented API it seems like a better direction to move such processing into to visualisations and do minimal
   //  and lazy processing here. Needs bigger refactor so keeping nodeGraph and Traces as they are for now.
-  return frames.filter((frame) => frame.meta?.preferredVisualisationType === 'nodeGraph');
+  return frames.filter((frame) => {
+    if (frame.meta?.preferredVisualisationType === 'nodeGraph') {
+      return true;
+    }
+    if (frame.name === 'nodes' || frame.name === 'edges') {
+      return true;
+    }
+
+    return false;
+  });
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the getNodeGraphDataFrames logic to support additional datasources. Internal tracing sources like Tempo add the preferred visualization type, but the filter needs to accept other frames, for example when generating node graph data from a postgres query

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #45986

**Special notes for your reviewer**:

