### PR TITLE
Reload permissions cache when adding a datasource

### DIFF
--- a/public/app/features/datasources/state/actions.ts
+++ b/public/app/features/datasources/state/actions.ts
@@ -24,6 +24,7 @@ import {
 } from './reducers';
 import { getDataSource, getDataSourceMeta } from './selectors';
 import { accessControlQueryParam } from 'app/core/utils/accessControl';
+import { contextSrv } from '../../../core/services/context_srv';
 
 export interface DataSourceTypesLoadedPayload {
   plugins: DataSourcePluginMeta[];
@@ -217,6 +218,9 @@ export function addDataSource(plugin: DataSourcePluginMeta): ThunkResult<void> {
 
     const result = await getBackendSrv().post('/api/datasources', newInstance);
     await getDatasourceSrv().reload();
+
+    await contextSrv.fetchUserPermissions();
+
     locationService.push(`/datasources/edit/${result.datasource.uid}`);
   };
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When user has permissions to create / modify a datasource, but not read all datasources, on adding of the datasource access control system automatically grants a permission to view that specific datasource. 

Grafana checks for the user permissions when viewing a data source, and since there is a cache in front of the permissions check (TTL 30 seconds), users permissions are still loaded from the cache after adding a new data source. This results to a bug, where users see "Data source could not be found" page for first 30 seconds. 

The desired behaviour is to immediately refresh user permissions, so that users will be able to see newly added data sources.

**Implementation**

We already have relevant functions to invalidate the cache, so the PR just adds a call to it. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-enterprise/issues/3153



