### PR TITLE
chore: update contribution docs

### DIFF
--- a/contribute/architecture/backend/communication.md
+++ b/contribute/architecture/backend/communication.md
@@ -2,7 +2,7 @@
 
 Grafana uses a _bus_ to pass messages between different parts of the application. All communication over the bus happens synchronously.
 
-> **Note:** There is an ongoing effort to remove use of the bus in favor of direct interaction with services.
+> **Deprecated:** The bus has officially been deprecated, however, we're still using the sending command/query objects paradigms.
 
 There are three types of messages: _events_, _commands_, and _queries_.
 

--- a/contribute/architecture/backend/communication.md
+++ b/contribute/architecture/backend/communication.md
@@ -2,6 +2,8 @@
 
 Grafana uses a _bus_ to pass messages between different parts of the application. All communication over the bus happens synchronously.
 
+> **Note:** There is an ongoing effort to remove use of the bus in favor of direct interaction with services.
+
 There are three types of messages: _events_, _commands_, and _queries_.
 
 ## Events

--- a/contribute/architecture/backend/communication.md
+++ b/contribute/architecture/backend/communication.md
@@ -2,7 +2,7 @@
 
 Grafana uses a _bus_ to pass messages between different parts of the application. All communication over the bus happens synchronously.
 
-> **Deprecated:** The bus has officially been deprecated, however, we're still using the sending command/query objects paradigms.
+> **Deprecated:** The bus has officially been deprecated, however, we're still using the command/query objects paradigms.
 
 There are three types of messages: _events_, _commands_, and _queries_.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds notice to contribution guidelines that use of the bus has been deprecated.