### PR TITLE
Prometheus: Fix inconsistent labels in exemplars resulting in marshal json error.

### DIFF
--- a/pkg/tsdb/prometheus/buffered/time_series_query.go
+++ b/pkg/tsdb/prometheus/buffered/time_series_query.go
@@ -438,7 +438,16 @@ func exemplarToDataFrames(response []apiv1.ExemplarQueryResult, query *Prometheu
 	// TODO: this preallocation is very naive.
 	// We should figure out a better approximation here.
 	events := make([]ExemplarEvent, 0, len(response)*2)
-
+	// Prometheus treats empty value as same as null, so `event.Labels` may not be consistent across `events`,
+	// leading errors like "frame has different field lengths, field 0 is len 5 but field 14 is len 2", need a fix.
+	eventLabels := make(map[string]struct{})
+	for _, exemplarData := range response {
+		for _, exemplar := range exemplarData.Exemplars {
+			for label := range exemplar.Labels {
+				eventLabels[string(label)] = struct{}{}
+			}
+		}
+	}
 	for _, exemplarData := range response {
 		for _, exemplar := range exemplarData.Exemplars {
 			event := ExemplarEvent{}
@@ -453,6 +462,15 @@ func exemplarToDataFrames(response []apiv1.ExemplarQueryResult, query *Prometheu
 
 			for seriesLabel, seriesValue := range exemplarData.SeriesLabels {
 				event.Labels[string(seriesLabel)] = string(seriesValue)
+			}
+
+			if len(event.Labels) != len(eventLabels) {
+				// Fill event labels with empty value.
+				for label := range eventLabels {
+					if _, ok := event.Labels[label]; !ok {
+						event.Labels[label] = ""
+					}
+				}
 			}
 
 			events = append(events, event)


### PR DESCRIPTION
**What this PR does / why we need it**:
Prometheus treats empty value as the same as null. So that, 
 The exemplar response may not have consistent labels across exemplars, this PR fix it with add empty value, make it data frame marshal JSON normally.


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #46134

**Special notes for your reviewer**:

