### PR TITLE
Loki: datasource-test functionality migrated to backend-mode

### DIFF
--- a/pkg/tsdb/loki/health.go
+++ b/pkg/tsdb/loki/health.go
@@ -1,0 +1,65 @@
+package loki
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/infra/log"
+	jsoniter "github.com/json-iterator/go"
+)
+
+// extracted to separate function for easier testing
+func checkHealth(ctx context.Context, api *LokiAPI, log log.Logger) (*backend.CheckHealthResult, error) {
+	// we run a query for labels for the last 10 minutes
+	endTime := time.Now().UnixNano()
+	startTime := endTime - (10 * 60 * 1000 * 1000 * 1000) // 10 minutes difference
+
+	qs := url.Values{}
+	qs.Set("start", strconv.FormatInt(startTime, 10))
+	qs.Set("end", strconv.FormatInt(endTime, 10))
+
+	url := fmt.Sprintf("/loki/api/v1/labels?%s", qs.Encode())
+
+	bytes, err := api.RawQuery(ctx, url)
+
+	if err != nil {
+		log.Error("Loki Query error", "err", err)
+		return &backend.CheckHealthResult{
+			Status:  backend.HealthStatusError,
+			Message: "Loki connection error. please inspect the Grafana server log for details",
+		}, nil
+	}
+
+	info := LokiLabelsResponse{}
+
+	err = jsoniter.Unmarshal(bytes, &info)
+	if err != nil {
+		return &backend.CheckHealthResult{
+			Status:  backend.HealthStatusError,
+			Message: "Loki returned invalid JSON data",
+		}, nil
+	}
+
+	if info.Status != "success" {
+		return &backend.CheckHealthResult{
+			Status:  backend.HealthStatusError,
+			Message: "Loki returned an error response",
+		}, nil
+	}
+
+	if len(info.Data) == 0 {
+		return &backend.CheckHealthResult{
+			Status:  backend.HealthStatusOk,
+			Message: "Data source connected, but no labels found",
+		}, nil
+	}
+
+	return &backend.CheckHealthResult{
+		Status:  backend.HealthStatusOk,
+		Message: "Data source connected, labels found",
+	}, nil
+}

--- a/pkg/tsdb/loki/health_test.go
+++ b/pkg/tsdb/loki/health_test.go
@@ -1,0 +1,85 @@
+package loki
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	gokitlog "github.com/go-kit/log"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthCheck(t *testing.T) {
+	t.Run("success with labels", func(t *testing.T) {
+		api := makeMockedAPI(200, "text/plain; charset=utf-8", []byte(`{"status":"success","data":["name1","name2"]}`), nil)
+
+		result, err := checkHealth(context.Background(), api, log.New("test"))
+		require.NoError(t, err)
+		require.Equal(t, backend.HealthStatusOk, result.Status)
+		require.Equal(t, "Data source connected, labels found", result.Message)
+	})
+
+	t.Run("success without labels", func(t *testing.T) {
+		api := makeMockedAPI(200, "text/plain; charset=utf-8", []byte(`{"status":"success","data":[]}`), nil)
+
+		result, err := checkHealth(context.Background(), api, log.New("test"))
+		require.NoError(t, err)
+		require.Equal(t, backend.HealthStatusOk, result.Status)
+		require.Equal(t, "Data source connected, but no labels found", result.Message)
+	})
+
+	t.Run("error in json-status", func(t *testing.T) {
+		api := makeMockedAPI(200, "text/plain; charset=utf-8", []byte(`{"status":"error"}`), nil)
+
+		result, err := checkHealth(context.Background(), api, log.New("test"))
+		require.NoError(t, err)
+		require.Equal(t, backend.HealthStatusError, result.Status)
+		require.Equal(t, "Loki returned an error response", result.Message)
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		api := makeMockedAPI(200, "text/plain; charset=utf-8", []byte(`{"sta`), nil)
+
+		result, err := checkHealth(context.Background(), api, log.New("test"))
+		require.NoError(t, err)
+		require.Equal(t, backend.HealthStatusError, result.Status)
+		require.Equal(t, "Loki returned invalid JSON data", result.Message)
+	})
+
+	t.Run("API error", func(t *testing.T) {
+		seenLog := false
+
+		// we setup a custom logger, and we check if we logged what we need to log
+		logger := gokitlog.Logger(gokitlog.LoggerFunc(func(keyvals ...interface{}) error {
+			// the `keyvals` array contains the log-item.
+			// as we logged it as `log.Error("Loki Query error", "err", error-object)`
+			// those 3 things become the last 3 items of the keyvals array
+			message := keyvals[len(keyvals)-3]
+			key := keyvals[len(keyvals)-2]
+			// this is not a string, and we need to do a string operation on it,
+			// so we convert it to a string
+			value := fmt.Sprintf("%v", keyvals[len(keyvals)-1])
+
+			if (message == "Loki Query error") && (key == "err") && (strings.Contains(value, "mocked error")) {
+				seenLog = true
+			}
+
+			return nil
+		}))
+
+		testLogger := log.New("test")
+		testLogger.Swap(logger)
+
+		err := fmt.Errorf("mocked error")
+		api := makeMockedAPI(200, "text/plain; charset=utf-8", []byte(`{"sta`), err)
+
+		result, err := checkHealth(context.Background(), api, testLogger)
+		require.NoError(t, err)
+		require.Equal(t, backend.HealthStatusError, result.Status)
+		require.Equal(t, "Loki connection error. please inspect the Grafana server log for details", result.Message)
+		require.True(t, seenLog)
+	})
+}

--- a/pkg/tsdb/loki/loki_bench_test.go
+++ b/pkg/tsdb/loki/loki_bench_test.go
@@ -17,7 +17,7 @@ func BenchmarkMatrixJson(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_, _ = runQuery(context.Background(), makeMockedAPI(http.StatusOK, "application/json", bytes), &lokiQuery{})
+		_, _ = runQuery(context.Background(), makeMockedAPI(http.StatusOK, "application/json", bytes, nil), &lokiQuery{})
 	}
 }
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -689,6 +689,11 @@ export class LokiDatasource
   };
 
   testDatasource() {
+    if (config.featureToggles.lokiBackendMode) {
+      // this will call the healthcheck in the backend
+      return super.testDatasource();
+    }
+
     // Consider only last 10 minutes otherwise request takes too long
     const startMs = Date.now() - 10 * 60 * 1000;
     const start = `${startMs}000000`; // API expects nanoseconds


### PR DESCRIPTION
When configuring a Loki datasource, and you press the `[Save & test]` button, currently the code executes a fetch-all-labels call directly from the frontend. this pull-request migrates this to the backend, so the frontend just asks the backend for a health-check.

how to test:
1. make sure loki-backend-mode is DISABLED
  - make sure Loki is running
  - go to the datasource-config page, press `[Save & test]`. you should get a success-message saying "Data source connected, labels found"
  - now turn off the Loki database, and repeat the test. you should get an error-message
2. now repeat the smae with loki-backend-mode ENABLED