### PR TITLE
Alerting: add confirmation modal for deleting notification policies

### DIFF
--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
-import { Button, HorizontalGroup, IconButton } from '@grafana/ui';
+import { Button, ConfirmModal, HorizontalGroup, IconButton } from '@grafana/ui';
 import { AmRouteReceiver, FormAmRoute } from '../../types/amroutes';
 import { prepareItems } from '../../utils/dynamicTable';
 import { DynamicTable, DynamicTableColumnProps, DynamicTableItemProps } from '../DynamicTable';
@@ -75,6 +75,7 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
   alertManagerSourceName,
 }) => {
   const [editMode, setEditMode] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
   const [expandedId, setExpandedId] = useState<string | number>();
   const permissions = getNotificationsPermissions(alertManagerSourceName);
   const canEditRoutes = contextSrv.hasPermission(permissions.update);
@@ -135,27 +136,40 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
               };
 
               return (
-                <HorizontalGroup>
-                  <Button
-                    aria-label="Edit route"
-                    icon="pen"
-                    onClick={expandWithCustomContent}
-                    size="sm"
-                    type="button"
-                    variant="secondary"
-                  >
-                    Edit
-                  </Button>
-                  <IconButton
-                    aria-label="Delete route"
-                    name="trash-alt"
-                    onClick={() => {
+                <>
+                  <HorizontalGroup>
+                    <Button
+                      aria-label="Edit route"
+                      icon="pen"
+                      onClick={expandWithCustomContent}
+                      size="sm"
+                      type="button"
+                      variant="secondary"
+                    >
+                      Edit
+                    </Button>
+                    <IconButton
+                      aria-label="Delete route"
+                      name="trash-alt"
+                      onClick={() => {
+                        setShowDeleteModal(true);
+                      }}
+                      type="button"
+                    />
+                  </HorizontalGroup>
+                  <ConfirmModal
+                    isOpen={showDeleteModal}
+                    title="Delete notification policy"
+                    body="Deleting this notification policy will permanently remove it. Are you sure you want to delete this policy?"
+                    confirmText="Yes, delete"
+                    icon="exclamation-triangle"
+                    onConfirm={() => {
                       const newRoutes = deleteRoute(routes, item.data);
                       onChange(newRoutes);
                     }}
-                    type="button"
+                    onDismiss={() => setShowDeleteModal(false)}
                   />
-                </HorizontalGroup>
+                </>
               );
             },
             size: '100px',
@@ -192,45 +206,47 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
   }
 
   return (
-    <DynamicTable
-      cols={cols}
-      isExpandable={true}
-      items={dynamicTableRoutes}
-      testIdGenerator={() => 'am-routes-row'}
-      onCollapse={collapseItem}
-      onExpand={expandItem}
-      isExpanded={(item) => expandedId === item.id}
-      renderExpandedContent={(item: RouteTableItemProps) =>
-        isAddMode || editMode ? (
-          <AmRoutesExpandedForm
-            onCancel={() => {
-              if (isAddMode) {
-                onCancelAdd();
-              }
-              setEditMode(false);
-            }}
-            onSave={(data) => {
-              const newRoutes = updatedRoute(routes, data);
+    <>
+      <DynamicTable
+        cols={cols}
+        isExpandable={true}
+        items={dynamicTableRoutes}
+        testIdGenerator={() => 'am-routes-row'}
+        onCollapse={collapseItem}
+        onExpand={expandItem}
+        isExpanded={(item) => expandedId === item.id}
+        renderExpandedContent={(item: RouteTableItemProps) =>
+          isAddMode || editMode ? (
+            <AmRoutesExpandedForm
+              onCancel={() => {
+                if (isAddMode) {
+                  onCancelAdd();
+                }
+                setEditMode(false);
+              }}
+              onSave={(data) => {
+                const newRoutes = updatedRoute(routes, data);
 
-              setEditMode(false);
-              onChange(newRoutes);
-            }}
-            receivers={receivers}
-            routes={item.data}
-          />
-        ) : (
-          <AmRoutesExpandedRead
-            onChange={(data) => {
-              const newRoutes = updatedRoute(routes, data);
-              onChange(newRoutes);
-            }}
-            receivers={receivers}
-            routes={item.data}
-            readOnly={readOnly}
-            alertManagerSourceName={alertManagerSourceName}
-          />
-        )
-      }
-    />
+                setEditMode(false);
+                onChange(newRoutes);
+              }}
+              receivers={receivers}
+              routes={item.data}
+            />
+          ) : (
+            <AmRoutesExpandedRead
+              onChange={(data) => {
+                const newRoutes = updatedRoute(routes, data);
+                onChange(newRoutes);
+              }}
+              receivers={receivers}
+              routes={item.data}
+              readOnly={readOnly}
+              alertManagerSourceName={alertManagerSourceName}
+            />
+          )
+        }
+      />
+    </>
   );
 };

--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.tsx
@@ -206,47 +206,45 @@ export const AmRoutesTable: FC<AmRoutesTableProps> = ({
   }
 
   return (
-    <>
-      <DynamicTable
-        cols={cols}
-        isExpandable={true}
-        items={dynamicTableRoutes}
-        testIdGenerator={() => 'am-routes-row'}
-        onCollapse={collapseItem}
-        onExpand={expandItem}
-        isExpanded={(item) => expandedId === item.id}
-        renderExpandedContent={(item: RouteTableItemProps) =>
-          isAddMode || editMode ? (
-            <AmRoutesExpandedForm
-              onCancel={() => {
-                if (isAddMode) {
-                  onCancelAdd();
-                }
-                setEditMode(false);
-              }}
-              onSave={(data) => {
-                const newRoutes = updatedRoute(routes, data);
+    <DynamicTable
+      cols={cols}
+      isExpandable={true}
+      items={dynamicTableRoutes}
+      testIdGenerator={() => 'am-routes-row'}
+      onCollapse={collapseItem}
+      onExpand={expandItem}
+      isExpanded={(item) => expandedId === item.id}
+      renderExpandedContent={(item: RouteTableItemProps) =>
+        isAddMode || editMode ? (
+          <AmRoutesExpandedForm
+            onCancel={() => {
+              if (isAddMode) {
+                onCancelAdd();
+              }
+              setEditMode(false);
+            }}
+            onSave={(data) => {
+              const newRoutes = updatedRoute(routes, data);
 
-                setEditMode(false);
-                onChange(newRoutes);
-              }}
-              receivers={receivers}
-              routes={item.data}
-            />
-          ) : (
-            <AmRoutesExpandedRead
-              onChange={(data) => {
-                const newRoutes = updatedRoute(routes, data);
-                onChange(newRoutes);
-              }}
-              receivers={receivers}
-              routes={item.data}
-              readOnly={readOnly}
-              alertManagerSourceName={alertManagerSourceName}
-            />
-          )
-        }
-      />
-    </>
+              setEditMode(false);
+              onChange(newRoutes);
+            }}
+            receivers={receivers}
+            routes={item.data}
+          />
+        ) : (
+          <AmRoutesExpandedRead
+            onChange={(data) => {
+              const newRoutes = updatedRoute(routes, data);
+              onChange(newRoutes);
+            }}
+            receivers={receivers}
+            routes={item.data}
+            readOnly={readOnly}
+            alertManagerSourceName={alertManagerSourceName}
+          />
+        )
+      }
+    />
   );
 };


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, removing a notification policy did not show a confirmation modal.

This PR adds a confirmation modal to prevent accidental destructive actions.