### PR TITLE
Do not run CodeQL analysis when some file types are updated

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,11 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
+    paths-ignore:
+      - '**/*.json'
+      - '**/*.md'
+      - '**/*.txt'
+      - '**/*.yml'
   schedule:
     - cron: '0 4 * * 6'
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This follows the recommendation in the GitHub Docs ["Configuring code scanning" > "Avoiding unnecessary scans of pull requests"](https://docs.github.com/en/enterprise-cloud@latest/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning?learn=code_security_actions&learnProduct=code-security#avoiding-unnecessary-scans-of-pull-requests).

I have noticed Go CodeQL analysis being run on https://github.com/grafana/grafana/pull/47038 which is why I'm doing these changes.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

