### PR TITLE
Devenv: Add documentation for integration tests

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -136,6 +136,20 @@ Running the backend tests on Windows currently needs some tweaking, so use the b
 go run build.go test
 ```
 
+### Run PostgreSQL and MySQL integration tests
+
+To run PostgreSQL and MySQL integration tests locally, you need start the docker blocks for MySQL and/or PostgreSQL test data sources by running `make devenv sources=mysql_tests,postgres_tests`. When your test data sources are running, you can execute integration tests by running:
+
+```
+GRAFANA_TEST_DB=mysql go test -covermode=atomic -tags=integration ./pkg/...
+```
+
+and/or
+
+```
+GRAFANA_TEST_DB=postgres go test -covermode=atomic -tags=integration ./pkg/...
+```
+
 ### Run end-to-end tests
 
 The end to end tests in Grafana use [Cypress](https://www.cypress.io/) to run automated scripts in a headless Chromium browser. Read more about our [e2e framework](/contribute/style-guides/e2e.md).

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -138,7 +138,7 @@ go run build.go test
 
 ### Run PostgreSQL and MySQL integration tests
 
-To run PostgreSQL and MySQL integration tests locally, you need start the docker blocks for MySQL and/or PostgreSQL test data sources by running `make devenv sources=mysql_tests,postgres_tests`. When your test data sources are running, you can execute integration tests by running:
+To run PostgreSQL and MySQL integration tests locally, you need to start the docker blocks for MySQL and/or PostgreSQL test data sources by running `make devenv sources=mysql_tests,postgres_tests`. When your test data sources are running, you can execute integration tests by running:
 
 ```
 GRAFANA_TEST_DB=mysql go test -covermode=atomic -tags=integration ./pkg/...


### PR DESCRIPTION
How to run integration tests for Postgres and MySQL was missing in documentation. This PR fixes this. 