### PR TITLE
Use `X-Forwarded-Host` for origin checks in proxy scenarios

### DIFF
--- a/pkg/middleware/csrf.go
+++ b/pkg/middleware/csrf.go
@@ -41,20 +41,18 @@ func CSRF(loginCookieName string, logger log.Logger) func(http.Handler) http.Han
 				logger.Error("error parsing Origin header", "err", err)
 			}
 
-			// X-Forwarded-Host for (reverse) proxy scenarios
-			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
-			xfh, err := url.Parse(r.Header.Get("X-Forwarded-Host"))
-			if err != nil {
-				logger.Error("error parsing X-Forwarded-Host header", "err", err)
-			}
-
-			// X-Forwarded-Host is only used and checked when GF_USE_BEHIND_PROXY is set to 'true'
 			if UseBehindProxy := os.Getenv("GF_USE_BEHIND_PROXY"); UseBehindProxy == "true" {
+
+				// X-Forwarded-Host for (reverse) proxy scenarios
+				// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
+				xfh, err := url.Parse(r.Header.Get("X-Forwarded-Host"))
+				if err != nil {
+					logger.Error("error parsing X-Forwarded-Host header", "err", err)
+				}
 
 				// Checking that the Host header is not empty AND that the the Origin header matches the Host OR X-Forwarded-Host matches the Origin
 				if err != nil || netAddr.Host == "" || ((origin.String() != "" && origin.Hostname() != netAddr.Host) && (xfh.String() != "" && xfh.String() != origin.Hostname())) {
-					errormsg := "XFH " + xfh.String() + " != Origin " + origin.Hostname()
-					http.Error(w, "origin not allowed - "+errormsg, http.StatusForbidden)
+					http.Error(w, "origin not allowed", http.StatusForbidden)
 					return
 				}
 
@@ -62,8 +60,7 @@ func CSRF(loginCookieName string, logger log.Logger) func(http.Handler) http.Han
 
 				// Checking that the Host header is not empty AND that the the Origin header matches the Host
 				if err != nil || netAddr.Host == "" || (origin.String() != "" && origin.Hostname() != netAddr.Host) {
-					errormsg := "Origin " + origin.Hostname() + "!= server host " + netAddr.Host
-					http.Error(w, "origin not allowed - "+errormsg, http.StatusForbidden)
+					http.Error(w, "origin not allowed", http.StatusForbidden)
 					return
 				}
 

--- a/pkg/middleware/csrf.go
+++ b/pkg/middleware/csrf.go
@@ -35,37 +35,30 @@ func CSRF(loginCookieName string, logger log.Logger) func(http.Handler) http.Han
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
-
 			origin, err := url.Parse(r.Header.Get("Origin"))
 			if err != nil {
 				logger.Error("error parsing Origin header", "err", err)
 			}
-
+			// env var GF_USE_BEHIND_PROXY controls if X-Forwarded-Host is used or not
 			if UseBehindProxy := os.Getenv("GF_USE_BEHIND_PROXY"); UseBehindProxy == "true" {
-
 				// X-Forwarded-Host for (reverse) proxy scenarios
 				// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
 				xfh, err := url.Parse(r.Header.Get("X-Forwarded-Host"))
 				if err != nil {
 					logger.Error("error parsing X-Forwarded-Host header", "err", err)
 				}
-
 				// Checking that the Host header is not empty AND that the the Origin header matches the Host OR X-Forwarded-Host matches the Origin
 				if err != nil || netAddr.Host == "" || ((origin.String() != "" && origin.Hostname() != netAddr.Host) && (xfh.String() != "" && xfh.String() != origin.Hostname())) {
 					http.Error(w, "origin not allowed", http.StatusForbidden)
 					return
 				}
-
 			} else {
-
 				// Checking that the Host header is not empty AND that the the Origin header matches the Host
 				if err != nil || netAddr.Host == "" || (origin.String() != "" && origin.Hostname() != netAddr.Host) {
 					http.Error(w, "origin not allowed", http.StatusForbidden)
 					return
 				}
-
 			}
-
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/pkg/middleware/csrf.go
+++ b/pkg/middleware/csrf.go
@@ -43,12 +43,12 @@ func CSRF(loginCookieName string, logger log.Logger) func(http.Handler) http.Han
 			if UseBehindProxy := os.Getenv("GF_USE_BEHIND_PROXY"); UseBehindProxy == "true" {
 				// X-Forwarded-Host for (reverse) proxy scenarios
 				// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
-				xfh, err := url.Parse(r.Header.Get("X-Forwarded-Host"))
+				xfh, err := util.SplitHostPortDefault(r.Header.Get("X-Forwarded-Host"), "", "0")
 				if err != nil {
 					logger.Error("error parsing X-Forwarded-Host header", "err", err)
 				}
 				// Checking that the Host header is not empty AND that the the Origin header matches the Host OR X-Forwarded-Host matches the Origin
-				if err != nil || netAddr.Host == "" || ((origin.String() != "" && origin.Hostname() != netAddr.Host) && (xfh.String() != "" && xfh.String() != origin.Hostname())) {
+				if err != nil || netAddr.Host == "" || ((origin.String() != "" && origin.Hostname() != netAddr.Host) && (xfh.Host != "" && xfh.Host != origin.Hostname())) {
 					http.Error(w, "origin not allowed", http.StatusForbidden)
 					return
 				}

--- a/pkg/middleware/csrf.go
+++ b/pkg/middleware/csrf.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"os"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/util"
@@ -39,9 +40,33 @@ func CSRF(loginCookieName string, logger log.Logger) func(http.Handler) http.Han
 			if err != nil {
 				logger.Error("error parsing Origin header", "err", err)
 			}
-			if err != nil || netAddr.Host == "" || (origin.String() != "" && origin.Hostname() != netAddr.Host) {
-				http.Error(w, "origin not allowed", http.StatusForbidden)
-				return
+
+			// X-Forwarded-Host for (reverse) proxy scenarios
+			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host
+			xfh, err := url.Parse(r.Header.Get("X-Forwarded-Host"))
+			if err != nil {
+				logger.Error("error parsing X-Forwarded-Host header", "err", err)
+			}
+
+			// X-Forwarded-Host is only used and checked when GF_USE_BEHIND_PROXY is set to 'true'
+			if UseBehindProxy := os.Getenv("GF_USE_BEHIND_PROXY"); UseBehindProxy == "true" {
+
+				// Checking that the Host header is not empty AND that the the Origin header matches the Host OR X-Forwarded-Host matches the Origin
+				if err != nil || netAddr.Host == "" || ((origin.String() != "" && origin.Hostname() != netAddr.Host) && (xfh.String() != "" && xfh.String() != origin.Hostname())) {
+					errormsg := "XFH " + xfh.String() + " != Origin " + origin.Hostname()
+					http.Error(w, "origin not allowed - "+errormsg, http.StatusForbidden)
+					return
+				}
+
+			} else {
+
+				// Checking that the Host header is not empty AND that the the Origin header matches the Host
+				if err != nil || netAddr.Host == "" || (origin.String() != "" && origin.Hostname() != netAddr.Host) {
+					errormsg := "Origin " + origin.Hostname() + "!= server host " + netAddr.Host
+					http.Error(w, "origin not allowed - "+errormsg, http.StatusForbidden)
+					return
+				}
+
 			}
 
 			next.ServeHTTP(w, r)


### PR DESCRIPTION
Adding an additional check to the `csrf.go` file to compare the Origin header with the `X-Forwared-Host` header in cases where Grafana runs behind a proxy server. 

`X-Forwarded-Host` is a defacto standard. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR addresses the issues described in #46321 (and others). Grafana returned `403` errors `origin not allowed` when used behind a (reverse) proxy server that does not support `PreserveHostHeader` like for example Apache or Nginx.

This PR might also make the workarounds documented for Traefik, Nginx and Apache obsolete as all of them should use or at least support `X-Forwarded-Host`, too.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #46321 

**Special notes for your reviewer**:

I've added an additional env var `GF_USED_BEHIND_PROXY` that allows us to enable (`true`) or disable (`false` or empty) the check of `X-Forwarded-Host` when not needed. Its using `os.Getenv` - I saw that there's a builtin mechanism to leverage env vars but I haven't figured out how to use it. This as well as the name of the env var might have to change.

CC: @sebader