### PR TITLE
Grafana-UI: Fix TimeSeries not updating when timeZone is changed

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
+++ b/packages/grafana-ui/src/components/GraphNG/GraphNG.tsx
@@ -216,7 +216,7 @@ export class GraphNG extends React.Component<GraphNGProps, GraphNGState> {
 
     const propsChanged = !sameProps(prevProps, this.props, propsToDiff);
 
-    if (frames !== prevProps.frames || propsChanged) {
+    if (frames !== prevProps.frames || propsChanged || timeZone !== prevProps.timeZone) {
       let newState = this.prepState(this.props, false);
 
       if (newState) {

--- a/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
@@ -9,7 +9,7 @@ import { withTheme2 } from '../../themes/ThemeContext';
 import { PanelContext, PanelContextRoot } from '../PanelChrome/PanelContext';
 import { PropDiffFn } from '../../../../../packages/grafana-ui/src/components/GraphNG/GraphNG';
 
-const propsToDiff: Array<string | PropDiffFn> = ['legend', 'options', 'timeZone'];
+const propsToDiff: Array<string | PropDiffFn> = ['legend', 'options'];
 
 type TimeSeriesProps = Omit<GraphNGProps, 'prepConfig' | 'propsToDiff' | 'renderLegend'>;
 

--- a/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/grafana-ui/src/components/TimeSeries/TimeSeries.tsx
@@ -9,7 +9,7 @@ import { withTheme2 } from '../../themes/ThemeContext';
 import { PanelContext, PanelContextRoot } from '../PanelChrome/PanelContext';
 import { PropDiffFn } from '../../../../../packages/grafana-ui/src/components/GraphNG/GraphNG';
 
-const propsToDiff: Array<string | PropDiffFn> = ['legend', 'options'];
+const propsToDiff: Array<string | PropDiffFn> = ['legend', 'options', 'timeZone'];
 
 type TimeSeriesProps = Omit<GraphNGProps, 'prepConfig' | 'propsToDiff' | 'renderLegend'>;
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes an issue with timeseries panels that are not in the viewport not being updated when the timezone is changed in the date range picker.

**Which issue(s) this PR fixes**:

Fixes #46536

**Special notes for your reviewer**:

This was a problem because on the `componentDidUpdate` method of `GraphNG`, it does the following check to update the `config` of the chart:

```
const propsChanged = !sameProps(prevProps, this.props, propsToDiff);

if (frames !== prevProps.frames || propsChanged) {
  ...update the state
}
```

But because a timezone change does not change the frame of the graph AND it was not included in the `propsToDiff`, this would not cause a rerender of the graph. Adding `timeZone` to the `propsToDiff` makes sure we do rerender the panel when the `timeZone` changes.