### PR TITLE
TimeSeries: Add migration for Graph panel's transform series override

### DIFF
--- a/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
+++ b/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
@@ -481,6 +481,56 @@ Object {
 }
 `;
 
+exports[`Graph Migrations transforms should preserve "constant" transform 1`] = `
+Object {
+  "defaults": Object {
+    "custom": Object {
+      "drawStyle": "points",
+      "spanNulls": false,
+    },
+  },
+  "overrides": Array [
+    Object {
+      "matcher": Object {
+        "id": "byName",
+        "options": "out",
+      },
+      "properties": Array [
+        Object {
+          "id": "custom.transform",
+          "value": "constant",
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`Graph Migrations transforms should preserve "negative-Y" transform 1`] = `
+Object {
+  "defaults": Object {
+    "custom": Object {
+      "drawStyle": "points",
+      "spanNulls": false,
+    },
+  },
+  "overrides": Array [
+    Object {
+      "matcher": Object {
+        "id": "byName",
+        "options": "out",
+      },
+      "properties": Array [
+        Object {
+          "id": "custom.transform",
+          "value": "negative-Y",
+        },
+      ],
+    },
+  ],
+}
+`;
+
 exports[`Graph Migrations twoYAxis 1`] = `
 Object {
   "alert": undefined,

--- a/public/app/plugins/panel/timeseries/migrations.test.ts
+++ b/public/app/plugins/panel/timeseries/migrations.test.ts
@@ -406,6 +406,24 @@ describe('Graph Migrations', () => {
       expect(panel.fieldConfig).toMatchSnapshot();
     });
   });
+
+  describe('transforms', () => {
+    test.each(['negative-Y', 'constant'])('should preserve %p transform', (transform) => {
+      const old: any = {
+        angular: {
+          seriesOverrides: [
+            {
+              alias: 'out',
+              transform,
+            },
+          ],
+        },
+      };
+      const panel = {} as PanelModel;
+      panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
+      expect(panel.fieldConfig).toMatchSnapshot();
+    });
+  });
 });
 
 const customColor = {

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -27,6 +27,7 @@ import {
   ScaleDistribution,
   StackingMode,
   SortOrder,
+  GraphTransform,
 } from '@grafana/schema';
 import { TimeSeriesOptions } from './types';
 import { omitBy, pickBy, isNil, isNumber, isString } from 'lodash';
@@ -240,6 +241,12 @@ export function flotToGraphOptions(angular: any): { fieldConfig: FieldConfigSour
                 fixedColor: v,
                 mode: FieldColorModeId.Fixed,
               },
+            });
+            break;
+          case 'transform':
+            rule.properties.push({
+              id: 'custom.transform',
+              value: v === 'negative-Y' ? GraphTransform.NegativeY : GraphTransform.Constant,
             });
             break;
           default:


### PR DESCRIPTION
When working on https://github.com/grafana/grafana/pull/44774 I have reverted the migration commit (by accident 😬 ) which made the migration not land in the latest release. This PR brings back the migration.


Fixes https://github.com/grafana/grafana/issues/45697