### PR TITLE
Postgres : Fix label overflow in TLS config options

### DIFF
--- a/public/app/plugins/datasource/postgres/partials/config.html
+++ b/public/app/plugins/datasource/postgres/partials/config.html
@@ -66,7 +66,7 @@
     <h6>TLS/SSL Auth Details</h6>
   </div>
   <div class="gf-form max-width-30">
-    <span class="gf-form-label width-10">TLS/SSL Root Certificate</span>
+    <span class="gf-form-label width-11">TLS/SSL Root Certificate</span>
     <input type="text" class="gf-form-input gf-form-input--has-help-icon"
       ng-model='ctrl.current.jsonData.sslRootCertFile' placeholder="TLS/SSL root cert file"></input>
     <info-popover mode="right-absolute">
@@ -74,7 +74,7 @@
     </info-popover>
   </div>
   <div class="gf-form max-width-30">
-    <span class="gf-form-label width-10">TLS/SSL Client Certificate</span>
+    <span class="gf-form-label width-11">TLS/SSL Client Certificate</span>
     <input type="text" class="gf-form-input gf-form-input--has-help-icon" ng-model='ctrl.current.jsonData.sslCertFile'
       placeholder="TLS/SSL client cert file"></input>
     <info-popover mode="right-absolute">
@@ -83,7 +83,7 @@
     </info-popover>
   </div>
   <div class="gf-form max-width-30">
-    <span class="gf-form-label width-10">TLS/SSL Client Key</span>
+    <span class="gf-form-label width-11">TLS/SSL Client Key</span>
     <input type="text" class="gf-form-input gf-form-input--has-help-icon" ng-model='ctrl.current.jsonData.sslKeyFile'
       placeholder="TLS/SSL client key file"></input>
     <info-popover mode="right-absolute">


### PR DESCRIPTION
**What this PR does / why we need it**:

Text is overflowing its box in the Postgres datasource configuration:

![CleanShot 2022-03-21 at 15 24 15@2x](https://user-images.githubusercontent.com/37156449/159389370-4f52b926-f8f7-416e-993d-3200c13d09d2.png)

This PR widens it:

![CleanShot 2022-03-21 at 15 23 55@2x](https://user-images.githubusercontent.com/37156449/159389341-3cba963f-c6b2-456c-9c78-b65c1d61e0e2.png)
**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #46800

**Special notes for your reviewer**:

