### PR TITLE
Azure Monitor: Bug Fix for incorrect variable cascading for template variables

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.test.ts
@@ -5,7 +5,6 @@ import createMockDatasource from './__mocks__/datasource';
 import { invalidSubscriptionError } from './__mocks__/errors';
 import { AzureMonitorQuery, AzureQueryType } from './types';
 import { VariableSupport } from './variables';
-import { it } from 'test/lib/common';
 
 jest.mock('@grafana/runtime', () => ({
   ...(jest.requireActual('@grafana/runtime') as unknown as object),

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.test.ts
@@ -5,6 +5,7 @@ import createMockDatasource from './__mocks__/datasource';
 import { invalidSubscriptionError } from './__mocks__/errors';
 import { AzureMonitorQuery, AzureQueryType } from './types';
 import { VariableSupport } from './variables';
+import { it } from 'test/lib/common';
 
 jest.mock('@grafana/runtime', () => ({
   ...(jest.requireActual('@grafana/runtime') as unknown as object),
@@ -468,6 +469,34 @@ describe('VariableSupport', () => {
       const observables = variableSupport.query(mockRequest);
       observables.subscribe((result: DataQueryResponseData) => {
         expect(result.data).toEqual([]);
+        done();
+      });
+    });
+
+    it('should return None when there is no data', (done) => {
+      const variableSupport = new VariableSupport(
+        createMockDatasource({
+          azureLogAnalyticsDatasource: {
+            defaultSubscriptionId: 'defaultSubscriptionId',
+          },
+          getMetricNames: jest.fn().mockResolvedValueOnce([]),
+        })
+      );
+      const mockRequest = {
+        targets: [
+          {
+            refId: 'A',
+            queryType: AzureQueryType.GrafanaTemplateVariableFn,
+            grafanaTemplateVariableFn: {
+              kind: 'MetricNamesQuery',
+              rawQuery: 'metricNames(resourceGroup, metricDefinition, resourceName, metricNamespace)',
+            },
+          } as AzureMonitorQuery,
+        ],
+      } as DataQueryRequest<AzureMonitorQuery>;
+      const observables = variableSupport.query(mockRequest);
+      observables.subscribe((result: DataQueryResponseData) => {
+        expect(result.data.length).toBe(0);
         done();
       });
     });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.ts
@@ -32,7 +32,7 @@ export class VariableSupport extends CustomVariableSupport<DataSource, AzureMoni
         try {
           const templateVariablesResults = await this.callGrafanaTemplateVariableFn(queryObj.grafanaTemplateVariableFn);
           return {
-            data: (templateVariablesResults && templateVariablesResults.length > 0) ? [toDataFrame(templateVariablesResults)] : [],
+            data: templateVariablesResults?.length ? [toDataFrame(templateVariablesResults)] : [],
           };
         } catch (err) {
           return { data: [], error: { message: messageFromError(err) } };

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.ts
@@ -32,7 +32,7 @@ export class VariableSupport extends CustomVariableSupport<DataSource, AzureMoni
         try {
           const templateVariablesResults = await this.callGrafanaTemplateVariableFn(queryObj.grafanaTemplateVariableFn);
           return {
-            data: templateVariablesResults ? [toDataFrame(templateVariablesResults)] : [],
+            data: (templateVariablesResults && templateVariablesResults.length > 0) ? [toDataFrame(templateVariablesResults)] : [],
           };
         } catch (err) {
           return { data: [], error: { message: messageFromError(err) } };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: Adds a minor fix so that variables cascade properly: 

![variableProperlyCascading](https://user-images.githubusercontent.com/20448042/162333937-75de32f8-7b91-48be-a34c-a1672bfc9b95.gif)

**Which issue(s) this PR fixes**: Right now, when cascading variables, it was failing to update to the value `None` when going from a combination that produced results to one that did not have any results: 
![cascadingVariablesNotUpdatingh](https://user-images.githubusercontent.com/20448042/162333759-769add89-05ea-435d-a022-8973b5adedad.gif)


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #47477 

**Special notes for your reviewer**:

