### PR TITLE
CI: Remove `is_downstream` var

### DIFF
--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -70,9 +70,8 @@ load('scripts/drone/vault.star', 'from_secret')
 
 ver_mode = 'main'
 
-def get_steps(edition, is_downstream=False):
+def get_steps(edition):
     services = integration_test_services(edition)
-    publish = edition != 'enterprise' or is_downstream
     include_enterprise2 = edition == 'enterprise'
     init_steps = [
         identify_runner_step(),
@@ -94,9 +93,9 @@ def get_steps(edition, is_downstream=False):
     build_steps = [
         trigger_test_release(),
         enterprise_downstream_step(edition=edition),
-        build_backend_step(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream),
-        build_frontend_step(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream),
-        build_frontend_package_step(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream),
+        build_backend_step(edition=edition, ver_mode=ver_mode),
+        build_frontend_step(edition=edition, ver_mode=ver_mode),
+        build_frontend_package_step(edition=edition, ver_mode=ver_mode),
         build_plugins_step(edition=edition, sign=True),
         validate_scuemata_step(),
         ensure_cuetsified_step(),
@@ -116,12 +115,12 @@ def get_steps(edition, is_downstream=False):
             test_backend_integration_step(edition=edition2),
         ])
         build_steps.extend([
-            build_backend_step(edition=edition2, ver_mode=ver_mode, variants=['linux-amd64'], is_downstream=is_downstream),
+            build_backend_step(edition=edition2, ver_mode=ver_mode, variants=['linux-amd64']),
         ])
 
     # Insert remaining steps
     build_steps.extend([
-        package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2, is_downstream=is_downstream),
+        package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2),
         grafana_server_step(edition=edition),
         e2e_tests_step('dashboards-suite', edition=edition),
         e2e_tests_step('smoke-tests-suite', edition=edition),
@@ -144,24 +143,24 @@ def get_steps(edition, is_downstream=False):
 
     build_steps.extend([
         release_canary_npm_packages_step(edition, trigger=trigger_oss),
-        upload_packages_step(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream, trigger=trigger_oss),
+        upload_packages_step(edition=edition, ver_mode=ver_mode, trigger=trigger_oss),
         upload_cdn_step(edition=edition, ver_mode=ver_mode, trigger=trigger_oss)
     ])
 
     if include_enterprise2:
         edition2 = 'enterprise2'
         build_steps.extend([
-            package_step(edition=edition2, ver_mode=ver_mode, include_enterprise2=include_enterprise2, variants=['linux-amd64'], is_downstream=is_downstream),
-            upload_packages_step(edition=edition2, ver_mode=ver_mode, is_downstream=is_downstream),
+            package_step(edition=edition2, ver_mode=ver_mode, include_enterprise2=include_enterprise2, variants=['linux-amd64']),
+            upload_packages_step(edition=edition2, ver_mode=ver_mode),
             upload_cdn_step(edition=edition2, ver_mode=ver_mode)
         ])
 
-    windows_steps = get_windows_steps(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream)
-    if edition == 'enterprise' and not is_downstream:
+    windows_steps = get_windows_steps(edition=edition, ver_mode=ver_mode)
+    if edition == 'enterprise':
         store_steps = []
     else:
         store_steps = [
-            store_packages_step(edition=edition, ver_mode=ver_mode, is_downstream=is_downstream),
+            store_packages_step(edition=edition, ver_mode=ver_mode),
         ]
 
     return init_steps, test_steps, build_steps, integration_test_steps, windows_steps, store_steps


### PR DESCRIPTION
**What this PR does / why we need it**:

`is_downstream` variable is no longer needed, since we have removed all the references to downstream enterprise builds.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #47646

**Special notes for your reviewer**:

