### PR TITLE
Dashboard: Validate refId when generating id for cloudwatch query

### DIFF
--- a/pkg/tsdb/cloudwatch/request_parser.go
+++ b/pkg/tsdb/cloudwatch/request_parser.go
@@ -10,9 +10,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 )
+
+var validMetricDataID = regexp.MustCompile(`^[a-z][a-zA-Z0-9_]*$`)
 
 // parseQueries parses the json queries and returns a map of cloudWatchQueries by region. The cloudWatchQuery has a 1 to 1 mapping to a query editor row
 func (e *cloudWatchExecutor) parseQueries(queries []backend.DataQuery, startTime time.Time, endTime time.Time) (map[string][]*cloudWatchQuery, error) {
@@ -140,7 +144,12 @@ func parseRequestQuery(model *simplejson.Json, refId string, startTime time.Time
 		// Why not just use refId if id is not specified in the frontend? When specifying an id in the editor,
 		// and alphabetical must be used. The id must be unique, so if an id like for example a, b or c would be used,
 		// it would likely collide with some ref id. That's why the `query` prefix is used.
-		id = fmt.Sprintf("query%s", refId)
+		suffix := refId
+		if !validMetricDataID.MatchString(suffix) {
+			uuid := uuid.NewString()
+			suffix = strings.Replace(uuid, "-", "", -1)
+		}
+		id = fmt.Sprintf("query%s", suffix)
 	}
 	expression := model.Get("expression").MustString("")
 	sqlExpression := model.Get("sqlExpression").MustString("")

--- a/pkg/tsdb/cloudwatch/request_parser.go
+++ b/pkg/tsdb/cloudwatch/request_parser.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 )

--- a/pkg/tsdb/cloudwatch/request_parser_test.go
+++ b/pkg/tsdb/cloudwatch/request_parser_test.go
@@ -294,6 +294,14 @@ func TestRequestParser(t *testing.T) {
 		})
 	})
 
+	t.Run("ID is the string `query` appended with refId if refId is a valid MetricData ID", func(t *testing.T) {
+		query := getBaseJsonQuery()
+		res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+		require.NoError(t, err)
+		assert.Equal(t, "ref1", res.RefId)
+		assert.Equal(t, "queryref1", res.Id)
+	})
+
 	t.Run("Valid id is generated if ID is not provided and refId is not a valid MetricData ID", func(t *testing.T) {
 		query := getBaseJsonQuery()
 		query.Set("refId", "$$")

--- a/pkg/tsdb/cloudwatch/request_parser_test.go
+++ b/pkg/tsdb/cloudwatch/request_parser_test.go
@@ -293,6 +293,15 @@ func TestRequestParser(t *testing.T) {
 			assert.Equal(t, GMDApiModeMathExpression, res.getGMDAPIMode())
 		})
 	})
+
+	t.Run("Valid id is generated if ID is not provided and refId is not a valid MetricData ID", func(t *testing.T) {
+		query := getBaseJsonQuery()
+		query.Set("refId", "$$")
+		res, err := parseRequestQuery(query, "$$", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+		require.NoError(t, err)
+		assert.Equal(t, "$$", res.RefId)
+		assert.Regexp(t, validMetricDataID, res.Id)
+	})
 }
 
 func getBaseJsonQuery() *simplejson.Json {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The CloudWatch plugin currently generates an `id` for the query if the `id` is not provided by the user. It does this by appending the `refId` to the string `query`. E.g. if the `refId` is `a`, the generated id is `querya` i.e. `query` + `a`.

In the case where we generate the ID, it is expected to have the regex pattern `^[a-z][a-zA-Z0-9_]*$` (alphanumeric and underscores with the leading letter being lowercase). If the `refId` doesn't conform to this pattern, the generated ID would cause a 400 status making a `GetMetricData` API call.

This PR checks the `refId` for this pattern and if it doesn't conform to it, we generate a unique ID which is a v4 UUID string with the hyphens stripped. This then gets appended to `query`.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #41401

**Special notes for your reviewer**:

