### PR TITLE
streaming frames: add a simple decode-labels-only mode

### DIFF
--- a/packages/grafana-runtime/src/services/live.ts
+++ b/packages/grafana-runtime/src/services/live.ts
@@ -33,6 +33,7 @@ export interface StreamingFrameOptions {
   maxLength: number; // 1000
   maxDelta: number; // how long to keep things
   action: StreamingFrameAction; // default will append
+  decodeLabelsOnly?: boolean;
 
   /** optionally format field names based on labels */
   displayNameFormat?: string;

--- a/public/app/features/live/data/StreamingDataFrame.test.ts
+++ b/public/app/features/live/data/StreamingDataFrame.test.ts
@@ -831,6 +831,101 @@ describe('Streaming JSON', () => {
     `);
   });
 
+  describe('streaming labels column, decodeLabelsOnly-mode', () => {
+    const stream = StreamingDataFrame.fromDataFrameJSON(
+      {
+        schema: {
+          fields: [
+            { name: 'labels', type: FieldType.string },
+            { name: 'time', type: FieldType.time },
+            { name: 'line', type: FieldType.string },
+          ],
+        },
+      },
+      {
+        maxLength: 4,
+        decodeLabelsOnly: true,
+      }
+    );
+
+    stream.push({
+      data: {
+        values: [
+          ['level=info', 'level=error'],
+          [101, 102],
+          ['line1', 'line2'],
+        ],
+      },
+    });
+
+    stream.push({
+      data: {
+        values: [
+          ['level=error', 'level=error'],
+          [102, 103],
+          ['line3', 'line4'],
+        ],
+      },
+    });
+
+    stream.push({
+      data: {
+        values: [
+          ['level=error', 'level=info'],
+          [104, 105],
+          ['line5', 'line6'],
+        ],
+      },
+    });
+
+    expect(stream.fields.map((f) => ({ name: f.name, type: f.type, labels: f.labels, values: f.values.buffer })))
+      .toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "labels": undefined,
+          "name": "labels",
+          "type": "other",
+          "values": Array [
+            Object {
+              "level": "error",
+            },
+            Object {
+              "level": "error",
+            },
+            Object {
+              "level": "error",
+            },
+            Object {
+              "level": "info",
+            },
+          ],
+        },
+        Object {
+          "labels": undefined,
+          "name": "time",
+          "type": "time",
+          "values": Array [
+            102,
+            103,
+            104,
+            105,
+          ],
+        },
+        Object {
+          "labels": undefined,
+          "name": "line",
+          "type": "string",
+          "values": Array [
+            "line3",
+            "line4",
+            "line5",
+            "line6",
+          ],
+        },
+      ]
+    `);
+  });
+
   describe('keep track of packets', () => {
     const json: DataFrameJSON = {
       schema: {


### PR DESCRIPTION
work in progress

when working on live-streaming loki-logs from the backend, we need a streaming-solution, where it decodes the labels-data from string to javascript-object, and does not do anything else.

this proof of concept does that.