### PR TITLE
Dashboard: Add vertical spacing between variables when they wrap

### DIFF
--- a/public/sass/components/_submenu.scss
+++ b/public/sass/components/_submenu.scss
@@ -4,6 +4,7 @@
   flex-wrap: wrap;
   align-content: flex-start;
   align-items: flex-start;
+  gap: $space-sm $space-md;
   padding: 0 0 $space-sm 0;
 }
 
@@ -18,7 +19,6 @@
 
 .submenu-item {
   display: inline-block;
-  margin-right: 15px;
 
   .fa-caret-down {
     font-size: 75%;


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds spacing between the variables in the dashboard sub menu when they wrap.

**Before:**

<img width="803" alt="Screen Shot 2022-04-14 at 10 25 49 am" src="https://user-images.githubusercontent.com/46142/163356059-461bc965-d3bf-4fe9-b0f0-ec822accb1f0.png">

**After:**

<img width="808" alt="Screen Shot 2022-04-14 at 10 23 11 am" src="https://user-images.githubusercontent.com/46142/163356143-88f8d5a5-c348-4eed-8db0-12042dab6a3e.png">




**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

 - I noticed this CSS is still in the old sass stylesheets. I would port them over to emotion, but I'm unsure about how to do the overrides for the different view modes (TV, Kiosk). I can look into this for this PR if we want? Or just merge it as is?
