### PR TITLE
Docs: Fix labels to fields transformer subsections

### DIFF
--- a/docs/sources/panels/reference-transformation-functions.md
+++ b/docs/sources/panels/reference-transformation-functions.md
@@ -281,6 +281,40 @@ In "Rows" mode, the result has a table for each series and show each label value
 | Server     | Server B |
 | Datacenter | EU       |
 
+### Value field name
+
+If you selected Server as the **Value field name**, then you would get one field for every value of the Server label.
+
+| Time                | Datacenter | Server A | Server B |
+| ------------------- | ---------- | -------- | -------- |
+| 2020-07-07 11:34:20 | EU         | 1        | 2        |
+
+### Merging behavior
+
+The labels to fields transformer is internally two separate transformations. The first acts on single series and extracts labels to fields. The second is the [merge](#merge) transformation that joins all the results into a single table. The merge transformation tries to join on all matching fields. This merge step is required and cannot be turned off.
+
+To illustrate this, here is an example where you have two queries that return time series with no overlapping labels.
+
+- Series 1: labels Server=ServerA
+- Series 2: labels Datacenter=EU
+
+This will first result in these two tables:
+
+| Time                | Server  | Value |
+| ------------------- | ------- | ----- |
+| 2020-07-07 11:34:20 | ServerA | 10    |
+
+| Time                | Datacenter | Value |
+| ------------------- | ---------- | ----- |
+| 2020-07-07 11:34:20 | EU         | 20    |
+
+After merge:
+
+| Time                | Server  | Value | Datacenter |
+| ------------------- | ------- | ----- | ---------- |
+| 2020-07-07 11:34:20 | ServerA | 10    |            |
+| 2020-07-07 11:34:20 |         | 20    | EU         |
+
 ## Merge
 
 Use this transformation to combine the result from multiple queries into one single result. This is helpful when using the table panel visualization. Values that can be merged are combined into the same row. Values are mergeable if the shared fields contain the same data. For information, refer to [Table panel]({{< relref "../visualizations/table/_index.md" >}}).
@@ -323,40 +357,6 @@ Grafana displays a list of fields returned by the query. You can:
 In the example below, I hid the value field and renamed Max and Min.
 
 {{< figure src="/static/img/docs/transformations/organize-fields-stat-example-7-0.png" class="docs-image--no-shadow" max-width= "1100px" >}}
-
-### Value field name
-
-If you selected Server as the **Value field name**, then you would get one field for every value of the Server label.
-
-| Time                | Datacenter | Server A | Server B |
-| ------------------- | ---------- | -------- | -------- |
-| 2020-07-07 11:34:20 | EU         | 1        | 2        |
-
-### Merging behavior
-
-The labels to fields transformer is internally two separate transformations. The first acts on single series and extracts labels to fields. The second is the [merge](#merge) transformation that joins all the results into a single table. The merge transformation tries to join on all matching fields. This merge step is required and cannot be turned off.
-
-To illustrate this, here is an example where you have two queries that return time series with no overlapping labels.
-
-- Series 1: labels Server=ServerA
-- Series 2: labels Datacenter=EU
-
-This will first result in these two tables:
-
-| Time                | Server  | Value |
-| ------------------- | ------- | ----- |
-| 2020-07-07 11:34:20 | ServerA | 10    |
-
-| Time                | Datacenter | Value |
-| ------------------- | ---------- | ----- |
-| 2020-07-07 11:34:20 | EU         | 20    |
-
-After merge:
-
-| Time                | Server  | Value | Datacenter |
-| ------------------- | ------- | ----- | ---------- |
-| 2020-07-07 11:34:20 | ServerA | 10    |            |
-| 2020-07-07 11:34:20 |         | 20    | EU         |
 
 ## Reduce
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactoring in PR #43569 (commit 3b39c9f) resulted in subsections of the Labels to Fields transformer's docs being unintentionally moved under the Organize transformer section. Move these back under Labels to Fields.

**Which issue(s) this PR fixes**:

No issue filed.

**Special notes for your reviewer**:

Reported to docs by @mem