### PR TITLE
LegacyBrowser: fix Safari 13.1 (lacks logical nullish assignent)

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/labelsToFields.ts
+++ b/packages/grafana-data/src/transformations/transformers/labelsToFields.ts
@@ -70,7 +70,7 @@ export const labelsToFieldsTransformer: SynchronousDataTransformerInfo<LabelsToF
             continue;
           }
 
-          const uniqueValues = (uniqueLabels[labelName] ||= new Set());
+          const uniqueValues = uniqueLabels[labelName] ?? (uniqueLabels[labelName] = new Set()); // (Safari 13.1 lacks ??= support)
           uniqueValues.add(field.labels[labelName]);
         }
       }

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -965,7 +965,7 @@ export class DashboardModel implements TimeModel {
 
         for (const panel of row.panels) {
           // set the y gridPos if it wasn't already set
-          panel.gridPos.y ??= row.gridPos.y;
+          panel.gridPos.y ?? (panel.gridPos.y = row.gridPos.y); // (Safari 13.1 lacks ??= support)
           // make sure y is adjusted (in case row moved while collapsed)
           panel.gridPos.y -= yDiff;
           // insert after row

--- a/public/app/plugins/panel/heatmap-new/module.tsx
+++ b/public/app/plugins/panel/heatmap-new/module.tsx
@@ -169,7 +169,7 @@ export const plugin = new PanelPlugin<PanelOptions, GraphFieldConfig>(HeatmapPan
       .addNumberInput({
         path: 'hideThreshold',
         name: 'Hide cell counts <=',
-        defaultValue: 0.000_000_001, // 1e-9
+        defaultValue: 1e-9,
         category,
       })
       .addSliderInput({


### PR DESCRIPTION
Fixes #46110

Judging by the feedback in the linked issue, these are the only changes needed to unbork Safari 13.1. Yes it's old, but looks easy to support currently.

The other problem found in that investigation for even older browsers is "Optional catch binding" which we emit as a result of targeting esnext in TypeScript and appears to be supported in Safari 13.1: https://caniuse.com/?search=Optional%20catch%20binding