### PR TITLE
Explore: Make the split resizable

### DIFF
--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -25,12 +25,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     background: ${theme.colors.secondary.main};
     transition: 0.3s background ease-in-out;
     position: relative;
-    width: 7px !important;
-    height: 20% !important;
-    top: calc(50% - 10%) !important;
-    left: -4px !important;
+    width: 2px !important;
+    height: 100% !important;
+    left: -1px !important;
     cursor: grab;
-    border-radius: 4px;
     &:hover {
       background: ${theme.colors.secondary.shade};
     }

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
+import { Resizable } from 're-resizable';
 import { ExploreId, ExploreQueryParams } from 'app/types/explore';
 import { ErrorBoundaryAlert } from '@grafana/ui';
 import { lastSavedUrl, resetExploreAction, richHistoryUpdatedAction } from './state/main';
@@ -80,7 +81,23 @@ class WrapperUnconnected extends PureComponent<Props> {
           </ErrorBoundaryAlert>
           {hasSplit && (
             <ErrorBoundaryAlert style="page">
-              <ExplorePaneContainer split={hasSplit} exploreId={ExploreId.right} urlQuery={right} />
+              <Resizable
+                defaultSize={{ width: '50%', height: '100%' }}
+                enable={{
+                  top: false,
+                  right: false,
+                  bottom: false,
+                  left: true,
+                  topRight: false,
+                  bottomRight: false,
+                  bottomLeft: false,
+                  topLeft: false,
+                }}
+                minWidth="30%"
+                maxWidth="70%"
+              >
+                <ExplorePaneContainer split={hasSplit} exploreId={ExploreId.right} urlQuery={right} />
+              </Resizable>
             </ErrorBoundaryAlert>
           )}
         </div>

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -1,8 +1,10 @@
 import React, { PureComponent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
+import { css } from '@emotion/css';
 import { Resizable } from 're-resizable';
 import { ExploreId, ExploreQueryParams } from 'app/types/explore';
-import { ErrorBoundaryAlert } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { ErrorBoundaryAlert, withTheme2 } from '@grafana/ui';
 import { lastSavedUrl, resetExploreAction, richHistoryUpdatedAction } from './state/main';
 import { getRichHistory } from '../../core/utils/richHistory';
 import { ExplorePaneContainer } from './ExplorePaneContainer';
@@ -14,7 +16,26 @@ import { StoreState } from 'app/types';
 import { locationService } from '@grafana/runtime';
 
 interface RouteProps extends GrafanaRouteComponentProps<{}, ExploreQueryParams> {}
-interface OwnProps {}
+interface OwnProps {
+  theme: GrafanaTheme2;
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  rzHandle: css`
+    background: ${theme.colors.secondary.main};
+    transition: 0.3s background ease-in-out;
+    position: relative;
+    width: 7px !important;
+    height: 20% !important;
+    top: calc(50% - 10%) !important;
+    left: -4px !important;
+    cursor: grab;
+    border-radius: 4px;
+    &:hover {
+      background: ${theme.colors.secondary.shade};
+    }
+  `,
+});
 
 const mapStateToProps = (state: StoreState) => {
   return {
@@ -70,8 +91,10 @@ class WrapperUnconnected extends PureComponent<Props> {
   }
 
   render() {
-    const { left, right } = this.props.queryParams;
+    const { queryParams, theme } = this.props;
+    const { left, right } = queryParams;
     const hasSplit = Boolean(left) && Boolean(right);
+    const styles = getStyles(theme);
 
     return (
       <div className="page-scrollbar-wrapper">
@@ -83,6 +106,7 @@ class WrapperUnconnected extends PureComponent<Props> {
             <ErrorBoundaryAlert style="page">
               <Resizable
                 defaultSize={{ width: '50%', height: '100%' }}
+                handleClasses={{ left: styles.rzHandle }}
                 enable={{
                   top: false,
                   right: false,
@@ -106,6 +130,6 @@ class WrapperUnconnected extends PureComponent<Props> {
   }
 }
 
-const Wrapper = connector(WrapperUnconnected);
+const Wrapper = connector(withTheme2(WrapperUnconnected));
 
 export default Wrapper;

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -21,7 +21,6 @@
 
 .explore-wrapper {
   display: flex;
-  height: 100%;
 
   > .explore-split:nth-child(1) {
     width: 30%; // Must correspond to Resizable's minWidth in Wrapper.tsx

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -11,10 +11,6 @@
   flex-direction: column;
 }
 
-.explore + .explore {
-  border-left: 1px dotted $table-border;
-}
-
 .explore-container {
   display: flex;
   flex: 1 1 auto;
@@ -27,8 +23,9 @@
   display: flex;
   height: 100%;
 
-  > .explore-split {
-    width: 50%;
+  > .explore-split:nth-child(1) {
+    width: 30%; // Must correspond to Resizable's minWidth in Wrapper.tsx
+    border-right: 1px dotted $table-border;
   }
 }
 

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -24,7 +24,6 @@
 
   > .explore-split:nth-child(1) {
     width: 30%; // Must correspond to Resizable's minWidth in Wrapper.tsx
-    border-right: 1px dotted $table-border;
   }
 }
 


### PR DESCRIPTION
- adds Resizable to Explore's Wrapper
- had to use percentages to keep panes widths non-absolute
- min width is 30%, max width is 70%

https://user-images.githubusercontent.com/859729/157470087-a73043a5-9c2a-4cc8-8710-f62c486e282d.mov


