### PR TITLE
Ignore vimspector configuration in the repo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ public/css/*.min.css
 .vs/
 .eslintcache
 .stylelintcache
+.vimspector.json
 
 /data/*
 /bin/*


### PR DESCRIPTION
Vimspector is a debug tool for vim that uses an in-project configuration
file called .vimspector.json. Adds that file to the "IDE junk" section
of .gitignore

Signed-off-by: Joe Blubaugh <joe.blubaugh@grafana.com>