### PR TITLE
Chore: Bump moment to 2.29.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,7 +325,7 @@
     "lru-cache": "7.7.1",
     "memoize-one": "6.0.0",
     "minisearch": "5.0.0-beta1",
-    "moment": "2.29.1",
+    "moment": "2.29.2",
     "moment-timezone": "0.5.34",
     "monaco-editor": "^0.31.1",
     "monaco-promql": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "@types/papaparse": "5.3.2",
     "@types/pluralize": "^0.0.29",
     "@types/prismjs": "1.26.0",
-    "@types/rc-time-picker": "^3",
+    "@types/rc-time-picker": "3.4.1",
     "@types/react": "17.0.42",
     "@types/react-beautiful-dnd": "13.1.2",
     "@types/react-dom": "17.0.14",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -29,7 +29,7 @@
     "eventemitter3": "4.0.7",
     "lodash": "4.17.21",
     "marked": "4.0.12",
-    "moment": "2.29.1",
+    "moment": "2.29.2",
     "moment-timezone": "0.5.34",
     "ol": "6.14.1",
     "papaparse": "5.3.2",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -58,7 +58,7 @@
     "jquery": "3.6.0",
     "lodash": "4.17.21",
     "memoize-one": "6.0.0",
-    "moment": "2.29.1",
+    "moment": "2.29.2",
     "monaco-editor": "^0.31.1",
     "ol": "6.14.1",
     "prismjs": "1.27.0",

--- a/packages/jaeger-ui-components/package.json
+++ b/packages/jaeger-ui-components/package.json
@@ -39,7 +39,7 @@
     "lodash": "4.17.21",
     "lru-memoize": "^1.1.0",
     "memoize-one": "6.0.0",
-    "moment": "2.29.1",
+    "moment": "2.29.2",
     "moment-timezone": "0.5.34",
     "prop-types": "15.8.1",
     "react": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4018,7 +4018,7 @@ __metadata:
     history: 4.10.1
     lodash: 4.17.21
     marked: 4.0.12
-    moment: 2.29.1
+    moment: 2.29.2
     moment-timezone: 0.5.34
     ol: 6.14.1
     papaparse: 5.3.2
@@ -4440,7 +4440,7 @@ __metadata:
     lodash: 4.17.21
     memoize-one: 6.0.0
     mock-raf: 1.0.1
-    moment: 2.29.1
+    moment: 2.29.2
     monaco-editor: ^0.31.1
     ol: 6.14.1
     postcss: 8.4.12
@@ -4614,7 +4614,7 @@ __metadata:
     lodash: 4.17.21
     lru-memoize: ^1.1.0
     memoize-one: 6.0.0
-    moment: 2.29.1
+    moment: 2.29.2
     moment-timezone: 0.5.34
     prop-types: 15.8.1
     react: 17.0.2
@@ -20605,7 +20605,7 @@ __metadata:
     memoize-one: 6.0.0
     mini-css-extract-plugin: 2.6.0
     minisearch: 5.0.0-beta1
-    moment: 2.29.1
+    moment: 2.29.2
     moment-timezone: 0.5.34
     monaco-editor: ^0.31.1
     monaco-promql: ^1.7.2
@@ -26255,7 +26255,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:2.29.1, moment@npm:2.x, moment@npm:>= 2.9.0, moment@npm:^2.19.4, moment@npm:^2.20.1":
+"moment@npm:2.29.2":
+  version: 2.29.2
+  resolution: "moment@npm:2.29.2"
+  checksum: ee850b5776485e2af0775ceb3cfebaa7d7638f0a750fe0678fcae24c310749f96c1938808384bd422a55e5703834a71fcb09c8a1d36d9cf847f6ed0205d7a3e5
+  languageName: node
+  linkType: hard
+
+"moment@npm:2.x, moment@npm:>= 2.9.0, moment@npm:^2.19.4, moment@npm:^2.20.1":
   version: 2.29.1
   resolution: "moment@npm:2.29.1"
   checksum: 1e14d5f422a2687996be11dd2d50c8de3bd577c4a4ca79ba5d02c397242a933e5b941655de6c8cb90ac18f01cc4127e55b4a12ae3c527a6c0a274e455979345e

--- a/yarn.lock
+++ b/yarn.lock
@@ -10374,7 +10374,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/rc-time-picker@npm:^3":
+"@types/rc-time-picker@npm:3.4.1":
   version: 3.4.1
   resolution: "@types/rc-time-picker@npm:3.4.1"
   dependencies:
@@ -20494,7 +20494,7 @@ __metadata:
     "@types/papaparse": 5.3.2
     "@types/pluralize": ^0.0.29
     "@types/prismjs": 1.26.0
-    "@types/rc-time-picker": ^3
+    "@types/rc-time-picker": 3.4.1
     "@types/react": 17.0.42
     "@types/react-beautiful-dnd": 13.1.2
     "@types/react-dom": 17.0.14
@@ -26255,17 +26255,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:2.29.2":
+"moment@npm:2.29.2, moment@npm:2.x, moment@npm:>= 2.9.0, moment@npm:^2.19.4, moment@npm:^2.20.1":
   version: 2.29.2
   resolution: "moment@npm:2.29.2"
   checksum: ee850b5776485e2af0775ceb3cfebaa7d7638f0a750fe0678fcae24c310749f96c1938808384bd422a55e5703834a71fcb09c8a1d36d9cf847f6ed0205d7a3e5
-  languageName: node
-  linkType: hard
-
-"moment@npm:2.x, moment@npm:>= 2.9.0, moment@npm:^2.19.4, moment@npm:^2.20.1":
-  version: 2.29.1
-  resolution: "moment@npm:2.29.1"
-  checksum: 1e14d5f422a2687996be11dd2d50c8de3bd577c4a4ca79ba5d02c397242a933e5b941655de6c8cb90ac18f01cc4127e55b4a12ae3c527a6c0a274e455979345e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps moment to 2.29.2 to fix a [security vulnerability](https://github.com/advisories/GHSA-8hfj-j24r-96c4).

```shell
$ yarn why moment
├─ @grafana/data@workspace:packages/grafana-data
│  └─ moment@npm:2.29.2 (via npm:2.29.2)
│
├─ @grafana/ui@workspace:packages/grafana-ui
│  └─ moment@npm:2.29.2 (via npm:2.29.2)
│
├─ @jaegertracing/jaeger-ui-components@workspace:packages/jaeger-ui-components
│  └─ moment@npm:2.29.2 (via npm:2.29.2)
│
├─ @types/rc-time-picker@npm:3.4.1
│  └─ moment@npm:2.29.2 (via npm:^2.19.4)
│
├─ grafana@workspace:.
│  └─ moment@npm:2.29.2 (via npm:2.29.2)
│
├─ moment-timezone@npm:0.5.34
│  └─ moment@npm:2.29.2 (via npm:>= 2.9.0)
│
├─ rc-time-picker@npm:3.7.3
│  └─ moment@npm:2.29.2 (via npm:2.x)
│
├─ rc-time-picker@npm:3.7.3 [8174f]
│  └─ moment@npm:2.29.2 (via npm:2.x)
│
└─ visjs-network@npm:4.25.0
   └─ moment@npm:2.29.2 (via npm:^2.20.1)
```