### PR TITLE
Loki: Add label_replace option to query builder

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.test.ts
@@ -127,7 +127,7 @@ describe('LokiQueryModeller', () => {
         labels: [{ label: 'app', op: '=', value: 'grafana' }],
         operations: [{ id: LokiOperationId.LabelFormat, params: ['new', 'old'] }],
       })
-    ).toBe('{app="grafana"} | label_format old=new');
+    ).toBe('{app="grafana"} | label_format old=`new`');
   });
 
   it('Can render simply binary operation with scalar', () => {

--- a/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.test.ts
@@ -121,6 +121,15 @@ describe('LokiQueryModeller', () => {
     ).toBe('{app="grafana"} | line_format "{{.status_code}}"');
   });
 
+  it('Can render with label_format operation', () => {
+    expect(
+      modeller.renderQuery({
+        labels: [{ label: 'app', op: '=', value: 'grafana' }],
+        operations: [{ id: LokiOperationId.LabelFormat, params: ['new', 'old'] }],
+      })
+    ).toBe('{app="grafana"} | label_format old=new');
+  });
+
   it('Can render simply binary operation with scalar', () => {
     expect(
       modeller.renderQuery({

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -95,12 +95,12 @@ export function getOperationDefintions(): QueryBuilderOperationDef[] {
       alternativesKey: 'format',
       category: LokiVisualQueryOperationCategory.Formats,
       orderRank: LokiOperationOrder.LineFormats,
-      renderer: (model, def, innerExpr) => `${innerExpr} | label_format ${model.params[1]}=${model.params[0]}`,
+      renderer: (model, def, innerExpr) => `${innerExpr} | label_format ${model.params[1]}=\`${model.params[0]}\``,
       addOperationHandler: addLokiOperation,
       explainHandler: () =>
         `This will change name of label to desired new label. In the example below, label "error_level" will be renamed to "level". 
 
-        Example: error_level=level
+        Example: error_level=\`level\`
 
         [Read the docs](https://grafana.com/docs/loki/latest/logql/log_queries/#labels-format-expression) for more.
         `,

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -84,6 +84,27 @@ export function getOperationDefintions(): QueryBuilderOperationDef[] {
         [Read the docs](https://grafana.com/docs/loki/latest/logql/log_queries/#line-format-expression) for more.
         `,
     },
+    {
+      id: LokiOperationId.LabelFormat,
+      name: 'Label format',
+      params: [
+        { name: 'Label', type: 'string' },
+        { name: 'Rename', type: 'string' },
+      ],
+      defaultParams: ['', ''],
+      alternativesKey: 'format',
+      category: LokiVisualQueryOperationCategory.Formats,
+      orderRank: LokiOperationOrder.LineFormats,
+      renderer: (model, def, innerExpr) => `${innerExpr} | label_format ${model.params[1]}=${model.params[0]}`,
+      addOperationHandler: addLokiOperation,
+      explainHandler: () =>
+        `This will change name of label to desired new label. In the example below, label "error_level" will be renamed to "level". 
+
+        Example: error_level=level
+
+        [Read the docs](https://grafana.com/docs/loki/latest/logql/log_queries/#labels-format-expression) for more.
+        `,
+    },
 
     {
       id: LokiOperationId.LineContains,

--- a/public/app/plugins/datasource/loki/querybuilder/types.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/types.ts
@@ -31,6 +31,7 @@ export enum LokiOperationId {
   Json = 'json',
   Logfmt = 'logfmt',
   LineFormat = 'line_format',
+  LabelFormat = 'label_format',
   Rate = 'rate',
   CountOverTime = 'count_over_time',
   SumOverTime = 'sum_over_time',


### PR DESCRIPTION
Adds label_format option to query builder

<img width="691" alt="image" src="https://user-images.githubusercontent.com/30407135/161517828-81d1f2ec-5be2-4427-8c99-8179ddd5d391.png">

Part of https://github.com/grafana/grafana/issues/44253

