### PR TITLE
ElasticSearch : Fix DataLink creation on `enter` - added button type

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/configuration/DataLinks.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/DataLinks.tsx
@@ -66,6 +66,7 @@ export const DataLinks = (props: Props) => {
       )}
 
       <Button
+        type="button"
         variant={'secondary'}
         className={css`
           margin-right: 10px;


### PR DESCRIPTION
## What this PR does / why we need it:

In the datasource creation form, wherever you press enter it adds or deletes a “Data Link”

### Screenshots

| Before | After |
| ---------- | ------------ |
| `enter` triggers creating DataLink | `enter` triggers the form submission |
| ![Screen Recording 2022-03-07 at 09 24 56](https://user-images.githubusercontent.com/42030685/161079954-789086fb-f52b-4ca9-9854-9814d75ca137.gif) | ![Screen Recording 2022-03-31 at 16 07 02](https://user-images.githubusercontent.com/42030685/161080043-5a866d88-f7c8-4056-bdcf-8a53584d98ea.gif) |

## Which issue(s) this PR fixes:

Fixes #46473 

## Special notes for your reviewer:

Maybe this button type should be made default in our `Button` component?

