### PR TITLE
Feature Highlights: add RS event to the recorded queries highlight badge

### DIFF
--- a/public/app/core/components/PageHeader/PageHeader.tsx
+++ b/public/app/core/components/PageHeader/PageHeader.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { css } from '@emotion/css';
 import { Tab, TabsBar, Icon, IconName, useStyles2 } from '@grafana/ui';
 import { NavModel, NavModelItem, NavModelBreadcrumb, GrafanaTheme2 } from '@grafana/data';
@@ -76,18 +76,27 @@ const Navigation = ({ children }: { children: NavModelItem[] }) => {
 export const PageHeader: FC<Props> = ({ model }) => {
   const styles = useStyles2(getStyles);
 
+  const main = model.main;
+  const [children, setChildren] = useState(main.children);
+
+  useEffect(() => {
+    const updatedChildren = main.children?.map((child) => {
+      // Add suffix component for the items that come from backend and are highlighted
+      if (child.highlightText && !child.tabSuffix) {
+        return {
+          ...child,
+          tabSuffix: () =>
+            ProBadge({ experimentId: child.highlightId ? `feature-highlights-${child.highlightId}-badge` : '' }),
+        };
+      }
+      return child;
+    });
+    setChildren(updatedChildren);
+  }, [main.children]);
+
   if (!model) {
     return null;
   }
-
-  const main = model.main;
-  const children = main.children?.map((child) => {
-    // Add suffix component for the items that come from backend and are highlighted
-    if (child.highlightText && !child.tabSuffix) {
-      return { ...child, tabSuffix: ProBadge };
-    }
-    return child;
-  });
 
   return (
     <div className={styles.headerCanvas}>


### PR DESCRIPTION
**What this PR does / why we need it**:
Add RS event for the recorded queries highlight badge.

**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**:
It was a bit more complicated than expected and it's why it started with a comment on the original PR and ended as a separate PR.

Some issues / questions I had:
- The event is still emitted twice when going on any Configuration tab and I don't understand why as `model.main.children` seems to be the same.
- I'm not sure the check on `model` is still needed, it doesn't seem like it can be `null` or `undefined` but maybe I'm missing something.

@Clarity-89  Feel free to make the changes on your PR directly if it's easier and I'll close this one. 
