### PR TITLE
CloudWatch: Use default http client from aws-sdk-go

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -223,6 +223,8 @@ func (e *cloudWatchExecutor) newSession(pluginCtx backend.PluginContext, region 
 	}
 
 	return e.sessions.GetSession(awsds.SessionConfig{
+		// https://github.com/grafana/grafana/issues/46365
+		// HTTPClient: dsInfo.HTTPClient,
 		Settings: awsds.AWSDatasourceSettings{
 			Profile:       dsInfo.profile,
 			Region:        region,

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -223,7 +223,6 @@ func (e *cloudWatchExecutor) newSession(pluginCtx backend.PluginContext, region 
 	}
 
 	return e.sessions.GetSession(awsds.SessionConfig{
-		HTTPClient: dsInfo.HTTPClient,
 		Settings: awsds.AWSDatasourceSettings{
 			Profile:       dsInfo.profile,
 			Region:        region,


### PR DESCRIPTION
**What this PR does / why we need it**:

In Grafana 8.4.0, the dependency to grafana-aws-sdk was upgraded from 0.7.0 to 0.10.0. When doing so, we no longer use the default http client provided by the aws-sdk-go, but instead use a custom one from the grafana http client provider. Since the upgrade, many Grafana Cloud users are intermittently seeing `SignatureDoesNotMatch` errors in the their alert queries. I have not been able to reproduce this problem or to verify that this PR solves the problem, but I _think_ it will. 

**Which issue(s) this PR fixes**:
Related to #46365. Don't want to close this before it's verified that it solves the `SignatureDoesNotMatch` seen by customers in Grafana Cloud.

**Special notes for your reviewer**:
Once this PR is merged, the issue #39089 needs to be reopened. 