### PR TITLE
Alerting: Add Silenced filter

### DIFF
--- a/public/app/features/alerting/unified/components/StateColoredText.tsx
+++ b/public/app/features/alerting/unified/components/StateColoredText.tsx
@@ -24,6 +24,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
   [PromAlertingRuleState.Firing]: css`
     color: ${theme.colors.error.text};
   `,
+  [PromAlertingRuleState.Silenced]: css`
+    color: ${theme.colors.text.secondary};
+  `,
   neutral: css`
     color: ${theme.colors.text.secondary};
   `,

--- a/public/app/features/alerting/unified/components/StateTag.tsx
+++ b/public/app/features/alerting/unified/components/StateTag.tsx
@@ -3,7 +3,7 @@ import { useStyles2 } from '@grafana/ui';
 import { css, cx } from '@emotion/css';
 import React, { FC } from 'react';
 
-export type State = 'good' | 'bad' | 'warning' | 'neutral' | 'info';
+export type State = 'good' | 'bad' | 'warning' | 'neutral' | 'info' | 'silenced';
 
 type Props = {
   state: State;

--- a/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListStateView.tsx
@@ -17,7 +17,7 @@ export const RuleListStateView: FC<Props> = ({ namespaces }) => {
   const filters = getFiltersFromUrlParams(useQueryParams()[0]);
 
   const groupedRules = useMemo(() => {
-    const result: GroupedRules = {
+    const result: Omit<GroupedRules, PromAlertingRuleState.Silenced> = {
       [PromAlertingRuleState.Firing]: [],
       [PromAlertingRuleState.Inactive]: [],
       [PromAlertingRuleState.Pending]: [],
@@ -26,7 +26,11 @@ export const RuleListStateView: FC<Props> = ({ namespaces }) => {
     namespaces.forEach((namespace) =>
       namespace.groups.forEach((group) =>
         group.rules.forEach((rule) => {
-          if (rule.promRule && isAlertingRule(rule.promRule)) {
+          if (
+            rule.promRule &&
+            isAlertingRule(rule.promRule) &&
+            rule.promRule.state !== PromAlertingRuleState.Silenced
+          ) {
             result[rule.promRule.state].push(rule);
           }
         })

--- a/public/app/features/alerting/unified/components/rules/RuleStats.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleStats.tsx
@@ -25,7 +25,7 @@ export const RuleStats: FC<Props> = ({ showInactive, showRecording, group, names
   const calculated = useMemo(() => {
     const stats = { ...emptyStats };
     const calcRule = (rule: CombinedRule) => {
-      if (rule.promRule && isAlertingRule(rule.promRule)) {
+      if (rule.promRule && isAlertingRule(rule.promRule) && rule.promRule.state !== PromAlertingRuleState.Silenced) {
         stats[rule.promRule.state] += 1;
       }
       if (rule.promRule?.health === 'err' || rule.promRule?.health === 'error') {

--- a/public/app/features/alerting/unified/utils/rules.ts
+++ b/public/app/features/alerting/unified/utils/rules.ts
@@ -101,6 +101,7 @@ export const alertStateToState: Record<PromAlertingRuleState | GrafanaAlertState
   [AlertState.OK]: 'good',
   [AlertState.Pending]: 'warning',
   [AlertState.Unknown]: 'info',
+  [PromAlertingRuleState.Silenced]: 'silenced',
 };
 
 export function getFirstActiveAt(promRule: AlertingRule) {

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -113,7 +113,8 @@ function filterRules(options: PanelProps<UnifiedAlertListOptions>['options'], ru
       return (
         (options.stateFilter.firing && rule.rule.state === PromAlertingRuleState.Firing) ||
         (options.stateFilter.pending && rule.rule.state === PromAlertingRuleState.Pending) ||
-        (options.stateFilter.inactive && rule.rule.state === PromAlertingRuleState.Inactive)
+        (options.stateFilter.inactive && rule.rule.state === PromAlertingRuleState.Inactive) ||
+        (options.stateFilter.silenced && rule.rule.state === PromAlertingRuleState.Silenced)
       );
     });
   }

--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -301,6 +301,12 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
       name: 'Error',
       defaultValue: true,
       category: ['Alert state filter'],
+    })
+    .addBooleanSwitch({
+      path: 'stateFilter.silenced',
+      name: 'Silenced',
+      defaultValue: false,
+      category: ['Alert state filter'],
     });
 });
 

--- a/public/app/plugins/panel/alertlist/types.ts
+++ b/public/app/plugins/panel/alertlist/types.ts
@@ -44,6 +44,7 @@ interface StateFilter {
   noData: boolean;
   normal: boolean;
   error: boolean;
+  silenced: boolean;
 }
 
 export interface UnifiedAlertListOptions {

--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -9,6 +9,7 @@ export enum PromAlertingRuleState {
   Firing = 'firing',
   Inactive = 'inactive',
   Pending = 'pending',
+  Silenced = 'silenced',
 }
 
 export enum GrafanaAlertState {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the ability to filter silenced alert rules in the Alertlist panel

**Which issue(s) this PR fixes**:


Fixes #43855 

**Special notes for your reviewer**:

