### PR TITLE
Access Control: Add test flag to enable access control

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -231,16 +231,16 @@ func setupAccessControlScenarioContext(t *testing.T, cfg *setting.Cfg, url strin
 	cfg.IsFeatureToggleEnabled = features.IsEnabled
 	cfg.Quota.Enabled = false
 
-	mockStore := sqlstore.InitTestDB(t)
+	store := sqlstore.InitTestDB(t)
 	hs := &HTTPServer{
 		Cfg:                cfg,
 		Bus:                bus.GetBus(),
-		Live:               newTestLive(t),
+		Live:               newTestLive(t, store),
 		Features:           features,
 		QuotaService:       &quota.QuotaService{Cfg: cfg},
 		RouteRegister:      routing.NewRouteRegister(),
 		AccessControl:      accesscontrolmock.New().WithPermissions(permissions),
-		searchUsersService: searchusers.ProvideUsersService(mockStore, filters.ProvideOSSSearchUserFilter()),
+		searchUsersService: searchusers.ProvideUsersService(store, filters.ProvideOSSSearchUserFilter()),
 		ldapGroups:         ldap.ProvideGroupsService(),
 	}
 
@@ -352,8 +352,11 @@ func setupHTTPServerWithMockDb(t *testing.T, useFakeAccessControl bool, enableAc
 }
 
 func setupHTTPServerWithCfg(t *testing.T, useFakeAccessControl, enableAccessControl bool, cfg *setting.Cfg) accessControlScenarioContext {
-	db := sqlstore.InitTestDB(t)
-	db.Cfg = cfg
+	var featureFlags []string
+	if enableAccessControl {
+		featureFlags = append(featureFlags, featuremgmt.FlagAccesscontrol)
+	}
+	db := sqlstore.InitTestDB(t, sqlstore.InitTestDBOpt{FeatureFlags: featureFlags})
 	return setupHTTPServerWithCfgDb(t, useFakeAccessControl, enableAccessControl, cfg, db, db)
 }
 
@@ -374,7 +377,7 @@ func setupHTTPServerWithCfgDb(t *testing.T, useFakeAccessControl, enableAccessCo
 		Cfg:                cfg,
 		Features:           features,
 		Bus:                bus.GetBus(),
-		Live:               newTestLive(t),
+		Live:               newTestLive(t, db),
 		QuotaService:       &quota.QuotaService{Cfg: cfg},
 		RouteRegister:      routeRegister,
 		SQLStore:           store,

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -85,14 +85,14 @@ func TestGetHomeDashboard(t *testing.T) {
 	}
 }
 
-func newTestLive(t *testing.T) *live.GrafanaLive {
+func newTestLive(t *testing.T, store *sqlstore.SQLStore) *live.GrafanaLive {
 	features := featuremgmt.WithFeatures()
 	cfg := &setting.Cfg{AppURL: "http://localhost:3000/"}
 	cfg.IsFeatureToggleEnabled = features.IsEnabled
 	gLive, err := live.ProvideService(nil, cfg,
 		routing.NewRouteRegister(),
 		nil, nil, nil,
-		sqlstore.InitTestDB(t),
+		store,
 		nil,
 		&usagestats.UsageStatsMock{T: t},
 		nil,
@@ -216,10 +216,11 @@ func TestDashboardAPIEndpoint(t *testing.T) {
 
 		cfg := setting.NewCfg()
 		features := featuremgmt.WithFeatures()
-		dashboardStore := database.ProvideDashboardStore(sqlstore.InitTestDB(t))
+		sql := sqlstore.InitTestDB(t)
+		dashboardStore := database.ProvideDashboardStore(sql)
 		hs := &HTTPServer{
 			Cfg:                   cfg,
-			Live:                  newTestLive(t),
+			Live:                  newTestLive(t, sql),
 			LibraryPanelService:   &mockLibraryPanelService{},
 			LibraryElementService: &mockLibraryElementService{},
 			SQLStore:              mockSQLStore,
@@ -1005,7 +1006,7 @@ func postDashboardScenario(t *testing.T, desc string, url string, routePattern s
 			Bus:                 bus.GetBus(),
 			Cfg:                 cfg,
 			ProvisioningService: provisioning.NewProvisioningServiceMock(context.Background()),
-			Live:                newTestLive(t),
+			Live:                newTestLive(t, sqlstore.InitTestDB(t)),
 			QuotaService: &quota.QuotaService{
 				Cfg: cfg,
 			},
@@ -1042,7 +1043,7 @@ func postDiffScenario(t *testing.T, desc string, url string, routePattern string
 			Cfg:                   cfg,
 			Bus:                   bus.GetBus(),
 			ProvisioningService:   provisioning.NewProvisioningServiceMock(context.Background()),
-			Live:                  newTestLive(t),
+			Live:                  newTestLive(t, sqlstore.InitTestDB(t)),
 			QuotaService:          &quota.QuotaService{Cfg: cfg},
 			LibraryPanelService:   &mockLibraryPanelService{},
 			LibraryElementService: &mockLibraryElementService{},
@@ -1079,7 +1080,7 @@ func restoreDashboardVersionScenario(t *testing.T, desc string, url string, rout
 			Cfg:                   cfg,
 			Bus:                   bus.GetBus(),
 			ProvisioningService:   provisioning.NewProvisioningServiceMock(context.Background()),
-			Live:                  newTestLive(t),
+			Live:                  newTestLive(t, sqlstore.InitTestDB(t)),
 			QuotaService:          &quota.QuotaService{Cfg: cfg},
 			LibraryPanelService:   &mockLibraryPanelService{},
 			LibraryElementService: &mockLibraryElementService{},

--- a/pkg/api/team_test.go
+++ b/pkg/api/team_test.go
@@ -217,8 +217,6 @@ func TestTeamAPIEndpoint_CreateTeam_FGAC(t *testing.T) {
 
 func TestTeamAPIEndpoint_SearchTeams_FGAC(t *testing.T) {
 	sc := setupHTTPServer(t, true, true)
-	sc.db = sqlstore.InitTestDB(t)
-
 	// Seed three teams
 	for i := 1; i <= 3; i++ {
 		_, err := sc.db.CreateTeam(fmt.Sprintf("team%d", i), fmt.Sprintf("team%d@example.org", i), 1)

--- a/pkg/services/sqlstore/org_users_test.go
+++ b/pkg/services/sqlstore/org_users_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 type getOrgUsersTestCase struct {
@@ -60,7 +61,7 @@ func TestSQLStore_GetOrgUsers(t *testing.T) {
 		},
 	}
 
-	store := InitTestDB(t, InitTestDBOpt{AccessControlEnabled: true})
+	store := InitTestDB(t, InitTestDBOpt{FeatureFlags: []string{featuremgmt.FlagAccesscontrol}})
 	seedOrgUsers(t, store, 10)
 
 	for _, tt := range tests {
@@ -125,7 +126,7 @@ func TestSQLStore_SearchOrgUsers(t *testing.T) {
 		},
 	}
 
-	store := InitTestDB(t, InitTestDBOpt{AccessControlEnabled: true})
+	store := InitTestDB(t, InitTestDBOpt{FeatureFlags: []string{featuremgmt.FlagAccesscontrol}})
 	seedOrgUsers(t, store, 10)
 
 	for _, tt := range tests {

--- a/pkg/services/sqlstore/org_users_test.go
+++ b/pkg/services/sqlstore/org_users_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 type getOrgUsersTestCase struct {
@@ -61,8 +60,7 @@ func TestSQLStore_GetOrgUsers(t *testing.T) {
 		},
 	}
 
-	store := InitTestDB(t)
-	store.Cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures(featuremgmt.FlagAccesscontrol).IsEnabled
+	store := InitTestDB(t, InitTestDBOpt{AccessControlEnabled: true})
 	seedOrgUsers(t, store, 10)
 
 	for _, tt := range tests {
@@ -127,8 +125,7 @@ func TestSQLStore_SearchOrgUsers(t *testing.T) {
 		},
 	}
 
-	store := InitTestDB(t)
-	store.Cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures(featuremgmt.FlagAccesscontrol).IsEnabled
+	store := InitTestDB(t, InitTestDBOpt{AccessControlEnabled: true})
 	seedOrgUsers(t, store, 10)
 
 	for _, tt := range tests {

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -496,6 +496,14 @@ func initTestDB(migration registry.DatabaseMigrator, opts ...InitTestDBOpt) (*SQ
 		opts = []InitTestDBOpt{{EnsureDefaultOrgAndUser: false, FeatureFlags: []string{}}}
 	}
 
+	features := make([]string, len(featuresEnabledDuringTests))
+	copy(features, featuresEnabledDuringTests)
+	for _, opt := range opts {
+		if len(opt.FeatureFlags) > 0 {
+			features = append(features, opt.FeatureFlags...)
+		}
+	}
+
 	if testSQLStore == nil {
 		dbType := migrator.SQLite
 
@@ -507,7 +515,7 @@ func initTestDB(migration registry.DatabaseMigrator, opts ...InitTestDBOpt) (*SQ
 		// set test db config
 		cfg := setting.NewCfg()
 		cfg.IsFeatureToggleEnabled = func(key string) bool {
-			for _, enabledFeature := range featuresEnabledDuringTests {
+			for _, enabledFeature := range features {
 				if enabledFeature == key {
 					return true
 				}
@@ -585,14 +593,6 @@ func initTestDB(migration registry.DatabaseMigrator, opts ...InitTestDBOpt) (*SQ
 		// temp global var until we get rid of global vars
 		dialect = testSQLStore.Dialect
 		return testSQLStore, nil
-	}
-
-	features := make([]string, len(featuresEnabledDuringTests))
-	copy(features, featuresEnabledDuringTests)
-	for _, opt := range opts {
-		if len(opt.FeatureFlags) > 0 {
-			features = append(features, opt.FeatureFlags...)
-		}
 	}
 
 	testSQLStore.Cfg.IsFeatureToggleEnabled = func(key string) bool {

--- a/pkg/services/sqlstore/team_test.go
+++ b/pkg/services/sqlstore/team_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 func TestTeamCommandsAndQueries(t *testing.T) {
@@ -396,8 +395,7 @@ func TestSQLStore_SearchTeams(t *testing.T) {
 		},
 	}
 
-	store := InitTestDB(t)
-	store.Cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures(featuremgmt.FlagAccesscontrol).IsEnabled
+	store := InitTestDB(t, InitTestDBOpt{AccessControlEnabled: true})
 
 	// Seed 10 teams
 	for i := 1; i <= 10; i++ {
@@ -456,9 +454,7 @@ func TestSQLStore_GetTeamMembers_ACFilter(t *testing.T) {
 		require.NoError(t, errAddMember)
 	}
 
-	store := InitTestDB(t)
-	store.Cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures(featuremgmt.FlagAccesscontrol).IsEnabled
-
+	store := InitTestDB(t, InitTestDBOpt{AccessControlEnabled: true})
 	setup(store)
 
 	type getTeamMembersTestCase struct {

--- a/pkg/services/sqlstore/team_test.go
+++ b/pkg/services/sqlstore/team_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 func TestTeamCommandsAndQueries(t *testing.T) {
@@ -395,7 +396,7 @@ func TestSQLStore_SearchTeams(t *testing.T) {
 		},
 	}
 
-	store := InitTestDB(t, InitTestDBOpt{AccessControlEnabled: true})
+	store := InitTestDB(t, InitTestDBOpt{FeatureFlags: []string{featuremgmt.FlagAccesscontrol}})
 
 	// Seed 10 teams
 	for i := 1; i <= 10; i++ {
@@ -454,7 +455,7 @@ func TestSQLStore_GetTeamMembers_ACFilter(t *testing.T) {
 		require.NoError(t, errAddMember)
 	}
 
-	store := InitTestDB(t, InitTestDBOpt{AccessControlEnabled: true})
+	store := InitTestDB(t, InitTestDBOpt{FeatureFlags: []string{featuremgmt.FlagAccesscontrol}})
 	setup(store)
 
 	type getTeamMembersTestCase struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Some database integration tests i broken due to setting the access control feature flag without resetting it for other tests.

To fix this i added an option for enabling access control for the test database

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

