### PR TITLE
AzureMonitor: Remove workaround in Logs editor

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/azure_log_analytics_datasource.test.ts
@@ -137,10 +137,7 @@ describe('AzureLogAnalyticsDatasource', () => {
 
     it('should include template variables as global parameters', async () => {
       const result = await ctx.ds.azureLogAnalyticsDatasource.getKustoSchema('myWorkspace');
-      expect(result.globalParameters.map((f: { name: string }) => f.name)).toEqual([
-        `$${singleVariable.name}`,
-        '$__timeFilter',
-      ]);
+      expect(result.globalParameters.map((f: { name: string }) => f.name)).toEqual([`$${singleVariable.name}`]);
     });
   });
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/response_parser.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_log_analytics/response_parser.ts
@@ -235,8 +235,8 @@ export function transformMetadataToKustoSchema(
         {
           name: 'timeColumn',
           type: 'System.String',
-          defaultValue: 'TimeGenerated',
-          cslDefaultValue: 'TimeGenerated',
+          defaultValue: '""',
+          cslDefaultValue: '""',
         },
       ],
     },
@@ -288,15 +288,6 @@ export function transformMetadataToKustoSchema(
       name: `$${v.name}`,
       type: 'dynamic',
     };
-  });
-
-  // It's not possible to define optional paramaters in Kusto
-  // and it's not possible to define the same function twice so
-  // we are defining $__timeFilter also as a parameter when used
-  // with no arguments as a workaround
-  globalParameters.push({
-    name: `$__timeFilter`,
-    type: 'boolean',
   });
 
   return {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Fixes the $__timeFilter syntax in the query editor so it can be used with an argument or none (it was an error with the default value definition).

![Screenshot from 2022-04-22 11-58-55](https://user-images.githubusercontent.com/4025665/164684220-4aba0b4f-4905-4472-a727-9f8cf60367d5.png)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

