### PR TITLE
Update cron library for ldap sync

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -608,7 +608,7 @@ allow_sign_up = true
 
 # LDAP background sync (Enterprise only)
 # At 1 am every day
-sync_cron = "0 0 1 * * *"
+sync_cron = "0 1 * * *"
 active_sync_enabled = true
 
 #################################### AWS ###########################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -591,7 +591,7 @@
 
 # LDAP background sync (Enterprise only)
 # At 1 am every day
-;sync_cron = "0 0 1 * * *"
+;sync_cron = "0 1 * * *"
 ;active_sync_enabled = true
 
 #################################### AWS ###########################

--- a/docs/sources/enterprise/enhanced_ldap.md
+++ b/docs/sources/enterprise/enhanced_ldap.md
@@ -48,9 +48,9 @@ Removed users are automatically logged out and their account disabled. These acc
 # @weekly                | Run once a week, midnight between Sat/Sun  | 0 0 0 * * 0
 # @daily (or @midnight)  | Run once a day, midnight                   | 0 0 0 * * *
 # @hourly                | Run once an hour, beginning of hour        | 0 0 * * * *
-sync_cron = "0 0 1 * * *" # This is default value (At 1 am every day)
+sync_cron = "0 1 * * *" # This is default value (At 1 am every day)
 # This cron expression format uses 6 space-separated fields (including seconds), for example
-# sync_cron = "* */10 * * * *"
+# sync_cron = "*/10 * * * *"
 # This will run the LDAP Synchronization every 10th minute, which is also the minimal interval between the Grafana sync times i.e. you cannot set it for every 9th minute
 
 # You can also disable active LDAP synchronization

--- a/docs/sources/enterprise/enhanced_ldap.md
+++ b/docs/sources/enterprise/enhanced_ldap.md
@@ -49,7 +49,7 @@ Removed users are automatically logged out and their account disabled. These acc
 # @daily (or @midnight)  | Run once a day, midnight                   | 0 0 0 * * *
 # @hourly                | Run once an hour, beginning of hour        | 0 0 * * * *
 sync_cron = "0 1 * * *" # This is default value (At 1 am every day)
-# This cron expression format uses 6 space-separated fields (including seconds), for example
+# This cron expression format uses 5 space-separated fields, for example
 # sync_cron = "*/10 * * * *"
 # This will run the LDAP Synchronization every 10th minute, which is also the minimal interval between the Grafana sync times i.e. you cannot set it for every 9th minute
 

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,6 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.32.1
 	github.com/prometheus/prometheus v1.8.2-0.20211011171444-354d8d2ecfac
-	github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/russellhaering/goxmldsig v1.1.1
 	github.com/stretchr/testify v1.7.1

--- a/pkg/extensions/main.go
+++ b/pkg/extensions/main.go
@@ -1,9 +1,6 @@
 package extensions
 
 import (
-	// Upgrade ldapsync from cron to cron.v3 and
-	// remove the cron (v1) dependency
-
 	_ "cloud.google.com/go/kms/apiv1"
 	_ "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	_ "github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys"
@@ -24,7 +21,6 @@ import (
 	_ "github.com/linkedin/goavro/v2"
 	_ "github.com/m3db/prometheus_remote_client_golang/promremote"
 	_ "github.com/pkg/errors"
-	_ "github.com/robfig/cron"
 	_ "github.com/robfig/cron/v3"
 	_ "github.com/russellhaering/goxmldsig"
 	_ "github.com/stretchr/testify/require"


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/grafana/grafana-enterprise/pull/3193

- Removes cron (v1) dependency without breaking previous configurations
- Nudge new users to use standard cron notation

>  The v1 branch accepted an optional seconds field at the beginning of the cron spec. This is non-standard and has led to a lot of confusion. The new default parser conforms to the standard as described by [the Cron wikipedia page](https://en.wikipedia.org/wiki/Cron).

https://github.com/robfig/cron#upgrading-to-v3-june-2019=
