### PR TITLE
Alerting: Add check for datasource permission in alert rule read API

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -96,7 +96,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 	api.RegisterPrometheusApiEndpoints(NewForkedProm(
 		api.DatasourceCache,
 		NewLotexProm(proxy, logger),
-		&PrometheusSrv{log: logger, manager: api.StateManager, store: api.RuleStore},
+		&PrometheusSrv{log: logger, manager: api.StateManager, store: api.RuleStore, ac: api.AccessControl},
 	), m)
 	// Register endpoints for proxying to Cortex Ruler-compatible backends.
 	api.RegisterRulerApiEndpoints(NewForkedRuler(

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -26,6 +27,7 @@ type PrometheusSrv struct {
 	log     log.Logger
 	manager state.AlertInstanceManager
 	store   store.RuleStore
+	ac      accesscontrol.AccessControl
 }
 
 const queryIncludeInternalLabels = "includeInternalLabels"
@@ -151,10 +153,16 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 		ruleResponse.DiscoveryBase.ErrorType = apiv1.ErrServer
 		return response.JSON(http.StatusInternalServerError, ruleResponse)
 	}
+	hasAccess := func(evaluator accesscontrol.Evaluator) bool {
+		return accesscontrol.HasAccess(srv.ac, c)(accesscontrol.ReqSignedIn, evaluator)
+	}
 
 	groupMap := make(map[string]*apimodels.RuleGroup)
 
 	for _, rule := range alertRuleQuery.Result {
+		if !authorizeDatasourceAccessForRule(rule, hasAccess) {
+			continue
+		}
 		groupKey := rule.RuleGroup + "-" + rule.NamespaceUID
 		newGroup, ok := groupMap[groupKey]
 		if !ok {

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -420,7 +420,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 	})
 
 	t.Run("when fine-grained access is enabled", func(t *testing.T) {
-		t.Run("should return only rules the user can query all data sources", func(t *testing.T) {
+		t.Run("should return only rules if the user can query all data sources", func(t *testing.T) {
 			ruleStore := store.NewFakeRuleStore(t)
 			fakeAIM := NewFakeAlertInstanceManager(t)
 

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -15,9 +15,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
-	"github.com/grafana/grafana/pkg/services/datasources"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -430,16 +428,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 			ruleStore.PutRule(context.Background(), rules...)
 			ruleStore.PutRule(context.Background(), ngmodels.GenerateAlertRules(rand.Intn(4)+2, ngmodels.AlertRuleGen(withOrgID(orgID)))...)
 
-			var permissions []*accesscontrol.Permission
-			for _, rule := range rules {
-				for _, query := range rule.Data {
-					permissions = append(permissions, &accesscontrol.Permission{
-						Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(query.DatasourceUID),
-					})
-				}
-			}
-
-			acMock := acmock.New().WithPermissions(permissions)
+			acMock := acmock.New().WithPermissions(createPermissionsForRules(rules))
 
 			api := PrometheusSrv{
 				log:     log.NewNopLogger(),

--- a/pkg/services/ngalert/api/api_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_prometheus_test.go
@@ -8,17 +8,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
-
-	"github.com/grafana/grafana-plugin-sdk-go/data"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_FormatValues(t *testing.T) {
@@ -83,7 +84,7 @@ func TestRouteGetAlertStatuses(t *testing.T) {
 	orgID := int64(1)
 
 	t.Run("with no alerts", func(t *testing.T) {
-		_, _, api := setupAPI(t)
+		_, _, _, api := setupAPI(t)
 		req, err := http.NewRequest("GET", "/api/v1/alerts", nil)
 		require.NoError(t, err)
 		c := &models.ReqContext{Context: &web.Context{Req: req}, SignedInUser: &models.SignedInUser{OrgId: orgID}}
@@ -101,7 +102,7 @@ func TestRouteGetAlertStatuses(t *testing.T) {
 	})
 
 	t.Run("with two alerts", func(t *testing.T) {
-		_, fakeAIM, api := setupAPI(t)
+		_, fakeAIM, _, api := setupAPI(t)
 		fakeAIM.GenerateAlertInstances(1, util.GenerateShortUID(), 2)
 		req, err := http.NewRequest("GET", "/api/v1/alerts", nil)
 		require.NoError(t, err)
@@ -143,7 +144,7 @@ func TestRouteGetAlertStatuses(t *testing.T) {
 	})
 
 	t.Run("with two firing alerts", func(t *testing.T) {
-		_, fakeAIM, api := setupAPI(t)
+		_, fakeAIM, _, api := setupAPI(t)
 		fakeAIM.GenerateAlertInstances(1, util.GenerateShortUID(), 2, withAlertingState())
 		req, err := http.NewRequest("GET", "/api/v1/alerts", nil)
 		require.NoError(t, err)
@@ -185,7 +186,7 @@ func TestRouteGetAlertStatuses(t *testing.T) {
 	})
 
 	t.Run("with the inclusion of internal labels", func(t *testing.T) {
-		_, fakeAIM, api := setupAPI(t)
+		_, fakeAIM, _, api := setupAPI(t)
 		fakeAIM.GenerateAlertInstances(orgID, util.GenerateShortUID(), 2)
 		req, err := http.NewRequest("GET", "/api/v1/alerts?includeInternalLabels=true", nil)
 		require.NoError(t, err)
@@ -251,10 +252,10 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/api/v1/rules", nil)
 	require.NoError(t, err)
-	c := &models.ReqContext{Context: &web.Context{Req: req}, SignedInUser: &models.SignedInUser{OrgId: orgID}}
+	c := &models.ReqContext{Context: &web.Context{Req: req}, SignedInUser: &models.SignedInUser{OrgId: orgID}, IsSignedIn: true}
 
 	t.Run("with no rules", func(t *testing.T) {
-		_, _, api := setupAPI(t)
+		_, _, _, api := setupAPI(t)
 		r := api.RouteGetRuleStatuses(c)
 
 		require.JSONEq(t, `
@@ -268,7 +269,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 	})
 
 	t.Run("with a rule that only has one query", func(t *testing.T) {
-		fakeStore, fakeAIM, api := setupAPI(t)
+		fakeStore, fakeAIM, _, api := setupAPI(t)
 		generateRuleAndInstanceWithQuery(t, orgID, fakeAIM, fakeStore, withClassicConditionSingleQuery())
 		folder := fakeStore.Folders[orgID][0]
 
@@ -315,13 +316,13 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 	})
 
 	t.Run("with the inclusion of internal Labels", func(t *testing.T) {
-		fakeStore, fakeAIM, api := setupAPI(t)
+		fakeStore, fakeAIM, _, api := setupAPI(t)
 		generateRuleAndInstanceWithQuery(t, orgID, fakeAIM, fakeStore, withClassicConditionSingleQuery())
 		folder := fakeStore.Folders[orgID][0]
 
 		req, err := http.NewRequest("GET", "/api/v1/rules?includeInternalLabels=true", nil)
 		require.NoError(t, err)
-		c := &models.ReqContext{Context: &web.Context{Req: req}, SignedInUser: &models.SignedInUser{OrgId: orgID}}
+		c := &models.ReqContext{Context: &web.Context{Req: req}, SignedInUser: &models.SignedInUser{OrgId: orgID}, IsSignedIn: true}
 
 		r := api.RouteGetRuleStatuses(c)
 		require.Equal(t, http.StatusOK, r.Status())
@@ -369,7 +370,7 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 	})
 
 	t.Run("with a rule that has multiple queries", func(t *testing.T) {
-		fakeStore, fakeAIM, api := setupAPI(t)
+		fakeStore, fakeAIM, _, api := setupAPI(t)
 		generateRuleAndInstanceWithQuery(t, orgID, fakeAIM, fakeStore, withExpressionsMultiQuery())
 		folder := fakeStore.Folders[orgID][0]
 
@@ -416,16 +417,19 @@ func TestRouteGetRuleStatuses(t *testing.T) {
 	})
 }
 
-func setupAPI(t *testing.T) (*store.FakeRuleStore, *fakeAlertInstanceManager, PrometheusSrv) {
+func setupAPI(t *testing.T) (*store.FakeRuleStore, *fakeAlertInstanceManager, *acmock.Mock, PrometheusSrv) {
 	fakeStore := store.NewFakeRuleStore(t)
 	fakeAIM := NewFakeAlertInstanceManager(t)
+	acMock := acmock.New().WithDisabled()
+
 	api := PrometheusSrv{
 		log:     log.NewNopLogger(),
 		manager: fakeAIM,
 		store:   fakeStore,
+		ac:      acMock,
 	}
 
-	return fakeStore, fakeAIM, api
+	return fakeStore, fakeAIM, acMock, api
 }
 
 func generateRuleAndInstanceWithQuery(t *testing.T, orgID int64, fakeAIM *fakeAlertInstanceManager, fakeStore *store.FakeRuleStore, query func(r *ngmodels.AlertRule)) {

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -128,11 +128,11 @@ func (srv RulerSrv) RouteGetNamespaceRulesConfig(c *models.ReqContext) response.
 		return toNamespaceErrorResponse(err)
 	}
 
-	q := ngmodels.ListNamespaceAlertRulesQuery{
+	q := ngmodels.GetAlertRulesQuery{
 		OrgID:        c.SignedInUser.OrgId,
 		NamespaceUID: namespace.Uid,
 	}
-	if err := srv.store.GetNamespaceAlertRules(c.Req.Context(), &q); err != nil {
+	if err := srv.store.GetAlertRules(c.Req.Context(), &q); err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "failed to update rule group")
 	}
 

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -264,19 +264,6 @@ func TestCalculateChanges(t *testing.T) {
 }
 
 func TestRouteDeleteAlertRules(t *testing.T) {
-	createService := func(ac *acMock.Mock, store *store.FakeRuleStore, scheduler schedule.ScheduleService) *RulerSrv {
-		return &RulerSrv{
-			xactManager:     store,
-			store:           store,
-			DatasourceCache: nil,
-			QuotaService:    nil,
-			scheduleService: scheduler,
-			log:             log.New("test"),
-			cfg:             nil,
-			ac:              ac,
-		}
-	}
-
 	getRecordedCommand := func(ruleStore *store.FakeRuleStore) []store.GenericRecordedQuery {
 		results := ruleStore.GetRecordedCommands(func(cmd interface{}) (interface{}, bool) {
 			c, ok := cmd.(store.GenericRecordedQuery)
@@ -484,6 +471,20 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 			})
 		})
 	})
+}
+
+
+func createService(ac *acMock.Mock, store *store.FakeRuleStore, scheduler schedule.ScheduleService) *RulerSrv {
+	return &RulerSrv{
+		xactManager:     store,
+		store:           store,
+		DatasourceCache: nil,
+		QuotaService:    nil,
+		scheduleService: scheduler,
+		log:             log.New("test"),
+		cfg:             nil,
+		ac:              ac,
+	}
 }
 
 func createRequestContext(orgID int64, role models2.RoleType, params map[string]string) *models2.ReqContext {

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -570,6 +570,7 @@ func createRequestContext(orgID int64, role models2.RoleType, params map[string]
 	ctx.Req = web.SetURLParams(ctx.Req, params)
 
 	return &models2.ReqContext{
+		IsSignedIn: true,
 		SignedInUser: &models2.SignedInUser{
 			OrgRole: role,
 			OrgId:   orgID,

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -478,7 +478,7 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 
 func TestRouteGetNamespaceRulesConfig(t *testing.T) {
 	t.Run("fine-grained access is enabled", func(t *testing.T) {
-		t.Run("should return rules user has access to data source", func(t *testing.T) {
+		t.Run("should return rules for which user has access to data source", func(t *testing.T) {
 			orgID := rand.Int63()
 			folder := randFolder()
 			ruleStore := store.NewFakeRuleStore(t)

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -421,15 +421,7 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 				scheduler := &schedule.FakeScheduleService{}
 				scheduler.On("DeleteAlertRule", mock.Anything)
 
-				var permissions []*accesscontrol.Permission
-				for _, rule := range rulesInFolder {
-					for _, query := range rule.Data {
-						permissions = append(permissions, &accesscontrol.Permission{
-							Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(query.DatasourceUID),
-						})
-					}
-				}
-				ac := acMock.New().WithPermissions(permissions)
+				ac := acMock.New().WithPermissions(createPermissionsForRules(rulesInFolder))
 				request := createRequestContext(orgID, "None", map[string]string{
 					":Namespace": folder.Title,
 				})
@@ -454,15 +446,7 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 				scheduler := &schedule.FakeScheduleService{}
 				scheduler.On("DeleteAlertRule", mock.Anything)
 
-				var permissions []*accesscontrol.Permission
-				for _, rule := range authorizedRulesInFolder {
-					for _, query := range rule.Data {
-						permissions = append(permissions, &accesscontrol.Permission{
-							Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(query.DatasourceUID),
-						})
-					}
-				}
-				ac := acMock.New().WithPermissions(permissions)
+				ac := acMock.New().WithPermissions(createPermissionsForRules(authorizedRulesInFolder))
 				request := createRequestContext(orgID, "None", map[string]string{
 					":Namespace": folder.Title,
 				})
@@ -489,15 +473,7 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 				scheduler := &schedule.FakeScheduleService{}
 				scheduler.On("DeleteAlertRule", mock.Anything)
 
-				var permissions []*accesscontrol.Permission
-				for _, rule := range authorizedRulesInGroup {
-					for _, query := range rule.Data {
-						permissions = append(permissions, &accesscontrol.Permission{
-							Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(query.DatasourceUID),
-						})
-					}
-				}
-				ac := acMock.New().WithPermissions(permissions)
+				ac := acMock.New().WithPermissions(createPermissionsForRules(authorizedRulesInGroup))
 				request := createRequestContext(orgID, "None", map[string]string{
 					":Namespace": folder.Title,
 					":Groupname": groupName,
@@ -521,6 +497,18 @@ func createRequestContext(orgID int64, role models2.RoleType, params map[string]
 		},
 		Context: &ctx,
 	}
+}
+
+func createPermissionsForRules(rules []*models.AlertRule) []*accesscontrol.Permission {
+	var permissions []*accesscontrol.Permission
+	for _, rule := range rules {
+		for _, query := range rule.Data {
+			permissions = append(permissions, &accesscontrol.Permission{
+				Action: datasources.ActionQuery, Scope: datasources.ScopeProvider.GetResourceScopeUID(query.DatasourceUID),
+			})
+		}
+	}
+	return permissions
 }
 
 func withOrgID(orgId int64) func(rule *models.AlertRule) {

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -39,7 +39,6 @@ type RuleStore interface {
 	GetAlertRuleByUID(ctx context.Context, query *ngmodels.GetAlertRuleByUIDQuery) error
 	GetAlertRulesForScheduling(ctx context.Context, query *ngmodels.ListAlertRulesQuery) error
 	GetOrgAlertRules(ctx context.Context, query *ngmodels.ListAlertRulesQuery) error
-	GetNamespaceAlertRules(ctx context.Context, query *ngmodels.ListNamespaceAlertRulesQuery) error
 	GetAlertRules(ctx context.Context, query *ngmodels.GetAlertRulesQuery) error
 	GetUserVisibleNamespaces(context.Context, int64, *models.SignedInUser) (map[string]*models.Folder, error)
 	GetNamespaceByTitle(context.Context, string, int64, *models.SignedInUser, bool) (*models.Folder, error)
@@ -221,21 +220,6 @@ func (st DBstore) GetOrgAlertRules(ctx context.Context, query *ngmodels.ListAler
 		q = fmt.Sprintf("%s ORDER BY id ASC", q)
 
 		if err := sess.SQL(q, params...).Find(&alertRules); err != nil {
-			return err
-		}
-
-		query.Result = alertRules
-		return nil
-	})
-}
-
-// GetNamespaceAlertRules is a handler for retrieving namespace alert rules of specific organisation.
-func (st DBstore) GetNamespaceAlertRules(ctx context.Context, query *ngmodels.ListNamespaceAlertRulesQuery) error {
-	return st.SQLStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		alertRules := make([]*ngmodels.AlertRule, 0)
-		// TODO rewrite using group by namespace_uid, rule_group
-		q := "SELECT * FROM alert_rule WHERE org_id = ? and namespace_uid = ?"
-		if err := sess.SQL(q, query.OrgID, query.NamespaceUID).Find(&alertRules); err != nil {
 			return err
 		}
 

--- a/pkg/services/ngalert/store/testing.go
+++ b/pkg/services/ngalert/store/testing.go
@@ -178,12 +178,6 @@ func (f *FakeRuleStore) GetOrgAlertRules(_ context.Context, q *models.ListAlertR
 	q.Result = rules
 	return nil
 }
-func (f *FakeRuleStore) GetNamespaceAlertRules(_ context.Context, q *models.ListNamespaceAlertRulesQuery) error {
-	f.mtx.Lock()
-	defer f.mtx.Unlock()
-	f.RecordedOps = append(f.RecordedOps, *q)
-	return nil
-}
 func (f *FakeRuleStore) GetAlertRules(_ context.Context, q *models.GetAlertRulesQuery) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
In PRs https://github.com/grafana/grafana/pull/46905 and https://github.com/grafana/grafana/pull/45749 we added a requirement for users to have permission to query all data sources that an alerting rule uses in order to update or delete a rule. This PR is a continuation of efforts in that area and introduces the check for permissions to query data sources in rules read APIs.
