### PR TITLE
Nav: Icon clickable area fills all available space

### DIFF
--- a/public/app/core/components/NavBar/Next/NavBarItemWithoutMenu.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarItemWithoutMenu.tsx
@@ -71,7 +71,6 @@ export function getNavBarItemWithoutMenuStyles(theme: GrafanaTheme2, isActive?: 
       position: 'relative',
       color: isActive ? theme.colors.text.primary : theme.colors.text.secondary,
       display: 'grid',
-      placeItems: 'center',
 
       '&:hover': {
         backgroundColor: theme.colors.action.hover,

--- a/public/app/core/components/NavBar/Next/NavBarMenu.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarMenu.tsx
@@ -314,6 +314,7 @@ function CollapsibleNavItem({
         target={link.target}
         onClick={link.onClick}
         className={styles.collapsibleMenuItem}
+        elClassName={styles.collapsibleIcon}
       >
         {link.img && (
           <img src={link.img} alt={`${link.text} logo`} height="24" width="24" style={{ borderRadius: '50%' }} />
@@ -349,6 +350,9 @@ const getCollapsibleStyles = (theme: GrafanaTheme2) => ({
   collapsibleMenuItem: css({
     height: theme.spacing(6),
     width: theme.spacing(7),
+    display: 'grid',
+  }),
+  collapsibleIcon: css({
     display: 'grid',
     placeContent: 'center',
   }),


### PR DESCRIPTION
**What this PR does / why we need it**:
Icon's clickable area now fills all available space.

**Which issue(s) this PR fixes**:
Closes #47255

