### PR TITLE
Add user_id to apikey table

### DIFF
--- a/pkg/models/apikey.go
+++ b/pkg/models/apikey.go
@@ -13,15 +13,15 @@ var (
 )
 
 type ApiKey struct {
-	Id               int64
-	OrgId            int64
-	Name             string
-	Key              string
-	Role             RoleType
-	Created          time.Time
-	Updated          time.Time
-	Expires          *int64
-	ServiceAccountId *int64
+	Id      int64
+	OrgId   int64
+	Name    string
+	Key     string
+	Role    RoleType
+	Created time.Time
+	Updated time.Time
+	Expires *int64
+	UserId  *int64
 }
 
 // ---------------------

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -235,7 +235,7 @@ func (h *ContextHandler) initContextWithAPIKey(reqContext *models.ReqContext) bo
 		return true
 	}
 
-	if apikey.ServiceAccountId == nil || *apikey.ServiceAccountId < 1 { //There is no service account attached to the apikey
+	if apikey.UserId == nil || *apikey.UserId < 1 { //There is no service account attached to the apikey
 		//Use the old APIkey method.  This provides backwards compatibility.
 		reqContext.SignedInUser = &models.SignedInUser{}
 		reqContext.OrgRole = apikey.Role
@@ -248,7 +248,7 @@ func (h *ContextHandler) initContextWithAPIKey(reqContext *models.ReqContext) bo
 	//There is a service account attached to the API key
 
 	//Use service account linked to API key as the signed in user
-	query := models.GetSignedInUserQuery{UserId: *apikey.ServiceAccountId, OrgId: apikey.OrgId}
+	query := models.GetSignedInUserQuery{UserId: *apikey.UserId, OrgId: apikey.OrgId}
 	if err := bus.Dispatch(reqContext.Req.Context(), &query); err != nil {
 		reqContext.Logger.Error(
 			"Failed to link API key to service account in",

--- a/pkg/services/serviceaccounts/api/token_test.go
+++ b/pkg/services/serviceaccounts/api/token_test.go
@@ -147,7 +147,7 @@ func TestServiceAccountsAPI_CreateToken(t *testing.T) {
 				err = store.GetApiKeyByName(context.Background(), &query)
 				require.NoError(t, err)
 
-				assert.Equal(t, sa.Id, *query.Result.ServiceAccountId)
+				assert.Equal(t, sa.Id, *query.Result.UserId)
 				assert.Equal(t, sa.OrgId, query.Result.OrgId)
 			}
 		})
@@ -272,11 +272,11 @@ func TestServiceAccountsAPI_ListTokens(t *testing.T) {
 		{
 			desc: "should be able to list serviceaccount with no expiration date",
 			tokens: []*models.ApiKey{{
-				Id:               1,
-				OrgId:            1,
-				ServiceAccountId: &saId,
-				Expires:          nil,
-				Name:             "Test1",
+				Id:      1,
+				OrgId:   1,
+				UserId:  &saId,
+				Expires: nil,
+				Name:    "Test1",
 			}},
 			acmock: tests.SetupMockAccesscontrol(
 				t,
@@ -292,11 +292,11 @@ func TestServiceAccountsAPI_ListTokens(t *testing.T) {
 		{
 			desc: "should be able to list serviceaccount with secondsUntilExpiration",
 			tokens: []*models.ApiKey{{
-				Id:               1,
-				OrgId:            1,
-				ServiceAccountId: &saId,
-				Expires:          &timeInFuture,
-				Name:             "Test2",
+				Id:      1,
+				OrgId:   1,
+				UserId:  &saId,
+				Expires: &timeInFuture,
+				Name:    "Test2",
 			}},
 			acmock: tests.SetupMockAccesscontrol(
 				t,
@@ -312,11 +312,11 @@ func TestServiceAccountsAPI_ListTokens(t *testing.T) {
 		{
 			desc: "should be able to list serviceaccount with expired token",
 			tokens: []*models.ApiKey{{
-				Id:               1,
-				OrgId:            1,
-				ServiceAccountId: &saId,
-				Expires:          &timeInPast,
-				Name:             "Test3",
+				Id:      1,
+				OrgId:   1,
+				UserId:  &saId,
+				Expires: &timeInPast,
+				Name:    "Test3",
 			}},
 			acmock: tests.SetupMockAccesscontrol(
 				t,

--- a/pkg/services/serviceaccounts/database/database.go
+++ b/pkg/services/serviceaccounts/database/database.go
@@ -56,7 +56,7 @@ func (s *ServiceAccountsStoreImpl) CreateServiceAccount(ctx context.Context, org
 }
 func ServiceAccountDeletions() []string {
 	deletes := []string{
-		"DELETE FROM api_key WHERE service_account_id = ?",
+		"DELETE FROM api_key WHERE user_id = ?",
 	}
 	deletes = append(deletes, sqlstore.UserDeletions()...)
 	return deletes
@@ -155,7 +155,7 @@ func (s *ServiceAccountsStoreImpl) ListTokens(ctx context.Context, orgID int64, 
 
 		quotedUser := s.sqlStore.Dialect.Quote("user")
 		sess = dbSession.
-			Join("inner", quotedUser, quotedUser+".id = api_key.service_account_id").
+			Join("inner", quotedUser, quotedUser+".id = api_key.user_id").
 			Where(quotedUser+".org_id=? AND "+quotedUser+".id=?", orgID, serviceAccountID).
 			Asc("name")
 
@@ -336,7 +336,7 @@ func (s *ServiceAccountsStoreImpl) SearchOrgServiceAccounts(
 			// we do a subquery to remove duplicates coming from joining in api_keys, if we find more than one api key that has expired
 			whereConditions = append(
 				whereConditions,
-				"(SELECT count(*) FROM api_key WHERE api_key.service_account_id = org_user.user_id AND api_key.expires < ?) > 0")
+				"(SELECT count(*) FROM api_key WHERE api_key.user_id = org_user.user_id AND api_key.expires < ?) > 0")
 			whereParams = append(whereParams, now)
 		default:
 			s.log.Warn("invalid filter user for service account filtering", "service account search filtering", filter)

--- a/pkg/services/serviceaccounts/database/stats.go
+++ b/pkg/services/serviceaccounts/database/stats.go
@@ -15,7 +15,7 @@ func (s *ServiceAccountsStoreImpl) GetUsageMetrics(ctx context.Context) (map[str
 	sb.Write(`(SELECT COUNT(*) FROM ` + dialect.Quote("user") +
 		` WHERE is_service_account = ` + dialect.BooleanStr(true) + `) AS serviceaccounts,`)
 	sb.Write(`(SELECT COUNT(*) FROM ` + dialect.Quote("api_key") +
-		` WHERE service_account_id IS NOT NULL ) AS serviceaccount_tokens`)
+		` WHERE user_id IS NOT NULL ) AS serviceaccount_tokens`)
 
 	type saStats struct {
 		ServiceAccounts int64 `xorm:"serviceaccounts"`

--- a/pkg/services/serviceaccounts/database/token_store.go
+++ b/pkg/services/serviceaccounts/database/token_store.go
@@ -45,7 +45,7 @@ func (s *ServiceAccountsStoreImpl) AddServiceAccountToken(ctx context.Context, s
 }
 
 func (s *ServiceAccountsStoreImpl) DeleteServiceAccountToken(ctx context.Context, orgID, serviceAccountID, tokenID int64) error {
-	rawSQL := "DELETE FROM api_key WHERE id=? and org_id=? and service_account_id=?"
+	rawSQL := "DELETE FROM api_key WHERE id=? and org_id=? and user_id=?"
 
 	return s.sqlStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		result, err := sess.Exec(rawSQL, tokenID, orgID, serviceAccountID)

--- a/pkg/services/serviceaccounts/database/token_store.go
+++ b/pkg/services/serviceaccounts/database/token_store.go
@@ -26,14 +26,14 @@ func (s *ServiceAccountsStoreImpl) AddServiceAccountToken(ctx context.Context, s
 		}
 
 		t := models.ApiKey{
-			OrgId:            cmd.OrgId,
-			Name:             cmd.Name,
-			Role:             cmd.Role,
-			Key:              cmd.Key,
-			Created:          updated,
-			Updated:          updated,
-			Expires:          expires,
-			ServiceAccountId: &saID,
+			OrgId:   cmd.OrgId,
+			Name:    cmd.Name,
+			Role:    cmd.Role,
+			Key:     cmd.Key,
+			Created: updated,
+			Updated: updated,
+			Expires: expires,
+			UserId:  &saID,
 		}
 
 		if _, err := sess.Insert(&t); err != nil {
@@ -75,7 +75,7 @@ func (s *ServiceAccountsStoreImpl) assignApiKeyToServiceAccount(ctx context.Cont
 			s.log.Warn("API key not found", "err", err)
 			return models.ErrApiKeyNotFound
 		}
-		key.ServiceAccountId = &saccountId
+		key.UserId = &saccountId
 
 		if _, err := sess.ID(key.Id).Update(&key); err != nil {
 			s.log.Warn("Could not update api key", "err", err)

--- a/pkg/services/sqlstore/apikey.go
+++ b/pkg/services/sqlstore/apikey.go
@@ -95,14 +95,14 @@ func (ss *SQLStore) AddAPIKey(ctx context.Context, cmd *models.AddApiKeyCommand)
 		}
 
 		t := models.ApiKey{
-			OrgId:            cmd.OrgId,
-			Name:             cmd.Name,
-			Role:             cmd.Role,
-			Key:              cmd.Key,
-			Created:          updated,
-			Updated:          updated,
-			Expires:          expires,
-			ServiceAccountId: nil,
+			OrgId:   cmd.OrgId,
+			Name:    cmd.Name,
+			Role:    cmd.Role,
+			Key:     cmd.Key,
+			Created: updated,
+			Updated: updated,
+			Expires: expires,
+			UserId:  nil,
 		}
 
 		if _, err := sess.Insert(&t); err != nil {

--- a/pkg/services/sqlstore/migrations/apikey_mig.go
+++ b/pkg/services/sqlstore/migrations/apikey_mig.go
@@ -91,4 +91,11 @@ func addApiKeyMigrations(mg *Migrator) {
 
 	mg.AddMigration("set service account foreign key to nil if 0", NewRawSQLMigration(
 		"UPDATE api_key SET service_account_id = NULL WHERE service_account_id = 0;"))
+
+	// adding the user_id reference
+	// TODO: need to add a delete migration for the service_account_id column
+	mg.AddMigration("Add service account foreign key for user_id", NewAddColumnMigration(apiKeyV2, &Column{
+		Name: "user_id", Type: DB_BigInt, Nullable: true, Default: "0",
+	}))
+
 }

--- a/pkg/services/sqlstore/migrations/apikey_mig.go
+++ b/pkg/services/sqlstore/migrations/apikey_mig.go
@@ -97,5 +97,4 @@ func addApiKeyMigrations(mg *Migrator) {
 	mg.AddMigration("Add service account foreign key for user_id", NewAddColumnMigration(apiKeyV2, &Column{
 		Name: "user_id", Type: DB_BigInt, Nullable: true, Default: "0",
 	}))
-
 }

--- a/pkg/services/sqlstore/stats.go
+++ b/pkg/services/sqlstore/stats.go
@@ -109,7 +109,7 @@ func (ss *SQLStore) GetSystemStats(ctx context.Context, query *models.GetSystemS
 		sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("team") + `) AS teams,`)
 		sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("user_auth_token") + `) AS auth_tokens,`)
 		sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("alert_rule") + `) AS alert_rules,`)
-		sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("api_key") + `WHERE service_account_id IS NULL) AS api_keys,`)
+		sb.Write(`(SELECT COUNT(id) FROM ` + dialect.Quote("api_key") + `WHERE user_id IS NULL) AS api_keys,`)
 		sb.Write(`(SELECT COUNT(id) FROM `+dialect.Quote("library_element")+` WHERE kind = ?) AS library_panels,`, models.PanelElement)
 		sb.Write(`(SELECT COUNT(id) FROM `+dialect.Quote("library_element")+` WHERE kind = ?) AS library_variables,`, models.VariableElement)
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
current:
we have `service_account_id` as the column in apikey table. However this will be used for PAT as well. In this instance it will be a user that as the id.
new:
it is better if we reference the `user_id` in the `user` table as it is the reflection of what we want going forwrd. This  is a step once we have this implemnted we will add a new migration to delete the `service_account_id` column. As that will no longer be used.

**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana-enterprise/issues/3033

<!--

- Automatically closes linked issue when the Pull Request is merged.