### PR TITLE
Heatmap: Fix heatmap scale parameter

### DIFF
--- a/packages/grafana-data/src/types/dataFrame.ts
+++ b/packages/grafana-data/src/types/dataFrame.ts
@@ -223,6 +223,7 @@ export interface FieldCalcs extends Record<string, any> {}
 
 export const TIME_SERIES_VALUE_FIELD_NAME = 'Value';
 export const TIME_SERIES_TIME_FIELD_NAME = 'Time';
+export const TIME_SERIES_SCALE_FIELD_NAME = 'Scale';
 export const TIME_SERIES_METRIC_FIELD_NAME = 'Metric';
 
 /**


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: 
Fixes the heatmap scale parameter for plugins with legacy timeseries results

**Special notes for your reviewer**:

The heatmap panel uses an optional 3rd element of the legacy
timeseries values array to represent the scale or weight of a
datapoint. This is commonly the number of entries in a histogram
bucket. This change preserves the 3rd value in the array through
the transformation to a DataFrame so that it will be sucessfully
processed by the heatmap panel.

See https://github.com/grafana/grafana/blob/bad048b7ba1fecd28e76509c545a67fc8b70fdeb/public/app/plugins/panel/heatmap/heatmap_data_converter.ts#L273-L275
