### PR TITLE
Dashboards: Defer loading of plugin exports until panel is visible (#47361)

### DIFF
--- a/public/app/features/dashboard/containers/DashboardPage.test.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
+import { useEffectOnce } from 'react-use';
 import { render, screen } from '@testing-library/react';
 import { Props, UnthemedDashboardPage } from './DashboardPage';
 import { Props as LazyLoaderProps } from '../dashgrid/LazyLoader';
@@ -17,7 +18,10 @@ import { AutoSizerProps } from 'react-virtualized-auto-sizer';
 import { setDashboardSrv } from '../services/DashboardSrv';
 
 jest.mock('app/features/dashboard/dashgrid/LazyLoader', () => {
-  const LazyLoader = ({ children }: Pick<LazyLoaderProps, 'children'>) => {
+  const LazyLoader = ({ children, onLoad }: Pick<LazyLoaderProps, 'children' | 'onLoad'>) => {
+    useEffectOnce(() => {
+      onLoad?.();
+    });
     return <>{typeof children === 'function' ? children({ isInView: true }) : children}</>;
   };
   return { LazyLoader };


### PR DESCRIPTION
Backport 8ae5dd74e617fcb8442514a1afa3229a5d938334 from #47361