### PR TITLE
Access control: Always append all permissions to role admin in oss

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -372,7 +372,7 @@ func setupHTTPServerWithCfg(t *testing.T, useFakeAccessControl, enableAccessCont
 			acmock = acmock.WithDisabled()
 		}
 		hs.AccessControl = acmock
-		teamPermissionService, err := ossaccesscontrol.ProvideTeamPermissions(routeRegister, db, acmock, database.ProvideService(db))
+		teamPermissionService, err := ossaccesscontrol.ProvideTeamPermissions(cfg, routeRegister, db, acmock, database.ProvideService(db))
 		require.NoError(t, err)
 		hs.teamPermissionsService = teamPermissionService
 	} else {
@@ -384,7 +384,7 @@ func setupHTTPServerWithCfg(t *testing.T, useFakeAccessControl, enableAccessCont
 		require.NoError(t, err)
 		err = ac.RegisterFixedRoles()
 		require.NoError(t, err)
-		teamPermissionService, err := ossaccesscontrol.ProvideTeamPermissions(routeRegister, db, ac, database.ProvideService(db))
+		teamPermissionService, err := ossaccesscontrol.ProvideTeamPermissions(cfg, routeRegister, db, ac, database.ProvideService(db))
 		require.NoError(t, err)
 		hs.teamPermissionsService = teamPermissionService
 	}

--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -11,18 +11,22 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
-func ProvidePermissionsServices(router routing.RouteRegister, sql *sqlstore.SQLStore, ac accesscontrol.AccessControl, store resourcepermissions.Store) (*PermissionsServices, error) {
-	teamPermissions, err := ProvideTeamPermissions(router, sql, ac, store)
+func ProvidePermissionsServices(
+	cfg *setting.Cfg, router routing.RouteRegister, sql *sqlstore.SQLStore,
+	ac accesscontrol.AccessControl, store resourcepermissions.Store,
+) (*PermissionsServices, error) {
+	teamPermissions, err := ProvideTeamPermissions(cfg, router, sql, ac, store)
 	if err != nil {
 		return nil, err
 	}
-	folderPermissions, err := provideFolderService(router, sql, ac, store)
+	folderPermissions, err := provideFolderService(cfg, router, sql, ac, store)
 	if err != nil {
 		return nil, err
 	}
-	dashboardPermissions, err := provideDashboardService(router, sql, ac, store)
+	dashboardPermissions, err := provideDashboardService(cfg, router, sql, ac, store)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +76,10 @@ var (
 	}
 )
 
-func ProvideTeamPermissions(router routing.RouteRegister, sql *sqlstore.SQLStore, ac accesscontrol.AccessControl, store resourcepermissions.Store) (*resourcepermissions.Service, error) {
+func ProvideTeamPermissions(
+	cfg *setting.Cfg, router routing.RouteRegister, sql *sqlstore.SQLStore,
+	ac accesscontrol.AccessControl, store resourcepermissions.Store,
+) (*resourcepermissions.Service, error) {
 	options := resourcepermissions.Options{
 		Resource:    "teams",
 		OnlyManaged: true,
@@ -126,7 +133,7 @@ func ProvideTeamPermissions(router routing.RouteRegister, sql *sqlstore.SQLStore
 		},
 	}
 
-	return resourcepermissions.New(options, router, ac, store, sql)
+	return resourcepermissions.New(options, cfg, router, ac, store, sql)
 }
 
 var DashboardViewActions = []string{accesscontrol.ActionDashboardsRead}
@@ -136,7 +143,10 @@ var FolderViewActions = []string{accesscontrol.ActionFoldersRead}
 var FolderEditActions = append(FolderViewActions, []string{accesscontrol.ActionFoldersWrite, accesscontrol.ActionFoldersDelete, accesscontrol.ActionDashboardsCreate}...)
 var FolderAdminActions = append(FolderEditActions, []string{accesscontrol.ActionFoldersPermissionsRead, accesscontrol.ActionFoldersPermissionsWrite}...)
 
-func provideDashboardService(router routing.RouteRegister, sql *sqlstore.SQLStore, accesscontrol accesscontrol.AccessControl, store resourcepermissions.Store) (*resourcepermissions.Service, error) {
+func provideDashboardService(
+	cfg *setting.Cfg, router routing.RouteRegister, sql *sqlstore.SQLStore,
+	accesscontrol accesscontrol.AccessControl, store resourcepermissions.Store,
+) (*resourcepermissions.Service, error) {
 	options := resourcepermissions.Options{
 		Resource: "dashboards",
 		ResourceValidator: func(ctx context.Context, orgID int64, resourceID string) error {
@@ -180,10 +190,13 @@ func provideDashboardService(router routing.RouteRegister, sql *sqlstore.SQLStor
 		RoleGroup:      "Dashboards",
 	}
 
-	return resourcepermissions.New(options, router, accesscontrol, store, sql)
+	return resourcepermissions.New(options, cfg, router, accesscontrol, store, sql)
 }
 
-func provideFolderService(router routing.RouteRegister, sql *sqlstore.SQLStore, accesscontrol accesscontrol.AccessControl, store resourcepermissions.Store) (*resourcepermissions.Service, error) {
+func provideFolderService(
+	cfg *setting.Cfg, router routing.RouteRegister, sql *sqlstore.SQLStore,
+	accesscontrol accesscontrol.AccessControl, store resourcepermissions.Store,
+) (*resourcepermissions.Service, error) {
 	options := resourcepermissions.Options{
 		Resource: "folders",
 		ResourceValidator: func(ctx context.Context, orgID int64, resourceID string) error {
@@ -227,7 +240,7 @@ func provideFolderService(router routing.RouteRegister, sql *sqlstore.SQLStore, 
 		RoleGroup:      "Folders",
 	}
 
-	return resourcepermissions.New(options, router, accesscontrol, store, sql)
+	return resourcepermissions.New(options, cfg, router, accesscontrol, store, sql)
 }
 
 func provideEmptyPermissionsService() accesscontrol.PermissionsService {

--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -87,6 +87,14 @@ func (a *api) getPermissions(c *models.ReqContext) response.Response {
 		return response.Error(http.StatusInternalServerError, "failed to get permissions", err)
 	}
 
+	if a.service.options.Assignments.BuiltInRoles && !a.service.cfg.IsEnterprise {
+		permissions = append(permissions, accesscontrol.ResourcePermission{
+			Actions:     a.service.actions,
+			Scope:       "*",
+			BuiltInRole: string(models.ROLE_ADMIN),
+		})
+	}
+
 	dto := make([]resourcePermissionDTO, 0, len(permissions))
 	for _, p := range permissions {
 		if permission := a.service.MapActions(p); permission != "" {

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions/types"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
-
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions/types"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type Store interface {
@@ -46,7 +46,7 @@ type Store interface {
 	GetResourcesPermissions(ctx context.Context, orgID int64, query types.GetResourcesPermissionsQuery) ([]accesscontrol.ResourcePermission, error)
 }
 
-func New(options Options, router routing.RouteRegister, ac accesscontrol.AccessControl, store Store, sqlStore *sqlstore.SQLStore) (*Service, error) {
+func New(options Options, cfg *setting.Cfg, router routing.RouteRegister, ac accesscontrol.AccessControl, store Store, sqlStore *sqlstore.SQLStore) (*Service, error) {
 	var permissions []string
 	actionSet := make(map[string]struct{})
 	for permission, actions := range options.PermissionsToActions {
@@ -68,6 +68,7 @@ func New(options Options, router routing.RouteRegister, ac accesscontrol.AccessC
 
 	s := &Service{
 		ac:          ac,
+		cfg:         cfg,
 		store:       store,
 		options:     options,
 		permissions: permissions,
@@ -88,6 +89,7 @@ func New(options Options, router routing.RouteRegister, ac accesscontrol.AccessC
 
 // Service is used to create access control sub system including api / and service for managed resource permission
 type Service struct {
+	cfg   *setting.Cfg
 	ac    accesscontrol.AccessControl
 	store Store
 	api   *api

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -220,7 +220,9 @@ func setupTestEnvironment(t *testing.T, permissions []*accesscontrol.Permission,
 
 	sql := sqlstore.InitTestDB(t)
 	store := database.ProvideService(sql)
-	service, err := New(ops, setting.NewCfg(), routing.NewRouteRegister(), accesscontrolmock.New().WithPermissions(permissions), store, sql)
+	cfg := setting.NewCfg()
+	cfg.IsEnterprise = true
+	service, err := New(ops, cfg, routing.NewRouteRegister(), accesscontrolmock.New().WithPermissions(permissions), store, sql)
 	require.NoError(t, err)
 
 	return service, sql

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol/database"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type setUserPermissionTest struct {
@@ -219,7 +220,7 @@ func setupTestEnvironment(t *testing.T, permissions []*accesscontrol.Permission,
 
 	sql := sqlstore.InitTestDB(t)
 	store := database.ProvideService(sql)
-	service, err := New(ops, routing.NewRouteRegister(), accesscontrolmock.New().WithPermissions(permissions), store, sql)
+	service, err := New(ops, setting.NewCfg(), routing.NewRouteRegister(), accesscontrolmock.New().WithPermissions(permissions), store, sql)
 	require.NoError(t, err)
 
 	return service, sql

--- a/pkg/services/guardian/accesscontrol_guardian_test.go
+++ b/pkg/services/guardian/accesscontrol_guardian_test.go
@@ -601,7 +601,7 @@ func setupAccessControlGuardianTest(t *testing.T, dashID int64, permissions []*a
 	require.NoError(t, err)
 
 	ac := accesscontrolmock.New().WithPermissions(permissions)
-	services, err := ossaccesscontrol.ProvidePermissionsServices(routing.NewRouteRegister(), store, ac, database.ProvideService(store))
+	services, err := ossaccesscontrol.ProvidePermissionsServices(setting.NewCfg(), routing.NewRouteRegister(), store, ac, database.ProvideService(store))
 	require.NoError(t, err)
 
 	return NewAccessControlDashboardGuardian(context.Background(), dashID, &models.SignedInUser{OrgId: 1}, store, ac, services)


### PR DESCRIPTION
**What this PR does / why we need it**:
In grafana oss all fixed access control roles lives in memory. When displaying new access control permissions for e.g. dashboards the fixed roles are not accounted for. 

![2022-03-07-11:03:45](https://user-images.githubusercontent.com/23356117/157010105-3ff9abd6-fed5-466b-8a69-09492f336ca2.png)

This pr will add admin permissions for oss if permissions can be assigned to built in roles
![2022-03-07-11:05:28](https://user-images.githubusercontent.com/23356117/157010378-073e7b6b-5cce-45f6-a113-ef40e407349f.png)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

