### PR TITLE
Alerting: Use correct scope for fine-grained access control action datasource:query

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -15,7 +15,6 @@ import (
 	models2 "github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	acMock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
-	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/schedule"
@@ -426,7 +425,7 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 				for _, rule := range rulesInFolder {
 					for _, query := range rule.Data {
 						permissions = append(permissions, &accesscontrol.Permission{
-							Action: datasources.ActionQuery, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(query.DatasourceUID),
+							Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(query.DatasourceUID),
 						})
 					}
 				}
@@ -459,7 +458,7 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 				for _, rule := range authorizedRulesInFolder {
 					for _, query := range rule.Data {
 						permissions = append(permissions, &accesscontrol.Permission{
-							Action: datasources.ActionQuery, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(query.DatasourceUID),
+							Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(query.DatasourceUID),
 						})
 					}
 				}
@@ -494,7 +493,7 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 				for _, rule := range authorizedRulesInGroup {
 					for _, query := range rule.Data {
 						permissions = append(permissions, &accesscontrol.Permission{
-							Action: datasources.ActionQuery, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID(query.DatasourceUID),
+							Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(query.DatasourceUID),
 						})
 					}
 				}

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -194,7 +194,7 @@ func authorizeDatasourceAccessForRule(rule *ngmodels.AlertRule, evaluator func(e
 		if query.QueryType == expr.DatasourceType || query.DatasourceUID == expr.OldDatasourceUID {
 			continue
 		}
-		if !evaluator(ac.EvalPermission(datasources.ActionQuery, dashboards.ScopeFoldersProvider.GetResourceScopeUID(query.DatasourceUID))) {
+		if !evaluator(ac.EvalPermission(datasources.ActionQuery, datasources.ScopeProvider.GetResourceScopeUID(query.DatasourceUID))) {
 			return false
 		}
 	}

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -91,7 +91,7 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 				var scopes []string
 				for _, rule := range c.New {
 					for _, query := range rule.Data {
-						scopes = append(scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(query.DatasourceUID))
+						scopes = append(scopes, datasources.ScopeProvider.GetResourceScopeUID(query.DatasourceUID))
 					}
 				}
 				return map[string][]string{
@@ -126,7 +126,7 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 				var scopes []string
 				for _, update := range c.Update {
 					for _, query := range update.New.Data {
-						scopes = append(scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(query.DatasourceUID))
+						scopes = append(scopes, datasources.ScopeProvider.GetResourceScopeUID(query.DatasourceUID))
 					}
 				}
 
@@ -164,7 +164,7 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 				var scopes []string
 				for _, update := range c.Update {
 					for _, query := range update.New.Data {
-						scopes = append(scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(query.DatasourceUID))
+						scopes = append(scopes, datasources.ScopeProvider.GetResourceScopeUID(query.DatasourceUID))
 					}
 				}
 				return map[string][]string{
@@ -221,7 +221,7 @@ func TestAuthorizeRuleDelete(t *testing.T) {
 		var scopes []string
 		for _, rule := range rules {
 			for _, query := range rule.Data {
-				scopes = append(scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(query.DatasourceUID))
+				scopes = append(scopes, datasources.ScopeProvider.GetResourceScopeUID(query.DatasourceUID))
 			}
 		}
 		return scopes
@@ -375,7 +375,7 @@ func TestCheckDatasourcePermissionsForRule(t *testing.T) {
 	expectedExecutions := rand.Intn(3) + 2
 	for i := 0; i < expectedExecutions; i++ {
 		q := models.GenerateAlertQuery()
-		scopes = append(scopes, dashboards.ScopeFoldersProvider.GetResourceScopeUID(q.DatasourceUID))
+		scopes = append(scopes, datasources.ScopeProvider.GetResourceScopeUID(q.DatasourceUID))
 		data = append(data, q)
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
In PR https://github.com/grafana/grafana/pull/45749 we introduced the check for datasource authorization but the scope referred to a folder not datasource. This PR fixes this to use the correct scope provider
