### PR TITLE
Chore: Remove bus from notification service

### DIFF
--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -233,6 +233,7 @@ var wireSet = wire.NewSet(
 	sqlstore.ProvideService,
 	wire.Bind(new(alerting.AlertStore), new(*sqlstore.SQLStore)),
 	ngmetrics.ProvideService,
+	wire.Bind(new(notifications.TempUserStore), new(*sqlstore.SQLStore)),
 	wire.Bind(new(notifications.Service), new(*notifications.NotificationService)),
 	wire.Bind(new(notifications.WebhookSender), new(*notifications.NotificationService)),
 	wire.Bind(new(notifications.EmailSender), new(*notifications.NotificationService)),
@@ -247,6 +248,7 @@ var wireTestSet = wire.NewSet(
 	wire.Bind(new(alerting.AlertStore), new(*sqlstore.SQLStore)),
 
 	notifications.MockNotificationService,
+	wire.Bind(new(notifications.TempUserStore), new(*mockstore.SQLStoreMock)),
 	wire.Bind(new(notifications.Service), new(*notifications.NotificationServiceMock)),
 	wire.Bind(new(notifications.WebhookSender), new(*notifications.NotificationServiceMock)),
 	wire.Bind(new(notifications.EmailSender), new(*notifications.NotificationServiceMock)),

--- a/pkg/services/ngalert/notifier/channels/email_test.go
+++ b/pkg/services/ngalert/notifier/channels/email_test.go
@@ -265,7 +265,7 @@ func createCoreEmailService(t *testing.T) *notifications.NotificationService {
 	cfg.Smtp.Host = "localhost:1234"
 	mailer := notifications.NewFakeMailer()
 
-	ns, err := notifications.ProvideService(bus, cfg, mailer)
+	ns, err := notifications.ProvideService(bus, cfg, mailer, nil)
 	require.NoError(t, err)
 
 	return ns

--- a/pkg/services/notifications/notifications.go
+++ b/pkg/services/notifications/notifications.go
@@ -29,10 +29,6 @@ type Service interface {
 	EmailSender
 }
 
-type Store interface {
-	GetUserByLogin(context.Context, *models.GetUserByLoginQuery) error
-}
-
 var mailTemplates *template.Template
 var tmplResetPassword = "reset_password"
 var tmplSignUpStarted = "signup_started"

--- a/pkg/services/notifications/notifications.go
+++ b/pkg/services/notifications/notifications.go
@@ -38,7 +38,7 @@ var tmplResetPassword = "reset_password"
 var tmplSignUpStarted = "signup_started"
 var tmplWelcomeOnSignUp = "welcome_on_signup"
 
-func ProvideService(bus bus.Bus, cfg *setting.Cfg, mailer Mailer) (*NotificationService, error) {
+func ProvideService(bus bus.Bus, cfg *setting.Cfg, mailer Mailer, store TempUserStore) (*NotificationService, error) {
 	ns := &NotificationService{
 		Bus:          bus,
 		Cfg:          cfg,
@@ -46,6 +46,7 @@ func ProvideService(bus bus.Bus, cfg *setting.Cfg, mailer Mailer) (*Notification
 		mailQueue:    make(chan *Message, 10),
 		webhookQueue: make(chan *Webhook, 10),
 		mailer:       mailer,
+		store:        store,
 	}
 
 	ns.Bus.AddHandler(ns.SendResetPasswordEmail)
@@ -81,6 +82,10 @@ func ProvideService(bus bus.Bus, cfg *setting.Cfg, mailer Mailer) (*Notification
 	return ns, nil
 }
 
+type TempUserStore interface {
+	UpdateTempUserWithEmailSent(ctx context.Context, cmd *models.UpdateTempUserWithEmailSentCommand) error
+}
+
 type NotificationService struct {
 	Bus bus.Bus
 	Cfg *setting.Cfg
@@ -89,6 +94,7 @@ type NotificationService struct {
 	webhookQueue chan *Webhook
 	mailer       Mailer
 	log          log.Logger
+	store        TempUserStore
 }
 
 func (ns *NotificationService) Run(ctx context.Context) error {
@@ -237,7 +243,7 @@ func (ns *NotificationService) signUpStartedHandler(ctx context.Context, evt *ev
 	}
 
 	emailSentCmd := models.UpdateTempUserWithEmailSentCommand{Code: evt.Code}
-	return bus.Dispatch(ctx, &emailSentCmd)
+	return ns.store.UpdateTempUserWithEmailSent(ctx, &emailSentCmd)
 }
 
 func (ns *NotificationService) signUpCompletedHandler(ctx context.Context, evt *events.SignUpCompleted) error {

--- a/pkg/services/notifications/notifications_test.go
+++ b/pkg/services/notifications/notifications_test.go
@@ -252,7 +252,7 @@ func createSut(t *testing.T, bus bus.Bus) (*NotificationService, *FakeMailer) {
 
 func createSutWithConfig(t *testing.T, bus bus.Bus, cfg *setting.Cfg) (*NotificationService, *FakeMailer, error) {
 	smtp := NewFakeMailer()
-	ns, err := ProvideService(bus, cfg, smtp)
+	ns, err := ProvideService(bus, cfg, smtp, nil)
 	return ns, smtp, err
 }
 
@@ -261,7 +261,7 @@ func createDisconnectedSut(t *testing.T, bus bus.Bus) *NotificationService {
 
 	cfg := createSmtpConfig()
 	smtp := NewFakeDisconnectedMailer()
-	ns, err := ProvideService(bus, cfg, smtp)
+	ns, err := ProvideService(bus, cfg, smtp, nil)
 	require.NoError(t, err)
 	return ns
 }


### PR DESCRIPTION
Related to #44130 
Had to use an additional single-function interface with wire.Bind to avoid import cycles. Tests are mostly unaffected.