### PR TITLE
pkg/bus: Remove unused code, add documentation, safe concurrency

### DIFF
--- a/pkg/api/admin_users_test.go
+++ b/pkg/api/admin_users_test.go
@@ -70,7 +70,7 @@ func TestAdminAPIEndpoint(t *testing.T) {
 		mock := mockstore.NewSQLStoreMock()
 		adminLogoutUserScenario(t, "Should not be allowed when calling POST on",
 			"/api/admin/users/1/logout", "/api/admin/users/:id/logout", func(sc *scenarioContext) {
-				bus.AddHandler("test", func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
+				bus.SetHandler("test", func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
 					cmd.Result = &models.User{Id: testUserID}
 					return nil
 				})

--- a/pkg/api/alerting_test.go
+++ b/pkg/api/alerting_test.go
@@ -46,12 +46,12 @@ func setUp(confs ...setUpConf) *HTTPServer {
 			aclMockResp = c.aclMockResp
 		}
 	}
-	bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
+	bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
 		query.Result = aclMockResp
 		return nil
 	})
 
-	bus.AddHandler("test", func(ctx context.Context, query *models.GetTeamsByUserQuery) error {
+	bus.SetHandler("test", func(ctx context.Context, query *models.GetTeamsByUserQuery) error {
 		query.Result = []*models.TeamDTO{}
 		return nil
 	})
@@ -129,7 +129,7 @@ func TestAlertingAPIEndpoint(t *testing.T) {
 }
 
 func callPauseAlert(sc *scenarioContext) {
-	bus.AddHandler("test", func(ctx context.Context, cmd *models.PauseAlertCommand) error {
+	bus.SetHandler("test", func(ctx context.Context, cmd *models.PauseAlertCommand) error {
 		return nil
 	})
 

--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -431,12 +431,12 @@ func setUpACL() {
 		{Role: &editorRole, Permission: models.PERMISSION_EDIT},
 	}
 
-	bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
+	bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
 		query.Result = aclMockResp
 		return nil
 	})
 
-	bus.AddHandler("test", func(ctx context.Context, query *models.GetTeamsByUserQuery) error {
+	bus.SetHandler("test", func(ctx context.Context, query *models.GetTeamsByUserQuery) error {
 		query.Result = []*models.TeamDTO{}
 		return nil
 	})

--- a/pkg/api/dashboard_snapshot_test.go
+++ b/pkg/api/dashboard_snapshot_test.go
@@ -52,7 +52,7 @@ func TestDashboardSnapshotAPIEndpoint_singleSnapshot(t *testing.T) {
 		sqlmock.ExpectedTeamsByUser = []*models.TeamDTO{}
 
 		// we need it here for now for the guadian service to work
-		bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
+		bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
 			query.Result = aclMockResp
 			return nil
 		})

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -133,7 +133,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				{Role: &editorRole, Permission: models.PERMISSION_EDIT},
 			}
 
-			bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
+			bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
 				query.Result = aclMockResp
 				return nil
 			})
@@ -246,7 +246,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				},
 			}
 
-			bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
+			bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
 				query.Result = aclMockResp
 				return nil
 			})
@@ -345,7 +345,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 
 			setUpInner := func() {
 				setUp()
-				bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
+				bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
 					query.Result = mockResult
 					return nil
 				})
@@ -405,7 +405,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 					{OrgId: 1, DashboardId: 2, UserId: 1, Permission: models.PERMISSION_VIEW},
 				}
 
-				bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
+				bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
 					query.Result = mockResult
 					return nil
 				})
@@ -446,7 +446,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				mockResult := []*models.DashboardAclInfoDTO{
 					{OrgId: 1, DashboardId: 2, UserId: 1, Permission: models.PERMISSION_ADMIN},
 				}
-				bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
+				bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
 					query.Result = mockResult
 					return nil
 				})
@@ -494,7 +494,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 				mockResult := []*models.DashboardAclInfoDTO{
 					{OrgId: 1, DashboardId: 2, UserId: 1, Permission: models.PERMISSION_VIEW},
 				}
-				bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
+				bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
 					query.Result = mockResult
 					return nil
 				})
@@ -744,7 +744,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 		sqlmock := mockstore.SQLStoreMock{ExpectedDashboardVersions: dashboardvs}
 		setUp := func() {
 			mockResult := []*models.DashboardAclInfoDTO{}
-			bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
+			bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
 				query.Result = mockResult
 				return nil
 			})
@@ -864,7 +864,7 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 
 	t.Run("Given provisioned dashboard", func(t *testing.T) {
 		setUp := func() {
-			bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
+			bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
 				query.Result = []*models.DashboardAclInfoDTO{
 					{OrgId: testOrgID, DashboardId: 1, UserId: testUserID, Permission: models.PERMISSION_EDIT},
 				}
@@ -975,7 +975,7 @@ func (hs *HTTPServer) callGetDashboard(sc *scenarioContext) {
 }
 
 func (hs *HTTPServer) callGetDashboardVersion(sc *scenarioContext) {
-	bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardVersionQuery) error {
+	bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardVersionQuery) error {
 		query.Result = &models.DashboardVersion{}
 		return nil
 	})
@@ -985,7 +985,7 @@ func (hs *HTTPServer) callGetDashboardVersion(sc *scenarioContext) {
 }
 
 func (hs *HTTPServer) callGetDashboardVersions(sc *scenarioContext) {
-	bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardVersionsQuery) error {
+	bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardVersionsQuery) error {
 		query.Result = []*models.DashboardVersionDTO{}
 		return nil
 	})
@@ -996,7 +996,7 @@ func (hs *HTTPServer) callGetDashboardVersions(sc *scenarioContext) {
 
 func (hs *HTTPServer) callDeleteDashboardByUID(t *testing.T,
 	sc *scenarioContext, mockDashboard *dashboards.FakeDashboardService) {
-	bus.AddHandler("test", func(ctx context.Context, cmd *models.DeleteDashboardCommand) error {
+	bus.SetHandler("test", func(ctx context.Context, cmd *models.DeleteDashboardCommand) error {
 		return nil
 	})
 

--- a/pkg/api/ldap_debug_test.go
+++ b/pkg/api/ldap_debug_test.go
@@ -493,14 +493,14 @@ func TestPostSyncUserWithLDAPAPIEndpoint_WhenUserNotInLDAP(t *testing.T) {
 
 		userSearchResult = nil
 
-		bus.AddHandler("test", func(ctx context.Context, q *models.GetExternalUserInfoByLoginQuery) error {
+		bus.SetHandler("test", func(ctx context.Context, q *models.GetExternalUserInfoByLoginQuery) error {
 			assert.Equal(t, "ldap-daniel", q.LoginOrEmail)
 			q.Result = &models.ExternalUserInfo{IsDisabled: true, UserId: 34}
 
 			return nil
 		})
 
-		bus.AddHandler("test", func(ctx context.Context, cmd *models.DisableUserCommand) error {
+		bus.SetHandler("test", func(ctx context.Context, cmd *models.DisableUserCommand) error {
 			assert.Equal(t, 34, cmd.UserId)
 			return nil
 		})

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -465,7 +465,7 @@ func TestDataSourceProxy_routeRule(t *testing.T) {
 	})
 
 	t.Run("When proxying a datasource that has OAuth token pass-through enabled", func(t *testing.T) {
-		bus.AddHandler("test", func(ctx context.Context, query *models.GetAuthInfoQuery) error {
+		bus.SetHandler("test", func(ctx context.Context, query *models.GetAuthInfoQuery) error {
 			query.Result = &models.UserAuth{
 				Id:                1,
 				UserId:            1,

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -108,7 +108,7 @@ func TestUserAPIEndpoint_userLoggedIn(t *testing.T) {
 
 	loggedInUserScenario(t, "When calling GET on", "/api/users/lookup", "/api/users/lookup", func(sc *scenarioContext) {
 		fakeNow := time.Date(2019, 2, 11, 17, 30, 40, 0, time.UTC)
-		bus.AddHandler("test", func(ctx context.Context, query *models.GetUserByLoginQuery) error {
+		bus.SetHandler("test", func(ctx context.Context, query *models.GetUserByLoginQuery) error {
 			require.Equal(t, "danlee", query.LoginOrEmail)
 
 			query.Result = &models.User{

--- a/pkg/api/user_token_test.go
+++ b/pkg/api/user_token_test.go
@@ -79,7 +79,7 @@ func TestUserTokenAPIEndpoint(t *testing.T) {
 		token := &models.UserToken{Id: 2}
 		mock := mockstore.NewSQLStoreMock()
 		revokeUserAuthTokenInternalScenario(t, "Should not be successful", cmd, testUserID, token, func(sc *scenarioContext) {
-			bus.AddHandler("test", func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
+			bus.SetHandler("test", func(ctx context.Context, cmd *models.GetUserByIdQuery) error {
 				cmd.Result = &models.User{Id: testUserID}
 				return nil
 			})

--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -1,3 +1,6 @@
+// Package bus provides a generic message bus that can be used to decouple dispatchers and publishers from handlers and listeners.
+//
+// Deprecated: Bus is being slowly phased out from Grafana. Do not use this package in new code.
 package bus
 
 import (
@@ -47,6 +50,8 @@ type TransactionManager interface {
 // functions like an Event in common event buses. Publish processes listeners
 // serially and returns the first non-nil error from a listener. If any
 // listener errors, subsequent listeners will not be called.
+//
+// Deprecated: Bus is being phased out of Grafana. Do not use this package in new code.
 type Bus interface {
 	Dispatch(ctx context.Context, msg Msg) error
 

--- a/pkg/bus/bus_test.go
+++ b/pkg/bus/bus_test.go
@@ -22,7 +22,7 @@ func TestDispatch(t *testing.T) {
 
 	var invoked bool
 
-	bus.AddHandler(func(ctx context.Context, query *testQuery) error {
+	bus.SetHandler(func(ctx context.Context, query *testQuery) error {
 		invoked = true
 		return nil
 	})
@@ -45,74 +45,6 @@ func TestDispatch_NoRegisteredHandler(t *testing.T) {
 		"expected bus to return HandlerNotFound since no handler is registered")
 }
 
-func TestDispatch_ContextHandler(t *testing.T) {
-	bus := New()
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-	bus.tracer = tracer
-
-	var invoked bool
-
-	bus.AddHandler(func(ctx context.Context, query *testQuery) error {
-		invoked = true
-		return nil
-	})
-
-	err = bus.Dispatch(context.Background(), &testQuery{})
-	require.NoError(t, err)
-
-	require.True(t, invoked, "expected handler to be called")
-}
-
-func TestDispatchCtx(t *testing.T) {
-	bus := New()
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-	bus.tracer = tracer
-
-	var invoked bool
-
-	bus.AddHandler(func(ctx context.Context, query *testQuery) error {
-		invoked = true
-		return nil
-	})
-
-	err = bus.Dispatch(context.Background(), &testQuery{})
-	require.NoError(t, err)
-
-	require.True(t, invoked, "expected handler to be called")
-}
-
-func TestDispatchCtx_NoContextHandler(t *testing.T) {
-	bus := New()
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-	bus.tracer = tracer
-
-	var invoked bool
-
-	bus.AddHandler(func(ctx context.Context, query *testQuery) error {
-		invoked = true
-		return nil
-	})
-
-	err = bus.Dispatch(context.Background(), &testQuery{})
-	require.NoError(t, err)
-
-	require.True(t, invoked, "expected handler to be called")
-}
-
-func TestDispatchCtx_NoRegisteredHandler(t *testing.T) {
-	bus := New()
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-	bus.tracer = tracer
-
-	err = bus.Dispatch(context.Background(), &testQuery{})
-	require.Equal(t, err, ErrHandlerNotFound,
-		"expected bus to return HandlerNotFound since no handler is registered")
-}
-
 func TestQuery(t *testing.T) {
 	bus := New()
 	tracer, err := tracing.InitializeTracerForTest()
@@ -121,7 +53,7 @@ func TestQuery(t *testing.T) {
 
 	want := "hello from handler"
 
-	bus.AddHandler(func(ctx context.Context, q *testQuery) error {
+	bus.SetHandler(func(ctx context.Context, q *testQuery) error {
 		q.Resp = want
 		return nil
 	})
@@ -140,7 +72,7 @@ func TestQuery_HandlerReturnsError(t *testing.T) {
 	require.NoError(t, err)
 	bus.tracer = tracer
 
-	bus.AddHandler(func(ctx context.Context, query *testQuery) error {
+	bus.SetHandler(func(ctx context.Context, query *testQuery) error {
 		return errors.New("handler error")
 	})
 
@@ -175,71 +107,4 @@ func TestEventPublish_NoRegisteredListener(t *testing.T) {
 
 	err = bus.Publish(context.Background(), &testQuery{})
 	require.NoError(t, err, "unable to publish event")
-}
-
-func TestEventCtxPublishCtx(t *testing.T) {
-	bus := New()
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-	bus.tracer = tracer
-
-	var invoked bool
-
-	bus.AddEventListener(func(ctx context.Context, query *testQuery) error {
-		invoked = true
-		return nil
-	})
-
-	err = bus.Publish(context.Background(), &testQuery{})
-	require.NoError(t, err, "unable to publish event")
-
-	require.True(t, invoked)
-}
-
-func TestEventPublishCtx_NoRegisteredListener(t *testing.T) {
-	bus := New()
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-	bus.tracer = tracer
-
-	err = bus.Publish(context.Background(), &testQuery{})
-	require.NoError(t, err, "unable to publish event")
-}
-
-func TestEventPublishCtx(t *testing.T) {
-	bus := New()
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-	bus.tracer = tracer
-
-	var invoked bool
-
-	bus.AddEventListener(func(ctx context.Context, query *testQuery) error {
-		invoked = true
-		return nil
-	})
-
-	err = bus.Publish(context.Background(), &testQuery{})
-	require.NoError(t, err, "unable to publish event")
-
-	require.True(t, invoked)
-}
-
-func TestEventCtxPublish(t *testing.T) {
-	bus := New()
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-	bus.tracer = tracer
-
-	var invoked bool
-
-	bus.AddEventListener(func(ctx context.Context, query *testQuery) error {
-		invoked = true
-		return nil
-	})
-
-	err = bus.Publish(context.Background(), &testQuery{})
-	require.NoError(t, err, "unable to publish event")
-
-	require.True(t, invoked)
 }

--- a/pkg/expr/service_test.go
+++ b/pkg/expr/service_test.go
@@ -38,7 +38,7 @@ func TestService(t *testing.T) {
 		secretsService: secretsService,
 	}
 
-	bus.AddHandler("test", func(_ context.Context, query *models.GetDataSourceQuery) error {
+	bus.SetHandler("test", func(_ context.Context, query *models.GetDataSourceQuery) error {
 		query.Result = &models.DataSource{Uid: "1", OrgId: 1, Type: "test", JsonData: simplejson.New()}
 		return nil
 	})

--- a/pkg/login/auth.go
+++ b/pkg/login/auth.go
@@ -28,7 +28,7 @@ var loginLogger = log.New("login")
 var AuthenticateUserFunc = AuthenticateUser
 
 func Init() {
-	bus.AddHandler("auth", AuthenticateUser)
+	bus.SetHandler("auth", AuthenticateUser)
 }
 
 // AuthenticateUser authenticates the user via username & password

--- a/pkg/login/brute_force_login_protection_test.go
+++ b/pkg/login/brute_force_login_protection_test.go
@@ -74,7 +74,7 @@ func TestSaveInvalidLoginAttempt(t *testing.T) {
 		t.Cleanup(func() { bus.ClearBusHandlers() })
 
 		createLoginAttemptCmd := &models.CreateLoginAttemptCommand{}
-		bus.AddHandler("test", func(ctx context.Context, cmd *models.CreateLoginAttemptCommand) error {
+		bus.SetHandler("test", func(ctx context.Context, cmd *models.CreateLoginAttemptCommand) error {
 			createLoginAttemptCmd = cmd
 			return nil
 		})
@@ -96,7 +96,7 @@ func TestSaveInvalidLoginAttempt(t *testing.T) {
 		t.Cleanup(func() { bus.ClearBusHandlers() })
 
 		var createLoginAttemptCmd *models.CreateLoginAttemptCommand
-		bus.AddHandler("test", func(ctx context.Context, cmd *models.CreateLoginAttemptCommand) error {
+		bus.SetHandler("test", func(ctx context.Context, cmd *models.CreateLoginAttemptCommand) error {
 			createLoginAttemptCmd = cmd
 			return nil
 		})
@@ -129,7 +129,7 @@ func cfgWithBruteForceLoginProtectionEnabled(t *testing.T) *setting.Cfg {
 
 func withLoginAttempts(t *testing.T, loginAttempts int64) {
 	t.Helper()
-	bus.AddHandler("test", func(ctx context.Context, query *models.GetUserLoginAttemptCountQuery) error {
+	bus.SetHandler("test", func(ctx context.Context, query *models.GetUserLoginAttemptCountQuery) error {
 		query.Result = loginAttempts
 		return nil
 	})

--- a/pkg/login/grafana_login_test.go
+++ b/pkg/login/grafana_login_test.go
@@ -95,7 +95,7 @@ func mockPasswordValidation(valid bool, sc *grafanaLoginScenarioContext) {
 }
 
 func (sc *grafanaLoginScenarioContext) getUserByLoginQueryReturns(user *models.User) {
-	bus.AddHandler("test", func(ctx context.Context, query *models.GetUserByLoginQuery) error {
+	bus.SetHandler("test", func(ctx context.Context, query *models.GetUserByLoginQuery) error {
 		if user == nil {
 			return models.ErrUserNotFound
 		}

--- a/pkg/middleware/middleware_basic_auth_test.go
+++ b/pkg/middleware/middleware_basic_auth_test.go
@@ -28,7 +28,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 		keyhash, err := util.EncodePassword("v5nAwpMafFP6znaS4urhdWDLS5511M42", "asd")
 		require.NoError(t, err)
 
-		bus.AddHandler("test", func(ctx context.Context, query *models.GetApiKeyByNameQuery) error {
+		bus.SetHandler("test", func(ctx context.Context, query *models.GetApiKeyByNameQuery) error {
 			query.Result = &models.ApiKey{OrgId: orgID, Role: models.ROLE_EDITOR, Key: keyhash}
 			return nil
 		})
@@ -47,7 +47,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 		const salt = "Salt"
 		const orgID int64 = 2
 
-		bus.AddHandler("grafana-auth", func(ctx context.Context, query *models.LoginUserQuery) error {
+		bus.SetHandler("grafana-auth", func(ctx context.Context, query *models.LoginUserQuery) error {
 			t.Log("Handling LoginUserQuery")
 			encoded, err := util.EncodePassword(password, salt)
 			if err != nil {
@@ -60,7 +60,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 			return nil
 		})
 
-		bus.AddHandler("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+		bus.SetHandler("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 			t.Log("Handling GetSignedInUserQuery")
 			query.Result = &models.SignedInUser{OrgId: orgID, UserId: id}
 			return nil
@@ -80,7 +80,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 
 		login.Init()
 
-		bus.AddHandler("user-query", func(ctx context.Context, query *models.GetUserByLoginQuery) error {
+		bus.SetHandler("user-query", func(ctx context.Context, query *models.GetUserByLoginQuery) error {
 			encoded, err := util.EncodePassword(password, salt)
 			if err != nil {
 				return err
@@ -93,7 +93,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 			return nil
 		})
 
-		bus.AddHandler("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+		bus.SetHandler("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 			query.Result = &models.SignedInUser{UserId: query.UserId}
 			return nil
 		})
@@ -119,7 +119,7 @@ func TestMiddlewareBasicAuth(t *testing.T) {
 	}, configure)
 
 	middlewareScenario(t, "Should return error if user & password do not match", func(t *testing.T, sc *scenarioContext) {
-		bus.AddHandler("user-query", func(ctx context.Context, loginUserQuery *models.GetUserByLoginQuery) error {
+		bus.SetHandler("user-query", func(ctx context.Context, loginUserQuery *models.GetUserByLoginQuery) error {
 			return nil
 		})
 

--- a/pkg/middleware/middleware_jwt_auth_test.go
+++ b/pkg/middleware/middleware_jwt_auth_test.go
@@ -46,7 +46,7 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 				"foo-username": myUsername,
 			}, nil
 		}
-		bus.AddHandler("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+		bus.SetHandler("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 			query.Result = &models.SignedInUser{
 				UserId: id,
 				OrgId:  orgID,
@@ -74,7 +74,7 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 				"foo-email": myEmail,
 			}, nil
 		}
-		bus.AddHandler("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+		bus.SetHandler("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 			query.Result = &models.SignedInUser{
 				UserId: id,
 				OrgId:  orgID,
@@ -103,7 +103,7 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 				"foo-email": myEmail,
 			}, nil
 		}
-		bus.AddHandler("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+		bus.SetHandler("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 			return models.ErrUserNotFound
 		})
 
@@ -124,7 +124,7 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 				"foo-email": myEmail,
 			}, nil
 		}
-		bus.AddHandler("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+		bus.SetHandler("get-sign-user", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 			query.Result = &models.SignedInUser{
 				UserId: id,
 				OrgId:  orgID,
@@ -132,7 +132,7 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 			}
 			return nil
 		})
-		bus.AddHandler("upsert-user", func(ctx context.Context, command *models.UpsertUserCommand) error {
+		bus.SetHandler("upsert-user", func(ctx context.Context, command *models.UpsertUserCommand) error {
 			command.Result = &models.User{
 				Id:    id,
 				Name:  command.ExternalUser.Name,

--- a/pkg/middleware/org_redirect_test.go
+++ b/pkg/middleware/org_redirect_test.go
@@ -46,11 +46,11 @@ func TestOrgRedirectMiddleware(t *testing.T) {
 	for _, tc := range testCases {
 		middlewareScenario(t, tc.desc, func(t *testing.T, sc *scenarioContext) {
 			sc.withTokenSessionCookie("token")
-			bus.AddHandler("test", func(ctx context.Context, query *models.SetUsingOrgCommand) error {
+			bus.SetHandler("test", func(ctx context.Context, query *models.SetUsingOrgCommand) error {
 				return nil
 			})
 
-			bus.AddHandler("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+			bus.SetHandler("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 				query.Result = &models.SignedInUser{OrgId: 1, UserId: 12}
 				return nil
 			})
@@ -72,11 +72,11 @@ func TestOrgRedirectMiddleware(t *testing.T) {
 
 	middlewareScenario(t, "when setting an invalid org for user", func(t *testing.T, sc *scenarioContext) {
 		sc.withTokenSessionCookie("token")
-		bus.AddHandler("test", func(ctx context.Context, query *models.SetUsingOrgCommand) error {
+		bus.SetHandler("test", func(ctx context.Context, query *models.SetUsingOrgCommand) error {
 			return fmt.Errorf("")
 		})
 
-		bus.AddHandler("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
+		bus.SetHandler("test", func(ctx context.Context, query *models.GetSignedInUserQuery) error {
 			query.Result = &models.SignedInUser{OrgId: 1, UserId: 12}
 			return nil
 		})

--- a/pkg/services/alerting/notifier_test.go
+++ b/pkg/services/alerting/notifier_test.go
@@ -205,11 +205,11 @@ func notificationServiceScenario(t *testing.T, name string, evalCtx *EvalContext
 			return nil
 		}
 
-		bus.AddHandler("test", func(ctx context.Context, cmd *models.SetAlertNotificationStateToPendingCommand) error {
+		bus.SetHandler("test", func(ctx context.Context, cmd *models.SetAlertNotificationStateToPendingCommand) error {
 			return nil
 		})
 
-		bus.AddHandler("test", func(ctx context.Context, cmd *models.SetAlertNotificationStateToCompleteCommand) error {
+		bus.SetHandler("test", func(ctx context.Context, cmd *models.SetAlertNotificationStateToCompleteCommand) error {
 			return nil
 		})
 

--- a/pkg/services/alerting/service.go
+++ b/pkg/services/alerting/service.go
@@ -28,19 +28,19 @@ func ProvideService(bus bus.Bus, store *sqlstore.SQLStore, encryptionService enc
 		NotificationService: notificationService,
 	}
 
-	s.Bus.AddHandler(s.GetAlertNotifications)
-	s.Bus.AddHandler(s.CreateAlertNotificationCommand)
-	s.Bus.AddHandler(s.UpdateAlertNotification)
-	s.Bus.AddHandler(s.DeleteAlertNotification)
-	s.Bus.AddHandler(s.GetAllAlertNotifications)
-	s.Bus.AddHandler(s.GetOrCreateAlertNotificationState)
-	s.Bus.AddHandler(s.SetAlertNotificationStateToCompleteCommand)
-	s.Bus.AddHandler(s.SetAlertNotificationStateToPendingCommand)
-	s.Bus.AddHandler(s.GetAlertNotificationsWithUid)
-	s.Bus.AddHandler(s.UpdateAlertNotificationWithUid)
-	s.Bus.AddHandler(s.DeleteAlertNotificationWithUid)
-	s.Bus.AddHandler(s.GetAlertNotificationsWithUidToSend)
-	s.Bus.AddHandler(s.HandleNotificationTestCommand)
+	s.Bus.SetHandler(s.GetAlertNotifications)
+	s.Bus.SetHandler(s.CreateAlertNotificationCommand)
+	s.Bus.SetHandler(s.UpdateAlertNotification)
+	s.Bus.SetHandler(s.DeleteAlertNotification)
+	s.Bus.SetHandler(s.GetAllAlertNotifications)
+	s.Bus.SetHandler(s.GetOrCreateAlertNotificationState)
+	s.Bus.SetHandler(s.SetAlertNotificationStateToCompleteCommand)
+	s.Bus.SetHandler(s.SetAlertNotificationStateToPendingCommand)
+	s.Bus.SetHandler(s.GetAlertNotificationsWithUid)
+	s.Bus.SetHandler(s.UpdateAlertNotificationWithUid)
+	s.Bus.SetHandler(s.DeleteAlertNotificationWithUid)
+	s.Bus.SetHandler(s.GetAlertNotificationsWithUidToSend)
+	s.Bus.SetHandler(s.HandleNotificationTestCommand)
 
 	return s
 }

--- a/pkg/services/contexthandler/auth_proxy_test.go
+++ b/pkg/services/contexthandler/auth_proxy_test.go
@@ -50,8 +50,8 @@ func TestInitContextWithAuthProxy_CachedInvalidUserID(t *testing.T) {
 		}
 		return nil
 	}
-	bus.AddHandler("", upsertHandler)
-	bus.AddHandler("", getUserHandler)
+	bus.SetHandler("", upsertHandler)
+	bus.SetHandler("", getUserHandler)
 	t.Cleanup(func() {
 		bus.ClearBusHandlers()
 	})

--- a/pkg/services/contexthandler/authproxy/authproxy_test.go
+++ b/pkg/services/contexthandler/authproxy/authproxy_test.go
@@ -105,7 +105,7 @@ func TestMiddlewareContext_ldap(t *testing.T) {
 	t.Run("Logs in via LDAP", func(t *testing.T) {
 		const id int64 = 42
 
-		bus.AddHandler("test", func(ctx context.Context, cmd *models.UpsertUserCommand) error {
+		bus.SetHandler("test", func(ctx context.Context, cmd *models.UpsertUserCommand) error {
 			cmd.Result = &models.User{
 				Id: id,
 			}

--- a/pkg/services/dashboards/manager/dashboard_service_test.go
+++ b/pkg/services/dashboards/manager/dashboard_service_test.go
@@ -218,7 +218,7 @@ func setupDeleteHandlers(t *testing.T) *Result {
 	t.Helper()
 
 	result := &Result{}
-	bus.AddHandler("test", func(ctx context.Context, cmd *models.DeleteDashboardCommand) error {
+	bus.SetHandler("test", func(ctx context.Context, cmd *models.DeleteDashboardCommand) error {
 		require.Equal(t, cmd.Id, int64(1))
 		require.Equal(t, cmd.OrgId, int64(1))
 		result.deleteWasCalled = true

--- a/pkg/services/dashboards/manager/folder_service_test.go
+++ b/pkg/services/dashboards/manager/folder_service_test.go
@@ -99,7 +99,7 @@ func TestFolderService(t *testing.T) {
 			})
 
 			t.Run("When updating folder should return access denied error", func(t *testing.T) {
-				bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
+				bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
 					query.Result = models.NewDashboardFolder("Folder")
 					return nil
 				})
@@ -132,7 +132,7 @@ func TestFolderService(t *testing.T) {
 				dash.Id = rand.Int63()
 				f := models.DashboardToFolder(dash)
 
-				bus.AddHandler("test", func(ctx context.Context, cmd *models.SaveDashboardCommand) error {
+				bus.SetHandler("test", func(ctx context.Context, cmd *models.SaveDashboardCommand) error {
 					cmd.Result = dash
 					return nil
 				})
@@ -153,12 +153,12 @@ func TestFolderService(t *testing.T) {
 				dashboardFolder.Uid = util.GenerateShortUID()
 				f := models.DashboardToFolder(dashboardFolder)
 
-				bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
+				bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardQuery) error {
 					query.Result = dashboardFolder
 					return nil
 				})
 
-				bus.AddHandler("test", func(ctx context.Context, cmd *models.SaveDashboardCommand) error {
+				bus.SetHandler("test", func(ctx context.Context, cmd *models.SaveDashboardCommand) error {
 					cmd.Result = dashboardFolder
 					return nil
 				})
@@ -185,7 +185,7 @@ func TestFolderService(t *testing.T) {
 				f.Uid = util.GenerateShortUID()
 				store.On("GetFolderByUID", mock.Anything, orgID, f.Uid).Return(f, nil)
 				var actualCmd *models.DeleteDashboardCommand
-				bus.AddHandler("test", func(ctx context.Context, cmd *models.DeleteDashboardCommand) error {
+				bus.SetHandler("test", func(ctx context.Context, cmd *models.DeleteDashboardCommand) error {
 					actualCmd = cmd
 					return nil
 				})

--- a/pkg/services/dashboardsnapshots/dashboardsnapshots.go
+++ b/pkg/services/dashboardsnapshots/dashboardsnapshots.go
@@ -23,11 +23,11 @@ func ProvideService(bus bus.Bus, store sqlstore.Store, secretsService secrets.Se
 		SecretsService: secretsService,
 	}
 
-	s.Bus.AddHandler(s.CreateDashboardSnapshot)
-	s.Bus.AddHandler(s.GetDashboardSnapshot)
-	s.Bus.AddHandler(s.DeleteDashboardSnapshot)
-	s.Bus.AddHandler(s.SearchDashboardSnapshots)
-	s.Bus.AddHandler(s.DeleteExpiredSnapshots)
+	s.Bus.SetHandler(s.CreateDashboardSnapshot)
+	s.Bus.SetHandler(s.GetDashboardSnapshot)
+	s.Bus.SetHandler(s.DeleteDashboardSnapshot)
+	s.Bus.SetHandler(s.SearchDashboardSnapshots)
+	s.Bus.SetHandler(s.DeleteExpiredSnapshots)
 
 	return s
 }

--- a/pkg/services/datasources/service/datasource_service.go
+++ b/pkg/services/datasources/service/datasource_service.go
@@ -74,13 +74,13 @@ func ProvideService(
 		permissionsService: permissionsServices.GetDataSourceService(),
 	}
 
-	s.Bus.AddHandler(s.GetDataSources)
-	s.Bus.AddHandler(s.GetDataSourcesByType)
-	s.Bus.AddHandler(s.GetDataSource)
-	s.Bus.AddHandler(s.AddDataSource)
-	s.Bus.AddHandler(s.DeleteDataSource)
-	s.Bus.AddHandler(s.UpdateDataSource)
-	s.Bus.AddHandler(s.GetDefaultDataSource)
+	s.Bus.SetHandler(s.GetDataSources)
+	s.Bus.SetHandler(s.GetDataSourcesByType)
+	s.Bus.SetHandler(s.GetDataSource)
+	s.Bus.SetHandler(s.AddDataSource)
+	s.Bus.SetHandler(s.DeleteDataSource)
+	s.Bus.SetHandler(s.UpdateDataSource)
+	s.Bus.SetHandler(s.GetDefaultDataSource)
 
 	ac.RegisterAttributeScopeResolver(NewNameScopeResolver(store))
 	ac.RegisterAttributeScopeResolver(NewUidScopeResolver(store))

--- a/pkg/services/guardian/guardian_test.go
+++ b/pkg/services/guardian/guardian_test.go
@@ -684,7 +684,7 @@ func TestGuardianGetHiddenACL(t *testing.T) {
 	t.Run("Get hidden ACL tests", func(t *testing.T) {
 		bus.ClearBusHandlers()
 
-		bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
+		bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
 			query.Result = []*models.DashboardAclInfoDTO{
 				{Inherited: false, UserId: 1, UserLogin: "user1", Permission: models.PERMISSION_EDIT},
 				{Inherited: false, UserId: 2, UserLogin: "user2", Permission: models.PERMISSION_ADMIN},
@@ -732,7 +732,7 @@ func TestGuardianGetAclWithoutDuplicates(t *testing.T) {
 	t.Run("Get hidden ACL tests", func(t *testing.T) {
 		t.Cleanup(bus.ClearBusHandlers)
 
-		bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
+		bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
 			query.Result = []*models.DashboardAclInfoDTO{
 				{Inherited: true, UserId: 3, UserLogin: "user3", Permission: models.PERMISSION_EDIT},
 				{Inherited: false, UserId: 3, UserLogin: "user3", Permission: models.PERMISSION_VIEW},

--- a/pkg/services/guardian/guardian_util_test.go
+++ b/pkg/services/guardian/guardian_util_test.go
@@ -75,7 +75,7 @@ func permissionScenario(desc string, dashboardID int64, sc *scenarioContext,
 	sc.t.Run(desc, func(t *testing.T) {
 		bus.ClearBusHandlers()
 
-		bus.AddHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
+		bus.SetHandler("test", func(ctx context.Context, query *models.GetDashboardAclInfoListQuery) error {
 			if query.OrgID != sc.givenUser.OrgId {
 				sc.reportFailure("Invalid organization id for GetDashboardAclInfoListQuery", sc.givenUser.OrgId, query.OrgID)
 			}
@@ -95,7 +95,7 @@ func permissionScenario(desc string, dashboardID int64, sc *scenarioContext,
 			}
 		}
 
-		bus.AddHandler("test", func(ctx context.Context, query *models.GetTeamsByUserQuery) error {
+		bus.SetHandler("test", func(ctx context.Context, query *models.GetTeamsByUserQuery) error {
 			if query.OrgId != sc.givenUser.OrgId {
 				sc.reportFailure("Invalid organization id for GetTeamsByUserQuery", sc.givenUser.OrgId, query.OrgId)
 			}

--- a/pkg/services/login/authinfoservice/database/database.go
+++ b/pkg/services/login/authinfoservice/database/database.go
@@ -33,11 +33,11 @@ func ProvideAuthInfoStore(sqlStore sqlstore.Store, bus bus.Bus, secretsService s
 }
 
 func (s *AuthInfoStore) registerBusHandlers() {
-	s.bus.AddHandler(s.GetExternalUserInfoByLogin)
-	s.bus.AddHandler(s.GetAuthInfo)
-	s.bus.AddHandler(s.SetAuthInfo)
-	s.bus.AddHandler(s.UpdateAuthInfo)
-	s.bus.AddHandler(s.DeleteAuthInfo)
+	s.bus.SetHandler(s.GetExternalUserInfoByLogin)
+	s.bus.SetHandler(s.GetAuthInfo)
+	s.bus.SetHandler(s.SetAuthInfo)
+	s.bus.SetHandler(s.UpdateAuthInfo)
+	s.bus.SetHandler(s.DeleteAuthInfo)
 }
 
 func (s *AuthInfoStore) GetExternalUserInfoByLogin(ctx context.Context, query *models.GetExternalUserInfoByLoginQuery) error {

--- a/pkg/services/login/loginservice/loginservice.go
+++ b/pkg/services/login/loginservice/loginservice.go
@@ -23,7 +23,7 @@ func ProvideService(sqlStore sqlstore.Store, bus bus.Bus, quotaService *quota.Qu
 		QuotaService:    quotaService,
 		AuthInfoService: authInfoService,
 	}
-	bus.AddHandler(s.UpsertUser)
+	bus.SetHandler(s.UpsertUser)
 	return s
 }
 

--- a/pkg/services/notifications/notifications.go
+++ b/pkg/services/notifications/notifications.go
@@ -48,12 +48,12 @@ func ProvideService(bus bus.Bus, cfg *setting.Cfg, mailer Mailer) (*Notification
 		mailer:       mailer,
 	}
 
-	ns.Bus.AddHandler(ns.SendResetPasswordEmail)
-	ns.Bus.AddHandler(ns.ValidateResetPasswordCode)
-	ns.Bus.AddHandler(ns.SendEmailCommandHandler)
+	ns.Bus.SetHandler(ns.SendResetPasswordEmail)
+	ns.Bus.SetHandler(ns.ValidateResetPasswordCode)
+	ns.Bus.SetHandler(ns.SendEmailCommandHandler)
 
-	ns.Bus.AddHandler(ns.SendEmailCommandHandlerSync)
-	ns.Bus.AddHandler(ns.SendWebhookSync)
+	ns.Bus.SetHandler(ns.SendEmailCommandHandlerSync)
+	ns.Bus.SetHandler(ns.SendWebhookSync)
 
 	ns.Bus.AddEventListener(ns.signUpStartedHandler)
 	ns.Bus.AddEventListener(ns.signUpCompletedHandler)

--- a/pkg/services/provisioning/dashboards/file_reader_test.go
+++ b/pkg/services/provisioning/dashboards/file_reader_test.go
@@ -98,7 +98,7 @@ func TestDashboardFileReader(t *testing.T) {
 	defer fakeService.AssertExpectations(t)
 	setup := func() {
 		bus.ClearBusHandlers()
-		bus.AddHandler("test", mockGetDashboardQuery)
+		bus.SetHandler("test", mockGetDashboardQuery)
 		cfg = &config{
 			Name:    configName,
 			Type:    "file",

--- a/pkg/services/provisioning/dashboards/validator_test.go
+++ b/pkg/services/provisioning/dashboards/validator_test.go
@@ -23,7 +23,7 @@ func TestDuplicatesValidator(t *testing.T) {
 	fakeService := &dashboards.FakeDashboardProvisioning{}
 	defer fakeService.AssertExpectations(t)
 
-	bus.AddHandler("test", mockGetDashboardQuery)
+	bus.SetHandler("test", mockGetDashboardQuery)
 	cfg := &config{
 		Name:    "Default",
 		Type:    "file",

--- a/pkg/services/search/service.go
+++ b/pkg/services/search/service.go
@@ -19,7 +19,7 @@ func ProvideService(cfg *setting.Cfg, bus bus.Bus) *SearchService {
 			SortAlphaDesc.Name: SortAlphaDesc,
 		},
 	}
-	s.Bus.AddHandler(s.SearchHandler)
+	s.Bus.SetHandler(s.SearchHandler)
 	return s
 }
 

--- a/pkg/services/search/service_test.go
+++ b/pkg/services/search/service_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSearch_SortedResults(t *testing.T) {
-	bus.AddHandler("test", func(_ context.Context, query *FindPersistedDashboardsQuery) error {
+	bus.SetHandler("test", func(_ context.Context, query *FindPersistedDashboardsQuery) error {
 		query.Result = HitList{
 			&Hit{ID: 16, Title: "CCAA", Type: "dash-db", Tags: []string{"BB", "AA"}},
 			&Hit{ID: 10, Title: "AABB", Type: "dash-db", Tags: []string{"CC", "AA"}},
@@ -22,12 +22,12 @@ func TestSearch_SortedResults(t *testing.T) {
 		return nil
 	})
 
-	bus.AddHandler("test", func(_ context.Context, query *models.GetUserStarsQuery) error {
+	bus.SetHandler("test", func(_ context.Context, query *models.GetUserStarsQuery) error {
 		query.Result = map[int64]bool{10: true, 12: true}
 		return nil
 	})
 
-	bus.AddHandler("test", func(_ context.Context, query *models.GetSignedInUserQuery) error {
+	bus.SetHandler("test", func(_ context.Context, query *models.GetSignedInUserQuery) error {
 		query.Result = &models.SignedInUser{IsGrafanaAdmin: true}
 		return nil
 	})

--- a/pkg/services/sqlstore/alert.go
+++ b/pkg/services/sqlstore/alert.go
@@ -15,13 +15,13 @@ import (
 var timeNow = time.Now
 
 func (ss *SQLStore) addAlertQueryAndCommandHandlers() {
-	bus.AddHandler("sql", ss.HandleAlertsQuery)
-	bus.AddHandler("sql", ss.GetAlertById)
-	bus.AddHandler("sql", ss.GetAllAlertQueryHandler)
-	bus.AddHandler("sql", ss.SetAlertState)
-	bus.AddHandler("sql", ss.GetAlertStatesForDashboard)
-	bus.AddHandler("sql", ss.PauseAlert)
-	bus.AddHandler("sql", ss.PauseAllAlerts)
+	bus.SetHandler("sql", ss.HandleAlertsQuery)
+	bus.SetHandler("sql", ss.GetAlertById)
+	bus.SetHandler("sql", ss.GetAllAlertQueryHandler)
+	bus.SetHandler("sql", ss.SetAlertState)
+	bus.SetHandler("sql", ss.GetAlertStatesForDashboard)
+	bus.SetHandler("sql", ss.PauseAlert)
+	bus.SetHandler("sql", ss.PauseAllAlerts)
 }
 
 func (ss *SQLStore) GetAlertById(ctx context.Context, query *models.GetAlertByIdQuery) error {

--- a/pkg/services/sqlstore/alert_notification.go
+++ b/pkg/services/sqlstore/alert_notification.go
@@ -80,7 +80,7 @@ func (ss *SQLStore) GetAlertNotifications(ctx context.Context, query *models.Get
 }
 
 func (ss *SQLStore) addAlertNotificationUidByIdHandler() {
-	bus.AddHandler("sql", ss.GetAlertNotificationUidWithId)
+	bus.SetHandler("sql", ss.GetAlertNotificationUidWithId)
 }
 
 func (ss *SQLStore) GetAlertNotificationUidWithId(ctx context.Context, query *models.GetAlertNotificationUidQuery) error {

--- a/pkg/services/sqlstore/alert_notification_test.go
+++ b/pkg/services/sqlstore/alert_notification_test.go
@@ -22,7 +22,7 @@ func TestAlertNotificationSQLAccess(t *testing.T) {
 	setup := func() {
 		sqlStore = InitTestDB(t)
 		// Set up bus handlers
-		bus.AddHandler("deleteAlertNotification", func(ctx context.Context, cmd *models.DeleteAlertNotificationCommand) error {
+		bus.SetHandler("deleteAlertNotification", func(ctx context.Context, cmd *models.DeleteAlertNotificationCommand) error {
 			return sqlStore.DeleteAlertNotification(ctx, cmd)
 		})
 	}

--- a/pkg/services/sqlstore/apikey.go
+++ b/pkg/services/sqlstore/apikey.go
@@ -11,11 +11,11 @@ import (
 )
 
 func (ss *SQLStore) addAPIKeysQueryAndCommandHandlers() {
-	bus.AddHandler("sql", ss.GetAPIKeys)
-	bus.AddHandler("sql", ss.GetApiKeyById)
-	bus.AddHandler("sql", ss.GetApiKeyByName)
-	bus.AddHandler("sql", ss.DeleteApiKey)
-	bus.AddHandler("sql", ss.AddAPIKey)
+	bus.SetHandler("sql", ss.GetAPIKeys)
+	bus.SetHandler("sql", ss.GetApiKeyById)
+	bus.SetHandler("sql", ss.GetApiKeyByName)
+	bus.SetHandler("sql", ss.DeleteApiKey)
+	bus.SetHandler("sql", ss.AddAPIKey)
 }
 
 // GetAPIKeys queries the database based

--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -31,16 +31,16 @@ func init() {
 }
 
 func (ss *SQLStore) addDashboardQueryAndCommandHandlers() {
-	bus.AddHandler("sql", ss.GetDashboard)
-	bus.AddHandler("sql", ss.GetDashboardUIDById)
-	bus.AddHandler("sql", ss.GetDashboardTags)
-	bus.AddHandler("sql", ss.SearchDashboards)
-	bus.AddHandler("sql", ss.DeleteDashboard)
-	bus.AddHandler("sql", ss.GetDashboards)
-	bus.AddHandler("sql", ss.HasEditPermissionInFolders)
-	bus.AddHandler("sql", ss.GetDashboardPermissionsForUser)
-	bus.AddHandler("sql", ss.GetDashboardSlugById)
-	bus.AddHandler("sql", ss.HasAdminPermissionInFolders)
+	bus.SetHandler("sql", ss.GetDashboard)
+	bus.SetHandler("sql", ss.GetDashboardUIDById)
+	bus.SetHandler("sql", ss.GetDashboardTags)
+	bus.SetHandler("sql", ss.SearchDashboards)
+	bus.SetHandler("sql", ss.DeleteDashboard)
+	bus.SetHandler("sql", ss.GetDashboards)
+	bus.SetHandler("sql", ss.HasEditPermissionInFolders)
+	bus.SetHandler("sql", ss.GetDashboardPermissionsForUser)
+	bus.SetHandler("sql", ss.GetDashboardSlugById)
+	bus.SetHandler("sql", ss.HasAdminPermissionInFolders)
 }
 
 var generateNewUid func() string = util.GenerateShortUID

--- a/pkg/services/sqlstore/dashboard_acl.go
+++ b/pkg/services/sqlstore/dashboard_acl.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (ss *SQLStore) addDashboardACLQueryAndCommandHandlers() {
-	bus.AddHandler("sql", ss.GetDashboardAclInfoList)
+	bus.SetHandler("sql", ss.GetDashboardAclInfoList)
 }
 
 // GetDashboardAclInfoList returns a list of permissions for a dashboard. They can be fetched from three

--- a/pkg/services/sqlstore/dashboard_version.go
+++ b/pkg/services/sqlstore/dashboard_version.go
@@ -10,9 +10,9 @@ import (
 )
 
 func (ss *SQLStore) addDashboardVersionQueryAndCommandHandlers() {
-	bus.AddHandler("sql", ss.GetDashboardVersion)
-	bus.AddHandler("sql", ss.GetDashboardVersions)
-	bus.AddHandler("sql", ss.DeleteExpiredVersions)
+	bus.SetHandler("sql", ss.GetDashboardVersion)
+	bus.SetHandler("sql", ss.GetDashboardVersions)
+	bus.SetHandler("sql", ss.DeleteExpiredVersions)
 }
 
 // GetDashboardVersion gets the dashboard version for the given dashboard ID and version number.

--- a/pkg/services/sqlstore/login_attempt.go
+++ b/pkg/services/sqlstore/login_attempt.go
@@ -12,9 +12,9 @@ import (
 var getTimeNow = time.Now
 
 func (ss *SQLStore) addLoginAttemptQueryAndCommandHandlers() {
-	bus.AddHandler("sql", ss.CreateLoginAttempt)
-	bus.AddHandler("sql", ss.DeleteOldLoginAttempts)
-	bus.AddHandler("sql", GetUserLoginAttemptCount)
+	bus.SetHandler("sql", ss.CreateLoginAttempt)
+	bus.SetHandler("sql", ss.DeleteOldLoginAttempts)
+	bus.SetHandler("sql", GetUserLoginAttemptCount)
 }
 
 func (ss *SQLStore) CreateLoginAttempt(ctx context.Context, cmd *models.CreateLoginAttemptCommand) error {

--- a/pkg/services/sqlstore/org.go
+++ b/pkg/services/sqlstore/org.go
@@ -16,13 +16,13 @@ import (
 const MainOrgName = "Main Org."
 
 func (ss *SQLStore) addOrgQueryAndCommandHandlers() {
-	bus.AddHandler("sql", ss.GetOrgById)
-	bus.AddHandler("sql", CreateOrg)
-	bus.AddHandler("sql", ss.UpdateOrg)
-	bus.AddHandler("sql", ss.UpdateOrgAddress)
-	bus.AddHandler("sql", ss.GetOrgByNameHandler)
-	bus.AddHandler("sql", ss.SearchOrgs)
-	bus.AddHandler("sql", ss.DeleteOrg)
+	bus.SetHandler("sql", ss.GetOrgById)
+	bus.SetHandler("sql", CreateOrg)
+	bus.SetHandler("sql", ss.UpdateOrg)
+	bus.SetHandler("sql", ss.UpdateOrgAddress)
+	bus.SetHandler("sql", ss.GetOrgByNameHandler)
+	bus.SetHandler("sql", ss.SearchOrgs)
+	bus.SetHandler("sql", ss.DeleteOrg)
 }
 
 func (ss *SQLStore) SearchOrgs(ctx context.Context, query *models.SearchOrgsQuery) error {

--- a/pkg/services/sqlstore/org_users.go
+++ b/pkg/services/sqlstore/org_users.go
@@ -14,10 +14,10 @@ import (
 )
 
 func (ss *SQLStore) addOrgUsersQueryAndCommandHandlers() {
-	bus.AddHandler("sql", ss.AddOrgUser)
-	bus.AddHandler("sql", ss.RemoveOrgUser)
-	bus.AddHandler("sql", ss.GetOrgUsers)
-	bus.AddHandler("sql", ss.UpdateOrgUser)
+	bus.SetHandler("sql", ss.AddOrgUser)
+	bus.SetHandler("sql", ss.RemoveOrgUser)
+	bus.SetHandler("sql", ss.GetOrgUsers)
+	bus.SetHandler("sql", ss.UpdateOrgUser)
 }
 
 func (ss *SQLStore) AddOrgUser(ctx context.Context, cmd *models.AddOrgUserCommand) error {

--- a/pkg/services/sqlstore/playlist.go
+++ b/pkg/services/sqlstore/playlist.go
@@ -8,12 +8,12 @@ import (
 )
 
 func (ss *SQLStore) addPlaylistQueryAndCommandHandlers() {
-	bus.AddHandler("sql", ss.CreatePlaylist)
-	bus.AddHandler("sql", ss.UpdatePlaylist)
-	bus.AddHandler("sql", ss.DeletePlaylist)
-	bus.AddHandler("sql", ss.SearchPlaylists)
-	bus.AddHandler("sql", ss.GetPlaylist)
-	bus.AddHandler("sql", ss.GetPlaylistItem)
+	bus.SetHandler("sql", ss.CreatePlaylist)
+	bus.SetHandler("sql", ss.UpdatePlaylist)
+	bus.SetHandler("sql", ss.DeletePlaylist)
+	bus.SetHandler("sql", ss.SearchPlaylists)
+	bus.SetHandler("sql", ss.GetPlaylist)
+	bus.SetHandler("sql", ss.GetPlaylistItem)
 }
 
 func (ss *SQLStore) CreatePlaylist(ctx context.Context, cmd *models.CreatePlaylistCommand) error {

--- a/pkg/services/sqlstore/preferences.go
+++ b/pkg/services/sqlstore/preferences.go
@@ -10,9 +10,9 @@ import (
 )
 
 func (ss *SQLStore) addPreferencesQueryAndCommandHandlers() {
-	bus.AddHandler("sql", ss.GetPreferences)
-	bus.AddHandler("sql", ss.GetPreferencesWithDefaults)
-	bus.AddHandler("sql", ss.SavePreferences)
+	bus.SetHandler("sql", ss.GetPreferences)
+	bus.SetHandler("sql", ss.GetPreferencesWithDefaults)
+	bus.SetHandler("sql", ss.SavePreferences)
 }
 
 func (ss *SQLStore) GetPreferencesWithDefaults(ctx context.Context, query *models.GetPreferencesWithDefaultsQuery) error {

--- a/pkg/services/sqlstore/quota.go
+++ b/pkg/services/sqlstore/quota.go
@@ -16,13 +16,13 @@ const (
 )
 
 func (ss *SQLStore) addQuotaQueryAndCommandHandlers() {
-	bus.AddHandler("sql", ss.GetOrgQuotaByTarget)
-	bus.AddHandler("sql", ss.GetOrgQuotas)
-	bus.AddHandler("sql", ss.UpdateOrgQuota)
-	bus.AddHandler("sql", ss.GetUserQuotaByTarget)
-	bus.AddHandler("sql", ss.GetUserQuotas)
-	bus.AddHandler("sql", ss.UpdateUserQuota)
-	bus.AddHandler("sql", ss.GetGlobalQuotaByTarget)
+	bus.SetHandler("sql", ss.GetOrgQuotaByTarget)
+	bus.SetHandler("sql", ss.GetOrgQuotas)
+	bus.SetHandler("sql", ss.UpdateOrgQuota)
+	bus.SetHandler("sql", ss.GetUserQuotaByTarget)
+	bus.SetHandler("sql", ss.GetUserQuotas)
+	bus.SetHandler("sql", ss.UpdateUserQuota)
+	bus.SetHandler("sql", ss.GetGlobalQuotaByTarget)
 }
 
 type targetCount struct {

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -132,7 +132,7 @@ func newSQLStore(cfg *setting.Cfg, cacheService *localcache.CacheService, b bus.
 	ss.addTeamQueryAndCommandHandlers()
 	ss.addOrgQueryAndCommandHandlers()
 
-	bus.AddHandler("sql", ss.GetDBHealthQuery)
+	bus.SetHandler("sql", ss.GetDBHealthQuery)
 
 	// if err := ss.Reset(); err != nil {
 	// 	return nil, err

--- a/pkg/services/sqlstore/star.go
+++ b/pkg/services/sqlstore/star.go
@@ -8,10 +8,10 @@ import (
 )
 
 func (ss *SQLStore) addStarQueryAndCommandHandlers() {
-	bus.AddHandler("sql", ss.StarDashboard)
-	bus.AddHandler("sql", ss.UnstarDashboard)
-	bus.AddHandler("sql", ss.GetUserStars)
-	bus.AddHandler("sql", ss.IsStarredByUserCtx)
+	bus.SetHandler("sql", ss.StarDashboard)
+	bus.SetHandler("sql", ss.UnstarDashboard)
+	bus.SetHandler("sql", ss.GetUserStars)
+	bus.SetHandler("sql", ss.IsStarredByUserCtx)
 }
 
 func (ss *SQLStore) IsStarredByUserCtx(ctx context.Context, query *models.IsStarredByUserQuery) error {

--- a/pkg/services/sqlstore/stats.go
+++ b/pkg/services/sqlstore/stats.go
@@ -10,12 +10,12 @@ import (
 )
 
 func (ss *SQLStore) addStatsQueryAndCommandHandlers() {
-	bus.AddHandler("sql", ss.GetAdminStats)
-	bus.AddHandler("sql", ss.GetSystemUserCountStats)
-	bus.AddHandler("sql", ss.GetAlertNotifiersUsageStats)
-	bus.AddHandler("sql", ss.GetDataSourceAccessStats)
-	bus.AddHandler("sql", ss.GetDataSourceStats)
-	bus.AddHandler("sql", ss.GetSystemStats)
+	bus.SetHandler("sql", ss.GetAdminStats)
+	bus.SetHandler("sql", ss.GetSystemUserCountStats)
+	bus.SetHandler("sql", ss.GetAlertNotifiersUsageStats)
+	bus.SetHandler("sql", ss.GetDataSourceAccessStats)
+	bus.SetHandler("sql", ss.GetDataSourceStats)
+	bus.SetHandler("sql", ss.GetSystemStats)
 }
 
 const activeUserTimeLimit = time.Hour * 24 * 30

--- a/pkg/services/sqlstore/team.go
+++ b/pkg/services/sqlstore/team.go
@@ -14,16 +14,16 @@ import (
 )
 
 func (ss *SQLStore) addTeamQueryAndCommandHandlers() {
-	bus.AddHandler("sql", ss.UpdateTeam)
-	bus.AddHandler("sql", ss.DeleteTeam)
-	bus.AddHandler("sql", ss.SearchTeams)
-	bus.AddHandler("sql", ss.GetTeamById)
-	bus.AddHandler("sql", ss.GetTeamsByUser)
+	bus.SetHandler("sql", ss.UpdateTeam)
+	bus.SetHandler("sql", ss.DeleteTeam)
+	bus.SetHandler("sql", ss.SearchTeams)
+	bus.SetHandler("sql", ss.GetTeamById)
+	bus.SetHandler("sql", ss.GetTeamsByUser)
 
-	bus.AddHandler("sql", ss.UpdateTeamMember)
-	bus.AddHandler("sql", ss.RemoveTeamMember)
-	bus.AddHandler("sql", ss.GetTeamMembers)
-	bus.AddHandler("sql", IsAdminOfTeams)
+	bus.SetHandler("sql", ss.UpdateTeamMember)
+	bus.SetHandler("sql", ss.RemoveTeamMember)
+	bus.SetHandler("sql", ss.GetTeamMembers)
+	bus.SetHandler("sql", IsAdminOfTeams)
 }
 
 type TeamStore interface {

--- a/pkg/services/sqlstore/temp_user.go
+++ b/pkg/services/sqlstore/temp_user.go
@@ -9,12 +9,12 @@ import (
 )
 
 func (ss *SQLStore) addTempUserQueryAndCommandHandlers() {
-	bus.AddHandler("sql", ss.CreateTempUser)
-	bus.AddHandler("sql", ss.GetTempUsersQuery)
-	bus.AddHandler("sql", ss.UpdateTempUserStatus)
-	bus.AddHandler("sql", ss.GetTempUserByCode)
-	bus.AddHandler("sql", ss.UpdateTempUserWithEmailSent)
-	bus.AddHandler("sql", ss.ExpireOldUserInvites)
+	bus.SetHandler("sql", ss.CreateTempUser)
+	bus.SetHandler("sql", ss.GetTempUsersQuery)
+	bus.SetHandler("sql", ss.UpdateTempUserStatus)
+	bus.SetHandler("sql", ss.GetTempUserByCode)
+	bus.SetHandler("sql", ss.UpdateTempUserWithEmailSent)
+	bus.SetHandler("sql", ss.ExpireOldUserInvites)
 }
 
 func (ss *SQLStore) UpdateTempUserStatus(ctx context.Context, cmd *models.UpdateTempUserStatusCommand) error {

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -16,22 +16,22 @@ import (
 )
 
 func (ss *SQLStore) addUserQueryAndCommandHandlers() {
-	ss.Bus.AddHandler(ss.GetSignedInUserWithCacheCtx)
+	ss.Bus.SetHandler(ss.GetSignedInUserWithCacheCtx)
 
-	bus.AddHandler("sql", ss.GetUserById)
-	bus.AddHandler("sql", ss.UpdateUser)
-	bus.AddHandler("sql", ss.ChangeUserPassword)
-	bus.AddHandler("sql", ss.GetUserByLogin)
-	bus.AddHandler("sql", ss.GetUserByEmail)
-	bus.AddHandler("sql", ss.SetUsingOrg)
-	bus.AddHandler("sql", ss.UpdateUserLastSeenAt)
-	bus.AddHandler("sql", ss.GetUserProfile)
-	bus.AddHandler("sql", SearchUsers)
-	bus.AddHandler("sql", ss.GetUserOrgList)
-	bus.AddHandler("sql", ss.DisableUser)
-	bus.AddHandler("sql", ss.BatchDisableUsers)
-	bus.AddHandler("sql", ss.DeleteUser)
-	bus.AddHandler("sql", ss.SetUserHelpFlag)
+	bus.SetHandler("sql", ss.GetUserById)
+	bus.SetHandler("sql", ss.UpdateUser)
+	bus.SetHandler("sql", ss.ChangeUserPassword)
+	bus.SetHandler("sql", ss.GetUserByLogin)
+	bus.SetHandler("sql", ss.GetUserByEmail)
+	bus.SetHandler("sql", ss.SetUsingOrg)
+	bus.SetHandler("sql", ss.UpdateUserLastSeenAt)
+	bus.SetHandler("sql", ss.GetUserProfile)
+	bus.SetHandler("sql", SearchUsers)
+	bus.SetHandler("sql", ss.GetUserOrgList)
+	bus.SetHandler("sql", ss.DisableUser)
+	bus.SetHandler("sql", ss.BatchDisableUsers)
+	bus.SetHandler("sql", ss.DeleteUser)
+	bus.SetHandler("sql", ss.SetUserHelpFlag)
 }
 
 func getOrgIdForNewUser(sess *DBSession, cmd models.CreateUserCommand) (int64, error) {


### PR DESCRIPTION
This change to pkg/bus does four things:
1. It removes all references to differences between DispatchWithCtx,
   PublishWithCtx and Dispatch, Publish. The non-context functions were
   removed long ago, and the naming already simplified to Dispatch,
   Publish. It also removes the two different maps for handlers and
   listeners with and without context parameters. The non-context maps
   are never written to, so they can be removed without danger.
2. It adds a mutex to the InProcBus, which is used when setting handlers,
   adding listeners, or retrieving handlers and listeners during
   Dispatch and Publish. This makes it safe to concurrently call
   SetHandler and Dispatch, or AddListener and Publish.
3. It adds a few detailed comments to the Bus interface type.
4. It renames AddHandler to SetHandler to convey that there can be only
   one handler per message type.