### PR TITLE
TimeSeries: fix too-thin widths of joined bar series with null values

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/utils.ts
+++ b/packages/grafana-ui/src/components/GraphNG/utils.ts
@@ -2,7 +2,13 @@ import { XYFieldMatchers } from './types';
 import { ArrayVector, DataFrame, FieldConfig, FieldType, outerJoinDataFrames, TimeRange } from '@grafana/data';
 import { nullToUndefThreshold } from './nullToUndefThreshold';
 import { applyNullInsertThreshold } from './nullInsertThreshold';
-import { AxisPlacement, GraphFieldConfig, ScaleDistribution, ScaleDistributionConfig } from '@grafana/schema';
+import {
+  AxisPlacement,
+  GraphDrawStyle,
+  GraphFieldConfig,
+  ScaleDistribution,
+  ScaleDistributionConfig,
+} from '@grafana/schema';
 import { FIXED_UNIT } from './GraphNG';
 
 // will mutate the DataFrame's fields' values
@@ -31,7 +37,23 @@ function applySpanNullsThresholds(frame: DataFrame) {
 
 export function preparePlotFrame(frames: DataFrame[], dimFields: XYFieldMatchers, timeRange?: TimeRange | null) {
   let alignedFrame = outerJoinDataFrames({
-    frames: frames.map((frame) => applyNullInsertThreshold(frame, null, timeRange?.to.valueOf())),
+    frames: frames.map((frame) => {
+      let fr = applyNullInsertThreshold(frame, null, timeRange?.to.valueOf());
+
+      // prevent minesweeper-expansion of nulls (gaps) when joining bars
+      // since bar width is determined from the minimum distance between non-null values
+      // (this strategy will still retain any original pre-join nulls, though)
+      fr.fields.forEach((f) => {
+        if (f.type === FieldType.number && f.config.custom?.drawStyle === GraphDrawStyle.Bars) {
+          f.config.custom = {
+            ...f.config.custom,
+            spanNulls: -1,
+          };
+        }
+      });
+
+      return fr;
+    }),
     joinBy: dimFields.x,
     keep: dimFields.y,
     keepOriginIndices: true,

--- a/packages/grafana-ui/src/components/GraphNG/utils.ts
+++ b/packages/grafana-ui/src/components/GraphNG/utils.ts
@@ -41,7 +41,7 @@ export function preparePlotFrame(frames: DataFrame[], dimFields: XYFieldMatchers
       let fr = applyNullInsertThreshold(frame, null, timeRange?.to.valueOf());
 
       // prevent minesweeper-expansion of nulls (gaps) when joining bars
-      // since bar width is determined from the minimum distance between non-null values
+      // since bar width is determined from the minimum distance between non-undefined values
       // (this strategy will still retain any original pre-join nulls, though)
       fr.fields.forEach((f) => {
         if (f.type === FieldType.number && f.config.custom?.drawStyle === GraphDrawStyle.Bars) {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/47294

uPlot's bar pathBuilder determines bar width from the minimum spacing between `!== undefined` values.

this fix is similar to what we do in StateTimeline - it sets `spanNulls: -1` on Bar series to prevent the frame joiner from expanding `null` runs.

```
bars: 70,null,70,null,70
line: 1,20,90,30,5,0,1,20,90,30,5,0
```

<details><summary>skinny-bars.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 142,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": [
          {
            "matcher": {
              "id": "byName",
              "options": "bars"
            },
            "properties": [
              {
                "id": "custom.drawStyle",
                "value": "bars"
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 18,
        "w": 24,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom"
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "alias": "bars",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_metric_values",
          "stringInput": "70,null,70,null,70"
        },
        {
          "alias": "line",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "B",
          "scenarioId": "csv_metric_values",
          "stringInput": "1,20,90,30,5,0,1,20,90,30,5,0"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "schemaVersion": 36,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "skinny-bars",
  "uid": "6-QUBg87z",
  "version": 1,
  "weekStart": ""
}
```
</details>

before:

![image](https://user-images.githubusercontent.com/43234/161866413-ed6955f1-a248-4222-b20c-7430d8fd2deb.png)

after:

![image](https://user-images.githubusercontent.com/43234/161866317-4719a3c7-a415-4566-870f-2d7b4b01eaf4.png)