### PR TITLE
WIP: Normalize request URL in web package

### DIFF
--- a/pkg/web/macaron.go
+++ b/pkg/web/macaron.go
@@ -21,6 +21,7 @@ package web
 import (
 	"context"
 	"net/http"
+	"path"
 	"reflect"
 	"strings"
 )
@@ -185,6 +186,7 @@ func (m *Macaron) createContext(rw http.ResponseWriter, req *http.Request) *Cont
 // Useful if you want to control your own HTTP server.
 // Be aware that none of middleware will run without registering any router.
 func (m *Macaron) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	req.URL.Path = path.Join("/", req.URL.Path)
 	req.URL.Path = strings.TrimPrefix(req.URL.Path, m.urlPrefix)
 	m.Router.ServeHTTP(rw, req)
 }

--- a/pkg/web/macaron_test.go
+++ b/pkg/web/macaron_test.go
@@ -1,0 +1,90 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServeHTTP(t *testing.T) {
+	m := New()
+	m.Use(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+	startTestServer(t, m)
+
+	testCases := []struct {
+		name               string
+		urlPath            string
+		expectedStatusCode int
+		expectedURLPath    string
+	}{
+		{
+			name:               "Valid path / should return unmodified path",
+			urlPath:            "/",
+			expectedStatusCode: http.StatusOK,
+			expectedURLPath:    "/",
+		},
+		{
+			name:               "Valid path /api/test should return unmodified path",
+			urlPath:            "/api/test",
+			expectedStatusCode: http.StatusOK,
+			expectedURLPath:    "/api/test",
+		},
+		{
+			name:               "Invalid path /api/test/../ should return modified path",
+			urlPath:            "/api/test/../",
+			expectedStatusCode: http.StatusOK,
+			expectedURLPath:    "/api",
+		},
+		{
+			name:               "Invalid path /api/test/%2E%2E/ should return modified path",
+			urlPath:            "/api/test/%2E%2E/",
+			expectedStatusCode: http.StatusOK,
+			expectedURLPath:    "/api",
+		},
+		{
+			name:               "Invalid path /api/test/%2e%2e%2f should return modified path",
+			urlPath:            "/api/test/%2e%2e%2f",
+			expectedStatusCode: http.StatusOK,
+			expectedURLPath:    "/api",
+		},
+		{
+			name:               "Invalid path /api/test/../a should return modified path",
+			urlPath:            "/api/test/../a",
+			expectedStatusCode: http.StatusOK,
+			expectedURLPath:    "/api/a",
+		},
+		{
+			name:               "Invalid path /api/test/%2E%2E/a should return modified path",
+			urlPath:            "/api/test/%2E%2E/a",
+			expectedStatusCode: http.StatusOK,
+			expectedURLPath:    "/api/a",
+		},
+		{
+			name:               "Invalid path /api/test/%2e%2e%2fa should return modified path",
+			urlPath:            "/api/test/%2e%2e%2fa",
+			expectedStatusCode: http.StatusOK,
+			expectedURLPath:    "/api/a",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.urlPath, nil)
+			recorder := httptest.NewRecorder()
+			m.ServeHTTP(recorder, req)
+			require.Equal(t, tc.expectedStatusCode, recorder.Result().StatusCode)
+			require.Equal(t, tc.expectedURLPath, req.URL.Path)
+		})
+	}
+}
+
+func startTestServer(t *testing.T, m *Macaron) {
+	t.Helper()
+
+	s := httptest.NewServer(m)
+	t.Cleanup(s.Close)
+}

--- a/pkg/web/macaron_test.go
+++ b/pkg/web/macaron_test.go
@@ -76,7 +76,9 @@ func TestServeHTTP(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, tc.urlPath, nil)
 			recorder := httptest.NewRecorder()
 			m.ServeHTTP(recorder, req)
-			require.Equal(t, tc.expectedStatusCode, recorder.Result().StatusCode)
+			resp := recorder.Result()
+			require.Equal(t, tc.expectedStatusCode, resp.StatusCode)
+			require.NoError(t, resp.Body.Close())
 			require.Equal(t, tc.expectedURLPath, req.URL.Path)
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
WIP normalizing request URL paths for any requests going through the web package. Proposed changes adds some basic path normalization in the web package. Another idea we evaluated was a middleware. But since we want this to apply to all incoming HTTP requests putting it in the web package feels like the most appropriate. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- The most convenient would be to use a Go library handling all the different cases of https://en.wikipedia.org/wiki/URI_normalization, but haven't found any with a proper license and/or is maintained. 
- On the negative side of using a Go library we could be in place where we think we're safe/protected, but the library doesn't work as expected.
- Haven't found that [Macaron](https://github.com/go-macaron/macaron/) have any URL normalization/path cleaning builtin in it's latest version.
- Seems like gorilla and gin frameworks have some various implementations of cleaning the path that we might be able to take some inspiration of
  - https://github.com/gorilla/mux/blob/3cf0d013e53d62a96c096366d300c84489c26dd5/mux.go#L464
  - https://github.com/gin-gonic/gin/blob/375714258462e46df07337b31dae4370d03ab28d/path.go#L21
- Some additional resource I've found:
  - https://dzx.cz/2021/04/02/go_path_traversal/
  - https://appcheck-ng.com/url-parsing-path-traversal/
  - https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.4