### PR TITLE
UserListAdminPage: Reset page when changing filters

### DIFF
--- a/public/app/features/admin/state/reducers.test.ts
+++ b/public/app/features/admin/state/reducers.test.ts
@@ -12,6 +12,7 @@ import {
   userSessionsLoadedAction,
   userListAdminReducer,
   queryChanged,
+  filterChanged,
 } from './reducers';
 import { LdapState, LdapUser, UserAdminState, UserDTO, UserListAdminState } from 'app/types';
 
@@ -284,6 +285,24 @@ describe('User List Admin reducer', () => {
           ...makeInitialUserListAdminState(),
           query: 'test',
           page: 0,
+        });
+    });
+  });
+
+  describe('When filter changed', () => {
+    it('should reset page to 0', () => {
+      const initialState = {
+        ...makeInitialUserListAdminState(),
+        page: 3,
+      };
+
+      reducerTester<UserListAdminState>()
+        .givenReducer(userListAdminReducer, initialState)
+        .whenActionIsDispatched(filterChanged({ test: true }))
+        .thenStateShouldEqual({
+          ...makeInitialUserListAdminState(),
+          page: 0,
+          filters: expect.arrayContaining([{ test: true }]),
         });
     });
   });

--- a/public/app/features/admin/state/reducers.ts
+++ b/public/app/features/admin/state/reducers.ts
@@ -178,11 +178,13 @@ export const userListAdminSlice = createSlice({
       if (state.filters.some((filter) => filter.name === name)) {
         return {
           ...state,
+          page: 0,
           filters: state.filters.map((filter) => (filter.name === name ? { ...filter, value } : filter)),
         };
       }
       return {
         ...state,
+        page: 0,
         filters: [...state.filters, action.payload],
       };
     },


### PR DESCRIPTION
**What this PR does / why we need it**:
If an admin was on page 2 of the user list and applied a filter, the second page of results for the filtered users would be requested even if there was less than `results_per_page` results. To avoid this, we always reset the page number to 0 before requesting filtered results.