### PR TITLE
AzureMonitor: Fix alert query for Azure Monitor metric dimension

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
@@ -117,7 +117,7 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<AzureM
           metricNamespace && metricNamespace !== defaultDropdownValue ? metricNamespace : metricDefinition,
         aggregation: aggregation,
         dimensionFilters,
-        top: top || '10',
+        top,
         alias: item.alias,
       },
     };

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/usePreparedQuery.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/usePreparedQuery.ts
@@ -12,6 +12,9 @@ const prepareQuery = (query: AzureMonitorQuery) => {
   // Note: _.defaults does not apply default values deeply.
   const withDefaults = defaults({}, query, DEFAULT_QUERY);
   const migratedQuery = migrateQuery(withDefaults);
+  if (migratedQuery.azureMonitor && !migratedQuery.azureMonitor.top) {
+    migratedQuery.azureMonitor.top = '10';
+  }
 
   // If we didn't make any changes to the object, then return the original object to keep the
   // identity the same, and not trigger any other useEffects or anything.


### PR DESCRIPTION
**What this PR does / why we need it:**

We have 2 issues report that if user specify metric dimension for Azure Monitor, the alert query will fail. 

**Which issue(s) this PR fixes:**

Fixed: #44918 
Fixed: #41243 

**Special notes for your reviewer:**

The empty `top` field is filled with 10 after being cached. But for alert test, it uses the query in cache directly. So, to fix the issues, I move the fix logic ahead of caching.

