### PR TITLE
Loki: Add aggregate by label support

### DIFF
--- a/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/AnnotationsQueryEditor.tsx
@@ -4,7 +4,7 @@ import React, { memo } from 'react';
 import { LokiQuery } from '../types';
 import { LokiQueryField } from './LokiQueryField';
 import { LokiOptionFields } from './LokiOptionFields';
-import LokiDatasource from '../datasource';
+import { LokiDatasource } from '../datasource';
 
 interface Props {
   expr: string;

--- a/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
@@ -16,7 +16,7 @@ import { LokiQuery, LokiOptions } from '../types';
 import { LanguageMap, languages as prismLanguages } from 'prismjs';
 import LokiLanguageProvider from '../language_provider';
 import { shouldRefreshLabels } from '../language_utils';
-import LokiDatasource from '../datasource';
+import { LokiDatasource } from '../datasource';
 import { LocalStorageValueProvider } from 'app/core/components/LocalStorageValueProvider';
 
 const LAST_USED_LABELS_KEY = 'grafana.datasources.loki.browser.labels';

--- a/public/app/plugins/datasource/loki/components/types.ts
+++ b/public/app/plugins/datasource/loki/components/types.ts
@@ -1,5 +1,5 @@
 import { QueryEditorProps } from '@grafana/data';
-import LokiDatasource from '../datasource';
+import { LokiDatasource } from '../datasource';
 import { LokiOptions, LokiQuery } from '../types';
 
 export type LokiQueryEditorProps = QueryEditorProps<LokiDatasource, LokiQuery, LokiOptions>;

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -13,8 +13,7 @@ import {
   toUtc,
 } from '@grafana/data';
 import { BackendSrvRequest, FetchResponse } from '@grafana/runtime';
-
-import LokiDatasource, { RangeQueryOptions } from './datasource';
+import { LokiDatasource, RangeQueryOptions } from './datasource';
 import { LokiQuery, LokiResponse, LokiResultType } from './types';
 import { getQueryOptions } from 'test/helpers/getQueryOptions';
 import { TemplateSrv } from 'app/features/templating/template_srv';

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -837,5 +837,3 @@ function getLogLevelFromLabels(labels: Labels): LogLevel {
   }
   return levelLabel ? getLogLevelFromKey(labels[levelLabel]) : LogLevel.unknown;
 }
-
-export default LokiDatasource;

--- a/public/app/plugins/datasource/loki/language_provider.test.ts
+++ b/public/app/plugins/datasource/loki/language_provider.test.ts
@@ -4,7 +4,7 @@ import LanguageProvider, { LokiHistoryItem } from './language_provider';
 import { TypeaheadInput } from '@grafana/ui';
 
 import { makeMockLokiDatasource } from './mocks';
-import LokiDatasource from './datasource';
+import { LokiDatasource } from './datasource';
 import { AbstractLabelOperator } from '@grafana/data';
 import { LokiQueryType } from './types';
 

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -15,7 +15,7 @@ import syntax, { FUNCTIONS, PIPE_PARSERS, PIPE_OPERATORS } from './syntax';
 import { LokiQuery, LokiQueryType } from './types';
 import { dateTime, AbsoluteTimeRange, LanguageProvider, HistoryItem, AbstractQuery } from '@grafana/data';
 
-import LokiDatasource from './datasource';
+import { LokiDatasource } from './datasource';
 import { CompletionItem, TypeaheadInput, TypeaheadOutput, CompletionItemGroup } from '@grafana/ui';
 import Prism, { Grammar } from 'prismjs';
 

--- a/public/app/plugins/datasource/loki/module.ts
+++ b/public/app/plugins/datasource/loki/module.ts
@@ -1,12 +1,12 @@
 import { DataSourcePlugin } from '@grafana/data';
-import Datasource from './datasource';
+import { LokiDatasource } from './datasource';
 
 import LokiCheatSheet from './components/LokiCheatSheet';
 import LokiQueryEditorByApp from './components/LokiQueryEditorByApp';
 import { LokiAnnotationsQueryCtrl } from './LokiAnnotationsQueryCtrl';
 import { ConfigEditor } from './configuration/ConfigEditor';
 
-export const plugin = new DataSourcePlugin(Datasource)
+export const plugin = new DataSourcePlugin(LokiDatasource)
   .setQueryEditor(LokiQueryEditorByApp)
   .setConfigEditor(ConfigEditor)
   .setQueryEditorHelp(LokiCheatSheet)

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -5,7 +5,6 @@ import { RadioButtonGroup, Select } from '@grafana/ui';
 import { LokiQuery, LokiQueryType } from '../../types';
 import { QueryOptionGroup } from 'app/plugins/datasource/prometheus/querybuilder/shared/QueryOptionGroup';
 import { preprocessMaxLines, queryTypeOptions, RESOLUTION_OPTIONS } from '../../components/LokiOptionFields';
-import { getLegendModeLabel } from 'app/plugins/datasource/prometheus/querybuilder/components/PromQueryLegendEditor';
 import { AutoSizeInput } from 'app/plugins/datasource/prometheus/querybuilder/shared/AutoSizeInput';
 import { isMetricsQuery } from '../../datasource';
 
@@ -99,7 +98,9 @@ function getCollapsedInfo(query: LokiQuery, queryType: LokiQueryType, showMaxLin
 
   const items: string[] = [];
 
-  items.push(`Legend: ${getLegendModeLabel(query.legendFormat)}`);
+  if (query.legendFormat) {
+    items.push(`Legend: ${query.legendFormat}`);
+  }
 
   if (query.resolution) {
     items.push(`Resolution: ${resolutionLabel?.label}`);

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -1,7 +1,5 @@
-import {
-  functionRendererLeft,
-  getPromAndLokiOperationDisplayName,
-} from '../../prometheus/querybuilder/shared/operationUtils';
+import { createAggregationOperation } from '../../prometheus/querybuilder/aggregations';
+import { getPromAndLokiOperationDisplayName } from '../../prometheus/querybuilder/shared/operationUtils';
 import {
   QueryBuilderOperation,
   QueryBuilderOperationDef,
@@ -12,6 +10,20 @@ import { FUNCTIONS } from '../syntax';
 import { LokiOperationId, LokiOperationOrder, LokiVisualQuery, LokiVisualQueryOperationCategory } from './types';
 
 export function getOperationDefintions(): QueryBuilderOperationDef[] {
+  const aggregations = [
+    LokiOperationId.Sum,
+    LokiOperationId.Min,
+    LokiOperationId.Max,
+    LokiOperationId.Avg,
+    LokiOperationId.TopK,
+    LokiOperationId.BottomK,
+  ].flatMap((opId) =>
+    createAggregationOperation(opId, {
+      addOperationHandler: addLokiOperation,
+      orderRank: LokiOperationOrder.Last,
+    })
+  );
+
   const list: QueryBuilderOperationDef[] = [
     createRangeOperation(LokiOperationId.Rate),
     createRangeOperation(LokiOperationId.CountOverTime),
@@ -19,10 +31,7 @@ export function getOperationDefintions(): QueryBuilderOperationDef[] {
     createRangeOperation(LokiOperationId.BytesRate),
     createRangeOperation(LokiOperationId.BytesOverTime),
     createRangeOperation(LokiOperationId.AbsentOverTime),
-    createAggregationOperation(LokiOperationId.Sum),
-    createAggregationOperation(LokiOperationId.Avg),
-    createAggregationOperation(LokiOperationId.Min),
-    createAggregationOperation(LokiOperationId.Max),
+    ...aggregations,
     {
       id: LokiOperationId.Json,
       name: 'Json',
@@ -195,24 +204,6 @@ function createRangeOperation(name: string): QueryBuilderOperationDef {
       } else {
         return `${opDocs} The [range vector](https://grafana.com/docs/loki/latest/logql/metric_queries/#range-vector-aggregation) is set to \`${op.params[0]}\`.`;
       }
-    },
-  };
-}
-
-function createAggregationOperation(name: string): QueryBuilderOperationDef {
-  return {
-    id: name,
-    name: getPromAndLokiOperationDisplayName(name),
-    params: [],
-    defaultParams: [],
-    alternativesKey: 'plain aggregation',
-    category: LokiVisualQueryOperationCategory.Aggregations,
-    orderRank: LokiOperationOrder.Last,
-    renderer: functionRendererLeft,
-    addOperationHandler: addLokiOperation,
-    explainHandler: (op, def) => {
-      const opDocs = FUNCTIONS.find((x) => x.insertText === op.id);
-      return `${opDocs?.documentation}.`;
     },
   };
 }

--- a/public/app/plugins/datasource/loki/querybuilder/types.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/types.ts
@@ -41,6 +41,8 @@ export enum LokiOperationId {
   Avg = 'avg',
   Min = 'min',
   Max = 'max',
+  TopK = 'topk',
+  BottomK = 'bottomk',
   LineContains = '__line_contains',
   LineContainsNot = '__line_contains_not',
   LineMatchesRegex = '__line_matches_regex',

--- a/public/app/plugins/datasource/loki/streaming.ts
+++ b/public/app/plugins/datasource/loki/streaming.ts
@@ -1,7 +1,7 @@
 import { DataFrameJSON, DataQueryRequest, DataQueryResponse, LiveChannelScope, LoadingState } from '@grafana/data';
 import { getGrafanaLiveSrv } from '@grafana/runtime';
 import { map, Observable, defer, mergeMap } from 'rxjs';
-import LokiDatasource from './datasource';
+import { LokiDatasource } from './datasource';
 import { LokiQuery } from './types';
 import { StreamingDataFrame } from 'app/features/live/data/StreamingDataFrame';
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelParamEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelParamEditor.tsx
@@ -29,7 +29,7 @@ export function LabelParamEditor({
       openMenuOnFocus
       onOpenMenu={async () => {
         setState({ isLoading: true });
-        const options = await loadGroupByLabels(query as PromVisualQuery, datasource as PrometheusDatasource);
+        const options = await loadGroupByLabels(query, datasource);
         setState({ options, isLoading: undefined });
       }}
       isLoading={state.isLoading}

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/LabelParamEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/LabelParamEditor.tsx
@@ -1,11 +1,10 @@
 import { DataSourceApi, SelectableValue, toOption } from '@grafana/data';
 import { Select } from '@grafana/ui';
-import { LokiDatasource } from 'app/plugins/datasource/loki/datasource';
 import React, { useState } from 'react';
 import { PrometheusDatasource } from '../../datasource';
 import { promQueryModeller } from '../PromQueryModeller';
 import { getOperationParamId } from '../shared/operationUtils';
-import { QueryBuilderOperationParamEditorProps } from '../shared/types';
+import { QueryBuilderLabelFilter, QueryBuilderOperationParamEditorProps } from '../shared/types';
 import { PromVisualQuery } from '../types';
 
 export function LabelParamEditor({
@@ -47,26 +46,18 @@ async function loadGroupByLabels(
   query: PromVisualQuery,
   datasource: DataSourceApi
 ): Promise<Array<SelectableValue<any>>> {
+  let labels: QueryBuilderLabelFilter[] = query.labels;
+
+  // This function is used by both Prometheus and Loki and this the only difference
   if (datasource instanceof PrometheusDatasource) {
-    const labels = [{ label: '__name__', op: '=', value: query.metric }, ...query.labels];
-    const expr = promQueryModeller.renderLabels(labels);
-    const result = await datasource.languageProvider.fetchSeriesLabels(expr);
-
-    return Object.keys(result).map((x) => ({
-      label: x,
-      value: x,
-    }));
+    labels = [{ label: '__name__', op: '=', value: query.metric }, ...query.labels];
   }
 
-  if (datasource instanceof LokiDatasource) {
-    const expr = promQueryModeller.renderLabels(query.labels);
-    const result = await datasource.languageProvider.fetchSeriesLabels(expr);
+  const expr = promQueryModeller.renderLabels(labels);
+  const result = await datasource.languageProvider.fetchSeriesLabels(expr);
 
-    return Object.keys(result).map((x) => ({
-      label: x,
-      value: x,
-    }));
-  }
-
-  return [];
+  return Object.keys(result).map((x) => ({
+    label: x,
+    value: x,
+  }));
 }

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/types.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/types.ts
@@ -32,7 +32,7 @@ export interface QueryBuilderOperationDef<T = any> extends RegistryItem {
   renderer: QueryBuilderOperationRenderer;
   addOperationHandler: QueryBuilderAddOperationHandler<T>;
   paramChangedHandler?: QueryBuilderOnParamChangedHandler;
-  explainHandler?: (op: QueryBuilderOperation, def: QueryBuilderOperationDef<T>) => string;
+  explainHandler?: QueryBuilderExplainOperationHandler;
   changeTypeHandler?: (op: QueryBuilderOperation, newDef: QueryBuilderOperationDef<T>) => QueryBuilderOperation;
 }
 
@@ -41,6 +41,8 @@ export type QueryBuilderAddOperationHandler<T> = (
   query: T,
   modeller: VisualQueryModeller
 ) => T;
+
+export type QueryBuilderExplainOperationHandler = (op: QueryBuilderOperation, def: QueryBuilderOperationDef) => string;
 
 export type QueryBuilderOnParamChangedHandler = (
   index: number,

--- a/public/app/plugins/datasource/prometheus/querybuilder/types.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/types.ts
@@ -100,7 +100,7 @@ export enum PromOperationId {
   Tanh = 'tanh',
   Time = 'time',
   Timestamp = 'timestamp',
-  Topk = 'topk',
+  TopK = 'topk',
   Vector = 'vector',
   Year = 'year',
   // Binary ops

--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -16,7 +16,7 @@ import React from 'react';
 import { LokiQueryField } from '../../loki/components/LokiQueryField';
 import { LokiQuery } from '../../loki/types';
 import { TempoDatasource, TempoQuery, TempoQueryType } from '../datasource';
-import LokiDatasource from '../../loki/datasource';
+import { LokiDatasource } from '../../loki/datasource';
 import useAsync from 'react-use/lib/useAsync';
 import NativeSearch from './NativeSearch';
 import { getDS } from './utils';


### PR DESCRIPTION
* [x] Adds the label param handling and `by` and `without` aggregation operation variants. 
* [x] Sharing code with Prometheus builder
* [x] Need to update LabelParamEditor to support loki as well, or create a specific component for Loki 