### PR TITLE
Fix double slash in share link

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
@@ -62,8 +62,10 @@ export const RuleDetailsActionButtons: FC<Props> = ({ rule, rulesSource }) => {
 
   const buildShareUrl = () => {
     if (isCloudRulesSource(rulesSource)) {
+      const { appUrl, appSubUrl } = config;
+      const baseUrl = appSubUrl !== '' ? `${appUrl}${appSubUrl}/` : config.appUrl;
       const ruleUrl = `${encodeURIComponent(rulesSource.name)}/${encodeURIComponent(rule.name)}`;
-      return `${config.appUrl}${config.appSubUrl}/alerting/${ruleUrl}/find`;
+      return `${baseUrl}alerting/${ruleUrl}/find`;
     }
 
     return window.location.href.split('?')[0];


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes double slashes from the share link when there's no `appSubUrl`.

**Which issue(s) this PR fixes**:

https://github.com/grafana/support-escalations/issues/2177