### PR TITLE
Templating: Expose more informative action names for keyed actions

### DIFF
--- a/public/app/features/variables/editor/actions.test.ts
+++ b/public/app/features/variables/editor/actions.test.ts
@@ -56,8 +56,15 @@ describe('switchToListMode', () => {
     const mockDispatch = jest.fn();
 
     switchToListMode(null)(mockDispatch, mockGetState, undefined);
+    const keyedAction = {
+      type: expect.any(String),
+      payload: {
+        key: 'null',
+        action: expect.any(Object),
+      },
+    };
     expect(mockDispatch).toHaveBeenCalledTimes(2);
-    expect(mockDispatch.mock.calls[0][0]).toEqual(toKeyedAction('null', expect.any(Object)));
-    expect(mockDispatch.mock.calls[1][0]).toEqual(toKeyedAction('null', expect.any(Object)));
+    expect(mockDispatch.mock.calls[0][0]).toMatchObject(keyedAction);
+    expect(mockDispatch.mock.calls[1][0]).toMatchObject(keyedAction);
   });
 });

--- a/public/app/features/variables/state/keyedVariablesReducer.ts
+++ b/public/app/features/variables/state/keyedVariablesReducer.ts
@@ -1,5 +1,5 @@
 import { AnyAction } from 'redux';
-import { createAction, PayloadAction } from '@reduxjs/toolkit';
+import { PayloadAction } from '@reduxjs/toolkit';
 import { getTemplatingReducers, TemplatingState } from './reducers';
 import { variablesInitTransaction } from './transactionReducer';
 import { toStateKey } from '../utils';
@@ -16,15 +16,27 @@ export interface KeyedAction {
   action: PayloadAction<any>;
 }
 
-const keyedAction = createAction<KeyedAction>('templating/keyedAction');
+const keyedAction = (payload: KeyedAction) => ({
+  type: `templating/keyed/${payload.action.type.replace(/^templating\//, '')}`,
+  payload,
+});
 
 export function toKeyedAction(key: string, action: PayloadAction<any>): PayloadAction<KeyedAction> {
   const keyAsString = toStateKey(key);
   return keyedAction({ key: keyAsString, action });
 }
 
+const isKeyedAction = (action: AnyAction): action is PayloadAction<KeyedAction> => {
+  return (
+    typeof action.type === 'string' &&
+    action.type.startsWith('templating/keyed') &&
+    'payload' in action &&
+    typeof action.payload.key === 'string'
+  );
+};
+
 export function keyedVariablesReducer(state = initialKeyedVariablesState, outerAction: AnyAction): KeyedVariablesState {
-  if (keyedAction.match(outerAction)) {
+  if (isKeyedAction(outerAction)) {
     const { key, action } = outerAction.payload;
     const stringKey = toStateKey(key);
     const lastKey = variablesInitTransaction.match(action) ? stringKey : state.lastKey;


### PR DESCRIPTION
**What this PR does / why we need it**:
Appends the inner action name to the top-level keyed variables action, providing easier debugging in tools like redux devtools.
