### PR TITLE
Prometheus: Query builder UX tweaks and feedback link

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -230,6 +230,9 @@ application_insights_connection_string =
 # Optional. Specifies an Application Insights endpoint URL where the endpoint string is wrapped in backticks ``.
 application_insights_endpoint_url =
 
+# Controls if the UI contains any links to user feedback forms
+hide_feedback_links = false
+
 #################################### Security ############################
 [security]
 # disable creation of admin user on first start of grafana

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -231,7 +231,7 @@ application_insights_connection_string =
 application_insights_endpoint_url =
 
 # Controls if the UI contains any links to user feedback forms
-hide_feedback_links = false
+feedback_links_enabled = true
 
 #################################### Security ############################
 [security]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -231,7 +231,7 @@
 ;rudderstack_config_url =
 
 # Controls if the UI contains any links to user feedback forms
-;hide_feedback_links = false
+;feedback_links_enabled = true
 
 #################################### Security ####################################
 [security]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -230,6 +230,9 @@
 # Rudderstack Config url, optional, used by Rudderstack SDK to fetch source config
 ;rudderstack_config_url =
 
+# Controls if the UI contains any links to user feedback forms
+;hide_feedback_links = false
+
 #################################### Security ####################################
 [security]
 # disable creation of admin user on first start of grafana

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -509,6 +509,10 @@ If you want to track Grafana usage via Azure Application Insights, then specify 
 
 <hr />
 
+### enable_feedback_links
+
+If set to false will remove all feedback links from the UI. Defaults to true.
+
 ## [security]
 
 ### disable_initial_admin_creation

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -180,5 +180,5 @@ export interface GrafanaConfig {
   geomapDisableCustomBaseLayer?: boolean;
   unifiedAlertingEnabled: boolean;
   angularSupportEnabled: boolean;
-  hideFeedbackLinks: boolean;
+  feedbackLinksEnabled: boolean;
 }

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -180,4 +180,5 @@ export interface GrafanaConfig {
   geomapDisableCustomBaseLayer?: boolean;
   unifiedAlertingEnabled: boolean;
   angularSupportEnabled: boolean;
+  hideFeedbackLinks: boolean;
 }

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -36,7 +36,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   externalUserMngLinkName = '';
   externalUserMngInfo = '';
   allowOrgCreate = false;
-  hideFeedbackLinks = false;
+  feedbackLinksEnabled = true;
   disableLoginForm = false;
   defaultDatasource = ''; // UID
   alertingEnabled = false;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -36,6 +36,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   externalUserMngLinkName = '';
   externalUserMngInfo = '';
   allowOrgCreate = false;
+  hideFeedbackLinks = false;
   disableLoginForm = false;
   defaultDatasource = ''; // UID
   alertingEnabled = false;

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -113,6 +113,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"rudderstackDataPlaneUrl":             setting.RudderstackDataPlaneUrl,
 		"rudderstackSdkUrl":                   setting.RudderstackSdkUrl,
 		"rudderstackConfigUrl":                setting.RudderstackConfigUrl,
+		"hideFeedbackLinks":                   hs.Cfg.HideFeedbackLinks,
 		"applicationInsightsConnectionString": hs.Cfg.ApplicationInsightsConnectionString,
 		"applicationInsightsEndpointUrl":      hs.Cfg.ApplicationInsightsEndpointUrl,
 		"disableLoginForm":                    setting.DisableLoginForm,

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -113,7 +113,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"rudderstackDataPlaneUrl":             setting.RudderstackDataPlaneUrl,
 		"rudderstackSdkUrl":                   setting.RudderstackSdkUrl,
 		"rudderstackConfigUrl":                setting.RudderstackConfigUrl,
-		"hideFeedbackLinks":                   hs.Cfg.HideFeedbackLinks,
+		"feedbackLinksEnabled":                hs.Cfg.FeedbackLinksEnabled,
 		"applicationInsightsConnectionString": hs.Cfg.ApplicationInsightsConnectionString,
 		"applicationInsightsEndpointUrl":      hs.Cfg.ApplicationInsightsEndpointUrl,
 		"disableLoginForm":                    setting.DisableLoginForm,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -393,7 +393,7 @@ type Cfg struct {
 	ReportingEnabled                    bool
 	ApplicationInsightsConnectionString string
 	ApplicationInsightsEndpointUrl      string
-	HideFeedbackLinks                   bool
+	FeedbackLinksEnabled                bool
 
 	// LDAP
 	LDAPEnabled     bool
@@ -949,7 +949,7 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 
 	cfg.ApplicationInsightsConnectionString = analytics.Key("application_insights_connection_string").String()
 	cfg.ApplicationInsightsEndpointUrl = analytics.Key("application_insights_endpoint_url").String()
-	cfg.HideFeedbackLinks = analytics.Key("hide_feedback_links").MustBool(false)
+	cfg.FeedbackLinksEnabled = analytics.Key("feedback_links_enabled").MustBool(true)
 
 	if err := readAlertingSettings(iniFile); err != nil {
 		return err

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -393,6 +393,7 @@ type Cfg struct {
 	ReportingEnabled                    bool
 	ApplicationInsightsConnectionString string
 	ApplicationInsightsEndpointUrl      string
+	HideFeedbackLinks                   bool
 
 	// LDAP
 	LDAPEnabled     bool
@@ -938,13 +939,17 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 	RudderstackDataPlaneUrl = analytics.Key("rudderstack_data_plane_url").String()
 	RudderstackSdkUrl = analytics.Key("rudderstack_sdk_url").String()
 	RudderstackConfigUrl = analytics.Key("rudderstack_config_url").String()
+
 	cfg.ReportingEnabled = analytics.Key("reporting_enabled").MustBool(true)
 	cfg.ReportingDistributor = analytics.Key("reporting_distributor").MustString("grafana-labs")
+
 	if len(cfg.ReportingDistributor) >= 100 {
 		cfg.ReportingDistributor = cfg.ReportingDistributor[:100]
 	}
+
 	cfg.ApplicationInsightsConnectionString = analytics.Key("application_insights_connection_string").String()
 	cfg.ApplicationInsightsEndpointUrl = analytics.Key("application_insights_endpoint_url").String()
+	cfg.HideFeedbackLinks = analytics.Key("hide_feedback_links").MustBool(false)
 
 	if err := readAlertingSettings(iniFile); err != nil {
 		return err

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderContainer.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderContainer.tsx
@@ -54,7 +54,7 @@ export function PromQueryBuilderContainer(props: Props) {
         onRunQuery={onRunQuery}
         data={data}
       />
-      {query.editorPreview && <QueryPreview query={query.expr} />}
+      {query.rawQuery && <QueryPreview query={query.expr} />}
     </>
   );
 }

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.test.tsx
@@ -90,24 +90,24 @@ describe('PromQueryEditorSelector', () => {
     });
   });
 
-  it('Can enable preview', async () => {
+  it('Can enable raw query', async () => {
     const { onChange } = renderWithMode(QueryEditorMode.Builder);
     expect(screen.queryByLabelText('selector')).not.toBeInTheDocument();
 
-    screen.getByLabelText('Preview').click();
+    screen.getByLabelText('Raw query').click();
 
     expect(onChange).toBeCalledWith({
       refId: 'A',
       expr: defaultQuery.expr,
       range: true,
       editorMode: QueryEditorMode.Builder,
-      editorPreview: true,
+      rawQuery: true,
     });
   });
 
-  it('Should show preview', async () => {
+  it('Should show raw query', async () => {
     renderWithProps({
-      editorPreview: true,
+      rawQuery: true,
       editorMode: QueryEditorMode.Builder,
       expr: 'my_metric',
     });

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
@@ -14,7 +14,8 @@ import { PromQueryBuilderContainer } from './PromQueryBuilderContainer';
 import { PromQueryBuilderOptions } from './PromQueryBuilderOptions';
 import { changeEditorMode, getQueryWithDefaults } from '../state';
 import { PromQuery } from '../../types';
-import { BetaBadge } from '../shared/BetaBadge';
+import { FeedbackLink } from '../shared/FeedbackLink';
+import { config } from '@grafana/runtime';
 
 export const PromQueryEditorSelector = React.memo<PromQueryEditorProps>((props) => {
   const { onChange, onRunQuery, data } = props;
@@ -45,7 +46,7 @@ export const PromQueryEditorSelector = React.memo<PromQueryEditorProps>((props) 
 
   const onQueryPreviewChange = (event: SyntheticEvent<HTMLInputElement>) => {
     const isEnabled = event.currentTarget.checked;
-    onChange({ ...query, editorPreview: isEnabled });
+    onChange({ ...query, rawQuery: isEnabled });
     onRunQuery();
   };
 
@@ -53,6 +54,8 @@ export const PromQueryEditorSelector = React.memo<PromQueryEditorProps>((props) 
     setDataIsStale(true);
     onChange(query);
   };
+
+  const showFeedbackLink = editorMode === QueryEditorMode.Builder && !config.hideFeedbackLinks;
 
   return (
     <>
@@ -86,12 +89,10 @@ export const PromQueryEditorSelector = React.memo<PromQueryEditorProps>((props) 
               }}
               options={promQueryModeller.getQueryPatterns().map((x) => ({ label: x.name, value: x }))}
             />
-            <QueryHeaderSwitch label="Raw query" value={query.editorPreview} onChange={onQueryPreviewChange} />
+            <QueryHeaderSwitch label="Raw query" value={query.rawQuery} onChange={onQueryPreviewChange} />
           </>
         )}
-        {editorMode === QueryEditorMode.Builder && (
-          <BetaBadge feedbackUrl="https://github.com/grafana/grafana/discussions/47693" />
-        )}
+        {showFeedbackLink && <FeedbackLink feedbackUrl="https://github.com/grafana/grafana/discussions/47693" />}
         <FlexItem grow={1} />
         <Button
           variant={dataIsStale ? 'primary' : 'secondary'}

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
@@ -14,6 +14,7 @@ import { PromQueryBuilderContainer } from './PromQueryBuilderContainer';
 import { PromQueryBuilderOptions } from './PromQueryBuilderOptions';
 import { changeEditorMode, getQueryWithDefaults } from '../state';
 import { PromQuery } from '../../types';
+import { BetaBadge } from '../shared/BetaBadge';
 
 export const PromQueryEditorSelector = React.memo<PromQueryEditorProps>((props) => {
   const { onChange, onRunQuery, data } = props;
@@ -67,16 +68,6 @@ export const PromQueryEditorSelector = React.memo<PromQueryEditorProps>((props) 
         onDismiss={() => setParseModalOpen(false)}
       />
       <EditorHeader>
-        <FlexItem grow={1} />
-        <Button
-          variant={dataIsStale ? 'primary' : 'secondary'}
-          size="sm"
-          onClick={onRunQuery}
-          icon={data?.state === LoadingState.Loading ? 'fa fa-spinner' : undefined}
-          disabled={data?.state === LoadingState.Loading}
-        >
-          Run query
-        </Button>
         {editorMode === QueryEditorMode.Builder && (
           <>
             <InlineSelect
@@ -95,14 +86,22 @@ export const PromQueryEditorSelector = React.memo<PromQueryEditorProps>((props) 
               }}
               options={promQueryModeller.getQueryPatterns().map((x) => ({ label: x.name, value: x }))}
             />
+            <QueryHeaderSwitch label="Raw query" value={query.editorPreview} onChange={onQueryPreviewChange} />
           </>
         )}
-        <QueryHeaderSwitch
-          label="Preview"
-          value={query.editorPreview}
-          onChange={onQueryPreviewChange}
-          disabled={editorMode !== QueryEditorMode.Builder}
-        />
+        {editorMode === QueryEditorMode.Builder && (
+          <BetaBadge feedbackUrl="https://github.com/grafana/grafana/pull/47653" />
+        )}
+        <FlexItem grow={1} />
+        <Button
+          variant={dataIsStale ? 'primary' : 'secondary'}
+          size="sm"
+          onClick={onRunQuery}
+          icon={data?.state === LoadingState.Loading ? 'fa fa-spinner' : undefined}
+          disabled={data?.state === LoadingState.Loading}
+        >
+          Run query
+        </Button>
         <QueryEditorModeToggle mode={editorMode} onChange={onEditorModeChange} />
       </EditorHeader>
       <Space v={0.5} />

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
@@ -15,7 +15,6 @@ import { PromQueryBuilderOptions } from './PromQueryBuilderOptions';
 import { changeEditorMode, getQueryWithDefaults } from '../state';
 import { PromQuery } from '../../types';
 import { FeedbackLink } from '../shared/FeedbackLink';
-import { config } from '@grafana/runtime';
 
 export const PromQueryEditorSelector = React.memo<PromQueryEditorProps>((props) => {
   const { onChange, onRunQuery, data } = props;

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
@@ -55,8 +55,6 @@ export const PromQueryEditorSelector = React.memo<PromQueryEditorProps>((props) 
     onChange(query);
   };
 
-  const showFeedbackLink = editorMode === QueryEditorMode.Builder && config.feedbackLinksEnabled;
-
   return (
     <>
       <ConfirmModal
@@ -92,7 +90,9 @@ export const PromQueryEditorSelector = React.memo<PromQueryEditorProps>((props) 
             <QueryHeaderSwitch label="Raw query" value={query.rawQuery} onChange={onQueryPreviewChange} />
           </>
         )}
-        {showFeedbackLink && <FeedbackLink feedbackUrl="https://github.com/grafana/grafana/discussions/47693" />}
+        {editorMode === QueryEditorMode.Builder && (
+          <FeedbackLink feedbackUrl="https://github.com/grafana/grafana/discussions/47693" />
+        )}
         <FlexItem grow={1} />
         <Button
           variant={dataIsStale ? 'primary' : 'secondary'}

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
@@ -55,7 +55,7 @@ export const PromQueryEditorSelector = React.memo<PromQueryEditorProps>((props) 
     onChange(query);
   };
 
-  const showFeedbackLink = editorMode === QueryEditorMode.Builder && !config.hideFeedbackLinks;
+  const showFeedbackLink = editorMode === QueryEditorMode.Builder && config.feedbackLinksEnabled;
 
   return (
     <>

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
@@ -90,7 +90,7 @@ export const PromQueryEditorSelector = React.memo<PromQueryEditorProps>((props) 
           </>
         )}
         {editorMode === QueryEditorMode.Builder && (
-          <BetaBadge feedbackUrl="https://github.com/grafana/grafana/pull/47653" />
+          <BetaBadge feedbackUrl="https://github.com/grafana/grafana/discussions/47693" />
         )}
         <FlexItem grow={1} />
         <Button

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/QueryPreview.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/QueryPreview.tsx
@@ -18,7 +18,7 @@ export function QueryPreview({ query }: Props) {
   return (
     <EditorRow>
       <EditorFieldGroup>
-        <EditorField label="Preview">
+        <EditorField label="Raw query">
           <div
             className={cx(styles.editorField, 'prism-syntax-highlight')}
             aria-label="selector"

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/BetaBadge.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/BetaBadge.tsx
@@ -15,7 +15,7 @@ export function BetaBadge({ feedbackUrl }: Props) {
       <a
         href={feedbackUrl}
         className={styles.link}
-        title="This query builder is new, please let us know how we can improve it."
+        title="This query builder is new, please let us know how we can improve it"
       >
         <Icon name="comment-alt-message" /> Give feedback
       </a>

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/BetaBadge.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/BetaBadge.tsx
@@ -1,0 +1,36 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { Stack } from '@grafana/experimental';
+import { Icon, Tag, useStyles2 } from '@grafana/ui';
+import React from 'react';
+
+export interface Props {
+  feedbackUrl?: string;
+}
+
+export function BetaBadge({ feedbackUrl }: Props) {
+  const styles = useStyles2(getStyles);
+  return (
+    <Stack gap={1}>
+      <a
+        href={feedbackUrl}
+        className={styles.link}
+        title="This query builder is new, please let us know how we can improve it."
+      >
+        <Icon name="comment-alt-message" /> Give feedback
+      </a>
+    </Stack>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    link: css({
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      ':hover': {
+        color: theme.colors.text.link,
+      },
+    }),
+  };
+}

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/BetaBadge.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/BetaBadge.tsx
@@ -16,6 +16,8 @@ export function BetaBadge({ feedbackUrl }: Props) {
         href={feedbackUrl}
         className={styles.link}
         title="This query builder is new, please let us know how we can improve it"
+        target="_blank"
+        rel="noreferrer noopener"
       >
         <Icon name="comment-alt-message" /> Give feedback
       </a>

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/FeedbackLink.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/FeedbackLink.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
+import { config } from '@grafana/runtime';
 import { Icon, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
@@ -10,6 +11,11 @@ export interface Props {
 
 export function FeedbackLink({ feedbackUrl }: Props) {
   const styles = useStyles2(getStyles);
+
+  if (!config.feedbackLinksEnabled) {
+    return null;
+  }
+
   return (
     <Stack gap={1}>
       <a

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/FeedbackLink.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/FeedbackLink.tsx
@@ -1,14 +1,14 @@
 import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
-import { Icon, Tag, useStyles2 } from '@grafana/ui';
+import { Icon, useStyles2 } from '@grafana/ui';
 import React from 'react';
 
 export interface Props {
   feedbackUrl?: string;
 }
 
-export function BetaBadge({ feedbackUrl }: Props) {
+export function FeedbackLink({ feedbackUrl }: Props) {
   const styles = useStyles2(getStyles);
   return (
     <Stack gap={1}>

--- a/public/app/plugins/datasource/prometheus/types.ts
+++ b/public/app/plugins/datasource/prometheus/types.ts
@@ -19,8 +19,8 @@ export interface PromQuery extends DataQuery {
   showingTable?: boolean;
   /** Code, Builder or Explain */
   editorMode?: QueryEditorMode;
-  /** Controls if the query preview is shown */
-  editorPreview?: boolean;
+  /** Controls if the raw query text is shown */
+  rawQuery?: boolean;
 }
 
 export interface PromOptions extends DataSourceJsonData {


### PR DESCRIPTION
* Move the query patterns & Preview toggle to the left  (To align with Big query data source , and cloudwatch data source) 
* Rename Preview to `Raw query`  (I will rename model property also after ok) 
* Introduce a Give feedback link 

![Screenshot from 2022-04-12 19-25-47](https://user-images.githubusercontent.com/10999/163019492-891ec448-eb8b-4115-a1f0-22f4e56dd1bc.png)

When you hover over the link it turns link blue (and has tooltip that says "This query builder is new, please let us know how we can improve it") 

* [x] Update editorPreview model property to rawQuery
* [x] Create GitHub discussion issue to link to for feedback 
