### PR TITLE
Dashboards: Fixes repeating by row and no refresh

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.repeat.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.repeat.test.ts
@@ -587,6 +587,14 @@ describe('given dashboard with row and panel repeat', () => {
     expect(panelTypes).toEqual(['row', 'graph', 'graph', 'row', 'graph', 'graph']);
   });
 
+  it('Row repeat should create new panel keys every repeat cycle', () => {
+    // This is the first repeated panel inside the second repeated row
+    // Since we create a new panel model every time (and new panel events bus) we need to create a new key here to trigger a re-mount & re-subscribe
+    const key1 = dashboard.panels[3].key;
+    dashboard.processRepeats();
+    expect(key1).not.toEqual(dashboard.panels[3].key);
+  });
+
   it('should clean up old repeated panels', () => {
     dashboardJSON.panels = [
       {

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -799,7 +799,6 @@ export class DashboardModel implements TimeModel {
   updateRepeatedPanelIds(panel: PanelModel, repeatedByRow?: boolean) {
     panel.repeatPanelId = panel.id;
     panel.id = this.getNextPanelId();
-    panel.key = `${panel.id}`;
     panel.repeatIteration = this.iteration;
     if (repeatedByRow) {
       panel.repeatedByRow = true;


### PR DESCRIPTION
Fixes #46444

The issue was with panel.key being set by using panel.id, since panel.id is actually reused
between repeats it caused the panel.key to be the same but the PanelModel (and panel eventbus) to
be different causing no one to subscribe to panel events.

Panel.key needs to be new every repeat cycle so that panels re-mount and resubscribe to events.

This is not ideal and I hope we can git rid of this re-mount after we update DashboardModel
to redux and get rid of panel.events (or find some equivalent solution that does not require remount)
