### PR TITLE
TestData: Interpolate variables in more fields

### DIFF
--- a/public/app/plugins/datasource/testdata/QueryEditor.tsx
+++ b/public/app/plugins/datasource/testdata/QueryEditor.tsx
@@ -163,7 +163,7 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
         .sort((a, b) => a.label.localeCompare(b.label)),
     [scenarioList]
   );
-  const showLabels = useMemo(() => showLabelsFor.includes(query.scenarioId), [query]);
+  const showLabels = useMemo(() => showLabelsFor.includes(query.scenarioId ?? ''), [query]);
 
   if (loading) {
     return null;

--- a/public/app/plugins/datasource/testdata/datasource.ts
+++ b/public/app/plugins/datasource/testdata/datasource.ts
@@ -107,12 +107,24 @@ export class TestDataDataSource extends DataSourceWithBackend<TestDataQuery> {
   }
 
   resolveTemplateVariables(query: TestDataQuery, scopedVars: ScopedVars) {
-    query.labels = this.templateSrv.replace(query.labels, scopedVars);
-    query.alias = this.templateSrv.replace(query.alias, scopedVars);
-    query.scenarioId = this.templateSrv.replace(query.scenarioId, scopedVars);
-    query.stringInput = this.templateSrv.replace(query.stringInput, scopedVars);
-    query.csvContent = this.templateSrv.replace(query.csvContent, scopedVars);
-    query.rawFrameContent = this.templateSrv.replace(query.rawFrameContent, scopedVars);
+    if (query.labels) {
+      query.labels = this.templateSrv.replace(query.labels, scopedVars);
+    }
+    if (query.alias) {
+      query.alias = this.templateSrv.replace(query.alias, scopedVars);
+    }
+    if (query.scenarioId) {
+      query.scenarioId = this.templateSrv.replace(query.scenarioId, scopedVars);
+    }
+    if (query.stringInput) {
+      query.stringInput = this.templateSrv.replace(query.stringInput, scopedVars);
+    }
+    if (query.csvContent) {
+      query.csvContent = this.templateSrv.replace(query.csvContent, scopedVars);
+    }
+    if (query.rawFrameContent) {
+      query.rawFrameContent = this.templateSrv.replace(query.rawFrameContent, scopedVars);
+    }
   }
 
   annotationDataTopicTest(target: TestDataQuery, req: DataQueryRequest<TestDataQuery>): Observable<DataQueryResponse> {

--- a/public/app/plugins/datasource/testdata/datasource.ts
+++ b/public/app/plugins/datasource/testdata/datasource.ts
@@ -87,10 +87,6 @@ export class TestDataDataSource extends DataSourceWithBackend<TestDataQuery> {
         }
 
         default:
-          if (target.alias) {
-            target.alias = this.templateSrv.replace(target.alias, options.scopedVars);
-          }
-
           backendQueries.push(target);
       }
     }
@@ -111,7 +107,12 @@ export class TestDataDataSource extends DataSourceWithBackend<TestDataQuery> {
   }
 
   resolveTemplateVariables(query: TestDataQuery, scopedVars: ScopedVars) {
-    query.labels = this.templateSrv.replace(query.labels!, scopedVars);
+    query.labels = this.templateSrv.replace(query.labels, scopedVars);
+    query.alias = this.templateSrv.replace(query.alias, scopedVars);
+    query.scenarioId = this.templateSrv.replace(query.scenarioId, scopedVars);
+    query.stringInput = this.templateSrv.replace(query.stringInput, scopedVars);
+    query.csvContent = this.templateSrv.replace(query.csvContent, scopedVars);
+    query.rawFrameContent = this.templateSrv.replace(query.rawFrameContent, scopedVars);
   }
 
   annotationDataTopicTest(target: TestDataQuery, req: DataQueryRequest<TestDataQuery>): Observable<DataQueryResponse> {

--- a/public/app/plugins/datasource/testdata/datasource.ts
+++ b/public/app/plugins/datasource/testdata/datasource.ts
@@ -158,10 +158,13 @@ export class TestDataDataSource extends DataSourceWithBackend<TestDataQuery> {
   }
 
   getQueryDisplayText(query: TestDataQuery) {
+    const scenario = query.scenarioId ?? 'Default scenario';
+
     if (query.alias) {
-      return query.scenarioId + ' as ' + query.alias;
+      return scenario + ' as ' + query.alias;
     }
-    return query.scenarioId;
+
+    return scenario;
   }
 
   testDatasource() {

--- a/public/app/plugins/datasource/testdata/types.ts
+++ b/public/app/plugins/datasource/testdata/types.ts
@@ -9,7 +9,7 @@ export interface Scenario {
 
 export interface TestDataQuery extends DataQuery {
   alias?: string;
-  scenarioId: string;
+  scenarioId?: string;
   stringInput?: string;
   stream?: StreamingQuery;
   pulseWave?: PulseWaveQuery;


### PR DESCRIPTION
**What this PR does / why we need it**:

_Finally_ adds variable interpolation to the fields in the Test Data data source.

Also fixes incorrectly typing of the `scenarioId` property which by default is not defined.
