### PR TITLE
A11y: Fix accessibility of 'Set color' button in Value Mappings modal

### DIFF
--- a/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingEditRow.tsx
+++ b/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingEditRow.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import { GrafanaTheme2, MappingType, SpecialValueMatch, SelectableValue, ValueMappingResult } from '@grafana/data';
 import { Draggable } from 'react-beautiful-dnd';
 import { css } from '@emotion/css';
-import { useStyles2, Icon, Select, HorizontalGroup, ColorPicker, IconButton, LinkButton, Input } from '@grafana/ui';
+import { useStyles2, Icon, Select, HorizontalGroup, ColorPicker, IconButton, Input, Button } from '@grafana/ui';
 
 export interface ValueMappingEditRowModel {
   type: MappingType;
@@ -176,9 +176,9 @@ export function ValueMappingEditRow({ mapping, index, onChange, onRemove, onDupl
             {!result.color && (
               <ColorPicker color={'gray'} onChange={onChangeColor} enableNamedColors={true}>
                 {(props) => (
-                  <LinkButton variant="primary" fill="text" onClick={props.showColorPicker} ref={props.ref} size="sm">
+                  <Button variant="primary" fill="text" onClick={props.showColorPicker} ref={props.ref} size="sm">
                     Set color
-                  </LinkButton>
+                  </Button>
                 )}
               </ColorPicker>
             )}


### PR DESCRIPTION
**What this PR does / why we need it**:

`LinkButton` with `onClick` is not accessible with the keyboard, so replaced it with `Button`

