### PR TITLE
Access control: Handle case where there are no matching ids for all actions passed to filter

### DIFF
--- a/pkg/services/accesscontrol/filter.go
+++ b/pkg/services/accesscontrol/filter.go
@@ -69,6 +69,10 @@ func Filter(user *models.SignedInUser, sqlID, prefix string, actions ...string) 
 		}
 	}
 
+	if len(ids) == 0 {
+		return denyQuery, nil
+	}
+
 	query := strings.Builder{}
 	query.WriteRune(' ')
 	query.WriteString(sqlID)

--- a/pkg/services/accesscontrol/filter_test.go
+++ b/pkg/services/accesscontrol/filter_test.go
@@ -117,6 +117,18 @@ func TestFilter_Datasources(t *testing.T) {
 			expectedDataSources: []string{"ds:3", "ds:7", "ds:8"},
 			expectErr:           false,
 		},
+		{
+			desc:    "expect no data sources when scopes does not match",
+			sqlID:   "data_source.id",
+			prefix:  "datasources",
+			actions: []string{"datasources:read", "datasources:write"},
+			permissions: map[string][]string{
+				"datasources:read":  {"datasources:id:3", "datasources:id:7", "datasources:id:8"},
+				"datasources:write": {"datasources:id:10"},
+			},
+			expectedDataSources: []string{},
+			expectErr:           false,
+		},
 	}
 
 	// set sqlIDAcceptList before running tests


### PR DESCRIPTION
**What this PR does / why we need it**:
When building a access control filter for several actions i missed handle the case where both action has scopes but none of them matches each other e.g.

Action: `folders:read` Scope: `folders:id:10`
Action: `dashboards:create` Scope: `folders:id:2`

**Which issue(s) this PR fixes**:

Fixes #46645

**Special notes for your reviewer**:

