### PR TITLE
Plugins: Pass OAuth Token to CallResource Function

### DIFF
--- a/docs/sources/developers/plugins/add-authentication-for-data-source-plugins.md
+++ b/docs/sources/developers/plugins/add-authentication-for-data-source-plugins.md
@@ -315,4 +315,15 @@ func (ds *dataSource) QueryData(ctx context.Context, req *backend.QueryDataReque
 }
 ```
 
+The `Authorization` and `X-ID-Token` headers will also be available on the `CallResourceRequest` object on the `CallResource` request in your backend data source when `jsonData.oauthPassThru` is `true`.
+
+```go
+func (ds *dataSource) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
+  token := req.Headers["Authorization"]
+  idToken := req.Headers["X-ID-Token"] // present if user's token includes an ID token
+
+  // ...
+}
+```
+
 > **Note:** Due to a bug in Grafana, using this feature with PostgreSQL can cause a deadlock. For more information, refer to [Grafana causes deadlocks in PostgreSQL, while trying to refresh users token](https://github.com/grafana/grafana/issues/20515).

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -506,6 +506,24 @@ func (hs *HTTPServer) callPluginResource(c *models.ReqContext, pluginID, dsUID s
 	}
 	clonedReq.URL = urlPath
 
+	ds, err := hs.DataSourceCache.GetDatasourceByUID(c.Req.Context(), dsUID, c.SignedInUser, c.SkipCache)
+
+	if err != nil && !errors.Is(err, models.ErrDataSourceNotFound) {
+		handleCallResourceError(err, c)
+		return
+	}
+
+	if ds != nil && hs.DataProxy.OAuthTokenService.IsOAuthPassThruEnabled(ds) {
+		if token := hs.DataProxy.OAuthTokenService.GetCurrentOAuthToken(c.Req.Context(), c.SignedInUser); token != nil {
+			clonedReq.Header.Add("Authorization", fmt.Sprintf("%s %s", token.Type(), token.AccessToken))
+
+			idToken, ok := token.Extra("id_token").(string)
+			if ok && idToken != "" {
+				clonedReq.Header.Add("X-ID-Token", idToken)
+			}
+		}
+	}
+
 	if err = hs.makePluginResourceRequest(c.Resp, clonedReq, pCtx); err != nil {
 		handleCallResourceError(err, c)
 	}

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -506,20 +506,22 @@ func (hs *HTTPServer) callPluginResource(c *models.ReqContext, pluginID, dsUID s
 	}
 	clonedReq.URL = urlPath
 
-	ds, err := hs.DataSourceCache.GetDatasourceByUID(c.Req.Context(), dsUID, c.SignedInUser, c.SkipCache)
+	if dsUID != "" {
+		ds, err := hs.DataSourceCache.GetDatasourceByUID(c.Req.Context(), dsUID, c.SignedInUser, c.SkipCache)
 
-	if err != nil && !errors.Is(err, models.ErrDataSourceNotFound) {
-		handleCallResourceError(err, c)
-		return
-	}
+		if err != nil && !errors.Is(err, models.ErrDataSourceNotFound) {
+			handleCallResourceError(err, c)
+			return
+		}
 
-	if ds != nil && hs.DataProxy.OAuthTokenService.IsOAuthPassThruEnabled(ds) {
-		if token := hs.DataProxy.OAuthTokenService.GetCurrentOAuthToken(c.Req.Context(), c.SignedInUser); token != nil {
-			clonedReq.Header.Add("Authorization", fmt.Sprintf("%s %s", token.Type(), token.AccessToken))
+		if ds != nil && hs.DataProxy.OAuthTokenService.IsOAuthPassThruEnabled(ds) {
+			if token := hs.DataProxy.OAuthTokenService.GetCurrentOAuthToken(c.Req.Context(), c.SignedInUser); token != nil {
+				clonedReq.Header.Add("Authorization", fmt.Sprintf("%s %s", token.Type(), token.AccessToken))
 
-			idToken, ok := token.Extra("id_token").(string)
-			if ok && idToken != "" {
-				clonedReq.Header.Add("X-ID-Token", idToken)
+				idToken, ok := token.Extra("id_token").(string)
+				if ok && idToken != "" {
+					clonedReq.Header.Add("X-ID-Token", idToken)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures there is OAuthPassThru support for the `CallResource` function in plugins in addition to the `QueryData` function. Note: This PR doesn't tackle getting the appropriate headers forwarded for additional endpoints such as `CheckHealth`. I probably won't tackle that work personally as I don't need it but I expect folks will want that as well.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/45938

Provided this general approach looks good I'd be happy to figure out how to add tests for this.

