### PR TITLE
Query history: Save user preferences in database

### DIFF
--- a/pkg/api/dtos/prefs.go
+++ b/pkg/api/dtos/prefs.go
@@ -3,11 +3,12 @@ package dtos
 import "github.com/grafana/grafana/pkg/models"
 
 type Prefs struct {
-	Theme           string                  `json:"theme"`
-	HomeDashboardID int64                   `json:"homeDashboardId"`
-	Timezone        string                  `json:"timezone"`
-	WeekStart       string                  `json:"weekStart"`
-	Navbar          models.NavbarPreference `json:"navbar,omitempty"`
+	Theme           string                        `json:"theme"`
+	HomeDashboardID int64                         `json:"homeDashboardId"`
+	Timezone        string                        `json:"timezone"`
+	WeekStart       string                        `json:"weekStart"`
+	Navbar          models.NavbarPreference       `json:"navbar,omitempty"`
+	QueryHistory    models.QueryHistoryPreference `json:"queryHistory,omitempty"`
 }
 
 // swagger:model
@@ -18,9 +19,10 @@ type UpdatePrefsCmd struct {
 	// Default:0
 	HomeDashboardID int64 `json:"homeDashboardId"`
 	// Enum: utc,browser
-	Timezone  string                   `json:"timezone"`
-	WeekStart string                   `json:"weekStart"`
-	Navbar    *models.NavbarPreference `json:"navbar,omitempty"`
+	Timezone     string                         `json:"timezone"`
+	WeekStart    string                         `json:"weekStart"`
+	Navbar       *models.NavbarPreference       `json:"navbar,omitempty"`
+	QueryHistory *models.QueryHistoryPreference `json:"queryHistory,omitempty"`
 }
 
 // swagger:model
@@ -31,7 +33,8 @@ type PatchPrefsCmd struct {
 	// Default:0
 	HomeDashboardID *int64 `json:"homeDashboardId,omitempty"`
 	// Enum: utc,browser
-	Timezone  *string                  `json:"timezone,omitempty"`
-	WeekStart *string                  `json:"weekStart,omitempty"`
-	Navbar    *models.NavbarPreference `json:"navbar,omitempty"`
+	Timezone     *string                        `json:"timezone,omitempty"`
+	WeekStart    *string                        `json:"weekStart,omitempty"`
+	Navbar       *models.NavbarPreference       `json:"navbar,omitempty"`
+	QueryHistory *models.QueryHistoryPreference `json:"queryHistory,omitempty"`
 }

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -53,6 +53,7 @@ func (hs *HTTPServer) getPreferencesFor(ctx context.Context, orgID, userID, team
 
 	if prefsQuery.Result.JsonData != nil {
 		dto.Navbar = prefsQuery.Result.JsonData.Navbar
+		dto.QueryHistory = prefsQuery.Result.JsonData.QueryHistory
 	}
 
 	return response.JSON(200, &dto)
@@ -110,6 +111,7 @@ func (hs *HTTPServer) patchPreferencesFor(ctx context.Context, orgID, userID, te
 		WeekStart:       dtoCmd.WeekStart,
 		HomeDashboardId: dtoCmd.HomeDashboardID,
 		Navbar:          dtoCmd.Navbar,
+		QueryHistory:    dtoCmd.QueryHistory,
 	}
 
 	if err := hs.SQLStore.PatchPreferences(ctx, &patchCmd); err != nil {

--- a/pkg/models/preferences.go
+++ b/pkg/models/preferences.go
@@ -49,8 +49,13 @@ type NavbarPreference struct {
 	SavedItems []NavLink `json:"savedItems"`
 }
 
+type QueryHistoryPreference struct {
+	HomeTab string `json:"homeTab"`
+}
+
 type PreferencesJsonData struct {
-	Navbar NavbarPreference `json:"navbar"`
+	Navbar       NavbarPreference       `json:"navbar"`
+	QueryHistory QueryHistoryPreference `json:"queryHistory"`
 }
 
 // ---------------------
@@ -78,11 +83,12 @@ type SavePreferencesCommand struct {
 	OrgId  int64
 	TeamId int64
 
-	HomeDashboardId int64             `json:"homeDashboardId,omitempty"`
-	Timezone        string            `json:"timezone,omitempty"`
-	WeekStart       string            `json:"weekStart,omitempty"`
-	Theme           string            `json:"theme,omitempty"`
-	Navbar          *NavbarPreference `json:"navbar,omitempty"`
+	HomeDashboardId int64                   `json:"homeDashboardId,omitempty"`
+	Timezone        string                  `json:"timezone,omitempty"`
+	WeekStart       string                  `json:"weekStart,omitempty"`
+	Theme           string                  `json:"theme,omitempty"`
+	Navbar          *NavbarPreference       `json:"navbar,omitempty"`
+	QueryHistory    *QueryHistoryPreference `json:"queryHistory,omitempty"`
 }
 
 type PatchPreferencesCommand struct {
@@ -90,9 +96,10 @@ type PatchPreferencesCommand struct {
 	OrgId  int64
 	TeamId int64
 
-	HomeDashboardId *int64            `json:"homeDashboardId,omitempty"`
-	Timezone        *string           `json:"timezone,omitempty"`
-	WeekStart       *string           `json:"weekStart,omitempty"`
-	Theme           *string           `json:"theme,omitempty"`
-	Navbar          *NavbarPreference `json:"navbar,omitempty"`
+	HomeDashboardId *int64                  `json:"homeDashboardId,omitempty"`
+	Timezone        *string                 `json:"timezone,omitempty"`
+	WeekStart       *string                 `json:"weekStart,omitempty"`
+	Theme           *string                 `json:"theme,omitempty"`
+	Navbar          *NavbarPreference       `json:"navbar,omitempty"`
+	QueryHistory    *QueryHistoryPreference `json:"queryHistory,omitempty"`
 }

--- a/pkg/services/sqlstore/preferences.go
+++ b/pkg/services/sqlstore/preferences.go
@@ -117,6 +117,11 @@ func (ss *SQLStore) SavePreferences(ctx context.Context, cmd *models.SavePrefere
 			if cmd.Navbar != nil {
 				prefs.JsonData.Navbar = *cmd.Navbar
 			}
+
+			if cmd.QueryHistory != nil {
+				prefs.JsonData.QueryHistory = *cmd.QueryHistory
+			}
+
 			_, err = sess.Insert(&prefs)
 			return err
 		}
@@ -129,6 +134,16 @@ func (ss *SQLStore) SavePreferences(ctx context.Context, cmd *models.SavePrefere
 				prefs.JsonData.Navbar.SavedItems = cmd.Navbar.SavedItems
 			}
 		}
+
+		if cmd.QueryHistory != nil {
+			if prefs.JsonData == nil {
+				prefs.JsonData = &models.PreferencesJsonData{}
+			}
+			if cmd.QueryHistory.HomeTab != "" {
+				prefs.JsonData.QueryHistory.HomeTab = cmd.QueryHistory.HomeTab
+			}
+		}
+
 		prefs.HomeDashboardId = cmd.HomeDashboardId
 		prefs.Timezone = cmd.Timezone
 		prefs.WeekStart = cmd.WeekStart
@@ -164,6 +179,15 @@ func (ss *SQLStore) PatchPreferences(ctx context.Context, cmd *models.PatchPrefe
 			}
 			if cmd.Navbar.SavedItems != nil {
 				prefs.JsonData.Navbar.SavedItems = cmd.Navbar.SavedItems
+			}
+		}
+
+		if cmd.QueryHistory != nil {
+			if prefs.JsonData == nil {
+				prefs.JsonData = &models.PreferencesJsonData{}
+			}
+			if cmd.QueryHistory.HomeTab != "" {
+				prefs.JsonData.QueryHistory.HomeTab = cmd.QueryHistory.HomeTab
 			}
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is the first part of moving query history to be stored in database instead of browser's local storage. The design document is [here](https://docs.google.com/document/d/1BdVtoXCxhH0Q6C-O_Z7jKi-u1m5pDoS9_HQKhYu_hEE/edit#)

To make PRs smaller and easier to review, I am splitting it into chunks. Here is the issue with steps: https://github.com/grafana/grafana/issues/44327

This PR adds user's query history preferences to preferences table. Query history preferences are json, so in the future we can store all preferences here. Currently we store `homeTab`.  

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/grafana/issues/44327

**Special notes for your reviewer**:

 In https://github.com/grafana/grafana/blob/main/public/app/features/explore/state/query.ts#L324 add:
 ` import { getBackendSrv } from '@grafana/runtime`
 
```
  //To test changing preferences
    getBackendSrv().patch(`/api/user/preferences`, {
      queryHistory: {
        homeTab: 'query',
      },
    });

   getBackendSrv().get(`/api/user/preferences`)
  // End of test
```
