### PR TITLE
Explore: Fix legend toggling

### DIFF
--- a/public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts
+++ b/public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts
@@ -141,7 +141,7 @@ const getExistingDisplayNames = (rule: SystemConfigOverrideRule): string[] => {
   if (!Array.isArray(names)) {
     return [];
   }
-  return names;
+  return [...names];
 };
 
 const allFieldsAreExcluded = (override: SystemConfigOverrideRule, data: DataFrame[]): boolean => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

As described in #45776, selecting multiple series on the graph legend doesn't work in Explore (works fine in Dashboards).

What's happening?

When [toggling the legend](https://github.com/grafana/grafana/blob/v8.5.x/public/app/features/explore/ExploreGraph.tsx#L137) a field config override is created in [createExtendedOverride](https://github.com/grafana/grafana/blob/v8.5.x/public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts#L121).

As part of its logic, the existing list of display names gets mutated [here](https://github.com/grafana/grafana/blob/v8.5.x/public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts#L13), because [getExistingDisplayNames](https://github.com/grafana/grafana/blob/v8.5.x/public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts#L144) does not create a copy of names but simply passes the current reference.

The line that mutates the existing field config display name causes this error to occur in Explore:

```
SeriesVisibilityConfigFactory.ts:131 Uncaught TypeError: Cannot add property 2, object is not extensible
    at Array.push (<anonymous>)
```


This happens [because the field config created by Explore is an immutable object](https://github.com/grafana/grafana/blob/v8.5.x/public/app/features/explore/exploreGraphStyleUtils.ts#L9) created by `immer` library and has prevented object extensions. 


One thing we could do is to revisit if we really need `immer` in Explore (it's used only in one place) but at the same time, it feels it makes sense to not mutate the existing config. @gabor do you have more context on why why added `immer`?

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #45776

**Special notes for your reviewer**:

How to test it? 

Try selecting multiple series on a TimeSeries graph in explore (by holding <kbd>Shift</kbd>)