### PR TITLE
Prometheus: Add beta tag to mode switch for Builder mode

### DIFF
--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
@@ -87,7 +87,7 @@ export function RadioButtonGroup<T>({
           >
             {o.icon && <Icon name={o.icon as IconName} className={styles.icon} />}
             {o.imgUrl && <img src={o.imgUrl} alt={o.label} className={styles.img} />}
-            {o.label}
+            {o.label} {o.component ? <o.component /> : null}
           </RadioButton>
         );
       })}

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryEditorSelector.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryEditorSelector.test.tsx
@@ -187,9 +187,9 @@ function expectExplain() {
 
 function switchToMode(mode: QueryEditorMode) {
   const label = {
-    [QueryEditorMode.Code]: 'Code',
-    [QueryEditorMode.Explain]: 'Explain',
-    [QueryEditorMode.Builder]: 'Builder',
+    [QueryEditorMode.Code]: /Code/,
+    [QueryEditorMode.Explain]: /Explain/,
+    [QueryEditorMode.Builder]: /Builder/,
   }[mode];
 
   const switchEl = screen.getByLabelText(label);

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.test.tsx
@@ -189,9 +189,9 @@ function expectExplain() {
 
 function switchToMode(mode: QueryEditorMode) {
   const label = {
-    [QueryEditorMode.Code]: 'Code',
-    [QueryEditorMode.Explain]: 'Explain',
-    [QueryEditorMode.Builder]: 'Builder',
+    [QueryEditorMode.Code]: /Code/,
+    [QueryEditorMode.Explain]: /Explain/,
+    [QueryEditorMode.Builder]: /Builder/,
   }[mode];
 
   const switchEl = screen.getByLabelText(label);

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/QueryEditorModeToggle.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/QueryEditorModeToggle.tsx
@@ -1,5 +1,6 @@
-import { RadioButtonGroup } from '@grafana/ui';
+import { RadioButtonGroup, Tag } from '@grafana/ui';
 import React from 'react';
+import { css } from '@emotion/css';
 import { QueryEditorMode } from './types';
 
 export interface Props {
@@ -9,7 +10,21 @@ export interface Props {
 
 const editorModes = [
   { label: 'Explain', value: QueryEditorMode.Explain },
-  { label: 'Builder', value: QueryEditorMode.Builder },
+  {
+    label: 'Builder',
+    value: QueryEditorMode.Builder,
+    component: () => (
+      <Tag
+        className={css({
+          fontSize: 10,
+          padding: '1px 5px',
+          verticalAlign: 'text-bottom',
+        })}
+        name={'Beta'}
+        colorIndex={1}
+      />
+    ),
+  },
   { label: 'Code', value: QueryEditorMode.Code },
 ];
 


### PR DESCRIPTION
Adds a beta tag for the builder:
![Screenshot from 2022-04-06 10-26-40](https://user-images.githubusercontent.com/1014802/161936501-d87c45f9-a556-4795-af4e-2e3baf6028e5.png)
