### PR TITLE
Alerting: Add GetRuleGroups to RuleStore

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -265,7 +265,14 @@ type GetAlertRulesQuery struct {
 	Result []*AlertRule
 }
 
+// ListRuleGroupsQuery is the query for listing unique rule groups
+// across all organizations
+type ListRuleGroupsQuery struct {
+	Result []string
+}
+
 // ListOrgRuleGroupsQuery is the query for listing unique rule groups
+// for an organization
 type ListOrgRuleGroupsQuery struct {
 	OrgID         int64
 	NamespaceUIDs []string

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -266,7 +266,7 @@ func (st DBstore) GetOrgAlertRules(ctx context.Context, query *ngmodels.ListAler
 func (st DBstore) GetRuleGroups(ctx context.Context, query *ngmodels.ListRuleGroupsQuery) error {
 	return st.SQLStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		ruleGroups := make([]string, 0)
-		if err := sess.SQL(`SELECT DISTINCT rule_group FROM alert_rule`).Find(&ruleGroups); err != nil {
+		if err := sess.Table("alert_rule").Distinct("rule_group").Find(&ruleGroups); err != nil {
 			return err
 		}
 		query.Result = ruleGroups

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -39,6 +39,8 @@ type RuleStore interface {
 	GetAlertRuleByUID(ctx context.Context, query *ngmodels.GetAlertRuleByUIDQuery) error
 	GetAlertRulesForScheduling(ctx context.Context, query *ngmodels.ListAlertRulesQuery) error
 	GetOrgAlertRules(ctx context.Context, query *ngmodels.ListAlertRulesQuery) error
+	// GetRuleGroups returns the unique rule groups across all organizations.
+	GetRuleGroups(ctx context.Context, query *ngmodels.ListRuleGroupsQuery) error
 	GetAlertRules(ctx context.Context, query *ngmodels.GetAlertRulesQuery) error
 	GetUserVisibleNamespaces(context.Context, int64, *models.SignedInUser) (map[string]*models.Folder, error)
 	GetNamespaceByTitle(context.Context, string, int64, *models.SignedInUser, bool) (*models.Folder, error)
@@ -257,6 +259,17 @@ func (st DBstore) GetOrgAlertRules(ctx context.Context, query *ngmodels.ListAler
 		}
 
 		query.Result = alertRules
+		return nil
+	})
+}
+
+func (st DBstore) GetRuleGroups(ctx context.Context, query *ngmodels.ListRuleGroupsQuery) error {
+	return st.SQLStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		ruleGroups := make([]string, 0)
+		if err := sess.SQL(`SELECT DISTINCT rule_group FROM alert_rule`).Find(&ruleGroups); err != nil {
+			return err
+		}
+		query.Result = ruleGroups
 		return nil
 	})
 }

--- a/pkg/services/ngalert/store/testing.go
+++ b/pkg/services/ngalert/store/testing.go
@@ -178,6 +178,26 @@ func (f *FakeRuleStore) GetOrgAlertRules(_ context.Context, q *models.ListAlertR
 	q.Result = rules
 	return nil
 }
+
+func (f *FakeRuleStore) GetRuleGroups(_ context.Context, q *models.ListRuleGroupsQuery) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	f.RecordedOps = append(f.RecordedOps, *q)
+
+	m := make(map[string]struct{})
+	for _, rules := range f.Rules {
+		for _, rule := range rules {
+			m[rule.RuleGroup] = struct{}{}
+		}
+	}
+
+	for s := range m {
+		q.Result = append(q.Result, s)
+	}
+
+	return nil
+}
+
 func (f *FakeRuleStore) GetAlertRules(_ context.Context, q *models.GetAlertRulesQuery) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds a new method GetRuleGroups to RuleStore which returns the set of rule groups across all organizations.

