### PR TITLE
pubdash: add public dashboards feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -41,6 +41,7 @@ export interface FeatureToggles {
   showFeatureFlagsInUI?: boolean;
   disable_http_request_histogram?: boolean;
   validatedQueries?: boolean;
+  publicDashboards?: boolean;
   lokiLive?: boolean;
   swaggerUi?: boolean;
   featureHighlights?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -144,6 +144,12 @@ var (
 			RequiresDevMode: true,
 		},
 		{
+			Name:            "publicDashboards",
+			Description:     "enables public access to dashboards",
+			State:           FeatureStateAlpha,
+			RequiresDevMode: true,
+		},
+		{
 			Name:        "lokiLive",
 			Description: "support websocket streaming for loki (early prototype)",
 			State:       FeatureStateAlpha,

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -107,6 +107,10 @@ const (
 	// only execute the query saved in a panel
 	FlagValidatedQueries = "validatedQueries"
 
+	// FlagPublicDashboards
+	// enables public access to dashboards
+	FlagPublicDashboards = "publicDashboards"
+
 	// FlagLokiLive
 	// support websocket streaming for loki (early prototype)
 	FlagLokiLive = "lokiLive"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds feature flag for public dashboards

**Which issue(s) this PR fixes**:
https://github.com/grafana/grafana-enterprise-partnerships-team/issues/87