### PR TITLE
Unified Alerting: Make log message follow codebase convention.

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -190,7 +190,7 @@ func newAlertmanager(ctx context.Context, orgID int64, cfg *setting.Cfg, store s
 		am.silences.Maintenance(silenceMaintenanceInterval, silencesFilePath, am.stopc, func() (int64, error) {
 			// Delete silences older than the retention period.
 			if _, err := am.silences.GC(); err != nil {
-				am.logger.Error("Silence Garbage Collection Failed at %v: %v", time.Now(), err)
+				am.logger.Error("silence garbage collection", "err", err)
 				// Don't return here - we need to snapshot our state first.
 			}
 


### PR DESCRIPTION

**What this PR does / why we need it**:
Fixes an inconsistency in a log line.

1. Keep log lines lower case.
2. The key-value pair arguments are not format argument for the string.
3. Always use the "err" key.

