### PR TITLE
Folders: Fix flaky test

### DIFF
--- a/public/app/features/folders/state/actions.test.ts
+++ b/public/app/features/folders/state/actions.test.ts
@@ -55,6 +55,7 @@ describe('folder actions', () => {
         createWarningNotification('Error checking folder permissions', 'Server error')
       );
       notificationAction.payload.id = expect.any(String);
+      notificationAction.payload.timestamp = expect.any(Number);
 
       expect(dispatchedActions).toEqual([
         expect.objectContaining(notificationAction),


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a flaky test that sometimes failed depending on how quickly it ran.
