### PR TITLE
Loki: send metadata requests through backend

### DIFF
--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -25,7 +25,7 @@ func newLokiAPI(client *http.Client, url string, log log.Logger) *LokiAPI {
 	return &LokiAPI{client: client, url: url, log: log}
 }
 
-func makeRequest(ctx context.Context, lokiDsUrl string, query lokiQuery) (*http.Request, error) {
+func makeDataRequest(ctx context.Context, lokiDsUrl string, query lokiQuery) (*http.Request, error) {
 	qs := url.Values{}
 	qs.Set("query", query.Expr)
 
@@ -135,8 +135,8 @@ func makeLokiError(body io.ReadCloser) error {
 	return fmt.Errorf("%v", errorMessage)
 }
 
-func (api *LokiAPI) Query(ctx context.Context, query lokiQuery) (*loghttp.QueryResponse, error) {
-	req, err := makeRequest(ctx, api.url, query)
+func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery) (*loghttp.QueryResponse, error) {
+	req, err := makeDataRequest(ctx, api.url, query)
 	if err != nil {
 		return nil, err
 	}
@@ -163,4 +163,42 @@ func (api *LokiAPI) Query(ctx context.Context, query lokiQuery) (*loghttp.QueryR
 	}
 
 	return &response, nil
+}
+
+func makeRawRequest(ctx context.Context, lokiDsUrl string, resourceURL string) (*http.Request, error) {
+	lokiUrl, err := url.Parse(lokiDsUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := lokiUrl.Parse(resourceURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.NewRequestWithContext(ctx, "GET", url.String(), nil)
+}
+
+func (api *LokiAPI) RawQuery(ctx context.Context, resourceURL string) ([]byte, error) {
+	req, err := makeRawRequest(ctx, api.url, resourceURL)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := api.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			api.log.Warn("Failed to close response body", "err", err)
+		}
+	}()
+
+	if resp.StatusCode/100 != 2 {
+		return nil, makeLokiError(resp.Body)
+	}
+
+	return io.ReadAll(resp.Body)
 }

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -438,8 +438,13 @@ export class LokiDatasource
   }
 
   async metadataRequest(url: string, params?: Record<string, string | number>) {
-    const res = await lastValueFrom(this._request(url, params, { hideFromInspector: true }));
-    return res.data.data || res.data.values || [];
+    if (config.featureToggles.lokiBackendMode) {
+      const res = await this.getResource(url, params);
+      return res.data || res.values || [];
+    } else {
+      const res = await lastValueFrom(this._request(url, params, { hideFromInspector: true }));
+      return res.data.data || res.data.values || [];
+    }
   }
 
   async metricFindQuery(query: string) {


### PR DESCRIPTION
as part of the migrate the Loki datasource to be a backend-data-source, this pull request moves the "get metadata from Loki" functionality to be backend bases. it uses the "resource"-functionality offered by the datasource API.

how to test:
1. make sure it works without backend-mode:
   - make sure backend-mode is disabled
   - use things that use the metadata-api and make sure they work:
       - logs-browser
       - variable-query-editor in the dashboard
2. check if it works with backend-mode:
   - make sure backend-mode is enabled
   - use things that use the metadata-api and make sure they work:
       - logs-browser
       - variable-query-editor in the dashboard
