### PR TITLE
Unified Alerting: Add additional delay to silences in test.

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -346,10 +346,6 @@ func TestPutAlert(t *testing.T) {
 // implement a custom maintenance function for silences, because we snapshot
 // our data differently, so we test that functionality.
 func TestSilenceCleanup(t *testing.T) {
-	// TODO: This test intermittently fails. Un-skip me!
-	// https://github.com/grafana/grafana/issues/47470
-	t.Skip("intermittent test")
-
 	require := require.New(t)
 
 	oldRetention := retentionNotificationsAndSilences
@@ -390,10 +386,10 @@ func TestSilenceCleanup(t *testing.T) {
 		makeSilence("", "tests", dt(now.Add(5*time.Hour)), dt(now.Add(6*time.Hour)), matchers),
 		// Active now
 		makeSilence("", "tests", dt(now.Add(-5*time.Hour)), dt(now.Add(6*time.Hour)), matchers),
-		// Expiring soon
-		makeSilence("", "tests", dt(now.Add(-5*time.Hour)), dt(now.Add(2*time.Second)), matchers),
+		// Expiring soon.
+		makeSilence("", "tests", dt(now.Add(-5*time.Hour)), dt(now.Add(5*time.Second)), matchers),
 		// Expiring *very* soon
-		makeSilence("", "tests", dt(now.Add(-5*time.Hour)), dt(now.Add(20*time.Millisecond)), matchers),
+		makeSilence("", "tests", dt(now.Add(-5*time.Hour)), dt(now.Add(2*time.Second)), matchers),
 	}
 
 	for _, s := range silences {
@@ -407,12 +403,12 @@ func TestSilenceCleanup(t *testing.T) {
 		found, err := am.ListSilences(nil)
 		require.NoError(err)
 		return len(found) == 3
-	}, 1500*time.Millisecond, 150*time.Millisecond)
+	}, 3*time.Second, 150*time.Millisecond)
 
 	// Wait again for another silence to expire.
 	require.Eventually(func() bool {
 		found, err := am.ListSilences(nil)
 		require.NoError(err)
 		return len(found) == 2
-	}, 2*time.Second, 150*time.Millisecond)
+	}, 6*time.Second, 150*time.Millisecond)
 }


### PR DESCRIPTION
TestSilenceCleanup was flaky because of its use of real wall
time. In CI environments with slow execution, delays could cause the
test to fail. This change mitigates the problem by increasing the end time of
silences in the test.

After Prometheus merges this PR: https://github.com/prometheus/alertmanager/pull/2867
we can make the test fully deterministic by using a fake clock.

Fixes #4740
