### PR TITLE
ValidatedQueries: route validatable queries to new api endpoint

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -493,6 +493,7 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   panelId?: number;
   dashboardId?: number;
   dashboardUid?: string;
+  userCanEditDashboard?: boolean;
 
   // Request Timing
   startTime: number;

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -492,6 +492,7 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   timeInfo?: string; // The query time description (blue text in the upper right)
   panelId?: number;
   dashboardId?: number;
+  dashboardUid?: string;
 
   // Request Timing
   startTime: number;

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -103,7 +103,12 @@ class DataSourceWithBackend<
   }
 
   getUrlForRequest(request: DataQueryRequest<TQuery>): string {
-    if (config.featureToggles.validatedQueries && request.dashboardUid != null && request.panelId != null) {
+    if (
+      config.featureToggles.validatedQueries &&
+      !request.userCanEditDashboard &&
+      request.dashboardUid != null &&
+      request.panelId != null
+    ) {
       // add additional params to query so we can validate on the backend.
       return `/api/dashboards/org/${config.bootData.user.orgId}/uid/${request.dashboardUid}/panels/${request.panelId}/query`;
     }

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -103,8 +103,11 @@ class DataSourceWithBackend<
   }
 
   getUrlForRequest(request: DataQueryRequest<TQuery>): string {
+    if(!config.featureToggles.validatedQueries) {
+      return '/api/ds/query';
+    }
+    
     if (
-      config.featureToggles.validatedQueries &&
       !request.userCanEditDashboard &&
       request.dashboardUid != null &&
       request.panelId != null

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -151,6 +151,10 @@ class DataSourceWithBackend<
 
     const body: any = { queries };
 
+    // add additional params to query so we can validate on the backend.
+    body.dashboardId = request.dashboardId;
+    body.panelId = request.panelId;
+
     if (range) {
       body.range = range;
       body.from = range.from.valueOf().toString();

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -102,23 +102,6 @@ class DataSourceWithBackend<
     super(instanceSettings);
   }
 
-  getUrlForRequest(request: DataQueryRequest<TQuery>): string {
-    if(!config.featureToggles.validatedQueries) {
-      return '/api/ds/query';
-    }
-    
-    if (
-      !request.userCanEditDashboard &&
-      request.dashboardUid != null &&
-      request.panelId != null
-    ) {
-      // add additional params to query so we can validate on the backend.
-      return `/api/dashboards/org/${config.bootData.user.orgId}/uid/${request.dashboardUid}/panels/${request.panelId}/query`;
-    }
-
-    return '/api/ds/query';
-  }
-
   /**
    * Ideally final -- any other implementation may not work as expected
    */
@@ -183,7 +166,7 @@ class DataSourceWithBackend<
 
     return getBackendSrv()
       .fetch<BackendDataSourceResponse>({
-        url: this.getUrlForRequest(request),
+        url: getUrlForRequest(request),
         method: 'POST',
         data: body,
         requestId,
@@ -272,6 +255,19 @@ class DataSourceWithBackend<
       throw new HealthCheckError(res.message, res.details);
     });
   }
+}
+
+function getUrlForRequest<TQuery extends DataQuery = DataQuery>(request: DataQueryRequest<TQuery>): string {
+  if (!config.featureToggles.validatedQueries) {
+    return '/api/ds/query';
+  }
+
+  if (!request.userCanEditDashboard && request.dashboardUid != null && request.panelId != null) {
+    // add additional params to query so we can validate on the backend.
+    return `/api/dashboards/org/${config.bootData.user.orgId}/uid/${request.dashboardUid}/panels/${request.panelId}/query`;
+  }
+
+  return '/api/ds/query';
 }
 
 /**

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -67,6 +67,12 @@ type MetricRequest struct {
 	Queries []*simplejson.Json `json:"queries"`
 	// required: false
 	Debug bool `json:"debug"`
+	// DashboardUid UID of dashboard where query originated.
+	// required: false
+	DashboardUid string
+	// PanelId ID of panel in above dashboard where query originated.
+	// required: false
+	PanelId int64
 }
 
 func GetGravatarUrl(text string) string {

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -67,12 +67,6 @@ type MetricRequest struct {
 	Queries []*simplejson.Json `json:"queries"`
 	// required: false
 	Debug bool `json:"debug"`
-	// DashboardUid UID of dashboard where query originated.
-	// required: false
-	DashboardUid string
-	// PanelId ID of panel in above dashboard where query originated.
-	// required: false
-	PanelId int64
 }
 
 func GetGravatarUrl(text string) string {

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -325,7 +325,7 @@ func TestAPIEndpoint_Metrics_checkDashboardAndPanel(t *testing.T) {
 		expectedError        error
 	}{
 		{
-			name:         "Work when correct dashboardId and panelId given",
+			name:         "Work when correct dashboardUid and panelId given",
 			orgId:        testOrgID,
 			dashboardUid: "1",
 			panelId:      2,
@@ -345,7 +345,7 @@ func TestAPIEndpoint_Metrics_checkDashboardAndPanel(t *testing.T) {
 			expectedError:        models.ErrDashboardNotFound,
 		},
 		{
-			name:                 "404 on invalid dashboardId",
+			name:                 "404 on invalid dashboardUid",
 			orgId:                testOrgID,
 			dashboardUid:         "",
 			panelId:              2,
@@ -419,7 +419,7 @@ func TestAPIEndpoint_Metrics_ParseDashboardQueryParams(t *testing.T) {
 		expectedError          error
 	}{
 		{
-			name: "Work when correct orgId, dashboardId and panelId given",
+			name: "Work when correct orgId, dashboardUid and panelId given",
 			params: map[string]string{
 				":orgId":        strconv.FormatInt(testOrgID, 10),
 				":dashboardUid": "1",

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
@@ -30,7 +30,14 @@ export function PanelEditorTableView({ width, height, panel, dashboard }: Props)
     const timeData = applyPanelTimeOverrides(panel, timeSrv.timeRange());
 
     const sub = panel.events.subscribe(RefreshEvent, () => {
-      panel.runAllPanelQueries(dashboard.id, dashboard.uid, dashboard.getTimezone(), timeData, width);
+      panel.runAllPanelQueries(
+        dashboard.id,
+        dashboard.uid,
+        dashboard.meta.canEdit || false,
+        dashboard.getTimezone(),
+        timeData,
+        width
+      );
     });
     return () => {
       sub.unsubscribe();

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
@@ -30,7 +30,7 @@ export function PanelEditorTableView({ width, height, panel, dashboard }: Props)
     const timeData = applyPanelTimeOverrides(panel, timeSrv.timeRange());
 
     const sub = panel.events.subscribe(RefreshEvent, () => {
-      panel.runAllPanelQueries(dashboard.id, dashboard.getTimezone(), timeData, width);
+      panel.runAllPanelQueries(dashboard.id, dashboard.uid, dashboard.getTimezone(), timeData, width);
     });
     return () => {
       sub.unsubscribe();

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -315,7 +315,13 @@ export class PanelChrome extends PureComponent<Props, State> {
       if (this.state.refreshWhenInView) {
         this.setState({ refreshWhenInView: false });
       }
-      panel.runAllPanelQueries(this.props.dashboard.id, this.props.dashboard.getTimezone(), timeData, width);
+      panel.runAllPanelQueries(
+        this.props.dashboard.id,
+        this.props.dashboard.uid,
+        this.props.dashboard.getTimezone(),
+        timeData,
+        width
+      );
     } else {
       // The panel should render on refresh as well if it doesn't have a query, like clock panel
       this.setState({

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -318,6 +318,7 @@ export class PanelChrome extends PureComponent<Props, State> {
       panel.runAllPanelQueries(
         this.props.dashboard.id,
         this.props.dashboard.uid,
+        this.props.dashboard.meta.canEdit || false,
         this.props.dashboard.getTimezone(),
         timeData,
         width

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -469,6 +469,7 @@ describe('PanelModel', () => {
           run: jest.fn(),
         });
         const dashboardId = 123;
+        const dashboardUid = 'potato';
         const dashboardTimezone = 'browser';
         const width = 860;
         const timeData = {
@@ -483,7 +484,7 @@ describe('PanelModel', () => {
           } as TimeRange,
         } as TimeOverrideResult;
 
-        model.runAllPanelQueries(dashboardId, dashboardTimezone, timeData, width);
+        model.runAllPanelQueries(dashboardId, dashboardUid, dashboardTimezone, timeData, width);
 
         expect(model.getQueryRunner).toBeCalled();
       });

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -309,7 +309,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
       datasource: this.datasource,
       queries: this.targets,
       panelId: this.id,
-      dashboardId: dashboardId,
+      dashboardId,
       dashboardUid,
       userCanEditDashboard,
       timezone: dashboardTimezone,

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -300,6 +300,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
   runAllPanelQueries(
     dashboardId: number,
     dashboardUid: string,
+    userCanEditDashboard: boolean,
     dashboardTimezone: string,
     timeData: TimeOverrideResult,
     width: number
@@ -310,6 +311,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
       panelId: this.id,
       dashboardId: dashboardId,
       dashboardUid,
+      userCanEditDashboard,
       timezone: dashboardTimezone,
       timeRange: timeData.timeRange,
       timeInfo: timeData.timeInfo,

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -297,12 +297,19 @@ export class PanelModel implements DataConfigSource, IPanelModel {
     this.gridPos.h = newPos.h;
   }
 
-  runAllPanelQueries(dashboardId: number, dashboardTimezone: string, timeData: TimeOverrideResult, width: number) {
+  runAllPanelQueries(
+    dashboardId: number,
+    dashboardUid: string,
+    dashboardTimezone: string,
+    timeData: TimeOverrideResult,
+    width: number
+  ) {
     this.getQueryRunner().run({
       datasource: this.datasource,
       queries: this.targets,
       panelId: this.id,
       dashboardId: dashboardId,
+      dashboardUid,
       timezone: dashboardTimezone,
       timeRange: timeData.timeRange,
       timeInfo: timeData.timeInfo,

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -47,6 +47,7 @@ export interface QueryRunnerOptions<
   queries: TQuery[];
   panelId?: number;
   dashboardId?: number;
+  dashboardUid?: string;
   timezone: TimeZone;
   timeRange: TimeRange;
   timeInfo?: string; // String description of time range for display
@@ -195,6 +196,7 @@ export class PanelQueryRunner {
       datasource,
       panelId,
       dashboardId,
+      dashboardUid,
       timeRange,
       timeInfo,
       cacheTimeout,
@@ -214,6 +216,7 @@ export class PanelQueryRunner {
       timezone,
       panelId,
       dashboardId,
+      dashboardUid,
       range: timeRange,
       timeInfo,
       interval: '',

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -48,6 +48,7 @@ export interface QueryRunnerOptions<
   panelId?: number;
   dashboardId?: number;
   dashboardUid?: string;
+  userCanEditDashboard?: boolean;
   timezone: TimeZone;
   timeRange: TimeRange;
   timeInfo?: string; // String description of time range for display
@@ -197,6 +198,7 @@ export class PanelQueryRunner {
       panelId,
       dashboardId,
       dashboardUid,
+      userCanEditDashboard,
       timeRange,
       timeInfo,
       cacheTimeout,
@@ -217,6 +219,7 @@ export class PanelQueryRunner {
       panelId,
       dashboardId,
       dashboardUid,
+      userCanEditDashboard,
       range: timeRange,
       timeInfo,
       interval: '',


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds frontend routing to the validated query api endpoint.
It first checks to see if validated queries feature toggle is enabled and then if the user is view only and the dashboardUid and panelId are available(dashboard is persisted), we route the query to the validated queries endpoint.

**Which issue(s) this PR fixes**:
Resolves: https://github.com/grafana/grafana-enterprise-partnerships-team/issues/58

first steps toward: https://github.com/grafana/grafana-enterprise-partnerships-team/issues/72 and https://github.com/grafana/grafana-enterprise/issues/691

**Special notes for your reviewer**:

