### PR TITLE
Config: fix buildInfo initialization

### DIFF
--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -130,7 +130,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
       appUrl: '',
       appSubUrl: '',
       buildInfo: {
-        version: 'v1.0',
+        version: '1.0',
         commit: '1',
         env: 'production',
       },

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -119,7 +119,6 @@ export class GrafanaBootConfig implements GrafanaConfig {
     this.theme2 = createTheme({ colors: { mode } });
     this.theme = this.theme2.v1;
     this.bootData = options.bootData;
-    this.buildInfo = options.buildInfo;
 
     const defaults = {
       datasources: {},
@@ -141,6 +140,8 @@ export class GrafanaBootConfig implements GrafanaConfig {
     };
 
     merge(this, defaults, options);
+
+    this.buildInfo = options.buildInfo;
 
     if (this.dateFormats) {
       systemDateFormats.update(this.dateFormats);

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -141,7 +141,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
 
     merge(this, defaults, options);
 
-    this.buildInfo = options.buildInfo;
+    this.buildInfo = options.buildInfo || defaults.buildInfo;
 
     if (this.dateFormats) {
       systemDateFormats.update(this.dateFormats);


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix version info in the frontend:
![image](https://user-images.githubusercontent.com/35176601/162011033-9c54988a-075a-49d1-a62d-e942a39a2da7.png)

The version info sent by the backend was overriden by the defaults, following up [this PR](https://github.com/grafana/grafana/pull/45322) (I think).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
It fixes the issue but I don't know if it's the best fix. 

