### PR TITLE
Elasticsearch: Respect maxConcurrentShardRequests datasource setting

### DIFF
--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/Masterminds/semver"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -95,8 +96,17 @@ func newInstanceSettings() datasource.InstanceFactoryFunc {
 			timeInterval = ""
 		}
 
-		maxConcurrentShardRequests, ok := jsonData["maxConcurrentShardRequests"].(float64)
-		if !ok {
+		var maxConcurrentShardRequests float64
+
+		switch v := jsonData["maxConcurrentShardRequests"].(type) {
+		case float64:
+			maxConcurrentShardRequests = v
+		case string:
+			maxConcurrentShardRequests, err = strconv.ParseFloat(v, 64)
+			if err != nil {
+				maxConcurrentShardRequests = 256
+			}
+		default:
 			maxConcurrentShardRequests = 256
 		}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

This PR fixes https://github.com/grafana/grafana/issues/47042, which overload Elasticsearch with huge amount of load, when you have a lot of indices or datasources, jsonData is expected as rawJson, but DatasourceInfo struct requires int somehow, so I see two way of resolves, convert to string or remap of struct and method to expect int
-->

**What this PR does / why we need it**:
fix https://github.com/grafana/grafana/issues/47042
**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana/issues/47042
<!--

- Automatically closes linked issue when the Pull Request is merged.

Fixes #47042



