### PR TITLE
Azure Monitor: Add feature gating for new MetricsQueryEditor with resource picker

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -46,4 +46,5 @@ export interface FeatureToggles {
   dashboardComments?: boolean;
   annotationComments?: boolean;
   migrationLocking?: boolean;
+  azureMonitorResourcePickerForMetrics?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -162,5 +162,12 @@ var (
 			Description: "Lock database during migrations",
 			State:       FeatureStateBeta,
 		},
+		{
+			Name:            "azureMonitorResourcePickerForMetrics",
+			Description:     "New UI for Azure Monitor Metrics Query",
+			State:           FeatureStateAlpha,
+			RequiresDevMode: true,
+			FrontendOnly:    true,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -122,4 +122,8 @@ const (
 	// FlagMigrationLocking
 	// Lock database during migrations
 	FlagMigrationLocking = "migrationLocking"
+
+	// FlagAzureMonitorResourcePickerForMetrics
+	// New UI for Azure Monitor Metrics Query
+	FlagAzureMonitorResourcePickerForMetrics = "azureMonitorResourcePickerForMetrics"
 )

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/NewMetricsQueryEditor/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/NewMetricsQueryEditor/MetricsQueryEditor.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+interface MetricsQueryEditorProps {}
+
+const MetricsQueryEditor: React.FC<MetricsQueryEditorProps> = ({}) => {
+  return <div data-testid="azure-monitor-metrics-query-editor-with-resource-picker">New Query Editor</div>;
+};
+
+export default MetricsQueryEditor;

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.test.tsx
@@ -133,10 +133,10 @@ describe('Azure Monitor QueryEditor', () => {
   });
 
   it('renders the new query editor for metrics when enabled with a feature toggle', async () => {
-    const originalConfigValue = config.featureToggles.resourcePickerForMetrics;
+    const originalConfigValue = config.featureToggles.azureMonitorResourcePickerForMetrics;
 
     // To do this irl go to custom.ini file and add resourcePickerForMetrics = true under [feature_toggles]
-    config.featureToggles.resourcePickerForMetrics = true;
+    config.featureToggles.azureMonitorResourcePickerForMetrics = true;
 
     const mockDatasource = createMockDatasource();
     const mockQuery = {
@@ -151,6 +151,6 @@ describe('Azure Monitor QueryEditor', () => {
     );
 
     // reset config to not impact future tests
-    config.featureToggles.resourcePickerForMetrics = originalConfigValue;
+    config.featureToggles.azureMonitorResourcePickerForMetrics = originalConfigValue;
   });
 });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.test.tsx
@@ -1,4 +1,5 @@
 import * as ui from '@grafana/ui';
+import { config } from '@grafana/runtime';
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import selectEvent from 'react-select-event';
@@ -129,5 +130,27 @@ describe('Azure Monitor QueryEditor', () => {
     await ui.selectOptionInTest(metrics, 'Logs');
 
     expect(screen.queryByText('Application Insights')).toBeInTheDocument();
+  });
+
+  it('renders the new query editor for metrics when enabled with a feature toggle', async () => {
+    const originalConfigValue = config.featureToggles.resourcePickerForMetrics;
+
+    // To do this irl go to custom.ini file and add resourcePickerForMetrics = true under [feature_toggles]
+    config.featureToggles.resourcePickerForMetrics = true;
+
+    const mockDatasource = createMockDatasource();
+    const mockQuery = {
+      ...createMockQuery(),
+      queryType: AzureQueryType.AzureMonitor,
+    };
+
+    render(<QueryEditor query={mockQuery} datasource={mockDatasource} onChange={() => {}} onRunQuery={() => {}} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('azure-monitor-metrics-query-editor-with-resource-picker')).toBeInTheDocument()
+    );
+
+    // reset config to not impact future tests
+    config.featureToggles.resourcePickerForMetrics = originalConfigValue;
   });
 });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.tsx
@@ -98,7 +98,7 @@ const EditorForQueryType: React.FC<EditorForQueryTypeProps> = ({
 }) => {
   switch (query.queryType) {
     case AzureQueryType.AzureMonitor:
-      if (config.featureToggles.resourcePickerForMetrics) {
+      if (config.featureToggles.azureMonitorResourcePickerForMetrics) {
         return <NewMetricsQueryEditor />;
       }
       return (

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.tsx
@@ -1,5 +1,7 @@
 import { QueryEditorProps } from '@grafana/data';
 import { Alert } from '@grafana/ui';
+import { config } from '@grafana/runtime';
+
 import { debounce } from 'lodash';
 import React, { useCallback, useMemo } from 'react';
 
@@ -19,6 +21,7 @@ import InsightsAnalyticsEditor from '../deprecated/components/InsightsAnalyticsE
 import { gtGrafana9 } from '../deprecated/utils';
 import LogsQueryEditor from '../LogsQueryEditor';
 import MetricsQueryEditor from '../MetricsQueryEditor';
+import NewMetricsQueryEditor from '../NewMetricsQueryEditor/MetricsQueryEditor';
 import { Space } from '../Space';
 import QueryTypeField from './QueryTypeField';
 import usePreparedQuery from './usePreparedQuery';
@@ -95,6 +98,9 @@ const EditorForQueryType: React.FC<EditorForQueryTypeProps> = ({
 }) => {
   switch (query.queryType) {
     case AzureQueryType.AzureMonitor:
+      if (config.featureToggles.resourcePickerForMetrics) {
+        return <NewMetricsQueryEditor />;
+      }
       return (
         <MetricsQueryEditor
           subscriptionId={subscriptionId}


### PR DESCRIPTION
**What this PR does / why we need it**:
We are hoping to add the Resource Picker to Metrics Queries for Azure Monitor, but this will be a bigger project over several PRs, with the potential for breaking changes, so we'd like to develop it under a feature gate if possible. This allows us to start that work 

**Which issue(s) this PR fixes**:

Fixes #46058

**Special notes for your reviewer**:

