### PR TITLE
the postgresql driver wants ipv6 hosts not enclosed in square brackets

### DIFF
--- a/pkg/tsdb/postgres/postgres.go
+++ b/pkg/tsdb/postgres/postgres.go
@@ -140,7 +140,7 @@ func (s *Service) generateConnectionString(dsInfo sqleng.DataSourceInfo) (string
 			}
 		} else {
 			if index == v6Index+1 {
-				host = dsInfo.URL[0:index]
+				host = dsInfo.URL[1 : index-1]
 				var err error
 				port, err = strconv.Atoi(dsInfo.URL[index+1:])
 				if err != nil {
@@ -149,7 +149,7 @@ func (s *Service) generateConnectionString(dsInfo sqleng.DataSourceInfo) (string
 
 				logger.Debug("Generating ipv6 connection string with network host/port pair", "host", host, "port", port)
 			} else {
-				host = dsInfo.URL
+				host = dsInfo.URL[1 : len(dsInfo.URL)-1]
 				logger.Debug("Generating ipv6 connection string with network host", "host", host)
 			}
 		}

--- a/pkg/tsdb/postgres/postgres_test.go
+++ b/pkg/tsdb/postgres/postgres_test.go
@@ -74,7 +74,7 @@ func TestGenerateConnectionString(t *testing.T) {
 			password:    "password",
 			database:    "database",
 			tlsSettings: tlsSettings{Mode: "verify-full"},
-			expConnStr:  "user='user' password='password' host='[::1]' dbname='database' sslmode='verify-full'",
+			expConnStr:  "user='user' password='password' host='::1' dbname='database' sslmode='verify-full'",
 		},
 		{
 			desc:        "Ipv6/port host",
@@ -83,7 +83,7 @@ func TestGenerateConnectionString(t *testing.T) {
 			password:    "password",
 			database:    "database",
 			tlsSettings: tlsSettings{Mode: "verify-full"},
-			expConnStr:  "user='user' password='password' host='[::1]' dbname='database' port=1234 sslmode='verify-full'",
+			expConnStr:  "user='user' password='password' host='::1' dbname='database' port=1234 sslmode='verify-full'",
 		},
 		{
 			desc:        "Invalid port",


### PR DESCRIPTION
This is a fixup for #46876 where I erroneously assumed that the "host" parameter would take an ipv6 address in square brackets, however the "host" parameter is passed through [net.JoinHostPort](https://pkg.go.dev/net#JoinHostPort), [here](https://github.com/lib/pq/blob/8446d16b8935fdf2b5c0fe333538ac395e3e1e4b/conn.go#L430).