### PR TITLE
Alerting: Add resolved count to notification title when both firing and resolved present

### DIFF
--- a/pkg/services/ngalert/notifier/channels/default_template.go
+++ b/pkg/services/ngalert/notifier/channels/default_template.go
@@ -12,7 +12,7 @@ import (
 const DefaultMessageTitleEmbed = `{{ template "default.title" . }}`
 
 var DefaultTemplateString = `
-{{ define "__subject" }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}{{ end }}
+{{ define "__subject" }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ if gt (.Alerts.Resolved | len) 0 }}, RESOLVED:{{ .Alerts.Resolved | len }}{{ end }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}{{ end }}
 
 {{ define "__text_alert_list" }}{{ range . }}
 Value: {{ or .ValueString "[no value]" }}

--- a/pkg/services/ngalert/notifier/channels/default_template_test.go
+++ b/pkg/services/ngalert/notifier/channels/default_template_test.go
@@ -86,7 +86,7 @@ func TestDefaultTemplateString(t *testing.T) {
 	}{
 		{
 			templateString: DefaultMessageTitleEmbed,
-			expected:       `[FIRING:2]  (alert1)`,
+			expected:       `[FIRING:2, RESOLVED:2]  (alert1)`,
 		},
 		{
 			templateString: `{{ template "default.message" .}}`,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Closes #42415

**Special notes for your reviewer**:
Simple PR, just adds "RESOLVED: <count>" alongside "FIRING: <count>" when both firing and resolved alerts exist together in a single route group notification.

***Screenshots***:

****Previous****:

![image](https://user-images.githubusercontent.com/8484471/158847871-23e0a8f5-bb8a-4058-bd04-ddcfe78f12a4.png)

****New****:

![image](https://user-images.githubusercontent.com/8484471/158848228-2ff79bb4-93d0-4a9c-97e2-ab308562d4f4.png)
