### PR TITLE
Extract Route validation from serialization methods so it can be re-used

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -51,6 +51,10 @@ func (srv *ProvisioningSrv) RoutePostPolicyTree(c *models.ReqContext, tree apimo
 	if errors.Is(err, store.ErrNoAlertmanagerConfiguration) {
 		return ErrResp(http.StatusNotFound, err, "")
 	}
+	var verr provisioning.ValidationError
+	if errors.As(err, &verr) {
+		return ErrResp(http.StatusBadRequest, err, "")
+	}
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "")
 	}

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -51,8 +51,7 @@ func (srv *ProvisioningSrv) RoutePostPolicyTree(c *models.ReqContext, tree apimo
 	if errors.Is(err, store.ErrNoAlertmanagerConfiguration) {
 		return ErrResp(http.StatusNotFound, err, "")
 	}
-	var verr provisioning.ValidationError
-	if errors.As(err, &verr) {
+	if errors.Is(err, provisioning.ErrValidation) {
 		return ErrResp(http.StatusBadRequest, err, "")
 	}
 	if err != nil {

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	alerting_models "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -35,7 +35,20 @@ func TestProvisioningApi(t *testing.T) {
 		require.Equal(t, 202, response.Status())
 	})
 
-	// TODO: we have not lifted out validation yet. Test that we are returning errors properly once validation has been lifted.
+	t.Run("when new policy tree is invalid", func(t *testing.T) {
+		t.Run("POST policies returns 400", func(t *testing.T) {
+			sut := createProvisioningSrvSut()
+			sut.policies = &fakeRejectingNotificationPolicyService{}
+			rc := createTestRequestCtx()
+			tree := apimodels.Route{}
+
+			response := sut.RoutePostPolicyTree(&rc, tree)
+
+			require.Equal(t, 400, response.Status())
+			expBody := `{"error":"invalid policy tree","message":"invalid policy tree"}`
+			require.Equal(t, expBody, string(response.Body()))
+		})
+	})
 
 	t.Run("when org has no AM config", func(t *testing.T) {
 		t.Run("GET policies returns 404", func(t *testing.T) {
@@ -145,4 +158,14 @@ func (f *fakeFailingNotificationPolicyService) GetPolicyTree(ctx context.Context
 
 func (f *fakeFailingNotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgID int64, tree apimodels.Route, p domain.Provenance) error {
 	return fmt.Errorf("something went wrong")
+}
+
+type fakeRejectingNotificationPolicyService struct{}
+
+func (f *fakeRejectingNotificationPolicyService) GetPolicyTree(ctx context.Context, orgID int64) (provisioning.EmbeddedRoutingTree, error) {
+	return provisioning.EmbeddedRoutingTree{}, nil
+}
+
+func (f *fakeRejectingNotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgID int64, tree apimodels.Route, p domain.Provenance) error {
+	return provisioning.NewValidationError("invalid policy tree")
 }

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -45,7 +45,7 @@ func TestProvisioningApi(t *testing.T) {
 			response := sut.RoutePostPolicyTree(&rc, tree)
 
 			require.Equal(t, 400, response.Status())
-			expBody := `{"error":"invalid policy tree","message":"invalid policy tree"}`
+			expBody := `{"error":"invalid route specification: invalid policy tree","message":"invalid route specification: invalid policy tree"}`
 			require.Equal(t, expBody, string(response.Body()))
 		})
 	})
@@ -167,5 +167,5 @@ func (f *fakeRejectingNotificationPolicyService) GetPolicyTree(ctx context.Conte
 }
 
 func (f *fakeRejectingNotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgID int64, tree apimodels.Route, p domain.Provenance) error {
-	return provisioning.NewValidationError("invalid policy tree")
+	return fmt.Errorf("%w: invalid policy tree", provisioning.ErrValidation)
 }

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -46,7 +46,7 @@ func TestProvisioningApi(t *testing.T) {
 			response := sut.RoutePostPolicyTree(&rc, tree)
 
 			require.Equal(t, 400, response.Status())
-			expBody := `{"error":"invalid route specification: invalid policy tree","message":"invalid route specification: invalid policy tree"}`
+			expBody := `{"error":"invalid object specification: invalid policy tree","message":"invalid object specification: invalid policy tree"}`
 			require.Equal(t, expBody, string(response.Body()))
 		})
 	})

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	domain "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/require"
@@ -162,8 +163,8 @@ func (f *fakeFailingNotificationPolicyService) UpdatePolicyTree(ctx context.Cont
 
 type fakeRejectingNotificationPolicyService struct{}
 
-func (f *fakeRejectingNotificationPolicyService) GetPolicyTree(ctx context.Context, orgID int64) (provisioning.EmbeddedRoutingTree, error) {
-	return provisioning.EmbeddedRoutingTree{}, nil
+func (f *fakeRejectingNotificationPolicyService) GetPolicyTree(ctx context.Context, orgID int64) (apimodels.Route, error) {
+	return apimodels.Route{}, nil
 }
 
 func (f *fakeRejectingNotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgID int64, tree apimodels.Route, p domain.Provenance) error {

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -726,48 +726,6 @@ func (r *Route) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return r.Validate()
 }
 
-func (r *Route) Validate() error {
-	for _, l := range r.GroupByStr {
-		if l == "..." {
-			r.GroupByAll = true
-		} else {
-			r.GroupBy = append(r.GroupBy, model.LabelName(l))
-		}
-	}
-
-	if len(r.GroupBy) > 0 && r.GroupByAll {
-		return fmt.Errorf("cannot have wildcard group_by (`...`) and other other labels at the same time")
-	}
-
-	groupBy := map[model.LabelName]struct{}{}
-
-	for _, ln := range r.GroupBy {
-		if _, ok := groupBy[ln]; ok {
-			return fmt.Errorf("duplicated label %q in group_by", ln)
-		}
-		groupBy[ln] = struct{}{}
-	}
-
-	if r.GroupInterval != nil && time.Duration(*r.GroupInterval) == time.Duration(0) {
-		return fmt.Errorf("group_interval cannot be zero")
-	}
-	if r.RepeatInterval != nil && time.Duration(*r.RepeatInterval) == time.Duration(0) {
-		return fmt.Errorf("repeat_interval cannot be zero")
-	}
-
-	// Routes are a self-referential structure.
-	if r.Routes != nil {
-		for _, child := range r.Routes {
-			err := child.Validate()
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
 // Return an alertmanager route from a Grafana route. The ObjectMatchers are converted to Matchers.
 func (r *Route) AsAMRoute() *config.Route {
 	amRoute := &config.Route{

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -723,7 +723,7 @@ func (r *Route) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	return r.Validate()
+	return r.validate()
 }
 
 // Return an alertmanager route from a Grafana route. The ObjectMatchers are converted to Matchers.

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -808,19 +808,9 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("no routes provided")
 	}
 
-	err := c.Route.Validate()
+	err := c.Route.ValidateRoot()
 	if err != nil {
 		return err
-	}
-
-	if len(c.Route.Receiver) == 0 {
-		return fmt.Errorf("root route must specify a default receiver")
-	}
-	if len(c.Route.Match) > 0 || len(c.Route.MatchRE) > 0 {
-		return fmt.Errorf("root route must not have any matchers")
-	}
-	if len(c.Route.MuteTimeIntervals) > 0 {
-		return fmt.Errorf("root route must not have any mute time intervals")
 	}
 
 	for _, r := range c.InhibitRules {

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -723,7 +723,7 @@ func (r *Route) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	return r.validate()
+	return r.validateChild()
 }
 
 // Return an alertmanager route from a Grafana route. The ObjectMatchers are converted to Matchers.
@@ -808,7 +808,7 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 		return fmt.Errorf("no routes provided")
 	}
 
-	err := c.Route.ValidateRoot()
+	err := c.Route.Validate()
 	if err != nil {
 		return err
 	}

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/common/model"
 )
 
+// Validate normalizes a Route r, and returns errors if r is invalid.
 func (r *Route) Validate() error {
 	for _, l := range r.GroupByStr {
 		if l == "..." {
@@ -47,4 +48,18 @@ func (r *Route) Validate() error {
 	}
 
 	return nil
+}
+
+// ValidateRoot normalizes a Route r, and returns errors if r is an invalid root route. Root routes must satisfy a few additional conditions.
+func (r *Route) ValidateRoot() error {
+	if len(r.Receiver) == 0 {
+		return fmt.Errorf("root route must specify a default receiver")
+	}
+	if len(r.Match) > 0 || len(r.MatchRE) > 0 {
+		return fmt.Errorf("root route must not have any matchers")
+	}
+	if len(r.MuteTimeIntervals) > 0 {
+		return fmt.Errorf("root route must not have any mute time intervals")
+	}
+	return r.Validate()
 }

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
@@ -7,8 +7,8 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-// Validate normalizes a Route r, and returns errors if r is invalid.
-func (r *Route) Validate() error {
+// Validate normalizes a possibly nested Route r, and returns errors if r is invalid.
+func (r *Route) validate() error {
 	r.GroupBy = nil
 	r.GroupByAll = false
 	for _, l := range r.GroupByStr {
@@ -42,7 +42,7 @@ func (r *Route) Validate() error {
 	// Routes are a self-referential structure.
 	if r.Routes != nil {
 		for _, child := range r.Routes {
-			err := child.Validate()
+			err := child.validate()
 			if err != nil {
 				return err
 			}
@@ -63,5 +63,5 @@ func (r *Route) ValidateRoot() error {
 	if len(r.MuteTimeIntervals) > 0 {
 		return fmt.Errorf("root route must not have any mute time intervals")
 	}
-	return r.Validate()
+	return r.validate()
 }

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
@@ -1,0 +1,50 @@
+package definitions
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/prometheus/common/model"
+)
+
+func (r *Route) Validate() error {
+	for _, l := range r.GroupByStr {
+		if l == "..." {
+			r.GroupByAll = true
+		} else {
+			r.GroupBy = append(r.GroupBy, model.LabelName(l))
+		}
+	}
+
+	if len(r.GroupBy) > 0 && r.GroupByAll {
+		return fmt.Errorf("cannot have wildcard group_by (`...`) and other other labels at the same time")
+	}
+
+	groupBy := map[model.LabelName]struct{}{}
+
+	for _, ln := range r.GroupBy {
+		if _, ok := groupBy[ln]; ok {
+			return fmt.Errorf("duplicated label %q in group_by", ln)
+		}
+		groupBy[ln] = struct{}{}
+	}
+
+	if r.GroupInterval != nil && time.Duration(*r.GroupInterval) == time.Duration(0) {
+		return fmt.Errorf("group_interval cannot be zero")
+	}
+	if r.RepeatInterval != nil && time.Duration(*r.RepeatInterval) == time.Duration(0) {
+		return fmt.Errorf("repeat_interval cannot be zero")
+	}
+
+	// Routes are a self-referential structure.
+	if r.Routes != nil {
+		for _, child := range r.Routes {
+			err := child.Validate()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
@@ -9,6 +9,8 @@ import (
 
 // Validate normalizes a Route r, and returns errors if r is invalid.
 func (r *Route) Validate() error {
+	r.GroupBy = nil
+	r.GroupByAll = false
 	for _, l := range r.GroupByStr {
 		if l == "..." {
 			r.GroupByAll = true
@@ -25,7 +27,7 @@ func (r *Route) Validate() error {
 
 	for _, ln := range r.GroupBy {
 		if _, ok := groupBy[ln]; ok {
-			return fmt.Errorf("duplicated label %q in group_by", ln)
+			return fmt.Errorf("duplicated label %q in group_by, %s %s", ln, r.Receiver, r.GroupBy)
 		}
 		groupBy[ln] = struct{}{}
 	}

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Validate normalizes a possibly nested Route r, and returns errors if r is invalid.
-func (r *Route) validate() error {
+func (r *Route) validateChild() error {
 	r.GroupBy = nil
 	r.GroupByAll = false
 	for _, l := range r.GroupByStr {
@@ -42,7 +42,7 @@ func (r *Route) validate() error {
 	// Routes are a self-referential structure.
 	if r.Routes != nil {
 		for _, child := range r.Routes {
-			err := child.validate()
+			err := child.validateChild()
 			if err != nil {
 				return err
 			}
@@ -52,8 +52,8 @@ func (r *Route) validate() error {
 	return nil
 }
 
-// ValidateRoot normalizes a Route r, and returns errors if r is an invalid root route. Root routes must satisfy a few additional conditions.
-func (r *Route) ValidateRoot() error {
+// Validate normalizes a Route r, and returns errors if r is an invalid root route. Root routes must satisfy a few additional conditions.
+func (r *Route) Validate() error {
 	if len(r.Receiver) == 0 {
 		return fmt.Errorf("root route must specify a default receiver")
 	}
@@ -63,5 +63,5 @@ func (r *Route) ValidateRoot() error {
 	if len(r.MuteTimeIntervals) > 0 {
 		return fmt.Errorf("root route must not have any mute time intervals")
 	}
-	return r.validate()
+	return r.validateChild()
 }

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation_test.go
@@ -45,7 +45,7 @@ func TestValidateRoutes(t *testing.T) {
 
 		for _, c := range cases {
 			t.Run(c.desc, func(t *testing.T) {
-				err := c.route.Validate()
+				err := c.route.validate()
 
 				require.NoError(t, err)
 			})
@@ -114,7 +114,7 @@ func TestValidateRoutes(t *testing.T) {
 
 		for _, c := range cases {
 			t.Run(c.desc, func(t *testing.T) {
-				err := c.route.Validate()
+				err := c.route.validate()
 
 				require.Error(t, err)
 				require.Contains(t, err.Error(), c.expMsg)
@@ -129,7 +129,7 @@ func TestValidateRoutes(t *testing.T) {
 				GroupByStr: []string{"abc", "def"},
 			}
 
-			_ = route.Validate()
+			_ = route.validate()
 
 			require.False(t, route.GroupByAll)
 			require.Equal(t, []model.LabelName{"abc", "def"}, route.GroupBy)
@@ -141,7 +141,7 @@ func TestValidateRoutes(t *testing.T) {
 				GroupByStr: []string{"..."},
 			}
 
-			_ = route.Validate()
+			_ = route.validate()
 
 			require.True(t, route.GroupByAll)
 			require.Nil(t, route.GroupBy)
@@ -153,9 +153,9 @@ func TestValidateRoutes(t *testing.T) {
 				GroupByStr: []string{"abc", "def"},
 			}
 
-			err := route.Validate()
+			err := route.validate()
 			require.NoError(t, err)
-			err = route.Validate()
+			err = route.validate()
 			require.NoError(t, err)
 
 			require.False(t, route.GroupByAll)

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation_test.go
@@ -146,6 +146,21 @@ func TestValidateRoutes(t *testing.T) {
 			require.True(t, route.GroupByAll)
 			require.Nil(t, route.GroupBy)
 		})
+
+		t.Run("idempotently", func(t *testing.T) {
+			route := Route{
+				Receiver:   "foo",
+				GroupByStr: []string{"abc", "def"},
+			}
+
+			err := route.Validate()
+			require.NoError(t, err)
+			err = route.Validate()
+			require.NoError(t, err)
+
+			require.False(t, route.GroupByAll)
+			require.Equal(t, []model.LabelName{"abc", "def"}, route.GroupBy)
+		})
 	})
 
 	t.Run("valid root route", func(t *testing.T) {

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation_test.go
@@ -1,0 +1,150 @@
+package definitions
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateRoutes(t *testing.T) {
+	zero := model.Duration(0)
+
+	type testCase struct {
+		desc   string
+		route  Route
+		expMsg string
+	}
+
+	t.Run("valid route", func(t *testing.T) {
+		cases := []testCase{
+			{
+				desc:  "empty",
+				route: Route{},
+			},
+			{
+				desc: "simple",
+				route: Route{
+					Receiver:   "foo",
+					GroupByStr: []string{"..."},
+				},
+			},
+			{
+				desc: "nested",
+				route: Route{
+					Receiver:   "foo",
+					GroupByStr: []string{"..."},
+					Routes: []*Route{
+						{
+							Receiver: "bar",
+						},
+					},
+				},
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.desc, func(t *testing.T) {
+				err := c.route.Validate()
+
+				require.NoError(t, err)
+			})
+		}
+	})
+
+	t.Run("invalid route", func(t *testing.T) {
+		cases := []testCase{
+			{
+				desc: "zero group interval",
+				route: Route{
+					Receiver:      "foo",
+					GroupByStr:    []string{"..."},
+					GroupInterval: &zero,
+				},
+				expMsg: "group_interval cannot be zero",
+			},
+			{
+				desc: "zero repeat interval",
+				route: Route{
+					Receiver:       "foo",
+					GroupByStr:     []string{"..."},
+					RepeatInterval: &zero,
+				},
+				expMsg: "repeat_interval cannot be zero",
+			},
+			{
+				desc: "duplicated label",
+				route: Route{
+					Receiver: "foo",
+					GroupByStr: []string{
+						"abc",
+						"abc",
+					},
+				},
+				expMsg: "duplicated label",
+			},
+			{
+				desc: "wildcard and non-wildcard label simultaneously",
+				route: Route{
+					Receiver: "foo",
+					GroupByStr: []string{
+						"...",
+						"abc",
+					},
+				},
+				expMsg: "cannot have wildcard",
+			},
+			{
+				desc: "valid with nested invalid",
+				route: Route{
+					Receiver:   "foo",
+					GroupByStr: []string{"..."},
+					Routes: []*Route{
+						{
+							GroupByStr: []string{
+								"abc",
+								"abc",
+							},
+						},
+					},
+				},
+				expMsg: "duplicated label",
+			},
+		}
+
+		for _, c := range cases {
+			t.Run(c.desc, func(t *testing.T) {
+				err := c.route.Validate()
+
+				require.Error(t, err)
+				require.Contains(t, err.Error(), c.expMsg)
+			})
+		}
+	})
+
+	t.Run("route validator normalizes group_by", func(t *testing.T) {
+		t.Run("when grouping normally", func(t *testing.T) {
+			route := Route{
+				Receiver:   "foo",
+				GroupByStr: []string{"abc", "def"},
+			}
+
+			_ = route.Validate()
+
+			require.False(t, route.GroupByAll)
+			require.Equal(t, []model.LabelName{"abc", "def"}, route.GroupBy)
+		})
+
+		t.Run("when grouping by wildcard, nil", func(t *testing.T) {
+			route := Route{
+				Receiver:   "foo",
+				GroupByStr: []string{"..."},
+			}
+
+			_ = route.Validate()
+
+			require.True(t, route.GroupByAll)
+			require.Nil(t, route.GroupBy)
+		})
+	})
+}

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation_test.go
@@ -45,7 +45,7 @@ func TestValidateRoutes(t *testing.T) {
 
 		for _, c := range cases {
 			t.Run(c.desc, func(t *testing.T) {
-				err := c.route.validate()
+				err := c.route.validateChild()
 
 				require.NoError(t, err)
 			})
@@ -114,7 +114,7 @@ func TestValidateRoutes(t *testing.T) {
 
 		for _, c := range cases {
 			t.Run(c.desc, func(t *testing.T) {
-				err := c.route.validate()
+				err := c.route.validateChild()
 
 				require.Error(t, err)
 				require.Contains(t, err.Error(), c.expMsg)
@@ -129,7 +129,7 @@ func TestValidateRoutes(t *testing.T) {
 				GroupByStr: []string{"abc", "def"},
 			}
 
-			_ = route.validate()
+			_ = route.validateChild()
 
 			require.False(t, route.GroupByAll)
 			require.Equal(t, []model.LabelName{"abc", "def"}, route.GroupBy)
@@ -141,7 +141,7 @@ func TestValidateRoutes(t *testing.T) {
 				GroupByStr: []string{"..."},
 			}
 
-			_ = route.validate()
+			_ = route.validateChild()
 
 			require.True(t, route.GroupByAll)
 			require.Nil(t, route.GroupBy)
@@ -153,9 +153,9 @@ func TestValidateRoutes(t *testing.T) {
 				GroupByStr: []string{"abc", "def"},
 			}
 
-			err := route.validate()
+			err := route.validateChild()
 			require.NoError(t, err)
-			err = route.validate()
+			err = route.validateChild()
 			require.NoError(t, err)
 
 			require.False(t, route.GroupByAll)
@@ -176,7 +176,7 @@ func TestValidateRoutes(t *testing.T) {
 
 		for _, c := range cases {
 			t.Run(c.desc, func(t *testing.T) {
-				err := c.route.ValidateRoot()
+				err := c.route.Validate()
 
 				require.NoError(t, err)
 			})
@@ -247,7 +247,7 @@ func TestValidateRoutes(t *testing.T) {
 
 		for _, c := range cases {
 			t.Run(c.desc, func(t *testing.T) {
-				err := c.route.ValidateRoot()
+				err := c.route.Validate()
 
 				require.Error(t, err)
 				require.Contains(t, err.Error(), c.expMsg)

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -61,7 +61,7 @@ func (nps *NotificationPolicyService) GetPolicyTree(ctx context.Context, orgID i
 func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgID int64, tree definitions.Route, p models.Provenance) error {
 	err := tree.ValidateRoot()
 	if err != nil {
-		return NewValidationError(err.Error())
+		return fmt.Errorf("%w: %s", ErrValidation, err.Error())
 	}
 
 	q := models.GetLatestAlertmanagerConfigurationQuery{

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -59,7 +59,7 @@ func (nps *NotificationPolicyService) GetPolicyTree(ctx context.Context, orgID i
 }
 
 func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgID int64, tree definitions.Route, p models.Provenance) error {
-	err := tree.Validate()
+	err := tree.ValidateRoot()
 	if err != nil {
 		return NewValidationError(err.Error())
 	}

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -59,10 +59,15 @@ func (nps *NotificationPolicyService) GetPolicyTree(ctx context.Context, orgID i
 }
 
 func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgID int64, tree definitions.Route, p models.Provenance) error {
+	err := tree.Validate()
+	if err != nil {
+		return NewValidationError(err.Error())
+	}
+
 	q := models.GetLatestAlertmanagerConfigurationQuery{
 		OrgID: orgID,
 	}
-	err := nps.amStore.GetLatestAlertmanagerConfiguration(ctx, &q)
+	err = nps.amStore.GetLatestAlertmanagerConfiguration(ctx, &q)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -59,7 +59,7 @@ func (nps *NotificationPolicyService) GetPolicyTree(ctx context.Context, orgID i
 }
 
 func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgID int64, tree definitions.Route, p models.Provenance) error {
-	err := tree.ValidateRoot()
+	err := tree.Validate()
 	if err != nil {
 		return fmt.Errorf("%w: %s", ErrValidation, err.Error())
 	}

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,6 +70,18 @@ func TestNotificationPolicyService(t *testing.T) {
 		fake := sut.GetAMConfigStore().(*fakeAMConfigStore)
 		intercepted := fake.lastSaveCommand
 		require.Equal(t, expectedConcurrencyToken, intercepted.FetchedConfigurationHash)
+	})
+
+	t.Run("updating invalid route returns ValidationError", func(t *testing.T) {
+		sut := createNotificationPolicyServiceSut()
+		invalid := createTestRoutingTree()
+		repeat := model.Duration(0)
+		invalid.RepeatInterval = &repeat
+
+		err := sut.UpdatePolicyTree(context.Background(), 1, invalid, models.ProvenanceNone)
+
+		require.Error(t, err)
+		require.ErrorAs(t, err, &ValidationError{})
 	})
 }
 

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -81,7 +81,7 @@ func TestNotificationPolicyService(t *testing.T) {
 		err := sut.UpdatePolicyTree(context.Background(), 1, invalid, models.ProvenanceNone)
 
 		require.Error(t, err)
-		require.ErrorAs(t, err, &ValidationError{})
+		require.ErrorIs(t, err, ErrValidation)
 	})
 }
 

--- a/pkg/services/ngalert/provisioning/validate.go
+++ b/pkg/services/ngalert/provisioning/validate.go
@@ -1,15 +1,5 @@
 package provisioning
 
-type ValidationError struct {
-	msg string
-}
+import "fmt"
 
-func (e ValidationError) Error() string {
-	return e.msg
-}
-
-func NewValidationError(msg string) ValidationError {
-	return ValidationError{
-		msg: msg,
-	}
-}
+var ErrValidation = fmt.Errorf("invalid route specification")

--- a/pkg/services/ngalert/provisioning/validate.go
+++ b/pkg/services/ngalert/provisioning/validate.go
@@ -1,0 +1,15 @@
+package provisioning
+
+type ValidationError struct {
+	msg string
+}
+
+func (e ValidationError) Error() string {
+	return e.msg
+}
+
+func NewValidationError(msg string) ValidationError {
+	return ValidationError{
+		msg: msg,
+	}
+}

--- a/pkg/services/ngalert/provisioning/validate.go
+++ b/pkg/services/ngalert/provisioning/validate.go
@@ -2,4 +2,4 @@ package provisioning
 
 import "fmt"
 
-var ErrValidation = fmt.Errorf("invalid route specification")
+var ErrValidation = fmt.Errorf("invalid object specification")


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The validation code for the `definitions.Route` object is blended together with its validation code. There are a few spots where we serialize and then deserialize the object just for validation. This technically matches prometheus's codebase, but it's difficult to re-use, and it's not always clear _which_ serialization route has the validation we need. Also, the validation is untested.

This PR:
- Extract the validation code to Validate() methods.
- Adds unit tests for the validation code. (Up for debate whether this is the best long-term strategy, but it's an improvement over what we have now, and verifies the shifted code still works)
- Updates the provisioning API to call the new validator, re-using it.

**Special notes for your reviewer**:

