### PR TITLE
Preferences: Fixes broken preferences after recent merge

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -665,7 +665,7 @@ func (hs *HTTPServer) setIndexViewData(c *models.ReqContext) (*dtos.IndexViewDat
 
 	settings["dateFormats"] = hs.Cfg.DateFormats
 
-	prefsQuery := pref.GetPreferenceWithDefaultsQuery{UserID: c.SignedInUser.UserId}
+	prefsQuery := pref.GetPreferenceWithDefaultsQuery{UserID: c.SignedInUser.UserId, OrgID: c.SignedInUser.OrgId, Teams: c.Teams}
 	prefs, err := hs.preferenceService.GetWithDefaults(c.Req.Context(), &prefsQuery)
 	if err != nil {
 		return nil, err

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -168,12 +168,12 @@ func (hs *HTTPServer) ReqCanAdminTeams(c *models.ReqContext) bool {
 	return c.OrgRole == models.ROLE_ADMIN || (hs.Cfg.EditorsCanAdmin && c.OrgRole == models.ROLE_EDITOR)
 }
 
-func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool) ([]*dtos.NavLink, error) {
+func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool, prefs *pref.Preference) ([]*dtos.NavLink, error) {
 	hasAccess := ac.HasAccess(hs.AccessControl, c)
 	navTree := []*dtos.NavLink{}
 
 	if hs.Features.IsEnabled(featuremgmt.FlagNewNavigation) {
-		savedItemsLinks, err := hs.buildSavedItemsNavLinks(c)
+		savedItemsLinks, err := hs.buildSavedItemsNavLinks(c, prefs)
 		if err != nil {
 			return nil, err
 		}
@@ -411,16 +411,11 @@ func (hs *HTTPServer) addHelpLinks(navTree []*dtos.NavLink, c *models.ReqContext
 	return navTree
 }
 
-func (hs *HTTPServer) buildSavedItemsNavLinks(c *models.ReqContext) ([]*dtos.NavLink, error) {
+func (hs *HTTPServer) buildSavedItemsNavLinks(c *models.ReqContext, prefs *pref.Preference) ([]*dtos.NavLink, error) {
 	savedItemsChildNavs := []*dtos.NavLink{}
 
 	// query preferences table for any saved items
-	prefsQuery := pref.GetPreferenceWithDefaultsQuery{UserID: c.SignedInUser.UserId}
-	preference, err := hs.preferenceService.GetWithDefaults(c.Req.Context(), &prefsQuery)
-	if err != nil {
-		return nil, err
-	}
-	savedItems := preference.JSONData.Navbar.SavedItems
+	savedItems := prefs.JSONData.Navbar.SavedItems
 
 	if len(savedItems) > 0 {
 		for _, savedItem := range savedItems {
@@ -690,7 +685,7 @@ func (hs *HTTPServer) setIndexViewData(c *models.ReqContext) (*dtos.IndexViewDat
 		settings["appSubUrl"] = ""
 	}
 
-	navTree, err := hs.getNavTree(c, hasEditPerm)
+	navTree, err := hs.getNavTree(c, hasEditPerm, prefs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -665,7 +665,7 @@ func (hs *HTTPServer) setIndexViewData(c *models.ReqContext) (*dtos.IndexViewDat
 
 	settings["dateFormats"] = hs.Cfg.DateFormats
 
-	prefsQuery := pref.GetPreferenceWithDefaultsQuery{UserID: c.SignedInUser.UserId, OrgID: c.SignedInUser.OrgId, Teams: c.Teams}
+	prefsQuery := pref.GetPreferenceWithDefaultsQuery{UserID: c.UserId, OrgID: c.OrgId, Teams: c.Teams}
 	prefs, err := hs.preferenceService.GetWithDefaults(c.Req.Context(), &prefsQuery)
 	if err != nil {
 		return nil, err

--- a/pkg/services/preference/prefimpl/pref.go
+++ b/pkg/services/preference/prefimpl/pref.go
@@ -34,6 +34,7 @@ func (s *Service) GetWithDefaults(ctx context.Context, query *pref.GetPreference
 	if err != nil {
 		return nil, err
 	}
+	s.cfg.Logger.Error("Prefere", "theme", listQuery)
 
 	res := s.GetDefaults()
 	for _, p := range prefs {

--- a/pkg/services/preference/prefimpl/pref.go
+++ b/pkg/services/preference/prefimpl/pref.go
@@ -25,10 +25,6 @@ func ProvideService(db db.DB, cfg *setting.Cfg) pref.Service {
 }
 
 func (s *Service) GetWithDefaults(ctx context.Context, query *pref.GetPreferenceWithDefaultsQuery) (*pref.Preference, error) {
-	if query.OrgID == 0 {
-		return nil, errors.New("missing OrgID in call to Preferences.GetWithDefaults")
-	}
-
 	listQuery := &pref.Preference{
 		Teams:  query.Teams,
 		OrgID:  query.OrgID,

--- a/pkg/services/preference/prefimpl/pref.go
+++ b/pkg/services/preference/prefimpl/pref.go
@@ -25,16 +25,20 @@ func ProvideService(db db.DB, cfg *setting.Cfg) pref.Service {
 }
 
 func (s *Service) GetWithDefaults(ctx context.Context, query *pref.GetPreferenceWithDefaultsQuery) (*pref.Preference, error) {
+	if query.OrgID == 0 {
+		return nil, errors.New("missing OrgID in call to Preferences.GetWithDefaults")
+	}
+
 	listQuery := &pref.Preference{
 		Teams:  query.Teams,
 		OrgID:  query.OrgID,
 		UserID: query.UserID,
 	}
+
 	prefs, err := s.store.List(ctx, listQuery)
 	if err != nil {
 		return nil, err
 	}
-	s.cfg.Logger.Error("Prefere", "theme", listQuery)
 
 	res := s.GetDefaults()
 	for _, p := range prefs {

--- a/pkg/services/preference/prefimpl/pref_test.go
+++ b/pkg/services/preference/prefimpl/pref_test.go
@@ -107,7 +107,7 @@ func TestPreferencesService(t *testing.T) {
 			Theme:    "light",
 			Timezone: "UTC",
 		}
-		query := &pref.GetPreferenceWithDefaultsQuery{}
+		query := &pref.GetPreferenceWithDefaultsQuery{OrgID: 1}
 		preference, err := prefService.GetWithDefaults(context.Background(), query)
 		require.NoError(t, err)
 		expected := &pref.Preference{


### PR DESCRIPTION
PR #47870 Added a Preferences service, but after this merge preferences no longer worked (try changing theme for example).

Discovered the query issued in index.go was lacking some required parameters. The call should probably panic if OrgId is not set.

