### PR TITLE
SSE: Keep FieldConfig for data source queries

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -328,7 +328,11 @@ func extractNumberSet(frame *data.Frame) ([]mathexp.Number, error) {
 		}
 
 		n := mathexp.NewNumber("", labels)
+
+		// The new value fields' configs gets pointed to the one in the original frame
+		n.Frame.Fields[0].Config = frame.Fields[numericField].Config
 		n.SetValue(&val)
+
 		numbers[rowIdx] = n
 	}
 	return numbers, nil
@@ -358,6 +362,10 @@ func WideToMany(frame *data.Frame) ([]mathexp.Series, error) {
 		f := data.NewFrameOfFieldTypes(frame.Name, l, frame.Fields[tsSchema.TimeIndex].Type(), frame.Fields[valIdx].Type())
 		f.Fields[0].Name = frame.Fields[tsSchema.TimeIndex].Name
 		f.Fields[1].Name = frame.Fields[valIdx].Name
+
+		// The new value fields' configs gets pointed to the one in the original frame
+		f.Fields[1].Config = frame.Fields[valIdx].Config
+
 		if frame.Fields[valIdx].Labels != nil {
 			f.Fields[1].Labels = frame.Fields[valIdx].Labels.Copy()
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Copies over the field config of the value field when querying data sources inside  

**Which issue(s) this PR fixes**:

Fixes #46325

**Special notes for your reviewer**:
Frame meta would be good as well, but since SSE always converts of the multiframe (aka many) format it would not be one to one, which could be or become problematic, so ignoring that for now.

Long term hope to stop mutating input queries.
