### PR TITLE
TestData: Modify the Server Error scenario to return frontend errors

### DIFF
--- a/public/app/plugins/datasource/testdata/QueryEditor.tsx
+++ b/public/app/plugins/datasource/testdata/QueryEditor.tsx
@@ -21,6 +21,7 @@ import { defaultStreamQuery } from './runStreams';
 import { CSVFileEditor } from './components/CSVFileEditor';
 import { CSVContentEditor } from './components/CSVContentEditor';
 import { USAQueryEditor, usaQueryModes } from './components/USAQueryEditor';
+import ErrorEditor from './components/ErrorEditor';
 
 const showLabelsFor = ['random_walk', 'predictable_pulse'];
 const endpoints = [
@@ -69,6 +70,7 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
     [scenarioList, query]
   );
   const scenarioId = currentScenario?.id;
+  const description = currentScenario?.description;
 
   const onScenarioChange = (item: SelectableValue<string>) => {
     const scenario = scenarioList?.find((sc) => sc.id === item.value);
@@ -287,6 +289,9 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
       {scenarioId === 'node_graph' && (
         <NodeGraphEditor onChange={(val: NodesQuery) => onChange({ ...query, nodes: val })} query={query} />
       )}
+      {scenarioId === 'server_error_500' && <ErrorEditor onChange={onUpdate} query={query} />}
+
+      {description && <p>{description}</p>}
     </>
   );
 };

--- a/public/app/plugins/datasource/testdata/components/ErrorEditor.tsx
+++ b/public/app/plugins/datasource/testdata/components/ErrorEditor.tsx
@@ -1,0 +1,36 @@
+import { InlineField, InlineFieldRow, Select } from '@grafana/ui';
+import React from 'react';
+import { EditorProps } from '../QueryEditor';
+
+const ERROR_OPTIONS = [
+  {
+    label: 'Server panic',
+    value: 'server_panic',
+  },
+  {
+    label: 'Frontend exception',
+    value: 'frontend_exception',
+  },
+  {
+    label: 'Frontend observable',
+    value: 'frontend_observable',
+  },
+];
+
+const FrontendErrorQueryEditor: React.FC<EditorProps> = ({ query, onChange }) => {
+  return (
+    <InlineFieldRow>
+      <InlineField labelWidth={14} label="Error type">
+        <Select
+          options={ERROR_OPTIONS}
+          value={query.errorType}
+          onChange={(v) => {
+            onChange({ ...query, errorType: v.value });
+          }}
+        />
+      </InlineField>
+    </InlineFieldRow>
+  );
+};
+
+export default FrontendErrorQueryEditor;

--- a/public/app/plugins/datasource/testdata/types.ts
+++ b/public/app/plugins/datasource/testdata/types.ts
@@ -4,6 +4,7 @@ export interface Scenario {
   id: string;
   name: string;
   stringInput: string;
+  description?: string;
 }
 
 export interface TestDataQuery extends DataQuery {
@@ -22,6 +23,7 @@ export interface TestDataQuery extends DataQuery {
   csvContent?: string;
   rawFrameContent?: string;
   usa?: USAQuery;
+  errorType?: 'server_panic' | 'frontend_exception' | 'frontend_observable';
 }
 
 export interface NodesQuery {


### PR DESCRIPTION
**What this PR does / why we need it**:

In investigating an issue, I had trouble reproducing a data source that would only fail on the frontend under certain conditions.

This PR renames and extends the "Server Error (500)" scenario to only return errors when the String Input field is empty.  It also adds new functionality to either throw an exception in the frontend (which doesn't seem to currently be handled?).

It also displays the scenario description for the two scenarios which have one.

![1442_2022-03-31-18-11_chrome](https://user-images.githubusercontent.com/46142/161111906-d4612216-893d-4a76-acd3-35f832dd4e31.png)

**Which issue(s) this PR fixes**:

None :)

**Special notes for your reviewer**:

