### PR TITLE
Github Actions: Remove branch regexp check

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -60,12 +60,6 @@ jobs:
           echo "::set-output name=branch_name::v${{steps.regex-match.outputs.group1}}"
           echo "::set-output name=branch_exist::$(git ls-remote --heads https://github.com/grafana/grafana.git v${{ steps.regex-match.outputs.group1 }}.x | wc -l)"
 
-      - name: Check input version is aligned with branch(not main)
-        if: ${{ github.event.inputs.version != '' && steps.intermedia.outputs.branch_exist != '0' && !contains(steps.intermedia.outputs.short_ref, steps.intermedia.outputs.branch_name) }}
-        run: |
-          echo " You need to run the workflow on branch v${{steps.regex-match.outputs.group1}}.x
-          exit 1
-
       - name: Check input version is aligned with branch(main)
         if: ${{ github.event.inputs.version != '' && steps.intermedia.outputs.branch_exist == '0' && !contains(steps.intermedia.outputs.short_ref, 'main') }}
         run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

When running `bump-verison` gh action, there is a step that tries to match the tag with the versioned branch name using regular expressions. This is no longer valid, since it's not necessary to bump the version based on the `vX.X.X` pattern, but using some different naming conventions instead. 
