### PR TITLE
A11y : Variables table - Updated span for Button to be accessible

### DIFF
--- a/public/app/features/variables/editor/VariableEditorListRow.tsx
+++ b/public/app/features/variables/editor/VariableEditorListRow.tsx
@@ -1,15 +1,15 @@
-import React, { ReactElement } from 'react';
 import { css } from '@emotion/css';
-import { Draggable } from 'react-beautiful-dnd';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Icon, IconButton, useStyles2, useTheme2 } from '@grafana/ui';
 import { selectors } from '@grafana/e2e-selectors';
 import { reportInteraction } from '@grafana/runtime';
+import { Button, Icon, IconButton, useStyles2, useTheme2 } from '@grafana/ui';
+import React, { ReactElement } from 'react';
+import { Draggable } from 'react-beautiful-dnd';
 
-import { getVariableUsages, UsagesToNetwork, VariableUsageTree } from '../inspect/utils';
 import { hasOptions, isAdHoc, isQuery } from '../guard';
-import { KeyedVariableIdentifier } from '../state/types';
+import { getVariableUsages, UsagesToNetwork, VariableUsageTree } from '../inspect/utils';
 import { VariableUsagesButton } from '../inspect/VariableUsagesButton';
+import { KeyedVariableIdentifier } from '../state/types';
 import { VariableModel } from '../types';
 import { toKeyedVariableIdentifier } from '../utils';
 
@@ -52,7 +52,9 @@ export function VariableEditorListRow({
           }}
         >
           <td className={styles.column}>
-            <span
+            <Button
+              size="xs"
+              fill="text"
               onClick={(event) => {
                 event.preventDefault();
                 propsOnEdit(identifier);
@@ -61,7 +63,7 @@ export function VariableEditorListRow({
               aria-label={selectors.pages.Dashboard.Settings.Variables.List.tableRowNameFields(variable.name)}
             >
               {variable.name}
-            </span>
+            </Button>
           </td>
           <td
             className={styles.definitionColumn}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

## What this PR does / why we need it

To improve A11y:

Currently a variable in the template variable list (dashboard settings) cannot be reached by using a keyboard only.
This PR turns the span into a text button to fix that.

### Screenshots

| - | Before | After |
|--------|--------|-------|
| Not focussed |    ![Screenshot 2022-03-07 at 15 57 29](https://user-images.githubusercontent.com/42030685/157059684-8e10d3d3-3756-4905-81f2-9b1700e30858.png)   |  ![Screenshot 2022-03-07 at 17 30 42](https://user-images.githubusercontent.com/42030685/157076418-b43937f1-dc19-4c15-8b5a-2fef0d7de758.png)  |
| Focussed |  N/A  | ![Screenshot 2022-03-07 at 15 58 12](https://user-images.githubusercontent.com/42030685/157059694-63270bf7-6eba-44ed-8416-58afd3fa1cf9.png)   |



## Which issue(s) this PR fixes

See the list of issues the a11y Hackathon team focuses on here: https://docs.google.com/spreadsheets/d/1e3sjrB3wjgQfttK5ANNkac5wmDwLszhgW0fO1kWT2LI/edit#gid=0 

## Special notes for your reviewer
This PR does change the UI a bit (see screenshots) I don't think it does in a bad way but I'm open to comments / requests to change it 🙂 

Also there might be no codeowners for this file as GH did not assign anyone automatically - I went with suggested reviewers, feel free to change 