### PR TITLE
TimeSeries: Preserve null/undefined values when performing negative y transform

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/utils.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.test.ts
@@ -88,6 +88,87 @@ describe('preparePlotData', () => {
         ]
       `);
     });
+
+    it('negative-y transform with null/undefined values', () => {
+      const df = new MutableDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [9997, 9998, 9999] },
+          { name: 'a', values: [-10, 20, 10, 30] },
+          { name: 'b', values: [10, 10, 10, null] },
+          { name: 'c', values: [null, 20, 20, 20], config: { custom: { transform: GraphTransform.NegativeY } } },
+          { name: 'd', values: [20, 20, 20, null], config: { custom: { transform: GraphTransform.NegativeY } } },
+          { name: 'e', values: [20, null, 20, 20], config: { custom: { transform: GraphTransform.NegativeY } } },
+          { name: 'f', values: [10, 10, 10, undefined] },
+          { name: 'g', values: [undefined, 20, 20, 20], config: { custom: { transform: GraphTransform.NegativeY } } },
+          { name: 'h', values: [20, 20, 20, undefined], config: { custom: { transform: GraphTransform.NegativeY } } },
+          { name: 'i', values: [20, undefined, 20, 20], config: { custom: { transform: GraphTransform.NegativeY } } },
+        ],
+      });
+      expect(preparePlotData([df])).toMatchInlineSnapshot(`
+        Array [
+          Array [
+            9997,
+            9998,
+            9999,
+            undefined,
+          ],
+          Array [
+            -10,
+            20,
+            10,
+            30,
+          ],
+          Array [
+            10,
+            10,
+            10,
+            null,
+          ],
+          Array [
+            null,
+            -20,
+            -20,
+            -20,
+          ],
+          Array [
+            -20,
+            -20,
+            -20,
+            null,
+          ],
+          Array [
+            -20,
+            null,
+            -20,
+            -20,
+          ],
+          Array [
+            10,
+            10,
+            10,
+            undefined,
+          ],
+          Array [
+            undefined,
+            -20,
+            -20,
+            -20,
+          ],
+          Array [
+            -20,
+            -20,
+            -20,
+            undefined,
+          ],
+          Array [
+            -20,
+            undefined,
+            -20,
+            -20,
+          ],
+        ]
+      `);
+    });
     it('constant transform', () => {
       const df = new MutableDataFrame({
         fields: [

--- a/packages/grafana-ui/src/components/uPlot/utils.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.ts
@@ -64,8 +64,9 @@ export function preparePlotData(
     const customConfig: GraphFieldConfig = f.config.custom || {};
 
     const values = f.values.toArray();
+
     if (customConfig.transform === GraphTransform.NegativeY) {
-      result.push(values.map((v) => v * -1));
+      result.push(values.map((v) => (v == null ? v : v * -1)));
     } else if (customConfig.transform === GraphTransform.Constant) {
       result.push(new Array(values.length).fill(values[0]));
     } else {


### PR DESCRIPTION
Fixes #45916
Fixes #46393

Before:
<img width="1797" alt="Screen Shot 2022-03-15 at 14 10 13" src="https://user-images.githubusercontent.com/2376619/158388237-bc6dcc5f-6a66-4354-8cc8-b847b9f5fe5f.png">


After:
<img width="1797" alt="Screen Shot 2022-03-15 at 14 22 30" src="https://user-images.githubusercontent.com/2376619/158388286-d0e96c3a-0af1-46f7-a1e3-2d8785d51255.png">

