### PR TITLE
User: Expose GCOM user ID as externalUserId in grafanaBootData

### DIFF
--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -28,6 +28,7 @@ type LoginCommand struct {
 type CurrentUser struct {
 	IsSignedIn                 bool               `json:"isSignedIn"`
 	Id                         int64              `json:"id"`
+	ExternalUserId             int                `json:"externalUserId"`
 	Login                      string             `json:"login"`
 	Email                      string             `json:"email"`
 	Name                       string             `json:"name"`

--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -28,7 +28,7 @@ type LoginCommand struct {
 type CurrentUser struct {
 	IsSignedIn                 bool               `json:"isSignedIn"`
 	Id                         int64              `json:"id"`
-	ExternalUserId             int                `json:"externalUserId"`
+	ExternalUserId             string             `json:"externalUserId"`
 	Login                      string             `json:"login"`
 	Email                      string             `json:"email"`
 	Name                       string             `json:"name"`

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -653,7 +653,7 @@ func (hs *HTTPServer) setIndexViewData(c *models.ReqContext) (*dtos.IndexViewDat
 			IsSignedIn:                 c.IsSignedIn,
 			Login:                      c.Login,
 			Email:                      c.Email,
-			ExternalUserId:				12345,
+			ExternalUserId:             c.SignedInUser.ExternalAuthId,
 			Name:                       c.Name,
 			OrgCount:                   c.OrgCount,
 			OrgId:                      c.OrgId,

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -653,6 +653,7 @@ func (hs *HTTPServer) setIndexViewData(c *models.ReqContext) (*dtos.IndexViewDat
 			IsSignedIn:                 c.IsSignedIn,
 			Login:                      c.Login,
 			Email:                      c.Email,
+			ExternalUserId:				12345,
 			Name:                       c.Name,
 			OrgCount:                   c.OrgCount,
 			OrgId:                      c.OrgId,

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -174,7 +174,7 @@ type SignedInUser struct {
 	OrgName        string
 	OrgRole        RoleType
 	UserAuthModule string
-	UserAuthId     int64
+	UserAuthId     string
 	Login          string
 	Name           string
 	Email          string

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -173,6 +173,8 @@ type SignedInUser struct {
 	OrgId          int64
 	OrgName        string
 	OrgRole        RoleType
+	UserAuthModule string
+	UserAuthId     int64
 	Login          string
 	Name           string
 	Email          string

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -169,22 +169,22 @@ type GetUserOrgListQuery struct {
 // DTO & Projections
 
 type SignedInUser struct {
-	UserId         int64
-	OrgId          int64
-	OrgName        string
-	OrgRole        RoleType
-	UserAuthModule string
-	UserAuthId     string
-	Login          string
-	Name           string
-	Email          string
-	ApiKeyId       int64
-	OrgCount       int
-	IsGrafanaAdmin bool
-	IsAnonymous    bool
-	HelpFlags1     HelpFlags1
-	LastSeenAt     time.Time
-	Teams          []int64
+	UserId             int64
+	OrgId              int64
+	OrgName            string
+	OrgRole            RoleType
+	ExternalAuthModule string
+	ExternalAuthId     string
+	Login              string
+	Name               string
+	Email              string
+	ApiKeyId           int64
+	OrgCount           int
+	IsGrafanaAdmin     bool
+	IsAnonymous        bool
+	HelpFlags1         HelpFlags1
+	LastSeenAt         time.Time
+	Teams              []int64
 	// Permissions grouped by orgID and actions
 	Permissions map[int64]map[string][]string `json:"-"`
 }

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -548,10 +548,13 @@ func (ss *SQLStore) GetSignedInUser(ctx context.Context, query *models.GetSigned
 		u.help_flags1    as help_flags1,
 		u.last_seen_at   as last_seen_at,
 		(SELECT COUNT(*) FROM org_user where org_user.user_id = u.id) as org_count,
+		user_auth.auth_module as user_auth_module,
+		user_auth.auth_id as user_auth_id,
 		org.name         as org_name,
 		org_user.role    as org_role,
 		org.id           as org_id
 		FROM ` + dialect.Quote("user") + ` as u
+		LEFT OUTER JOIN user_auth on user_auth.user_id = u.id
 		LEFT OUTER JOIN org_user on org_user.org_id = ` + orgId + ` and org_user.user_id = u.id
 		LEFT OUTER JOIN org on org.id = org_user.org_id `
 

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -540,19 +540,19 @@ func (ss *SQLStore) GetSignedInUser(ctx context.Context, query *models.GetSigned
 		}
 
 		var rawSQL = `SELECT
-		u.id             as user_id,
-		u.is_admin       as is_grafana_admin,
-		u.email          as email,
-		u.login          as login,
-		u.name           as name,
-		u.help_flags1    as help_flags1,
-		u.last_seen_at   as last_seen_at,
+		u.id                  as user_id,
+		u.is_admin            as is_grafana_admin,
+		u.email               as email,
+		u.login               as login,
+		u.name                as name,
+		u.help_flags1         as help_flags1,
+		u.last_seen_at        as last_seen_at,
 		(SELECT COUNT(*) FROM org_user where org_user.user_id = u.id) as org_count,
 		user_auth.auth_module as external_auth_module,
-		user_auth.auth_id as external_auth_id,
-		org.name         as org_name,
-		org_user.role    as org_role,
-		org.id           as org_id
+		user_auth.auth_id     as external_auth_id,
+		org.name              as org_name,
+		org_user.role         as org_role,
+		org.id                as org_id
 		FROM ` + dialect.Quote("user") + ` as u
 		LEFT OUTER JOIN user_auth on user_auth.user_id = u.id
 		LEFT OUTER JOIN org_user on org_user.org_id = ` + orgId + ` and org_user.user_id = u.id

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -548,8 +548,8 @@ func (ss *SQLStore) GetSignedInUser(ctx context.Context, query *models.GetSigned
 		u.help_flags1    as help_flags1,
 		u.last_seen_at   as last_seen_at,
 		(SELECT COUNT(*) FROM org_user where org_user.user_id = u.id) as org_count,
-		user_auth.auth_module as user_auth_module,
-		user_auth.auth_id as user_auth_id,
+		user_auth.auth_module as external_auth_module,
+		user_auth.auth_id as external_auth_id,
 		org.name         as org_name,
 		org_user.role    as org_role,
 		org.id           as org_id
@@ -580,6 +580,10 @@ func (ss *SQLStore) GetSignedInUser(ctx context.Context, query *models.GetSigned
 		if user.OrgRole == "" {
 			user.OrgId = -1
 			user.OrgName = "Org missing"
+		}
+
+		if user.ExternalAuthModule != "oauth_grafana_com" {
+			user.ExternalAuthId = ""
 		}
 
 		getTeamsByUserQuery := &models.GetTeamsByUserQuery{OrgId: user.OrgId, UserId: user.UserId}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new `externalUserId` property to grafanaBootData, populated with just the gcom user ID if available.

This is so we can identify user's via the gcom user ID to rudderstack when configured (in a follow up PR)

**Which issue(s) this PR fixes**:

Part of #47021

