### PR TITLE
Chore: Remove bus from dashboard service

### DIFF
--- a/pkg/api/dashboard_permission_test.go
+++ b/pkg/api/dashboard_permission_test.go
@@ -47,12 +47,6 @@ func TestDashboardPermissionAPIEndpoint(t *testing.T) {
 			})
 
 			guardian.MockDashboardGuardian(&guardian.FakeDashboardGuardian{CanAdminValue: false})
-
-			getDashboardQueryResult := models.NewDashboard("Dash")
-			mockSQLStore := mockstore.NewSQLStoreMock()
-			mockSQLStore.ExpectedDashboard = getDashboardQueryResult
-			mockSQLStore.ExpectedError = nil
-			hs.SQLStore = mockSQLStore
 			loggedInUserScenarioWithRole(t, "When calling GET on", "GET", "/api/dashboards/id/1/permissions",
 				"/api/dashboards/id/:dashboardId/permissions", models.ROLE_EDITOR, func(sc *scenarioContext) {
 					callGetDashboardPermissions(sc, hs)
@@ -95,10 +89,6 @@ func TestDashboardPermissionAPIEndpoint(t *testing.T) {
 					{OrgId: 1, DashboardId: 1, TeamId: 2, Permission: models.PERMISSION_ADMIN},
 				},
 			})
-
-			mockSQLStore := mockstore.NewSQLStoreMock()
-			mockSQLStore.ExpectedDashboard = models.NewDashboard("Dash")
-			hs.SQLStore = mockSQLStore
 
 			loggedInUserScenarioWithRole(t, "When calling GET on", "GET", "/api/dashboards/id/1/permissions",
 				"/api/dashboards/id/:dashboardId/permissions", models.ROLE_ADMIN, func(sc *scenarioContext) {

--- a/pkg/services/dashboards/dashboard.go
+++ b/pkg/services/dashboards/dashboard.go
@@ -51,6 +51,7 @@ type Store interface {
 	UnprovisionDashboard(ctx context.Context, id int64) error
 	// GetDashboardsByPluginID retrieves dashboards identified by plugin.
 	GetDashboardsByPluginID(ctx context.Context, query *models.GetDashboardsByPluginIdQuery) error
+	DeleteDashboard(ctx context.Context, cmd *models.DeleteDashboardCommand) error
 	FolderStore
 }
 

--- a/pkg/services/dashboards/database/database_dashboard_test.go
+++ b/pkg/services/dashboards/database/database_dashboard_test.go
@@ -118,7 +118,7 @@ func TestDashboardDataAccess(t *testing.T) {
 		setup()
 		dash := insertTestDashboard(t, dashboardStore, "delete me", 1, 0, false, "delete this")
 
-		err := sqlStore.DeleteDashboard(context.Background(), &models.DeleteDashboardCommand{
+		err := dashboardStore.DeleteDashboard(context.Background(), &models.DeleteDashboardCommand{
 			Id:    dash.Id,
 			OrgId: 1,
 		})
@@ -193,21 +193,21 @@ func TestDashboardDataAccess(t *testing.T) {
 		emptyFolder := insertTestDashboard(t, dashboardStore, "2 test dash folder", 1, 0, true, "prod", "webapp")
 
 		deleteCmd := &models.DeleteDashboardCommand{Id: emptyFolder.Id}
-		err := sqlStore.DeleteDashboard(context.Background(), deleteCmd)
+		err := dashboardStore.DeleteDashboard(context.Background(), deleteCmd)
 		require.NoError(t, err)
 	})
 
 	t.Run("Should be not able to delete a dashboard if force delete rules is disabled", func(t *testing.T) {
 		setup()
 		deleteCmd := &models.DeleteDashboardCommand{Id: savedFolder.Id, ForceDeleteFolderRules: false}
-		err := sqlStore.DeleteDashboard(context.Background(), deleteCmd)
+		err := dashboardStore.DeleteDashboard(context.Background(), deleteCmd)
 		require.True(t, errors.Is(err, models.ErrFolderContainsAlertRules))
 	})
 
 	t.Run("Should be able to delete a dashboard folder and its children if force delete rules is enabled", func(t *testing.T) {
 		setup()
 		deleteCmd := &models.DeleteDashboardCommand{Id: savedFolder.Id, ForceDeleteFolderRules: true}
-		err := sqlStore.DeleteDashboard(context.Background(), deleteCmd)
+		err := dashboardStore.DeleteDashboard(context.Background(), deleteCmd)
 		require.NoError(t, err)
 
 		query := models.FindPersistedDashboardsQuery{

--- a/pkg/services/dashboards/database/database_provisioning_test.go
+++ b/pkg/services/dashboards/database/database_provisioning_test.go
@@ -120,7 +120,7 @@ func TestDashboardProvisioningTest(t *testing.T) {
 				OrgId: 1,
 			}
 
-			require.Nil(t, sqlStore.DeleteDashboard(context.Background(), deleteCmd))
+			require.Nil(t, dashboardStore.DeleteDashboard(context.Background(), deleteCmd))
 
 			data, err := dashboardStore.GetProvisionedDataByDashboardID(dash.Id)
 			require.Nil(t, err)

--- a/pkg/services/dashboards/database_mock.go
+++ b/pkg/services/dashboards/database_mock.go
@@ -14,6 +14,20 @@ type FakeDashboardStore struct {
 	mock.Mock
 }
 
+// DeleteDashboard provides a mock function with given fields: ctx, cmd
+func (_m *FakeDashboardStore) DeleteDashboard(ctx context.Context, cmd *models.DeleteDashboardCommand) error {
+	ret := _m.Called(ctx, cmd)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *models.DeleteDashboardCommand) error); ok {
+		r0 = rf(ctx, cmd)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteOrphanedProvisionedDashboards provides a mock function with given fields: ctx, cmd
 func (_m *FakeDashboardStore) DeleteOrphanedProvisionedDashboards(ctx context.Context, cmd *models.DeleteOrphanedProvisionedDashboardsCommand) error {
 	ret := _m.Called(ctx, cmd)

--- a/pkg/services/dashboards/manager/dashboard_service.go
+++ b/pkg/services/dashboards/manager/dashboard_service.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 
-	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -408,7 +407,7 @@ func (dr *DashboardServiceImpl) deleteDashboard(ctx context.Context, dashboardId
 		}
 	}
 	cmd := &models.DeleteDashboardCommand{OrgId: orgId, Id: dashboardId}
-	return bus.Dispatch(ctx, cmd)
+	return dr.dashboardStore.DeleteDashboard(ctx, cmd)
 }
 
 func (dr *DashboardServiceImpl) ImportDashboard(ctx context.Context, dto *m.SaveDashboardDTO) (

--- a/pkg/services/dashboards/manager/dashboard_service_test.go
+++ b/pkg/services/dashboards/manager/dashboard_service_test.go
@@ -176,35 +176,34 @@ func TestDashboardService(t *testing.T) {
 
 		t.Run("Given provisioned dashboard", func(t *testing.T) {
 			t.Run("DeleteProvisionedDashboard should delete it", func(t *testing.T) {
-				result := setupDeleteHandlers(t)
+				args := &models.DeleteDashboardCommand{OrgId: 1, Id: 1}
+				fakeStore.On("DeleteDashboard", mock.Anything, args).Return(nil).Once()
 				err := service.DeleteProvisionedDashboard(context.Background(), 1, 1)
 				require.NoError(t, err)
-				require.True(t, result.deleteWasCalled)
 			})
 
-			t.Run("DeleteDashboard should fail to delete it", func(t *testing.T) {
+			t.Run("DeleteDashboard should fail to delete it when provisioning information is missing", func(t *testing.T) {
 				fakeStore.On("GetProvisionedDataByDashboardID", mock.Anything).Return(&models.DashboardProvisioning{}, nil).Once()
-				result := setupDeleteHandlers(t)
 				err := service.DeleteDashboard(context.Background(), 1, 1)
 				require.Equal(t, err, models.ErrDashboardCannotDeleteProvisionedDashboard)
-				require.False(t, result.deleteWasCalled)
 			})
 		})
 
 		t.Run("Given non provisioned dashboard", func(t *testing.T) {
-			result := setupDeleteHandlers(t)
 
-			t.Run("DeleteProvisionedDashboard should delete it", func(t *testing.T) {
+			t.Run("DeleteProvisionedDashboard should delete the dashboard", func(t *testing.T) {
+				args := &models.DeleteDashboardCommand{OrgId: 1, Id: 1, ForceDeleteFolderRules: false}
+				fakeStore.On("DeleteDashboard", mock.Anything, args).Return(nil).Once()
 				err := service.DeleteProvisionedDashboard(context.Background(), 1, 1)
 				require.NoError(t, err)
-				require.True(t, result.deleteWasCalled)
 			})
 
 			t.Run("DeleteDashboard should delete it", func(t *testing.T) {
+				args := &models.DeleteDashboardCommand{OrgId: 1, Id: 1}
+				fakeStore.On("DeleteDashboard", mock.Anything, args).Return(nil).Once()
 				fakeStore.On("GetProvisionedDataByDashboardID", mock.Anything).Return(nil, nil).Once()
 				err := service.DeleteDashboard(context.Background(), 1, 1)
 				require.NoError(t, err)
-				require.True(t, result.deleteWasCalled)
 			})
 		})
 	})
@@ -212,18 +211,4 @@ func TestDashboardService(t *testing.T) {
 
 type Result struct {
 	deleteWasCalled bool
-}
-
-func setupDeleteHandlers(t *testing.T) *Result {
-	t.Helper()
-
-	result := &Result{}
-	bus.AddHandler("test", func(ctx context.Context, cmd *models.DeleteDashboardCommand) error {
-		require.Equal(t, cmd.Id, int64(1))
-		require.Equal(t, cmd.OrgId, int64(1))
-		result.deleteWasCalled = true
-		return nil
-	})
-
-	return result
 }

--- a/pkg/services/dashboards/manager/folder_service.go
+++ b/pkg/services/dashboards/manager/folder_service.go
@@ -233,7 +233,8 @@ func (f *FolderServiceImpl) DeleteFolder(ctx context.Context, user *models.Signe
 	}
 
 	deleteCmd := models.DeleteDashboardCommand{OrgId: orgID, Id: dashFolder.Id, ForceDeleteFolderRules: forceDeleteRules}
-	if err := bus.Dispatch(ctx, &deleteCmd); err != nil {
+
+	if err := f.dashboardStore.DeleteDashboard(ctx, &deleteCmd); err != nil {
 		return nil, toFolderError(err)
 	}
 

--- a/pkg/services/dashboards/manager/folder_service_test.go
+++ b/pkg/services/dashboards/manager/folder_service_test.go
@@ -184,12 +184,11 @@ func TestFolderService(t *testing.T) {
 				f.Id = rand.Int63()
 				f.Uid = util.GenerateShortUID()
 				store.On("GetFolderByUID", mock.Anything, orgID, f.Uid).Return(f, nil)
+
 				var actualCmd *models.DeleteDashboardCommand
-				bus.AddHandler("test", func(ctx context.Context, cmd *models.DeleteDashboardCommand) error {
-					actualCmd = cmd
-					return nil
-				})
-				defer bus.ClearBusHandlers()
+				store.On("DeleteDashboard", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+					actualCmd = args.Get(1).(*models.DeleteDashboardCommand)
+				}).Return(nil).Once()
 
 				expectedForceDeleteRules := rand.Int63()%2 == 0
 				_, err := service.DeleteFolder(context.Background(), user, orgID, f.Uid, expectedForceDeleteRules)

--- a/pkg/services/sqlstore/alert.go
+++ b/pkg/services/sqlstore/alert.go
@@ -155,23 +155,6 @@ func (ss *SQLStore) HandleAlertsQuery(ctx context.Context, query *models.GetAler
 	})
 }
 
-func deleteAlertDefinition(dashboardId int64, sess *DBSession) error {
-	alerts := make([]*models.Alert, 0)
-	if err := sess.Where("dashboard_id = ?", dashboardId).Find(&alerts); err != nil {
-		return err
-	}
-
-	for _, alert := range alerts {
-		if err := deleteAlertByIdInternal(alert.Id, "Dashboard deleted", sess); err != nil {
-			// If we return an error, the current transaction gets rolled back, so no use
-			// trying to delete more
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (ss *SQLStore) SaveAlerts(ctx context.Context, dashID int64, alerts []*models.Alert) error {
 	return ss.WithTransactionalDbSession(ctx, func(sess *DBSession) error {
 		existingAlerts, err := GetAlertsByDashboardId2(dashID, sess)

--- a/pkg/services/sqlstore/alert_test.go
+++ b/pkg/services/sqlstore/alert_test.go
@@ -245,9 +245,10 @@ func TestAlertingDataAccess(t *testing.T) {
 		err := sqlStore.SaveAlerts(context.Background(), testDash.Id, items)
 		require.Nil(t, err)
 
-		err = sqlStore.DeleteDashboard(context.Background(), &models.DeleteDashboardCommand{
-			OrgId: 1,
-			Id:    testDash.Id,
+		err = sqlStore.WithDbSession(context.Background(), func(sess *DBSession) error {
+			dash := models.Dashboard{Id: testDash.Id, OrgId: 1}
+			_, err := sess.Delete(dash)
+			return err
 		})
 		require.Nil(t, err)
 

--- a/pkg/services/sqlstore/mockstore/mockstore.go
+++ b/pkg/services/sqlstore/mockstore/mockstore.go
@@ -482,12 +482,6 @@ func (m *SQLStoreMock) GetDashboardTags(ctx context.Context, query *models.GetDa
 	return nil // TODO: Implement
 }
 
-func (m *SQLStoreMock) DeleteDashboard(ctx context.Context, cmd *models.DeleteDashboardCommand) error {
-	cmd.Id = m.ExpectedDashboard.Id
-	cmd.OrgId = m.ExpectedDashboard.OrgId
-	return m.ExpectedError
-}
-
 func (m *SQLStoreMock) GetDashboards(ctx context.Context, query *models.GetDashboardsQuery) error {
 	return m.ExpectedError
 }

--- a/pkg/services/sqlstore/store.go
+++ b/pkg/services/sqlstore/store.go
@@ -105,7 +105,6 @@ type Store interface {
 	GetDashboard(ctx context.Context, query *models.GetDashboardQuery) error
 	GetDashboardTags(ctx context.Context, query *models.GetDashboardTagsQuery) error
 	SearchDashboards(ctx context.Context, query *models.FindPersistedDashboardsQuery) error
-	DeleteDashboard(ctx context.Context, cmd *models.DeleteDashboardCommand) error
 	GetDashboards(ctx context.Context, query *models.GetDashboardsQuery) error
 	GetDashboardUIDById(ctx context.Context, query *models.GetDashboardRefByIdQuery) error
 	GetDataSource(ctx context.Context, query *models.GetDataSourceQuery) error


### PR DESCRIPTION
It removes the bus for dashboard service.

I decided to move `DeleteDashboard` function from sqlstore package into the service. I did it like this because it only was called in dashboard service and in one test related to the alerting.