### PR TITLE
Alerting squad should code-own alerting integration tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,6 +63,7 @@ go.sum @grafana/backend-platform
 /pkg/services/ngalert @grafana/alerting-squad-backend
 /pkg/services/sqlstore/migrations/ualert @grafana/alerting-squad-backend
 /pkg/services/alerting @grafana/alerting-squad-backend
+/pkg/tests/api/alerting @grafana/alerting-squad-backend
 /public/app/features/alerting @grafana/alerting-squad-frontend
 
 # Library Services

--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -181,7 +181,7 @@
   },
   {
     "type": "changedfiles",
-    "matches": ["/pkg/services/ngalert/**/*", "/pkg/services/sqlstore/migrations/ualert/**/*", "/pkg/services/alerting/**/*", "/public/app/features/alerting/**/*"],
+    "matches": ["/pkg/services/ngalert/**/*", "/pkg/services/sqlstore/migrations/ualert/**/*", "/pkg/services/alerting/**/*", "/public/app/features/alerting/**/*", "/pkg/tests/api/alerting/**/*"],
     "action": "updateLabel",
     "addLabel": "area/alerting"
   },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

After adding an integration test in a separate PR, I noticed that the Alerting squad does not code-own the Alerting integration tests. This PR makes us own the `api/alerting` integration test package.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

Adjusted the autolabeler to match. Please let me know if there are any other bot/action paths I am missing, although search did not yield any.
