### PR TITLE
Alerting: Adds AWS SNS notifier support

### DIFF
--- a/docs/sources/alerting/old-alerting/notifications.md
+++ b/docs/sources/alerting/old-alerting/notifications.md
@@ -51,7 +51,8 @@ These examples show how often and when reminders are sent for a triggered alert.
 ## List of supported notifiers
 
 | Name                                          | Type                      | Supports images    | Supports alert rule tags |
-| --------------------------------------------- | ------------------------- | ------------------ | ------------------------ |
+|-----------------------------------------------|---------------------------|--------------------|--------------------------|
+| [Amazon SNS](#amazon-sns)                     | `sns`                       | no                 | yes                      |
 | [DingDing](#dingdingdingtalk)                 | `dingding`                | yes, external only | no                       |
 | [Discord](#discord)                           | `discord`                 | yes                | no                       |
 | [Email](#email)                               | `email`                   | yes                | no                       |
@@ -260,6 +261,17 @@ Alertmanager handles alerts sent by client applications such as Prometheus serve
 ### Sensu Go
 
 Grafana alert notifications can be sent to [Sensu](<(https://sensu.io)>) Go as events via the API. This operation requires an API key. For information on creating this key, refer to [Sensu Go documentation](https://docs.sensu.io/sensu-go/latest/operations/control-access/use-apikeys/#api-key-authentication).
+
+### Amazon SNS
+
+Grafana alert notifications can be sent to [Amazon Simple Notification Service (SNS)](https://aws.amazon.com/sns/).
+
+| Setting                         | Description                                                         |
+|---------------------------------|---------------------------------------------------------------------|
+| Topic                           | ARN of the SNS topic                                                |
+| Auth Provider                   | Desired authentication provider to access the SNS resource          |
+| Message Body Format             | Specify the format of the message body                              |
+| Include all tags in the message | If checked, will include all grafana alert tags in the message body |
 
 ## Enable images in notifications {#external-image-store}
 

--- a/docs/sources/alerting/old-alerting/notifications.md
+++ b/docs/sources/alerting/old-alerting/notifications.md
@@ -51,7 +51,7 @@ These examples show how often and when reminders are sent for a triggered alert.
 ## List of supported notifiers
 
 | Name                                          | Type                      | Supports images    | Supports alert rule tags |
-|-----------------------------------------------|---------------------------|--------------------|--------------------------|
+| --------------------------------------------- | ------------------------- | ------------------ | ------------------------ |
 | [Amazon SNS](#amazon-sns)                     | `sns`                     | no                 | yes                      |
 | [DingDing](#dingdingdingtalk)                 | `dingding`                | yes, external only | no                       |
 | [Discord](#discord)                           | `discord`                 | yes                | no                       |
@@ -267,7 +267,7 @@ Grafana alert notifications can be sent to [Sensu](<(https://sensu.io)>) Go as e
 Grafana alert notifications can be sent to [Amazon Simple Notification Service (SNS)](https://aws.amazon.com/sns/).
 
 | Setting                         | Description                                                         |
-|---------------------------------|---------------------------------------------------------------------|
+| ------------------------------- | ------------------------------------------------------------------- |
 | Topic                           | ARN of the SNS topic                                                |
 | Auth Provider                   | Desired authentication provider to access the SNS resource          |
 | Message Body Format             | Specify the format of the message body                              |

--- a/docs/sources/alerting/old-alerting/notifications.md
+++ b/docs/sources/alerting/old-alerting/notifications.md
@@ -52,7 +52,7 @@ These examples show how often and when reminders are sent for a triggered alert.
 
 | Name                                          | Type                      | Supports images    | Supports alert rule tags |
 |-----------------------------------------------|---------------------------|--------------------|--------------------------|
-| [Amazon SNS](#amazon-sns)                     | `sns`                       | no                 | yes                      |
+| [Amazon SNS](#amazon-sns)                     | `sns`                     | no                 | yes                      |
 | [DingDing](#dingdingdingtalk)                 | `dingding`                | yes, external only | no                       |
 | [Discord](#discord)                           | `discord`                 | yes                | no                       |
 | [Email](#email)                               | `email`                   | yes                | no                       |

--- a/pkg/services/alerting/notifiers/sns.go
+++ b/pkg/services/alerting/notifiers/sns.go
@@ -39,7 +39,7 @@ func init() {
 				SelectOptions: []alerting.SelectOption{
 					{
 						Value: "default",
-						Label: "Workspace IAM Role",
+						Label: "AWS SDK Default",
 					},
 					{
 						Value: "credentials",

--- a/pkg/services/alerting/notifiers/sns.go
+++ b/pkg/services/alerting/notifiers/sns.go
@@ -1,0 +1,314 @@
+package notifiers
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/metrics"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+)
+
+func init() {
+	alerting.RegisterNotifier(&alerting.NotifierPlugin{
+		Type:        "sns",
+		Name:        "AWS SNS",
+		Description: "Sends message to AWS SNS Topic",
+		Heading:     "AWS SNS settings",
+		Factory:     newSNSNotifier,
+		Options: []alerting.NotifierOption{
+			{
+				Label:        "Topic",
+				Element:      alerting.ElementTypeInput,
+				Required:     true,
+				InputType:    alerting.InputTypeText,
+				Placeholder:  "snsTopic",
+				PropertyName: "topic",
+			},
+			{
+				Label:    "Auth Provider",
+				Element:  alerting.ElementTypeSelect,
+				Required: true,
+				SelectOptions: []alerting.SelectOption{
+					{
+						Value: "authTypeDefault",
+						Label: "Workspace IAM Role",
+					},
+					// {
+					// 	Value: "credentialsProfile",
+					// 	Label: "Credentials profile",
+					// },
+					{
+						Value: "accessKeyAndSecretKey",
+						Label: "Access & secret key",
+					},
+					{
+						Value: "arn",
+						Label: "ARN",
+					},
+				},
+				PropertyName: "authProvider",
+			},
+			{
+				Label:    "Message body format",
+				Element:  alerting.ElementTypeSelect,
+				Required: true,
+				SelectOptions: []alerting.SelectOption{
+					{
+						Value: "text",
+						Label: "Text",
+					},
+					{
+						Value: "json",
+						Label: "JSON",
+					},
+				},
+				PropertyName: "messageFormat",
+			},
+			{
+				Label:        "Include all tags in the message",
+				Element:      alerting.ElementTypeCheckbox,
+				PropertyName: "includeTags",
+			},
+			{
+				Label:        "Credentials Profile",
+				Element:      alerting.ElementTypeInput,
+				Required:     true,
+				InputType:    alerting.InputTypeText,
+				Placeholder:  "default",
+				PropertyName: "credentialsProfile",
+				ShowWhen: alerting.ShowWhen{
+					Field: "authProvider",
+					Is:    "credentialsProfile",
+				},
+			},
+			{
+				Label:        "Access Key",
+				Element:      alerting.ElementTypeInput,
+				Required:     true,
+				Secure:       true,
+				InputType:    alerting.InputTypeText,
+				Placeholder:  "",
+				PropertyName: "accessKey",
+				ShowWhen: alerting.ShowWhen{
+					Field: "authProvider",
+					Is:    "accessKeyAndSecretKey",
+				},
+			},
+			{
+				Label:        "Secret Key",
+				Element:      alerting.ElementTypeInput,
+				Required:     true,
+				Secure:       true,
+				InputType:    alerting.InputTypeText,
+				Placeholder:  "",
+				PropertyName: "secretKey",
+				ShowWhen: alerting.ShowWhen{
+					Field: "authProvider",
+					Is:    "accessKeyAndSecretKey",
+				},
+			},
+			{
+				Label:        "Assume Role ARN",
+				Element:      alerting.ElementTypeInput,
+				Required:     true,
+				InputType:    alerting.InputTypeText,
+				Placeholder:  "arn:aws:iam:*",
+				PropertyName: "assumeRoleARN",
+				ShowWhen: alerting.ShowWhen{
+					Field: "authProvider",
+					Is:    "arn",
+				},
+			},
+			{
+				Label:        "External ID",
+				Element:      alerting.ElementTypeInput,
+				Required:     false,
+				InputType:    alerting.InputTypeText,
+				Placeholder:  "ExternalID",
+				PropertyName: "externalId",
+				ShowWhen: alerting.ShowWhen{
+					Field: "authProvider",
+					Is:    "arn",
+				},
+			},
+		},
+	})
+}
+func newSNSNotifier(model *models.AlertNotification) (alerting.Notifier, error) {
+	topicArn := model.Settings.Get("topic").MustString()
+
+	// parse the region out of the ARN example: arn:aws:sns:us-west-2:479104307918:GrafanaTestUSWEST2
+	arnSlice := strings.Split(topicArn, ":")
+	if len(arnSlice) != 6 {
+		return nil, alerting.ValidationError{Reason: "Invalid topic ARN provided."}
+	}
+
+	region := arnSlice[3]
+
+	authType := model.Settings.Get("authProvider").MustString()
+	assumeRoleArn := model.Settings.Get("assumeRoleARN").MustString()
+	externalID := model.Settings.Get("externalId").MustString()
+	accessKey := model.DecryptedValue("accessKey", model.Settings.Get("accessKey").MustString())
+	secretKey := model.DecryptedValue("secretKey", model.Settings.Get("secretKey").MustString())
+	credentialsProfile := model.Settings.Get("credentialsProfile").MustString()
+	messageFormat := model.Settings.Get("messageFormat").MustString("text")
+	includeTags := model.Settings.Get("includeTags").MustBool(false)
+
+	switch {
+	case authType == "arn":
+		if assumeRoleArn == "" {
+			return nil, alerting.ValidationError{Reason: "IAM Role not provided."}
+		}
+	case authType == "accessKeyAndSecretKey":
+		if accessKey == "" {
+			return nil, alerting.ValidationError{Reason: "Access Key not provided."}
+		}
+		if secretKey == "" {
+			return nil, alerting.ValidationError{Reason: "Secret Key not provided."}
+		}
+	case authType == "credentialsProfile":
+		if credentialsProfile == "" {
+			return nil, alerting.ValidationError{Reason: "Credentials Profile not provided."}
+		}
+	}
+
+	awsSessionCredentialsInput := AwsSessionCredentialsInput{
+		AuthType:           authType,
+		AssumeRoleArn:      assumeRoleArn,
+		ExternalID:         externalID,
+		AccessKey:          accessKey,
+		SecretKey:          secretKey,
+		CredentialsProfile: credentialsProfile,
+		Region:             region,
+	}
+
+	return &SNSNotifier{
+		NotifierBase:               NewNotifierBase(model),
+		SnsTopic:                   topicArn,
+		Region:                     region,
+		AwsSessionCredentialsInput: awsSessionCredentialsInput,
+		Message:                    "",
+		MessageFormat:              messageFormat,
+		IncludeTags:                includeTags,
+		log:                        log.New("alerting.notifier.sns"),
+	}, nil
+}
+
+// SNSNotifier is responsible for sending alert notifications to AWS SNS.
+type SNSNotifier struct {
+	NotifierBase
+	SnsTopic                   string
+	Message                    string
+	MessageFormat              string
+	IncludeTags                bool
+	SNSClient                  *sns.SNS
+	Region                     string
+	AwsSessionCredentialsInput AwsSessionCredentialsInput
+	log                        log.Logger
+}
+
+// createTextContent is a helper function creating the text formatted string return message.
+func (snsNotifier *SNSNotifier) createTextContent(evalContext *alerting.EvalContext) string {
+	var textContent string
+
+	if snsNotifier.IncludeTags {
+		textContent = string("state:" + evalContext.Rule.State + "\n")
+		textContent += "body:" + evalContext.Rule.Message + "\n"
+		for _, tag := range evalContext.Rule.AlertRuleTags {
+			addTags := tag.Key + ":" + tag.Value + "\n"
+			textContent += addTags
+		}
+	} else {
+		textContent = string("State: " + evalContext.Rule.State + "\n")
+		textContent += evalContext.Rule.Message
+	}
+
+	return textContent
+}
+
+// createJSONContent is a helper function creating the JSON formatted string return message.
+func (snsNotifier *SNSNotifier) createJSONContent(evalContext *alerting.EvalContext) (string, error) {
+	jsonPayload := simplejson.New()
+	jsonPayload.Set("state", evalContext.Rule.State)
+	jsonPayload.Set("body", evalContext.Rule.Message)
+
+	if snsNotifier.IncludeTags {
+		for _, tag := range evalContext.Rule.AlertRuleTags {
+			jsonPayload.Set(tag.Key, tag.Value)
+		}
+	}
+
+	rawBytes, jsonErr := json.MarshalIndent(jsonPayload, "", "    ")
+	jsonContent := string(rawBytes)
+	return jsonContent, jsonErr
+}
+
+// buildMessageContent creates the message content sent to AWS SNS.
+func (snsNotifier *SNSNotifier) buildMessageContent(evalContext *alerting.EvalContext) (string, error) {
+	var err error = nil
+	var messageContent string
+
+	switch snsNotifier.MessageFormat {
+	case "text":
+		messageContent = snsNotifier.createTextContent(evalContext)
+
+	case "json":
+		messageContent, err = snsNotifier.createJSONContent(evalContext)
+
+	default:
+		snsNotifier.log.Warn("Invalid message format specified. Defaulting to text message format", "messageFormat", snsNotifier.MessageFormat)
+		messageContent = snsNotifier.createTextContent(evalContext)
+	}
+
+	return messageContent, err
+}
+
+// Notify sends the alert notification to AWS SNS.
+func (snsNotifier *SNSNotifier) Notify(evalContext *alerting.EvalContext) error {
+	snsNotifier.log.Info("Sending to AWS SNS")
+	metrics.MAlertingSNS.Inc()
+
+	session, err := getAWSAuthorizedSession(&snsNotifier.AwsSessionCredentialsInput)
+
+	if err != nil {
+		return err
+	}
+
+	message, err := snsNotifier.buildMessageContent(evalContext)
+
+	if err != nil {
+		return err
+	}
+
+	snsClient := sns.New(session, aws.NewConfig())
+
+	input := &sns.PublishInput{
+		Subject:  aws.String("State: " + strings.ToUpper(string(evalContext.Rule.State))),
+		Message:  aws.String(message),
+		TopicArn: aws.String(snsNotifier.SnsTopic),
+	}
+
+	_, err = snsClient.Publish(input)
+
+	if err != nil {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) {
+			switch awsErr.Code() {
+			case sns.ErrCodeAuthorizationErrorException:
+				metrics.MAlertingSNSAccessDenied.Inc()
+			default:
+				metrics.MAlertingSNSInternalError.Inc()
+			}
+		}
+		snsNotifier.log.Error("Failed to publish to AWS SNS. ", "error", err)
+	}
+
+	return nil
+}

--- a/pkg/services/alerting/notifiers/sns.go
+++ b/pkg/services/alerting/notifiers/sns.go
@@ -3,17 +3,17 @@ package notifiers
 import (
 	"context"
 	"encoding/json"
-	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
-	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/services/notifications"
-	"github.com/grafana/grafana/pkg/setting"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/notifications"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func init() {

--- a/pkg/services/alerting/notifiers/sns_test.go
+++ b/pkg/services/alerting/notifiers/sns_test.go
@@ -1,0 +1,467 @@
+package notifiers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/validations"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestSNSNotifier(t *testing.T) {
+	Convey("AWS SNS notifier tests", t, func() {
+		Convey("Parsing alert notification from settings", func() {
+			Convey("empty settings return error", func() {
+				json := `{ }`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				model := &models.AlertNotification{
+					Name:     "AWS SNS",
+					Type:     "sns",
+					Settings: settingsJSON,
+				}
+
+				_, err := newSNSNotifier(model)
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("invalid topic arn", func() {
+				json := `
+				{
+					"topic": "arn:aws:sns:us-east-1:123456789",
+					"accessKey": "",
+					"secretKey": "tzNZYf36y0ohWwXo4XoUrB61rz1A4o",
+					"authProvider": "credentialsProf"
+				}`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				model := &models.AlertNotification{
+					Name:     "AWS SNS",
+					Type:     "sns",
+					Settings: settingsJSON,
+				}
+
+				_, err := newSNSNotifier(model)
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("assume role auth provider settings", func() {
+				Convey("Empty Access Key or Secret Key", func() {
+					json := `
+					{
+						"topic": "arn:aws:sns:us-east-1:123456789:test",
+						"assumeRoleARN": "",
+						"authProvider": "arn"
+					}`
+
+					settingsJSON, _ := simplejson.NewJson([]byte(json))
+					model := &models.AlertNotification{
+						Name:     "AWS SNS",
+						Type:     "sns",
+						Settings: settingsJSON,
+					}
+
+					_, err := newSNSNotifier(model)
+					So(err, ShouldNotBeNil)
+				})
+				Convey("Valid Assume Role ARN", func() {
+					json := `
+					{
+						"topic": "arn:aws:sns:us-east-1:123456789:test",
+						"assumeRoleARN": "testARN",
+						"authProvider": "arn"
+					}`
+
+					settingsJSON, _ := simplejson.NewJson([]byte(json))
+					model := &models.AlertNotification{
+						Name:     "AWS SNS",
+						Type:     "sns",
+						Settings: settingsJSON,
+					}
+
+					not, err := newSNSNotifier(model)
+					snsNotifier := not.(*SNSNotifier)
+
+					So(err, ShouldBeNil)
+					So(snsNotifier.Name, ShouldEqual, "AWS SNS")
+					So(snsNotifier.Type, ShouldEqual, "sns")
+					So(snsNotifier.SnsTopic, ShouldEqual, "arn:aws:sns:us-east-1:123456789:test")
+					So(snsNotifier.AwsSessionCredentialsInput.Region, ShouldEqual, "us-east-1")
+					So(snsNotifier.AwsSessionCredentialsInput.AuthType, ShouldEqual, "arn")
+					So(snsNotifier.AwsSessionCredentialsInput.AssumeRoleArn, ShouldEqual, "testARN")
+				})
+			})
+
+			Convey("access key and secret key auth provider settings", func() {
+				Convey("Empty Access Key or Secret Key", func() {
+					json := `
+					{
+						"topic": "arn:aws:sns:us-east-1:123456789:test",
+						"accessKey": "",
+						"secretKey": "tzNZYf36y0ohWwXo4XoUrB61rz1A4o",
+						"authProvider": "accessKeyAndSecretKey"
+					}`
+
+					settingsJSON, _ := simplejson.NewJson([]byte(json))
+					model := &models.AlertNotification{
+						Name:     "AWS SNS",
+						Type:     "sns",
+						Settings: settingsJSON,
+					}
+
+					_, err := newSNSNotifier(model)
+					So(err, ShouldNotBeNil)
+
+					json = `
+					{
+						"topic": "arn:aws:sns:us-east-1:123456789:test",
+						"accessKey": "4SrUFQL4A5V5TQ1z5Pg9nxHXPXSTve",
+						"secretKey": "",
+						"authProvider": "accessKeyAndSecretKey"
+					}`
+
+					settingsJSON, _ = simplejson.NewJson([]byte(json))
+					model = &models.AlertNotification{
+						Name:     "AWS SNS",
+						Type:     "sns",
+						Settings: settingsJSON,
+					}
+
+					_, err = newSNSNotifier(model)
+					So(err, ShouldNotBeNil)
+				})
+
+				Convey("Valid Access and Secret Key", func() {
+					json := `
+					{
+						"topic": "arn:aws:sns:us-east-1:123456789:test",
+						"accessKey": "4SrUFQL4A5V5TQ1z5Pg9nxHXPXSTve",
+						"secretKey": "tzNZYf36y0ohWwXo4XoUrB61rz1A4o",
+						"authProvider": "accessKeyAndSecretKey"
+					}`
+
+					settingsJSON, _ := simplejson.NewJson([]byte(json))
+					model := &models.AlertNotification{
+						Name:     "AWS SNS",
+						Type:     "sns",
+						Settings: settingsJSON,
+					}
+
+					not, err := newSNSNotifier(model)
+					snsNotifier := not.(*SNSNotifier)
+
+					So(err, ShouldBeNil)
+					So(snsNotifier.Name, ShouldEqual, "AWS SNS")
+					So(snsNotifier.Type, ShouldEqual, "sns")
+					So(snsNotifier.SnsTopic, ShouldEqual, "arn:aws:sns:us-east-1:123456789:test")
+					So(snsNotifier.AwsSessionCredentialsInput.AuthType, ShouldEqual, "accessKeyAndSecretKey")
+					So(snsNotifier.AwsSessionCredentialsInput.AccessKey, ShouldEqual, "4SrUFQL4A5V5TQ1z5Pg9nxHXPXSTve")
+					So(snsNotifier.AwsSessionCredentialsInput.SecretKey, ShouldEqual, "tzNZYf36y0ohWwXo4XoUrB61rz1A4o")
+				})
+			})
+
+			Convey("Credential Profile auth provider settings", func() {
+				Convey("Empty profile", func() {
+					json := `
+					{
+						"topic": "arn:aws:sns:us-east-1:123456789:test",
+						"credentialsProfile": "",
+						"authProvider": "credentialsProfile"
+					}`
+
+					settingsJSON, _ := simplejson.NewJson([]byte(json))
+					model := &models.AlertNotification{
+						Name:     "AWS SNS",
+						Type:     "sns",
+						Settings: settingsJSON,
+					}
+
+					_, err := newSNSNotifier(model)
+					So(err, ShouldNotBeNil)
+				})
+
+				Convey("Valid Credentials Profile", func() {
+					json := `
+					{
+						"topic": "arn:aws:sns:us-east-1:123456789:test",
+						"credentialsProfile": "dev",
+						"authProvider": "credentialsProfile"
+					}`
+
+					settingsJSON, _ := simplejson.NewJson([]byte(json))
+					model := &models.AlertNotification{
+						Name:     "AWS SNS",
+						Type:     "sns",
+						Settings: settingsJSON,
+					}
+
+					not, err := newSNSNotifier(model)
+					snsNotifier := not.(*SNSNotifier)
+
+					So(err, ShouldBeNil)
+					So(snsNotifier.Name, ShouldEqual, "AWS SNS")
+					So(snsNotifier.Type, ShouldEqual, "sns")
+					So(snsNotifier.SnsTopic, ShouldEqual, "arn:aws:sns:us-east-1:123456789:test")
+					So(snsNotifier.AwsSessionCredentialsInput.AuthType, ShouldEqual, "credentialsProfile")
+					So(snsNotifier.AwsSessionCredentialsInput.CredentialsProfile, ShouldEqual, "dev")
+				})
+			})
+
+			Convey("AWS SDK Default auth provider settings", func() {
+				json := `
+					{
+						"topic": "arn:aws:sns:us-east-1:123456789:test",
+						"authProvider": "authTypeDefault"
+					}`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(json))
+				model := &models.AlertNotification{
+					Name:     "AWS SNS",
+					Type:     "sns",
+					Settings: settingsJSON,
+				}
+
+				not, err := newSNSNotifier(model)
+				snsNotifier := not.(*SNSNotifier)
+
+				So(err, ShouldBeNil)
+				So(snsNotifier.Name, ShouldEqual, "AWS SNS")
+				So(snsNotifier.Type, ShouldEqual, "sns")
+				So(snsNotifier.SnsTopic, ShouldEqual, "arn:aws:sns:us-east-1:123456789:test")
+				So(snsNotifier.AwsSessionCredentialsInput.AuthType, ShouldEqual, "authTypeDefault")
+			})
+
+			Convey("Valid JSON message body without tags", func() {
+				setupJson := `
+					{
+						"topic": "arn:aws:sns:us-east-1:123456789:test",
+						"authProvider": "authTypeDefault",
+						"messageFormat": "json"
+					}`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(setupJson))
+				model := &models.AlertNotification{
+					Name:     "AWS SNS",
+					Type:     "sns",
+					Settings: settingsJSON,
+				}
+
+				evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
+					ID:      0,
+					Name:    "someRule",
+					Message: "someMessage",
+					State:   models.AlertStateAlerting,
+					AlertRuleTags: []*models.Tag{
+						{Key: "sns_tag-prefix-sample", Value: "don't show this tag"},
+						{Key: "no-tag-prefix-sample", Value: "don't show this tag"},
+						{Key: "severity", Value: "warning"},
+					},
+				}, &validations.OSSPluginRequestValidator{})
+				evalContext.IsTestRun = true
+				not, err := newSNSNotifier(model)
+				snsNotifier := not.(*SNSNotifier)
+				So(err, ShouldBeNil)
+				So(snsNotifier.Name, ShouldEqual, "AWS SNS")
+				So(snsNotifier.Type, ShouldEqual, "sns")
+				So(snsNotifier.SnsTopic, ShouldEqual, "arn:aws:sns:us-east-1:123456789:test")
+				So(snsNotifier.AwsSessionCredentialsInput.AuthType, ShouldEqual, "authTypeDefault")
+
+				expectedResultJson := simplejson.New()
+				expectedResultJson.Set("state", evalContext.Rule.State)
+				expectedResultJson.Set("body", evalContext.Rule.Message)
+				rawBytes, err := json.MarshalIndent(expectedResultJson, "", "    ")
+				So(err, ShouldBeNil)
+
+				expectedResult := string(rawBytes)
+				result, err := snsNotifier.buildMessageContent(evalContext)
+				So(result, ShouldEqual, expectedResult)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Valid JSON message body with tags", func() {
+				setupJson := `
+					{
+						"topic": "arn:aws:sns:us-east-1:123456789:test",
+						"authProvider": "authTypeDefault",
+						"messageFormat": "json",
+						"includeTags": true
+					}`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(setupJson))
+				model := &models.AlertNotification{
+					Name:     "AWS SNS",
+					Type:     "sns",
+					Settings: settingsJSON,
+				}
+
+				evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
+					ID:      0,
+					Name:    "someRule",
+					Message: "someMessage",
+					State:   models.AlertStateAlerting,
+					AlertRuleTags: []*models.Tag{
+						{Key: "sns_tag-prefix-sample", Value: "this tag should be visible"},
+						{Key: "no-tag-prefix-sample", Value: "this tag should be visible"},
+						{Key: "severity", Value: "warning"},
+					},
+				}, &validations.OSSPluginRequestValidator{})
+				evalContext.IsTestRun = true
+				not, err := newSNSNotifier(model)
+				snsNotifier := not.(*SNSNotifier)
+				So(err, ShouldBeNil)
+				So(snsNotifier.Name, ShouldEqual, "AWS SNS")
+				So(snsNotifier.Type, ShouldEqual, "sns")
+				So(snsNotifier.SnsTopic, ShouldEqual, "arn:aws:sns:us-east-1:123456789:test")
+				So(snsNotifier.AwsSessionCredentialsInput.AuthType, ShouldEqual, "authTypeDefault")
+
+				expectedResultJson := simplejson.New()
+				expectedResultJson.Set("state", evalContext.Rule.State)
+				expectedResultJson.Set("body", evalContext.Rule.Message)
+				expectedResultJson.Set("sns_tag-prefix-sample", "this tag should be visible")
+				expectedResultJson.Set("no-tag-prefix-sample", "this tag should be visible")
+				expectedResultJson.Set("severity", "warning")
+				rawBytes, err := json.MarshalIndent(expectedResultJson, "", "    ")
+				So(err, ShouldBeNil)
+
+				expectedResult := string(rawBytes)
+				result, err := snsNotifier.buildMessageContent(evalContext)
+				So(result, ShouldEqual, expectedResult)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Valid text message body without tags", func() {
+				setupJson := `
+					{
+						"topic": "arn:aws:sns:us-east-1:123456789:test",
+						"authProvider": "authTypeDefault",
+						"messageFormat": "text"
+					}`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(setupJson))
+				model := &models.AlertNotification{
+					Name:     "AWS SNS",
+					Type:     "sns",
+					Settings: settingsJSON,
+				}
+
+				evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
+					ID:      0,
+					Name:    "someRule",
+					Message: "someMessage",
+					State:   models.AlertStateAlerting,
+					AlertRuleTags: []*models.Tag{
+						{Key: "sns_tag-prefix-sample", Value: "always show this tag"},
+						{Key: "no-tag-prefix-sample", Value: "don't show this tag"},
+						{Key: "severity", Value: "warning"},
+					},
+				}, &validations.OSSPluginRequestValidator{})
+				evalContext.IsTestRun = true
+				not, err := newSNSNotifier(model)
+				snsNotifier := not.(*SNSNotifier)
+				So(err, ShouldBeNil)
+				So(snsNotifier.Name, ShouldEqual, "AWS SNS")
+				So(snsNotifier.Type, ShouldEqual, "sns")
+				So(snsNotifier.SnsTopic, ShouldEqual, "arn:aws:sns:us-east-1:123456789:test")
+				So(snsNotifier.AwsSessionCredentialsInput.AuthType, ShouldEqual, "authTypeDefault")
+
+				expectedResult := string("State: " + evalContext.Rule.State + "\n")
+				expectedResult += evalContext.Rule.Message
+
+				result, err := snsNotifier.buildMessageContent(evalContext)
+				So(result, ShouldEqual, expectedResult)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Valid text message body with tags", func() {
+				setupJson := `
+					{
+						"topic": "arn:aws:sns:us-east-1:123456789:test",
+						"authProvider": "authTypeDefault",
+						"messageFormat": "text",
+						"includeTags": true
+					}`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(setupJson))
+				model := &models.AlertNotification{
+					Name:     "AWS SNS",
+					Type:     "sns",
+					Settings: settingsJSON,
+				}
+
+				evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
+					ID:      0,
+					Name:    "someRule",
+					Message: "someMessage",
+					State:   models.AlertStateAlerting,
+					AlertRuleTags: []*models.Tag{
+						{Key: "tag-sample-1", Value: "show this tag"},
+						{Key: "tag-sample-2", Value: "show this tag"},
+						{Key: "severity", Value: "warning"},
+					},
+				}, &validations.OSSPluginRequestValidator{})
+				evalContext.IsTestRun = true
+				not, err := newSNSNotifier(model)
+				snsNotifier := not.(*SNSNotifier)
+				So(err, ShouldBeNil)
+				So(snsNotifier.Name, ShouldEqual, "AWS SNS")
+				So(snsNotifier.Type, ShouldEqual, "sns")
+				So(snsNotifier.SnsTopic, ShouldEqual, "arn:aws:sns:us-east-1:123456789:test")
+				So(snsNotifier.AwsSessionCredentialsInput.AuthType, ShouldEqual, "authTypeDefault")
+
+				expectedResult := string("state:" + evalContext.Rule.State + "\n")
+				expectedResult += "body:" + evalContext.Rule.Message + "\n"
+				expectedResult += "tag-sample-1:show this tag\n"
+				expectedResult += "tag-sample-2:show this tag\n"
+				expectedResult += "severity:warning\n"
+
+				result, err := snsNotifier.buildMessageContent(evalContext)
+				So(result, ShouldEqual, expectedResult)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Unspecified messageFormat backwards compatible", func() {
+				setupJson := `
+					{
+						"topic": "arn:aws:sns:us-east-1:123456789:test",
+						"authProvider": "authTypeDefault"
+					}`
+
+				settingsJSON, _ := simplejson.NewJson([]byte(setupJson))
+				model := &models.AlertNotification{
+					Name:     "AWS SNS",
+					Type:     "sns",
+					Settings: settingsJSON,
+				}
+
+				evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
+					ID:      0,
+					Name:    "someRule",
+					Message: "someMessage",
+					State:   models.AlertStateAlerting,
+					AlertRuleTags: []*models.Tag{
+						{Key: "severity", Value: "warning"},
+					},
+				}, &validations.OSSPluginRequestValidator{})
+				evalContext.IsTestRun = true
+				not, err := newSNSNotifier(model)
+				snsNotifier := not.(*SNSNotifier)
+				So(err, ShouldBeNil)
+				So(snsNotifier.Name, ShouldEqual, "AWS SNS")
+				So(snsNotifier.Type, ShouldEqual, "sns")
+				So(snsNotifier.SnsTopic, ShouldEqual, "arn:aws:sns:us-east-1:123456789:test")
+				So(snsNotifier.AwsSessionCredentialsInput.AuthType, ShouldEqual, "authTypeDefault")
+
+				expectedResult := string("State: " + evalContext.Rule.State + "\n")
+				expectedResult += evalContext.Rule.Message
+
+				result, err := snsNotifier.buildMessageContent(evalContext)
+				So(result, ShouldEqual, expectedResult)
+				So(err, ShouldBeNil)
+			})
+		})
+	})
+}

--- a/pkg/services/alerting/notifiers/sns_test.go
+++ b/pkg/services/alerting/notifiers/sns_test.go
@@ -3,15 +3,15 @@ package notifiers
 import (
 	"context"
 	"encoding/json"
-	"github.com/grafana/grafana/pkg/services/encryption/ossencryption"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/encryption/ossencryption"
 	"github.com/grafana/grafana/pkg/services/validations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSNSNotifier(t *testing.T) {

--- a/public/app/features/alerting/components/NotificationChannelOptions.tsx
+++ b/public/app/features/alerting/components/NotificationChannelOptions.tsx
@@ -25,12 +25,17 @@ export const NotificationChannelOptions: FC<Props> = ({
   return (
     <>
       {selectedChannelOptions.map((option: NotificationChannelOption, index: number) => {
+        let selectedOptionValue;
         const key = `${option.label}-${index}`;
-        // Some options can be dependent on other options, this determines what is selected in the dependency options
-        // I think this needs more thought.
-        const selectedOptionValue =
-          currentFormValues[`settings.${option.showWhen.field}`] &&
-          (currentFormValues[`settings.${option.showWhen.field}`] as SelectableValue<string>).value;
+        if (typeof currentFormValues[`settings`][option.showWhen.field] === 'string') {
+          selectedOptionValue =
+            currentFormValues[`settings`][option.showWhen.field] &&
+            (currentFormValues[`settings`][option.showWhen.field] as String);
+        } else {
+          selectedOptionValue =
+            currentFormValues[`settings`][option.showWhen.field] &&
+            (currentFormValues[`settings`][option.showWhen.field] as SelectableValue<string>).value;
+        }
 
         if (option.showWhen.field && selectedOptionValue !== option.showWhen.is) {
           return null;


### PR DESCRIPTION
**What this PR does / why we need it**:

* Addition of AWS SNS as a notification channel option for legacy grafana alerts.
* Bug fix for the legacy grafana alerts `ShowWhen` property.
    * The `ShowWhen` property used in Grafana's alerting component hides certain input fields unless a specified condition is met. This feature is not working properly. Specifically, any field using this property remains hidden, regardless of the specified condition being met.

Screenshot of the SNS notifier form:

<img width="616" alt="Screen Shot 2022-04-14 at 10 24 32 AM" src="https://user-images.githubusercontent.com/31365193/163441471-48f34292-90be-48d4-99e2-bfa493462a0a.png">


