### PR TITLE
Update grafana/experimental and fix Cloudwatch components

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "@grafana/aws-sdk": "0.0.35",
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
-    "@grafana/experimental": "^0.0.2-canary.25",
+    "@grafana/experimental": "^0.0.2-canary.30",
     "@grafana/google-sdk": "0.0.3",
     "@grafana/lezer-logql": "^0.0.11",
     "@grafana/runtime": "workspace:*",

--- a/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor.tsx
@@ -1,8 +1,8 @@
 import React, { ChangeEvent } from 'react';
 
 import { PanelData } from '@grafana/data';
-import { EditorField, EditorHeader, EditorRow, InlineSelect, Space } from '@grafana/experimental';
-import { Input, Switch } from '@grafana/ui';
+import { EditorField, EditorHeader, EditorRow, EditorSwitch, InlineSelect, Space } from '@grafana/experimental';
+import { Input } from '@grafana/ui';
 
 import { CloudWatchDatasource } from '../datasource';
 import { useRegions } from '../hooks';
@@ -52,7 +52,7 @@ export function AnnotationQueryEditor(props: React.PropsWithChildren<Props>) {
           />
         </EditorField>
         <EditorField label="Enable Prefix Matching" optional={true}>
-          <Switch
+          <EditorSwitch
             value={query.prefixMatching}
             onChange={(e) => {
               onChange({
@@ -62,18 +62,16 @@ export function AnnotationQueryEditor(props: React.PropsWithChildren<Props>) {
             }}
           />
         </EditorField>
-        <EditorField label="Action" optional={true}>
+        <EditorField label="Action" optional={true} disabled={!query.prefixMatching}>
           <Input
-            disabled={!query.prefixMatching}
             value={query.actionPrefix || ''}
             onChange={(event: ChangeEvent<HTMLInputElement>) =>
               onChange({ ...query, actionPrefix: event.target.value })
             }
           />
         </EditorField>
-        <EditorField label="Alarm Name" optional={true}>
+        <EditorField label="Alarm Name" optional={true} disabled={!query.prefixMatching}>
           <Input
-            disabled={!query.prefixMatching}
             value={query.alarmNamePrefix || ''}
             onChange={(event: ChangeEvent<HTMLInputElement>) =>
               onChange({ ...query, alarmNamePrefix: event.target.value })

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { EditorField, EditorFieldGroup, EditorRow, EditorRows } from '@grafana/experimental';
-import { Select, Switch } from '@grafana/ui';
+import { EditorField, EditorFieldGroup, EditorRow, EditorRows, EditorSwitch } from '@grafana/experimental';
+import { Select } from '@grafana/ui';
 
 import { Dimensions } from '..';
 import { CloudWatchDatasource } from '../../datasource';
@@ -128,7 +128,7 @@ export function MetricStatEditor({
             optional={true}
             tooltip="Only show metrics that exactly match all defined dimension names."
           >
-            <Switch
+            <EditorSwitch
               id={`${query.refId}-cloudwatch-match-exact`}
               value={!!query.matchExact}
               onChange={(e) => {

--- a/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor.tsx
@@ -147,6 +147,7 @@ export class MetricsQueryEditor extends PureComponent<Props, State> {
             width={26}
             optional
             tooltip="ID can be used to reference other queries in math expressions. The ID can include numbers, letters, and underscore, and must start with a lowercase letter."
+            invalid={!!query.id && !/^$|^[a-z][a-zA-Z0-9_]*$/.test(query.id)}
           >
             <Input
               id={`${query.refId}-cloudwatch-metric-query-editor-id`}
@@ -155,7 +156,6 @@ export class MetricsQueryEditor extends PureComponent<Props, State> {
                 this.onChange({ ...metricsQuery, id: event.target.value })
               }
               type="text"
-              invalid={!!query.id && !/^$|^[a-z][a-zA-Z0-9_]*$/.test(query.id)}
               value={query.id}
             />
           </EditorField>

--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLBuilderSelectRow.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useMemo } from 'react';
 
 import { SelectableValue, toOption } from '@grafana/data';
-import { EditorField, EditorFieldGroup } from '@grafana/experimental';
-import { Select, Switch } from '@grafana/ui';
+import { EditorField, EditorFieldGroup, EditorSwitch } from '@grafana/experimental';
+import { Select } from '@grafana/ui';
 
 import { STATISTICS } from '../../cloudwatch-sql/language';
 import { CloudWatchDatasource } from '../../datasource';
@@ -87,7 +87,7 @@ const SQLBuilderSelectRow: React.FC<SQLBuilderSelectRowProps> = ({ datasource, q
         </EditorField>
 
         <EditorField label="With schema">
-          <Switch
+          <EditorSwitch
             id={`${query.refId}-cloudwatch-sql-withSchema`}
             value={withSchemaEnabled}
             onChange={(ev) =>
@@ -97,12 +97,11 @@ const SQLBuilderSelectRow: React.FC<SQLBuilderSelectRowProps> = ({ datasource, q
         </EditorField>
 
         {withSchemaEnabled && (
-          <EditorField label="Schema labels">
+          <EditorField label="Schema labels" disabled={!namespace}>
             <Select
               id={`${query.refId}-cloudwatch-sql-schema-label-keys`}
               width="auto"
               isMulti={true}
-              disabled={!namespace}
               value={schemaLabels ? schemaLabels.map(toOption) : null}
               options={dimensionKeys}
               allowCustomValue

--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLOrderByGroup.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLOrderByGroup.tsx
@@ -1,8 +1,7 @@
-import { css } from '@emotion/css';
 import React from 'react';
 
 import { SelectableValue, toOption } from '@grafana/data';
-import { AccessoryButton, EditorField, EditorFieldGroup } from '@grafana/experimental';
+import { AccessoryButton, EditorField, EditorFieldGroup, InputGroup } from '@grafana/experimental';
 import { Select } from '@grafana/ui';
 
 import { ASC, DESC, STATISTICS } from '../../cloudwatch-sql/language';
@@ -31,11 +30,7 @@ const SQLOrderByGroup: React.FC<SQLBuilderSelectRowProps> = ({ query, onQueryCha
   return (
     <EditorFieldGroup>
       <EditorField label="Order by" optional width={16}>
-        <div
-          className={css`
-            display: flex;
-          `}
-        >
+        <InputGroup>
           <Select
             aria-label="Order by"
             onChange={({ value }) => value && onQueryChange(setOrderBy(query, value))}
@@ -51,7 +46,7 @@ const SQLOrderByGroup: React.FC<SQLBuilderSelectRowProps> = ({ query, onQueryCha
               onClick={() => onQueryChange(setSql(query, { orderBy: undefined }))}
             />
           )}
-        </div>
+        </InputGroup>
       </EditorField>
 
       <EditorField label="Direction" disabled={!orderBy} width={16}>

--- a/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLOrderByGroup.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/SQLBuilderEditor/SQLOrderByGroup.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/css';
 import React from 'react';
 
 import { SelectableValue, toOption } from '@grafana/data';
@@ -30,7 +31,11 @@ const SQLOrderByGroup: React.FC<SQLBuilderSelectRowProps> = ({ query, onQueryCha
   return (
     <EditorFieldGroup>
       <EditorField label="Order by" optional width={16}>
-        <>
+        <div
+          className={css`
+            display: flex;
+          `}
+        >
           <Select
             aria-label="Order by"
             onChange={({ value }) => value && onQueryChange(setOrderBy(query, value))}
@@ -46,14 +51,13 @@ const SQLOrderByGroup: React.FC<SQLBuilderSelectRowProps> = ({ query, onQueryCha
               onClick={() => onQueryChange(setSql(query, { orderBy: undefined }))}
             />
           )}
-        </>
+        </div>
       </EditorField>
 
-      <EditorField label="Direction" width={16}>
+      <EditorField label="Direction" disabled={!orderBy} width={16}>
         <Select
           aria-label="Direction"
           inputId="cloudwatch-sql-order-by-direction"
-          disabled={!orderBy}
           value={orderByDirection ? toOption(orderByDirection) : orderByDirections[0]}
           options={appendTemplateVariables(datasource, orderByDirections)}
           onChange={(item) => item && onQueryChange(setSql(query, { orderByDirection: item.value }))}

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.tsx
@@ -1,8 +1,8 @@
 import React, { SyntheticEvent } from 'react';
 
 import { CoreApp, SelectableValue } from '@grafana/data';
-import { EditorRow, EditorField } from '@grafana/experimental';
-import { RadioButtonGroup, Select, Switch } from '@grafana/ui';
+import { EditorRow, EditorField, EditorSwitch } from '@grafana/experimental';
+import { RadioButtonGroup, Select } from '@grafana/ui';
 
 import { getQueryTypeChangeHandler, getQueryTypeOptions } from '../../components/PromExploreExtraField';
 import { FORMAT_OPTIONS, INTERVAL_FACTOR_OPTIONS } from '../../components/PromQueryEditor';
@@ -82,7 +82,7 @@ export const PromQueryBuilderOptions = React.memo<Props>(({ query, app, onChange
         </EditorField>
         {shouldShowExemplarSwitch(query, app) && (
           <EditorField label="Exemplars">
-            <Switch value={query.exemplar} onChange={onExemplarChange} />
+            <EditorSwitch value={query.exemplar} onChange={onExemplarChange} />
           </EditorField>
         )}
         {query.intervalFactor && query.intervalFactor > 1 && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -4135,9 +4135,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/experimental@npm:^0.0.2-canary.25":
-  version: 0.0.2-canary.25
-  resolution: "@grafana/experimental@npm:0.0.2-canary.25"
+"@grafana/experimental@npm:^0.0.2-canary.30":
+  version: 0.0.2-canary.30
+  resolution: "@grafana/experimental@npm:0.0.2-canary.30"
   dependencies:
     "@types/uuid": ^8.3.3
     uuid: ^8.3.2
@@ -4145,7 +4145,7 @@ __metadata:
     "@emotion/css": 11.1.3
     react: 17.0.1
     react-select: 5.2.1
-  checksum: 20532d6a1ff1bb7a98db71728bc34474f87663431fef349a53f4673d12b6356336b9250bc85028693e7bbfeec8e468d9910837f4062cb49239d581dc974c55c9
+  checksum: b5b453b9372cde8f89021c50ae1191a2506ebbb069ad6331d22a5c7267ecd8c0db7f9f5fdd9cfab49fafce4e0b6809609e67449b78fe3ccc63cedfeceb64b911
   languageName: node
   linkType: hard
 
@@ -20530,7 +20530,7 @@ __metadata:
     "@grafana/e2e": "workspace:*"
     "@grafana/e2e-selectors": "workspace:*"
     "@grafana/eslint-config": 3.0.0
-    "@grafana/experimental": ^0.0.2-canary.25
+    "@grafana/experimental": ^0.0.2-canary.30
     "@grafana/google-sdk": 0.0.3
     "@grafana/lezer-logql": ^0.0.11
     "@grafana/runtime": "workspace:*"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is related to https://github.com/grafana/grafana-experimental/pull/30/files where we extracted styling for Switch to separate component. This way, `EditorField` component works correctly and doesn't encounter the issue described and discussed in https://raintank-corp.slack.com/archives/CHKLEJ668/p1650617120848589.

For grafana repo it means, that we have to :
1. Update `Switch` inside `EditorField` to `EditorSwitch`
2. For `Remove Order by` button create `InputGroup`
  now: 
  
  <img width="507" alt="image" src="https://user-images.githubusercontent.com/30407135/164743677-0019f1ef-a9e8-4289-801d-dd014288f7f7.png">

  before: 
  
<img width="369" alt="image" src="https://user-images.githubusercontent.com/30407135/164743780-261dd4ea-8d67-4048-a80f-97f8f1a3c461.png">

3. Last thing is related to how `Field` (underlying  component for `EditorField`) works. We need to pass `disabled/loading/invalid` params to it instead of component within it (Switch/Input/...), because Field overwrites it in https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/Forms/Field.tsx#L104 as [cloneElement](https://reactjs.org/docs/react-api.html#cloneelement) is almost equivalent to `<element.type {...element.props} {...props}>{children}</element.type>` . I am not sure if this is intended behaviour, but it is how it works and how it is used across Grafana now. I have created this issue https://github.com/grafana/grafana/issues/48131 to open up the topic on not overwriting these params, but it is up to team responsible for UI components to decide on this, as this would be breaking change. 

**Special notes for your reviewer**:

Can you please manually test Cloudwatch editor to make sure there are no other regressions. Thank you! 🙏 

