### PR TITLE
Alerting: fix flakey test

### DIFF
--- a/public/app/features/alerting/unified/RuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditor.test.tsx
@@ -132,6 +132,7 @@ describe('RuleEditor', () => {
 
     await renderRuleEditor();
     await waitFor(() => expect(mocks.searchFolders).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.api.fetchRulerRulesGroup).toHaveBeenCalled());
 
     userEvent.type(await ui.inputs.name.find(), 'my great new rule');
     userEvent.click(await ui.buttons.lotexAlert.get());


### PR DESCRIPTION
**What this PR does / why we need it**:

This is an attempt to fix a flakey test previously observed in https://drone.grafana.net/grafana/grafana/55587/2/12

I believe the root cause is the mock of `fetchRulerRulesGroup` not having been called before we try to select a Lotex rule,  until this API response is returned the user is unable to click the option and therefor the card does not include a `button` we are trying to click (because the card is disabled).

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Pretty rough to test this locally; if anyone has any great tips or tricks to verify this fix I will retest locally ✌️ 

