### PR TITLE
bumping version of github.com/tidwall/match to v1.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -292,6 +292,8 @@ replace github.com/apache/thrift => github.com/apache/thrift v0.14.1
 
 replace github.com/hashicorp/consul => github.com/hashicorp/consul v1.10.2
 
+replace github.com/tidwall/match => github.com/tidwall/match v1.1.1
+
 // Thema's thema CLI requires cobra, which eventually works its way down to go-hclog@v1.0.0.
 // Upgrading affects backend plugins: https://github.com/grafana/grafana/pull/47653#discussion_r850508593
 // No harm to Thema because it's only a dependency in its main package.

--- a/go.mod
+++ b/go.mod
@@ -292,6 +292,8 @@ replace github.com/apache/thrift => github.com/apache/thrift v0.14.1
 
 replace github.com/hashicorp/consul => github.com/hashicorp/consul v1.10.2
 
+// Upgraded to fix CVE-2020-26066. This can be removed when go.opentelemetry.io/collector and github.com/influxdata/telegraf are upgraded
+// github.com/tidwall/match v1.0.1 should not be used.
 replace github.com/tidwall/match => github.com/tidwall/match v1.1.1
 
 // Thema's thema CLI requires cobra, which eventually works its way down to go-hclog@v1.0.0.

--- a/go.sum
+++ b/go.sum
@@ -2515,7 +2515,7 @@ github.com/thanos-io/thanos v0.13.1-0.20210401085038-d7dff0c84d17/go.mod h1:zU8K
 github.com/thanos-io/thanos v0.22.0/go.mod h1:SZDWz3phcUcBr4MYFoPFRvl+Z9Nbi45HlwQlwSZSt+Q=
 github.com/tidwall/gjson v1.6.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/gjson v1.6.1/go.mod h1:BaHyNc5bjzYkPqgLq7mdVzeiRtULKULXLgZFKsxEHI0=
-github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.0.2 h1:Z7S3cePv9Jwm1KwS0513MRaoUe3S01WPbLNV40pwWZU=


### PR DESCRIPTION
Fixes CVE-2020-26066, found during a vulnerability scan of Microsoft's build of Grafana OSS.

References - links for context:
Type: Go
Found in these component versions: https://github.com/tidwall/match

github.com/tidwall/match (V1.0.1)

