### PR TITLE
Datemath: Fix weekstart calculation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
 	github.com/unknwon/com v1.0.1
 	github.com/urfave/cli/v2 v2.3.0
-	github.com/vectordotdev/go-datemath v0.1.1-0.20220110192739-f9ce83ec349f
+	github.com/vectordotdev/go-datemath v0.1.1-0.20220323213446-f3954d0b18ae
 	github.com/weaveworks/common v0.0.0-20210913144402-035033b78a78
 	github.com/xorcare/pointer v1.1.0
 	github.com/yudai/gojsondiff v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -2464,6 +2464,8 @@ github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/vectordotdev/go-datemath v0.1.1-0.20220110192739-f9ce83ec349f h1:2upw/ZfjkCKpc4k6DXg7lMfCSLkfw/8epV5/y2ZUQ8U=
 github.com/vectordotdev/go-datemath v0.1.1-0.20220110192739-f9ce83ec349f/go.mod h1:PnwzbSst7KD3vpBzzlntZU5gjVa455Uqa5QPiKSYJzQ=
+github.com/vectordotdev/go-datemath v0.1.1-0.20220323213446-f3954d0b18ae h1:oyiy3uBj1F4O3AaFh7hUGBrJjAssJhKyAbwxtkslxqo=
+github.com/vectordotdev/go-datemath v0.1.1-0.20220323213446-f3954d0b18ae/go.mod h1:PnwzbSst7KD3vpBzzlntZU5gjVa455Uqa5QPiKSYJzQ=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy7Y31EnHRDm1JkChoC7LXIJ7Ex0VYLWtZtQ=
 github.com/vishvananda/netlink v0.0.0-20171020171820-b2de5d10e38e/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=

--- a/pkg/tsdb/legacydata/time_range.go
+++ b/pkg/tsdb/legacydata/time_range.go
@@ -159,9 +159,6 @@ func (t parsableTime) datemathOptions() []func(*datemath.Options) {
 	}
 	if t.weekstart != nil {
 		weekstart := *t.weekstart
-		if weekstart > t.now.Weekday() {
-			weekstart = weekstart - 7
-		}
 		options = append(options, datemath.WithStartOfWeek(weekstart))
 	}
 	if t.fiscalStartMonth != nil {

--- a/pkg/tsdb/legacydata/time_range.go
+++ b/pkg/tsdb/legacydata/time_range.go
@@ -158,8 +158,7 @@ func (t parsableTime) datemathOptions() []func(*datemath.Options) {
 		options = append(options, datemath.WithLocation(t.location))
 	}
 	if t.weekstart != nil {
-		weekstart := *t.weekstart
-		options = append(options, datemath.WithStartOfWeek(weekstart))
+		options = append(options, datemath.WithStartOfWeek(*t.weekstart))
 	}
 	if t.fiscalStartMonth != nil {
 		loc := time.UTC


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

In Enterprise there's a test in reporting that fails on Saturdays due to incorrect weekstart calculation.

This PR:
- Upgrades `vectordotdev/go-datemath` version that includes the recent fix https://github.com/vectordotdev/go-datemath/pull/27 made by @sakjur 
- Removes unnecessary code

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

