### PR TITLE
Alerting: Support OK option for Error state

### DIFF
--- a/pkg/services/ngalert/CHANGELOG.md
+++ b/pkg/services/ngalert/CHANGELOG.md
@@ -46,5 +46,5 @@ Scopes must have an order to ensure consistency and ease of search, this helps u
 ## Grafana Alerting - main / unreleased
 
 - [CHANGE] Prometheus Compatible API: Use float-like values for `api/prometheus/grafana/api/v1/alerts` and `api/prometheus/grafana/api/v1/rules` instead of the evaluation string #47216
-- [BUGFIX] Fix state manager to support OK option of AlertRule.ExecErrState #47670 
+- [BUGFIX] Scheduler: Fix state manager to support OK option of `AlertRule.ExecErrState` #47670 
 - [ENHANCEMENT] Templates: Enable the use of classic condition values in templates #46971

--- a/pkg/services/ngalert/CHANGELOG.md
+++ b/pkg/services/ngalert/CHANGELOG.md
@@ -46,4 +46,5 @@ Scopes must have an order to ensure consistency and ease of search, this helps u
 ## Grafana Alerting - main / unreleased
 
 - [CHANGE] Prometheus Compatible API: Use float-like values for `api/prometheus/grafana/api/v1/alerts` and `api/prometheus/grafana/api/v1/rules` instead of the evaluation string #47216
+- [BUGFIX] Fix state manager to support OK option of AlertRule.ExecErrState #47670 
 - [ENHANCEMENT] Templates: Enable the use of classic condition values in templates #46971

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -51,8 +52,7 @@ func NewEvaluationValues(m map[string]eval.NumberValueCapture) map[string]*float
 }
 
 func (a *State) resultNormal(_ *ngModels.AlertRule, result eval.Result) {
-	a.Error = result.Error // should be nil since state is not error
-
+	a.Error = nil // should be nil since state is not error
 	if a.State != eval.Normal {
 		a.EndsAt = result.EvaluatedAt
 		a.StartsAt = result.EvaluatedAt
@@ -88,9 +88,10 @@ func (a *State) resultError(alertRule *ngModels.AlertRule, result eval.Result) {
 	a.Error = result.Error
 
 	execErrState := eval.Error
-	if alertRule.ExecErrState == ngModels.AlertingErrState {
+	switch alertRule.ExecErrState {
+	case ngModels.AlertingErrState:
 		execErrState = eval.Alerting
-	} else if alertRule.ExecErrState == ngModels.ErrorErrState {
+	case ngModels.ErrorErrState:
 		// If the evaluation failed because a query returned an error then
 		// update the state with the Datasource UID as a label and the error
 		// message as an annotation so other code can use this metadata to
@@ -107,6 +108,11 @@ func (a *State) resultError(alertRule *ngModels.AlertRule, result eval.Result) {
 			a.Annotations["Error"] = queryError.Error()
 		}
 		execErrState = eval.Error
+	case ngModels.OkErrState:
+		a.resultNormal(alertRule, result)
+		return
+	default:
+		a.Error = fmt.Errorf("cannot map error to a state because option [%s] is not supported. original error: %w", alertRule.ExecErrState, a.Error)
 	}
 
 	switch a.State {

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -112,7 +112,7 @@ func (a *State) resultError(alertRule *ngModels.AlertRule, result eval.Result) {
 		a.resultNormal(alertRule, result)
 		return
 	default:
-		a.Error = fmt.Errorf("cannot map error to a state because option [%s] is not supported. original error: %w", alertRule.ExecErrState, a.Error)
+		a.Error = fmt.Errorf("cannot map error to a state because option [%s] is not supported. evaluation error: %w", alertRule.ExecErrState, a.Error)
 	}
 
 	switch a.State {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Grafana Alerting supports 3 options for mapping the evaluation error state to an alert state: Alerting, Error, OK. Apparently, the OK option is not supported by the alerting engine. Instead, it is treated as "Alerting" option, which causes confusion for users. 

This PR adds proper support for the option OK which means that the alert state is supposed to switch to Normal in the case of evaluation error.

**Which issue(s) this PR fixes**:
Related: https://github.com/grafana/grafana/pull/45262
