### PR TITLE
Escape backslashes in Loki queries (#45809).

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -168,7 +168,7 @@ export class LokiDatasource
     const filteredTargets = request.targets
       .filter((target) => target.expr && !target.hide)
       .map((target) => {
-        const expr = this.addAdHocFilters(target.expr);
+        const expr = this.addAdHocFilters(target.expr).replace(/\\/g, '\\\\');
         return {
           ...target,
           expr: this.templateSrv.replace(expr, scopedVars, this.interpolateQueryExpr),


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Fixes #45809

**Special notes for your reviewer**:

Not sure changed line is a proper place to escape, so feel free to move/refactor it.