### PR TITLE
Loki: use the same dataframe-format for both live and normal queries

### DIFF
--- a/public/app/core/logs_model.test.ts
+++ b/public/app/core/logs_model.test.ts
@@ -437,6 +437,55 @@ describe('dataFrameToLogsModel', () => {
     });
   });
 
+  it('given one series with labels-field it should work regardless the label-fields position', () => {
+    const labels = {
+      name: 'labels',
+      type: FieldType.other,
+      values: [
+        {
+          node: 'first',
+          mode: 'slow',
+        },
+      ],
+    };
+
+    const time = {
+      name: 'time',
+      type: FieldType.time,
+      values: ['2019-04-26T09:28:11.352440161Z'],
+    };
+
+    const line = {
+      name: 'line',
+      type: FieldType.string,
+      values: ['line1'],
+    };
+
+    const frame1 = new MutableDataFrame({
+      fields: [labels, time, line],
+    });
+
+    const frame2 = new MutableDataFrame({
+      fields: [time, labels, line],
+    });
+
+    const frame3 = new MutableDataFrame({
+      fields: [time, line, labels],
+    });
+
+    const logsModel1 = dataFrameToLogsModel([frame1], 1);
+    expect(logsModel1.rows).toHaveLength(1);
+    expect(logsModel1.rows[0].labels).toStrictEqual({ mode: 'slow', node: 'first' });
+
+    const logsModel2 = dataFrameToLogsModel([frame2], 1);
+    expect(logsModel2.rows).toHaveLength(1);
+    expect(logsModel2.rows[0].labels).toStrictEqual({ mode: 'slow', node: 'first' });
+
+    const logsModel3 = dataFrameToLogsModel([frame3], 1);
+    expect(logsModel3.rows).toHaveLength(1);
+    expect(logsModel3.rows[0].labels).toStrictEqual({ mode: 'slow', node: 'first' });
+  });
+
   it('given one series with error should return expected logs model', () => {
     const series: DataFrame[] = [
       new MutableDataFrame({

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -310,8 +310,9 @@ interface LogFields {
 }
 
 function getAllLabels(fields: LogFields): Labels[] {
-  // there are two types of dataframes we handle.
-  // either labels-on-the-string-field, or labels-in-the-labels-field
+  // there are two types of dataframes we handle:
+  // 1. labels are in a separate field (more efficient when labels change by every log-row)
+  // 2. labels are in in the string-field's `.labels` attribute
 
   const { stringField, labelsField } = fields;
 

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -416,19 +416,13 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
       }
 
       let logLevel = LogLevel.unknown;
-      if (logLevelField && logLevelField.values.get(j)) {
-        logLevel = getLogLevelFromKey(logLevelField.values.get(j));
+      const logLevelKey = (logLevelField && logLevelField.values.get(j)) || (labels && labels['level']);
+      if (logLevelKey) {
+        logLevel = getLogLevelFromKey(logLevelKey);
       } else {
-        let fromLabelLogLevel: LogLevel | undefined = undefined;
-        if (labels && Object.keys(labels).indexOf('level') !== -1) {
-          fromLabelLogLevel = getLogLevelFromKey(labels['level']);
-        }
-        if (fromLabelLogLevel) {
-          logLevel = fromLabelLogLevel;
-        } else {
-          logLevel = getLogLevel(entry);
-        }
+        logLevel = getLogLevel(entry);
       }
+
       rows.push({
         entryFieldIndex: stringField.index,
         rowIndex: j,

--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -303,9 +303,35 @@ interface LogFields {
 
   timeField: FieldWithIndex;
   stringField: FieldWithIndex;
+  labelsField?: FieldWithIndex;
   timeNanosecondField?: FieldWithIndex;
   logLevelField?: FieldWithIndex;
   idField?: FieldWithIndex;
+}
+
+function getAllLabels(fields: LogFields): Labels[] {
+  // there are two types of dataframes we handle.
+  // either labels-on-the-string-field, or labels-in-the-labels-field
+
+  const { stringField, labelsField } = fields;
+
+  const fieldLabels = stringField.labels !== undefined ? [stringField.labels] : [];
+
+  const labelsFieldLabels: Labels[] = labelsField !== undefined ? labelsField.values.toArray() : [];
+
+  return [...fieldLabels, ...labelsFieldLabels];
+}
+
+function getLabelsForFrameRow(fields: LogFields, index: number): Labels {
+  // there are two types of dataframes we handle.
+  // either labels-on-the-string-field, or labels-in-the-labels-field
+
+  const { stringField, labelsField } = fields;
+
+  return {
+    ...stringField.labels,
+    ...labelsField?.values.get(index),
+  };
 }
 
 /**
@@ -316,7 +342,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
   if (logSeries.length === 0) {
     return undefined;
   }
-  const allLabels: Labels[] = [];
+  const allLabels: Labels[][] = [];
 
   // Find the fields we care about and collect all labels
   let allSeries: LogFields[] = [];
@@ -330,43 +356,39 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
       const fieldCache = new FieldCache(series);
       const stringField = fieldCache.getFirstFieldOfType(FieldType.string);
       const timeField = fieldCache.getFirstFieldOfType(FieldType.time);
+      const labelsField = fieldCache.getFieldByName('labels');
 
       if (stringField !== undefined && timeField !== undefined) {
-        if (stringField?.labels) {
-          allLabels.push(stringField.labels);
-        }
-
-        allSeries.push({
+        const info = {
           series,
           timeField,
+          labelsField,
           timeNanosecondField: fieldCache.hasFieldWithNameAndType('tsNs', FieldType.time)
             ? fieldCache.getFieldByName('tsNs')
             : undefined,
           stringField,
           logLevelField: fieldCache.getFieldByName('level'),
           idField: getIdField(fieldCache),
-        });
+        };
+
+        allSeries.push(info);
+
+        const labels = getAllLabels(info);
+        if (labels.length > 0) {
+          allLabels.push(labels);
+        }
       }
     });
   }
 
-  const commonLabels = allLabels.length > 0 ? findCommonLabels(allLabels) : {};
+  const flatAllLabels = allLabels.flat();
+  const commonLabels = flatAllLabels.length > 0 ? findCommonLabels(flatAllLabels) : {};
 
   const rows: LogRowModel[] = [];
   let hasUniqueLabels = false;
 
   for (const info of allSeries) {
     const { timeField, timeNanosecondField, stringField, logLevelField, idField, series } = info;
-    const labels = stringField.labels;
-    const uniqueLabels = findUniqueLabels(labels, commonLabels);
-    if (Object.keys(uniqueLabels).length > 0) {
-      hasUniqueLabels = true;
-    }
-
-    let seriesLogLevel: LogLevel | undefined = undefined;
-    if (labels && Object.keys(labels).indexOf('level') !== -1) {
-      seriesLogLevel = getLogLevelFromKey(labels['level']);
-    }
 
     for (let j = 0; j < series.length; j++) {
       const ts = timeField.values.get(j);
@@ -386,13 +408,25 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
       const searchWords = series.meta && series.meta.searchWords ? series.meta.searchWords : [];
       const entry = hasAnsi ? ansicolor.strip(message) : message;
 
+      const labels = getLabelsForFrameRow(info, j);
+      const uniqueLabels = findUniqueLabels(labels, commonLabels);
+      if (Object.keys(uniqueLabels).length > 0) {
+        hasUniqueLabels = true;
+      }
+
       let logLevel = LogLevel.unknown;
       if (logLevelField && logLevelField.values.get(j)) {
         logLevel = getLogLevelFromKey(logLevelField.values.get(j));
-      } else if (seriesLogLevel) {
-        logLevel = seriesLogLevel;
       } else {
-        logLevel = getLogLevel(entry);
+        let fromLabelLogLevel: LogLevel | undefined = undefined;
+        if (labels && Object.keys(labels).indexOf('level') !== -1) {
+          fromLabelLogLevel = getLogLevelFromKey(labels['level']);
+        }
+        if (fromLabelLogLevel) {
+          logLevel = fromLabelLogLevel;
+        } else {
+          logLevel = getLogLevel(entry);
+        }
       }
       rows.push({
         entryFieldIndex: stringField.index,
@@ -410,7 +444,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
         searchWords,
         entry,
         raw: message,
-        labels: stringField.labels || {},
+        labels: labels || {},
         uid: idField ? idField.values.get(j) : j.toString(),
       });
     }

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -41,7 +41,7 @@ import { convertToWebSocketUrl } from 'app/core/utils/explore';
 import {
   lokiResultsToTableModel,
   lokiStreamsToDataFrames,
-  lokiStreamsToRawDataframe,
+  lokiStreamsToRawDataFrame,
   processRangeQueryResponse,
 } from './result_transformer';
 import { transformBackendResult } from './backendResultTransformer';
@@ -537,7 +537,7 @@ export class LokiDatasource
         }),
         switchMap((res) =>
           of({
-            data: res.data ? [lokiStreamsToRawDataframe(res.data.data.result, reverse)] : [],
+            data: res.data ? [lokiStreamsToRawDataFrame(res.data.data.result, reverse)] : [],
           })
         )
       )

--- a/public/app/plugins/datasource/loki/live_streams.ts
+++ b/public/app/plugins/datasource/loki/live_streams.ts
@@ -30,11 +30,11 @@ export class LiveStreams {
     }
 
     const data = new CircularDataFrame({ capacity: target.size });
-    data.addField({ name: 'ts', type: FieldType.time, config: { displayName: 'Time' } });
-    data.addField({ name: 'tsNs', type: FieldType.time, config: { displayName: 'Time ns' } });
-    data.addField({ name: 'line', type: FieldType.string }).labels = parseLabels(target.query);
     data.addField({ name: 'labels', type: FieldType.other }); // The labels for each line
+    data.addField({ name: 'ts', type: FieldType.time, config: { displayName: 'Time' } });
+    data.addField({ name: 'line', type: FieldType.string }).labels = parseLabels(target.query);
     data.addField({ name: 'id', type: FieldType.string });
+    data.addField({ name: 'tsNs', type: FieldType.time, config: { displayName: 'Time ns' } });
     data.meta = { ...data.meta, preferredVisualisationType: 'logs' };
     data.refId = target.refId;
 

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -64,18 +64,20 @@ describe('loki result transformer', () => {
     jest.clearAllMocks();
   });
 
-  describe('lokiStreamResultToDataFrame', () => {
+  describe('lokiStreamsToRawDataframe', () => {
     it('converts streams to series', () => {
-      const data = streamResult.map((stream) => ResultTransformer.lokiStreamResultToDataFrame(stream));
+      const data = ResultTransformer.lokiStreamsToRawDataframe(streamResult);
 
-      expect(data.length).toBe(2);
-      expect(data[0].fields[1].labels!['foo']).toEqual('bar');
-      expect(data[0].fields[0].values.get(0)).toEqual('2020-01-24T09:19:22.021Z');
-      expect(data[0].fields[1].values.get(0)).toEqual(streamResult[0].values[0][1]);
-      expect(data[0].fields[2].values.get(0)).toEqual('4b79cb43-81ce-52f7-b1e9-a207fff144dc');
-      expect(data[1].fields[0].values.get(0)).toEqual('2020-01-24T09:19:22.031Z');
-      expect(data[1].fields[1].values.get(0)).toEqual(streamResult[1].values[0][1]);
-      expect(data[1].fields[2].values.get(0)).toEqual('73d144f6-57f2-5a45-a49c-eb998e2006b1');
+      expect(data.fields[0].values.get(0)).toStrictEqual({ foo: 'bar' });
+      expect(data.fields[1].values.get(0)).toEqual('2020-01-24T09:19:22.021Z');
+      expect(data.fields[2].values.get(0)).toEqual(streamResult[0].values[0][1]);
+      expect(data.fields[3].values.get(0)).toEqual(streamResult[0].values[0][0]);
+      expect(data.fields[4].values.get(0)).toEqual('4b79cb43-81ce-52f7-b1e9-a207fff144dc');
+      expect(data.fields[0].values.get(1)).toStrictEqual({ bar: 'foo' });
+      expect(data.fields[1].values.get(1)).toEqual('2020-01-24T09:19:22.031Z');
+      expect(data.fields[2].values.get(1)).toEqual(streamResult[1].values[0][1]);
+      expect(data.fields[3].values.get(1)).toEqual(streamResult[1].values[0][0]);
+      expect(data.fields[4].values.get(1)).toEqual('73d144f6-57f2-5a45-a49c-eb998e2006b1');
     });
 
     it('should always generate unique ids for logs', () => {
@@ -100,20 +102,19 @@ describe('loki result transformer', () => {
         },
       ];
 
-      const data = streamResultWithDuplicateLogs.map((stream) => ResultTransformer.lokiStreamResultToDataFrame(stream));
+      const data = ResultTransformer.lokiStreamsToRawDataframe(streamResultWithDuplicateLogs);
 
-      expect(data[0].fields[2].values.get(0)).toEqual('b48fe7dc-36aa-5d37-bfba-087ef810d8fa');
-      expect(data[0].fields[2].values.get(1)).toEqual('b48fe7dc-36aa-5d37-bfba-087ef810d8fa_1');
-      expect(data[0].fields[2].values.get(2)).not.toEqual('b48fe7dc-36aa-5d37-bfba-087ef810d8fa_2');
-      expect(data[0].fields[2].values.get(3)).toEqual('b48fe7dc-36aa-5d37-bfba-087ef810d8fa_2');
-      expect(data[1].fields[2].values.get(0)).not.toEqual('b48fe7dc-36aa-5d37-bfba-087ef810d8fa_3');
+      expect(data.fields[4].values.get(0)).toEqual('b48fe7dc-36aa-5d37-bfba-087ef810d8fa');
+      expect(data.fields[4].values.get(1)).toEqual('b48fe7dc-36aa-5d37-bfba-087ef810d8fa_1');
+      expect(data.fields[4].values.get(2)).not.toEqual('b48fe7dc-36aa-5d37-bfba-087ef810d8fa_2');
+      expect(data.fields[4].values.get(3)).toEqual('b48fe7dc-36aa-5d37-bfba-087ef810d8fa_2');
+      expect(data.fields[4].values.get(4)).not.toEqual('b48fe7dc-36aa-5d37-bfba-087ef810d8fa_3');
     });
 
     it('should append refId to the unique ids if refId is provided', () => {
-      const data = streamResult.map((stream) => ResultTransformer.lokiStreamResultToDataFrame(stream, false, 'B'));
-      expect(data.length).toBe(2);
-      expect(data[0].fields[2].values.get(0)).toEqual('4b79cb43-81ce-52f7-b1e9-a207fff144dc_B');
-      expect(data[1].fields[2].values.get(0)).toEqual('73d144f6-57f2-5a45-a49c-eb998e2006b1_B');
+      const data = ResultTransformer.lokiStreamsToRawDataframe(streamResult, false, 'B');
+      expect(data.fields[4].values.get(0)).toEqual('4b79cb43-81ce-52f7-b1e9-a207fff144dc_B');
+      expect(data.fields[4].values.get(1)).toEqual('73d144f6-57f2-5a45-a49c-eb998e2006b1_B');
     });
   });
 
@@ -159,11 +160,11 @@ describe('loki result transformer', () => {
       };
 
       const data = new CircularDataFrame({ capacity: 1 });
-      data.addField({ name: 'ts', type: FieldType.time, config: { displayName: 'Time' } });
-      data.addField({ name: 'tsNs', type: FieldType.time, config: { displayName: 'Time ns' } });
-      data.addField({ name: 'line', type: FieldType.string }).labels = { job: 'grafana' };
       data.addField({ name: 'labels', type: FieldType.other });
+      data.addField({ name: 'ts', type: FieldType.time, config: { displayName: 'Time' } });
+      data.addField({ name: 'line', type: FieldType.string }).labels = { job: 'grafana' };
       data.addField({ name: 'id', type: FieldType.string });
+      data.addField({ name: 'tsNs', type: FieldType.time, config: { displayName: 'Time ns' } });
 
       ResultTransformer.appendResponseToBufferedData(tailResponse, data);
       expect(data.get(0)).toEqual({
@@ -196,11 +197,11 @@ describe('loki result transformer', () => {
       };
 
       const data = new CircularDataFrame({ capacity: 6 });
-      data.addField({ name: 'ts', type: FieldType.time, config: { displayName: 'Time' } });
-      data.addField({ name: 'tsNs', type: FieldType.time, config: { displayName: 'Time ns' } });
-      data.addField({ name: 'line', type: FieldType.string }).labels = { job: 'grafana' };
       data.addField({ name: 'labels', type: FieldType.other });
+      data.addField({ name: 'ts', type: FieldType.time, config: { displayName: 'Time' } });
+      data.addField({ name: 'line', type: FieldType.string }).labels = { job: 'grafana' };
       data.addField({ name: 'id', type: FieldType.string });
+      data.addField({ name: 'tsNs', type: FieldType.time, config: { displayName: 'Time ns' } });
       data.refId = 'C';
 
       ResultTransformer.appendResponseToBufferedData(tailResponse, data);

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -64,9 +64,9 @@ describe('loki result transformer', () => {
     jest.clearAllMocks();
   });
 
-  describe('lokiStreamsToRawDataframe', () => {
+  describe('lokiStreamsToRawDataFrame', () => {
     it('converts streams to series', () => {
-      const data = ResultTransformer.lokiStreamsToRawDataframe(streamResult);
+      const data = ResultTransformer.lokiStreamsToRawDataFrame(streamResult);
 
       expect(data.fields[0].values.get(0)).toStrictEqual({ foo: 'bar' });
       expect(data.fields[1].values.get(0)).toEqual('2020-01-24T09:19:22.021Z');
@@ -102,7 +102,7 @@ describe('loki result transformer', () => {
         },
       ];
 
-      const data = ResultTransformer.lokiStreamsToRawDataframe(streamResultWithDuplicateLogs);
+      const data = ResultTransformer.lokiStreamsToRawDataFrame(streamResultWithDuplicateLogs);
 
       expect(data.fields[4].values.get(0)).toEqual('b48fe7dc-36aa-5d37-bfba-087ef810d8fa');
       expect(data.fields[4].values.get(1)).toEqual('b48fe7dc-36aa-5d37-bfba-087ef810d8fa_1');
@@ -112,7 +112,7 @@ describe('loki result transformer', () => {
     });
 
     it('should append refId to the unique ids if refId is provided', () => {
-      const data = ResultTransformer.lokiStreamsToRawDataframe(streamResult, false, 'B');
+      const data = ResultTransformer.lokiStreamsToRawDataFrame(streamResult, false, 'B');
       expect(data.fields[4].values.get(0)).toEqual('4b79cb43-81ce-52f7-b1e9-a207fff144dc_B');
       expect(data.fields[4].values.get(1)).toEqual('73d144f6-57f2-5a45-a49c-eb998e2006b1_B');
     });

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -43,15 +43,10 @@ import { renderLegendFormat } from '../prometheus/legend';
 const UUID_NAMESPACE = '6ec946da-0f49-47a8-983a-1d76d17e7c92';
 
 /**
- * Transforms LokiStreamResult structure into a dataFrame. Used when doing standard queries and newer version of Loki.
+ * Transforms LokiStreamResult structure into a dataFrame. Used when doing standard queries
  */
-export function lokiStreamResultToDataFrame(stream: LokiStreamResult, reverse?: boolean, refId?: string): DataFrame {
-  const labels: Labels = stream.stream;
-  const labelsString = Object.entries(labels)
-    .map(([key, val]) => `${key}="${val}"`)
-    .sort()
-    .join('');
-
+export function lokiStreamsToRawDataframe(streams: LokiStreamResult[], reverse?: boolean, refId?: string): DataFrame {
+  const labels = new ArrayVector<{}>([]);
   const times = new ArrayVector<string>([]);
   const timesNs = new ArrayVector<string>([]);
   const lines = new ArrayVector<string>([]);
@@ -60,12 +55,21 @@ export function lokiStreamResultToDataFrame(stream: LokiStreamResult, reverse?: 
   // We need to store and track all used uids to ensure that uids are unique
   const usedUids: { string?: number } = {};
 
-  for (const [ts, line] of stream.values) {
-    // num ns epoch in string, we convert it to iso string here so it matches old format
-    times.add(new Date(parseInt(ts.slice(0, -6), 10)).toISOString());
-    timesNs.add(ts);
-    lines.add(line);
-    uids.add(createUid(ts, labelsString, line, usedUids, refId));
+  for (const stream of streams) {
+    const streamLabels: Labels = stream.stream;
+    const labelsString = Object.entries(streamLabels)
+      .map(([key, val]) => `${key}="${val}"`)
+      .sort()
+      .join('');
+
+    for (const [ts, line] of stream.values) {
+      labels.add(streamLabels);
+      // num ns epoch in string, we convert it to iso string here so it matches old format
+      times.add(new Date(parseInt(ts.slice(0, -6), 10)).toISOString());
+      timesNs.add(ts);
+      lines.add(line);
+      uids.add(createUid(ts, labelsString, line, usedUids, refId));
+    }
   }
 
   return constructDataFrame(times, timesNs, lines, uids, labels, reverse, refId);
@@ -79,17 +83,18 @@ function constructDataFrame(
   timesNs: ArrayVector<string>,
   lines: ArrayVector<string>,
   uids: ArrayVector<string>,
-  labels: Labels,
+  labels: ArrayVector<{}>,
   reverse?: boolean,
   refId?: string
 ) {
   const dataFrame = {
     refId,
     fields: [
+      { name: 'labels', type: FieldType.other, config: {}, values: labels },
       { name: 'ts', type: FieldType.time, config: { displayName: 'Time' }, values: times }, // Time
-      { name: 'line', type: FieldType.string, config: {}, values: lines, labels }, // Line - needs to be the first field with string type
-      { name: 'id', type: FieldType.string, config: {}, values: uids },
+      { name: 'line', type: FieldType.string, config: {}, values: lines }, // Line - needs to be the first field with string type
       { name: 'tsNs', type: FieldType.time, config: { displayName: 'Time ns' }, values: timesNs }, // Time
+      { name: 'id', type: FieldType.string, config: {}, values: uids },
     ],
     length: times.length,
   };
@@ -128,11 +133,11 @@ export function appendResponseToBufferedData(response: LokiTailResponse, data: M
     }
   }
 
-  const tsField = data.fields[0];
-  const tsNsField = data.fields[1];
+  const labelsField = data.fields[0];
+  const tsField = data.fields[1];
   const lineField = data.fields[2];
-  const labelsField = data.fields[3];
-  const idField = data.fields[4];
+  const idField = data.fields[3];
+  const tsNsField = data.fields[4];
 
   // We are comparing used ids only within the received stream. This could be a problem if the same line + labels + nanosecond timestamp came in 2 separate batches.
   // As this is very unlikely, and the result would only affect live-tailing css animation we have decided to not compare all received uids from data param as this would slow down processing.
@@ -350,20 +355,12 @@ export function lokiStreamsToDataFrames(
     preferredVisualisationType: 'logs',
   };
 
-  const series: DataFrame[] = data.map((stream) => {
-    const dataFrame = lokiStreamResultToDataFrame(stream, reverse, target.refId);
-    enhanceDataFrame(dataFrame, config);
+  const dataFrame = lokiStreamsToRawDataframe(data, reverse, target.refId);
+  enhanceDataFrame(dataFrame, config);
 
-    if (meta.custom && dataFrame.fields.some((f) => f.labels && Object.keys(f.labels).some((l) => l === '__error__'))) {
-      meta.custom.error = 'Error when parsing some of the logs';
-    }
-
-    return {
-      ...dataFrame,
-      refId: target.refId,
-      meta,
-    };
-  });
+  if (meta.custom && dataFrame.fields.some((f) => f.labels && Object.keys(f.labels).some((l) => l === '__error__'))) {
+    meta.custom.error = 'Error when parsing some of the logs';
+  }
 
   if (stats.length && !data.length) {
     return [
@@ -376,7 +373,13 @@ export function lokiStreamsToDataFrames(
     ];
   }
 
-  return series;
+  return [
+    {
+      ...dataFrame,
+      refId: target.refId,
+      meta,
+    },
+  ];
 }
 
 /**

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -45,7 +45,7 @@ const UUID_NAMESPACE = '6ec946da-0f49-47a8-983a-1d76d17e7c92';
 /**
  * Transforms LokiStreamResult structure into a dataFrame. Used when doing standard queries
  */
-export function lokiStreamsToRawDataframe(streams: LokiStreamResult[], reverse?: boolean, refId?: string): DataFrame {
+export function lokiStreamsToRawDataFrame(streams: LokiStreamResult[], reverse?: boolean, refId?: string): DataFrame {
   const labels = new ArrayVector<{}>([]);
   const times = new ArrayVector<string>([]);
   const timesNs = new ArrayVector<string>([]);
@@ -355,7 +355,7 @@ export function lokiStreamsToDataFrames(
     preferredVisualisationType: 'logs',
   };
 
-  const dataFrame = lokiStreamsToRawDataframe(data, reverse, target.refId);
+  const dataFrame = lokiStreamsToRawDataFrame(data, reverse, target.refId);
   enhanceDataFrame(dataFrame, config);
 
   if (meta.custom && dataFrame.fields.some((f) => f.labels && Object.keys(f.labels).some((l) => l === '__error__'))) {


### PR DESCRIPTION
(NOTE: this is planned for grafana9, as it breaks backward compatibility)

currently, when doing a normal loki query, we create a separate dataframe for every unique label-combination.
but, when we do a live-streaming query, we maintain a single dataframe, where we store the labels in a separate field.

the second (the live-streaming) format is better for us, because, the normal-query-dataframe-format often creates situations, where 100lines of logs gets represented as 100 dataframes, each containing a single line. this is why we want to change it. this might cause backward incompatibility in some corner cases (for example, loading logs into a table-panel and adding transforms), so we are planning to do it in grafana9.

the diff:
- `logs_model.ts`: before it was reading labels from the string-field's header. now it looks both there and also in a field named labels. meaning, we still support the logs-format used by loki previously, we don't know what datasources use it, i did not want to remove support for it.
- `result_transformer.ts`: we switched from `lokiStreamResultToDataFrame` to `lokiStreamsToRawDataframe`, this is the new function that creates a single dataframe from an array-of-stream.
- unit tests had to be updated
- i adjusted the order of the fields in the dataframe, even in the live-format. it's important to have the `labels` field first (this is needed for the future, when we switch to backend-mode, for technical reasons, when streaming in backend-mode, we need labels-field to be first), so i wanted to make sure all works ok with this field-order

# Release notice breaking change

In the Loki data source, the dataframe format used to represent Loki logs-data has been changed to a more efficient format. The query-result is represented by a single dataframe with a "labels" column, instead of the separate dataframes for every labels-value. When displaying such data in explore, or in a logs-panel in the dashboard will continue to work without changes, but if the data was loaded into a different dashboard-panel, or Transforms were used, adjustments may be necessary. For example, if you used the "labels to fields" transformation with the logs data, please switch to the "extract fields" transformation.