### PR TITLE
Access control: Ingore permissions in json serialization

### DIFF
--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -184,7 +184,7 @@ type SignedInUser struct {
 	LastSeenAt     time.Time
 	Teams          []int64
 	// Permissions grouped by orgID and actions
-	Permissions map[int64]map[string][]string
+	Permissions map[int64]map[string][]string `json:"-"`
 }
 
 func (u *SignedInUser) ShouldUpdateLastSeenAt() bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
The pluing proxy passes the SingedInUser object in a request header "X-Grafana-Context". The addition of dashboard and folder permissions to access control caused the SginedInUser object to grow a lot. Permissions are atm only used in grafana and can be ignored when passed ower the wire.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

