### PR TITLE
Dashboards: Display values of 0 with the configured decimal places

### DIFF
--- a/packages/grafana-data/src/valueFormats/valueFormats.test.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.test.ts
@@ -103,6 +103,9 @@ describe('valueFormats', () => {
 
       expect(toFixed(100.4, 2)).toBe('100.40');
       expect(toFixed(100.5, 2)).toBe('100.50');
+
+      expect(toFixed(0, 1)).toBe('0.0');
+      expect(toFixed(0, 2)).toBe('0.00');
     });
   });
 

--- a/packages/grafana-data/src/valueFormats/valueFormats.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.ts
@@ -56,6 +56,10 @@ export function toFixed(value: number, decimals?: DecimalCount): string {
     decimals = getDecimalsForValue(value);
   }
 
+  if (value === 0) {
+    return value.toFixed(decimals);
+  }
+
   const factor = decimals ? Math.pow(10, Math.max(0, decimals)) : 1;
   const formatted = String(Math.round(value * factor) / factor);
 


### PR DESCRIPTION
**What this PR does / why we need it**:
metrics with no value should use decimals for consistent appearance

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #47661
