### PR TITLE
Alerting: Add permission checking to alert rules in the folders view

### DIFF
--- a/public/app/features/folders/state/navModel.ts
+++ b/public/app/features/folders/state/navModel.ts
@@ -1,6 +1,7 @@
 import { NavModel, NavModelItem } from '@grafana/data';
+import { contextSrv } from 'app/core/services/context_srv';
 
-import { FolderDTO } from 'app/types';
+import { AccessControlAction, FolderDTO } from 'app/types';
 
 export function buildNavModel(folder: FolderDTO): NavModelItem {
   const model = {
@@ -29,13 +30,15 @@ export function buildNavModel(folder: FolderDTO): NavModelItem {
     url: `${folder.url}/library-panels`,
   });
 
-  model.children.push({
-    active: false,
-    icon: 'bell',
-    id: `folder-alerting-${folder.uid}`,
-    text: 'Alert rules',
-    url: `${folder.url}/alerting`,
-  });
+  if (contextSrv.hasPermission(AccessControlAction.AlertingRuleRead)) {
+    model.children.push({
+      active: false,
+      icon: 'bell',
+      id: `folder-alerting-${folder.uid}`,
+      text: 'Alert rules',
+      url: `${folder.url}/alerting`,
+    });
+  }
 
   if (folder.canAdmin) {
     model.children.push({

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -406,6 +406,8 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     {
       path: '/dashboards/f/:uid/:slug/alerting',
+      roles: () =>
+        contextSrv.evaluatePermission(() => ['Viewer', 'Editor', 'Admin'], [AccessControlAction.AlertingRuleRead]),
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "FolderAlerting"*/ 'app/features/folders/FolderAlerting')
       ),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds permissions checking to alert rules in the folder view

**Which issue(s) this PR fixes**:
Fixes #46349

