### PR TITLE
AzureMonitor: Skip App Insights check for v9

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
@@ -17,6 +17,7 @@ import AzureMonitorDatasource from './azure_monitor/azure_monitor_datasource';
 import AzureResourceGraphDatasource from './azure_resource_graph/azure_resource_graph_datasource';
 import AppInsightsDatasource from './components/deprecated/app_insights/app_insights_datasource';
 import InsightsAnalyticsDatasource from './components/deprecated/insights_analytics/insights_analytics_datasource';
+import { gtGrafana9 } from './components/deprecated/utils';
 import { getAzureCloud } from './credentials';
 import ResourcePickerData from './resourcePicker/resourcePickerData';
 import {
@@ -174,7 +175,7 @@ export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDa
     promises.push(this.azureMonitorDatasource.testDatasource());
     promises.push(this.azureLogAnalyticsDatasource.testDatasource());
 
-    if (this.appInsightsDatasource?.isConfigured()) {
+    if (!gtGrafana9() && this.appInsightsDatasource?.isConfigured()) {
       promises.push(this.appInsightsDatasource.testDatasource());
     }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Fixes a panic error when trying to save the Azure Monitor data source in Grafana `9-pre` versions (App Insights is no longer available there).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

This code should be deleted anyway after #46161

**Special notes for your reviewer**:

