### PR TITLE
chore: remove golang.org/x/net/context in favor of stdlib's context

### DIFF
--- a/pkg/services/notifications/webhook.go
+++ b/pkg/services/notifications/webhook.go
@@ -11,8 +11,6 @@ import (
 	"net/http"
 	"time"
 
-	"golang.org/x/net/context/ctxhttp"
-
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -52,7 +50,7 @@ func (ns *NotificationService) sendWebRequestSync(ctx context.Context, webhook *
 		return fmt.Errorf("webhook only supports HTTP methods PUT or POST")
 	}
 
-	request, err := http.NewRequest(webhook.HttpMethod, webhook.Url, bytes.NewReader([]byte(webhook.Body)))
+	request, err := http.NewRequestWithContext(ctx, webhook.HttpMethod, webhook.Url, bytes.NewReader([]byte(webhook.Body)))
 	if err != nil {
 		return err
 	}
@@ -72,7 +70,7 @@ func (ns *NotificationService) sendWebRequestSync(ctx context.Context, webhook *
 		request.Header.Set(k, v)
 	}
 
-	resp, err := ctxhttp.Do(ctx, netClient, request)
+	resp, err := netClient.Do(request)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/provisioning/notifiers/alert_notifications.go
+++ b/pkg/services/provisioning/notifiers/alert_notifications.go
@@ -1,11 +1,12 @@
 package notifiers
 
 import (
+	"context"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/encryption"
 	"github.com/grafana/grafana/pkg/services/notifications"
-	"golang.org/x/net/context"
 )
 
 type Manager interface {


### PR DESCRIPTION
This PR removes golang.org context imports under pkg/services/* and replaces them with the stdlib context.

Closes #44178
