### PR TITLE
Chore: Remove brackets from drone precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "*pkg/**/*.go": [
       "gofmt -w -s"
     ],
-    "*.{star}": [
+    "*.star": [
       "make drone"
     ]
   },


### PR DESCRIPTION
**What this PR does / why we need it**:

While precommit hooks for changes on `*.star` files run, we get the warning: 

```
⚠ Detected incorrect braces with only single value: `*.{star}`. Reformatted as: `*.star`
```
This PR removes the brackets and fixes the issue.
