### PR TITLE
Help: Expose option to disable help menu

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -868,6 +868,11 @@ max_annotations_to_keep =
 # Enable the Explore section
 enabled = true
 
+#################################### Help #############################
+[help]
+# Enable the Help section
+enabled = true
+
 #################################### Query History #############################
 [query_history]
 # Enable the Query history

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -851,6 +851,11 @@
 # Enable the Explore section
 ;enabled = true
 
+#################################### Help #############################
+[help]
+# Enable the Help section
+;enabled = true
+
 #################################### Query History #############################
 [query_history]
 # Enable the Query history

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1316,6 +1316,14 @@ For more information about this feature, refer to [Explore]({{< relref "../explo
 
 Enable or disable the Explore section. Default is `enabled`.
 
+## [help]
+
+Configures the help menu.
+
+### enabled
+
+Enable or disable the Help menu. Default is `enabled`.
+
 ## [metrics]
 
 For detailed instructions, refer to [Internal Grafana metrics]({{< relref "view-server/internal-metrics.md" >}}).

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -91,6 +91,7 @@ export interface GrafanaConfig {
   alertingMinInterval: number;
   authProxyEnabled: boolean;
   exploreEnabled: boolean;
+  helpEnabled: boolean;
   ldapEnabled: boolean;
   sigV4AuthEnabled: boolean;
   samlEnabled: boolean;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -42,6 +42,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   alertingMinInterval = 1;
   authProxyEnabled = false;
   exploreEnabled = false;
+  helpEnabled = false;
   ldapEnabled = false;
   sigV4AuthEnabled = false;
   samlEnabled = false;

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -213,6 +213,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"verifyEmailEnabled":                  setting.VerifyEmailEnabled,
 		"sigV4AuthEnabled":                    setting.SigV4AuthEnabled,
 		"exploreEnabled":                      setting.ExploreEnabled,
+		"helpEnabled":                         setting.HelpEnabled,
 		"queryHistoryEnabled":                 hs.Cfg.QueryHistoryEnabled,
 		"googleAnalyticsId":                   setting.GoogleAnalyticsId,
 		"rudderstackWriteKey":                 setting.RudderstackWriteKey,

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -367,21 +367,23 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 		navTree = append(navTree, serverAdminNode)
 	}
 
-	helpVersion := fmt.Sprintf(`%s v%s (%s)`, setting.ApplicationName, setting.BuildVersion, setting.BuildCommit)
-	if hs.Cfg.AnonymousHideVersion && !c.IsSignedIn {
-		helpVersion = setting.ApplicationName
-	}
+	if setting.HelpEnabled {
+		helpVersion := fmt.Sprintf(`%s v%s (%s)`, setting.ApplicationName, setting.BuildVersion, setting.BuildCommit)
+		if hs.Cfg.AnonymousHideVersion && !c.IsSignedIn {
+			helpVersion = setting.ApplicationName
+		}
 
-	navTree = append(navTree, &dtos.NavLink{
-		Text:       "Help",
-		SubTitle:   helpVersion,
-		Id:         "help",
-		Url:        "#",
-		Icon:       "question-circle",
-		SortWeight: dtos.WeightHelp,
-		Section:    dtos.NavSectionConfig,
-		Children:   []*dtos.NavLink{},
-	})
+		navTree = append(navTree, &dtos.NavLink{
+			Text:       "Help",
+			SubTitle:   helpVersion,
+			Id:         "help",
+			Url:        "#",
+			Icon:       "question-circle",
+			SortWeight: dtos.WeightHelp,
+			Section:    dtos.NavSectionConfig,
+			Children:   []*dtos.NavLink{},
+		})
+	}
 
 	return navTree, nil
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -171,6 +171,9 @@ var (
 	// Explore UI
 	ExploreEnabled bool
 
+	// Help UI
+	HelpEnabled bool
+
 	// Grafana.NET URL
 	GrafanaComUrl string
 
@@ -945,6 +948,9 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 
 	explore := iniFile.Section("explore")
 	ExploreEnabled = explore.Key("enabled").MustBool(true)
+
+	help := iniFile.Section("help")
+	HelpEnabled = help.Key("enabled").MustBool(true)
 
 	queryHistory := iniFile.Section("query_history")
 	cfg.QueryHistoryEnabled = queryHistory.Key("enabled").MustBool(false)


### PR DESCRIPTION
**What this PR does / why we need it**:

Exposes an option to hide the help menu. There are already configurations to "disable" (hide) other functionality that results in menu options being hidden. This PR simply adds support to hide the "help" menu option.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

I wasn't able to find tests that covered related functionality (e.g. disabling of "explore" functionality), so I've left any testing out for the time being. If this feature is accepted and testing is required, I'd be more than happy to look into including some tests.