### PR TITLE
Timerange: auto refresh timeout overflow

### DIFF
--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -384,10 +384,8 @@ export class TimeSrv {
   private getTimeout = (callback: any, timeout: number, ...args: any): NodeJS.Timeout => {
     const MAX_32_BIT_SIGNED = 2147483647;
     if (timeout / MAX_32_BIT_SIGNED > 1) {
-      console.log('longTimeout');
       return this.setLongTimeout(callback, timeout, args);
     } else {
-      console.log('timeout');
       return setTimeout(callback, timeout);
     }
   };

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -390,6 +390,7 @@ export class TimeSrv {
     }
   };
 
+  //
   // this was taken from https://stackoverflow.com/a/67351415 and modified accordingly.
   // it is needed to avoid overflow on auto refresh timer, for more than ~24 days,
   // due to the max delay value mentioned here:

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -390,7 +390,6 @@ export class TimeSrv {
     }
   };
 
-  //
   // this was taken from https://stackoverflow.com/a/67351415 and modified accordingly.
   // it is needed to avoid overflow on auto refresh timer, for more than ~24 days,
   // due to the max delay value mentioned here:


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
As mentioned in [this comment](https://github.com/grafana/grafana/issues/26757#issue-671630733), when setting the auto refresh to more than about 24 days the value in milliseconds is stored in a 32-bit signed integer internally ([setTimeout](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value)) which  overflows resulting in refresh firing almost instantly. 

The proposed solution still uses set timeout when delay is less than the maximum delay value but switches to a  custom timeout implementation for bigger delay values. 
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #26757

**Special notes for your reviewer**:
Based on my testing, the proposed solution works but still feels a little hacky and that is why i suggested using the new method only when really necessary. Hence the existence of getTimeout(), to distinguish between the two cases.

In terms of testing i changed the MAX_32_BIT_SIGNED value to 4000ms and got the following results:

[accounts for input less than MAX_32_BIT_SIGNED] timeout input : 3000 ms -> actual method call seconds: 3.004s
[accounts for input equal to MAX_32_BIT_SIGNED] timeout input : 4000 ms -> actual method call seconds: 4.006s
[accounts for input more than MAX_32_BIT_SIGNED] timeout input : 10000 ms -> actual method call seconds: 10.006s
