### PR TITLE
HeatmapNG: fix Prometheus frame-per-bucket heatmap response rendering

### DIFF
--- a/public/app/features/transformers/calculateHeatmap/heatmap.ts
+++ b/public/app/features/transformers/calculateHeatmap/heatmap.ts
@@ -46,12 +46,28 @@ export function sortAscStrInf(aName?: string | null, bName?: string | null) {
 }
 
 /** Given existing buckets, create a values style frame */
+// Assumes frames have already been sorted ASC and de-accumulated.
 export function createHeatmapFromBuckets(frames: DataFrame[]): DataFrame {
-  frames = frames.slice();
+  // assumes all Time fields are identical
+  // TODO: handle null-filling w/ fields[0].config.interval?
+  const xField = frames[0].fields[0];
+  const xValues = xField.values.toArray();
+  const yField = frames[0].fields[1];
 
-  // sort ASC by frame.name (Prometheus bucket bound)
-  // or use frame.fields[1].config.displayNameFromDS ?
-  frames.sort((a, b) => sortAscStrInf(a.name, b.name));
+  // similar to initBins() below
+  const len = xValues.length * frames.length;
+  const xs = new Array(len);
+  const ys = new Array(len);
+  const counts2 = new Array(len);
+
+  const counts = frames.map((frame) => frame.fields[1].values.toArray().slice());
+
+  // transpose
+  counts.forEach((bucketCounts, bi) => {
+    for (let i = 0; i < bucketCounts.length; i++) {
+      counts2[counts.length * i + bi] = bucketCounts[i];
+    }
+  });
 
   const bucketBounds = frames.map((frame, i) => {
     return i; // until we have y ordinal scales working for facets/scatter
@@ -68,39 +84,6 @@ export function createHeatmapFromBuckets(frames: DataFrame[]): DataFrame {
 
     return bound;
     */
-  });
-
-  // assumes all Time fields are identical
-  // TODO: handle null-filling w/ fields[0].config.interval?
-  const xField = frames[0].fields[0];
-  const xValues = xField.values.toArray();
-  const yField = frames[0].fields[1];
-
-  // similar to initBins() below
-  const len = xValues.length * bucketBounds.length;
-  const xs = new Array(len);
-  const ys = new Array(len);
-  const counts2 = new Array(len);
-
-  // cumulative counts
-  const counts = frames.map((frame) => frame.fields[1].values.toArray().slice());
-
-  // de-accumulate
-  counts.reverse();
-  counts.forEach((bucketCounts, bi) => {
-    if (bi < counts.length - 1) {
-      for (let i = 0; i < bucketCounts.length; i++) {
-        bucketCounts[i] -= counts[bi + 1][i];
-      }
-    }
-  });
-  counts.reverse();
-
-  // transpose
-  counts.forEach((bucketCounts, bi) => {
-    for (let i = 0; i < bucketCounts.length; i++) {
-      counts2[counts.length * i + bi] = bucketCounts[i];
-    }
   });
 
   // fill flat/repeating array
@@ -142,6 +125,41 @@ export function createHeatmapFromBuckets(frames: DataFrame[]): DataFrame {
       },
     ],
   };
+}
+
+// Sorts frames ASC by numeric bucket name and de-accumulates values in each frame's Value field [1]
+// similar to Prometheus result_transformer.ts -> transformToHistogramOverTime()
+export function prepBucketFrames(frames: DataFrame[]): DataFrame[] {
+  frames = frames.slice();
+
+  // sort ASC by frame.name (Prometheus bucket bound)
+  // or use frame.fields[1].config.displayNameFromDS ?
+  frames.sort((a, b) => sortAscStrInf(a.name, b.name));
+
+  // cumulative counts
+  const counts = frames.map((frame) => frame.fields[1].values.toArray().slice());
+
+  // de-accumulate
+  counts.reverse();
+  counts.forEach((bucketCounts, bi) => {
+    if (bi < counts.length - 1) {
+      for (let i = 0; i < bucketCounts.length; i++) {
+        bucketCounts[i] -= counts[bi + 1][i];
+      }
+    }
+  });
+  counts.reverse();
+
+  return frames.map((frame, i) => ({
+    ...frame,
+    fields: [
+      frame.fields[0],
+      {
+        ...frame.fields[1],
+        values: new ArrayVector(counts[i]),
+      },
+    ],
+  }));
 }
 
 export function calculateHeatmapFromData(frames: DataFrame[], options: HeatmapCalculationOptions): DataFrame {

--- a/public/app/plugins/panel/heatmap-new/fields.ts
+++ b/public/app/plugins/panel/heatmap-new/fields.ts
@@ -2,7 +2,6 @@ import { DataFrame, DataFrameType, getDisplayProcessor, GrafanaTheme2 } from '@g
 import {
   calculateHeatmapFromData,
   createHeatmapFromBuckets,
-  prepBucketFrames,
   sortAscStrInf,
 } from 'app/features/transformers/calculateHeatmap/heatmap';
 import { HeatmapSourceMode, PanelOptions } from './models.gen';

--- a/public/app/plugins/panel/heatmap-new/fields.ts
+++ b/public/app/plugins/panel/heatmap-new/fields.ts
@@ -2,6 +2,7 @@ import { DataFrame, DataFrameType, getDisplayProcessor, GrafanaTheme2 } from '@g
 import {
   calculateHeatmapFromData,
   createHeatmapFromBuckets,
+  prepBucketFrames,
   sortAscStrInf,
 } from 'app/features/transformers/calculateHeatmap/heatmap';
 import { HeatmapSourceMode, PanelOptions } from './models.gen';
@@ -59,6 +60,9 @@ export function prepareHeatmapData(
   // detect a frame-per-bucket heatmap frame
   // TODO: improve heuristic? infer from fields[1].labels.le === '+Inf' ?
   if (frames[0].meta?.custom?.resultType === 'matrix' && frames.some((f) => f.name?.startsWith('+Inf'))) {
+    // already done by the Prometheus datasource frontend
+    //frames = prepBucketFrames(frames);
+
     return {
       yAxisValues: frames.map((f) => f.name ?? null).sort(sortAscStrInf),
       ...getHeatmapData(createHeatmapFromBuckets(frames), theme),

--- a/public/app/plugins/panel/heatmap-new/fields.ts
+++ b/public/app/plugins/panel/heatmap-new/fields.ts
@@ -1,9 +1,5 @@
 import { DataFrame, DataFrameType, getDisplayProcessor, GrafanaTheme2 } from '@grafana/data';
-import {
-  calculateHeatmapFromData,
-  createHeatmapFromBuckets,
-  sortAscStrInf,
-} from 'app/features/transformers/calculateHeatmap/heatmap';
+import { calculateHeatmapFromData, createHeatmapFromBuckets } from 'app/features/transformers/calculateHeatmap/heatmap';
 import { HeatmapSourceMode, PanelOptions } from './models.gen';
 
 export const enum BucketLayout {
@@ -63,7 +59,7 @@ export function prepareHeatmapData(
     //frames = prepBucketFrames(frames);
 
     return {
-      yAxisValues: frames.map((f) => f.name ?? null).sort(sortAscStrInf),
+      yAxisValues: frames.map((f) => f.name ?? null),
       ...getHeatmapData(createHeatmapFromBuckets(frames), theme),
     };
   }


### PR DESCRIPTION
This eliminates a secondary de-accumulation pass when processing a Prometheus frame-per-bucket heatmap response.

I did not realize this already occurred in the Prometheus datasource frontend [1], and was originally working off the raw network response data.

the top panel is the old heatmap (correct), and the bottom is new heatmap that's de-accumulated twice (wrong).

![image](https://user-images.githubusercontent.com/43234/157146441-b413c3ba-3c44-4dc7-8caa-f2c104b1591e.png)

[1] https://github.com/grafana/grafana/blob/5d2f34d8e249877cdd8e1ddda4976dcc4b732048/public/app/plugins/datasource/prometheus/result_transformer.ts#L536-L557