### PR TITLE
Annotation FGAC checks for comments

### DIFF
--- a/devenv/bulk-dashboards/bulk-dashboards.yaml
+++ b/devenv/bulk-dashboards/bulk-dashboards.yaml
@@ -6,9 +6,3 @@ providers:
    type: file
    options:
      path: devenv/bulk-dashboards
- - name: 'Bulk dashboards 2'
-   folder: 'Bulk dashboards 2'
-   type: file
-   options:
-     path: devenv/dev-dashboards/panel-barchart
-

--- a/devenv/bulk-dashboards/bulk-dashboards.yaml
+++ b/devenv/bulk-dashboards/bulk-dashboards.yaml
@@ -6,3 +6,4 @@ providers:
    type: file
    options:
      path: devenv/bulk-dashboards
+

--- a/devenv/bulk-dashboards/bulk-dashboards.yaml
+++ b/devenv/bulk-dashboards/bulk-dashboards.yaml
@@ -6,4 +6,9 @@ providers:
    type: file
    options:
      path: devenv/bulk-dashboards
+ - name: 'Bulk dashboards 2'
+   folder: 'Bulk dashboards 2'
+   type: file
+   options:
+     path: devenv/dev-dashboards/panel-barchart
 

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -96,7 +96,7 @@ func newTestLive(t *testing.T, store *sqlstore.SQLStore) *live.GrafanaLive {
 		nil,
 		&usagestats.UsageStatsMock{T: t},
 		nil,
-		features, nil)
+		features, nil, accesscontrolmock.New())
 	require.NoError(t, err)
 	return gLive
 }

--- a/pkg/services/comments/commentmodel/permissions.go
+++ b/pkg/services/comments/commentmodel/permissions.go
@@ -4,21 +4,22 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/grafana/grafana/pkg/services/sqlstore"
-
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/guardian"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 )
 
 type PermissionChecker struct {
-	sqlStore *sqlstore.SQLStore
-	features featuremgmt.FeatureToggles
+	sqlStore      *sqlstore.SQLStore
+	features      featuremgmt.FeatureToggles
+	accessControl accesscontrol.AccessControl
 }
 
-func NewPermissionChecker(sqlStore *sqlstore.SQLStore, features featuremgmt.FeatureToggles) *PermissionChecker {
-	return &PermissionChecker{sqlStore: sqlStore, features: features}
+func NewPermissionChecker(sqlStore *sqlstore.SQLStore, features featuremgmt.FeatureToggles, accessControl accesscontrol.AccessControl) *PermissionChecker {
+	return &PermissionChecker{sqlStore: sqlStore, features: features, accessControl: accessControl}
 }
 
 func (c *PermissionChecker) getDashboardByUid(ctx context.Context, orgID int64, uid string) (*models.Dashboard, error) {
@@ -103,6 +104,12 @@ func (c *PermissionChecker) CheckWritePermissions(ctx context.Context, orgId int
 	case ObjectTypeAnnotation:
 		if !c.features.IsEnabled(featuremgmt.FlagAnnotationComments) {
 			return false, nil
+		}
+		if c.features.IsEnabled(featuremgmt.FlagAccesscontrol) {
+			evaluator := accesscontrol.EvalPermission(accesscontrol.ActionAnnotationsWrite, accesscontrol.ScopeAnnotationsTypeDashboard)
+			if canEdit, err := c.accessControl.Evaluate(ctx, signedInUser, evaluator); err != nil || !canEdit {
+				return canEdit, err
+			}
 		}
 		repo := annotations.GetRepository()
 		annotationID, err := strconv.ParseInt(objectID, 10, 64)

--- a/pkg/services/comments/service.go
+++ b/pkg/services/comments/service.go
@@ -3,6 +3,7 @@ package comments
 import (
 	"context"
 
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/comments/commentmodel"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/live"
@@ -18,7 +19,7 @@ type Service struct {
 	permissions *commentmodel.PermissionChecker
 }
 
-func ProvideService(cfg *setting.Cfg, store *sqlstore.SQLStore, live *live.GrafanaLive, features featuremgmt.FeatureToggles) *Service {
+func ProvideService(cfg *setting.Cfg, store *sqlstore.SQLStore, live *live.GrafanaLive, features featuremgmt.FeatureToggles, accessControl accesscontrol.AccessControl) *Service {
 	s := &Service{
 		cfg:      cfg,
 		live:     live,
@@ -26,7 +27,7 @@ func ProvideService(cfg *setting.Cfg, store *sqlstore.SQLStore, live *live.Grafa
 		storage: &sqlStorage{
 			sql: store,
 		},
-		permissions: commentmodel.NewPermissionChecker(store, features),
+		permissions: commentmodel.NewPermissionChecker(store, features, accessControl),
 	}
 	return s
 }

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -24,6 +24,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/plugincontext"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/comments/commentmodel"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -70,7 +71,7 @@ func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, r
 	pluginStore plugins.Store, cacheService *localcache.CacheService,
 	dataSourceCache datasources.CacheService, sqlStore *sqlstore.SQLStore, secretsService secrets.Service,
 	usageStatsService usagestats.Service, queryDataService *query.Service, toggles featuremgmt.FeatureToggles,
-	bus bus.Bus) (*GrafanaLive, error) {
+	bus bus.Bus, accessControl accesscontrol.AccessControl) (*GrafanaLive, error) {
 	g := &GrafanaLive{
 		Cfg:                   cfg,
 		Features:              toggles,
@@ -242,7 +243,7 @@ func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, r
 	g.GrafanaScope.Dashboards = dash
 	g.GrafanaScope.Features["dashboard"] = dash
 	g.GrafanaScope.Features["broadcast"] = features.NewBroadcastRunner(g.storage)
-	g.GrafanaScope.Features["comment"] = features.NewCommentHandler(commentmodel.NewPermissionChecker(g.SQLStore, g.Features))
+	g.GrafanaScope.Features["comment"] = features.NewCommentHandler(commentmodel.NewPermissionChecker(g.SQLStore, g.Features, accessControl))
 
 	g.surveyCaller = survey.NewCaller(managedStreamRunner, node)
 	err = g.surveyCaller.SetupHandlers()


### PR DESCRIPTION
**What this PR does / why we need it**:
We've added fine-grained access control (FGAC) checks for annotations, and from what I can see the comment feature endpoints currently allow editing annotations without those. So I've added the appropriate FGAC check. Note that for annotation reads no additional check is necessary, as only the annotations that the user is allowed to read will be returned by  annotation SQL store after https://github.com/grafana/grafana/pull/47467 is merged.