### PR TITLE
CloudMonitoring: Refactor annotations editor

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor.tsx
@@ -10,7 +10,6 @@ import { AnnotationsHelp, LabelFilter, Metrics, Project, QueryEditorRow } from '
 const { Input } = LegacyForms;
 
 export interface Props {
-  refId: string;
   onQueryChange: (target: AnnotationTarget) => void;
   target: AnnotationTarget;
   datasource: CloudMonitoringDatasource;
@@ -98,14 +97,14 @@ export class AnnotationQueryEditor extends React.Component<Props, State> {
     return (
       <>
         <Project
-          refId={this.props.refId}
+          refId={this.state.target.refId}
           templateVariableOptions={variableOptions}
           datasource={datasource}
           projectName={projectName || datasource.getDefaultProject()}
           onChange={(value) => this.onChange('projectName', value)}
         />
         <Metrics
-          refId={this.props.refId}
+          refId={this.state.target.refId}
           projectName={projectName}
           metricType={metricType}
           templateSrv={datasource.templateSrv}

--- a/public/app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor.tsx
@@ -10,8 +10,8 @@ import { AnnotationsHelp, LabelFilter, Metrics, Project, QueryEditorRow } from '
 const { Input } = LegacyForms;
 
 export interface Props {
-  onChange: (target: CloudMonitoringQuery) => void;
-  query: CloudMonitoringQuery;
+  onChange: (target: AnnotationTarget) => void;
+  query: AnnotationTarget;
   datasource: CloudMonitoringDatasource;
 }
 

--- a/public/app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor.tsx
@@ -4,16 +4,15 @@ import { LegacyForms } from '@grafana/ui';
 import React from 'react';
 
 import CloudMonitoringDatasource from '../datasource';
-import { AnnotationTarget, EditorMode, MetricDescriptor, MetricKind } from '../types';
+import { CloudMonitoringQuery, AnnotationTarget, EditorMode, MetricDescriptor, MetricKind } from '../types';
 import { AnnotationsHelp, LabelFilter, Metrics, Project, QueryEditorRow } from './';
 
 const { Input } = LegacyForms;
 
 export interface Props {
-  onQueryChange: (target: AnnotationTarget) => void;
-  target: AnnotationTarget;
+  onChange: (target: CloudMonitoringQuery) => void;
+  query: CloudMonitoringQuery;
   datasource: CloudMonitoringDatasource;
-  templateSrv: TemplateSrv;
 }
 
 interface State extends AnnotationTarget {
@@ -45,7 +44,7 @@ export class AnnotationQueryEditor extends React.Component<Props, State> {
   async UNSAFE_componentWillMount() {
     // Unfortunately, migrations like this need to go UNSAFE_componentWillMount. As soon as there's
     // migration hook for this module.ts, we can do the migrations there instead.
-    const { target, datasource } = this.props;
+    const { query: target, datasource } = this.props;
     if (!target.projectName) {
       target.projectName = datasource.getDefaultProject();
     }
@@ -69,7 +68,7 @@ export class AnnotationQueryEditor extends React.Component<Props, State> {
   }
 
   onMetricTypeChange = ({ valueType, metricKind, type, unit }: MetricDescriptor) => {
-    const { onQueryChange, datasource } = this.props;
+    const { onChange: onQueryChange, datasource } = this.props;
     this.setState(
       {
         metricType: type,
@@ -86,7 +85,7 @@ export class AnnotationQueryEditor extends React.Component<Props, State> {
 
   onChange(prop: string, value: string | string[]) {
     this.setState({ [prop]: value }, () => {
-      this.props.onQueryChange(this.state);
+      this.props.onChange(this.state);
     });
   }
 

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -1,26 +1,21 @@
-import { chunk, flatten, isString, isArray } from 'lodash';
+import { DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings, ScopedVars, SelectableValue } from '@grafana/data';
+import { DataSourceWithBackend, getBackendSrv, toDataQueryResponse } from '@grafana/runtime';
+import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
+import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
+import { chunk, flatten, isArray, isString } from 'lodash';
 import { from, lastValueFrom, Observable, of } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
-import {
-  DataQueryRequest,
-  DataQueryResponse,
-  DataSourceInstanceSettings,
-  ScopedVars,
-  SelectableValue,
-} from '@grafana/data';
-import { DataSourceWithBackend, getBackendSrv, toDataQueryResponse } from '@grafana/runtime';
 
-import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
-import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
+import { AnnotationQueryEditor } from './components/AnnotationQueryEditor';
 import {
+  Aggregation,
   CloudMonitoringOptions,
   CloudMonitoringQuery,
   EditorMode,
   Filter,
   MetricDescriptor,
-  QueryType,
   PostResponse,
-  Aggregation,
+  QueryType,
 } from './types';
 import { CloudMonitoringVariableSupport } from './variables';
 
@@ -40,6 +35,19 @@ export default class CloudMonitoringDatasource extends DataSourceWithBackend<
     this.authenticationType = instanceSettings.jsonData.authenticationType || 'jwt';
     this.variables = new CloudMonitoringVariableSupport(this);
     this.intervalMs = 0;
+
+    // This will support annotation queries for 7.2+
+    this.annotations = {
+      prepareAnnotation: (json: any) => {
+        if (!json.target) {
+          return json;
+        }
+        console.log({ json });
+        return json;
+      },
+
+      QueryEditor: AnnotationQueryEditor,
+    };
   }
 
   getVariables() {

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -9,8 +9,6 @@ import { map, mergeMap } from 'rxjs/operators';
 import { AnnotationQueryEditor } from './components/AnnotationQueryEditor';
 import {
   Aggregation,
-  CloudMonitoringAnnotationQuery,
-  CloudMonitoringAnyQuery,
   CloudMonitoringOptions,
   CloudMonitoringQuery,
   EditorMode,
@@ -21,10 +19,7 @@ import {
 } from './types';
 import { CloudMonitoringVariableSupport } from './variables';
 
-export default class CloudMonitoringDatasource extends DataSourceWithBackend<
-  CloudMonitoringAnnotationQuery,
-  CloudMonitoringOptions
-> {
+export default class CloudMonitoringDatasource extends DataSourceWithBackend<CloudMonitoringQuery, CloudMonitoringOptions> {
   authenticationType: string;
   intervalMs: number;
 

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -9,6 +9,8 @@ import { map, mergeMap } from 'rxjs/operators';
 import { AnnotationQueryEditor } from './components/AnnotationQueryEditor';
 import {
   Aggregation,
+  CloudMonitoringAnnotationQuery,
+  CloudMonitoringAnyQuery,
   CloudMonitoringOptions,
   CloudMonitoringQuery,
   EditorMode,
@@ -20,7 +22,7 @@ import {
 import { CloudMonitoringVariableSupport } from './variables';
 
 export default class CloudMonitoringDatasource extends DataSourceWithBackend<
-  CloudMonitoringQuery,
+  CloudMonitoringAnnotationQuery,
   CloudMonitoringOptions
 > {
   authenticationType: string;

--- a/public/app/plugins/datasource/cloud-monitoring/module.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/module.ts
@@ -4,7 +4,6 @@ import { QueryEditor } from './components/QueryEditor';
 import { ConfigEditor } from './components/ConfigEditor/ConfigEditor';
 
 import CloudMonitoringCheatSheet from './components/CloudMonitoringCheatSheet';
-import { CloudMonitoringAnnotationsQueryCtrl } from './annotations_query_ctrl';
 import { CloudMonitoringVariableQueryEditor } from './components/VariableQueryEditor';
 import { CloudMonitoringQuery } from './types';
 
@@ -12,5 +11,4 @@ export const plugin = new DataSourcePlugin<CloudMonitoringDatasource, CloudMonit
   .setQueryEditorHelp(CloudMonitoringCheatSheet)
   .setQueryEditor(QueryEditor)
   .setConfigEditor(ConfigEditor)
-  .setAnnotationQueryCtrl(CloudMonitoringAnnotationsQueryCtrl)
   .setVariableQueryEditor(CloudMonitoringVariableQueryEditor);

--- a/public/app/plugins/datasource/cloud-monitoring/types.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/types.ts
@@ -146,6 +146,14 @@ export interface CloudMonitoringQuery extends DataQuery {
   type: string;
 }
 
+export interface CloudMonitoringAnnotationProps {
+  refId: string;
+  onQueryChange: (target: AnnotationTarget) => void;
+  target: AnnotationTarget;
+}
+
+export type CloudMonitoringAnnotationQuery = CloudMonitoringQuery & CloudMonitoringAnnotationProps;
+
 export interface CloudMonitoringOptions extends DataSourceJsonData {
   defaultProject?: string;
   gceDefaultProject?: string;

--- a/public/app/plugins/datasource/cloud-monitoring/types.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/types.ts
@@ -154,6 +154,8 @@ export interface CloudMonitoringAnnotationProps {
 
 export type CloudMonitoringAnnotationQuery = CloudMonitoringQuery & CloudMonitoringAnnotationProps;
 
+export type CloudMonitoringAnyQuery = CloudMonitoringQuery | CloudMonitoringAnnotationQuery;
+
 export interface CloudMonitoringOptions extends DataSourceJsonData {
   defaultProject?: string;
   gceDefaultProject?: string;


### PR DESCRIPTION
The [annotation editor](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor.tsx) in the CloudMonitoring plugin is written in react. However, when it was initially built there was only API support for registering annotation editors written in angular.

This is similar to #47457 

This PR :

Uses the new API (registering react annotation editors in the datasource file) for registering the annotation editor in the CloudMonitoring datasource
Removes what's left of angular

Progress following mob sessions 14/04/22
Removed .setAnnotationQueryCtrl from module.ts
Added annotation object in datasource.ts with a QueryEditor that's using the existing AnnotationQueryEditor

Next Steps:
Fix typing issues
- Try changing the AnnotationQueryEditor state type to CloudMonitoringQuery?
