### PR TITLE
Theme: Increase contrast for overlays and drawers

### DIFF
--- a/packages/grafana-data/src/themes/createComponents.ts
+++ b/packages/grafana-data/src/themes/createComponents.ts
@@ -77,7 +77,7 @@ export function createComponents(colors: ThemeColors, shadows: ThemeShadows): Th
       padding: 1,
     },
     overlay: {
-      background: colors.mode === 'dark' ? 'rgba(0, 0, 0, 0.45)' : 'rgba(208, 209, 211, 0.24)',
+      background: colors.mode === 'dark' ? 'rgba(63, 62, 62, 0.45)' : 'rgba(208, 209, 211, 0.24)',
     },
     sidemenu: {
       width: 48,


### PR DESCRIPTION
I find the modals & drawer backdrop in the dark theme blend into the dark overlay to much, meaning the modal & drawer does not stand out enough, This is not an issue on the light theme where the darkened overlay and shadow work together to great effect.

This problem very much depends on your screen brightness / and room brightness. Some times I find it not that bad, other times the edge between modal/drawer and overlay is very hard to make out. 

During the v8 theme work I did try to persuade for this change but was overruled. I'm not sure why. If we darken the overlay in the light theme we should lighten the overlay in the dark theme,  not like we do today when both light and dark theme has darkened overlay. 

Before: 
![Screenshot from 2022-03-16 12-25-36](https://user-images.githubusercontent.com/10999/158581403-6cbcaac2-6134-4c51-8598-d615e62c2b68.png)
![Screenshot from 2022-03-16 12-25-46](https://user-images.githubusercontent.com/10999/158581407-855807c0-30b6-4b93-bfa3-f84af3728e32.png)
![Screenshot from 2022-03-16 12-25-58](https://user-images.githubusercontent.com/10999/158581412-9619a618-469e-495c-8cb7-426d9a1b2875.png)

After: Note the effect looks very stark here, but is actually much more subtle when you try it out live. 
![Screenshot from 2022-03-16 12-23-53](https://user-images.githubusercontent.com/10999/158581430-1fea3e31-8b69-4b47-b27c-fe5fb32dbf63.png)
![Screenshot from 2022-03-16 12-24-01](https://user-images.githubusercontent.com/10999/158581440-005379b0-68d3-4c83-9af7-e752902652f0.png)
![Screenshot from 2022-03-16 12-24-26](https://user-images.githubusercontent.com/10999/158581445-da631cd2-d8f8-4300-af97-637ab8b6963c.png)

