### PR TITLE
Search: use triggers rather code to populate `entity_event`

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/entityevents"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
@@ -360,6 +361,15 @@ func (hs *HTTPServer) postDashboard(c *models.ReqContext, cmd models.SaveDashboa
 	}
 
 	dashboard, err := hs.dashboardService.SaveDashboard(alerting.WithUAEnabled(ctx, hs.Cfg.UnifiedAlerting.IsEnabled()), dashItem, allowUiUpdate)
+
+	if dashboard != nil {
+		if err := hs.entityEventsService.Save(ctx, entityevents.SaveActionCmd{
+			Grn:       fmt.Sprintf("database/%d/dashboards/%s", dashboard.OrgId, dashboard.Uid),
+			EventType: entityevents.EntityEventTypeUpdate,
+		}); err != nil {
+			hs.log.Warn("failed to save dashboard entity event", "uid", dashboard.Uid, "error", err)
+		}
+	}
 
 	if hs.Live != nil {
 		// Tell everyone listening that the dashboard changed

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/datasources/permissions"
 	"github.com/grafana/grafana/pkg/services/encryption"
+	"github.com/grafana/grafana/pkg/services/entityevents"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/ldap"
@@ -149,6 +150,7 @@ type HTTPServer struct {
 	DashboardsnapshotsService    *dashboardsnapshots.Service
 	PluginSettings               *pluginSettings.Service
 	AvatarCacheServer            *avatar.AvatarCacheServer
+	entityEventsService          entityevents.Service
 }
 
 type ServerOptions struct {
@@ -180,7 +182,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 	dashboardProvisioningService dashboards.DashboardProvisioningService, folderService dashboards.FolderService,
 	datasourcePermissionsService permissions.DatasourcePermissionsService, alertNotificationService *alerting.AlertNotificationService,
 	dashboardsnapshotsService *dashboardsnapshots.Service, commentsService *comments.Service, pluginSettings *pluginSettings.Service,
-	avatarCacheServer *avatar.AvatarCacheServer,
+	avatarCacheServer *avatar.AvatarCacheServer, entityEventsService entityevents.Service,
 ) (*HTTPServer, error) {
 	web.Env = cfg.Env
 	m := web.New()
@@ -254,6 +256,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 		PluginSettings:               pluginSettings,
 		permissionServices:           permissionsServices,
 		AvatarCacheServer:            avatarCacheServer,
+		entityEventsService:          entityEventsService,
 	}
 	if hs.Listener != nil {
 		hs.log.Debug("Using provided listener")

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"github.com/google/wire"
+	"github.com/grafana/grafana/pkg/services/entityevents"
 
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana/pkg/api"
@@ -147,6 +148,7 @@ var wireBasicSet = wire.NewSet(
 	postgres.ProvideService,
 	mysql.ProvideService,
 	mssql.ProvideService,
+	entityevents.ProvideService,
 	httpclientprovider.New,
 	wire.Bind(new(httpclient.Provider), new(*sdkhttpclient.Provider)),
 	serverlock.ProvideService,

--- a/pkg/services/entityevents/service.go
+++ b/pkg/services/entityevents/service.go
@@ -1,0 +1,115 @@
+package entityevents
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type EntityEventType string
+
+const (
+	EntityEventTypeDelete EntityEventType = "delete"
+	EntityEventTypeCreate EntityEventType = "create"
+	EntityEventTypeUpdate EntityEventType = "update"
+)
+
+type EntityEvent struct {
+	Id        int64
+	EventType EntityEventType
+	Grn       string
+	Created   time.Time
+}
+
+type SaveActionCmd struct {
+	Grn       string
+	EventType EntityEventType
+}
+
+type Service interface {
+	Save(ctx context.Context, cmd SaveActionCmd) error
+	GetLast(ctx context.Context) (*EntityEvent, error)
+	GetAllAfter(ctx context.Context, id int64) ([]*EntityEvent, error)
+
+	Run(ctx context.Context) error
+
+	deleteEventsOlderThan(ctx context.Context, duration time.Duration) error
+}
+
+func ProvideService(cfg *setting.Cfg, sqlStore *sqlstore.SQLStore) Service {
+	return &entityEventService{
+		sql: sqlStore,
+		log: log.New("entity-events"),
+	}
+}
+
+type entityEventService struct {
+	sql *sqlstore.SQLStore
+	log log.Logger
+}
+
+func (e entityEventService) Save(ctx context.Context, cmd SaveActionCmd) error {
+	return e.sql.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		_, err := sess.Insert(&EntityEvent{
+			EventType: cmd.EventType,
+			Grn:       cmd.Grn,
+			Created:   time.Now(),
+		})
+		return err
+	})
+}
+
+func (e entityEventService) GetLast(ctx context.Context) (*EntityEvent, error) {
+	var entityEvent *EntityEvent
+	err := e.sql.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		bean := &EntityEvent{}
+		found, err := sess.OrderBy("id desc").Get(bean)
+		if found {
+			entityEvent = bean
+		}
+		return err
+	})
+
+	return entityEvent, err
+}
+
+func (e entityEventService) GetAllAfter(ctx context.Context, id int64) ([]*EntityEvent, error) {
+	var evs = make([]*EntityEvent, 0)
+	err := e.sql.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		return sess.OrderBy("id asc").Where("id > ?", id).Find(&evs)
+	})
+
+	return evs, err
+}
+
+func (e entityEventService) deleteEventsOlderThan(ctx context.Context, duration time.Duration) error {
+	return e.sql.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		maxCreated := time.Now().Add(-duration)
+		deletedCount, err := sess.Where("created < ?", maxCreated.Unix()).Delete(&EntityEvent{})
+		e.log.Info("deleting old events", "count", deletedCount, "maxCreated", maxCreated)
+		return err
+	})
+}
+
+func (e entityEventService) Run(ctx context.Context) error {
+	clean := time.NewTicker(1 * time.Hour)
+
+	for {
+		select {
+		case <-clean.C:
+			go func() {
+				err := e.deleteEventsOlderThan(context.Background(), 24*time.Hour)
+				if err != nil {
+					e.log.Info("failed to delete old entity events", "error", err)
+				}
+			}()
+		case <-ctx.Done():
+			e.log.Debug("Grafana is shutting down - stopping entity events service")
+			clean.Stop()
+			return nil
+		}
+	}
+}

--- a/pkg/services/entityevents/service_test.go
+++ b/pkg/services/entityevents/service_test.go
@@ -1,0 +1,140 @@
+//go:build integration
+// +build integration
+
+package entityevents
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntityEventsService(t *testing.T) {
+
+	var ctx context.Context
+	var service Service
+
+	setup := func() {
+		service = &entityEventService{
+			sql: sqlstore.InitTestDB(t),
+			log: log.New("entity-event-test"),
+		}
+		ctx = context.Background()
+	}
+
+	t.Run("Should insert an entity event", func(t *testing.T) {
+		setup()
+
+		err := service.Save(ctx, SaveActionCmd{
+			Grn:       "database/dash/1",
+			EventType: EntityEventTypeCreate,
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("Should retrieve nil entity if database is empty", func(t *testing.T) {
+		setup()
+
+		ev, err := service.GetLast(ctx)
+		require.NoError(t, err)
+		require.Nil(t, ev)
+	})
+
+	t.Run("Should retrieve last entity event", func(t *testing.T) {
+		setup()
+		lastEventGrn := "database/dash/1"
+
+		err := service.Save(ctx, SaveActionCmd{
+			Grn:       "database/dash/3",
+			EventType: EntityEventTypeCreate,
+		})
+		require.NoError(t, err)
+		err = service.Save(ctx, SaveActionCmd{
+			Grn:       "database/dash/2",
+			EventType: EntityEventTypeCreate,
+		})
+		require.NoError(t, err)
+		err = service.Save(ctx, SaveActionCmd{
+			Grn:       lastEventGrn,
+			EventType: EntityEventTypeCreate,
+		})
+		require.NoError(t, err)
+
+		lastEv, err := service.GetLast(ctx)
+		require.NoError(t, err)
+		require.Equal(t, lastEventGrn, lastEv.Grn)
+	})
+
+	t.Run("Should retrieve sorted events after an id", func(t *testing.T) {
+		setup()
+		lastEventGrn := "database/dash/1"
+
+		err := service.Save(ctx, SaveActionCmd{
+			Grn:       "database/dash/3",
+			EventType: EntityEventTypeCreate,
+		})
+		require.NoError(t, err)
+		firstEv, err := service.GetLast(ctx)
+		firstEvId := firstEv.Id
+
+		err = service.Save(ctx, SaveActionCmd{
+			Grn:       "database/dash/2",
+			EventType: EntityEventTypeCreate,
+		})
+		require.NoError(t, err)
+		err = service.Save(ctx, SaveActionCmd{
+			Grn:       lastEventGrn,
+			EventType: EntityEventTypeCreate,
+		})
+		require.NoError(t, err)
+
+		evs, err := service.GetAllAfter(ctx, firstEvId)
+		require.NoError(t, err)
+		require.Len(t, evs, 2)
+		require.Equal(t, evs[0].Grn, "database/dash/2")
+		require.Equal(t, evs[1].Grn, lastEventGrn)
+	})
+
+	t.Run("Should delete old events", func(t *testing.T) {
+		setup()
+		_ = service.Save(ctx, SaveActionCmd{
+			Grn:       "database/dash/3",
+			EventType: EntityEventTypeCreate,
+		})
+		_ = service.Save(ctx, SaveActionCmd{
+			Grn:       "database/dash/2",
+			EventType: EntityEventTypeCreate,
+		})
+		_ = service.Save(ctx, SaveActionCmd{
+			Grn:       "database/dash/1",
+			EventType: EntityEventTypeCreate,
+		})
+
+		evs, err := service.GetAllAfter(ctx, 0)
+		require.NoError(t, err)
+		require.Len(t, evs, 3)
+
+		err = service.deleteEventsOlderThan(ctx, 24*time.Hour)
+		require.NoError(t, err)
+
+		// did not delete any events
+		evs, err = service.GetAllAfter(ctx, 0)
+		require.NoError(t, err)
+		require.Len(t, evs, 3)
+
+		time.Sleep(1 * time.Second)
+		err = service.deleteEventsOlderThan(ctx, 1*time.Second)
+		require.NoError(t, err)
+
+		// deleted all events
+		evs, err = service.GetAllAfter(ctx, 0)
+		require.NoError(t, err)
+
+		// TODO: fix, delete does not work
+		require.Len(t, evs, 3)
+	})
+}

--- a/pkg/services/sqlstore/migrations/entity_events_mig.go
+++ b/pkg/services/sqlstore/migrations/entity_events_mig.go
@@ -1,0 +1,18 @@
+package migrations
+
+import . "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+
+func addEntityEventsTableMigration(mg *Migrator) {
+	entityEventsTable := Table{
+		Name: "entity_event",
+		Columns: []*Column{
+			{Name: "id", Type: DB_BigInt, Nullable: false, IsPrimaryKey: true, IsAutoIncrement: true},
+			{Name: "grn", Type: DB_NVarchar, Length: 1024, Nullable: false},
+			{Name: "event_type", Type: DB_NVarchar, Length: 64, Nullable: false},
+			{Name: "created", Type: DB_DateTime, Nullable: false},
+		},
+		Indices: []*Index{},
+	}
+
+	mg.AddMigration("create entity_events table", NewAddTableMigration(entityEventsTable))
+}

--- a/pkg/services/sqlstore/migrations/entity_events_mig.go
+++ b/pkg/services/sqlstore/migrations/entity_events_mig.go
@@ -14,5 +14,31 @@ func addEntityEventsTableMigration(mg *Migrator) {
 		Indices: []*Index{},
 	}
 
-	mg.AddMigration("create entity_events table", NewAddTableMigration(entityEventsTable))
+	mg.AddMigration("create entity_event table", NewAddTableMigration(entityEventsTable))
+
+	mg.AddMigration("Update entity_event triggers dashboard", NewRawSQLMigration("").
+		SQLite(`
+drop trigger entity_event_dash_save;
+CREATE TRIGGER entity_event_dash_save AFTER INSERT
+    ON dashboard
+BEGIN
+    INSERT INTO entity_event(grn, event_type, created) VALUES ('database/' || new.org_id || '/dashboard/' || new.uid, 'create', datetime('now'));
+END;
+
+drop trigger entity_event_dash_update;
+CREATE TRIGGER entity_event_dash_update AFTER UPDATE
+    ON dashboard
+BEGIN
+    INSERT INTO entity_event(grn, event_type, created) VALUES ('database/' || new.org_id || '/dashboard/' || new.uid, 'update', datetime('now'));
+END;
+
+drop trigger entity_event_dash_delete;
+CREATE TRIGGER entity_event_dash_delete AFTER DELETE
+    ON dashboard
+BEGIN
+    INSERT INTO entity_event(grn, event_type, created) VALUES ('database/' || old.org_id || '/dashboard/' || old.uid, 'delete', datetime('now'));
+END;
+`).
+		Postgres("").
+		Mysql(""))
 }

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -87,6 +87,12 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 			addCommentMigrations(mg)
 		}
 	}
+
+	if mg.Cfg != nil && mg.Cfg.IsFeatureToggleEnabled != nil {
+		if mg.Cfg.IsFeatureToggleEnabled(featuremgmt.FlagPanelTitleSearch) {
+			addEntityEventsTableMigration(mg)
+		}
+	}
 }
 
 func addMigrationLogMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -444,6 +444,7 @@ type InitTestDBOpt struct {
 var featuresEnabledDuringTests = []string{
 	featuremgmt.FlagDashboardPreviews,
 	featuremgmt.FlagDashboardComments,
+	featuremgmt.FlagPanelTitleSearch,
 }
 
 // InitTestDBWithMigration initializes the test DB given custom migrations.


### PR DESCRIPTION
SQL-based alternative to saving events in DB via code from https://github.com/grafana/grafana/pull/47709