### PR TITLE
grafana-ui: logRowContext: improve field-selection

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRowContextProvider.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContextProvider.tsx
@@ -6,6 +6,7 @@ import {
   LogsSortOrder,
   DataQueryResponse,
   DataQueryError,
+  FieldType,
 } from '@grafana/data';
 import React, { useState, useEffect } from 'react';
 import useAsync from 'react-use/lib/useAsync';
@@ -76,7 +77,7 @@ export const getRowContexts = async (
     for (let index = 0; index < dataResult.data.length; index++) {
       const dataFrame = toDataFrame(dataResult.data[index]);
       const fieldCache = new FieldCache(dataFrame);
-      const timestampField: Field<string> = fieldCache.getFieldByName('ts')!;
+      const timestampField: Field<string> = fieldCache.getFirstFieldOfType(FieldType.time)!;
       const idField: Field<string> | undefined = fieldCache.getFieldByName('id');
 
       for (let fieldIndex = 0; fieldIndex < timestampField.values.length; fieldIndex++) {
@@ -104,7 +105,7 @@ export const getRowContexts = async (
           }
         }
 
-        const lineField: Field<string> = dataFrame.fields.filter((field) => field.name === 'line')[0];
+        const lineField: Field<string> = fieldCache.getFirstFieldOfType(FieldType.string)!;
         const line = lineField.values.get(fieldIndex); // assuming that both fields have same length
 
         data.push(line);

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -15,7 +15,6 @@ import {
   DataSourceWithLogsVolumeSupport,
   DateTime,
   dateTime,
-  Field,
   getDefaultTimeRange,
   AbstractQuery,
   getLogLevelFromKey,


### PR DESCRIPTION
the LogRowContext code needs to access certain logs-related fields, like the line-field, or the timestamp-field.
but, the way it accesses them is not the same as how the logs_model accesses them. this could cause problems.
this PR changes the LogRowContext code to use the same logic as uses by logs_model:
- selecting the timestamp field, we choose the first field of type=time, as done at https://github.com/grafana/grafana/blob/main/public/app/core/logs_model.ts#L359
- selecting the line-field, we choose the first field of type=string, as done at https://github.com/grafana/grafana/blob/main/public/app/core/logs_model.ts#L358

an even better approach would be to export some standardized functions from grafana-something (grafana-data?), to do the `getTimestampField`, `getLogLineField` etc., but this small change should also help to improve the situation.