### PR TITLE
Query history: Add migration endpoint

### DIFF
--- a/pkg/services/queryhistory/api.go
+++ b/pkg/services/queryhistory/api.go
@@ -126,10 +126,10 @@ func (s *QueryHistoryService) migrateHandler(c *models.ReqContext) response.Resp
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 
-	queries, err := s.MigrateQueriesToQueryHistory(c.Req.Context(), c.SignedInUser, cmd)
+	err := s.MigrateQueriesToQueryHistory(c.Req.Context(), c.SignedInUser, cmd)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to migrate query history", err)
 	}
 
-	return response.JSON(http.StatusOK, QueryHistoryMigrationResponse{Result: queries})
+	return response.JSON(http.StatusOK, QueryHistoryMigrationResponse{Message: "Query history successfully migrated"})
 }

--- a/pkg/services/queryhistory/api.go
+++ b/pkg/services/queryhistory/api.go
@@ -126,10 +126,10 @@ func (s *QueryHistoryService) migrateHandler(c *models.ReqContext) response.Resp
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 
-	err := s.MigrateQueriesToQueryHistory(c.Req.Context(), c.SignedInUser, cmd)
+	totalCount, starredCount, err := s.MigrateQueriesToQueryHistory(c.Req.Context(), c.SignedInUser, cmd)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to migrate query history", err)
 	}
 
-	return response.JSON(http.StatusOK, QueryHistoryMigrationResponse{Message: "Query history successfully migrated"})
+	return response.JSON(http.StatusOK, QueryHistoryMigrationResponse{Message: "Query history successfully migrated", TotalCount: totalCount, StarredCount: starredCount})
 }

--- a/pkg/services/queryhistory/database.go
+++ b/pkg/services/queryhistory/database.go
@@ -276,10 +276,6 @@ func (s QueryHistoryService) migrateQueries(ctx context.Context, user *models.Si
 				break
 			}
 
-			if query.CreatedAt == 0 {
-				query.CreatedAt = time.Now().Unix()
-			}
-
 			// First add query to query history table
 			queryHistory := QueryHistory{
 				OrgID:         user.OrgId,

--- a/pkg/services/queryhistory/database.go
+++ b/pkg/services/queryhistory/database.go
@@ -276,6 +276,11 @@ func (s QueryHistoryService) migrateQueries(ctx context.Context, user *models.Si
 			if instertError != nil {
 				break
 			}
+
+			if query.CreatedAt == 0 {
+				query.CreatedAt = time.Now().Unix()
+			}
+
 			// First add query to query history table
 			queryHistory := QueryHistory{
 				OrgID:         user.OrgId,

--- a/pkg/services/queryhistory/database.go
+++ b/pkg/services/queryhistory/database.go
@@ -266,8 +266,7 @@ func (s QueryHistoryService) unstarQuery(ctx context.Context, user *models.Signe
 	return dto, nil
 }
 
-func (s QueryHistoryService) migrateQueries(ctx context.Context, user *models.SignedInUser, cmd MigrateQueriesToQueryHistoryCommand) ([]QueryHistoryDTO, error) {
-	var dtos []QueryHistoryDTO
+func (s QueryHistoryService) migrateQueries(ctx context.Context, user *models.SignedInUser, cmd MigrateQueriesToQueryHistoryCommand) error {
 	err := s.SQLStore.WithTransactionalDbSession(ctx, func(session *sqlstore.DBSession) error {
 		var instertError error
 
@@ -317,24 +316,9 @@ func (s QueryHistoryService) migrateQueries(ctx context.Context, user *models.Si
 					break
 				}
 			}
-
-			dto := QueryHistoryDTO{
-				UID:           queryHistory.UID,
-				DatasourceUID: queryHistory.DatasourceUID,
-				CreatedBy:     queryHistory.CreatedBy,
-				CreatedAt:     queryHistory.CreatedAt,
-				Comment:       queryHistory.Comment,
-				Queries:       queryHistory.Queries,
-				Starred:       query.Starred,
-			}
-			dtos = append(dtos, dto)
 		}
 		return instertError
 	})
 
-	if err != nil {
-		return []QueryHistoryDTO{}, err
-	}
-
-	return dtos, nil
+	return err
 }

--- a/pkg/services/queryhistory/database.go
+++ b/pkg/services/queryhistory/database.go
@@ -292,16 +292,29 @@ func (s QueryHistoryService) migrateQueries(ctx context.Context, user *models.Si
 			}
 		}
 
-		_, err := session.InsertMulti(queryHistories)
-		if err != nil {
-			return err
+		batchSize := 50
+		var err error
+		for i := 0; i < len(queryHistories); i += batchSize {
+			j := i + batchSize
+			if j > len(queryHistories) {
+				j = len(queryHistories)
+			}
+			_, err = session.InsertMulti(queryHistories[i:j])
+			if err != nil {
+				return err
+			}
 		}
 
-		_, err = session.InsertMulti(starredQueries)
-		if err != nil {
-			return err
+		for i := 0; i < len(starredQueries); i += batchSize {
+			j := i + batchSize
+			if j > len(starredQueries) {
+				j = len(starredQueries)
+			}
+			_, err = session.InsertMulti(starredQueries[i:j])
+			if err != nil {
+				return err
+			}
 		}
-
 		return err
 	})
 

--- a/pkg/services/queryhistory/database.go
+++ b/pkg/services/queryhistory/database.go
@@ -3,6 +3,7 @@ package queryhistory
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/grafana/grafana/pkg/models"
@@ -266,55 +267,47 @@ func (s QueryHistoryService) unstarQuery(ctx context.Context, user *models.Signe
 	return dto, nil
 }
 
-func (s QueryHistoryService) migrateQueries(ctx context.Context, user *models.SignedInUser, cmd MigrateQueriesToQueryHistoryCommand) error {
+func (s QueryHistoryService) migrateQueries(ctx context.Context, user *models.SignedInUser, cmd MigrateQueriesToQueryHistoryCommand) (int, int, error) {
+	queryHistories := make([]*QueryHistory, 0, len(cmd.Queries))
+	starredQueries := make([]*QueryHistoryStar, 0)
+
 	err := s.SQLStore.WithTransactionalDbSession(ctx, func(session *sqlstore.DBSession) error {
-		var instertError error
-
 		for _, query := range cmd.Queries {
-			// At the beginning of the loop check if there was any error and if so, break and return error
-			if instertError != nil {
-				break
-			}
-
-			// First add query to query history table
-			queryHistory := QueryHistory{
+			uid := util.GenerateShortUID()
+			queryHistories = append(queryHistories, &QueryHistory{
 				OrgID:         user.OrgId,
-				UID:           util.GenerateShortUID(),
+				UID:           uid,
 				Queries:       query.Queries,
 				DatasourceUID: query.DatasourceUID,
 				CreatedBy:     user.UserId,
 				CreatedAt:     query.CreatedAt,
 				Comment:       query.Comment,
-			}
+			})
 
-			_, err := session.Insert(&queryHistory)
-
-			if err != nil {
-				instertError = err
-				break
-			}
-
-			// Check if it should be starred and star it
 			if query.Starred {
-				queryHistoryStar := QueryHistoryStar{
+				starredQueries = append(starredQueries, &QueryHistoryStar{
 					UserID:   user.UserId,
-					QueryUID: queryHistory.UID,
-				}
-
-				_, err = session.Insert(&queryHistoryStar)
-
-				if err != nil {
-					if s.SQLStore.Dialect.IsUniqueConstraintViolation(err) {
-						instertError = ErrQueryAlreadyStarred
-						break
-					}
-					instertError = err
-					break
-				}
+					QueryUID: uid,
+				})
 			}
 		}
-		return instertError
+
+		_, err := session.InsertMulti(queryHistories)
+		if err != nil {
+			return err
+		}
+
+		_, err = session.InsertMulti(starredQueries)
+		if err != nil {
+			return err
+		}
+
+		return err
 	})
 
-	return err
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to migrate query history: %w", err)
+	}
+
+	return len(queryHistories), len(starredQueries), nil
 }

--- a/pkg/services/queryhistory/models.go
+++ b/pkg/services/queryhistory/models.go
@@ -78,3 +78,19 @@ type DeleteQueryFromQueryHistoryResponse struct {
 	ID      int64  `json:"id"`
 	Message string `json:"message"`
 }
+
+type MigrateQueriesToQueryHistoryCommand struct {
+	Queries []QueryToMigrate `json:"queries"`
+}
+
+type QueryToMigrate struct {
+	DatasourceUID string           `json:"datasourceUid"`
+	Queries       *simplejson.Json `json:"queries"`
+	CreatedAt     int64            `json:"createdAt"`
+	Comment       string           `json:"comment"`
+	Starred       bool             `json:"starred"`
+}
+
+type QueryHistoryMigrationResponse struct {
+	Result []QueryHistoryDTO `json:"result"`
+}

--- a/pkg/services/queryhistory/models.go
+++ b/pkg/services/queryhistory/models.go
@@ -92,5 +92,5 @@ type QueryToMigrate struct {
 }
 
 type QueryHistoryMigrationResponse struct {
-	Result []QueryHistoryDTO `json:"result"`
+	Message string `json:"message"`
 }

--- a/pkg/services/queryhistory/models.go
+++ b/pkg/services/queryhistory/models.go
@@ -92,5 +92,7 @@ type QueryToMigrate struct {
 }
 
 type QueryHistoryMigrationResponse struct {
-	Message string `json:"message"`
+	Message      string `json:"message"`
+	TotalCount   int    `json:"totalCount"`
+	StarredCount int    `json:"starredCount"`
 }

--- a/pkg/services/queryhistory/queryhistory.go
+++ b/pkg/services/queryhistory/queryhistory.go
@@ -33,6 +33,7 @@ type Service interface {
 	PatchQueryCommentInQueryHistory(ctx context.Context, user *models.SignedInUser, UID string, cmd PatchQueryCommentInQueryHistoryCommand) (QueryHistoryDTO, error)
 	StarQueryInQueryHistory(ctx context.Context, user *models.SignedInUser, UID string) (QueryHistoryDTO, error)
 	UnstarQueryInQueryHistory(ctx context.Context, user *models.SignedInUser, UID string) (QueryHistoryDTO, error)
+	MigrateQueriesToQueryHistory(ctx context.Context, user *models.SignedInUser, cmd MigrateQueriesToQueryHistoryCommand) ([]QueryHistoryDTO, error)
 }
 
 type QueryHistoryService struct {
@@ -64,4 +65,8 @@ func (s QueryHistoryService) StarQueryInQueryHistory(ctx context.Context, user *
 
 func (s QueryHistoryService) UnstarQueryInQueryHistory(ctx context.Context, user *models.SignedInUser, UID string) (QueryHistoryDTO, error) {
 	return s.unstarQuery(ctx, user, UID)
+}
+
+func (s QueryHistoryService) MigrateQueriesToQueryHistory(ctx context.Context, user *models.SignedInUser, cmd MigrateQueriesToQueryHistoryCommand) ([]QueryHistoryDTO, error) {
+	return s.migrateQueries(ctx, user, cmd)
 }

--- a/pkg/services/queryhistory/queryhistory.go
+++ b/pkg/services/queryhistory/queryhistory.go
@@ -33,7 +33,7 @@ type Service interface {
 	PatchQueryCommentInQueryHistory(ctx context.Context, user *models.SignedInUser, UID string, cmd PatchQueryCommentInQueryHistoryCommand) (QueryHistoryDTO, error)
 	StarQueryInQueryHistory(ctx context.Context, user *models.SignedInUser, UID string) (QueryHistoryDTO, error)
 	UnstarQueryInQueryHistory(ctx context.Context, user *models.SignedInUser, UID string) (QueryHistoryDTO, error)
-	MigrateQueriesToQueryHistory(ctx context.Context, user *models.SignedInUser, cmd MigrateQueriesToQueryHistoryCommand) ([]QueryHistoryDTO, error)
+	MigrateQueriesToQueryHistory(ctx context.Context, user *models.SignedInUser, cmd MigrateQueriesToQueryHistoryCommand) error
 }
 
 type QueryHistoryService struct {
@@ -67,6 +67,6 @@ func (s QueryHistoryService) UnstarQueryInQueryHistory(ctx context.Context, user
 	return s.unstarQuery(ctx, user, UID)
 }
 
-func (s QueryHistoryService) MigrateQueriesToQueryHistory(ctx context.Context, user *models.SignedInUser, cmd MigrateQueriesToQueryHistoryCommand) ([]QueryHistoryDTO, error) {
+func (s QueryHistoryService) MigrateQueriesToQueryHistory(ctx context.Context, user *models.SignedInUser, cmd MigrateQueriesToQueryHistoryCommand) error {
 	return s.migrateQueries(ctx, user, cmd)
 }

--- a/pkg/services/queryhistory/queryhistory.go
+++ b/pkg/services/queryhistory/queryhistory.go
@@ -33,7 +33,7 @@ type Service interface {
 	PatchQueryCommentInQueryHistory(ctx context.Context, user *models.SignedInUser, UID string, cmd PatchQueryCommentInQueryHistoryCommand) (QueryHistoryDTO, error)
 	StarQueryInQueryHistory(ctx context.Context, user *models.SignedInUser, UID string) (QueryHistoryDTO, error)
 	UnstarQueryInQueryHistory(ctx context.Context, user *models.SignedInUser, UID string) (QueryHistoryDTO, error)
-	MigrateQueriesToQueryHistory(ctx context.Context, user *models.SignedInUser, cmd MigrateQueriesToQueryHistoryCommand) error
+	MigrateQueriesToQueryHistory(ctx context.Context, user *models.SignedInUser, cmd MigrateQueriesToQueryHistoryCommand) (int, int, error)
 }
 
 type QueryHistoryService struct {
@@ -67,6 +67,6 @@ func (s QueryHistoryService) UnstarQueryInQueryHistory(ctx context.Context, user
 	return s.unstarQuery(ctx, user, UID)
 }
 
-func (s QueryHistoryService) MigrateQueriesToQueryHistory(ctx context.Context, user *models.SignedInUser, cmd MigrateQueriesToQueryHistoryCommand) error {
+func (s QueryHistoryService) MigrateQueriesToQueryHistory(ctx context.Context, user *models.SignedInUser, cmd MigrateQueriesToQueryHistoryCommand) (int, int, error) {
 	return s.migrateQueries(ctx, user, cmd)
 }

--- a/pkg/services/queryhistory/queryhistory_migrate_test.go
+++ b/pkg/services/queryhistory/queryhistory_migrate_test.go
@@ -1,0 +1,140 @@
+//go:build integration
+// +build integration
+
+package queryhistory
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateQueriesToQueryHistory(t *testing.T) {
+	testScenario(t, "When users tries to migrate 1 query in query history it should succeed",
+		func(t *testing.T, sc scenarioContext) {
+			command := MigrateQueriesToQueryHistoryCommand{
+				Queries: []QueryToMigrate{
+					{
+						DatasourceUID: "NCzh67i",
+						Queries: simplejson.NewFromAny(map[string]interface{}{
+							"expr": "test",
+						}),
+						Comment:   "",
+						Starred:   false,
+						CreatedAt: time.Now().Unix(),
+					},
+				},
+			}
+			sc.reqContext.Req.Body = mockRequestBody(command)
+			resp := sc.service.migrateHandler(sc.reqContext)
+			var response QueryHistoryMigrationResponse
+			err := json.Unmarshal(resp.Body(), &response)
+			require.NoError(t, err)
+			require.Equal(t, 200, resp.Status())
+			require.Equal(t, 1, len(response.Result))
+		})
+
+	testScenario(t, "When users tries to migrate multiple queries in query history it should succeed",
+		func(t *testing.T, sc scenarioContext) {
+			command := MigrateQueriesToQueryHistoryCommand{
+				Queries: []QueryToMigrate{
+					{
+						DatasourceUID: "NCzh67i",
+						Queries: simplejson.NewFromAny(map[string]interface{}{
+							"expr": "test1",
+						}),
+						Comment:   "",
+						Starred:   false,
+						CreatedAt: time.Now().Unix(),
+					},
+					{
+						DatasourceUID: "NCzh67i",
+						Queries: simplejson.NewFromAny(map[string]interface{}{
+							"expr": "test2",
+						}),
+						Comment:   "",
+						Starred:   false,
+						CreatedAt: time.Now().Unix() - int64(100),
+					},
+					{
+						DatasourceUID: "ABch68f",
+						Queries: simplejson.NewFromAny(map[string]interface{}{
+							"expr": "test3",
+						}),
+						Comment:   "",
+						Starred:   false,
+						CreatedAt: time.Now().Unix() - int64(1000),
+					},
+				},
+			}
+			sc.reqContext.Req.Body = mockRequestBody(command)
+			resp := sc.service.migrateHandler(sc.reqContext)
+			var response QueryHistoryMigrationResponse
+			err := json.Unmarshal(resp.Body(), &response)
+			require.NoError(t, err)
+			require.Equal(t, 200, resp.Status())
+			require.Equal(t, 3, len(response.Result))
+		})
+	testScenario(t, "When users tries to migrate starred query in query history it should succeed",
+		func(t *testing.T, sc scenarioContext) {
+			command := MigrateQueriesToQueryHistoryCommand{
+				Queries: []QueryToMigrate{
+					{
+						DatasourceUID: "NCzh67i",
+						Queries: simplejson.NewFromAny(map[string]interface{}{
+							"expr": "test1",
+						}),
+						Comment:   "",
+						Starred:   true,
+						CreatedAt: time.Now().Unix(),
+					},
+				},
+			}
+			sc.reqContext.Req.Body = mockRequestBody(command)
+			resp := sc.service.migrateHandler(sc.reqContext)
+			var response QueryHistoryMigrationResponse
+			err := json.Unmarshal(resp.Body(), &response)
+			require.NoError(t, err)
+			require.Equal(t, 200, resp.Status())
+			require.Equal(t, 1, len(response.Result))
+			require.Equal(t, true, response.Result[0].Starred)
+		})
+
+	testScenario(t, "When users tries to migrate starred and not starred query in query history it should succeed",
+		func(t *testing.T, sc scenarioContext) {
+			command := MigrateQueriesToQueryHistoryCommand{
+				Queries: []QueryToMigrate{
+					{
+						DatasourceUID: "NCzh67i",
+						Queries: simplejson.NewFromAny(map[string]interface{}{
+							"expr": "test1",
+						}),
+						Comment:   "",
+						Starred:   true,
+						CreatedAt: time.Now().Unix(),
+					},
+					{
+						DatasourceUID: "NCzh67i",
+						Queries: simplejson.NewFromAny(map[string]interface{}{
+							"expr": "test2",
+						}),
+						Comment:   "",
+						Starred:   false,
+						CreatedAt: time.Now().Unix() - int64(100),
+					},
+				},
+			}
+			sc.reqContext.Req.Body = mockRequestBody(command)
+			resp := sc.service.migrateHandler(sc.reqContext)
+			var response QueryHistoryMigrationResponse
+			err := json.Unmarshal(resp.Body(), &response)
+			require.NoError(t, err)
+			require.Equal(t, 200, resp.Status())
+			require.Equal(t, 2, len(response.Result))
+			require.Equal(t, true, response.Result[0].Starred)
+			require.Equal(t, false, response.Result[1].Starred)
+		})
+}

--- a/pkg/services/queryhistory/queryhistory_migrate_test.go
+++ b/pkg/services/queryhistory/queryhistory_migrate_test.go
@@ -34,7 +34,7 @@ func TestMigrateQueriesToQueryHistory(t *testing.T) {
 			err := json.Unmarshal(resp.Body(), &response)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
-			require.Equal(t, 1, len(response.Result))
+			require.Equal(t, "Query history successfully migrated", response.Message)
 		})
 
 	testScenario(t, "When users tries to migrate multiple queries in query history it should succeed",
@@ -76,31 +76,7 @@ func TestMigrateQueriesToQueryHistory(t *testing.T) {
 			err := json.Unmarshal(resp.Body(), &response)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
-			require.Equal(t, 3, len(response.Result))
-		})
-	testScenario(t, "When users tries to migrate starred query in query history it should succeed",
-		func(t *testing.T, sc scenarioContext) {
-			command := MigrateQueriesToQueryHistoryCommand{
-				Queries: []QueryToMigrate{
-					{
-						DatasourceUID: "NCzh67i",
-						Queries: simplejson.NewFromAny(map[string]interface{}{
-							"expr": "test1",
-						}),
-						Comment:   "",
-						Starred:   true,
-						CreatedAt: time.Now().Unix(),
-					},
-				},
-			}
-			sc.reqContext.Req.Body = mockRequestBody(command)
-			resp := sc.service.migrateHandler(sc.reqContext)
-			var response QueryHistoryMigrationResponse
-			err := json.Unmarshal(resp.Body(), &response)
-			require.NoError(t, err)
-			require.Equal(t, 200, resp.Status())
-			require.Equal(t, 1, len(response.Result))
-			require.Equal(t, true, response.Result[0].Starred)
+			require.Equal(t, "Query history successfully migrated", response.Message)
 		})
 
 	testScenario(t, "When users tries to migrate starred and not starred query in query history it should succeed",
@@ -133,8 +109,6 @@ func TestMigrateQueriesToQueryHistory(t *testing.T) {
 			err := json.Unmarshal(resp.Body(), &response)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
-			require.Equal(t, 2, len(response.Result))
-			require.Equal(t, true, response.Result[0].Starred)
-			require.Equal(t, false, response.Result[1].Starred)
+			require.Equal(t, "Query history successfully migrated", response.Message)
 		})
 }

--- a/pkg/services/queryhistory/queryhistory_migrate_test.go
+++ b/pkg/services/queryhistory/queryhistory_migrate_test.go
@@ -35,6 +35,8 @@ func TestMigrateQueriesToQueryHistory(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
 			require.Equal(t, "Query history successfully migrated", response.Message)
+			require.Equal(t, 1, response.TotalCount)
+			require.Equal(t, 0, response.StarredCount)
 		})
 
 	testScenario(t, "When users tries to migrate multiple queries in query history it should succeed",
@@ -77,6 +79,8 @@ func TestMigrateQueriesToQueryHistory(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
 			require.Equal(t, "Query history successfully migrated", response.Message)
+			require.Equal(t, 3, response.TotalCount)
+			require.Equal(t, 0, response.StarredCount)
 		})
 
 	testScenario(t, "When users tries to migrate starred and not starred query in query history it should succeed",
@@ -110,5 +114,7 @@ func TestMigrateQueriesToQueryHistory(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, 200, resp.Status())
 			require.Equal(t, "Query history successfully migrated", response.Message)
+			require.Equal(t, 2, response.TotalCount)
+			require.Equal(t, 1, response.StarredCount)
 		})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When switching to Query history saved in database, we need to migrate queries stored in local storage. We could  migrate them with `createQuery` endpoint, but this could potentially create hundreds of requests. That's why we have decided to create `/migrate` endpoint that will be removed in the next major (v10) release that will be used to migrate all queries from localStorage to database. 

**Which issue(s) this PR fixes**:

Part of #44327

**Special notes for your reviewer**:
**Special notes for your reviewer**:
1. Enable query history `enabled = true` flag in custom.ini
2. Add testing functions to frontend:

In https://github.com/grafana/grafana/blob/main/public/app/features/explore/state/query.ts#L322 add following code snippet: 
 ` import { getBackendSrv } from '@grafana/runtime`
 
```
  // To test migration of query history
  const dataSourceUid = queries[0]?.datasource?.uid;
  if (dataSourceUid) {
    const { result } = await getBackendSrv().post(`/api/query-history/migrate`, {
      queries: [
        {
          dataSourceUid,
          queries,
          comment: 'unique1',
          createdAt: Date.now(),
          starred: false,
        },
        {
          dataSourceUid,
          queries,
          comment: 'unique2',
          createdAt: Date.now() - 1000,
          starred: false,
        },
        {
          dataSourceUid,
          queries,
          comment: 'unique3',
          createdAt: Date.now() - 2000,
          starred: false,
        },
        {
          dataSourceUid,
          queries,
          comment: 'unique4',
          createdAt: Date.now() - 3000,
          starred: false,
        },
      ],
    });
  }
  // End of test
```


