### PR TITLE
Loki,Prometheus: Fix of showing error message for empty query

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -2,6 +2,15 @@ import { buildVisualQueryFromString } from './parsing';
 import { LokiVisualQuery } from './types';
 
 describe('buildVisualQueryFromString', () => {
+  it('creates no errors for empty query', () => {
+    expect(buildVisualQueryFromString('')).toEqual(
+      noErrors({
+        labels: [],
+        operations: [],
+      })
+    );
+  });
+
   it('parses simple query with label-values', () => {
     expect(buildVisualQueryFromString('{app="frontend"}')).toEqual(
       noErrors({

--- a/public/app/plugins/datasource/prometheus/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/parsing.test.ts
@@ -2,6 +2,15 @@ import { buildVisualQueryFromString } from './parsing';
 import { PromVisualQuery } from './types';
 
 describe('buildVisualQueryFromString', () => {
+  it('creates no errors for empty query', () => {
+    expect(buildVisualQueryFromString('')).toEqual(
+      noErrors({
+        labels: [],
+        operations: [],
+        metric: '',
+      })
+    );
+  });
   it('parses simple query', () => {
     expect(buildVisualQueryFromString('counters_logins{app="frontend"}')).toEqual(
       noErrors({

--- a/public/app/plugins/datasource/prometheus/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/parsing.ts
@@ -46,6 +46,11 @@ export function buildVisualQueryFromString(expr: string): Context {
       text: err.message,
     });
   }
+
+  // If we have empty query, we want to reset errors
+  if (isEmptyQuery(context.query)) {
+    context.errors = [];
+  }
   return context;
 }
 
@@ -372,4 +377,11 @@ function getBinaryModifier(
       matchType: matcher.getChild('On') ? 'on' : 'ignoring',
     };
   }
+}
+
+function isEmptyQuery(query: PromVisualQuery) {
+  if (query.labels.length === 0 && query.operations.length === 0 && !query.metric) {
+    return true;
+  }
+  return false;
 }

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils.ts
@@ -30,7 +30,7 @@ export function makeError(expr: string, node: SyntaxNode) {
 const variableRegex = /\$(\w+)|\[\[([\s\S]+?)(?::(\w+))?\]\]|\${(\w+)(?:\.([^:^\}]+))?(?::([^\}]+))?}/g;
 
 /**
- * As variables with $ are creating parsing errors, we first replace them with magic string that is parseable and at
+ * As variables with $ are creating parsing errors, we first replace them with magic string that is parsable and at
  * the same time we can get the variable and it's format back from it.
  * @param expr
  */


### PR DESCRIPTION
**What this PR does / why we need it**:
When we have empty query and switch from text editor to query builder, we don't want to show error that the user might loose some parts of the query, because at that point there is no query. 

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/grafana/issues/44253

