### PR TITLE
Logger: Enable new logging format by default

### DIFF
--- a/pkg/infra/log/log.go
+++ b/pkg/infra/log/log.go
@@ -446,7 +446,9 @@ func ReadLoggingConfig(modes []string, logsPath string, cfg *ini.File) error {
 	}
 
 	var err error
-	root.gokitLogActivated, err = isNewLoggerActivated(cfg)
+	isOldLoggerActivated, err := isOldLoggerActivated(cfg)
+	root.gokitLogActivated = !isOldLoggerActivated
+
 	if err != nil {
 		return err
 	}
@@ -459,13 +461,13 @@ func ReadLoggingConfig(modes []string, logsPath string, cfg *ini.File) error {
 
 // This would be removed eventually, no need to make a fancy design.
 // For the sake of important cycle I just copied the function
-func isNewLoggerActivated(cfg *ini.File) (bool, error) {
+func isOldLoggerActivated(cfg *ini.File) (bool, error) {
 	section := cfg.Section("feature_toggles")
 	toggles, err := readFeatureTogglesFromInitFile(section)
 	if err != nil {
 		return false, err
 	}
-	return toggles["newlog"], nil
+	return toggles["oldlog"], nil
 }
 
 func readFeatureTogglesFromInitFile(featureTogglesSection *ini.Section) (map[string]bool, error) {


### PR DESCRIPTION
…ogger

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #47319 

**Special notes for your reviewer**:

# Release notice breaking change

The format of log messages have been updated, `lvl` is now `level` and `eror`and `dbug` has been replaced with `error` and `debug`. The precision of timestamps has been increased. To smooth the transition, it is possible to opt-out of the new log format by enabling the feature toggle `oldlog`. This option will be removed in a future minor release.