### PR TITLE
Text Panel: Fixes mailto links not working

### DIFF
--- a/public/app/core/navigation/patch/interceptLinkClicks.ts
+++ b/public/app/core/navigation/patch/interceptLinkClicks.ts
@@ -23,7 +23,7 @@ export function interceptLinkClicks(e: MouseEvent) {
       // Make sure external links are handled correctly
       // That is they where seen as being absolute from app root
       if (href[0] !== '/') {
-        // if still contains protocol it's an absolute link to another domain or web application
+        // if still contains protocol or is a mailto link, it's an absolute link to another domain or web application
         if (href.indexOf('://') > 0 || href.indexOf('mailto:') === 0) {
           window.location.href = href;
           return;

--- a/public/app/core/navigation/patch/interceptLinkClicks.ts
+++ b/public/app/core/navigation/patch/interceptLinkClicks.ts
@@ -24,7 +24,7 @@ export function interceptLinkClicks(e: MouseEvent) {
       // That is they where seen as being absolute from app root
       if (href[0] !== '/') {
         // if still contains protocol it's an absolute link to another domain or web application
-        if (href.indexOf('://') > 0) {
+        if (href.indexOf('://') > 0 || href.indexOf('mailto:') === 0) {
           window.location.href = href;
           return;
         } else {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently if you add something like `<a href="mailto:test@org.com"/>Mail me!</a>` to a Text Panel in HTML, it will try to redirect you to `https://play.grafana.org/mailto:test@org.com`. This is because if we don't specify a `target` for the anchor, it will assume it is a local link unless it contains `://`, this PR adds `mailto:` as another exception where it recognises it as an external link.

**Which issue(s) this PR fixes**:

Fixes #42690