### PR TITLE
CI: Add GH token when adding the remote

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -711,9 +711,9 @@ steps:
     && git push origin $${TEST_TAG}
   - cd -
   - git fetch origin "refs/tags/*:refs/tags/*"
-  - git remote add downstream https://github.com/grafana/$${DOWNSTREAM_REPO}.git
-  - git tag -d $${TEST_TAG} && git push --delete downstream $${TEST_TAG} && git tag
-    $${TEST_TAG} && git push downstream $${TEST_TAG}
+  - git remote add downstream https://$${GITHUB_TOKEN}@github.com/grafana/$${DOWNSTREAM_REPO}.git
+  - git tag -d $${TEST_TAG} && git push --delete downstream --quiet $${TEST_TAG} &&
+    git tag $${TEST_TAG} && git push downstream $${TEST_TAG} --quiet
   environment:
     DOWNSTREAM_REPO:
       from_secret: downstream
@@ -4411,6 +4411,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: a6d1a7ba0b32ac93ba85f81961ee7494818f214829e034f2ef98f88d7728cbd0
+hmac: 7b8d6e6cb7f6b8846de99626b8e0e61c795e93f1a02b32103ec13547c9007f5e
 
 ...

--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -171,8 +171,8 @@ def trigger_test_release():
             'git tag -d $${TEST_TAG} && git push --delete origin $${TEST_TAG} && git tag $${TEST_TAG} && git push origin $${TEST_TAG}',
             'cd -',
             'git fetch origin "refs/tags/*:refs/tags/*"',
-            'git remote add downstream https://github.com/grafana/$${DOWNSTREAM_REPO}.git',
-            'git tag -d $${TEST_TAG} && git push --delete downstream $${TEST_TAG} && git tag $${TEST_TAG} && git push downstream $${TEST_TAG}',
+            'git remote add downstream https://$${GITHUB_TOKEN}@github.com/grafana/$${DOWNSTREAM_REPO}.git',
+            'git tag -d $${TEST_TAG} && git push --delete downstream --quiet $${TEST_TAG} && git tag $${TEST_TAG} && git push downstream $${TEST_TAG} --quiet',
         ],
         'failure': 'ignore',
         'when': {


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to use the GH token when we refer to the downstream repo as a remote.
