### PR TITLE
Loki: do not use the old labels-api

### DIFF
--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -98,7 +98,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	if req.Method != "GET" {
 		return fmt.Errorf("invalid resource method: %s", req.Method)
 	}
-	if (!strings.HasPrefix(url, "/loki/api/v1/label?")) &&
+	if (!strings.HasPrefix(url, "/loki/api/v1/labels?")) &&
 		(!strings.HasPrefix(url, "/loki/api/v1/label/")) && // the `/label/$label_name/values` form
 		(!strings.HasPrefix(url, "/loki/api/v1/series?")) {
 		return fmt.Errorf("invalid resource URL: %s", url)

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -441,10 +441,10 @@ export class LokiDatasource
   async metadataRequest(url: string, params?: Record<string, string | number>) {
     if (config.featureToggles.lokiBackendMode) {
       const res = await this.getResource(url, params);
-      return res.data || res.values || [];
+      return res.data || [];
     } else {
       const res = await lastValueFrom(this._request(url, params, { hideFromInspector: true }));
-      return res.data.data || res.data.values || [];
+      return res.data.data || [];
     }
   }
 
@@ -479,7 +479,7 @@ export class LokiDatasource
   }
 
   async labelNamesQuery() {
-    const url = `${LOKI_ENDPOINT}/label`;
+    const url = `${LOKI_ENDPOINT}/labels`;
     const params = this.getTimeRangeParams();
     const result = await this.metadataRequest(url, params);
     return result.map((value: string) => ({ text: value }));

--- a/public/app/plugins/datasource/loki/language_provider.test.ts
+++ b/public/app/plugins/datasource/loki/language_provider.test.ts
@@ -259,7 +259,7 @@ describe('Request URL', () => {
 
     const instance = new LanguageProvider(datasourceWithLabels);
     instance.fetchLabels();
-    const expectedUrl = '/loki/api/v1/label';
+    const expectedUrl = '/loki/api/v1/labels';
     expect(datasourceSpy).toHaveBeenCalledWith(expectedUrl, rangeParams);
   });
 });

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -364,7 +364,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
    * Fetches all label keys
    */
   async fetchLabels(): Promise<string[]> {
-    const url = '/loki/api/v1/label';
+    const url = '/loki/api/v1/labels';
     const timeRange = this.datasource.getTimeRangeParams();
     this.labelFetchTs = Date.now().valueOf();
 

--- a/public/app/plugins/datasource/loki/mocks.ts
+++ b/public/app/plugins/datasource/loki/mocks.ts
@@ -21,7 +21,7 @@ export function makeMockLokiDatasource(labelsAndValues: Labels, series?: SeriesF
   const lokiLabelsAndValuesEndpointRegex = /^\/loki\/api\/v1\/label\/(\w*)\/values/;
   const lokiSeriesEndpointRegex = /^\/loki\/api\/v1\/series/;
 
-  const lokiLabelsEndpoint = `${LOKI_ENDPOINT}/label`;
+  const lokiLabelsEndpoint = `${LOKI_ENDPOINT}/labels`;
   const rangeMock = {
     start: 1560153109000,
     end: 1560163909000,


### PR DESCRIPTION
based on the Loki documentation, the list-all-labels endpoint is `/loki/api/v1/labels`, but grafana uses `/loki/api/v1/label` (no `s` at the end). this seems to be an older version of the API. the new API works since Loki 1.2.0, so we can switch to it, to use the documented version.

this pull-request makes the change. it has 2 parts:
1. switch the URl from `label` to `labels`
2. the data in the JSON is always in `.data`, never in `.values` anymore, so we simplify the code to only use `.data`

NOTE: a different way to look at this: we also use the `series` endpoint, which is only available since Loki 1.5.0, so we don't work with older Loki anyway. and the new labels-API is already there in Loki 1.5.0, so we can rely on it being there.

how to test:
1. go to explore, choose a Loki datasource
2. open the logs-browser, click on a label-name, then on a label-value. this should work, you should not get any error.