### PR TITLE
Alerting: rule group update API to ignore deletes of rules user is not authorized to access

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -289,7 +289,8 @@ func (srv RulerSrv) updateAlertRulesInGroup(c *models.ReqContext, namespace *mod
 		}
 
 		if authorizedChanges.isEmpty() {
-			return fmt.Errorf("%w to update alert group '%s' because neither of changes are authorized", ErrAuthorization, groupName)
+			logger.Info("no authorized changes detected in the request. Do nothing", "not_authorized_add", len(groupChanges.New), "not_authorized_update", len(groupChanges.Update), "not_authorized_delete", len(groupChanges.Delete))
+			return nil
 		}
 
 		if len(groupChanges.Delete) > len(authorizedChanges.Delete) {

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -278,7 +278,7 @@ func (srv RulerSrv) updateAlertRulesInGroup(c *models.ReqContext, namespace *mod
 			return nil
 		}
 
-		err = authorizeRuleChanges(namespace, groupChanges, func(evaluator accesscontrol.Evaluator) bool {
+		groupChanges, err = authorizeRuleChanges(namespace, groupChanges, func(evaluator accesscontrol.Evaluator) bool {
 			return hasAccess(accesscontrol.ReqOrgAdminOrEditor, evaluator)
 		})
 		if err != nil {

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -212,11 +212,6 @@ func authorizeRuleChanges(namespace *models.Folder, change *changes, evaluator f
 			}
 		}
 		result.Delete = allowedToDelete
-
-		// if there are no more changes other than unauthorized deletes, return error
-		if result.isEmpty() {
-			return nil, fmt.Errorf("%w to delete alert rules that use data sources the user does not have access to", ErrAuthorization)
-		}
 	}
 
 	var addAuthorized, updateAuthorized bool

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -185,49 +185,72 @@ func authorizeDatasourceAccessForRule(rule *ngmodels.AlertRule, evaluator func(e
 	return true
 }
 
-// authorizeRuleChanges analyzes changes in the rule group, determines what actions the user is trying to perform and check whether those actions are authorized.
-// If the user is not authorized to perform the changes the function returns ErrAuthorization with a description of what action is not authorized. If the evaluator function returns an error, the function returns it.
-func authorizeRuleChanges(namespace *models.Folder, changes *changes, evaluator func(evaluator ac.Evaluator) bool) error {
+// authorizeRuleChanges analyzes changes in the rule group, and checks whether the changes are authorized.
+// NOTE: if there are rules for deletion, and the user does not have access to data sources that a rule uses, the rule is removed from the list.
+// If the user is not authorized to perform the changes the function returns ErrAuthorization with a description of what action is not authorized.
+// Return changes that the user is authorized to perform or ErrAuthorization
+func authorizeRuleChanges(namespace *models.Folder, change *changes, evaluator func(evaluator ac.Evaluator) bool) (*changes, error) {
+	var result = &changes{
+		New:    change.New,
+		Update: change.Update,
+		Delete: change.Delete,
+	}
+
 	namespaceScope := dashboards.ScopeFoldersProvider.GetResourceScope(strconv.FormatInt(namespace.Id, 10))
-	if len(changes.Delete) > 0 {
-		allowed := evaluator(ac.EvalPermission(ac.ActionAlertingRuleDelete, namespaceScope))
-		if !allowed {
-			return fmt.Errorf("%w user cannot delete alert rules that belong to folder %s", ErrAuthorization, namespace.Title)
+	if len(change.Delete) > 0 {
+		var allowedToDelete []*ngmodels.AlertRule
+		for _, rule := range change.Delete {
+			dsAllowed := authorizeDatasourceAccessForRule(rule, evaluator)
+			if dsAllowed {
+				allowedToDelete = append(allowedToDelete, rule)
+			}
+		}
+		if len(allowedToDelete) > 0 {
+			allowed := evaluator(ac.EvalPermission(ac.ActionAlertingRuleDelete, namespaceScope))
+			if !allowed {
+				return nil, fmt.Errorf("%w to delete alert rules that belong to folder %s", ErrAuthorization, namespace.Title)
+			}
+		}
+		result.Delete = allowedToDelete
+
+		// if there are no more changes other than unauthorized deletes, return error
+		if result.isEmpty() {
+			return nil, fmt.Errorf("%w to delete alert rules that use data sources the user does not have access to", ErrAuthorization)
 		}
 	}
 
 	var addAuthorized, updateAuthorized bool
 
-	if len(changes.New) > 0 {
+	if len(change.New) > 0 {
 		addAuthorized = evaluator(ac.EvalPermission(ac.ActionAlertingRuleCreate, namespaceScope))
 		if !addAuthorized {
-			return fmt.Errorf("%w user cannot create alert rules in the folder %s", ErrAuthorization, namespace.Title)
+			return nil, fmt.Errorf("%w to create alert rules in the folder %s", ErrAuthorization, namespace.Title)
 		}
-		for _, rule := range changes.New {
+		for _, rule := range change.New {
 			dsAllowed := authorizeDatasourceAccessForRule(rule, evaluator)
 			if !dsAllowed {
-				return fmt.Errorf("%w to create a new alert rule '%s' because the user does not have read permissions for one or many datasources the rule uses", ErrAuthorization, rule.Title)
+				return nil, fmt.Errorf("%w to create a new alert rule '%s' because the user does not have read permissions for one or many datasources the rule uses", ErrAuthorization, rule.Title)
 			}
 		}
 	}
 
-	for _, rule := range changes.Update {
+	for _, rule := range change.Update {
 		dsAllowed := authorizeDatasourceAccessForRule(rule.New, evaluator)
 		if !dsAllowed {
-			return fmt.Errorf("%w to update alert rule '%s' (UID: %s) because the user does not have read permissions for one or many datasources the rule uses", ErrAuthorization, rule.Existing.Title, rule.Existing.UID)
+			return nil, fmt.Errorf("%w to update alert rule '%s' (UID: %s) because the user does not have read permissions for one or many datasources the rule uses", ErrAuthorization, rule.Existing.Title, rule.Existing.UID)
 		}
 
 		// Check if the rule is moved from one folder to the current. If yes, then the user must have the authorization to delete rules from the source folder and add rules to the target folder.
 		if rule.Existing.NamespaceUID != rule.New.NamespaceUID {
 			allowed := evaluator(ac.EvalAll(ac.EvalPermission(ac.ActionAlertingRuleDelete, dashboards.ScopeFoldersProvider.GetResourceScopeUID(rule.Existing.NamespaceUID))))
 			if !allowed {
-				return fmt.Errorf("%w to delete alert rules from folder UID %s", ErrAuthorization, rule.Existing.NamespaceUID)
+				return nil, fmt.Errorf("%w to delete alert rules from folder UID %s", ErrAuthorization, rule.Existing.NamespaceUID)
 			}
 
 			if !addAuthorized {
 				addAuthorized = evaluator(ac.EvalPermission(ac.ActionAlertingRuleCreate, namespaceScope))
 				if !addAuthorized {
-					return fmt.Errorf("%w to create alert rules in the folder '%s'", ErrAuthorization, namespace.Title)
+					return nil, fmt.Errorf("%w to create alert rules in the folder '%s'", ErrAuthorization, namespace.Title)
 				}
 			}
 			continue
@@ -236,9 +259,9 @@ func authorizeRuleChanges(namespace *models.Folder, changes *changes, evaluator 
 		if !updateAuthorized { // if it is false then the authorization was not checked. If it is true then the user is authorized to update rules
 			updateAuthorized = evaluator(ac.EvalAll(ac.EvalPermission(ac.ActionAlertingRuleUpdate, namespaceScope)))
 			if !updateAuthorized {
-				return fmt.Errorf("%w to update alert rules that belong to folder %s", ErrAuthorization, namespace.Title)
+				return nil, fmt.Errorf("%w to update alert rules that belong to folder %s", ErrAuthorization, namespace.Title)
 			}
 		}
 	}
-	return nil
+	return result, nil
 }

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -280,7 +280,7 @@ func TestAuthorizeRuleDelete(t *testing.T) {
 			},
 		},
 		{
-			name: "should fail if no changes other than unauthorized",
+			name: "should not fail if no changes other than unauthorized",
 			changes: func() *changes {
 				return &changes{
 					New:    nil,
@@ -296,9 +296,9 @@ func TestAuthorizeRuleDelete(t *testing.T) {
 				}
 			},
 			assert: func(t *testing.T, orig, authz *changes, err error) {
-				require.ErrorIs(t, err, ErrAuthorization)
-				require.NotNil(t, orig)
-				require.Nil(t, authz)
+				require.NoError(t, err)
+				require.False(t, orig.isEmpty())
+				require.True(t, authz.isEmpty())
 			},
 		},
 		{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Currently, access to an alert rule (when fine-grained access control feature is enabled) is a composition of many permissions:
folder and data source(s), i.e. to add, update or delete a rule user must have permission to create/update/delete rules in a folder as well as query permission for all data sources used by the rule.

On another side, the rule update API accepts rule groups, not individual rules. A group can contain many rules, and when a user updates the rules group they can delete, update and add rules. Therefore, the API's responsibility is to determine what changes the user tries to apply to a rule group, verify that the user has permission to do such changes, and update the database.

In the worst-case scenario, there can be a situation when the group contains alert rules to which the user does not have access to (no permissions to query data sources). Although this scenario is not common because currently all rules created via UI are created in their own group (e.g. one rule per group) as well as groups are not supported by the Grafana Alerting engine, it is worth assuming the more general case. 
In future PRs the read API will not return those alerts when the user requests an alert group, and therefore, if the user submits that response back to rule update API, the API will detect that the user tries to delete the rules that they cannot see. To avoid such situations, we decided to make API ignore deletes that are not authorized. 

This PR is a follow up for https://github.com/grafana/grafana/pull/45749 and updates the authorization logic of rule update API to:
- verify that the user has access to all data sources used by the rule that needs to be deleted from the group
- if a user is not authorized to access the rule, the rule is removed from the list to delete

**Which issue(s) this PR fixes**:
Related:  https://github.com/grafana/grafana/pull/45749