### PR TITLE
Cloudwatch : Use new api for registering annotation editor

### DIFF
--- a/public/app/angular/angular_wrappers.ts
+++ b/public/app/angular/angular_wrappers.ts
@@ -1,11 +1,3 @@
-import { react2AngularDirective } from 'app/angular/react2angular';
-import { QueryEditor as CloudMonitoringQueryEditor } from 'app/plugins/datasource/cloud-monitoring/components/QueryEditor';
-import { AnnotationQueryEditor as CloudMonitoringAnnotationQueryEditor } from 'app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor';
-import { AnnotationQueryEditor as CloudWatchAnnotationQueryEditor } from 'app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor';
-import PageHeader from '../core/components/PageHeader/PageHeader';
-import EmptyListCTA from '../core/components/EmptyListCTA/EmptyListCTA';
-import { TagFilter } from '../core/components/TagFilter/TagFilter';
-import { MetricSelect } from '../core/components/Select/MetricSelect';
 import {
   ClipboardButton,
   ColorPicker,
@@ -18,13 +10,25 @@ import {
   Spinner,
   UnitPicker,
 } from '@grafana/ui';
-import { LokiAnnotationsQueryEditor } from '../plugins/datasource/loki/components/AnnotationsQueryEditor';
-import { HelpModal } from '../core/components/help/HelpModal';
-import { Footer } from '../core/components/Footer/Footer';
+import { react2AngularDirective } from 'app/angular/react2angular';
 import { FolderPicker } from 'app/core/components/Select/FolderPicker';
-import { SearchField, SearchResults, SearchResultsFilter } from '../features/search';
 import { TimePickerSettings } from 'app/features/dashboard/components/DashboardSettings/TimePickerSettings';
+import {
+  AnnotationQueryEditor as CloudMonitoringAnnotationQueryEditor,
+} from 'app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor';
+import {
+  QueryEditor as CloudMonitoringQueryEditor,
+} from 'app/plugins/datasource/cloud-monitoring/components/QueryEditor';
 import QueryEditor from 'app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor';
+
+import EmptyListCTA from '../core/components/EmptyListCTA/EmptyListCTA';
+import { Footer } from '../core/components/Footer/Footer';
+import { HelpModal } from '../core/components/help/HelpModal';
+import PageHeader from '../core/components/PageHeader/PageHeader';
+import { MetricSelect } from '../core/components/Select/MetricSelect';
+import { TagFilter } from '../core/components/TagFilter/TagFilter';
+import { SearchField, SearchResults, SearchResultsFilter } from '../features/search';
+import { LokiAnnotationsQueryEditor } from '../plugins/datasource/loki/components/AnnotationsQueryEditor';
 
 const { SecretFormField } = LegacyForms;
 
@@ -123,11 +127,6 @@ export function registerAngularDirectives() {
     'onQueryChange',
     ['datasource', { watchDepth: 'reference' }],
     ['templateSrv', { watchDepth: 'reference' }],
-  ]);
-  react2AngularDirective('cloudwatchAnnotationQueryEditor', CloudWatchAnnotationQueryEditor, [
-    'query',
-    'onChange',
-    ['datasource', { watchDepth: 'reference' }],
   ]);
   react2AngularDirective('secretFormField', SecretFormField, [
     'value',

--- a/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
@@ -1,11 +1,17 @@
-import React, { ChangeEvent } from 'react';
 import { PanelData } from '@grafana/data';
 import { EditorField, EditorHeader, EditorRow, InlineSelect, Space } from '@grafana/experimental';
 import { Input, Switch } from '@grafana/ui';
+import React, { ChangeEvent } from 'react';
+
 import { CloudWatchDatasource } from '../datasource';
 import { useRegions } from '../hooks';
 import { CloudWatchAnnotationQuery, CloudWatchMetricsQuery } from '../types';
 import { MetricStatEditor } from './MetricStatEditor';
+
+// datasource: DSType;
+// query: TVQuery;
+// onRunQuery: () => void;
+// onChange: (value: TVQuery) => void;
 
 export type Props = {
   query: CloudWatchAnnotationQuery;

--- a/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
@@ -16,7 +16,7 @@ import { MetricStatEditor } from './MetricStatEditor';
 export type Props = {
   query: CloudWatchQuery;
   datasource: CloudWatchDatasource;
-  onChange: (value: CloudWatchAnnotationQuery) => void;
+  onChange: (value: CloudWatchQuery) => void;
   data?: PanelData;
 };
 

--- a/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
@@ -5,7 +5,7 @@ import React, { ChangeEvent } from 'react';
 
 import { CloudWatchDatasource } from '../datasource';
 import { useRegions } from '../hooks';
-import { CloudWatchAnnotationQuery, CloudWatchMetricsQuery, CloudWatchQuery } from '../types';
+import { CloudWatchMetricsQuery, CloudWatchQuery } from '../types';
 import { MetricStatEditor } from './MetricStatEditor';
 
 // datasource: DSType;

--- a/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
@@ -5,7 +5,7 @@ import React, { ChangeEvent } from 'react';
 
 import { CloudWatchDatasource } from '../datasource';
 import { useRegions } from '../hooks';
-import { CloudWatchMetricsQuery, CloudWatchQuery } from '../types';
+import { CloudWatchAnnotationQuery, CloudWatchMetricsQuery, CloudWatchQuery } from '../types';
 import { MetricStatEditor } from './MetricStatEditor';
 
 // datasource: DSType;
@@ -22,7 +22,7 @@ export type Props = {
 
 export function AnnotationQueryEditor(props: React.PropsWithChildren<Props>) {
   const { query, onChange, datasource } = props;
-
+  const annotationQuery = query as CloudWatchAnnotationQuery;
   const [regions, regionIsLoading] = useRegions(datasource);
 
   return (
@@ -41,25 +41,28 @@ export function AnnotationQueryEditor(props: React.PropsWithChildren<Props>) {
       <Space v={0.5} />
       <MetricStatEditor
         {...props}
+        query={annotationQuery}
         disableExpressions={true}
-        onChange={(editorQuery: CloudWatchMetricsQuery) => onChange({ ...query, ...editorQuery })}
+        onChange={(editorQuery: CloudWatchMetricsQuery) => onChange({ ...annotationQuery, ...editorQuery })}
         onRunQuery={() => {}}
       ></MetricStatEditor>
       <Space v={0.5} />
       <EditorRow>
         <EditorField label="Period" width={26} tooltip="Minimum interval between points in seconds.">
           <Input
-            value={query.period || ''}
+            value={annotationQuery.period || ''}
             placeholder="auto"
-            onChange={(event: ChangeEvent<HTMLInputElement>) => onChange({ ...query, period: event.target.value })}
+            onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              onChange({ ...annotationQuery, period: event.target.value })
+            }
           />
         </EditorField>
         <EditorField label="Enable Prefix Matching" optional={true}>
           <Switch
-            value={query.prefixMatching}
+            value={annotationQuery.prefixMatching}
             onChange={(e) => {
               onChange({
-                ...query,
+                ...annotationQuery,
                 prefixMatching: e.currentTarget.checked,
               });
             }}
@@ -67,19 +70,19 @@ export function AnnotationQueryEditor(props: React.PropsWithChildren<Props>) {
         </EditorField>
         <EditorField label="Action" optional={true}>
           <Input
-            disabled={!query.prefixMatching}
-            value={query.actionPrefix || ''}
+            disabled={!annotationQuery.prefixMatching}
+            value={annotationQuery.actionPrefix || ''}
             onChange={(event: ChangeEvent<HTMLInputElement>) =>
-              onChange({ ...query, actionPrefix: event.target.value })
+              onChange({ ...annotationQuery, actionPrefix: event.target.value })
             }
           />
         </EditorField>
         <EditorField label="Alarm Name" optional={true}>
           <Input
-            disabled={!query.prefixMatching}
-            value={query.alarmNamePrefix || ''}
+            disabled={!annotationQuery.prefixMatching}
+            value={annotationQuery.alarmNamePrefix || ''}
             onChange={(event: ChangeEvent<HTMLInputElement>) =>
-              onChange({ ...query, alarmNamePrefix: event.target.value })
+              onChange({ ...annotationQuery, alarmNamePrefix: event.target.value })
             }
           />
         </EditorField>

--- a/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
@@ -5,7 +5,7 @@ import React, { ChangeEvent } from 'react';
 
 import { CloudWatchDatasource } from '../datasource';
 import { useRegions } from '../hooks';
-import { CloudWatchAnnotationQuery, CloudWatchMetricsQuery } from '../types';
+import { CloudWatchAnnotationQuery, CloudWatchMetricsQuery, CloudWatchQuery } from '../types';
 import { MetricStatEditor } from './MetricStatEditor';
 
 // datasource: DSType;
@@ -14,7 +14,7 @@ import { MetricStatEditor } from './MetricStatEditor';
 // onChange: (value: TVQuery) => void;
 
 export type Props = {
-  query: CloudWatchAnnotationQuery;
+  query: CloudWatchQuery;
   datasource: CloudWatchDatasource;
   onChange: (value: CloudWatchAnnotationQuery) => void;
   data?: PanelData;

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -1,5 +1,4 @@
 import {
-  AnnotationQuery,
   DataFrame,
   DataQueryError,
   DataQueryErrorType,
@@ -104,7 +103,7 @@ export class CloudWatchDatasource
   annotations = {
     prepareAnnotation: (json: any) => {
       console.log({ json });
-      return {} as AnnotationQuery<CloudWatchQuery>;
+      return json;
     },
 
     // QueryEditor: AnnotationQueryEditor,

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -1,4 +1,5 @@
 import {
+  AnnotationQuery,
   DataFrame,
   DataQueryError,
   DataQueryErrorType,
@@ -31,7 +32,6 @@ import { from, lastValueFrom, merge, Observable, of, throwError, zip } from 'rxj
 import { catchError, concatMap, finalize, map, mergeMap, repeat, scan, share, takeWhile, tap } from 'rxjs/operators';
 
 import { SQLCompletionItemProvider } from './cloudwatch-sql/completion/CompletionItemProvider';
-import { AnnotationQueryEditor } from './components/AnnotationQueryEditor';
 import { ThrottlingErrorMessage } from './components/ThrottlingErrorMessage';
 import { CloudWatchLanguageProvider } from './language_provider';
 import memoizedDebounce from './memoizedDebounce';
@@ -102,7 +102,12 @@ export class CloudWatchDatasource
 
   // This will support annotation queries for 7.2+
   annotations = {
-    QueryEditor: AnnotationQueryEditor,
+    prepareAnnotation: (json: any) => {
+      console.log({ json });
+      return {} as AnnotationQuery<CloudWatchQuery>;
+    },
+
+    // QueryEditor: AnnotationQueryEditor,
   };
 
   debouncedAlert: (datasourceName: string, region: string) => void = memoizedDebounce(

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -31,6 +31,7 @@ import { from, lastValueFrom, merge, Observable, of, throwError, zip } from 'rxj
 import { catchError, concatMap, finalize, map, mergeMap, repeat, scan, share, takeWhile, tap } from 'rxjs/operators';
 
 import { SQLCompletionItemProvider } from './cloudwatch-sql/completion/CompletionItemProvider';
+import { AnnotationQueryEditor } from './components/AnnotationQueryEditor';
 import { ThrottlingErrorMessage } from './components/ThrottlingErrorMessage';
 import { CloudWatchLanguageProvider } from './language_provider';
 import memoizedDebounce from './memoizedDebounce';
@@ -109,7 +110,7 @@ export class CloudWatchDatasource
       return json;
     },
 
-    // QueryEditor: AnnotationQueryEditor,
+    QueryEditor: AnnotationQueryEditor,
   };
 
   debouncedAlert: (datasourceName: string, region: string) => void = memoizedDebounce(

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -102,6 +102,9 @@ export class CloudWatchDatasource
   // This will support annotation queries for 7.2+
   annotations = {
     prepareAnnotation: (json: any) => {
+      if (!json.target) {
+        return json;
+      }
       console.log({ json });
       return json;
     },

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -31,6 +31,7 @@ import { from, lastValueFrom, merge, Observable, of, throwError, zip } from 'rxj
 import { catchError, concatMap, finalize, map, mergeMap, repeat, scan, share, takeWhile, tap } from 'rxjs/operators';
 
 import { SQLCompletionItemProvider } from './cloudwatch-sql/completion/CompletionItemProvider';
+import { AnnotationQueryEditor } from './components/AnnotationQueryEditor';
 import { ThrottlingErrorMessage } from './components/ThrottlingErrorMessage';
 import { CloudWatchLanguageProvider } from './language_provider';
 import memoizedDebounce from './memoizedDebounce';
@@ -98,6 +99,11 @@ export class CloudWatchDatasource
 
   type = 'cloudwatch';
   standardStatistics = ['Average', 'Maximum', 'Minimum', 'Sum', 'SampleCount'];
+
+  // This will support annotation queries for 7.2+
+  annotations = {
+    QueryEditor: AnnotationQueryEditor,
+  };
 
   debouncedAlert: (datasourceName: string, region: string) => void = memoizedDebounce(
     displayAlert,

--- a/public/app/plugins/datasource/cloudwatch/module.tsx
+++ b/public/app/plugins/datasource/cloudwatch/module.tsx
@@ -1,12 +1,12 @@
 import { DataSourcePlugin } from '@grafana/data';
+
 import { ConfigEditor } from './components/ConfigEditor';
-import { CloudWatchDatasource } from './datasource';
-import { CloudWatchAnnotationsQueryCtrl } from './annotations_query_ctrl';
-import { CloudWatchJsonData, CloudWatchQuery } from './types';
-import { CloudWatchLogsQueryEditor } from './components/LogsQueryEditor';
-import { PanelQueryEditor } from './components/PanelQueryEditor';
-import { MetaInspector } from './components/MetaInspector';
 import LogsCheatSheet from './components/LogsCheatSheet';
+import { CloudWatchLogsQueryEditor } from './components/LogsQueryEditor';
+import { MetaInspector } from './components/MetaInspector';
+import { PanelQueryEditor } from './components/PanelQueryEditor';
+import { CloudWatchDatasource } from './datasource';
+import { CloudWatchJsonData, CloudWatchQuery } from './types';
 
 export const plugin = new DataSourcePlugin<CloudWatchDatasource, CloudWatchQuery, CloudWatchJsonData>(
   CloudWatchDatasource
@@ -16,5 +16,4 @@ export const plugin = new DataSourcePlugin<CloudWatchDatasource, CloudWatchQuery
   .setQueryEditor(PanelQueryEditor)
   .setMetadataInspector(MetaInspector)
   .setExploreMetricsQueryField(PanelQueryEditor)
-  .setExploreLogsQueryField(CloudWatchLogsQueryEditor)
-  .setAnnotationQueryCtrl(CloudWatchAnnotationsQueryCtrl);
+  .setExploreLogsQueryField(CloudWatchLogsQueryEditor);

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -96,7 +96,7 @@ export interface CloudWatchLogsQuery extends DataQuery {
   statsGroups?: string[];
 }
 
-export type CloudWatchQuery = CloudWatchMetricsQuery | CloudWatchLogsQuery | CloudWatchAnnotationQuery;
+export type CloudWatchQuery = CloudWatchMetricsQuery | CloudWatchLogsQuery;
 
 export const isCloudWatchLogsQuery = (cloudwatchQuery: CloudWatchQuery): cloudwatchQuery is CloudWatchLogsQuery =>
   (cloudwatchQuery as CloudWatchLogsQuery).queryMode === 'Logs';

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -1,15 +1,15 @@
+import { AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData } from '@grafana/aws-sdk';
 import { DataQuery, DataSourceRef, SelectableValue } from '@grafana/data';
-import { AwsAuthDataSourceSecureJsonData, AwsAuthDataSourceJsonData } from '@grafana/aws-sdk';
-
-export interface Dimensions {
-  [key: string]: string | string[];
-}
 
 import {
   QueryEditorArrayExpression,
   QueryEditorFunctionExpression,
   QueryEditorPropertyExpression,
 } from './expressions';
+
+export interface Dimensions {
+  [key: string]: string | string[];
+}
 
 export type CloudWatchQueryMode = 'Metrics' | 'Logs';
 
@@ -96,7 +96,14 @@ export interface CloudWatchLogsQuery extends DataQuery {
   statsGroups?: string[];
 }
 
-export type CloudWatchQuery = CloudWatchMetricsQuery | CloudWatchLogsQuery;
+export interface CloudWatchQuery extends <CloudWatchMetricsQuery | CloudWatchLogsQuery> {
+  enable?: boolean;
+  name?: string;
+  iconColor?: string;
+  prefixMatching?: boolean;
+  actionPrefix?: string;
+  alarmNamePrefix?: string;
+}
 
 export const isCloudWatchLogsQuery = (cloudwatchQuery: CloudWatchQuery): cloudwatchQuery is CloudWatchLogsQuery =>
   (cloudwatchQuery as CloudWatchLogsQuery).queryMode === 'Logs';

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -1,11 +1,7 @@
 import { AwsAuthDataSourceJsonData, AwsAuthDataSourceSecureJsonData } from '@grafana/aws-sdk';
 import { DataQuery, DataSourceRef, SelectableValue } from '@grafana/data';
 
-import {
-  QueryEditorArrayExpression,
-  QueryEditorFunctionExpression,
-  QueryEditorPropertyExpression,
-} from './expressions';
+import { QueryEditorArrayExpression, QueryEditorFunctionExpression, QueryEditorPropertyExpression } from './expressions';
 
 export interface Dimensions {
   [key: string]: string | string[];
@@ -96,14 +92,7 @@ export interface CloudWatchLogsQuery extends DataQuery {
   statsGroups?: string[];
 }
 
-export interface CloudWatchQuery extends <CloudWatchMetricsQuery | CloudWatchLogsQuery> {
-  enable?: boolean;
-  name?: string;
-  iconColor?: string;
-  prefixMatching?: boolean;
-  actionPrefix?: string;
-  alarmNamePrefix?: string;
-}
+export type CloudWatchQuery = CloudWatchMetricsQuery | CloudWatchLogsQuery | CloudWatchAnnotationQuery;
 
 export const isCloudWatchLogsQuery = (cloudwatchQuery: CloudWatchQuery): cloudwatchQuery is CloudWatchLogsQuery =>
   (cloudwatchQuery as CloudWatchLogsQuery).queryMode === 'Logs';

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -96,7 +96,7 @@ export interface CloudWatchLogsQuery extends DataQuery {
   statsGroups?: string[];
 }
 
-export type CloudWatchQuery = CloudWatchMetricsQuery | CloudWatchLogsQuery;
+export type CloudWatchQuery = CloudWatchMetricsQuery | CloudWatchLogsQuery | CloudWatchAnnotationQuery;
 
 export const isCloudWatchLogsQuery = (cloudwatchQuery: CloudWatchQuery): cloudwatchQuery is CloudWatchLogsQuery =>
   (cloudwatchQuery as CloudWatchLogsQuery).queryMode === 'Logs';


### PR DESCRIPTION
## What this PR does / why we need it

The [annotation editor](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx) in the CloudWatch plugin is written in react. However, when it was initially built there was only API support for registering annotation editors written in angular. For that reason, we currently register an [angular controller](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/cloudwatch/annotations_query_ctrl.ts) which in turn is just a wrapper around the react component.

This PR :
* Uses the new API (registering react annotation editors in the datasource file) for registering the annotation editor in the CloudWatch datasource
* Removes what's left of angular

### Screenshots

// TODO

## Which issue(s) this PR fixes

Fixes #47203 

## Progress following mob sessions 07/04/22

* Removed `.setAnnotationQueryCtrl` from `module.ts`
* Added `annotation` object in`datasource.ts` with a QueryEditor that's using the existing `AnnotationQueryEditor`
* Modified `AnnotationQueryEditor.tsx` prop `query` type  -> ugly but done in other plugins, we cast the query (`CloudWatchQuery`) as `CloudWatchAnnotationQuery` to avoid ts complaining

### Next steps:
