### PR TITLE
Tracing: Prevent createSpanLink from returning an invalid Loki query in Trace to Logs

### DIFF
--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -195,6 +195,25 @@ describe('createSpanLinkFactory', () => {
         )}`
       );
     });
+
+    it('handles empty queries', () => {
+      const createLink = setupSpanLinkFactory({
+        tags: [],
+      });
+      expect(createLink).toBeDefined();
+      const linkDef = createLink!(
+        createTraceSpan({
+          process: {
+            serviceName: 'service',
+            tags: [
+              { key: 'service.name', value: 'serviceName' },
+              { key: 'k8s.pod.name', value: 'podName' },
+            ],
+          },
+        })
+      );
+      expect(linkDef).toBeUndefined();
+    });
   });
 });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Returns undefined if the resulting expression would be an invalid Loki query, like `{}` which doesn't render the link/button

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #46860

**Special notes for your reviewer**:

