### PR TITLE
Datasource: Fixes changing default data source causes inconsistency between panel data source and query data source

### DIFF
--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -17,6 +17,13 @@ const dataSources = {
   prom: mockDataSource({
     name: 'prom',
     type: 'prometheus',
+    isDefault: true,
+  }),
+  notDefault: mockDataSource({
+    name: 'prom-not-default',
+    uid: 'prom-not-default-uid',
+    type: 'prometheus',
+    isDefault: false,
   }),
   [MIXED_DATASOURCE_NAME]: mockDataSource({
     name: MIXED_DATASOURCE_NAME,
@@ -1837,6 +1844,33 @@ describe('DashboardModel', () => {
 
     it('should update datasources in panels collapsed rows', () => {
       expect(model.panels[3].panels[0].datasource).toEqual({ type: 'prometheus', uid: 'mock-ds-2' });
+    });
+  });
+
+  describe('when fixing query and panel data source refs out of sync due to default data source change', () => {
+    let model: DashboardModel;
+
+    beforeEach(() => {
+      model = new DashboardModel({
+        templating: {
+          list: [],
+        },
+        panels: [
+          {
+            id: 2,
+            datasource: null,
+            targets: [
+              {
+                datasource: 'prom-not-default',
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('should not update panel datasource to that of query level ds', () => {
+      expect(model.panels[0].datasource?.uid).toEqual('prom-not-default-uid');
     });
   });
 

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -72,16 +72,22 @@ export class DashboardMigrator {
    * data source uid & type set that is different from the now new default
    */
   syncQueryDataSources() {
+    const dataSourceSrv = getDataSourceSrv();
+    // This only happens in some unit tests that does not set a DataSourceSrv
+    if (!dataSourceSrv) {
+      return;
+    }
+
+    const defaultDS = getDataSourceSrv().getInstanceSettings(null);
+    // if default ds is mixed then skip this
+    if (!defaultDS || defaultDS.meta.mixed) {
+      return;
+    }
+
     for (const panel of this.dashboard.panels) {
       // only interested in panels that use default (null) data source
       if (panel.datasource) {
         continue;
-      }
-
-      const defaultDS = getDataSourceSrv().getInstanceSettings(null);
-      // if default ds is mixed then skip this
-      if (!defaultDS || defaultDS.meta.mixed) {
-        return;
       }
 
       for (const target of panel.targets) {

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -67,6 +67,34 @@ export class DashboardMigrator {
     this.dashboard = dashboardModel;
   }
 
+  /**
+   * When changing default datasource which is stored as null Grafana get's into a mixed state where queries have
+   * data source uid & type set that is different from the now new default
+   */
+  syncQueryDataSources() {
+    for (const panel of this.dashboard.panels) {
+      // only interested in panels that use default (null) data source
+      if (panel.datasource) {
+        continue;
+      }
+
+      const defaultDS = getDataSourceSrv().getInstanceSettings(null);
+      // if default ds is mixed then skip this
+      if (!defaultDS || defaultDS.meta.mixed) {
+        return;
+      }
+
+      for (const target of panel.targets) {
+        // If query level data source is different from panel
+        if (target.datasource && target.datasource.uid !== defaultDS?.uid) {
+          // set panel level data source to data source on the query as this is more likely the correct one
+          // But impossible to say, and this changes the behavior of of what default means ahead of the big change to default
+          panel.datasource = target.datasource;
+        }
+      }
+    }
+  }
+
   updateSchema(old: any) {
     let i, j, k, n;
     const oldVersion = this.dashboard.schemaVersion;

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -1069,6 +1069,7 @@ export class DashboardModel implements TimeModel {
   private updateSchema(old: any) {
     const migrator = new DashboardMigrator(this);
     migrator.updateSchema(old);
+    migrator.syncQueryDataSources();
   }
 
   resetOriginalTime() {


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/2031


The default data source concept is a bit broken in 8.3 and 8.4 where we
started storing data source on query level always. But there we always store
the real data source ref even if it's the default data source selected.

So this means the panel.datasource is null but the queries have the actual data source
 that was deault at the time. If you later change default data source it will only
 change at the panel level but if you go into panel edit it the old datasource will
be used for each query.


There is no good way to solve this really. Feels like no matter how we fix it it's going to
break somethings. We could add post migration fix that syncs the query level datasource
property to the current default data source. This is probably the most consistent
thing to do. But it won't fix the bug reported in that escalation as there they changed
default data source and did not expect it to impact any current dashboards.

Since we plan to change the meaning of default via https://github.com/grafana/grafana/pull/45132
The other way to sort of fix this is to instead set the panel level data source to
be what ever the data source is on the query level.

Not sure what is best here.

