### PR TITLE
grafana-data: removed DataQueryRequest.reverse

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -481,7 +481,6 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   intervalMs: number;
   maxDataPoints?: number;
   range: TimeRange;
-  reverse?: boolean;
   scopedVars: ScopedVars;
   targets: TQuery[];
   timezone: string;

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -310,8 +310,7 @@ export class LokiDatasource
           responseListLength,
           maxDataPoints,
           this.instanceSettings.jsonData,
-          (options as DataQueryRequest<LokiQuery>).scopedVars,
-          (options as DataQueryRequest<LokiQuery>).reverse
+          (options as DataQueryRequest<LokiQuery>).scopedVars
         )
       )
     );

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -517,13 +517,12 @@ export function processRangeQueryResponse(
   responseListLength: number,
   limit: number,
   config: LokiOptions,
-  scopedVars: ScopedVars,
-  reverse = false
+  scopedVars: ScopedVars
 ) {
   switch (response.data.resultType) {
     case LokiResultType.Stream:
       return of({
-        data: lokiStreamsToDataFrames(response as LokiStreamResponse, target, limit, config, reverse),
+        data: lokiStreamsToDataFrames(response as LokiStreamResponse, target, limit, config),
         key: `${target.refId}_log`,
       });
 


### PR DESCRIPTION
this attribute appears to be unused:
- i see no place which sets this attribute, so it is always falsy
- the only place where the value is consumed is in the loki-datasource, but because it is always falsy, i can just replace it with `false` in the loki datasource, and remove the unused code