### PR TITLE
Alerting: fix alert creation interval layout bug

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaConditionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaConditionsStep.tsx
@@ -57,7 +57,10 @@ export const GrafanaConditionsStep: FC = () => {
   return (
     <RuleEditorSection stepNo={3} title="Define alert conditions">
       <ConditionField />
-      <Field label="Evaluate">
+      <Field
+        label="Evaluate"
+        description="Evaluation interval applies to every rule within a group. It can overwrite the interval of an existing alert rule."
+      >
         <div className={styles.flexRow}>
           <InlineLabel
             htmlFor={evaluateEveryId}
@@ -66,12 +69,7 @@ export const GrafanaConditionsStep: FC = () => {
           >
             Evaluate every
           </InlineLabel>
-          <Field
-            label="Evaluate"
-            description="Evaluation internal applies to every rule within a group. It can overwrite the interval of an existing alert rule."
-          >
-            <Input id={evaluateEveryId} width={8} {...register('evaluateEvery', evaluateEveryValidationOptions)} />
-          </Field>
+          <Input id={evaluateEveryId} width={8} {...register('evaluateEvery', evaluateEveryValidationOptions)} />
           <InlineLabel
             htmlFor={evaluateForId}
             width={7}


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a small layout bug in the alert creation flow.

**Before**
<img width="822" alt="Screenshot 2022-04-22 at 14 15 26" src="https://user-images.githubusercontent.com/868844/164712814-c3d8eae5-0c5a-4d05-8b63-a33d1e1f3e5a.png">

**After**
<img width="583" alt="Screenshot 2022-04-22 at 14 15 36" src="https://user-images.githubusercontent.com/868844/164712828-fb2edc7c-afa6-4bae-b794-b01d8785a3e2.png">

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

