### PR TITLE
Grafana-UI: Fixes timezone offset for default timezone

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneOption.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneOption.tsx
@@ -33,16 +33,24 @@ export const WideTimeZoneOption: React.FC<PropsWithChildren<Props>> = (props, re
     return null;
   }
 
+  const timeZoneInfo = getTimeZoneInfo(data.value, timestamp);
+
   return (
     <div className={containerStyles} {...innerProps} aria-label="Select option">
       <div className={cx(styles.leftColumn, styles.row)}>
         <div className={cx(styles.leftColumn, styles.wideRow)}>
           <TimeZoneTitle title={children} />
           <div className={styles.spacer} />
-          <TimeZoneDescription info={getTimeZoneInfo(data.value, timestamp)} />
+          <TimeZoneDescription info={timeZoneInfo} />
         </div>
         <div className={styles.rightColumn}>
-          <TimeZoneOffset timeZone={data.value} timestamp={timestamp} className={offsetClassName} />
+          <TimeZoneOffset
+            /* Use the timeZoneInfo to pass the correct timeZone name,
+               as 'Default' has value '' which defaults to browser timezone */
+            timeZone={timeZoneInfo?.ianaName || data.value}
+            timestamp={timestamp}
+            className={offsetClassName}
+          />
           {isSelected && (
             <span>
               <Icon name="check" />
@@ -65,6 +73,8 @@ export const CompactTimeZoneOption: React.FC<PropsWithChildren<Props>> = (props,
     return null;
   }
 
+  const timeZoneInfo = getTimeZoneInfo(data.value, timestamp);
+
   return (
     <div className={containerStyles} {...innerProps} aria-label="Select option">
       <div className={styles.body}>
@@ -82,10 +92,16 @@ export const CompactTimeZoneOption: React.FC<PropsWithChildren<Props>> = (props,
         </div>
         <div className={styles.row}>
           <div className={styles.leftColumn}>
-            <TimeZoneDescription info={getTimeZoneInfo(data.value, timestamp)} />
+            <TimeZoneDescription info={timeZoneInfo} />
           </div>
           <div className={styles.rightColumn}>
-            <TimeZoneOffset timestamp={timestamp} timeZone={data.value} className={offsetClassName} />
+            <TimeZoneOffset
+              timestamp={timestamp}
+              /* Use the timeZoneInfo to pass the correct timeZone name,
+                 as 'Default' has value '' which defaults to browser timezone */
+              timeZone={timeZoneInfo?.ianaName || data.value}
+              className={offsetClassName}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
**What this PR does / why we need it**:

When the default timezone is different to the browser timezone, the offset is displayed incorrectly (displays it as the browser offset). This PR fixes that:

| Before | After |
| -------| ----- |
| <img width="559" alt="Screenshot 2022-03-21 at 15 56 50" src="https://user-images.githubusercontent.com/100691367/159300321-84120404-86d0-4328-b994-c05d53bcf294.png"> | <img width="566" alt="Screenshot 2022-03-21 at 15 44 41" src="https://user-images.githubusercontent.com/100691367/159300140-a43c3f1e-2bdc-4f11-8190-0cd7ba38e46a.png"> |

**Which issue(s) this PR fixes**:

Fixes #46720

**Special notes for your reviewer**:

The default timezone has `data.value = ''`, which when moment tries to convert it to a timeZone it fails so it defaults to using `.local()` in [`grafana-data/src/datetime/formatter.ts`](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/datetime/formatter.ts#L105). By converting these timeZones to their final names using our own `getTimeZoneInfo` we can get the actual name of the default timezone.