### PR TITLE
chore: optimize packages/* rollup bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ debug.test
 
 # Ignoring frontend packages specifics
 /packages/**/dist
+/packages/**/stats.html
 /packages/**/compiled
 /packages/**/.rpt2_cache
 /packages/**/tsdoc-metadata.json

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -71,6 +71,7 @@
     "rollup": "2.70.1",
     "rollup-plugin-sourcemaps": "0.6.3",
     "rollup-plugin-terser": "7.0.2",
+    "rollup-plugin-visualizer": "^5.6.0",
     "sinon": "13.0.1",
     "tinycolor2": "1.4.2",
     "typescript": "4.4.4"

--- a/packages/grafana-data/rollup.config.ts
+++ b/packages/grafana-data/rollup.config.ts
@@ -3,6 +3,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import sourceMaps from 'rollup-plugin-sourcemaps';
 import json from '@rollup/plugin-json';
 import { terser } from 'rollup-plugin-terser';
+import { visualizer } from 'rollup-plugin-visualizer';
 import path from 'path';
 
 const pkg = require('./package.json');
@@ -25,6 +26,12 @@ const buildCjsPackage = ({ env }) => {
     external: [
       'lodash',
       'rxjs',
+      'rxjs/operators',
+      'moment',
+      'react',
+      'react-dom',
+      'regenerator-runtime',
+      'moment-timezone',
       '@grafana/schema', // Load from host
     ],
     plugins: [
@@ -37,6 +44,7 @@ const buildCjsPackage = ({ env }) => {
       }),
       resolve(),
       sourceMaps(),
+      env === 'development' && visualizer(),
       env === 'production' && terser(),
     ],
   };

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -169,6 +169,7 @@
     "rollup": "2.70.1",
     "rollup-plugin-sourcemaps": "0.6.3",
     "rollup-plugin-terser": "7.0.2",
+    "rollup-plugin-visualizer": "^5.6.0",
     "sass-loader": "12.6.0",
     "storybook-dark-mode": "1.0.9",
     "style-loader": "3.3.1",

--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -2,6 +2,7 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import image from '@rollup/plugin-image';
 import { terser } from 'rollup-plugin-terser';
+import { visualizer } from 'rollup-plugin-visualizer';
 
 const pkg = require('./package.json');
 
@@ -28,6 +29,7 @@ const buildCjsPackage = ({ env }) => {
     external: [
       'react',
       'react-dom',
+      'lodash',
       '@grafana/aws-sdk',
       '@grafana/data',
       '@grafana/schema',
@@ -42,6 +44,7 @@ const buildCjsPackage = ({ env }) => {
       }),
       resolve(),
       image(),
+      env === 'development' && visualizer(),
       env === 'production' && terser(),
     ],
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4030,6 +4030,7 @@ __metadata:
     rollup: 2.70.1
     rollup-plugin-sourcemaps: 0.6.3
     rollup-plugin-terser: 7.0.2
+    rollup-plugin-visualizer: ^5.6.0
     rxjs: 7.5.5
     sinon: 13.0.1
     tinycolor2: 1.4.2
@@ -4477,6 +4478,7 @@ __metadata:
     rollup: 2.70.1
     rollup-plugin-sourcemaps: 0.6.3
     rollup-plugin-terser: 7.0.2
+    rollup-plugin-visualizer: ^5.6.0
     rxjs: 7.5.5
     sass-loader: 12.6.0
     slate: 0.47.8
@@ -26467,6 +26469,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.1.32":
+  version: 3.3.2
+  resolution: "nanoid@npm:3.3.2"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 376717f0685251fad77850bd84c6b8d57837c71eeb1c05be7c742140cc1835a5a2953562add05166d6dbc8fb65f3fdffa356213037b967a470e1691dc3e7b9cc
+  languageName: node
+  linkType: hard
+
 "nanomatch@npm:^1.2.9":
   version: 1.2.13
   resolution: "nanomatch@npm:1.2.13"
@@ -32382,6 +32393,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rollup-plugin-visualizer@npm:^5.6.0":
+  version: 5.6.0
+  resolution: "rollup-plugin-visualizer@npm:5.6.0"
+  dependencies:
+    nanoid: ^3.1.32
+    open: ^8.4.0
+    source-map: ^0.7.3
+    yargs: ^17.3.1
+  peerDependencies:
+    rollup: ^2.0.0
+  bin:
+    rollup-plugin-visualizer: dist/bin/cli.js
+  checksum: 1036a3873f3b6a0c46d692538aaac5dc9f7a7b2a5aec9e7ab816aaf8a31576ae750f415e1019e401707d18490b634a982fbe8c22d9761cafbd9b12c756e7fd99
+  languageName: node
+  linkType: hard
+
 "rollup@npm:2.70.1":
   version: 2.70.1
   resolution: "rollup@npm:2.70.1"
@@ -37532,6 +37559,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yargs-parser@npm:^21.0.0":
+  version: 21.0.1
+  resolution: "yargs-parser@npm:21.0.1"
+  checksum: c3ea2ed12cad0377ce3096b3f138df8267edf7b1aa7d710cd502fe16af417bafe4443dd71b28158c22fcd1be5dfd0e86319597e47badf42ff83815485887323a
+  languageName: node
+  linkType: hard
+
 "yargs-unparser@npm:2.0.0":
   version: 2.0.0
   resolution: "yargs-unparser@npm:2.0.0"
@@ -37575,6 +37609,21 @@ __metadata:
     y18n: ^4.0.0
     yargs-parser: ^18.1.2
   checksum: 40b974f508d8aed28598087720e086ecd32a5fd3e945e95ea4457da04ee9bdb8bdd17fd91acff36dc5b7f0595a735929c514c40c402416bbb87c03f6fb782373
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.3.1":
+  version: 17.4.0
+  resolution: "yargs@npm:17.4.0"
+  dependencies:
+    cliui: ^7.0.2
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.3
+    y18n: ^5.0.5
+    yargs-parser: ^21.0.0
+  checksum: 63985bddddf1fb6b9c98744591e8b70f99839591521cb84eea60903d52ec0da35ab46c42c325d151f3ab5c41935f976c10da096b5a7067c217714a91c0bd4be3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What this PR does / why we need it**:
optimize @grafana/data and @grafana/ui packages bundle size.
I notice @grafana/data package using rollup bundle config `external rxjs`, but `rxjs/operators` is ignore

**Which issue(s) this PR fixes**:
None.
When using different version packages, bundle external lib may cause unknown error.

---
by the way, have you considered using pnpm as a dependency management tool?