### PR TITLE
Heatmap: make x axis a time field

### DIFF
--- a/public/app/plugins/panel/heatmap-new/utils.ts
+++ b/public/app/plugins/panel/heatmap-new/utils.ts
@@ -126,6 +126,7 @@ export function prepConfig(opts: PrepConfigOpts) {
   builder.addAxis({
     scaleKey: 'x',
     placement: AxisPlacement.Bottom,
+    isTime: true,
     theme: theme,
   });
 


### PR DESCRIPTION
The scale is set as time, but the axis is not.