### PR TITLE
Icon: Fix default icon color mismatch with default fill color

### DIFF
--- a/public/app/features/canvas/elements/icon.tsx
+++ b/public/app/features/canvas/elements/icon.tsx
@@ -157,7 +157,10 @@ export const iconItem: CanvasElementItem<IconConfig, IconData> = {
         name: 'Stroke color',
         editor: ColorDimensionEditor,
         settings: {},
-        defaultValue: {},
+        defaultValue: {
+          // Configured values
+          fixed: 'grey',
+        },
         showIf: (cfg) => Boolean(cfg?.config?.stroke?.width),
       })
       .addCustomEditor({

--- a/public/app/features/canvas/elements/icon.tsx
+++ b/public/app/features/canvas/elements/icon.tsx
@@ -101,7 +101,7 @@ export const iconItem: CanvasElementItem<IconConfig, IconData> = {
 
     const data: IconData = {
       path,
-      fill: cfg.fill ? ctx.getColor(cfg.fill).value() : '#19730E',
+      fill: cfg.fill ? ctx.getColor(cfg.fill).value() : '#CCC',
       api: cfg?.api ?? undefined,
     };
 

--- a/public/app/features/canvas/elements/icon.tsx
+++ b/public/app/features/canvas/elements/icon.tsx
@@ -101,7 +101,7 @@ export const iconItem: CanvasElementItem<IconConfig, IconData> = {
 
     const data: IconData = {
       path,
-      fill: cfg.fill ? ctx.getColor(cfg.fill).value() : '#CCC',
+      fill: cfg.fill ? ctx.getColor(cfg.fill).value() : '#19730E',
       api: cfg?.api ?? undefined,
     };
 
@@ -157,10 +157,7 @@ export const iconItem: CanvasElementItem<IconConfig, IconData> = {
         name: 'Stroke color',
         editor: ColorDimensionEditor,
         settings: {},
-        defaultValue: {
-          // Configured values
-          fixed: 'grey',
-        },
+        defaultValue: {},
         showIf: (cfg) => Boolean(cfg?.config?.stroke?.width),
       })
       .addCustomEditor({

--- a/public/app/plugins/panel/icon/models.gen.ts
+++ b/public/app/plugins/panel/icon/models.gen.ts
@@ -18,6 +18,9 @@ export const defaultPanelOptions: PanelOptions = {
         mode: ResourceDimensionMode.Fixed,
         fixed: 'img/icons/unicons/analysis.svg',
       },
+      fill: {
+        fixed: '#19730E' // 'dark-green' to match default fill color
+      }
     },
   },
 };

--- a/public/app/plugins/panel/icon/models.gen.ts
+++ b/public/app/plugins/panel/icon/models.gen.ts
@@ -19,7 +19,7 @@ export const defaultPanelOptions: PanelOptions = {
         fixed: 'img/icons/unicons/analysis.svg',
       },
       fill: {
-        fixed: '#19730E' // 'dark-green' to match default fill color
+        fixed: 'green'
       }
     },
   },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Update default color of icon in panel to match default fill color.

Before
<img width="1512" alt="Initial Issue" src="https://user-images.githubusercontent.com/22381771/158438024-79dbf18c-0116-4377-bc77-d9795752ee4c.png">


After
<img width="1512" alt="Screen Shot 2022-03-16 at 8 31 56 AM" src="https://user-images.githubusercontent.com/22381771/158627629-c46b0c20-50fb-450f-adfb-4763d13ed102.png">


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #46595

