### PR TITLE
AzureMonitor: build azure portal deep link with resource uri

### DIFF
--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -34,7 +34,7 @@ type AzureMonitorDatasource struct {
 var (
 	// Used to convert the aggregation value to the Azure enum for deep linking
 	aggregationTypeMap   = map[string]int{"None": 0, "Total": 1, "Minimum": 2, "Maximum": 3, "Average": 4, "Count": 7}
-	resourceNameLandmark = regexp.MustCompile(`(?i)(/(?P<resourceName>\w+)/providers/Microsoft\.Insights/metrics)`)
+	resourceNameLandmark = regexp.MustCompile(`(?i)(/(?P<resourceName>[\w-\.]+)/providers/Microsoft\.Insights/metrics)`)
 )
 
 const azureMonitorAPIVersion = "2018-01-01"

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -75,6 +75,8 @@ func (e *AzureMonitorDatasource) buildQueries(queries []backend.DataQuery, dsInf
 		azJSONModel := queryJSONModel.AzureMonitor
 
 		urlComponents := map[string]string{}
+		urlComponents["resourceURI"] = azJSONModel.ResourceURI
+		// Legacy fields used for constructing a deep link to display the query in Azure Portal.
 		urlComponents["subscription"] = queryJSONModel.Subscription
 		urlComponents["resourceGroup"] = azJSONModel.ResourceGroup
 		urlComponents["metricDefinition"] = azJSONModel.MetricDefinition
@@ -338,12 +340,18 @@ func getQueryUrl(query *types.AzureMonitorQuery, azurePortalUrl string) (string,
 	}
 	escapedTime := url.QueryEscape(string(timespan))
 
-	id := fmt.Sprintf("/subscriptions/%v/resourceGroups/%v/providers/%v/%v",
-		query.UrlComponents["subscription"],
-		query.UrlComponents["resourceGroup"],
-		query.UrlComponents["metricDefinition"],
-		query.UrlComponents["resourceName"],
-	)
+	id := query.UrlComponents["resourceURI"]
+
+	if id == "" {
+		ub := urlBuilder{
+			Subscription:     query.UrlComponents["subscription"],
+			ResourceGroup:    query.UrlComponents["resourceGroup"],
+			MetricDefinition: query.UrlComponents["metricDefinition"],
+			ResourceName:     query.UrlComponents["resourceName"],
+		}
+		id = ub.BuildResourceURIFromLegacyQuery()
+	}
+
 	chartDef, err := json.Marshal(map[string]interface{}{
 		"v2charts": []interface{}{
 			map[string]interface{}{

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -677,17 +677,17 @@ func TestAzureMonitorCreateRequest(t *testing.T) {
 
 func TestExtractResourceNameFromMetricsURL(t *testing.T) {
 	t.Run("it should extract the resourceName from a well-formed Metrics URL", func(t *testing.T) {
-		url := "/subscriptions/44693801-6ee6-49de-9b2d-9106972f9572/resourceGroups/cloud-datasources/providers/Microsoft.Compute/virtualMachines/GithubTestDataVM/providers/microsoft.insights/metrics"
-		expected := "GithubTestDataVM"
+		url := "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/Grafana-Test.VM/providers/microsoft.insights/metrics"
+		expected := "Grafana-Test.VM"
 		require.Equal(t, expected, extractResourceNameFromMetricsURL((url)))
 	})
 	t.Run("it should extract the resourceName from a well-formed Metrics URL in a case insensitive manner", func(t *testing.T) {
-		url := "/subscriptions/44693801-6ee6-49de-9b2d-9106972f9572/resourceGroups/cloud-datasources/providers/Microsoft.Compute/virtualMachines/GithubTestDataVM/pRoViDeRs/MiCrOsOfT.iNsIgHtS/mEtRiCs"
-		expected := "GithubTestDataVM"
+		url := "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/Grafana-Test.VM/pRoViDeRs/MiCrOsOfT.iNsIgHtS/mEtRiCs"
+		expected := "Grafana-Test.VM"
 		require.Equal(t, expected, extractResourceNameFromMetricsURL((url)))
 	})
 	t.Run("it should return an empty string if no match is found", func(t *testing.T) {
-		url := "/subscriptions/44693801-6ee6-49de-9b2d-9106972f9572/resourceGroups/cloud-datasources/providers/Microsoft.Compute/virtualMachines/GithubTestDataVM/providers/microsoft.insights/nope-this-part-does-not-match"
+		url := "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/Grafana-Test.VM/providers/microsoft.insights/nope-this-part-does-not-match"
 		expected := ""
 		require.Equal(t, expected, extractResourceNameFromMetricsURL((url)))
 	})

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -218,19 +218,19 @@ func makeTestDataLink(url string) data.DataLink {
 func TestAzureMonitorParseResponse(t *testing.T) {
 	// datalinks for the test frames
 	averageLink := makeTestDataLink(`http://ds/#blade/Microsoft_Azure_MonitoringMetrics/Metrics.ReactView/Referer/MetricsExplorer/TimeContext/%7B%22absolute%22%3A%7B%22startTime%22%3A%220001-01-01T00%3A00%3A00Z%22%2C%22endTime%22%3A%220001-01-01T00%3A00%3A00Z%22%7D%7D/` +
-		`ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F%2FresourceGroups%2F%2Fproviders%2F%2Fgrafana%22%7D%2C%22name%22%3A%22%22%2C%22aggregationType%22%3A4%2C%22namespace%22%3A%22%22%2C` +
+		`ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F12345678-aaaa-bbbb-cccc-123456789abc%2FresourceGroups%2Fgrafanastaging%2Fproviders%2FMicrosoft.Compute%2FvirtualMachines%2Fgrafana%22%7D%2C%22name%22%3A%22%22%2C%22aggregationType%22%3A4%2C%22namespace%22%3A%22%22%2C` +
 		`%22metricVisualization%22%3A%7B%22displayName%22%3A%22%22%2C%22resourceDisplayName%22%3A%22grafana%22%7D%7D%5D%7D%5D%7D`)
 	totalLink := makeTestDataLink(`http://ds/#blade/Microsoft_Azure_MonitoringMetrics/Metrics.ReactView/Referer/MetricsExplorer/TimeContext/%7B%22absolute%22%3A%7B%22startTime%22%3A%220001-01-01T00%3A00%3A00Z%22%2C%22endTime%22%3A%220001-01-01T00%3A00%3A00Z%22%7D%7D/` +
-		`ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F%2FresourceGroups%2F%2Fproviders%2F%2Fgrafana%22%7D%2C%22name%22%3A%22%22%2C%22aggregationType%22%3A1%2C%22namespace%22%3A%22%22%2C` +
+		`ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F12345678-aaaa-bbbb-cccc-123456789abc%2FresourceGroups%2Fgrafanastaging%2Fproviders%2FMicrosoft.Compute%2FvirtualMachines%2Fgrafana%22%7D%2C%22name%22%3A%22%22%2C%22aggregationType%22%3A1%2C%22namespace%22%3A%22%22%2C` +
 		`%22metricVisualization%22%3A%7B%22displayName%22%3A%22%22%2C%22resourceDisplayName%22%3A%22grafana%22%7D%7D%5D%7D%5D%7D`)
 	maxLink := makeTestDataLink(`http://ds/#blade/Microsoft_Azure_MonitoringMetrics/Metrics.ReactView/Referer/MetricsExplorer/TimeContext/%7B%22absolute%22%3A%7B%22startTime%22%3A%220001-01-01T00%3A00%3A00Z%22%2C%22endTime%22%3A%220001-01-01T00%3A00%3A00Z%22%7D%7D/` +
-		`ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F%2FresourceGroups%2F%2Fproviders%2F%2Fgrafana%22%7D%2C%22name%22%3A%22%22%2C%22aggregationType%22%3A3%2C%22namespace%22%3A%22%22%2C` +
+		`ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F12345678-aaaa-bbbb-cccc-123456789abc%2FresourceGroups%2Fgrafanastaging%2Fproviders%2FMicrosoft.Compute%2FvirtualMachines%2Fgrafana%22%7D%2C%22name%22%3A%22%22%2C%22aggregationType%22%3A3%2C%22namespace%22%3A%22%22%2C` +
 		`%22metricVisualization%22%3A%7B%22displayName%22%3A%22%22%2C%22resourceDisplayName%22%3A%22grafana%22%7D%7D%5D%7D%5D%7D`)
 	minLink := makeTestDataLink(`http://ds/#blade/Microsoft_Azure_MonitoringMetrics/Metrics.ReactView/Referer/MetricsExplorer/TimeContext/%7B%22absolute%22%3A%7B%22startTime%22%3A%220001-01-01T00%3A00%3A00Z%22%2C%22endTime%22%3A%220001-01-01T00%3A00%3A00Z%22%7D%7D/` +
-		`ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F%2FresourceGroups%2F%2Fproviders%2F%2Fgrafana%22%7D%2C%22name%22%3A%22%22%2C%22aggregationType%22%3A2%2C%22namespace%22%3A%22%22%2C` +
+		`ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F12345678-aaaa-bbbb-cccc-123456789abc%2FresourceGroups%2Fgrafanastaging%2Fproviders%2FMicrosoft.Compute%2FvirtualMachines%2Fgrafana%22%7D%2C%22name%22%3A%22%22%2C%22aggregationType%22%3A2%2C%22namespace%22%3A%22%22%2C` +
 		`%22metricVisualization%22%3A%7B%22displayName%22%3A%22%22%2C%22resourceDisplayName%22%3A%22grafana%22%7D%7D%5D%7D%5D%7D`)
 	countLink := makeTestDataLink(`http://ds/#blade/Microsoft_Azure_MonitoringMetrics/Metrics.ReactView/Referer/MetricsExplorer/TimeContext/%7B%22absolute%22%3A%7B%22startTime%22%3A%220001-01-01T00%3A00%3A00Z%22%2C%22endTime%22%3A%220001-01-01T00%3A00%3A00Z%22%7D%7D/` +
-		`ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F%2FresourceGroups%2F%2Fproviders%2F%2Fgrafana%22%7D%2C%22name%22%3A%22%22%2C%22aggregationType%22%3A7%2C%22namespace%22%3A%22%22%2C` +
+		`ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F12345678-aaaa-bbbb-cccc-123456789abc%2FresourceGroups%2Fgrafanastaging%2Fproviders%2FMicrosoft.Compute%2FvirtualMachines%2Fgrafana%22%7D%2C%22name%22%3A%22%22%2C%22aggregationType%22%3A7%2C%22namespace%22%3A%22%22%2C` +
 		`%22metricVisualization%22%3A%7B%22displayName%22%3A%22%22%2C%22resourceDisplayName%22%3A%22grafana%22%7D%7D%5D%7D%5D%7D`)
 
 	tests := []struct {
@@ -246,6 +246,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			mockQuery: &types.AzureMonitorQuery{
 				UrlComponents: map[string]string{
 					"resourceName": "grafana",
+					"resourceURI":  "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana",
 				},
 				Params: url.Values{
 					"aggregation": {"Average"},
@@ -267,6 +268,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			mockQuery: &types.AzureMonitorQuery{
 				UrlComponents: map[string]string{
 					"resourceName": "grafana",
+					"resourceURI":  "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana",
 				},
 				Params: url.Values{
 					"aggregation": {"Total"},
@@ -288,6 +290,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			mockQuery: &types.AzureMonitorQuery{
 				UrlComponents: map[string]string{
 					"resourceName": "grafana",
+					"resourceURI":  "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana",
 				},
 				Params: url.Values{
 					"aggregation": {"Maximum"},
@@ -309,6 +312,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			mockQuery: &types.AzureMonitorQuery{
 				UrlComponents: map[string]string{
 					"resourceName": "grafana",
+					"resourceURI":  "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana",
 				},
 				Params: url.Values{
 					"aggregation": {"Minimum"},
@@ -330,6 +334,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			mockQuery: &types.AzureMonitorQuery{
 				UrlComponents: map[string]string{
 					"resourceName": "grafana",
+					"resourceURI":  "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana",
 				},
 				Params: url.Values{
 					"aggregation": {"Count"},
@@ -351,6 +356,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 			mockQuery: &types.AzureMonitorQuery{
 				UrlComponents: map[string]string{
 					"resourceName": "grafana",
+					"resourceURI":  "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana",
 				},
 				Params: url.Values{
 					"aggregation": {"Average"},
@@ -386,6 +392,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 				Alias: "custom {{resourcegroup}} {{namespace}} {{resourceName}} {{metric}}",
 				UrlComponents: map[string]string{
 					"resourceName": "grafana",
+					"resourceURI":  "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana",
 				},
 				Params: url.Values{
 					"aggregation": {"Total"},
@@ -408,6 +415,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 				Alias: "{{dimensionname}}={{DimensionValue}}",
 				UrlComponents: map[string]string{
 					"resourceName": "grafana",
+					"resourceURI":  "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana",
 				},
 				Params: url.Values{
 					"aggregation": {"Average"},
@@ -445,6 +453,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 				Alias: "{{resourcegroup}} {Blob Type={{blobtype}}, Tier={{Tier}}}",
 				UrlComponents: map[string]string{
 					"resourceName": "grafana",
+					"resourceURI":  "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana",
 				},
 				Params: url.Values{
 					"aggregation": {"Average"},
@@ -483,6 +492,7 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 				Alias: "custom",
 				UrlComponents: map[string]string{
 					"resourceName": "grafana",
+					"resourceURI":  "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana",
 				},
 				Params: url.Values{
 					"aggregation": {"Average"},
@@ -496,6 +506,57 @@ func TestAzureMonitorParseResponse(t *testing.T) {
 					data.NewField("Percentage CPU", nil, []*float64{
 						ptr.Float64(2.0875),
 					}).SetConfig(&data.FieldConfig{DisplayName: "custom", Links: []data.DataLink{averageLink}})),
+			},
+		},
+		{
+			name:         "with legacy azure monitor query properties and without a resource uri",
+			responseFile: "2-azure-monitor-response-total.json",
+			mockQuery: &types.AzureMonitorQuery{
+				Alias: "custom {{resourcegroup}} {{namespace}} {{resourceName}} {{metric}}",
+				UrlComponents: map[string]string{
+					"subscription":     "12345678-aaaa-bbbb-cccc-123456789abc",
+					"resourceGroup":    "grafanastaging",
+					"metricDefinition": "Microsoft.Compute/virtualMachines",
+					"resourceName":     "grafana",
+				},
+				Params: url.Values{
+					"aggregation": {"Total"},
+				},
+			},
+			expectedFrames: data.Frames{
+				data.NewFrame("",
+					data.NewField("Time", nil,
+						makeDates(time.Date(2019, 2, 9, 13, 29, 0, 0, time.UTC), 5, time.Minute),
+					).SetConfig(&data.FieldConfig{Links: []data.DataLink{totalLink}}),
+					data.NewField("Percentage CPU", nil, []*float64{
+						ptr.Float64(8.26), ptr.Float64(8.7), ptr.Float64(14.82), ptr.Float64(10.07), ptr.Float64(8.52),
+					}).SetConfig(&data.FieldConfig{Unit: "percent", DisplayName: "custom grafanastaging Microsoft.Compute/virtualMachines grafana Percentage CPU", Links: []data.DataLink{totalLink}})),
+			},
+		},
+		{
+			name:         "with legacy azure monitor query properties and with a resource uri it should use the resource uri",
+			responseFile: "2-azure-monitor-response-total.json",
+			mockQuery: &types.AzureMonitorQuery{
+				Alias: "custom {{resourcegroup}} {{namespace}} {{resourceName}} {{metric}}",
+				UrlComponents: map[string]string{
+					"resourceURI":      "/subscriptions/12345678-aaaa-bbbb-cccc-123456789abc/resourceGroups/grafanastaging/providers/Microsoft.Compute/virtualMachines/grafana",
+					"subscription":     "12345678-aaaa-bbbb-cccc-123456789abc-nope",
+					"resourceGroup":    "grafanastaging-nope",
+					"metricDefinition": "Microsoft.Compute/virtualMachines-nope",
+					"resourceName":     "grafana",
+				},
+				Params: url.Values{
+					"aggregation": {"Total"},
+				},
+			},
+			expectedFrames: data.Frames{
+				data.NewFrame("",
+					data.NewField("Time", nil,
+						makeDates(time.Date(2019, 2, 9, 13, 29, 0, 0, time.UTC), 5, time.Minute),
+					).SetConfig(&data.FieldConfig{Links: []data.DataLink{totalLink}}),
+					data.NewField("Percentage CPU", nil, []*float64{
+						ptr.Float64(8.26), ptr.Float64(8.7), ptr.Float64(14.82), ptr.Float64(10.07), ptr.Float64(8.52),
+					}).SetConfig(&data.FieldConfig{Unit: "percent", DisplayName: "custom grafanastaging Microsoft.Compute/virtualMachines grafana Percentage CPU", Links: []data.DataLink{totalLink}})),
 			},
 		},
 	}

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -674,3 +674,21 @@ func TestAzureMonitorCreateRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractResourceNameFromMetricsURL(t *testing.T) {
+	t.Run("it should extract the resourceName from a well-formed Metrics URL", func(t *testing.T) {
+		url := "/subscriptions/44693801-6ee6-49de-9b2d-9106972f9572/resourceGroups/cloud-datasources/providers/Microsoft.Compute/virtualMachines/GithubTestDataVM/providers/microsoft.insights/metrics"
+		expected := "GithubTestDataVM"
+		require.Equal(t, expected, extractResourceNameFromMetricsURL((url)))
+	})
+	t.Run("it should extract the resourceName from a well-formed Metrics URL in a case insensitive manner", func(t *testing.T) {
+		url := "/subscriptions/44693801-6ee6-49de-9b2d-9106972f9572/resourceGroups/cloud-datasources/providers/Microsoft.Compute/virtualMachines/GithubTestDataVM/pRoViDeRs/MiCrOsOfT.iNsIgHtS/mEtRiCs"
+		expected := "GithubTestDataVM"
+		require.Equal(t, expected, extractResourceNameFromMetricsURL((url)))
+	})
+	t.Run("it should return an empty string if no match is found", func(t *testing.T) {
+		url := "/subscriptions/44693801-6ee6-49de-9b2d-9106972f9572/resourceGroups/cloud-datasources/providers/Microsoft.Compute/virtualMachines/GithubTestDataVM/providers/microsoft.insights/nope-this-part-does-not-match"
+		expected := ""
+		require.Equal(t, expected, extractResourceNameFromMetricsURL((url)))
+	})
+}

--- a/pkg/tsdb/azuremonitor/metrics/url-builder.go
+++ b/pkg/tsdb/azuremonitor/metrics/url-builder.go
@@ -18,7 +18,7 @@ type urlBuilder struct {
 	ResourceName        string
 }
 
-func (params *urlBuilder) BuildResourceURIFromLegacyQuery() string {
+func (params *urlBuilder) buildResourceURIFromLegacyQuery() string {
 	subscription := params.Subscription
 
 	if params.Subscription == "" {
@@ -54,7 +54,7 @@ func (params *urlBuilder) BuildMetricsURL() string {
 
 	// Prior to Grafana 9, we had a legacy query object rather than a resourceURI, so we manually create the resource URI
 	if resourceURI == "" {
-		resourceURI = params.BuildResourceURIFromLegacyQuery()
+		resourceURI = params.buildResourceURIFromLegacyQuery()
 	}
 
 	return fmt.Sprintf("%s/providers/microsoft.insights/metrics", resourceURI)

--- a/pkg/tsdb/azuremonitor/metrics/url-builder.go
+++ b/pkg/tsdb/azuremonitor/metrics/url-builder.go
@@ -18,7 +18,7 @@ type urlBuilder struct {
 	ResourceName        string
 }
 
-func (params *urlBuilder) buildMetricsURLFromLegacyQuery() string {
+func (params *urlBuilder) BuildResourceURIFromLegacyQuery() string {
 	subscription := params.Subscription
 
 	if params.Subscription == "" {
@@ -54,7 +54,7 @@ func (params *urlBuilder) BuildMetricsURL() string {
 
 	// Prior to Grafana 9, we had a legacy query object rather than a resourceURI, so we manually create the resource URI
 	if resourceURI == "" {
-		resourceURI = params.buildMetricsURLFromLegacyQuery()
+		resourceURI = params.BuildResourceURIFromLegacyQuery()
 	}
 
 	return fmt.Sprintf("%s/providers/microsoft.insights/metrics", resourceURI)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Builds a deep link to the Azure Portal using a resource uri. As a part of the work to introduce a resource picker into the Azure Monitor Metrics Query editor, we will be passing a resource uri to the query api instead of the individual parts that make up the resource uri. This PR allows us to use the resource uri to build the deep link to the Azure Portal.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #47784

**Special notes for your reviewer**:
The deep link to the Azure Portal is available if you click on a data point and click on `View in Azure Portal` link. See the screenshot below.

<img width="267" alt="Screen Shot 2022-04-20 at 5 04 21 AM" src="https://user-images.githubusercontent.com/19530599/164226713-5946b3db-778c-4adb-8774-c95b18f899a0.png">

I tested the link with the feature toggle `azureMonitorResourcePickerForMetrics = true` and with it being unset in my `custom.ini` file.

---

The lack of the legacy query properties affected the generated deep link because the `resourceName` was used to set the `ResourceDisplayName` property.

It also affected the legend if the `Legend format` field used `{{resourcename}}` in the alias pattern. If it was used, the legend would not display the resource name. I added functionality to extract the resource name from the azure metrics url. The screenshots below show what the Legend format field is when using and not using `{{resourcename}}` as an alias pattern.

New metrics query editor with resource picker:
<img width="2068" alt="New" src="https://user-images.githubusercontent.com/19530599/164534459-6fa4220c-b1bb-469d-8205-a7907e4fa400.png">

Current metrics query editor without the resource picker:
<img width="2068" alt="Old" src="https://user-images.githubusercontent.com/19530599/164534453-d21d343a-815f-4f80-be55-d11ba69d631e.png">


