### PR TITLE
add ability to pass builds flags/tags to go via make, update bra config

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -1,8 +1,8 @@
 [run]
 init_cmds = [
   ["make", "gen-go"],
-  ["go", "run", "build.go", "-dev", "build-cli"],
-  ["go", "run", "build.go", "-dev", "build-server"],
+  ["GO_BUILD_DEV=1", "make", "build-cli"],
+  ["GO_BUILD_DEV=1", "make", "build-server"],
   ["./bin/grafana-server", "-packaging=dev", "cfg:app_mode=development"]
 ]
 watch_all = true
@@ -13,10 +13,10 @@ watch_dirs = [
   "$WORKDIR/conf",
 ]
 watch_exts = [".go", ".ini", ".toml", ".template.html"]
-ignore_files = ["wire_gen.go"] 
+ignore_files = ["wire_gen.go"]
 build_delay = 1500
 cmds = [
   ["make", "gen-go"],
-  ["go", "run", "build.go", "-dev", "build-server"],
+  ["GO_BUILD_DEV=1", "make", "build-server"],
   ["./bin/grafana-server", "-packaging=dev", "cfg:app_mode=development"]
 ]

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ GO_FILES ?= ./pkg/...
 SH_FILES ?= $(shell find ./scripts -name *.sh)
 API_DEFINITION_FILES = $(shell find ./pkg/api/docs/definitions -name '*.go' -print)
 SWAGGER_TAG ?= latest
+GO_BUILD_FLAGS += $(if $(GO_BUILD_DEV),-dev)
+GO_BUILD_FLAGS += $(if $(GO_BUILD_TAGS),-build-tags=$(GO_BUILD_TAGS))
 
 all: deps build
 
@@ -87,15 +89,15 @@ gen-go: $(WIRE)
 
 build-go: $(MERGED_SPEC_TARGET) gen-go ## Build all Go binaries.
 	@echo "build go files"
-	$(GO) run build.go build
+	$(GO) run build.go $(GO_BUILD_FLAGS) build
 
 build-server: ## Build Grafana server.
 	@echo "build server"
-	$(GO) run build.go build-server
+	$(GO) run build.go $(GO_BUILD_FLAGS) build-server
 
 build-cli: ## Build Grafana CLI application.
 	@echo "build grafana-cli"
-	$(GO) run build.go build-cli
+	$(GO) run build.go $(GO_BUILD_FLAGS) build-cli
 
 build-js: ## Build frontend assets.
 	@echo "build frontend"


### PR DESCRIPTION
This PR updates our Makefile so that it is possible to pass go build tags via the environment, and updates the bra config to use make rather than invoking build.go directly.

This makes it easier to build grafana with custom build tags using syntax like `GO_BUILD_TAGS=mytag make build-server` or `GO_BUILD_TAGS=tag1,tag2 make run`