### PR TITLE
Storage: create a specific HTTP service (option A)

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -111,7 +111,7 @@ type HTTPServer struct {
 	Live                         *live.GrafanaLive
 	LivePushGateway              *pushhttp.Gateway
 	ThumbService                 thumbs.Service
-	StorageService               store.StorageService
+	StorageService               store.HTTPStorageService
 	ContextHandler               *contexthandler.ContextHandler
 	SQLStore                     sqlstore.Store
 	AlertEngine                  *alerting.AlertEngine
@@ -171,7 +171,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 	pluginsUpdateChecker *updatechecker.PluginsService, searchUsersService searchusers.Service,
 	dataSourcesService datasources.DataSourceService, secretsService secrets.Service, queryDataService *query.Service,
 	ldapGroups ldap.Groups, teamGuardian teamguardian.TeamGuardian, serviceaccountsService serviceaccounts.Service,
-	authInfoService login.AuthInfoService, permissionsServices accesscontrol.PermissionsServices, storageService store.StorageService,
+	authInfoService login.AuthInfoService, permissionsServices accesscontrol.PermissionsServices, storageService store.HTTPStorageService,
 	notificationService *notifications.NotificationService, dashboardService dashboards.DashboardService,
 	dashboardProvisioningService dashboards.DashboardProvisioningService, folderService dashboards.FolderService,
 	datasourcePermissionsService permissions.DatasourcePermissionsService, alertNotificationService *alerting.AlertNotificationService,

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -160,6 +160,7 @@ var wireBasicSet = wire.NewSet(
 	search.ProvideService,
 	searchV2.ProvideService,
 	store.ProvideService,
+	store.ProvideHTTPService,
 	live.ProvideService,
 	pushhttp.ProvideService,
 	plugincontext.ProvideService,

--- a/pkg/services/store/http.go
+++ b/pkg/services/store/http.go
@@ -1,0 +1,59 @@
+package store
+
+import (
+	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+// HTTPStorageService passes raw HTTP requests to a well typed storage service
+type HTTPStorageService interface {
+	Browse(c *models.ReqContext) response.Response
+	Upload(c *models.ReqContext) response.Response
+	Delete(c *models.ReqContext) response.Response
+}
+
+type httpStorage struct {
+	store StorageService
+}
+
+func ProvideHTTPService(store StorageService) HTTPStorageService {
+	return &httpStorage{
+		store: store,
+	}
+}
+
+func (s *httpStorage) Upload(c *models.ReqContext) response.Response {
+	action := "Upload"
+	scope, path := getPathAndScope(c)
+
+	return response.JSON(200, map[string]string{
+		"action": action,
+		"scope":  scope,
+		"path":   path,
+	})
+}
+
+func (s *httpStorage) Delete(c *models.ReqContext) response.Response {
+	action := "Delete"
+	scope, path := getPathAndScope(c)
+
+	return response.JSON(200, map[string]string{
+		"action": action,
+		"scope":  scope,
+		"path":   path,
+	})
+}
+
+func (s *httpStorage) Browse(c *models.ReqContext) response.Response {
+	params := web.Params(c.Req)
+	path := params["*"]
+	frame, err := s.store.List(c.Req.Context(), c.SignedInUser, path)
+	if err != nil {
+		return response.Error(400, "error reading path", err)
+	}
+	if frame == nil {
+		return response.Error(404, "not found", nil)
+	}
+	return response.JSONStreaming(200, frame)
+}


### PR DESCRIPTION
Thinking about approaches to make the storage API more explicit.  It seems we want to separate our untyped calls that take raw `c *models.ReqContext` from the real API.

This approach proposes a new service for this translation

See also:
* https://github.com/grafana/grafana/pull/46604
* https://github.com/grafana/grafana/pull/46669
* https://github.com/grafana/grafana/pull/46671