### PR TITLE
A11y : Updated EmptyListCTA to switch between Button and LinkButton

### DIFF
--- a/public/app/core/components/EmptyListCTA/EmptyListCTA.test.tsx
+++ b/public/app/core/components/EmptyListCTA/EmptyListCTA.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import EmptyListCTA from './EmptyListCTA';
+
+describe('EmptyListCTA', () => {
+  it('should return a button element if there is no buttonLink prop', () => {
+    render(<EmptyListCTA title="title" buttonIcon="plus" buttonTitle="button title" />);
+
+    expect(screen.getByRole('button', { name: 'button title' }));
+  });
+
+  it('should return an anchor element if there is a buttonLink prop', () => {
+    render(<EmptyListCTA title="title" buttonIcon="plus" buttonLink="href" buttonTitle="button title" />);
+
+    expect(screen.getByRole('link', { name: 'button title' }));
+  });
+});

--- a/public/app/core/components/EmptyListCTA/EmptyListCTA.tsx
+++ b/public/app/core/components/EmptyListCTA/EmptyListCTA.tsx
@@ -1,7 +1,7 @@
-import React, { MouseEvent } from 'react';
 import { css } from '@emotion/css';
-import { CallToActionCard, Icon, IconName, LinkButton } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
+import { Button, CallToActionCard, Icon, IconName, LinkButton } from '@grafana/ui';
+import React, { MouseEvent } from 'react';
 
 export interface Props {
   title: string;
@@ -75,8 +75,9 @@ const EmptyListCTA: React.FunctionComponent<Props> = ({
       `
     : '';
 
+  const ButtonEl = buttonLink ? LinkButton : Button;
   const ctaElement = (
-    <LinkButton
+    <ButtonEl
       size="lg"
       onClick={onClick}
       href={buttonLink}
@@ -86,7 +87,7 @@ const EmptyListCTA: React.FunctionComponent<Props> = ({
       disabled={buttonDisabled}
     >
       {buttonTitle}
-    </LinkButton>
+    </ButtonEl>
   );
 
   return <CallToActionCard className={ctaStyle} message={title} footer={footer()} callToActionElement={ctaElement} />;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

To improve A11y:

Currently the buttons for EmptyListCTA (used in variables / annotations / links ... in dashboard settings but also Permissions and Cache in datasources set up) are not keyboard clickable (they are link elements without an href). This PR changes that and renders a button instead.


**Which issue(s) this PR fixes**:

Some of the issues identified as part of a11y hackathon: https://docs.google.com/spreadsheets/d/1e3sjrB3wjgQfttK5ANNkac5wmDwLszhgW0fO1kWT2LI/edit#gid=0

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


