### PR TITLE
Transformations: Support escaped characters in key-value pair parsing

### DIFF
--- a/public/app/features/transformers/extractFields/fieldExtractor.test.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractor.test.ts
@@ -14,6 +14,20 @@ describe('Extract fields from text', () => {
     `);
   });
 
+  it('Test key-values with spaces', async () => {
+    const extractor = fieldExtractors.get(FieldExtractorID.KeyValues);
+    const out = extractor.parse('a="1",   "b"=\'2\',c=3  x:y ;\r\nz="7 test"');
+    expect(out).toMatchInlineSnapshot(`
+      Object {
+        "a": "1",
+        "b": "2",
+        "c": "3",
+        "x": "y",
+        "z": "7 test",
+      }
+    `);
+  });
+
   it('Split key+values', async () => {
     const extractor = fieldExtractors.get(FieldExtractorID.KeyValues);
     const out = extractor.parse('a="1",   "b"=\'2\',c=3  x:y ;\r\nz="7"');

--- a/public/app/features/transformers/extractFields/fieldExtractor.test.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractor.test.ts
@@ -31,7 +31,7 @@ describe('Extract fields from text', () => {
   it('Test key-values with nested single/double quotes', async () => {
     const extractor = fieldExtractors.get(FieldExtractorID.KeyValues);
     const out = extractor.parse(
-      `a="1",   "b"=\'2\',c=3  x:y ;\r\nz="dbl_quotes="Double Quotes" sgl_quotes='Single Quotes'"`
+      `a="1",   "b"=\'2\',c=3  x:y ;\r\nz="dbl_quotes=\\"Double Quotes\\" sgl_quotes='Single Quotes'"`
     );
 
     expect(out).toMatchInlineSnapshot(`

--- a/public/app/features/transformers/extractFields/fieldExtractor.test.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractor.test.ts
@@ -14,7 +14,7 @@ describe('Extract fields from text', () => {
     `);
   });
 
-  it('Test key-values with spaces', async () => {
+  it('Test key-values with single/double quotes', async () => {
     const extractor = fieldExtractors.get(FieldExtractorID.KeyValues);
     const out = extractor.parse('a="1",   "b"=\'2\',c=3  x:y ;\r\nz="7 test"');
     expect(out).toMatchInlineSnapshot(`

--- a/public/app/features/transformers/extractFields/fieldExtractor.test.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractor.test.ts
@@ -16,14 +16,31 @@ describe('Extract fields from text', () => {
 
   it('Test key-values with single/double quotes', async () => {
     const extractor = fieldExtractors.get(FieldExtractorID.KeyValues);
-    const out = extractor.parse('a="1",   "b"=\'2\',c=3  x:y ;\r\nz="7 test"');
+    const out = extractor.parse('a="1",   "b"=\'2\',c=3  x:y ;\r\nz="d and 4"');
     expect(out).toMatchInlineSnapshot(`
       Object {
         "a": "1",
         "b": "2",
         "c": "3",
         "x": "y",
-        "z": "7 test",
+        "z": "d and 4",
+      }
+    `);
+  });
+
+  it('Test key-values with nested single/double quotes', async () => {
+    const extractor = fieldExtractors.get(FieldExtractorID.KeyValues);
+    const out = extractor.parse(
+      `a="1",   "b"=\'2\',c=3  x:y ;\r\nz="dbl_quotes="Double Quotes": sgl_quotes='Single Quotes'"`
+    );
+
+    expect(out).toMatchInlineSnapshot(`
+      Object {
+        "a": "1",
+        "b": "2",
+        "c": "3",
+        "x": "y",
+        "z": "dbl_quotes=\\"Double Quotes\\" sgl_quotes=\\"Single Quotes\\"",
       }
     `);
   });

--- a/public/app/features/transformers/extractFields/fieldExtractor.test.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractor.test.ts
@@ -31,7 +31,7 @@ describe('Extract fields from text', () => {
   it('Test key-values with nested single/double quotes', async () => {
     const extractor = fieldExtractors.get(FieldExtractorID.KeyValues);
     const out = extractor.parse(
-      `a="1",   "b"=\'2\',c=3  x:y ;\r\nz="dbl_quotes="Double Quotes": sgl_quotes='Single Quotes'"`
+      `a="1",   "b"=\'2\',c=3  x:y ;\r\nz="dbl_quotes="Double Quotes" sgl_quotes='Single Quotes'"`
     );
 
     expect(out).toMatchInlineSnapshot(`

--- a/public/app/features/transformers/extractFields/fieldExtractor.test.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractor.test.ts
@@ -40,7 +40,36 @@ describe('Extract fields from text', () => {
         "b": "2",
         "c": "3",
         "x": "y",
-        "z": "dbl_quotes=\\"Double Quotes\\" sgl_quotes=\\"Single Quotes\\"",
+        "z": "dbl_quotes=\\"Double Quotes\\" sgl_quotes='Single Quotes'",
+      }
+    `);
+  });
+
+  it('Test key-values with nested separator characters', async () => {
+    const extractor = fieldExtractors.get(FieldExtractorID.KeyValues);
+    const out = extractor.parse(`a="1",   "b"=\'2\',c=3  x:y ;\r\nz="This is; testing& validating, 1=:2"`);
+
+    expect(out).toMatchInlineSnapshot(`
+      Object {
+        "a": "1",
+        "b": "2",
+        "c": "3",
+        "x": "y",
+        "z": "This is; testing& validating, 1=:2",
+      }
+    `);
+  });
+
+  it('Test key-values where some values are null', async () => {
+    const extractor = fieldExtractors.get(FieldExtractorID.KeyValues);
+    const out = extractor.parse(`a=, "b"=\'2\',c=3  x: `);
+
+    expect(out).toMatchInlineSnapshot(`
+      Object {
+        "a": "",
+        "b": "2",
+        "c": "3",
+        "x": "",
       }
     `);
   });

--- a/public/app/features/transformers/extractFields/fieldExtractors.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractors.ts
@@ -25,6 +25,10 @@ const stripDecor = /['"]|^\{|\}$/g;
 const splitLines = /[\s,;&]+/g;
 // splits kv pairs
 const splitPair = /[=:]/g;
+// finds all strings in single/double quotes
+const quotedValues = /['"](.*?)['"]/g;
+// finds the quoted value placeholder
+const prefixRegex = /(\$val\d+\$)/g;
 
 const extLabels: FieldExtractor = {
   id: FieldExtractorID.KeyValues,
@@ -32,12 +36,28 @@ const extLabels: FieldExtractor = {
   description: 'Look for a=b, c: d values in the line',
   parse: (v: string) => {
     const obj: Record<string, any> = {};
-
+    const quotedValuesMap: Map<string, string> = new Map<string, string>();
+    const placeholderPrefix = '$val';
+    let quoteCounter = 0;
     v.trim()
+      .replace(quotedValues, (matched) => {
+        const placeholder = `${placeholderPrefix}${quoteCounter}$`;
+        quotedValuesMap.set(placeholder, matched);
+        quoteCounter++;
+        return placeholder;
+      })
       .replace(stripDecor, '')
       .split(splitLines)
       .forEach((pair) => {
-        let [k, v] = pair.split(splitPair);
+        let [k, v] = pair
+          .replace(prefixRegex, (matched, _index) => {
+            const originalValue = quotedValuesMap.get(matched);
+            if (originalValue) {
+              return originalValue.replace(stripDecor, '');
+            }
+            return matched;
+          })
+          .split(splitPair);
 
         if (k != null) {
           obj[k] = v;

--- a/public/app/features/transformers/extractFields/fieldExtractors.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractors.ts
@@ -40,6 +40,7 @@ const extLabels: FieldExtractor = {
     const placeholderPrefix = '$val';
     let quoteCounter = 0;
     v.trim()
+      .replace(/[\r\n]/g, '')
       .replace(quotedValues, (matched) => {
         const placeholder = `${placeholderPrefix}${quoteCounter}$`;
         quotedValuesMap.set(placeholder, matched);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR provides updated logic for the field extractor that allows for keys/values containing single or double quoted strings to be parsed appropriately when they include any potential character that may be used as a delimiter. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #47604 

**Special notes for your reviewer**:

Additional tests added for this specific use-case. Testing the correct parsing of quoted values and also values containing nested quotes.

Test was also carried out using the following steps:

1. Creating a custom metric in GCP with the following properties:
Metric Type: `counter`
Metric name: `extractor-test`
Filter: `resource.labels.project_id="PROJECT_NAME"`
Custom label: `Label name: test_fields,
Description: '',
Label type: STRING,
Field Name: textPayload`
2. The Cloud monitoring datasource was then configured to query `Logging` service of the specified project, selecting the metric name described above.
3.  Set the `Group by` value to the custom label name defined above.
4. Add the `Series to rows` transformation.
5. Add the `Extract fields` transformation, selecting the source as `Metric` and leaving the other parameters as default.
6. The `metric.label.test_fields` metric should be extracted as a single column with no extraneous fields extracted.

