### PR TITLE
Annotations: Fixes data source showing as a uid in annotation settings

### DIFF
--- a/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsList.tsx
+++ b/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsList.tsx
@@ -4,6 +4,7 @@ import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
 import { DashboardModel } from '../../state/DashboardModel';
 import { ListNewButton } from '../DashboardSettings/ListNewButton';
 import { arrayUtils } from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
 
 type Props = {
   dashboard: DashboardModel;
@@ -26,6 +27,7 @@ export const AnnotationSettingsList: React.FC<Props> = ({ dashboard, onNew, onEd
 
   const showEmptyListCTA = annotations.length === 0 || (annotations.length === 1 && annotations[0].builtIn);
 
+  const dataSourceSrv = getDataSourceSrv();
   return (
     <VerticalGroup>
       {annotations.length > 0 && (
@@ -50,7 +52,7 @@ export const AnnotationSettingsList: React.FC<Props> = ({ dashboard, onNew, onEd
                   </td>
                 )}
                 <td className="pointer" onClick={() => onEdit(idx)}>
-                  {annotation.datasource?.uid}
+                  {dataSourceSrv.getInstanceSettings(annotation.datasource)?.name || annotation.datasource?.uid}
                 </td>
                 <td style={{ width: '1%' }}>
                   {idx !== 0 && (

--- a/public/app/features/dashboard/components/DashboardSettings/AnnotationsSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/AnnotationsSettings.test.tsx
@@ -15,7 +15,7 @@ describe('AnnotationsSettings', () => {
     grafana: mockDataSource(
       {
         name: 'Grafana',
-        uid: 'Grafana',
+        uid: 'uid1',
         type: 'grafana',
         isDefault: true,
       },
@@ -24,7 +24,7 @@ describe('AnnotationsSettings', () => {
     Testdata: mockDataSource(
       {
         name: 'Testdata',
-        uid: 'Testdata',
+        uid: 'uid2',
         type: 'testdata',
         isDefault: true,
       },
@@ -33,7 +33,7 @@ describe('AnnotationsSettings', () => {
     Prometheus: mockDataSource(
       {
         name: 'Prometheus',
-        uid: 'Prometheus',
+        uid: 'uid3',
         type: 'prometheus',
       },
       { annotations: true }
@@ -63,7 +63,7 @@ describe('AnnotationsSettings', () => {
         list: [
           {
             builtIn: 1,
-            datasource: { uid: 'Grafana', type: 'grafana' },
+            datasource: { uid: 'uid1', type: 'grafana' },
             enable: true,
             hide: true,
             iconColor: 'rgba(0, 211, 255, 1)',
@@ -120,12 +120,12 @@ describe('AnnotationsSettings', () => {
     ).toBeInTheDocument();
   });
 
-  test('it renders a sortable table of annotations', async () => {
+  test('it renders the anotation names or uid if annotation doesnt exist', async () => {
     const annotationsList = [
       ...dashboard.annotations.list,
       {
         builtIn: 0,
-        datasource: { uid: 'Prometheus', type: 'prometheus' },
+        datasource: { uid: 'uid3', type: 'prometheus' },
         enable: true,
         hide: true,
         iconColor: 'rgba(0, 211, 255, 1)',
@@ -134,7 +134,41 @@ describe('AnnotationsSettings', () => {
       },
       {
         builtIn: 0,
-        datasource: { uid: 'Prometheus', type: 'prometheus' },
+        datasource: { uid: 'deletedAnnotationId', type: 'prometheus' },
+        enable: true,
+        hide: true,
+        iconColor: 'rgba(0, 211, 255, 1)',
+        name: 'Annotation 2',
+        type: 'dashboard',
+      },
+    ];
+    const dashboardWithAnnotations = {
+      ...dashboard,
+      annotations: {
+        list: [...annotationsList],
+      },
+    };
+    render(<AnnotationsSettings dashboard={dashboardWithAnnotations} />);
+    // Check that we have the correct annotations
+    expect(screen.queryByText(/prometheus/i)).toBeInTheDocument();
+    expect(screen.queryByText(/deletedAnnotationId/i)).toBeInTheDocument();
+  });
+
+  test('it renders a sortable table of annotations', async () => {
+    const annotationsList = [
+      ...dashboard.annotations.list,
+      {
+        builtIn: 0,
+        datasource: { uid: 'uid3', type: 'prometheus' },
+        enable: true,
+        hide: true,
+        iconColor: 'rgba(0, 211, 255, 1)',
+        name: 'Annotation 2',
+        type: 'dashboard',
+      },
+      {
+        builtIn: 0,
+        datasource: { uid: 'uid3', type: 'prometheus' },
         enable: true,
         hide: true,
         iconColor: 'rgba(0, 211, 255, 1)',


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously on Dashboard Settings > Annotations, we were showing the data sources as a uid, this PR changes that to retrieve the name of that data source and show it, if it can't be found, stick to showing uid.

| Before | After |
| --- | --- |
| <img width="720" alt="Screenshot 2022-04-21 at 16 27 38" src="https://user-images.githubusercontent.com/100691367/164493554-0e402dd1-e28c-48b0-a5d8-806197c923e7.png"> | <img width="715" alt="Screenshot 2022-04-21 at 16 27 18" src="https://user-images.githubusercontent.com/100691367/164493631-1843b26b-2890-4fcd-82b1-c48f4b9132f0.png"> |


**Which issue(s) this PR fixes**:

Fixes #48048
