### PR TITLE
Query history: Search in comments

### DIFF
--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -111,7 +111,7 @@ func TestGetQueriesFromQueryHistory(t *testing.T) {
 			err := json.Unmarshal(resp.Body(), &response)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
-			require.Equal(t, 1, response.Result.TotalCount)
+			require.Equal(t, 2, response.Result.TotalCount)
 			require.Equal(t, true, response.Result.QueryHistory[0].Starred)
 		})
 }

--- a/pkg/services/queryhistory/queryhistory_test.go
+++ b/pkg/services/queryhistory/queryhistory_test.go
@@ -115,6 +115,12 @@ func testScenarioWithMultipleQueriesInQueryHistory(t *testing.T, desc string, fn
 		resp1 := sc.service.createHandler(sc.reqContext)
 		sc.initialResult = validateAndUnMarshalResponse(t, resp1)
 
+		// Add comment
+		cmd := PatchQueryCommentInQueryHistoryCommand{Comment: "test comment 2"}
+		sc.ctx.Req = web.SetURLParams(sc.ctx.Req, map[string]string{":uid": sc.initialResult.Result.UID})
+		sc.reqContext.Req.Body = mockRequestBody(cmd)
+		sc.service.patchCommentHandler(sc.reqContext)
+
 		time.Sleep(1 * time.Second)
 		command2 := CreateQueryInQueryHistoryCommand{
 			DatasourceUID: testDsUID1,

--- a/pkg/services/queryhistory/writers.go
+++ b/pkg/services/queryhistory/writers.go
@@ -23,12 +23,12 @@ func writeStarredSQL(query SearchInQueryHistoryQuery, sqlStore *sqlstore.SQLStor
 }
 
 func writeFiltersSQL(query SearchInQueryHistoryQuery, user *models.SignedInUser, sqlStore *sqlstore.SQLStore, builder *sqlstore.SQLBuilder) {
-	params := []interface{}{user.OrgId, user.UserId, "%" + query.SearchString + "%"}
+	params := []interface{}{user.OrgId, user.UserId, "%" + query.SearchString + "%", "%" + query.SearchString + "%"}
 	for _, uid := range query.DatasourceUIDs {
 		params = append(params, uid)
 	}
 	var sql bytes.Buffer
-	sql.WriteString(" WHERE query_history.org_id = ? AND query_history.created_by = ? AND query_history.queries " + sqlStore.Dialect.LikeStr() + " ? AND query_history.datasource_uid IN (? " + strings.Repeat(",?", len(query.DatasourceUIDs)-1) + ") ")
+	sql.WriteString(" WHERE query_history.org_id = ? AND query_history.created_by = ? AND (query_history.queries " + sqlStore.Dialect.LikeStr() + " ? OR query_history.comment " + sqlStore.Dialect.LikeStr() + " ?) AND query_history.datasource_uid IN (? " + strings.Repeat(",?", len(query.DatasourceUIDs)-1) + ") ")
 	builder.Write(sql.String(), params...)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Following up on https://github.com/grafana/grafana/pull/45932 that implemented search in query history, this adds searching to comments as well. 

This PR is part of  https://github.com/grafana/grafana/issues/44327. The design document is [here](https://docs.google.com/document/d/1BdVtoXCxhH0Q6C-O_Z7jKi-u1m5pDoS9_HQKhYu_hEE/edit#)

**Which issue(s) this PR fixes**:
Part of https://github.com/grafana/grafana/issues/44327

**Special notes for your reviewer**:
1. Enable query history `enabled = true` flag in custom.ini
2. Add testing functions to frontend:

In https://github.com/grafana/grafana/blob/main/public/app/features/explore/state/query.ts#L322 add following code snippet In the snippet we are:
- adding every new query to history
- randomly starring some
- searching queries using `createParams` function where you can pass/test different props

 ` import { getBackendSrv } from '@grafana/runtime`
 
```
  //To test query history search
  const dataSourceUid = queries[0]?.datasource?.uid;
  if (dataSourceUid) {
    const { result } = await getBackendSrv().post(`/api/query-history`, {
      dataSourceUid,
      queries,
    });

    // Randomly star queries
    if (Math.random() * 10 < 3) {
      getBackendSrv().post(`/api/query-history/star/${result.uid}`);
    }

    // Function to add/remove params for testing
    const createParams = (p: {
      datasourceUids: string[];
      searchString?: string;
      sort?: string;
      limit?: number;
      page?: number;
      onlyStarred?: boolean;
    }) => {
      let params = `${p.datasourceUids.map((uid) => `datasourceUid=${encodeURIComponent(uid)}`).join('&')}`;
      if (p.searchString) {
        params = params + `&searchString=${p.searchString}`;
      }
      if (p.sort) {
        params = params + `&sort=${p.sort}`;
      }
      if (p.limit) {
        params = params + `&limit=${p.limit}`;
      }
      if (p.page) {
        params = params + `&page=${p.page}`;
      }
      if (p.onlyStarred) {
        params = params + `&onlyStarred=${p.onlyStarred}`;
      }
      return params;
    };

    // Here you can add/change params you want!
    const params = createParams({ datasourceUids: [dataSourceUid], onlyStarred: true });

    const queryHistory = await getBackendSrv().get(`/api/query-history?${params}`);
    // Show query history in console
    console.log(queryHistory);
  }
  // End of test
```

If the feature is enabled, it should be able to star/unstar/delete queries.

This PR is missing adding of API endpoints to the the OpenAPI spec. But after this PR there is only 'getQueryHistory` PR left and I was thinking about adding query history API then. If it is okay with reviewer. 


