### PR TITLE
CI: Fetch tags when cloning repos, for the test release step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -706,9 +706,11 @@ steps:
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
     --depth=1
   - cd grafana-enterprise
+  - git fetch origin "refs/tags/*:refs/tags/*"
   - git tag -d $${TEST_TAG} && git push --delete origin $${TEST_TAG} && git tag $${TEST_TAG}
     && git push origin $${TEST_TAG}
   - cd -
+  - git fetch origin "refs/tags/*:refs/tags/*"
   - git remote add downstream https://github.com/grafana/$${DOWNSTREAM_REPO}.git
   - git tag -d $${TEST_TAG} && git push --delete downstream $${TEST_TAG} && git tag
     $${TEST_TAG} && git push downstream $${TEST_TAG}
@@ -4409,6 +4411,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: f8ee7ebfe0dd8221b71c0f0d01fa7dfd41be01526959c35b6f2eb4069babbf51
+hmac: a6d1a7ba0b32ac93ba85f81961ee7494818f214829e034f2ef98f88d7728cbd0
 
 ...

--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -167,8 +167,10 @@ def trigger_test_release():
         'commands': [
             'git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git" --depth=1',
             'cd grafana-enterprise',
+            'git fetch origin "refs/tags/*:refs/tags/*"',
             'git tag -d $${TEST_TAG} && git push --delete origin $${TEST_TAG} && git tag $${TEST_TAG} && git push origin $${TEST_TAG}',
             'cd -',
+            'git fetch origin "refs/tags/*:refs/tags/*"',
             'git remote add downstream https://github.com/grafana/$${DOWNSTREAM_REPO}.git',
             'git tag -d $${TEST_TAG} && git push --delete downstream $${TEST_TAG} && git tag $${TEST_TAG} && git push downstream $${TEST_TAG}',
         ],


### PR DESCRIPTION
**What this PR does / why we need it**:

`trigger-test-release` step fails because it indicates that it cannot find `tags`. That happens because during OSS clone (Drone automated operation), the tags are not fetched.
For enterprise, we use `--depth=1` to prevent the repo from downloading too much, and so we need to fetch the tags there as well.

