### PR TITLE
intentapi: Specify coremodel component

### DIFF
--- a/compgen.yaml
+++ b/compgen.yaml
@@ -4,6 +4,7 @@ groups:
       DefinesCoremodel:
         ruletype: goident
         name: Coremodel
+        kind: struct
         implements:
           - "github.com/grafana/grafana/internal/components.Coremodel"
       ProvidesCoremodel:
@@ -12,4 +13,3 @@ groups:
         kind: func
         implements:
           - "github.com/grafana/grafana/internal/components.CoremodelProvider"
-        # TODO would be really lovely to enforce some type uniformity here

--- a/compgen.yaml
+++ b/compgen.yaml
@@ -1,0 +1,15 @@
+groups:
+  coremodel:
+    must:
+      DefinesCoremodel:
+        ruletype: goident
+        name: Coremodel
+        implements:
+          - "github.com/grafana/grafana/internal/components.Coremodel"
+      ProvidesCoremodel:
+        ruletype: goident
+        name: ProvideCoremodel
+        kind: func
+        implements:
+          - "github.com/grafana/grafana/internal/components.CoremodelProvider"
+        # TODO would be really lovely to enforce some type uniformity here

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -19,6 +19,9 @@ type Coremodel interface {
 	RegisterController(ctrl.Manager) error
 }
 
+// CoremodelProvider is a wire-friendly func that provides a coremodel.
+type CoremodelProvider func(store Store, loader SchemaLoader) (*Coremodel, error)
+
 // SchemaLoader is a generic schema loader, that can load different schema types.
 type SchemaLoader interface {
 	LoadSchema(

--- a/internal/components/datasource/componentroot
+++ b/internal/components/datasource/componentroot
@@ -1,1 +1,0 @@
-(presence of this file marks the root of a component. maybe we'll put something in here, but intentionally blank for now)

--- a/internal/components/datasource/componentroot.yaml
+++ b/internal/components/datasource/componentroot.yaml
@@ -1,0 +1,4 @@
+groups:
+  - "coremodel"
+owners:
+  - "@grafana/backend-platform"


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces components (a la [compgen](https://github.com/grafana/hackathon-2022-03-compgen)) onto the intent-api branch. Rules are, for now, pretty simple - there has to be a type-valid `Coremodel` struct, and a type-valid `ProvideCoremodel` func.

Also cleans up an old OWNERS file, and adds another interface (func type, actually) for coremodel component uniformity checking.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

