### PR TITLE
[v8.4.x] CI: Run publishing steps only on OSS repo for main/version branches (#47315)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -727,6 +727,8 @@ steps:
     paths:
       include:
       - .drone.yml
+    repo:
+    - grafana/grafana
 - image: grafana/drone-downstream
   name: trigger-enterprise-downstream
   settings:
@@ -921,6 +923,9 @@ steps:
       from_secret: prerelease_bucket
   image: grafana/grafana-ci-deploy:1.3.1
   name: store-storybook
+  when:
+    repo:
+    - grafana/grafana
 - commands:
   - yarn wait-on http://$HOST:$PORT
   - pa11y-ci --config .pa11yci.conf.js --json > pa11y-ci-results.json
@@ -944,6 +949,9 @@ steps:
   failure: ignore
   image: grafana/build-container:1.5.3
   name: publish-frontend-metrics
+  when:
+    repo:
+    - grafana/grafana
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -993,6 +1001,9 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    repo:
+    - grafana/grafana
 - commands:
   - ./bin/grabpl artifacts docker publish --dockerhub-repo grafana-oss --base alpine
     --base ubuntu --arch amd64 --arch arm64 --arch armv7
@@ -1011,6 +1022,9 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    repo:
+    - grafana/grafana
 - commands:
   - ./scripts/circle-release-canary-packages.sh
   depends_on:
@@ -1023,6 +1037,9 @@ steps:
       from_secret: npm_token
   image: grafana/build-container:1.5.3
   name: release-canary-npm-packages
+  when:
+    repo:
+    - grafana/grafana
 - commands:
   - ./bin/grabpl upload-packages --edition oss --packages-bucket grafana-downloads
   depends_on:
@@ -1037,6 +1054,9 @@ steps:
       from_secret: prerelease_bucket
   image: grafana/grafana-ci-deploy:1.3.1
   name: upload-packages
+  when:
+    repo:
+    - grafana/grafana
 - commands:
   - ./bin/grabpl upload-cdn --edition oss --src-bucket "grafana-static-assets"
   depends_on:
@@ -1048,6 +1068,9 @@ steps:
       from_secret: prerelease_bucket
   image: grafana/grafana-ci-deploy:1.3.1
   name: upload-cdn-assets
+  when:
+    repo:
+    - grafana/grafana
 trigger:
   branch: main
   event:
@@ -1197,6 +1220,8 @@ trigger:
   branch: main
   event:
   - push
+  repo:
+  - grafana/grafana
 type: docker
 volumes:
 - host:
@@ -1281,6 +1306,8 @@ trigger:
   branch: main
   event:
   - push
+  repo:
+  - grafana/grafana
 type: docker
 volumes:
 - host:
@@ -3317,6 +3344,9 @@ steps:
       from_secret: prerelease_bucket
   image: grafana/grafana-ci-deploy:1.3.1
   name: upload-cdn-assets
+  when:
+    repo:
+    - grafana/grafana
 - commands:
   - ./bin/grabpl upload-packages --edition oss --packages-bucket grafana-downloads
   depends_on:
@@ -3331,6 +3361,9 @@ steps:
       from_secret: prerelease_bucket
   image: grafana/grafana-ci-deploy:1.3.1
   name: upload-packages
+  when:
+    repo:
+    - grafana/grafana
 trigger:
   ref:
   - refs/heads/v[0-9]*
@@ -3849,6 +3882,9 @@ steps:
       from_secret: prerelease_bucket
   image: grafana/grafana-ci-deploy:1.3.1
   name: upload-cdn-assets
+  when:
+    repo:
+    - grafana/grafana
 - commands:
   - ./bin/grabpl upload-packages --edition enterprise --packages-bucket grafana-downloads
   depends_on:
@@ -3860,6 +3896,9 @@ steps:
       from_secret: prerelease_bucket
   image: grafana/grafana-ci-deploy:1.3.1
   name: upload-packages
+  when:
+    repo:
+    - grafana/grafana
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
     --no-pull-enterprise --variants linux-amd64 --sign
@@ -4413,6 +4452,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 44e231d2b9a32f86b414ad57bd5d144eb6746baf3b01b037e3a1f4cb94df8a76
+hmac: 5085b8b1ecc48d9efb2a43644f250e208c453ffcd9b9a04b04a374afb089fb5c
 
 ...

--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -38,7 +38,8 @@ load(
     'upload_cdn_step',
     'validate_scuemata_step',
     'ensure_cuetsified_step',
-    'test_a11y_frontend_step'
+    'test_a11y_frontend_step',
+    'trigger_oss'
 )
 
 load(
@@ -118,23 +119,23 @@ def get_steps(edition, is_downstream=False):
         e2e_tests_step('various-suite', edition=edition),
         e2e_tests_artifacts(edition=edition),
         build_storybook_step(edition=edition, ver_mode=ver_mode),
-        store_storybook_step(edition=edition, ver_mode=ver_mode),
+        store_storybook_step(edition=edition, ver_mode=ver_mode, trigger=trigger_oss),
         test_a11y_frontend_step(ver_mode=ver_mode, edition=edition),
-        frontend_metrics_step(edition=edition),
+        frontend_metrics_step(edition=edition, trigger=trigger_oss),
         copy_packages_for_docker_step(),
         build_docker_images_step(edition=edition, ver_mode=ver_mode, publish=False),
         build_docker_images_step(edition=edition, ver_mode=ver_mode, ubuntu=True, publish=False),
-        publish_images_step(edition=edition, ver_mode=ver_mode, mode='', docker_repo='grafana', ubuntu=False),
-        publish_images_step(edition=edition, ver_mode=ver_mode, mode='', docker_repo='grafana-oss', ubuntu=True)
+        publish_images_step(edition=edition, ver_mode=ver_mode, mode='', docker_repo='grafana', trigger=trigger_oss),
+        publish_images_step(edition=edition, ver_mode=ver_mode, mode='', docker_repo='grafana-oss', trigger=trigger_oss)
     ])
 
     if include_enterprise2:
       integration_test_steps.extend([redis_integration_tests_step(edition=edition2, ver_mode=ver_mode), memcached_integration_tests_step(edition=edition2, ver_mode=ver_mode)])
 
     build_steps.extend([
-        release_canary_npm_packages_step(edition),
-        upload_packages_step(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream),
-        upload_cdn_step(edition=edition, ver_mode=ver_mode)
+        release_canary_npm_packages_step(edition, trigger=trigger_oss),
+        upload_packages_step(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream, trigger=trigger_oss),
+        upload_cdn_step(edition=edition, ver_mode=ver_mode, trigger=trigger_oss)
     ])
 
     if include_enterprise2:
@@ -180,7 +181,10 @@ def trigger_test_release():
                 'include': [
                     '.drone.yml',
                 ]
-            }
+            },
+            'repo': [
+                'grafana/grafana',
+            ]
         }
     }
 
@@ -227,7 +231,7 @@ def main_pipelines(edition):
             volumes=volumes,
         ),
         pipeline(
-            name='windows-main', edition=edition, trigger=trigger,
+            name='windows-main', edition=edition, trigger=dict(trigger, repo = ['grafana/grafana']),
             steps=initialize_step(edition, platform='windows', ver_mode=ver_mode) + windows_steps,
             depends_on=['main-test', 'main-build-e2e-publish', 'main-integration-tests'], platform='windows',
         ), notify_pipeline(
@@ -236,7 +240,7 @@ def main_pipelines(edition):
     ]
     if edition != 'enterprise':
         pipelines.append(pipeline(
-            name='publish-main', edition=edition, trigger=trigger,
+            name='publish-main', edition=edition, trigger=dict(trigger, repo = ['grafana/grafana']),
             steps=[download_grabpl_step()] + initialize_step(edition, platform='linux', ver_mode=ver_mode, install_deps=False) + store_steps,
             depends_on=['main-test', 'main-build-e2e-publish', 'main-integration-tests', 'windows-main',],
         ))

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -4,7 +4,6 @@ load(
     'download_grabpl_step',
     'initialize_step',
     'lint_drone_step',
-    'test_release_ver',
     'build_image',
     'publish_image',
     'lint_backend_step',
@@ -31,14 +30,14 @@ load(
     'memcached_integration_tests_step',
     'get_windows_steps',
     'benchmark_ldap_step',
-    'frontend_metrics_step',
     'store_storybook_step',
     'upload_packages_step',
     'store_packages_step',
     'upload_cdn_step',
     'validate_scuemata_step',
     'ensure_cuetsified_step',
-    'publish_images_step'
+    'publish_images_step',
+    'trigger_oss'
 )
 
 load(
@@ -228,8 +227,8 @@ def get_steps(edition, ver_mode):
       integration_test_steps.extend([redis_integration_tests_step(edition=edition2, ver_mode=ver_mode), memcached_integration_tests_step(edition=edition2, ver_mode=ver_mode)])
 
     if should_upload:
-        publish_steps.append(upload_cdn_step(edition=edition, ver_mode=ver_mode))
-        publish_steps.append(upload_packages_step(edition=edition, ver_mode=ver_mode))
+        publish_steps.append(upload_cdn_step(edition=edition, ver_mode=ver_mode, trigger=trigger_oss))
+        publish_steps.append(upload_packages_step(edition=edition, ver_mode=ver_mode, trigger=trigger_oss))
     if should_publish:
         publish_step = store_storybook_step(edition=edition, ver_mode=ver_mode)
         build_npm_step = build_npm_packages_step(edition=edition, ver_mode=ver_mode)
@@ -429,7 +428,7 @@ def release_pipelines(ver_mode='release', trigger=None, environment=None):
             },
             'ref': ['refs/tags/v*',],
             'repo': {
-              'exclude': ['grafana/grafana'],
+                'exclude': ['grafana/grafana'],
             },
         }
 

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -8,9 +8,15 @@ alpine_image = 'alpine:3.15'
 curl_image = 'byrnedo/alpine-curl:0.1.8'
 windows_image = 'mcr.microsoft.com/windows:1809'
 wix_image = 'grafana/ci-wix:0.1.1'
-test_release_ver = 'v7.3.0-test'
 
 disable_tests = False
+trigger_oss = {
+    'when': {
+        'repo': [
+            'grafana/grafana',
+        ]
+    }
+}
 
 def slack_step(channel, template, secret):
     return {
@@ -253,7 +259,7 @@ def build_storybook_step(edition, ver_mode):
     }
 
 
-def store_storybook_step(edition, ver_mode):
+def store_storybook_step(edition, ver_mode, trigger=None):
     if edition in ('enterprise', 'enterprise2'):
         return None
 
@@ -272,7 +278,7 @@ def store_storybook_step(edition, ver_mode):
                         for c in channels
                     ])
 
-    return {
+    step = {
         'name': 'store-storybook',
         'image': publish_image,
         'depends_on': ['build-storybook',] + end_to_end_tests_deps(edition),
@@ -282,6 +288,9 @@ def store_storybook_step(edition, ver_mode):
         },
         'commands': commands,
     }
+    if trigger and ver_mode in ("release-branch", "main"):
+        step.update(trigger)
+    return step
 
 def e2e_tests_artifacts(edition):
     return {
@@ -322,7 +331,7 @@ def e2e_tests_artifacts(edition):
     }
 
 
-def upload_cdn_step(edition, ver_mode):
+def upload_cdn_step(edition, ver_mode, trigger=None):
     src_dir = ''
     if ver_mode == "release":
         bucket = "$${PRERELEASE_BUCKET}"
@@ -340,7 +349,7 @@ def upload_cdn_step(edition, ver_mode):
             'grafana-server',
         ])
 
-    return {
+    step = {
         'name': 'upload-cdn-assets' + enterprise2_suffix(edition),
         'image': publish_image,
         'depends_on': deps,
@@ -352,6 +361,9 @@ def upload_cdn_step(edition, ver_mode):
             './bin/grabpl upload-cdn --edition {} --src-bucket "{}"{}'.format(edition, bucket, src_dir),
         ],
     }
+    if trigger and ver_mode in ("release-branch", "main"):
+        step.update(trigger)
+    return step
 
 
 def build_backend_step(edition, ver_mode, variants=None, is_downstream=False):
@@ -581,11 +593,11 @@ def test_a11y_frontend_step(ver_mode, edition, port=3001):
     }
 
 
-def frontend_metrics_step(edition):
+def frontend_metrics_step(edition, trigger=None):
     if edition in ('enterprise', 'enterprise2'):
         return None
 
-    return {
+    step = {
         'name': 'publish-frontend-metrics',
         'image': build_image,
         'depends_on': [
@@ -599,6 +611,9 @@ def frontend_metrics_step(edition):
             './scripts/ci-frontend-metrics.sh | ./bin/grabpl publish-metrics $${GRAFANA_MISC_STATS_API_KEY}',
         ],
     }
+    if trigger:
+        step.update(trigger)
+    return step
 
 
 def codespell_step():
@@ -798,7 +813,7 @@ def build_docker_images_step(edition, ver_mode, archs=None, ubuntu=False, publis
         },
     }
 
-def publish_images_step(edition, ver_mode, mode, docker_repo, ubuntu=False):
+def publish_images_step(edition, ver_mode, mode, docker_repo, trigger=None):
     if mode == 'security':
         mode = '--{} '.format(mode)
     else:
@@ -812,7 +827,7 @@ def publish_images_step(edition, ver_mode, mode, docker_repo, ubuntu=False):
     else:
         deps = ['build-docker-images', 'build-docker-images-ubuntu']
 
-    return {
+    step = {
         'name': 'publish-images-{}'.format(docker_repo),
         'image': 'google/cloud-sdk',
         'environment': {
@@ -827,6 +842,10 @@ def publish_images_step(edition, ver_mode, mode, docker_repo, ubuntu=False):
             'path': '/var/run/docker.sock'
         }],
     }
+    if trigger and ver_mode in ("release-branch", "main"):
+        step.update(trigger)
+
+    return step
 
 
 def postgres_integration_tests_step(edition, ver_mode):
@@ -923,11 +942,11 @@ def memcached_integration_tests_step(edition, ver_mode):
     }
 
 
-def release_canary_npm_packages_step(edition):
+def release_canary_npm_packages_step(edition, trigger=None):
     if edition in ('enterprise', 'enterprise2'):
         return None
 
-    return {
+    step = {
         'name': 'release-canary-npm-packages',
         'image': build_image,
         'depends_on': end_to_end_tests_deps(edition),
@@ -938,6 +957,9 @@ def release_canary_npm_packages_step(edition):
             './scripts/circle-release-canary-packages.sh',
         ],
     }
+    if trigger:
+        step.update(trigger)
+    return step
 
 
 def enterprise2_suffix(edition):
@@ -946,7 +968,7 @@ def enterprise2_suffix(edition):
     return ''
 
 
-def upload_packages_step(edition, ver_mode, is_downstream=False):
+def upload_packages_step(edition, ver_mode, is_downstream=False, trigger=None):
     if ver_mode == 'main' and edition in ('enterprise', 'enterprise2') and not is_downstream:
         return None
 
@@ -966,7 +988,7 @@ def upload_packages_step(edition, ver_mode, is_downstream=False):
     else:
         deps.extend(end_to_end_tests_deps(edition))
 
-    return {
+    step = {
         'name': 'upload-packages' + enterprise2_suffix(edition),
         'image': publish_image,
         'depends_on': deps,
@@ -976,6 +998,9 @@ def upload_packages_step(edition, ver_mode, is_downstream=False):
         },
         'commands': [cmd, ],
     }
+    if trigger and ver_mode in ("release-branch", "main"):
+        step.update(trigger)
+    return step
 
 
 def store_packages_step(edition, ver_mode, is_downstream=False):


### PR DESCRIPTION
* Convert steps to run on OSS repo only

* Exclude versioned branches from publishing artifacts

* Change trigger -> when

* Add trigger to upload_* steps

* Add conditions to remaining steps

* Exclude release steps

* Bring back exclusion for release builds

(cherry picked from commit bd386df617fe6ec4d4ba4986ea30b309faf55d15)

Backport of #47315