### PR TITLE
Navigation: Put expand toggle at beginning of tab order

### DIFF
--- a/public/app/core/components/NavBar/Next/NavBarMenu.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarMenu.tsx
@@ -8,6 +8,7 @@ import { css, cx } from '@emotion/css';
 import { NavBarMenuItem } from './NavBarMenuItem';
 import { NavBarItemWithoutMenu } from './NavBarItemWithoutMenu';
 import { isMatchOrChildMatch } from '../utils';
+import { NavBarToggle } from './NavBarToggle';
 
 export interface Props {
   activeItem?: NavModelItem;
@@ -33,12 +34,7 @@ export function NavBarMenu({ activeItem, isOpen, navItems, onClose }: Props) {
     <div data-testid="navbarmenu" className={styles.container}>
       <FocusScope contain restoreFocus autoFocus>
         <nav className={styles.content} ref={ref} {...overlayProps} {...dialogProps}>
-          <IconButton
-            name={isOpen ? 'angle-left' : 'angle-right'}
-            className={styles.menuCollapseIcon}
-            size="xl"
-            onClick={onClose}
-          />
+          <NavBarToggle className={styles.menuCollapseIcon} isExpanded={isOpen} onClick={onClose} />
           <CustomScrollbar hideHorizontalTrack>
             <ul className={styles.itemList}>
               {navItems.map((link) => (
@@ -82,18 +78,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     gridAutoRows: `minmax(${theme.spacing(6)}, auto)`,
   }),
   menuCollapseIcon: css({
-    backgroundColor: theme.colors.background.secondary,
-    border: `1px solid ${theme.colors.border.weak}`,
     position: 'absolute',
     marginRight: 0,
     top: '43px',
     right: '0px',
-    zIndex: theme.zIndex.sidemenu,
-    borderRadius: '50%',
-
-    [theme.breakpoints.down('md')]: {
-      display: 'none',
-    },
   }),
 });
 

--- a/public/app/core/components/NavBar/Next/NavBarMenu.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
-import { CollapsableSection, CustomScrollbar, Icon, IconName, useStyles2 } from '@grafana/ui';
+import { CollapsableSection, CustomScrollbar, Icon, IconButton, IconName, useStyles2 } from '@grafana/ui';
 import { FocusScope } from '@react-aria/focus';
 import { useDialog } from '@react-aria/dialog';
 import { useOverlay } from '@react-aria/overlays';
@@ -11,18 +11,19 @@ import { isMatchOrChildMatch } from '../utils';
 
 export interface Props {
   activeItem?: NavModelItem;
+  isOpen: boolean;
   navItems: NavModelItem[];
   onClose: () => void;
 }
 
-export function NavBarMenu({ activeItem, navItems, onClose }: Props) {
+export function NavBarMenu({ activeItem, isOpen, navItems, onClose }: Props) {
   const styles = useStyles2(getStyles);
   const ref = useRef(null);
   const { dialogProps } = useDialog({}, ref);
   const { overlayProps } = useOverlay(
     {
       isDismissable: true,
-      isOpen: true,
+      isOpen,
       onClose,
     },
     ref
@@ -32,6 +33,12 @@ export function NavBarMenu({ activeItem, navItems, onClose }: Props) {
     <div data-testid="navbarmenu" className={styles.container}>
       <FocusScope contain restoreFocus autoFocus>
         <nav className={styles.content} ref={ref} {...overlayProps} {...dialogProps}>
+          <IconButton
+            name={isOpen ? 'angle-left' : 'angle-right'}
+            className={styles.menuCollapseIcon}
+            size="xl"
+            onClick={onClose}
+          />
           <CustomScrollbar hideHorizontalTrack>
             <ul className={styles.itemList}>
               {navItems.map((link) => (
@@ -73,6 +80,20 @@ const getStyles = (theme: GrafanaTheme2) => ({
   itemList: css({
     display: 'grid',
     gridAutoRows: `minmax(${theme.spacing(6)}, auto)`,
+  }),
+  menuCollapseIcon: css({
+    backgroundColor: theme.colors.background.secondary,
+    border: `1px solid ${theme.colors.border.weak}`,
+    position: 'absolute',
+    marginRight: 0,
+    top: '43px',
+    right: '0px',
+    zIndex: theme.zIndex.sidemenu,
+    borderRadius: '50%',
+
+    [theme.breakpoints.down('md')]: {
+      display: 'none',
+    },
   }),
 });
 

--- a/public/app/core/components/NavBar/Next/NavBarMenu.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
-import { CollapsableSection, CustomScrollbar, Icon, IconButton, IconName, useStyles2 } from '@grafana/ui';
+import { CollapsableSection, CustomScrollbar, Icon, IconName, useStyles2 } from '@grafana/ui';
 import { FocusScope } from '@react-aria/focus';
 import { useDialog } from '@react-aria/dialog';
 import { useOverlay } from '@react-aria/overlays';

--- a/public/app/core/components/NavBar/Next/NavBarMenu.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarMenu.tsx
@@ -79,7 +79,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   menuCollapseIcon: css({
     position: 'absolute',
-    marginRight: 0,
     top: '43px',
     right: '0px',
   }),

--- a/public/app/core/components/NavBar/Next/NavBarNext.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarNext.tsx
@@ -16,6 +16,7 @@ import { useSelector } from 'react-redux';
 import { NavBarItemWithoutMenu } from './NavBarItemWithoutMenu';
 import { FocusScope } from '@react-aria/focus';
 import { NavBarContext } from '../context';
+import { NavBarToggle } from './NavBarToggle';
 
 const onOpenSearch = () => {
   locationService.partial({ search: 'open' });
@@ -79,12 +80,12 @@ export const NavBarNext = React.memo(() => {
               <Icon name="bars" size="xl" />
             </div>
 
-            <IconButton
-              name={'angle-right'}
+            <NavBarToggle
               className={styles.menuExpandIcon}
-              size="xl"
-              onClick={() => setMenuOpen(true)}
+              isExpanded={menuOpen}
+              onClick={() => setMenuOpen(!menuOpen)}
             />
+
             <ul className={styles.itemList}>
               <NavBarItemWithoutMenu
                 isActive={isMatchOrChildMatch(homeItem, activeItem)}
@@ -235,19 +236,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
     zIndex: theme.zIndex.sidemenu,
   }),
   menuExpandIcon: css({
-    backgroundColor: theme.colors.background.secondary,
-    border: `1px solid ${theme.colors.border.weak}`,
     position: 'absolute',
     marginRight: 0,
     top: '43px',
     right: '0px',
-    zIndex: theme.zIndex.sidemenu,
     transform: `translateX(50%)`,
-    borderRadius: '50%',
-
-    [theme.breakpoints.down('md')]: {
-      display: 'none',
-    },
   }),
 });
 
@@ -268,34 +261,23 @@ const getAnimStyles = (theme: GrafanaTheme2) => {
     width: theme.spacing(7),
   };
 
-  const buttonShift = {
-    '& + button': {
-      transform: 'translateX(0%)',
-    },
-  };
-
   return {
     enter: css({
       ...closedStyles,
-      ...buttonShift,
     }),
     enterActive: css({
       ...transitionProps,
       ...openStyles,
-      ...buttonShift,
     }),
     enterDone: css({
       ...openStyles,
-      ...buttonShift,
     }),
     exit: css({
       ...openStyles,
-      ...buttonShift,
     }),
     exitActive: css({
       ...transitionProps,
       ...closedStyles,
-      ...buttonShift,
     }),
   };
 };

--- a/public/app/core/components/NavBar/Next/NavBarNext.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarNext.tsx
@@ -79,6 +79,12 @@ export const NavBarNext = React.memo(() => {
               <Icon name="bars" size="xl" />
             </div>
 
+            <IconButton
+              name={'angle-right'}
+              className={styles.menuExpandIcon}
+              size="xl"
+              onClick={() => setMenuOpen(true)}
+            />
             <ul className={styles.itemList}>
               <NavBarItemWithoutMenu
                 isActive={isMatchOrChildMatch(homeItem, activeItem)}
@@ -132,16 +138,11 @@ export const NavBarNext = React.memo(() => {
         <CSSTransition in={menuOpen} classNames={animStyles} timeout={150} unmountOnExit>
           <NavBarMenu
             activeItem={activeItem}
+            isOpen={menuOpen}
             navItems={[homeItem, searchItem, ...coreItems, ...pluginItems, ...configItems]}
             onClose={() => setMenuOpen(false)}
           />
         </CSSTransition>
-        <IconButton
-          name={menuOpen ? 'angle-left' : 'angle-right'}
-          className={styles.menuToggle}
-          size="xl"
-          onClick={() => setMenuOpen(!menuOpen)}
-        />
       </div>
     </div>
   );
@@ -233,7 +234,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     height: '100%',
     zIndex: theme.zIndex.sidemenu,
   }),
-  menuToggle: css({
+  menuExpandIcon: css({
     backgroundColor: theme.colors.background.secondary,
     border: `1px solid ${theme.colors.border.weak}`,
     position: 'absolute',
@@ -241,7 +242,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     top: '43px',
     right: '0px',
     zIndex: theme.zIndex.sidemenu,
-    transform: `translateX(calc(${theme.spacing(7)} + 50%))`,
+    transform: `translateX(50%)`,
     borderRadius: '50%',
 
     [theme.breakpoints.down('md')]: {

--- a/public/app/core/components/NavBar/Next/NavBarNext.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarNext.tsx
@@ -4,7 +4,7 @@ import CSSTransition from 'react-transition-group/CSSTransition';
 import { css, cx } from '@emotion/css';
 import { cloneDeep } from 'lodash';
 import { GrafanaTheme2, NavModelItem, NavSection } from '@grafana/data';
-import { Icon, IconButton, IconName, useStyles2, useTheme2 } from '@grafana/ui';
+import { Icon, IconName, useStyles2, useTheme2 } from '@grafana/ui';
 import { config, locationService } from '@grafana/runtime';
 import { getKioskMode } from 'app/core/navigation/kiosk';
 import { KioskMode, StoreState } from 'app/types';

--- a/public/app/core/components/NavBar/Next/NavBarNext.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarNext.tsx
@@ -237,7 +237,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   menuExpandIcon: css({
     position: 'absolute',
-    marginRight: 0,
     top: '43px',
     right: '0px',
     transform: `translateX(50%)`,

--- a/public/app/core/components/NavBar/Next/NavBarToggle.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarToggle.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { IconButton, useTheme2 } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+import { css } from '@emotion/css';
+import classnames from 'classnames';
+
+export interface Props {
+  className?: string;
+  isExpanded: boolean;
+  onClick: () => void;
+}
+
+export const NavBarToggle = ({ className, isExpanded, onClick }: Props) => {
+  const theme = useTheme2();
+  const styles = getStyles(theme);
+
+  return (
+    <IconButton
+      name={isExpanded ? 'angle-left' : 'angle-right'}
+      className={classnames(className, styles.icon)}
+      size="xl"
+      onClick={onClick}
+    />
+  );
+};
+
+NavBarToggle.displayName = 'NavBarToggle';
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  icon: css({
+    backgroundColor: theme.colors.background.secondary,
+    border: `1px solid ${theme.colors.border.weak}`,
+    zIndex: theme.zIndex.sidemenu,
+    borderRadius: '50%',
+
+    [theme.breakpoints.down('md')]: {
+      display: 'none',
+    },
+  }),
+});

--- a/public/app/core/components/NavBar/Next/NavBarToggle.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarToggle.tsx
@@ -30,8 +30,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
   icon: css({
     backgroundColor: theme.colors.background.secondary,
     border: `1px solid ${theme.colors.border.weak}`,
-    zIndex: theme.zIndex.sidemenu,
     borderRadius: '50%',
+    marginRight: 0,
+    zIndex: theme.zIndex.sidemenu,
 
     [theme.breakpoints.down('md')]: {
       display: 'none',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- puts the expand/collapse toggle at the beginning of the tab order
- ensures you can navigate to the toggle with the keyboard when the menu is expanded

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #47193 

**Special notes for your reviewer**:

