### PR TITLE
Logging: Fix syslog messages should be sent with correct severity

### DIFF
--- a/pkg/infra/log/level/level.go
+++ b/pkg/infra/log/level/level.go
@@ -1,6 +1,9 @@
 package level
 
-import "github.com/go-kit/log"
+import (
+	"github.com/go-kit/log"
+	gokitlevel "github.com/go-kit/log/level"
+)
 
 // Error returns a logger that includes a Key/ErrorValue pair.
 func Error(logger log.Logger) log.Logger {
@@ -195,6 +198,35 @@ const (
 	levelWarn
 	levelError
 )
+
+func IsKey(v interface{}) bool {
+	return v != nil && (v == Key() || v == gokitlevel.Key())
+}
+
+func GetValue(v interface{}) Value {
+	if v == nil {
+		return nil
+	}
+
+	if val, ok := v.(Value); ok {
+		return val
+	}
+
+	if val, ok := v.(gokitlevel.Value); ok {
+		switch val {
+		case gokitlevel.InfoValue():
+			return InfoValue()
+		case gokitlevel.WarnValue():
+			return WarnValue()
+		case gokitlevel.ErrorValue():
+			return ErrorValue()
+		case gokitlevel.DebugValue():
+			return DebugValue()
+		}
+	}
+
+	return nil
+}
 
 type levelValue struct {
 	name string

--- a/pkg/infra/log/syslog.go
+++ b/pkg/infra/log/syslog.go
@@ -8,8 +8,8 @@ import (
 	"os"
 
 	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	gokitsyslog "github.com/go-kit/log/syslog"
+	"github.com/grafana/grafana/pkg/infra/log/level"
 	"gopkg.in/ini.v1"
 )
 
@@ -25,31 +25,26 @@ type SysLogHandler struct {
 
 var selector = func(keyvals ...interface{}) syslog.Priority {
 	for i := 0; i < len(keyvals); i += 2 {
-		if keyvals[i] == level.Key() {
-			if v, ok := keyvals[i+1].(string); ok {
-				switch v {
-				case "emergency":
-					return syslog.LOG_EMERG
-				case "alert":
-					return syslog.LOG_ALERT
-				case "critical":
-					return syslog.LOG_CRIT
-				case "error":
+		if level.IsKey(keyvals[i]) {
+			val := level.GetValue(keyvals[i+1])
+			if val != nil {
+				switch val {
+				case level.ErrorValue():
 					return syslog.LOG_ERR
-				case "warning":
+				case level.WarnValue():
 					return syslog.LOG_WARNING
-				case "notice":
-					return syslog.LOG_NOTICE
-				case "info":
+				case level.InfoValue():
 					return syslog.LOG_INFO
-				case "debug":
+				case level.DebugValue():
 					return syslog.LOG_DEBUG
 				}
-				return syslog.LOG_LOCAL0
 			}
+
+			break
 		}
 	}
-	return syslog.LOG_LOCAL0
+
+	return syslog.LOG_INFO
 }
 
 func NewSyslog(sec *ini.Section, format Formatedlogger) *SysLogHandler {
@@ -62,7 +57,7 @@ func NewSyslog(sec *ini.Section, format Formatedlogger) *SysLogHandler {
 	handler.Tag = sec.Key("tag").MustString("")
 
 	if err := handler.Init(); err != nil {
-		_ = level.Error(root).Log("Failed to init syslog log handler", "error", err)
+		root.Error("Failed to init syslog log handler", "error", err)
 		os.Exit(1)
 	}
 	handler.logger = gokitsyslog.NewSyslogLogger(handler.syslog, format, gokitsyslog.PrioritySelectorOption(selector))


### PR DESCRIPTION
**What this PR does / why we need it**:
Syslog messages should now be sent with correct severity. Fixes _"1. All syslog messages are sent as Emergency severity"_ of #45752.

**Which issue(s) this PR fixes**:
Ref #45752 

**Special notes for your reviewer**:
Without these changes and enabling syslog using my local rsyslog I got broadcast messages in all my terminal at the same time. With these changes I no longer get those. Used the following config with no changes to local rsyslog:
```
[log]
mode = console file syslog

[log.syslog]
level = debug

# log line format, valid options are text, console and json
format = text

# Syslog network type and address. This can be udp, tcp, or unix. If left blank, the default unix endpoints will be used.
network =
address =

# Syslog facility. user, daemon and local0 through local7 are valid.
facility =

# Syslog tag. By default, the process' argv[0] is used.
tag =
```