### PR TITLE
Grafana/UI: Limit tooltip size to window size

### DIFF
--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipContainer.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipContainer.tsx
@@ -45,13 +45,13 @@ export const VizTooltipContainer: React.FC<VizTooltipContainerProps> = ({
           const tH = Math.floor(entry.contentRect.height + 2 * 8);
           if (tooltipMeasurement.width !== tW || tooltipMeasurement.height !== tH) {
             setTooltipMeasurement({
-              width: tW,
-              height: tH,
+              width: Math.min(tW, width),
+              height: Math.min(tH, height),
             });
           }
         }
       }),
-    [tooltipMeasurement]
+    [tooltipMeasurement, width, height]
   );
 
   useLayoutEffect(() => {


### PR DESCRIPTION
**What this PR does / why we need it**
When using too many series the tooltip overflows the viewport and the top part is clipped. Generally the top part is the most important if you're sorting. This PR limits the size of the tooltip to the size of the window.

**Which issue(s) this PR fixes**: 
Fixes #46131

