### PR TITLE
FileStore: add dummy implementation

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -45,5 +45,5 @@ export interface FeatureToggles {
   dashboardComments?: boolean;
   annotationComments?: boolean;
   migrationLocking?: boolean;
-  dbFileStorage?: boolean;
+  fileStoreApi?: boolean;
 }

--- a/pkg/infra/filestorage/api.go
+++ b/pkg/infra/filestorage/api.go
@@ -3,15 +3,16 @@ package filestorage
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 )
 
-// type StorageName string
+type StorageName string
 
-// const (
-// 	StorageNameGrafanaDS StorageName = "grafanads"
-// )
+const (
+	StorageNameGrafanaDS StorageName = "grafanads"
+)
 
 var (
 	ErrRelativePath          = errors.New("path cant be relative")
@@ -22,13 +23,17 @@ var (
 	Delimiter                = "/"
 )
 
-// func Path(path string, storageName StorageName) string {
-// 	if strings.HasPrefix(path, Delimiter) {
-// 		return fmt.Sprintf("%s%s", string(storageName), path)
-// 	}
+func Path(path string, storageName StorageName) string {
+	if strings.HasPrefix(path, Delimiter) {
+		return fmt.Sprintf("%s%s", string(storageName), path)
+	}
 
-// 	return fmt.Sprintf("%s%s%s", string(storageName), Delimiter, path)
-// }
+	return fmt.Sprintf("%s%s%s", string(storageName), Delimiter, path)
+}
+
+func belongsToStorage(path string, storageName StorageName) bool {
+	return strings.HasPrefix(path, string(storageName))
+}
 
 type File struct {
 	Contents []byte

--- a/pkg/infra/filestorage/api.go
+++ b/pkg/infra/filestorage/api.go
@@ -11,7 +11,7 @@ import (
 type StorageName string
 
 const (
-	StorageNameGrafanaDS StorageName = "grafanads"
+	StorageNamePublic StorageName = "public"
 )
 
 var (

--- a/pkg/infra/filestorage/api.go
+++ b/pkg/infra/filestorage/api.go
@@ -3,7 +3,6 @@ package filestorage
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 	"time"
 )
@@ -23,12 +22,8 @@ var (
 	Delimiter                = "/"
 )
 
-func Path(path string, storageName StorageName) string {
-	if strings.HasPrefix(path, Delimiter) {
-		return fmt.Sprintf("%s%s", string(storageName), path)
-	}
-
-	return fmt.Sprintf("%s%s%s", string(storageName), Delimiter, path)
+func Join(parts ...string) string {
+	return Delimiter + strings.Join(parts, Delimiter)
 }
 
 func belongsToStorage(path string, storageName StorageName) bool {

--- a/pkg/infra/filestorage/api_test.go
+++ b/pkg/infra/filestorage/api_test.go
@@ -1,0 +1,37 @@
+package filestorage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilestorageApi_Join(t *testing.T) {
+
+	var tests = []struct {
+		name     string
+		parts    []string
+		expected string
+	}{
+		{
+			name:     "multiple parts",
+			parts:    []string{"prefix", "p1", "p2"},
+			expected: "/prefix/p1/p2",
+		},
+		{
+			name:     "no parts",
+			parts:    []string{},
+			expected: "/",
+		},
+		{
+			name:     "a single part",
+			parts:    []string{"prefix"},
+			expected: "/prefix",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, Join(tt.parts...))
+		})
+	}
+}

--- a/pkg/infra/filestorage/api_test.go
+++ b/pkg/infra/filestorage/api_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestFilestorageApi_Join(t *testing.T) {
-
 	var tests = []struct {
 		name     string
 		parts    []string

--- a/pkg/infra/filestorage/dummy.go
+++ b/pkg/infra/filestorage/dummy.go
@@ -1,0 +1,47 @@
+package filestorage
+
+import (
+	"context"
+
+	_ "gocloud.dev/blob/fileblob"
+	_ "gocloud.dev/blob/memblob"
+)
+
+type dummyFileStorage struct {
+}
+
+func (d dummyFileStorage) Get(ctx context.Context, path string) (*File, error) {
+	return nil, nil
+}
+
+func (d dummyFileStorage) Delete(ctx context.Context, path string) error {
+	return nil
+}
+
+func (d dummyFileStorage) Upsert(ctx context.Context, file *UpsertFileCommand) error {
+	return nil
+}
+
+func (d dummyFileStorage) ListFiles(ctx context.Context, path string, cursor *Paging, options *ListOptions) (*ListFilesResponse, error) {
+	return nil, nil
+}
+
+func (d dummyFileStorage) ListFolders(ctx context.Context, path string, options *ListOptions) ([]FileMetadata, error) {
+	return nil, nil
+}
+
+func (d dummyFileStorage) CreateFolder(ctx context.Context, path string) error {
+	return nil
+}
+
+func (d dummyFileStorage) DeleteFolder(ctx context.Context, path string) error {
+	return nil
+}
+
+func (d dummyFileStorage) IsFolderEmpty(ctx context.Context, path string) (bool, error) {
+	return true, nil
+}
+
+func (d dummyFileStorage) close() error {
+	return nil
+}

--- a/pkg/infra/filestorage/dummy.go
+++ b/pkg/infra/filestorage/dummy.go
@@ -7,6 +7,10 @@ import (
 	_ "gocloud.dev/blob/memblob"
 )
 
+var (
+	_ FileStorage = (*dummyFileStorage)(nil) // dummyFileStorage implements FileStorage
+)
+
 type dummyFileStorage struct {
 }
 

--- a/pkg/infra/filestorage/filestorage.go
+++ b/pkg/infra/filestorage/filestorage.go
@@ -3,10 +3,15 @@ package filestorage
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
+	"gocloud.dev/blob"
+
 	_ "gocloud.dev/blob/fileblob"
 	_ "gocloud.dev/blob/memblob"
 )
@@ -15,9 +20,44 @@ const (
 	ServiceName = "FileStorage"
 )
 
-func ProvideService(cfg *setting.Cfg, sqlStore *sqlstore.SQLStore) (FileStorage, error) {
+func ProvideService(features featuremgmt.FeatureToggles, cfg *setting.Cfg) (FileStorage, error) {
+	grafanaDsStorageLogger := log.New("grafanaDsStorage")
+
+	path := fmt.Sprintf("file://%s", cfg.StaticRootPath)
+	grafanaDsStorageLogger.Info("Initializing grafana ds storage", "path", path)
+	bucket, err := blob.OpenBucket(context.Background(), path)
+	if err != nil {
+		currentDir, _ := os.Getwd()
+		grafanaDsStorageLogger.Error("Failed to initialize grafana ds storage", "path", path, "error", err, "cwd", currentDir)
+		return nil, err
+	}
+
+	prefixes := []string{
+		"testdata/",
+		"img/icons/",
+		"img/bg/",
+		"gazetteer/",
+		"maps/",
+		"upload/",
+	}
+
+	var grafanaDsStorage FileStorage
+	if features.IsEnabled(featuremgmt.FlagFileStoreApi) {
+		grafanaDsStorage = &wrapper{
+			log: grafanaDsStorageLogger,
+			wrapped: cdkBlobStorage{
+				log:        grafanaDsStorageLogger,
+				bucket:     bucket,
+				rootFolder: "",
+			},
+			pathFilters: &PathFilters{allowedPrefixes: prefixes},
+		}
+	} else {
+		grafanaDsStorage = &dummyFileStorage{}
+	}
+
 	return &service{
-		grafanaDsStorage: nil,
+		grafanaDsStorage: grafanaDsStorage,
 		log:              log.New("fileStorageService"),
 	}, nil
 }
@@ -28,7 +68,38 @@ type service struct {
 }
 
 func (b service) Get(ctx context.Context, path string) (*File, error) {
-	return nil, errors.New("not implemented")
+	var filestorage FileStorage
+	if belongsToStorage(path, StorageNameGrafanaDS) {
+		filestorage = b.grafanaDsStorage
+		path = removeStoragePrefix(path)
+	}
+
+	if err := validatePath(path); err != nil {
+		return nil, err
+	}
+
+	return filestorage.Get(ctx, path)
+}
+
+func removeStoragePrefix(path string) string {
+	if path == Delimiter || path == "" {
+		return Delimiter
+	}
+
+	if !strings.Contains(path, Delimiter) {
+		return Delimiter
+	}
+
+	split := strings.Split(path, Delimiter)
+
+	// root of storage
+	if len(split) == 2 && split[1] == "" {
+		return Delimiter
+	}
+
+	// replace storage
+	split[0] = ""
+	return strings.Join(split, Delimiter)
 }
 
 func (b service) Delete(ctx context.Context, path string) error {
@@ -40,11 +111,35 @@ func (b service) Upsert(ctx context.Context, file *UpsertFileCommand) error {
 }
 
 func (b service) ListFiles(ctx context.Context, path string, cursor *Paging, options *ListOptions) (*ListFilesResponse, error) {
-	return nil, errors.New("not implemented")
+	var filestorage FileStorage
+	if belongsToStorage(path, StorageNameGrafanaDS) {
+		filestorage = b.grafanaDsStorage
+		path = removeStoragePrefix(path)
+	} else {
+		return nil, errors.New("not implemented")
+	}
+
+	if err := validatePath(path); err != nil {
+		return nil, err
+	}
+
+	return filestorage.ListFiles(ctx, path, cursor, options)
 }
 
 func (b service) ListFolders(ctx context.Context, path string, options *ListOptions) ([]FileMetadata, error) {
-	return nil, errors.New("not implemented")
+	var filestorage FileStorage
+	if belongsToStorage(path, StorageNameGrafanaDS) {
+		filestorage = b.grafanaDsStorage
+		path = removeStoragePrefix(path)
+	} else {
+		return nil, errors.New("not implemented")
+	}
+
+	if err := validatePath(path); err != nil {
+		return nil, err
+	}
+
+	return filestorage.ListFolders(ctx, path, options)
 }
 
 func (b service) CreateFolder(ctx context.Context, path string) error {
@@ -52,13 +147,13 @@ func (b service) CreateFolder(ctx context.Context, path string) error {
 }
 
 func (b service) DeleteFolder(ctx context.Context, path string) error {
-	return errors.New("not available")
+	return errors.New("not implemented")
 }
 
 func (b service) IsFolderEmpty(ctx context.Context, path string) (bool, error) {
-	return true, errors.New("not available")
+	return true, errors.New("not implemented")
 }
 
 func (b service) close() error {
-	return errors.New("not implemented")
+	return b.grafanaDsStorage.close()
 }

--- a/pkg/infra/filestorage/filestorage.go
+++ b/pkg/infra/filestorage/filestorage.go
@@ -69,7 +69,7 @@ type service struct {
 
 func (b service) Get(ctx context.Context, path string) (*File, error) {
 	var filestorage FileStorage
-	if belongsToStorage(path, StorageNameGrafanaDS) {
+	if belongsToStorage(path, StorageNamePublic) {
 		filestorage = b.grafanaDsStorage
 		path = removeStoragePrefix(path)
 	}
@@ -112,7 +112,7 @@ func (b service) Upsert(ctx context.Context, file *UpsertFileCommand) error {
 
 func (b service) ListFiles(ctx context.Context, path string, cursor *Paging, options *ListOptions) (*ListFilesResponse, error) {
 	var filestorage FileStorage
-	if belongsToStorage(path, StorageNameGrafanaDS) {
+	if belongsToStorage(path, StorageNamePublic) {
 		filestorage = b.grafanaDsStorage
 		path = removeStoragePrefix(path)
 	} else {
@@ -128,7 +128,7 @@ func (b service) ListFiles(ctx context.Context, path string, cursor *Paging, opt
 
 func (b service) ListFolders(ctx context.Context, path string, options *ListOptions) ([]FileMetadata, error) {
 	var filestorage FileStorage
-	if belongsToStorage(path, StorageNameGrafanaDS) {
+	if belongsToStorage(path, StorageNamePublic) {
 		filestorage = b.grafanaDsStorage
 		path = removeStoragePrefix(path)
 	} else {

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -158,8 +158,8 @@ var (
 			State:       FeatureStateBeta,
 		},
 		{
-			Name:            "dbFileStorage",
-			Description:     "Store files in the database",
+			Name:            "fileStoreApi",
+			Description:     "Simple API for managing files",
 			State:           FeatureStateAlpha,
 			RequiresDevMode: true,
 		},

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -119,7 +119,7 @@ const (
 	// Lock database during migrations
 	FlagMigrationLocking = "migrationLocking"
 
-	// FlagDbFileStorage
-	// Store files in the database
-	FlagDbFileStorage = "dbFileStorage"
+	// FlagFileStoreApi
+	// Simple API for managing files
+	FlagFileStoreApi = "fileStoreApi"
 )

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -465,7 +465,6 @@ type InitTestDBOpt struct {
 var featuresEnabledDuringTests = []string{
 	featuremgmt.FlagDashboardPreviews,
 	featuremgmt.FlagDashboardComments,
-	featuremgmt.FlagDbFileStorage,
 }
 
 // InitTestDBWithMigration initializes the test DB given custom migrations.


### PR DESCRIPTION
1. add back `public` list files implementation to facilitate testing
2. gate the implementation behind a `filestorageApi` feature flag:

targets https://github.com/grafana/grafana/pull/46051