### PR TITLE
Logs: Handle missing fields in dataframes better

### DIFF
--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -326,24 +326,27 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
   const seriesWithFields = logSeries.filter((series) => series.fields.length);
 
   if (seriesWithFields.length) {
-    allSeries = seriesWithFields.map((series) => {
+    seriesWithFields.forEach((series) => {
       const fieldCache = new FieldCache(series);
       const stringField = fieldCache.getFirstFieldOfType(FieldType.string);
+      const timeField = fieldCache.getFirstFieldOfType(FieldType.time);
 
-      if (stringField?.labels) {
-        allLabels.push(stringField.labels);
+      if (stringField !== undefined && timeField !== undefined) {
+        if (stringField?.labels) {
+          allLabels.push(stringField.labels);
+        }
+
+        allSeries.push({
+          series,
+          timeField,
+          timeNanosecondField: fieldCache.hasFieldWithNameAndType('tsNs', FieldType.time)
+            ? fieldCache.getFieldByName('tsNs')
+            : undefined,
+          stringField,
+          logLevelField: fieldCache.getFieldByName('level'),
+          idField: getIdField(fieldCache),
+        });
       }
-
-      return {
-        series,
-        timeField: fieldCache.getFirstFieldOfType(FieldType.time),
-        timeNanosecondField: fieldCache.hasFieldWithNameAndType('tsNs', FieldType.time)
-          ? fieldCache.getFieldByName('tsNs')
-          : undefined,
-        stringField,
-        logLevelField: fieldCache.getFieldByName('level'),
-        idField: getIdField(fieldCache),
-      } as LogFields;
     });
   }
 


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/45473

in `logs_model.ts` at a place we do not handle cases where the time-field or the string-field might be missing. in this PR we adjust the code to handle this and just skip the dataframe with the missing fields.

why do we need this?
theoretically, when we reach this code, we already checked at a different place that we have a time-field and a string-field. but, in some corner-cases things can go through, as you can see in the linked github-issue. there, in some cases, the dataframe has a time-field and two string-fields, which have a custom-property `hidden=true`. and, in `FieldCache.getFirstFieldOfType` we skip hidden-fields: https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/dataframe/FieldCache.ts#L62 . this caused the issue:
- first we checked by simply going through the fields, and we found a string-field, so we thought this is a good dataframe
- second time we asked for the string-field using `FieldCache.getFirstFieldOfType`, and it returned `undefined`

how to test:
- go to dashboards, create a logs-panel, use the test datasource, choose "Raw Frames" as the mode, and use this JSON as content:
```json
[
  {
    "fields": [
      {
        "name": "ts",
        "type": "time",
        "values": ["2022-03-25T14:43:15.078Z"]
      },
      {
        "name": "line",
        "type": "string",
        "config": {
          "custom": {
            "hidden": true
          }
        },
        "values": ["line1"]
      }
    ],
    "length": 2
  }
]
```

on main-branch this will cause an error, while on this pull-request it will simply say "Cannot visualize data"