### PR TITLE
Bug fix: fix argument ordering

### DIFF
--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -52,7 +52,7 @@ func (hs *HTTPServer) GetFolderByID(c *models.ReqContext) response.Response {
 	if err != nil {
 		return response.Error(http.StatusBadRequest, "id is invalid", err)
 	}
-	folder, err := hs.folderService.GetFolderByID(c.Req.Context(), c.SignedInUser, c.OrgId, id)
+	folder, err := hs.folderService.GetFolderByID(c.Req.Context(), c.SignedInUser, id, c.OrgId)
 	if err != nil {
 		return apierrors.ToFolderErrorResponse(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

[GetFolderByID](https://github.com/grafana/grafana/blob/main/pkg/services/dashboards/manager/folder_service.go#L79) is expecting arguments in this order: `GetFolderByID(ctx context.Context, user *models.SignedInUser, id int64, orgID int64)`, but they’re being passed in in this order: `folder, err := hs.folderService.GetFolderByID(c.Req.Context(), c.SignedInUser, c.OrgId, id)` by the endpoint handler. Thus searching for folders by ID fails with `folder not found`.

[Relevant Slack conversation](https://raintank-corp.slack.com/archives/C036J5B39/p1650626746105709).