### PR TITLE
Loki: do not special-case __name__ label

### DIFF
--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -290,12 +290,10 @@ export function createMetricLabel(labelData: { [key: string]: string }, options?
 }
 
 function getOriginalMetricName(labelData: { [key: string]: string }) {
-  // we do not want to mutate the original labels-structure
-  const labels = { ...labelData };
-  const labelPart = Object.entries(labels)
+  const labelPart = Object.entries(labelData)
     .map((label) => `${label[0]}="${label[1]}"`)
     .join(',');
-  return `${metricName}{${labelPart}}`;
+  return `{${labelPart}}`;
 }
 
 export function decamelize(s: string): string {

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -292,8 +292,6 @@ export function createMetricLabel(labelData: { [key: string]: string }, options?
 function getOriginalMetricName(labelData: { [key: string]: string }) {
   // we do not want to mutate the original labels-structure
   const labels = { ...labelData };
-  const metricName = labels.__name__ || '';
-  delete labels.__name__;
   const labelPart = Object.entries(labels)
     .map((label) => `${label[0]}="${label[1]}"`)
     .join(',');

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -290,8 +290,7 @@ export function createMetricLabel(labelData: { [key: string]: string }, options?
 }
 
 function getOriginalMetricName(labelData: { [key: string]: string }) {
-  // we do not want to mutate the origianl labels-structure,
-  // so we make a copy
+  // we do not want to mutate the original labels-structure
   const labels = { ...labelData };
   const metricName = labels.__name__ || '';
   delete labels.__name__;

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -290,9 +290,12 @@ export function createMetricLabel(labelData: { [key: string]: string }, options?
 }
 
 function getOriginalMetricName(labelData: { [key: string]: string }) {
-  const metricName = labelData.__name__ || '';
-  delete labelData.__name__;
-  const labelPart = Object.entries(labelData)
+  // we do not want to mutate the origianl labels-structure,
+  // so we make a copy
+  const labels = { ...labelData };
+  const metricName = labels.__name__ || '';
+  delete labels.__name__;
+  const labelPart = Object.entries(labels)
     .map((label) => `${label[0]}="${label[1]}"`)
     .join(',');
   return `${metricName}{${labelPart}}`;


### PR DESCRIPTION
in the Loki datasource we special-case the handling of the label named `__name__`. this should not happen.