### PR TITLE
Loki: use millisecond-steps

### DIFF
--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -51,7 +51,13 @@ func makeRequest(ctx context.Context, lokiDsUrl string, query lokiQuery) (*http.
 			// is ignored, so it would be nicer to not send it in such cases,
 			// but we cannot detect that situation, so we always send it.
 			// it should not break anything.
-			qs.Set("step", query.Step.String())
+			// NOTE2: we do this at millisecond precision for two reasons:
+			//  a. Loki cannot do steps with better precision anyway,
+			//     so the microsecond & nanosecond part can be ignored.
+			//  b. having it always be number+'ms' makes it more robust,
+			//     otherwise, if we want to have steps like `5m20s`,
+			//     we risk that we create a combination that Loki cannot read.
+			qs.Set("step", fmt.Sprintf("%dms", query.Step.Milliseconds()))
 			lokiUrl.Path = "/loki/api/v1/query_range"
 		}
 	case QueryTypeInstant:

--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -54,9 +54,8 @@ func makeRequest(ctx context.Context, lokiDsUrl string, query lokiQuery) (*http.
 			// NOTE2: we do this at millisecond precision for two reasons:
 			//  a. Loki cannot do steps with better precision anyway,
 			//     so the microsecond & nanosecond part can be ignored.
-			//  b. having it always be number+'ms' makes it more robust,
-			//     otherwise, if we want to have steps like `5m20s`,
-			//     we risk that we create a combination that Loki cannot read.
+			//  b. having it always be number+'ms' makes it more robust and
+			//     precise, as Loki does not support step with float number.
 			qs.Set("step", fmt.Sprintf("%dms", query.Step.Milliseconds()))
 			lokiUrl.Path = "/loki/api/v1/query_range"
 		}

--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -55,7 +55,8 @@ func makeRequest(ctx context.Context, lokiDsUrl string, query lokiQuery) (*http.
 			//  a. Loki cannot do steps with better precision anyway,
 			//     so the microsecond & nanosecond part can be ignored.
 			//  b. having it always be number+'ms' makes it more robust and
-			//     precise, as Loki does not support step with float number.
+			//     precise, as Loki does not support step with float number
+			//     and time-specifier, like "1.5s"
 			qs.Set("step", fmt.Sprintf("%dms", query.Step.Milliseconds()))
 			lokiUrl.Path = "/loki/api/v1/query_range"
 		}


### PR DESCRIPTION
when we send a query to Loki, we need to set the `step` attribute. the value is represented by a Go `time.Duration` object. until now we simply called it's `String()` method ( https://pkg.go.dev/time#Duration.String ), and it created something that is both nice to read and usable by Loki, like `15h30m5s`.
the problem is, that one time i had a `step`, where the value got formatted to something like `1.296s`, and Loki said it does not support it.

so this PR changes this, and we ask the `time.Duration` object for how many milliseconds it is, and send it as `30000ms` for example.  this is less nice to read, but should remove the chance that some of the formatted values are not readable by Loki.

how to test:
- you will have to have a way to see what data is sent from the go-server to loki, i use `mitmproxy` for this:
- (i assume your Loki database is running on `127.0.0.1:3100`)
- run `mitmproxy` with: `mitmproxy --mode=reverse:http://127.0.0.1:3100 --listen-host=127.0.0.1 --listen-port=9999 --set console_mouse=false`
  - this wll make `mitmproxy` run in the console, it will listen on `127.0.0.1:9999`, and whatever arrives there, it will display it, and also send it through to `127.0.0.1:3100`, and the same with the response
- setup a loki Data source, with the address `127.0.0.1:9999`
- now run a query, and in the mitmproxy-console you will see the requests appear. (you can navigate the list up&down with the cursor keys, `enter` goes in, `q` comes out).. you can see the step-value is sent in millisecond
- to be sure, select in grafana a large time-range, for example last-7-days. run the query, and verify it has a step-value of `600000ms`