### PR TITLE
Chore: Replace deprecated String.prototype.substr() (again)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -113,8 +113,8 @@ exports[`no enzyme tests`] = {
     "public/app/plugins/datasource/loki/configuration/DebugSection.test.tsx:1551927716": [
       [0, 17, 13, "RegExp match", "2409514259"]
     ],
-    "public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx:3570129984": [
-      [0, 19, 13, "RegExp match", "2409514259"]
+    "public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx:3399719410": [
+      [1, 35, 13, "RegExp match", "2409514259"]
     ],
     "public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx:2402631398": [
       [0, 17, 13, "RegExp match", "2409514259"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -1,5 +1,5 @@
 // BETTERER RESULTS V2.
-//
+// 
 // If this file contains merge conflicts, use `betterer merge` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -80,8 +80,8 @@ exports[`no enzyme tests`] = {
     "public/app/features/alerting/TestRuleResult.test.tsx:2358420489": [
       [0, 19, 13, "RegExp match", "2409514259"]
     ],
-    "public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx:3716733755": [
-      [0, 35, 13, "RegExp match", "2409514259"]
+    "public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx:3399719410": [
+      [1, 35, 13, "RegExp match", "2409514259"]
     ],
     "public/app/features/dashboard/dashgrid/DashboardGrid.test.tsx:2723773538": [
       [0, 35, 13, "RegExp match", "2409514259"]
@@ -112,9 +112,6 @@ exports[`no enzyme tests`] = {
     ],
     "public/app/plugins/datasource/loki/configuration/DebugSection.test.tsx:1551927716": [
       [0, 17, 13, "RegExp match", "2409514259"]
-    ],
-    "public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx:3399719410": [
-      [1, 35, 13, "RegExp match", "2409514259"]
     ],
     "public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx:2402631398": [
       [0, 17, 13, "RegExp match", "2409514259"]
@@ -1205,7 +1202,7 @@ exports[`better eslint`] = {
       [31, 49, 3, "Unexpected any. Specify a different type.", "193409811"],
       [31, 73, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "packages/grafana-runtime/src/config.ts:2639113063": [
+    "packages/grafana-runtime/src/config.ts:826757766": [
       [66, 11, 3, "Unexpected any. Specify a different type.", "193409811"],
       [75, 29, 17, "Do not use any type assertions.", "4278379396"],
       [107, 16, 3, "Unexpected any. Specify a different type.", "193409811"],
@@ -11722,7 +11719,7 @@ exports[`better eslint`] = {
       [87, 39, 23, "Do not use any type assertions.", "3906212682"],
       [87, 59, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "public/app/plugins/panel/heatmap/utils.ts:2227722730": [
+    "public/app/plugins/panel/heatmap/utils.ts:1133312811": [
       [260, 23, 53, "Do not use any type assertions.", "4087268626"],
       [287, 49, 51, "Do not use any type assertions.", "4216242190"],
       [287, 49, 28, "Do not use any type assertions.", "1631991143"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,11 @@
     "import/external-module-folders": ["node_modules", ".yarn"]
   },
   "rules": {
+    "no-restricted-properties": [
+      "error",
+      { "property": "substring", "message": "Use .slice instead of .substring." },
+      { "property": "substr", "message": "Use .slice instead of .substr." }
+    ],
     "react/prop-types": "off",
     "@emotion/jsx-import": "error",
     "lodash/import-scope": [2, "member"],

--- a/devenv/docker/loadtest/modules/client.js
+++ b/devenv/docker/loadtest/modules/client.js
@@ -91,11 +91,11 @@ export const GrafanaClient = class GrafanaClient {
 export const BaseClient = class BaseClient {
   constructor(url, subUrl) {
     if (url.endsWith('/')) {
-      url = url.substring(0, url.length - 1);
+      url = url.slice(0, -1);
     }
 
     if (subUrl.endsWith('/')) {
-      subUrl = subUrl.substring(0, subUrl.length - 1);
+      subUrl = subUrl.slice(0, -1);
     }
 
     this.url = url + subUrl;

--- a/packages/grafana-data/src/datetime/datemath.ts
+++ b/packages/grafana-data/src/datetime/datemath.ts
@@ -15,7 +15,7 @@ export function isMathString(text: string | DateTime | Date): boolean {
     return false;
   }
 
-  if (typeof text === 'string' && (text.substring(0, 3) === 'now' || text.includes('||'))) {
+  if (typeof text === 'string' && (text.slice(0, 3) === 'now' || text.includes('||'))) {
     return true;
   } else {
     return false;
@@ -54,17 +54,17 @@ export function parse(
     let index;
     let parseString;
 
-    if (text.substring(0, 3) === 'now') {
+    if (text.slice(0, 3) === 'now') {
       time = dateTimeForTimeZone(timezone);
-      mathString = text.substring('now'.length);
+      mathString = text.slice('now'.length);
     } else {
       index = text.indexOf('||');
       if (index === -1) {
         parseString = text;
         mathString = ''; // nothing else
       } else {
-        parseString = text.substring(0, index);
-        mathString = text.substring(index + 2);
+        parseString = text.slice(0, index);
+        mathString = text.slice(index + 2);
       }
       // We're going to just require ISO8601 timestamps, k?
       time = dateTime(parseString, ISO_8601);
@@ -143,7 +143,7 @@ export function parseDateMath(
           return undefined;
         }
       }
-      num = parseInt(strippedMathString.substring(numFrom, i), 10);
+      num = parseInt(strippedMathString.slice(numFrom, i), 10);
     }
 
     if (type === 0) {

--- a/packages/grafana-data/src/text/string.ts
+++ b/packages/grafana-data/src/text/string.ts
@@ -97,5 +97,5 @@ export function toFloatOrUndefined(value: string): number | undefined {
 
 export const toPascalCase = (string: string) => {
   const str = camelCase(string);
-  return str.charAt(0).toUpperCase() + str.substring(1);
+  return str.charAt(0).toUpperCase() + str.slice(1);
 };

--- a/packages/grafana-data/src/themes/colorManipulator.ts
+++ b/packages/grafana-data/src/themes/colorManipulator.ts
@@ -126,7 +126,7 @@ export function decomposeColor(color: string | DecomposeColor): DecomposeColor {
   }
 
   const marker = color.indexOf('(');
-  const type = color.substring(0, marker);
+  const type = color.slice(0, marker !== -1 ? marker : 0);
 
   if (['rgb', 'rgba', 'hsl', 'hsla', 'color'].indexOf(type) === -1) {
     throw new Error(
@@ -134,7 +134,7 @@ export function decomposeColor(color: string | DecomposeColor): DecomposeColor {
     );
   }
 
-  let values: any = color.substring(marker + 1, color.length - 1);
+  let values: any = color.slice(marker + 1, -1);
   let colorSpace;
 
   if (type === 'color') {
@@ -264,7 +264,7 @@ export function alpha(color: string, value: number) {
   // hex 3, hex 4 (w/alpha), hex 6, hex 8 (w/alpha)
   if (color[0] === '#') {
     if (color.length === 9) {
-      color = color.substring(0, 7);
+      color = color.slice(0, 7);
     } else if (color.length <= 5) {
       let c = '#';
       for (let i = 1; i < 4; i++) {
@@ -288,7 +288,8 @@ export function alpha(color: string, value: number) {
   }
   // rgba(, hsla(
   else if (color[4] === '(') {
-    return color.substring(0, color.lastIndexOf(',')) + `, ${value})`;
+    const lastComma = color.lastIndexOf(',');
+    return color.slice(0, lastComma !== -1 ? lastComma : 0) + `, ${value})`;
   }
 
   const parts = decomposeColor(color);

--- a/packages/grafana-data/src/utils/location.ts
+++ b/packages/grafana-data/src/utils/location.ts
@@ -68,7 +68,7 @@ const assureBaseUrl = (url: string): string => {
  */
 const getUrlForPartial = (location: Location<any>, searchParamsToUpdate: Record<string, any>) => {
   const searchParams = urlUtil.parseKeyValue(
-    location.search.startsWith('?') ? location.search.substring(1) : location.search
+    location.search.startsWith('?') ? location.search.slice(1) : location.search
   );
   for (const key of Object.keys(searchParamsToUpdate)) {
     // removing params with null | undefined

--- a/packages/grafana-data/src/utils/url.ts
+++ b/packages/grafana-data/src/utils/url.ts
@@ -107,7 +107,7 @@ function appendQueryToUrl(url: string, stringToAppend: string) {
  * Return search part (as object) of current url
  */
 function getUrlSearchParams(): UrlQueryMap {
-  const search = window.location.search.substring(1);
+  const search = window.location.search.slice(1);
   const searchParamsSegments = search.split('&');
   const params: UrlQueryMap = {};
   for (const p of searchParamsSegments) {
@@ -149,8 +149,8 @@ export function parseKeyValue(keyValue: string) {
       splitPoint = keyValue.indexOf('=');
 
       if (splitPoint !== -1) {
-        key = keyValue.substring(0, splitPoint);
-        val = keyValue.substring(splitPoint + 1);
+        key = keyValue.slice(0, splitPoint);
+        val = keyValue.slice(splitPoint + 1);
       }
 
       key = tryDecodeURIComponent(key);

--- a/packages/grafana-data/src/valueFormats/arithmeticFormatters.ts
+++ b/packages/grafana-data/src/valueFormats/arithmeticFormatters.ts
@@ -21,8 +21,8 @@ export function toHex0x(value: number, decimals: DecimalCount): FormattedValue {
     return { text: '' };
   }
   const asHex = toHex(value, decimals);
-  if (asHex.text.substring(0, 1) === '-') {
-    asHex.text = '-0x' + asHex.text.substring(1);
+  if (asHex.text.slice(0, 1) === '-') {
+    asHex.text = '-0x' + asHex.text.slice(1);
   } else {
     asHex.text = '0x' + asHex.text;
   }

--- a/packages/grafana-data/src/valueFormats/valueFormats.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.ts
@@ -214,8 +214,8 @@ export function getValueFormat(id?: string | null): ValueFormatter {
     let idx = id.indexOf(':');
 
     if (idx > 0) {
-      const key = id.substring(0, idx);
-      const sub = id.substring(idx + 1);
+      const key = id.slice(0, idx);
+      const sub = id.slice(idx + 1);
 
       if (key === 'prefix') {
         return toFixedUnit(sub, true);
@@ -231,7 +231,7 @@ export function getValueFormat(id?: string | null): ValueFormatter {
 
       if (key === 'si') {
         const offset = getOffsetFromSIPrefix(sub.charAt(0));
-        const unit = offset === 0 ? sub : sub.substring(1);
+        const unit = offset === 0 ? sub : sub.slice(1);
         return SIPrefix(unit, offset);
       }
 
@@ -246,8 +246,8 @@ export function getValueFormat(id?: string | null): ValueFormatter {
       if (key === 'bool') {
         idx = sub.indexOf('/');
         if (idx >= 0) {
-          const t = sub.substring(0, idx);
-          const f = sub.substring(idx + 1);
+          const t = sub.slice(0, idx);
+          const f = sub.slice(idx + 1);
           return booleanValueFormatter(t, f);
         }
         return booleanValueFormatter(sub, '-');

--- a/packages/grafana-e2e/cypress/plugins/benchmark/index.ts
+++ b/packages/grafana-e2e/cypress/plugins/benchmark/index.ts
@@ -10,7 +10,7 @@ const getOrAddRemoteDebuggingPort = (args: string[]) => {
   const existing = args.find((arg) => arg.startsWith(remoteDebuggingPortOptionPrefix));
 
   if (existing) {
-    return Number(existing.substring(remoteDebuggingPortOptionPrefix.length));
+    return Number(existing.slice(remoteDebuggingPortOptionPrefix.length));
   }
 
   const port = 40000 + Math.round(Math.random() * 25000);

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -180,7 +180,7 @@ function overrideFeatureTogglesFromUrl(config: GrafanaBootConfig) {
   const params = new URLSearchParams(window.location.search);
   params.forEach((value, key) => {
     if (key.startsWith('__feature.')) {
-      const featureName = key.substring(10);
+      const featureName = key.slice(10);
       const toggleState = value === 'true';
       if (toggleState !== config.featureToggles[key]) {
         config.featureToggles[featureName] = toggleState;

--- a/packages/grafana-runtime/src/services/LocationService.ts
+++ b/packages/grafana-runtime/src/services/LocationService.ts
@@ -131,7 +131,7 @@ export function locationSearchToObject(search: string | number): UrlQueryMap {
 
   if (queryString.length > 0) {
     if (queryString.startsWith('?')) {
-      return urlUtil.parseKeyValue(queryString.substring(1));
+      return urlUtil.parseKeyValue(queryString.slice(1));
     }
     return urlUtil.parseKeyValue(queryString);
   }

--- a/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
+++ b/packages/grafana-toolkit/src/config/webpack.plugin.config.ts
@@ -60,7 +60,7 @@ const getManualChunk = (id: string) => {
   if (id.endsWith('module.ts') || id.endsWith('module.js') || id.endsWith('module.tsx')) {
     const idx = id.lastIndexOf(path.sep + 'src' + path.sep);
     if (idx > 0) {
-      const name = id.substring(idx + 5, id.lastIndexOf('.'));
+      const name = id.slice(idx + 5, id.lastIndexOf('.'));
 
       return {
         name,
@@ -120,7 +120,7 @@ const getCommonPlugins = (options: WebpackConfigurationOptions) => {
           },
           {
             search: '%TODAY%',
-            replace: new Date().toISOString().substring(0, 10),
+            replace: new Date().toISOString().slice(0, 10),
           },
         ],
       },

--- a/packages/grafana-toolkit/src/plugins/env.ts
+++ b/packages/grafana-toolkit/src/plugins/env.ts
@@ -9,7 +9,7 @@ import { JobInfo } from './types';
 const getJobFromProcessArgv = () => {
   const arg = process.argv[2];
   if (arg && arg.startsWith('plugin:ci-')) {
-    const task = arg.substring('plugin:ci-'.length);
+    const task = arg.slice('plugin:ci-'.length);
     if ('build' === task) {
       if ('--backend' === process.argv[3] && process.argv[4]) {
         return task + '_' + process.argv[4];
@@ -44,7 +44,7 @@ export const getPluginBuildInfo = async (): Promise<PluginBuildInfo> => {
       build = parseInt(process.env.CIRCLE_BUILD_NUM || '', 10);
       const url = process.env.CIRCLE_PULL_REQUEST || '';
       const idx = url.lastIndexOf('/') + 1;
-      pr = parseInt(url.substring(idx), 10);
+      pr = parseInt(url.slice(idx), 10);
     }
 
     const info: PluginBuildInfo = {
@@ -87,7 +87,7 @@ export const getPullRequestNumber = (): number | undefined => {
   } else if (process.env.CIRCLECI === 'true') {
     const url = process.env.CIRCLE_PULL_REQUEST || '';
     const idx = url.lastIndexOf('/') + 1;
-    return parseInt(url.substring(idx), 10);
+    return parseInt(url.slice(idx), 10);
   }
 
   return undefined;
@@ -137,7 +137,7 @@ export async function getCircleDownloadBaseURL(): Promise<string | undefined> {
     for (const s of rsp.data) {
       const { path, url } = s;
       if (url && path && path.endsWith('report.json')) {
-        return url.substring(url.length - 'report.json'.length);
+        return url.slice(-'report.json'.length);
       }
     }
   } catch (e) {

--- a/packages/grafana-toolkit/src/plugins/utils.ts
+++ b/packages/grafana-toolkit/src/plugins/utils.ts
@@ -36,7 +36,7 @@ export function getFileSizeReportInFolder(dir: string, info?: ExtensionSize): Ex
         let ext = '_none_';
         const idx = file.lastIndexOf('.');
         if (idx > 0) {
-          ext = file.substring(idx + 1).toLowerCase();
+          ext = file.slice(idx + 1).toLowerCase();
         }
         const current = acc[ext];
         if (current) {
@@ -64,7 +64,7 @@ export async function getPackageDetails(zipFile: string, zipSrc: string, writeCh
   try {
     const exe = await execa('shasum', [zipFile]);
     const idx = exe.stdout.indexOf(' ');
-    const sha1 = exe.stdout.substring(0, idx);
+    const sha1 = exe.stdout.slice(0, idx !== -1 ? idx : 0);
     if (writeChecksum) {
       fs.writeFile(zipFile + '.sha1', sha1, (err) => {});
     }

--- a/packages/grafana-toolkit/src/plugins/workflow.ts
+++ b/packages/grafana-toolkit/src/plugins/workflow.ts
@@ -64,7 +64,7 @@ export const agregateCoverageInfo = (): CoverageInfo[] => {
               summary: raw.total,
             };
             if (fs.existsSync(r)) {
-              info.report = r.substring(ciDir.length);
+              info.report = r.slice(ciDir.length);
             }
             coverage.push(info);
           }

--- a/packages/grafana-ui/src/components/Monaco/suggestions.ts
+++ b/packages/grafana-ui/src/components/Monaco/suggestions.ts
@@ -11,7 +11,7 @@ export function findInsertIndex(line: string): { index: number; prefix: string }
     if (ch === '$') {
       return {
         index: i,
-        prefix: line.substring(i),
+        prefix: line.slice(i),
       };
     }
 
@@ -19,7 +19,7 @@ export function findInsertIndex(line: string): { index: number; prefix: string }
     if (ch === ' ' || ch === '\t' || ch === '"' || ch === "'") {
       return {
         index: i + 1,
-        prefix: line.substring(i + 1),
+        prefix: line.slice(i + 1),
       };
     }
   }

--- a/packages/grafana-ui/src/components/Typeahead/PartialHighlighter.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/PartialHighlighter.tsx
@@ -49,7 +49,7 @@ export const PartialHighlighter: React.FC<Props> = (props: Props) => {
           key: i - 1,
           className: highlighted ? highlightClassName : undefined,
         },
-        text.substring(start, end)
+        text.slice(start, end)
       )
     );
     highlighted = !highlighted;

--- a/packages/grafana-ui/src/utils/file.ts
+++ b/packages/grafana-ui/src/utils/file.ts
@@ -5,12 +5,12 @@
 export function trimFileName(fileName: string): string {
   const nameLength = 16;
   const delimiter = fileName.lastIndexOf('.');
-  const extension = fileName.substring(delimiter);
-  const file = fileName.substring(0, delimiter);
+  const extension = fileName.slice(delimiter !== -1 ? delimiter : 0);
+  const file = fileName.slice(0, delimiter !== -1 ? delimiter : 0);
 
   if (file.length < nameLength) {
     return fileName;
   }
 
-  return `${file.substring(0, nameLength)}...${extension}`;
+  return `${file.slice(0, nameLength)}...${extension}`;
 }

--- a/public/app/angular/components/form_dropdown/form_dropdown.ts
+++ b/public/app/angular/components/form_dropdown/form_dropdown.ts
@@ -10,10 +10,10 @@ function typeaheadMatcher(this: any, item: string) {
     return true;
   }
   if (str[0] === '/') {
-    str = str.substring(1);
+    str = str.slice(1);
   }
   if (str[str.length - 1] === '/') {
-    str = str.substring(0, str.length - 1);
+    str = str.slice(0, -1);
   }
   return item.toLowerCase().match(str.toLowerCase());
 }

--- a/public/app/angular/components/sql_part/sql_part.ts
+++ b/public/app/angular/components/sql_part/sql_part.ts
@@ -15,7 +15,7 @@ export class SqlPartDef {
     if (options.label) {
       this.label = options.label;
     } else {
-      this.label = this.type[0].toUpperCase() + this.type.substring(1) + ':';
+      this.label = this.type[0].toUpperCase() + this.type.slice(1) + ':';
     }
     this.style = options.style;
     if (this.style === 'function') {

--- a/public/app/angular/metric_segment.ts
+++ b/public/app/angular/metric_segment.ts
@@ -125,10 +125,10 @@ export function metricSegment($compile: any, $sce: any, templateSrv: TemplateSrv
         }
         let str = this.query;
         if (str[0] === '/') {
-          str = str.substring(1);
+          str = str.slice(1);
         }
         if (str[str.length - 1] === '/') {
-          str = str.substring(0, str.length - 1);
+          str = str.slice(0, -1);
         }
         try {
           return item.toLowerCase().match(str.toLowerCase());

--- a/public/app/core/navigation/parseKeyValue.ts
+++ b/public/app/core/navigation/parseKeyValue.ts
@@ -133,8 +133,8 @@ function parseKeyValue(keyValue: string | null) {
       key = keyValue = keyValue.replace(/\+/g, '%20');
       splitPoint = keyValue.indexOf('=');
       if (splitPoint !== -1) {
-        key = keyValue.substring(0, splitPoint);
-        val = keyValue.substring(splitPoint + 1);
+        key = keyValue.slice(0, splitPoint);
+        val = keyValue.slice(splitPoint + 1);
       }
       key = tryDecodeURIComponent(key);
       if (key) {

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -164,7 +164,7 @@ export class BackendSrv implements BackendService {
       }
 
       if (options.url.startsWith('/')) {
-        options.url = options.url.substring(1);
+        options.url = options.url.slice(1);
       }
 
       if (options.headers?.Authorization) {

--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -13,7 +13,7 @@ function buildHostUrl() {
 
 function getRelativeURLPath(url: string) {
   let path = url.replace(buildHostUrl(), '');
-  return path.startsWith('/') ? path.substring(1, path.length) : path;
+  return path.startsWith('/') ? path.slice(1) : path;
 }
 
 export const createShortLink = memoizeOne(async function (path: string) {

--- a/public/app/features/annotations/components/AnnotationResultMapper.tsx
+++ b/public/app/features/annotations/components/AnnotationResultMapper.tsx
@@ -60,7 +60,7 @@ export class AnnotationFieldMapper extends PureComponent<Props, State> {
         }
 
         if (description.length > 50) {
-          description = description.substring(0, 50) + '...';
+          description = description.slice(0, 50) + '...';
         }
 
         return {

--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.ts
@@ -104,7 +104,7 @@ export class DashboardExporter {
       // ignore data source properties that contain a variable
       if (datasourceUid) {
         if (datasourceUid.indexOf('$') === 0) {
-          datasourceVariable = variableLookup[datasourceUid.substring(1)];
+          datasourceVariable = variableLookup[datasourceUid.slice(1)];
           if (datasourceVariable && datasourceVariable.current) {
             datasource = datasourceVariable.current.value;
           }

--- a/public/app/features/dashboard/components/PanelEditor/utils.ts
+++ b/public/app/features/dashboard/components/PanelEditor/utils.ts
@@ -73,8 +73,8 @@ export function setOptionImmutably<T extends object>(options: T, path: string | 
   const key = splat.shift()!;
   if (key.endsWith(']')) {
     const idx = key.lastIndexOf('[');
-    const index = +key.substring(idx + 1, key.length - 1);
-    const propKey = key.substring(0, idx);
+    const index = +key.slice(idx + 1, -1);
+    const propKey = key.slice(0, idx !== -1 ? idx : 0);
     let current = (options as Record<string, any>)[propKey];
     const arr = Array.isArray(current) ? [...current] : [];
     if (splat.length) {

--- a/public/app/features/dashboard/components/ShareModal/ShareEmbed.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareEmbed.test.tsx
@@ -34,7 +34,7 @@ function mockLocationHref(href: string) {
   let search = '';
   const searchPos = href.indexOf('?');
   if (searchPos >= 0) {
-    search = href.substring(searchPos);
+    search = href.slice(searchPos);
   }
 
   // @ts-ignore

--- a/public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareLink.test.tsx
@@ -27,7 +27,7 @@ function mockLocationHref(href: string) {
   let search = '';
   const searchPos = href.indexOf('?');
   if (searchPos >= 0) {
-    search = href.substring(searchPos);
+    search = href.slice(searchPos);
   }
 
   //@ts-ignore

--- a/public/app/features/dashboard/components/ShareModal/utils.ts
+++ b/public/app/features/dashboard/components/ShareModal/utils.ts
@@ -47,7 +47,7 @@ export function buildBaseUrl() {
   const queryStart = baseUrl.indexOf('?');
 
   if (queryStart !== -1) {
-    baseUrl = baseUrl.substring(0, queryStart);
+    baseUrl = baseUrl.slice(0, queryStart);
   }
 
   return baseUrl;

--- a/public/app/features/dimensions/editors/FolderPickerTab.tsx
+++ b/public/app/features/dimensions/editors/FolderPickerTab.tsx
@@ -84,7 +84,7 @@ export const FolderPickerTab = (props: Props) => {
                   cards.push({
                     value: `${folder}/${item.name}`,
                     label: item.name,
-                    search: (idx ? item.name.substring(0, idx) : item.name).toLowerCase(),
+                    search: (idx ? item.name.slice(0, idx !== -1 ? idx : 0) : item.name).toLowerCase(),
                     imgUrl: `public/${folder}/${item.name}`,
                   });
                 }

--- a/public/app/features/dimensions/editors/ResourceDimensionEditor.tsx
+++ b/public/app/features/dimensions/editors/ResourceDimensionEditor.tsx
@@ -130,7 +130,7 @@ export function niceName(value?: string): string | undefined {
   }
   const idx = value.lastIndexOf('/');
   if (idx > 0) {
-    return value.substring(idx + 1);
+    return value.slice(idx + 1);
   }
   return value;
 }

--- a/public/app/features/dimensions/editors/URLPickerTab.tsx
+++ b/public/app/features/dimensions/editors/URLPickerTab.tsx
@@ -20,9 +20,9 @@ export const URLPickerTab = (props: Props) => {
 
   const imgSrc = getPublicOrAbsoluteUrl(newValue!);
 
-  let shortName = newValue?.substring(newValue.lastIndexOf('/') + 1, newValue.lastIndexOf('.'));
+  let shortName = newValue?.slice(newValue.lastIndexOf('/') + 1, newValue.lastIndexOf('.') !== -1 ? newValue.lastIndexOf('.') : 0);
   if (shortName.length > 20) {
-    shortName = shortName.substring(0, 20) + '...';
+    shortName = shortName.slice(0, 20) + '...';
   }
 
   return (

--- a/public/app/features/dimensions/editors/URLPickerTab.tsx
+++ b/public/app/features/dimensions/editors/URLPickerTab.tsx
@@ -20,7 +20,10 @@ export const URLPickerTab = (props: Props) => {
 
   const imgSrc = getPublicOrAbsoluteUrl(newValue!);
 
-  let shortName = newValue?.slice(newValue.lastIndexOf('/') + 1, newValue.lastIndexOf('.') !== -1 ? newValue.lastIndexOf('.') : 0);
+  let shortName = newValue?.slice(
+    newValue.lastIndexOf('/') + 1,
+    newValue.lastIndexOf('.') !== -1 ? newValue.lastIndexOf('.') : 0
+  );
   if (shortName.length > 20) {
     shortName = shortName.slice(0, 20) + '...';
   }

--- a/public/app/features/live/index.ts
+++ b/public/app/features/live/index.ts
@@ -12,7 +12,7 @@ export const sessionId =
   '/' +
   Date.now().toString(16) +
   '/' +
-  Math.random().toString(36).substring(2, 15);
+  Math.random().toString(36).slice(2, 15);
 
 export function initGrafanaLive() {
   const centrifugeServiceDeps = {

--- a/public/app/features/live/pages/PipelineTable.tsx
+++ b/public/app/features/live/pages/PipelineTable.tsx
@@ -62,13 +62,13 @@ export const PipelineTable: React.FC<Props> = (props) => {
     if (pattern.startsWith('ds/')) {
       const idx = pattern.indexOf('/', 4);
       if (idx > 3) {
-        const uid = pattern.substring(3, idx);
+        const uid = pattern.slice(3, idx);
         const ds = getDatasourceSrv().getInstanceSettings(uid);
         if (ds) {
           return (
             <div>
               <Tag name={ds.name} colorIndex={1} /> &nbsp;
-              <span>{pattern.substring(idx + 1)}</span>
+              <span>{pattern.slice(idx + 1)}</span>
             </div>
           );
         }

--- a/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
+++ b/public/app/features/manage-dashboards/components/SnapshotListTable.tsx
@@ -21,7 +21,7 @@ export const SnapshotListTable: FC = () => {
   const [removeSnapshot, setRemoveSnapshot] = useState<Snapshot | undefined>();
   const currentPath = locationService.getLocation().pathname;
   const fullUrl = window.location.href;
-  const baseUrl = fullUrl.substring(0, fullUrl.indexOf(currentPath));
+  const baseUrl = fullUrl.slice(0, fullUrl.indexOf(currentPath) !== -1 ? fullUrl.indexOf(currentPath) : 0);
 
   useAsync(async () => {
     const response = await getSnapshots();

--- a/public/app/features/plugins/admin/pages/PluginDetails.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.tsx
@@ -26,7 +26,7 @@ export default function PluginDetails({ match, queryParams }: Props): JSX.Elemen
     params: { pluginId = '' },
     url,
   } = match;
-  const parentUrl = url.substring(0, url.lastIndexOf('/'));
+  const parentUrl = url.slice(0, url.lastIndexOf('/') !== -1 ? url.lastIndexOf('/') : 0);
   const defaultTabs: PluginDetailsTab[] = [
     {
       label: PluginTabLabels.OVERVIEW,

--- a/public/app/features/plugins/admin/state/reducer.ts
+++ b/public/app/features/plugins/admin/state/reducer.ts
@@ -19,7 +19,7 @@ const isRejectedRequest = (action: AnyAction) => new RegExp(`${STATE_PREFIX}\/(.
 const getOriginalActionType = (type: string) => {
   const separator = type.lastIndexOf('/');
 
-  return type.substring(0, separator);
+  return type.slice(0, separator !== -1 ? separator : 0);
 };
 
 const slice = createSlice({

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -7,7 +7,7 @@ if (window.public_cdn_path) {
 }
 
 // This is a path to the public folder without '/build'
-if(__webpack_public_path__.indexOf('build/') !== -1) {
+if (__webpack_public_path__.indexOf('build/') !== -1) {
   window.__grafana_public_path__ = __webpack_public_path__.slice(0, __webpack_public_path__.lastIndexOf('build/'));
 } else {
   window.__grafana_public_path__ = __webpack_public_path__;

--- a/public/app/index.ts
+++ b/public/app/index.ts
@@ -7,8 +7,11 @@ if (window.public_cdn_path) {
 }
 
 // This is a path to the public folder without '/build'
-window.__grafana_public_path__ =
-  __webpack_public_path__.substring(0, __webpack_public_path__.lastIndexOf('build/')) || __webpack_public_path__;
+if(__webpack_public_path__.indexOf('build/') !== -1) {
+  window.__grafana_public_path__ = __webpack_public_path__.slice(0, __webpack_public_path__.lastIndexOf('build/'));
+} else {
+  window.__grafana_public_path__ = __webpack_public_path__;
+}
 
 if (window.nonce) {
   __webpack_nonce__ = window.nonce;

--- a/public/app/plugins/datasource/elasticsearch/elastic_response.ts
+++ b/public/app/plugins/datasource/elasticsearch/elastic_response.ts
@@ -339,7 +339,7 @@ export class ElasticResponse {
         const group = g1 || g2;
 
         if (group.indexOf('term ') === 0) {
-          return series.props[group.substring(5)];
+          return series.props[group.slice(5)];
         }
         if (series.props[group] !== void 0) {
           return series.props[group];

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/log_analytics/querystring_builder.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/log_analytics/querystring_builder.ts
@@ -65,8 +65,8 @@ export default class LogAnalyticsQuerystringBuilder {
 
   getMultiContains(inputs: string) {
     const firstCommaIndex = inputs.indexOf(',');
-    const field = inputs.substring(0, firstCommaIndex);
-    const templateVar = inputs.substring(inputs.indexOf(',') + 1);
+    const field = inputs.slice(0, firstCommaIndex !== -1 ? firstCommaIndex : 0);
+    const templateVar = inputs.slice(firstCommaIndex + 1);
 
     if (templateVar && templateVar.toLowerCase().trim() === 'all') {
       return '1 == 1';
@@ -77,7 +77,7 @@ export default class LogAnalyticsQuerystringBuilder {
 
   escape(inputs: string) {
     return inputs
-      .substring(1, inputs.length - 1)
+      .slice(1, -1)
       .split(`','`)
       .map((v) => `@'${v}'`)
       .join(', ');

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/time_grain_converter.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/time_grain_converter.ts
@@ -55,12 +55,12 @@ export default class TimeGrainConverter {
 
   static createTimeGrainFromISO8601Duration(duration: string) {
     let offset = 1;
-    if (duration.substring(0, 2) === 'PT') {
+    if (duration.slice(0, 2) === 'PT') {
       offset = 2;
     }
 
-    const value = duration.substring(offset, duration.length - 1);
-    const unit = duration.substring(duration.length - 1);
+    const value = duration.slice(offset, -1);
+    const unit = duration.slice(-1);
 
     return value + ' ' + TimeGrainConverter.timeUnitToText(+value, unit);
   }
@@ -94,12 +94,12 @@ export default class TimeGrainConverter {
     }
 
     let offset = 1;
-    if (duration.substring(0, 2) === 'PT') {
+    if (duration.slice(0, 2) === 'PT') {
       offset = 2;
     }
 
-    const value = duration.substring(offset, duration.length - 1);
-    const unit = duration.substring(duration.length - 1);
+    const value = duration.slice(offset, -1);
+    const unit = duration.slice(-1);
 
     return value + TimeGrainConverter.timeUnitToKbn(+value, unit);
   }

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -427,7 +427,7 @@ export class GraphiteDatasource
       if (date === 'now') {
         return 'now';
       } else if (date.indexOf('now-') >= 0 && date.indexOf('/') === -1) {
-        date = date.substring(3);
+        date = date.slice(3);
         date = date.replace('m', 'min');
         date = date.replace('M', 'mon');
         return date;

--- a/public/app/plugins/datasource/loki/add_label_to_query.ts
+++ b/public/app/plugins/datasource/loki/add_label_to_query.ts
@@ -53,7 +53,7 @@ function getStreamSelectorPositions(query: string): StreamSelectorPosition[] {
   tree.iterate({
     enter: (type, from, to, get): false | void => {
       if (type.name === 'Selector') {
-        const visQuery = buildVisualQueryFromString(query.substring(from, to));
+        const visQuery = buildVisualQueryFromString(query.slice(from, to));
         positions.push({ query: visQuery.query, from, to });
         return false;
       }
@@ -106,8 +106,8 @@ function addFilterToStreamSelector(
     const match = vectorSelectorPositions[i];
     const isLast = i === vectorSelectorPositions.length - 1;
 
-    const start = query.substring(prev, match.from);
-    const end = isLast ? query.substring(match.to) : '';
+    const start = query.slice(prev, match.from);
+    const end = isLast ? query.slice(match.to) : '';
 
     if (!labelExists(match.query.labels, filter)) {
       // We don't want to add duplicate labels.
@@ -139,8 +139,8 @@ function addFilterAsLabelFilter(
     const match = parserPositions[i];
     const isLast = i === parserPositions.length - 1;
 
-    const start = query.substring(prev, match.to);
-    const end = isLast ? query.substring(match.to) : '';
+    const start = query.slice(prev, match.to);
+    const end = isLast ? query.slice(match.to) : '';
 
     const labelFilter = ` | ${filter.label}${filter.op}\`${filter.value}\``;
     newQuery += start + labelFilter + end;

--- a/public/app/plugins/datasource/mysql/mysql_query_model.ts
+++ b/public/app/plugins/datasource/mysql/mysql_query_model.ts
@@ -40,7 +40,7 @@ export default class MySQLQueryModel {
   // remove identifier quoting from identifier to use in metadata queries
   unquoteIdentifier(value: string) {
     if (value[0] === '"' && value[value.length - 1] === '"') {
-      return value.substring(1, value.length - 1).replace(/""/g, '"');
+      return value.slice(1, -1).replace(/""/g, '"');
     } else {
       return value;
     }

--- a/public/app/plugins/datasource/postgres/postgres_query_model.ts
+++ b/public/app/plugins/datasource/postgres/postgres_query_model.ts
@@ -40,7 +40,7 @@ export default class PostgresQueryModel {
   // remove identifier quoting from identifier to use in metadata queries
   unquoteIdentifier(value: string) {
     if (value[0] === '"' && value[value.length - 1] === '"') {
-      return value.substring(1, value.length - 1).replace(/""/g, '"');
+      return value.slice(1, -1).replace(/""/g, '"');
     } else {
       return value;
     }

--- a/public/app/plugins/datasource/prometheus/add_label_to_query.ts
+++ b/public/app/plugins/datasource/prometheus/add_label_to_query.ts
@@ -46,7 +46,7 @@ function getVectorSelectorPositions(query: string): VectorSelectorPosition[] {
   tree.iterate({
     enter: (type, from, to, get): false | void => {
       if (type.name === 'VectorSelector') {
-        const visQuery = buildVisualQueryFromString(query.substring(from, to));
+        const visQuery = buildVisualQueryFromString(query.slice(from, to));
         positions.push({ query: visQuery.query, from, to });
         return false;
       }
@@ -76,8 +76,8 @@ function addFilter(
     const match = vectorSelectorPositions[i];
     const isLast = i === vectorSelectorPositions.length - 1;
 
-    const start = query.substring(prev, match.from);
-    const end = isLast ? query.substring(match.to) : '';
+    const start = query.slice(prev, match.from);
+    const end = isLast ? query.slice(match.to) : '';
 
     if (!labelExists(match.query.labels, filter)) {
       // We don't want to add duplicate labels.

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -351,8 +351,8 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     const suggestions: CompletionItemGroup[] = [];
     const line = value.anchorBlock.getText();
     const cursorOffset = value.selection.anchor.offset;
-    const suffix = line.substr(cursorOffset);
-    const prefix = line.substr(0, cursorOffset);
+    const suffix = line.slice(cursorOffset);
+    const prefix = line.slice(0, cursorOffset);
     const isValueStart = text.match(/^(=|=~|!=|!~)/);
     const isValueEnd = suffix.match(/^"?[,}]|$/);
     // Detect cursor in front of value, e.g., {key=|"}

--- a/public/app/plugins/datasource/prometheus/language_utils.ts
+++ b/public/app/plugins/datasource/prometheus/language_utils.ts
@@ -329,7 +329,7 @@ export function extractLabelMatchers(tokens: Array<string | Token>): AbstractLab
                 break;
               case 'label-value':
                 labelValue = contentTokens[currentToken].content as string;
-                labelValue = labelValue.substring(1, labelValue.length - 1);
+                labelValue = labelValue.slice(1, -1);
                 const labelComparator = FromPromLikeMap[labelOperator];
                 if (labelComparator) {
                   labelMatchers.push({ name: labelKey, operator: labelComparator, value: labelValue });

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils.ts
@@ -81,7 +81,7 @@ export function getString(expr: string, node: SyntaxNode | TreeCursor | null | u
   if (!node) {
     return '';
   }
-  return returnVariables(expr.substring(node.from, node.to));
+  return returnVariables(expr.slice(node.from, node.to));
 }
 
 /**

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -250,7 +250,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptionsEX> = ({
 
 function shortenValue(value: string, length: number) {
   if (value.length > length) {
-    return value.substring(0, length).concat('...');
+    return value.slice(0, length).concat('...');
   } else {
     return value;
   }

--- a/public/app/plugins/panel/heatmap-old/rendering.ts
+++ b/public/app/plugins/panel/heatmap-old/rendering.ts
@@ -355,7 +355,7 @@ export class HeatmapRenderer {
         } else if (valueFormatted && typeof valueFormatted === 'string' && valueFormatted !== '') {
           if (yAxisWidth) {
             const scale = 0.15; // how to have a better calculation for this
-            const trimmed = valueFormatted.substring(0, Math.floor(yAxisWidth * scale));
+            const trimmed = valueFormatted.slice(0, Math.floor(yAxisWidth * scale));
             const postfix = trimmed.length < valueFormatted.length ? '...' : '';
             valueFormatted = `${trimmed}${postfix}`;
           }

--- a/public/app/plugins/panel/heatmap/utils.ts
+++ b/public/app/plugins/panel/heatmap/utils.ts
@@ -267,7 +267,7 @@ export function prepConfig(opts: PrepConfigOpts) {
 
   // random to prevent syncing y in other heatmaps
   // TODO: try to match TimeSeries y keygen algo to sync with TimeSeries panels (when not isOrdianalY)
-  const yScaleKey = 'y_' + (Math.random() + 1).toString(36).substring(7);
+  const yScaleKey = 'y_' + (Math.random() + 1).toString(36).slice(7);
 
   builder.addScale({
     scaleKey: yScaleKey,


### PR DESCRIPTION
**What this PR does / why we need it**:

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which work similarily but isnt't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

[String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) and [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) are [very similar](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring#differences_between_substring_and_slice) but `slice()` is shorter and generally faster so lets use it all the time.

I've added an ESLint rule to forbid the usage of `substr()` and `substring()` in the future.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This is a follow up to #46763 as a new usage of the deprecated [String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) was added since then.
