### PR TITLE
Prometheus: Add text to Add operation button

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationList.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationList.tsx
@@ -115,7 +115,9 @@ export function OperationList<T extends QueryWithOperations>({
               placeholder={'Search'}
             />
           ) : (
-            <Button icon={'plus'} variant={'secondary'} onClick={() => setCascaderOpen(true)} title={'Add operation'} />
+            <Button icon={'plus'} variant={'secondary'} onClick={() => setCascaderOpen(true)} title={'Add operation'}>
+              Operations
+            </Button>
           )}
         </div>
       </Stack>
@@ -126,17 +128,20 @@ export function OperationList<T extends QueryWithOperations>({
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     heading: css({
+      label: 'heading',
       fontSize: 12,
       fontWeight: theme.typography.fontWeightMedium,
       marginBottom: 0,
     }),
     operationList: css({
+      label: 'operationList',
       display: 'flex',
       flexWrap: 'wrap',
       gap: theme.spacing(2),
     }),
     addButton: css({
-      width: 150,
+      label: 'addButton',
+      width: 126,
       paddingBottom: theme.spacing(1),
     }),
   };


### PR DESCRIPTION
As the add operation button was changed so it allowed for search in the cascader, it changed from simple icon button to input which changed the sizing. To prevent jumping of elements, mainly at the end of row where it would jump to next row, permanent width was applied to to button wrapper but that created weird space when there were hints next to it.

This PR adds text to the button so now the button and the input after clicking is the same width and so there is no jumping and no empty spacing:

![Screenshot from 2022-03-04 15-13-52](https://user-images.githubusercontent.com/1014802/156779635-67e5f46d-0da1-4b24-909b-9828367b8739.png)
![Screenshot from 2022-03-04 15-13-44](https://user-images.githubusercontent.com/1014802/156779639-8810fea1-3f76-4d64-b7e2-9db89be58380.png)
