### PR TITLE
Histogram: updated bucket size/offeset settings

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -152,7 +152,7 @@ export function buildHistogram(frames: DataFrame[], options?: HistogramTransform
   let bucketOffset = options?.bucketOffset ?? 0;
 
   // if bucket size is auto, try to calc from all numeric fields
-  if (!bucketSize) {
+  if (!bucketSize || bucketSize < 0) {
     let allValues: number[] = [];
 
     // TODO: include field configs!

--- a/public/app/plugins/panel/histogram/module.tsx
+++ b/public/app/plugins/panel/histogram/module.tsx
@@ -23,6 +23,7 @@ export const plugin = new PanelPlugin<PanelOptions, PanelFieldConfig>(HistogramP
         description: histogramFieldInfo.bucketSize.description,
         settings: {
           placeholder: 'Auto',
+          min: 0,
         },
         defaultValue: defaultPanelOptions.bucketSize,
         showIf: (opts, data) => !originalDataHasHistogram(data),
@@ -33,6 +34,7 @@ export const plugin = new PanelPlugin<PanelOptions, PanelFieldConfig>(HistogramP
         description: histogramFieldInfo.bucketOffset.description,
         settings: {
           placeholder: '0',
+          min: 0,
         },
         defaultValue: defaultPanelOptions.bucketOffset,
         showIf: (opts, data) => !originalDataHasHistogram(data),


### PR DESCRIPTION
**What this PR does / why we need it**:
 
The app was crashing when a negative value was added for bucket size. The buckets size/offset wasn't taking into account the min/max settings, so updated the code to do so.

Updated the bucket size/offset settings for histogram to have a min. Adding this in addition to the changes from #46046 offers input validation/restrictions.


https://user-images.githubusercontent.com/88068998/156674537-17876d70-8e8c-4840-95d9-44edf76b6bbf.mov



**Which issue(s) this PR fixes**:
Fixes #40872 
