### PR TITLE
Geomap: applying multiple line builders should keep each segment

### DIFF
--- a/public/app/features/geo/format/utils.ts
+++ b/public/app/features/geo/format/utils.ts
@@ -1,6 +1,6 @@
 import { ArrayVector, Field, FieldConfig, FieldType } from '@grafana/data';
 import { getCenterPoint } from 'app/features/transformers/spatial/utils';
-import { Geometry, LineString, Point } from 'ol/geom';
+import { Geometry, GeometryCollection, LineString, Point } from 'ol/geom';
 import { fromLonLat } from 'ol/proj';
 import { Gazetteer } from '../gazetteer/gazetteer';
 import { decodeGeohash } from './geohash';
@@ -41,6 +41,40 @@ export function getGeoFieldFromGazetteer(gaz: Gazetteer, field: Field<string>): 
   const geo = new Array<Geometry | undefined>(count);
   for (let i = 0; i < count; i++) {
     geo[i] = gaz.find(field.values.get(i))?.geometry();
+  }
+  return {
+    name: 'Geometry',
+    type: FieldType.geo,
+    values: new ArrayVector(geo),
+    config: hiddenTooltipField,
+  };
+}
+
+export function createGeometryCollection(
+  src: Field<Geometry | undefined>,
+  dest: Field<Geometry | undefined>
+): Field<Geometry | undefined> {
+  const v0 = src.values.toArray();
+  const v1 = dest.values.toArray();
+  if (!v0 || !v1) {
+    throw 'missing src/dest';
+  }
+  if (v0.length !== v1.length) {
+    throw 'Source and destination field lengths do not match';
+  }
+
+  const count = src.values.length!;
+  const geo = new Array<Geometry | undefined>(count);
+  for (let i = 0; i < count; i++) {
+    const a = v0[i];
+    const b = v1[i];
+    if (a && b) {
+      geo[i] = new GeometryCollection([a, b]);
+    } else if (a) {
+      geo[i] = a;
+    } else if (b) {
+      geo[i] = b;
+    }
   }
   return {
     name: 'Geometry',

--- a/public/app/features/transformers/spatial/spatialTransformer.ts
+++ b/public/app/features/transformers/spatial/spatialTransformer.ts
@@ -30,7 +30,7 @@ async function doSetGeometry(frames: DataFrame[], options: SpatialTransformOptio
         const line = createLineBetween(src.field, target.field);
         const first = fields[0];
         if (first.type === FieldType.geo && first !== src.field && first !== target.field) {
-          fields.unshift(createGeometryCollection(first, line)); //
+          fields[0] = createGeometryCollection(first, line); //
         } else {
           fields.unshift(line);
         }

--- a/public/app/features/transformers/spatial/spatialTransformer.ts
+++ b/public/app/features/transformers/spatial/spatialTransformer.ts
@@ -1,5 +1,5 @@
 import { ArrayVector, DataFrame, DataTransformerID, DataTransformerInfo, FieldType } from '@grafana/data';
-import { createLineBetween } from 'app/features/geo/format/utils';
+import { createGeometryCollection, createLineBetween } from 'app/features/geo/format/utils';
 import { getGeometryField, getLocationMatchers } from 'app/features/geo/utils/location';
 import { mergeMap, from } from 'rxjs';
 import { SpatialOperation, SpatialAction, SpatialTransformOptions } from './models.gen';
@@ -26,10 +26,17 @@ async function doSetGeometry(frames: DataFrame[], options: SpatialTransformOptio
       const src = getGeometryField(frame, location);
       const target = getGeometryField(frame, targetLocation);
       if (src.field && target.field) {
+        const fields = [...frame.fields];
         const line = createLineBetween(src.field, target.field);
+        const first = fields[0];
+        if (first.type === FieldType.geo && first !== src.field && first !== target.field) {
+          fields.unshift(createGeometryCollection(first, line)); //
+        } else {
+          fields.unshift(line);
+        }
         return {
           ...frame,
-          fields: [line, ...frame.fields],
+          fields,
         };
       }
       return frame;


### PR DESCRIPTION
When multiple lines are constructed, we should keep all segments.  See:
![image](https://user-images.githubusercontent.com/705951/158306375-a23d4a26-be9d-4a81-a543-410660f2d4c6.png)
![Peek 2022-03-14 22-05](https://user-images.githubusercontent.com/705951/158310355-f6b088df-07cc-4bdd-8f04-2ab2d2a47605.gif)
