### PR TITLE
Docs: Revert move of "Config from query" options

### DIFF
--- a/docs/sources/panels/reference-transformation-functions.md
+++ b/docs/sources/panels/reference-transformation-functions.md
@@ -53,6 +53,12 @@ This transformation allow you to select one query and from it extract standard o
 
 If you want to extract a unique config for every row in the config query result then try the rows to fields transformation.
 
+### Options
+
+- **Config query**: Select the query that returns the data you want to use as configuration.
+- **Apply to**: Select what fields or series to apply the configuration to.
+- **Apply to options**: Usually a field type or field name regex depending on what option you selected in **Apply to**.
+
 ## Convert field type
 
 This transformation changes the field type of the specified field.

--- a/docs/sources/panels/transform-data/apply-transformation-to-data.md
+++ b/docs/sources/panels/transform-data/apply-transformation-to-data.md
@@ -28,9 +28,3 @@ The following steps guide you in applying a transformation to data. This documen
    This transformation acts on the result set returned by the previous transformation.
 
    {{< figure src="/static/img/docs/transformations/transformations-7-0.png" class="docs-image--no-shadow" max-width= "1100px" >}}
-
-## Options
-
-- **Config query**: Select the query that returns the data you want to use as configuration.
-- **Apply to**: Select what fields or series to apply the configuration to.
-- **Apply to options**: Usually a field type or field name regex depending on what option you selected in **Apply to**.


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactoring in 449c608 / PR #43569 moved the "Options" subsection of the "Config from query" transformation to be a subsection of the "Apply transformation to data" doc, but those options are not relevant to that content.

Move this content to be a subsection of the "Config from query" transformation in the transformation functions reference doc.

**Which issue(s) this PR fixes**:

Contributes to #46818, but does not resolve it.

**Special notes for your reviewer**:

None