### PR TITLE
Docs: Fix built-in annotations in docs

### DIFF
--- a/docs/sources/alerting/unified-alerting/alerting-rules/alert-annotation-label.md
+++ b/docs/sources/alerting/unified-alerting/alerting-rules/alert-annotation-label.md
@@ -11,7 +11,7 @@ Annotations and labels are key value pairs associated with alerts originating fr
 
 ## Annotations
 
-Annotations are key-value pairs that provide additional meta-information about an alert. You can use the following annotations: `description`, `summary`, `runbook_url`, `alertId`, `dashboardUid`, and `panelId`. For example, a description, a summary, and a runbook URL. These are displayed in rule and alert details in the UI and can be used in contact point message templates.
+Annotations are key-value pairs that provide additional meta-information about an alert. You can use the following annotations: `description`, `summary`, `runbook_url`, `__alertId__`, `__dashboardUid__`, and `__panelId__`. For example, a description, a summary, and a runbook URL. These are displayed in rule and alert details in the UI and can be used in contact point message templates.
 
 ## Labels
 


### PR DESCRIPTION
This allows to see links to Panels/Dashboard list from Alerting.


**What this PR does / why we need it**:

According to this
https://github.com/grafana/grafana/blob/68ca5b2e0561d33fd7910ae605b608225fbe3d87/public/app/features/alerting/unified/utils/constants.ts#L18-L20
format of built-in annotations should be __dashboardUid__ not dashboardUid so links to dashboards/panels are working from Alerting section.
<img width="631" alt="image" src="https://user-images.githubusercontent.com/14870891/165065078-7c01e08c-abc1-478d-bc5f-5e91497a91ca.png">
