### PR TITLE
Slider: respect min/max in the text (number) field

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -47,7 +47,7 @@ exports[`no enzyme tests`] = {
     "packages/grafana-ui/src/components/QueryField/QueryField.test.tsx:1297745712": [
       [1, 19, 13, "RegExp match", "2409514259"]
     ],
-    "packages/grafana-ui/src/components/Slider/Slider.test.tsx:2110443485": [
+    "packages/grafana-ui/src/components/Slider/Slider.test.tsx:1264182027": [
       [3, 17, 13, "RegExp match", "2409514259"]
     ],
     "packages/grafana-ui/src/components/Typeahead/PartialHighlighter.test.tsx:3831493850": [

--- a/packages/grafana-ui/src/components/Slider/Slider.test.tsx
+++ b/packages/grafana-ui/src/components/Slider/Slider.test.tsx
@@ -36,14 +36,14 @@ describe('Slider', () => {
     expect(wrapper.html()).toContain('aria-valuenow="50"');
   });
 
-  it('defaults after blur if input value is outside of range', () => {
+  it('check that input is clamped within range', () => {
     const wrapper = mount(<Slider {...sliderProps} value={10} min={10} max={100} />);
     const sliderInput = wrapper.find('input');
     sliderInput.simulate('focus');
     sliderInput.simulate('change', { target: { value: 200 } });
     // re-grab to check value is out of range before blur
     const sliderInputIncorrect = wrapper.find('input');
-    expect(sliderInputIncorrect.get(0).props.value).toEqual('200');
+    expect(sliderInputIncorrect.get(0).props.value).toEqual('100');
 
     sliderInput.simulate('blur');
     expect(wrapper.html()).toContain('aria-valuenow="100"');

--- a/packages/grafana-ui/src/components/Slider/Slider.tsx
+++ b/packages/grafana-ui/src/components/Slider/Slider.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, ChangeEvent, FunctionComponent, FocusEvent } from 'react';
+import React, { useState, useCallback, ChangeEvent, FunctionComponent, FocusEvent, KeyboardEvent } from 'react';
 import SliderComponent from 'rc-slider';
 
 import { cx } from '@emotion/css';
@@ -32,13 +32,20 @@ export const Slider: FunctionComponent<SliderProps> = ({
 
   const onSliderChange = useCallback(
     (v: number) => {
+      if (v > max) {
+        v = max;
+      }
+      if (v < min) {
+        v = min;
+      }
+
       setSliderValue(v);
 
       if (onChange) {
         onChange(v);
       }
     },
-    [setSliderValue, onChange]
+    [setSliderValue, onChange, min, max]
   );
 
   const onSliderInputChange = useCallback(
@@ -49,17 +56,43 @@ export const Slider: FunctionComponent<SliderProps> = ({
         v = 0;
       }
 
-      setSliderValue(v);
-
-      if (onChange) {
-        onChange(v);
-      }
+      onSliderChange(v);
 
       if (onAfterChange) {
         onAfterChange(v);
       }
     },
-    [onChange, onAfterChange]
+    [onSliderChange, onAfterChange]
+  );
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (isNaN(+e.key) && !e.ctrlKey) {
+        switch (e.key) {
+          case 'ArrowUp':
+            onSliderChange(value! + (step ?? 1));
+            break;
+          case 'ArrowDown':
+            onSliderChange(value! - (step ?? 1));
+            break;
+
+          // Do normal behavior
+          case 'ArrowLeft':
+          case 'ArrowRight':
+          case 'Backspace':
+          case 'Delete':
+          case '-': // negative numbers
+          case '.': // decimal places
+            return;
+
+          // Skip everything else
+          default:
+            console.log('SKIP key', e.key);
+        }
+        e.preventDefault();
+      }
+    },
+    [value, step, onSliderChange]
   );
 
   // Check for min/max on input blur so user is able to enter
@@ -99,15 +132,14 @@ export const Slider: FunctionComponent<SliderProps> = ({
           marks={marks}
           included={included}
         />
-        {/* Uses text input so that the number spinners are not shown */}
+        {/* Uses text input so that the number spinners are not shown; manually implements arrow keys and validation */}
         <Input
           type="text"
           className={cx(styles.sliderInputField, ...sliderInputFieldClassNames)}
           value={`${sliderValue}`} // to fix the react leading zero issue
           onChange={onSliderInputChange}
           onBlur={onSliderInputBlur}
-          min={min}
-          max={max}
+          onKeyDown={onKeyDown}
         />
       </label>
     </div>

--- a/packages/grafana-ui/src/components/Slider/Slider.tsx
+++ b/packages/grafana-ui/src/components/Slider/Slider.tsx
@@ -87,7 +87,7 @@ export const Slider: FunctionComponent<SliderProps> = ({
 
           // Skip everything else
           default:
-            console.log('SKIP key', e.key);
+          // console.log('SKIP key', e.key);
         }
         e.preventDefault();
       }


### PR DESCRIPTION
This is pulled out from #45571

Currently the input box next to a slider does not force things to be a number and in range :grimacing:, it does not support stepping values with arrow keys -- If we used `<Input type="number" ... />` this would come for free, but visually we do not want the spinner buttons