### PR TITLE
Alerting: Fix issue with Slack contact point validation

### DIFF
--- a/pkg/services/ngalert/notifier/available_channels.go
+++ b/pkg/services/ngalert/notifier/available_channels.go
@@ -383,7 +383,7 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 					Description:  "Specify channel, private group, or IM channel (can be an encoded ID or a name) - required unless you provide a webhook",
 					PropertyName: "recipient",
 					Required:     true,
-					DependsOn:    "secureSettings.url",
+					DependsOn:    "url",
 				},
 				// Logically, this field should be required when not using a webhook, since the Slack API needs a token.
 				// However, since the UI doesn't allow to say that a field is required or not depending on another field,
@@ -397,7 +397,7 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 					PropertyName: "token",
 					Secure:       true,
 					Required:     true,
-					DependsOn:    "secureSettings.url",
+					DependsOn:    "url",
 				},
 				{
 					Label:        "Username",
@@ -463,7 +463,7 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 					PropertyName: "url",
 					Secure:       true,
 					Required:     true,
-					DependsOn:    "secureSettings.token",
+					DependsOn:    "token",
 				},
 				{ // New in 8.4.
 					Label:        "Endpoint URL",

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
@@ -9,6 +9,7 @@ export interface Props<R extends ChannelValues> {
   defaultValues: R;
   selectedChannelOptions: NotificationChannelOption[];
   secureFields: NotificationChannelSecureFields;
+  channelIndex: number;
 
   onResetSecureField: (key: string) => void;
   errors?: FieldErrors<R>;
@@ -22,6 +23,7 @@ export function ChannelOptions<R extends ChannelValues>({
   onResetSecureField,
   secureFields,
   errors,
+  channelIndex,
   pathPrefix = '',
   readOnly = false,
 }: Props<R>): JSX.Element {
@@ -76,6 +78,7 @@ export function ChannelOptions<R extends ChannelValues>({
             error={error}
             pathPrefix={option.secure ? `${pathPrefix}secureSettings.` : `${pathPrefix}settings.`}
             option={option}
+            channelIndex={channelIndex}
           />
         );
       })}

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
@@ -9,7 +9,6 @@ export interface Props<R extends ChannelValues> {
   defaultValues: R;
   selectedChannelOptions: NotificationChannelOption[];
   secureFields: NotificationChannelSecureFields;
-  channelIndex: number;
 
   onResetSecureField: (key: string) => void;
   errors?: FieldErrors<R>;
@@ -23,7 +22,6 @@ export function ChannelOptions<R extends ChannelValues>({
   onResetSecureField,
   secureFields,
   errors,
-  channelIndex,
   pathPrefix = '',
   readOnly = false,
 }: Props<R>): JSX.Element {
@@ -49,12 +47,7 @@ export function ChannelOptions<R extends ChannelValues>({
                 value="Configured"
                 suffix={
                   readOnly ? null : (
-                    <Button
-                      onClick={() => onResetSecureField(option.propertyName)}
-                      variant="link"
-                      type="button"
-                      size="sm"
-                    >
+                    <Button onClick={() => onResetSecureField(option.propertyName)} fill="text" type="button" size="sm">
                       Clear
                     </Button>
                   )
@@ -78,7 +71,6 @@ export function ChannelOptions<R extends ChannelValues>({
             error={error}
             pathPrefix={option.secure ? `${pathPrefix}secureSettings.` : `${pathPrefix}settings.`}
             option={option}
-            channelIndex={channelIndex}
           />
         );
       })}

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
@@ -69,7 +69,7 @@ export function ChannelOptions<R extends ChannelValues>({
             readOnly={readOnly}
             key={key}
             error={error}
-            pathPrefix={option.secure ? `${pathPrefix}secureSettings.` : `${pathPrefix}settings.`}
+            pathPrefix={pathPrefix}
             option={option}
           />
         );

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
@@ -70,6 +70,7 @@ export function ChannelOptions<R extends ChannelValues>({
             key={key}
             error={error}
             pathPrefix={pathPrefix}
+            pathSuffix={option.secure ? 'secureSettings.' : 'settings.'}
             option={option}
           />
         );

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
@@ -43,6 +43,9 @@ export function ChannelSubForm<R extends ChannelValues>({
 
   useEffect(() => {
     register(`${pathPrefix}.__id`);
+    /* Need to manually register secureFields or else they'll
+     be lost when testing a contact point */
+    register(`${pathPrefix}.secureFields`);
   }, [register, pathPrefix]);
 
   const [_secureFields, setSecureFields] = useState(secureFields ?? {});

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
@@ -37,7 +37,7 @@ export function ChannelSubForm<R extends ChannelValues>({
 }: Props<R>): JSX.Element {
   const styles = useStyles2(getStyles);
   const name = (fieldName: string) => `${pathPrefix}${fieldName}`;
-  const { control, watch, register, trigger, formState } = useFormContext();
+  const { control, watch, register, trigger, formState, setValue } = useFormContext();
   const selectedType = watch(name('type')) ?? defaultValues.type; // nope, setting "default" does not work at all.
   const { loading: testingReceiver } = useUnifiedAlertingSelector((state) => state.testReceivers);
 
@@ -55,6 +55,7 @@ export function ChannelSubForm<R extends ChannelValues>({
       const updatedSecureFields = { ...secureFields };
       delete updatedSecureFields[key];
       setSecureFields(updatedSecureFields);
+      setValue(`${pathPrefix}.secureFields`, updatedSecureFields);
     }
   };
 

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -188,13 +188,13 @@ const determineRequired = (option: NotificationChannelOption, getValues: any, pa
   }
 };
 
-const determineReadOnly = (option: NotificationChannelOption, getValues: any) => {
+const determineReadOnly = (option: NotificationChannelOption, getValues: any, pathIndex: string) => {
   if (!option.dependsOn) {
     return false;
   }
-  if (isEmpty(getValues(`items[0].secureSettings`))) {
-    return getValues(`items[0].secureFields.${option.dependsOn}`);
+  if (isEmpty(getValues(`${pathIndex}secureFields`))) {
+    return getValues(`${pathIndex}secureSettings.${option.dependsOn}`);
   } else {
-    return getValues(`items[0].secureSettings.${option.dependsOn}`);
+    return getValues(`${pathIndex}secureFields.${option.dependsOn}`);
   }
 };

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -170,19 +170,23 @@ const determineRequired = (option: NotificationChannelOption, getValues: any) =>
   if (!option.dependsOn) {
     return option.required ? 'Required' : false;
   }
-  let dependentOn = '';
-  if (isEmpty(getValues(`items[0].secureSettings`))) {
-    dependentOn = getValues(`items[0].secureFields.${option.dependsOn}`);
+  console.log(getValues('items[0].secureFields'));
+  if (isEmpty(getValues('items[0].secureFields'))) {
+    const dependentOn = getValues(`items[0].secureSettings.${option.dependsOn}`);
+    return !Boolean(dependentOn) && option.required ? 'Required' : false;
   } else {
-    dependentOn = getValues(`items[0].secureSettings.${option.dependsOn}`);
+    const dependentOn: boolean = getValues(`items[0].secureFields.${option.dependsOn}`);
+    return !dependentOn && option.required ? 'Required' : false;
   }
-  return !Boolean(dependentOn) && option.required ? 'Required' : false;
 };
 
 const determineReadOnly = (option: NotificationChannelOption, getValues: any) => {
   if (!option.dependsOn) {
     return false;
   }
-
-  return getValues(`items[0].${option.dependsOn}`);
+  if (isEmpty(getValues(`items[0].secureSettings`))) {
+    return getValues(`items[0].secureFields.${option.dependsOn}`);
+  } else {
+    return getValues(`items[0].secureSettings.${option.dependsOn}`);
+  }
 };

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useEffect } from 'react';
 import { Checkbox, Field, Input, InputControl, Select, TextArea } from '@grafana/ui';
+import { isEmpty } from 'lodash';
 import { NotificationChannelOption } from 'app/types';
 import { useFormContext, FieldError, DeepMap } from 'react-hook-form';
 import { SubformField } from './SubformField';
@@ -169,8 +170,12 @@ const determineRequired = (option: NotificationChannelOption, getValues: any) =>
   if (!option.dependsOn) {
     return option.required ? 'Required' : false;
   }
-  const dependentOn = getValues(`items[0].${option.dependsOn}`);
-  console.log(dependentOn);
+  let dependentOn = '';
+  if (isEmpty(getValues(`items[0].secureSettings`))) {
+    dependentOn = getValues(`items[0].secureFields.${option.dependsOn}`);
+  } else {
+    dependentOn = getValues(`items[0].secureSettings.${option.dependsOn}`);
+  }
   return !Boolean(dependentOn) && option.required ? 'Required' : false;
 };
 

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -97,7 +97,7 @@ const OptionInput: FC<Props & { id: string; pathIndex: string }> = ({
       return (
         <Input
           id={id}
-          readOnly={readOnly || determineReadOnly(option, getValues)}
+          readOnly={readOnly || determineReadOnly(option, getValues, pathIndex)}
           invalid={invalid}
           type={option.inputType}
           {...register(name, {

--- a/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/OptionField.tsx
@@ -14,12 +14,22 @@ interface Props {
   option: NotificationChannelOption;
   invalid?: boolean;
   pathPrefix: string;
+  pathSuffix?: string;
   error?: FieldError | DeepMap<any, FieldError>;
   readOnly?: boolean;
 }
 
-export const OptionField: FC<Props> = ({ option, invalid, pathPrefix, error, defaultValue, readOnly = false }) => {
-  const settingsPath = option.secure ? `${pathPrefix}secureSettings.` : `${pathPrefix}settings.`;
+export const OptionField: FC<Props> = ({
+  option,
+  invalid,
+  pathPrefix,
+  pathSuffix = '',
+  error,
+  defaultValue,
+  readOnly = false,
+}) => {
+  const optionPath = `${pathPrefix}${pathSuffix}`;
+
   if (option.element === 'subform') {
     return (
       <SubformField
@@ -27,7 +37,7 @@ export const OptionField: FC<Props> = ({ option, invalid, pathPrefix, error, def
         defaultValue={defaultValue}
         option={option}
         errors={error as DeepMap<any, FieldError> | undefined}
-        pathPrefix={settingsPath}
+        pathPrefix={optionPath}
       />
     );
   }
@@ -37,7 +47,7 @@ export const OptionField: FC<Props> = ({ option, invalid, pathPrefix, error, def
         readOnly={readOnly}
         defaultValues={defaultValue}
         option={option}
-        pathPrefix={settingsPath}
+        pathPrefix={optionPath}
         errors={error as Array<DeepMap<any, FieldError>> | undefined}
       />
     );
@@ -50,11 +60,11 @@ export const OptionField: FC<Props> = ({ option, invalid, pathPrefix, error, def
       error={error?.message}
     >
       <OptionInput
-        id={`${settingsPath}${option.propertyName}`}
+        id={`${optionPath}${option.propertyName}`}
         defaultValue={defaultValue}
         option={option}
         invalid={invalid}
-        pathPrefix={settingsPath}
+        pathPrefix={optionPath}
         readOnly={readOnly}
         pathIndex={pathPrefix}
       />
@@ -62,12 +72,12 @@ export const OptionField: FC<Props> = ({ option, invalid, pathPrefix, error, def
   );
 };
 
-const OptionInput: FC<Props & { id: string; pathIndex: string }> = ({
+const OptionInput: FC<Props & { id: string; pathIndex?: string }> = ({
   option,
   invalid,
   id,
   pathPrefix = '',
-  pathIndex,
+  pathIndex = '',
   readOnly = false,
 }) => {
   const { control, register, unregister, getValues } = useFormContext();


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/grafana/grafana/pull/45618 we added some more validation to support the Slack contact point. This however did not take into account that `secureSettings` is an empty object for existing notifiers. 

**Which issue(s) this PR fixes**:

Fixes #47404

**Special notes for your reviewer**:

