### PR TITLE
Alerting: Add support for fine-grained access to alerting APIs

### DIFF
--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
+//nolint:gocyclo
 func (api *API) authorize(method, path string) web.Handler {
 	authorize := acmiddleware.Middleware(api.AccessControl)
 	var eval ac.Evaluator = nil

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -1,11 +1,163 @@
 package api
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/grafana/grafana/pkg/middleware"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	acmiddleware "github.com/grafana/grafana/pkg/services/accesscontrol/middleware"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/web"
 )
 
 func (api *API) authorize(method, path string) web.Handler {
-	// TODO Add fine-grained authorization for every route
-	return middleware.ReqSignedIn
+	authorize := acmiddleware.Middleware(api.AccessControl)
+	var eval ac.Evaluator = nil
+
+	switch method + path {
+	// Alert Rules
+
+	// Grafana Paths
+	case http.MethodDelete + "/api/ruler/grafana/api/v1/rules/{Namespace}/{Groupname}":
+		eval = ac.EvalPermission(ac.ActionAlertingRuleDelete, dashboards.ScopeFoldersProvider.GetResourceScopeName(ac.Parameter(":Namespace")))
+	case http.MethodDelete + "/api/ruler/grafana/api/v1/rules/{Namespace}":
+		eval = ac.EvalPermission(ac.ActionAlertingRuleDelete, dashboards.ScopeFoldersProvider.GetResourceScopeName(ac.Parameter(":Namespace")))
+	case http.MethodGet + "/api/ruler/grafana/api/v1/rules/{Namespace}/{Groupname}":
+		eval = ac.EvalPermission(ac.ActionAlertingRuleRead, dashboards.ScopeFoldersProvider.GetResourceScopeName(ac.Parameter(":Namespace")))
+	case http.MethodGet + "/api/ruler/grafana/api/v1/rules/{Namespace}":
+		eval = ac.EvalPermission(ac.ActionAlertingRuleRead, dashboards.ScopeFoldersProvider.GetResourceScopeName(ac.Parameter(":Namespace")))
+	case http.MethodGet + "/api/ruler/grafana/api/v1/rules":
+		eval = ac.EvalPermission(ac.ActionAlertingRuleRead)
+	case http.MethodPost + "/api/ruler/grafana/api/v1/rules/{Namespace}":
+		scope := dashboards.ScopeFoldersProvider.GetResourceScopeName(ac.Parameter(":Namespace"))
+		// more granular permissions are enforced by the handler via "authorizeRuleChanges"
+		eval = ac.EvalAny(
+			ac.EvalPermission(ac.ActionAlertingRuleUpdate, scope),
+			ac.EvalPermission(ac.ActionAlertingRuleCreate, scope),
+			ac.EvalPermission(ac.ActionAlertingRuleDelete, scope),
+		)
+
+	// Grafana, Prometheus-compatible Paths
+	case http.MethodGet + "/api/prometheus/grafana/api/v1/rules":
+		eval = ac.EvalPermission(ac.ActionAlertingRuleRead)
+
+	// Grafana Rules Testing Paths
+	case http.MethodPost + "/api/v1/rule/test/grafana":
+		// additional authorization is done in the request handler
+		eval = ac.EvalPermission(ac.ActionAlertingRuleRead)
+	case http.MethodPost + "/api/v1/eval":
+		// additional authorization is done in the request handler
+		eval = ac.EvalPermission(ac.ActionAlertingRuleRead)
+
+	// Lotex Paths
+	case http.MethodDelete + "/api/ruler/{Recipient}/api/v1/rules/{Namespace}":
+		eval = ac.EvalPermission(ac.ActionAlertingRuleExternalWrite, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+	case http.MethodDelete + "/api/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname}":
+		eval = ac.EvalPermission(ac.ActionAlertingRuleExternalWrite, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+	case http.MethodGet + "/api/ruler/{Recipient}/api/v1/rules/{Namespace}":
+		eval = ac.EvalPermission(ac.ActionAlertingRuleExternalRead, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+	case http.MethodGet + "/api/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname}":
+		eval = ac.EvalPermission(ac.ActionAlertingRuleExternalRead, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+	case http.MethodGet + "/api/ruler/{Recipient}/api/v1/rules":
+		eval = ac.EvalPermission(ac.ActionAlertingRuleExternalRead, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+	case http.MethodPost + "/api/ruler/{Recipient}/api/v1/rules/{Namespace}":
+		eval = ac.EvalPermission(ac.ActionAlertingInstancesExternalWrite, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+
+	// Lotex Prometheus-compatible Paths
+	case http.MethodGet + "/api/prometheus/{Recipient}/api/v1/rules":
+		eval = ac.EvalPermission(ac.ActionAlertingRuleExternalRead, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+
+	// Lotex Rules testing
+	case http.MethodPost + "/api/v1/rule/test/{Recipient}":
+		eval = ac.EvalPermission(ac.ActionAlertingRuleExternalRead, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+
+	// Alert Instances and Silences
+
+	// Silences. Grafana Paths
+	case http.MethodDelete + "/api/alertmanager/grafana/api/v2/silence/{SilenceId}":
+		eval = ac.EvalPermission(ac.ActionAlertingInstanceUpdate) // delete endpoint actually expires silence
+	case http.MethodGet + "/api/alertmanager/grafana/api/v2/silence/{SilenceId}":
+		eval = ac.EvalPermission(ac.ActionAlertingInstanceRead)
+	case http.MethodGet + "/api/alertmanager/grafana/api/v2/silences":
+		eval = ac.EvalPermission(ac.ActionAlertingInstanceRead)
+	case http.MethodPost + "/api/alertmanager/grafana/api/v2/silences":
+		// additional authorization is done in the request handler
+		eval = ac.EvalAny(ac.EvalPermission(ac.ActionAlertingInstanceCreate), ac.EvalPermission(ac.ActionAlertingInstanceUpdate))
+
+	// Alert Instances. Grafana Paths
+	case http.MethodGet + "/api/alertmanager/grafana/api/v2/alerts/groups":
+		eval = ac.EvalPermission(ac.ActionAlertingInstanceRead)
+	case http.MethodGet + "/api/alertmanager/grafana/api/v2/alerts":
+		eval = ac.EvalPermission(ac.ActionAlertingInstanceRead)
+	case http.MethodPost + "/api/alertmanager/grafana/api/v2/alerts":
+		eval = ac.EvalAny(ac.EvalPermission(ac.ActionAlertingInstanceCreate), ac.EvalPermission(ac.ActionAlertingInstanceUpdate))
+
+	// Grafana Prometheus-compatible Paths
+	case http.MethodGet + "/api/prometheus/grafana/api/v1/alerts":
+		eval = ac.EvalPermission(ac.ActionAlertingInstanceRead)
+
+	// Silences. External AM.
+	case http.MethodDelete + "/api/alertmanager/{Recipient}/api/v2/silence/{SilenceId}":
+		eval = ac.EvalPermission(ac.ActionAlertingInstancesExternalWrite, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+	case http.MethodPost + "/api/alertmanager/{Recipient}/api/v2/silences":
+		eval = ac.EvalPermission(ac.ActionAlertingInstancesExternalWrite, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+	case http.MethodGet + "/api/alertmanager/{Recipient}/api/v2/silence/{SilenceId}":
+		eval = ac.EvalPermission(ac.ActionAlertingInstancesExternalRead, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+	case http.MethodGet + "/api/alertmanager/{Recipient}/api/v2/silences":
+		eval = ac.EvalPermission(ac.ActionAlertingInstancesExternalRead, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+
+	// Alert instances. External AM.
+	case http.MethodGet + "/api/alertmanager/{Recipient}/api/v2/alerts/groups":
+		eval = ac.EvalPermission(ac.ActionAlertingInstancesExternalRead, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+	case http.MethodGet + "/api/alertmanager/{Recipient}/api/v2/alerts":
+		eval = ac.EvalPermission(ac.ActionAlertingInstancesExternalRead, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+	case http.MethodPost + "/api/alertmanager/{Recipient}/api/v2/alerts":
+		eval = ac.EvalPermission(ac.ActionAlertingInstancesExternalWrite, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+
+	// Prometheus-compatible Paths
+	case http.MethodGet + "/api/prometheus/{Recipient}/api/v1/alerts":
+		eval = ac.EvalPermission(ac.ActionAlertingInstancesExternalRead, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+
+	// Notification Policies, Contact Points and Templates
+
+	// Grafana Paths
+	case http.MethodDelete + "/api/alertmanager/grafana/config/api/v1/alerts": // reset alertmanager config to the default
+		eval = ac.EvalPermission(ac.ActionAlertingNotificationsDelete)
+	case http.MethodGet + "/api/alertmanager/grafana/config/api/v1/alerts":
+		eval = ac.EvalPermission(ac.ActionAlertingNotificationsRead)
+	case http.MethodGet + "/api/alertmanager/grafana/api/v2/status":
+		eval = ac.EvalPermission(ac.ActionAlertingNotificationsRead)
+	case http.MethodPost + "/api/alertmanager/grafana/config/api/v1/alerts":
+		// additional authorization is done in the request handler
+		eval = ac.EvalAny(ac.EvalPermission(ac.ActionAlertingNotificationsUpdate), ac.EvalPermission(ac.ActionAlertingNotificationsCreate), ac.EvalPermission(ac.ActionAlertingNotificationsDelete))
+	case http.MethodPost + "/api/alertmanager/grafana/config/api/v1/receivers/test":
+		eval = ac.EvalPermission(ac.ActionAlertingNotificationsRead)
+
+	// External Alertmanager Paths
+	case http.MethodDelete + "/api/alertmanager/{Recipient}/config/api/v1/alerts":
+		eval = ac.EvalPermission(ac.ActionAlertingNotificationsDelete, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+	case http.MethodGet + "/api/alertmanager/{Recipient}/api/v2/status":
+		eval = ac.EvalPermission(ac.ActionAlertingNotificationsExternalRead, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+	case http.MethodGet + "/api/alertmanager/{Recipient}/config/api/v1/alerts":
+		eval = ac.EvalPermission(ac.ActionAlertingNotificationsExternalRead, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+	case http.MethodPost + "/api/alertmanager/{Recipient}/config/api/v1/alerts":
+		eval = ac.EvalPermission(ac.ActionAlertingNotificationsExternalWrite, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+	case http.MethodPost + "/api/alertmanager/{Recipient}/config/api/v1/receivers/test":
+		eval = ac.EvalPermission(ac.ActionAlertingNotificationsExternalRead, datasources.ScopeDatasourcesProvider.GetResourceScope(ac.Parameter(":Recipient")))
+
+	// Raw Alertmanager Config Paths
+	case http.MethodDelete + "/api/v1/ngalert/admin_config",
+		http.MethodGet + "/api/v1/ngalert/admin_config",
+		http.MethodPost + "/api/v1/ngalert/admin_config",
+		http.MethodGet + "/api/v1/ngalert/alertmanagers":
+		return middleware.ReqOrgAdmin
+	}
+
+	if eval != nil {
+		return authorize(middleware.ReqSignedIn, eval)
+	}
+
+	panic(fmt.Sprintf("no authorization handler for method [%s] of endpoint [%s]", method, path))
 }

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-openapi/loads"
+	"github.com/stretchr/testify/require"
+
+	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+)
+
+func TestAuthorize(t *testing.T) {
+	json, err := os.ReadFile(filepath.Join("tooling", "spec.json"))
+	require.NoError(t, err)
+	swaggerSpec, err := loads.Analyzed(json, "")
+	require.NoError(t, err)
+
+	paths := make(map[string][]string)
+
+	for p, item := range swaggerSpec.Spec().Paths.Paths {
+		var methods []string
+
+		if item.Get != nil {
+			methods = append(methods, http.MethodGet)
+		}
+		if item.Put != nil {
+			methods = append(methods, http.MethodPut)
+		}
+		if item.Post != nil {
+			methods = append(methods, http.MethodPost)
+		}
+		if item.Delete != nil {
+			methods = append(methods, http.MethodDelete)
+		}
+		if item.Patch != nil {
+			methods = append(methods, http.MethodPatch)
+		}
+		paths[p] = methods
+	}
+
+	require.Len(t, paths, 29)
+
+	require.NoErrorf(t, err, "failed to read swagger specification")
+
+	ac := acmock.New()
+	api := &API{AccessControl: ac}
+
+	for path, methods := range paths {
+		for _, method := range methods {
+			require.NotPanics(t, func() {
+				api.authorize(method, path)
+			})
+		}
+	}
+}

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -40,19 +40,24 @@ func TestAuthorize(t *testing.T) {
 		}
 		paths[p] = methods
 	}
-
 	require.Len(t, paths, 29)
-
-	require.NoErrorf(t, err, "failed to read swagger specification")
 
 	ac := acmock.New()
 	api := &API{AccessControl: ac}
 
-	for path, methods := range paths {
-		for _, method := range methods {
-			require.NotPanics(t, func() {
-				api.authorize(method, path)
-			})
+	t.Run("should not panic on known routes", func(t *testing.T) {
+		for path, methods := range paths {
+			for _, method := range methods {
+				require.NotPanics(t, func() {
+					api.authorize(method, path)
+				})
+			}
 		}
-	}
+	})
+
+	t.Run("should panic if route is unknown", func(t *testing.T) {
+		require.Panics(t, func() {
+			api.authorize("test", "test")
+		})
+	})
 }

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -155,9 +155,6 @@ func (ng *AlertNG) init() error {
 	}
 	api.RegisterAPIEndpoints(ng.Metrics.GetAPIMetrics())
 
-	if ng.isFgacDisabled() {
-		return nil
-	}
 	return DeclareFixedRoles(ng.accesscontrol)
 }
 
@@ -185,10 +182,4 @@ func (ng *AlertNG) IsDisabled() bool {
 		return true
 	}
 	return !ng.Cfg.UnifiedAlerting.IsEnabled()
-}
-
-// TODO temporary. Remove after https://github.com/grafana/grafana/pull/46358 is merged
-// isFgacDisabled returns true if fine-grained access for Alerting is enabled.
-func (ng *AlertNG) isFgacDisabled() bool {
-	return ng.Cfg.IsFeatureToggleEnabled == nil || !ng.Cfg.IsFeatureToggleEnabled("alerting_fgac")
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR adds support for fine-grained authorization to all Grafana Alerting APIs. 

<details> <summary> Actions Paths </summary>

```
"alert.instances:create" OR "alert.instances:update" - `POST /api/alertmanager/grafana/api/v2/silences`
"alert.instances:create" OR "alert.instances:update" - `POST /api/alertmanager/grafana/api/v2/alerts`
"alert.instances:read" - `GET /api/alertmanager/grafana/api/v2/alerts/groups`
"alert.instances:read" - `GET /api/alertmanager/grafana/api/v2/alerts`
"alert.instances:read" - `GET /api/alertmanager/grafana/api/v2/silence/{SilenceId}`
"alert.instances:read" - `GET /api/alertmanager/grafana/api/v2/silences`
"alert.instances:read" - `GET /api/prometheus/grafana/api/v1/alerts`
"alert.instances:update" - `DELETE /api/alertmanager/grafana/api/v2/silence/{SilenceId}`
"alert.instances.external:edit" - `DELETE /api/alertmanager/{Recipient}/api/v2/silence/{SilenceId}`
"alert.instances.external:edit" - `POST /api/alertmanager/{Recipient}/api/v2/alerts`
"alert.instances.external:edit" - `POST /api/alertmanager/{Recipient}/api/v2/silences`
"alert.instances.external:edit" - `POST /api/ruler/{Recipient}/api/v1/rules/{Namespace}`
"alert.instances.external:read" - `GET /api/alertmanager/{Recipient}/api/v2/alerts/groups`
"alert.instances.external:read" - `GET /api/alertmanager/{Recipient}/api/v2/alerts`
"alert.instances.external:read" - `GET /api/alertmanager/{Recipient}/api/v2/silence/{SilenceId}`
"alert.instances.external:read" - `GET /api/alertmanager/{Recipient}/api/v2/silences`
"alert.instances.external:read" - `GET /api/prometheus/{Recipient}/api/v1/alerts`
"alert.notifications:delete" - `DELETE /api/alertmanager/{Recipient}/config/api/v1/alerts`
"alert.notifications:delete" - `DELETE /api/alertmanager/grafana/config/api/v1/alerts`
"alert.notifications:read" - `GET /api/alertmanager/grafana/api/v2/status`
"alert.notifications:read" - `GET /api/alertmanager/grafana/config/api/v1/alerts`
"alert.notifications:read" - `POST /api/alertmanager/grafana/config/api/v1/receivers/test`
"alert.notifications:update" OR "alert.notifications:create" OR "alert.notifications:delete" - `POST /api/alertmanager/grafana/config/api/v1/alerts`
"alert.notifications.external:edit" - `POST /api/alertmanager/{Recipient}/config/api/v1/alerts`
"alert.notifications.external:read" - `GET /api/alertmanager/{Recipient}/api/v2/status`
"alert.notifications.external:read" - `GET /api/alertmanager/{Recipient}/config/api/v1/alerts`
"alert.notifications.external:read" - `POST /api/alertmanager/{Recipient}/config/api/v1/receivers/test`
"alert.rules:delete" - `DELETE /api/ruler/grafana/api/v1/rules/{Namespace}/{Groupname}`
"alert.rules:delete" - `DELETE /api/ruler/grafana/api/v1/rules/{Namespace}`
"alert.rules:read" - `GET /api/prometheus/grafana/api/v1/rules`
"alert.rules:read" - `GET /api/ruler/grafana/api/v1/rules/{Namespace}/{Groupname}`
"alert.rules:read" - `GET /api/ruler/grafana/api/v1/rules/{Namespace}`
"alert.rules:read" - `GET /api/ruler/grafana/api/v1/rules`
"alert.rules:read" - `POST /api/v1/eval`
"alert.rules:read" - `POST /api/v1/rule/test/grafana`
"alert.rules:update" OR "alert.rules:create" OR "alert.rules:delete" - `POST /api/ruler/grafana/api/v1/rules/{Namespace}`
"alert.rules.external:edit" - `DELETE /api/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname}`
"alert.rules.external:edit" - `DELETE /api/ruler/{Recipient}/api/v1/rules/{Namespace}`
"alert.rules.external:read" - `GET /api/prometheus/{Recipient}/api/v1/rules`
"alert.rules.external:read" - `GET /api/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname}`
"alert.rules.external:read" - `GET /api/ruler/{Recipient}/api/v1/rules/{Namespace}`
"alert.rules.external:read" - `GET /api/ruler/{Recipient}/api/v1/rules`
"alert.rules.external:read" - `POST /api/v1/rule/test/{Recipient}`
ADMIN - `DELETE /api/v1/ngalert/admin_config`
ADMIN - `GET /api/v1/ngalert/admin_config`
ADMIN - `GET /api/v1/ngalert/alertmanagers`
ADMIN - `POST /api/v1/ngalert/admin_config`
```

</details>

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

