### PR TITLE
Loki: Use single string expr as a state for the visual editor

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -7,7 +7,6 @@ import { QueryBuilderLabelFilter } from 'app/plugins/datasource/prometheus/query
 import { lokiQueryModeller } from '../LokiQueryModeller';
 import { DataSourceApi, SelectableValue } from '@grafana/data';
 import { EditorRow } from '@grafana/experimental';
-import { QueryPreview } from './QueryPreview';
 import { OperationsEditorRow } from 'app/plugins/datasource/prometheus/querybuilder/shared/OperationsEditorRow';
 import { NestedQueryList } from './NestedQueryList';
 
@@ -83,11 +82,6 @@ export const LokiQueryBuilder = React.memo<Props>(({ datasource, query, nested, 
       </OperationsEditorRow>
       {query.binaryQueries && query.binaryQueries.length > 0 && (
         <NestedQueryList query={query} datasource={datasource} onChange={onChange} onRunQuery={onRunQuery} />
-      )}
-      {!nested && (
-        <EditorRow>
-          <QueryPreview query={query} />
-        </EditorRow>
       )}
     </>
   );

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LokiQueryBuilderContainer } from './LokiQueryBuilderContainer';
+import { LokiDatasource } from '../../datasource';
+import { addOperation } from 'app/plugins/datasource/prometheus/querybuilder/shared/OperationList.testUtils';
+
+describe('LokiQueryBuilderContainer', () => {
+  it('translates query between string and model', async () => {
+    const props = {
+      query: {
+        expr: '{job="testjob"}',
+        refId: 'A',
+      },
+      datasource: new LokiDatasource(
+        {
+          id: 1,
+          uid: '',
+          type: 'loki',
+          name: 'loki-test',
+          access: 'proxy',
+          url: '',
+          jsonData: {},
+          meta: {} as any,
+        },
+        undefined,
+        undefined
+      ),
+      onChange: jest.fn(),
+      onRunQuery: () => {},
+    };
+    render(<LokiQueryBuilderContainer {...props} />);
+    expect(screen.getByText('testjob')).toBeInTheDocument();
+    addOperation('Range functions', 'Rate');
+    expect(props.onChange).toBeCalledWith({
+      expr: 'rate({job="testjob"} [$__interval])',
+      refId: 'A',
+    });
+  });
+});

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { LokiDatasource } from '../../datasource';
+import { LokiQuery } from '../../types';
+import { buildVisualQueryFromString } from '../parsing';
+import { lokiQueryModeller } from '../LokiQueryModeller';
+import { LokiQueryBuilder } from './LokiQueryBuilder';
+import { QueryPreview } from './QueryPreview';
+import { LokiVisualQuery } from '../types';
+
+export interface Props {
+  query: LokiQuery;
+  datasource: LokiDatasource;
+  onChange: (update: LokiQuery) => void;
+  onRunQuery: () => void;
+}
+
+/**
+ * This component is here just to contain the translation logic between string query and the visual query builder model.
+ * @param props
+ * @constructor
+ */
+export function LokiQueryBuilderContainer(props: Props) {
+  const { query, onChange, onRunQuery, datasource } = props;
+
+  const visQuery = buildVisualQueryFromString(query.expr || '').query;
+
+  const onVisQueryChange = (newVisQuery: LokiVisualQuery) => {
+    const rendered = lokiQueryModeller.renderQuery(newVisQuery);
+    onChange({ ...query, expr: rendered });
+  };
+
+  return (
+    <>
+      <LokiQueryBuilder query={visQuery} datasource={datasource} onChange={onVisQueryChange} onRunQuery={onRunQuery} />
+      <QueryPreview query={query.expr} />
+    </>
+  );
+}

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderExplained.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderExplained.tsx
@@ -4,19 +4,22 @@ import { Stack } from '@grafana/experimental';
 import { lokiQueryModeller } from '../LokiQueryModeller';
 import { OperationListExplained } from 'app/plugins/datasource/prometheus/querybuilder/shared/OperationListExplained';
 import { OperationExplainedBox } from 'app/plugins/datasource/prometheus/querybuilder/shared/OperationExplainedBox';
+import { buildVisualQueryFromString } from '../parsing';
 
 export interface Props {
-  query: LokiVisualQuery;
+  query: string;
   nested?: boolean;
 }
 
 export const LokiQueryBuilderExplained = React.memo<Props>(({ query, nested }) => {
+  const visQuery = buildVisualQueryFromString(query || '').query;
+
   return (
     <Stack gap={0} direction="column">
-      <OperationExplainedBox stepNumber={1} title={`${lokiQueryModeller.renderLabels(query.labels)}`}>
+      <OperationExplainedBox stepNumber={1} title={`${lokiQueryModeller.renderLabels(visQuery.labels)}`}>
         Fetch all log lines matching label filters.
       </OperationExplainedBox>
-      <OperationListExplained<LokiVisualQuery> stepNumber={2} queryModeller={lokiQueryModeller} query={query} />
+      <OperationListExplained<LokiVisualQuery> stepNumber={2} queryModeller={lokiQueryModeller} query={visQuery} />
     </Stack>
   );
 });

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryEditorSelector.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryEditorSelector.test.tsx
@@ -79,13 +79,6 @@ describe('LokiQueryEditorSelector', () => {
       expr: defaultQuery.expr,
       queryType: LokiQueryType.Range,
       editorMode: QueryEditorMode.Builder,
-      visualQuery: {
-        labels: [
-          { label: 'label1', op: '=', value: 'foo' },
-          { label: 'label2', op: '=', value: 'bar' },
-        ],
-        operations: [],
-      },
     });
   });
 

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryEditorSelector.tsx
@@ -4,7 +4,7 @@ import { EditorHeader, EditorRows, FlexItem, InlineSelect, Space } from '@grafan
 import { Button, useStyles2, ConfirmModal } from '@grafana/ui';
 import { QueryEditorModeToggle } from 'app/plugins/datasource/prometheus/querybuilder/shared/QueryEditorModeToggle';
 import { QueryEditorMode } from 'app/plugins/datasource/prometheus/querybuilder/shared/types';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { LokiQueryEditorProps } from '../../components/types';
 import { lokiQueryModeller } from '../LokiQueryModeller';
 import { getQueryWithDefaults } from '../state';
@@ -36,9 +36,21 @@ export const LokiQueryEditorSelector = React.memo<LokiQueryEditorProps>((props) 
     [onChange, query]
   );
 
+  useEffect(() => {
+    const defaultEmptyQuery = '{} |= ``';
+    // For visual query builder we use default query
+    if (query.editorMode === QueryEditorMode.Builder && !query.expr) {
+      onChange({ ...query, expr: defaultEmptyQuery });
+    }
+
+    // For text editor we use empty query as default
+    if (query.editorMode === QueryEditorMode.Code && query.expr === defaultEmptyQuery) {
+      onChange({ ...query, expr: '' });
+    }
+  }, [query, onChange]);
+
   // If no expr (ie new query) then default to builder
   const editorMode = query.editorMode ?? (query.expr ? QueryEditorMode.Code : QueryEditorMode.Builder);
-
   return (
     <>
       <ConfirmModal

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryEditorSelector.tsx
@@ -4,7 +4,7 @@ import { EditorHeader, EditorRows, FlexItem, InlineSelect, Space } from '@grafan
 import { Button, useStyles2, ConfirmModal } from '@grafana/ui';
 import { QueryEditorModeToggle } from 'app/plugins/datasource/prometheus/querybuilder/shared/QueryEditorModeToggle';
 import { QueryEditorMode } from 'app/plugins/datasource/prometheus/querybuilder/shared/types';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { LokiQueryEditorProps } from '../../components/types';
 import { lokiQueryModeller } from '../LokiQueryModeller';
 import { getQueryWithDefaults } from '../state';
@@ -35,19 +35,6 @@ export const LokiQueryEditorSelector = React.memo<LokiQueryEditorProps>((props) 
     },
     [onChange, query]
   );
-
-  useEffect(() => {
-    const defaultEmptyQuery = '{} |= ``';
-    // For visual query builder we use default query
-    if (query.editorMode === QueryEditorMode.Builder && !query.expr) {
-      onChange({ ...query, expr: defaultEmptyQuery });
-    }
-
-    // For text editor we use empty query as default
-    if (query.editorMode === QueryEditorMode.Code && query.expr === defaultEmptyQuery) {
-      onChange({ ...query, expr: '' });
-    }
-  }, [query, onChange]);
 
   // If no expr (ie new query) then default to builder
   const editorMode = query.editorMode ?? (query.expr ? QueryEditorMode.Code : QueryEditorMode.Builder);
@@ -91,7 +78,7 @@ export const LokiQueryEditorSelector = React.memo<LokiQueryEditorProps>((props) 
           }}
           options={lokiQueryModeller.getQueryPatterns().map((x) => ({ label: x.name, value: x }))}
         />
-        <QueryEditorModeToggle mode={editorMode} onChange={onEditorModeChange} />
+        <QueryEditorModeToggle mode={editorMode!} onChange={onEditorModeChange} />
       </EditorHeader>
       <Space v={0.5} />
       <EditorRows>

--- a/public/app/plugins/datasource/loki/querybuilder/components/QueryPreview.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/QueryPreview.tsx
@@ -1,21 +1,19 @@
 import React from 'react';
-import { LokiVisualQuery } from '../types';
 import { useTheme2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import { EditorField, EditorFieldGroup } from '@grafana/experimental';
 import Prism from 'prismjs';
 import { lokiGrammar } from '../../syntax';
-import { lokiQueryModeller } from '../LokiQueryModeller';
 
 export interface Props {
-  query: LokiVisualQuery;
+  query: string;
 }
 
 export function QueryPreview({ query }: Props) {
   const theme = useTheme2();
   const styles = getStyles(theme);
-  const hightlighted = Prism.highlight(lokiQueryModeller.renderQuery(query), lokiGrammar, 'lokiql');
+  const highlighted = Prism.highlight(query, lokiGrammar, 'lokiql');
 
   return (
     <EditorFieldGroup>
@@ -23,7 +21,7 @@ export function QueryPreview({ query }: Props) {
         <div
           className={cx(styles.editorField, 'prism-syntax-highlight')}
           aria-label="selector"
-          dangerouslySetInnerHTML={{ __html: hightlighted }}
+          dangerouslySetInnerHTML={{ __html: highlighted }}
         />
       </EditorField>
     </EditorFieldGroup>

--- a/public/app/plugins/datasource/loki/querybuilder/components/QueryPreview.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/QueryPreview.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTheme2 } from '@grafana/ui';
 import { GrafanaTheme2 } from '@grafana/data';
 import { css, cx } from '@emotion/css';
-import { EditorField, EditorFieldGroup } from '@grafana/experimental';
+import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
 import Prism from 'prismjs';
 import { lokiGrammar } from '../../syntax';
 
@@ -16,22 +16,23 @@ export function QueryPreview({ query }: Props) {
   const highlighted = Prism.highlight(query, lokiGrammar, 'lokiql');
 
   return (
-    <EditorFieldGroup>
-      <EditorField label="Query text">
-        <div
-          className={cx(styles.editorField, 'prism-syntax-highlight')}
-          aria-label="selector"
-          dangerouslySetInnerHTML={{ __html: highlighted }}
-        />
-      </EditorField>
-    </EditorFieldGroup>
+    <EditorRow>
+      <EditorFieldGroup>
+        <EditorField label="Raw query">
+          <div
+            className={cx(styles.editorField, 'prism-syntax-highlight')}
+            aria-label="selector"
+            dangerouslySetInnerHTML={{ __html: highlighted }}
+          />
+        </EditorField>
+      </EditorFieldGroup>
+    </EditorRow>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     editorField: css({
-      padding: theme.spacing(0.25, 1),
       fontFamily: theme.typography.fontFamilyMonospace,
       fontSize: theme.typography.bodySmall.fontSize,
     }),

--- a/public/app/plugins/datasource/loki/querybuilder/types.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/types.ts
@@ -90,10 +90,3 @@ export enum LokiOperationOrder {
   RangeVectorFunction = 5,
   Last = 6,
 }
-
-export function getDefaultEmptyQuery(): LokiVisualQuery {
-  return {
-    labels: [],
-    operations: [{ id: '__line_contains', params: [''] }],
-  };
-}

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -1,6 +1,5 @@
 import { DataQuery, DataSourceJsonData, QueryResultMeta, ScopedVars } from '@grafana/data';
 import { QueryEditorMode } from '../prometheus/querybuilder/shared/types';
-import { LokiVisualQuery } from './querybuilder/types';
 
 export interface LokiInstantQueryRequest {
   query: string;
@@ -46,8 +45,6 @@ export interface LokiQuery extends DataQuery {
   /* @deprecated now use queryType */
   instant?: boolean;
   editorMode?: QueryEditorMode;
-  /** Temporary until we have a parser */
-  visualQuery?: LokiVisualQuery;
 }
 
 export interface LokiOptions extends DataSourceJsonData {

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/QueryPreview.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/QueryPreview.tsx
@@ -13,7 +13,7 @@ export interface Props {
 export function QueryPreview({ query }: Props) {
   const theme = useTheme2();
   const styles = getStyles(theme);
-  const hightlighted = Prism.highlight(query, promqlGrammar, 'promql');
+  const highlighted = Prism.highlight(query, promqlGrammar, 'promql');
 
   return (
     <EditorRow>
@@ -22,7 +22,7 @@ export function QueryPreview({ query }: Props) {
           <div
             className={cx(styles.editorField, 'prism-syntax-highlight')}
             aria-label="selector"
-            dangerouslySetInnerHTML={{ __html: hightlighted }}
+            dangerouslySetInnerHTML={{ __html: highlighted }}
           />
         </EditorField>
       </EditorFieldGroup>


### PR DESCRIPTION
Similar to [Prometheus: Use single string expr as a state for the visual editor](https://github.com/grafana/grafana/pull/45232) and part of https://github.com/grafana/grafana/issues/44253

This removes the `visualQuery` section from query and instead always uses the `query.exp`. It parses it on the way in and updates it on the way out, making the visual editor model just a derived state.