### PR TITLE
Alerting: don't allow editing rule types for existing rules

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/AlertTypeStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertTypeStep.tsx
@@ -38,27 +38,24 @@ export const AlertTypeStep: FC<Props> = ({ editingExistingRule }) => {
 
   return (
     <RuleEditorSection stepNo={1} title="Rule type">
-      <Field
-        disabled={editingExistingRule}
-        error={errors.type?.message}
-        invalid={!!errors.type?.message}
-        data-testid="alert-type-picker"
-      >
-        <InputControl
-          render={({ field: { onChange } }) => (
-            <RuleTypePicker
-              aria-label="Rule type"
-              selected={getValues('type') ?? RuleFormType.grafana}
-              onChange={onChange}
-            />
-          )}
-          name="type"
-          control={control}
-          rules={{
-            required: { value: true, message: 'Please select alert type' },
-          }}
-        />
-      </Field>
+      {!editingExistingRule && (
+        <Field error={errors.type?.message} invalid={!!errors.type?.message} data-testid="alert-type-picker">
+          <InputControl
+            render={({ field: { onChange } }) => (
+              <RuleTypePicker
+                aria-label="Rule type"
+                selected={getValues('type') ?? RuleFormType.grafana}
+                onChange={onChange}
+              />
+            )}
+            name="type"
+            control={control}
+            rules={{
+              required: { value: true, message: 'Please select alert type' },
+            }}
+          />
+        </Field>
+      )}
 
       <Field
         className={styles.formInput}


### PR DESCRIPTION
**What this PR does / why we need it**:

@peterholmberg discovered a recent regression where we allowed users to edit the rule type for existing rules.

This change effectively hides that option again.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

