### PR TITLE
Loki: Fix operator description propup from being shortened

### DIFF
--- a/packages/grafana-ui/src/components/Typeahead/TypeaheadInfo.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/TypeaheadInfo.tsx
@@ -21,7 +21,7 @@ const getStyles = (theme: GrafanaTheme, height: number, visible: boolean) => {
       box-shadow: 0 0 20px ${theme.colors.dropdownShadow};
       visibility: ${visible === true ? 'visible' : 'hidden'};
       width: 250px;
-      height: ${height + parseInt(theme.spacing.xxs, 10)}px;
+      min-height: ${height + parseInt(theme.spacing.xxs, 10)}px;
       position: relative;
       word-break: break-word;
     `,


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Fixes #46574

