### PR TITLE
Plugins: skip `.DS_Store` file checksum verification

### DIFF
--- a/pkg/plugins/manager/signature/manifest.go
+++ b/pkg/plugins/manager/signature/manifest.go
@@ -279,6 +279,11 @@ func pluginFilesRequiringVerification(plugin *plugins.Plugin) ([]string, error) 
 			}
 		}
 
+		if info.Name() == ".DS_Store" {
+			// skip MacOS directory metadata file https://en.wikipedia.org/wiki/.DS_Store
+			return nil
+		}
+
 		// skip directories and MANIFEST.txt
 		if info.IsDir() || info.Name() == "MANIFEST.txt" {
 			return nil


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana-image-renderer/pull/326#discussion_r826654460