### PR TITLE
Alerting: fix collapsable toggle text regression

### DIFF
--- a/public/app/features/alerting/unified/components/CollapseToggle.test.tsx
+++ b/public/app/features/alerting/unified/components/CollapseToggle.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { noop } from 'lodash';
+import React from 'react';
+import { CollapseToggle } from './CollapseToggle';
+
+describe('TestToggle', () => {
+  it('should render text', () => {
+    render(<CollapseToggle isCollapsed={true} text="Hello, world" onToggle={noop} />);
+    expect(screen.getByRole('button')).toHaveTextContent('Hello, world');
+  });
+
+  it('should respect isCollapsed', () => {
+    const { rerender } = render(<CollapseToggle isCollapsed={false} text="Hello, world" onToggle={noop} />);
+    expect(screen.getByRole('button', { expanded: true })).toBeInTheDocument();
+
+    rerender(<CollapseToggle isCollapsed={true} text="Hello, world" onToggle={noop} />);
+    expect(screen.getByRole('button', { expanded: false })).toBeInTheDocument();
+  });
+
+  it('should call onToggle', () => {
+    const onToggle = jest.fn();
+    render(<CollapseToggle isCollapsed={true} text="Hello, world" onToggle={onToggle} />);
+    screen.getByRole('button').click();
+
+    expect(onToggle).toHaveBeenCalledWith(false);
+    // it should also not have any impact on the actual expanded state since the component does not track its own state
+    expect(screen.getByRole('button', { expanded: false })).toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/CollapseToggle.tsx
+++ b/public/app/features/alerting/unified/components/CollapseToggle.tsx
@@ -34,7 +34,9 @@ export const CollapseToggle: FC<Props> = ({
       icon={isCollapsed ? 'angle-right' : 'angle-down'}
       onClick={() => onToggle(!isCollapsed)}
       {...restOfProps}
-    />
+    >
+      {text}
+    </Button>
   );
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A small regression in https://github.com/grafana/grafana/pull/46405 caused the `text` property to no longer show up in a `CollapseToggle`.

This PR re-introduces the prop and will render it properly if passed.

<img width="341" alt="image" src="https://user-images.githubusercontent.com/868844/162445453-54c39091-f053-443b-b887-398b7370eba3.png">


**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

