### PR TITLE
Alerting: handle folder permissions when fine-grained access enabled

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -85,7 +85,7 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 		labelOptions = append(labelOptions, ngmodels.WithoutInternalLabels())
 	}
 
-	namespaceMap, err := srv.store.GetNamespaces(c.Req.Context(), c.OrgId, c.SignedInUser)
+	namespaceMap, err := srv.store.GetUserVisibleNamespaces(c.Req.Context(), c.OrgId, c.SignedInUser)
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "failed to get namespaces visible to the user")
 	}

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -196,7 +196,7 @@ func (srv RulerSrv) RouteGetRulegGroupConfig(c *models.ReqContext) response.Resp
 }
 
 func (srv RulerSrv) RouteGetRulesConfig(c *models.ReqContext) response.Response {
-	namespaceMap, err := srv.store.GetNamespaces(c.Req.Context(), c.OrgId, c.SignedInUser)
+	namespaceMap, err := srv.store.GetUserVisibleNamespaces(c.Req.Context(), c.OrgId, c.SignedInUser)
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "failed to get namespaces visible to the user")
 	}

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -93,6 +93,7 @@ func (ng *AlertNG) init() error {
 		SQLStore:        ng.SQLStore,
 		Logger:          ng.Log,
 		FolderService:   ng.folderService,
+		AccessControl:   ng.accesscontrol,
 	}
 
 	decryptFn := ng.SecretsService.GetDecryptedValue

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -6,14 +6,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/grafana/pkg/services/guardian"
-	"github.com/grafana/grafana/pkg/services/sqlstore/searchstore"
-
 	"github.com/grafana/grafana/pkg/models"
-
+	"github.com/grafana/grafana/pkg/services/guardian"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/sqlstore/searchstore"
 	"github.com/grafana/grafana/pkg/util"
 )
 

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -322,7 +322,8 @@ func (st DBstore) GetNamespaceByTitle(ctx context.Context, namespace string, org
 		return nil, err
 	}
 
-	if withCanSave {
+	// if access control is disabled, check that the user is allowed to save in the folder.
+	if withCanSave && st.AccessControl.IsDisabled() {
 		g := guardian.New(ctx, folder.Id, orgID, user)
 		if canSave, err := g.CanSave(); err != nil || !canSave {
 			if err != nil {

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -283,7 +283,7 @@ func (st DBstore) GetNamespaces(ctx context.Context, orgID int64, user *models.S
 		Permission:   models.PERMISSION_VIEW,
 		Sort:         models.SortOption{},
 		Filters: []interface{}{
-			searchstore.FolderThatHaveAlertsFilter{},
+			searchstore.FolderWithAlertsFilter{},
 		},
 	}
 

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -41,7 +41,7 @@ type RuleStore interface {
 	GetOrgAlertRules(ctx context.Context, query *ngmodels.ListAlertRulesQuery) error
 	GetNamespaceAlertRules(ctx context.Context, query *ngmodels.ListNamespaceAlertRulesQuery) error
 	GetAlertRules(ctx context.Context, query *ngmodels.GetAlertRulesQuery) error
-	GetNamespaces(context.Context, int64, *models.SignedInUser) (map[string]*models.Folder, error)
+	GetUserVisibleNamespaces(context.Context, int64, *models.SignedInUser) (map[string]*models.Folder, error)
 	GetNamespaceByTitle(context.Context, string, int64, *models.SignedInUser, bool) (*models.Folder, error)
 	GetOrgRuleGroups(ctx context.Context, query *ngmodels.ListOrgRuleGroupsQuery) error
 	UpsertAlertRules(ctx context.Context, rule []UpsertRule) error
@@ -270,7 +270,7 @@ func (st DBstore) GetAlertRules(ctx context.Context, query *ngmodels.GetAlertRul
 }
 
 // GetNamespaces returns the folders that are visible to the user and have at least one alert in it
-func (st DBstore) GetNamespaces(ctx context.Context, orgID int64, user *models.SignedInUser) (map[string]*models.Folder, error) {
+func (st DBstore) GetUserVisibleNamespaces(ctx context.Context, orgID int64, user *models.SignedInUser) (map[string]*models.Folder, error) {
 	namespaceMap := make(map[string]*models.Folder)
 
 	searchQuery := models.FindPersistedDashboardsQuery{

--- a/pkg/services/ngalert/store/database.go
+++ b/pkg/services/ngalert/store/database.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
@@ -34,4 +35,5 @@ type DBstore struct {
 	SQLStore        *sqlstore.SQLStore
 	Logger          log.Logger
 	FolderService   dashboards.FolderService
+	AccessControl   accesscontrol.AccessControl
 }

--- a/pkg/services/ngalert/store/testing.go
+++ b/pkg/services/ngalert/store/testing.go
@@ -208,7 +208,7 @@ func (f *FakeRuleStore) GetAlertRules(_ context.Context, q *models.GetAlertRules
 	q.Result = result
 	return nil
 }
-func (f *FakeRuleStore) GetNamespaces(_ context.Context, orgID int64, _ *models2.SignedInUser) (map[string]*models2.Folder, error) {
+func (f *FakeRuleStore) GetUserVisibleNamespaces(_ context.Context, orgID int64, _ *models2.SignedInUser) (map[string]*models2.Folder, error) {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -91,7 +91,7 @@ func NewAccessControlDashboardPermissionFilter(user *models.SignedInUser, permis
 	if queryType == searchstore.TypeAlertFolder {
 		folderActions = append(folderActions, accesscontrol.ActionAlertingRuleRead)
 		if needEdit {
-			folderActions = append(folderActions, accesscontrol.ActionAlertingRuleUpdate)
+			folderActions = append(folderActions, accesscontrol.ActionAlertingRuleCreate)
 		}
 	} else {
 		dashboardActions = append(dashboardActions, accesscontrol.ActionDashboardsRead)

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -29,7 +29,7 @@ func TestNewAccessControlDashboardPermissionFilter(t *testing.T) {
 			expectedFolderActions: []string{
 				dashboards.ActionFoldersRead,
 				accesscontrol.ActionAlertingRuleRead,
-				accesscontrol.ActionAlertingRuleUpdate,
+				accesscontrol.ActionAlertingRuleCreate,
 			},
 		},
 		{
@@ -39,7 +39,7 @@ func TestNewAccessControlDashboardPermissionFilter(t *testing.T) {
 			expectedFolderActions: []string{
 				dashboards.ActionFoldersRead,
 				accesscontrol.ActionAlertingRuleRead,
-				accesscontrol.ActionAlertingRuleUpdate,
+				accesscontrol.ActionAlertingRuleCreate,
 			},
 		},
 		{

--- a/pkg/services/sqlstore/searchstore/filters.go
+++ b/pkg/services/sqlstore/searchstore/filters.go
@@ -149,3 +149,13 @@ func sqlIDin(column string, ids []int64) (string, []interface{}) {
 	}
 	return fmt.Sprintf("%s IN %s", column, sqlArray), params
 }
+
+// FolderThatHaveAlertsFilter applies a filter that makes the result contain only folders that contain alert rules
+type FolderThatHaveAlertsFilter struct {
+}
+
+var _ FilterWhere = &FolderThatHaveAlertsFilter{}
+
+func (f FolderThatHaveAlertsFilter) Where() (string, []interface{}) {
+	return "EXISTS (SELECT 1 FROM alert_rule WHERE alert_rule.namespace_uid = dashboard.uid)", nil
+}

--- a/pkg/services/sqlstore/searchstore/filters.go
+++ b/pkg/services/sqlstore/searchstore/filters.go
@@ -150,12 +150,12 @@ func sqlIDin(column string, ids []int64) (string, []interface{}) {
 	return fmt.Sprintf("%s IN %s", column, sqlArray), params
 }
 
-// FolderThatHaveAlertsFilter applies a filter that makes the result contain only folders that contain alert rules
-type FolderThatHaveAlertsFilter struct {
+// FolderWithAlertsFilter applies a filter that makes the result contain only folders that contain alert rules
+type FolderWithAlertsFilter struct {
 }
 
-var _ FilterWhere = &FolderThatHaveAlertsFilter{}
+var _ FilterWhere = &FolderWithAlertsFilter{}
 
-func (f FolderThatHaveAlertsFilter) Where() (string, []interface{}) {
+func (f FolderWithAlertsFilter) Where() (string, []interface{}) {
 	return "EXISTS (SELECT 1 FROM alert_rule WHERE alert_rule.namespace_uid = dashboard.uid)", nil
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Currently, Grafana alerting uses FolderService to retrieve information about folders:
-  `DbStore.GetNamespaces` get a list of folders the current user can view. This list is used to retrieve alerts.
-  `DbStore.GetNamespaceByTitle` get a folder UID by its title.

FolderService adds an additional layer of abstraction on top of the Dashboard\FolderStore that implements user authorization.

#### Method `DbStore.GetNamespaces`
This method is basically a wrapper for the method `FolderService.GetFolders` that uses the method `SearchService.SearchHandler` that uses the method `SqlStore.FindDashboards`. 
The method `FindDashboards` uses the user permissions to build an SQL query that returns only folders\dashboards that the user has access to. When the fine-grained access is enabled this method limits the result to folder scopes for an action `folders:read` (and `folders:write` when a query is supposed to return folders the user has permission to write to). However, in the case of Grafana Alerting, this requirement is not enough. In addition to the action `folders:read` user needs folder scopes for action `alert.rules:read` in order to get folders a user can read alerts from. PR https://github.com/grafana/grafana/pull/46483 solves this problem by introducing support for a new query type `dash-folder-alerting`. This way it gives Grafana Alerting UI as well as back-end ability to share access logic. However, FolderService does not support query type. Also, FolderService uses SearchService that does some additional processing of the results returned by `FindDashboard` method (setting favorites, generating URLs etc) that are not needed for the Grafana Alerting. At last, the FolderService does not support additional filters, which can be useful in the case of Grafana Alerting to remove folders that do not have any alert rules from the result. 

Based on these factors, I decided to _temporarily_ replace the usage of FolderService in the method `DbStore.GetNamespaces` by direct execution of `FindDashboard`. Later we can refactor the FolderService and make it more flexible.

<details><summary>Example</summary>

Therefore, in order to see alert rule in the folder with ID=10 that uses datasource with ID=123, the user will need the following permissions:
```
{
"action": "folders:read" 
"scope": "folders:id:10"
},
{
"action": "alert.rule:read" 
"scope": "folders:id:10"
},
{
"action": "datasources:query" 
"scope": "datasources:id:123"
}
```

</details>

####  Method `DbStore.GetNamespaceByTitle`
This method also calls the method `FolderService.GetFolderByTitle` that retrieves a folder by its title and then checks that the user has permissions to read it. 
However, if the argument `withCanSave` is set to true, method GetNamespaceByTitle checks that user can write to the folder. The flag is set to true when API handler processes requests to create\update\delete rules.
However, the guardian does not check alerting permissions and verifies that the user can write to the folder. When fine-grained access is enabled this check is not necessary because API layer verifies that user permissions to do CRUD operations (alert.rule:[create|update|delete]). To avoid requiring users to have two actions `folders:write` and `alert.rule:create` I decided to skip checking for `CanSave`. 

<details> <summary> Example </summary>

Therefore, in order to create an alert rule that queries datasource with ID=123 in a folder with ID=10, the user will need the following permissions:

```
{
"action": "folders:read" 
"scope": "folders:id:10"
},
{
"action": "alert.rule:create" 
"scope": "folders:id:10"
},
{
"action": "datasources:query" 
"scope": "datasources:id:123"
}
```

</details>


This PR: 
1. updates method `DbStore.GetNamespaces` to use `SqlStore.FindDashboards` with query type `dash-folder-alerting` that returns only folders the current user can see alerts in, and a custom filter `FolderThatHaveAlertsFilter` that removes folders that do not contain any alerts from the result.
2. updates method `DbStore.GetNamespaceByTitle` to not check whether user can save into the folder if fine-grained access is enabled.
3. changes filter `AccessControlDashboardPermissionFilter` to use action `alert.rules:create` instead of `alert.rules:update`. This filter is used by `SqlStore.FindDashboards` when fine-grained access is enabled and query type is `dash-folder-alerting`.