### PR TITLE
Accesscontrol: fix data source name resolver and add uid name resolver

### DIFF
--- a/pkg/services/datasources/service/datasource_service.go
+++ b/pkg/services/datasources/service/datasource_service.go
@@ -104,6 +104,9 @@ func NewNameScopeResolver(db DataSourceRetriever) (string, accesscontrol.Attribu
 		}
 
 		dsName := initialScope[len(prefix):]
+		if dsName == "" {
+			return "", accesscontrol.ErrInvalidScope
+		}
 
 		query := models.GetDataSourceQuery{Name: dsName, OrgId: orgID}
 		if err := db.GetDataSource(ctx, &query); err != nil {
@@ -126,6 +129,9 @@ func NewUidScopeResolver(db DataSourceRetriever) (string, accesscontrol.Attribut
 		}
 
 		dsUID := initialScope[len(prefix):]
+		if dsUID == "" {
+			return "", accesscontrol.ErrInvalidScope
+		}
 
 		query := models.GetDataSourceQuery{Uid: dsUID, OrgId: orgID}
 		if err := db.GetDataSource(ctx, &query); err != nil {

--- a/pkg/services/datasources/service/datasource_service.go
+++ b/pkg/services/datasources/service/datasource_service.go
@@ -83,6 +83,7 @@ func ProvideService(
 	s.Bus.AddHandler(s.GetDefaultDataSource)
 
 	ac.RegisterAttributeScopeResolver(NewNameScopeResolver(store))
+	ac.RegisterAttributeScopeResolver(NewUidScopeResolver(store))
 
 	return s
 }

--- a/pkg/services/datasources/service/datasource_service_test.go
+++ b/pkg/services/datasources/service/datasource_service_test.go
@@ -138,6 +138,12 @@ func TestService_NameScopeResolver(t *testing.T) {
 			want:    "",
 			wantErr: accesscontrol.ErrInvalidScope,
 		},
+		{
+			desc:    "empty name scope",
+			given:   "datasources:name:",
+			want:    "",
+			wantErr: accesscontrol.ErrInvalidScope,
+		},
 	}
 	prefix, resolver := NewNameScopeResolver(retriever)
 	require.Equal(t, "datasources:name:", prefix)
@@ -184,6 +190,12 @@ func TestService_UIDScopeResolver(t *testing.T) {
 		{
 			desc:    "malformed scope",
 			given:   "datasources:unknown",
+			want:    "",
+			wantErr: accesscontrol.ErrInvalidScope,
+		},
+		{
+			desc:    "empty uid scope",
+			given:   "datasources:uid:",
 			want:    "",
 			wantErr: accesscontrol.ErrInvalidScope,
 		},

--- a/pkg/services/datasources/service/datasource_service_test.go
+++ b/pkg/services/datasources/service/datasource_service_test.go
@@ -121,7 +121,7 @@ func TestService_NameScopeResolver(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			desc:    "semicolon in name",
+			desc:    "colon in name",
 			given:   "datasources:name::",
 			want:    "datasources:id:4",
 			wantErr: nil,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR intends to remove the resolution of `datasource:name:*` to `datasource:id:*` since this would mean that someone creating a data source with the name `*` would need permissions scoped with `datasource:id:*` (equivalent to all data sources), to access it.

This PR also adds a UID scope resolver required for the delete endpoint: https://github.com/grafana/grafana/blob/52decfaebcb040e87e82842833e63ec0fc7617d2/pkg/api/api.go#L282

Related conversation: https://github.com/grafana/grafana/pull/46380/files#r823422562

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

