### PR TITLE
Geomap: Resize map on changing window size

### DIFF
--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -120,6 +120,12 @@ export class GeomapPanel extends Component<Props, State> {
     return true; // always?
   }
 
+  componentDidUpdate(prevProps: Props) {
+    if (this.map && (this.props.height !== prevProps.height || this.props.width !== prevProps.width)) {
+      this.map.updateSize();
+    }
+  }
+
   /** This function will actually update the JSON model */
   private doOptionsUpdate(selected: number) {
     const { options, onOptionsChange } = this.props;


### PR DESCRIPTION
Geomap was not returning to the original size after window resizing.

https://user-images.githubusercontent.com/88068998/160937191-9b711d4a-deba-486f-a969-554c264a8163.mov

Fixes #43125


