### PR TITLE
Docs: Removed extra word in Time range controls topic

### DIFF
--- a/docs/sources/dashboards/time-range-controls.md
+++ b/docs/sources/dashboards/time-range-controls.md
@@ -36,7 +36,7 @@ Here are some examples:
 
 ### Note about Grafana alerting
 
-For Grafana alerting, we do not support are the following syntaxes at this time.
+For Grafana alerting, we do not support the following syntaxes at this time.
 
 - now+n for future timestamps.
 - now-1n/n for "start of n until end of n" since this is an absolute timestamp.


### PR DESCRIPTION
Fixed typo in "Time range controls" topic.