### PR TITLE
Histogram: updated bucket size/offset settings

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -152,7 +152,7 @@ export function buildHistogram(frames: DataFrame[], options?: HistogramTransform
   let bucketOffset = options?.bucketOffset ?? 0;
 
   // if bucket size is auto, try to calc from all numeric fields
-  if (!bucketSize) {
+  if (!bucketSize || bucketSize < 0) {
     let allValues: number[] = [];
 
     // TODO: include field configs!

--- a/public/app/plugins/panel/histogram/module.tsx
+++ b/public/app/plugins/panel/histogram/module.tsx
@@ -23,6 +23,7 @@ export const plugin = new PanelPlugin<PanelOptions, PanelFieldConfig>(HistogramP
         description: histogramFieldInfo.bucketSize.description,
         settings: {
           placeholder: 'Auto',
+          min: 0,
         },
         defaultValue: defaultPanelOptions.bucketSize,
         showIf: (opts, data) => !originalDataHasHistogram(data),
@@ -33,6 +34,7 @@ export const plugin = new PanelPlugin<PanelOptions, PanelFieldConfig>(HistogramP
         description: histogramFieldInfo.bucketOffset.description,
         settings: {
           placeholder: '0',
+          min: 0,
         },
         defaultValue: defaultPanelOptions.bucketOffset,
         showIf: (opts, data) => !originalDataHasHistogram(data),


### PR DESCRIPTION
Duplicate of #46218 (corrected base branch)
Fixes https://github.com/grafana/grafana/issues/40872