### PR TITLE
Loki: Replace auto range vector option with $__interval

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
@@ -43,7 +43,7 @@ export class LokiQueryModeller extends LokiAndPromQueryModellerBase {
           { id: LokiOperationId.Logfmt, params: [] },
           { id: LokiOperationId.LabelFilterNoErrors, params: [] },
           { id: LokiOperationId.Unwrap, params: [''] },
-          { id: LokiOperationId.SumOverTime, params: ['auto'] },
+          { id: LokiOperationId.SumOverTime, params: ['$__interval'] },
           { id: LokiOperationId.Sum, params: [] },
         ],
       },

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -360,7 +360,7 @@ export function addLokiOperation(
           modeller,
           (def) => def.category === LokiVisualQueryOperationCategory.Functions
         );
-        operations.splice(placeToInsert, 0, { id: LokiOperationId.Rate, params: ['auto'] });
+        operations.splice(placeToInsert, 0, { id: LokiOperationId.Rate, params: ['$__interval'] });
       }
       operations.push(newOperation);
       break;


### PR DESCRIPTION
**What this PR does / why we need it**:
Similar PR to https://github.com/grafana/grafana/pull/45715 that removed `auto` option from Prometheus. This PR removes `auto` option from Loki query builder and replaces it with `$__interval`. I have searched for `auto` across Loki query builder and found it used only at these 2 places. I also tested this locally and didn't find `auto` anywhere else. 

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/grafana/issues/44253

