### PR TITLE
loki: remove unused reverse-attribute

### DIFF
--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -35,7 +35,6 @@ export interface LokiQuery extends DataQuery {
   expr: string;
   query?: string;
   format?: string;
-  reverse?: boolean;
   legendFormat?: string;
   valueWithRefId?: boolean;
   maxLines?: number;


### PR DESCRIPTION
the `LokiQuery.reverse` attribute is not used, so this PR removes it.