### PR TITLE
Azure Monitor: Fix space character encoding for metrics query link to Azure Portal

### DIFF
--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -368,6 +368,10 @@ func getQueryUrl(query *types.AzureMonitorQuery, azurePortalUrl string) (string,
 		return "", err
 	}
 	escapedChart := url.QueryEscape(string(chartDef))
+	// Azure Portal will timeout if the chart definition includes a space character encoded as '+'.
+	// url.QueryEscape encodes spaces as '+'.
+	// Note: this will not encode '+' literals as those are already encoded as '%2B' by url.QueryEscape
+	escapedChart = strings.ReplaceAll(escapedChart, "+", "%20")
 
 	return fmt.Sprintf("%s/#blade/Microsoft_Azure_MonitoringMetrics/Metrics.ReactView/Referer/MetricsExplorer/TimeContext/%s/ChartDefinition/%s", azurePortalUrl, escapedTime, escapedChart), nil
 }

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -188,7 +188,7 @@ func TestAzureMonitorBuildQueries(t *testing.T) {
 			expected := `http://ds/#blade/Microsoft_Azure_MonitoringMetrics/Metrics.ReactView/Referer/MetricsExplorer/` +
 				`TimeContext/%7B%22absolute%22%3A%7B%22startTime%22%3A%222018-03-15T13%3A00%3A00Z%22%2C%22endTime%22%3A%222018-03-15T13%3A34%3A00Z%22%7D%7D/` +
 				`ChartDefinition/%7B%22v2charts%22%3A%5B%7B%22metrics%22%3A%5B%7B%22resourceMetadata%22%3A%7B%22id%22%3A%22%2Fsubscriptions%2F12345678-aaaa-bbbb-cccc-123456789abc%2FresourceGroups%2Fgrafanastaging%2Fproviders%2FMicrosoft.Compute%2FvirtualMachines%2Fgrafana%22%7D%2C` +
-				`%22name%22%3A%22Percentage+CPU%22%2C%22aggregationType%22%3A4%2C%22namespace%22%3A%22Microsoft.Compute-virtualMachines%22%2C%22metricVisualization%22%3A%7B%22displayName%22%3A%22Percentage+CPU%22%2C%22resourceDisplayName%22%3A%22grafana%22%7D%7D%5D%7D%5D%7D`
+				`%22name%22%3A%22Percentage%20CPU%22%2C%22aggregationType%22%3A4%2C%22namespace%22%3A%22Microsoft.Compute-virtualMachines%22%2C%22metricVisualization%22%3A%7B%22displayName%22%3A%22Percentage%20CPU%22%2C%22resourceDisplayName%22%3A%22grafana%22%7D%7D%5D%7D%5D%7D`
 			actual, err := getQueryUrl(queries[0], "http://ds")
 			require.NoError(t, err)
 			require.Equal(t, expected, actual)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fixes the encoding of space characters in the generated link to Azure Portal.

If a space character is included in one of the encoded fields, e.g. the metric name is `Percentage CPU`, then it is currently encoded as `Percentage+CPU`. The link results in an error message as shown in the screen shot below.

<img width="2223" alt="Screen shot showing an error message in Azure Portal after clicking on a link including an incorrect encoding of a space character" src="https://user-images.githubusercontent.com/19530599/164773906-f77eb250-601d-40f2-b213-30a463e59774.png">

This PR encodes space characters as `%20` instead of `+`

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
Note: this PR is just taking the fix from https://github.com/grafana/grafana/pull/47947. This was opened to make it easier to backport this fix.

The deep link to Azure Portal is shown when you click on a data point in the panel and click the `View in Azure Portal` link.

<img width="267" alt="Screen Shot 2022-04-20 at 5 04 21 AM" src="https://user-images.githubusercontent.com/19530599/164773131-2f898485-a988-4871-ac00-5c6eeb05611f.png">

