### PR TITLE
Docs: Fix `lint-docs` step

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "packages:clean": "lerna run clean",
     "precommit": "yarn run lint-staged",
     "prettier:check": "prettier --check --list-different=false --loglevel=warn \"**/*.{ts,tsx,scss,md,mdx}\"",
-    "prettier:checkDocs": "prettier --check --list-different=false --loglevel=warn \"docs/**.md\" \"packages/**.{ts,tsx,scss,md,mdx}\"",
+    "prettier:checkDocs": "prettier --check --list-different=false --loglevel=warn \"docs/**/*.md\" \"packages/**/*.{ts,tsx,scss,md,mdx}\"",
     "prettier:write": "prettier --list-different \"**/*.{js,ts,tsx,scss,md,mdx}\" --write",
     "start": "yarn themes:generate && yarn dev --watch",
     "start:noTsCheck": "yarn start --env noTsCheck=1",


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes `lint-docs` step. Replaces `docs/**.md` and `packages/**` paths with `docs/**/*.md` and `packages/**/*` to make sure that all the paths are checked. 
