### PR TITLE
Perf: don't re-init plots when changing dashboard timeRange

### DIFF
--- a/packages/grafana-data/src/dataframe/frameComparisons.ts
+++ b/packages/grafana-data/src/dataframe/frameComparisons.ts
@@ -60,7 +60,9 @@ export function compareDataFrameStructures(a: DataFrame, b: DataFrame, skipConfi
         return false;
       }
 
-      if (key === 'custom') {
+      if (key === 'interval') {
+        continue;
+      } else if (key === 'custom') {
         if (!shallowCompare(cfgA[key], cfgB[key])) {
           return false;
         }

--- a/packages/grafana-data/src/dataframe/frameComparisons.ts
+++ b/packages/grafana-data/src/dataframe/frameComparisons.ts
@@ -62,7 +62,8 @@ export function compareDataFrameStructures(a: DataFrame, b: DataFrame, skipConfi
 
       if (key === 'interval') {
         continue;
-      } else if (key === 'custom') {
+      }
+      if (key === 'custom') {
         if (!shallowCompare(cfgA[key], cfgB[key])) {
           return false;
         }


### PR DESCRIPTION
when we added the query-dependent `field.config.interval` to the backend responses of Prometheus and Loki, we neglected to omit it from schema comparisons, so any time the interval changed (like during zooming), we would increment the schema and cause the plots to re-init. this PR omits `interval` from the schema diff.