### PR TITLE
Backporting bump version fixes

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       version:
         required: true
-        default: '7.x.x'
+        default: '8.x.x'
   workflow_call:
     inputs:
       version_call:
@@ -16,6 +16,8 @@ on:
           required: true
         metricsWriteAPIKey:
           required: true
+env:
+    YARN_ENABLE_IMMUTABLE_INSTALLS: false
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Backporting changes from https://github.com/grafana/grafana/pull/46016 into `8.4.x` branch