### PR TITLE
Tempo: Download span references in data inspector

### DIFF
--- a/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
+++ b/packages/grafana-ui/src/components/Table/JSONViewCell.tsx
@@ -29,7 +29,7 @@ export function JSONViewCell(props: TableCellProps): JSX.Element {
   return (
     <div {...cellProps} className={inspectEnabled ? tableStyles.cellContainerNoOverflow : tableStyles.cellContainer}>
       <div className={cx(tableStyles.cellText, txt)}>
-        {!link && <div className={tableStyles.cellText}>{value}</div>}
+        {!link && <div className={tableStyles.cellText}>{displayValue}</div>}
         {link && (
           <a
             href={link.href}

--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanDetail/AccordianReferences.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanDetail/AccordianReferences.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as React from 'react';
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { Icon, useStyles2 } from '@grafana/ui';
 
 import AccordianKeyValues from './AccordianKeyValues';
@@ -98,6 +98,9 @@ const getStyles = (theme: GrafanaTheme2) => {
         content: attr(data-label);
       }
     `,
+    serviceName: css`
+      margin-right: 8px;
+    `,
   };
 };
 
@@ -134,7 +137,9 @@ export function References(props: ReferenceItemProps) {
               <span className={styles.itemContent}>
                 {reference.span ? (
                   <span>
-                    <span className="span-svc-name">{reference.span.process.serviceName}</span>
+                    <span className={cx('span-svc-name', styles.serviceName)}>
+                      {reference.span.process.serviceName}
+                    </span>
                     <small className="endpoint-name">{reference.span.operationName}</small>
                   </span>
                 ) : (

--- a/public/app/plugins/datasource/tempo/mockJsonResponse.json
+++ b/public/app/plugins/datasource/tempo/mockJsonResponse.json
@@ -3,12 +3,42 @@
     {
       "resource": {
         "attributes": [
-          { "key": "service.name", "value": { "stringValue": "db" } },
-          { "key": "job", "value": { "stringValue": "tns/db" } },
-          { "key": "opencensus.exporterversion", "value": { "stringValue": "Jaeger-Go-2.22.1" } },
-          { "key": "host.name", "value": { "stringValue": "63d16772b4a2" } },
-          { "key": "ip", "value": { "stringValue": "172.24.0.2" } },
-          { "key": "client-uuid", "value": { "stringValue": "39fb01637a579639" } }
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "db"
+            }
+          },
+          {
+            "key": "job",
+            "value": {
+              "stringValue": "tns/db"
+            }
+          },
+          {
+            "key": "opencensus.exporterversion",
+            "value": {
+              "stringValue": "Jaeger-Go-2.22.1"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "63d16772b4a2"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "172.24.0.2"
+            }
+          },
+          {
+            "key": "client-uuid",
+            "value": {
+              "stringValue": "39fb01637a579639"
+            }
+          }
         ]
       },
       "instrumentationLibrarySpans": [
@@ -24,10 +54,55 @@
               "startTimeUnixNano": "1627471657255809000",
               "endTimeUnixNano": "1627471657256268000",
               "attributes": [
-                { "key": "http.status_code", "value": { "intValue": "200" } },
-                { "key": "http.method", "value": { "stringValue": "GET" } },
-                { "key": "http.url", "value": { "stringValue": "/" } },
-                { "key": "component", "value": { "stringValue": "net/http" } }
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "component",
+                  "value": {
+                    "stringValue": "net/http"
+                  }
+                }
+              ],
+              "links": [
+                {
+                  "spanId": "spanId",
+                  "traceId": "traceId",
+                  "attributes": [
+                    {
+                      "key": "key",
+                      "value": {
+                        "stringValue": "Value"
+                      }
+                    },
+                    {
+                      "key": "intValue",
+                      "value": {
+                        "intValue": 4
+                      }
+                    }
+                  ]
+                },
+                {
+                  "spanId": "spanId2",
+                  "traceId": "traceId2",
+                  "attributes": []
+                }
               ],
               "status": {}
             }
@@ -38,12 +113,42 @@
     {
       "resource": {
         "attributes": [
-          { "key": "service.name", "value": { "stringValue": "app" } },
-          { "key": "job", "value": { "stringValue": "tns/app" } },
-          { "key": "opencensus.exporterversion", "value": { "stringValue": "Jaeger-Go-2.22.1" } },
-          { "key": "host.name", "value": { "stringValue": "f68212e86151" } },
-          { "key": "ip", "value": { "stringValue": "172.24.0.7" } },
-          { "key": "client-uuid", "value": { "stringValue": "8b6e8600b53a24" } }
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "app"
+            }
+          },
+          {
+            "key": "job",
+            "value": {
+              "stringValue": "tns/app"
+            }
+          },
+          {
+            "key": "opencensus.exporterversion",
+            "value": {
+              "stringValue": "Jaeger-Go-2.22.1"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "f68212e86151"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "172.24.0.7"
+            }
+          },
+          {
+            "key": "client-uuid",
+            "value": {
+              "stringValue": "8b6e8600b53a24"
+            }
+          }
         ]
       },
       "instrumentationLibrarySpans": [
@@ -66,12 +171,42 @@
     {
       "resource": {
         "attributes": [
-          { "key": "service.name", "value": { "stringValue": "lb" } },
-          { "key": "job", "value": { "stringValue": "tns/loadgen" } },
-          { "key": "opencensus.exporterversion", "value": { "stringValue": "Jaeger-Go-2.22.1" } },
-          { "key": "host.name", "value": { "stringValue": "6475ba6d3c8b" } },
-          { "key": "ip", "value": { "stringValue": "172.24.0.8" } },
-          { "key": "client-uuid", "value": { "stringValue": "535eb863d7ade742" } }
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "lb"
+            }
+          },
+          {
+            "key": "job",
+            "value": {
+              "stringValue": "tns/loadgen"
+            }
+          },
+          {
+            "key": "opencensus.exporterversion",
+            "value": {
+              "stringValue": "Jaeger-Go-2.22.1"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "6475ba6d3c8b"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "172.24.0.8"
+            }
+          },
+          {
+            "key": "client-uuid",
+            "value": {
+              "stringValue": "535eb863d7ade742"
+            }
+          }
         ]
       },
       "instrumentationLibrarySpans": [
@@ -85,8 +220,18 @@
               "startTimeUnixNano": "1627471657247632000",
               "endTimeUnixNano": "1627471657260233000",
               "attributes": [
-                { "key": "sampler.type", "value": { "stringValue": "const" } },
-                { "key": "sampler.param", "value": { "boolValue": true } }
+                {
+                  "key": "sampler.type",
+                  "value": {
+                    "stringValue": "const"
+                  }
+                },
+                {
+                  "key": "sampler.param",
+                  "value": {
+                    "boolValue": true
+                  }
+                }
               ],
               "status": {}
             }
@@ -97,12 +242,42 @@
     {
       "resource": {
         "attributes": [
-          { "key": "service.name", "value": { "stringValue": "lb" } },
-          { "key": "job", "value": { "stringValue": "tns/loadgen" } },
-          { "key": "opencensus.exporterversion", "value": { "stringValue": "Jaeger-Go-2.22.1" } },
-          { "key": "host.name", "value": { "stringValue": "6475ba6d3c8b" } },
-          { "key": "ip", "value": { "stringValue": "172.24.0.8" } },
-          { "key": "client-uuid", "value": { "stringValue": "535eb863d7ade742" } }
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "lb"
+            }
+          },
+          {
+            "key": "job",
+            "value": {
+              "stringValue": "tns/loadgen"
+            }
+          },
+          {
+            "key": "opencensus.exporterversion",
+            "value": {
+              "stringValue": "Jaeger-Go-2.22.1"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "6475ba6d3c8b"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "172.24.0.8"
+            }
+          },
+          {
+            "key": "client-uuid",
+            "value": {
+              "stringValue": "535eb863d7ade742"
+            }
+          }
         ]
       },
       "instrumentationLibrarySpans": [
@@ -118,67 +293,189 @@
               "startTimeUnixNano": "1627471657247674000",
               "endTimeUnixNano": "1627471657261178000",
               "attributes": [
-                { "key": "http.status_code", "value": { "intValue": "200" } },
-                { "key": "component", "value": { "stringValue": "net/http" } },
-                { "key": "http.method", "value": { "stringValue": "GET" } },
-                { "key": "http.url", "value": { "stringValue": "app:80" } },
-                { "key": "net/http.reused", "value": { "boolValue": false } },
-                { "key": "net/http.was_idle", "value": { "boolValue": false } }
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "component",
+                  "value": {
+                    "stringValue": "net/http"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "app:80"
+                  }
+                },
+                {
+                  "key": "net/http.reused",
+                  "value": {
+                    "boolValue": false
+                  }
+                },
+                {
+                  "key": "net/http.was_idle",
+                  "value": {
+                    "boolValue": false
+                  }
+                }
               ],
               "events": [
                 {
                   "timeUnixNano": "1627471657247711000",
-                  "attributes": [{ "key": "event", "value": { "stringValue": "GetConn" } }]
+                  "attributes": [
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "GetConn"
+                      }
+                    }
+                  ]
                 },
                 {
                   "timeUnixNano": "1627471657247822000",
                   "attributes": [
-                    { "key": "event", "value": { "stringValue": "DNSStart" } },
-                    { "key": "host", "value": { "stringValue": "app" } }
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "DNSStart"
+                      }
+                    },
+                    {
+                      "key": "host",
+                      "value": {
+                        "stringValue": "app"
+                      }
+                    }
                   ]
                 },
                 {
                   "timeUnixNano": "1627471657249309000",
                   "attributes": [
-                    { "key": "event", "value": { "stringValue": "DNSDone" } },
-                    { "key": "addr", "value": { "stringValue": "172.24.0.7" } }
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "DNSDone"
+                      }
+                    },
+                    {
+                      "key": "addr",
+                      "value": {
+                        "stringValue": "172.24.0.7"
+                      }
+                    }
                   ]
                 },
                 {
                   "timeUnixNano": "1627471657249395000",
                   "attributes": [
-                    { "key": "event", "value": { "stringValue": "ConnectStart" } },
-                    { "key": "network", "value": { "stringValue": "tcp" } },
-                    { "key": "addr", "value": { "stringValue": "172.24.0.7:80" } }
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "ConnectStart"
+                      }
+                    },
+                    {
+                      "key": "network",
+                      "value": {
+                        "stringValue": "tcp"
+                      }
+                    },
+                    {
+                      "key": "addr",
+                      "value": {
+                        "stringValue": "172.24.0.7:80"
+                      }
+                    }
                   ]
                 },
                 {
                   "timeUnixNano": "1627471657250250000",
                   "attributes": [
-                    { "key": "event", "value": { "stringValue": "ConnectDone" } },
-                    { "key": "network", "value": { "stringValue": "tcp" } },
-                    { "key": "addr", "value": { "stringValue": "172.24.0.7:80" } }
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "ConnectDone"
+                      }
+                    },
+                    {
+                      "key": "network",
+                      "value": {
+                        "stringValue": "tcp"
+                      }
+                    },
+                    {
+                      "key": "addr",
+                      "value": {
+                        "stringValue": "172.24.0.7:80"
+                      }
+                    }
                   ]
                 },
                 {
                   "timeUnixNano": "1627471657250313000",
-                  "attributes": [{ "key": "event", "value": { "stringValue": "GotConn" } }]
+                  "attributes": [
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "GotConn"
+                      }
+                    }
+                  ]
                 },
                 {
                   "timeUnixNano": "1627471657250446000",
-                  "attributes": [{ "key": "event", "value": { "stringValue": "WroteHeaders" } }]
+                  "attributes": [
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "WroteHeaders"
+                      }
+                    }
+                  ]
                 },
                 {
                   "timeUnixNano": "1627471657250465000",
-                  "attributes": [{ "key": "event", "value": { "stringValue": "WroteRequest" } }]
+                  "attributes": [
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "WroteRequest"
+                      }
+                    }
+                  ]
                 },
                 {
                   "timeUnixNano": "1627471657260087000",
-                  "attributes": [{ "key": "event", "value": { "stringValue": "GotFirstResponseByte" } }]
+                  "attributes": [
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "GotFirstResponseByte"
+                      }
+                    }
+                  ]
                 },
                 {
                   "timeUnixNano": "1627471657260804000",
-                  "attributes": [{ "key": "event", "value": { "stringValue": "ClosedBody" } }]
+                  "attributes": [
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "ClosedBody"
+                      }
+                    }
+                  ]
                 }
               ],
               "status": {}
@@ -190,12 +487,42 @@
     {
       "resource": {
         "attributes": [
-          { "key": "service.name", "value": { "stringValue": "app" } },
-          { "key": "job", "value": { "stringValue": "tns/app" } },
-          { "key": "opencensus.exporterversion", "value": { "stringValue": "Jaeger-Go-2.22.1" } },
-          { "key": "host.name", "value": { "stringValue": "f68212e86151" } },
-          { "key": "ip", "value": { "stringValue": "172.24.0.7" } },
-          { "key": "client-uuid", "value": { "stringValue": "8b6e8600b53a24" } }
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "app"
+            }
+          },
+          {
+            "key": "job",
+            "value": {
+              "stringValue": "tns/app"
+            }
+          },
+          {
+            "key": "opencensus.exporterversion",
+            "value": {
+              "stringValue": "Jaeger-Go-2.22.1"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "f68212e86151"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "172.24.0.7"
+            }
+          },
+          {
+            "key": "client-uuid",
+            "value": {
+              "stringValue": "8b6e8600b53a24"
+            }
+          }
         ]
       },
       "instrumentationLibrarySpans": [
@@ -211,67 +538,189 @@
               "startTimeUnixNano": "1627471657251445000",
               "endTimeUnixNano": "1627471657260828000",
               "attributes": [
-                { "key": "http.status_code", "value": { "intValue": "200" } },
-                { "key": "component", "value": { "stringValue": "net/http" } },
-                { "key": "http.method", "value": { "stringValue": "GET" } },
-                { "key": "http.url", "value": { "stringValue": "db:80" } },
-                { "key": "net/http.reused", "value": { "boolValue": false } },
-                { "key": "net/http.was_idle", "value": { "boolValue": false } }
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "component",
+                  "value": {
+                    "stringValue": "net/http"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "db:80"
+                  }
+                },
+                {
+                  "key": "net/http.reused",
+                  "value": {
+                    "boolValue": false
+                  }
+                },
+                {
+                  "key": "net/http.was_idle",
+                  "value": {
+                    "boolValue": false
+                  }
+                }
               ],
               "events": [
                 {
                   "timeUnixNano": "1627471657251575000",
-                  "attributes": [{ "key": "event", "value": { "stringValue": "GetConn" } }]
+                  "attributes": [
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "GetConn"
+                      }
+                    }
+                  ]
                 },
                 {
                   "timeUnixNano": "1627471657251700000",
                   "attributes": [
-                    { "key": "event", "value": { "stringValue": "DNSStart" } },
-                    { "key": "host", "value": { "stringValue": "db" } }
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "DNSStart"
+                      }
+                    },
+                    {
+                      "key": "host",
+                      "value": {
+                        "stringValue": "db"
+                      }
+                    }
                   ]
                 },
                 {
                   "timeUnixNano": "1627471657254144000",
                   "attributes": [
-                    { "key": "event", "value": { "stringValue": "DNSDone" } },
-                    { "key": "addr", "value": { "stringValue": "172.24.0.2" } }
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "DNSDone"
+                      }
+                    },
+                    {
+                      "key": "addr",
+                      "value": {
+                        "stringValue": "172.24.0.2"
+                      }
+                    }
                   ]
                 },
                 {
                   "timeUnixNano": "1627471657254295000",
                   "attributes": [
-                    { "key": "event", "value": { "stringValue": "ConnectStart" } },
-                    { "key": "network", "value": { "stringValue": "tcp" } },
-                    { "key": "addr", "value": { "stringValue": "172.24.0.2:80" } }
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "ConnectStart"
+                      }
+                    },
+                    {
+                      "key": "network",
+                      "value": {
+                        "stringValue": "tcp"
+                      }
+                    },
+                    {
+                      "key": "addr",
+                      "value": {
+                        "stringValue": "172.24.0.2:80"
+                      }
+                    }
                   ]
                 },
                 {
                   "timeUnixNano": "1627471657255054000",
                   "attributes": [
-                    { "key": "event", "value": { "stringValue": "ConnectDone" } },
-                    { "key": "network", "value": { "stringValue": "tcp" } },
-                    { "key": "addr", "value": { "stringValue": "172.24.0.2:80" } }
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "ConnectDone"
+                      }
+                    },
+                    {
+                      "key": "network",
+                      "value": {
+                        "stringValue": "tcp"
+                      }
+                    },
+                    {
+                      "key": "addr",
+                      "value": {
+                        "stringValue": "172.24.0.2:80"
+                      }
+                    }
                   ]
                 },
                 {
                   "timeUnixNano": "1627471657255199000",
-                  "attributes": [{ "key": "event", "value": { "stringValue": "GotConn" } }]
+                  "attributes": [
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "GotConn"
+                      }
+                    }
+                  ]
                 },
                 {
                   "timeUnixNano": "1627471657255257000",
-                  "attributes": [{ "key": "event", "value": { "stringValue": "WroteHeaders" } }]
+                  "attributes": [
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "WroteHeaders"
+                      }
+                    }
+                  ]
                 },
                 {
                   "timeUnixNano": "1627471657255274000",
-                  "attributes": [{ "key": "event", "value": { "stringValue": "WroteRequest" } }]
+                  "attributes": [
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "WroteRequest"
+                      }
+                    }
+                  ]
                 },
                 {
                   "timeUnixNano": "1627471657258308000",
-                  "attributes": [{ "key": "event", "value": { "stringValue": "GotFirstResponseByte" } }]
+                  "attributes": [
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "GotFirstResponseByte"
+                      }
+                    }
+                  ]
                 },
                 {
                   "timeUnixNano": "1627471657260811000",
-                  "attributes": [{ "key": "event", "value": { "stringValue": "ClosedBody" } }]
+                  "attributes": [
+                    {
+                      "key": "event",
+                      "value": {
+                        "stringValue": "ClosedBody"
+                      }
+                    }
+                  ]
                 }
               ],
               "status": {}
@@ -283,12 +732,42 @@
     {
       "resource": {
         "attributes": [
-          { "key": "service.name", "value": { "stringValue": "app" } },
-          { "key": "job", "value": { "stringValue": "tns/app" } },
-          { "key": "opencensus.exporterversion", "value": { "stringValue": "Jaeger-Go-2.22.1" } },
-          { "key": "host.name", "value": { "stringValue": "f68212e86151" } },
-          { "key": "ip", "value": { "stringValue": "172.24.0.7" } },
-          { "key": "client-uuid", "value": { "stringValue": "8b6e8600b53a24" } }
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "app"
+            }
+          },
+          {
+            "key": "job",
+            "value": {
+              "stringValue": "tns/app"
+            }
+          },
+          {
+            "key": "opencensus.exporterversion",
+            "value": {
+              "stringValue": "Jaeger-Go-2.22.1"
+            }
+          },
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "f68212e86151"
+            }
+          },
+          {
+            "key": "ip",
+            "value": {
+              "stringValue": "172.24.0.7"
+            }
+          },
+          {
+            "key": "client-uuid",
+            "value": {
+              "stringValue": "8b6e8600b53a24"
+            }
+          }
         ]
       },
       "instrumentationLibrarySpans": [
@@ -304,10 +783,30 @@
               "startTimeUnixNano": "1627471657251228000",
               "endTimeUnixNano": "1627471657260930000",
               "attributes": [
-                { "key": "http.status_code", "value": { "intValue": "200" } },
-                { "key": "http.method", "value": { "stringValue": "GET" } },
-                { "key": "http.url", "value": { "stringValue": "/" } },
-                { "key": "component", "value": { "stringValue": "net/http" } }
+                {
+                  "key": "http.status_code",
+                  "value": {
+                    "intValue": "200"
+                  }
+                },
+                {
+                  "key": "http.method",
+                  "value": {
+                    "stringValue": "GET"
+                  }
+                },
+                {
+                  "key": "http.url",
+                  "value": {
+                    "stringValue": "/"
+                  }
+                },
+                {
+                  "key": "component",
+                  "value": {
+                    "stringValue": "net/http"
+                  }
+                }
               ],
               "status": {}
             }

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -390,6 +390,7 @@ export function transformToOTLP(data: MutableDataFrame): {
       droppedLinksCount: 0,
       status: getOTLPStatus(span.tags),
       events: getOTLPEvents(span.logs),
+      links: getOTLPReferences(span.references),
     });
   }
 
@@ -500,6 +501,35 @@ function getOTLPEvents(logs: TraceLog[]): collectorTypes.opentelemetryProto.trac
     events.push(event);
   }
   return events;
+}
+
+function getOTLPReferences(
+  references: TraceSpanReference[]
+): collectorTypes.opentelemetryProto.trace.v1.Span.Link[] | undefined {
+  if (!references || !references.length) {
+    return undefined;
+  }
+
+  let links: collectorTypes.opentelemetryProto.trace.v1.Span.Link[] = [];
+  for (const ref of references) {
+    let link: collectorTypes.opentelemetryProto.trace.v1.Span.Link = {
+      traceId: ref.traceID,
+      spanId: ref.spanID,
+      attributes: [],
+      droppedAttributesCount: 0,
+    };
+    if (ref.tags?.length) {
+      for (const tag of ref.tags) {
+        link.attributes?.push({
+          key: tag.key,
+          value: toAttributeValue(tag),
+        });
+      }
+    }
+    links.push(link);
+  }
+  console.log({ links });
+  return links;
 }
 
 export function transformTrace(response: DataQueryResponse, nodeGraph = false): DataQueryResponse {

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -528,7 +528,6 @@ function getOTLPReferences(
     }
     links.push(link);
   }
-  console.log({ links });
   return links;
 }
 

--- a/public/app/plugins/datasource/tempo/testResponse.ts
+++ b/public/app/plugins/datasource/tempo/testResponse.ts
@@ -1928,7 +1928,23 @@ export const otlpDataFrameFromResponse = new MutableDataFrame({
       type: 'other',
       config: {},
       labels: undefined,
-      values: [[]],
+      values: [
+        [
+          {
+            spanID: 'spanId',
+            traceID: 'traceId',
+            tags: [
+              { key: 'key', value: 'Value' },
+              { key: 'intValue', value: 4 },
+            ],
+          },
+          {
+            spanID: 'spanId2',
+            traceID: 'traceId2',
+            tags: [],
+          },
+        ],
+      ],
       state: {
         displayName: 'references',
       },
@@ -2118,6 +2134,32 @@ export const otlpDataFrameToResponse = new MutableDataFrame({
         displayName: 'tags',
       },
     },
+    {
+      name: 'references',
+      type: 'other',
+      config: {},
+      labels: undefined,
+      values: [
+        [
+          {
+            spanID: 'spanId',
+            traceID: 'traceId',
+            tags: [
+              { key: 'key', value: 'Value' },
+              { key: 'intValue', value: 4 },
+            ],
+          },
+          {
+            spanID: 'spanId2',
+            traceID: 'traceId2',
+            tags: [],
+          },
+        ],
+      ],
+      state: {
+        displayName: 'references',
+      },
+    },
   ],
   first: ['60ba2abb44f13eae'],
   length: 1,
@@ -2152,6 +2194,31 @@ export const otlpResponse = {
                 { key: 'http.method', value: { stringValue: 'GET' } },
                 { key: 'http.url', value: { stringValue: '/' } },
                 { key: 'component', value: { stringValue: 'net/http' } },
+              ],
+              links: [
+                {
+                  spanId: 'spanId',
+                  traceId: 'traceId',
+                  attributes: [
+                    {
+                      key: 'key',
+                      value: {
+                        stringValue: 'Value',
+                      },
+                    },
+                    {
+                      key: 'intValue',
+                      value: {
+                        intValue: 4,
+                      },
+                    },
+                  ],
+                },
+                {
+                  spanId: 'spanId2',
+                  traceId: 'traceId2',
+                  attributes: [],
+                },
               ],
             },
           ],


### PR DESCRIPTION
**What this PR does / why we need it**:
After adding support for span references, we should handle uploading/downloading them as well. 

**Which issue(s) this PR fixes**:
Fixes #45925

**Special notes for your reviewer**:
Attached is a json file (zipped) which has references. You can test this by uploading the file, checking the span references display in the trace viewer, download the trace (Inspector > Data > Download traces), and verify the references are downloaded.
[Explore-traces-2022-03-30 11_26_54.json.zip](https://github.com/grafana/grafana/files/8382883/Explore-traces-2022-03-30.11_26_54.json.zip)

