### PR TITLE
Fix SCC-S1017 linting issue in alerting codebase

### DIFF
--- a/pkg/services/alerting/notifiers/hipchat.go
+++ b/pkg/services/alerting/notifiers/hipchat.go
@@ -55,9 +55,7 @@ const (
 // for the HipChatNotifier
 func NewHipChatNotifier(model *models.AlertNotification, _ alerting.GetDecryptedValueFn, ns notifications.Service) (alerting.Notifier, error) {
 	url := model.Settings.Get("url").MustString()
-	if strings.HasSuffix(url, "/") {
-		url = url[:len(url)-1]
-	}
+	url = strings.TrimSuffix(url, "/")
 	if url == "" {
 		return nil, alerting.ValidationError{Reason: "Could not find url property in settings"}
 	}


### PR DESCRIPTION
This resolves the issue stated in https://github.com/grafana/grafana/pull/47156#issuecomment-1094995320. We could also remove the Hipchat notifier code but, as this notifier is already not in the new alerting system, I found this quick fix simpler to move forward.