### PR TITLE
Alerting: Display alert instances instead of alert rules when creating silence

### DIFF
--- a/public/app/features/alerting/unified/components/silences/MatchedSilencedRules.tsx
+++ b/public/app/features/alerting/unified/components/silences/MatchedSilencedRules.tsx
@@ -3,7 +3,7 @@ import { useFormContext } from 'react-hook-form';
 import { useDebounce } from 'react-use';
 import { useDispatch } from 'react-redux';
 import { css } from '@emotion/css';
-import { GrafanaTheme2 } from '@grafana/data';
+import { dateTime, GrafanaTheme2 } from '@grafana/data';
 import { Badge, useStyles2 } from '@grafana/ui';
 import { DynamicTable, DynamicTableColumnProps, DynamicTableItemProps } from '../DynamicTable';
 import { useCombinedRuleNamespaces } from '../../hooks/useCombinedRuleNamespaces';
@@ -53,7 +53,7 @@ export const MatchedSilencedRules = () => {
   return (
     <div>
       <h4 className={styles.title}>
-        Affected alerts
+        Affected alert instances
         {matchedAlertRules.length > 0 ? (
           <Badge className={styles.badge} color="blue" text={matchedAlertRules.length} />
         ) : null}
@@ -96,13 +96,7 @@ function useColumns(): MatchedRulesTableColumnProps[] {
       id: 'created',
       label: 'Created',
       renderCell: function renderSummary({ data: { matchedInstance } }) {
-        return (
-          <>
-            {matchedInstance.activeAt.startsWith('0001')
-              ? '-'
-              : matchedInstance.activeAt.substr(0, 19).replace('T', ' ')}
-          </>
-        );
+        return <>{dateTime(matchedInstance.activeAt).format('YYYY-MM-DD HH:mm:ss')}</>;
       },
       size: '400px',
     },

--- a/public/app/features/alerting/unified/components/silences/MatchedSilencedRules.tsx
+++ b/public/app/features/alerting/unified/components/silences/MatchedSilencedRules.tsx
@@ -96,7 +96,13 @@ function useColumns(): MatchedRulesTableColumnProps[] {
       id: 'created',
       label: 'Created',
       renderCell: function renderSummary({ data: { matchedInstance } }) {
-        return <>{dateTime(matchedInstance.activeAt).format('YYYY-MM-DD HH:mm:ss')}</>;
+        return (
+          <>
+            {matchedInstance.activeAt.startsWith('0001')
+              ? '-'
+              : dateTime(matchedInstance.activeAt).format('YYYY-MM-DD HH:mm:ss')}
+          </>
+        );
       },
       size: '400px',
     },

--- a/public/app/features/alerting/unified/utils/matchers.test.ts
+++ b/public/app/features/alerting/unified/utils/matchers.test.ts
@@ -1,6 +1,6 @@
 import { MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
-import { getMatcherQueryParams, findAlertRulesWithMatchers, parseQueryParamMatchers } from './matchers';
-import { mockCombinedRule } from '../mocks';
+import { getMatcherQueryParams, findAlertInstancesWithMatchers, parseQueryParamMatchers } from './matchers';
+import { mockPromAlert } from '../mocks';
 
 describe('Unified Alerting matchers', () => {
   describe('getMatcherQueryParams tests', () => {
@@ -39,42 +39,42 @@ describe('Unified Alerting matchers', () => {
   describe('matchLabelsToMatchers', () => {
     it('should match for equal', () => {
       const matchers = [{ name: 'foo', value: 'bar', operator: MatcherOperator.equal }];
-      const rules = [mockCombinedRule({ labels: { foo: 'bar' } }), mockCombinedRule({ labels: { foo: 'baz' } })];
-      const matchedRules = findAlertRulesWithMatchers(rules, matchers);
+      const alerts = [mockPromAlert({ labels: { foo: 'bar' } }), mockPromAlert({ labels: { foo: 'baz' } })];
+      const matchedAlerts = findAlertInstancesWithMatchers(alerts, matchers);
 
-      expect(matchedRules).toHaveLength(1);
+      expect(matchedAlerts).toHaveLength(1);
     });
 
     it('should match for not equal', () => {
       const matchers = [{ name: 'foo', value: 'bar', operator: MatcherOperator.notEqual }];
-      const rules = [mockCombinedRule({ labels: { foo: 'bar' } }), mockCombinedRule({ labels: { foo: 'baz' } })];
+      const alerts = [mockPromAlert({ labels: { foo: 'bar' } }), mockPromAlert({ labels: { foo: 'baz' } })];
 
-      const matchedRules = findAlertRulesWithMatchers(rules, matchers);
-      expect(matchedRules).toHaveLength(1);
+      const matchedAlerts = findAlertInstancesWithMatchers(alerts, matchers);
+      expect(matchedAlerts).toHaveLength(1);
     });
 
     it('should match for regex', () => {
       const matchers = [{ name: 'foo', value: 'bar', operator: MatcherOperator.regex }];
-      const rules = [
-        mockCombinedRule({ labels: { foo: 'bar' } }),
-        mockCombinedRule({ labels: { foo: 'baz' } }),
-        mockCombinedRule({ labels: { foo: 'bas' } }),
+      const alerts = [
+        mockPromAlert({ labels: { foo: 'bar' } }),
+        mockPromAlert({ labels: { foo: 'baz' } }),
+        mockPromAlert({ labels: { foo: 'bas' } }),
       ];
 
-      const matchedRules = findAlertRulesWithMatchers(rules, matchers);
-      expect(matchedRules).toHaveLength(1);
+      const matchedAlerts = findAlertInstancesWithMatchers(alerts, matchers);
+      expect(matchedAlerts).toHaveLength(1);
     });
 
     it('should not match regex', () => {
       const matchers = [{ name: 'foo', value: 'bar', operator: MatcherOperator.notRegex }];
-      const rules = [
-        mockCombinedRule({ labels: { foo: 'bar' } }),
-        mockCombinedRule({ labels: { foo: 'baz' } }),
-        mockCombinedRule({ labels: { foo: 'bas' } }),
+      const alerts = [
+        mockPromAlert({ labels: { foo: 'bar' } }),
+        mockPromAlert({ labels: { foo: 'baz' } }),
+        mockPromAlert({ labels: { foo: 'bas' } }),
       ];
 
-      const matchedRules = findAlertRulesWithMatchers(rules, matchers);
-      expect(matchedRules).toHaveLength(2);
+      const matchedAlerts = findAlertInstancesWithMatchers(alerts, matchers);
+      expect(matchedAlerts).toHaveLength(2);
     });
   });
 });

--- a/public/app/features/alerting/unified/utils/matchers.ts
+++ b/public/app/features/alerting/unified/utils/matchers.ts
@@ -3,7 +3,7 @@ import { Labels } from '@grafana/data';
 import { parseMatcher } from './alertmanager';
 import { uniqBy } from 'lodash';
 import { MatcherFieldValue } from '../types/silence-form';
-import { CombinedRule } from 'app/types/unified-alerting';
+import { Alert } from 'app/types/unified-alerting';
 
 // Parses a list of entries like like "['foo=bar', 'baz=~bad*']" into SilenceMatcher[]
 export function parseQueryParamMatchers(matcherPairs: string[]): Matcher[] {
@@ -27,16 +27,19 @@ export const getMatcherQueryParams = (labels: Labels) => {
   return matcherUrlParams;
 };
 
-interface MatchedRule {
+interface MatchedInstance {
   id: string;
   data: {
-    matchedRule: CombinedRule;
+    matchedRule: Alert;
   };
 }
 
-export const findAlertRulesWithMatchers = (rules: CombinedRule[], matchers: MatcherFieldValue[]): MatchedRule[] => {
-  const hasMatcher = (rule: CombinedRule, matcher: MatcherFieldValue) => {
-    return Object.entries(rule.labels).some(([key, value]) => {
+export const findAlertInstancesWithMatchers = (
+  instances: Alert[],
+  matchers: MatcherFieldValue[]
+): MatchedInstance[] => {
+  const hasMatcher = (instance: Alert, matcher: MatcherFieldValue) => {
+    return Object.entries(instance.labels).some(([key, value]) => {
       if (!matcher.name || !matcher.value) {
         return false;
       }
@@ -56,13 +59,13 @@ export const findAlertRulesWithMatchers = (rules: CombinedRule[], matchers: Matc
     });
   };
 
-  const filteredRules = rules.filter((rule) => {
-    return matchers.every((matcher) => hasMatcher(rule, matcher));
+  const filteredInstances = instances.filter((instance) => {
+    return matchers.every((matcher) => hasMatcher(instance, matcher));
   });
-  const mappedRules = filteredRules.map((rule) => ({
-    id: `${rule.namespace}-${rule.name}`,
-    data: { matchedRule: rule },
+  const mappedInstances = filteredInstances.map((instance) => ({
+    id: `${instance.activeAt}-${instance.value}`,
+    data: { matchedRule: instance },
   }));
 
-  return mappedRules;
+  return mappedInstances;
 };

--- a/public/app/features/alerting/unified/utils/matchers.ts
+++ b/public/app/features/alerting/unified/utils/matchers.ts
@@ -30,7 +30,7 @@ export const getMatcherQueryParams = (labels: Labels) => {
 interface MatchedInstance {
   id: string;
   data: {
-    matchedRule: Alert;
+    matchedInstance: Alert;
   };
 }
 
@@ -64,7 +64,7 @@ export const findAlertInstancesWithMatchers = (
   });
   const mappedInstances = filteredInstances.map((instance) => ({
     id: `${instance.activeAt}-${instance.value}`,
-    data: { matchedRule: instance },
+    data: { matchedInstance: instance },
   }));
 
   return mappedInstances;


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/grafana/grafana/pull/44307 we introduced visualizing which alert rules would be affected by a Silence. This however was not fine grained enough since you can have matchers in a Silence that only match a specific alert (instance).

This PR changes the behavior and lists affected alerts/instances rather than alert rules.

**Which issue(s) this PR fixes**:

Fixes #46621

**Special notes for your reviewer**:

