### PR TITLE
Build: Fix failing recompile of Grafana packages

### DIFF
--- a/packages/grafana-data/tsconfig.json
+++ b/packages/grafana-data/tsconfig.json
@@ -6,7 +6,6 @@
     "paths": {
       "@grafana/data": ["."]
     },
-    "incremental": true,
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "exclude": ["dist", "node_modules"],

--- a/packages/grafana-data/tsconfig.json
+++ b/packages/grafana-data/tsconfig.json
@@ -5,8 +5,7 @@
     "rootDirs": ["."],
     "paths": {
       "@grafana/data": ["."]
-    },
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+    }
   },
   "exclude": ["dist", "node_modules"],
   "extends": "@grafana/tsconfig",

--- a/packages/grafana-e2e-selectors/tsconfig.json
+++ b/packages/grafana-e2e-selectors/tsconfig.json
@@ -3,7 +3,6 @@
     "declarationDir": "dist",
     "outDir": "compiled",
     "rootDirs": ["."],
-    "incremental": true,
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "exclude": ["dist", "node_modules"],

--- a/packages/grafana-e2e-selectors/tsconfig.json
+++ b/packages/grafana-e2e-selectors/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "declarationDir": "dist",
     "outDir": "compiled",
-    "rootDirs": ["."],
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+    "rootDirs": ["."]
   },
   "exclude": ["dist", "node_modules"],
   "extends": "@grafana/tsconfig",

--- a/packages/grafana-e2e/tsconfig.json
+++ b/packages/grafana-e2e/tsconfig.json
@@ -3,8 +3,7 @@
     "declarationDir": "dist",
     "outDir": "compiled",
     "rootDirs": ["."],
-    "types": ["cypress"],
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+    "types": ["cypress"]
   },
   "exclude": ["dist", "node_modules"],
   "extends": "@grafana/tsconfig",

--- a/packages/grafana-e2e/tsconfig.json
+++ b/packages/grafana-e2e/tsconfig.json
@@ -4,7 +4,6 @@
     "outDir": "compiled",
     "rootDirs": ["."],
     "types": ["cypress"],
-    "incremental": true,
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "exclude": ["dist", "node_modules"],

--- a/packages/grafana-runtime/tsconfig.json
+++ b/packages/grafana-runtime/tsconfig.json
@@ -4,7 +4,6 @@
     "declarationDir": "dist",
     "outDir": "compiled",
     "rootDirs": ["."],
-    "incremental": true,
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "exclude": ["dist", "node_modules"],

--- a/packages/grafana-runtime/tsconfig.json
+++ b/packages/grafana-runtime/tsconfig.json
@@ -3,8 +3,7 @@
     "baseUrl": ".",
     "declarationDir": "dist",
     "outDir": "compiled",
-    "rootDirs": ["."],
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+    "rootDirs": ["."]
   },
   "exclude": ["dist", "node_modules"],
   "extends": "@grafana/tsconfig",

--- a/packages/grafana-schema/tsconfig.json
+++ b/packages/grafana-schema/tsconfig.json
@@ -3,7 +3,6 @@
     "declarationDir": "dist",
     "outDir": "compiled",
     "rootDirs": ["."],
-    "incremental": true,
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "exclude": ["dist", "node_modules"],

--- a/packages/grafana-schema/tsconfig.json
+++ b/packages/grafana-schema/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "declarationDir": "dist",
     "outDir": "compiled",
-    "rootDirs": ["."],
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+    "rootDirs": ["."]
   },
   "exclude": ["dist", "node_modules"],
   "extends": "@grafana/tsconfig",

--- a/packages/grafana-ui/tsconfig.json
+++ b/packages/grafana-ui/tsconfig.json
@@ -4,7 +4,6 @@
     "declarationDir": "dist",
     "outDir": "compiled",
     "rootDirs": [".", "stories"],
-    "incremental": true,
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "exclude": ["dist", "node_modules"],

--- a/packages/grafana-ui/tsconfig.json
+++ b/packages/grafana-ui/tsconfig.json
@@ -3,8 +3,7 @@
     "baseUrl": "./",
     "declarationDir": "dist",
     "outDir": "compiled",
-    "rootDirs": [".", "stories"],
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
+    "rootDirs": [".", "stories"]
   },
   "exclude": ["dist", "node_modules"],
   "extends": "@grafana/tsconfig",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR reverts the addition of `incremental: true` from the `packages/**/tsconfig.json` files as it prevents a recompile of the packages to work. The workaround proposed [here](https://github.com/grafana/grafana/pull/46288#discussion_r820644431) highlights that it's gonna be tricky right now to benefit from this caching so removing to keep things simple.
