### PR TITLE
Loki: Add parsing for vector aggregations with grouping

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -179,6 +179,44 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
+  it('parses metrics query with function and aggregation with grouping', () => {
+    expect(buildVisualQueryFromString('sum by (job,name) (rate({app="frontend"} | json [5m]))')).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [
+          { id: 'json', params: [] },
+          { id: 'rate', params: ['5m'] },
+          { id: '__sum_by', params: ['job', 'name'] },
+        ],
+      })
+    );
+  });
+
+  it('parses metrics query with function and aggregation with grouping at the end', () => {
+    expect(buildVisualQueryFromString('sum(rate({app="frontend"} | json [5m])) without(job,name)')).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [
+          { id: 'json', params: [] },
+          { id: 'rate', params: ['5m'] },
+          { id: '__sum_without', params: ['job', 'name'] },
+        ],
+      })
+    );
+  });
+
   it('parses metrics query with function and aggregation and filters', () => {
     expect(buildVisualQueryFromString('sum(rate({app="frontend"} |~ `abc` | json | bar="baz" [5m]))')).toEqual(
       noErrors({

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -2,6 +2,7 @@ import { parser } from '@grafana/lezer-logql';
 import { SyntaxNode } from '@lezer/common';
 import {
   ErrorName,
+  getAllByType,
   getLeftMostChild,
   getString,
   makeBinOp,
@@ -423,27 +424,4 @@ function getLastChildWithSelector(node: SyntaxNode, selector: string) {
     }
   }
   return child;
-}
-
-/**
- * Get all nodes with type in the tree. This traverses the tree so it is safe only when you know there shouldn't be
- * too much nesting but you just want to skip some of the wrappers. For example getting function args this way would
- * not be safe is it would also find arguments of nested functions.
- * @param expr
- * @param cur
- * @param type
- */
-function getAllByType(expr: string, cur: SyntaxNode, type: string): string[] {
-  if (cur.name === type) {
-    return [getString(expr, cur)];
-  }
-  const values: string[] = [];
-  let pos = 0;
-  let child = cur.childAfter(pos);
-  while (child) {
-    values.push(...getAllByType(expr, child, type));
-    pos = child.to;
-    child = cur.childAfter(pos);
-  }
-  return values;
 }

--- a/public/app/plugins/datasource/prometheus/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/parsing.ts
@@ -3,7 +3,15 @@ import { SyntaxNode } from '@lezer/common';
 import { QueryBuilderLabelFilter, QueryBuilderOperation } from './shared/types';
 import { PromVisualQuery, PromVisualQueryBinary } from './types';
 import { binaryScalarDefs } from './binaryScalarOperations';
-import { ErrorName, getLeftMostChild, getString, makeBinOp, makeError, replaceVariables } from './shared/parsingUtils';
+import {
+  ErrorName,
+  getAllByType,
+  getLeftMostChild,
+  getString,
+  makeBinOp,
+  makeError,
+  replaceVariables,
+} from './shared/parsingUtils';
 
 /**
  * Parses a PromQL query into a visual query model.
@@ -364,27 +372,4 @@ function getBinaryModifier(
       matchType: matcher.getChild('On') ? 'on' : 'ignoring',
     };
   }
-}
-
-/**
- * Get all nodes with type in the tree. This traverses the tree so it is safe only when you know there shouldn't be
- * too much nesting but you just want to skip some of the wrappers. For example getting function args this way would
- * not be safe is it would also find arguments of nested functions.
- * @param expr
- * @param cur
- * @param type
- */
-function getAllByType(expr: string, cur: SyntaxNode, type: string): string[] {
-  if (cur.name === type) {
-    return [getString(expr, cur)];
-  }
-  const values: string[] = [];
-  let pos = 0;
-  let child = cur.childAfter(pos);
-  while (child) {
-    values.push(...getAllByType(expr, child, type));
-    pos = child.to;
-    child = cur.childAfter(pos);
-  }
-  return values;
 }

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils.ts
@@ -106,6 +106,29 @@ export function makeBinOp(
   };
 }
 
+/**
+ * Get all nodes with type in the tree. This traverses the tree so it is safe only when you know there shouldn't be
+ * too much nesting but you just want to skip some of the wrappers. For example getting function args this way would
+ * not be safe is it would also find arguments of nested functions.
+ * @param expr
+ * @param cur
+ * @param type
+ */
+export function getAllByType(expr: string, cur: SyntaxNode, type: string): string[] {
+  if (cur.name === type) {
+    return [getString(expr, cur)];
+  }
+  const values: string[] = [];
+  let pos = 0;
+  let child = cur.childAfter(pos);
+  while (child) {
+    values.push(...getAllByType(expr, child, type));
+    pos = child.to;
+    child = cur.childAfter(pos);
+  }
+  return values;
+}
+
 // Debugging function for convenience. Gives you nice output similar to linux tree util.
 // @ts-ignore
 export function log(expr: string, cur?: SyntaxNode) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds parsing for vector aggregations with grouping (e.g. `sum by()`)

https://user-images.githubusercontent.com/30407135/161532252-00c99b0c-caef-486b-8afa-9d3d8cfce927.mov

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/grafana/issues/44253

