### PR TITLE
Escape backslashes in regexps in Loki label browser (#45809, #47039).

### DIFF
--- a/packages/grafana-ui/src/components/Typeahead/TypeaheadItem.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/TypeaheadItem.tsx
@@ -92,7 +92,12 @@ export const TypeaheadItem: React.FC<Props> = (props: Props) => {
           highlightParts={item.highlightParts}
         ></PartialHighlighter>
       ) : (
-        <Highlighter textToHighlight={label} searchWords={[prefix ?? '']} highlightClassName={highlightClassName} />
+        <Highlighter
+          textToHighlight={label}
+          searchWords={[prefix ?? '']}
+          autoEscape={true}
+          highlightClassName={highlightClassName}
+        />
       )}
     </li>
   );

--- a/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx
@@ -18,6 +18,7 @@ import {
 
 import PromQlLanguageProvider from '../../prometheus/language_provider';
 import LokiLanguageProvider from '../language_provider';
+import { escapeLabelValueInExactSelector, escapeLabelValueInRegexSelector } from '../language_utils';
 
 // Hard limit on labels to render
 const MAX_LABEL_COUNT = 1000;
@@ -67,9 +68,9 @@ export function buildSelector(labels: SelectableLabel[]): string {
     if (label.selected && label.values && label.values.length > 0) {
       const selectedValues = label.values.filter((value) => value.selected).map((value) => value.name);
       if (selectedValues.length > 1) {
-        selectedLabels.push(`${label.name}=~"${selectedValues.join('|')}"`);
+        selectedLabels.push(`${label.name}=~"${selectedValues.map(escapeLabelValueInRegexSelector).join('|')}"`);
       } else if (selectedValues.length === 1) {
-        selectedLabels.push(`${label.name}="${selectedValues[0]}"`);
+        selectedLabels.push(`${label.name}="${escapeLabelValueInExactSelector(selectedValues[0])}"`);
       }
     }
   }

--- a/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
@@ -17,9 +17,8 @@ import { LocalStorageValueProvider } from 'app/core/components/LocalStorageValue
 
 import { LokiDatasource } from '../datasource';
 import LokiLanguageProvider from '../language_provider';
-import { shouldRefreshLabels } from '../language_utils';
+import { escapeLabelValueInSelector, isRegexSelector, shouldRefreshLabels } from '../language_utils';
 import { LokiQuery, LokiOptions } from '../types';
-
 import { LokiLabelBrowser } from './LokiLabelBrowser';
 
 const LAST_USED_LABELS_KEY = 'grafana.datasources.loki.browser.labels';
@@ -47,17 +46,26 @@ function willApplySuggestion(suggestion: string, { typeaheadContext, typeaheadTe
 
     case 'context-label-values': {
       // Always add quotes and remove existing ones instead
+      let suggestionModified = '';
+
       if (!typeaheadText.match(/^(!?=~?"|")/)) {
-        suggestion = `"${suggestion}`;
+        suggestionModified = '"';
       }
+
+      suggestionModified += escapeLabelValueInSelector(suggestion, isRegexSelector(typeaheadText));
+
       if (DOMUtil.getNextCharacter() !== '"') {
-        suggestion = `${suggestion}"`;
+        suggestionModified += '"';
       }
+
+      suggestion = suggestionModified;
+
       break;
     }
 
     default:
   }
+
   return suggestion;
 }
 

--- a/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryField.tsx
@@ -17,8 +17,9 @@ import { LocalStorageValueProvider } from 'app/core/components/LocalStorageValue
 
 import { LokiDatasource } from '../datasource';
 import LokiLanguageProvider from '../language_provider';
-import { escapeLabelValueInSelector, isRegexSelector, shouldRefreshLabels } from '../language_utils';
+import { escapeLabelValueInSelector, shouldRefreshLabels } from '../language_utils';
 import { LokiQuery, LokiOptions } from '../types';
+
 import { LokiLabelBrowser } from './LokiLabelBrowser';
 
 const LAST_USED_LABELS_KEY = 'grafana.datasources.loki.browser.labels';
@@ -52,7 +53,7 @@ function willApplySuggestion(suggestion: string, { typeaheadContext, typeaheadTe
         suggestionModified = '"';
       }
 
-      suggestionModified += escapeLabelValueInSelector(suggestion, isRegexSelector(typeaheadText));
+      suggestionModified += escapeLabelValueInSelector(suggestion, typeaheadText);
 
       if (DOMUtil.getNextCharacter() !== '"') {
         suggestionModified += '"';

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -64,6 +64,7 @@ import {
   LokiResultType,
   LokiStreamResponse,
 } from './types';
+import { escapeLabelValueInSelector, isRegexSelector } from './language_utils';
 
 export type RangeQueryOptions = DataQueryRequest<LokiQuery> | AnnotationQueryRequest<LokiQuery>;
 export const DEFAULT_MAX_LINES = 1000;
@@ -825,10 +826,6 @@ export class LokiDatasource
     expr = adhocFilters.reduce((acc: string, filter: { key?: any; operator?: any; value?: any }) => {
       const { key, operator } = filter;
       let { value } = filter;
-      if (operator === '=~' || operator === '!~') {
-        value = lokiRegularEscape(value);
-      }
-
       return this.addLabelToQuery(acc, key, value, operator, true);
     }, expr);
 
@@ -843,11 +840,13 @@ export class LokiDatasource
     // Override to make sure that we use label as actual label and not parsed label
     notParsedLabelOverride?: boolean
   ) {
+    let escapedValue = escapeLabelValueInSelector(value.toString(), isRegexSelector(operator));
+
     if (queryHasPipeParser(queryExpr) && !isMetricsQuery(queryExpr) && !notParsedLabelOverride) {
       // If query has parser, we treat all labels as parsed and use | key="value" syntax
-      return addParsedLabelToQuery(queryExpr, key, value, operator);
+      return addParsedLabelToQuery(queryExpr, key, escapedValue, operator);
     } else {
-      return addLabelToQuery(queryExpr, key, value, operator, true);
+      return addLabelToQuery(queryExpr, key, escapedValue, operator, true);
     }
   }
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -49,6 +49,7 @@ import { addLabelToQuery } from './add_label_to_query';
 import { transformBackendResult } from './backendResultTransformer';
 import { DEFAULT_RESOLUTION } from './components/LokiOptionFields';
 import LanguageProvider from './language_provider';
+import { escapeLabelValueInSelector } from './language_utils';
 import { LiveStreams, LokiLiveTarget } from './live_streams';
 import { addParsedLabelToQuery, getNormalizedLokiQuery, queryHasPipeParser } from './query_utils';
 import { lokiResultsToTableModel, lokiStreamsToDataFrames, processRangeQueryResponse } from './result_transformer';
@@ -64,7 +65,6 @@ import {
   LokiResultType,
   LokiStreamResponse,
 } from './types';
-import { escapeLabelValueInSelector, isRegexSelector } from './language_utils';
 
 export type RangeQueryOptions = DataQueryRequest<LokiQuery> | AnnotationQueryRequest<LokiQuery>;
 export const DEFAULT_MAX_LINES = 1000;
@@ -840,7 +840,7 @@ export class LokiDatasource
     // Override to make sure that we use label as actual label and not parsed label
     notParsedLabelOverride?: boolean
   ) {
-    let escapedValue = escapeLabelValueInSelector(value.toString(), isRegexSelector(operator));
+    let escapedValue = escapeLabelValueInSelector(value.toString(), operator);
 
     if (queryHasPipeParser(queryExpr) && !isMetricsQuery(queryExpr) && !notParsedLabelOverride) {
       // If query has parser, we treat all labels as parsed and use | key="value" syntax

--- a/public/app/plugins/datasource/loki/language_utils.ts
+++ b/public/app/plugins/datasource/loki/language_utils.ts
@@ -39,12 +39,14 @@ export function escapeLabelValueInRegexSelector(labelValue: string): string {
   return escapeLabelValueInExactSelector(escapeLokiRegexp(labelValue));
 }
 
-export function escapeLabelValueInSelector(labelValue: string, isRegex: boolean): string {
-  return isRegex ? escapeLabelValueInRegexSelector(labelValue) : escapeLabelValueInExactSelector(labelValue);
+export function escapeLabelValueInSelector(labelValue: string, selector?: string): string {
+  return isRegexSelector(selector)
+    ? escapeLabelValueInRegexSelector(labelValue)
+    : escapeLabelValueInExactSelector(labelValue);
 }
 
-export function isRegexSelector(selector: string) {
-  if (selector.includes('=~') || selector.includes('!~')) {
+export function isRegexSelector(selector?: string) {
+  if (selector && (selector.includes('=~') || selector.includes('!~'))) {
     return true;
   }
   return false;

--- a/public/app/plugins/datasource/loki/language_utils.ts
+++ b/public/app/plugins/datasource/loki/language_utils.ts
@@ -17,3 +17,35 @@ export function shouldRefreshLabels(range?: TimeRange, prevRange?: TimeRange): b
   }
   return false;
 }
+
+// Loki regular-expressions use the RE2 syntax (https://github.com/google/re2/wiki/Syntax),
+// so every character that matches something in that list has to be escaped.
+// the list of meta characters is: *+?()|\.[]{}^$
+// we make a javascript regular expression that matches those characters:
+const RE2_METACHARACTERS = /[*+?()|\\.\[\]{}^$]/g;
+function escapeLokiRegexp(value: string): string {
+  return value.replace(RE2_METACHARACTERS, '\\$&');
+}
+
+// based on the openmetrics-documentation, the 3 symbols we have to handle are:
+// - \n ... the newline character
+// - \  ... the backslash character
+// - "  ... the double-quote character
+export function escapeLabelValueInExactSelector(labelValue: string): string {
+  return labelValue.replace(/\\/g, '\\\\').replace(/\n/g, '\\n').replace(/"/g, '\\"');
+}
+
+export function escapeLabelValueInRegexSelector(labelValue: string): string {
+  return escapeLabelValueInExactSelector(escapeLokiRegexp(labelValue));
+}
+
+export function escapeLabelValueInSelector(labelValue: string, isRegex: boolean): string {
+  return isRegex ? escapeLabelValueInRegexSelector(labelValue) : escapeLabelValueInExactSelector(labelValue);
+}
+
+export function isRegexSelector(selector: string) {
+  if (selector.includes('=~') || selector.includes('!~')) {
+    return true;
+  }
+  return false;
+}

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -50,18 +50,17 @@ export const LokiQueryBuilder = React.memo<Props>(({ datasource, query, nested, 
       return [];
     }
 
+    let values;
     const labelsToConsider = query.labels.filter((x) => x !== forLabel);
     if (labelsToConsider.length === 0) {
-      return await datasource.languageProvider.fetchLabelValues(forLabel.label);
+      values = await datasource.languageProvider.fetchLabelValues(forLabel.label);
+    } else {
+      const expr = lokiQueryModeller.renderLabels(labelsToConsider);
+      const result = await datasource.languageProvider.fetchSeriesLabels(expr);
+      values = result[datasource.interpolateString(forLabel.label)];
     }
 
-    const expr = lokiQueryModeller.renderLabels(labelsToConsider);
-    const result = await datasource.languageProvider.fetchSeriesLabels(expr);
-    const forLabelInterpolated = datasource.interpolateString(forLabel.label);
-
-    return result[forLabelInterpolated]
-      ? result[forLabelInterpolated].map((v) => escapeLabelValueInSelector(v, forLabel.op))
-      : [];
+    return values ? values.map((v) => escapeLabelValueInSelector(v, forLabel.op)) : []; // Escape values in return
   };
 
   const labelFilterError: string | undefined = useMemo(() => {

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -8,6 +8,7 @@ import { OperationsEditorRow } from 'app/plugins/datasource/prometheus/querybuil
 import { QueryBuilderLabelFilter } from 'app/plugins/datasource/prometheus/querybuilder/shared/types';
 
 import { LokiDatasource } from '../../datasource';
+import { escapeLabelValueInSelector } from '../../language_utils';
 import { lokiQueryModeller } from '../LokiQueryModeller';
 import { LokiOperationId, LokiVisualQuery } from '../types';
 
@@ -57,7 +58,10 @@ export const LokiQueryBuilder = React.memo<Props>(({ datasource, query, nested, 
     const expr = lokiQueryModeller.renderLabels(labelsToConsider);
     const result = await datasource.languageProvider.fetchSeriesLabels(expr);
     const forLabelInterpolated = datasource.interpolateString(forLabel.label);
-    return result[forLabelInterpolated] ?? [];
+
+    return result[forLabelInterpolated]
+      ? result[forLabelInterpolated].map((v) => escapeLabelValueInSelector(v, forLabel.op))
+      : [];
   };
 
   const labelFilterError: string | undefined = useMemo(() => {


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Fixes #45809, #47039.

**Special notes for your reviewer**:

@ivanahuckova please take a look.