### PR TITLE
Postgres: Add aggregate histogram, and time_bucket in dropdown when TimescaleDB is enabled

### DIFF
--- a/public/app/plugins/datasource/postgres/query_ctrl.ts
+++ b/public/app/plugins/datasource/postgres/query_ctrl.ts
@@ -171,6 +171,8 @@ export class PostgresQueryCtrl extends QueryCtrl {
     if (this.datasource.jsonData.timescaledb === true) {
       aggregates.submenu.push({ text: 'First', value: 'first' });
       aggregates.submenu.push({ text: 'Last', value: 'last' });
+      aggregates.submenu.push({ text: 'Histogram', value: 'histogram' });
+      aggregates.submenu.push({ text: 'Time Bucket', value: 'time_bucket' });
     }
 
     this.selectMenu.push(aggregates);

--- a/public/app/plugins/datasource/postgres/sql_part.ts
+++ b/public/app/plugins/datasource/postgres/sql_part.ts
@@ -51,7 +51,7 @@ register({
       type: 'string',
       options: [],
       baseOptions: ['avg', 'count', 'min', 'max', 'sum', 'stddev', 'variance'],
-      timescaleOptions: ['first', 'last'],
+      timescaleOptions: ['first', 'last', 'histogram', 'time_bucket'],
     },
   ],
   defaultParams: ['avg'],


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Add aggregate `histogram`, and `time_bucket` in the dropdown when TimescaleDB is enabled.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Extends the fix for https://github.com/grafana/grafana/issues/24906

**Special notes for your reviewer**:
I'm new with TDD, can I get some pairing for the same, if required?

TimescaleDB Docs reference
histogram() - https://docs.timescale.com/api/latest/hyperfunctions/histogram/
time_bucket() - https://docs.timescale.com/api/latest/hyperfunctions/time_bucket/