### PR TITLE
A11y : Fix option panes not accessible when collapsed

### DIFF
--- a/public/app/features/alerting/unified/components/CollapseToggle.tsx
+++ b/public/app/features/alerting/unified/components/CollapseToggle.tsx
@@ -32,6 +32,7 @@ export const CollapseToggle: FC<Props> = ({
       className={cx(styles.expandButton, className)}
       icon={isCollapsed ? 'angle-right' : 'angle-down'}
       onClick={() => onToggle(!isCollapsed)}
+      {...restOfProps}
     />
   );
 };

--- a/public/app/features/alerting/unified/components/CollapseToggle.tsx
+++ b/public/app/features/alerting/unified/components/CollapseToggle.tsx
@@ -1,43 +1,44 @@
 import React, { FC, HTMLAttributes } from 'react';
 import { css, cx } from '@emotion/css';
-import { IconSize, useStyles, Icon } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { IconSize, useStyles2, Button } from '@grafana/ui';
 
 interface Props extends HTMLAttributes<HTMLButtonElement> {
   isCollapsed: boolean;
   onToggle: (isCollapsed: boolean) => void;
+  // Todo: this should be made compulsory for a11y purposes
+  idControlled?: string;
   size?: IconSize;
   className?: string;
   text?: string;
 }
 
-export const CollapseToggle: FC<Props> = ({ isCollapsed, onToggle, className, text, size = 'xl', ...restOfProps }) => {
-  const styles = useStyles(getStyles);
+export const CollapseToggle: FC<Props> = ({
+  isCollapsed,
+  onToggle,
+  idControlled,
+  className,
+  text,
+  size = 'xl',
+  ...restOfProps
+}) => {
+  const styles = useStyles2(getStyles);
 
   return (
-    <button
-      aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} alert group`}
+    <Button
+      fill="text"
+      aria-expanded={!isCollapsed}
+      aria-controls={idControlled}
       className={cx(styles.expandButton, className)}
+      icon={isCollapsed ? 'angle-right' : 'angle-down'}
       onClick={() => onToggle(!isCollapsed)}
-      {...restOfProps}
-    >
-      <Icon size={size} name={isCollapsed ? 'angle-right' : 'angle-down'} />
-      {text}
-    </button>
+    />
   );
 };
 
-export const getStyles = () => ({
+export const getStyles = (theme: GrafanaTheme2) => ({
   expandButton: css`
-    background: none;
-    border: none;
-
-    outline: none !important;
-
-    display: inline-flex;
-    align-items: center;
-
-    svg {
-      margin-bottom: 0;
-    }
+    color: ${theme.colors.text.secondary};
+    margin-right: ${theme.spacing(1)};
   `,
 });

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -106,11 +106,12 @@ export const OptionsPaneCategory: FC<OptionsPaneCategoryProps> = React.memo(
             fill="text"
             aria-expanded="true"
             aria-controls={id}
-            id={`button-${id}`}
             className={cx(styles.toggle, 'editor-options-group-toggle')}
             icon={isExpanded ? 'angle-down' : 'angle-right'}
           />
-          <h6 className={styles.title}>{renderTitle(isExpanded)}</h6>
+          <h6 id={`button-${id}`} className={styles.title}>
+            {renderTitle(isExpanded)}
+          </h6>
         </div>
         {isExpanded && (
           <div className={bodyStyles} id={id} aria-labelledby={`button-${id}`}>

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -103,7 +103,7 @@ export const OptionsPaneCategory: FC<OptionsPaneCategoryProps> = React.memo(
         <div className={headerStyles} onClick={onToggle} aria-label={selectors.components.OptionsGroup.toggle(id)}>
           <Button
             fill="text"
-            aria-expanded="true"
+            aria-expanded={isExpanded}
             aria-controls={id}
             className={cx(styles.toggle, 'editor-options-group-toggle')}
             icon={isExpanded ? 'angle-down' : 'angle-right'}

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -1,11 +1,12 @@
 import React, { FC, ReactNode, useCallback, useEffect, useState, useRef } from 'react';
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, Counter, useStyles2 } from '@grafana/ui';
+import { Counter, useStyles2 } from '@grafana/ui';
 import { PANEL_EDITOR_UI_STATE_STORAGE_KEY } from './state/reducers';
 import { useLocalStorage } from 'react-use';
 import { selectors } from '@grafana/e2e-selectors';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
+import { CollapseToggle } from 'app/features/alerting/unified/components/CollapseToggle';
 
 export interface OptionsPaneCategoryProps {
   id: string;
@@ -101,13 +102,7 @@ export const OptionsPaneCategory: FC<OptionsPaneCategoryProps> = React.memo(
         ref={ref}
       >
         <div className={headerStyles} onClick={onToggle} aria-label={selectors.components.OptionsGroup.toggle(id)}>
-          <Button
-            fill="text"
-            aria-expanded={isExpanded}
-            aria-controls={id}
-            className={cx(styles.toggle, 'editor-options-group-toggle')}
-            icon={isExpanded ? 'angle-down' : 'angle-right'}
-          />
+          <CollapseToggle isCollapsed={!isExpanded} idControlled={id} onToggle={onToggle} />
           <h6 id={`button-${id}`} className={styles.title}>
             {renderTitle(isExpanded)}
           </h6>
@@ -131,10 +126,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     `,
     boxNestedExpanded: css`
       margin-bottom: ${theme.spacing(2)};
-    `,
-    toggle: css`
-      color: ${theme.colors.text.secondary};
-      margin-right: ${theme.spacing(1)};
     `,
     title: css`
       flex-grow: 1;

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -108,9 +108,8 @@ export const OptionsPaneCategory: FC<OptionsPaneCategoryProps> = React.memo(
             aria-controls={id}
             id={`button-${id}`}
             className={cx(styles.toggle, 'editor-options-group-toggle')}
-          >
-            <Icon name={isExpanded ? 'angle-down' : 'angle-right'} />
-          </Button>
+            icon={isExpanded ? 'angle-down' : 'angle-right'}
+          />
           <h6 className={styles.title}>{renderTitle(isExpanded)}</h6>
         </div>
         {isExpanded && (

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -1,7 +1,7 @@
 import React, { FC, ReactNode, useCallback, useEffect, useState, useRef } from 'react';
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Counter, Icon, useStyles2 } from '@grafana/ui';
+import { Button, Counter, Icon, useStyles2 } from '@grafana/ui';
 import { PANEL_EDITOR_UI_STATE_STORAGE_KEY } from './state/reducers';
 import { useLocalStorage } from 'react-use';
 import { selectors } from '@grafana/e2e-selectors';
@@ -100,13 +100,25 @@ export const OptionsPaneCategory: FC<OptionsPaneCategoryProps> = React.memo(
         aria-label={selectors.components.OptionsGroup.group(id)}
         ref={ref}
       >
-        <div className={headerStyles} onClick={onToggle} aria-label={selectors.components.OptionsGroup.toggle(id)}>
+        <Button
+          fill="text"
+          aria-expanded="true"
+          aria-controls={id}
+          id={`button-${id}`}
+          className={headerStyles}
+          onClick={onToggle}
+          aria-label={selectors.components.OptionsGroup.toggle(id)}
+        >
           <div className={cx(styles.toggle, 'editor-options-group-toggle')}>
             <Icon name={isExpanded ? 'angle-down' : 'angle-right'} />
           </div>
           <h6 className={styles.title}>{renderTitle(isExpanded)}</h6>
-        </div>
-        {isExpanded && <div className={bodyStyles}>{children}</div>}
+        </Button>
+        {isExpanded && (
+          <div className={bodyStyles} id={id} aria-labelledby={`button-${id}`}>
+            {children}
+          </div>
+        )}
       </div>
     );
   }

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -100,20 +100,19 @@ export const OptionsPaneCategory: FC<OptionsPaneCategoryProps> = React.memo(
         aria-label={selectors.components.OptionsGroup.group(id)}
         ref={ref}
       >
-        <Button
-          fill="text"
-          aria-expanded="true"
-          aria-controls={id}
-          id={`button-${id}`}
-          className={headerStyles}
-          onClick={onToggle}
-          aria-label={selectors.components.OptionsGroup.toggle(id)}
-        >
-          <div className={cx(styles.toggle, 'editor-options-group-toggle')}>
+        <div className={headerStyles} onClick={onToggle} aria-label={selectors.components.OptionsGroup.toggle(id)}>
+          <Button
+            size="sm"
+            fill="text"
+            aria-expanded="true"
+            aria-controls={id}
+            id={`button-${id}`}
+            className={cx(styles.toggle, 'editor-options-group-toggle')}
+          >
             <Icon name={isExpanded ? 'angle-down' : 'angle-right'} />
-          </div>
+          </Button>
           <h6 className={styles.title}>{renderTitle(isExpanded)}</h6>
-        </Button>
+        </div>
         {isExpanded && (
           <div className={bodyStyles} id={id} aria-labelledby={`button-${id}`}>
             {children}

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -102,7 +102,6 @@ export const OptionsPaneCategory: FC<OptionsPaneCategoryProps> = React.memo(
       >
         <div className={headerStyles} onClick={onToggle} aria-label={selectors.components.OptionsGroup.toggle(id)}>
           <Button
-            size="md"
             fill="text"
             aria-expanded="true"
             aria-controls={id}
@@ -149,7 +148,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: flex;
       cursor: pointer;
       align-items: baseline;
-      padding: ${theme.spacing(1)};
+      padding: ${theme.spacing(0.5)};
       color: ${theme.colors.text.primary};
       font-weight: ${theme.typography.fontWeightMedium};
 

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -1,7 +1,7 @@
 import React, { FC, ReactNode, useCallback, useEffect, useState, useRef } from 'react';
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, Counter, Icon, useStyles2 } from '@grafana/ui';
+import { Button, Counter, useStyles2 } from '@grafana/ui';
 import { PANEL_EDITOR_UI_STATE_STORAGE_KEY } from './state/reducers';
 import { useLocalStorage } from 'react-use';
 import { selectors } from '@grafana/e2e-selectors';
@@ -102,7 +102,7 @@ export const OptionsPaneCategory: FC<OptionsPaneCategoryProps> = React.memo(
       >
         <div className={headerStyles} onClick={onToggle} aria-label={selectors.components.OptionsGroup.toggle(id)}>
           <Button
-            size="sm"
+            size="md"
             fill="text"
             aria-expanded="true"
             aria-controls={id}


### PR DESCRIPTION
## What this PR does / why we need it

To improve A11y:

Currently when editing a dashboard, option pans that are collapsed are not accessible by keyboard - and some are collapsed by default meaning a keyboard-only user would not be able to expand and use them.

This PR fixes that by turning the caret icon (angle-down or angle-right) into a button. 
It also adds the prop `aria-expanded` and `aria-controls` to it.

### Screenshots

| - | Before | After |
|--------|--------|-------|
| Not focussed |   ![Screenshot 2022-03-10 at 13 05 03](https://user-images.githubusercontent.com/42030685/157661980-de6f23c4-d7e3-481c-a838-7a8f9e46268e.png)   | ![Screenshot 2022-03-10 at 16 10 28](https://user-images.githubusercontent.com/42030685/157691698-17937115-6c5a-4557-8aab-4a050b48e59d.png) |
| Focussed |  N/A  |  ![Screenshot 2022-03-10 at 16 10 42](https://user-images.githubusercontent.com/42030685/157691706-013a6415-8d30-4ce9-872f-5d991eae38df.png)  |

## Which issue(s) this PR fixes

See the list of issues the a11y Hackathon team focuses on here: https://docs.google.com/spreadsheets/d/1e3sjrB3wjgQfttK5ANNkac5wmDwLszhgW0fO1kWT2LI/edit#gid=0 

## Special notes for your reviewer
1. This PR does change the UI a bit (see screenshots each optionPane is slightly bigger in this PR's version) I don't think it does in a bad way but I'm open to comments / requests to change it 🙂 

2. I have tried a solution that would make the whole row focussable but I've ran into issues with the `override` pane as it also has a delete button and buttons cannot be embedded into each others. I find that using the caret icon is the best compromise at it fixes a high priority a11y issue all the while not disturbing the existing solution too much. Happy for it to be iterated upon in the future 🙂 