### PR TITLE
Graph (old): use timeField.config.interval to apply null insertion logic

### DIFF
--- a/public/app/plugins/panel/graph/data_processor.ts
+++ b/public/app/plugins/panel/graph/data_processor.ts
@@ -12,6 +12,7 @@ import {
 } from '@grafana/data';
 import TimeSeries from 'app/core/time_series2';
 import config from 'app/core/config';
+import { applyNullInsertThreshold } from '@grafana/ui/src/components/GraphNG/nullInsertThreshold';
 
 type Options = {
   dataList: DataFrame[];
@@ -30,12 +31,14 @@ export class DataProcessor {
     }
 
     for (let i = 0; i < dataList.length; i++) {
-      const series = dataList[i];
+      let series = dataList[i];
       const { timeField } = getTimeField(series);
 
       if (!timeField) {
         continue;
       }
+
+      series = applyNullInsertThreshold(series, timeField.name);
 
       for (let j = 0; j < series.fields.length; j++) {
         const field = series.fields[j];


### PR DESCRIPTION
addresses a regression found in Graph (old) https://github.com/grafana/grafana/issues/44513#issuecomment-1056120108.

likely caused by migrating Prometheus and Loki datasources to backend and moving where we do null-insertion (from frontend datasource plugins to panels).

not sure if i got the issue labels and milestone right, but seems like something we should try to land asap.

also not sure if this is the right place for the fix :)

<details><summary>graph-old-null-gaps.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": "-- Grafana --",
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 121,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "aliasColors": {},
      "bars": false,
      "dashLength": 10,
      "dashes": false,
      "fill": 1,
      "fillGradient": 0,
      "gridPos": {
        "h": 18,
        "w": 24,
        "x": 0,
        "y": 0
      },
      "hiddenSeries": false,
      "id": 2,
      "legend": {
        "avg": false,
        "current": false,
        "max": false,
        "min": false,
        "show": true,
        "total": false,
        "values": false
      },
      "lines": true,
      "linewidth": 1,
      "maxDataPoints": 100,
      "nullPointMode": "null",
      "options": {
        "alertThreshold": true
      },
      "percentage": false,
      "pluginVersion": "8.5.0-pre",
      "pointradius": 2,
      "points": false,
      "renderer": "flot",
      "seriesOverrides": [],
      "spaceLength": 10,
      "stack": false,
      "steppedLine": false,
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "drop": 5,
          "refId": "A",
          "scenarioId": "random_walk"
        }
      ],
      "thresholds": [],
      "timeRegions": [],
      "title": "Panel Title",
      "tooltip": {
        "shared": true,
        "sort": 0,
        "value_type": "individual"
      },
      "type": "graph",
      "xaxis": {
        "mode": "time",
        "show": true,
        "values": []
      },
      "yaxes": [
        {
          "format": "short",
          "logBase": 1,
          "show": true
        },
        {
          "format": "short",
          "logBase": 1,
          "show": true
        }
      ],
      "yaxis": {
        "align": false
      }
    }
  ],
  "refresh": "",
  "schemaVersion": 35,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "unbork-graph-old",
  "uid": "FZbm7IY7k",
  "version": 3,
  "weekStart": ""
}
```
</details>