### PR TITLE
ServiceAccounts: Add API key migration to ensure fk is null

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -182,7 +182,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 				},
 			},
 		},
-		Grants: []string{"Admin"},
+		Grants: []string{string(models.ROLE_ADMIN)},
 	}
 
 	orgReaderRole := ac.RoleRegistration{

--- a/pkg/services/sqlstore/migrations/apikey_mig.go
+++ b/pkg/services/sqlstore/migrations/apikey_mig.go
@@ -1,6 +1,8 @@
 package migrations
 
-import . "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+import (
+	. "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+)
 
 func addApiKeyMigrations(mg *Migrator) {
 	apiKeyV1 := Table{
@@ -86,4 +88,7 @@ func addApiKeyMigrations(mg *Migrator) {
 	mg.AddMigration("Add service account foreign key", NewAddColumnMigration(apiKeyV2, &Column{
 		Name: "service_account_id", Type: DB_BigInt, Nullable: true,
 	}))
+
+	mg.AddMigration("set service account foreign key to nil if 0", NewRawSQLMigration(
+		"UPDATE api_key SET service_account_id = NULL WHERE service_account_id = 0;"))
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- Migrates legacy API keys created in 8.4 with service_account_id = 0 to conform to standard null

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

