### PR TITLE
Alerting: migration to fail Graphite query contains unexpanded references.

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -198,6 +198,9 @@ type alertQuery struct {
 
 	// JSON is the raw JSON query and includes the above properties as well as custom properties.
 	Model json.RawMessage `json:"model"`
+
+	// datasourceType is a type of data source. Omitted during serialization.
+	datasourceType string
 }
 
 // RelativeTimeRange is the per query start and end time

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestMigrateAlertRuleQueries(t *testing.T) {
-
 	tc := []struct {
 		name     string
 		input    alertQuery

--- a/pkg/services/sqlstore/migrations/ualert/cond_trans.go
+++ b/pkg/services/sqlstore/migrations/ualert/cond_trans.go
@@ -120,7 +120,7 @@ func transConditions(set dashAlertSettings, orgID int64, dsUIDMap dsUIDLookup) (
 			}
 
 			// one could have an alert saved but datasource deleted, so can not require match.
-			dsUID := dsUIDMap.GetUID(orgID, set.Conditions[condIdx].Query.DatasourceID)
+			ds := dsUIDMap.Get(orgID, set.Conditions[condIdx].Query.DatasourceID)
 			queryObj["refId"] = refID
 
 			encodedObj, err := json.Marshal(queryObj)
@@ -140,8 +140,9 @@ func transConditions(set dashAlertSettings, orgID int64, dsUIDMap dsUIDLookup) (
 				RefID:             refID,
 				Model:             encodedObj,
 				RelativeTimeRange: *rTR,
-				DatasourceUID:     dsUID,
+				DatasourceUID:     ds.UID,
 				QueryType:         queryType,
+				datasourceType:    ds.Type,
 			}
 			newCond.Data = append(newCond.Data, alertQuery)
 		}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Graphite data source plugin supports nested references between queries. For example, a panel can use many queries that refer to other queries:
```
A: sumSeries(some.query)
B: asPercent( diffSeries( #A, timeShift(#A, '1d') ) ,sumSeries( #A ) )
```
In this example, query `B` refers to query `A`.

The Graphite plugin expands the query `B` to the following:

`asPercent( diffSeries( sumSeries(some.query), timeShift(sumSeries(some.query), '1d') ) ,sumSeries( sumSeries(some.query)) )` 

and saves it to a field `targetFull`. Since https://github.com/grafana/grafana/pull/42493 alerting migration uses that field if it exists. However, due to a bug https://github.com/grafana/grafana/issues/42623 sometimes the expanded query still contains references to other queries, and this causes migrated alert rules to start failing.

This PR updates the migration code to check the field `target` (and `targetFull`) for unexpanded queries and fail if there is at least one. This is only applicable to Graphite data sources.

Also, PR updates intermediate structure alertRule to keep field `datasourceType`
