### PR TITLE
Live: Fix support for `StreamingFrameAction.Replace`

### DIFF
--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -260,7 +260,7 @@ export class LiveDataStream<T = unknown> {
         // send empty frame with error
         return {
           key: subKey,
-          state: error ? LoadingState.Error : LoadingState.Streaming,
+          state: LoadingState.Error,
           data: [
             {
               type: StreamingResponseDataType.FullFrame,
@@ -276,7 +276,7 @@ export class LiveDataStream<T = unknown> {
         // send empty frame
         return {
           key: subKey,
-          state: error ? LoadingState.Error : LoadingState.Streaming,
+          state: LoadingState.Streaming,
           data: [
             {
               type: StreamingResponseDataType.FullFrame,

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -84,9 +84,7 @@ type InternalStreamMessageTypeToData = {
   [InternalStreamMessageType.Error]: {
     error: DataQueryError;
   };
-  [InternalStreamMessageType.ChangedSchema]: {
-    values: unknown[][];
-  };
+  [InternalStreamMessageType.ChangedSchema]: {};
   [InternalStreamMessageType.NewValuesSameSchema]: {
     values: unknown[][];
   };
@@ -190,17 +188,15 @@ export class LiveDataStream<T = unknown> {
 
   private process = (msg: DataFrameJSON) => {
     const packetInfo = this.frameBuffer.push(msg);
-    const newValues = this.frameBuffer.getValuesFromLastPacket();
 
     if (packetInfo.schemaChanged) {
       this.stream.next({
         type: InternalStreamMessageType.ChangedSchema,
-        values: newValues,
       });
     } else {
       this.stream.next({
         type: InternalStreamMessageType.NewValuesSameSchema,
-        values: newValues,
+        values: this.frameBuffer.getValuesFromLastPacket(),
       });
     }
   };

--- a/public/app/features/live/centrifuge/LiveDataStream.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.ts
@@ -1,4 +1,4 @@
-import type { LiveDataStreamOptions, StreamingFrameOptions } from '@grafana/runtime/src/services/live';
+import { LiveDataStreamOptions, StreamingFrameAction, StreamingFrameOptions } from '@grafana/runtime/src/services/live';
 import { toDataQueryError } from '@grafana/runtime/src/utils/toDataQueryError';
 import {
   DataFrameJSON,
@@ -84,7 +84,9 @@ type InternalStreamMessageTypeToData = {
   [InternalStreamMessageType.Error]: {
     error: DataQueryError;
   };
-  [InternalStreamMessageType.ChangedSchema]: {};
+  [InternalStreamMessageType.ChangedSchema]: {
+    values: unknown[][];
+  };
   [InternalStreamMessageType.NewValuesSameSchema]: {
     values: unknown[][];
   };
@@ -188,15 +190,17 @@ export class LiveDataStream<T = unknown> {
 
   private process = (msg: DataFrameJSON) => {
     const packetInfo = this.frameBuffer.push(msg);
+    const newValues = this.frameBuffer.getValuesFromLastPacket();
 
     if (packetInfo.schemaChanged) {
       this.stream.next({
         type: InternalStreamMessageType.ChangedSchema,
+        values: newValues,
       });
     } else {
       this.stream.next({
         type: InternalStreamMessageType.NewValuesSameSchema,
-        values: this.frameBuffer.getValuesFromLastPacket(),
+        values: newValues,
       });
     }
   };
@@ -228,30 +232,89 @@ export class LiveDataStream<T = unknown> {
     this.resizeBuffer(buffer);
     this.prepareInternalStreamForNewSubscription(options);
 
+    const shouldSendLastPacketOnly = options?.buffer?.action === StreamingFrameAction.Replace;
     const fieldsNamesFilter = options.filter?.fields;
     const dataNeedsFiltering = fieldsNamesFilter?.length;
     const fieldFilterPredicate = dataNeedsFiltering ? ({ name }: Field) => fieldsNamesFilter.includes(name) : undefined;
     let matchingFieldIndexes: number[] | undefined = undefined;
 
-    const getFullFrameResponseData = (error?: DataQueryError): StreamingDataQueryResponse => {
+    const getFullFrameResponseData = <T>(
+      messages: InternalStreamMessage[],
+      error?: DataQueryError
+    ): StreamingDataQueryResponse => {
       matchingFieldIndexes = fieldFilterPredicate
         ? this.frameBuffer.getMatchingFieldIndexes(fieldFilterPredicate)
         : undefined;
 
+      if (!shouldSendLastPacketOnly) {
+        return {
+          key: subKey,
+          state: error ? LoadingState.Error : LoadingState.Streaming,
+          data: [
+            {
+              type: StreamingResponseDataType.FullFrame,
+              frame: this.frameBuffer.serialize(fieldFilterPredicate, buffer),
+            },
+          ],
+          error,
+        };
+      }
+
+      if (error) {
+        // send empty frame with error
+        return {
+          key: subKey,
+          state: error ? LoadingState.Error : LoadingState.Streaming,
+          data: [
+            {
+              type: StreamingResponseDataType.FullFrame,
+              frame: this.frameBuffer.serialize(fieldFilterPredicate, buffer, { maxLength: 0 }),
+            },
+          ],
+          error,
+        };
+      }
+
+      if (!messages.length) {
+        console.warn(`expected to find at least one non error message ${messages.map(({ type }) => type)}`);
+        // send empty frame
+        return {
+          key: subKey,
+          state: error ? LoadingState.Error : LoadingState.Streaming,
+          data: [
+            {
+              type: StreamingResponseDataType.FullFrame,
+              frame: this.frameBuffer.serialize(fieldFilterPredicate, buffer, { maxLength: 0 }),
+            },
+          ],
+          error,
+        };
+      }
+
       return {
         key: subKey,
-        state: error ? LoadingState.Error : LoadingState.Streaming,
+        state: LoadingState.Streaming,
         data: [
           {
             type: StreamingResponseDataType.FullFrame,
-            frame: this.frameBuffer.serialize(fieldFilterPredicate, buffer),
+            frame: this.frameBuffer.serialize(fieldFilterPredicate, buffer, {
+              maxLength: this.frameBuffer.packetInfo.length,
+            }),
           },
         ],
         error,
       };
     };
 
-    const getNewValuesSameSchemaResponseData = (values: unknown[][]): StreamingDataQueryResponse => {
+    const getNewValuesSameSchemaResponseData = (
+      messages: Array<InternalStreamMessage<InternalStreamMessageType.NewValuesSameSchema>>
+    ): StreamingDataQueryResponse => {
+      const lastMessage = messages.length ? messages[messages.length - 1] : undefined;
+      const values =
+        shouldSendLastPacketOnly && lastMessage
+          ? lastMessage.values
+          : reduceNewValuesSameSchemaMessages(messages).values;
+
       const filteredValues = matchingFieldIndexes
         ? values.filter((v, i) => (matchingFieldIndexes as number[]).includes(i))
         : values;
@@ -277,18 +340,18 @@ export class LiveDataStream<T = unknown> {
 
         if (shouldSendFullFrame) {
           shouldSendFullFrame = false;
-          return getFullFrameResponseData(lastError);
+          return getFullFrameResponseData(messages, lastError);
         }
 
         if (errors.length) {
           // send the latest frame with the last error, discard everything else
-          return getFullFrameResponseData(lastError);
+          return getFullFrameResponseData(messages, lastError);
         }
 
         const schemaChanged = messages.some((n) => n.type === InternalStreamMessageType.ChangedSchema);
         if (schemaChanged) {
           // send the latest frame, discard intermediate appends
-          return getFullFrameResponseData();
+          return getFullFrameResponseData(messages, undefined);
         }
 
         const newValueSameSchemaMessages = filterMessages(messages, InternalStreamMessageType.NewValuesSameSchema);
@@ -296,7 +359,7 @@ export class LiveDataStream<T = unknown> {
           console.warn(`unsupported message type ${messages.map(({ type }) => type)}`);
         }
 
-        return getNewValuesSameSchemaResponseData(reduceNewValuesSameSchemaMessages(newValueSameSchemaMessages).values);
+        return getNewValuesSameSchemaResponseData(newValueSameSchemaMessages);
       })
     );
 

--- a/public/app/features/live/data/StreamingDataFrame.test.ts
+++ b/public/app/features/live/data/StreamingDataFrame.test.ts
@@ -1,6 +1,6 @@
-import {DataFrame, DataFrameJSON, FieldType, getFieldDisplayName, reduceField, ReducerID} from '@grafana/data';
-import {StreamingFrameAction, StreamingFrameOptions} from '@grafana/runtime';
-import {closestIdx, getStreamingFrameOptions, StreamingDataFrame} from './StreamingDataFrame';
+import { DataFrame, DataFrameJSON, FieldType, getFieldDisplayName, reduceField, ReducerID } from '@grafana/data';
+import { StreamingFrameAction, StreamingFrameOptions } from '@grafana/runtime';
+import { closestIdx, getStreamingFrameOptions, StreamingDataFrame } from './StreamingDataFrame';
 
 describe('Streaming JSON', () => {
   describe('closestIdx', function () {

--- a/public/app/features/live/data/StreamingDataFrame.test.ts
+++ b/public/app/features/live/data/StreamingDataFrame.test.ts
@@ -551,11 +551,13 @@ describe('Streaming JSON', () => {
           maxDelta: 300,
         }).serialize()
       );
+      expect(frame.length).toEqual(3);
       frame.pushNewValues([
         [601, 602],
         ['x', 'y'],
         [10, 11],
       ]);
+      expect(frame.length).toEqual(3);
       expect(frame.fields.map((f) => ({ name: f.name, value: f.values.buffer }))).toMatchInlineSnapshot(`
         Array [
           Object {
@@ -594,11 +596,13 @@ describe('Streaming JSON', () => {
           action: StreamingFrameAction.Replace,
         }).serialize()
       );
+      expect(frame.length).toEqual(3);
       frame.pushNewValues([
         [601, 602],
         ['x', 'y'],
         [10, 11],
       ]);
+      expect(frame.length).toEqual(2);
       expect(frame.fields.map((f) => ({ name: f.name, value: f.values.buffer }))).toMatchInlineSnapshot(`
         Array [
           Object {

--- a/public/app/features/live/data/StreamingDataFrame.test.ts
+++ b/public/app/features/live/data/StreamingDataFrame.test.ts
@@ -1,6 +1,6 @@
-import { DataFrame, DataFrameJSON, FieldType, getFieldDisplayName, reduceField, ReducerID } from '@grafana/data';
-import { StreamingFrameAction, StreamingFrameOptions } from '@grafana/runtime';
-import { closestIdx, getStreamingFrameOptions, StreamingDataFrame } from './StreamingDataFrame';
+import {DataFrame, DataFrameJSON, FieldType, getFieldDisplayName, reduceField, ReducerID} from '@grafana/data';
+import {StreamingFrameAction, StreamingFrameOptions} from '@grafana/runtime';
+import {closestIdx, getStreamingFrameOptions, StreamingDataFrame} from './StreamingDataFrame';
 
 describe('Streaming JSON', () => {
   describe('closestIdx', function () {
@@ -367,7 +367,8 @@ describe('Streaming JSON', () => {
     });
 
     it('should resize the buffer', function () {
-      const serializedFrame = frame.serialize((f) => ['time', 'name'].includes(f.name), { maxLength: 2 });
+      const options = { maxLength: 2 };
+      const serializedFrame = frame.serialize((f) => ['time', 'name'].includes(f.name), options);
       expect(serializedFrame.fields).toEqual([
         {
           config: {},
@@ -382,6 +383,48 @@ describe('Streaming JSON', () => {
           values: ['b', 'c'],
         },
       ]);
+    });
+
+    it('should trim values and retain option override values', function () {
+      const options = { maxLength: 2 };
+      const trimValues = { maxLength: 1 };
+      const serializedFrame = frame.serialize((f) => ['time', 'name'].includes(f.name), options, trimValues);
+      expect(serializedFrame.fields).toEqual([
+        {
+          config: {},
+          name: 'time',
+          type: 'time',
+          values: [300],
+        },
+        {
+          config: {},
+          name: 'name',
+          type: 'string',
+          values: ['c'],
+        },
+      ]);
+      expect(serializedFrame.options.maxLength).toEqual(options.maxLength);
+    });
+
+    it('should use maxLength from options if its lower than maxLength from trimValues', function () {
+      const options = { maxLength: 1 };
+      const trimValues = { maxLength: 2 };
+      const serializedFrame = frame.serialize((f) => ['time', 'name'].includes(f.name), options, trimValues);
+      expect(serializedFrame.fields).toEqual([
+        {
+          config: {},
+          name: 'time',
+          type: 'time',
+          values: [300],
+        },
+        {
+          config: {},
+          name: 'name',
+          type: 'string',
+          values: ['c'],
+        },
+      ]);
+      expect(serializedFrame.options.maxLength).toEqual(options.maxLength);
     });
   });
 
@@ -501,14 +544,18 @@ describe('Streaming JSON', () => {
       },
     };
 
-    const serializedFrame = StreamingDataFrame.fromDataFrameJSON(json, {
-      maxLength: 5,
-      maxDelta: 300,
-    }).serialize();
-
-    it('should support pushing new values matching the existing schema', function () {
-      const frame = StreamingDataFrame.deserialize(serializedFrame);
-      frame.pushNewValues([[601], ['x'], [10]]);
+    it('should support pushing new values matching the existing schema in `append` mode', function () {
+      const frame = StreamingDataFrame.deserialize(
+        StreamingDataFrame.fromDataFrameJSON(json, {
+          maxLength: 5,
+          maxDelta: 300,
+        }).serialize()
+      );
+      frame.pushNewValues([
+        [601, 602],
+        ['x', 'y'],
+        [10, 11],
+      ]);
       expect(frame.fields.map((f) => ({ name: f.name, value: f.values.buffer }))).toMatchInlineSnapshot(`
         Array [
           Object {
@@ -516,6 +563,7 @@ describe('Streaming JSON', () => {
             "value": Array [
               300,
               601,
+              602,
             ],
           },
           Object {
@@ -523,6 +571,7 @@ describe('Streaming JSON', () => {
             "value": Array [
               "c",
               "x",
+              "y",
             ],
           },
           Object {
@@ -530,6 +579,47 @@ describe('Streaming JSON', () => {
             "value": Array [
               3,
               10,
+              11,
+            ],
+          },
+        ]
+      `);
+    });
+
+    it('should support pushing new values matching the existing schema in `replace` mode', function () {
+      const frame = StreamingDataFrame.deserialize(
+        StreamingDataFrame.fromDataFrameJSON(json, {
+          maxLength: 5,
+          maxDelta: 300,
+          action: StreamingFrameAction.Replace,
+        }).serialize()
+      );
+      frame.pushNewValues([
+        [601, 602],
+        ['x', 'y'],
+        [10, 11],
+      ]);
+      expect(frame.fields.map((f) => ({ name: f.name, value: f.values.buffer }))).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "name": "time",
+            "value": Array [
+              601,
+              602,
+            ],
+          },
+          Object {
+            "name": "name",
+            "value": Array [
+              "x",
+              "y",
+            ],
+          },
+          Object {
+            "name": "value",
+            "value": Array [
+              10,
+              11,
             ],
           },
         ]

--- a/public/app/features/live/data/StreamingDataFrame.ts
+++ b/public/app/features/live/data/StreamingDataFrame.ts
@@ -13,10 +13,10 @@ import {
   QueryResultMeta,
   toFilteredDataFrameDTO,
 } from '@grafana/data';
-import { join } from '@grafana/data/src/transformations/transformers/joinDataFrames';
-import { StreamingFrameAction, StreamingFrameOptions } from '@grafana/runtime/src/services/live';
-import { renderLegendFormat } from 'app/plugins/datasource/prometheus/legend';
-import { AlignedData } from 'uplot';
+import {join} from '@grafana/data/src/transformations/transformers/joinDataFrames';
+import {StreamingFrameAction, StreamingFrameOptions} from '@grafana/runtime/src/services/live';
+import {renderLegendFormat} from 'app/plugins/datasource/prometheus/legend';
+import {AlignedData} from 'uplot';
 
 /**
  * Stream packet info is attached to StreamingDataFrames and indicate how many
@@ -100,7 +100,7 @@ export class StreamingDataFrame implements DataFrame {
 
     const numberOfItemsToRemove = getNumberOfItemsToRemove(
       dataFrameDTO.fields.map((f) => f.values) as unknown[][],
-      typeof trimValues?.maxLength === 'number' ? trimValues.maxLength : options.maxLength,
+      typeof trimValues?.maxLength === 'number' ? Math.min(trimValues.maxLength, options.maxLength) : options.maxLength,
       this.timeFieldIndex,
       options.maxDelta
     );

--- a/public/app/features/live/data/StreamingDataFrame.ts
+++ b/public/app/features/live/data/StreamingDataFrame.ts
@@ -387,6 +387,10 @@ export class StreamingDataFrame implements DataFrame {
         this.options.maxDelta
       );
     }
+    const newLength = this.fields?.[0]?.values?.buffer?.length;
+    if (newLength !== undefined) {
+      this.length = newLength;
+    }
   };
 
   resetStateCalculations = () => {

--- a/public/app/features/live/data/StreamingDataFrame.ts
+++ b/public/app/features/live/data/StreamingDataFrame.ts
@@ -90,14 +90,17 @@ export class StreamingDataFrame implements DataFrame {
 
   serialize = (
     fieldPredicate?: (f: Field) => boolean,
-    optionsOverride?: Partial<StreamingFrameOptions>
+    optionsOverride?: Partial<StreamingFrameOptions>,
+    trimValues?: {
+      maxLength?: number;
+    }
   ): SerializedStreamingDataFrame => {
     const options = optionsOverride ? Object.assign({}, { ...this.options, ...optionsOverride }) : this.options;
     const dataFrameDTO = toFilteredDataFrameDTO(this, fieldPredicate);
 
     const numberOfItemsToRemove = getNumberOfItemsToRemove(
       dataFrameDTO.fields.map((f) => f.values) as unknown[][],
-      options.maxLength,
+      typeof trimValues?.maxLength === 'number' ? trimValues.maxLength : options.maxLength,
       this.timeFieldIndex,
       options.maxDelta
     );
@@ -357,18 +360,33 @@ export class StreamingDataFrame implements DataFrame {
       return;
     }
 
-    this.packetInfo.action = StreamingFrameAction.Append;
+    this.packetInfo.action = this.options.action;
     this.packetInfo.number++;
     this.packetInfo.length = values[0].length;
     this.packetInfo.schemaChanged = false;
 
-    circPush(
-      this.fields.map((f) => f.values.buffer),
-      values,
-      this.options.maxLength,
-      this.timeFieldIndex,
-      this.options.maxDelta
-    );
+    if (this.options.action === StreamingFrameAction.Append) {
+      circPush(
+        this.fields.map((f) => f.values.buffer),
+        values,
+        this.options.maxLength,
+        this.timeFieldIndex,
+        this.options.maxDelta
+      );
+    } else {
+      values.forEach((v, i) => {
+        if (this.fields[i]?.values) {
+          this.fields[i].values.buffer = v;
+        }
+      });
+
+      assureValuesAreWithinLengthLimit(
+        this.fields.map((f) => f.values.buffer),
+        this.options.maxLength,
+        this.timeFieldIndex,
+        this.options.maxDelta
+      );
+    }
   };
 
   resetStateCalculations = () => {

--- a/public/app/features/live/data/StreamingDataFrame.ts
+++ b/public/app/features/live/data/StreamingDataFrame.ts
@@ -13,10 +13,10 @@ import {
   QueryResultMeta,
   toFilteredDataFrameDTO,
 } from '@grafana/data';
-import {join} from '@grafana/data/src/transformations/transformers/joinDataFrames';
-import {StreamingFrameAction, StreamingFrameOptions} from '@grafana/runtime/src/services/live';
-import {renderLegendFormat} from 'app/plugins/datasource/prometheus/legend';
-import {AlignedData} from 'uplot';
+import { join } from '@grafana/data/src/transformations/transformers/joinDataFrames';
+import { StreamingFrameAction, StreamingFrameOptions } from '@grafana/runtime/src/services/live';
+import { renderLegendFormat } from 'app/plugins/datasource/prometheus/legend';
+import { AlignedData } from 'uplot';
 
 /**
  * Stream packet info is attached to StreamingDataFrames and indicate how many


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/pull/46086
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The new frontend live data pipeline I added in https://github.com/grafana/grafana/pull/41492 does not support the `StreamingFrameAction.Replace` streaming buffer option - this PR re-adds that support


TODO:
- [x] unit tests for `StreamingDataFrame.ts`
- [x] unit tests for `LiveDataStream.ts`
- [x] manual exploratory tests


cc @sd2k 

