### PR TITLE
Access control: Display inherited folder permissions in dashboards

### DIFF
--- a/pkg/services/accesscontrol/database/resource_permissions.go
+++ b/pkg/services/accesscontrol/database/resource_permissions.go
@@ -13,10 +13,12 @@ import (
 )
 
 type flatResourcePermission struct {
-	ID            int64 `xorm:"id"`
-	RoleName      string
-	Action        string
-	Scope         string
+	ID       int64 `xorm:"id"`
+	RoleName string
+	Action   string
+	// Scope is what is stored in the database
+	Scope string
+	// ResourceScope is what we ask for
 	ResourceScope string
 	UserId        int64
 	UserLogin     string

--- a/pkg/services/accesscontrol/database/resource_permissions.go
+++ b/pkg/services/accesscontrol/database/resource_permissions.go
@@ -582,7 +582,7 @@ func (s *AccessControlStore) getResourcePermissionsByIds(sess *sqlstore.DBSessio
 	rawSql := `
 	SELECT
 		p.*,
-		? as resource_scope
+		? as resource_scope,
 		ur.user_id AS user_id,
 		u.login AS user_login,
 		u.email AS user_email,

--- a/pkg/services/accesscontrol/database/resource_permissions_bench_test.go
+++ b/pkg/services/accesscontrol/database/resource_permissions_bench_test.go
@@ -55,10 +55,10 @@ func benchmarkDSPermissions(b *testing.B, dsNum, usersNum int) {
 func getDSPermissions(b *testing.B, store *AccessControlStore, dataSources []int64) {
 	dsId := dataSources[0]
 
-	permissions, err := store.GetResourcesPermissions(context.Background(), accesscontrol.GlobalOrgID, types.GetResourcesPermissionsQuery{
-		Actions:     []string{dsAction},
-		Resource:    dsResource,
-		ResourceIDs: []string{strconv.Itoa(int(dsId))},
+	permissions, err := store.GetResourcePermissions(context.Background(), accesscontrol.GlobalOrgID, types.GetResourcePermissionsQuery{
+		Actions:    []string{dsAction},
+		Resource:   dsResource,
+		ResourceID: strconv.Itoa(int(dsId)),
 	})
 	require.NoError(b, err)
 	assert.GreaterOrEqual(b, len(permissions), 2)

--- a/pkg/services/accesscontrol/database/resource_permissions_test.go
+++ b/pkg/services/accesscontrol/database/resource_permissions_test.go
@@ -311,29 +311,29 @@ func TestAccessControlStore_SetResourcePermissions(t *testing.T) {
 	}
 }
 
-type getResourcesPermissionsTest struct {
+type getResourcePermissionsTest struct {
 	desc        string
 	user        *models.SignedInUser
 	numUsers    int
 	actions     []string
 	resource    string
-	resourceIDs []string
+	resourceID  string
 	onlyManaged bool
 }
 
-func TestAccessControlStore_GetResourcesPermissions(t *testing.T) {
-	tests := []getResourcesPermissionsTest{
+func TestAccessControlStore_GetResourcePermissions(t *testing.T) {
+	tests := []getResourcePermissionsTest{
 		{
-			desc: "should return permissions for all resource ids",
+			desc: "should return permissions for resource id",
 			user: &models.SignedInUser{
 				OrgId: 1,
 				Permissions: map[int64]map[string][]string{
 					1: {accesscontrol.ActionOrgUsersRead: {accesscontrol.ScopeUsersAll}},
 				}},
-			numUsers:    3,
-			actions:     []string{"datasources:query"},
-			resource:    "datasources",
-			resourceIDs: []string{"1", "2"},
+			numUsers:   3,
+			actions:    []string{"datasources:query"},
+			resource:   "datasources",
+			resourceID: "1",
 		},
 		{
 			desc: "should return manage permissions for all resource ids",
@@ -345,7 +345,7 @@ func TestAccessControlStore_GetResourcesPermissions(t *testing.T) {
 			numUsers:    3,
 			actions:     []string{"datasources:query"},
 			resource:    "datasources",
-			resourceIDs: []string{"1", "2"},
+			resourceID:  "1",
 			onlyManaged: true,
 		},
 	}
@@ -389,22 +389,20 @@ func TestAccessControlStore_GetResourcesPermissions(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			for _, id := range test.resourceIDs {
-				seedResourcePermissions(t, store, sql, test.actions, test.resource, id, test.numUsers)
-			}
+			seedResourcePermissions(t, store, sql, test.actions, test.resource, test.resourceID, test.numUsers)
 
-			permissions, err := store.GetResourcesPermissions(context.Background(), test.user.OrgId, types.GetResourcesPermissionsQuery{
+			permissions, err := store.GetResourcePermissions(context.Background(), test.user.OrgId, types.GetResourcePermissionsQuery{
 				User:        test.user,
 				Actions:     test.actions,
 				Resource:    test.resource,
-				ResourceIDs: test.resourceIDs,
+				ResourceID:  test.resourceID,
 				OnlyManaged: test.onlyManaged,
 			})
 			require.NoError(t, err)
 
-			expectedLen := test.numUsers * len(test.resourceIDs)
+			expectedLen := test.numUsers
 			if !test.onlyManaged {
-				expectedLen += len(test.resourceIDs)
+				expectedLen += 1
 			}
 			assert.Len(t, permissions, expectedLen)
 		})

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -195,7 +195,6 @@ type ScopeParams struct {
 // can perform against specific resource.
 type ResourcePermission struct {
 	ID          int64
-	ResourceID  string
 	RoleName    string
 	Actions     []string
 	Scope       string
@@ -206,12 +205,9 @@ type ResourcePermission struct {
 	TeamEmail   string
 	Team        string
 	BuiltInRole string
+	IsManaged   bool
 	Created     time.Time
 	Updated     time.Time
-}
-
-func (p *ResourcePermission) IsManaged() bool {
-	return strings.HasPrefix(p.RoleName, "managed:")
 }
 
 func (p *ResourcePermission) Contains(targetActions []string) bool {

--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -148,7 +148,6 @@ func provideDashboardService(
 	cfg *setting.Cfg, router routing.RouteRegister, sql *sqlstore.SQLStore,
 	ac accesscontrol.AccessControl, store resourcepermissions.Store,
 ) (*resourcepermissions.Service, error) {
-
 	getDashboard := func(ctx context.Context, orgID int64, resourceID string) (*models.Dashboard, error) {
 		id, err := strconv.ParseInt(resourceID, 10, 64)
 		if err != nil {

--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -146,21 +146,30 @@ var FolderAdminActions = append(FolderEditActions, []string{dashboards.ActionFol
 
 func provideDashboardService(
 	cfg *setting.Cfg, router routing.RouteRegister, sql *sqlstore.SQLStore,
-	accesscontrol accesscontrol.AccessControl, store resourcepermissions.Store,
+	ac accesscontrol.AccessControl, store resourcepermissions.Store,
 ) (*resourcepermissions.Service, error) {
+
+	getDashboard := func(ctx context.Context, orgID int64, resourceID string) (*models.Dashboard, error) {
+		id, err := strconv.ParseInt(resourceID, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		query := &models.GetDashboardQuery{Id: id, OrgId: orgID}
+		if err := sql.GetDashboard(ctx, query); err != nil {
+			return nil, err
+		}
+		return query.Result, nil
+	}
+
 	options := resourcepermissions.Options{
 		Resource: "dashboards",
 		ResourceValidator: func(ctx context.Context, orgID int64, resourceID string) error {
-			id, err := strconv.ParseInt(resourceID, 10, 64)
+			dashboard, err := getDashboard(ctx, orgID, resourceID)
 			if err != nil {
 				return err
 			}
-			query := &models.GetDashboardQuery{Id: id, OrgId: orgID}
-			if err := sql.GetDashboard(ctx, query); err != nil {
-				return err
-			}
 
-			if query.Result.IsFolder {
+			if dashboard.IsFolder {
 				return errors.New("not found")
 			}
 
@@ -175,6 +184,16 @@ func provideDashboardService(
 				return 0, err
 			}
 			return query.Result.Id, nil
+		},
+		InheritedScopes: func(ctx context.Context, orgID int64, resourceID string) ([]string, error) {
+			dashboard, err := getDashboard(ctx, orgID, resourceID)
+			if err != nil {
+				return nil, err
+			}
+			if dashboard.FolderId > 0 {
+				return []string{accesscontrol.GetResourceScope("folders", strconv.FormatInt(dashboard.FolderId, 10))}, nil
+			}
+			return []string{}, nil
 		},
 		Assignments: resourcepermissions.Assignments{
 			Users:        true,
@@ -191,7 +210,7 @@ func provideDashboardService(
 		RoleGroup:      "Dashboards",
 	}
 
-	return resourcepermissions.New(options, cfg, router, accesscontrol, store, sql)
+	return resourcepermissions.New(options, cfg, router, ac, store, sql)
 }
 
 func provideFolderService(

--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -185,7 +185,7 @@ func provideDashboardService(
 			}
 			return query.Result.Id, nil
 		},
-		InheritedScopes: func(ctx context.Context, orgID int64, resourceID string) ([]string, error) {
+		InheritedScopesSolver: func(ctx context.Context, orgID int64, resourceID string) ([]string, error) {
 			dashboard, err := getDashboard(ctx, orgID, resourceID)
 			if err != nil {
 				return nil, err

--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -65,7 +65,6 @@ func (a *api) getDescription(c *models.ReqContext) response.Response {
 
 type resourcePermissionDTO struct {
 	ID            int64    `json:"id"`
-	ResourceID    string   `json:"resourceId"`
 	RoleName      string   `json:"roleName"`
 	IsManaged     bool     `json:"isManaged"`
 	UserID        int64    `json:"userId,omitempty"`
@@ -105,9 +104,7 @@ func (a *api) getPermissions(c *models.ReqContext) response.Response {
 
 			dto = append(dto, resourcePermissionDTO{
 				ID:            p.ID,
-				ResourceID:    p.ResourceID,
 				RoleName:      p.RoleName,
-				IsManaged:     p.IsManaged(),
 				UserID:        p.UserId,
 				UserLogin:     p.UserLogin,
 				UserAvatarUrl: dtos.GetGravatarUrl(p.UserEmail),
@@ -117,6 +114,7 @@ func (a *api) getPermissions(c *models.ReqContext) response.Response {
 				BuiltInRole:   p.BuiltInRole,
 				Actions:       p.Actions,
 				Permission:    permission,
+				IsManaged:     p.IsManaged,
 			})
 		}
 	}

--- a/pkg/services/accesscontrol/resourcepermissions/api_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_test.go
@@ -482,7 +482,7 @@ func TestApi_UidSolver(t *testing.T) {
 	}
 }
 
-func withSolver(options Options, solver uidSolver) Options {
+func withSolver(options Options, solver UidSolver) Options {
 	options.UidSolver = solver
 	return options
 }

--- a/pkg/services/accesscontrol/resourcepermissions/middleware.go
+++ b/pkg/services/accesscontrol/resourcepermissions/middleware.go
@@ -1,7 +1,6 @@
 package resourcepermissions
 
 import (
-	"context"
 	"net/http"
 	"strconv"
 
@@ -10,9 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
-type uidSolver func(ctx context.Context, orgID int64, uid string) (int64, error)
-
-func solveUID(solve uidSolver) web.Handler {
+func solveUID(solve UidSolver) web.Handler {
 	return func(c *models.ReqContext) {
 		if solve != nil && util.IsValidShortUID(web.Params(c.Req)[":resourceID"]) {
 			params := web.Params(c.Req)

--- a/pkg/services/accesscontrol/resourcepermissions/options.go
+++ b/pkg/services/accesscontrol/resourcepermissions/options.go
@@ -7,6 +7,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 )
 
+type UidSolver func(ctx context.Context, orgID int64, uid string) (int64, error)
+
+// TODO: better name
+type InheritedScopes func(ctx context.Context, orgID int64, resourceID string) ([]string, error)
 type ResourceValidator func(ctx context.Context, orgID int64, resourceID string) error
 
 type Options struct {
@@ -35,5 +39,7 @@ type Options struct {
 	// OnSetBuiltInRole if configured will be called each time a permission is set for a built-in role
 	OnSetBuiltInRole func(session *sqlstore.DBSession, orgID int64, builtInRole, resourceID, permission string) error
 	// UidSolver if configured will be used in a middleware to translate an uid to id for each request
-	UidSolver uidSolver
+	UidSolver UidSolver
+	// InheritedScopes
+	InheritedScopes InheritedScopes
 }

--- a/pkg/services/accesscontrol/resourcepermissions/options.go
+++ b/pkg/services/accesscontrol/resourcepermissions/options.go
@@ -8,10 +8,8 @@ import (
 )
 
 type UidSolver func(ctx context.Context, orgID int64, uid string) (int64, error)
-
-// TODO: better name
-type InheritedScopesSolver func(ctx context.Context, orgID int64, resourceID string) ([]string, error)
 type ResourceValidator func(ctx context.Context, orgID int64, resourceID string) error
+type InheritedScopesSolver func(ctx context.Context, orgID int64, resourceID string) ([]string, error)
 
 type Options struct {
 	// Resource is the action and scope prefix that is generated

--- a/pkg/services/accesscontrol/resourcepermissions/options.go
+++ b/pkg/services/accesscontrol/resourcepermissions/options.go
@@ -10,7 +10,7 @@ import (
 type UidSolver func(ctx context.Context, orgID int64, uid string) (int64, error)
 
 // TODO: better name
-type InheritedScopes func(ctx context.Context, orgID int64, resourceID string) ([]string, error)
+type InheritedScopesSolver func(ctx context.Context, orgID int64, resourceID string) ([]string, error)
 type ResourceValidator func(ctx context.Context, orgID int64, resourceID string) error
 
 type Options struct {
@@ -40,6 +40,6 @@ type Options struct {
 	OnSetBuiltInRole func(session *sqlstore.DBSession, orgID int64, builtInRole, resourceID, permission string) error
 	// UidSolver if configured will be used in a middleware to translate an uid to id for each request
 	UidSolver UidSolver
-	// InheritedScopes
-	InheritedScopes InheritedScopes
+	// InheritedScopesSolver if configured can generate additional scopes that will be used when fetching permissions for a resource
+	InheritedScopesSolver InheritedScopesSolver
 }

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -42,8 +42,8 @@ type Store interface {
 		hooks types.ResourceHooks,
 	) ([]accesscontrol.ResourcePermission, error)
 
-	// GetResourcesPermissions will return all permission for all supplied resource ids
-	GetResourcesPermissions(ctx context.Context, orgID int64, query types.GetResourcesPermissionsQuery) ([]accesscontrol.ResourcePermission, error)
+	// GetResourcePermissions will return all permission for supplied resource id
+	GetResourcePermissions(ctx context.Context, orgID int64, query types.GetResourcePermissionsQuery) ([]accesscontrol.ResourcePermission, error)
 }
 
 func New(options Options, cfg *setting.Cfg, router routing.RouteRegister, ac accesscontrol.AccessControl, store Store, sqlStore *sqlstore.SQLStore) (*Service, error) {
@@ -101,11 +101,11 @@ type Service struct {
 }
 
 func (s *Service) GetPermissions(ctx context.Context, user *models.SignedInUser, resourceID string) ([]accesscontrol.ResourcePermission, error) {
-	return s.store.GetResourcesPermissions(ctx, user.OrgId, types.GetResourcesPermissionsQuery{
+	return s.store.GetResourcePermissions(ctx, user.OrgId, types.GetResourcePermissionsQuery{
 		User:        user,
 		Actions:     s.actions,
 		Resource:    s.options.Resource,
-		ResourceIDs: []string{resourceID},
+		ResourceID:  resourceID,
 		OnlyManaged: s.options.OnlyManaged,
 	})
 }

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -102,9 +102,9 @@ type Service struct {
 
 func (s *Service) GetPermissions(ctx context.Context, user *models.SignedInUser, resourceID string) ([]accesscontrol.ResourcePermission, error) {
 	var inheritedScopes []string
-	if s.options.InheritedScopes != nil {
+	if s.options.InheritedScopesSolver != nil {
 		var err error
-		inheritedScopes, err = s.options.InheritedScopes(ctx, user.OrgId, resourceID)
+		inheritedScopes, err = s.options.InheritedScopesSolver(ctx, user.OrgId, resourceID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -101,12 +101,22 @@ type Service struct {
 }
 
 func (s *Service) GetPermissions(ctx context.Context, user *models.SignedInUser, resourceID string) ([]accesscontrol.ResourcePermission, error) {
+	var inheritedScopes []string
+	if s.options.InheritedScopes != nil {
+		var err error
+		inheritedScopes, err = s.options.InheritedScopes(ctx, user.OrgId, resourceID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return s.store.GetResourcePermissions(ctx, user.OrgId, types.GetResourcePermissionsQuery{
-		User:        user,
-		Actions:     s.actions,
-		Resource:    s.options.Resource,
-		ResourceID:  resourceID,
-		OnlyManaged: s.options.OnlyManaged,
+		User:            user,
+		Actions:         s.actions,
+		Resource:        s.options.Resource,
+		ResourceID:      resourceID,
+		InheritedScopes: inheritedScopes,
+		OnlyManaged:     s.options.OnlyManaged,
 	})
 }
 

--- a/pkg/services/accesscontrol/resourcepermissions/types/models.go
+++ b/pkg/services/accesscontrol/resourcepermissions/types/models.go
@@ -20,10 +20,11 @@ type SetResourcePermissionsCommand struct {
 	SetResourcePermissionCommand
 }
 
-type GetResourcesPermissionsQuery struct {
-	Actions     []string
-	Resource    string
-	ResourceIDs []string
-	OnlyManaged bool
-	User        *models.SignedInUser
+type GetResourcePermissionsQuery struct {
+	Actions         []string
+	Resource        string
+	ResourceID      string
+	OnlyManaged     bool
+	InheritedScopes []string
+	User            *models.SignedInUser
 }

--- a/pkg/services/guardian/accesscontrol_guardian.go
+++ b/pkg/services/guardian/accesscontrol_guardian.go
@@ -178,7 +178,7 @@ func (a *AccessControlDashboardGuardian) GetAcl() ([]*models.DashboardAclInfoDTO
 
 	acl := make([]*models.DashboardAclInfoDTO, 0, len(permissions))
 	for _, p := range permissions {
-		if !p.IsManaged() {
+		if !p.IsManaged {
 			continue
 		}
 

--- a/pkg/services/guardian/accesscontrol_guardian_test.go
+++ b/pkg/services/guardian/accesscontrol_guardian_test.go
@@ -551,11 +551,11 @@ func TestAccessControlDashboardGuardian_GetHiddenACL(t *testing.T) {
 		{
 			desc: "should only return permissions containing hidden users",
 			permissions: []accesscontrol.ResourcePermission{
-				{RoleName: "managed:users:1:permissions", UserId: 1, UserLogin: "user1"},
-				{RoleName: "managed:teams:1:permissions", TeamId: 1, Team: "team1"},
-				{RoleName: "managed:users:2:permissions", UserId: 2, UserLogin: "user2"},
-				{RoleName: "managed:users:3:permissions", UserId: 3, UserLogin: "user3"},
-				{RoleName: "managed:users:4:permissions", UserId: 4, UserLogin: "user4"},
+				{RoleName: "managed:users:1:permissions", UserId: 1, UserLogin: "user1", IsManaged: true},
+				{RoleName: "managed:teams:1:permissions", TeamId: 1, Team: "team1", IsManaged: true},
+				{RoleName: "managed:users:2:permissions", UserId: 2, UserLogin: "user2", IsManaged: true},
+				{RoleName: "managed:users:3:permissions", UserId: 3, UserLogin: "user3", IsManaged: true},
+				{RoleName: "managed:users:4:permissions", UserId: 4, UserLogin: "user4", IsManaged: true},
 			},
 			hiddenUsers: map[string]struct{}{"user2": {}, "user3": {}},
 		},
@@ -564,7 +564,6 @@ func TestAccessControlDashboardGuardian_GetHiddenACL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			guardian := setupAccessControlGuardianTest(t, 1, nil)
-			guardian.permissionServices.GetDashboardService()
 
 			mocked := accesscontrolmock.NewPermissionsServicesMock()
 			guardian.permissionServices = mocked


### PR DESCRIPTION
**What this PR does / why we need it**:
When displaying dashboard permissions using access control we need a way to lookup inherited scopes.
To achieve this i added an option (InheritedScopesSolver) that can generate additional scopes to look after when fetching permissions for a resource.

For dashboards this would be folder scopes. I also reused then managed flag to display permissions than cannot be changed in the ui for that resource 

![2022-03-10-17:26:05](https://user-images.githubusercontent.com/23356117/157708764-2626b263-0131-44a0-9004-a504d126125a.png)

Enterprise pr: https://github.com/grafana/grafana-enterprise/pull/2995

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

