### PR TITLE
Grafana/UI: Bundle raw SVG icon strings

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -98,7 +98,6 @@
     "@grafana/tsconfig": "^1.2.0-rc1",
     "@mdx-js/react": "1.6.22",
     "@rollup/plugin-commonjs": "21.0.2",
-    "@rollup/plugin-image": "2.1.1",
     "@rollup/plugin-node-resolve": "13.1.3",
     "@storybook/addon-a11y": "6.4.15",
     "@storybook/addon-actions": "6.4.15",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -168,6 +168,7 @@
     "rimraf": "3.0.2",
     "rollup": "2.70.1",
     "rollup-plugin-sourcemaps": "0.6.3",
+    "rollup-plugin-svg-import": "^1.6.0",
     "rollup-plugin-terser": "7.0.2",
     "sass-loader": "12.6.0",
     "storybook-dark-mode": "1.0.9",

--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -1,6 +1,6 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import image from '@rollup/plugin-image';
+import svg from 'rollup-plugin-svg-import';
 import { terser } from 'rollup-plugin-terser';
 
 const pkg = require('./package.json');
@@ -41,7 +41,7 @@ const buildCjsPackage = ({ env }) => {
         include: /node_modules/,
       }),
       resolve(),
-      image(),
+      svg({ stringify: true }),
       env === 'production' && terser(),
     ],
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4476,6 +4476,7 @@ __metadata:
     rimraf: 3.0.2
     rollup: 2.70.1
     rollup-plugin-sourcemaps: 0.6.3
+    rollup-plugin-svg-import: ^1.6.0
     rollup-plugin-terser: 7.0.2
     rxjs: 7.5.5
     sass-loader: 12.6.0
@@ -7305,6 +7306,16 @@ __metadata:
   peerDependencies:
     rollup: ^1.20.0||^2.0.0
   checksum: 8be16e27863c219edbb25a4e6ec2fe0e1e451d9e917b6a43cf2ae5bc025a6b8faaa40f82a6e53b66d0de37b58ff472c6c3d57a83037ae635041f8df959d6d9aa
+  languageName: node
+  linkType: hard
+
+"@rollup/pluginutils@npm:^4.1.1":
+  version: 4.2.0
+  resolution: "@rollup/pluginutils@npm:4.2.0"
+  dependencies:
+    estree-walker: ^2.0.1
+    picomatch: ^2.2.2
+  checksum: 2e86d9bfb95919727bcba0bbbdbedc98e25a1e51fe3047f18ec6d85e0743d1c73e1c0de3f9fdbd2ff6b90c32f30d4b2706c9e794f3c2e7a80156980081558e2e
   languageName: node
   linkType: hard
 
@@ -32353,6 +32364,17 @@ __metadata:
     "@types/node":
       optional: true
   checksum: bb4909a90f2e824717a67ad146b2cccc40411ee54709ffa548c47c4dfe485bd55039a5850d7640ecb2691de9dc30e3fd57287e4d74331f36fed9c263d86dd4dc
+  languageName: node
+  linkType: hard
+
+"rollup-plugin-svg-import@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "rollup-plugin-svg-import@npm:1.6.0"
+  dependencies:
+    "@rollup/pluginutils": ^4.1.1
+  peerDependencies:
+    rollup: ">=1.29.0 <3.0.0"
+  checksum: 453862c39d2301563d9d07f6647c295377ff66cf3174d2a0612389fda4bfd9fa72718d90279feb782d3525f1d6f9710e1dc78641cd9d4044360a0179f88054b0
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4366,7 +4366,6 @@ __metadata:
     "@react-aria/overlays": 3.8.1
     "@react-stately/menu": 3.2.6
     "@rollup/plugin-commonjs": 21.0.2
-    "@rollup/plugin-image": 2.1.1
     "@rollup/plugin-node-resolve": 13.1.3
     "@sentry/browser": 6.19.1
     "@storybook/addon-a11y": 6.4.15
@@ -7254,18 +7253,6 @@ __metadata:
   peerDependencies:
     rollup: ^2.38.3
   checksum: 5fd4c7b75d7881070f4395d7ba5f9035934f53b25e92d136583cc794461a456efc1e2a2204f946ec567dfea58073c38cb48f24d27155b89af0df0447c2cd0758
-  languageName: node
-  linkType: hard
-
-"@rollup/plugin-image@npm:2.1.1":
-  version: 2.1.1
-  resolution: "@rollup/plugin-image@npm:2.1.1"
-  dependencies:
-    "@rollup/pluginutils": ^3.1.0
-    mini-svg-data-uri: ^1.2.3
-  peerDependencies:
-    rollup: ^1.20.0 || ^2.0.0
-  checksum: a629c8f22233ca159c23655fdbc3449dab3c939372178ed4462fc9c525cc4ecd8b11fae359eb94be4f769d26f48b85fb18eb16ce1fbc33ed16b6a7c1f84391f6
   languageName: node
   linkType: hard
 
@@ -25952,15 +25939,6 @@ __metadata:
   peerDependencies:
     webpack: ^4.4.0
   checksum: dd783b1d3f002b1d2f606e0458c99f2f45507c0b2e9f91ce99807f9875d4b394fc201cad07c1d2bda7ce88877f97ab6228178be93133b9586f93cc7b7da3cf02
-  languageName: node
-  linkType: hard
-
-"mini-svg-data-uri@npm:^1.2.3":
-  version: 1.4.3
-  resolution: "mini-svg-data-uri@npm:1.4.3"
-  bin:
-    mini-svg-data-uri: cli.js
-  checksum: bd1789c34907a36ae9157897b7c7f6ad700e71c8cb6d725bb2810ce6211abcaa3717333ca17408f6f8b2a44055e571cd5b78d478688e1864513cb7f8e023ae3f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the `@grafana/ui` package bundles and encodes svg icons as data URI's (ex: "data:image/svg+xml,%3csvg xmlns=...")

When using the grafana UI components outside of Grafana (via developing in Storybook, etc), Grafana's icons fail to render.
<img width="788" alt="Screen Shot 2022-04-12 at 3 33 22 PM" src="https://user-images.githubusercontent.com/5048947/163058347-d086ddab-b9b4-46c8-804f-3c037cc91ddb.png">

This PR bundles the SVG icons as raw strings (just like they are bundled in webpack for the Grafana UI and Grafana's storybook)

Converting this:
<img width="692" alt="Screen Shot 2022-04-12 at 3 37 09 PM" src="https://user-images.githubusercontent.com/5048947/163058691-39a00811-afa4-4062-a48d-9e0f992738c2.png">

to this:
<img width="910" alt="Screen Shot 2022-04-12 at 3 37 51 PM" src="https://user-images.githubusercontent.com/5048947/163058770-f0bb76c5-7c26-46bd-a9ea-3dc49aa86e0f.png">

**Which issue(s) this PR fixes**:

Haven't submitted an issue, but I can if needed.

**Special notes for your reviewer**:

Seems normally `react-inlinesvg` would handle the data URI's, but since it's directly injected in the exposed cache (of `react-inlinesvg`), the underlying logic can't handle it.

Slightly related PR's (https://github.com/grafana/grafana/pull/24258, https://github.com/grafana/grafana/pull/33607)
