### PR TITLE
Graphite Datasource: add responseType: 'text' to http options to return full list of functions

### DIFF
--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -1,10 +1,18 @@
+<<<<<<< HEAD
+=======
+import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
+import { TemplateSrv } from 'app/features/templating/template_srv';
+>>>>>>> cc5bfd9134 (remove extra logic for graphite /functions endpoint returning {} #46681)
 import { isArray } from 'lodash';
 import { of } from 'rxjs';
 import { createFetchResponse } from 'test/helpers/createFetchResponse';
 
 import { AbstractLabelMatcher, AbstractLabelOperator, dateTime, getFrameDisplayName } from '@grafana/data';
+<<<<<<< HEAD
 import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
 import { TemplateSrv } from 'app/features/templating/template_srv';
+=======
+>>>>>>> cc5bfd9134 (remove extra logic for graphite /functions endpoint returning {} #46681)
 
 import { fromString } from './configuration/parseLokiLabelMappings';
 import { GraphiteDatasource } from './datasource';
@@ -302,14 +310,6 @@ describe('graphiteDatasource', () => {
           ],
         },
       });
-    });
-
-    it('should use hardcoded list of functions when no functions are returned', async () => {
-      fetchMock.mockImplementation(() => {
-        return of(createFetchResponse('{}'));
-      });
-      const funcDefs = await ctx.ds.getFuncDefs();
-      expect(Object.keys(funcDefs)).not.toHaveLength(0);
     });
   });
 

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -1,18 +1,10 @@
-<<<<<<< HEAD
-=======
-import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
-import { TemplateSrv } from 'app/features/templating/template_srv';
->>>>>>> cc5bfd9134 (remove extra logic for graphite /functions endpoint returning {} #46681)
 import { isArray } from 'lodash';
 import { of } from 'rxjs';
 import { createFetchResponse } from 'test/helpers/createFetchResponse';
 
 import { AbstractLabelMatcher, AbstractLabelOperator, dateTime, getFrameDisplayName } from '@grafana/data';
-<<<<<<< HEAD
 import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
 import { TemplateSrv } from 'app/features/templating/template_srv';
-=======
->>>>>>> cc5bfd9134 (remove extra logic for graphite /functions endpoint returning {} #46681)
 
 import { fromString } from './configuration/parseLokiLabelMappings';
 import { GraphiteDatasource } from './datasource';

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -19,8 +19,6 @@ import {
   toDataFrame,
 } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
-<<<<<<< HEAD
-<<<<<<< HEAD
 import { isVersionGtOrEq, SemVersion } from 'app/core/utils/version';
 import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
 import { getRollupNotice, getRuntimeConsolidationNotice } from 'app/plugins/datasource/graphite/meta';
@@ -28,24 +26,8 @@ import { getRollupNotice, getRuntimeConsolidationNotice } from 'app/plugins/data
 import { getSearchFilterScopedVar } from '../../../features/variables/utils';
 
 import gfunc, { FuncDefs, FuncInstance } from './gfunc';
-import { default as GraphiteQueryModel } from './graphite_query';
-=======
-=======
-import { isVersionGtOrEq, SemVersion } from 'app/core/utils/version';
-import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
-import { getRollupNotice, getRuntimeConsolidationNotice } from 'app/plugins/datasource/graphite/meta';
->>>>>>> 8967f8df3e (add graphite functions list logic back in to see why alert test broke)
-
-import { getSearchFilterScopedVar } from '../../../features/variables/utils';
-
-import gfunc, { FuncDefs, FuncInstance } from './gfunc';
-<<<<<<< HEAD
 import GraphiteQueryModel from './graphite_query';
 // Types
->>>>>>> cc5bfd9134 (remove extra logic for graphite /functions endpoint returning {} #46681)
-=======
-import { default as GraphiteQueryModel } from './graphite_query';
->>>>>>> 8967f8df3e (add graphite functions list logic back in to see why alert test broke)
 import {
   GraphiteLokiMapping,
   GraphiteMetricLokiMatcher,

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -750,6 +750,7 @@ export class GraphiteDatasource
     const httpOptions = {
       method: 'GET',
       url: '/functions',
+      // to work around Graphite returning invalid JSON
       responseType: 'text',
     };
 

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -1,17 +1,20 @@
+import { isVersionGtOrEq, SemVersion } from 'app/core/utils/version';
+import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
+import { getRollupNotice, getRuntimeConsolidationNotice } from 'app/plugins/datasource/graphite/meta';
 import { each, indexOf, isArray, isString, map as _map } from 'lodash';
 import { lastValueFrom, Observable, of, OperatorFunction, pipe, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
 import {
+  AbstractLabelMatcher,
+  AbstractLabelOperator,
+  AbstractQuery,
   DataFrame,
   DataQueryRequest,
   DataQueryResponse,
   DataSourceApi,
   DataSourceWithQueryExportSupport,
   dateMath,
-  AbstractQuery,
-  AbstractLabelOperator,
-  AbstractLabelMatcher,
   MetricFindValue,
   QueryResultMetaStat,
   ScopedVars,
@@ -19,6 +22,7 @@ import {
   toDataFrame,
 } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
+<<<<<<< HEAD
 import { isVersionGtOrEq, SemVersion } from 'app/core/utils/version';
 import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
 import { getRollupNotice, getRuntimeConsolidationNotice } from 'app/plugins/datasource/graphite/meta';
@@ -27,6 +31,13 @@ import { getSearchFilterScopedVar } from '../../../features/variables/utils';
 
 import gfunc, { FuncDefs, FuncInstance } from './gfunc';
 import { default as GraphiteQueryModel } from './graphite_query';
+=======
+
+import { getSearchFilterScopedVar } from '../../../features/variables/utils';
+import gfunc, { FuncDefs, FuncInstance } from './gfunc';
+import GraphiteQueryModel from './graphite_query';
+// Types
+>>>>>>> cc5bfd9134 (remove extra logic for graphite /functions endpoint returning {} #46681)
 import {
   GraphiteLokiMapping,
   GraphiteMetricLokiMatcher,
@@ -757,30 +768,15 @@ export class GraphiteDatasource
     return lastValueFrom(
       this.doGraphiteRequest(httpOptions).pipe(
         map((results: any) => {
-          if (results.status !== 200 || typeof results.data !== 'object') {
-            if (typeof results.data === 'string') {
-              // Fix for a Graphite bug: https://github.com/graphite-project/graphite-web/issues/2609
-              // There is a fix for it https://github.com/graphite-project/graphite-web/pull/2612 but
-              // it was merged to master in July 2020 but it has never been released (the last Graphite
-              // release was 1.1.7 - March 2020). The bug was introduced in Graphite 1.1.7, in versions
-              // 1.1.0 - 1.1.6 /functions endpoint returns a valid JSON
-              const fixedData = JSON.parse(results.data.replace(/"default": ?Infinity/g, '"default": 1e9999'));
-              this.funcDefs = gfunc.parseFuncDefs(fixedData);
-            } else {
-              this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
-            }
-          } else {
-            this.funcDefs = gfunc.parseFuncDefs(results.data);
-          }
+          // Fix for a Graphite bug: https://github.com/graphite-project/graphite-web/issues/2609
+          // There is a fix for it https://github.com/graphite-project/graphite-web/pull/2612 but
+          // it was merged to master in July 2020 but it has never been released (the last Graphite
+          // release was 1.1.7 - March 2020). The bug was introduced in Graphite 1.1.7, in versions
+          // 1.1.0 - 1.1.6 /functions endpoint returns a valid JSON
+          const fixedData = JSON.parse(results.data.replace(/"default": ?Infinity/g, '"default": 1e9999'));
 
-          // When /functions endpoint returns application/json response but containing invalid JSON the fix above
-          // wont' be triggered due to the changes in https://github.com/grafana/grafana/pull/45598 (parsing happens
-          // in fetch and Graphite receives an empty object and no error). In such cases, when the provided JSON
-          // seems empty we fallback to the hardcoded list of functions.
-          // See also: https://github.com/grafana/grafana/issues/45948
-          if (Object.keys(this.funcDefs).length === 0) {
-            this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
-          }
+          this.funcDefs = gfunc.parseFuncDefs(fixedData);
+
           return this.funcDefs;
         }),
         catchError((error: any) => {

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -1,20 +1,17 @@
-import { isVersionGtOrEq, SemVersion } from 'app/core/utils/version';
-import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
-import { getRollupNotice, getRuntimeConsolidationNotice } from 'app/plugins/datasource/graphite/meta';
 import { each, indexOf, isArray, isString, map as _map } from 'lodash';
 import { lastValueFrom, Observable, of, OperatorFunction, pipe, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
 import {
-  AbstractLabelMatcher,
-  AbstractLabelOperator,
-  AbstractQuery,
   DataFrame,
   DataQueryRequest,
   DataQueryResponse,
   DataSourceApi,
   DataSourceWithQueryExportSupport,
   dateMath,
+  AbstractQuery,
+  AbstractLabelOperator,
+  AbstractLabelMatcher,
   MetricFindValue,
   QueryResultMetaStat,
   ScopedVars,
@@ -22,6 +19,7 @@ import {
   toDataFrame,
 } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
+<<<<<<< HEAD
 <<<<<<< HEAD
 import { isVersionGtOrEq, SemVersion } from 'app/core/utils/version';
 import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
@@ -32,12 +30,22 @@ import { getSearchFilterScopedVar } from '../../../features/variables/utils';
 import gfunc, { FuncDefs, FuncInstance } from './gfunc';
 import { default as GraphiteQueryModel } from './graphite_query';
 =======
+=======
+import { isVersionGtOrEq, SemVersion } from 'app/core/utils/version';
+import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
+import { getRollupNotice, getRuntimeConsolidationNotice } from 'app/plugins/datasource/graphite/meta';
+>>>>>>> 8967f8df3e (add graphite functions list logic back in to see why alert test broke)
 
 import { getSearchFilterScopedVar } from '../../../features/variables/utils';
+
 import gfunc, { FuncDefs, FuncInstance } from './gfunc';
+<<<<<<< HEAD
 import GraphiteQueryModel from './graphite_query';
 // Types
 >>>>>>> cc5bfd9134 (remove extra logic for graphite /functions endpoint returning {} #46681)
+=======
+import { default as GraphiteQueryModel } from './graphite_query';
+>>>>>>> 8967f8df3e (add graphite functions list logic back in to see why alert test broke)
 import {
   GraphiteLokiMapping,
   GraphiteMetricLokiMatcher,
@@ -761,22 +769,35 @@ export class GraphiteDatasource
     const httpOptions = {
       method: 'GET',
       url: '/functions',
-      // to work around Graphite returning invalid JSON
-      responseType: 'text',
     };
 
     return lastValueFrom(
       this.doGraphiteRequest(httpOptions).pipe(
         map((results: any) => {
-          // Fix for a Graphite bug: https://github.com/graphite-project/graphite-web/issues/2609
-          // There is a fix for it https://github.com/graphite-project/graphite-web/pull/2612 but
-          // it was merged to master in July 2020 but it has never been released (the last Graphite
-          // release was 1.1.7 - March 2020). The bug was introduced in Graphite 1.1.7, in versions
-          // 1.1.0 - 1.1.6 /functions endpoint returns a valid JSON
-          const fixedData = JSON.parse(results.data.replace(/"default": ?Infinity/g, '"default": 1e9999'));
+          if (results.status !== 200 || typeof results.data !== 'object') {
+            if (typeof results.data === 'string') {
+              // Fix for a Graphite bug: https://github.com/graphite-project/graphite-web/issues/2609
+              // There is a fix for it https://github.com/graphite-project/graphite-web/pull/2612 but
+              // it was merged to master in July 2020 but it has never been released (the last Graphite
+              // release was 1.1.7 - March 2020). The bug was introduced in Graphite 1.1.7, in versions
+              // 1.1.0 - 1.1.6 /functions endpoint returns a valid JSON
+              const fixedData = JSON.parse(results.data.replace(/"default": ?Infinity/g, '"default": 1e9999'));
+              this.funcDefs = gfunc.parseFuncDefs(fixedData);
+            } else {
+              this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
+            }
+          } else {
+            this.funcDefs = gfunc.parseFuncDefs(results.data);
+          }
 
-          this.funcDefs = gfunc.parseFuncDefs(fixedData);
-
+          // When /functions endpoint returns application/json response but containing invalid JSON the fix above
+          // wont' be triggered due to the changes in https://github.com/grafana/grafana/pull/45598 (parsing happens
+          // in fetch and Graphite receives an empty object and no error). In such cases, when the provided JSON
+          // seems empty we fallback to the hardcoded list of functions.
+          // See also: https://github.com/grafana/grafana/issues/45948
+          if (Object.keys(this.funcDefs).length === 0) {
+            this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
+          }
           return this.funcDefs;
         }),
         catchError((error: any) => {

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -750,6 +750,7 @@ export class GraphiteDatasource
     const httpOptions = {
       method: 'GET',
       url: '/functions',
+      responseType: 'text',
     };
 
     return lastValueFrom(

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -751,7 +751,8 @@ export class GraphiteDatasource
     const httpOptions = {
       method: 'GET',
       url: '/functions',
-      // add responseType because if this is not defined, backend_srv defaults to json
+      // add responseType because if this is not defined,
+      // backend_srv defaults to json
       responseType: 'text',
     };
 

--- a/public/app/plugins/datasource/graphite/datasource_integration.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource_integration.test.ts
@@ -1,16 +1,12 @@
-import { GraphiteDatasource } from './datasource';
-import { TemplateSrv } from 'app/features/templating/template_srv';
 import { BackendSrv } from 'app/core/services/backend_srv';
 import { of } from 'rxjs';
-import { ContextSrv, User } from '../../../core/services/context_srv';
+
 import { setBackendSrv } from '@grafana/runtime';
 
-jest.mock('@grafana/runtime', () => ({
-  ...(jest.requireActual('@grafana/runtime') as unknown as object),
-}));
+import { ContextSrv, User } from '../../../core/services/context_srv';
+import { GraphiteDatasource } from './datasource';
 
 interface Context {
-  templateSrv: TemplateSrv;
   ds: GraphiteDatasource;
 }
 
@@ -27,9 +23,8 @@ describe('graphiteDatasource integration with backendSrv and fetch', () => {
         rollupIndicatorEnabled: true,
       },
     };
-    const templateSrv = new TemplateSrv();
-    const ds = new GraphiteDatasource(instanceSettings, templateSrv);
-    ctx = { templateSrv, ds };
+    const ds = new GraphiteDatasource(instanceSettings);
+    ctx = { ds };
   });
 
   describe('returns a list of functions', () => {
@@ -139,7 +134,6 @@ function mockBackendSrv(data: string) {
     user,
   } as any as ContextSrv;
   const logoutMock = jest.fn();
-  const parseRequestOptionsMock = jest.fn().mockImplementation((options) => options);
 
   const mockedBackendSrv = new BackendSrv({
     fromFetch: fromFetchMock,
@@ -147,8 +141,6 @@ function mockBackendSrv(data: string) {
     contextSrv: contextSrvMock,
     logout: logoutMock,
   });
-
-  mockedBackendSrv['parseRequestOptions'] = parseRequestOptionsMock;
 
   setBackendSrv(mockedBackendSrv);
 }

--- a/public/app/plugins/datasource/graphite/datasource_integration.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource_integration.test.ts
@@ -1,9 +1,10 @@
-import { BackendSrv } from 'app/core/services/backend_srv';
 import { of } from 'rxjs';
 
 import { setBackendSrv } from '@grafana/runtime';
+import { BackendSrv } from 'app/core/services/backend_srv';
 
 import { ContextSrv, User } from '../../../core/services/context_srv';
+
 import { GraphiteDatasource } from './datasource';
 
 interface Context {

--- a/public/app/plugins/datasource/graphite/datasource_integration.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource_integration.test.ts
@@ -1,0 +1,154 @@
+import { GraphiteDatasource } from './datasource';
+import { TemplateSrv } from 'app/features/templating/template_srv';
+import { BackendSrv } from 'app/core/services/backend_srv';
+import { of } from 'rxjs';
+import { ContextSrv, User } from '../../../core/services/context_srv';
+import { setBackendSrv } from '@grafana/runtime';
+
+jest.mock('@grafana/runtime', () => ({
+  ...(jest.requireActual('@grafana/runtime') as unknown as object),
+}));
+
+interface Context {
+  templateSrv: TemplateSrv;
+  ds: GraphiteDatasource;
+}
+
+describe('graphiteDatasource integration with backendSrv and fetch', () => {
+  let ctx = {} as Context;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const instanceSettings = {
+      url: '/api/datasources/proxy/1',
+      name: 'graphiteProd',
+      jsonData: {
+        rollupIndicatorEnabled: true,
+      },
+    };
+    const templateSrv = new TemplateSrv();
+    const ds = new GraphiteDatasource(instanceSettings, templateSrv);
+    ctx = { templateSrv, ds };
+  });
+
+  describe('returns a list of functions', () => {
+    it('should return a list of functions with invalid JSON', async () => {
+      const INVALID_JSON =
+        '{"testFunction":{"name":"function","description":"description","module":"graphite.render.functions","group":"Transform","params":[{"name":"param","type":"intOrInf","required":true,"default":Infinity}]}}';
+
+      mockBackendSrv(INVALID_JSON);
+
+      const funcDefs = await ctx.ds.getFuncDefs();
+
+      expect(funcDefs).toEqual({
+        testFunction: {
+          category: 'Transform',
+          defaultParams: ['inf'],
+          description: 'description',
+          fake: true,
+          name: 'function',
+          params: [
+            {
+              multiple: false,
+              name: 'param',
+              optional: false,
+              options: undefined,
+              type: 'int_or_infinity',
+            },
+          ],
+        },
+      });
+    });
+
+    it('should return a list of functions with valid JSON', async () => {
+      const VALID_JSON =
+        '{"testFunction":{"name":"function","description":"description","module":"graphite.render.functions","group":"Transform","params":[{"name":"param","type":"intOrInf","required":true,"default":1e9999}]}}';
+
+      mockBackendSrv(VALID_JSON);
+
+      const funcDefs = await ctx.ds.getFuncDefs();
+
+      expect(funcDefs).toEqual({
+        testFunction: {
+          category: 'Transform',
+          defaultParams: ['inf'],
+          description: 'description',
+          fake: true,
+          name: 'function',
+          params: [
+            {
+              multiple: false,
+              name: 'param',
+              optional: false,
+              options: undefined,
+              type: 'int_or_infinity',
+            },
+          ],
+        },
+      });
+    });
+  });
+});
+
+function mockBackendSrv(data: string) {
+  const defaults = {
+    data: '',
+    ok: true,
+    status: 200,
+    statusText: 'Ok',
+    isSignedIn: true,
+    orgId: 1337,
+    redirected: false,
+    type: 'basic',
+    url: 'http://localhost:3000/api/some-mock',
+  };
+
+  const props = { ...defaults };
+
+  props.data = data;
+
+  const textMock = jest.fn().mockResolvedValue(props.data);
+
+  const fromFetchMock = jest.fn().mockImplementation(() => {
+    const mockedResponse = {
+      ok: props.ok,
+      status: props.status,
+      statusText: props.statusText,
+      text: textMock,
+      redirected: false,
+      type: 'basic',
+      url: 'http://localhost:3000/api/some-mock',
+      headers: {
+        method: 'GET',
+        url: '/functions',
+        // to work around Graphite returning invalid JSON
+        responseType: 'text',
+      },
+    };
+    return of(mockedResponse);
+  });
+
+  const appEventsMock = {} as any;
+
+  const user: User = {
+    isSignedIn: props.isSignedIn,
+    orgId: props.orgId,
+  } as any as User;
+  const contextSrvMock: ContextSrv = {
+    user,
+  } as any as ContextSrv;
+  const logoutMock = jest.fn();
+  const parseRequestOptionsMock = jest.fn().mockImplementation((options) => options);
+
+  const mockedBackendSrv = new BackendSrv({
+    fromFetch: fromFetchMock,
+    appEvents: appEventsMock,
+    contextSrv: contextSrvMock,
+    logout: logoutMock,
+  });
+
+  mockedBackendSrv['parseRequestOptions'] = parseRequestOptionsMock;
+
+  setBackendSrv(mockedBackendSrv);
+}


### PR DESCRIPTION
This fix is allows the graphite datasource to successfully return a full list of functions. 

#### What is the problem? 
https://github.com/grafana/observability-metrics-squad/issues/16

In a previous update to the core fetch functionality, https://github.com/grafana/grafana/pull/45188, we began passing in responseType which we had not been passing in before. The graphite response type was previously undefined which then defaulted to json based on the change by @leeoniya. 

Returning the graphite response.json() results in an error due to graphite returning large numbers as the keyword Infinity, https://raintank-corp.slack.com/archives/C0368BHNQ79. A week or so after Leon's fix, there was this change to fetch, https://github.com/grafana/grafana/pull/45598, which caught the error and returned an empty object. This resulted in no functions being returned and was fixed by this change https://github.com/grafana/grafana/commit/ed155e47c4f9a2c57acfee0a9a5ca681b5dd2894 by @ifrost.

There is currently another change by @leventebalogh, https://github.com/grafana/grafana/pull/47493. This change removes the error handling for json response types in the fetch parse response body function. This then causes the graphite datasource to receive the error from response.json() and eventually returns a default list of functions due to this https://github.com/grafana/grafana/blob/a4381ebc9122d121e80cb7636c69c408422271fe/public/app/plugins/datasource/graphite/datasource.ts#L783-L787. @ryantxu made the suggestion we set the responseType to text to handle this.

##### The fix
So, this fix sets the responseType to text so that we bypass the json issue in fetch parseResponseBody and then allows the workaround for the graphite Infinity issue here https://github.com/grafana/grafana/blob/a4381ebc9122d121e80cb7636c69c408422271fe/public/app/plugins/datasource/graphite/datasource.ts#L757-L765.