### PR TITLE
46900 fix datepicker content when pane splitted

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -45,6 +45,7 @@ export interface TimeRangePickerProps extends Themeable {
   onZoom: () => void;
   history?: TimeRange[];
   hideQuickRanges?: boolean;
+  splitted?: boolean;
 }
 
 export interface State {
@@ -68,6 +69,7 @@ export function UnthemedTimeRangePicker(props: TimeRangePickerProps): ReactEleme
     onChangeTimeZone,
     onChangeFiscalYearStartMonth,
     hideQuickRanges,
+    splitted,
   } = props;
 
   const onChange = (timeRange: TimeRange) => {
@@ -129,6 +131,7 @@ export function UnthemedTimeRangePicker(props: TimeRangePickerProps): ReactEleme
               quickOptions={quickOptions}
               history={history}
               showHistory
+              splitted={splitted}
               onChangeTimeZone={onChangeTimeZone}
               onChangeFiscalYearStartMonth={onChangeFiscalYearStartMonth}
               hideQuickRanges={hideQuickRanges}

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerContent.tsx
@@ -29,6 +29,7 @@ interface Props {
   /** Reverse the order of relative and absolute range pickers. Used to left align the picker in forms */
   isReversed?: boolean;
   hideQuickRanges?: boolean;
+  splitted?: boolean;
 }
 
 export interface PropsWithScreenSize extends Props {
@@ -112,8 +113,9 @@ export const TimePickerContentWithScreenSize: React.FC<PropsWithScreenSize> = (p
 };
 
 export const TimePickerContent: React.FC<Props> = (props) => {
+  const { splitted } = props;
   const theme = useTheme2();
-  const isFullscreen = useMedia(`(min-width: ${theme.breakpoints.values.lg}px)`);
+  const isFullscreen = useMedia(`(min-width: ${theme.breakpoints.values.lg}px)`) && !splitted;
 
   return <TimePickerContentWithScreenSize {...props} isFullscreen={isFullscreen} />;
 };

--- a/public/app/features/explore/ExploreTimeControls.tsx
+++ b/public/app/features/explore/ExploreTimeControls.tsx
@@ -92,6 +92,7 @@ export class ExploreTimeControls extends Component<Props> {
         {...timePickerCommonProps}
         timeSyncButton={timeSyncButton}
         isSynced={syncedTimes}
+        splitted={splitted}
         onChange={this.onChangeTimePicker}
         onChangeTimeZone={onChangeTimeZone}
         onChangeFiscalYearStartMonth={onChangeFiscalYearStartMonth}

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -168,7 +168,7 @@ export class LokiDatasource
     const filteredTargets = request.targets
       .filter((target) => target.expr && !target.hide)
       .map((target) => {
-        const expr = this.addAdHocFilters(target.expr);
+        const expr = this.addAdHocFilters(target.expr).replace(/\\/g, '\\\\');
         return {
           ...target,
           expr: this.templateSrv.replace(expr, scopedVars, this.interpolateQueryExpr),


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Fixes #46900.

**Special notes for your reviewer**:

Actually, this is a workaround and the fix just takes into account pane split.
Really good and universal fix is to rework this UI element to make it unattached to pane. Instead, add dom elements to root divs. Also date picker can be much more mobile-friendly.