### PR TITLE
Unified Alerting, Issue 41156: Clean up expired silences.

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -49,8 +49,6 @@ const (
 	silencesFilename        = "silences"
 
 	workingDir = "alerting"
-	// How long should we keep silences and notification entries on-disk after they've served their purpose.
-	retentionNotificationsAndSilences = 5 * 24 * time.Hour
 	// maintenanceNotificationAndSilences how often should we flush and gargabe collect notifications and silences
 	maintenanceNotificationAndSilences = 15 * time.Minute
 	// defaultResolveTimeout is the default timeout used for resolving an alert
@@ -59,6 +57,10 @@ const (
 	// memoryAlertsGCInterval is the interval at which we'll remove resolved alerts from memory.
 	memoryAlertsGCInterval = 30 * time.Minute
 )
+
+// How long should we keep silences and notification entries on-disk after they've served their purpose.
+var retentionNotificationsAndSilences = 5 * 24 * time.Hour
+var silenceMaintenanceInterval = 15 * time.Minute
 
 func init() {
 	silence.ValidateMatcher = func(m *pb.Matcher) error {
@@ -185,7 +187,13 @@ func newAlertmanager(ctx context.Context, orgID int64, cfg *setting.Cfg, store s
 
 	am.wg.Add(1)
 	go func() {
-		am.silences.Maintenance(15*time.Minute, silencesFilePath, am.stopc, func() (int64, error) {
+		am.silences.Maintenance(silenceMaintenanceInterval, silencesFilePath, am.stopc, func() (int64, error) {
+			// Delete silences older than the retention period.
+			if _, err := am.silences.GC(); err != nil {
+				return 0, err
+			}
+
+			// Snapshot our silences to the Grafana KV store
 			return am.fileStore.Persist(ctx, silencesFilename, am.silences)
 		})
 		am.wg.Done()

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -190,7 +190,8 @@ func newAlertmanager(ctx context.Context, orgID int64, cfg *setting.Cfg, store s
 		am.silences.Maintenance(silenceMaintenanceInterval, silencesFilePath, am.stopc, func() (int64, error) {
 			// Delete silences older than the retention period.
 			if _, err := am.silences.GC(); err != nil {
-				return 0, err
+				am.logger.Error("Silence Garbage Collection Failed at %v: %v", time.Now(), err)
+				// Don't return here - we need to snapshot our state first.
 			}
 
 			// Snapshot our silences to the Grafana KV store

--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -13,10 +13,12 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/prometheus/alertmanager/api/v2/models"
+	amv2 "github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/alertmanager/provider/mem"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -345,4 +347,81 @@ func TestPutAlert(t *testing.T) {
 			require.Equal(t, expAlerts, alerts)
 		})
 	}
+}
+
+// Tests cleanup of expired Silences. We rely on prometheus/alertmanager for
+// our alert silencing functionality, so we rely on its tests. However, we
+// implement a custom maintenance function for silences, because we snapshot
+// our data differently, so we test that functionality.
+func TestSilenceCleanup(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	// TODO: We have to use a real clock because Prometheus doesn't support clock
+	// injection. So modify the retention constant. This isn't great - we should
+	// make this an argument to the alertmanager so we can safely change it.
+	oldRetention := retentionNotificationsAndSilences
+	retentionNotificationsAndSilences = 30 * time.Millisecond
+	oldMaintenance := silenceMaintenanceInterval
+	silenceMaintenanceInterval = 15 * time.Millisecond
+	defer func() {
+		retentionNotificationsAndSilences = oldRetention
+		silenceMaintenanceInterval = oldMaintenance
+	}()
+
+	am := setupAMTest(t)
+	now := time.Now()
+	dt := func(t time.Time) strfmt.DateTime { return strfmt.DateTime(t) }
+
+	makeSilence := func(comment string, createdBy string,
+		startsAt, endsAt strfmt.DateTime, matchers amv2.Matchers) *apimodels.PostableSilence {
+		return &apimodels.PostableSilence{
+			ID: "",
+			Silence: amv2.Silence{
+				Comment:   &comment,
+				CreatedBy: &createdBy,
+				StartsAt:  &startsAt,
+				EndsAt:    &endsAt,
+				Matchers:  matchers,
+			},
+		}
+	}
+
+	tru := true
+	testString := "testName"
+	matchers := amv2.Matchers{&amv2.Matcher{Name: &testString, IsEqual: &tru, IsRegex: &tru, Value: &testString}}
+	// Create silences - one in the future, one currently active, one expired but
+	// retained, one expired and not retained.
+	silences := []*apimodels.PostableSilence{
+		// Active in future
+		makeSilence("", "tests", dt(now.Add(5*time.Hour)), dt(now.Add(6*time.Hour)), matchers),
+		// Active now
+		makeSilence("", "tests", dt(now.Add(-5*time.Hour)), dt(now.Add(6*time.Hour)), matchers),
+		// Expiring soon
+		makeSilence("", "tests", dt(now.Add(-5*time.Hour)), dt(now.Add(2*time.Second)), matchers),
+		// Expiring *very* soon
+		makeSilence("", "tests", dt(now.Add(-5*time.Hour)), dt(now.Add(1*time.Millisecond)), matchers),
+	}
+
+	for _, s := range silences {
+		_, err := am.CreateSilence(s)
+		require.NoError(err)
+	}
+
+	// Let enough time pass for the maintenance window to run.
+	tick := time.NewTicker(1500 * time.Millisecond)
+	<-tick.C
+
+	// So, what silences do we have now?
+	found, err := am.ListSilences(nil)
+	require.NoError(err)
+	assert.Len(found, 3)
+
+	// Wait again for the expired silence to fall out of retention.
+	<-tick.C
+
+	// So, what silences do we have now?
+	found, err = am.ListSilences(nil)
+	require.NoError(err)
+	require.Len(found, 2)
 }

--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -13,12 +13,10 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/prometheus/alertmanager/api/v2/models"
-	amv2 "github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/alertmanager/provider/mem"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -355,29 +353,26 @@ func TestPutAlert(t *testing.T) {
 // our data differently, so we test that functionality.
 func TestSilenceCleanup(t *testing.T) {
 	require := require.New(t)
-	assert := assert.New(t)
 
-	// TODO: We have to use a real clock because Prometheus doesn't support clock
-	// injection. So modify the retention constant. This isn't great - we should
-	// make this an argument to the alertmanager so we can safely change it.
 	oldRetention := retentionNotificationsAndSilences
 	retentionNotificationsAndSilences = 30 * time.Millisecond
 	oldMaintenance := silenceMaintenanceInterval
 	silenceMaintenanceInterval = 15 * time.Millisecond
-	defer func() {
-		retentionNotificationsAndSilences = oldRetention
-		silenceMaintenanceInterval = oldMaintenance
-	}()
+	t.Cleanup(
+		func() {
+			retentionNotificationsAndSilences = oldRetention
+			silenceMaintenanceInterval = oldMaintenance
+		})
 
 	am := setupAMTest(t)
 	now := time.Now()
 	dt := func(t time.Time) strfmt.DateTime { return strfmt.DateTime(t) }
 
 	makeSilence := func(comment string, createdBy string,
-		startsAt, endsAt strfmt.DateTime, matchers amv2.Matchers) *apimodels.PostableSilence {
+		startsAt, endsAt strfmt.DateTime, matchers models.Matchers) *apimodels.PostableSilence {
 		return &apimodels.PostableSilence{
 			ID: "",
-			Silence: amv2.Silence{
+			Silence: models.Silence{
 				Comment:   &comment,
 				CreatedBy: &createdBy,
 				StartsAt:  &startsAt,
@@ -389,7 +384,7 @@ func TestSilenceCleanup(t *testing.T) {
 
 	tru := true
 	testString := "testName"
-	matchers := amv2.Matchers{&amv2.Matcher{Name: &testString, IsEqual: &tru, IsRegex: &tru, Value: &testString}}
+	matchers := models.Matchers{&models.Matcher{Name: &testString, IsEqual: &tru, IsRegex: &tru, Value: &testString}}
 	// Create silences - one in the future, one currently active, one expired but
 	// retained, one expired and not retained.
 	silences := []*apimodels.PostableSilence{
@@ -400,7 +395,7 @@ func TestSilenceCleanup(t *testing.T) {
 		// Expiring soon
 		makeSilence("", "tests", dt(now.Add(-5*time.Hour)), dt(now.Add(2*time.Second)), matchers),
 		// Expiring *very* soon
-		makeSilence("", "tests", dt(now.Add(-5*time.Hour)), dt(now.Add(1*time.Millisecond)), matchers),
+		makeSilence("", "tests", dt(now.Add(-5*time.Hour)), dt(now.Add(20*time.Millisecond)), matchers),
 	}
 
 	for _, s := range silences {
@@ -409,19 +404,17 @@ func TestSilenceCleanup(t *testing.T) {
 	}
 
 	// Let enough time pass for the maintenance window to run.
-	tick := time.NewTicker(1500 * time.Millisecond)
-	<-tick.C
+	require.Eventually(func() bool {
+		// So, what silences do we have now?
+		found, err := am.ListSilences(nil)
+		require.NoError(err)
+		return len(found) == 3
+	}, 1500*time.Millisecond, 150*time.Millisecond)
 
-	// So, what silences do we have now?
-	found, err := am.ListSilences(nil)
-	require.NoError(err)
-	assert.Len(found, 3)
-
-	// Wait again for the expired silence to fall out of retention.
-	<-tick.C
-
-	// So, what silences do we have now?
-	found, err = am.ListSilences(nil)
-	require.NoError(err)
-	require.Len(found, 2)
+	// Wait again for another silence to expire.
+	require.Eventually(func() bool {
+		found, err := am.ListSilences(nil)
+		require.NoError(err)
+		return len(found) == 2
+	}, 2*time.Second, 150*time.Millisecond)
 }

--- a/pkg/services/ngalert/notifier/silences.go
+++ b/pkg/services/ngalert/notifier/silences.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-openapi/strfmt"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	v2 "github.com/prometheus/alertmanager/api/v2"
 	"github.com/prometheus/alertmanager/silence"
@@ -76,14 +75,6 @@ func (am *Alertmanager) GetSilence(silenceID string) (apimodels.GettableSilence,
 
 // CreateSilence persists the provided silence and returns the silence ID if successful.
 func (am *Alertmanager) CreateSilence(ps *apimodels.PostableSilence) (string, error) {
-	// Validate our silence to avoid segfaults
-	// TODO: do we care about the format registry? Should we reinitialize it each time?
-	err := ps.Validate(strfmt.NewFormats())
-	if err != nil {
-		am.logger.Error("argument failed validation", "err", err)
-		return "", fmt.Errorf("%s: failed to convert API silence to internal silence: %w",
-			ErrCreateSilenceBadPayload.Error(), err)
-	}
 	sil, err := v2.PostableSilenceToProto(ps)
 	if err != nil {
 		am.logger.Error("marshaling to protobuf failed", "err", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Expired silences older than the retention period were not being cleaned
up. The root problem was that AlertManager overrides Prometheus's
silence maintenance function and was not calling Silences.GC() in the
overriden function.

**Which issue(s) this PR fixes**: 

Fixes #41156

**Special notes for your reviewer**:

