### PR TITLE
Adds replace directive for tidwall/gjson

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -295,6 +295,8 @@ replace github.com/hashicorp/consul => github.com/hashicorp/consul v1.10.2
 
 replace github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.7
 
+replace github.com/tidwall/gjson => github.com/tidwall/gjson v1.6.4
+
 // Upgraded to fix CVE-2020-26066. This can be removed when go.opentelemetry.io/collector and github.com/influxdata/telegraf are upgraded
 // github.com/tidwall/match v1.0.1 should not be used.
 replace github.com/tidwall/match => github.com/tidwall/match v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -295,7 +295,7 @@ replace github.com/hashicorp/consul => github.com/hashicorp/consul v1.10.2
 
 replace github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.7
 
-replace github.com/tidwall/gjson => github.com/tidwall/gjson v1.6.4
+replace github.com/tidwall/gjson => github.com/tidwall/gjson v1.14.1
 
 // Upgraded to fix CVE-2020-26066. This can be removed when go.opentelemetry.io/collector and github.com/influxdata/telegraf are upgraded
 // github.com/tidwall/match v1.0.1 should not be used.


### PR DESCRIPTION
**What this PR does / why we need it**:

`tidwall/gjson` is not present in the binary. So added a replace directive in case someone decides to use it.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-enterprise-mirror-shared-microsoft/issues/58

