### PR TITLE
Plugins: allow using both Function and Class components for app plugins

### DIFF
--- a/packages/grafana-data/src/types/app.ts
+++ b/packages/grafana-data/src/types/app.ts
@@ -1,4 +1,4 @@
-import { ComponentClass, FunctionComponent } from 'react';
+import { ComponentType } from 'react';
 import { KeyValue } from './data';
 import { NavModel } from './navModel';
 import { PluginMeta, GrafanaPlugin, PluginIncludeType } from './plugin';
@@ -48,7 +48,7 @@ export interface AppPluginMeta<T = KeyValue> extends PluginMeta<T> {
 
 export class AppPlugin<T = KeyValue> extends GrafanaPlugin<AppPluginMeta<T>> {
   // Content under: /a/${plugin-id}/*
-  root?: ComponentClass<AppRootProps<T>> | FunctionComponent<AppRootProps<T>>;
+  root?: ComponentType<AppRootProps<T>>;
   rootNav?: NavModel; // Initial navigation model
 
   /**
@@ -66,7 +66,7 @@ export class AppPlugin<T = KeyValue> extends GrafanaPlugin<AppPluginMeta<T>> {
    *
    * NOTE: this structure will change in 7.2+ so that it is managed with a normal react router
    */
-  setRootPage(root: ComponentClass<AppRootProps<T>> | FunctionComponent<AppRootProps<T>>, rootNav?: NavModel) {
+  setRootPage(root: ComponentType<AppRootProps<T>>, rootNav?: NavModel) {
     this.root = root;
     this.rootNav = rootNav;
     return this;

--- a/packages/grafana-data/src/types/app.ts
+++ b/packages/grafana-data/src/types/app.ts
@@ -1,4 +1,4 @@
-import { ComponentClass } from 'react';
+import { ComponentClass, FunctionComponent } from 'react';
 import { KeyValue } from './data';
 import { NavModel } from './navModel';
 import { PluginMeta, GrafanaPlugin, PluginIncludeType } from './plugin';
@@ -48,7 +48,7 @@ export interface AppPluginMeta<T = KeyValue> extends PluginMeta<T> {
 
 export class AppPlugin<T = KeyValue> extends GrafanaPlugin<AppPluginMeta<T>> {
   // Content under: /a/${plugin-id}/*
-  root?: ComponentClass<AppRootProps<T>>;
+  root?: ComponentClass<AppRootProps<T>> | FunctionComponent<AppRootProps<T>>;
   rootNav?: NavModel; // Initial navigation model
 
   /**
@@ -66,7 +66,7 @@ export class AppPlugin<T = KeyValue> extends GrafanaPlugin<AppPluginMeta<T>> {
    *
    * NOTE: this structure will change in 7.2+ so that it is managed with a normal react router
    */
-  setRootPage(root: ComponentClass<AppRootProps<T>>, rootNav?: NavModel) {
+  setRootPage(root: ComponentClass<AppRootProps<T>> | FunctionComponent<AppRootProps<T>>, rootNav?: NavModel) {
     this.root = root;
     this.rootNav = rootNav;
     return this;

--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -1,4 +1,4 @@
-import { ComponentClass } from 'react';
+import React from 'react';
 import { KeyValue } from './data';
 
 /** Describes plugins life cycle status */
@@ -159,7 +159,7 @@ export interface PluginConfigPage<T extends PluginMeta> {
   icon?: string;
   id: string; // Unique, in URL
 
-  body: ComponentClass<PluginConfigPageProps<T>>;
+  body: React.FunctionComponent<PluginConfigPageProps<T>> | React.ComponentClass<PluginConfigPageProps<T>>;
 }
 
 export class GrafanaPlugin<T extends PluginMeta = PluginMeta> {

--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -1,4 +1,4 @@
-import { ComponentClass, FunctionComponent } from 'react';
+import { ComponentType } from 'react';
 import { KeyValue } from './data';
 
 /** Describes plugins life cycle status */
@@ -159,7 +159,7 @@ export interface PluginConfigPage<T extends PluginMeta> {
   icon?: string;
   id: string; // Unique, in URL
 
-  body: FunctionComponent<PluginConfigPageProps<T>> | ComponentClass<PluginConfigPageProps<T>>;
+  body: ComponentType<PluginConfigPageProps<T>>;
 }
 
 export class GrafanaPlugin<T extends PluginMeta = PluginMeta> {

--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ComponentClass, FunctionComponent } from 'react';
 import { KeyValue } from './data';
 
 /** Describes plugins life cycle status */
@@ -159,7 +159,7 @@ export interface PluginConfigPage<T extends PluginMeta> {
   icon?: string;
   id: string; // Unique, in URL
 
-  body: React.FunctionComponent<PluginConfigPageProps<T>> | React.ComponentClass<PluginConfigPageProps<T>>;
+  body: FunctionComponent<PluginConfigPageProps<T>> | ComponentClass<PluginConfigPageProps<T>>;
 }
 
 export class GrafanaPlugin<T extends PluginMeta = PluginMeta> {


### PR DESCRIPTION
**Related issue:** https://github.com/grafana/grafana/issues/45791

### What changed?
Currently only class components are allowed to be used as configuration page or root page components for app plugins.
[It is because of the TS type here.](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/plugin.ts#L162)

This PR fixes that.