### PR TITLE
CloudWatch: Run query on blur in logs query field

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -290,7 +290,7 @@ exports[`no enzyme tests`] = {
     "public/app/plugins/datasource/cloudwatch/components/ConfigEditor.test.tsx:2974837543": [
       [1, 19, 13, "RegExp match", "2409514259"]
     ],
-    "public/app/plugins/datasource/cloudwatch/components/LogsQueryField.test.tsx:132770839": [
+    "public/app/plugins/datasource/cloudwatch/components/LogsQueryField.test.tsx:3888529428": [
       [1, 19, 13, "RegExp match", "2409514259"]
     ],
     "public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.test.tsx:1089831034": [

--- a/public/app/plugins/datasource/cloudwatch/__mocks__/CloudWatchDataSource.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/CloudWatchDataSource.ts
@@ -41,6 +41,8 @@ export function setupMockedDataSource({ data = [], variables }: { data?: any; va
       },
     } as any
   );
+  datasource.getVariables = () => ['test'];
+  datasource.getRegions = () => Promise.resolve([]);
   const fetchMock = jest.fn().mockReturnValue(of({ data }));
   setBackendSrv({ fetch: fetchMock } as any);
 

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryEditor.tsx
@@ -41,7 +41,9 @@ export const CloudWatchLogsQueryEditor = memo(function CloudWatchLogsQueryEditor
       exploreId={exploreId}
       datasource={datasource}
       query={query}
-      onBlur={() => {}}
+      onBlur={() => {
+        console.log('fluffles');
+      }}
       onChange={onChange}
       onRunQuery={onRunQuery}
       history={[]}

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryEditor.tsx
@@ -41,9 +41,6 @@ export const CloudWatchLogsQueryEditor = memo(function CloudWatchLogsQueryEditor
       exploreId={exploreId}
       datasource={datasource}
       query={query}
-      onBlur={() => {
-        console.log('fluffles');
-      }}
       onChange={onChange}
       onRunQuery={onRunQuery}
       history={[]}

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.test.tsx
@@ -6,12 +6,29 @@ import { DescribeLogGroupsRequest } from '../types';
 import { SelectableValue } from '@grafana/data';
 // eslint-disable-next-line lodash/import-scope
 import _, { DebouncedFunc } from 'lodash';
+import { render } from '@testing-library/react';
+import { setupMockedDataSource } from '../__mocks__/CloudWatchDataSource';
 
 jest
   .spyOn(_, 'debounce')
   .mockImplementation((func: (...args: any) => any, wait?: number) => func as DebouncedFunc<typeof func>);
 
 describe('CloudWatchLogsQueryField', () => {
+  it('runs onRunQuery on blur', () => {
+    const ds = setupMockedDataSource();
+    const onRunQuery = jest.fn();
+    render(
+      <CloudWatchLogsQueryField
+        absoluteRange={{ from: 1, to: 10 }}
+        exploreId={ExploreId.left}
+        datasource={ds.datasource}
+        query={{} as any}
+        onRunQuery={onRunQuery}
+        onChange={() => {}}
+      />
+    );
+  });
+
   it('updates upstream query log groups on region change', async () => {
     const onChange = jest.fn();
     const wrapper = shallow(

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.test.tsx
@@ -6,7 +6,8 @@ import { DescribeLogGroupsRequest } from '../types';
 import { SelectableValue } from '@grafana/data';
 // eslint-disable-next-line lodash/import-scope
 import _, { DebouncedFunc } from 'lodash';
-import { render } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 import { setupMockedDataSource } from '../__mocks__/CloudWatchDataSource';
 
 jest
@@ -14,9 +15,10 @@ jest
   .mockImplementation((func: (...args: any) => any, wait?: number) => func as DebouncedFunc<typeof func>);
 
 describe('CloudWatchLogsQueryField', () => {
-  it('runs onRunQuery on blur', () => {
-    const ds = setupMockedDataSource();
+  it('runs onRunQuery on blur of Log Groups', async () => {
     const onRunQuery = jest.fn();
+    const ds = setupMockedDataSource();
+
     render(
       <CloudWatchLogsQueryField
         absoluteRange={{ from: 1, to: 10 }}
@@ -27,6 +29,12 @@ describe('CloudWatchLogsQueryField', () => {
         onChange={() => {}}
       />
     );
+
+    const multiSelect = screen.getByLabelText('Log Groups');
+    await act(async () => {
+      fireEvent.blur(multiSelect);
+    });
+    expect(onRunQuery).toHaveBeenCalled();
   });
 
   it('updates upstream query log groups on region change', async () => {

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
@@ -345,7 +345,6 @@ export class CloudWatchLogsQueryField extends React.PureComponent<CloudWatchLogs
               additionalPlugins={this.plugins}
               query={query.expression ?? ''}
               onChange={this.onChangeQuery}
-              onBlur={this.props.onRunQuery}
               onClick={this.onQueryFieldClick}
               onRunQuery={this.props.onRunQuery}
               onTypeahead={this.onTypeahead}

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
@@ -321,9 +321,7 @@ export class CloudWatchLogsQueryField extends React.PureComponent<CloudWatchLogs
                 onCreateOption={(v) => {
                   this.setCustomLogGroups(v);
                 }}
-                onBlur={() => {
-                  console.log('hey!');
-                }}
+                onBlur={this.props.onRunQuery}
                 className={containerClass}
                 closeMenuOnSelect={false}
                 isClearable={true}
@@ -347,7 +345,7 @@ export class CloudWatchLogsQueryField extends React.PureComponent<CloudWatchLogs
               additionalPlugins={this.plugins}
               query={query.expression ?? ''}
               onChange={this.onChangeQuery}
-              onBlur={this.props.onBlur}
+              onBlur={this.props.onRunQuery}
               onClick={this.onQueryFieldClick}
               onRunQuery={this.props.onRunQuery}
               onTypeahead={this.onTypeahead}

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
@@ -321,6 +321,9 @@ export class CloudWatchLogsQueryField extends React.PureComponent<CloudWatchLogs
                 onCreateOption={(v) => {
                   this.setCustomLogGroups(v);
                 }}
+                onBlur={() => {
+                  console.log('hey!');
+                }}
                 className={containerClass}
                 closeMenuOnSelect={false}
                 isClearable={true}

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -236,6 +236,7 @@ export class CloudWatchDatasource
 
   filterQuery(query: CloudWatchQuery): boolean {
     if (query.queryMode === 'Logs') {
+      console.log("hello")
       return !!query.logGroupNames?.length;
     }
     const { region, metricQueryType, metricEditorMode, expression, metricName, namespace, sqlExpression, statistic } =

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -236,7 +236,6 @@ export class CloudWatchDatasource
 
   filterQuery(query: CloudWatchQuery): boolean {
     if (query.queryMode === 'Logs') {
-      console.log("hello")
       return !!query.logGroupNames?.length;
     }
     const { region, metricQueryType, metricEditorMode, expression, metricName, namespace, sqlExpression, statistic } =


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

#47224 noted that queries should be run whenever the `MultiSelect` or `QueryField` for `LogsQueryField` are blurred.

**Which issue(s) this PR fixes**:
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #47224

**Special notes for your reviewer**:
- Shortcut to run just the cloudwatch tests: `yarn jest -i --testPathPattern=/cloudwatch/components/`
- Create a CloudWatch panel and specify at least one log group along with a query and note whenever either field is blurred the "refresh dashboard" icon spins to indicate the query is being run.

