### PR TITLE
Prometheus: Set default mode to Code

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.test.tsx
@@ -51,7 +51,7 @@ describe('PromQueryEditorSelector', () => {
     expectCodeEditor();
   });
 
-  it('shows builder if new query', async () => {
+  it('shows code if new query', async () => {
     render(
       <PromQueryEditorSelector
         {...defaultProps}
@@ -61,7 +61,7 @@ describe('PromQueryEditorSelector', () => {
         }}
       />
     );
-    expectBuilder();
+    expectCodeEditor();
   });
 
   it('shows code editor when code mode is set', async () => {

--- a/public/app/plugins/datasource/prometheus/querybuilder/state.test.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/state.test.ts
@@ -5,7 +5,7 @@ import { changeEditorMode, getQueryWithDefaults } from './state';
 describe('getQueryWithDefaults(', () => {
   it('should set defaults', () => {
     expect(getQueryWithDefaults({ refId: 'A' } as any, CoreApp.Dashboard)).toEqual({
-      editorMode: 'builder',
+      editorMode: 'code',
       expr: '',
       legendFormat: '__auto',
       range: true,
@@ -15,7 +15,7 @@ describe('getQueryWithDefaults(', () => {
 
   it('should set both range and instant to true when in Explore', () => {
     expect(getQueryWithDefaults({ refId: 'A' } as any, CoreApp.Explore)).toEqual({
-      editorMode: 'builder',
+      editorMode: 'code',
       expr: '',
       legendFormat: '__auto',
       range: true,

--- a/public/app/plugins/datasource/prometheus/querybuilder/state.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/state.ts
@@ -14,7 +14,8 @@ export function changeEditorMode(query: PromQuery, editorMode: QueryEditorMode, 
   onChange({ ...query, editorMode });
 }
 
-export function getDefaultEditorMode(expr: string) {
+// @ts-ignore Will be used after builder is out of beta
+function getDefaultEditorMode(expr: string) {
   // If we already have an expression default to code view
   if (expr != null && expr !== '') {
     return QueryEditorMode.Code;
@@ -35,11 +36,11 @@ export function getDefaultEditorMode(expr: string) {
  * Returns query with defaults, and boolean true/false depending on change was required
  */
 export function getQueryWithDefaults(query: PromQuery, app: CoreApp | undefined): PromQuery {
-  // If no expr (ie new query) then default to builder
   let result = query;
 
   if (!query.editorMode) {
-    result = { ...query, editorMode: getDefaultEditorMode(query.expr) };
+    // Default to Code mode until we are out of beta with the builder, then use getDefaultEditorMode.
+    result = { ...query, editorMode: QueryEditorMode.Code };
   }
 
   if (query.expr == null) {


### PR DESCRIPTION
As Builder is in Beta for now, the default for new queries is Code mode.