### PR TITLE
Alerting: Change getEvaluatorForAlertRule to checkDatasourcePermissionsForRule

### DIFF
--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -172,16 +172,17 @@ func (api *API) authorize(method, path string) web.Handler {
 	panic(fmt.Sprintf("no authorization handler for method [%s] of endpoint [%s]", method, path))
 }
 
-// GetDatasourceScopesFromAlertRule extracts data source scopes from an alert rule
-func getEvaluatorForAlertRule(rule *ngmodels.AlertRule) ac.Evaluator {
-	scopes := make([]ac.Evaluator, 0, len(rule.Data))
+// checkDatasourcePermissionsForRule checks that user has access to all data sources
+func checkDatasourcePermissionsForRule(rule *ngmodels.AlertRule, evaluator func(evaluator ac.Evaluator) bool) bool {
 	for _, query := range rule.Data {
 		if query.QueryType == expr.DatasourceType || query.DatasourceUID == expr.OldDatasourceUID {
 			continue
 		}
-		scopes = append(scopes, ac.EvalPermission(datasources.ActionQuery, dashboards.ScopeFoldersProvider.GetResourceScopeUID(query.DatasourceUID)))
+		if !evaluator(ac.EvalPermission(datasources.ActionQuery, dashboards.ScopeFoldersProvider.GetResourceScopeUID(query.DatasourceUID))) {
+			return false
+		}
 	}
-	return ac.EvalAll(scopes...)
+	return true
 }
 
 // authorizeRuleChanges analyzes changes in the rule group, determines what actions the user is trying to perform and check whether those actions are authorized.
@@ -203,7 +204,7 @@ func authorizeRuleChanges(namespace *models.Folder, changes *changes, evaluator 
 			return fmt.Errorf("%w user cannot create alert rules in the folder %s", ErrAuthorization, namespace.Title)
 		}
 		for _, rule := range changes.New {
-			dsAllowed := evaluator(getEvaluatorForAlertRule(rule))
+			dsAllowed := checkDatasourcePermissionsForRule(rule, evaluator)
 			if !dsAllowed {
 				return fmt.Errorf("%w to create a new alert rule '%s' because the user does not have read permissions for one or many datasources the rule uses", ErrAuthorization, rule.Title)
 			}
@@ -211,7 +212,7 @@ func authorizeRuleChanges(namespace *models.Folder, changes *changes, evaluator 
 	}
 
 	for _, rule := range changes.Update {
-		dsAllowed := evaluator(getEvaluatorForAlertRule(rule.New))
+		dsAllowed := checkDatasourcePermissionsForRule(rule.New, evaluator)
 		if !dsAllowed {
 			return fmt.Errorf("%w to update alert rule '%s' (UID: %s) because the user does not have read permissions for one or many datasources the rule uses", ErrAuthorization, rule.Existing.Title, rule.Existing.UID)
 		}

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -259,7 +259,7 @@ func TestCheckDatasourcePermissionsForRule(t *testing.T) {
 
 		executed := 0
 
-		eval := checkDatasourcePermissionsForRule(rule, func(evaluator ac.Evaluator) bool {
+		eval := authorizeDatasourceAccessForRule(rule, func(evaluator ac.Evaluator) bool {
 			response, err := evaluator.Evaluate(permissions)
 			require.Truef(t, response, "provided permissions [%v] is not enough for requested permissions [%s]", permissions, evaluator.GoString())
 			require.NoError(t, err)
@@ -274,7 +274,7 @@ func TestCheckDatasourcePermissionsForRule(t *testing.T) {
 	t.Run("should return on first negative evaluation", func(t *testing.T) {
 		executed := 0
 
-		eval := checkDatasourcePermissionsForRule(rule, func(evaluator ac.Evaluator) bool {
+		eval := authorizeDatasourceAccessForRule(rule, func(evaluator ac.Evaluator) bool {
 			executed++
 			return false
 		})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR updates method getEvaluatorForAlertRule to accept permissions evaluator and exit on the first negative result rather than generating a slice of string. This is more effective and will let us use it in other places.