### PR TITLE
Explore/Logs: Improve and add descriptions of Explore's Escape newlines feature

### DIFF
--- a/docs/sources/explore/logs-integration.md
+++ b/docs/sources/explore/logs-integration.md
@@ -101,7 +101,7 @@ Each log row has an extendable area with its labels and detected fields, for mor
 
 Explore automatically detects some incorrectly escaped sequences in log lines, such as newlines (`\n`, `\r`) or tabs (`\t`). When it detects such sequences, Explore provides an "Escape newlines" option.
 
-To automatically fix detected incorrectly escaped sequences:
+To automatically fix incorrectly escaped sequences that Explore has detected:
 
 1. Click "Escape newlines" to replace the sequences.
 2. Manually review the replacements to confirm their correctness.

--- a/docs/sources/explore/logs-integration.md
+++ b/docs/sources/explore/logs-integration.md
@@ -101,7 +101,7 @@ Each log row has an extendable area with its labels and detected fields, for mor
 
 > **Note:** Available in Grafana 7.5 and later versions.
 
-Explore can automatically detect and attempt to fix incorrectly escaped sequences in log lines, such as newlines (`\n`, `\r`) or tabs (`\t`). This feature appears only when Explore detects incorrectly escaped sequences.
+Explore automatically detects some incorrectly escaped sequences in log lines, such as newlines (`\n`, `\r`) or tabs (`\t`). When it detects such sequences, Explore provides an "Escape newlines" option.
 
 1. Click the "Escape newlines" button to fix incorrectly escaped sequences.
 2. Manually review the replacements to confirm that the detection and replacement were correct.

--- a/docs/sources/explore/logs-integration.md
+++ b/docs/sources/explore/logs-integration.md
@@ -97,6 +97,16 @@ You can change the order of received logs from the default descending order (new
 
 Each log row has an extendable area with its labels and detected fields, for more robust interaction. For all labels we have added the ability to filter for (positive filter) and filter out (negative filter) selected labels. Each field or label also has a stats icon to display ad-hoc statistics in relation to all displayed logs.
 
+### Escaping newlines
+
+> **Note:** Available in Grafana 7.5 and later versions.
+
+Explore can automatically detect and attempt to fix incorrectly escaped sequences in log lines, such as newlines (`\n`, `\r`) or tabs (`\t`). This feature appears only when Explore detects incorrectly escaped sequences.
+
+1. Click the "Escape newlines" button to fix incorrectly escaped sequences.
+2. Manually review the replacements to confirm that the detection and replacement were correct.
+3. To revert the replacements, click "Remove escaping".
+
 #### Derived fields links
 
 By using Derived fields, you can turn any part of a log message into an internal or external link. The created link is visible as a button next to the Detected field in the Log details view.

--- a/docs/sources/explore/logs-integration.md
+++ b/docs/sources/explore/logs-integration.md
@@ -106,7 +106,7 @@ To automatically fix incorrectly escaped sequences that Explore has detected:
 1. Click "Escape newlines" to replace the sequences.
 2. Manually review the replacements to confirm their correctness.
 
-After replacing these sequences, Explore changes the option from "Escape newlines" to "Remove escaping". Clicking this option reverts the replacements.
+Explore replaces these sequences. When it does so, the option will change from "Escape newlines" to "Remove escaping". Evaluate the changes as the parsing may not be accurate based on the input received. You can revert the replacements by clicking "Remove escaping".
 
 #### Derived fields links
 

--- a/docs/sources/explore/logs-integration.md
+++ b/docs/sources/explore/logs-integration.md
@@ -99,8 +99,6 @@ Each log row has an extendable area with its labels and detected fields, for mor
 
 ### Escaping newlines
 
-> **Note:** Available in Grafana 7.5 and later versions.
-
 Explore automatically detects some incorrectly escaped sequences in log lines, such as newlines (`\n`, `\r`) or tabs (`\t`). When it detects such sequences, Explore provides an "Escape newlines" option.
 
 To automatically fix detected incorrectly escaped sequences:

--- a/docs/sources/explore/logs-integration.md
+++ b/docs/sources/explore/logs-integration.md
@@ -103,9 +103,12 @@ Each log row has an extendable area with its labels and detected fields, for mor
 
 Explore automatically detects some incorrectly escaped sequences in log lines, such as newlines (`\n`, `\r`) or tabs (`\t`). When it detects such sequences, Explore provides an "Escape newlines" option.
 
-1. Click the "Escape newlines" button to fix incorrectly escaped sequences.
-2. Manually review the replacements to confirm that the detection and replacement were correct.
-3. To revert the replacements, click "Remove escaping".
+To automatically fix detected incorrectly escaped sequences:
+
+1. Click "Escape newlines" to replace the sequences.
+2. Manually review the replacements to confirm their correctness.
+
+After replacing these sequences, Explore changes the option from "Escape newlines" to "Remove escaping". Clicking this option reverts the replacements.
 
 #### Derived fields links
 

--- a/public/app/features/explore/LogsMetaRow.tsx
+++ b/public/app/features/explore/LogsMetaRow.tsx
@@ -71,7 +71,7 @@ export const LogsMetaRow: React.FC<Props> = React.memo(
         label: 'Your logs might have incorrectly escaped content',
         value: (
           <Tooltip
-            content="We suggest to try to fix the escaping of your log lines first. This is an experimental feature, your logs might not be correctly escaped."
+            content="Attempt to automatically fix incorrectly escaped newline and tab sequences in log lines. Manually review the results to confirm that the replacements are correct."
             placement="right"
           >
             <Button variant="secondary" size="sm" onClick={onEscapeNewlines}>

--- a/public/app/features/explore/LogsMetaRow.tsx
+++ b/public/app/features/explore/LogsMetaRow.tsx
@@ -71,7 +71,7 @@ export const LogsMetaRow: React.FC<Props> = React.memo(
         label: 'Your logs might have incorrectly escaped content',
         value: (
           <Tooltip
-            content="Attempt to automatically fix incorrectly escaped newline and tab sequences in log lines. Manually review the results to confirm that the replacements are correct."
+            content="Fix incorrectly escaped newline and tab sequences in log lines. Manually review the results to confirm that the replacements are correct."
             placement="right"
           >
             <Button variant="secondary" size="sm" onClick={onEscapeNewlines}>


### PR DESCRIPTION
**What this PR does / why we need it**:

Per issue #45770, the tooltip describing the "Escape newlines" feature in Explore suggests the feature is experimental, which can be interpreted to mean the feature might be removed. The intent was to communicate to users that the results should be manually confirmed, since the automatic replacement of incorrectly escaped sequences might not always be accurate.

This PR rewrites the tooltip to clarify these points, and adds documentation describing the feature.

**Which issue(s) this PR fixes**:

Fixes #45770 

**Special notes for your reviewer**:

This PR changes a tooltip in code and also adds supporting documentation. Please let me know if these changes should be split into separate PRs for the code change and docs addition.