### PR TITLE
CI: Make `publish-packages` depend on Docker publish steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3026,6 +3026,8 @@ volumes:
 ---
 depends_on:
 - publish-artifacts-public
+- publish-docker-oss-public
+- publish-docker-enterprise-public
 kind: pipeline
 name: publish-packages
 node:
@@ -4427,6 +4429,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 34da09de18d4295faf119f924982bb0f0df454d0976d1354a09da4aa1192a733
+hmac: 64d764ee7d8344c23b0366b4320a93eb9fe3e65541fe434f7a281e27c2e614c2
 
 ...

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -399,7 +399,11 @@ def publish_packages_pipeline():
     ]
 
     return [pipeline(
-        name='publish-packages', trigger=trigger, steps=steps, edition="all", depends_on=['publish-artifacts-public']
+        name='publish-packages', trigger=trigger, steps=steps, edition="all", depends_on=[
+            'publish-artifacts-public',
+            'publish-docker-oss-public',
+            'publish-docker-enterprise-public'
+        ]
     )]
 
 def publish_npm_pipelines(mode):


### PR DESCRIPTION
**What this PR does / why we need it**:

There was an incident (8.4.3) where DockerHub had a problem pushing manifests, when we had already pushed debs and rpms, and also updated _grafana.com_.

This PR solves this problem, since for _grafana.com_ to be updated, both `artifacts` and `docker images` must be pushed.

