### PR TITLE
AzureMonitor: set resourceUri is empty string when other parameters are changed.

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/setQueryValue.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/setQueryValue.ts
@@ -25,6 +25,7 @@ export function setSubscriptionID(query: AzureMonitorQuery, subscriptionID: stri
     subscription: subscriptionID,
     azureMonitor: {
       ...query.azureMonitor,
+      resourceUri: '',
       resourceGroup: undefined,
       metricDefinition: undefined,
       metricNamespace: undefined,
@@ -46,6 +47,7 @@ export function setResourceGroup(query: AzureMonitorQuery, resourceGroup: string
     ...query,
     azureMonitor: {
       ...query.azureMonitor,
+      resourceUri: '',
       resourceGroup: resourceGroup,
       metricDefinition: undefined,
       metricNamespace: undefined,
@@ -68,6 +70,7 @@ export function setResourceType(query: AzureMonitorQuery, resourceType: string |
     ...query,
     azureMonitor: {
       ...query.azureMonitor,
+      resourceUri: '',
       metricDefinition: resourceType,
       resourceName: undefined,
       metricNamespace: undefined,
@@ -90,6 +93,7 @@ export function setResourceName(query: AzureMonitorQuery, resourceName: string |
     ...query,
     azureMonitor: {
       ...query.azureMonitor,
+      resourceUri: '',
       resourceName: resourceName,
       metricNamespace: undefined,
       metricName: undefined,


### PR DESCRIPTION
**What this PR does / why we need it**:

The resourceUri is not updating when other parameters are changed.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #47979

