### PR TITLE
Card: make elements in metadata clickable

### DIFF
--- a/packages/grafana-ui/src/components/Card/Card.mdx
+++ b/packages/grafana-ui/src/components/Card/Card.mdx
@@ -126,7 +126,7 @@ Tags can be rendered inside the Card, by being wrapped in `Card.Tags` component.
 
 ### As a link
 
-Card can be used as a clickable link item by specifying `href` prop. In this case the Card's content will be rendered inside `a`.
+Card can be used as a clickable link item by specifying `href` prop.
 
 ```jsx
 <Card href="https://grafana.com">
@@ -139,6 +139,45 @@ Card can be used as a clickable link item by specifying `href` prop. In this cas
   <Card href="https://grafana.com">
     <Card.Heading>Redirect to Grafana</Card.Heading>
     <Card.Description>Clicking this card will redirect to grafana website</Card.Description>
+  </Card>
+</Preview>
+
+### As a button
+
+Card can be used as a clickable buttons item by specifying `onClick` prop.
+
+```jsx
+<Card onClick={() => alert('Hello, Grafana!')}>
+  <Card.Heading>Hello, Grafana</Card.Heading>
+  <Card.Description>Clicking this card will create an alert</Card.Description>
+</Card>
+```
+
+<Preview>
+  <Card onClick={() => alert('Hello, Grafana!')}>
+    <Card.Heading>Hello, Grafana</Card.Heading>
+    <Card.Description>Clicking this card will create an alert</Card.Description>
+  </Card>
+</Preview>
+
+> **Note**: When used in conjunction with [Metadata elements](#multiple-metadata-elements), clicking on any element
+> inside `<Card.Meta>` will prevent the card action to be executed (either `href` to be followed or `onClick` to be called).
+>
+> Example:
+
+```jsx
+<Card onClick={() => alert('Hello, Grafana!')}>
+  <Card.Heading>Hello, Grafana</Card.Heading>
+  <Card.Meta>Clicking on this text (Meta) WILL NOT trigger the alert!</Card.Meta>
+  <Card.Description>Clicking on this text (Description) WILL trigger the alert!</Card.Description>
+</Card>
+```
+
+<Preview>
+  <Card onClick={() => alert('Hello, Grafana!')}>
+    <Card.Heading>Hello, Grafana</Card.Heading>
+    <Card.Meta>Clicking on this text (Meta) WILL NOT trigger the alert!</Card.Meta>
+    <Card.Description>Clicking on this text (Description) WILL trigger the alert!</Card.Description>
   </Card>
 </Preview>
 

--- a/packages/grafana-ui/src/components/Card/Card.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.tsx
@@ -261,6 +261,7 @@ const getMetaStyles = (theme: GrafanaTheme2) => ({
     margin: theme.spacing(0.5, 0, 0),
     lineHeight: theme.typography.bodySmall.lineHeight,
     overflowWrap: 'anywhere',
+    zIndex: 0,
   }),
   separator: css({
     margin: `0 ${theme.spacing(1)}`,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
`Meta`s children (as per the component documentation) should be clickable. When the card has the `onClick` prop set, the title's click area covers the whole card space by positioning its `::after` pseudo element absolutely (therefore creating a stacking context). This causes that pseudo-element to have an higher stack level (because no `zIndex` is specified in `Meta`'s styles), making it impossible to click on underlying elements unless their stack level is higher. 

By setting `Meta`'s zIndex to 0 (can be any positive value as title's `::after`'s z-index is not set) we default Meta items to appear higher in the stacking context. 



**Special notes for your reviewer**:

As a side effect, card's `onClick` won't be called if clicking anywhere inside the `Meta` component, even if the click target is not interactive. 

Another possible approach to fix this issue (without blocking card's click when said click happen on non-interactive elements) would be to manually set `z-index` in children passed to `Meta`, but that puts extra burden on the consumer that has to be aware of this limitation.


Note 2:
this does not happen for `SecondaryActions` only because they are usually used only with `IconButton`s, and `IconButton` has z-index set to 0.