### PR TITLE
Navigation: Fixes issue with menu closing when hovering the trigger again

### DIFF
--- a/public/app/core/components/NavBar/Next/NavBarItemMenuTrigger.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarItemMenuTrigger.tsx
@@ -101,6 +101,7 @@ export function NavBarItemMenuTrigger(props: NavBarItemMenuTriggerProps): ReactE
       className={styles.element}
       {...buttonProps}
       {...keyboardProps}
+      {...hoverProps}
       ref={ref as React.RefObject<HTMLButtonElement>}
       onClick={item?.onClick}
       aria-label={label}
@@ -115,6 +116,7 @@ export function NavBarItemMenuTrigger(props: NavBarItemMenuTriggerProps): ReactE
         <Link
           {...buttonProps}
           {...keyboardProps}
+          {...hoverProps}
           ref={ref as React.RefObject<HTMLAnchorElement>}
           href={item.url}
           target={item.target}
@@ -131,6 +133,7 @@ export function NavBarItemMenuTrigger(props: NavBarItemMenuTriggerProps): ReactE
           onClick={item?.onClick}
           {...buttonProps}
           {...keyboardProps}
+          {...hoverProps}
           ref={ref as React.RefObject<HTMLAnchorElement>}
           className={styles.element}
           aria-label={label}
@@ -179,7 +182,7 @@ export function NavBarItemMenuTrigger(props: NavBarItemMenuTriggerProps): ReactE
   });
 
   return (
-    <div className={cx(styles.element, 'dropdown')} {...focusWithinProps} {...hoverProps}>
+    <div className={cx(styles.element, 'dropdown')} {...focusWithinProps}>
       {element}
       {state.isOpen && (
         <OverlayContainer portalContainer={getPortalContainer()}>


### PR DESCRIPTION
**What this PR does / why we need it**:

| Before | After |
| ------ | ----- |
| https://user-images.githubusercontent.com/100691367/164285268-9ee0ce99-c42b-447a-86f8-a78ae948bc58.mov | https://user-images.githubusercontent.com/100691367/164285061-c81d9ef3-3cc2-41e2-bf23-29d5367daa96.mov |

**Which issue(s) this PR fixes**:

Fixes #47989

**Special notes for your reviewer**:

This is the structure of each menu item:
```
<wrapper>
  <trigger/>
  <subMenu/>
</wrapper>
```

Previously the `hoverProps` were set on both the subMenu and the wrapper, but that meant the `isHovering` was a bit glitchy when hovering in and out of items, so moved it to the be in the subMenu and trigger button as that means there is no overlap.