### PR TITLE
TimeSeries: treat 0 as positive when determining stacking direction

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/utils.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.test.ts
@@ -580,13 +580,13 @@ describe('auto stacking groups', () => {
           "dir": -1,
           "series": Array [
             1,
-            3,
           ],
         },
         Object {
           "dir": 1,
           "series": Array [
             2,
+            3,
           ],
         },
       ]
@@ -622,11 +622,6 @@ describe('auto stacking groups', () => {
           "series": Array [
             1,
             2,
-          ],
-        },
-        Object {
-          "dir": -1,
-          "series": Array [
             3,
           ],
         },

--- a/packages/grafana-ui/src/components/uPlot/utils.test.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.test.ts
@@ -230,29 +230,29 @@ describe('preparePlotData2', () => {
         ],
       });
       expect(preparePlotData2(df, getStackingGroups(df))).toMatchInlineSnapshot(`
-              Array [
-                Array [
-                  9997,
-                  9998,
-                  9999,
-                ],
-                Array [
-                  -10,
-                  20,
-                  10,
-                ],
-                Array [
-                  10,
-                  10,
-                  10,
-                ],
-                Array [
-                  20,
-                  20,
-                  20,
-                ],
-              ]
-          `);
+        Array [
+          Array [
+            9997,
+            9998,
+            9999,
+          ],
+          Array [
+            -10,
+            20,
+            10,
+          ],
+          Array [
+            10,
+            10,
+            10,
+          ],
+          Array [
+            20,
+            20,
+            20,
+          ],
+        ]
+      `);
     });
 
     it('standard', () => {
@@ -289,14 +289,14 @@ describe('preparePlotData2', () => {
             10,
           ],
           Array [
-            0,
-            30,
-            20,
+            10,
+            10,
+            10,
           ],
           Array [
-            20,
-            50,
-            40,
+            30,
+            30,
+            30,
           ],
         ]
       `);
@@ -345,19 +345,19 @@ describe('preparePlotData2', () => {
             10,
           ],
           Array [
+            10,
+            10,
+            10,
+          ],
+          Array [
+            -30,
             0,
-            30,
-            20,
+            -10,
           ],
           Array [
+            -40,
+            -10,
             -20,
-            -20,
-            -20,
-          ],
-          Array [
-            -30,
-            -30,
-            -30,
           ],
         ]
       `);
@@ -413,14 +413,14 @@ describe('preparePlotData2', () => {
             10,
           ],
           Array [
-            0,
-            30,
-            20,
+            10,
+            10,
+            10,
           ],
           Array [
-            20,
-            50,
-            40,
+            30,
+            30,
+            30,
           ],
           Array [
             1,

--- a/packages/grafana-ui/src/components/uPlot/utils.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.ts
@@ -115,16 +115,17 @@ export function getStackingGroups(frame: DataFrame) {
     // will this be stacked up or down after any transforms applied
     let vals = values.toArray();
     let transform = custom.transform;
+    let firstValue = vals.find((v) => v != null);
     let stackDir =
       transform === GraphTransform.Constant
-        ? vals[0] != null && vals[0] >= 0
+        ? firstValue >= 0
           ? StackDirection.Pos
           : StackDirection.Neg
         : transform === GraphTransform.NegativeY
-        ? vals.some((v) => v != null && v >= 0)
+        ? firstValue >= 0
           ? StackDirection.Neg
           : StackDirection.Pos
-        : vals.some((v) => v != null && v >= 0)
+        : firstValue >= 0
         ? StackDirection.Pos
         : StackDirection.Neg;
 

--- a/packages/grafana-ui/src/components/uPlot/utils.ts
+++ b/packages/grafana-ui/src/components/uPlot/utils.ts
@@ -117,14 +117,14 @@ export function getStackingGroups(frame: DataFrame) {
     let transform = custom.transform;
     let stackDir =
       transform === GraphTransform.Constant
-        ? vals[0] > 0
+        ? vals[0] != null && vals[0] >= 0
           ? StackDirection.Pos
           : StackDirection.Neg
         : transform === GraphTransform.NegativeY
-        ? vals.some((v) => v > 0)
+        ? vals.some((v) => v != null && v >= 0)
           ? StackDirection.Neg
           : StackDirection.Pos
-        : vals.some((v) => v > 0)
+        : vals.some((v) => v != null && v >= 0)
         ? StackDirection.Pos
         : StackDirection.Neg;
 


### PR DESCRIPTION
Fixes #48165

<details><summary>stacking-0.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 244,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "line",
            "fillOpacity": 19,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "normal"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 18,
        "w": 18,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom"
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_metric_values",
          "stringInput": "1,2,1,2"
        },
        {
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "B",
          "scenarioId": "csv_metric_values",
          "stringInput": "0,0,0,0"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "schemaVersion": 36,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "stack-0",
  "uid": "fGfD1-Q7z",
  "version": 2,
  "weekStart": ""
}
```
</details>

![Peek 2022-04-25 11-34](https://user-images.githubusercontent.com/43234/165133908-2639b489-c8fa-4722-bb3b-e0d6b921595b.gif)

This switches the stacking direction heuristic to use the first non-null datapoint of each series.

- Positive (upward) stacked series have a first value >= 0
- Negative (downward) stacked series have a first value < 0

For performance, this continues to side-step an exhaustive scan of all data for negative values, which tend to be uncommon. This strategy _does_ carry the risk of mis-stacking negative-valued series that start with 0. If this proves to be too problematic, we can switch to doing the exhaustive checks at the cost of initial rendering performance (these checks are only done during chart init, not on every data update).