### PR TITLE
Access control: annotation scope naming refactor

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -276,15 +276,15 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		Grants: []string{string(models.ROLE_VIEWER)},
 	}
 
-	localAnnotationsWriterRole := ac.RoleRegistration{
+	dashboardAnnotationsWriterRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Name:        "fixed:annotations.local:writer",
-			DisplayName: "Local annotation writer",
+			Name:        "fixed:annotations.dashboard:writer",
+			DisplayName: "Dashboard annotation writer",
 			Description: "Update annotations associated with dashboards.",
 			Group:       "Annotations",
-			Version:     1,
+			Version:     2,
 			Permissions: []ac.Permission{
-				{Action: ac.ActionAnnotationsWrite, Scope: ac.ScopeAnnotationsTypeLocal},
+				{Action: ac.ActionAnnotationsWrite, Scope: ac.ScopeAnnotationsTypeDashboard},
 			},
 		},
 		Grants: []string{string(models.ROLE_VIEWER)},
@@ -407,7 +407,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		provisioningWriterRole, datasourcesReaderRole, datasourcesWriterRole, datasourcesIdReaderRole,
 		datasourcesCompatibilityReaderRole, orgReaderRole, orgWriterRole,
 		orgMaintainerRole, teamsCreatorRole, teamsWriterRole, datasourcesExplorerRole,
-		annotationsReaderRole, localAnnotationsWriterRole, annotationsWriterRole,
+		annotationsReaderRole, dashboardAnnotationsWriterRole, annotationsWriterRole,
 		dashboardsCreatorRole, dashboardsReaderRole, dashboardsWriterRole,
 		foldersCreatorRole, foldersReaderRole, foldersWriterRole, apikeyWriterRole,
 	)

--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -481,13 +481,13 @@ func TestService_AnnotationTypeScopeResolver(t *testing.T) {
 		{
 			desc:    "correctly resolves local annotations",
 			given:   "annotations:id:1",
-			want:    accesscontrol.ScopeAnnotationsTypeLocal,
+			want:    accesscontrol.ScopeAnnotationsTypeDashboard,
 			wantErr: nil,
 		},
 		{
 			desc:    "correctly resolves global annotations",
 			given:   "annotations:id:2",
-			want:    accesscontrol.ScopeAnnotationsTypeGlobal,
+			want:    accesscontrol.ScopeAnnotationsTypeOrganization,
 			wantErr: nil,
 		},
 		{

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -372,12 +372,12 @@ var (
 	ScopeTeamsID = Scope("teams", "id", Parameter(":teamId"))
 
 	// Annotation scopes
-	ScopeAnnotationsRoot       = "annotations"
-	ScopeAnnotationsProvider   = NewScopeProvider(ScopeAnnotationsRoot)
-	ScopeAnnotationsAll        = ScopeAnnotationsProvider.GetResourceAllScope()
-	ScopeAnnotationsID         = Scope(ScopeAnnotationsRoot, "id", Parameter(":annotationId"))
-	ScopeAnnotationsTypeLocal  = ScopeAnnotationsProvider.GetResourceScopeType("dashboard")
-	ScopeAnnotationsTypeGlobal = ScopeAnnotationsProvider.GetResourceScopeType("organization")
+	ScopeAnnotationsRoot             = "annotations"
+	ScopeAnnotationsProvider         = NewScopeProvider(ScopeAnnotationsRoot)
+	ScopeAnnotationsAll              = ScopeAnnotationsProvider.GetResourceAllScope()
+	ScopeAnnotationsID               = Scope(ScopeAnnotationsRoot, "id", Parameter(":annotationId"))
+	ScopeAnnotationsTypeDashboard    = ScopeAnnotationsProvider.GetResourceScopeType("dashboard")
+	ScopeAnnotationsTypeOrganization = ScopeAnnotationsProvider.GetResourceScopeType("organization")
 
 	// Annotation tag scopes
 	ScopeAnnotationsTagsAll = "annotations:tags:*"

--- a/pkg/services/annotations/annotations.go
+++ b/pkg/services/annotations/annotations.go
@@ -149,13 +149,13 @@ type ItemDTO struct {
 type annotationType int
 
 const (
-	Global annotationType = iota
-	Local
+	Organization annotationType = iota
+	Dashboard
 )
 
 func (annotation *ItemDTO) GetType() annotationType {
 	if annotation.DashboardId != 0 {
-		return Local
+		return Dashboard
 	}
-	return Global
+	return Organization
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

I realised that in https://github.com/grafana/grafana/pull/46462 I missed a few places where I was referring to annotation types as "local" and "global" before we settled with "dashboard" and "organization". This PR cleans up annotation type naming.
