### PR TITLE
Histogram Panel: Take decimal into consideration

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -159,7 +159,9 @@ export function buildHistogram(frames: DataFrame[], options?: HistogramTransform
     for (const frame of frames) {
       for (const field of frame.fields) {
         if (field.type === FieldType.number) {
-          allValues = allValues.concat(field.values.toArray());
+          allValues = allValues.concat(
+            field.values.toArray().map((val: number) => Number(val.toFixed(field.config.decimals ?? 0)))
+          );
         }
       }
     }
@@ -217,7 +219,7 @@ export function buildHistogram(frames: DataFrame[], options?: HistogramTransform
             unit: undefined,
           },
         });
-        if (!config && field.config.unit) {
+        if (!config && Object.keys(field.config).length) {
           config = field.config;
         }
       }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Histogram panel now defaults values to int (decimal 0) and groups data correctly in bins, when data consists of floating point numbers. The user can change decimal point from the options and thus trigger the recalculation of the histogram with the decimal point data set in the correct bins with the correct labels.

e.g:

https://user-images.githubusercontent.com/36818606/161780671-24fe0bb5-b653-4f17-a2a6-754c6f944b8d.mov



**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana/issues/45365
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

