### PR TITLE
Access Control: Fix Filter to correctly handle duplicated scopes

### DIFF
--- a/pkg/services/accesscontrol/filter.go
+++ b/pkg/services/accesscontrol/filter.go
@@ -51,7 +51,7 @@ func Filter(user *models.SignedInUser, sqlID, prefix string, actions ...string) 
 		if len(ids) == 0 {
 			return denyQuery, nil
 		}
-		for _, id := range ids {
+		for id := range ids {
 			result[id] += 1
 		}
 	}
@@ -84,14 +84,15 @@ func Filter(user *models.SignedInUser, sqlID, prefix string, actions ...string) 
 	return SQLFilter{query.String(), ids}, nil
 }
 
-func parseScopes(prefix string, scopes []string) (ids []int64, hasWildcard bool) {
+func parseScopes(prefix string, scopes []string) (ids map[int64]struct{}, hasWildcard bool) {
+	ids = make(map[int64]struct{})
 	for _, scope := range scopes {
 		if strings.HasPrefix(scope, prefix) || scope == "*" {
 			if id := strings.TrimPrefix(scope, prefix); id == "*" || id == ":*" || id == ":id:*" {
 				return nil, true
 			}
 			if id, err := parseScopeID(scope); err == nil {
-				ids = append(ids, id)
+				ids[id] = struct{}{}
 			}
 		}
 	}

--- a/pkg/services/accesscontrol/filter_test.go
+++ b/pkg/services/accesscontrol/filter_test.go
@@ -129,6 +129,18 @@ func TestFilter_Datasources(t *testing.T) {
 			expectedDataSources: []string{},
 			expectErr:           false,
 		},
+		{
+			desc:    "expect to not crash if duplicates in the scope",
+			sqlID:   "data_source.id",
+			prefix:  "datasources",
+			actions: []string{"datasources:read", "datasources:write"},
+			permissions: map[string][]string{
+				"datasources:read":  {"datasources:id:3", "datasources:id:7", "datasources:id:8", "datasources:id:3", "datasources:id:8"},
+				"datasources:write": {"datasources:id:3", "datasources:id:7"},
+			},
+			expectedDataSources: []string{"ds:3", "ds:7"},
+			expectErr:           false,
+		},
 	}
 
 	// set sqlIDAcceptList before running tests


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Currently, user permissions can have duplicates in the slice of scopes for action (see the test). In this case, the temporary map `result` where value is a number of times the Id was detected in the scope can contain an incorrect number. When it creates a list of `ids` it picks only those ids that are detected the same number of times as number of actions, and considering the behavior, it can cause either false negative or false positive matches

