### PR TITLE
Fix delete dashboard from datasource configuration

### DIFF
--- a/public/app/features/dashboard/state/actions.ts
+++ b/public/app/features/dashboard/state/actions.ts
@@ -106,9 +106,9 @@ export function importDashboard(data: any, dashboardTitle: string): ThunkResult<
   };
 }
 
-export function removeDashboard(uri: string): ThunkResult<void> {
+export function removeDashboard(uid: string): ThunkResult<void> {
   return async (dispatch) => {
-    await getBackendSrv().delete(`/api/dashboards/${uri}`);
+    await getBackendSrv().delete(`/api/dashboards/uid/${uid}`);
     dispatch(loadPluginDashboards());
   };
 }

--- a/public/app/features/datasources/DataSourceDashboards.tsx
+++ b/public/app/features/datasources/DataSourceDashboards.tsx
@@ -71,7 +71,7 @@ export class DataSourceDashboards extends PureComponent<Props> {
   };
 
   onRemove = (dashboard: PluginDashboard) => {
-    this.props.removeDashboard(dashboard.importedUri);
+    this.props.removeDashboard(dashboard.uid);
   };
 
   render() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes error when deleting a dashboard from the datasource configuratino

**Which issue(s) this PR fixes**:
Fixes #46636

**Special notes for your reviewer**:
Changed how url is formated, instead of using slug name of the dashboard (that api was deleted) now uses the UID

![gdev-graphite-Dashboards---Grafana - solution](https://user-images.githubusercontent.com/34773040/158598341-333f0cd9-9921-417f-9f84-df4a0cda399f.gif)

