### PR TITLE
loki: allow dashboards queries to go through the backend-mode

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -8,7 +8,6 @@ import Prism from 'prismjs';
 import {
   AnnotationEvent,
   AnnotationQueryRequest,
-  CoreApp,
   DataFrame,
   DataFrameView,
   DataQueryError,
@@ -153,9 +152,7 @@ export class LokiDatasource
       ...this.getRangeScopedVars(request.range),
     };
 
-    const shouldRunBackendQuery = config.featureToggles.lokiBackendMode && request.app === CoreApp.Explore;
-
-    if (shouldRunBackendQuery) {
+    if (config.featureToggles.lokiBackendMode) {
       // we "fix" the loki queries to have `.queryType` and not have `.instant` and `.range`
       const fixedRequest = {
         ...request,
@@ -766,7 +763,7 @@ export class LokiDatasource
   }
 
   // Used when running queries through backend
-  applyTemplateVariables(target: LokiQuery, scopedVars: ScopedVars): Record<string, any> {
+  applyTemplateVariables(target: LokiQuery, scopedVars: ScopedVars): LokiQuery {
     // We want to interpolate these variables on backend
     const { __interval, __interval_ms, ...rest } = scopedVars;
 


### PR DESCRIPTION
this enables the backend-mode (still behind feature-flag) to run dashboard-queries too.

how to test:
- make sure you have loki-backend-mode enabled in your grafana config
- go to a dashboard
- add a loki query
- open the network-tab in your browser, run the request and check the URL of the ajax query, it should be `/api/ds/query`