### PR TITLE
Rename FGAC to RBAC in the codebase

### DIFF
--- a/packages/grafana-data/src/types/accesscontrol.ts
+++ b/packages/grafana-data/src/types/accesscontrol.ts
@@ -1,7 +1,7 @@
 import { KeyValue } from '.';
 
 /**
- * With FGAC, the backend will return additional access control metadata to objects.
+ * With RBAC, the backend will return additional access control metadata to objects.
  * These metadata will contain user permissions associated to a given resource.
  *
  * For example:

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -273,7 +273,7 @@ func (hs *HTTPServer) MassDeleteAnnotations(c *models.ReqContext) response.Respo
 	repo := annotations.GetRepository()
 	var deleteParams *annotations.DeleteParams
 
-	// validations only for FGAC. A user can mass delete all annotations in a (dashboard + panel) or a specific annotation
+	// validations only for RBAC. A user can mass delete all annotations in a (dashboard + panel) or a specific annotation
 	// if has access to that dashboard.
 	if hs.Features.IsEnabled(featuremgmt.FlagAccesscontrol) {
 		var dashboardId int64

--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -720,7 +720,7 @@ func TestAPI_Annotations_AccessControl(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setUpFGACGuardian(t)
+			setUpRBACGuardian(t)
 			sc.acmock.
 				RegisterAttributeScopeResolver(AnnotationTypeScopeResolver())
 			setAccessControlPermissions(sc.acmock, tt.args.permissions, sc.initCtx.OrgId)
@@ -914,7 +914,7 @@ func TestAPI_MassDeleteAnnotations_AccessControl(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setUpFGACGuardian(t)
+			setUpRBACGuardian(t)
 			setAccessControlPermissions(sc.acmock, tt.args.permissions, sc.initCtx.OrgId)
 			dashboardAnnotation := &annotations.Item{Id: 1, DashboardId: 1}
 			organizationAnnotation := &annotations.Item{Id: 2, DashboardId: 0}
@@ -945,7 +945,7 @@ func setUpACL() {
 	guardian.InitLegacyGuardian(store)
 }
 
-func setUpFGACGuardian(t *testing.T) {
+func setUpRBACGuardian(t *testing.T) {
 	origNewGuardian := guardian.New
 	t.Cleanup(func() {
 		guardian.New = origNewGuardian

--- a/pkg/api/team_members_test.go
+++ b/pkg/api/team_members_test.go
@@ -191,7 +191,7 @@ func TestAddTeamMembersAPIEndpoint_LegacyAccessControl(t *testing.T) {
 	})
 }
 
-func TestGetTeamMembersAPIEndpoint_FGAC(t *testing.T) {
+func TestGetTeamMembersAPIEndpoint_RBAC(t *testing.T) {
 	sc := setupHTTPServer(t, true, true)
 	sc.hs.License = &licensing.OSSLicensingService{}
 
@@ -245,7 +245,7 @@ func TestGetTeamMembersAPIEndpoint_FGAC(t *testing.T) {
 	})
 }
 
-func TestAddTeamMembersAPIEndpoint_FGAC(t *testing.T) {
+func TestAddTeamMembersAPIEndpoint_RBAC(t *testing.T) {
 	sc := setupHTTPServer(t, true, true)
 	sc.hs.License = &licensing.OSSLicensingService{}
 
@@ -325,7 +325,7 @@ func TestUpdateTeamMembersAPIEndpoint_LegacyAccessControl(t *testing.T) {
 	})
 }
 
-func TestUpdateTeamMembersAPIEndpoint_FGAC(t *testing.T) {
+func TestUpdateTeamMembersAPIEndpoint_RBAC(t *testing.T) {
 	sc := setupHTTPServer(t, true, true)
 	sc.hs.License = &licensing.OSSLicensingService{}
 
@@ -399,7 +399,7 @@ func TestDeleteTeamMembersAPIEndpoint_LegacyAccessControl(t *testing.T) {
 	})
 }
 
-func TestDeleteTeamMembersAPIEndpoint_FGAC(t *testing.T) {
+func TestDeleteTeamMembersAPIEndpoint_RBAC(t *testing.T) {
 	sc := setupHTTPServer(t, true, true)
 	sc.hs.License = &licensing.OSSLicensingService{}
 

--- a/pkg/api/team_test.go
+++ b/pkg/api/team_test.go
@@ -196,7 +196,7 @@ func TestTeamAPIEndpoint_CreateTeam_LegacyAccessControl_EditorsCanAdmin(t *testi
 	})
 }
 
-func TestTeamAPIEndpoint_CreateTeam_FGAC(t *testing.T) {
+func TestTeamAPIEndpoint_CreateTeam_RBAC(t *testing.T) {
 	sc := setupHTTPServer(t, true, true)
 
 	setInitCtxSignedInViewer(sc.initCtx)
@@ -215,7 +215,7 @@ func TestTeamAPIEndpoint_CreateTeam_FGAC(t *testing.T) {
 	})
 }
 
-func TestTeamAPIEndpoint_SearchTeams_FGAC(t *testing.T) {
+func TestTeamAPIEndpoint_SearchTeams_RBAC(t *testing.T) {
 	sc := setupHTTPServer(t, true, true)
 	// Seed three teams
 	for i := 1; i <= 3; i++ {
@@ -259,7 +259,7 @@ func TestTeamAPIEndpoint_SearchTeams_FGAC(t *testing.T) {
 	})
 }
 
-func TestTeamAPIEndpoint_GetTeamByID_FGAC(t *testing.T) {
+func TestTeamAPIEndpoint_GetTeamByID_RBAC(t *testing.T) {
 	sc := setupHTTPServer(t, true, true)
 	sc.db = sqlstore.InitTestDB(t)
 
@@ -289,7 +289,7 @@ func TestTeamAPIEndpoint_GetTeamByID_FGAC(t *testing.T) {
 // Given a team with a user, when the user is granted X permission,
 // Then the endpoint should return 200 if the user has accesscontrol.ActionTeamsWrite with teams:id:1 scope
 // else return 403
-func TestTeamAPIEndpoint_UpdateTeam_FGAC(t *testing.T) {
+func TestTeamAPIEndpoint_UpdateTeam_RBAC(t *testing.T) {
 	sc := setupHTTPServer(t, true, true)
 	sc.db = sqlstore.InitTestDB(t)
 	_, err := sc.db.CreateTeam("team1", "", 1)
@@ -338,7 +338,7 @@ func TestTeamAPIEndpoint_UpdateTeam_FGAC(t *testing.T) {
 // Given a team with a user, when the user is granted X permission,
 // Then the endpoint should return 200 if the user has accesscontrol.ActionTeamsDelete with teams:id:1 scope
 // else return 403
-func TestTeamAPIEndpoint_DeleteTeam_FGAC(t *testing.T) {
+func TestTeamAPIEndpoint_DeleteTeam_RBAC(t *testing.T) {
 	sc := setupHTTPServer(t, true, true)
 	sc.db = sqlstore.InitTestDB(t)
 	_, err := sc.db.CreateTeam("team1", "", 1)
@@ -370,7 +370,7 @@ func TestTeamAPIEndpoint_DeleteTeam_FGAC(t *testing.T) {
 // Given a team with a user, when the user is granted X permission,
 // Then the endpoint should return 200 if the user has accesscontrol.ActionTeamsRead with teams:id:1 scope
 // else return 403
-func TestTeamAPIEndpoint_GetTeamPreferences_FGAC(t *testing.T) {
+func TestTeamAPIEndpoint_GetTeamPreferences_RBAC(t *testing.T) {
 	sc := setupHTTPServer(t, true, true)
 	sc.db = sqlstore.InitTestDB(t)
 	_, err := sc.db.CreateTeam("team1", "", 1)
@@ -396,7 +396,7 @@ func TestTeamAPIEndpoint_GetTeamPreferences_FGAC(t *testing.T) {
 // Given a team with a user, when the user is granted X permission,
 // Then the endpoint should return 200 if the user has accesscontrol.ActionTeamsWrite with teams:id:1 scope
 // else return 403
-func TestTeamAPIEndpoint_UpdateTeamPreferences_FGAC(t *testing.T) {
+func TestTeamAPIEndpoint_UpdateTeamPreferences_RBAC(t *testing.T) {
 	sc := setupHTTPServer(t, true, true)
 	sc.db = sqlstore.InitTestDB(t)
 	_, err := sc.db.CreateTeam("team1", "", 1)

--- a/pkg/services/ngalert/api/api_alertmanager_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_test.go
@@ -219,7 +219,7 @@ func TestRouteCreateSilence(t *testing.T) {
 		expectedStatus int
 	}{
 		{
-			name:    "new silence, fine-grained access control is enabled, not authorized",
+			name:    "new silence, role-based access control is enabled, not authorized",
 			silence: silenceGen(withEmptyID),
 			accessControl: func() accesscontrol.AccessControl {
 				return acMock.New()
@@ -227,7 +227,7 @@ func TestRouteCreateSilence(t *testing.T) {
 			expectedStatus: http.StatusUnauthorized,
 		},
 		{
-			name:    "new silence, fine-grained access control is enabled, authorized",
+			name:    "new silence, role-based access control is enabled, authorized",
 			silence: silenceGen(withEmptyID),
 			accessControl: func() accesscontrol.AccessControl {
 				return acMock.New().WithPermissions([]*accesscontrol.Permission{
@@ -237,7 +237,7 @@ func TestRouteCreateSilence(t *testing.T) {
 			expectedStatus: http.StatusAccepted,
 		},
 		{
-			name:    "new silence, fine-grained access control is disabled, Viewer",
+			name:    "new silence, role-based access control is disabled, Viewer",
 			silence: silenceGen(withEmptyID),
 			accessControl: func() accesscontrol.AccessControl {
 				return acMock.New().WithDisabled()
@@ -246,7 +246,7 @@ func TestRouteCreateSilence(t *testing.T) {
 			expectedStatus: http.StatusUnauthorized,
 		},
 		{
-			name:    "new silence, fine-grained access control is disabled, Editor",
+			name:    "new silence, role-based access control is disabled, Editor",
 			silence: silenceGen(withEmptyID),
 			accessControl: func() accesscontrol.AccessControl {
 				return acMock.New().WithDisabled()
@@ -255,7 +255,7 @@ func TestRouteCreateSilence(t *testing.T) {
 			expectedStatus: http.StatusAccepted,
 		},
 		{
-			name:    "new silence, fine-grained access control is disabled, Admin",
+			name:    "new silence, role-based access control is disabled, Admin",
 			silence: silenceGen(withEmptyID),
 			accessControl: func() accesscontrol.AccessControl {
 				return acMock.New().WithDisabled()
@@ -264,7 +264,7 @@ func TestRouteCreateSilence(t *testing.T) {
 			expectedStatus: http.StatusAccepted,
 		},
 		{
-			name:    "update silence, fine-grained access control is enabled, not authorized",
+			name:    "update silence, role-based access control is enabled, not authorized",
 			silence: silenceGen(),
 			accessControl: func() accesscontrol.AccessControl {
 				return acMock.New()
@@ -272,7 +272,7 @@ func TestRouteCreateSilence(t *testing.T) {
 			expectedStatus: http.StatusUnauthorized,
 		},
 		{
-			name:    "update silence, fine-grained access control is enabled, authorized",
+			name:    "update silence, role-based access control is enabled, authorized",
 			silence: silenceGen(),
 			accessControl: func() accesscontrol.AccessControl {
 				return acMock.New().WithPermissions([]*accesscontrol.Permission{
@@ -282,7 +282,7 @@ func TestRouteCreateSilence(t *testing.T) {
 			expectedStatus: http.StatusAccepted,
 		},
 		{
-			name:    "update silence, fine-grained access control is disabled, Viewer",
+			name:    "update silence, role-based access control is disabled, Viewer",
 			silence: silenceGen(),
 			accessControl: func() accesscontrol.AccessControl {
 				return acMock.New().WithDisabled()
@@ -291,7 +291,7 @@ func TestRouteCreateSilence(t *testing.T) {
 			expectedStatus: http.StatusUnauthorized,
 		},
 		{
-			name:    "update silence, fine-grained access control is disabled, Editor",
+			name:    "update silence, role-based access control is disabled, Editor",
 			silence: silenceGen(),
 			accessControl: func() accesscontrol.AccessControl {
 				return acMock.New().WithDisabled()
@@ -300,7 +300,7 @@ func TestRouteCreateSilence(t *testing.T) {
 			expectedStatus: http.StatusAccepted,
 		},
 		{
-			name:    "update silence, fine-grained access control is disabled, Admin",
+			name:    "update silence, role-based access control is disabled, Admin",
 			silence: silenceGen(),
 			accessControl: func() accesscontrol.AccessControl {
 				return acMock.New().WithDisabled()

--- a/pkg/services/sqlstore/annotation_test.go
+++ b/pkg/services/sqlstore/annotation_test.go
@@ -337,7 +337,7 @@ func TestAnnotations(t *testing.T) {
 	})
 }
 
-func TestAnnotationListingWithFGAC(t *testing.T) {
+func TestAnnotationListingWithRBAC(t *testing.T) {
 	sql := sqlstore.InitTestDB(t)
 	sql.Cfg.IsFeatureToggleEnabled = func(key string) bool {
 		return key == featuremgmt.FlagAccesscontrol

--- a/pkg/services/sqlstore/migrations/accesscontrol/team_membership.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/team_membership.go
@@ -61,8 +61,8 @@ func (p *teamPermissionMigrator) setRolePermissions(roleID int64, permissions []
 	return nil
 }
 
-// mapPermissionToFGAC translates the legacy membership (Member or Admin) into FGAC permissions
-func (p *teamPermissionMigrator) mapPermissionToFGAC(permission models.PermissionType, teamID int64) []accesscontrol.Permission {
+// mapPermissionToRBAC translates the legacy membership (Member or Admin) into RBAC permissions
+func (p *teamPermissionMigrator) mapPermissionToRBAC(permission models.PermissionType, teamID int64) []accesscontrol.Permission {
 	teamIDScope := accesscontrol.Scope("teams", "id", strconv.FormatInt(teamID, 10))
 	switch permission {
 	case 0:
@@ -222,7 +222,7 @@ func (p *teamPermissionMigrator) generateAssociatedPermissions(teamMemberships [
 		if !initialized {
 			userPermissions = map[int64][]accesscontrol.Permission{}
 		}
-		userPermissions[m.UserId] = append(userPermissions[m.UserId], p.mapPermissionToFGAC(m.Permission, m.TeamId)...)
+		userPermissions[m.UserId] = append(userPermissions[m.UserId], p.mapPermissionToRBAC(m.Permission, m.TeamId)...)
 		userPermissionsByOrg[m.OrgId] = userPermissions
 	}
 

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/ac_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/ac_test.go
@@ -91,7 +91,7 @@ func TestMigrations(t *testing.T) {
 	setupTeams(t, x)
 
 	// Create managed user roles with teams permissions (ex: teams:read and teams.permissions:read)
-	setupUnecessaryFGACPermissions(t, x)
+	setupUnecessaryRBACPermissions(t, x)
 
 	team1Scope := accesscontrol.Scope("teams", "id", "1")
 	team2Scope := accesscontrol.Scope("teams", "id", "2")
@@ -347,7 +347,7 @@ func setupTeams(t *testing.T, x *xorm.Engine) {
 	require.Equal(t, int64(5), membersCount, "needed 5 members for this test to run")
 }
 
-func setupUnecessaryFGACPermissions(t *testing.T, x *xorm.Engine) {
+func setupUnecessaryRBACPermissions(t *testing.T, x *xorm.Engine) {
 	t.Helper()
 
 	now := time.Now()

--- a/public/app/features/alerting/unified/components/rule-editor/AlertTypeStep.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AlertTypeStep.test.tsx
@@ -33,7 +33,7 @@ function renderAlertTypeStep() {
 }
 
 describe('RuleTypePicker', () => {
-  describe('FGAC', () => {
+  describe('RBAC', () => {
     it('Should display grafana, mimir alert and mimir recording buttons when user has rule create and write permissions', async () => {
       jest.spyOn(contextSrv, 'hasPermission').mockImplementation((action) => {
         return [AccessControlAction.AlertingRuleCreate, AccessControlAction.AlertingRuleExternalWrite].includes(

--- a/public/app/features/alerting/unified/components/rules/RuleDetails.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetails.test.tsx
@@ -27,7 +27,7 @@ const ui = {
 
 jest.spyOn(contextSrv, 'accessControlEnabled').mockReturnValue(true);
 
-describe('RuleDetails FGAC', () => {
+describe('RuleDetails RBAC', () => {
   describe('Grafana rules action buttons', () => {
     const grafanaRule = getGrafanaRule({ name: 'Grafana' });
     it('Should not render Edit button for users without the update permission', () => {

--- a/public/app/features/alerting/unified/components/rules/RuleListGroupView.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListGroupView.test.tsx
@@ -18,7 +18,7 @@ const ui = {
 };
 
 describe('RuleListGroupView', () => {
-  describe('FGAC', () => {
+  describe('RBAC', () => {
     jest.spyOn(contextSrv, 'accessControlEnabled').mockReturnValue(true);
 
     it('Should display Grafana rules when the user has the alert rule read permission', () => {

--- a/public/app/features/alerting/unified/hooks/useIsRuleEditable.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useIsRuleEditable.test.tsx
@@ -17,7 +17,7 @@ const mocks = {
 };
 
 describe('useIsRuleEditable', () => {
-  describe('FGAC enabled', () => {
+  describe('RBAC enabled', () => {
     jest.spyOn(contextSrv, 'accessControlEnabled').mockReturnValue(true);
     describe('Grafana rules', () => {
       it('Should allow editing when the user has the alert rule update permission and folder permissions', () => {

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -1198,7 +1198,7 @@ export class DashboardModel implements TimeModel {
   canEditAnnotations(dashboardId: number) {
     let canEdit = true;
 
-    // if FGAC is enabled there are additional conditions to check
+    // if RBAC is enabled there are additional conditions to check
     if (contextSrv.accessControlEnabled()) {
       if (dashboardId === 0) {
         canEdit = !!this.meta.annotationsPermissions?.organization.canEdit;
@@ -1212,7 +1212,7 @@ export class DashboardModel implements TimeModel {
   canAddAnnotations() {
     let canAdd = true;
 
-    // if FGAC is enabled there are additional conditions to check
+    // if RBAC is enabled there are additional conditions to check
     if (contextSrv.accessControlEnabled()) {
       canAdd = !!this.meta.annotationsPermissions?.dashboard.canAdd;
     }

--- a/public/app/features/teams/TeamPages.tsx
+++ b/public/app/features/teams/TeamPages.tsx
@@ -42,7 +42,7 @@ function mapStateToProps(state: StoreState, props: OwnProps) {
   const team = getTeam(state.team, teamId);
   let defaultPage = 'members';
   if (contextSrv.accessControlEnabled()) {
-    // With FGAC the settings page will always be available
+    // With RBAC the settings page will always be available
     if (!team || !contextSrv.hasPermissionInMetadata(AccessControlAction.ActionTeamsPermissionsRead, team)) {
       defaultPage = 'settings';
     }

--- a/public/app/features/teams/state/navModel.ts
+++ b/public/app/features/teams/state/navModel.ts
@@ -24,7 +24,7 @@ export function buildNavModel(team: Team): NavModelItem {
     text: team.name,
     breadcrumbs: [{ title: 'Teams', url: 'org/teams' }],
     children: [
-      // With FGAC this tab will always be available (but not always editable)
+      // With RBAC this tab will always be available (but not always editable)
       // With Legacy it will be hidden by hideTabsFromNonTeamAdmin should the user not be allowed to see it
       {
         active: false,
@@ -37,7 +37,7 @@ export function buildNavModel(team: Team): NavModelItem {
   };
 
   // While team is loading we leave the members tab
-  // With FGAC the Members tab is available when user has ActionTeamsPermissionsRead for this team
+  // With RBAC the Members tab is available when user has ActionTeamsPermissionsRead for this team
   // With Legacy it will always be present
   if (
     team === loadingTeam ||
@@ -67,9 +67,9 @@ export function buildNavModel(team: Team): NavModelItem {
       ProBadge({ experimentId: isLoadingTeam ? '' : 'feature-highlights-team-sync-badge', eventVariant: 'trial' });
   }
 
-  // With both Legacy and FGAC the tab is protected being featureEnabled
+  // With both Legacy and RBAC the tab is protected being featureEnabled
   // While team is loading we leave the teamsync tab
-  // With FGAC the External Group Sync tab is available when user has ActionTeamsPermissionsRead for this team
+  // With RBAC the External Group Sync tab is available when user has ActionTeamsPermissionsRead for this team
   if (featureEnabled('teamsync')) {
     if (isLoadingTeam || contextSrv.hasPermissionInMetadata(AccessControlAction.ActionTeamsPermissionsRead, team)) {
       navModel.children!.push(teamGroupSync);


### PR DESCRIPTION
**What this PR does / why we need it**:

We are renaming fine-grained access control to role-based access control.

This PR update the codebase to replace the FGAC usage with RBAC. The package is called `accesscontrol`, so we have minimum changes to do.
