### PR TITLE
GrafanaUI: Change chevron directions for open/closed state

### DIFF
--- a/packages/grafana-ui/src/components/Collapse/CollapsableSection.tsx
+++ b/packages/grafana-ui/src/components/Collapse/CollapsableSection.tsx
@@ -60,7 +60,7 @@ export const CollapsableSection: FC<Props> = ({
           {loading ? (
             <Spinner className={styles.spinner} />
           ) : (
-            <Icon name={open ? 'angle-down' : 'angle-right'} className={styles.icon} />
+            <Icon name={open ? 'angle-up' : 'angle-down'} className={styles.icon} />
           )}
         </button>
         <div className={styles.label} id={`collapse-label-${id}`}>


### PR DESCRIPTION
**What this PR does / why we need it**:

For new nav, we want to change the chevron direction so when a section is collapsed, chevron should point down, when expanded, should point up.

Decided to change this in the component, and change it everywhere. 🔥  Controversial 🔥 

This impacts:

 - [Alerting ChannelSettings](https://github.dev/grafana/grafana/blob/25e04d77be3fecba00902b5312f011c95589f901/public/app/features/alerting/components/ChannelSettings.tsx#L23)
 - [Alerting NotificationSettings](https://github.dev/grafana/grafana/blob/25e04d77be3fecba00902b5312f011c95589f901/public/app/features/alerting/components/NotificationSettings.tsx#L11)
 - [AnnotationSettings](https://github.dev/grafana/grafana/blob/25e04d77be3fecba00902b5312f011c95589f901/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx#L99)
 - and a few places in [DashboardSettings](https://github.dev/grafana/grafana/blob/25e04d77be3fecba00902b5312f011c95589f901/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx#L144)

In a separate PR, I want to remove `CollapsableSection` from most of DashboardSettings and just replace it with a FieldSet. "Graph tooltip" doesn't need to be collapsible.

**Which issue(s) this PR fixes**:


Fixes #47273

**Special notes for your reviewer**:

