### PR TITLE
loki: removed unused fields, params, attributes

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -411,7 +411,7 @@ describe('LokiDatasource', () => {
 
       it('should not modify expression with no filters', async () => {
         await lastValueFrom(ds.query(options as any));
-        expect(ds.runRangeQuery).toBeCalledWith({ expr: DEFAULT_EXPR }, expect.anything(), expect.anything());
+        expect(ds.runRangeQuery).toBeCalledWith({ expr: DEFAULT_EXPR }, expect.anything());
       });
 
       it('should add filters to expression', async () => {
@@ -431,7 +431,6 @@ describe('LokiDatasource', () => {
         await lastValueFrom(ds.query(options as any));
         expect(ds.runRangeQuery).toBeCalledWith(
           { expr: 'rate({bar="baz",job="foo",k1="v1",k2!="v2"} |= "bar" [5m])' },
-          expect.anything(),
           expect.anything()
         );
       });
@@ -452,7 +451,6 @@ describe('LokiDatasource', () => {
         await lastValueFrom(ds.query(options as any));
         expect(ds.runRangeQuery).toBeCalledWith(
           { expr: 'rate({bar="baz",job="foo",k1=~"v.*",k2=~"v\\\\\'.*"} |= "bar" [5m])' },
-          expect.anything(),
           expect.anything()
         );
       });

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -184,7 +184,7 @@ export class LokiDatasource
       ) {
         subQueries.push(doLokiChannelStream(target, this, request));
       } else {
-        subQueries.push(this.runRangeQuery(target, request, filteredTargets.length));
+        subQueries.push(this.runRangeQuery(target, request));
       }
     }
 
@@ -275,11 +275,7 @@ export class LokiDatasource
   /**
    * Attempts to send a query to /loki/api/v1/query_range
    */
-  runRangeQuery = (
-    target: LokiQuery,
-    options: RangeQueryOptions,
-    responseListLength = 1
-  ): Observable<DataQueryResponse> => {
+  runRangeQuery = (target: LokiQuery, options: RangeQueryOptions): Observable<DataQueryResponse> => {
     // For metric query we use maxDataPoints from the request options which should be something like width of the
     // visualisation in pixels. In case of logs request we either use lines limit defined in the query target or
     // global limit defined for the data source which ever is lower.
@@ -306,7 +302,6 @@ export class LokiDatasource
           response.data,
           target,
           query,
-          responseListLength,
           maxDataPoints,
           this.instanceSettings.jsonData,
           (options as DataQueryRequest<LokiQuery>).scopedVars

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -234,7 +234,7 @@ export class LokiDatasource
         }
 
         return {
-          data: [lokiResultsToTableModel(response.data.data.result, responseListLength, target.refId, meta, true)],
+          data: [lokiResultsToTableModel(response.data.data.result, responseListLength, target.refId, meta)],
           key: `${target.refId}_instant`,
         };
       }),

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -522,15 +522,7 @@ export function processRangeQueryResponse(
     case LokiResultType.Vector:
     case LokiResultType.Matrix:
       return of({
-        data: rangeQueryResponseToDataFrames(
-          response,
-          query,
-          {
-            ...target,
-            format: 'time_series',
-          },
-          scopedVars
-        ),
+        data: rangeQueryResponseToDataFrames(response, query, target, scopedVars),
         key: target.refId,
       });
     default:

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -452,7 +452,6 @@ function rangeQueryResponseToTimeSeries(
   response: LokiResponse,
   query: LokiRangeQueryRequest,
   target: LokiQuery,
-  responseListLength: number,
   scopedVars: ScopedVars
 ): TimeSeries[] {
   /** Show results of Loki metric queries only in graph */
@@ -460,13 +459,8 @@ function rangeQueryResponseToTimeSeries(
     preferredVisualisationType: 'graph',
   };
   const transformerOptions: TransformerOptions = {
-    format: target.format,
     legendFormat: target.legendFormat ?? '',
-    start: query.start!,
-    end: query.end!,
-    step: query.step!,
     query: query.query,
-    responseListLength,
     refId: target.refId,
     meta,
     scopedVars,
@@ -488,10 +482,9 @@ export function rangeQueryResponseToDataFrames(
   response: LokiResponse,
   query: LokiRangeQueryRequest,
   target: LokiQuery,
-  responseListLength: number,
   scopedVars: ScopedVars
 ): DataFrame[] {
-  const series = rangeQueryResponseToTimeSeries(response, query, target, responseListLength, scopedVars);
+  const series = rangeQueryResponseToTimeSeries(response, query, target, scopedVars);
   const frames = series.map((s) => toDataFrame(s));
 
   const { step } = query;
@@ -515,7 +508,6 @@ export function processRangeQueryResponse(
   response: LokiResponse,
   target: LokiQuery,
   query: LokiRangeQueryRequest,
-  responseListLength: number,
   limit: number,
   config: LokiOptions,
   scopedVars: ScopedVars
@@ -537,7 +529,6 @@ export function processRangeQueryResponse(
             ...target,
             format: 'time_series',
           },
-          responseListLength,
           scopedVars
         ),
         key: target.refId,

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -226,8 +226,7 @@ export function lokiResultsToTableModel(
   lokiResults: Array<LokiMatrixResult | LokiVectorResult>,
   resultCount: number,
   refId: string,
-  meta: QueryResultMeta,
-  valueWithRefId?: boolean
+  meta: QueryResultMeta
 ): TableModel {
   if (!lokiResults || lokiResults.length === 0) {
     return new TableModel();
@@ -246,7 +245,7 @@ export function lokiResultsToTableModel(
   table.columns = [
     { text: 'Time', type: FieldType.time },
     ...sortedLabels.map((label) => ({ text: label, filterable: true, type: FieldType.string })),
-    { text: resultCount > 1 || valueWithRefId ? `Value #${refId}` : 'Value', type: FieldType.number },
+    { text: `Value #${refId}`, type: FieldType.number },
   ];
 
   // Populate rows, set value to empty string when label not present.

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -469,7 +469,6 @@ function rangeQueryResponseToTimeSeries(
     responseListLength,
     refId: target.refId,
     meta,
-    valueWithRefId: target.valueWithRefId,
     scopedVars,
   };
 

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -33,7 +33,6 @@ export enum LokiQueryType {
 export interface LokiQuery extends DataQuery {
   queryType?: LokiQueryType;
   expr: string;
-  query?: string;
   legendFormat?: string;
   maxLines?: number;
   resolution?: number;

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -34,7 +34,6 @@ export interface LokiQuery extends DataQuery {
   queryType?: LokiQueryType;
   expr: string;
   query?: string;
-  format?: string;
   legendFormat?: string;
   maxLines?: number;
   resolution?: number;

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -36,7 +36,6 @@ export interface LokiQuery extends DataQuery {
   query?: string;
   format?: string;
   legendFormat?: string;
-  valueWithRefId?: boolean;
   maxLines?: number;
   resolution?: number;
   /** Used in range queries */
@@ -144,5 +143,4 @@ export interface TransformerOptions {
   refId: string;
   scopedVars: ScopedVars;
   meta?: QueryResultMeta;
-  valueWithRefId?: boolean;
 }

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -133,13 +133,8 @@ export type DerivedFieldConfig = {
 };
 
 export interface TransformerOptions {
-  format?: string;
   legendFormat?: string;
-  step: number;
-  start: number;
-  end: number;
   query: string;
-  responseListLength: number;
   refId: string;
   scopedVars: ScopedVars;
   meta?: QueryResultMeta;


### PR DESCRIPTION
it seems many fields in the `LokiQuery` type are unused, so i removed them.

it might be easier to read the diff commit-by-commit, they are all separate changes that remove certain fields.