### PR TITLE
Profile/Help: Expose option to disable profile section and help menu

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -890,6 +890,11 @@ max_annotations_to_keep =
 # Enable the Explore section
 enabled = true
 
+#################################### Help #############################
+[help]
+# Enable the Help section
+enabled = true
+
 #################################### Query History #############################
 [query_history]
 # Enable the Query history

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -895,6 +895,11 @@ enabled = true
 # Enable the Help section
 enabled = true
 
+#################################### Profile #############################
+[profile]
+# Enable the Profile menu
+enabled = true
+
 #################################### Query History #############################
 [query_history]
 # Enable the Query history

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -897,7 +897,7 @@ enabled = true
 
 #################################### Profile #############################
 [profile]
-# Enable the Profile menu
+# Enable the Profile section
 enabled = true
 
 #################################### Query History #############################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -872,6 +872,11 @@
 # Enable the Explore section
 ;enabled = true
 
+#################################### Help #############################
+[help]
+# Enable the Help section
+;enabled = true
+
 #################################### Query History #############################
 [query_history]
 # Enable the Query history

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -877,6 +877,11 @@
 # Enable the Help section
 ;enabled = true
 
+#################################### Profile #############################
+[profile]
+# Enable the Profile menu
+;enabled = true
+
 #################################### Query History #############################
 [query_history]
 # Enable the Query history

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -879,7 +879,7 @@
 
 #################################### Profile #############################
 [profile]
-# Enable the Profile menu
+# Enable the Profile section
 ;enabled = true
 
 #################################### Query History #############################

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1345,6 +1345,14 @@ For more information about this feature, refer to [Explore]({{< relref "../explo
 
 Enable or disable the Explore section. Default is `enabled`.
 
+## [help]
+
+Configures the help menu.
+
+### enabled
+
+Enable or disable the Help menu. Default is `enabled`.
+
 ## [metrics]
 
 For detailed instructions, refer to [Internal Grafana metrics]({{< relref "view-server/internal-metrics.md" >}}).

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1353,6 +1353,14 @@ Configures the help menu.
 
 Enable or disable the Help menu. Default is `enabled`.
 
+## [profile]
+
+Configures the Profile menu.
+
+### enabled
+
+Enable or disable the Profile menu. Default is `enabled`.
+
 ## [metrics]
 
 For detailed instructions, refer to [Internal Grafana metrics]({{< relref "view-server/internal-metrics.md" >}}).

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1347,19 +1347,19 @@ Enable or disable the Explore section. Default is `enabled`.
 
 ## [help]
 
-Configures the help menu.
+Configures the help section.
 
 ### enabled
 
-Enable or disable the Help menu. Default is `enabled`.
+Enable or disable the Help section. Default is `enabled`.
 
 ## [profile]
 
-Configures the Profile menu.
+Configures the Profile section.
 
 ### enabled
 
-Enable or disable the Profile menu. Default is `enabled`.
+Enable or disable the Profile section. Default is `enabled`.
 
 ## [metrics]
 

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -112,6 +112,7 @@ export interface GrafanaConfig {
   authProxyEnabled: boolean;
   exploreEnabled: boolean;
   helpEnabled: boolean;
+  profileEnabled: boolean;
   ldapEnabled: boolean;
   sigV4AuthEnabled: boolean;
   samlEnabled: boolean;

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -111,6 +111,7 @@ export interface GrafanaConfig {
   alertingMinInterval: number;
   authProxyEnabled: boolean;
   exploreEnabled: boolean;
+  helpEnabled: boolean;
   ldapEnabled: boolean;
   sigV4AuthEnabled: boolean;
   samlEnabled: boolean;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -44,6 +44,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   angularSupportEnabled = false;
   authProxyEnabled = false;
   exploreEnabled = false;
+  helpEnabled = false;
   ldapEnabled = false;
   sigV4AuthEnabled = false;
   samlEnabled = false;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -45,6 +45,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   authProxyEnabled = false;
   exploreEnabled = false;
   helpEnabled = false;
+  profileEnabled = false;
   ldapEnabled = false;
   sigV4AuthEnabled = false;
   samlEnabled = false;

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -105,6 +105,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"verifyEmailEnabled":                  setting.VerifyEmailEnabled,
 		"sigV4AuthEnabled":                    setting.SigV4AuthEnabled,
 		"exploreEnabled":                      setting.ExploreEnabled,
+		"helpEnabled":                         setting.HelpEnabled,
 		"queryHistoryEnabled":                 hs.Cfg.QueryHistoryEnabled,
 		"googleAnalyticsId":                   setting.GoogleAnalyticsId,
 		"rudderstackWriteKey":                 setting.RudderstackWriteKey,

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -106,6 +106,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"sigV4AuthEnabled":                    setting.SigV4AuthEnabled,
 		"exploreEnabled":                      setting.ExploreEnabled,
 		"helpEnabled":                         setting.HelpEnabled,
+		"profileEnabled":                      setting.ProfileEnabled,
 		"queryHistoryEnabled":                 hs.Cfg.QueryHistoryEnabled,
 		"googleAnalyticsId":                   setting.GoogleAnalyticsId,
 		"rudderstackWriteKey":                 setting.RudderstackWriteKey,

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -221,9 +221,7 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 		})
 	}
 
-	if setting.ProfileEnabled && c.IsSignedIn {
-		navTree = append(navTree, hs.getProfileNode(c))
-	}
+	navTree = hs.addProfile(navTree, c)
 
 	_, uaIsDisabledForOrg := hs.Cfg.UnifiedAlerting.DisabledOrgs[c.OrgId]
 	uaVisibleForOrg := hs.Cfg.UnifiedAlerting.IsEnabled() && !uaIsDisabledForOrg
@@ -364,6 +362,19 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 		navTree = append(navTree, serverAdminNode)
 	}
 
+	navTree = hs.addHelpLinks(navTree, c)
+
+	return navTree, nil
+}
+
+func (hs *HTTPServer) addProfile(navTree []*dtos.NavLink, c *models.ReqContext) []*dtos.NavLink {
+	if setting.ProfileEnabled && c.IsSignedIn {
+		navTree = append(navTree, hs.getProfileNode(c))
+	}
+	return navTree
+}
+
+func (hs *HTTPServer) addHelpLinks(navTree []*dtos.NavLink, c *models.ReqContext) []*dtos.NavLink {
 	if setting.HelpEnabled {
 		helpVersion := fmt.Sprintf(`%s v%s (%s)`, setting.ApplicationName, setting.BuildVersion, setting.BuildCommit)
 		if hs.Cfg.AnonymousHideVersion && !c.IsSignedIn {
@@ -381,8 +392,7 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 			Children:   []*dtos.NavLink{},
 		})
 	}
-
-	return navTree, nil
+	return navTree
 }
 
 func (hs *HTTPServer) buildSavedItemsNavLinks(c *models.ReqContext) ([]*dtos.NavLink, error) {

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -364,21 +364,23 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 		navTree = append(navTree, serverAdminNode)
 	}
 
-	helpVersion := fmt.Sprintf(`%s v%s (%s)`, setting.ApplicationName, setting.BuildVersion, setting.BuildCommit)
-	if hs.Cfg.AnonymousHideVersion && !c.IsSignedIn {
-		helpVersion = setting.ApplicationName
-	}
+	if setting.HelpEnabled {
+		helpVersion := fmt.Sprintf(`%s v%s (%s)`, setting.ApplicationName, setting.BuildVersion, setting.BuildCommit)
+		if hs.Cfg.AnonymousHideVersion && !c.IsSignedIn {
+			helpVersion = setting.ApplicationName
+		}
 
-	navTree = append(navTree, &dtos.NavLink{
-		Text:       "Help",
-		SubTitle:   helpVersion,
-		Id:         "help",
-		Url:        "#",
-		Icon:       "question-circle",
-		SortWeight: dtos.WeightHelp,
-		Section:    dtos.NavSectionConfig,
-		Children:   []*dtos.NavLink{},
-	})
+		navTree = append(navTree, &dtos.NavLink{
+			Text:       "Help",
+			SubTitle:   helpVersion,
+			Id:         "help",
+			Url:        "#",
+			Icon:       "question-circle",
+			SortWeight: dtos.WeightHelp,
+			Section:    dtos.NavSectionConfig,
+			Children:   []*dtos.NavLink{},
+		})
+	}
 
 	return navTree, nil
 }

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -221,7 +221,7 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dto
 		})
 	}
 
-	if c.IsSignedIn {
+	if setting.ProfileEnabled && c.IsSignedIn {
 		navTree = append(navTree, hs.getProfileNode(c))
 	}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -171,6 +171,9 @@ var (
 	// Explore UI
 	ExploreEnabled bool
 
+	// Help UI
+	HelpEnabled bool
+
 	// Grafana.NET URL
 	GrafanaComUrl string
 
@@ -942,6 +945,9 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 
 	explore := iniFile.Section("explore")
 	ExploreEnabled = explore.Key("enabled").MustBool(true)
+
+	help := iniFile.Section("help")
+	HelpEnabled = help.Key("enabled").MustBool(true)
 
 	queryHistory := iniFile.Section("query_history")
 	cfg.QueryHistoryEnabled = queryHistory.Key("enabled").MustBool(false)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -174,7 +174,7 @@ var (
 	// Help UI
 	HelpEnabled bool
 
-	// Profile menu
+	// Profile UI
 	ProfileEnabled bool
 
 	// Grafana.NET URL

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -174,6 +174,9 @@ var (
 	// Help UI
 	HelpEnabled bool
 
+	// Profile menu
+	ProfileEnabled bool
+
 	// Grafana.NET URL
 	GrafanaComUrl string
 
@@ -948,6 +951,9 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 
 	help := iniFile.Section("help")
 	HelpEnabled = help.Key("enabled").MustBool(true)
+
+	profile := iniFile.Section("profile")
+	ProfileEnabled = profile.Key("enabled").MustBool(true)
 
 	queryHistory := iniFile.Section("query_history")
 	cfg.QueryHistoryEnabled = queryHistory.Key("enabled").MustBool(false)

--- a/public/app/features/profile/FeatureTogglePage.tsx
+++ b/public/app/features/profile/FeatureTogglePage.tsx
@@ -8,8 +8,8 @@ export default function FeatureTogglePage() {
   return (
     <Page navModel={navModel}>
       <Page.Contents>
-        <h1>Profile is not enabled</h1>
-        To enable profile, enable it in the Grafana config:
+        <h1>Profile is not enabled.</h1>
+       Enable profile in the Grafana config file.
         <div>
           <pre>
             {`[profile]

--- a/public/app/features/profile/FeatureTogglePage.tsx
+++ b/public/app/features/profile/FeatureTogglePage.tsx
@@ -9,7 +9,7 @@ export default function FeatureTogglePage() {
     <Page navModel={navModel}>
       <Page.Contents>
         <h1>Profile is not enabled.</h1>
-       Enable profile in the Grafana config file.
+        Enable profile in the Grafana config file.
         <div>
           <pre>
             {`[profile]

--- a/public/app/features/profile/FeatureTogglePage.tsx
+++ b/public/app/features/profile/FeatureTogglePage.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Page from 'app/core/components/Page/Page';
+import { useNavModel } from 'app/core/hooks/useNavModel';
+
+export default function FeatureTogglePage() {
+  const navModel = useNavModel('profile-settings');
+
+  return (
+    <Page navModel={navModel}>
+      <Page.Contents>
+        <h1>Profile is not enabled</h1>
+        To enable profile, enable it in the Grafana config:
+        <div>
+          <pre>
+            {`[profile]
+enable = true
+`}
+          </pre>
+        </div>
+      </Page.Contents>
+    </Page>
+  );
+}

--- a/public/app/features/profile/routes.tsx
+++ b/public/app/features/profile/routes.tsx
@@ -1,0 +1,39 @@
+import { SafeDynamicImport } from 'app/core/components/DynamicImports/SafeDynamicImport';
+import { config } from 'app/core/config';
+import { RouteDescriptor } from 'app/core/navigation/types';
+import { uniq } from 'lodash';
+
+const profileRoutes: RouteDescriptor[] = [
+  {
+    path: '/profile',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "UserProfileEditPage" */ 'app/features/profile/UserProfileEditPage')
+    ),
+  },
+  {
+    path: '/profile/password',
+    component: SafeDynamicImport(
+      () => import(/* webPackChunkName: "ChangePasswordPage" */ 'app/features/profile/ChangePasswordPage')
+    ),
+  },
+  {
+    path: '/profile/select-org',
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "SelectOrgPage" */ 'app/features/org/SelectOrgPage')
+    ),
+  },
+];
+
+export function getProfileRoutes(cfg = config): RouteDescriptor[] {
+  if (cfg.profileEnabled) {
+    return profileRoutes;
+  }
+
+  const uniquePaths = uniq(profileRoutes.map((route) => route.path));
+  return uniquePaths.map((path) => ({
+    path,
+    component: SafeDynamicImport(
+      () => import(/* webpackChunkName: "Profile feature toggle page"*/ 'app/features/profile/FeatureTogglePage')
+    ),
+  }));
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -12,6 +12,7 @@ import { getRoutes as getPluginCatalogRoutes } from 'app/features/plugins/admin/
 import { contextSrv } from 'app/core/services/context_srv';
 import { getLiveRoutes } from 'app/features/live/pages/routes';
 import { getAlertingRoutes } from 'app/features/alerting/routes';
+import { getProfileRoutes } from 'app/features/profile/routes';
 import { ServiceAccountPage } from 'app/features/serviceaccounts/ServiceAccountPage';
 
 export const extraRoutes: RouteDescriptor[] = [];
@@ -247,24 +248,6 @@ export function getAppRoutes(): RouteDescriptor[] {
         ),
       component: SafeDynamicImport(() => import(/* webpackChunkName: "TeamPages" */ 'app/features/teams/TeamPages')),
     },
-    {
-      path: '/profile',
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "UserProfileEditPage" */ 'app/features/profile/UserProfileEditPage')
-      ),
-    },
-    {
-      path: '/profile/password',
-      component: SafeDynamicImport(
-        () => import(/* webPackChunkName: "ChangePasswordPage" */ 'app/features/profile/ChangePasswordPage')
-      ),
-    },
-    {
-      path: '/profile/select-org',
-      component: SafeDynamicImport(
-        () => import(/* webpackChunkName: "SelectOrgPage" */ 'app/features/org/SelectOrgPage')
-      ),
-    },
     // ADMIN
 
     {
@@ -436,6 +419,7 @@ export function getAppRoutes(): RouteDescriptor[] {
     ...getPluginCatalogRoutes(),
     ...getLiveRoutes(),
     ...getAlertingRoutes(),
+    ...getProfileRoutes(),
     ...extraRoutes,
     {
       path: '/*',


### PR DESCRIPTION
**What this PR does / why we need it**:

Exposes options to hide the profile and help sections. There are already configurations to "disable" (hide) other functionality that results in menu/section being hidden. This PR simply adds support to hide the "profile" and "help".

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

I wasn't able to find tests that covered related functionality (e.g. disabling of "explore" functionality), so I've left any testing out for the time being. If this feature is accepted and testing is required, I'd be more than happy to look into including some tests.