### PR TITLE
Prometheus: Report error when parens are used and switching to visual builder

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/parsing.test.ts
@@ -541,6 +541,35 @@ describe('buildVisualQueryFromString', () => {
       },
     });
   });
+
+  it('reports error on parenthesis', () => {
+    expect(buildVisualQueryFromString('foo / (bar + baz)')).toEqual({
+      errors: [
+        {
+          from: 6,
+          parentType: 'Expr',
+          text: '(bar + baz)',
+          to: 17,
+        },
+      ],
+      query: {
+        metric: 'foo',
+        labels: [],
+        operations: [],
+        binaryQueries: [
+          {
+            operator: '/',
+            query: {
+              binaryQueries: [{ operator: '+', query: { labels: [], metric: 'baz', operations: [] } }],
+              metric: 'bar',
+              labels: [],
+              operations: [],
+            },
+          },
+        ],
+      },
+    });
+  });
 });
 
 function noErrors(query: PromVisualQuery) {

--- a/public/app/plugins/datasource/prometheus/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/parsing.ts
@@ -155,6 +155,11 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
     }
 
     default: {
+      if (node.name === 'ParenExpr') {
+        // We don't support parenthesis in the query to group expressions. We just report error but go on with the
+        // parsing.
+        context.errors.push(makeError(expr, node));
+      }
       // Any other nodes we just ignore and go to it's children. This should be fine as there are lot's of wrapper
       // nodes that can be skipped.
       // TODO: there are probably cases where we will just skip nodes we don't support and we should be able to


### PR DESCRIPTION
Queries like `foo / (bar + baz)` aren't properly parsed because we don't really support grouping with parens in the visual editor but they did not report an error before.