### PR TITLE
Variables: Ensure variables in query params are correctly recognised

### DIFF
--- a/public/app/features/variables/utils.test.ts
+++ b/public/app/features/variables/utils.test.ts
@@ -184,14 +184,17 @@ describe('ensureStringValues', () => {
 
 describe('containsVariable', () => {
   it.each`
-    value                               | expected
-    ${''}                               | ${false}
-    ${'$var'}                           | ${true}
-    ${{ thing1: '${var}' }}             | ${true}
-    ${{ thing1: ['1', '${var}'] }}      | ${true}
-    ${{ thing1: { thing2: '${var}' } }} | ${true}
-    ${{ params: [['param', '$var']] }}  | ${true}
-    ${{ params: [['param', '${var}']] }}  | ${true}
+    value                                | expected
+    ${''}                                | ${false}
+    ${'$var'}                            | ${true}
+    ${{ thing1: '${var}' }}              | ${true}
+    ${{ thing1: '${var:fmt}' }}          | ${true}
+    ${{ thing1: ['1', '${var}'] }}       | ${true}
+    ${{ thing1: ['1', '[[var]]'] }}      | ${true}
+    ${{ thing1: ['1', '[[var:fmt]]'] }}  | ${true}
+    ${{ thing1: { thing2: '${var}' } }}  | ${true}
+    ${{ params: [['param', '$var']] }}   | ${true}
+    ${{ params: [['param', '${var}']] }} | ${true}
   `('when called with value:$value then result should be:$expected', ({ value, expected }) => {
     expect(containsVariable(value, 'var')).toEqual(expected);
   });

--- a/public/app/features/variables/utils.test.ts
+++ b/public/app/features/variables/utils.test.ts
@@ -190,6 +190,8 @@ describe('containsVariable', () => {
     ${{ thing1: '${var}' }}             | ${true}
     ${{ thing1: ['1', '${var}'] }}      | ${true}
     ${{ thing1: { thing2: '${var}' } }} | ${true}
+    ${{ params: [['param', '$var']] }}  | ${true}
+    ${{ params: [['param', '${var}']] }}  | ${true}
   `('when called with value:$value then result should be:$expected', ({ value, expected }) => {
     expect(containsVariable(value, 'var')).toEqual(expected);
   });

--- a/public/app/features/variables/utils.ts
+++ b/public/app/features/variables/utils.ts
@@ -18,7 +18,7 @@ import { KeyedVariableIdentifier, VariableIdentifier, VariablePayload } from './
  * \[\[([\s\S]+?)(?::(\w+))?\]\]    [[var2]] or [[var2:fmt2]]
  * \${(\w+)(?::(\w+))?}             ${var3} or ${var3:fmt3}
  */
-export const variableRegex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^\}]+))?(?::([^\}]+))?}/g;
+export const variableRegex = /\$(\w+)|\[\[(\w+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^\}]+))?(?::([^\}]+))?}/g;
 
 // Helper function since lastIndex is not reset
 export const variableRegexExec = (variableString: string) => {

--- a/public/app/features/variables/utils.ts
+++ b/public/app/features/variables/utils.ts
@@ -15,7 +15,7 @@ import { KeyedVariableIdentifier, VariableIdentifier, VariablePayload } from './
 /*
  * This regex matches 3 types of variable reference with an optional format specifier
  * \$(\w+)                          $var1
- * \[\[([\s\S]+?)(?::(\w+))?\]\]    [[var2]] or [[var2:fmt2]]
+ * \[\[(\w+?)(?::(\w+))?\]\]        [[var2]] or [[var2:fmt2]]
  * \${(\w+)(?::(\w+))?}             ${var3} or ${var3:fmt3}
  */
 export const variableRegex = /\$(\w+)|\[\[(\w+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^\}]+))?(?::([^\}]+))?}/g;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- when a variable is used in a query param, the stringified json looks like `{ params: [['param', '$var']] }`
- the regex to match the `[[var:fmt]]` pattern is too generous, causing it to match the whole thing (e.g. `[['param', '$var']]`) instead of matching on the individual variable `$var`
- make the regex to match the `[[var:fmt]]` pattern more specific such that it can only include alphanumeric and `_`

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/44304

**Special notes for your reviewer**:

