### PR TITLE
Accessibility: Make tooltip component tabable

### DIFF
--- a/packages/grafana-ui/src/components/Forms/InlineLabel.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineLabel.tsx
@@ -1,9 +1,10 @@
-import React, { FunctionComponent } from 'react';
-import { GrafanaTheme } from '@grafana/data';
 import { css, cx } from '@emotion/css';
-import { Tooltip, PopoverContent } from '../Tooltip';
-import { Icon } from '../Icon/Icon';
+import { GrafanaTheme } from '@grafana/data';
+import React, { FunctionComponent } from 'react';
+
 import { useTheme } from '../../themes';
+import { Icon } from '../Icon/Icon';
+import { PopoverContent, Tooltip } from '../Tooltip';
 import { LabelProps } from './Label';
 
 export interface Props extends Omit<LabelProps, 'css' | 'description' | 'category'> {
@@ -41,7 +42,7 @@ export const InlineLabel: FunctionComponent<Props> = ({
       {children}
       {tooltip && (
         <Tooltip placement="top" content={tooltip} theme="info">
-          <Icon name="info-circle" size="sm" className={styles.icon} />
+          <Icon tabIndex={0} name="info-circle" size="sm" className={styles.icon} />
         </Tooltip>
       )}
     </Component>


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a tab index to the tooltip, making the tooltip text keyboard accessible. 
![Screenshot from 2022-03-31 15-27-46](https://user-images.githubusercontent.com/2388950/161065847-0272f6b1-f9d5-44cf-aae6-c66047edce5a.png)

This tooltip is still not accessible for screen reader users. A separate issue was raised for adding support for that: #47138 47138  

**Which issue(s) this PR fixes**:

Fixes #46471 

