### PR TITLE
Access control: Support filter on several actions

### DIFF
--- a/pkg/services/accesscontrol/database/resource_permissions.go
+++ b/pkg/services/accesscontrol/database/resource_permissions.go
@@ -365,17 +365,17 @@ func (s *AccessControlStore) getResourcesPermissions(sess *sqlstore.DBSession, o
 	if err != nil {
 		return nil, err
 	}
-	user := userSelect + userFrom + where + " AND " + userFilter.Where()
-	args = append(args, userFilter.Args()...)
+	user := userSelect + userFrom + where + " AND " + userFilter.Where
+	args = append(args, userFilter.Args...)
 
 	teamFilter, err := accesscontrol.Filter(query.User, "t.id", "teams", accesscontrol.ActionTeamsRead)
 	if err != nil {
 		return nil, err
 	}
 
-	team := teamSelect + teamFrom + where + " AND " + teamFilter.Where()
+	team := teamSelect + teamFrom + where + " AND " + teamFilter.Where
 	args = append(args, args[:initialLength]...)
-	args = append(args, teamFilter.Args()...)
+	args = append(args, teamFilter.Args...)
 
 	builtin := builtinSelect + builtinFrom + where
 	args = append(args, args[:initialLength]...)

--- a/pkg/services/accesscontrol/database/resource_permissions.go
+++ b/pkg/services/accesscontrol/database/resource_permissions.go
@@ -361,21 +361,21 @@ func (s *AccessControlStore) getResourcesPermissions(sess *sqlstore.DBSession, o
 
 	initialLength := len(args)
 
-	userFilter, err := accesscontrol.Filter(context.Background(), "u.id", "users", accesscontrol.ActionOrgUsersRead, query.User)
+	userFilter, err := accesscontrol.Filter(query.User, "u.id", "users", accesscontrol.ActionOrgUsersRead)
 	if err != nil {
 		return nil, err
 	}
-	user := userSelect + userFrom + where + " AND " + userFilter.Where
-	args = append(args, userFilter.Args...)
+	user := userSelect + userFrom + where + " AND " + userFilter.Where()
+	args = append(args, userFilter.Args()...)
 
-	teamFilter, err := accesscontrol.Filter(context.Background(), "t.id", "teams", accesscontrol.ActionTeamsRead, query.User)
+	teamFilter, err := accesscontrol.Filter(query.User, "t.id", "teams", accesscontrol.ActionTeamsRead)
 	if err != nil {
 		return nil, err
 	}
 
-	team := teamSelect + teamFrom + where + " AND " + teamFilter.Where
+	team := teamSelect + teamFrom + where + " AND " + teamFilter.Where()
 	args = append(args, args[:initialLength]...)
-	args = append(args, teamFilter.Args...)
+	args = append(args, teamFilter.Args()...)
 
 	builtin := builtinSelect + builtinFrom + where
 	args = append(args, args[:initialLength]...)

--- a/pkg/services/accesscontrol/filter.go
+++ b/pkg/services/accesscontrol/filter.go
@@ -31,8 +31,7 @@ type SQLFilter struct {
 }
 
 // Filter creates a where clause to restrict the view of a query based on a users permissions
-// Scopes for a certain action will be compared against prefix:id:sqlID where prefix is the scope prefix and sqlID
-// is the id to generate scope from e.g. user.id
+// Scopes that exists for all actions will be parsed and compared against the supplied sqlID
 func Filter(user *models.SignedInUser, sqlID, prefix string, actions ...string) (SQLFilter, error) {
 	if _, ok := sqlIDAcceptList[sqlID]; !ok {
 		return denyQuery, errors.New("sqlID is not in the accept list")

--- a/pkg/services/accesscontrol/filter.go
+++ b/pkg/services/accesscontrol/filter.go
@@ -49,7 +49,7 @@ func Filter(user *models.SignedInUser, sqlID, prefix string, actions ...string) 
 			wildcards += 1
 			continue
 		}
-		if len(ids) == 0 && !hasWildcard {
+		if len(ids) == 0 {
 			return denyQuery, nil
 		}
 		for _, id := range ids {

--- a/pkg/services/accesscontrol/filter.go
+++ b/pkg/services/accesscontrol/filter.go
@@ -26,16 +26,8 @@ var (
 )
 
 type SQLFilter struct {
-	where string
-	args  []interface{}
-}
-
-func (f SQLFilter) Where() string {
-	return f.where
-}
-
-func (f SQLFilter) Args() []interface{} {
-	return f.args
+	Where string
+	Args  []interface{}
 }
 
 // Filter creates a where clause to restrict the view of a query based on a users permissions

--- a/pkg/services/accesscontrol/filter_bench_test.go
+++ b/pkg/services/accesscontrol/filter_bench_test.go
@@ -41,7 +41,7 @@ func benchmarkFilter(b *testing.B, numDs, numPermissions int) {
 
 		var datasources []models.DataSource
 		sess := store.NewSession(context.Background())
-		err = sess.SQL(baseSql+acFilter.Where(), acFilter.Args()...).Find(&datasources)
+		err = sess.SQL(baseSql+acFilter.Where, acFilter.Args...).Find(&datasources)
 		require.NoError(b, err)
 		sess.Close()
 		require.Len(b, datasources, numPermissions)

--- a/pkg/services/accesscontrol/filter_test.go
+++ b/pkg/services/accesscontrol/filter_test.go
@@ -112,7 +112,7 @@ func TestFilter_Datasources(t *testing.T) {
 			actions: []string{"datasources:read", "datasources:write"},
 			permissions: map[string][]string{
 				"datasources:read":  {"datasources:id:3", "datasources:id:7", "datasources:id:8"},
-				"datasources:write": {"datasources:*"},
+				"datasources:write": {"datasources:*", "datasources:id:8"},
 			},
 			expectedDataSources: []string{"ds:3", "ds:7", "ds:8"},
 			expectErr:           false,

--- a/pkg/services/accesscontrol/filter_test.go
+++ b/pkg/services/accesscontrol/filter_test.go
@@ -152,7 +152,7 @@ func TestFilter_Datasources(t *testing.T) {
 			if !tt.expectErr {
 				require.NoError(t, err)
 				var datasources []models.DataSource
-				err = sess.SQL(baseSql+acFilter.Where(), acFilter.Args()...).Find(&datasources)
+				err = sess.SQL(baseSql+acFilter.Where, acFilter.Args...).Find(&datasources)
 				require.NoError(t, err)
 
 				assert.Len(t, datasources, len(tt.expectedDataSources))

--- a/pkg/services/accesscontrol/filter_test.go
+++ b/pkg/services/accesscontrol/filter_test.go
@@ -14,9 +14,12 @@ import (
 )
 
 type filterDatasourcesTestCase struct {
-	desc                string
-	sqlID               string
-	permissions         []*accesscontrol.Permission
+	desc        string
+	sqlID       string
+	prefix      string
+	actions     []string
+	permissions map[string][]string
+
 	expectedDataSources []string
 	expectErr           bool
 }
@@ -24,63 +27,83 @@ type filterDatasourcesTestCase struct {
 func TestFilter_Datasources(t *testing.T) {
 	tests := []filterDatasourcesTestCase{
 		{
-			desc:  "expect all data sources to be returned",
-			sqlID: "data_source.id",
-			permissions: []*accesscontrol.Permission{
-				{Action: "datasources:read", Scope: "datasources:*"},
+			desc:    "expect all data sources to be returned",
+			sqlID:   "data_source.id",
+			prefix:  "datasources",
+			actions: []string{"datasources:read"},
+			permissions: map[string][]string{
+				"datasources:read": {"datasources:*"},
 			},
 			expectedDataSources: []string{"ds:1", "ds:2", "ds:3", "ds:4", "ds:5", "ds:6", "ds:7", "ds:8", "ds:9", "ds:10"},
 		},
 		{
-			desc:  "expect all data sources for wildcard id scope to be returned",
-			sqlID: "data_source.id",
-			permissions: []*accesscontrol.Permission{
-				{Action: "datasources:read", Scope: "datasources:id:*"},
+			desc:    "expect all data sources for wildcard id scope to be returned",
+			sqlID:   "data_source.id",
+			prefix:  "datasources",
+			actions: []string{"datasources:read"},
+			permissions: map[string][]string{
+				"datasources:read": {"datasources:id:*"},
 			},
 			expectedDataSources: []string{"ds:1", "ds:2", "ds:3", "ds:4", "ds:5", "ds:6", "ds:7", "ds:8", "ds:9", "ds:10"},
 		},
 		{
-			desc:  "expect all data sources for wildcard scope to be returned",
-			sqlID: "data_source.id",
-			permissions: []*accesscontrol.Permission{
-				{Action: "datasources:read", Scope: "*"},
+			desc:    "expect all data sources for wildcard scope to be returned",
+			sqlID:   "data_source.id",
+			prefix:  "datasources",
+			actions: []string{"datasources:read"},
+			permissions: map[string][]string{
+				"datasources:read": {"*"},
 			},
 			expectedDataSources: []string{"ds:1", "ds:2", "ds:3", "ds:4", "ds:5", "ds:6", "ds:7", "ds:8", "ds:9", "ds:10"},
 		},
 		{
 			desc:                "expect no data sources to be returned",
 			sqlID:               "data_source.id",
-			permissions:         []*accesscontrol.Permission{},
+			prefix:              "datasources",
+			actions:             []string{"datasources:read"},
+			permissions:         map[string][]string{},
 			expectedDataSources: []string{},
 		},
 		{
-			desc:  "expect data sources with id 3, 7 and 8 to be returned",
-			sqlID: "data_source.id",
-			permissions: []*accesscontrol.Permission{
-				{Action: "datasources:read", Scope: "datasources:id:3"},
-				{Action: "datasources:read", Scope: "datasources:id:7"},
-				{Action: "datasources:read", Scope: "datasources:id:8"},
+			desc:    "expect data sources with id 3, 7 and 8 to be returned",
+			sqlID:   "data_source.id",
+			prefix:  "datasources",
+			actions: []string{"datasources:read"},
+			permissions: map[string][]string{
+				"datasources:read": {"datasources:id:3", "datasources:id:7", "datasources:id:8"},
 			},
 			expectedDataSources: []string{"ds:3", "ds:7", "ds:8"},
 		},
 		{
-			desc:  "expect no data sources to be returned for malformed scope",
-			sqlID: "data_source.id",
-			permissions: []*accesscontrol.Permission{
-				{Action: "datasources:read", Scope: "datasources:id:1*"},
+			desc:    "expect no data sources to be returned for malformed scope",
+			sqlID:   "data_source.id",
+			prefix:  "datasources",
+			actions: []string{"datasources:read"},
+			permissions: map[string][]string{
+				"datasources:read": {"datasources:id:1*"},
 			},
-			expectedDataSources: []string{},
 		},
 		{
-			desc:  "expect error if sqlID is not in the accept list",
-			sqlID: "other.id",
-			permissions: []*accesscontrol.Permission{
-				{Action: "datasources:read", Scope: "datasources:id:3"},
-				{Action: "datasources:read", Scope: "datasources:id:7"},
-				{Action: "datasources:read", Scope: "datasources:id:8"},
+			desc:    "expect error if sqlID is not in the accept list",
+			sqlID:   "other.id",
+			prefix:  "datasources",
+			actions: []string{"datasources:read"},
+			permissions: map[string][]string{
+				"datasources:read": {"datasources:id:3", "datasources:id:7", "datasources:id:8"},
 			},
-			expectedDataSources: []string{"ds:3", "ds:7", "ds:8"},
-			expectErr:           true,
+			expectErr: true,
+		},
+		{
+			desc:    "expect data sources that users has several actions for",
+			sqlID:   "data_source.id",
+			prefix:  "datasources",
+			actions: []string{"datasources:read", "datasources:write"},
+			permissions: map[string][]string{
+				"datasources:read":  {"datasources:id:3", "datasources:id:7", "datasources:id:8"},
+				"datasources:write": {"datasources:id:3", "datasources:id:8"},
+			},
+			expectedDataSources: []string{"ds:3", "ds:8"},
+			expectErr:           false,
 		},
 	}
 
@@ -104,12 +127,14 @@ func TestFilter_Datasources(t *testing.T) {
 			}
 
 			baseSql := `SELECT data_source.* FROM data_source WHERE`
-			acFilter, err := accesscontrol.Filter(
-				context.Background(),
+			acFilter, err := accesscontrol.Filter2(
+				&models.SignedInUser{
+					OrgId:       1,
+					Permissions: map[int64]map[string][]string{1: tt.permissions},
+				},
 				tt.sqlID,
-				"datasources",
-				"datasources:read",
-				&models.SignedInUser{OrgId: 1, Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByAction(tt.permissions)}},
+				tt.prefix,
+				tt.actions...,
 			)
 
 			if !tt.expectErr {

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -241,11 +241,6 @@ type SetResourcePermissionCommand struct {
 	Permission  string
 }
 
-type SQLFilter struct {
-	Where string
-	Args  []interface{}
-}
-
 const (
 	GlobalOrgID = 0
 	// Permission actions

--- a/pkg/services/serviceaccounts/database/database.go
+++ b/pkg/services/serviceaccounts/database/database.go
@@ -317,12 +317,12 @@ func (s *ServiceAccountsStoreImpl) SearchOrgServiceAccounts(ctx context.Context,
 				s.sqlStore.Dialect.BooleanStr(true)))
 
 		if s.sqlStore.Cfg.IsFeatureToggleEnabled(featuremgmt.FlagAccesscontrol) {
-			acFilter, err := accesscontrol.Filter(ctx, "org_user.user_id", "serviceaccounts", "serviceaccounts:read", query.User)
+			acFilter, err := accesscontrol.Filter(query.User, "org_user.user_id", "serviceaccounts", serviceaccounts.ActionRead)
 			if err != nil {
 				return err
 			}
-			whereConditions = append(whereConditions, acFilter.Where)
-			whereParams = append(whereParams, acFilter.Args...)
+			whereConditions = append(whereConditions, acFilter.Where())
+			whereParams = append(whereParams, acFilter.Args()...)
 		}
 
 		if query.Query != "" {

--- a/pkg/services/serviceaccounts/database/database.go
+++ b/pkg/services/serviceaccounts/database/database.go
@@ -321,8 +321,8 @@ func (s *ServiceAccountsStoreImpl) SearchOrgServiceAccounts(ctx context.Context,
 			if err != nil {
 				return err
 			}
-			whereConditions = append(whereConditions, acFilter.Where())
-			whereParams = append(whereParams, acFilter.Args()...)
+			whereConditions = append(whereConditions, acFilter.Where)
+			whereParams = append(whereParams, acFilter.Args...)
 		}
 
 		if query.Query != "" {

--- a/pkg/services/sqlstore/org_users.go
+++ b/pkg/services/sqlstore/org_users.go
@@ -123,8 +123,8 @@ func (ss *SQLStore) GetOrgUsers(ctx context.Context, query *models.GetOrgUsersQu
 		if err != nil {
 			return err
 		}
-		whereConditions = append(whereConditions, acFilter.Where())
-		whereParams = append(whereParams, acFilter.Args()...)
+		whereConditions = append(whereConditions, acFilter.Where)
+		whereParams = append(whereParams, acFilter.Args...)
 	}
 
 	if query.Query != "" {
@@ -188,8 +188,8 @@ func (ss *SQLStore) SearchOrgUsers(ctx context.Context, query *models.SearchOrgU
 		if err != nil {
 			return err
 		}
-		whereConditions = append(whereConditions, acFilter.Where())
-		whereParams = append(whereParams, acFilter.Args()...)
+		whereConditions = append(whereConditions, acFilter.Where)
+		whereParams = append(whereParams, acFilter.Args...)
 	}
 
 	if query.Query != "" {

--- a/pkg/services/sqlstore/org_users.go
+++ b/pkg/services/sqlstore/org_users.go
@@ -119,12 +119,12 @@ func (ss *SQLStore) GetOrgUsers(ctx context.Context, query *models.GetOrgUsersQu
 	whereConditions = append(whereConditions, fmt.Sprintf("%s.is_service_account = %t", x.Dialect().Quote("user"), query.IsServiceAccount))
 
 	if ss.Cfg.IsFeatureToggleEnabled(featuremgmt.FlagAccesscontrol) && query.User != nil {
-		acFilter, err := accesscontrol.Filter(ctx, "org_user.user_id", "users", "org.users:read", query.User)
+		acFilter, err := accesscontrol.Filter(query.User, "org_user.user_id", "users", accesscontrol.ActionOrgUsersRead)
 		if err != nil {
 			return err
 		}
-		whereConditions = append(whereConditions, acFilter.Where)
-		whereParams = append(whereParams, acFilter.Args...)
+		whereConditions = append(whereConditions, acFilter.Where())
+		whereParams = append(whereParams, acFilter.Args()...)
 	}
 
 	if query.Query != "" {
@@ -184,12 +184,12 @@ func (ss *SQLStore) SearchOrgUsers(ctx context.Context, query *models.SearchOrgU
 	whereConditions = append(whereConditions, fmt.Sprintf("%s.is_service_account = %t", x.Dialect().Quote("user"), query.IsServiceAccount))
 
 	if ss.Cfg.IsFeatureToggleEnabled(featuremgmt.FlagAccesscontrol) {
-		acFilter, err := accesscontrol.Filter(ctx, "org_user.user_id", "users", "org.users:read", query.User)
+		acFilter, err := accesscontrol.Filter(query.User, "org_user.user_id", "users", accesscontrol.ActionOrgUsersRead)
 		if err != nil {
 			return err
 		}
-		whereConditions = append(whereConditions, acFilter.Where)
-		whereParams = append(whereParams, acFilter.Args...)
+		whereConditions = append(whereConditions, acFilter.Where())
+		whereParams = append(whereParams, acFilter.Args()...)
 	}
 
 	if query.Query != "" {

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -94,20 +94,20 @@ func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) 
 	builder.WriteString("(((")
 
 	dashFilter, _ := accesscontrol.Filter(f.User, "dashboard.id", "dashboards", dashboardActions...)
-	builder.WriteString(dashFilter.Where())
-	args = append(args, dashFilter.Args()...)
+	builder.WriteString(dashFilter.Where)
+	args = append(args, dashFilter.Args...)
 
 	builder.WriteString(" OR ")
 
 	dashFolderFilter, _ := accesscontrol.Filter(f.User, "dashboard.folder_id", "folders", dashboardActions...)
-	builder.WriteString(dashFolderFilter.Where())
+	builder.WriteString(dashFolderFilter.Where)
 	builder.WriteString(") AND NOT dashboard.is_folder) OR (")
-	args = append(args, dashFolderFilter.Args()...)
+	args = append(args, dashFolderFilter.Args...)
 
 	folderFilter, _ := accesscontrol.Filter(f.User, "dashboard.id", "folders", folderActions...)
-	builder.WriteString(folderFilter.Where())
+	builder.WriteString(folderFilter.Where)
 	builder.WriteString(" AND dashboard.is_folder))")
-	args = append(args, folderFilter.Args()...)
+	args = append(args, folderFilter.Args...)
 
 	return builder.String(), args
 }

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -1,7 +1,6 @@
 package permissions
 
 import (
-	"context"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/models"
@@ -83,30 +82,32 @@ type AccessControlDashboardPermissionFilter struct {
 }
 
 func (f AccessControlDashboardPermissionFilter) Where() (string, []interface{}) {
-	folderAction := dashboards.ActionFoldersRead
-	dashboardAction := accesscontrol.ActionDashboardsRead
+	folderActions := []string{dashboards.ActionFoldersRead}
+	dashboardActions := []string{accesscontrol.ActionDashboardsRead}
 	if f.PermissionLevel == models.PERMISSION_EDIT {
-		folderAction = accesscontrol.ActionDashboardsCreate
-		dashboardAction = accesscontrol.ActionDashboardsWrite
+		folderActions = append(folderActions, accesscontrol.ActionDashboardsCreate)
+		dashboardActions = append(dashboardActions, accesscontrol.ActionDashboardsWrite)
 	}
 
+	var args []interface{}
 	builder := strings.Builder{}
-
 	builder.WriteString("(((")
 
-	dashFilter, _ := accesscontrol.Filter(context.Background(), "dashboard.id", "dashboards", dashboardAction, f.User)
-	builder.WriteString(dashFilter.Where)
+	dashFilter, _ := accesscontrol.Filter(f.User, "dashboard.id", "dashboards", dashboardActions...)
+	builder.WriteString(dashFilter.Where())
+	args = append(args, dashFilter.Args()...)
 
 	builder.WriteString(" OR ")
 
-	dashFolderFilter, _ := accesscontrol.Filter(context.Background(), "dashboard.folder_id", "folders", dashboardAction, f.User)
-	builder.WriteString(dashFolderFilter.Where)
-
+	dashFolderFilter, _ := accesscontrol.Filter(f.User, "dashboard.folder_id", "folders", dashboardActions...)
+	builder.WriteString(dashFolderFilter.Where())
 	builder.WriteString(") AND NOT dashboard.is_folder) OR (")
+	args = append(args, dashFolderFilter.Args()...)
 
-	folderFilter, _ := accesscontrol.Filter(context.Background(), "dashboard.id", "folders", folderAction, f.User)
-	builder.WriteString(folderFilter.Where)
+	folderFilter, _ := accesscontrol.Filter(f.User, "dashboard.id", "folders", folderActions...)
+	builder.WriteString(folderFilter.Where())
 	builder.WriteString(" AND dashboard.is_folder))")
+	args = append(args, folderFilter.Args()...)
 
-	return builder.String(), append(dashFilter.Args, append(dashFolderFilter.Args, folderFilter.Args...)...)
+	return builder.String(), args
 }

--- a/pkg/services/sqlstore/team.go
+++ b/pkg/services/sqlstore/team.go
@@ -233,8 +233,8 @@ func (ss *SQLStore) SearchTeams(ctx context.Context, query *models.SearchTeamsQu
 		if err != nil {
 			return err
 		}
-		sql.WriteString(` and` + acFilter.Where())
-		params = append(params, acFilter.Args()...)
+		sql.WriteString(` and` + acFilter.Where)
+		params = append(params, acFilter.Args...)
 	}
 
 	sql.WriteString(` order by team.name asc`)
@@ -274,7 +274,7 @@ func (ss *SQLStore) SearchTeams(ctx context.Context, query *models.SearchTeamsQu
 
 	// Only count teams user can see
 	if ss.Cfg.IsFeatureToggleEnabled(featuremgmt.FlagAccesscontrol) {
-		countSess.Where(acFilter.Where(), acFilter.Args()...)
+		countSess.Where(acFilter.Where, acFilter.Args...)
 	}
 
 	count, err := countSess.Count(&team)
@@ -547,7 +547,7 @@ func (ss *SQLStore) getTeamMembers(ctx context.Context, query *models.GetTeamMem
 	)
 
 	if acUserFilter != nil {
-		sess.Where(acUserFilter.Where(), acUserFilter.Args()...)
+		sess.Where(acUserFilter.Where, acUserFilter.Args...)
 	}
 
 	// Join with only most recent auth module


### PR DESCRIPTION
**What this PR does / why we need it**:
When filtering with access control permissions there are cases when we want to generate a sql filter on several actions.

One example is for alerting when we have to list folders that you both can read and create alerts for.
This pr adds support to generate an access control filter over several actions.
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

