### PR TITLE
Loki: Fix showing of default visual query only if no expression

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
@@ -66,7 +66,7 @@ export function LokiQueryBuilderContainer(props: Props) {
 }
 
 const stateSlice = createSlice({
-  name: 'prom-builder-container',
+  name: 'loki-builder-container',
   initialState: { expr: '' } as State,
   reducers: {
     visualQueryChange: (state, action: PayloadAction<{ visQuery: LokiVisualQuery; expr: string }>) => {

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
@@ -28,12 +28,13 @@ export function LokiQueryBuilderContainer(props: Props) {
   const [state, dispatch] = useReducer(stateSlice.reducer, {
     expr: query.expr,
     // Use initial visual query only if query.expr is empty string
-    visQuery: query.expr === ''
-      ? undefined
-      : {
-          labels: [],
-          operations: [{ id: '__line_contains', params: [''] }],
-        },
+    visQuery:
+      query.expr === ''
+        ? {
+            labels: [],
+            operations: [{ id: '__line_contains', params: [''] }],
+          }
+        : undefined,
   });
 
   // Only rebuild visual query if expr changes from outside

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
@@ -28,7 +28,7 @@ export function LokiQueryBuilderContainer(props: Props) {
   const [state, dispatch] = useReducer(stateSlice.reducer, {
     expr: query.expr,
     // Use initial visual query only if query.expr is empty string
-    visQuery: query.expr
+    visQuery: query.expr === ''
       ? undefined
       : {
           labels: [],

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
@@ -27,7 +27,7 @@ export function LokiQueryBuilderContainer(props: Props) {
   const { query, onChange, onRunQuery, datasource } = props;
   const [state, dispatch] = useReducer(stateSlice.reducer, {
     expr: query.expr,
-    // Use initial visual query only if empty query
+    // Use initial visual query only if query.expr is empty string
     visQuery: query.expr
       ? undefined
       : {

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderContainer.tsx
@@ -26,11 +26,14 @@ export interface State {
 export function LokiQueryBuilderContainer(props: Props) {
   const { query, onChange, onRunQuery, datasource } = props;
   const [state, dispatch] = useReducer(stateSlice.reducer, {
-    expr: '',
-    visQuery: {
-      labels: [],
-      operations: [{ id: '__line_contains', params: [''] }],
-    },
+    expr: query.expr,
+    // Use initial visual query only if empty query
+    visQuery: query.expr
+      ? undefined
+      : {
+          labels: [],
+          operations: [{ id: '__line_contains', params: [''] }],
+        },
   });
 
   // Only rebuild visual query if expr changes from outside

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/AutoSizeInput.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/AutoSizeInput.tsx
@@ -11,19 +11,26 @@ export interface Props extends InputProps {
 }
 
 export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
-  const { defaultValue = '', minWidth = 10, maxWidth, onCommitChange, onKeyDown, onBlur, ...restProps } = props;
-  const [value, setValue] = React.useState(defaultValue);
-  const [inputWidth, setInputWidth] = React.useState(minWidth);
+  const { defaultValue, minWidth = 10, maxWidth, onCommitChange, onKeyDown, onBlur, ...restProps } = props;
+  const [value, setValue] = React.useState('');
+  const [inputWidth, setInputWidth] = React.useState(0);
 
   useEffect(() => {
     setInputWidth(getWidthFor(value.toString(), minWidth, maxWidth));
   }, [value, maxWidth, minWidth]);
 
+  useEffect(() => {
+    setInputWidth(minWidth);
+    if (defaultValue) {
+      setValue(defaultValue.toString());
+    }
+  }, [minWidth, defaultValue]);
+
   return (
     <Input
       {...restProps}
       ref={ref}
-      value={value.toString()}
+      value={value}
       onChange={(event) => {
         setValue(event.currentTarget.value);
       }}

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/AutoSizeInput.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/AutoSizeInput.tsx
@@ -11,9 +11,9 @@ export interface Props extends InputProps {
 }
 
 export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
-  const { defaultValue = '', minWidth = 10, maxWidth, onCommitChange, onKeyDown, onBlur, ...restProps } = props;
-  const [value, setValue] = React.useState(defaultValue.toString());
-  const [inputWidth, setInputWidth] = React.useState(minWidth);
+  const { defaultValue, minWidth = 10, maxWidth, onCommitChange, onKeyDown, onBlur, ...restProps } = props;
+  const [value, setValue] = React.useState('');
+  const [inputWidth, setInputWidth] = React.useState(0);
 
   useEffect(() => {
     setInputWidth(getWidthFor(value.toString(), minWidth, maxWidth));
@@ -21,7 +21,9 @@ export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, r
 
   useEffect(() => {
     setInputWidth(minWidth);
-    setValue(defaultValue.toString());
+    if (defaultValue) {
+      setValue(defaultValue.toString());
+    }
   }, [minWidth, defaultValue]);
 
   return (

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/AutoSizeInput.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/AutoSizeInput.tsx
@@ -11,9 +11,9 @@ export interface Props extends InputProps {
 }
 
 export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
-  const { defaultValue, minWidth = 10, maxWidth, onCommitChange, onKeyDown, onBlur, ...restProps } = props;
-  const [value, setValue] = React.useState('');
-  const [inputWidth, setInputWidth] = React.useState(0);
+  const { defaultValue = '', minWidth = 10, maxWidth, onCommitChange, onKeyDown, onBlur, ...restProps } = props;
+  const [value, setValue] = React.useState(defaultValue.toString());
+  const [inputWidth, setInputWidth] = React.useState(minWidth);
 
   useEffect(() => {
     setInputWidth(getWidthFor(value.toString(), minWidth, maxWidth));
@@ -21,9 +21,7 @@ export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, r
 
   useEffect(() => {
     setInputWidth(minWidth);
-    if (defaultValue) {
-      setValue(defaultValue.toString());
-    }
+    setValue(defaultValue.toString());
   }, [minWidth, defaultValue]);
 
   return (

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/AutoSizeInput.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/AutoSizeInput.tsx
@@ -11,26 +11,19 @@ export interface Props extends InputProps {
 }
 
 export const AutoSizeInput = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
-  const { defaultValue, minWidth = 10, maxWidth, onCommitChange, onKeyDown, onBlur, ...restProps } = props;
-  const [value, setValue] = React.useState('');
-  const [inputWidth, setInputWidth] = React.useState(0);
+  const { defaultValue = '', minWidth = 10, maxWidth, onCommitChange, onKeyDown, onBlur, ...restProps } = props;
+  const [value, setValue] = React.useState(defaultValue);
+  const [inputWidth, setInputWidth] = React.useState(minWidth);
 
   useEffect(() => {
     setInputWidth(getWidthFor(value.toString(), minWidth, maxWidth));
   }, [value, maxWidth, minWidth]);
 
-  useEffect(() => {
-    setInputWidth(minWidth);
-    if (defaultValue) {
-      setValue(defaultValue.toString());
-    }
-  }, [minWidth, defaultValue]);
-
   return (
     <Input
       {...restProps}
       ref={ref}
-      value={value}
+      value={value.toString()}
       onChange={(event) => {
         setValue(event.currentTarget.value);
       }}


### PR DESCRIPTION
**What this PR does / why we need it**:
There was an issue in LokiQueryBuilder that when we used label filter expression, the first input (label) wasn't filled. This happened only if label filter was first operation. The issue was with AutoSizeInput. It looks like for first AutoSize input render the first defaultValue was empty string and not actual defaultValue. We need to use `useEffect` to correctly update the value when defaultValue changes.