### PR TITLE
CloudWatch: Prevent log groups from being removed on query change

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -416,6 +416,7 @@ export type ExploreQueryFieldProps<
 
 export interface QueryEditorHelpProps<TQuery extends DataQuery = DataQuery> {
   datasource: DataSourceApi<TQuery>;
+  query: TQuery;
   onClickExample: (query: TQuery) => void;
   exploreId?: any;
 }

--- a/public/app/features/explore/RichHistory/RichHistoryContainer.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryContainer.tsx
@@ -1,8 +1,8 @@
 // Libraries
 import React, { useEffect, useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
-import { useTheme2 } from '@grafana/ui';
 
+import { useTheme2 } from '@grafana/ui';
 // Types
 import { ExploreItemState, StoreState } from 'app/types';
 import { ExploreId } from 'app/types/explore';

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -416,6 +416,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
                 <OperationRowHelp>
                   <DatasourceCheatsheet
                     onClickExample={(query) => this.onClickExample(query)}
+                    query={this.props.query}
                     datasource={datasource}
                   />
                 </OperationRowHelp>

--- a/public/app/plugins/datasource/cloudwatch/components/LogsCheatSheet.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsCheatSheet.tsx
@@ -229,8 +229,15 @@ export default class LogsCheatSheet extends PureComponent<
       <div
         className="cheat-sheet-item__example"
         key={expr}
-        onClick={(e) =>
-          this.onClickExample({ refId: 'A', expression: expr, queryMode: 'Logs', region: 'default', id: 'A' })
+        onClick={() =>
+          this.onClickExample({
+            refId: this.props.query.refId ?? 'A',
+            expression: expr,
+            queryMode: 'Logs',
+            region: this.props.query.region,
+            id: this.props.query.refId ?? 'A',
+            logGroupNames: 'logGroupNames' in this.props.query ? this.props.query.logGroupNames : [],
+          })
         }
       >
         <pre>{renderHighlightedMarkup(expr, keyPrefix)}</pre>

--- a/public/app/plugins/datasource/cloudwatch/utils/logsRetry.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/logsRetry.ts
@@ -10,9 +10,9 @@ type Result = { frames: DataFrameJSON[]; error?: string };
 /**
  * A retry strategy specifically for cloud watch logs query. Cloud watch logs queries need first starting the query
  * and the polling for the results. The start query can fail because of the concurrent queries rate limit,
- * and so we hove to retry the start query call if there is already lot of queries running.
+ * and so we have to retry the start query call if there is already lot of queries running.
  *
- * As we send multiple queries in single request some can fail and some can succeed and we have to also handle those
+ * As we send multiple queries in a single request some can fail and some can succeed and we have to also handle those
  * cases by only retrying the failed queries. We retry the failed queries until we hit the time limit or all queries
  * succeed and only then we pass the data forward. This means we wait longer but makes the code a bit simpler as we
  * can treat starting the query and polling as steps in a pipeline.


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously when a query was changed the existing log groups for that query were "dropped". The fix is to combine the
new query with the existing query object in memory to preserve the log groups.

**Which issue(s) this PR fixes**:
Fixes #33626

**Special notes for your reviewer**:
1. Have Cloudwatch configured as a datasource
2. Head to explore, `/explore`
3. Add a cloudwatch query
4. Change from metrics to logs if metrics is per-selected
5. Select a log group
6. Insert a query either from the help menu
7. Click `Run Query` and note there is no longer an error message requiring a Log Group
