### PR TITLE
Graph (old): fix null interval insertion, again (follow-up to #46069)

### DIFF
--- a/public/app/plugins/panel/graph/data_processor.ts
+++ b/public/app/plugins/panel/graph/data_processor.ts
@@ -32,13 +32,14 @@ export class DataProcessor {
 
     for (let i = 0; i < dataList.length; i++) {
       let series = dataList[i];
-      const { timeField } = getTimeField(series);
+      let { timeField } = getTimeField(series);
 
       if (!timeField) {
         continue;
       }
 
       series = applyNullInsertThreshold(series, timeField.name);
+      timeField = getTimeField(series).timeField!; // use updated length
 
       for (let j = 0; j < series.fields.length; j++) {
         const field = series.fields[j];


### PR DESCRIPTION
Fixes #46136

Test dashboard:

<details><summary>graph-old-null-gaps-bug.json</summary>

```json
{
    "annotations": {
      "list": [
        {
          "builtIn": 1,
          "datasource": "-- Grafana --",
          "enable": true,
          "hide": true,
          "iconColor": "rgba(0, 211, 255, 1)",
          "name": "Annotations & Alerts",
          "target": {
            "limit": 100,
            "matchAny": false,
            "tags": [],
            "type": "dashboard"
          },
          "type": "dashboard"
        }
      ]
    },
    "editable": true,
    "fiscalYearStartMonth": 0,
    "graphTooltip": 0,
    "id": 123,
    "links": [],
    "liveNow": false,
    "panels": [
      {
        "fieldConfig": {
          "defaults": {
            "color": {
              "mode": "thresholds"
            },
            "custom": {
              "align": "auto",
              "displayMode": "auto",
              "inspect": false
            },
            "mappings": [],
            "max": 150,
            "min": 50,
            "thresholds": {
              "mode": "absolute",
              "steps": [
                {
                  "color": "green",
                  "value": null
                },
                {
                  "color": "red",
                  "value": 80
                }
              ]
            },
            "unit": "short"
          },
          "overrides": []
        },
        "gridPos": {
          "h": 28,
          "w": 4,
          "x": 0,
          "y": 0
        },
        "id": 6,
        "maxDataPoints": 30,
        "options": {
          "footer": {
            "fields": "",
            "reducer": [
              "sum"
            ],
            "show": false
          },
          "showHeader": true
        },
        "pluginVersion": "8.5.0-pre",
        "targets": [
          {
            "datasource": {
              "type": "testdata",
              "uid": "PD8C576611E62080A"
            },
            "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"fields\": [\n        {\n          \"name\": \"time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\",\n            \"nullable\": true\n          },\n          \"config\": {\n            \"interval\": 600000\n          },\n          \"entities\": {}\n        },\n        {\n          \"name\": \"A-series\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          },\n          \"labels\": {},\n          \"config\": {},\n          \"entities\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1646094600000,\n          1646095200000,\n          1646095800000,\n          1646096400000,\n          1646097600000,\n          1646098200000,\n          1646098800000,\n          1646099400000,\n          1646100000000,\n          1646101200000,\n          1646102400000,\n          1646103000000,\n          1646103600000,\n          1646104200000,\n          1646104800000,\n          1646105400000,\n          1646106000000,\n          1646106600000,\n          1646107200000,\n          1646107800000,\n          1646108400000,\n          1646109000000,\n          1646109600000,\n          1646110200000,\n          1646110800000,\n          1646112000000,\n          1646112600000,\n          1646113200000,\n          1646113800000\n        ],\n        [\n          100,\n          100,\n          105.81006995329166,\n          116.90080371040095,\n          121.80853278756048,\n          123.05318949121924,\n          130.00762477392445,\n          137.62415948596018,\n          129.27116400788705,\n          113.12000683270352,\n          123.53377270621095,\n          122.19163151221835,\n          123.13083874976354,\n          107.543072312524,\n          108.40824224119145,\n          100,\n          106.37357490746014,\n          111.38577485138248,\n          100.10775293837538,\n          101.7856850859778,\n          110.73330625027617,\n          109.52384522516263,\n          100,\n          101.8758619626383,\n          105.75636893840684,\n          112.86095357917831,\n          119.76408932860197,\n          120.0721570803906,\n          112.25628084541167\n        ]\n      ]\n    }\n  }\n]",
            "refId": "A",
            "scenarioId": "raw_frame"
          }
        ],
        "title": "Data1",
        "type": "table"
      },
      {
        "datasource": {
          "type": "datasource",
          "uid": "-- Dashboard --"
        },
        "fieldConfig": {
          "defaults": {
            "color": {
              "mode": "palette-classic"
            },
            "custom": {
              "axisLabel": "",
              "axisPlacement": "auto",
              "barAlignment": 0,
              "drawStyle": "line",
              "fillOpacity": 10,
              "gradientMode": "none",
              "hideFrom": {
                "legend": false,
                "tooltip": false,
                "viz": false
              },
              "lineInterpolation": "linear",
              "lineWidth": 1,
              "pointSize": 5,
              "scaleDistribution": {
                "type": "linear"
              },
              "showPoints": "auto",
              "spanNulls": false,
              "stacking": {
                "group": "A",
                "mode": "none"
              },
              "thresholdsStyle": {
                "mode": "off"
              }
            },
            "mappings": [],
            "max": 150,
            "min": 50,
            "thresholds": {
              "mode": "absolute",
              "steps": [
                {
                  "color": "green",
                  "value": null
                },
                {
                  "color": "red",
                  "value": 80
                }
              ]
            },
            "unit": "short"
          },
          "overrides": []
        },
        "gridPos": {
          "h": 7,
          "w": 12,
          "x": 4,
          "y": 0
        },
        "id": 4,
        "options": {
          "legend": {
            "calcs": [],
            "displayMode": "list",
            "placement": "bottom"
          },
          "tooltip": {
            "mode": "multi",
            "sort": "none"
          }
        },
        "pluginVersion": "8.5.0-pre",
        "targets": [
          {
            "datasource": {
              "type": "datasource",
              "uid": "-- Dashboard --"
            },
            "panelId": 6,
            "refId": "A"
          }
        ],
        "title": "TimeSeries",
        "type": "timeseries"
      },
      {
        "datasource": {
          "type": "datasource",
          "uid": "-- Dashboard --"
        },
        "fieldConfig": {
          "defaults": {
            "color": {
              "mode": "palette-classic"
            },
            "custom": {
              "axisLabel": "",
              "axisPlacement": "auto",
              "barAlignment": 0,
              "drawStyle": "line",
              "fillOpacity": 10,
              "gradientMode": "none",
              "hideFrom": {
                "legend": false,
                "tooltip": false,
                "viz": false
              },
              "lineInterpolation": "stepAfter",
              "lineWidth": 1,
              "pointSize": 5,
              "scaleDistribution": {
                "type": "linear"
              },
              "showPoints": "always",
              "spanNulls": false,
              "stacking": {
                "group": "A",
                "mode": "none"
              },
              "thresholdsStyle": {
                "mode": "off"
              }
            },
            "mappings": [],
            "max": 150,
            "min": 50,
            "thresholds": {
              "mode": "absolute",
              "steps": [
                {
                  "color": "green",
                  "value": null
                },
                {
                  "color": "red",
                  "value": 80
                }
              ]
            },
            "unit": "short"
          },
          "overrides": []
        },
        "gridPos": {
          "h": 7,
          "w": 12,
          "x": 4,
          "y": 7
        },
        "id": 5,
        "options": {
          "legend": {
            "calcs": [],
            "displayMode": "list",
            "placement": "bottom"
          },
          "tooltip": {
            "mode": "multi",
            "sort": "none"
          }
        },
        "pluginVersion": "8.5.0-pre",
        "targets": [
          {
            "datasource": {
              "type": "datasource",
              "uid": "-- Dashboard --"
            },
            "panelId": 6,
            "refId": "A"
          }
        ],
        "title": "TimeSeries (step after)",
        "type": "timeseries"
      },
      {
        "aliasColors": {},
        "bars": false,
        "dashLength": 10,
        "dashes": false,
        "datasource": {
          "type": "datasource",
          "uid": "-- Dashboard --"
        },
        "fill": 1,
        "fillGradient": 0,
        "gridPos": {
          "h": 7,
          "w": 12,
          "x": 4,
          "y": 14
        },
        "hiddenSeries": false,
        "id": 2,
        "legend": {
          "avg": false,
          "current": false,
          "max": false,
          "min": false,
          "show": true,
          "total": false,
          "values": false
        },
        "lines": true,
        "linewidth": 1,
        "maxDataPoints": 30,
        "nullPointMode": "null",
        "options": {
          "alertThreshold": true
        },
        "percentage": false,
        "pluginVersion": "8.5.0-pre",
        "pointradius": 2,
        "points": true,
        "renderer": "flot",
        "seriesOverrides": [],
        "spaceLength": 10,
        "stack": false,
        "steppedLine": false,
        "targets": [
          {
            "datasource": {
              "type": "datasource",
              "uid": "-- Dashboard --"
            },
            "panelId": 6,
            "refId": "A"
          }
        ],
        "thresholds": [],
        "timeRegions": [],
        "title": "Graph (old)",
        "tooltip": {
          "shared": true,
          "sort": 0,
          "value_type": "individual"
        },
        "type": "graph",
        "xaxis": {
          "mode": "time",
          "show": true,
          "values": []
        },
        "yaxes": [
          {
            "$$hashKey": "object:124",
            "format": "short",
            "logBase": 1,
            "max": "150",
            "min": "50",
            "show": true
          },
          {
            "$$hashKey": "object:125",
            "format": "short",
            "logBase": 1,
            "show": true
          }
        ],
        "yaxis": {
          "align": false
        }
      },
      {
        "aliasColors": {},
        "bars": false,
        "dashLength": 10,
        "dashes": false,
        "datasource": {
          "type": "datasource",
          "uid": "-- Dashboard --"
        },
        "fill": 1,
        "fillGradient": 0,
        "gridPos": {
          "h": 7,
          "w": 12,
          "x": 4,
          "y": 21
        },
        "hiddenSeries": false,
        "id": 3,
        "legend": {
          "avg": false,
          "current": false,
          "max": false,
          "min": false,
          "show": true,
          "total": false,
          "values": false
        },
        "lines": true,
        "linewidth": 1,
        "nullPointMode": "null",
        "options": {
          "alertThreshold": true
        },
        "percentage": false,
        "pluginVersion": "8.5.0-pre",
        "pointradius": 2,
        "points": true,
        "renderer": "flot",
        "seriesOverrides": [],
        "spaceLength": 10,
        "stack": false,
        "steppedLine": true,
        "targets": [
          {
            "datasource": {
              "type": "datasource",
              "uid": "-- Dashboard --"
            },
            "panelId": 6,
            "refId": "A"
          }
        ],
        "thresholds": [],
        "timeRegions": [],
        "title": "Graph (old) (staircase)",
        "tooltip": {
          "shared": true,
          "sort": 0,
          "value_type": "individual"
        },
        "type": "graph",
        "xaxis": {
          "mode": "time",
          "show": true,
          "values": []
        },
        "yaxes": [
          {
            "$$hashKey": "object:184",
            "format": "short",
            "logBase": 1,
            "max": "150",
            "min": "50",
            "show": true
          },
          {
            "$$hashKey": "object:185",
            "format": "short",
            "logBase": 1,
            "show": true
          }
        ],
        "yaxis": {
          "align": false
        }
      }
    ],
    "refresh": false,
    "schemaVersion": 35,
    "style": "dark",
    "tags": [],
    "templating": {
      "list": []
    },
    "time": {
      "from": "2022-03-01T00:00:00.000Z",
      "to": "2022-03-01T06:00:00.000Z"
    },
    "timepicker": {},
    "timezone": "utc",
    "title": "graph-old-nulls",
    "uid": "2dwZyvY7z",
    "version": 19,
    "weekStart": ""
  }
```
</details>

### 8.4.2 (original issue, gaps not rendered):
![1](https://user-images.githubusercontent.com/43234/156511953-8db3693b-cd4e-4a20-80ce-d8dbecab6082.png)

### 8.4.3 (with #46069, gaps rendered but incorrectly, and datapoints shifted along x)
![2](https://user-images.githubusercontent.com/43234/156511955-28f63f71-5ec8-47ce-988c-93e2fa674c65.png)

### this PR (full fix, hopefully):
![3](https://user-images.githubusercontent.com/43234/156511958-7c520857-87d9-453b-b0fb-e59e34eba659.png)
