### PR TITLE
Fetch: Return text content when JSON parsing fails

### DIFF
--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -109,7 +109,7 @@ export async function parseResponseBody<T>(
           return await response.json();
         } catch (err) {
           console.warn(`${response.url} returned an invalid JSON -`, err);
-          return {} as unknown as T;
+          return response.text() as any;
         }
 
       case 'text':


### PR DESCRIPTION
Return text content instead of {} when JSON parsing fails. 