### PR TITLE
Explore: Prevent direct access to explore if disabled via feature toggle

### DIFF
--- a/public/app/features/explore/FeatureTogglePage.tsx
+++ b/public/app/features/explore/FeatureTogglePage.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Page from 'app/core/components/Page/Page';
+import { css } from '@emotion/css';
+import { useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2 } from '@grafana/data';
+
+export default function FeatureTogglePage() {
+  const styles = useStyles2(
+    (theme: GrafanaTheme2) =>
+      css`
+        margin-top: ${theme.spacing(2)};
+      `
+  );
+
+  return (
+    <Page className={styles}>
+      <Page.Contents>
+        <h1>Explore is disabled</h1>
+        To enable Explore, enable it in the Grafana config:
+        <div>
+          <pre>
+            {`[explore]
+enable = true
+`}
+          </pre>
+        </div>
+      </Page.Contents>
+    </Page>
+  );
+}

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -14,7 +14,6 @@ import { getLiveRoutes } from 'app/features/live/pages/routes';
 import { getAlertingRoutes } from 'app/features/alerting/routes';
 import { getProfileRoutes } from 'app/features/profile/routes';
 import { ServiceAccountPage } from 'app/features/serviceaccounts/ServiceAccountPage';
-import type { Truthy } from 'lodash';
 
 export const extraRoutes: RouteDescriptor[] = [];
 
@@ -154,7 +153,7 @@ export function getAppRoutes(): RouteDescriptor[] {
         () => import(/* webpackChunkName: "DashboardListPage"*/ 'app/features/search/components/DashboardListPage')
       ),
     },
-    config.exploreEnabled && {
+    {
       path: '/explore',
       pageClass: 'page-explore',
       roles: () =>
@@ -162,7 +161,11 @@ export function getAppRoutes(): RouteDescriptor[] {
           () => (config.viewersCanEdit ? [] : ['Editor', 'Admin']),
           [AccessControlAction.DataSourcesExplore]
         ),
-      component: SafeDynamicImport(() => import(/* webpackChunkName: "explore" */ 'app/features/explore/Wrapper')),
+      component: SafeDynamicImport(() =>
+        config.exploreEnabled
+          ? import(/* webpackChunkName: "explore" */ 'app/features/explore/Wrapper')
+          : import(/* webpackChunkName: "explore-feature-toggle-page" */ 'app/features/explore/FeatureTogglePage')
+      ),
     },
     {
       path: '/a/:pluginId/',
@@ -430,9 +433,5 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     // TODO[Router]
     // ...playlistRoutes,
-  ].filter(isTruthy);
-}
-
-function isTruthy<T>(v: T): v is Truthy<T> {
-  return Boolean(v);
+  ];
 }

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -14,6 +14,7 @@ import { getLiveRoutes } from 'app/features/live/pages/routes';
 import { getAlertingRoutes } from 'app/features/alerting/routes';
 import { getProfileRoutes } from 'app/features/profile/routes';
 import { ServiceAccountPage } from 'app/features/serviceaccounts/ServiceAccountPage';
+import type { Truthy } from 'lodash';
 
 export const extraRoutes: RouteDescriptor[] = [];
 
@@ -153,7 +154,7 @@ export function getAppRoutes(): RouteDescriptor[] {
         () => import(/* webpackChunkName: "DashboardListPage"*/ 'app/features/search/components/DashboardListPage')
       ),
     },
-    {
+    config.exploreEnabled && {
       path: '/explore',
       pageClass: 'page-explore',
       roles: () =>
@@ -429,5 +430,9 @@ export function getAppRoutes(): RouteDescriptor[] {
     },
     // TODO[Router]
     // ...playlistRoutes,
-  ];
+  ].filter(isTruthy);
+}
+
+function isTruthy<T>(v: T): v is Truthy<T> {
+  return Boolean(v);
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

setting
```ini
[explore]
enabled = false
```
prevents the Explore nav item to be added to the navbar but does not prevent direct access ( by typing `/explore` in the URL).

this PR changes that by avoid registering the route altogether if explore is disabled.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #46430

**Special notes for your reviewer**:

