### PR TITLE
InfluxDB: Migrate InfluxDB testdatasource to use backend query

### DIFF
--- a/devenv/docker/blocks/influxdb/docker-compose.yaml
+++ b/devenv/docker/blocks/influxdb/docker-compose.yaml
@@ -12,7 +12,6 @@
       DOCKER_INFLUXDB_INIT_BUCKET: 'mybucket'
       DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: 'mytoken'
     volumes:
-      - ./docker/blocks/influxdb/config.yaml:/etc/influxdb2/config.yaml
       - ./docker/blocks/influxdb/setup_influxql.sh:/docker-entrypoint-initdb.d/setup_influxql.sh
 
   telegraf:

--- a/pkg/tsdb/influxdb/handler_healthcheck.go
+++ b/pkg/tsdb/influxdb/handler_healthcheck.go
@@ -1,0 +1,126 @@
+package influxdb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/tsdb/influxdb/flux"
+	"github.com/grafana/grafana/pkg/tsdb/influxdb/models"
+)
+
+func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	dsInfo, err := s.getDSInfo(req.PluginContext)
+	if err != nil || dsInfo == nil {
+		return &backend.CheckHealthResult{
+			Message: fmt.Sprintf("Error getting datasource info. %s", err.Error()),
+			Status:  backend.HealthStatusError,
+		}, nil
+	}
+	switch dsInfo.Version {
+	case influxVersionFlux:
+		return CheckFluxHealth(ctx, dsInfo, req)
+	case influxVersionInfluxQL:
+		return CheckInfluxQLHealth(ctx, dsInfo, s)
+	default:
+		return &backend.CheckHealthResult{
+			Message: "unknown influx version",
+			Status:  backend.HealthStatusError,
+		}, nil
+	}
+}
+
+func CheckFluxHealth(ctx context.Context, dsInfo *models.DatasourceInfo, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	ds, err := flux.Query(ctx, dsInfo, backend.QueryDataRequest{
+		PluginContext: req.PluginContext,
+		Queries: []backend.DataQuery{
+			{
+				RefID: "healthcheck",
+				TimeRange: backend.TimeRange{
+					From: time.Now().AddDate(0, 0, -1),
+					To:   time.Now(),
+				},
+				Interval:      1 * time.Minute,
+				MaxDataPoints: 423,
+				JSON:          []byte(`{ "query" : "buckets()" }`),
+			},
+		},
+	})
+	if err != nil {
+		return &backend.CheckHealthResult{
+			Message: fmt.Sprintf("Error reading InfluxDB. %s", err.Error()),
+			Status:  backend.HealthStatusError,
+		}, nil
+	}
+	if res, ok := ds.Responses["healthcheck"]; ok {
+		if res.Error != nil {
+			return &backend.CheckHealthResult{
+				Message: fmt.Sprintf("Error reading buckets. %s", res.Error.Error()),
+				Status:  backend.HealthStatusError,
+			}, nil
+		}
+		if len(res.Frames) > 0 && len(res.Frames[0].Fields) > 0 {
+			return &backend.CheckHealthResult{
+				Message: fmt.Sprintf("Data source is working. %d buckets found", res.Frames[0].Fields[0].Len()),
+				Status:  backend.HealthStatusOk,
+			}, nil
+		}
+	}
+	return &backend.CheckHealthResult{
+		Message: "Error reading buckets",
+		Status:  backend.HealthStatusError,
+	}, nil
+}
+
+func CheckInfluxQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo, s *Service) (*backend.CheckHealthResult, error) {
+	influxQLHealthCheckQuery := "SHOW TAG KEYS"
+	request, err := s.createRequest(ctx, dsInfo, influxQLHealthCheckQuery)
+	if err != nil {
+		return &backend.CheckHealthResult{
+			Message: fmt.Sprintf("Error reading InfluxDB. %s", err.Error()),
+			Status:  backend.HealthStatusError,
+		}, nil
+	}
+	res, err := dsInfo.HTTPClient.Do(request)
+	if err != nil {
+		return &backend.CheckHealthResult{
+			Message: fmt.Sprintf("Error reading InfluxDB. %s", err.Error()),
+			Status:  backend.HealthStatusError,
+		}, nil
+	}
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			s.glog.Warn("Failed to close response body", "err", err)
+		}
+	}()
+	if res.StatusCode/100 != 2 {
+		return &backend.CheckHealthResult{
+			Message: fmt.Sprintf("Error reading InfluxDB. Status Code : %d", res.StatusCode),
+			Status:  backend.HealthStatusError,
+		}, nil
+	}
+	resp := s.responseParser.Parse(res.Body, []Query{{
+		RefID:       "healthcheck",
+		UseRawQuery: true,
+		RawQuery:    influxQLHealthCheckQuery,
+	}})
+	if res, ok := resp.Responses["healthcheck"]; ok {
+		if res.Error != nil {
+			return &backend.CheckHealthResult{
+				Message: fmt.Sprintf("Error reading InfluxDB. %s", res.Error.Error()),
+				Status:  backend.HealthStatusError,
+			}, nil
+		}
+		if len(res.Frames) > 0 && len(res.Frames[0].Fields) > 0 {
+			return &backend.CheckHealthResult{
+				Message: fmt.Sprintf("Data source is working. %d tag keys found", res.Frames[0].Fields[0].Len()),
+				Status:  backend.HealthStatusOk,
+			}, nil
+		}
+	}
+	return &backend.CheckHealthResult{
+		Message: "Error connecting influxDB influxQL",
+		Status:  backend.HealthStatusError,
+	}, nil
+}

--- a/pkg/tsdb/influxdb/handler_healthcheck.go
+++ b/pkg/tsdb/influxdb/handler_healthcheck.go
@@ -2,6 +2,7 @@ package influxdb
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -12,26 +13,23 @@ import (
 
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	dsInfo, err := s.getDSInfo(req.PluginContext)
-	if err != nil || dsInfo == nil {
-		return &backend.CheckHealthResult{
-			Message: fmt.Sprintf("Error getting datasource info. %s", err.Error()),
-			Status:  backend.HealthStatusError,
-		}, nil
+	if err != nil {
+		return getHealthCheckMessage(s, "error getting datasource info", err)
+	}
+	if dsInfo == nil {
+		return getHealthCheckMessage(s, "", errors.New("invalid datasource info received"))
 	}
 	switch dsInfo.Version {
 	case influxVersionFlux:
-		return CheckFluxHealth(ctx, dsInfo, req)
+		return CheckFluxHealth(ctx, dsInfo, s, req)
 	case influxVersionInfluxQL:
 		return CheckInfluxQLHealth(ctx, dsInfo, s)
 	default:
-		return &backend.CheckHealthResult{
-			Message: "unknown influx version",
-			Status:  backend.HealthStatusError,
-		}, nil
+		return getHealthCheckMessage(s, "", errors.New("unknown influx version"))
 	}
 }
 
-func CheckFluxHealth(ctx context.Context, dsInfo *models.DatasourceInfo, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+func CheckFluxHealth(ctx context.Context, dsInfo *models.DatasourceInfo, s *Service, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	ds, err := flux.Query(ctx, dsInfo, backend.QueryDataRequest{
 		PluginContext: req.PluginContext,
 		Queries: []backend.DataQuery{
@@ -48,79 +46,63 @@ func CheckFluxHealth(ctx context.Context, dsInfo *models.DatasourceInfo, req *ba
 		},
 	})
 	if err != nil {
-		return &backend.CheckHealthResult{
-			Message: fmt.Sprintf("Error reading InfluxDB. %s", err.Error()),
-			Status:  backend.HealthStatusError,
-		}, nil
+		return getHealthCheckMessage(s, "error performing flux query", err)
 	}
 	if res, ok := ds.Responses["healthcheck"]; ok {
 		if res.Error != nil {
-			return &backend.CheckHealthResult{
-				Message: fmt.Sprintf("Error reading buckets. %s", res.Error.Error()),
-				Status:  backend.HealthStatusError,
-			}, nil
+			return getHealthCheckMessage(s, "error reading buckets", res.Error)
 		}
 		if len(res.Frames) > 0 && len(res.Frames[0].Fields) > 0 {
-			return &backend.CheckHealthResult{
-				Message: fmt.Sprintf("Data source is working. %d buckets found", res.Frames[0].Fields[0].Len()),
-				Status:  backend.HealthStatusOk,
-			}, nil
+			return getHealthCheckMessage(s, fmt.Sprintf("%d buckets found", res.Frames[0].Fields[0].Len()), nil)
 		}
 	}
-	return &backend.CheckHealthResult{
-		Message: "Error reading buckets",
-		Status:  backend.HealthStatusError,
-	}, nil
+	return getHealthCheckMessage(s, "", errors.New("error getting flux query buckets"))
 }
 
 func CheckInfluxQLHealth(ctx context.Context, dsInfo *models.DatasourceInfo, s *Service) (*backend.CheckHealthResult, error) {
-	influxQLHealthCheckQuery := "SHOW TAG KEYS"
-	request, err := s.createRequest(ctx, dsInfo, influxQLHealthCheckQuery)
+	request, err := s.createRequest(ctx, dsInfo, "SHOW measurements")
 	if err != nil {
-		return &backend.CheckHealthResult{
-			Message: fmt.Sprintf("Error reading InfluxDB. %s", err.Error()),
-			Status:  backend.HealthStatusError,
-		}, nil
+		return getHealthCheckMessage(s, "error creating influxDB healthcheck request", err)
 	}
 	res, err := dsInfo.HTTPClient.Do(request)
 	if err != nil {
-		return &backend.CheckHealthResult{
-			Message: fmt.Sprintf("Error reading InfluxDB. %s", err.Error()),
-			Status:  backend.HealthStatusError,
-		}, nil
+		return getHealthCheckMessage(s, "error performing influxQL query", err)
 	}
 	defer func() {
 		if err := res.Body.Close(); err != nil {
-			s.glog.Warn("Failed to close response body", "err", err)
+			s.glog.Warn("failed to close response body", "err", err)
 		}
 	}()
 	if res.StatusCode/100 != 2 {
-		return &backend.CheckHealthResult{
-			Message: fmt.Sprintf("Error reading InfluxDB. Status Code : %d", res.StatusCode),
-			Status:  backend.HealthStatusError,
-		}, nil
+		return getHealthCheckMessage(s, "", fmt.Errorf("error reading InfluxDB. Status Code : %d", res.StatusCode))
 	}
 	resp := s.responseParser.Parse(res.Body, []Query{{
 		RefID:       "healthcheck",
 		UseRawQuery: true,
-		RawQuery:    influxQLHealthCheckQuery,
+		RawQuery:    "SHOW measurements",
 	}})
 	if res, ok := resp.Responses["healthcheck"]; ok {
 		if res.Error != nil {
-			return &backend.CheckHealthResult{
-				Message: fmt.Sprintf("Error reading InfluxDB. %s", res.Error.Error()),
-				Status:  backend.HealthStatusError,
-			}, nil
+			return getHealthCheckMessage(s, "error reading influxDB", res.Error)
 		}
 		if len(res.Frames) > 0 && len(res.Frames[0].Fields) > 0 {
-			return &backend.CheckHealthResult{
-				Message: fmt.Sprintf("Data source is working. %d tag keys found", res.Frames[0].Fields[0].Len()),
-				Status:  backend.HealthStatusOk,
-			}, nil
+			return getHealthCheckMessage(s, fmt.Sprintf("%d measurements found", res.Frames[0].Fields[0].Len()), nil)
 		}
 	}
+	return getHealthCheckMessage(s, "", errors.New("error connecting influxDB influxQL"))
+}
+
+func getHealthCheckMessage(s *Service, message string, err error) (*backend.CheckHealthResult, error) {
+	if err == nil {
+		return &backend.CheckHealthResult{
+			Status:  backend.HealthStatusOk,
+			Message: fmt.Sprintf("datasource is working. %s", message),
+		}, nil
+	}
+	s.glog.Warn("error performing influxdb healthcheck", "err", err.Error())
+	errorMessage := fmt.Sprintf("%s %s", err.Error(), message)
 	return &backend.CheckHealthResult{
-		Message: "Error connecting influxDB influxQL",
 		Status:  backend.HealthStatusError,
+		Message: errorMessage,
 	}, nil
 }

--- a/pkg/tsdb/influxdb/influxdb.go
+++ b/pkg/tsdb/influxdb/influxdb.go
@@ -64,11 +64,15 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 		if maxSeries == 0 {
 			maxSeries = 1000
 		}
+		version := jsonData.Version
+		if version == "" {
+			version = influxVersionInfluxQL
+		}
 		model := &models.DatasourceInfo{
 			HTTPClient:    client,
 			URL:           settings.URL,
 			Database:      settings.Database,
-			Version:       jsonData.Version,
+			Version:       version,
 			HTTPMode:      httpMode,
 			TimeInterval:  jsonData.TimeInterval,
 			DefaultBucket: jsonData.DefaultBucket,

--- a/pkg/tsdb/influxdb/settings.go
+++ b/pkg/tsdb/influxdb/settings.go
@@ -1,0 +1,6 @@
+package influxdb
+
+const (
+	influxVersionFlux     = "Flux"
+	influxVersionInfluxQL = "InfluxQL"
+)

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -1,7 +1,6 @@
-import { cloneDeep, extend, get, groupBy, has, isString, map as _map, omit, pick, reduce } from 'lodash';
+import { cloneDeep, extend, groupBy, has, isString, map as _map, omit, pick, reduce } from 'lodash';
 import { lastValueFrom, Observable, of, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-import { v4 as uuidv4 } from 'uuid';
 import {
   BackendDataSourceResponse,
   DataSourceWithBackend,
@@ -18,9 +17,7 @@ import {
   DataQueryResponse,
   DataSourceInstanceSettings,
   dateMath,
-  dateTime,
   FieldType,
-  LoadingState,
   MetricFindValue,
   QueryResultMeta,
   ScopedVars,
@@ -551,85 +548,6 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       },
       [] as string[]
     ).join('&');
-  }
-
-  testDatasource() {
-    if (this.isFlux) {
-      // TODO: eventually use the real /health endpoint
-      const request: DataQueryRequest<InfluxQuery> = {
-        targets: [{ refId: 'test', query: 'buckets()' }],
-        requestId: `${this.id}-health-${uuidv4()}`,
-        dashboardId: 0,
-        panelId: 0,
-        interval: '1m',
-        intervalMs: 60000,
-        maxDataPoints: 423,
-        range: {
-          from: dateTime(1000),
-          to: dateTime(2000),
-        },
-      } as DataQueryRequest<InfluxQuery>;
-
-      return lastValueFrom(super.query(request))
-        .then((res: DataQueryResponse) => {
-          if (!res || !res.data || res.state !== LoadingState.Done) {
-            console.error('InfluxDB Error', res);
-            return { status: 'error', message: 'Error reading InfluxDB' };
-          }
-          const first = res.data[0];
-          if (first && first.length) {
-            return { status: 'success', message: `${first.length} buckets found` };
-          }
-          console.error('InfluxDB Error', res);
-          return { status: 'error', message: 'Error reading buckets' };
-        })
-        .catch((err: any) => {
-          console.error('InfluxDB Error', err);
-          return { status: 'error', message: err.message };
-        });
-    }
-
-    if (this.isMigrationToggleOnAndIsAccessProxy()) {
-      const target: InfluxQuery = {
-        refId: 'metricFindQuery',
-        query: 'SHOW TAG KEYS',
-        rawQuery: true,
-      };
-      return lastValueFrom(super.query({ targets: [target] } as DataQueryRequest))
-        .then((res: DataQueryResponse) => {
-          if (!res || !res.data || res.state !== LoadingState.Done) {
-            return {
-              status: 'error',
-              message: 'Error reading InfluxDB.',
-            };
-          }
-          if (res.data?.length) {
-            return { status: 'success', message: 'Data source is working.' };
-          }
-          return {
-            status: 'error',
-            message: 'Successfully connected to InfluxDB, but no tags found.',
-          };
-        })
-        .catch((err: any) => {
-          return { status: 'error', message: err.message };
-        });
-    }
-
-    const queryBuilder = new InfluxQueryBuilder({ measurement: '', tags: [] }, this.database);
-    const query = queryBuilder.buildExploreQuery('RETENTION POLICIES');
-
-    return lastValueFrom(this._seriesQuery(query))
-      .then((res: any) => {
-        const error = get(res, 'results[0].error');
-        if (error) {
-          return { status: 'error', message: error };
-        }
-        return { status: 'success', message: 'Data source is working' };
-      })
-      .catch((err: any) => {
-        return { status: 'error', message: err.message };
-      });
   }
 
   _influxRequest(method: string, url: string, data: any, options?: any) {


### PR DESCRIPTION
As part of the [influxDB migration to backend](https://github.com/grafana/grafana/issues/47570), all the queries will be going from grafana server. 
