### PR TITLE
Prometheus/Loki: Allow custom value in operation selects

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
@@ -120,4 +120,5 @@ const operators = [
   { label: '=~', value: '=~' },
   { label: '=', value: '=' },
   { label: '!=', value: '!=' },
+  { label: '!~', value: '!~' },
 ];

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationParamEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationParamEditor.tsx
@@ -76,6 +76,7 @@ function SelectInputParamEditor({
       value={valueOption}
       options={selectOptions}
       placeholder={paramDef.placeholder}
+      allowCustomValue={true}
       onChange={(value) => onChange(index, value.value!)}
     />
   );


### PR DESCRIPTION
Allow custom values in selects like the rate range vector

Also adds the missing operator to label filters 