### PR TITLE
CPS: Remove the hardcoded Content-Security-Policy header from proxyutil

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -58,7 +58,6 @@ func (t *handleResponseTransport) RoundTrip(req *http.Request) (*http.Response, 
 		return nil, err
 	}
 	res.Header.Del("Set-Cookie")
-	proxyutil.SetProxyResponseHeaders(res.Header)
 	return res, nil
 }
 

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -682,7 +682,6 @@ func TestDataSourceProxy_requestHandling(t *testing.T) {
 		proxy.HandleRequest()
 
 		require.NoError(t, writeErr)
-		assert.Equal(t, "sandbox", proxy.ctx.Resp.Header().Get("Content-Security-Policy"))
 	})
 
 	t.Run("Data source returns status code 401", func(t *testing.T) {

--- a/pkg/api/pluginproxy/pluginproxy.go
+++ b/pkg/api/pluginproxy/pluginproxy.go
@@ -83,11 +83,5 @@ func NewApiPluginProxy(ctx *models.ReqContext, proxyPath string, route *plugins.
 		}
 	}
 
-	return &httputil.ReverseProxy{Director: director, ModifyResponse: modifyResponse}
-}
-
-func modifyResponse(resp *http.Response) error {
-	proxyutil.SetProxyResponseHeaders(resp.Header)
-
-	return nil
+	return &httputil.ReverseProxy{Director: director}
 }

--- a/pkg/api/pluginproxy/pluginproxy_test.go
+++ b/pkg/api/pluginproxy/pluginproxy_test.go
@@ -280,8 +280,6 @@ func TestPluginProxy(t *testing.T) {
 				break
 			}
 		}
-
-		require.Equal(t, "sandbox", ctx.Resp.Header().Get("Content-Security-Policy"))
 	})
 }
 

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -609,8 +609,6 @@ func (hs *HTTPServer) flushStream(stream callResourceClientResponseStream, w htt
 				}
 			}
 
-			proxyutil.SetProxyResponseHeaders(w.Header())
-
 			w.WriteHeader(resp.Status)
 		}
 

--- a/pkg/api/plugins_test.go
+++ b/pkg/api/plugins_test.go
@@ -207,8 +207,6 @@ func TestMakePluginResourceRequest(t *testing.T) {
 			break
 		}
 	}
-
-	require.Equal(t, "sandbox", resp.Header().Get("Content-Security-Policy"))
 }
 
 func callGetPluginAsset(sc *scenarioContext) {

--- a/pkg/middleware/csp.go
+++ b/pkg/middleware/csp.go
@@ -45,7 +45,9 @@ func AddCSPHeader(cfg *setting.Cfg, logger log.Logger) func(http.Handler) http.H
 			rootPath := re.ReplaceAllString(cfg.AppURL, "")
 			val = strings.ReplaceAll(val, "$ROOT_PATH", rootPath)
 			rw.Header().Set("Content-Security-Policy", val)
-			ctx.RequestNonce = nonce
+			if ctx != nil {
+				ctx.RequestNonce = nonce
+			}
 			logger.Debug("Successfully generated CSP nonce", "nonce", nonce)
 			next.ServeHTTP(rw, req)
 		})

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -58,6 +58,14 @@ func TestMiddleWareSecurityHeaders(t *testing.T) {
 		cfg.XSSProtectionHeader = false
 	})
 
+	middlewareScenario(t, "middleware should get content-security-policy header when content_security_policy is enabled", func(t *testing.T, sc *scenarioContext) {
+		sc.fakeReq("GET", "/api/").exec()
+		assert.Equal(t, "default-src 'self'; img-src *;", sc.resp.Header().Get("Content-Security-Policy"))
+	}, func(cfg *setting.Cfg) {
+		cfg.CSPEnabled = true
+		cfg.CSPTemplate = "default-src 'self'; img-src *;"
+	})
+
 	middlewareScenario(t, "middleware should add correct Strict-Transport-Security header", func(t *testing.T, sc *scenarioContext) {
 		sc.fakeReq("GET", "/api/").exec()
 		assert.Equal(t, "max-age=64000", sc.resp.Header().Get("Strict-Transport-Security"))

--- a/pkg/util/proxyutil/proxyutil.go
+++ b/pkg/util/proxyutil/proxyutil.go
@@ -42,9 +42,3 @@ func ClearCookieHeader(req *http.Request, keepCookiesNames []string) {
 		req.AddCookie(c)
 	}
 }
-
-// SetProxyResponseHeaders sets proxy response headers.
-// Sets Content-Security-Policy: sandbox
-func SetProxyResponseHeaders(header http.Header) {
-	header.Set("Content-Security-Policy", "sandbox")
-}


### PR DESCRIPTION
For this test case, Grafana is the only endpoint available to the monitoring system and all used Datasources are accessible via the Grafana Datasource Proxy API

After upgrading Grafana from version `8.3.3` to the latest release `8.4.3`, the “**Data source proxy calls**” stopped to work.

Fixes https://github.com/grafana/grafana/issues/46456

Maybe this bug affects following issues reported:
* #45817 
* #44452 
* #13706

## How to reproduce it in a local environment?

1.) Start Grafana and add Prometheus to the Data Sources:
* use the URL http://127.0.0.1:9090/
* make sure the “Access” is set to “Server (default)”

2.) Afterwards download the prometheus binary and run following command:

```bash
prometheus --web.listen-address=127.0.0.1:9090 --config.file=./prometheus.yml \
    --web.external-url=http://127.0.0.1:9090/api/datasources/proxy/1/ \
    --web.route-prefix=/ 
```

3.) Check for the Content-Security-Policy header and verify that “sandbox” is set:

```bash
curl -s -i -u admin:admin http://127.0.0.1:3000/api/datasources/proxy/1/
HTTP/1.1 302 Found
Content-Length: 53
Content-Security-Policy: sandbox
Content-Type: text/html; charset=utf-8
Date: Thu, 10 Mar 2022 15:07:04 GMT
Location: /api/datasources/proxy/1/graph
X-Content-Type-Options: nosniff
X-Frame-Options: deny
X-Xss-Protection: 1; mode=block
```

4.) Try to change or update this header in the grafana `defaults.ini` configuration file, even though it was disabled by default:

```ini
content_security_policy = true

content_security_policy_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
```

5.) After applying the change rerun the same curl command from above. You should see the _Content-Security-Policy_ header set  twice:

```bash
curl -s -i -u admin:admin http://127.0.0.1:3000/api/datasources/proxy/1/

HTTP/1.1 302 Found
Content-Length: 53
Content-Security-Policy: script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' 'nonce-9WKe0+AGmpoDBtHOdhOtEw';object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://localhost:3000/ wss://localhost:3000/;manifest-src 'self';media-src 'none';form-action 'self';
Content-Security-Policy: sandbox
Content-Type: text/html; charset=utf-8
Date: Thu, 10 Mar 2022 15:06:06 GMT
Location: /api/datasources/proxy/1/graph
X-Content-Type-Options: nosniff
X-Frame-Options: deny
X-Xss-Protection: 1; mode=block
```

## Changes made to the code

The hardcorded header was implemented here, for some background, I believe that with the syncing changes, some unwished peace of code slippered in:
* https://github.com/grafana/grafana/pull/45083/files

If I understood it right, there is a Middleware named **AddCSPHeader**, which manages the CPS header conformed with the config file. This middleware is applied in the package API, this means, if the **content_security_policy** option is set to `true`, this rule should be applied for all API endpoints:

https://github.com/grafana/grafana/blob/main/pkg/api/http_server.go#L504
> m.UseMiddleware(middleware.AddCSPHeader(hs.Cfg, hs.log))

I did write a small test for approving it. To do so I had to check if the context is set, otherwise I was getting a nil pointer exception:

```golang
    --- FAIL: TestMiddleWareSecurityHeaders/middleware_should_get_a_not_empty_content_of_header_content-security-policy_when_content_security_policy_is_enabled (0.02s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x119ca09]

goroutine 153 [running]:
testing.tRunner.func1.2({0x1396300, 0x223ced0})
        /home/rfxchlx/Root/usr/local/go/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
        /home/rfxchlx/Root/usr/local/go/src/testing/testing.go:1212 +0x218
panic({0x1396300, 0x223ced0})
        /home/rfxchlx/Root/usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/grafana/grafana/pkg/middleware.AddCSPHeader.func1.1({0x18d82c0, 0xc0001162d0}, 0xc000d31700)
        /home/rfxchlx/Git/github.com/rchicoli/grafana/pkg/middleware/csp.go:48 +0x4e9
```

It is my first time contributing to this project, so please, let me know, if I am missing something