### PR TITLE
Prometheus: Fix parsing of binary operations

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/parsing.test.ts
@@ -444,6 +444,67 @@ describe('buildVisualQueryFromString', () => {
       },
     });
   });
+
+  it('handles multiple binary operations', () => {
+    expect(buildVisualQueryFromString('foo{x="yy"} * metric{y="zz",a="bb"} * metric2')).toEqual({
+      errors: [],
+      query: {
+        metric: 'foo',
+        labels: [{ label: 'x', op: '=', value: 'yy' }],
+        operations: [],
+        binaryQueries: [
+          {
+            operator: '*',
+            query: {
+              metric: 'metric',
+              labels: [
+                { label: 'y', op: '=', value: 'zz' },
+                { label: 'a', op: '=', value: 'bb' },
+              ],
+              operations: [],
+            },
+          },
+          {
+            operator: '*',
+            query: {
+              metric: 'metric2',
+              labels: [],
+              operations: [],
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('handles multiple binary operations and scalar', () => {
+    expect(buildVisualQueryFromString('foo{x="yy"} * metric{y="zz",a="bb"} * 2')).toEqual({
+      errors: [],
+      query: {
+        metric: 'foo',
+        labels: [{ label: 'x', op: '=', value: 'yy' }],
+        operations: [
+          {
+            id: '__multiply_by',
+            params: [2],
+          },
+        ],
+        binaryQueries: [
+          {
+            operator: '*',
+            query: {
+              metric: 'metric',
+              labels: [
+                { label: 'y', op: '=', value: 'zz' },
+                { label: 'a', op: '=', value: 'bb' },
+              ],
+              operations: [],
+            },
+          },
+        ],
+      },
+    });
+  });
 });
 
 function noErrors(query: PromVisualQuery) {


### PR DESCRIPTION
While working on https://github.com/grafana/grafana/pull/46547 noticed multiple binary queries did not parse correctly. This now correctly parses expression like `foo{x="yy"} * metric{y="zz",a="bb"} * metric2`