### PR TITLE
Backporting bump version fixes

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -4,7 +4,9 @@ on:
     inputs:
       version:
         required: true
-        default: '7.x.x'
+        default: '8.x.x'
+env:
+    YARN_ENABLE_IMMUTABLE_INSTALLS: false
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -55,7 +57,7 @@ jobs:
           ref: main
       - uses: actions/setup-node@v2.4.1
         with:
-          node-version: '14'
+          node-version: '16'
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: Run bump version


### PR DESCRIPTION
Backporting changes from https://github.com/grafana/grafana/pull/46016 into `8.3.x` branch