### PR TITLE
fix: span links use correct trace id when span in different trace

### DIFF
--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash';
 import {
   DataFrame,
   DataLink,
@@ -221,13 +222,20 @@ function useFocusSpanLink(options: {
   );
 
   const createFocusSpanLink = (traceId: string, spanId: string) => {
+    let tempQuery: any;
+
+    if ('queryType' in query && query.queryType === 'traceId' && query.query !== traceId) {
+      tempQuery = cloneDeep(query);
+      tempQuery.query = traceId;
+    }
+
     const link: DataLink = {
       title: 'Deep link to this span',
       url: '',
       internal: {
         datasourceUid: options.datasource?.uid!,
         datasourceName: options.datasource?.name!,
-        query: query,
+        query: tempQuery || query,
         panelsState: {
           trace: {
             spanId,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR addresses https://github.com/grafana/grafana/issues/48018, and ensures that span links (/references) which have a different `traceID` than the current span will open a link for the correct traceId, with the correct span focused.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/48018

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:


The Span Links feature was introduced recently, (see: https://github.com/grafana/grafana/pull/45632) and adds an implementation of the [`createLinkToExternalSpan` method](https://github.com/grafana/grafana/blob/bd21355f87e0be6493813e1a7c8fc8e91f1090b0/public/app/features/explore/TraceView/TraceView.tsx#L95), which uses the `createFocusSpanLink` method to generate the link `href`. However, oddly enough, while [this method accepts both `traceId` and `spanId` as arguments, it doesn't actually use the `traceId` for anything](https://github.com/grafana/grafana/blob/bd21355f87e0be6493813e1a7c8fc8e91f1090b0/public/app/features/explore/TraceView/TraceView.tsx#L271-L285) 🤷 , and instead just looks up the existing `query` that's been generated for that page. This query is an Object which includes the `traceId` originally used to load the trace.

Unlike most other portions of traceView, a span link in OpenTelemetry can reference a different trace entirely.

[From the OpenTelemetry spec](https://github.com/open-telemetry/opentelemetry-specification/blob/70fecd2dcba505b3ac3a7cb1851f947047743d24/specification/overview.md#links-between-spans):
> A Span may be linked to zero or more other Spans (defined by SpanContext) that are causally related. Links can point to Spans inside a single Trace or across different Traces.

So, this PR updates `createFocusSpanLink` to accommodate this use case. It's a small change in terms of LOC., I wanted to avoid messing with the underlying `query` mechanics as much as possible, so all this change does is, detects whether a different `traceId` has been passed in than what's stored in the `query` for that page, and if so, it make a copy of the query object with an updated `traceId` field, to use when generating the `href`.

For context, we've been using this patch on our fork without issue for a month or so.

https://user-images.githubusercontent.com/14250318/159588913-9cf40646-e573-4b53-8529-a16d4e1b7606.mp4
