### PR TITLE
BackendSrv: Throw an error when fetching an invalid JSON

### DIFF
--- a/public/app/core/utils/fetch.test.ts
+++ b/public/app/core/utils/fetch.test.ts
@@ -135,7 +135,12 @@ describe('parseCredentials', () => {
 });
 
 describe('parseResponseBody', () => {
-  const rsp = {} as unknown as Response;
+  let rsp: Response;
+
+  beforeEach(() => {
+    rsp = new Response();
+  });
+
   it('parses json', async () => {
     const value = { hello: 'world' };
     const body = await parseResponseBody(
@@ -146,6 +151,24 @@ describe('parseResponseBody', () => {
       'json'
     );
     expect(body).toEqual(value);
+  });
+
+  it('returns an empty object {} when the response is empty but is declared as JSON type', async () => {
+    rsp.headers.set('Content-Length', '0');
+    jest.spyOn(console, 'warn').mockImplementation();
+
+    const json = jest.fn();
+    const body = await parseResponseBody(
+      {
+        ...rsp,
+        json,
+      },
+      'json'
+    );
+
+    expect(body).toEqual({});
+    expect(json).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledTimes(1);
   });
 
   it('parses text', async () => {

--- a/public/app/core/utils/fetch.ts
+++ b/public/app/core/utils/fetch.ts
@@ -106,12 +106,14 @@ export async function parseResponseBody<T>(
         return response.blob() as any;
 
       case 'json':
-        try {
-          return await response.json();
-        } catch (err) {
-          console.warn(`${response.url} returned an invalid JSON -`, err);
+        // An empty string is not a valid JSON.
+        // Sometimes (unfortunately) our APIs declare their Content-Type as JSON, however they return an empty body.
+        if (response.headers.get('Content-Length') === '0') {
+          console.warn(`${response.url} returned an invalid JSON`);
           return {} as unknown as T;
         }
+
+        return await response.json();
 
       case 'text':
         return response.text() as any;


### PR DESCRIPTION
**Connecting PRs:** https://github.com/grafana/grafana/pull/45598, https://github.com/grafana/grafana/pull/45188
**Slack thread:**  https://raintank-corp.slack.com/archives/C01C4K8DETW/p1649323075247569

### What changed?
**Fetching an incorrect JSON response using `backendSrv` will throw an error from now on.** 
Previously it was masking JSON errors, and returned an empty object `{}`. 

### What is the problem?

#### Problem 1.
After our change in https://github.com/grafana/grafana/pull/45598 fetching an invalid json using `backend_srv` didn't throw an error, but was only logging a warning and returning an empty object `{}`. This was understandably causing issues in places where an error was expected and which had a logic in place to handle it. **This PR is trying to give a fix for that by not swallowing the JSON parsing error, except if the response was empty.**

#### Problem 2.
There are API endpoints which return some text in the response body, but the text is not valid JSON.
In certain cases instead (or besides) throwing an error we would like to be able to read the response as text (so we can do something with it), even if the json parsing errored out. Unfortunately this is hard, as the response stream can only be read out once. A workaround can be cloning the original response stream, but that doubles the memory overhead as we need to retain the original stream in memory:
```javascript
response.clone().body.asJSON().catch(function() {
    // parsing as JSON failed, let's get the text
    response.body.asText().then(function(text) {
      // ...
});
```
As this has clear downsides, I think it is a decision we have to make together if we are ok with taking this compromise.

---

The proper long-term solution would be I think to update the corresponding APIs to return a correct response type, e.g. `Content-Type: text`.

@aocenas 
@leeoniya 
@ryantxu 

# Release notice breaking change

We have changed the internals of `backendSrv.fetch()` to throw an error when the response is an incorrect JSON. 
```javascript
// PREVIOUSLY: this was returning with an empty object {} - in case the response is an invalid JSON
return await getBackendSrv().post(`${API_ROOT}/${id}/install`);

// AFTER THIS CHANGE: the following will throw an error - in case the response is an invalid JSON
return await getBackendSrv().post(`${API_ROOT}/${id}/install`);
```

**When is the response handled as JSON?**
- If the response has the `"Content-Type: application/json"` header, OR
- If the backendSrv options ([`BackendSrvRequest`](https://github.com/grafana/grafana/blob/e237ff20a996c7313632b2e28f38032012f0e340/packages/grafana-runtime/src/services/backendSrv.ts#L8)) specify the response as JSON: `{ responseType: 'json' }`

**How does it work after this change?**
- In case it is recognised as a JSON response and the response is empty, it returns an empty object `{}`
- In case it is recognised as a JSON response and it has formatting errors, it throws an error

**How to migrate?**
Make sure to handle possible errors on the callsite where using `backendSrv.fetch()` (or any other `backendSrv` methods). 