### PR TITLE
[v8.3.x] Prometheus: Fix timestamp truncation (#46302)

### DIFF
--- a/pkg/tsdb/prometheus/time_series_query.go
+++ b/pkg/tsdb/prometheus/time_series_query.go
@@ -338,11 +338,11 @@ func matrixToDataFramesWithNullFill(matrix model.Matrix, query *PrometheusQuery,
 			value := float64(pair.Value)
 
 			for t := baseTimestamp; t < timestamp; t += query.Step.Milliseconds() {
-				timeField.Set(idx, time.Unix(0, t*1000000).UTC())
+				timeField.Set(idx, time.Unix(0, t*1_000_000).UTC())
 				idx++
 			}
 
-			timeField.Set(idx, time.Unix(pair.Timestamp.Unix(), 0).UTC())
+			timeField.Set(idx, pair.Timestamp.Time().UTC())
 			if !math.IsNaN(value) {
 				valueField.Set(idx, &value)
 			}
@@ -351,7 +351,7 @@ func matrixToDataFramesWithNullFill(matrix model.Matrix, query *PrometheusQuery,
 		}
 
 		for t := baseTimestamp; t <= endTimestamp; t += query.Step.Milliseconds() {
-			timeField.Set(idx, time.Unix(0, t*1000000).UTC())
+			timeField.Set(idx, time.Unix(0, t*1_000_000).UTC())
 			idx++
 		}
 
@@ -377,7 +377,7 @@ func matrixToDataFrames(matrix model.Matrix, query *PrometheusQuery, frames data
 		valueField := data.NewFieldFromFieldType(data.FieldTypeNullableFloat64, len(v.Values))
 
 		for i, k := range v.Values {
-			timeField.Set(i, time.Unix(k.Timestamp.Unix(), 0).UTC())
+			timeField.Set(i, k.Timestamp.Time().UTC())
 			value := float64(k.Value)
 
 			if !math.IsNaN(value) {
@@ -397,7 +397,7 @@ func matrixToDataFrames(matrix model.Matrix, query *PrometheusQuery, frames data
 }
 
 func scalarToDataFrames(scalar *model.Scalar, query *PrometheusQuery, frames data.Frames) data.Frames {
-	timeVector := []time.Time{time.Unix(scalar.Timestamp.Unix(), 0).UTC()}
+	timeVector := []time.Time{scalar.Timestamp.Time().UTC()}
 	values := []float64{float64(scalar.Value)}
 	name := fmt.Sprintf("%g", values[0])
 
@@ -416,7 +416,7 @@ func vectorToDataFrames(vector model.Vector, query *PrometheusQuery, frames data
 	for _, v := range vector {
 		name := formatLegend(v.Metric, query)
 		tags := make(map[string]string, len(v.Metric))
-		timeVector := []time.Time{time.Unix(v.Timestamp.Unix(), 0).UTC()}
+		timeVector := []time.Time{v.Timestamp.Time().UTC()}
 		values := []float64{float64(v.Value)}
 
 		for k, v := range v.Metric {
@@ -445,7 +445,7 @@ func exemplarToDataFrames(response []apiv1.ExemplarQueryResult, query *Prometheu
 	for _, exemplarData := range response {
 		for _, exemplar := range exemplarData.Exemplars {
 			event := ExemplarEvent{}
-			exemplarTime := time.Unix(exemplar.Timestamp.Unix(), 0).UTC()
+			exemplarTime := exemplar.Timestamp.Time().UTC()
 			event.Time = exemplarTime
 			event.Value = float64(exemplar.Value)
 			event.Labels = make(map[string]string)

--- a/pkg/tsdb/prometheus/time_series_query_test.go
+++ b/pkg/tsdb/prometheus/time_series_query_test.go
@@ -707,7 +707,7 @@ func TestPrometheus_parseTimeSeriesResponse(t *testing.T) {
 			&p.Sample{
 				Metric:    p.Metric{"app": "Application", "tag2": "tag2"},
 				Value:     1,
-				Timestamp: 1000,
+				Timestamp: 123,
 			},
 		}
 		query := &PrometheusQuery{
@@ -730,13 +730,14 @@ func TestPrometheus_parseTimeSeriesResponse(t *testing.T) {
 		// Ensure the timestamps are UTC zoned
 		testValue := res[0].Fields[0].At(0)
 		require.Equal(t, "UTC", testValue.(time.Time).Location().String())
+		require.Equal(t, int64(123), testValue.(time.Time).UnixMilli())
 	})
 
 	t.Run("scalar response should be parsed normally", func(t *testing.T) {
 		value := make(map[TimeSeriesQueryType]interface{})
 		value[RangeQueryType] = &p.Scalar{
 			Value:     1,
-			Timestamp: 1000,
+			Timestamp: 123,
 		}
 
 		query := &PrometheusQuery{}
@@ -754,6 +755,7 @@ func TestPrometheus_parseTimeSeriesResponse(t *testing.T) {
 		// Ensure the timestamps are UTC zoned
 		testValue := res[0].Fields[0].At(0)
 		require.Equal(t, "UTC", testValue.(time.Time).Location().String())
+		require.Equal(t, int64(123), testValue.(time.Time).UnixMilli())
 	})
 }
 


### PR DESCRIPTION
Backport db5f480a8fdd5d1b33608e89327fa8d825124e94 from #46302