### PR TITLE
[v8.4.x] Remove deprecated @types/braintree__sanitize-url package

### DIFF
--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -52,7 +52,6 @@
     "@testing-library/react": "12.1.2",
     "@testing-library/react-hooks": "7.0.2",
     "@testing-library/user-event": "13.5.0",
-    "@types/braintree__sanitize-url": "4.1.0",
     "@types/jest": "27.4.0",
     "@types/jquery": "3.5.11",
     "@types/lodash": "4.14.149",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3100,13 +3100,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@braintree/sanitize-url@npm:*":
-  version: 5.0.2
-  resolution: "@braintree/sanitize-url@npm:5.0.2"
-  checksum: c033f9a0e6dd6fbd4022df2d3916a278510f759971b1e8ab278b3ce1123a3816d5fdd9d84c5c9fbcd6c94c05f8421c4c669f110c8db67eaf58f3018825af514e
-  languageName: node
-  linkType: hard
-
 "@braintree/sanitize-url@npm:6.0.0":
   version: 6.0.0
   resolution: "@braintree/sanitize-url@npm:6.0.0"
@@ -3699,7 +3692,6 @@ __metadata:
     "@testing-library/react": 12.1.2
     "@testing-library/react-hooks": 7.0.2
     "@testing-library/user-event": 13.5.0
-    "@types/braintree__sanitize-url": 4.1.0
     "@types/d3-interpolate": ^1.4.0
     "@types/jest": 27.4.0
     "@types/jquery": 3.5.11
@@ -8959,15 +8951,6 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: bfcadb042a41b124c4e3de4925e3be6d35b78f93f27c4535d5ff86980dc0f8bc407ed99b9b54528952dc62834d5a779392f7a12c2947dd19330eb05a6bcae15a
-  languageName: node
-  linkType: hard
-
-"@types/braintree__sanitize-url@npm:4.1.0":
-  version: 4.1.0
-  resolution: "@types/braintree__sanitize-url@npm:4.1.0"
-  dependencies:
-    "@braintree/sanitize-url": "*"
-  checksum: 29b91a4c6923d5e52cabd263abff9eecd24c2cdc7a1f16d945a26fa599e370d490bf1a4c7080157836850736c962712d26fe83cae94d5a67a0a968d2ef14950f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backport 30d0219de8315a18bb9169d8ba89115cee04665b from #47003