### PR TITLE
Alerting: Fix UI to match external AM by host name and path

### DIFF
--- a/public/app/features/alerting/unified/hooks/useExternalAMSelector.test.ts
+++ b/public/app/features/alerting/unified/hooks/useExternalAMSelector.test.ts
@@ -126,4 +126,26 @@ describe('useExternalAmSelector', () => {
       },
     ]);
   });
+
+  it('should match urls by host and path and ignore other parts', () => {
+    useSelectorMock.mockImplementation((callback) => {
+      return callback(
+          createMockStoreState(
+              [{ url: 'http://localhost:9000/some/url/to/am/api/v2/alerts' }],
+              [],
+              ['http://user:password@localhost:9000/some/url/to/am']
+          )
+      );
+    });
+
+    const alertmanagers = useExternalAmSelector();
+
+    expect(alertmanagers).toEqual([
+      {
+        url: 'http://localhost:9000/some/url/to/am',
+        actualUrl: 'http://user:password@localhost:9000/some/url/to/am',
+        status: 'active',
+      }
+    ]);
+  })
 });

--- a/public/app/features/alerting/unified/hooks/useExternalAMSelector.test.ts
+++ b/public/app/features/alerting/unified/hooks/useExternalAMSelector.test.ts
@@ -32,13 +32,13 @@ describe('useExternalAmSelector', () => {
   });
   it('should have one in pending', () => {
     useSelectorMock.mockImplementation((callback) => {
-      return callback(createMockStoreState([], [], ['some/url/to/am']));
+      return callback(createMockStoreState([], [], ['http://localhost:9000/some/url/to/am']));
     });
     const alertmanagers = useExternalAmSelector();
 
     expect(alertmanagers).toEqual([
       {
-        url: 'some/url/to/am',
+        url: 'http://localhost:9000/some/url/to/am',
         status: 'pending',
         actualUrl: '',
       },
@@ -48,7 +48,11 @@ describe('useExternalAmSelector', () => {
   it('should have one active, one pending', () => {
     useSelectorMock.mockImplementation((callback) => {
       return callback(
-        createMockStoreState([{ url: 'some/url/to/am/api/v2/alerts' }], [], ['some/url/to/am', 'some/url/to/am1'])
+        createMockStoreState(
+          [{ url: 'http://localhost:9000/some/url/to/am/api/v2/alerts' }],
+          [],
+          ['http://localhost:9000/some/url/to/am', 'http://localhost:9000/some/url/to/am1']
+        )
       );
     });
 
@@ -56,12 +60,12 @@ describe('useExternalAmSelector', () => {
 
     expect(alertmanagers).toEqual([
       {
-        url: 'some/url/to/am',
-        actualUrl: 'some/url/to/am/api/v2/alerts',
+        url: 'http://localhost:9000/some/url/to/am',
+        actualUrl: 'http://localhost:9000/some/url/to/am',
         status: 'active',
       },
       {
-        url: 'some/url/to/am1',
+        url: 'http://localhost:9000/some/url/to/am1',
         actualUrl: '',
         status: 'pending',
       },
@@ -72,9 +76,12 @@ describe('useExternalAmSelector', () => {
     useSelectorMock.mockImplementation((callback) => {
       return callback(
         createMockStoreState(
-          [{ url: 'some/url/to/am/api/v2/alerts' }, { url: 'some/url/to/am1/api/v2/alerts' }],
+          [
+            { url: 'http://localhost:9000/some/url/to/am/api/v2/alerts' },
+            { url: 'http://localhost:9000/some/url/to/am1/api/v2/alerts' },
+          ],
           [],
-          ['some/url/to/am', 'some/url/to/am1']
+          ['http://localhost:9000/some/url/to/am', 'http://localhost:9000/some/url/to/am1']
         )
       );
     });
@@ -83,13 +90,13 @@ describe('useExternalAmSelector', () => {
 
     expect(alertmanagers).toEqual([
       {
-        url: 'some/url/to/am',
-        actualUrl: 'some/url/to/am/api/v2/alerts',
+        url: 'http://localhost:9000/some/url/to/am',
+        actualUrl: 'http://localhost:9000/some/url/to/am',
         status: 'active',
       },
       {
-        url: 'some/url/to/am1',
-        actualUrl: 'some/url/to/am1/api/v2/alerts',
+        url: 'http://localhost:9000/some/url/to/am1',
+        actualUrl: 'http://localhost:9000/some/url/to/am1',
         status: 'active',
       },
     ]);
@@ -99,9 +106,9 @@ describe('useExternalAmSelector', () => {
     useSelectorMock.mockImplementation((callback) => {
       return callback(
         createMockStoreState(
-          [{ url: 'some/url/to/am/api/v2/alerts' }],
-          [{ url: 'some/dropped/url/api/v2/alerts' }],
-          ['some/url/to/am', 'some/url/to/am1']
+          [{ url: 'http://localhost:9000/some/url/to/am/api/v2/alerts' }],
+          [{ url: 'http://localhost:9000/some/dropped/url/api/v2/alerts' }],
+          ['http://localhost:9000/some/url/to/am', 'http://localhost:9000/some/url/to/am1']
         )
       );
     });
@@ -110,18 +117,18 @@ describe('useExternalAmSelector', () => {
 
     expect(alertmanagers).toEqual([
       {
-        url: 'some/url/to/am',
-        actualUrl: 'some/url/to/am/api/v2/alerts',
+        url: 'http://localhost:9000/some/url/to/am',
+        actualUrl: 'http://localhost:9000/some/url/to/am',
         status: 'active',
       },
       {
-        url: 'some/url/to/am1',
+        url: 'http://localhost:9000/some/url/to/am1',
         actualUrl: '',
         status: 'pending',
       },
       {
-        url: 'some/dropped/url',
-        actualUrl: 'some/dropped/url/api/v2/alerts',
+        url: 'http://localhost:9000/some/dropped/url',
+        actualUrl: 'http://localhost:9000/some/dropped/url/api/v2/alerts',
         status: 'dropped',
       },
     ]);
@@ -130,11 +137,11 @@ describe('useExternalAmSelector', () => {
   it('should match urls by host and path and ignore other parts', () => {
     useSelectorMock.mockImplementation((callback) => {
       return callback(
-          createMockStoreState(
-              [{ url: 'http://localhost:9000/some/url/to/am/api/v2/alerts' }],
-              [],
-              ['http://user:password@localhost:9000/some/url/to/am']
-          )
+        createMockStoreState(
+          [{ url: 'http://localhost:9000/some/url/to/am/api/v2/alerts' }],
+          [],
+          ['http://user:password@localhost:9000/some/url/to/am']
+        )
       );
     });
 
@@ -145,7 +152,7 @@ describe('useExternalAmSelector', () => {
         url: 'http://localhost:9000/some/url/to/am',
         actualUrl: 'http://user:password@localhost:9000/some/url/to/am',
         status: 'active',
-      }
+      },
     ]);
-  })
+  });
 });

--- a/public/app/features/alerting/unified/hooks/useExternalAmSelector.ts
+++ b/public/app/features/alerting/unified/hooks/useExternalAmSelector.ts
@@ -24,6 +24,7 @@ export function useExternalAmSelector(): AlertmanagerConfig[] | [] {
   }));
 
   for (const url of alertmanagerConfig) {
+    let cfgUrl = new URL(url);
     if (discoveredAlertmanagers.activeAlertManagers.length === 0) {
       enabledAlertmanagers.push({
         url: url,
@@ -33,7 +34,8 @@ export function useExternalAmSelector(): AlertmanagerConfig[] | [] {
     } else {
       let found = false;
       for (const activeAM of discoveredAlertmanagers.activeAlertManagers) {
-        if (activeAM.url === `${url}/api/v2/alerts`) {
+        let activeUrl = new URL(activeAM.url)
+        if (activeUrl.hostname === cfgUrl.hostname && activeUrl.pathname.startsWith(cfgUrl.pathname) && activeUrl.protocol === cfgUrl.protocol) {
           found = true;
           enabledAlertmanagers.push({
             url: activeAM.url.replace(SUFFIX_REGEX, ''),

--- a/public/app/features/alerting/unified/hooks/useExternalAmSelector.ts
+++ b/public/app/features/alerting/unified/hooks/useExternalAmSelector.ts
@@ -24,7 +24,7 @@ export function useExternalAmSelector(): AlertmanagerConfig[] | [] {
   }));
 
   for (const url of alertmanagerConfig) {
-    let cfgUrl = new URL(url);
+    const cfgUrl = new URL(url);
     if (discoveredAlertmanagers.activeAlertManagers.length === 0) {
       enabledAlertmanagers.push({
         url: url,
@@ -34,13 +34,17 @@ export function useExternalAmSelector(): AlertmanagerConfig[] | [] {
     } else {
       let found = false;
       for (const activeAM of discoveredAlertmanagers.activeAlertManagers) {
-        let activeUrl = new URL(activeAM.url)
-        if (activeUrl.hostname === cfgUrl.hostname && activeUrl.pathname.startsWith(cfgUrl.pathname) && activeUrl.protocol === cfgUrl.protocol) {
+        const activeUrl = new URL(activeAM.url);
+        if (
+          activeUrl.hostname === cfgUrl.hostname &&
+          (activeUrl.pathname.startsWith(cfgUrl.pathname + '/') || activeUrl.pathname === cfgUrl.pathname) &&
+          activeUrl.protocol === cfgUrl.protocol
+        ) {
           found = true;
           enabledAlertmanagers.push({
             url: activeAM.url.replace(SUFFIX_REGEX, ''),
             status: 'active',
-            actualUrl: activeAM.url,
+            actualUrl: url,
           });
         }
       }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When the user configures external Alertmanager and provides URL that includes authentication details, the Alertmanager is kept in pending mode indefinitely 

![image](https://user-images.githubusercontent.com/25988953/159525562-536b0efc-ea64-4b11-98f1-c9d06e58ddbf.png)

even though that API returns that Alermtanager is active.

To determine the status of the Alertmanager UI matches results of two API calls:
- `/api/v1/ngalert/alertmanagers`  that returns 
```json
{
  "status": "success",
  "data": {
    "activeAlertManagers": [
      {
        "url": "http://localhost:9093/api/v2/alerts"
      }
    ],
    "droppedAlertManagers": []
  }
}
```
- `/api/v1/ngalert/admin_config` that returns the configuration 
```
{
  "alertmanagers": [
    "http://root:pass@localhost:9093"
  ],
  "alertmanagersChoice": "all"
}
```

The latter response contains the URI exactly the same as provided by the user. The former - contains a sanitized version without permissions and appended path.

The current implementation of UI does not recognize credentials and considers it as a part of the hostname. As the result, the user always sees that URI in `pending` status.

This PR fixes the comparison and compares only hostnames and paths prefixes