### PR TITLE
A11y : Fixed new variable button keyboard clickable

### DIFF
--- a/public/app/features/variables/editor/VariableEditorContainer.tsx
+++ b/public/app/features/variables/editor/VariableEditorContainer.tsx
@@ -1,21 +1,21 @@
-import React, { MouseEvent, PureComponent } from 'react';
-import { bindActionCreators } from 'redux';
-import { connect, ConnectedProps } from 'react-redux';
-import { Icon, LinkButton } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
-
-import { KeyedVariableIdentifier } from '../state/types';
-import { StoreState, ThunkDispatch } from '../../../types';
-import { VariableEditorEditor } from './VariableEditorEditor';
-import { getEditorVariables, getVariablesState } from '../state/selectors';
-import { switchToEditMode, switchToListMode, switchToNewMode } from './actions';
-import { changeVariableOrder, duplicateVariable, removeVariable } from '../state/sharedReducer';
-import { VariableEditorList } from './VariableEditorList';
-import { VariablesUnknownTable } from '../inspect/VariablesUnknownTable';
-import { VariablesDependenciesButton } from '../inspect/VariablesDependenciesButton';
+import { Button, Icon } from '@grafana/ui';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
+import React, { MouseEvent, PureComponent } from 'react';
+import { connect, ConnectedProps } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import { StoreState, ThunkDispatch } from '../../../types';
+import { VariablesDependenciesButton } from '../inspect/VariablesDependenciesButton';
+import { VariablesUnknownTable } from '../inspect/VariablesUnknownTable';
 import { toKeyedAction } from '../state/keyedVariablesReducer';
+import { getEditorVariables, getVariablesState } from '../state/selectors';
+import { changeVariableOrder, duplicateVariable, removeVariable } from '../state/sharedReducer';
+import { KeyedVariableIdentifier } from '../state/types';
 import { toKeyedVariableIdentifier, toVariablePayload } from '../utils';
+import { switchToEditMode, switchToListMode, switchToNewMode } from './actions';
+import { VariableEditorEditor } from './VariableEditorEditor';
+import { VariableEditorList } from './VariableEditorList';
 
 const mapStateToProps = (state: StoreState, ownProps: OwnProps) => {
   const { uid } = ownProps.dashboard;
@@ -116,13 +116,13 @@ class VariableEditorContainerUnconnected extends PureComponent<Props> {
           {this.props.variables.length > 0 && variableToEdit === null && (
             <>
               <VariablesDependenciesButton variables={this.props.variables} />
-              <LinkButton
+              <Button
                 type="button"
                 onClick={this.onNewVariable}
                 aria-label={selectors.pages.Dashboard.Settings.Variables.List.newButton}
               >
                 New
-              </LinkButton>
+              </Button>
             </>
           )}
         </div>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

To improve A11y

Currently the `new` button in the variables tab of the dashboard settings is not keyboard clickable.

This PR fixes that by making it a `button` instead of a `link`

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

An issue identified as part of a11y hackathon: https://docs.google.com/spreadsheets/d/1e3sjrB3wjgQfttK5ANNkac5wmDwLszhgW0fO1kWT2LI/edit#gid=0

