### PR TITLE
Bump publish docs node version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-node@v2.5.1
       id: generate-docs
       with:
-        node-version: '14'
+        node-version: '16'
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn config get cacheFolder)"

--- a/UPGRADING_DEPENDENCIES.md
+++ b/UPGRADING_DEPENDENCIES.md
@@ -15,6 +15,7 @@ Upgrading Go or Node.js requires making changes in many different files. See bel
 - `grafana/build-container`
 - Appveyor
 - Dockerfile
+- `.github/workflows/publish.yml`
 
 ## Go dependencies
 


### PR DESCRIPTION
Publish docs workflow hangs because of recent yarn upgrade. Make sure to use the latest version.

