### PR TITLE
build: setBuildEnv before building

### DIFF
--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -177,21 +177,23 @@ func doBuild(binaryName, pkg string, opts BuildOpts) error {
 	args = append(args, "-o", binary)
 	args = append(args, pkg)
 
+	if !opts.isDev {
+		if err := setBuildEnv(opts); err != nil {
+			return err
+		}
+		runPrint("go", "version")
+		libcPart = ""
+		if opts.libc != "" {
+			libcPart = fmt.Sprintf("/%s", opts.libc)
+		}
+		fmt.Printf("Targeting %s/%s%s\n", opts.goos, opts.goarch, libcPart)
+	}
+
 	runPrint("go", args...)
 
 	if opts.isDev {
 		return nil
 	}
-
-	if err := setBuildEnv(opts); err != nil {
-		return err
-	}
-	runPrint("go", "version")
-	libcPart = ""
-	if opts.libc != "" {
-		libcPart = fmt.Sprintf("/%s", opts.libc)
-	}
-	fmt.Printf("Targeting %s/%s%s\n", opts.goos, opts.goarch, libcPart)
 
 	// Create an md5 checksum of the binary, to be included in the archive for
 	// automatic upgrades.


### PR DESCRIPTION



**What this PR does / why we need it**:

I am trying to cross-compile grafana using
```
go run build.go -goarch=armv6 -cgo-enabled=1 -cc=arm-linux-gnueabihf-gcc -pkg-arch=armhf build-server
```

It produces a binary, however running `file` on it yields:
```
grafana-server: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), statically linked, BuildID[sha1]=b012673ccd9fadf7d426d646f1129836c69a7395, for GNU/Linux 3.2.0, not stripped
```

So I got a 64-bits x86-64 executable instead of a 32-bits armv6 :bug: 

I traced the issue in the `build` package, where the build is done before setting the `GO*` env variables.

**Special notes for your reviewer**:

Partial revert of 3cb8978f05a41348c786938ffd10caa49b6b50c0 (#38726):
https://github.com/grafana/grafana/pull/38726/files#diff-60d42249bb53df5d3ffd44f507aee87a57c2cff5a20f6b1d8403a76d0ce609b0L277-L287