### PR TITLE
Chore: Update go version used in CI to 1.17.8

### DIFF
--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-alpine/scripts/deploy.sh
@@ -18,8 +18,8 @@ apk add --no-cache curl npm yarn build-base openssh git-lfs perl-utils coreutils
 # apk add --no-cache xvfb glib nss nspr gdk-pixbuf "gtk+3.0" pango atk cairo dbus-libs libxcomposite libxrender libxi libxtst libxrandr libxscrnsaver alsa-lib at-spi2-atk at-spi2-core cups-libs gcompat libc6-compat
 
 # Install Go
-filename="go1.17.linux-amd64.tar.gz"
-get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d"
+filename="go1.17.8.linux-amd64.tar.gz"
+get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "980e65a863377e69fd9b67df9d8395fd8e93858e7a24c9f55803421e453f4f99"
 untar_file "/tmp/$filename"
 
 # Install golangci-lint

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci-e2e/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci-e2e/scripts/deploy.sh
@@ -22,8 +22,8 @@ source "/etc/profile"
 npm i -g yarn
 
 # Install Go
-filename="go1.17.linux-amd64.tar.gz"
-get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d"
+filename="go1.17.8.linux-amd64.tar.gz"
+get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "980e65a863377e69fd9b67df9d8395fd8e93858e7a24c9f55803421e453f4f99"
 untar_file "/tmp/$filename"
 
 # Install golangci-lint

--- a/packages/grafana-toolkit/docker/grafana-plugin-ci/scripts/deploy.sh
+++ b/packages/grafana-toolkit/docker/grafana-plugin-ci/scripts/deploy.sh
@@ -2,8 +2,8 @@
 source "./deploy-common.sh"
 
 # Install Go
-filename="go1.17.linux-amd64.tar.gz"
-get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d"
+filename="go1.17.8.linux-amd64.tar.gz"
+get_file "https://dl.google.com/go/$filename" "/tmp/$filename" "980e65a863377e69fd9b67df9d8395fd8e93858e7a24c9f55803421e453f4f99"
 untar_file "/tmp/$filename"
 
 # Install golangci-lint

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:testing-20210111-slim
 
 # Use ARG so as not to persist environment variable in image
-ARG GOVERSION=1.17 \
-  GO_CHECKSUM=6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d \
+ARG GOVERSION=1.17.8 \
+  GO_CHECKSUM=980e65a863377e69fd9b67df9d8395fd8e93858e7a24c9f55803421e453f4f99 \
   DEBIAN_FRONTEND=noninteractive
 
 ENV PATH=/usr/local/go/bin:$PATH \


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This updates the version of go used in CI. There are some security patches in recent releases (and probably more in older 1.17.x patch releases):

go 1.17.7:
* [CVE-2022-24921](https://nvd.nist.gov/vuln/detail/CVE-2022-24921)

go 1.17.8:
* [CVE-2022-23806](https://nvd.nist.gov/vuln/detail/CVE-2022-23806)
* [CVE-2022-23772](https://nvd.nist.gov/vuln/detail/CVE-2022-23772)
* [CVE-2022-23773](https://nvd.nist.gov/vuln/detail/CVE-2022-23773)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

