### PR TITLE
Loki: improve backend-compatibility

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -162,23 +162,6 @@ export class LokiDatasource
     });
   }
 
-  _querySingle(query: LokiQuery, range: TimeRange, app: CoreApp, requestId: string): Observable<DataQueryResponse> {
-    const intervalInfo = rangeUtil.calculateInterval(range, 1);
-    const request: DataQueryRequest<LokiQuery> = {
-      targets: [query],
-      requestId,
-      interval: intervalInfo.interval,
-      intervalMs: intervalInfo.intervalMs,
-      range: range,
-      scopedVars: {},
-      timezone: 'UTC',
-      app,
-      startTime: Date.now(),
-    };
-
-    return this.query(request);
-  }
-
   query(request: DataQueryRequest<LokiQuery>): Observable<DataQueryResponse> {
     const subQueries: Array<Observable<DataQueryResponse>> = [];
     const scopedVars = {


### PR DESCRIPTION
when moving to backend-mode, we need to have every query going to Loki to go through `datasource.query()`. this pull requests adjusts the annotation queries to go through `datasource.query()`.

how to test:
1. make sure you do not have backend-mode enabled in your config
2. try annotation-queries, it should work
3. now enable backend-mode in your config
4. try annotation-queries, it should work
