### PR TITLE
Gauge: Fixes blank viz when data link exists and orientation was horizontal

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinksContextMenu.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinksContextMenu.tsx
@@ -60,7 +60,7 @@ export const DataLinksContextMenu: React.FC<DataLinksContextMenuProps> = ({ chil
         onClick={linkModel.onClick}
         target={linkModel.target}
         title={linkModel.title}
-        style={{ display: 'flex' }}
+        style={{ display: 'flex', width: '100%' }}
         aria-label={selectors.components.DataLinksContextMenu.singleLink}
       >
         {children({})}


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/2066

Data links anchor has no width when used in Gauge panel. Setting width to 100% seems to fix
issue and have tested this in Bar Gauge, and PieChart and does not seem to cause issues.
