### PR TITLE
TraceView: Label-values style

### DIFF
--- a/packages/jaeger-ui-components/src/common/LabeledList.tsx
+++ b/packages/jaeger-ui-components/src/common/LabeledList.tsx
@@ -48,6 +48,10 @@ const getStyles = (divider: boolean) => (theme: GrafanaTheme2) => {
       color: ${theme.isLight ? '#999' : '#666'};
       margin-right: 0.25rem;
     `,
+    LabeledListValue: css`
+      label: LabeledListValue;
+      margin-right: 0.55rem;
+    `,
   };
 };
 
@@ -67,7 +71,7 @@ export default function LabeledList(props: LabeledListProps) {
         return (
           <li className={styles.LabeledListItem} key={`${key}`}>
             <span className={styles.LabeledListLabel}>{label}</span>
-            <strong>{value}</strong>
+            <strong className={styles.LabeledListValue}>{value}</strong>
           </li>
         );
       })}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added margin right to space out previously squashed labels and values.

**Special notes for your reviewer**:
Before
![Before - margin-right](https://user-images.githubusercontent.com/90795735/157012345-d97513a9-b728-4151-949f-46fe85a08c16.png)
After
![After - mergin-right](https://user-images.githubusercontent.com/90795735/157012358-b9a50fb6-8382-4c7b-9415-d0d2e9c28a02.png)

