### PR TITLE
Text Panel: Fixes issue with hash anchor links

### DIFF
--- a/public/app/core/navigation/patch/interceptLinkClicks.ts
+++ b/public/app/core/navigation/patch/interceptLinkClicks.ts
@@ -27,6 +27,10 @@ export function interceptLinkClicks(e: MouseEvent) {
         if (href.indexOf('://') > 0 || href.indexOf('mailto:') === 0) {
           window.location.href = href;
           return;
+        } else if (href.indexOf('#') === 0) {
+          // If it is a hash click, update the hash instead of trying to update the history
+          window.location.hash = href;
+          return;
         } else {
           href = `/${href}`;
         }


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently an anchor with a hash link (i.e. `<a href="#tag">...`) is treated just like a normal link, by adding a slash behind it and updating history, which will just redirect the user to the home page with `/#tag`. We can fix this by updating the `hash` property of the location when intercepting one of these clicks.

**Which issue(s) this PR fixes**:

Fixes #47799

