### PR TITLE
packages/grafana-data/text: Improve escaping for special characters

### DIFF
--- a/packages/grafana-data/src/text/string.test.ts
+++ b/packages/grafana-data/src/text/string.test.ts
@@ -60,11 +60,12 @@ describe('stringToMs', () => {
 describe('[un]escapeStringForRegex', () => {
   it.each([
     '[]',
+    '\\',
     '[(abc])',
     'onetwothree',
     '<namedgroup}(this is not a regex>',
     'string\\with\\backslash',
-    'everyspecialchar([{])}.,/?&*^&<>#',
+    'everyspecialchar([{])}.,/?&*-^&<>#',
   ])('should be symmetric', (input) => {
     const output = unEscapeStringFromRegex(escapeStringForRegex(input));
     expect(output).toEqual(input);
@@ -74,15 +75,14 @@ describe('[un]escapeStringForRegex', () => {
 describe('escapeStringForRegex', () => {
   it.each([
     '[[[',
-    '[]',
+    '[]\\',
     '[(abc])',
     'onetwothree',
     '<namedgroup}(this is not a regex>',
     'string\\with\\backslash',
-    'everyspecialchar([{])}.,/?&*^&<>#',
+    'everyspecialchar([{])}.,/?&*-^&<>#',
   ])('should always produce output that compiles', (value) => {
-    const _ignored = new RegExp(escapeStringForRegex(value));
-    // There should be no error.
+    expect(() => new RegExp(escapeStringForRegex(value))).not.toThrowError();
   });
 
   describe('when using a string without special chars', () => {

--- a/packages/grafana-data/src/text/string.test.ts
+++ b/packages/grafana-data/src/text/string.test.ts
@@ -57,12 +57,32 @@ describe('stringToMs', () => {
   });
 });
 
+describe('[un]escapeStringForRegex', () => {
+  it.each([
+    '[]',
+    '[(abc])',
+    'onetwothree',
+    '<namedgroup}(this is not a regex>',
+    'string\\with\\backslash',
+    'everyspecialchar([{])}.,/?&*^&<>#',
+  ])('should be symmetric', (input) => {
+    const output = unEscapeStringFromRegex(escapeStringForRegex(input));
+    expect(output).toEqual(input);
+  });
+});
+
 describe('escapeStringForRegex', () => {
-  describe('when using a string with special chars', () => {
-    it('then all special chars should be escaped', () => {
-      const result = escapeStringForRegex('([{}])|*+-.?<>#&^$');
-      expect(result).toBe('\\(\\[\\{\\}\\]\\)\\|\\*\\+\\-\\.\\?\\<\\>\\#\\&\\^\\$');
-    });
+  it.each([
+    '[[[',
+    '[]',
+    '[(abc])',
+    'onetwothree',
+    '<namedgroup}(this is not a regex>',
+    'string\\with\\backslash',
+    'everyspecialchar([{])}.,/?&*^&<>#',
+  ])('should always produce output that compiles', (value) => {
+    const _ignored = new RegExp(escapeStringForRegex(value));
+    // There should be no error.
   });
 
   describe('when using a string without special chars', () => {

--- a/packages/grafana-data/src/text/string.ts
+++ b/packages/grafana-data/src/text/string.ts
@@ -1,16 +1,15 @@
 import { camelCase } from 'lodash';
+
 const specialChars = ['(', '[', '{', '}', ']', ')', '\\', '|', '*', '+', '-', '.', '?', '<', '>', '#', '&', '^', '$'];
 const specialMatcher = '([\\' + specialChars.join('\\') + '])';
-
 const specialCharEscape = new RegExp(specialMatcher, 'g');
 const specialCharUnescape = new RegExp('(\\\\)' + specialMatcher, 'g');
+
 export const escapeStringForRegex = (value: string) => {
   if (!value) {
     return value;
   }
 
-  // For reviewers: this could simply be replaceAll if we're willing to
-  // increase the yarn compile target to es2021. What's the policy on that?
   return value.replace(specialCharEscape, '\\$1');
 };
 
@@ -19,8 +18,6 @@ export const unEscapeStringFromRegex = (value: string) => {
     return value;
   }
 
-  // For reviewers: this could simply be replaceAll if we're willing to
-  // increase the yarn compile target to es2021. What's the policy on that?
   return value.replace(specialCharUnescape, '$2');
 };
 

--- a/packages/grafana-data/src/text/string.ts
+++ b/packages/grafana-data/src/text/string.ts
@@ -1,5 +1,5 @@
 import { camelCase } from 'lodash';
-const specialChars = ['(', '[', '{', '}', ']', ')', '|', '*', '+', '-', '.', '?', '<', '>', '#', '&', '^', '$'];
+const specialChars = ['(', '[', '{', '}', ']', ')', '\\', '|', '*', '+', '-', '.', '?', '<', '>', '#', '&', '^', '$'];
 const specialMatcher = '([\\' + specialChars.join('\\') + '])';
 
 const specialCharEscape = new RegExp(specialMatcher, 'g');

--- a/packages/grafana-data/src/text/string.ts
+++ b/packages/grafana-data/src/text/string.ts
@@ -1,12 +1,17 @@
 import { camelCase } from 'lodash';
 const specialChars = ['(', '[', '{', '}', ']', ')', '|', '*', '+', '-', '.', '?', '<', '>', '#', '&', '^', '$'];
+const specialMatcher = '([\\' + specialChars.join('\\') + '])';
 
+const specialCharEscape = new RegExp(specialMatcher, 'g');
+const specialCharUnescape = new RegExp('(\\\\)' + specialMatcher, 'g');
 export const escapeStringForRegex = (value: string) => {
   if (!value) {
     return value;
   }
 
-  return specialChars.reduce((escaped, currentChar) => escaped.replace(currentChar, '\\' + currentChar), value);
+  // For reviewers: this could simply be replaceAll if we're willing to
+  // increase the yarn compile target to es2021. What's the policy on that?
+  return value.replace(specialCharEscape, '\\$1');
 };
 
 export const unEscapeStringFromRegex = (value: string) => {
@@ -14,7 +19,9 @@ export const unEscapeStringFromRegex = (value: string) => {
     return value;
   }
 
-  return specialChars.reduce((escaped, currentChar) => escaped.replace('\\' + currentChar, currentChar), value);
+  // For reviewers: this could simply be replaceAll if we're willing to
+  // increase the yarn compile target to es2021. What's the policy on that?
+  return value.replace(specialCharUnescape, '$2');
 };
 
 export function stringStartsAsRegEx(str: string): boolean {


### PR DESCRIPTION
**What this PR does / why we need it**:

FilterInput escapes all input strings for special characters that might
be used in a RegExp by calling escapeStringForRegex, and using
unEscapeStringFromRegex for display. Both of these functions used
string.prototype.replace() for escaping. replace() only replaces the
first occurence of a search string unless called with a global RegExp.
The output of these functions was not necessarily safe to compile into a
RegExp literal.

This change creates RegExps for escapeStringForRegex and
unEscapeStringFromRegex to match all occurrences of the special
characters instead of just their first occurrence. This makes a variety
of strings safe for RegExp compilation.

**Special notes for your reviewer**:
Requesting specific reviews from @gillesdemey because this relates to a Grafana support escalation he's viewed, and from @joshhunt to give a look over my test style. Thanks for the pointers!



