### PR TITLE
Navigation: Hide nav bar in dashboard settings and panel edit

### DIFF
--- a/public/app/core/components/NavBar/Next/NavBarNext.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarNext.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { matchPath, useLocation, useRouteMatch } from 'react-router-dom';
 import { css, cx } from '@emotion/css';
 import { cloneDeep } from 'lodash';
 import { GrafanaTheme2, NavModelItem, NavSection } from '@grafana/data';
 import { Icon, IconButton, IconName, useTheme2 } from '@grafana/ui';
 import { config, locationService } from '@grafana/runtime';
 import { getKioskMode } from 'app/core/navigation/kiosk';
+import { useQueryParams } from 'app/core/hooks/useQueryParams';
+import { getAppRoutes } from 'app/routes/routes';
 import { KioskMode, StoreState } from 'app/types';
 import { enrichConfigItems, getActiveItem, isMatchOrChildMatch, isSearchActive, SEARCH_ITEM_ID } from '../utils';
 import { OrgSwitcher } from '../../OrgSwitcher';
@@ -55,8 +57,16 @@ export const NavBarNext = React.memo(() => {
   );
   const activeItem = isSearchActive(location) ? searchItem : getActiveItem(navTree, location.pathname);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [queryParams] = useQueryParams();
+  const { path } = useRouteMatch();
+  const hideNavBar = getAppRoutes().some(
+    (r) =>
+      matchPath(path, { path: r.path, exact: r.exact }) &&
+      ((typeof r.hideNavBar === 'boolean' && r.hideNavBar) ||
+        (typeof r.hideNavBar === 'function' && r.hideNavBar(queryParams)))
+  );
 
-  if (kiosk !== KioskMode.Off) {
+  if (kiosk !== KioskMode.Off || hideNavBar) {
     return null;
   }
 

--- a/public/app/core/navigation/types.ts
+++ b/public/app/core/navigation/types.ts
@@ -17,4 +17,5 @@ export interface RouteDescriptor {
   /** Can be used like an id for the route if the same component is used by many routes */
   routeName?: string;
   exact?: boolean;
+  hideNavBar?: boolean | ((queryParams: UrlQueryMap) => boolean);
 }

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { UrlQueryMap } from '@grafana/data';
 import LdapPage from 'app/features/admin/ldap/LdapPage';
 import UserAdminPage from 'app/features/admin/UserAdminPage';
 import { LoginPage } from 'app/core/components/Login/LoginPage';
@@ -15,6 +16,10 @@ import { getAlertingRoutes } from 'app/features/alerting/routes';
 import { getProfileRoutes } from 'app/features/profile/routes';
 import { ServiceAccountPage } from 'app/features/serviceaccounts/ServiceAccountPage';
 
+function hideNavBarOnDashboard(queryParams: UrlQueryMap) {
+  return 'editview' in queryParams || 'editPanel' in queryParams;
+}
+
 export const extraRoutes: RouteDescriptor[] = [];
 
 export function getAppRoutes(): RouteDescriptor[] {
@@ -26,6 +31,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "DashboardPage" */ '../features/dashboard/containers/DashboardPage')
       ),
+      hideNavBar: hideNavBarOnDashboard,
     },
     {
       path: '/d/:uid/:slug?',
@@ -34,6 +40,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "DashboardPage" */ '../features/dashboard/containers/DashboardPage')
       ),
+      hideNavBar: hideNavBarOnDashboard,
     },
     {
       path: '/dashboard/:type/:slug',
@@ -42,6 +49,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "DashboardPage" */ '../features/dashboard/containers/DashboardPage')
       ),
+      hideNavBar: hideNavBarOnDashboard,
     },
     {
       path: '/dashboard/new',
@@ -52,6 +60,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "DashboardPage" */ '../features/dashboard/containers/DashboardPage')
       ),
+      hideNavBar: hideNavBarOnDashboard,
     },
     {
       path: '/d-solo/:uid/:slug',
@@ -60,6 +69,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "SoloPanelPage" */ '../features/dashboard/containers/SoloPanelPage')
       ),
+      hideNavBar: hideNavBarOnDashboard,
     },
     // This route handles embedding of snapshot/scripted dashboard panels
     {
@@ -69,6 +79,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "SoloPanelPage" */ '../features/dashboard/containers/SoloPanelPage')
       ),
+      hideNavBar: hideNavBarOnDashboard,
     },
     {
       path: '/d-solo/:uid',
@@ -77,6 +88,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "SoloPanelPage" */ '../features/dashboard/containers/SoloPanelPage')
       ),
+      hideNavBar: hideNavBarOnDashboard,
     },
     {
       path: '/dashboard/import',


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows for hiding the navbar when dashboard settings or panel edit are open.
This hides the open/close toggle for the nav menu (which probably has its z-index set too high), but also prevents the nav menu from being keyboard accessible when dashboard settings or panel edit are open.

**Special notes for your reviewer**:
In retrospect, this could probably also be solved just by lowering the toggle's z-index and using `FocusScope` or similar from `react-aria`. If that approach is preferred, this PR can be closed.