### PR TITLE
Data links: Fix issue with not being able to click a variable after scroll

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinkInput.tsx
@@ -80,6 +80,7 @@ export const DataLinkInput: React.FC<DataLinkInputProps> = memo(
     const [suggestionsIndex, setSuggestionsIndex] = useState(0);
     const [linkUrl, setLinkUrl] = useState<Value>(makeValue(value));
     const prevLinkUrl = usePrevious<Value>(linkUrl);
+    const [scrollTop, setScrollTop] = useState(0);
 
     // Workaround for https://github.com/ianstormtaylor/slate/issues/2927
     const stateRef = useRef({ showingSuggestions, suggestions, suggestionsIndex, linkUrl, onChange });
@@ -87,10 +88,9 @@ export const DataLinkInput: React.FC<DataLinkInputProps> = memo(
 
     // Used to get the height of the suggestion elements in order to scroll to them.
     const activeRef = useRef<HTMLDivElement>(null);
-    const activeIndexPosition = useMemo(
-      () => getElementPosition(activeRef.current, suggestionsIndex),
-      [suggestionsIndex]
-    );
+    useEffect(() => {
+      setScrollTop(getElementPosition(activeRef.current, suggestionsIndex));
+    }, [suggestionsIndex]);
 
     // SelectionReference is used to position the variables suggestion relatively to current DOM selection
     const selectionRef = useMemo(() => new SelectionReference(), []);
@@ -183,7 +183,11 @@ export const DataLinkInput: React.FC<DataLinkInputProps> = memo(
                   {({ ref, style, placement }) => {
                     return (
                       <div ref={ref} style={style} data-placement={placement} className={styles.suggestionsWrapper}>
-                        <CustomScrollbar scrollTop={activeIndexPosition} autoHeightMax="300px">
+                        <CustomScrollbar
+                          scrollTop={scrollTop}
+                          autoHeightMax="300px"
+                          setScrollTop={({ scrollTop }) => setScrollTop(scrollTop)}
+                        >
                           <DataLinkSuggestions
                             activeRef={activeRef}
                             suggestions={stateRef.current.suggestions}


### PR DESCRIPTION
**What this PR does / why we need it**:

There was an issue with the data links dropdown where you could not select any items that you had to scroll to (see the issue), this PR fixes that issue:

https://user-images.githubusercontent.com/100691367/158603924-977ed6e4-4981-4767-b1e9-4de230ef2ca8.mov

**Which issue(s) this PR fixes**:

Fixes #43501

**Special notes for your reviewer**:

When you add a `setScrollTop` prop to the `CustomScrollbar`, it calls that function every time the user has scrolled that section, so we are using that to maintain a state of `scrollTop` inside `DataLinkInput` that gets updated when the user scrolls or when the user changes the active option (for instance using the keyboard).
