### PR TITLE
Graphite: Fallback to hardcoded list of functions when no functions are returned

### DIFF
--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -292,6 +292,14 @@ describe('graphiteDatasource', () => {
         },
       });
     });
+
+    it('should use hardcoded list of functions when no functions are returned', async () => {
+      fetchMock.mockImplementation(() => {
+        return of(createFetchResponse('{}'));
+      });
+      const funcDefs = await ctx.ds.getFuncDefs();
+      expect(Object.keys(funcDefs)).not.toHaveLength(0);
+    });
   });
 
   describe('building graphite params', () => {

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -769,6 +769,15 @@ export class GraphiteDatasource
           } else {
             this.funcDefs = gfunc.parseFuncDefs(results.data);
           }
+
+          // When /functions endpoint returns application/json response but containing invalid JSON the fix above
+          // wont' be triggered due to the changes in https://github.com/grafana/grafana/pull/45598 (parsing happens
+          // in fetch and Graphite receives an empty object and no error). In such cases, when the provided JSON
+          // seems empty we fallback to the hardcoded list of functions.
+          // See also: https://github.com/grafana/grafana/issues/45948
+          if (Object.keys(this.funcDefs).length === 0) {
+            this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
+          }
           return this.funcDefs;
         }),
         catchError((error: any) => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Graphite Query editor has[ a workaround](https://github.com/grafana/grafana/pull/32305/files#diff-c27e82d1dbdf51beeab4bc60a1546fce8a7ffec7a7905f78f4fee06375ab05cbR584) for Graphite bug -[ returning invalid JSON](https://github.com/graphite-project/graphite-web/issues/2609). The recent[ change in Grafana’s core fetch function](https://github.com/grafana/grafana/pull/45598/files) caused the workaround to stop working as the core’s fetch.ts attempts to parse JSON and passes an empty object as the response body to the query editor if JSON is invalid. When an empty object is passed, the query editor assumes /functions endpoint returned no available functions. That causes empty list and red rectangles at function names. Previously (before that core changes) the query editor was doing the parsing and handling invalid JSON internally.

To mitigate the problem Graphite will fallback to hardcoded list of functions when no functions are returned.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #45948

**Special notes for your reviewer**:

Can be tested with latest Grafana and latest Graphite version (you can use devenv).