### PR TITLE
UI: Export sparkline from @grafana/ui and fix a broken storybook page

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/BigValue.story.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.story.tsx
@@ -71,6 +71,7 @@ export const Basic: Story<StoryProps> = ({
       name: '',
       values: new ArrayVector([1, 2, 3, 4, 3]),
       type: FieldType.number,
+      state: { range: { min: 1, max: 4, delta: 3 } },
       config: {},
     },
   };

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -43,6 +43,7 @@ const defaultConfig: GraphFieldConfig = {
   axisPlacement: AxisPlacement.Hidden,
 };
 
+/** @internal */
 export class Sparkline extends PureComponent<SparklineProps, State> {
   constructor(props: SparklineProps) {
     super(props);

--- a/packages/grafana-ui/src/components/index.ts
+++ b/packages/grafana-ui/src/components/index.ts
@@ -84,6 +84,7 @@ export {
   BigValueJustifyMode,
   BigValueTextMode,
 } from './BigValue/BigValue';
+export { Sparkline } from './Sparkline/Sparkline';
 
 export { Gauge } from './Gauge/Gauge';
 export { Graph } from './Graph/Graph';


### PR DESCRIPTION
**What this PR does / why we need it**:

- We'd like to use the Sparkline visualization in plugins, but it the moment it isn't being exposed externally through Grafana UI. This PR adds the missing export. 
- While trying to use the sparkline embedded in BigValue I noticed that the storybook story was crashing, so I fixed that as well.

Before:
<img width="830" alt="Screen Shot 2022-04-04 at 07 37 29" src="https://user-images.githubusercontent.com/8377044/161582190-0ca45c91-e9ea-4e94-af20-79006fdaaa89.png">

After:
<img width="824" alt="Screen Shot 2022-04-04 at 07 39 45" src="https://user-images.githubusercontent.com/8377044/161582227-d3f4c62b-157e-43b5-97c3-72fd2cfca03a.png">



