### PR TITLE
Loki: Show error when parsing nodes not supported in visual query builder

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -151,7 +151,7 @@ describe('buildVisualQueryFromString', () => {
     ]);
   });
 
-  it('returns error for query with IP label filter', () => {
+  it('returns error for query with ip label filter', () => {
     const context = buildVisualQueryFromString('{app="frontend"} | logfmt | address=ip("192.168.4.5/16")');
     expect(context.errors).toEqual([
       {

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -67,6 +67,18 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
+  it('returns error for query with ip matching line filter', () => {
+    const context = buildVisualQueryFromString('{app="frontend"} |= ip("192.168.4.5/16")');
+    expect(context.errors).toEqual([
+      {
+        text: 'Matching IP addresses not supported in query builder: |= ip("192.168.4.5/16")',
+        from: 17,
+        to: 40,
+        parentType: 'LineFilters',
+      },
+    ]);
+  });
+
   it('parses query with matcher label filter', () => {
     expect(buildVisualQueryFromString('{app="frontend"} | bar="baz"')).toEqual(
       noErrors({
@@ -127,6 +139,30 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
+  it('returns error for query with "and", "or", "comma" in label filter', () => {
+    const context = buildVisualQueryFromString('{app="frontend"} | logfmt | level="error" and job="grafana"');
+    expect(context.errors).toEqual([
+      {
+        text: 'Label filter with comma, "and", "or" not supported in query builder: level="error" and job="grafana"',
+        from: 28,
+        to: 59,
+        parentType: 'PipelineStage',
+      },
+    ]);
+  });
+
+  it('returns error for query with IP label filter', () => {
+    const context = buildVisualQueryFromString('{app="frontend"} | logfmt | address=ip("192.168.4.5/16")');
+    expect(context.errors).toEqual([
+      {
+        text: 'IpLabelFilter not supported in query builder: address=ip("192.168.4.5/16")',
+        from: 28,
+        to: 56,
+        parentType: 'PipelineStage',
+      },
+    ]);
+  });
+
   it('parses query with with parser', () => {
     expect(buildVisualQueryFromString('{app="frontend"} | json')).toEqual(
       noErrors({
@@ -140,6 +176,18 @@ describe('buildVisualQueryFromString', () => {
         operations: [{ id: 'json', params: [] }],
       })
     );
+  });
+
+  it('returns error for query with JSON expression parser', () => {
+    const context = buildVisualQueryFromString('{app="frontend"} | json label="value" ');
+    expect(context.errors).toEqual([
+      {
+        text: 'JsonExpressionParser not supported in visual query builder: json label="value"',
+        from: 19,
+        to: 37,
+        parentType: 'PipelineStage',
+      },
+    ]);
   });
 
   it('parses query with with simple unwrap', () => {
@@ -161,6 +209,20 @@ describe('buildVisualQueryFromString', () => {
         ],
       })
     );
+  });
+
+  it('returns error for query with unwrap and conversion operation', () => {
+    const context = buildVisualQueryFromString(
+      'sum_over_time({app="frontend"} | logfmt | unwrap duration(label) [5m])'
+    );
+    expect(context.errors).toEqual([
+      {
+        text: 'Unwrap with conversion operator not supported in query builder: | unwrap duration(label)',
+        from: 40,
+        to: 64,
+        parentType: 'LogRangeExpr',
+      },
+    ]);
   });
 
   it('parses metrics query with function', () => {
@@ -323,7 +385,7 @@ describe('buildVisualQueryFromString', () => {
             label: 'app',
           },
         ],
-        operations: [{ id: 'label_format', params: ['newLabel', '=', 'oldLabel'] }],
+        operations: [{ id: 'label_format', params: ['newLabel', 'oldLabel'] }],
       })
     );
   });
@@ -339,8 +401,8 @@ describe('buildVisualQueryFromString', () => {
           },
         ],
         operations: [
-          { id: 'label_format', params: ['newLabel', '=', 'oldLabel'] },
-          { id: 'label_format', params: ['bar', '=', 'baz'] },
+          { id: 'label_format', params: ['newLabel', 'oldLabel'] },
+          { id: 'label_format', params: ['bar', 'baz'] },
         ],
       })
     );

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -71,7 +71,7 @@ describe('buildVisualQueryFromString', () => {
     const context = buildVisualQueryFromString('{app="frontend"} |= ip("192.168.4.5/16")');
     expect(context.errors).toEqual([
       {
-        text: 'Matching IP addresses not supported in query builder: |= ip("192.168.4.5/16")',
+        text: 'Matching ip addresses not supported in query builder: |= ip("192.168.4.5/16")',
         from: 17,
         to: 40,
         parentType: 'LineFilters',

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -171,7 +171,7 @@ function getLineFilter(expr: string, node: SyntaxNode): { operation?: QueryBuild
   const ipLineFilter = getAllByType(expr, node, 'Ip');
   if (ipLineFilter.length > 0) {
     return {
-      error: 'Matching IP addresses not supported in query builder',
+      error: 'Matching ip addresses not supported in query builder',
     };
   }
 

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -64,9 +64,7 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
       }
       // Show error for query patterns not supported in visual query builder
       if (error) {
-        const err = makeError(expr, node);
-        err.text = `${error}: ${err.text}`;
-        context.errors.push(err);
+        context.errors.push(createNotSupportedError(expr, node, error));
       }
       break;
     }
@@ -83,18 +81,16 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
       }
       // Show error for query patterns not supported in visual query builder
       if (error) {
-        const err = makeError(expr, node);
-        err.text = `${error}: ${err.text}`;
-        context.errors.push(err);
+        context.errors.push(createNotSupportedError(expr, node, error));
       }
       break;
     }
 
     case 'JsonExpressionParser': {
       // JsonExpressionParser is not supported in query builder
-      const err = makeError(expr, node);
-      err.text = `JsonExpressionParser not supported in visual query builder: ${err.text}`;
-      context.errors.push(err);
+      const error = 'JsonExpressionParser not supported in visual query builder';
+
+      context.errors.push(createNotSupportedError(expr, node, error));
     }
 
     case 'LineFormatExpr': {
@@ -114,9 +110,7 @@ export function handleExpression(expr: string, node: SyntaxNode, context: Contex
       }
       // Show error for query patterns not supported in visual query builder
       if (error) {
-        const err = makeError(expr, node);
-        err.text = `${error}: ${err.text}`;
-        context.errors.push(err);
+        context.errors.push(createNotSupportedError(expr, node, error));
       }
 
       break;
@@ -489,4 +483,16 @@ function getLastChildWithSelector(node: SyntaxNode, selector: string) {
     }
   }
   return child;
+}
+
+/**
+ * Helper function to enrich error text with information that visual query builder doesn't support that logQL
+ * @param expr
+ * @param node
+ * @param error
+ */
+function createNotSupportedError(expr: string, node: SyntaxNode, error: string) {
+  const err = makeError(expr, node);
+  err.text = `${error}: ${err.text}`;
+  return err;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the UX experience for logQL patterns that are not supported in visual query builder yet. Instead of silently failing them/parsing them incorrectly, we create error that informs user that they might loose some parts of the query.

It was implemented for: 
- Ip matching line filter
- Label filter with comma, "and", "or"
- IP label filter
- JSON expression parser
- Unwrap with conversion operator

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/grafana/issues/44253


