### PR TITLE
CI: Add `yarn-install` step when publishing npm packages

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3068,6 +3068,12 @@ steps:
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
 - commands:
+  - yarn install --immutable
+  depends_on:
+  - grabpl
+  image: grafana/build-container:1.5.4
+  name: yarn-install
+- commands:
   - ./bin/grabpl artifacts npm retrieve --tag v${TAG}
   depends_on:
   - grabpl
@@ -4530,6 +4536,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: aea46d49d8ad417e04e7b6bc48a7a02affb1b53a1048d0970d4ec7a0d9858eaf
+hmac: 9380beb722ab1276e9219ae41fa07c84db1e7dc249f69e42386f868c026e1795
 
 ...

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -423,6 +423,7 @@ def publish_npm_pipelines(mode):
     }
     steps = [
         download_grabpl_step(),
+        yarn_install_step(),
         retrieve_npm_packages_step(),
         release_npm_packages_step()
     ]


### PR DESCRIPTION
**What this PR does / why we need it**:

`initialize` step has been removed now, and split to `wire-install`, `yarn-install` and `gen-version`.

npm packages publishing step needs `yarn-install` for the commands inside `package.json` to be generated.