### PR TITLE
Trace view: Reduce whitespace in KeyValuesTable

### DIFF
--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -33,7 +33,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       label: KeyValueTable;
       background: ${autoColor(theme, '#fff')};
       border: 1px solid ${autoColor(theme, '#ddd')};
-      margin-bottom: 0.7em;
+      margin-bottom: 0.5rem;
       max-height: 450px;
       overflow: auto;
     `,
@@ -44,9 +44,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
     row: css`
       label: row;
       & > td {
-        padding: 0.25rem 0.5rem;
-        padding: 0.25rem 0.5rem;
-        vertical-align: top;
+        padding: 0rem 0.5rem;
       }
       &:nth-child(2n) > td {
         background: ${autoColor(theme, '#f5f5f5')};


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleans up vertical spacing in the Span Details section

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #45794

**Special notes for your reviewer**:
Before and after
![Screen Shot 2022-03-02 at 8 44 17 AM](https://user-images.githubusercontent.com/12838032/156396422-2373d658-026f-4c03-9bbc-6680e2ae3da1.png)
![Screen Shot 2022-03-02 at 8 43 54 AM](https://user-images.githubusercontent.com/12838032/156396434-a8997094-690c-4878-915c-6444e5e793dd.png)

