### PR TITLE
Service Accounts: Refactor login service to use sqlstore methods

### DIFF
--- a/pkg/services/login/authinfoservice/database/database.go
+++ b/pkg/services/login/authinfoservice/database/database.go
@@ -214,33 +214,32 @@ func (s *AuthInfoStore) DeleteAuthInfo(ctx context.Context, cmd *models.DeleteAu
 	})
 }
 
-func (s *AuthInfoStore) GetUserById(id int64) (bool, *models.User, error) {
-	var (
-		has bool
-		err error
-	)
-	user := &models.User{}
-	err = s.sqlStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
-		has, err = sess.ID(id).Get(user)
-		return err
-	})
-	if err != nil {
-		return false, nil, err
+func (s *AuthInfoStore) GetUserById(ctx context.Context, id int64) (*models.User, error) {
+	query := models.GetUserByIdQuery{Id: id}
+	if err := s.sqlStore.GetUserById(ctx, &query); err != nil {
+		return nil, err
 	}
 
-	return has, user, nil
+	return query.Result, nil
 }
 
-func (s *AuthInfoStore) GetUser(user *models.User) (bool, error) {
-	var err error
-	var has bool
+func (s *AuthInfoStore) GetUserByLogin(ctx context.Context, login string) (*models.User, error) {
+	query := models.GetUserByLoginQuery{LoginOrEmail: login}
+	if err := s.sqlStore.GetUserByLogin(ctx, &query); err != nil {
+		return nil, err
+	}
 
-	err = s.sqlStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
-		has, err = sess.Get(user)
-		return err
-	})
+	return query.Result, nil
+}
 
-	return has, err
+func (s *AuthInfoStore) GetUserByEmail(ctx context.Context, email string) (*models.User, error) {
+	query := models.GetUserByEmailQuery{Email: email}
+	if err := s.sqlStore.GetUserByEmail(ctx, &query); err != nil {
+		return nil, err
+	}
+
+	return query.Result, nil
+
 }
 
 // decodeAndDecrypt will decode the string with the standard base64 decoder and then decrypt it

--- a/pkg/services/login/authinfoservice/database/database.go
+++ b/pkg/services/login/authinfoservice/database/database.go
@@ -239,7 +239,6 @@ func (s *AuthInfoStore) GetUserByEmail(ctx context.Context, email string) (*mode
 	}
 
 	return query.Result, nil
-
 }
 
 // decodeAndDecrypt will decode the string with the standard base64 decoder and then decrypt it

--- a/pkg/services/login/authinfoservice/user_auth_test.go
+++ b/pkg/services/login/authinfoservice/user_auth_test.go
@@ -47,7 +47,7 @@ func TestUserAuth(t *testing.T) {
 			// By ID
 			id := user.Id
 
-			_, user, err = srv.LookupByOneOf(id, "", "")
+			user, err = srv.LookupByOneOf(context.Background(), id, "", "")
 
 			require.Nil(t, err)
 			require.Equal(t, user.Id, id)
@@ -55,7 +55,7 @@ func TestUserAuth(t *testing.T) {
 			// By Email
 			email := "user1@test.com"
 
-			_, user, err = srv.LookupByOneOf(0, email, "")
+			user, err = srv.LookupByOneOf(context.Background(), 0, email, "")
 
 			require.Nil(t, err)
 			require.Equal(t, user.Email, email)
@@ -63,7 +63,7 @@ func TestUserAuth(t *testing.T) {
 			// Don't find nonexistent user
 			email = "nonexistent@test.com"
 
-			_, user, err = srv.LookupByOneOf(0, email, "")
+			user, err = srv.LookupByOneOf(context.Background(), 0, email, "")
 
 			require.Equal(t, models.ErrUserNotFound, err)
 			require.Nil(t, user)

--- a/pkg/services/login/userprotection.go
+++ b/pkg/services/login/userprotection.go
@@ -16,6 +16,7 @@ type Store interface {
 	SetAuthInfo(ctx context.Context, cmd *models.SetAuthInfoCommand) error
 	UpdateAuthInfo(ctx context.Context, cmd *models.UpdateAuthInfoCommand) error
 	DeleteAuthInfo(ctx context.Context, cmd *models.DeleteAuthInfoCommand) error
-	GetUserById(id int64) (bool, *models.User, error)
-	GetUser(user *models.User) (bool, error)
+	GetUserById(ctx context.Context, id int64) (*models.User, error)
+	GetUserByLogin(ctx context.Context, login string) (*models.User, error)
+	GetUserByEmail(ctx context.Context, email string) (*models.User, error)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

- Login service reimplements sqlstore methods for retrieving users, not taking into account service accounts
  - It's unlikely for collisions to happen here but for safety we should exclude service accounts
  - Took opportunity to re-utilize sqlstore methods that already include service account filtering

Fixes https://github.com/grafana/grafana-enterprise/issues/3015

