### PR TITLE
API: enable proxying datasource calls using the datasource UID

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -322,7 +322,9 @@ func (hs *HTTPServer) registerRoutes() {
 
 		apiRoute.Get("/frontend/settings/", hs.GetFrontendSettings)
 		apiRoute.Any("/datasources/proxy/:id/*", authorize(reqSignedIn, ac.EvalPermission(datasources.ActionQuery)), hs.ProxyDataSourceRequest)
+		apiRoute.Any("/datasources/proxy/uid/:uid/*", authorize(reqSignedIn, ac.EvalPermission(datasources.ActionQuery)), hs.ProxyDataSourceRequestWithUID)
 		apiRoute.Any("/datasources/proxy/:id", authorize(reqSignedIn, ac.EvalPermission(datasources.ActionQuery)), hs.ProxyDataSourceRequest)
+		apiRoute.Any("/datasources/proxy/uid/:uid", authorize(reqSignedIn, ac.EvalPermission(datasources.ActionQuery)), hs.ProxyDataSourceRequestWithUID)
 		apiRoute.Any("/datasources/:id/resources", authorize(reqSignedIn, ac.EvalPermission(datasources.ActionQuery)), hs.CallDatasourceResource)
 		apiRoute.Any("/datasources/:id/resources/*", authorize(reqSignedIn, ac.EvalPermission(datasources.ActionQuery)), hs.CallDatasourceResource)
 		apiRoute.Any("/datasources/:id/health", authorize(reqSignedIn, ac.EvalPermission(datasources.ActionQuery)), routing.Wrap(hs.CheckDatasourceHealth))

--- a/pkg/api/dataproxy.go
+++ b/pkg/api/dataproxy.go
@@ -5,3 +5,7 @@ import "github.com/grafana/grafana/pkg/models"
 func (hs *HTTPServer) ProxyDataSourceRequest(c *models.ReqContext) {
 	hs.DataProxy.ProxyDataSourceRequest(c)
 }
+
+func (hs *HTTPServer) ProxyDataSourceRequestWithUID(c *models.ReqContext) {
+	hs.DataProxy.ProxyDatasourceRequestWithUID(c)
+}

--- a/pkg/services/datasourceproxy/datasourceproxy.go
+++ b/pkg/services/datasourceproxy/datasourceproxy.go
@@ -54,7 +54,7 @@ type DataSourceProxyService struct {
 func (p *DataSourceProxyService) ProxyDataSourceRequest(c *models.ReqContext) {
 	id, err := strconv.ParseInt(web.Params(c.Req)[":id"], 10, 64)
 	if err != nil {
-		p.ProxyDatasourceRequestWithUID(c)
+		c.JsonApiErr(http.StatusBadRequest, "id is invalid", err)
 		return
 	}
 	p.ProxyDatasourceRequestWithID(c, id)
@@ -63,7 +63,7 @@ func (p *DataSourceProxyService) ProxyDataSourceRequest(c *models.ReqContext) {
 func (p *DataSourceProxyService) ProxyDatasourceRequestWithUID(c *models.ReqContext) {
 	c.TimeRequest(metrics.MDataSourceProxyReqTimer)
 
-	dsUID := web.Params(c.Req)[":id"]
+	dsUID := web.Params(c.Req)[":uid"]
 	if !util.IsValidShortUID(dsUID) {
 		c.JsonApiErr(http.StatusBadRequest, "UID is invalid", nil)
 		return
@@ -128,7 +128,7 @@ func (p *DataSourceProxyService) proxyDatasourceRequest(c *models.ReqContext, ds
 	proxy.HandleRequest()
 }
 
-var proxyPathRegexp = regexp.MustCompile(`^\/api\/datasources\/proxy\/[\w]+\/?`)
+var proxyPathRegexp = regexp.MustCompile(`^\/api\/datasources\/proxy\/([\d]+|uid\/[\w]+)\/?`)
 
 func extractProxyPath(originalRawPath string) string {
 	return proxyPathRegexp.ReplaceAllString(originalRawPath, "")

--- a/pkg/services/datasourceproxy/datasourceproxy.go
+++ b/pkg/services/datasourceproxy/datasourceproxy.go
@@ -97,7 +97,6 @@ func toAPIError(c *models.ReqContext, err error) {
 		return
 	}
 	c.JsonApiErr(http.StatusInternalServerError, "Unable to load datasource meta data", err)
-	return
 }
 
 func (p *DataSourceProxyService) proxyDatasourceRequest(c *models.ReqContext, ds *models.DataSource) {

--- a/pkg/services/datasourceproxy/datasourceproxy_test.go
+++ b/pkg/services/datasourceproxy/datasourceproxy_test.go
@@ -25,15 +25,15 @@ func TestDataProxy(t *testing.T) {
 				"api/services/afsd%2Fafsd/operations",
 			},
 			{
-				"/api/datasources/proxy/26MI0wZ7k",
+				"/api/datasources/proxy/uid/26MI0wZ7k",
 				"",
 			},
 			{
-				"/api/datasources/proxy/26MI0wZ7k/some/thing",
+				"/api/datasources/proxy/uid/26MI0wZ7k/some/thing",
 				"some/thing",
 			},
 			{
-				"/api/datasources/proxy/26MI0wZ7k/api/services/afsd%2Fafsd/operations",
+				"/api/datasources/proxy/uid/26MI0wZ7k/api/services/afsd%2Fafsd/operations",
 				"api/services/afsd%2Fafsd/operations",
 			},
 		}

--- a/pkg/services/datasourceproxy/datasourceproxy_test.go
+++ b/pkg/services/datasourceproxy/datasourceproxy_test.go
@@ -24,6 +24,18 @@ func TestDataProxy(t *testing.T) {
 				"/api/datasources/proxy/54/api/services/afsd%2Fafsd/operations",
 				"api/services/afsd%2Fafsd/operations",
 			},
+			{
+				"/api/datasources/proxy/26MI0wZ7k",
+				"",
+			},
+			{
+				"/api/datasources/proxy/26MI0wZ7k/some/thing",
+				"some/thing",
+			},
+			{
+				"/api/datasources/proxy/26MI0wZ7k/api/services/afsd%2Fafsd/operations",
+				"api/services/afsd%2Fafsd/operations",
+			},
 		}
 		for _, tc := range testCases {
 			t.Run("Given raw path, should extract expected proxy path", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
It allows proxying requests to a datasource using the data source UID instead of the sequential data source ID.
This is part of work of removing the sequential IDs from the API and store layers. For more details you can refer to [this doc](https://docs.google.com/document/d/1LN55IDeLXQEPbuIJR2l02VM5I5GJLNpOlUQDfThDKe8/edit).

**Special notes for your reviewer**:
Example request of proxying using datasource ID:
```
curl -X 'GET' \
  'http://localhost:3000/api/datasources/proxy/28/loki/api/v1/label?start=1649763662030000000' \
  -H 'accept: application/json' \
  -H 'authorization: Basic YWRtaW46YWRtaW4='
{"status":"success","data":["__name__","filename","job"]}
```

Example request of proxying using datasource UID:
```
curl -X 'GET' \
  'http://localhost:3000/api/datasources/proxy/uid/PDDA8E780A17E7EF1/loki/api/v1/label?start=1649763662030000000' \
  -H 'accept: application/json' \
  -H 'authorization: Basic YWRtaW46YWRtaW4='
{"status":"success","data":["__name__","filename","job"]}
```

Example request of proxying to an unknown datasource UID:
```
curl -X 'GET'   'http://localhost:3000/api/datasources/proxy/uid/unknown/loki/api/v1/label?start=1649763662030000000'   -H 'accept: application/json'   -H 'authorization: Basic YWRtaW46YWRtaW4='
{
  "error": "data source not found",
  "message": "Unable to find datasource"
}
```

The former at some point it will be deprecated.

I plan to add the new endpoints in the OpenAPI/Swagger specification in a separate PR.