### PR TITLE
Azure Monitor: allow metrics call to use resource uri

### DIFF
--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -81,13 +81,16 @@ func (e *AzureMonitorDatasource) buildQueries(queries []backend.DataQuery, dsInf
 		urlComponents["resourceName"] = azJSONModel.ResourceName
 
 		ub := urlBuilder{
+			ResourceURI: azJSONModel.ResourceURI,
+			// Legacy, used to reconstruct resource URI if it's not present
 			DefaultSubscription: dsInfo.Settings.SubscriptionId,
 			Subscription:        queryJSONModel.Subscription,
-			ResourceGroup:       queryJSONModel.AzureMonitor.ResourceGroup,
+			ResourceGroup:       azJSONModel.ResourceGroup,
 			MetricDefinition:    azJSONModel.MetricDefinition,
 			ResourceName:        azJSONModel.ResourceName,
 		}
-		azureURL := ub.Build()
+		azureURL := ub.BuildMetricsURL()
+		azlog.Info("build azureURL", "ResourceURI", azJSONModel.ResourceURI, "azureURL", azureURL)
 
 		alias := azJSONModel.Alias
 

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -90,7 +90,6 @@ func (e *AzureMonitorDatasource) buildQueries(queries []backend.DataQuery, dsInf
 			ResourceName:        azJSONModel.ResourceName,
 		}
 		azureURL := ub.BuildMetricsURL()
-		azlog.Info("build azureURL", "ResourceURI", azJSONModel.ResourceURI, "azureURL", azureURL)
 
 		alias := azJSONModel.Alias
 

--- a/pkg/tsdb/azuremonitor/metrics/url-builder.go
+++ b/pkg/tsdb/azuremonitor/metrics/url-builder.go
@@ -3,10 +3,16 @@ package metrics
 import (
 	"fmt"
 	"strings"
+
+	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/azlog"
 )
 
 // urlBuilder builds the URL for calling the Azure Monitor API
 type urlBuilder struct {
+	ResourceURI string
+
+	// Following fields are deprecated and are not included in new queries.
+	// For backwards compat, we recreate the ResourceURI using these fields
 	DefaultSubscription string
 	Subscription        string
 	ResourceGroup       string
@@ -14,26 +20,40 @@ type urlBuilder struct {
 	ResourceName        string
 }
 
-// Build checks the metric definition property to see which form of the url
+// BuildMetricsURL checks the metric definition property to see which form of the url
 // should be returned
-func (ub *urlBuilder) Build() string {
-	subscription := ub.Subscription
+func (params *urlBuilder) BuildMetricsURL() string {
+	resourceURI := params.ResourceURI
 
-	if ub.Subscription == "" {
-		subscription = ub.DefaultSubscription
+	// We have a legacy query from before the resource picker, so we manually create the resource URI
+	if resourceURI == "" {
+		azlog.Info("Detected legacy query without a resource URI")
+		subscription := params.Subscription
+
+		if params.Subscription == "" {
+			subscription = params.DefaultSubscription
+		}
+
+		metricDefinitionArray := strings.Split(params.MetricDefinition, "/")
+		resourceNameArray := strings.Split(params.ResourceName, "/")
+		provider := metricDefinitionArray[0]
+		metricDefinitionArray = metricDefinitionArray[1:]
+
+		urlArray := []string{
+			subscription,
+			"resourceGroups",
+			params.ResourceGroup,
+			"providers",
+			provider,
+		}
+
+		for i := range metricDefinitionArray {
+			urlArray = append(urlArray, metricDefinitionArray[i])
+			urlArray = append(urlArray, resourceNameArray[i])
+		}
+
+		resourceURI = strings.Join(urlArray[:], "/")
 	}
 
-	metricDefinitionArray := strings.Split(ub.MetricDefinition, "/")
-	resourceNameArray := strings.Split(ub.ResourceName, "/")
-	provider := metricDefinitionArray[0]
-	metricDefinitionArray = metricDefinitionArray[1:]
-
-	urlArray := []string{subscription, "resourceGroups", ub.ResourceGroup, "providers", provider}
-
-	for i := range metricDefinitionArray {
-		urlArray = append(urlArray, metricDefinitionArray[i])
-		urlArray = append(urlArray, resourceNameArray[i])
-	}
-
-	return fmt.Sprintf("%s/providers/microsoft.insights/metrics", strings.Join(urlArray[:], "/"))
+	return fmt.Sprintf("%s/providers/microsoft.insights/metrics", resourceURI)
 }

--- a/pkg/tsdb/azuremonitor/metrics/url-builder.go
+++ b/pkg/tsdb/azuremonitor/metrics/url-builder.go
@@ -9,7 +9,7 @@ import (
 type urlBuilder struct {
 	ResourceURI string
 
-	// Following fields are deprecated and are not included in new queries.
+	// Following fields will be deprecated in grafana 9 and will not included in new queries.
 	// For backwards compat, we recreate the ResourceURI using these fields
 	DefaultSubscription string
 	Subscription        string
@@ -23,7 +23,7 @@ type urlBuilder struct {
 func (params *urlBuilder) BuildMetricsURL() string {
 	resourceURI := params.ResourceURI
 
-	// We have a legacy query from before the resource picker, so we manually create the resource URI
+	// Prior to Grafana 9, we had a legacy query object rather than a resourceURI, so we manually create the resource URI
 	if resourceURI == "" {
 		subscription := params.Subscription
 

--- a/pkg/tsdb/azuremonitor/metrics/url-builder.go
+++ b/pkg/tsdb/azuremonitor/metrics/url-builder.go
@@ -3,8 +3,6 @@ package metrics
 import (
 	"fmt"
 	"strings"
-
-	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/azlog"
 )
 
 // urlBuilder builds the URL for calling the Azure Monitor API
@@ -27,7 +25,6 @@ func (params *urlBuilder) BuildMetricsURL() string {
 
 	// We have a legacy query from before the resource picker, so we manually create the resource URI
 	if resourceURI == "" {
-		azlog.Info("Detected legacy query without a resource URI")
 		subscription := params.Subscription
 
 		if params.Subscription == "" {

--- a/pkg/tsdb/azuremonitor/metrics/url-builder_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/url-builder_test.go
@@ -16,7 +16,7 @@ func TestURLBuilder(t *testing.T) {
 				ResourceName:        "rn",
 			}
 
-			url := ub.Build()
+			url := ub.BuildMetricsURL()
 			require.Equal(t, url, "default-sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/rn/providers/microsoft.insights/metrics")
 		})
 
@@ -29,7 +29,7 @@ func TestURLBuilder(t *testing.T) {
 				ResourceName:        "rn",
 			}
 
-			url := ub.Build()
+			url := ub.BuildMetricsURL()
 			require.Equal(t, url, "specified-sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/rn/providers/microsoft.insights/metrics")
 		})
 
@@ -41,7 +41,7 @@ func TestURLBuilder(t *testing.T) {
 				ResourceName:        "rn1/default",
 			}
 
-			url := ub.Build()
+			url := ub.BuildMetricsURL()
 			require.Equal(t, url, "default-sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/rn1/blobServices/default/providers/microsoft.insights/metrics")
 		})
 
@@ -53,7 +53,7 @@ func TestURLBuilder(t *testing.T) {
 				ResourceName:        "rn1/default",
 			}
 
-			url := ub.Build()
+			url := ub.BuildMetricsURL()
 			require.Equal(t, url, "default-sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/rn1/fileServices/default/providers/microsoft.insights/metrics")
 		})
 
@@ -65,8 +65,21 @@ func TestURLBuilder(t *testing.T) {
 				ResourceName:        "rn1/rn2/rn3",
 			}
 
-			url := ub.Build()
+			url := ub.BuildMetricsURL()
 			require.Equal(t, url, "default-sub/resourceGroups/rg/providers/Microsoft.NetApp/netAppAccounts/rn1/capacityPools/rn2/volumes/rn3/providers/microsoft.insights/metrics")
+		})
+
+		t.Run("when resource uri is provided the legacy fields are ignored", func(t *testing.T) {
+			ub := &urlBuilder{
+				ResourceURI:         "resource/uri",
+				DefaultSubscription: "default-sub",
+				ResourceGroup:       "rg",
+				MetricDefinition:    "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
+				ResourceName:        "rn1/rn2/rn3",
+			}
+
+			url := ub.BuildMetricsURL()
+			require.Equal(t, url, "resource/uri/providers/microsoft.insights/metrics")
 		})
 	})
 }

--- a/pkg/tsdb/azuremonitor/metrics/url-builder_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/url-builder_test.go
@@ -8,68 +8,7 @@ import (
 
 func TestURLBuilder(t *testing.T) {
 	t.Run("AzureMonitor URL Builder", func(t *testing.T) {
-		t.Run("when metric definition is in the short form", func(t *testing.T) {
-			ub := &urlBuilder{
-				DefaultSubscription: "default-sub",
-				ResourceGroup:       "rg",
-				MetricDefinition:    "Microsoft.Compute/virtualMachines",
-				ResourceName:        "rn",
-			}
-
-			url := ub.BuildMetricsURL()
-			require.Equal(t, url, "default-sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/rn/providers/microsoft.insights/metrics")
-		})
-
-		t.Run("when metric definition is in the short form and a subscription is defined", func(t *testing.T) {
-			ub := &urlBuilder{
-				DefaultSubscription: "default-sub",
-				Subscription:        "specified-sub",
-				ResourceGroup:       "rg",
-				MetricDefinition:    "Microsoft.Compute/virtualMachines",
-				ResourceName:        "rn",
-			}
-
-			url := ub.BuildMetricsURL()
-			require.Equal(t, url, "specified-sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/rn/providers/microsoft.insights/metrics")
-		})
-
-		t.Run("when metric definition is Microsoft.Storage/storageAccounts/blobServices", func(t *testing.T) {
-			ub := &urlBuilder{
-				DefaultSubscription: "default-sub",
-				ResourceGroup:       "rg",
-				MetricDefinition:    "Microsoft.Storage/storageAccounts/blobServices",
-				ResourceName:        "rn1/default",
-			}
-
-			url := ub.BuildMetricsURL()
-			require.Equal(t, url, "default-sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/rn1/blobServices/default/providers/microsoft.insights/metrics")
-		})
-
-		t.Run("when metric definition is Microsoft.Storage/storageAccounts/fileServices", func(t *testing.T) {
-			ub := &urlBuilder{
-				DefaultSubscription: "default-sub",
-				ResourceGroup:       "rg",
-				MetricDefinition:    "Microsoft.Storage/storageAccounts/fileServices",
-				ResourceName:        "rn1/default",
-			}
-
-			url := ub.BuildMetricsURL()
-			require.Equal(t, url, "default-sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/rn1/fileServices/default/providers/microsoft.insights/metrics")
-		})
-
-		t.Run("when metric definition is Microsoft.NetApp/netAppAccounts/capacityPools/volumes", func(t *testing.T) {
-			ub := &urlBuilder{
-				DefaultSubscription: "default-sub",
-				ResourceGroup:       "rg",
-				MetricDefinition:    "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
-				ResourceName:        "rn1/rn2/rn3",
-			}
-
-			url := ub.BuildMetricsURL()
-			require.Equal(t, url, "default-sub/resourceGroups/rg/providers/Microsoft.NetApp/netAppAccounts/rn1/capacityPools/rn2/volumes/rn3/providers/microsoft.insights/metrics")
-		})
-
-		t.Run("when only resource uri is provided", func(t *testing.T) {
+		t.Run("when only resource uri is provided it returns resource/uri/providers/microsoft.insights/metrics", func(t *testing.T) {
 			ub := &urlBuilder{
 				ResourceURI: "resource/uri",
 			}
@@ -89,6 +28,69 @@ func TestURLBuilder(t *testing.T) {
 
 			url := ub.BuildMetricsURL()
 			require.Equal(t, url, "resource/uri/providers/microsoft.insights/metrics")
+		})
+
+		t.Run("Legacy URL Builder params", func(t *testing.T) {
+			t.Run("when metric definition is in the short form", func(t *testing.T) {
+				ub := &urlBuilder{
+					DefaultSubscription: "default-sub",
+					ResourceGroup:       "rg",
+					MetricDefinition:    "Microsoft.Compute/virtualMachines",
+					ResourceName:        "rn",
+				}
+
+				url := ub.BuildMetricsURL()
+				require.Equal(t, url, "default-sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/rn/providers/microsoft.insights/metrics")
+			})
+
+			t.Run("when metric definition is in the short form and a subscription is defined", func(t *testing.T) {
+				ub := &urlBuilder{
+					DefaultSubscription: "default-sub",
+					Subscription:        "specified-sub",
+					ResourceGroup:       "rg",
+					MetricDefinition:    "Microsoft.Compute/virtualMachines",
+					ResourceName:        "rn",
+				}
+
+				url := ub.BuildMetricsURL()
+				require.Equal(t, url, "specified-sub/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/rn/providers/microsoft.insights/metrics")
+			})
+
+			t.Run("when metric definition is Microsoft.Storage/storageAccounts/blobServices", func(t *testing.T) {
+				ub := &urlBuilder{
+					DefaultSubscription: "default-sub",
+					ResourceGroup:       "rg",
+					MetricDefinition:    "Microsoft.Storage/storageAccounts/blobServices",
+					ResourceName:        "rn1/default",
+				}
+
+				url := ub.BuildMetricsURL()
+				require.Equal(t, url, "default-sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/rn1/blobServices/default/providers/microsoft.insights/metrics")
+			})
+
+			t.Run("when metric definition is Microsoft.Storage/storageAccounts/fileServices", func(t *testing.T) {
+				ub := &urlBuilder{
+					DefaultSubscription: "default-sub",
+					ResourceGroup:       "rg",
+					MetricDefinition:    "Microsoft.Storage/storageAccounts/fileServices",
+					ResourceName:        "rn1/default",
+				}
+
+				url := ub.BuildMetricsURL()
+				require.Equal(t, url, "default-sub/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/rn1/fileServices/default/providers/microsoft.insights/metrics")
+			})
+
+			t.Run("when metric definition is Microsoft.NetApp/netAppAccounts/capacityPools/volumes", func(t *testing.T) {
+				ub := &urlBuilder{
+					DefaultSubscription: "default-sub",
+					ResourceGroup:       "rg",
+					MetricDefinition:    "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
+					ResourceName:        "rn1/rn2/rn3",
+				}
+
+				url := ub.BuildMetricsURL()
+				require.Equal(t, url, "default-sub/resourceGroups/rg/providers/Microsoft.NetApp/netAppAccounts/rn1/capacityPools/rn2/volumes/rn3/providers/microsoft.insights/metrics")
+			})
 		})
 	})
 }

--- a/pkg/tsdb/azuremonitor/metrics/url-builder_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/url-builder_test.go
@@ -69,7 +69,16 @@ func TestURLBuilder(t *testing.T) {
 			require.Equal(t, url, "default-sub/resourceGroups/rg/providers/Microsoft.NetApp/netAppAccounts/rn1/capacityPools/rn2/volumes/rn3/providers/microsoft.insights/metrics")
 		})
 
-		t.Run("when resource uri is provided the legacy fields are ignored", func(t *testing.T) {
+		t.Run("when only resource uri is provided", func(t *testing.T) {
+			ub := &urlBuilder{
+				ResourceURI: "resource/uri",
+			}
+
+			url := ub.BuildMetricsURL()
+			require.Equal(t, url, "resource/uri/providers/microsoft.insights/metrics")
+		})
+
+		t.Run("when resource uri and legacy fields are provided the legacy fields are ignored", func(t *testing.T) {
 			ub := &urlBuilder{
 				ResourceURI:         "resource/uri",
 				DefaultSubscription: "default-sub",

--- a/pkg/tsdb/azuremonitor/types/types.go
+++ b/pkg/tsdb/azuremonitor/types/types.go
@@ -109,21 +109,26 @@ type AzureResponseTable struct {
 // AzureMonitorJSONQuery is the frontend JSON query model for an Azure Monitor query.
 type AzureMonitorJSONQuery struct {
 	AzureMonitor struct {
-		Aggregation         string  `json:"aggregation"`
-		Alias               string  `json:"alias"`
+		ResourceURI     string `json:"resource"`
+		MetricNamespace string `json:"metricNamespace"`
+		MetricName      string `json:"metricName"`
+
+		Aggregation      string                        `json:"aggregation"`
+		Alias            string                        `json:"alias"`
+		DimensionFilters []AzureMonitorDimensionFilter `json:"dimensionFilters"` // new model
+		TimeGrain        string                        `json:"timeGrain"`
+		Top              string                        `json:"top"`
+
+		MetricDefinition string `json:"metricDefinition"`
+		ResourceGroup    string `json:"resourceGroup"`
+		ResourceName     string `json:"resourceName"`
+
+		// Legecy "resource" fields from before the resource picker provided just a single ResourceURI
+		// These are used for pre-resource picker queries to reconstruct a resource URI
 		AllowedTimeGrainsMs []int64 `json:"allowedTimeGrainsMs"`
 		Dimension           string  `json:"dimension"`       // old model
 		DimensionFilter     string  `json:"dimensionFilter"` // old model
 		Format              string  `json:"format"`
-		MetricDefinition    string  `json:"metricDefinition"`
-		MetricName          string  `json:"metricName"`
-		MetricNamespace     string  `json:"metricNamespace"`
-		ResourceGroup       string  `json:"resourceGroup"`
-		ResourceName        string  `json:"resourceName"`
-		TimeGrain           string  `json:"timeGrain"`
-		Top                 string  `json:"top"`
-
-		DimensionFilters []AzureMonitorDimensionFilter `json:"dimensionFilters"` // new model
 	} `json:"azureMonitor"`
 	Subscription string `json:"subscription"`
 }

--- a/pkg/tsdb/azuremonitor/types/types.go
+++ b/pkg/tsdb/azuremonitor/types/types.go
@@ -119,12 +119,12 @@ type AzureMonitorJSONQuery struct {
 		TimeGrain        string                        `json:"timeGrain"`
 		Top              string                        `json:"top"`
 
+		// Legecy "resource" fields from before the resource picker provided just a single ResourceURI
+		// These are used for pre-resource picker queries to reconstruct a resource URI
 		MetricDefinition string `json:"metricDefinition"`
 		ResourceGroup    string `json:"resourceGroup"`
 		ResourceName     string `json:"resourceName"`
 
-		// Legecy "resource" fields from before the resource picker provided just a single ResourceURI
-		// These are used for pre-resource picker queries to reconstruct a resource URI
 		AllowedTimeGrainsMs []int64 `json:"allowedTimeGrainsMs"`
 		Dimension           string  `json:"dimension"`       // old model
 		DimensionFilter     string  `json:"dimensionFilter"` // old model

--- a/pkg/tsdb/azuremonitor/types/types.go
+++ b/pkg/tsdb/azuremonitor/types/types.go
@@ -109,7 +109,7 @@ type AzureResponseTable struct {
 // AzureMonitorJSONQuery is the frontend JSON query model for an Azure Monitor query.
 type AzureMonitorJSONQuery struct {
 	AzureMonitor struct {
-		ResourceURI     string `json:"resource"`
+		ResourceURI     string `json:"resourceUri"`
 		MetricNamespace string `json:"metricNamespace"`
 		MetricName      string `json:"metricName"`
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This adds the ability for the Azure Monitor plugin backend to accept a `resource` field that is a resource URI that can be used to query the Azure Metrics API.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #46059

**Special notes for your reviewer**:

I tested this by copying the `curl` for the `query` network request from the Chrome devtools network tab and made a request to my local Grafana instance. I edited the payload to:
1. Include the resource uri and removed the legacy fields
1. Included the resource uri as well as the legacy fields
1. Use the `curl` as is to test the current behaviour