### PR TITLE
Accesscontrol: fix data source name resolver and add uid name resolver (#46409)

### DIFF
--- a/pkg/services/datasources/service_test.go
+++ b/pkg/services/datasources/service_test.go
@@ -69,19 +69,30 @@ func TestService(t *testing.T) {
 }
 
 type dataSourceMockRetriever struct {
-	res *models.DataSource
+	res []*models.DataSource
 }
 
 func (d *dataSourceMockRetriever) GetDataSource(ctx context.Context, query *models.GetDataSourceQuery) error {
-	if query.Name == d.res.Name {
-		query.Result = d.res
+	for _, datasource := range d.res {
+		nameMatch := query.Name != "" && query.Name == datasource.Name
+		uidMatch := query.Uid != "" && query.Uid == datasource.Uid
+		if nameMatch || uidMatch {
+			query.Result = datasource
 
-		return nil
+			return nil
+		}
 	}
 	return models.ErrDataSourceNotFound
 }
 
 func TestService_NameScopeResolver(t *testing.T) {
+	retriever := &dataSourceMockRetriever{[]*models.DataSource{
+		{Id: 1, Name: "test-datasource"},
+		{Id: 2, Name: "*"},
+		{Id: 3, Name: ":/*"},
+		{Id: 4, Name: ":"},
+	}}
+
 	type testCaseResolver struct {
 		desc    string
 		given   string
@@ -97,9 +108,21 @@ func TestService_NameScopeResolver(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			desc:    "correct",
+			desc:    "asterisk in name",
 			given:   "datasources:name:*",
-			want:    "datasources:id:*",
+			want:    "datasources:id:2",
+			wantErr: nil,
+		},
+		{
+			desc:    "complex name",
+			given:   "datasources:name::/*",
+			want:    "datasources:id:3",
+			wantErr: nil,
+		},
+		{
+			desc:    "colon in name",
+			given:   "datasources:name::",
+			want:    "datasources:id:4",
 			wantErr: nil,
 		},
 		{
@@ -114,11 +137,70 @@ func TestService_NameScopeResolver(t *testing.T) {
 			want:    "",
 			wantErr: accesscontrol.ErrInvalidScope,
 		},
+		{
+			desc:    "empty name scope",
+			given:   "datasources:name:",
+			want:    "",
+			wantErr: accesscontrol.ErrInvalidScope,
+		},
+	}
+	prefix, resolver := NewNameScopeResolver(retriever)
+	require.Equal(t, "datasources:name:", prefix)
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			resolved, err := resolver(context.Background(), 1, tc.given)
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				require.Equal(t, tc.wantErr, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, resolved)
+			}
+		})
+	}
+}
+
+func TestService_UIDScopeResolver(t *testing.T) {
+	retriever := &dataSourceMockRetriever{[]*models.DataSource{
+		{Id: 1, Uid: "NnftN9Lnz"},
+	}}
+
+	type testCaseResolver struct {
+		desc    string
+		given   string
+		want    string
+		wantErr error
 	}
 
-	testDataSource := &models.DataSource{Id: 1, Name: "test-datasource"}
-	prefix, resolver := NewNameScopeResolver(&dataSourceMockRetriever{testDataSource})
-	require.Equal(t, "datasources:name:", prefix)
+	testCases := []testCaseResolver{
+		{
+			desc:    "correct",
+			given:   "datasources:uid:NnftN9Lnz",
+			want:    "datasources:id:1",
+			wantErr: nil,
+		},
+		{
+			desc:    "unknown datasource",
+			given:   "datasources:uid:unknown",
+			want:    "",
+			wantErr: models.ErrDataSourceNotFound,
+		},
+		{
+			desc:    "malformed scope",
+			given:   "datasources:unknown",
+			want:    "",
+			wantErr: accesscontrol.ErrInvalidScope,
+		},
+		{
+			desc:    "empty uid scope",
+			given:   "datasources:uid:",
+			want:    "",
+			wantErr: accesscontrol.ErrInvalidScope,
+		},
+	}
+	prefix, resolver := NewUidScopeResolver(retriever)
+	require.Equal(t, "datasources:uid:", prefix)
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
Backport of: Accesscontrol: fix data source name resolver and add uid name resolver (#46409)

* Fix data source name scope resolver

* Register ds UID scope resolver

* Check name/uid is not empty (even if it cannot be empty as of now and is also checked by store, better safe than sorry)

(cherry picked from commit bd918927b45c0a32b54276975f8f3ca67a5535c6)

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

