### PR TITLE
PanelQueryRunner: use refId from results if the `key` value was not set in the packet

### DIFF
--- a/public/app/features/query/state/runRequest.test.ts
+++ b/public/app/features/query/state/runRequest.test.ts
@@ -156,7 +156,7 @@ describe('runRequest', () => {
     });
   });
 
-  runRequestScenario('After tree responses, 2 with different keys', (ctx) => {
+  runRequestScenario('After three responses, 2 with different keys', (ctx) => {
     ctx.setup(() => {
       ctx.start();
       ctx.emitPacket({
@@ -183,6 +183,40 @@ describe('runRequest', () => {
 
     it('should have loading state Done', () => {
       expect(ctx.results[2].state).toEqual(LoadingState.Done);
+    });
+  });
+
+  runRequestScenario('When the key is defined in refId', (ctx) => {
+    ctx.setup(() => {
+      ctx.start();
+      ctx.emitPacket({
+        data: [{ name: 'DataX-1', refId: 'X' } as DataFrame],
+      });
+      ctx.emitPacket({
+        data: [{ name: 'DataY-1', refId: 'Y' } as DataFrame],
+      });
+      ctx.emitPacket({
+        data: [{ name: 'DataY-2', refId: 'Y' } as DataFrame],
+      });
+    });
+
+    it('should emit 3 separate results', () => {
+      expect(ctx.results.length).toBe(3);
+    });
+
+    it('should keep data for X and Y', () => {
+      expect(ctx.results[2].series).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "name": "DataX-1",
+            "refId": "X",
+          },
+          Object {
+            "name": "DataY-2",
+            "refId": "Y",
+          },
+        ]
+      `);
     });
   });
 

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -43,7 +43,9 @@ export function processResponsePacket(packet: DataQueryResponse, state: RunningQ
     ...state.packets,
   };
 
-  packets[packet.key || 'A'] = packet;
+  // updates to the same key will replace previous values
+  const key = packet.key || packet.data?.[0]?.refId || 'A';
+  packets[key] = packet;
 
   let loadingState = packet.state || LoadingState.Done;
   let error: DataQueryError | undefined = undefined;

--- a/public/app/features/query/state/runRequest.ts
+++ b/public/app/features/query/state/runRequest.ts
@@ -44,7 +44,7 @@ export function processResponsePacket(packet: DataQueryResponse, state: RunningQ
   };
 
   // updates to the same key will replace previous values
-  const key = packet.key || packet.data?.[0]?.refId || 'A';
+  const key = packet.key ?? packet.data?.[0]?.refId ?? 'A';
   packets[key] = packet;
 
   let loadingState = packet.state || LoadingState.Done;


### PR DESCRIPTION
While trying to debug https://github.com/grafana/grafana/issues/45524, I discovered that when we have multiple queries that return results with undefined 'key' in the packet, the results can clober each other.  See:
https://github.com/grafana/grafana/issues/45524#issuecomment-1083913583


![Peek 2022-03-30 18-06](https://user-images.githubusercontent.com/705951/160955872-7858ea64-9586-4b42-86ee-25033caf6e6a.gif)

This is a dashboard to reproduce.
[with empty-1648688946778.json.txt](https://github.com/grafana/grafana/files/8385122/with.empty-1648688946778.json.txt)


When digging deeper, it looks like we assume 'A' is the key if a datasource has not specified one.  In this PR, we also check the first frame for the key.
