### PR TITLE
replaced references to Cortex with Mimir

### DIFF
--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -10,7 +10,7 @@ Alerts allow you to learn about problems in your systems moments after they occu
 Grafana 8.0 introduced new and improved alerting that centralizes alerting information in a single, searchable view. It allows you to:
 
 - Create and manage Grafana alerts
-- Create and manage Cortex and Loki managed alerts
+- Create and manage Mimir and Loki managed alerts
 - View alerting information from Prometheus and Alertmanager compatible data sources
 
 Grafana alerting is enabled by default for new OSS installations. For older installations, it is still an [opt-in]({{< relref "./unified-alerting/opt-in.md" >}}) feature.

--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -10,7 +10,7 @@ Alerts allow you to learn about problems in your systems moments after they occu
 Grafana 8.0 introduced new and improved alerting that centralizes alerting information in a single, searchable view. It allows you to:
 
 - Create and manage Grafana alerts
-- Create and manage Mimir and Loki managed alerts
+- Create and manage Grafana Mimir and Loki managed alerts
 - View alerting information from Prometheus and Alertmanager compatible data sources
 
 Grafana alerting is enabled by default for new OSS installations. For older installations, it is still an [opt-in]({{< relref "./unified-alerting/opt-in.md" >}}) feature.

--- a/docs/sources/alerting/unified-alerting/_index.md
+++ b/docs/sources/alerting/unified-alerting/_index.md
@@ -11,7 +11,7 @@ Grafana 8.0 has new and improved alerting that centralizes alerting information 
 When Grafana alerting is enabled, you can:
 
 - [Create Grafana managed alerting rules]({{< relref "alerting-rules/create-grafana-managed-rule.md" >}})
-- [Create Mimir or Loki managed alerting rules]({{< relref "alerting-rules/create-mimir-loki-managed-rule.md" >}})
+- [Create Grafana Mimir or Loki managed alerting rules]({{< relref "alerting-rules/create-mimir-loki-managed-rule.md" >}})
 - [View existing alerting rules and manage their current state]({{< relref "alerting-rules/rule-list.md" >}})
 - [View the state and health of alerting rules]({{< relref "./fundamentals/state-and-health.md" >}})
 - [Add or edit an alert contact point]({{< relref "./contact-points.md" >}})

--- a/docs/sources/alerting/unified-alerting/_index.md
+++ b/docs/sources/alerting/unified-alerting/_index.md
@@ -11,7 +11,7 @@ Grafana 8.0 has new and improved alerting that centralizes alerting information 
 When Grafana alerting is enabled, you can:
 
 - [Create Grafana managed alerting rules]({{< relref "alerting-rules/create-grafana-managed-rule.md" >}})
-- [Create Cortex or Loki managed alerting rules]({{< relref "alerting-rules/create-cortex-loki-managed-rule.md" >}})
+- [Create Mimir or Loki managed alerting rules]({{< relref "alerting-rules/create-mimir-loki-managed-rule.md" >}})
 - [View existing alerting rules and manage their current state]({{< relref "alerting-rules/rule-list.md" >}})
 - [View the state and health of alerting rules]({{< relref "./fundamentals/state-and-health.md" >}})
 - [Add or edit an alert contact point]({{< relref "./contact-points.md" >}})

--- a/docs/sources/alerting/unified-alerting/alerting-rules/_index.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/_index.md
@@ -12,9 +12,9 @@ While queries and expressions select the data set to evaluate, a condition sets 
 
 You can:
 
-- [Create Cortex or Loki managed alert rule]({{< relref "./create-cortex-loki-managed-rule.md" >}})
-- [Create Cortex or Loki managed recording rule]({{< relref "./create-cortex-loki-managed-recording-rule.md" >}})
-- [Edit Cortex or Loki rule groups and namespaces]({{< relref "./edit-cortex-loki-namespace-group.md" >}})
+- [Create Mimir or Loki managed alert rule]({{< relref "./create-mimir-loki-managed-rule.md" >}})
+- [Create Mimir or Loki managed recording rule]({{< relref "./create-mimir-loki-managed-recording-rule.md" >}})
+- [Edit Mimir or Loki rule groups and namespaces]({{< relref "./edit-mimir-loki-namespace-group.md" >}})
 - [Create Grafana managed alert rule]({{< relref "./create-grafana-managed-rule.md" >}})
 - [State and health of alerting rules]({{< relref "../fundamentals/state-and-health.md" >}})
 - [Manage alerting rules]({{< relref "./rule-list.md" >}})

--- a/docs/sources/alerting/unified-alerting/alerting-rules/_index.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/_index.md
@@ -13,8 +13,8 @@ While queries and expressions select the data set to evaluate, a condition sets 
 You can:
 
 - [Create Grafana Mimir or Loki managed alert rule]({{< relref "./create-mimir-loki-managed-rule.md" >}})
-- [Create Mimir or Loki managed recording rule]({{< relref "./create-mimir-loki-managed-recording-rule.md" >}})
-- [Edit Mimir or Loki rule groups and namespaces]({{< relref "./edit-mimir-loki-namespace-group.md" >}})
+- [Create Grafana Mimir or Loki managed recording rule]({{< relref "./create-mimir-loki-managed-recording-rule.md" >}})
+- [Edit Grafana Mimir or Loki rule groups and namespaces]({{< relref "./edit-mimir-loki-namespace-group.md" >}})
 - [Create Grafana managed alert rule]({{< relref "./create-grafana-managed-rule.md" >}})
 - [State and health of alerting rules]({{< relref "../fundamentals/state-and-health.md" >}})
 - [Manage alerting rules]({{< relref "./rule-list.md" >}})

--- a/docs/sources/alerting/unified-alerting/alerting-rules/_index.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/_index.md
@@ -12,7 +12,7 @@ While queries and expressions select the data set to evaluate, a condition sets 
 
 You can:
 
-- [Create Mimir or Loki managed alert rule]({{< relref "./create-mimir-loki-managed-rule.md" >}})
+- [Create Grafana Mimir or Loki managed alert rule]({{< relref "./create-mimir-loki-managed-rule.md" >}})
 - [Create Mimir or Loki managed recording rule]({{< relref "./create-mimir-loki-managed-recording-rule.md" >}})
 - [Edit Mimir or Loki rule groups and namespaces]({{< relref "./edit-mimir-loki-namespace-group.md" >}})
 - [Create Grafana managed alert rule]({{< relref "./create-grafana-managed-rule.md" >}})

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
@@ -1,38 +1,38 @@
 +++
-title = "Create Cortex or Loki managed recording rule"
-description = "Create Cortex or Loki managed recording rule"
+title = "Create Mimir or Loki managed recording rule"
+description = "Create Mimir or Loki managed recording rule"
 keywords = ["grafana", "alerting", "guide", "rules", "recording rules", "create"]
 weight = 400
 +++
 
-# Create a Cortex or Loki managed recording rule
+# Create a Mimir or Loki managed recording rule
 
-You can create and manage recording rules for an external Cortex or Loki instance. Recording rules calculate frequently needed expressions or computationally expensive expressions in advance and save the result as a new set of time series. Querying this new time series is faster, especially for dashboards since they query the same expression every time the dashboards refresh.
+You can create and manage recording rules for an external Mimir or Loki instance. Recording rules calculate frequently needed expressions or computationally expensive expressions in advance and save the result as a new set of time series. Querying this new time series is faster, especially for dashboards since they query the same expression every time the dashboards refresh.
 
 ## Before you begin
 
-For Cortex and Loki data sources to work with Grafana 8.0 alerting, enable the ruler API by configuring their respective services.
+For Mimir and Loki data sources to work with Grafana 8.0 alerting, enable the ruler API by configuring their respective services.
 
 **Loki** - The `local` rule storage type, default for the Loki data source, supports only viewing of rules. To edit rules, configure one of the other rule storage types.
 
-**Cortex** - When configuring a Grafana Prometheus data source to point to Cortex, use the legacy `/api/prom` prefix, not `/prometheus`. Currently, we support only single-binary mode and you cannot provide a separate URL for the ruler API.
+**Mimir** - When configuring a Grafana Prometheus data source to point to Mimir, use the legacy `/api/prom` prefix, not `/prometheus`. Currently, we support only single-binary mode and you cannot provide a separate URL for the ruler API.
 
 > **Note:** If you do not want to manage alerting rules for a particular Loki or Prometheus data source, go to its settings page and clear the **Manage alerts via Alerting UI** checkbox.
 
-## Add a Cortex or Loki managed recording rule
+## Add a Mimir or Loki managed recording rule
 
 1. In the Grafana menu, click the **Alerting** (bell) icon to open the Alerting page listing existing alerts.
 1. Click **New alert rule**.
 1. In Step 1, add the rule name, type, and storage location.
    - In **Rule name**, add a descriptive name. This name is displayed in the alert rule list. It is also the `alertname` label for every alert instance that is created from this rule.
-   - From the **Rule type** drop-down, select **Cortex / Loki managed alert**.
+   - From the **Rule type** drop-down, select **Mimir / Loki managed alert**.
    - From the **Select data source** drop-down, select an external Prometheus, an external Loki, or a Grafana Cloud data source.
    - From the **Namespace** drop-down, select an existing rule namespace. Otherwise, click **Add new** and enter a name to create a new one. Namespaces can contain one or more rule groups and only have an organizational purpose.
    - From the **Group** drop-down, select an existing group within the selected namespace. Otherwise, click **Add new** and enter a name to create a new one. Newly created rules are appended to the end of the group. Rules within a group are run sequentially at a regular interval, with the same evaluation time.
-     {{< figure src="/static/img/docs/alerting/unified/rule-edit-cortex-alert-type-8-0.png" max-width="550px" caption="Alert details" >}}
+     {{< figure src="/static/img/docs/alerting/unified/rule-edit-mimir-alert-type-8-0.png" max-width="550px" caption="Alert details" >}}
 1. In Step 2, add the query to evaluate.
    - Enter a PromQL or LogQL expression. The rule fires if the evaluation result has at least one series with a value that is greater than 0. An alert is created for each series.
-     {{< figure src="/static/img/docs/alerting/unified/rule-edit-cortex-query-8-0.png" max-width="550px" caption="Alert details" >}}
+     {{< figure src="/static/img/docs/alerting/unified/rule-edit-mimir-query-8-0.png" max-width="550px" caption="Alert details" >}}
 1. In Step 3, add additional metadata associated with the rule.
    - Add a description and summary to customize alert messages. Use the guidelines in [Annotations and labels for alerting]({{< relref "./alert-annotation-label.md" >}}).
    - Add Runbook URL, panel, dashboard, and alert IDs.

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
@@ -15,7 +15,7 @@ For Mimir and Loki data sources to work with Grafana 8.0 alerting, enable the ru
 
 **Loki** - The `local` rule storage type, default for the Loki data source, supports only viewing of rules. To edit rules, configure one of the other rule storage types.
 
-**Mimir** - When configuring a Grafana Prometheus data source to point to Mimir, use the legacy `/api/prom` prefix, not `/prometheus`. Currently, we support only single-binary mode and you cannot provide a separate URL for the ruler API.
+**Grafana Mimir** - When configuring a Grafana Prometheus data source to point to Grafana Mimir, use the legacy `/api/prom` prefix, not `/prometheus`. Currently, we support only single-binary mode and you cannot provide a separate URL for the ruler API.
 
 > **Note:** If you do not want to manage alerting rules for a particular Loki or Prometheus data source, go to its settings page and clear the **Manage alerts via Alerting UI** checkbox.
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
@@ -5,7 +5,7 @@ keywords = ["grafana", "alerting", "guide", "rules", "recording rules", "create"
 weight = 400
 +++
 
-# Create a Mimir or Loki managed recording rule
+# Create a Grafana Mimir or Loki managed recording rule
 
 You can create and manage recording rules for an external Grafana Mimir or Loki instance. Recording rules calculate frequently needed expressions or computationally expensive expressions in advance and save the result as a new set of time series. Querying this new time series is faster, especially for dashboards since they query the same expression every time the dashboards refresh.
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
@@ -19,7 +19,7 @@ For Mimir and Loki data sources to work with Grafana 8.0 alerting, enable the ru
 
 > **Note:** If you do not want to manage alerting rules for a particular Loki or Prometheus data source, go to its settings page and clear the **Manage alerts via Alerting UI** checkbox.
 
-## Add a Mimir or Loki managed recording rule
+## Add a Grafana Mimir or Loki managed recording rule
 
 1. In the Grafana menu, click the **Alerting** (bell) icon to open the Alerting page listing existing alerts.
 1. Click **New alert rule**.

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
@@ -11,7 +11,7 @@ You can create and manage recording rules for an external Grafana Mimir or Loki 
 
 ## Before you begin
 
-For Mimir and Loki data sources to work with Grafana 8.0 alerting, enable the ruler API by configuring their respective services.
+For Grafana Mimir and Loki data sources to work with Grafana 8.0 alerting, enable the ruler API by configuring their respective services.
 
 **Loki** - The `local` rule storage type, default for the Loki data source, supports only viewing of rules. To edit rules, configure one of the other rule storage types.
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
@@ -7,7 +7,7 @@ weight = 400
 
 # Create a Mimir or Loki managed recording rule
 
-You can create and manage recording rules for an external Mimir or Loki instance. Recording rules calculate frequently needed expressions or computationally expensive expressions in advance and save the result as a new set of time series. Querying this new time series is faster, especially for dashboards since they query the same expression every time the dashboards refresh.
+You can create and manage recording rules for an external Grafana Mimir or Loki instance. Recording rules calculate frequently needed expressions or computationally expensive expressions in advance and save the result as a new set of time series. Querying this new time series is faster, especially for dashboards since they query the same expression every time the dashboards refresh.
 
 ## Before you begin
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule.md
@@ -1,6 +1,6 @@
 +++
-title = "Create Mimir or Loki managed recording rule"
-description = "Create Mimir or Loki managed recording rule"
+title = "Create Grafana Mimir or Loki managed recording rule"
+description = "Create Grafana Mimir or Loki managed recording rule"
 keywords = ["grafana", "alerting", "guide", "rules", "recording rules", "create"]
 weight = 400
 +++

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
@@ -11,7 +11,7 @@ Grafana allows you to create alerting rules for an external Grafana Mimir or Lok
 
 ## Before you begin
 
-- Verify that you have write permission to the Prometheus data source. Otherwise, you will not be able to create or update Mimir managed alerting rules.
+- Verify that you have write permission to the Prometheus data source. Otherwise, you will not be able to create or update Grafana Mimir managed alerting rules.
 
 - For Mimir and Loki data sources, enable the ruler API by configuring their respective services.
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
@@ -5,7 +5,7 @@ keywords = ["grafana", "alerting", "guide", "rules", "create"]
 weight = 400
 +++
 
-# Create a Mimir or Loki managed alerting rule
+# Create a Grafana Mimir or Loki managed alerting rule
 
 Grafana allows you to create alerting rules for an external Mimir or Loki instance.
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
@@ -7,7 +7,7 @@ weight = 400
 
 # Create a Grafana Mimir or Loki managed alerting rule
 
-Grafana allows you to create alerting rules for an external Mimir or Loki instance.
+Grafana allows you to create alerting rules for an external Grafana Mimir or Loki instance.
 
 ## Before you begin
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
@@ -17,7 +17,7 @@ Grafana allows you to create alerting rules for an external Mimir or Loki instan
 
   - **Loki** - The `local` rule storage type, default for the Loki data source, supports only viewing of rules. To edit rules, configure one of the other rule storage types.
 
-  - **Mimir** - use the [legacy `/api/prom` prefix](https://cortexmetrics.io/docs/api/#path-prefixes), not `/prometheus`. The Prometheus data source supports both Mimir and Prometheus, and Grafana expects that both the [Query API](https://cortexmetrics.io/docs/api/#querier--query-frontend) and [Ruler API](https://cortexmetrics.io/docs/api/#ruler) are under the same URL. You cannot provide a separate URL for the Ruler API.
+  - **Mimir** - use the [legacy `/api/prom` prefix](https://grafana.com/docs/mimir/latest/operators-guide/reference-http-api/#path-prefixes), not `/prometheus`. The Prometheus data source supports both Mimir and Prometheus, and Grafana expects that both the [Query API](https://grafana.com/docs/mimir/latest/operators-guide/reference-http-api/#querier--query-frontend) and [Ruler API](https://grafana.com/docs/mimir/latest/operators-guide/reference-http-api/#ruler) are under the same URL. You cannot provide a separate URL for the Ruler API.
 
 > **Note:** If you do not want to manage alerting rules for a particular Loki or Prometheus data source, go to its settings and clear the **Manage alerts via Alerting UI** checkbox.
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
@@ -17,7 +17,7 @@ Grafana allows you to create alerting rules for an external Mimir or Loki instan
 
   - **Loki** - The `local` rule storage type, default for the Loki data source, supports only viewing of rules. To edit rules, configure one of the other rule storage types.
 
-  - **Mimir** - use the [legacy `/api/prom` prefix](https://grafana.com/docs/mimir/latest/operators-guide/reference-http-api/#path-prefixes), not `/prometheus`. The Prometheus data source supports both Mimir and Prometheus, and Grafana expects that both the [Query API](https://grafana.com/docs/mimir/latest/operators-guide/reference-http-api/#querier--query-frontend) and [Ruler API](https://grafana.com/docs/mimir/latest/operators-guide/reference-http-api/#ruler) are under the same URL. You cannot provide a separate URL for the Ruler API.
+  - **Grafana Mimir** - use the [legacy `/api/prom` prefix](https://grafana.com/docs/mimir/latest/operators-guide/reference-http-api/#path-prefixes), not `/prometheus`. The Prometheus data source supports both Grafana Mimir and Prometheus, and Grafana expects that both the [Query API](https://grafana.com/docs/mimir/latest/operators-guide/reference-http-api/#querier--query-frontend) and [Ruler API](https://grafana.com/docs/mimir/latest/operators-guide/reference-http-api/#ruler) are under the same URL. You cannot provide a separate URL for the Ruler API.
 
 > **Note:** If you do not want to manage alerting rules for a particular Loki or Prometheus data source, go to its settings and clear the **Manage alerts via Alerting UI** checkbox.
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
@@ -13,7 +13,7 @@ Grafana allows you to create alerting rules for an external Grafana Mimir or Lok
 
 - Verify that you have write permission to the Prometheus data source. Otherwise, you will not be able to create or update Grafana Mimir managed alerting rules.
 
-- For Mimir and Loki data sources, enable the ruler API by configuring their respective services.
+- For Grafana Mimir and Loki data sources, enable the ruler API by configuring their respective services.
 
   - **Loki** - The `local` rule storage type, default for the Loki data source, supports only viewing of rules. To edit rules, configure one of the other rule storage types.
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
@@ -1,6 +1,6 @@
 +++
-title = "Create Mimir or Loki managed alert rule"
-description = "Create Mimir or Loki managed alerting rule"
+title = "Create Grafana Mimir or Loki managed alert rule"
+description = "Create Grafana Mimir or Loki managed alerting rule"
 keywords = ["grafana", "alerting", "guide", "rules", "create"]
 weight = 400
 +++

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
@@ -21,7 +21,7 @@ Grafana allows you to create alerting rules for an external Grafana Mimir or Lok
 
 > **Note:** If you do not want to manage alerting rules for a particular Loki or Prometheus data source, go to its settings and clear the **Manage alerts via Alerting UI** checkbox.
 
-## Add a Mimir or Loki managed alerting rule
+## Add a Grafana Mimir or Loki managed alerting rule
 
 1. In the Grafana menu, click the **Alerting** (bell) icon to open the Alerting page listing existing alerts.
 1. Click **New alert rule**.

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
@@ -29,7 +29,7 @@ Grafana allows you to create alerting rules for an external Mimir or Loki instan
    - In **Rule name**, add a descriptive name. This name is displayed in the alert rule list. It is also the `alertname` label for every alert instance that is created from this rule.
    - From the **Rule type** drop-down, select **Mimir / Loki managed alert**.
    - From the **Select data source** drop-down, select an external Prometheus, an external Loki, or a Grafana Cloud data source.
-   - From the **Namespace** drop-down, select an existing rule namespace. Otherwise, click **Add new** and enter a name to create a new one. Namespaces can contain one or more rule groups and only have an organizational purpose. For more information, see [Mimir or Loki rule groups and namespaces]({{< relref "./edit-mimir-loki-namespace-group.md" >}}).
+   - From the **Namespace** drop-down, select an existing rule namespace. Otherwise, click **Add new** and enter a name to create a new one. Namespaces can contain one or more rule groups and only have an organizational purpose. For more information, see [Grafana Mimir or Loki rule groups and namespaces]({{< relref "./edit-mimir-loki-namespace-group.md" >}}).
    - From the **Group** drop-down, select an existing group within the selected namespace. Otherwise, click **Add new** and enter a name to create a new one. Newly created rules are appended to the end of the group. Rules within a group are run sequentially at a regular interval, with the same evaluation time.
      {{< figure src="/static/img/docs/alerting/unified/rule-edit-mimir-alert-type-8-0.png" max-width="550px" caption="Alert details" >}}
 1. In Step 2, add the query to evaluate.

--- a/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-rule.md
@@ -1,40 +1,40 @@
 +++
-title = "Create Cortex or Loki managed alert rule"
-description = "Create Cortex or Loki managed alerting rule"
+title = "Create Mimir or Loki managed alert rule"
+description = "Create Mimir or Loki managed alerting rule"
 keywords = ["grafana", "alerting", "guide", "rules", "create"]
 weight = 400
 +++
 
-# Create a Cortex or Loki managed alerting rule
+# Create a Mimir or Loki managed alerting rule
 
-Grafana allows you to create alerting rules for an external Cortex or Loki instance.
+Grafana allows you to create alerting rules for an external Mimir or Loki instance.
 
 ## Before you begin
 
-- Verify that you have write permission to the Prometheus data source. Otherwise, you will not be able to create or update Cortex managed alerting rules.
+- Verify that you have write permission to the Prometheus data source. Otherwise, you will not be able to create or update Mimir managed alerting rules.
 
-- For Cortex and Loki data sources, enable the ruler API by configuring their respective services.
+- For Mimir and Loki data sources, enable the ruler API by configuring their respective services.
 
   - **Loki** - The `local` rule storage type, default for the Loki data source, supports only viewing of rules. To edit rules, configure one of the other rule storage types.
 
-  - **Cortex** - use the [legacy `/api/prom` prefix](https://cortexmetrics.io/docs/api/#path-prefixes), not `/prometheus`. The Prometheus data source supports both Cortex and Prometheus, and Grafana expects that both the [Query API](https://cortexmetrics.io/docs/api/#querier--query-frontend) and [Ruler API](https://cortexmetrics.io/docs/api/#ruler) are under the same URL. You cannot provide a separate URL for the Ruler API.
+  - **Mimir** - use the [legacy `/api/prom` prefix](https://cortexmetrics.io/docs/api/#path-prefixes), not `/prometheus`. The Prometheus data source supports both Mimir and Prometheus, and Grafana expects that both the [Query API](https://cortexmetrics.io/docs/api/#querier--query-frontend) and [Ruler API](https://cortexmetrics.io/docs/api/#ruler) are under the same URL. You cannot provide a separate URL for the Ruler API.
 
 > **Note:** If you do not want to manage alerting rules for a particular Loki or Prometheus data source, go to its settings and clear the **Manage alerts via Alerting UI** checkbox.
 
-## Add a Cortex or Loki managed alerting rule
+## Add a Mimir or Loki managed alerting rule
 
 1. In the Grafana menu, click the **Alerting** (bell) icon to open the Alerting page listing existing alerts.
 1. Click **New alert rule**.
 1. In Step 1, add the rule name, type, and storage location.
    - In **Rule name**, add a descriptive name. This name is displayed in the alert rule list. It is also the `alertname` label for every alert instance that is created from this rule.
-   - From the **Rule type** drop-down, select **Cortex / Loki managed alert**.
+   - From the **Rule type** drop-down, select **Mimir / Loki managed alert**.
    - From the **Select data source** drop-down, select an external Prometheus, an external Loki, or a Grafana Cloud data source.
-   - From the **Namespace** drop-down, select an existing rule namespace. Otherwise, click **Add new** and enter a name to create a new one. Namespaces can contain one or more rule groups and only have an organizational purpose. For more information, see [Cortex or Loki rule groups and namespaces]({{< relref "./edit-cortex-loki-namespace-group.md" >}}).
+   - From the **Namespace** drop-down, select an existing rule namespace. Otherwise, click **Add new** and enter a name to create a new one. Namespaces can contain one or more rule groups and only have an organizational purpose. For more information, see [Mimir or Loki rule groups and namespaces]({{< relref "./edit-mimir-loki-namespace-group.md" >}}).
    - From the **Group** drop-down, select an existing group within the selected namespace. Otherwise, click **Add new** and enter a name to create a new one. Newly created rules are appended to the end of the group. Rules within a group are run sequentially at a regular interval, with the same evaluation time.
-     {{< figure src="/static/img/docs/alerting/unified/rule-edit-cortex-alert-type-8-0.png" max-width="550px" caption="Alert details" >}}
+     {{< figure src="/static/img/docs/alerting/unified/rule-edit-mimir-alert-type-8-0.png" max-width="550px" caption="Alert details" >}}
 1. In Step 2, add the query to evaluate.
    - Enter a PromQL or LogQL expression. The rule fires if the evaluation result has at least one series with a value that is greater than 0. An alert is created for each series.
-     {{< figure src="/static/img/docs/alerting/unified/rule-edit-cortex-query-8-0.png" max-width="550px" caption="Alert details" >}}
+     {{< figure src="/static/img/docs/alerting/unified/rule-edit-mimir-query-8-0.png" max-width="550px" caption="Alert details" >}}
 1. In Step 3, add conditions.
    - In the **For** text box, specify the duration for which the condition must be true before an alert fires. If you specify `5m`, the condition must be true for 5 minutes before the alert fires.
      > **Note:** Once a condition is met, the alert goes into the `Pending` state. If the condition remains active for the duration specified, the alert transitions to the `Firing` state, else it reverts to the `Normal` state.

--- a/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
@@ -18,7 +18,7 @@ A namespace contains one or more groups. The rules within a group are run sequen
 To rename a namespace:
 
 1. In the Grafana menu, click the **Alerting** (bell) icon to open the Alerting page listing existing alerts.
-1. Find a Mimir or Loki managed rule with the group that belongs to the namespace you want to edit.
+1. Find a Grafana Mimir or Loki managed rule with the group that belongs to the namespace you want to edit.
 1. Click the **Edit** (pen) icon.
 1. Enter a new name in the **Namespace** field, then click **Save changes**.
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
@@ -1,7 +1,7 @@
 +++
 title = "Grafana Mimir or Loki rule groups and namespaces"
 description = "Edit Mimir or Loki rule groups and namespaces"
-keywords = ["grafana", "alerting", "guide", "group", "namespace", "mimir", "loki"]
+keywords = ["grafana", "alerting", "guide", "group", "namespace", "grafana mimir", "loki"]
 weight = 405
 +++
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
@@ -1,6 +1,6 @@
 +++
 title = "Grafana Mimir or Loki rule groups and namespaces"
-description = "Edit Mimir or Loki rule groups and namespaces"
+description = "Edit Grafana Mimir or Loki rule groups and namespaces"
 keywords = ["grafana", "alerting", "guide", "group", "namespace", "grafana mimir", "loki"]
 weight = 405
 +++

--- a/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
@@ -1,5 +1,5 @@
 +++
-title = "Mimir or Loki rule groups and namespaces"
+title = "Grafana Mimir or Loki rule groups and namespaces"
 description = "Edit Mimir or Loki rule groups and namespaces"
 keywords = ["grafana", "alerting", "guide", "group", "namespace", "mimir", "loki"]
 weight = 405

--- a/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
@@ -29,7 +29,7 @@ A new namespace is created and all groups are copied into this namespace from th
 The rules within a group are run sequentially at a regular interval, the default interval is one (1) minute. You can modify this interval using the following instructions.
 
 1. n the Grafana menu, click the **Alerting** (bell) icon to open the Alerting page listing existing alerts.
-1. Find a Mimir or Loki managed rule with the group you want to edit.
+1. Find a Grafana Mimir or Loki managed rule with the group you want to edit.
 1. Click **Edit** (pen) icon.
 1. Modify the **Rule group** and **Rule group evaluation interval** information as necessary.
 1. Click **Save changes**.

--- a/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
@@ -5,7 +5,7 @@ keywords = ["grafana", "alerting", "guide", "group", "namespace", "mimir", "loki
 weight = 405
 +++
 
-# Mimir or Loki rule groups and namespaces
+# Grafana Mimir or Loki rule groups and namespaces
 
 A namespace contains one or more groups. The rules within a group are run sequentially at a regular interval. The default interval is one (1) minute. You can rename Mimir or Loki rule namespaces and groups, and edit group evaluation intervals.
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
@@ -1,24 +1,24 @@
 +++
-title = "Cortex or Loki rule groups and namespaces"
-description = "Edit Cortex or Loki rule groups and namespaces"
-keywords = ["grafana", "alerting", "guide", "group", "namespace", "cortex", "loki"]
+title = "Mimir or Loki rule groups and namespaces"
+description = "Edit Mimir or Loki rule groups and namespaces"
+keywords = ["grafana", "alerting", "guide", "group", "namespace", "mimir", "loki"]
 weight = 405
 +++
 
-# Cortex or Loki rule groups and namespaces
+# Mimir or Loki rule groups and namespaces
 
-A namespace contains one or more groups. The rules within a group are run sequentially at a regular interval. The default interval is one (1) minute. You can rename Cortex or Loki rule namespaces and groups, and edit group evaluation intervals.
+A namespace contains one or more groups. The rules within a group are run sequentially at a regular interval. The default interval is one (1) minute. You can rename Mimir or Loki rule namespaces and groups, and edit group evaluation intervals.
 
-![Group list](/static/img/docs/alerting/unified/rule-list-edit-cortex-loki-icon-8-2.png 'Rule group list screenshot')
+![Group list](/static/img/docs/alerting/unified/rule-list-edit-mimir-loki-icon-8-2.png 'Rule group list screenshot')
 
-{{< figure src="/static/img/docs/alerting/unified/rule-list-edit-cortex-loki-icon-8-2.png" max-width="550px" caption="Alert details" >}}
+{{< figure src="/static/img/docs/alerting/unified/rule-list-edit-mimir-loki-icon-8-2.png" max-width="550px" caption="Alert details" >}}
 
 ## Rename a namespace
 
 To rename a namespace:
 
 1. In the Grafana menu, click the **Alerting** (bell) icon to open the Alerting page listing existing alerts.
-1. Find a Cortex or Loki managed rule with the group that belongs to the namespace you want to edit.
+1. Find a Mimir or Loki managed rule with the group that belongs to the namespace you want to edit.
 1. Click the **Edit** (pen) icon.
 1. Enter a new name in the **Namespace** field, then click **Save changes**.
 
@@ -29,11 +29,11 @@ A new namespace is created and all groups are copied into this namespace from th
 The rules within a group are run sequentially at a regular interval, the default interval is one (1) minute. You can modify this interval using the following instructions.
 
 1. n the Grafana menu, click the **Alerting** (bell) icon to open the Alerting page listing existing alerts.
-1. Find a Cortex or Loki managed rule with the group you want to edit.
+1. Find a Mimir or Loki managed rule with the group you want to edit.
 1. Click **Edit** (pen) icon.
 1. Modify the **Rule group** and **Rule group evaluation interval** information as necessary.
 1. Click **Save changes**.
 
 When you rename the group, a new group with all the rules from the old group is created. The old group is deleted.
 
-![Group edit modal](/static/img/docs/alerting/unified/rule-list-cortex-loki-edit-ns-group-8-2.png 'Rule group edit modal screenshot')
+![Group edit modal](/static/img/docs/alerting/unified/rule-list-mimir-loki-edit-ns-group-8-2.png 'Rule group edit modal screenshot')

--- a/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/edit-cortex-loki-namespace-group.md
@@ -7,7 +7,7 @@ weight = 405
 
 # Grafana Mimir or Loki rule groups and namespaces
 
-A namespace contains one or more groups. The rules within a group are run sequentially at a regular interval. The default interval is one (1) minute. You can rename Mimir or Loki rule namespaces and groups, and edit group evaluation intervals.
+A namespace contains one or more groups. The rules within a group are run sequentially at a regular interval. The default interval is one (1) minute. You can rename Grafana Mimir or Loki rule namespaces and groups, and edit group evaluation intervals.
 
 ![Group list](/static/img/docs/alerting/unified/rule-list-edit-mimir-loki-icon-8-2.png 'Rule group list screenshot')
 

--- a/docs/sources/alerting/unified-alerting/alerting-rules/rule-list.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/rule-list.md
@@ -54,5 +54,5 @@ Grafana managed alerting rules can only be edited or deleted by users with Edit 
 To edit or delete a rule:
 
 1. Expand a rule row until you can see the rule controls of **View**, **Edit**, and **Delete**.
-1. Click **Edit** to open the create rule page. Make updates following instructions in [Create a Grafana managed alerting rule]({{< relref "./create-grafana-managed-rule.md" >}}) or [Create a Mimir or Loki managed alerting rule]({{< relref "./create-mimir-loki-managed-rule.md" >}}).
+1. Click **Edit** to open the create rule page. Make updates following instructions in [Create a Grafana managed alerting rule]({{< relref "./create-grafana-managed-rule.md" >}}) or [Create a Grafana Mimir or Loki managed alerting rule]({{< relref "./create-mimir-loki-managed-rule.md" >}}).
 1. Click **Delete** to delete a rule.

--- a/docs/sources/alerting/unified-alerting/alerting-rules/rule-list.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/rule-list.md
@@ -50,7 +50,7 @@ To filter alerting rules:
 
 ## Edit or delete an alerting rule
 
-Grafana managed alerting rules can only be edited or deleted by users with Edit permissions for the folder storing the rules. Alerting rules for an external Mimir or Loki instance can be edited or deleted by users with Editor or Admin roles.
+Grafana managed alerting rules can only be edited or deleted by users with Edit permissions for the folder storing the rules. Alerting rules for an external Grafana Mimir or Loki instance can be edited or deleted by users with Editor or Admin roles.
 To edit or delete a rule:
 
 1. Expand a rule row until you can see the rule controls of **View**, **Edit**, and **Delete**.

--- a/docs/sources/alerting/unified-alerting/alerting-rules/rule-list.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/rule-list.md
@@ -9,11 +9,14 @@ weight = 402
 
 The Alerting page lists existing Grafana 8 alerting rules. By default, rules are grouped by types of data sources. The Grafana section lists all Grafana managed rules. Alerting rules for Prometheus compatible data sources are also listed here. You can view alerting rules for Prometheus compatible data sources but you cannot edit them.
 
-The Cortex/Loki rules section lists all rules for external Prometheus or Loki data sources. Cloud alerting rules are also listed in this section.
+The Mimir/Loki rules section lists all rules for external Prometheus or Loki data sources. Cloud alerting rules are also listed in this section.
 
-- [View alerting rules](#view-alerting-rule)
-- [Filter alerting rules](#filter-alerting-rules)
-- [Edit or delete an alerting rule](#edit-or-delete-an-alerting-rule)
+- [Manage alerting rules](#manage-alerting-rules)
+  - [View alerting rules](#view-alerting-rules)
+    - [Group view](#group-view)
+    - [State view](#state-view)
+  - [Filter alerting rules](#filter-alerting-rules)
+  - [Edit or delete an alerting rule](#edit-or-delete-an-alerting-rule)
 
 ## View alerting rules
 
@@ -47,9 +50,9 @@ To filter alerting rules:
 
 ## Edit or delete an alerting rule
 
-Grafana managed alerting rules can only be edited or deleted by users with Edit permissions for the folder storing the rules. Alerting rules for an external Cortex or Loki instance can be edited or deleted by users with Editor or Admin roles.
+Grafana managed alerting rules can only be edited or deleted by users with Edit permissions for the folder storing the rules. Alerting rules for an external Mimir or Loki instance can be edited or deleted by users with Editor or Admin roles.
 To edit or delete a rule:
 
 1. Expand a rule row until you can see the rule controls of **View**, **Edit**, and **Delete**.
-1. Click **Edit** to open the create rule page. Make updates following instructions in [Create a Grafana managed alerting rule]({{< relref "./create-grafana-managed-rule.md" >}}) or [Create a Cortex or Loki managed alerting rule]({{< relref "./create-cortex-loki-managed-rule.md" >}}).
+1. Click **Edit** to open the create rule page. Make updates following instructions in [Create a Grafana managed alerting rule]({{< relref "./create-grafana-managed-rule.md" >}}) or [Create a Mimir or Loki managed alerting rule]({{< relref "./create-mimir-loki-managed-rule.md" >}}).
 1. Click **Delete** to delete a rule.

--- a/docs/sources/alerting/unified-alerting/difference-old-new.md
+++ b/docs/sources/alerting/unified-alerting/difference-old-new.md
@@ -19,9 +19,9 @@ Unlike legacy dashboard alerts, Grafana alerts allow you to create queries and e
 
 Since unified alerts are no longer directly tied to panel queries, they do not include images or query values in the notification email. You can use customized notification templates to view query values.
 
-## Create Loki and Cortex alerting rules
+## Create Loki and Mimir alerting rules
 
-In Grafana alerting, you can manage Loki and Cortex alerting rules using the same UI and API as your Grafana managed alerts.
+In Grafana alerting, you can manage Loki and Mimir alerting rules using the same UI and API as your Grafana managed alerts.
 
 ## View and search for alerts from Prometheus compatible data sources
 

--- a/docs/sources/alerting/unified-alerting/difference-old-new.md
+++ b/docs/sources/alerting/unified-alerting/difference-old-new.md
@@ -21,7 +21,7 @@ Since unified alerts are no longer directly tied to panel queries, they do not i
 
 ## Create Loki and Mimir alerting rules
 
-In Grafana alerting, you can manage Loki and Mimir alerting rules using the same UI and API as your Grafana managed alerts.
+In Grafana alerting, you can manage Loki and Grafana Mimir alerting rules using the same UI and API as your Grafana managed alerts.
 
 ## View and search for alerts from Prometheus compatible data sources
 

--- a/docs/sources/alerting/unified-alerting/difference-old-new.md
+++ b/docs/sources/alerting/unified-alerting/difference-old-new.md
@@ -19,7 +19,7 @@ Unlike legacy dashboard alerts, Grafana alerts allow you to create queries and e
 
 Since unified alerts are no longer directly tied to panel queries, they do not include images or query values in the notification email. You can use customized notification templates to view query values.
 
-## Create Loki and Mimir alerting rules
+## Create Loki and Grafana Mimir alerting rules
 
 In Grafana alerting, you can manage Loki and Grafana Mimir alerting rules using the same UI and API as your Grafana managed alerts.
 

--- a/docs/sources/alerting/unified-alerting/fundamentals/alertmanager.md
+++ b/docs/sources/alerting/unified-alerting/fundamentals/alertmanager.md
@@ -12,7 +12,7 @@ Grafana includes built-in support for Prometheus Alertmanager. By default, notif
 
 > **Note:** Before v8.2, the configuration of the embedded Alertmanager was shared across organizations. If you are on an older Grafana version, we recommend that you use Grafana alerts only if you have one organization. Otherwise, your contact points are visible to all organizations.
 
-Grafana alerting added support for external Alertmanager configuration. When you add an [Alertmanager data source]({{< relref "../../../datasources/alertmanager.md" >}}), the Alertmanager drop-down shows a list of available external Alertmanager data sources. Select a data source to create and manage alerting for standalone Cortex or Loki data sources.
+Grafana alerting added support for external Alertmanager configuration. When you add an [Alertmanager data source]({{< relref "../../../datasources/alertmanager.md" >}}), the Alertmanager drop-down shows a list of available external Alertmanager data sources. Select a data source to create and manage alerting for standalone Mimir or Loki data sources.
 
 {{< figure max-width="40%" src="/static/img/docs/alerting/unified/contact-points-select-am-8-0.gif" max-width="250px" caption="Select Alertmanager" >}}
 

--- a/docs/sources/alerting/unified-alerting/fundamentals/alertmanager.md
+++ b/docs/sources/alerting/unified-alerting/fundamentals/alertmanager.md
@@ -12,7 +12,7 @@ Grafana includes built-in support for Prometheus Alertmanager. By default, notif
 
 > **Note:** Before v8.2, the configuration of the embedded Alertmanager was shared across organizations. If you are on an older Grafana version, we recommend that you use Grafana alerts only if you have one organization. Otherwise, your contact points are visible to all organizations.
 
-Grafana alerting added support for external Alertmanager configuration. When you add an [Alertmanager data source]({{< relref "../../../datasources/alertmanager.md" >}}), the Alertmanager drop-down shows a list of available external Alertmanager data sources. Select a data source to create and manage alerting for standalone Mimir or Loki data sources.
+Grafana alerting added support for external Alertmanager configuration. When you add an [Alertmanager data source]({{< relref "../../../datasources/alertmanager.md" >}}), the Alertmanager drop-down shows a list of available external Alertmanager data sources. Select a data source to create and manage alerting for standalone Grafana Mimir or Loki data sources.
 
 {{< figure max-width="40%" src="/static/img/docs/alerting/unified/contact-points-select-am-8-0.gif" max-width="250px" caption="Select Alertmanager" >}}
 

--- a/docs/sources/datasources/alertmanager.md
+++ b/docs/sources/datasources/alertmanager.md
@@ -12,7 +12,7 @@ Grafana includes built-in support for Prometheus Alertmanager. It is presently i
 
 ## Alertmanager implementations
 
-[Prometheus](https://prometheus.io/) and [Cortex](https://cortexmetrics.io/) (default) implementations of Alertmanager are supported. You can specify implementation in the data source settings page. In case of Prometheus contact points and notification policies are read-only in the Grafana alerting UI, as it does not support updating configuration via HTTP API.
+[Prometheus](https://prometheus.io/) and [Mimir](https://grafana.com/docs/mimir/latest/) (default) implementations of Alertmanager are supported. You can specify implementation in the data source settings page. In case of Prometheus contact points and notification policies are read-only in the Grafana alerting UI, as it does not support updating configuration via HTTP API.
 
 ## Provision the Alertmanager data source
 
@@ -29,7 +29,7 @@ datasources:
     url: http://localhost:9093
     access: proxy
     jsonData:
-      implementation: 'prometheus' # alternatively 'cortex'
+      implementation: 'prometheus' # alternatively 'mimir'
     # optionally
     basicAuth: true
     basicAuthUser: my_user

--- a/docs/sources/datasources/alertmanager.md
+++ b/docs/sources/datasources/alertmanager.md
@@ -12,7 +12,7 @@ Grafana includes built-in support for Prometheus Alertmanager. It is presently i
 
 ## Alertmanager implementations
 
-[Prometheus](https://prometheus.io/) and [Mimir](https://grafana.com/docs/mimir/latest/) (default) implementations of Alertmanager are supported. You can specify implementation in the data source settings page. In case of Prometheus contact points and notification policies are read-only in the Grafana alerting UI, as it does not support updating configuration via HTTP API.
+[Prometheus](https://prometheus.io/) and [Grafana Mimir](https://grafana.com/docs/mimir/latest/) (default) implementations of Alertmanager are supported. You can specify implementation in the data source settings page. In case of Prometheus contact points and notification policies are read-only in the Grafana alerting UI, as it does not support updating configuration via HTTP API.
 
 ## Provision the Alertmanager data source
 

--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -200,7 +200,7 @@ For detailed instructions, refer to [Internal Grafana metrics]({{< relref "../ad
 
 The Prometheus data source works with other projects that implement the [Prometheus query API](https://prometheus.io/docs/prometheus/latest/querying/api/) including:
 
-- [Mimir](https://grafana.com/docs/mimir/latest/)
+- [Grafana Mimir](https://grafana.com/docs/mimir/latest/)
 - [Thanos](https://thanos.io/v0.17/components/query.md/)
 
 For more information on how to query other Prometheus-compatible projects from Grafana, refer to the specific project documentation.

--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -200,7 +200,7 @@ For detailed instructions, refer to [Internal Grafana metrics]({{< relref "../ad
 
 The Prometheus data source works with other projects that implement the [Prometheus query API](https://prometheus.io/docs/prometheus/latest/querying/api/) including:
 
-- [Cortex](https://cortexmetrics.io/docs/)
+- [Mimir](https://grafana.com/docs/mimir/latest/)
 - [Thanos](https://thanos.io/v0.17/components/query.md/)
 
 For more information on how to query other Prometheus-compatible projects from Grafana, refer to the specific project documentation.


### PR DESCRIPTION
This PR replaces references to Cortex with Mimir in Alerting documentation. 

The only places I have left them are in release notes for 8.1 and 8.2. 