### PR TITLE
Create fixed roles for reading API Keys and service accounts and fix listing of service account tokens

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -149,6 +149,23 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		Grants: []string{string(models.ROLE_VIEWER)},
 	}
 
+	apikeyReaderRole := ac.RoleRegistration{
+		Role: ac.RoleDTO{
+			Version:     1,
+			Name:        "fixed:apikeys:reader",
+			DisplayName: "APIKeys reader",
+			Description: "Gives access to read api keys.",
+			Group:       "API Keys",
+			Permissions: []ac.Permission{
+				{
+					Action: ac.ActionAPIKeyRead,
+					Scope:  ac.ScopeAPIKeysAll,
+				},
+			},
+		},
+		Grants: []string{string(models.ROLE_ADMIN)},
+	}
+
 	apikeyWriterRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
 			Version:     1,
@@ -410,7 +427,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		orgMaintainerRole, teamsCreatorRole, teamsWriterRole, datasourcesExplorerRole,
 		annotationsReaderRole, dashboardAnnotationsWriterRole, annotationsWriterRole,
 		dashboardsCreatorRole, dashboardsReaderRole, dashboardsWriterRole,
-		foldersCreatorRole, foldersReaderRole, foldersWriterRole, apikeyWriterRole,
+		foldersCreatorRole, foldersReaderRole, foldersWriterRole, apikeyReaderRole, apikeyWriterRole,
 	)
 }
 

--- a/pkg/services/serviceaccounts/database/database.go
+++ b/pkg/services/serviceaccounts/database/database.go
@@ -157,7 +157,7 @@ func (s *ServiceAccountsStoreImpl) ListTokens(ctx context.Context, orgID int64, 
 		sess = dbSession.
 			Join("inner", quotedUser, quotedUser+".id = api_key.service_account_id").
 			Where(quotedUser+".org_id=? AND "+quotedUser+".id=?", orgID, serviceAccountID).
-			Asc("name")
+			Asc("api_key.name")
 
 		return sess.Find(&result)
 	})

--- a/pkg/services/serviceaccounts/manager/roles.go
+++ b/pkg/services/serviceaccounts/manager/roles.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 )
@@ -8,10 +9,10 @@ import (
 func RegisterRoles(ac accesscontrol.AccessControl) error {
 	saReader := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
-			Version:     4,
+			Version:     1,
 			Name:        "fixed:serviceaccounts:reader",
 			DisplayName: "Service accounts reader",
-			Description: "Read service accounts.",
+			Description: "Read service accounts and service account tokens.",
 			Group:       "Service accounts",
 			Permissions: []accesscontrol.Permission{
 				{
@@ -20,7 +21,7 @@ func RegisterRoles(ac accesscontrol.AccessControl) error {
 				},
 			},
 		},
-		Grants: []string{"Admin"},
+		Grants: []string{string(models.ROLE_ADMIN)},
 	}
 
 	saWriter := accesscontrol.RoleRegistration{
@@ -48,7 +49,7 @@ func RegisterRoles(ac accesscontrol.AccessControl) error {
 				},
 			},
 		},
-		Grants: []string{"Admin"},
+		Grants: []string{string(models.ROLE_ADMIN)},
 	}
 
 	if err := ac.DeclareFixedRoles(saReader, saWriter); err != nil {

--- a/pkg/services/serviceaccounts/manager/roles.go
+++ b/pkg/services/serviceaccounts/manager/roles.go
@@ -6,7 +6,24 @@ import (
 )
 
 func RegisterRoles(ac accesscontrol.AccessControl) error {
-	role := accesscontrol.RoleRegistration{
+	saReader := accesscontrol.RoleRegistration{
+		Role: accesscontrol.RoleDTO{
+			Version:     4,
+			Name:        "fixed:serviceaccounts:reader",
+			DisplayName: "Service accounts reader",
+			Description: "Read service accounts.",
+			Group:       "Service accounts",
+			Permissions: []accesscontrol.Permission{
+				{
+					Action: serviceaccounts.ActionRead,
+					Scope:  serviceaccounts.ScopeAll,
+				},
+			},
+		},
+		Grants: []string{"Admin"},
+	}
+
+	saWriter := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
 			Version:     4,
 			Name:        "fixed:serviceaccounts:writer",
@@ -34,7 +51,7 @@ func RegisterRoles(ac accesscontrol.AccessControl) error {
 		Grants: []string{"Admin"},
 	}
 
-	if err := ac.DeclareFixedRoles(role); err != nil {
+	if err := ac.DeclareFixedRoles(saReader, saWriter); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- The pattern we follow with most of the fixed roles assumes to have two roles for reading and writing. This PR adds two fixed roles for reading API Keys and Service Accounts.
- Additionally, when viewing a service account, listing tokens was failing with an error due to wrong SQL query. This is also fixed in this PR.

<img width="1536" alt="Screenshot 2022-04-14 at 13 56 04" src="https://user-images.githubusercontent.com/1861190/163386549-83130253-dd21-4ae9-9c58-f68e759ada23.png">

**Special notes for your reviewer**:

I am not touching the docs now to avoid conflict with the refactoring, instead creating an issue to add the new roles into the docs.

