### PR TITLE
Indicate whether routes are provisioned when GETting Alertmanager configuration

### DIFF
--- a/pkg/services/ngalert/CHANGELOG.md
+++ b/pkg/services/ngalert/CHANGELOG.md
@@ -50,3 +50,4 @@ Scopes must have an order to ensure consistency and ease of search, this helps u
 - [BUGFIX] Scheduler: Fix state manager to support OK option of `AlertRule.ExecErrState` #47670 
 - [ENHANCEMENT] Templates: Enable the use of classic condition values in templates #46971
 - [CHANGE] Notification URL points to alert view page instead of alert edit page. #47752
+- [FEATURE]  Indicate whether routes are provisioned when GETting Alertmanager configuration #47857

--- a/pkg/services/ngalert/api/api_alertmanager_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_test.go
@@ -410,7 +410,7 @@ func createMultiOrgAlertmanager(t *testing.T) *notifier.MultiOrgAlertmanager {
 		},
 	}
 
-	mam, err := notifier.NewMultiOrgAlertmanager(cfg, &configStore, &orgStore, kvStore, decryptFn, m.GetMultiOrgAlertmanagerMetrics(), nil, log.New("testlogger"), secretsService, provStore)
+	mam, err := notifier.NewMultiOrgAlertmanager(cfg, &configStore, &orgStore, kvStore, provStore, decryptFn, m.GetMultiOrgAlertmanagerMetrics(), nil, log.New("testlogger"), secretsService)
 	require.NoError(t, err)
 	err = mam.LoadAndSyncAlertmanagersForOrgs(context.Background())
 	require.NoError(t, err)

--- a/pkg/services/ngalert/api/api_alertmanager_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_test.go
@@ -346,19 +346,11 @@ func createSut(t *testing.T, accessControl accesscontrol.AccessControl) Alertman
 	t.Helper()
 
 	mam := createMultiOrgAlertmanager(t)
-	configs := map[int64]*ngmodels.AlertConfiguration{
-		1: {AlertmanagerConfiguration: validConfig, OrgID: 1},
-		2: {AlertmanagerConfiguration: validConfig, OrgID: 2},
-		3: {AlertmanagerConfiguration: brokenConfig, OrgID: 3},
-	}
-	configStore := notifier.NewFakeConfigStore(t, configs)
-	secrets := fakes.NewFakeSecretsService()
 	if accessControl == nil {
 		accessControl = acMock.New().WithDisabled()
 	}
 	log := log.NewNopLogger()
-	crypto := notifier.NewCrypto(secrets, &configStore, log)
-	return AlertmanagerSrv{mam: mam, crypto: crypto, ac: accessControl, log: log}
+	return AlertmanagerSrv{mam: mam, crypto: mam.Crypto, ac: accessControl, log: log}
 }
 
 func createAmConfigRequest(t *testing.T) apimodels.PostableUserConfig {

--- a/pkg/services/ngalert/api/api_alertmanager_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_test.go
@@ -516,7 +516,7 @@ func createRequestCtxInOrg(org int64) *models.ReqContext {
 // setRouteProvenance marks an org's routing tree as provisioned.
 func setRouteProvenance(t *testing.T, org int64, ps provisioning.ProvisioningStore) {
 	t.Helper()
-	adp := provenanceOrgAdapter{inner: &apimodels.Route{}, orgID: org}
+	adp := provisioning.ProvenanceOrgAdapter{Inner: &apimodels.Route{}, OrgID: org}
 	err := ps.SetProvenance(context.Background(), adp, ngmodels.ProvenanceAPI)
 	require.NoError(t, err)
 }
@@ -527,22 +527,4 @@ func asGettableUserConfig(t *testing.T, r response.Response) *apimodels.Gettable
 	err := json.Unmarshal(r.Body(), body)
 	require.NoError(t, err)
 	return body
-}
-
-// TODO: extract to shared location
-type provenanceOrgAdapter struct {
-	inner ngmodels.ProvisionableInOrg
-	orgID int64
-}
-
-func (a provenanceOrgAdapter) ResourceType() string {
-	return a.inner.ResourceType()
-}
-
-func (a provenanceOrgAdapter) ResourceID() string {
-	return a.inner.ResourceID()
-}
-
-func (a provenanceOrgAdapter) ResourceOrgID() int64 {
-	return a.orgID
 }

--- a/pkg/services/ngalert/api/api_alertmanager_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_test.go
@@ -213,17 +213,6 @@ func TestAlertmanagerConfig(t *testing.T) {
 		require.Equal(t, 202, response.Status())
 	})
 
-	t.Run("assert provenance status is returned", func(t *testing.T) {
-		t.Run("when routes are provisioned", func(t *testing.T) {
-			sut := createSut(t, nil)
-			rc := createRequestCtxInOrg(1)
-
-			response := sut.RouteGetAlertingConfig(rc)
-
-			require.Equal(t, 200, response.Status())
-		})
-	})
-
 	t.Run("when objects are not provisioned", func(t *testing.T) {
 		t.Run("route from GET config has no provenance", func(t *testing.T) {
 			sut := createSut(t, nil)

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	alerting_models "github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
@@ -30,7 +29,7 @@ type ContactPointService interface {
 }
 
 type NotificationPolicyService interface {
-	GetPolicyTree(ctx context.Context, orgID int64) (provisioning.EmbeddedRoutingTree, error)
+	GetPolicyTree(ctx context.Context, orgID int64) (apimodels.Route, error)
 	UpdatePolicyTree(ctx context.Context, orgID int64, tree apimodels.Route, p alerting_models.Provenance) error
 }
 

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	domain "github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/require"
@@ -120,14 +119,13 @@ func newFakeNotificationPolicyService() *fakeNotificationPolicyService {
 	}
 }
 
-func (f *fakeNotificationPolicyService) GetPolicyTree(ctx context.Context, orgID int64) (provisioning.EmbeddedRoutingTree, error) {
+func (f *fakeNotificationPolicyService) GetPolicyTree(ctx context.Context, orgID int64) (apimodels.Route, error) {
 	if orgID != 1 {
-		return provisioning.EmbeddedRoutingTree{}, store.ErrNoAlertmanagerConfiguration
+		return apimodels.Route{}, store.ErrNoAlertmanagerConfiguration
 	}
-	return provisioning.EmbeddedRoutingTree{
-		Route:      f.tree,
-		Provenance: f.prov,
-	}, nil
+	result := f.tree
+	result.Provenance = f.prov
+	return result, nil
 }
 
 func (f *fakeNotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgID int64, tree apimodels.Route, p domain.Provenance) error {
@@ -141,8 +139,8 @@ func (f *fakeNotificationPolicyService) UpdatePolicyTree(ctx context.Context, or
 
 type fakeFailingNotificationPolicyService struct{}
 
-func (f *fakeFailingNotificationPolicyService) GetPolicyTree(ctx context.Context, orgID int64) (provisioning.EmbeddedRoutingTree, error) {
-	return provisioning.EmbeddedRoutingTree{}, fmt.Errorf("something went wrong")
+func (f *fakeFailingNotificationPolicyService) GetPolicyTree(ctx context.Context, orgID int64) (apimodels.Route, error) {
+	return apimodels.Route{}, fmt.Errorf("something went wrong")
 }
 
 func (f *fakeFailingNotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgID int64, tree apimodels.Route, p domain.Provenance) error {

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
@@ -66,7 +66,7 @@ type EmbeddedContactPoint struct {
 	Type                  string           `json:"type" binding:"required"`
 	Settings              *simplejson.Json `json:"settings" binding:"required"`
 	DisableResolveMessage bool             `json:"disableResolveMessage"`
-	Provenance            string           `json:"provanance"`
+	Provenance            string           `json:"provenance"`
 }
 
 const RedactedValue = "[REDACTED]"

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -99,7 +99,7 @@ func (ng *AlertNG) init() error {
 
 	decryptFn := ng.SecretsService.GetDecryptedValue
 	multiOrgMetrics := ng.Metrics.GetMultiOrgAlertmanagerMetrics()
-	ng.MultiOrgAlertmanager, err = notifier.NewMultiOrgAlertmanager(ng.Cfg, store, store, ng.KVStore, decryptFn, multiOrgMetrics, ng.NotificationService, log.New("ngalert.multiorg.alertmanager"), ng.SecretsService)
+	ng.MultiOrgAlertmanager, err = notifier.NewMultiOrgAlertmanager(ng.Cfg, store, store, ng.KVStore, store, decryptFn, multiOrgMetrics, ng.NotificationService, log.New("ngalert.multiorg.alertmanager"), ng.SecretsService)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -132,7 +132,7 @@ func (moa *MultiOrgAlertmanager) mergeProvenance(ctx context.Context, config def
 			inner: config.Route,
 			orgID: org,
 		}
-		provenance, err := moa.provStore.GetProvenance(ctx, adp)
+		provenance, err := moa.ProvStore.GetProvenance(ctx, adp)
 		if err != nil {
 			return definitions.GettableApiAlertingConfig{}, err
 		}

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 )
 
@@ -128,9 +129,9 @@ func (moa *MultiOrgAlertmanager) ApplyAlertmanagerConfiguration(ctx context.Cont
 
 func (moa *MultiOrgAlertmanager) mergeProvenance(ctx context.Context, config definitions.GettableApiAlertingConfig, org int64) (definitions.GettableApiAlertingConfig, error) {
 	if config.Route != nil {
-		adp := provenanceOrgAdapter{
-			inner: config.Route,
-			orgID: org,
+		adp := provisioning.ProvenanceOrgAdapter{
+			Inner: config.Route,
+			OrgID: org,
 		}
 		provenance, err := moa.ProvStore.GetProvenance(ctx, adp)
 		if err != nil {
@@ -139,21 +140,4 @@ func (moa *MultiOrgAlertmanager) mergeProvenance(ctx context.Context, config def
 		config.Route.Provenance = provenance
 	}
 	return config, nil
-}
-
-type provenanceOrgAdapter struct {
-	inner models.ProvisionableInOrg
-	orgID int64
-}
-
-func (a provenanceOrgAdapter) ResourceType() string {
-	return a.inner.ResourceType()
-}
-
-func (a provenanceOrgAdapter) ResourceID() string {
-	return a.inner.ResourceID()
-}
-
-func (a provenanceOrgAdapter) ResourceOrgID() int64 {
-	return a.orgID
 }

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/services/secrets"
 
@@ -45,6 +46,7 @@ type MultiOrgAlertmanager struct {
 	configStore store.AlertingStore
 	orgStore    store.OrgStore
 	kvStore     kvstore.KVStore
+	provStore   provisioning.ProvisioningStore
 
 	decryptFn channels.GetDecryptedValueFn
 
@@ -53,8 +55,8 @@ type MultiOrgAlertmanager struct {
 }
 
 func NewMultiOrgAlertmanager(cfg *setting.Cfg, configStore store.AlertingStore, orgStore store.OrgStore,
-	kvStore kvstore.KVStore, decryptFn channels.GetDecryptedValueFn, m *metrics.MultiOrgAlertmanager,
-	ns notifications.Service, l log.Logger, s secrets.Service,
+	kvStore kvstore.KVStore, provStore provisioning.ProvisioningStore, decryptFn channels.GetDecryptedValueFn,
+	m *metrics.MultiOrgAlertmanager, ns notifications.Service, l log.Logger, s secrets.Service,
 ) (*MultiOrgAlertmanager, error) {
 	moa := &MultiOrgAlertmanager{
 		Crypto: NewCrypto(s, configStore, l),
@@ -64,6 +66,7 @@ func NewMultiOrgAlertmanager(cfg *setting.Cfg, configStore store.AlertingStore, 
 		alertmanagers: map[int64]*Alertmanager{},
 		configStore:   configStore,
 		orgStore:      orgStore,
+		provStore:     provStore,
 		kvStore:       kvStore,
 		decryptFn:     decryptFn,
 		metrics:       m,

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -31,7 +31,8 @@ var (
 )
 
 type MultiOrgAlertmanager struct {
-	Crypto Crypto
+	Crypto    Crypto
+	ProvStore provisioning.ProvisioningStore
 
 	alertmanagersMtx sync.RWMutex
 	alertmanagers    map[int64]*Alertmanager
@@ -46,7 +47,6 @@ type MultiOrgAlertmanager struct {
 	configStore store.AlertingStore
 	orgStore    store.OrgStore
 	kvStore     kvstore.KVStore
-	provStore   provisioning.ProvisioningStore
 
 	decryptFn channels.GetDecryptedValueFn
 
@@ -59,14 +59,14 @@ func NewMultiOrgAlertmanager(cfg *setting.Cfg, configStore store.AlertingStore, 
 	m *metrics.MultiOrgAlertmanager, ns notifications.Service, l log.Logger, s secrets.Service,
 ) (*MultiOrgAlertmanager, error) {
 	moa := &MultiOrgAlertmanager{
-		Crypto: NewCrypto(s, configStore, l),
+		Crypto:    NewCrypto(s, configStore, l),
+		ProvStore: provStore,
 
 		logger:        l,
 		settings:      cfg,
 		alertmanagers: map[int64]*Alertmanager{},
 		configStore:   configStore,
 		orgStore:      orgStore,
-		provStore:     provStore,
 		kvStore:       kvStore,
 		decryptFn:     decryptFn,
 		metrics:       m,

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
 	"github.com/grafana/grafana/pkg/setting"
@@ -214,6 +215,7 @@ func TestMultiOrgAlertmanager_AlertmanagerFor(t *testing.T) {
 		UnifiedAlerting: setting.UnifiedAlertingSettings{AlertmanagerConfigPollInterval: 3 * time.Minute, DefaultConfiguration: setting.GetAlertmanagerDefaultConfiguration()}, // do not poll in tests.
 	}
 	kvStore := NewFakeKVStore(t)
+	provStore := provisioning.NewFakeProvisioningStore()
 	secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
 	decryptFn := secretsService.GetDecryptedValue
 	reg := prometheus.NewPedanticRegistry()

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -33,6 +33,7 @@ func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgs(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	kvStore := NewFakeKVStore(t)
+	provStore := provisioning.NewFakeProvisioningStore()
 	secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
 	decryptFn := secretsService.GetDecryptedValue
 	reg := prometheus.NewPedanticRegistry()
@@ -45,7 +46,7 @@ func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgs(t *testing.T) {
 			DisabledOrgs:                   map[int64]struct{}{5: {}},
 		}, // do not poll in tests.
 	}
-	mam, err := NewMultiOrgAlertmanager(cfg, configStore, orgStore, kvStore, decryptFn, m.GetMultiOrgAlertmanagerMetrics(), nil, log.New("testlogger"), secretsService)
+	mam, err := NewMultiOrgAlertmanager(cfg, configStore, orgStore, kvStore, provStore, decryptFn, m.GetMultiOrgAlertmanagerMetrics(), nil, log.New("testlogger"), secretsService)
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -158,6 +159,7 @@ func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgsWithFailures(t *testing.T)
 
 	tmpDir := t.TempDir()
 	kvStore := NewFakeKVStore(t)
+	provStore := provisioning.NewFakeProvisioningStore()
 	secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
 	decryptFn := secretsService.GetDecryptedValue
 	reg := prometheus.NewPedanticRegistry()
@@ -169,7 +171,7 @@ func TestMultiOrgAlertmanager_SyncAlertmanagersForOrgsWithFailures(t *testing.T)
 			DefaultConfiguration:           setting.GetAlertmanagerDefaultConfiguration(),
 		}, // do not poll in tests.
 	}
-	mam, err := NewMultiOrgAlertmanager(cfg, configStore, orgStore, kvStore, decryptFn, m.GetMultiOrgAlertmanagerMetrics(), nil, log.New("testlogger"), secretsService)
+	mam, err := NewMultiOrgAlertmanager(cfg, configStore, orgStore, kvStore, provStore, decryptFn, m.GetMultiOrgAlertmanagerMetrics(), nil, log.New("testlogger"), secretsService)
 	require.NoError(t, err)
 	ctx := context.Background()
 
@@ -220,7 +222,7 @@ func TestMultiOrgAlertmanager_AlertmanagerFor(t *testing.T) {
 	decryptFn := secretsService.GetDecryptedValue
 	reg := prometheus.NewPedanticRegistry()
 	m := metrics.NewNGAlert(reg)
-	mam, err := NewMultiOrgAlertmanager(cfg, configStore, orgStore, kvStore, decryptFn, m.GetMultiOrgAlertmanagerMetrics(), nil, log.New("testlogger"), secretsService)
+	mam, err := NewMultiOrgAlertmanager(cfg, configStore, orgStore, kvStore, provStore, decryptFn, m.GetMultiOrgAlertmanagerMetrics(), nil, log.New("testlogger"), secretsService)
 	require.NoError(t, err)
 	ctx := context.Background()
 

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -177,9 +177,9 @@ func (ecp *ContactPointService) CreateContactPoint(ctx context.Context, orgID in
 		if err != nil {
 			return err
 		}
-		adapter := provenanceOrgAdapter{
-			inner: &contactPoint,
-			orgID: orgID,
+		adapter := ProvenanceOrgAdapter{
+			Inner: &contactPoint,
+			OrgID: orgID,
 		}
 		err = ecp.provenanceStore.SetProvenance(ctx, adapter, provenance)
 		if err != nil {
@@ -218,9 +218,9 @@ func (ecp *ContactPointService) UpdateContactPoint(ctx context.Context, orgID in
 		return err
 	}
 	// check that provenance is not changed in a invalid way
-	storedProvenance, err := ecp.provenanceStore.GetProvenance(ctx, provenanceOrgAdapter{
-		inner: &contactPoint,
-		orgID: orgID,
+	storedProvenance, err := ecp.provenanceStore.GetProvenance(ctx, ProvenanceOrgAdapter{
+		Inner: &contactPoint,
+		OrgID: orgID,
 	})
 	if err != nil {
 		return err
@@ -283,9 +283,9 @@ func (ecp *ContactPointService) UpdateContactPoint(ctx context.Context, orgID in
 		if err != nil {
 			return err
 		}
-		adapter := provenanceOrgAdapter{
-			inner: &contactPoint,
-			orgID: orgID,
+		adapter := ProvenanceOrgAdapter{
+			Inner: &contactPoint,
+			OrgID: orgID,
 		}
 		err = ecp.provenanceStore.SetProvenance(ctx, adapter, provenance)
 		if err != nil {
@@ -330,11 +330,11 @@ func (ecp *ContactPointService) DeleteContactPoint(ctx context.Context, orgID in
 		return err
 	}
 	return ecp.xact.InTransaction(ctx, func(ctx context.Context) error {
-		err := ecp.provenanceStore.DeleteProvenance(ctx, provenanceOrgAdapter{
-			inner: &apimodels.EmbeddedContactPoint{
+		err := ecp.provenanceStore.DeleteProvenance(ctx, ProvenanceOrgAdapter{
+			Inner: &apimodels.EmbeddedContactPoint{
 				UID: uid,
 			},
-			orgID: orgID,
+			OrgID: orgID,
 		})
 		if err != nil {
 			return err

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -178,7 +178,7 @@ func TestContactPointInUse(t *testing.T) {
 func createContactPointServiceSut(secretService secrets.Service) *ContactPointService {
 	return &ContactPointService{
 		amStore:           newFakeAMConfigStore(),
-		provenanceStore:   newFakeProvisioningStore(),
+		provenanceStore:   NewFakeProvisioningStore(),
 		xact:              newNopTransactionManager(),
 		encryptionService: secretService,
 		log:               log.NewNopLogger(),

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -47,9 +47,9 @@ func (nps *NotificationPolicyService) GetPolicyTree(ctx context.Context, orgID i
 		return definitions.Route{}, fmt.Errorf("no route present in current alertmanager config")
 	}
 
-	adapter := provenanceOrgAdapter{
-		inner: cfg.AlertmanagerConfig.Route,
-		orgID: orgID,
+	adapter := ProvenanceOrgAdapter{
+		Inner: cfg.AlertmanagerConfig.Route,
+		OrgID: orgID,
 	}
 	provenance, err := nps.provenanceStore.GetProvenance(ctx, adapter)
 	if err != nil {
@@ -95,9 +95,9 @@ func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgI
 		if err != nil {
 			return err
 		}
-		adapter := provenanceOrgAdapter{
-			inner: &tree,
-			orgID: orgID,
+		adapter := ProvenanceOrgAdapter{
+			Inner: &tree,
+			OrgID: orgID,
 		}
 		err = nps.provenanceStore.SetProvenance(ctx, adapter, p)
 		if err != nil {
@@ -110,21 +110,4 @@ func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgI
 	}
 
 	return nil
-}
-
-type provenanceOrgAdapter struct {
-	inner models.ProvisionableInOrg
-	orgID int64
-}
-
-func (a provenanceOrgAdapter) ResourceType() string {
-	return a.inner.ResourceType()
-}
-
-func (a provenanceOrgAdapter) ResourceID() string {
-	return a.inner.ResourceID()
-}
-
-func (a provenanceOrgAdapter) ResourceOrgID() int64 {
-	return a.orgID
 }

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -75,7 +75,7 @@ func TestNotificationPolicyService(t *testing.T) {
 func createNotificationPolicyServiceSut() *NotificationPolicyService {
 	return &NotificationPolicyService{
 		amStore:         newFakeAMConfigStore(),
-		provenanceStore: newFakeProvisioningStore(),
+		provenanceStore: NewFakeProvisioningStore(),
 		xact:            newNopTransactionManager(),
 		log:             log.NewNopLogger(),
 	}

--- a/pkg/services/ngalert/provisioning/persist.go
+++ b/pkg/services/ngalert/provisioning/persist.go
@@ -24,3 +24,20 @@ type ProvisioningStore interface {
 type TransactionManager interface {
 	InTransaction(ctx context.Context, work func(ctx context.Context) error) error
 }
+
+type ProvenanceOrgAdapter struct {
+	Inner models.ProvisionableInOrg
+	OrgID int64
+}
+
+func (a ProvenanceOrgAdapter) ResourceType() string {
+	return a.Inner.ResourceType()
+}
+
+func (a ProvenanceOrgAdapter) ResourceID() string {
+	return a.Inner.ResourceID()
+}
+
+func (a ProvenanceOrgAdapter) ResourceOrgID() int64 {
+	return a.OrgID
+}

--- a/pkg/services/ngalert/provisioning/testing.go
+++ b/pkg/services/ngalert/provisioning/testing.go
@@ -92,7 +92,7 @@ type fakeProvisioningStore struct {
 	records map[int64]map[string]models.Provenance
 }
 
-func newFakeProvisioningStore() *fakeProvisioningStore {
+func NewFakeProvisioningStore() *fakeProvisioningStore {
 	return &fakeProvisioningStore{
 		records: map[int64]map[string]models.Provenance{},
 	}

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/sender"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
@@ -1015,7 +1016,7 @@ func setupScheduler(t *testing.T, rs store.RuleStore, is store.InstanceStore, ac
 	m := metrics.NewNGAlert(registry)
 	secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
 	decryptFn := secretsService.GetDecryptedValue
-	moa, err := notifier.NewMultiOrgAlertmanager(&setting.Cfg{}, &notifier.FakeConfigStore{}, &notifier.FakeOrgStore{}, &notifier.FakeKVStore{}, decryptFn, m.GetMultiOrgAlertmanagerMetrics(), nil, log.New("testlogger"), secretsService)
+	moa, err := notifier.NewMultiOrgAlertmanager(&setting.Cfg{}, &notifier.FakeConfigStore{}, &notifier.FakeOrgStore{}, &notifier.FakeKVStore{}, provisioning.NewFakeProvisioningStore(), decryptFn, m.GetMultiOrgAlertmanagerMetrics(), nil, log.New("testlogger"), secretsService)
 	require.NoError(t, err)
 
 	schedCfg := SchedulerCfg{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The GET AM config route will now indicate whether sub-objects are provisioned. This is done by an additional JSON key `provenance`. If an object is not provisioned, the key will not be present.

If the provisioning FF is not enabled, the flag will not be present.

This PR only implements this for notif. policies. It adds the infrastructure for this kind of change though, so the other resources will be much simpler in follow-on PRs.

**Which issue(s) this PR fixes**:

rel: https://github.com/grafana/grafana/issues/36153

**Special notes for your reviewer**:

