### PR TITLE
Alerting: Add additional customisation to ngalert MS Teams notifier

### DIFF
--- a/pkg/services/ngalert/notifier/available_channels.go
+++ b/pkg/services/ngalert/notifier/available_channels.go
@@ -562,6 +562,21 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 					PropertyName: "url",
 					Required:     true,
 				},
+				{
+					Label:        "Title",
+					Element:      alerting.ElementTypeInput,
+					InputType:    alerting.InputTypeText,
+					Description:  "Templated title of the Teams message.",
+					PropertyName: "title",
+					Placeholder:  `{{ template "default.title" . }}`,
+				},
+				{
+					Label:        "Section Title",
+					Element:      alerting.ElementTypeInput,
+					InputType:    alerting.InputTypeText,
+					Description:  "Section title for the Teams message. Leave blank for none.",
+					PropertyName: "sectiontitle",
+				},
 				{ // New in 8.0.
 					Label:        "Message",
 					Element:      alerting.ElementTypeTextArea,

--- a/pkg/services/ngalert/notifier/channels/teams_test.go
+++ b/pkg/services/ngalert/notifier/channels/teams_test.go
@@ -48,7 +48,7 @@ func TestTeamsNotifier(t *testing.T) {
 				"themeColor": "#D63232",
 				"sections": []map[string]interface{}{
 					{
-						"title": "Details",
+						"title": "",
 						"text":  "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
 					},
 				},
@@ -66,6 +66,8 @@ func TestTeamsNotifier(t *testing.T) {
 			name: "Custom config with multiple alerts",
 			settings: `{
 				"url": "http://localhost",
+				"title": "{{ .CommonLabels.alertname }}",
+				"sectiontitle": "Details",
 				"message": "{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved"
 			}`,
 			alerts: []*types.Alert{
@@ -84,8 +86,8 @@ func TestTeamsNotifier(t *testing.T) {
 			expMsg: map[string]interface{}{
 				"@type":      "MessageCard",
 				"@context":   "http://schema.org/extensions",
-				"summary":    "[FIRING:2]  ",
-				"title":      "[FIRING:2]  ",
+				"summary":    "alert1",
+				"title":      "alert1",
 				"themeColor": "#D63232",
 				"sections": []map[string]interface{}{
 					{
@@ -107,6 +109,8 @@ func TestTeamsNotifier(t *testing.T) {
 			name: "Missing field in template",
 			settings: `{
 				"url": "http://localhost",
+				"title": "{{ .CommonLabels.alertname }}",
+				"sectiontitle": "Details",
 				"message": "I'm a custom template {{ .NotAField }} bad template"
 			}`,
 			alerts: []*types.Alert{
@@ -125,8 +129,8 @@ func TestTeamsNotifier(t *testing.T) {
 			expMsg: map[string]interface{}{
 				"@type":      "MessageCard",
 				"@context":   "http://schema.org/extensions",
-				"summary":    "[FIRING:2]  ",
-				"title":      "[FIRING:2]  ",
+				"summary":    "alert1",
+				"title":      "alert1",
 				"themeColor": "#D63232",
 				"sections": []map[string]interface{}{
 					{
@@ -148,6 +152,8 @@ func TestTeamsNotifier(t *testing.T) {
 			name: "Invalid template",
 			settings: `{
 				"url": "http://localhost",
+				"title": "{{ .CommonLabels.alertname }}",
+				"sectiontitle": "Details",
 				"message": "I'm a custom template {{ {.NotAField }} bad template"
 			}`,
 			alerts: []*types.Alert{
@@ -166,8 +172,8 @@ func TestTeamsNotifier(t *testing.T) {
 			expMsg: map[string]interface{}{
 				"@type":      "MessageCard",
 				"@context":   "http://schema.org/extensions",
-				"summary":    "[FIRING:2]  ",
-				"title":      "[FIRING:2]  ",
+				"summary":    "alert1",
+				"title":      "alert1",
 				"themeColor": "#D63232",
 				"sections": []map[string]interface{}{
 					{

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -2226,7 +2226,7 @@ var expNonEmailNotifications = map[string][]string{
 		  "sections": [
 			{
 			  "text": "**Firing**\n\nValue: [ var='A' labels={} value=1 ]\nLabels:\n - alertname = TeamsAlert\nAnnotations:\nSource: http://localhost:3000/alerting/grafana/UID_TeamsAlert/view\nSilence: http://localhost:3000/alerting/silence/new?alertmanager=grafana&matcher=alertname%3DTeamsAlert\n",
-			  "title": "Details"
+			  "title": ""
 			}
 		  ],
 		  "summary": "[FIRING:1] TeamsAlert ",


### PR DESCRIPTION
Makes the Title and Section Title of the Teams message customisable.
Closes #46366

![image](https://user-images.githubusercontent.com/28299281/165128317-b7f05e2d-ffb3-4a39-a118-6d8e779a141c.png)
