### PR TITLE
Alerting: fix flakey default time range assertion

### DIFF
--- a/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
+++ b/public/app/features/alerting/unified/state/AlertingQueryRunner.test.ts
@@ -93,12 +93,15 @@ describe('AlertingQueryRunner', () => {
 
     await expect(data.pipe(take(1))).toEmitValuesWith((values) => {
       const [data] = values;
+
+      // these test are flakey since the absolute computed "timeRange" can differ from the relative "defaultRelativeTimeRange"
+      // so instead we will check if the size of the timeranges match
       const relativeA = rangeUtil.timeRangeToRelative(data.A.timeRange);
       const relativeB = rangeUtil.timeRangeToRelative(data.B.timeRange);
-      const expected = getDefaultRelativeTimeRange();
+      const defaultRange = getDefaultRelativeTimeRange();
 
-      expect(relativeA).toEqual(expected);
-      expect(relativeB).toEqual(expected);
+      expect(relativeA.from - defaultRange.from).toEqual(relativeA.to - defaultRange.to);
+      expect(relativeB.from - defaultRange.from).toEqual(relativeB.to - defaultRange.to);
     });
   });
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Attempts to fix a flakey test in `AlertingQueryRunner.test.ts` as observed in https://drone.grafana.net/grafana/grafana/56582/2/12

The `timeRange` returned from the query runner contains an absolute `from` and `to` timestamp computed from a relative time range.

If the test was slow the `timeRangeToRelative()` result would no longer match the `getDefaultRelativeTimeRange()` value.

This changes the assertion to check if the size of the computed time ranges match instead of asserting on the seconds offsets.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

