### PR TITLE
Prometheus: Remove running of query on raw query toggle

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
@@ -46,7 +46,6 @@ export const PromQueryEditorSelector = React.memo<PromQueryEditorProps>((props) 
   const onQueryPreviewChange = (event: SyntheticEvent<HTMLInputElement>) => {
     const isEnabled = event.currentTarget.checked;
     onChange({ ...query, rawQuery: isEnabled });
-    onRunQuery();
   };
 
   const onChangeInternal = (query: PromQuery) => {


### PR DESCRIPTION
We shouldn't run the query on raw query toggle. 