### PR TITLE
Query history: Pass config to frontend and add missing documentation

### DIFF
--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1371,6 +1371,14 @@ Configures the Profile section.
 
 Enable or disable the Profile section. Default is `enabled`.
 
+## [query_history]
+
+Configures Query history in Explore.
+
+### enabled
+
+Enable or disable the Query history. Default is `disabled`.
+
 ## [metrics]
 
 For detailed instructions, refer to [Internal Grafana metrics]({{< relref "view-server/internal-metrics.md" >}}).

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -153,6 +153,7 @@ export interface GrafanaConfig {
   alertingMinInterval: number;
   authProxyEnabled: boolean;
   exploreEnabled: boolean;
+  queryHistoryEnabled: boolean;
   helpEnabled: boolean;
   profileEnabled: boolean;
   ldapEnabled: boolean;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -72,7 +72,6 @@ export class GrafanaBootConfig implements GrafanaConfig {
   featureToggles: FeatureToggles = {};
   licenseInfo: LicenseInfo = {} as LicenseInfo;
   rendererAvailable = false;
-
   dashboardPreviews: {
     systemRequirements: {
       met: boolean;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -47,6 +47,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   angularSupportEnabled = false;
   authProxyEnabled = false;
   exploreEnabled = false;
+  queryHistoryEnabled = false;
   helpEnabled = false;
   profileEnabled = false;
   ldapEnabled = false;
@@ -71,6 +72,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   featureToggles: FeatureToggles = {};
   licenseInfo: LicenseInfo = {} as LicenseInfo;
   rendererAvailable = false;
+
   dashboardPreviews: {
     systemRequirements: {
       met: boolean;


### PR DESCRIPTION
**What this PR does / why we need it**:
We were missing:
1. documentation for query history in config 
2. pass queryHistoryEnabled to frontend 


Part of: https://github.com/grafana/grafana/issues/44327