### PR TITLE
Docs: Clarify and document dashboard URL query parameters for variables

### DIFF
--- a/docs/sources/linking/_index.md
+++ b/docs/sources/linking/_index.md
@@ -22,7 +22,7 @@ The next step is to figure out which link type is right for your workflow. Even 
 
 ## Controlling time range using the URL
 
-You can control the time range of a panel or dashboard by providing following query parameters in dashboard URL:
+To control the time range of a panel or dashboard, you can provide the following query parameters in the dashboard URL:
 
 - `from` - defines lower limit of the time range, specified in ms epoch
 - `to` - defines upper limit of the time range, specified in ms epoch

--- a/docs/sources/linking/dashboard-links.md
+++ b/docs/sources/linking/dashboard-links.md
@@ -29,7 +29,7 @@ Add links to other dashboards at the top of your current dashboard.
    - **With tags** – Enter tags to limit the linked dashboards to only the ones with the tags you enter. Otherwise, Grafana includes links to all other dashboards.
    - **As dropdown** – If you are linking to lots of dashboards, then you probably want to select this option and add an optional title to the dropdown. Otherwise, Grafana displays the dashboard links side by side across the top of your dashboard.
    - **Time range** – Select this option to include the dashboard time range in the link. When the user clicks the link, the linked dashboard opens with the indicated time range already set. **Example:** https://play.grafana.org/d/000000010/annotations?orgId=1&from=now-3h&to=now
-   - **Variable values** – Select this option to include template variables currently used as query parameters in the link. When the user clicks the link, any matching templates in the linked dashboard are set to the values from the link. Here is the variable format: `https://${you-domain}/path/to/your/dashboard?var-${template-variable1}=value1&var-${template-variable2}=value2` **Example:** https://play.grafana.org/d/000000074/alerting?var-app=backend&var-server=backend_01&var-server=backend_03&var-interval=1h
+   - **Variable values** – Select this option to include template variables currently used as query parameters in the link. When the user clicks the link, any matching templates in the linked dashboard are set to the values from the link. For more information, see [Dashboard URL variables]({{< relref "dashboard-url-variables.md" >}}).
    - **Open in new tab** – Select this option if you want the dashboard link to open in a new tab or window.
 1. Click **Add**.
 
@@ -49,7 +49,7 @@ Add a link to a URL at the top of your current dashboard. You can link to any av
      - `from` - Defines the lower limit of the time range, specified in ms epoch.
      - `to` - Defines the upper limit of the time range, specified in ms epoch.
      - `time` and `time.window` - Define a time range from `time-time.window/2` to `time+time.window/2`. Both params should be specified in ms. For example `?time=1500000000000&time.window=10000` will result in 10s time range from 1499999995000 to 1500000005000.
-   - **Variable values** – Select this option to include template variables currently used as query parameters in the link. When the user clicks the link, any matching templates in the linked dashboard are set to the values from the link. Here is the variable format: `https://${you-domain}/path/to/your/dashboard?var-${template-varable1}=value1&var-{template-variable2}=value2` **Example:** https://play.grafana.org/d/000000074/alerting?var-app=backend&var-server=backend_01&var-server=backend_03&var-interval=1h
+   - **Variable values** – Select this option to include template variables currently used as query parameters in the link. When the user clicks the link, any matching templates in the linked dashboard are set to the values from the link. For more information, see [Dashboard URL variables]({{< relref "dashboard-url-variables.md" >}}).
    - **Open in new tab** – Select this option if you want the dashboard link to open in a new tab or window.
 1. Click **Add**.
 

--- a/docs/sources/linking/dashboard-url-variables.md
+++ b/docs/sources/linking/dashboard-url-variables.md
@@ -2,7 +2,7 @@
 title = "Dashboard URL variables"
 keywords = ["grafana", "url variables", "documentation", "variables", "dashboards"]
 aliases = ["/docs/grafana/latest/variables/url-variables.md","/docs/grafana/latest/variables/variable-types/url-variables.md"]
-weight = 400
+weight = 250
 +++
 
 # Dashboard URL variables

--- a/docs/sources/linking/dashboard-url-variables.md
+++ b/docs/sources/linking/dashboard-url-variables.md
@@ -1,0 +1,60 @@
++++
+title = "Dashboard URL variables"
+keywords = ["grafana", "url variables", "documentation", "variables", "dashboards"]
+aliases = ["/docs/grafana/latest/variables/url-variables.md","/docs/grafana/latest/variables/variable-types/url-variables.md"]
+weight = 400
++++
+
+# Dashboard URL variables
+
+Grafana can apply variable values passed as query parameters in dashboard URLs. For more information, refer to [Dashboard links]({{< relref "dashboard-links.md" >}}) and [Templates and variables]({{< relref "../variables/_index.md" >}}).
+
+## Passing variables as query parameters
+
+Grafana interprets query string parameters prefixed with `var-` as variables in the given dashboard.
+
+For example, in this URL:
+
+```
+https://${your-domain}/path/to/your/dashboard?var-example=value
+```
+
+The query parameter `var-example=value` represents the dashboard variable `example` with a value of `value`.
+
+### Passing multiple values for a variable
+
+To pass multiple values, repeat the variable parameter once for each value:
+
+```
+https://${your-domain}/path/to/your/dashboard?var-example=value1&var-example=value2
+```
+
+Grafana interprets `var-example=value1&var-example=value2` as the dashboard variable `example` with two values: `value1` and `value2`.
+
+### Example
+
+See https://play.grafana.org/d/000000074/alerting?var-app=backend&var-server=backend_01&var-server=backend_03&var-interval=1h - this passes the variable `server` with multiple values, and the variables `app` and `interval` with a single value each.
+
+## Adding variables to dashboard links
+
+Grafana can add variables to dashboard links when you generate them from a dashboard's settings. For more information and steps to add variables, refer to [Dashboard links]({{< relref "dashboard-links.md" >}}).
+
+## Passing ad hoc filters
+
+Ad hoc filters apply key/value filters to all metric queries that use a specified data source. For more information, refer to [Add ad hoc filters]({{< relref "../variables/variable-types/add-ad-hoc-filters.md" >}}).
+
+To pass an ad hoc filter as a query parameter, use the variable syntax to pass the ad hoc filter variable and provide the key, and provide as the value the operator, and value as a pipe-separated list.
+
+For example, in this URL:
+
+```
+https://${your-domain}/path/to/your/dashboard?var-adhoc=example_key|=|example_value
+```
+
+The query parameter `var-adhoc=key|=|value` applies the ad hoc filter configured as the `adhoc` dashboard variable using the `example_key` key, the `=` operator, and the `example_value` value.
+
+> **Note:** When sharing URLs with ad hoc filters, remember to encode the URL. In the above example, replace the pipes (`|`) with `%7C` and the equality operator (`=`) with `%3D`.
+
+### Example
+
+See https://play.grafana.org/d/000000002/influxdb-templated?orgId=1&var-datacenter=America&var-host=All&var-summarize=1m&var-adhoc=datacenter%7C%3D%7CAmerica

--- a/docs/sources/linking/dashboard-url-variables.md
+++ b/docs/sources/linking/dashboard-url-variables.md
@@ -57,4 +57,4 @@ The query parameter `var-adhoc=key|=|value` applies the ad hoc filter configured
 
 ### Example
 
-See https://play.grafana.org/d/000000002/influxdb-templated?orgId=1&var-datacenter=America&var-host=All&var-summarize=1m&var-adhoc=datacenter%7C%3D%7CAmerica
+See https://play.grafana.org/d/000000002/influxdb-templated?orgId=1&var-datacenter=America&var-host=All&var-summarize=1m&var-adhoc=datacenter%7C%3D%7CAmerica - this passes the ad hoc filter variable `adhoc` with the filter value `datacenter = America`.

--- a/docs/sources/linking/dashboard-url-variables.md
+++ b/docs/sources/linking/dashboard-url-variables.md
@@ -58,3 +58,7 @@ The query parameter `var-adhoc=key|=|value` applies the ad hoc filter configured
 ### Example
 
 See https://play.grafana.org/d/000000002/influxdb-templated?orgId=1&var-datacenter=America&var-host=All&var-summarize=1m&var-adhoc=datacenter%7C%3D%7CAmerica - this passes the ad hoc filter variable `adhoc` with the filter value `datacenter = America`.
+
+## Controlling time range using the URL
+
+To set a dashboard's time range, use the `from`, `to`, `time`, and `time.window` query parameters. Because these are not variables, they do not require the `var-` prefix. For more information, see the [Linking overview]({{< relref "_index.md" >}}).

--- a/docs/sources/linking/data-link-variables.md
+++ b/docs/sources/linking/data-link-variables.md
@@ -13,8 +13,6 @@ To see a list of available variables, type `$` in the data link **URL** field.
 
 > **Note:** These variables changed in 6.4 so if you have an older version of Grafana, then use the version picker to select docs for an older version of Grafana.
 
-You can also use template variables in your data links URLs, refer to [Templates and variables]({{< relref "../variables/_index.md" >}}) for more information on template variables.
-
 ## Time range panel variables
 
 These variables allow you to include the current time range in the data link URL.
@@ -47,7 +45,9 @@ Value-specific variables are available under `__value` namespace:
 
 ## Template variables
 
-When linking to another dashboard that uses template variables, select variable values for whoever clicks the link.
+You can also use template variables in data link URLs. For more information, refer to [Templates and variables]({{< relref "../variables/_index.md" >}}).
+
+When linking to another dashboard that uses template variables, select variable values to apply them for whoever clicks the link.
 
 `${myvar:queryparams}` - where `myvar` is a name of the template variable that matches one in the current dashboard that you want to use.
 

--- a/docs/sources/linking/data-link-variables.md
+++ b/docs/sources/linking/data-link-variables.md
@@ -51,6 +51,6 @@ When linking to another dashboard that uses template variables, select variable 
 
 - `${myvar:queryparams}` - where `myvar` matches the name of the desired template variable in the current dashboard
 
-  > **Note:** This example uses advanced variable formatting to convert variables, including those with multiple values, into query parameters. For more information, refer to [Advanced variable format options](https://grafana.com/docs/grafana/latest/variables/advanced-variable-format-options/).
+  > **Note:** This example uses advanced variable formatting to convert variables, including those with multiple values, into query parameters. For more information, refer to [Advanced variable format options]({{< relref "../variables/advanced-variable-format-options.md" >}}).
 
 - `__all_variables` - add all of the current dashboard's variables to the URL

--- a/docs/sources/linking/data-link-variables.md
+++ b/docs/sources/linking/data-link-variables.md
@@ -1,7 +1,7 @@
 +++
-title = "URL variables"
+title = "Data link variables"
 keywords = ["grafana", "url variables", "documentation", "variables", "data link"]
-aliases = ["/docs/grafana/latest/variables/url-variables.md","/docs/grafana/latest/variables/variable-types/url-variables.md"]
+aliases = ["/docs/grafana/latest/variables/data-link-variables.md","/docs/grafana/latest/variables/url-variables.md","/docs/grafana/latest/variables/variable-types/url-variables.md"]
 weight = 400
 +++
 

--- a/docs/sources/linking/data-link-variables.md
+++ b/docs/sources/linking/data-link-variables.md
@@ -49,6 +49,8 @@ You can also use template variables in data link URLs. For more information, ref
 
 When linking to another dashboard that uses template variables, select variable values to apply them for whoever clicks the link.
 
-`${myvar:queryparams}` - where `myvar` is a name of the template variable that matches one in the current dashboard that you want to use.
+- `${myvar:queryparams}` - where `myvar` matches the name of the desired template variable in the current dashboard
 
-If you want to add all of the current dashboard's variables to the URL, then use `__all_variables`.
+  > **Note:** This example uses advanced variable formatting to convert variables, including those with multiple values, into query parameters. For more information, refer to [Advanced variable format options](https://grafana.com/docs/grafana/latest/variables/advanced-variable-format-options/).
+
+- `__all_variables` - add all of the current dashboard's variables to the URL

--- a/docs/sources/linking/data-link-variables.md
+++ b/docs/sources/linking/data-link-variables.md
@@ -1,7 +1,7 @@
 +++
 title = "Data link variables"
 keywords = ["grafana", "url variables", "documentation", "variables", "data link"]
-aliases = ["/docs/grafana/latest/variables/data-link-variables.md","/docs/grafana/latest/variables/url-variables.md","/docs/grafana/latest/variables/variable-types/url-variables.md"]
+aliases = ["/docs/grafana/latest/variables/data-link-variables.md"]
 weight = 400
 +++
 

--- a/docs/sources/linking/data-link-variables.md
+++ b/docs/sources/linking/data-link-variables.md
@@ -9,7 +9,7 @@ weight = 400
 
 You can use variables in data links to refer to series fields, labels, and values. For more information about data links, refer to [Data links]({{< relref "data-links.md" >}}).
 
-To see a list of available variables, type `$` in the data link **URL** field to see a list of variables that you can use.
+To see a list of available variables, type `$` in the data link **URL** field.
 
 > **Note:** These variables changed in 6.4 so if you have an older version of Grafana, then use the version picker to select docs for an older version of Grafana.
 

--- a/docs/sources/linking/data-link-variables.md
+++ b/docs/sources/linking/data-link-variables.md
@@ -2,7 +2,7 @@
 title = "Data link variables"
 keywords = ["grafana", "url variables", "documentation", "variables", "data link"]
 aliases = ["/docs/grafana/latest/variables/data-link-variables.md"]
-weight = 400
+weight = 450
 +++
 
 # Data link variables

--- a/docs/sources/variables/_index.md
+++ b/docs/sources/variables/_index.md
@@ -27,7 +27,7 @@ For example, if you were administering a dashboard to monitor several servers, y
 wmi_system_threads{instance=~"$server"}
 ```
 
-Variable values are always synced to the URL using the syntax `var-<varname>=value`. For more information, refer to [Dashboard URL variables]({{< relref "../linking/dashboard-url-variables.md" }}).
+Variable values are always synced to the URL using the syntax `var-<varname>=value`. For more information, refer to [Dashboard URL variables]({{< relref "../linking/dashboard-url-variables.md" >}}).
 
 ## Examples of templates and variables
 

--- a/docs/sources/variables/_index.md
+++ b/docs/sources/variables/_index.md
@@ -27,7 +27,7 @@ For example, if you were administering a dashboard to monitor several servers, y
 wmi_system_threads{instance=~"$server"}
 ```
 
-Variable values are always synced to the URL using the syntax `var-<varname>=value`.
+Variable values are always synced to the URL using the syntax `var-<varname>=value`. For more information, refer to [Dashboard URL variables]({{< relref "../linking/dashboard-url-variables.md" }}).
 
 ## Examples of templates and variables
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Dashboard URL query parameters for variables are referred to from multiple docs, but don't have a document explaining their format and structure. This leads to multiple redundant descriptions in other docs, and a lack of clarity about what the query parameters are, how they're formatted, and where to document further details about them.

[Data link variables are documented](https://grafana.com/docs/grafana/latest/linking/data-link-variables/), a related but distinct context from dashboard URLs. However, this distinction is clearer in the document's H1 and URL ("Data link variables") than in its ToC listing and metadata title ("URL variables").

This PR:

- Creates a new "Dashboard URL variables" document (`linking/dashboard-url-variables.md`)
- Revises and renames the "Data link variables" document's metadata title and ToC listing to clarify the distinction
- Moves the aliases for old `url-variables` docs links from "Data link variables" to "Dashboard URL variables"
- Documents the ad hoc filter query parameter format for Dashboard URLs, which uses a dashboard variable and a special pipe-deliminated `key|operator|value` query param value (#15535).

**Which issue(s) this PR fixes**:

Fixes #15535.

**Special notes for your reviewer**:

None