### PR TITLE
Add documentation about Unified Alerting Performance

### DIFF
--- a/docs/sources/alerting/unified-alerting/_index.md
+++ b/docs/sources/alerting/unified-alerting/_index.md
@@ -24,3 +24,29 @@ Before you begin using Grafana alerting, we recommend that you familiarize yours
 
 - The Grafana alerting system can retrieve rules from all available Prometheus, Loki, and Alertmanager data sources. It might not be able to fetch rules from other supported data sources.
 - We aim to support the latest two minor versions of both Prometheus and Alertmanager. We cannot guarantee that older versions will work. As an example, if the current Prometheus version is `2.31.1`, we support >= `2.29.0`.
+
+## Performance Considerations.
+
+Grafana Alerting now support multi-dimensional alerting, or templatized alerting, so that one alert rule can generate many separate alerts. For example, one alert rule could generate an alert for each VM that's CPU is maxed out. This new capability adds some new performance considerations.
+
+Evaluating Alerting rules consumes RAM and CPU to compute the output of an alerting query, and network resources to write the results to the Grafana SQL database. The SQL database's network connections are often saturated before RAM or CPU are exhausted. The configuration of alert rules affects how many resources the Alertmanager consumes, and therefore the maximum number of rules a given configuration can support.
+
+These load factors include:
+
+1. The **frequency of rule evaluation**, controlled by the "Evaluate Every" field in the alert editor. Use the lowest acceptable evaluation frequency to support more concurrent rules.
+2. The **cardinality of the rule's result set**. For example, you might be monitoring API response errors by monitoring errors for every API path, on every VM in your fleet. This has a cardinality of # paths x # VMs. Where possible, reduce the cardinality of a result set - perhaps by monitoring errors-per-VM instead for each path, for each VM.
+3. The **complexity of the alerting query**. Queries that datasources are able to process and respond to quickly consume fewer resources. This is less important than the frequency of evaluation and the cardinality of the result set, but if you have reduced those as much as you can, looking at the performance of individual queries could make a difference.
+
+Each evaluation of an alert rule generates a set of "alert instances", one for each member of the result set. The state of all alert instances are written to Grafana's SQL database in the `alert_instance` table.
+
+To estimate the load that alerting queries are putting on your system, you can count the number of alert instances that have been updated recently. This is a rough estimate - if you some rules evaluated every 30m, and others every 10s, load will be unevenly distributed.
+
+The query will differ based on your database backend. For MySQL, over the last 5 minutes:
+
+```sql
+SELECT COUNT(*)
+FROM 'alert_instance'
+WHERE UNIX_TIMESTAMP() - 300 > 'last_eval_time';
+```
+
+These factors affect the load on the Grafana Alertmanager. You should also be aware of the load that evaluating these rules puts onto your datasources. Alerting queries are often the vast majority of queries handled by monitoring databases, so the same load factors that affect the Alertmanager affect them as well.

--- a/docs/sources/alerting/unified-alerting/_index.md
+++ b/docs/sources/alerting/unified-alerting/_index.md
@@ -27,7 +27,7 @@ Before you begin using Grafana alerting, we recommend that you familiarize yours
 
 ## Performance Considerations.
 
-Grafana Alerting now support multi-dimensional alerting, or templatized alerting, so that one alert rule can generate many separate alerts. For example, one alert rule could generate an alert for each VM that's CPU is maxed out. This new capability adds some new performance considerations.
+Grafana Alerting now supports multi-dimensional alerting, or templatized alerting, so that one alert rule can generate many separate alerts. For example, one alert rule could generate an alert for each VM that's CPU is maxed out. This new capability adds some new performance considerations.
 
 Evaluating Alerting rules consumes RAM and CPU to compute the output of an alerting query, and network resources to write the results to the Grafana SQL database. The SQL database's network connections are often saturated before RAM or CPU are exhausted. The configuration of alert rules affects how many resources the Alertmanager consumes, and therefore the maximum number of rules a given configuration can support.
 
@@ -39,7 +39,7 @@ These load factors include:
 
 Each evaluation of an alert rule generates a set of "alert instances", one for each member of the result set. The state of all alert instances are written to Grafana's SQL database in the `alert_instance` table.
 
-To estimate the load that alerting queries are putting on your system, you can count the number of alert instances that have been updated recently. This is a rough estimate - if you some rules evaluated every 30m, and others every 10s, load will be unevenly distributed.
+To estimate the load that alerting queries are putting on your system, you can count the number of alert instances that have been updated recently. This is a rough estimate - if you have some rules evaluated every 30m, and others every 10s, load will be unevenly distributed.
 
 The query will differ based on your database backend. For MySQL, over the last 5 minutes:
 

--- a/docs/sources/alerting/unified-alerting/_index.md
+++ b/docs/sources/alerting/unified-alerting/_index.md
@@ -25,28 +25,20 @@ Before you begin using Grafana alerting, we recommend that you familiarize yours
 - The Grafana alerting system can retrieve rules from all available Prometheus, Loki, and Alertmanager data sources. It might not be able to fetch rules from other supported data sources.
 - We aim to support the latest two minor versions of both Prometheus and Alertmanager. We cannot guarantee that older versions will work. As an example, if the current Prometheus version is `2.31.1`, we support >= `2.29.0`.
 
-## Performance Considerations.
+## Performance considerations.
 
-Grafana Alerting now supports multi-dimensional alerting, or templatized alerting, so that one alert rule can generate many separate alerts. For example, one alert rule could generate an alert for each VM that's CPU is maxed out. This new capability adds some new performance considerations.
+Grafana alerting supports multi-dimensional alerting, where one alert rule can generate many alerts. For example, you can configure an alert rule to fire an alert every time the CPU of individual VMs max out. This topic discusses performance considerations resulting from multi-dimensional alerting.
 
-Evaluating Alerting rules consumes RAM and CPU to compute the output of an alerting query, and network resources to write the results to the Grafana SQL database. The SQL database's network connections are often saturated before RAM or CPU are exhausted. The configuration of alert rules affects how many resources the Alertmanager consumes, and therefore the maximum number of rules a given configuration can support.
+Evaluating alerting rules consumes RAM and CPU to compute the output of an alerting query, and network resources to send alert notifications and write the results to the Grafana SQL database. The configuration of individual alert rules affects the resource consumption and, therefore, the maximum number of rules a given configuration can support.
 
-These load factors include:
+Considerations include:
 
-1. The **frequency of rule evaluation**, controlled by the "Evaluate Every" field in the alert editor. Use the lowest acceptable evaluation frequency to support more concurrent rules.
-2. The **cardinality of the rule's result set**. For example, you might be monitoring API response errors by monitoring errors for every API path, on every VM in your fleet. This has a cardinality of # paths x # VMs. Where possible, reduce the cardinality of a result set - perhaps by monitoring errors-per-VM instead for each path, for each VM.
-3. The **complexity of the alerting query**. Queries that datasources are able to process and respond to quickly consume fewer resources. This is less important than the frequency of evaluation and the cardinality of the result set, but if you have reduced those as much as you can, looking at the performance of individual queries could make a difference.
+- The frequency of rule evaluation consideration. The "Evaluate Every" propery of an alert rule controls the frequency of rule evalution. We recommend using the lowest acceptable evaluation frequency to support more concurrent rules.
+- The cardinality of the rule's result set. For example, suppouse you are monitoring API response errors for every API path, on every VM in your fleet. This set has a cardinality of _n_ number of paths multipled by _v_ number of VMs. You can reduce the cardinality of a result set - perhaps by monitoring errors-per-VM instead of for each path per VM.
+- The complexity of the alerting query consideration. Queries that data sources can process and respond to quickly consume fewer resources. Although this consideration is less important than the other considerations listed above, if you have reduced those as much as possible, looking at individual query performance could make a difference.
 
-Each evaluation of an alert rule generates a set of "alert instances", one for each member of the result set. The state of all alert instances are written to Grafana's SQL database in the `alert_instance` table.
+Each evaluation of an alert rule generates a set of alert instances, one for each member of the result set. The state of all the instances is written to the `alert_instance` table in Grafana's SQL database.
 
-To estimate the load that alerting queries are putting on your system, you can count the number of alert instances that have been updated recently. This is a rough estimate - if you have some rules evaluated every 30m, and others every 10s, load will be unevenly distributed.
+Grafana alerting exposes a metric, `grafana_alerting_rule_evaluations_total`, that counts the number of alert rule evaluations. To get a feel for the influence of rule evaluations on your Grafana instance, you can observe the rate of evaluations and compare it with resource consumption. In a Prometheus-compatible database, you can use the query `rate(grafana_alerting_rule_evaluations_total[5m])` to compute the rate over 5 minute windows of time. It's important to remember that this isn't the full picture of rule evaluation. For example, the load will be unevenly distributed if you have some rules that evaluate every 10 seconds, and others every 30 minutes.
 
-The query will differ based on your database backend. For MySQL, over the last 5 minutes:
-
-```sql
-SELECT COUNT(*)
-FROM 'alert_instance'
-WHERE UNIX_TIMESTAMP() - 300 > 'last_eval_time';
-```
-
-These factors affect the load on the Grafana Alertmanager. You should also be aware of the load that evaluating these rules puts onto your datasources. Alerting queries are often the vast majority of queries handled by monitoring databases, so the same load factors that affect the Alertmanager affect them as well.
+These factors all affect the load on the Grafana instance, but you should also be aware of the performance impact that evaluating these rules has on your data sources. Alerting queries are often the vast majority of queries handled by monitoring databases, so the same load factors that affect the Grafana instance affect them as well.


### PR DESCRIPTION
This change adds documentation about how the configuration of Unified
Alerting affects the performance of the Grafana backend, and how to
control the load that Unified Alerting generates.

Signed-off-by: Joe Blubaugh <joe.blubaugh@grafana.com>
