### PR TITLE
Explore: Update Show original line button name 

### DIFF
--- a/public/app/features/explore/LogsMetaRow.tsx
+++ b/public/app/features/explore/LogsMetaRow.tsx
@@ -58,7 +58,7 @@ export const LogsMetaRow: React.FC<Props> = React.memo(
           label: '',
           value: (
             <Button variant="secondary" size="sm" onClick={clearDetectedFields}>
-              Show all detected fields
+              Show original line
             </Button>
           ),
         }


### PR DESCRIPTION
This PR changes the name of the button from `Show all detected fields` to `Show original line` to make it more clear what is going to happen when you click on it. 