### PR TITLE
Chore: Remove deprecated no-op option PreferServerCipherSuites

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -381,8 +381,7 @@ func (hs *HTTPServer) configureHttps() error {
 	}
 
 	tlsCfg := &tls.Config{
-		MinVersion:               tls.VersionTLS12,
-		PreferServerCipherSuites: true,
+		MinVersion: tls.VersionTLS12,
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -421,8 +421,7 @@ func (hs *HTTPServer) configureHttp2() error {
 	}
 
 	tlsCfg := &tls.Config{
-		MinVersion:               tls.VersionTLS12,
-		PreferServerCipherSuites: true,
+		MinVersion: tls.VersionTLS12,
 		CipherSuites: []uint16{
 			tls.TLS_CHACHA20_POLY1305_SHA256,
 			tls.TLS_AES_128_GCM_SHA256,


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove deprecated no-op option PreferServerCipherSuites from TLS config. Per golang docs: "PreferServerCipherSuites is a legacy field and has no effect."

