### PR TITLE
A11y : Fix a11y in CollapsibleSection

### DIFF
--- a/public/app/features/alerting/unified/components/CollapseToggle.tsx
+++ b/public/app/features/alerting/unified/components/CollapseToggle.tsx
@@ -26,6 +26,7 @@ export const CollapseToggle: FC<Props> = ({
 
   return (
     <Button
+      type="button"
       fill="text"
       aria-expanded={!isCollapsed}
       aria-controls={idControlled}

--- a/public/app/features/alerting/unified/components/receivers/form/CollapsibleSection.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/CollapsibleSection.tsx
@@ -1,15 +1,17 @@
 import { css, cx } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
-import { Icon, useStyles2 } from '@grafana/ui';
+import { IconSize, useStyles2 } from '@grafana/ui';
 import React, { FC, useState } from 'react';
+import { CollapseToggle } from '../../CollapseToggle';
 
 interface Props {
   label: string;
   description?: string;
   className?: string;
+  size?: IconSize;
 }
 
-export const CollapsibleSection: FC<Props> = ({ label, description, children, className }) => {
+export const CollapsibleSection: FC<Props> = ({ label, description, children, className, size = 'xl' }) => {
   const styles = useStyles2(getStyles);
   const [isCollapsed, setIsCollapsed] = useState(true);
 
@@ -18,7 +20,7 @@ export const CollapsibleSection: FC<Props> = ({ label, description, children, cl
   return (
     <div className={cx(styles.wrapper, className)}>
       <div className={styles.heading} onClick={toggleCollapse}>
-        <Icon className={styles.caret} size="xl" name={isCollapsed ? 'angle-right' : 'angle-down'} />
+        <CollapseToggle className={styles.caret} size={size} onToggle={toggleCollapse} isCollapsed={isCollapsed} />
         <h6>{label}</h6>
       </div>
       {description && <p className={styles.description}>{description}</p>}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

## What this PR does / why we need it

Various Unified Alerting elements are nested inside `CollapsibleSection` components. you cannot expand these dropdowns using the keyboard. 
Once expanded, the elements are focusable.

### Screenshots


https://user-images.githubusercontent.com/42030685/161216013-b0e73e0b-9833-4f0a-900a-1475381f37f7.mov



## Which issue(s) this PR fixes
Fixes #46503


