### PR TITLE
Redux: PoC of dashboard state redux migration

### DIFF
--- a/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.tsx
+++ b/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.tsx
@@ -179,7 +179,7 @@ function cleanDashboardFromIgnoredChanges(dashData: any) {
   dash.time = 0;
   dash.refresh = 0;
   dash.schemaVersion = 0;
-  dash.timezone = 0;
+  dash.timezone = '';
 
   // ignore iteration property
   delete dash.iteration;

--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
@@ -3,6 +3,7 @@ import { useDialog } from '@react-aria/dialog';
 import { FocusScope } from '@react-aria/focus';
 import { useOverlay } from '@react-aria/overlays';
 import React, { useCallback, useMemo, useRef } from 'react';
+import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 
 import { GrafanaTheme2, locationUtil } from '@grafana/data';
@@ -10,7 +11,7 @@ import { locationService, reportInteraction } from '@grafana/runtime';
 import { Button, CustomScrollbar, Icon, IconName, PageToolbar, stylesFactory, useForceUpdate } from '@grafana/ui';
 import config from 'app/core/config';
 import { contextSrv } from 'app/core/services/context_srv';
-import { AccessControlAction } from 'app/types';
+import { AccessControlAction, StoreState } from 'app/types';
 
 import { VariableEditorContainer } from '../../../variables/editor/VariableEditorContainer';
 import { DashboardModel } from '../../state/DashboardModel';
@@ -151,11 +152,12 @@ export function DashboardSettings({ dashboard, editview }: Props) {
   const canSaveAs = contextSrv.hasEditPermissionInFolders;
   const canSave = dashboard.meta.canSave;
   const styles = getStyles(config.theme2);
+  const dashboardTitle = useSelector((state: StoreState) => state.dashboard.title);
 
   return (
     <FocusScope contain autoFocus restoreFocus>
       <div className="dashboard-settings" ref={ref} {...overlayProps} {...dialogProps}>
-        <PageToolbar title={`${dashboard.title} / Settings`} parent={folderTitle} onGoBack={onClose} />
+        <PageToolbar title={`${dashboardTitle} / Settings`} parent={folderTitle} onGoBack={onClose} />
         <CustomScrollbar>
           <div className={styles.scrollInner}>
             <div className={styles.settingsWrapper}>

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
@@ -5,10 +5,11 @@ import { byRole } from 'testing-library-selector';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { selectOptionInTest } from '@grafana/ui';
+import { updateTimeZone } from 'app/features/profile/state/reducers';
 
 import { DashboardModel } from '../../state';
 
-import { GeneralSettingsUnconnected as GeneralSettings, Props } from './GeneralSettings';
+import { GeneralSettings, Props } from './GeneralSettings';
 
 const setupTestContext = (options: Partial<Props>) => {
   const defaults: Props = {
@@ -25,8 +26,6 @@ const setupTestContext = (options: Partial<Props>) => {
       },
       timezone: 'utc',
     } as unknown as DashboardModel,
-    updateTimeZone: jest.fn(),
-    updateWeekStart: jest.fn(),
   };
 
   const props = { ...defaults, ...options };
@@ -54,7 +53,7 @@ describe('General Settings', () => {
       const timeZonePicker = screen.getByTestId(selectors.components.TimeZonePicker.containerV2);
       await userEvent.click(byRole('combobox').get(timeZonePicker));
       await selectOptionInTest(timeZonePicker, 'Browser Time');
-      expect(props.updateTimeZone).toHaveBeenCalledWith('browser');
+      expect(updateTimeZone).toHaveBeenCalledWith('browser');
       expect(props.dashboard.timezone).toBe('browser');
     });
   });

--- a/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
+++ b/public/app/features/dashboard/components/DeleteDashboard/DeleteDashboardModal.tsx
@@ -1,10 +1,12 @@
 import { css } from '@emotion/css';
 import { sumBy } from 'lodash';
 import React from 'react';
+import { useSelector } from 'react-redux';
 import useAsyncFn from 'react-use/lib/useAsyncFn';
 
 import { Modal, ConfirmModal, Button } from '@grafana/ui';
 import { config } from 'app/core/config';
+import { StoreState } from 'app/types';
 
 import { DashboardModel, PanelModel } from '../../state';
 
@@ -18,13 +20,14 @@ type DeleteDashboardModalProps = {
 export const DeleteDashboardModal: React.FC<DeleteDashboardModalProps> = ({ hideModal, dashboard }) => {
   const isProvisioned = dashboard.meta.provisioned;
   const { onDeleteDashboard } = useDashboardDelete(dashboard.uid);
+  const dashboardTitle = useSelector((state: StoreState) => state.dashboard.title);
 
   const [, onConfirm] = useAsyncFn(async () => {
     await onDeleteDashboard();
     hideModal();
   }, [hideModal]);
 
-  const modalBody = getModalBody(dashboard.panels, dashboard.title);
+  const modalBody = getModalBody(dashboard.panels, dashboardTitle);
 
   if (isProvisioned) {
     return <ProvisionedDeleteModal hideModal={hideModal} provisionedId={dashboard.meta.provisionedExternalId!} />;

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -70,6 +70,7 @@ const mapStateToProps = (state: StoreState, ownProps: OwnProps) => {
     uiState: state.panelEditor.ui,
     tableViewEnabled: state.panelEditor.tableViewEnabled,
     variables: getVariablesByKey(ownProps.dashboard.uid, state),
+    dashboardTitle: state.dashboard.title,
   };
 };
 
@@ -431,7 +432,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
   };
 
   render() {
-    const { dashboard, initDone, updatePanelEditorUIState, uiState } = this.props;
+    const { dashboardTitle, initDone, updatePanelEditorUIState, uiState } = this.props;
     const styles = getStyles(config.theme, this.props);
 
     if (!initDone) {
@@ -440,7 +441,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
 
     return (
       <div className={styles.wrapper} aria-label={selectors.components.PanelEditor.General.content}>
-        <PageToolbar title={`${dashboard.title} / Edit Panel`} onGoBack={this.onGoBackToDashboard}>
+        <PageToolbar title={`${dashboardTitle} / Edit Panel`} onGoBack={this.onGoBackToDashboard}>
           {this.renderEditorActions()}
         </PageToolbar>
         <div className={styles.verticalSplitPanesWrapper}>

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 
 import { Button, Input, Switch, Form, Field, InputControl, HorizontalGroup } from '@grafana/ui';
 import { FolderPicker } from 'app/core/components/Select/FolderPicker';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { validationSrv } from 'app/features/manage-dashboards/services/ValidationSrv';
+import { StoreState } from 'app/types';
 
 import { SaveDashboardFormProps } from '../types';
 
@@ -47,8 +49,9 @@ export const SaveDashboardAsForm: React.FC<SaveDashboardAsFormProps> = ({
   onCancel,
   onSuccess,
 }) => {
+  const dashboardTitle = useSelector((state: StoreState) => state.dashboard.title);
   const defaultValues: SaveDashboardAsFormDTO = {
-    title: isNew ? dashboard.title : `${dashboard.title} Copy`,
+    title: isNew ? dashboardTitle : `${dashboardTitle} Copy`,
     $folder: {
       id: dashboard.meta.folderId,
       title: dashboard.meta.folderTitle,

--- a/public/app/features/dashboard/components/SaveDashboard/forms/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/forms/SaveProvisionedDashboardForm.tsx
@@ -1,17 +1,20 @@
 import { css } from '@emotion/css';
 import { saveAs } from 'file-saver';
 import React, { useCallback, useState } from 'react';
+import { useSelector } from 'react-redux';
 
 import { GrafanaTheme } from '@grafana/data';
 import { Stack } from '@grafana/experimental';
 import { Button, ClipboardButton, HorizontalGroup, stylesFactory, TextArea, useTheme } from '@grafana/ui';
 import { useAppNotification } from 'app/core/copy/appNotification';
+import { StoreState } from 'app/types';
 
 import { SaveDashboardFormProps } from '../types';
 
 export const SaveProvisionedDashboardForm: React.FC<SaveDashboardFormProps> = ({ dashboard, onCancel }) => {
   const theme = useTheme();
   const notifyApp = useAppNotification();
+  const dashboardTitle = useSelector((state: StoreState) => state.dashboard.title);
   const [dashboardJSON, setDashboardJson] = useState(() => {
     const clone = dashboard.getSaveModelClone();
     delete clone.id;
@@ -22,8 +25,8 @@ export const SaveProvisionedDashboardForm: React.FC<SaveDashboardFormProps> = ({
     const blob = new Blob([dashboardJSON], {
       type: 'application/json;charset=utf-8',
     });
-    saveAs(blob, dashboard.title + '-' + new Date().getTime() + '.json');
-  }, [dashboard.title, dashboardJSON]);
+    saveAs(blob, dashboardTitle + '-' + new Date().getTime() + '.json');
+  }, [dashboardTitle, dashboardJSON]);
 
   const onCopyToClipboardSuccess = useCallback(() => {
     notifyApp.success('Dashboard JSON copied to clipboard');

--- a/public/app/features/dashboard/containers/DashboardPage.test.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.test.tsx
@@ -105,6 +105,8 @@ function dashboardPageScenario(description: string, scenarioFn: (ctx: ScenarioCo
       mount: (propOverrides?: Partial<Props>) => {
         const store = configureStore();
         const props: Props = {
+          dashboardTitle: '',
+          dashboardLiveNow: false,
           ...getRouteComponentProps({
             match: { params: { slug: 'my-dash', uid: '11' } } as any,
             route: { routeName: DashboardRoutes.Normal } as any,

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -55,6 +55,8 @@ export const mapStateToProps = (state: StoreState) => ({
   initPhase: state.dashboard.initPhase,
   initError: state.dashboard.initError,
   dashboard: state.dashboard.getModel(),
+  dashboardLiveNow: state.dashboard.liveNow,
+  dashboardTitle: state.dashboard.title,
 });
 
 const mapDispatchToProps = {
@@ -132,7 +134,7 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    const { dashboard, match, templateVarsChangedInUrl } = this.props;
+    const { dashboard, dashboardTitle, match, templateVarsChangedInUrl } = this.props;
     const routeReloadCounter = (this.props.history.location.state as any)?.routeReloadCounter;
 
     if (!dashboard) {
@@ -141,7 +143,7 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
 
     // if we just got dashboard update title
     if (prevProps.dashboard !== dashboard) {
-      document.title = dashboard.title + ' - ' + Branding.AppTitle;
+      document.title = dashboardTitle + ' - ' + Branding.AppTitle;
     }
 
     if (
@@ -202,7 +204,7 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
 
   updateLiveTimer = () => {
     let tr: TimeRange | undefined = undefined;
-    if (this.props.dashboard?.liveNow) {
+    if (this.props.dashboardLiveNow) {
       tr = getTimeSrv().timeRange();
     }
     liveTimer.setLiveTimeRange(tr);
@@ -312,7 +314,7 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
   }
 
   render() {
-    const { dashboard, initError, queryParams, theme } = this.props;
+    const { dashboard, dashboardTitle, initError, queryParams, theme } = this.props;
     const { editPanel, viewPanel, updateScrollTop } = this.state;
     const kioskMode = getKioskMode();
     const styles = getStyles(theme, kioskMode);
@@ -333,7 +335,7 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
           <header data-testid={selectors.pages.Dashboard.DashNav.navV2}>
             <DashNav
               dashboard={dashboard}
-              title={dashboard.title}
+              title={dashboardTitle}
               folderTitle={dashboard.meta.folderTitle}
               isFullscreen={!!viewPanel}
               onAddPanel={this.onAddPanel}

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -24,8 +24,8 @@ export class TimeSrv {
   time: any;
   refreshTimer: any;
   refresh: any;
-  previousAutoRefresh: any;
-  oldRefresh: string | null | undefined;
+  previousAutoRefresh: string | undefined;
+  oldRefresh: string | undefined;
   timeModel?: TimeModel;
   timeAtLoad: any;
   private autoRefreshBlocked?: boolean;
@@ -165,7 +165,7 @@ export class TimeSrv {
     if (params.get('to') && params.get('to')!.indexOf('now') === -1) {
       this.refresh = false;
       if (this.timeModel) {
-        this.timeModel.refresh = false;
+        this.timeModel.refresh = undefined;
       }
     }
 
@@ -214,7 +214,7 @@ export class TimeSrv {
     return this.timeAtLoad && (this.timeAtLoad.from !== this.time.from || this.timeAtLoad.to !== this.time.to);
   }
 
-  setAutoRefresh(interval: any) {
+  setAutoRefresh(interval: string | undefined) {
     if (this.timeModel) {
       this.timeModel.refresh = interval;
     }
@@ -284,10 +284,10 @@ export class TimeSrv {
     // disable refresh if zoom in or zoom out
     if (isDateTime(time.to)) {
       this.oldRefresh = this.timeModel?.refresh || this.oldRefresh;
-      this.setAutoRefresh(false);
+      this.setAutoRefresh(undefined);
     } else if (this.oldRefresh && this.oldRefresh !== this.timeModel?.refresh) {
       this.setAutoRefresh(this.oldRefresh);
-      this.oldRefresh = null;
+      this.oldRefresh = undefined;
     }
 
     if (updateUrl === true) {

--- a/public/app/features/dashboard/state/TimeModel.ts
+++ b/public/app/features/dashboard/state/TimeModel.ts
@@ -3,7 +3,7 @@ import { TimeRange, TimeZone } from '@grafana/data';
 export interface TimeModel {
   time: any;
   fiscalYearStartMonth?: number;
-  refresh: any;
+  refresh?: string;
   timepicker: any;
   getTimezone(): TimeZone;
   timeRangeUpdated(timeRange: TimeRange): void;

--- a/public/app/features/dashboard/state/reducers.ts
+++ b/public/app/features/dashboard/state/reducers.ts
@@ -1,9 +1,9 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import { PanelPlugin } from '@grafana/data';
+import { DashboardCursorSync, PanelPlugin } from '@grafana/data';
 import { AngularComponent } from '@grafana/runtime';
 import { processAclItems } from 'app/core/utils/acl';
-import { DashboardAclDTO, DashboardInitError, DashboardInitPhase, DashboardState } from 'app/types';
+import { DashboardAclDTO, DashboardInitError, DashboardInitPhase, DashboardProps, DashboardState } from 'app/types';
 
 import { DashboardModel } from './DashboardModel';
 import { PanelModel } from './PanelModel';
@@ -13,6 +13,12 @@ export const initialState: DashboardState = {
   getModel: () => null,
   permissions: [],
   initError: null,
+  title: '',
+  liveNow: false,
+  graphTooltip: DashboardCursorSync.Off,
+  description: '',
+  style: 'dark',
+  tags: [],
 };
 
 const dashboardSlice = createSlice({
@@ -44,6 +50,9 @@ const dashboardSlice = createSlice({
       state.initError = null;
       state.getModel = () => null;
     },
+    updateDashboard: (state, action: PayloadAction<Partial<DashboardProps>>) => {
+      Object.assign(state, action.payload);
+    },
     addPanel: (state, action: PayloadAction<PanelModel>) => {
       //state.panels[action.payload.id] = { pluginId: action.payload.type };
     },
@@ -73,6 +82,7 @@ export const {
   dashboardInitServices,
   cleanUpDashboard,
   addPanel,
+  updateDashboard,
 } = dashboardSlice.actions;
 
 export const dashboardReducer = dashboardSlice.reducer;

--- a/public/app/features/explore/state/time.ts
+++ b/public/app/features/explore/state/time.ts
@@ -100,7 +100,7 @@ export const updateTime = (config: {
     const absoluteRange: AbsoluteTimeRange = { from: range.from.valueOf(), to: range.to.valueOf() };
     const timeModel: TimeModel = {
       time: range.raw,
-      refresh: false,
+      refresh: undefined,
       timepicker: {},
       getTimezone: () => timeZone,
       timeRangeUpdated: (rawTimeRange: RawTimeRange) => {

--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -1,4 +1,4 @@
-import { DataQuery } from '@grafana/data';
+import { DashboardCursorSync, DataQuery } from '@grafana/data';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { VariableModel } from 'app/features/variables/types';
 
@@ -93,7 +93,16 @@ export interface QueriesToUpdateOnDashboardLoad {
   queries: DataQuery[];
 }
 
-export interface DashboardState {
+export interface DashboardProps {
+  title: string;
+  liveNow: boolean;
+  graphTooltip: DashboardCursorSync;
+  description: string;
+  style: 'dark' | 'light';
+  tags: string[];
+}
+
+export interface DashboardState extends DashboardProps {
   getModel: GetMutableDashboardModelFn;
   initPhase: DashboardInitPhase;
   initError: DashboardInitError | null;


### PR DESCRIPTION
**What this PR does / why we need it**:
Quick PoC of what migrating dashboard state to redux might look like in a way that doesn't immediately break everything.
The main "trick" here I suppose is using getters/setters in DashboardModel to access redux state while preserving the old interface. I think the end goal would be to do away with these though and just access the state through redux selectors rather than through DashboardModel.

**Special notes for your reviewer**:
There's a fair bit of miscellaneous "clean-up" here that I did while patching up the relevant files to work with redux, but if it makes this PR too hard to read I can try and separate it out into its own PR. 🙂
