### PR TITLE
Docs: Mention queryparam function on data-link-variables.md

### DIFF
--- a/docs/sources/linking/data-link-variables.md
+++ b/docs/sources/linking/data-link-variables.md
@@ -49,6 +49,17 @@ Value-specific variables are available under `__value` namespace:
 
 When linking to another dashboard that uses template variables, select variable values for whoever clicks the link.
 
-`${myvar:queryparams}` - where `myvar` is a name of the template variable that matches one in the current dashboard that you want to use.
+- `${myvar:queryparams}` - where `myvar` is a name of the template variable that matches one in the current dashboard that you want to use the currently selected value of. 
+  |State|Result|
+  |---|---|
+  |one selected|`value`|
+  |multiple|htmlescaped `{value1,valuen}`|
+  |if All is supported and selected|the allValue with no surrounding symbols such as `.+` if that is the allValue|
+- `${myvar:queryparam}` - where `myvar` is a name of the template variable that matches one in the current dashboard that you want to use as a query parameter. 
+  |State|Result|
+  |---|---|
+  |one selected|`var-myvar=value`|
+  |multiple|`var-myvar=value1&var-myvar=value2`|
+  |if All is supported and selected|the all text `var-myvar=All`|
 
-If you want to add all of the current dashboard's variables to the URL, then use `__all_variables`.
+If you want to add all of the current dashboard's variables to the URL, then use `__all_variables` which behaves like `${some_var:queryparam}` but for all variables.

--- a/docs/sources/linking/data-link-variables.md
+++ b/docs/sources/linking/data-link-variables.md
@@ -49,7 +49,7 @@ Value-specific variables are available under `__value` namespace:
 
 When linking to another dashboard that uses template variables, select variable values for whoever clicks the link.
 
-- `${myvar:queryparams}` - where `myvar` is a name of the template variable that matches one in the current dashboard that you want to use the currently selected value of. 
+- `${myvar:queryparams}` - where `myvar` is the name of the template variable that matches a variable in the dashboard that contains the selected value you want to use.
   |State|Result|
   |---|---|
   |one selected|`value`|


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds queryparam function to data link variables documentation to match the other listed variables. It is visible in the UI but only queryparams is described on the page.

**Which issue(s) this PR fixes**:

None that I know of, I was just using some of the variables, came by as a reference, and noticed that some variables I use weren't listed on the page and felt I should add them.

**Special notes for your reviewer**:
