### PR TITLE
Access-control: documentation for general folder uid restrictions

### DIFF
--- a/docs/sources/enterprise/access-control/_index.md
+++ b/docs/sources/enterprise/access-control/_index.md
@@ -36,6 +36,9 @@ Fine-grained access control is available for the following capabilities:
 - [Provision Grafana]({{< relref "../../administration/provisioning/_index.md" >}})
 - [Manage reports]({{< relref "../reporting.md" >}})
 - [View server information]({{< relref "../../administration/view-server/_index.md" >}})
+- [Manage teams]({{< relref "../../administration/manage-users-and-permissions/manage-teams/_index.md" >}})
+- [Manage dashboards and folders]({{< relref "../../dashboards/_index.md" >}})
+- [Manage annotations]({{< relref "../../visualizations/annotations.md" >}})
 
 To learn about specific endpoints where you can use fine-grained access control, refer to [Permissions]({{< relref "./permissions.md" >}}) and to the relevant [API]({{< relref "../../http_api/_index.md" >}}) documentation.
 

--- a/docs/sources/enterprise/access-control/_index.md
+++ b/docs/sources/enterprise/access-control/_index.md
@@ -63,3 +63,8 @@ Refer to [Configuring with environment variables]({{< relref "../../administrati
 ### Verify if enabled
 
 You can verify if fine-grained access control is enabled or not by sending an HTTP request to the [Check endpoint]({{< relref "../../http_api/access_control.md#check-if-enabled" >}}).
+
+## Caveats
+
+If you have created a folder with unique identifier (uid) set to "general", you will not be able to manage its permissions with fine-grained access control.
+Any [folder permissions]({{< relref "../../administration/manage-users-and-permissions/manage-dashboard-permissions/_index.md" >}}) set for this folder will be disregarded when fine-grained access control is enabled.

--- a/docs/sources/http_api/folder.md
+++ b/docs/sources/http_api/folder.md
@@ -19,6 +19,7 @@ The uid can have a maximum length of 40 characters.
 
 The General folder (id=0) is special and is not part of the Folder API which means
 that you cannot use this API for retrieving information about the General folder.
+It also means that folder name "General" and uid "general" are reserved, so you cannot use them when creating folders.
 
 ## Get all folders
 

--- a/docs/sources/http_api/folder.md
+++ b/docs/sources/http_api/folder.md
@@ -19,7 +19,6 @@ The uid can have a maximum length of 40 characters.
 
 The General folder (id=0) is special and is not part of the Folder API which means
 that you cannot use this API for retrieving information about the General folder.
-It also means that folder name "General" and uid "general" are reserved, so you cannot use them when creating folders.
 
 ## Get all folders
 


### PR DESCRIPTION
**What this PR does / why we need it**:
mentions a caveat with using "general" as a folder uid when FGAC is enabled.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-enterprise/issues/3090

