### PR TITLE
Tracing: Add string unit to traceID in search results to prevent Infinity bug

### DIFF
--- a/public/app/plugins/datasource/jaeger/responseTransform.ts
+++ b/public/app/plugins/datasource/jaeger/responseTransform.ts
@@ -71,6 +71,7 @@ export function createTableFrame(data: TraceResponse[], instanceSettings: DataSo
         name: 'traceID',
         type: FieldType.string,
         config: {
+          unit: 'string',
           displayNameFromDS: 'Trace ID',
           links: [
             {

--- a/public/app/plugins/datasource/tempo/resultTransformer.test.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.test.ts
@@ -102,6 +102,9 @@ describe('createTableFrameFromSearch()', () => {
     expect(frame.fields[0].name).toBe('traceID');
     expect(frame.fields[0].values.get(0)).toBe('e641dcac1c3a0565');
 
+    // TraceID must have unit = 'string' to prevent the ID from rendering as Infinity
+    expect(frame.fields[0].config.unit).toBe('string');
+
     expect(frame.fields[1].name).toBe('traceName');
     expect(frame.fields[1].values.get(0)).toBe('c10d7ca4e3a00354 ');
 

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -600,6 +600,7 @@ export function createTableFrameFromSearch(data: SearchResponse[], instanceSetti
         name: 'traceID',
         type: FieldType.string,
         config: {
+          unit: 'string',
           displayNameFromDS: 'Trace ID',
           links: [
             {


### PR DESCRIPTION
**What this PR does / why we need it**:
Some trace ids were being displayed as Infinity in the search results if they seemed to be in scientific notation (ex: '374e76010383810'). Adding `unit: 'string'` to the trace id field prevents this accidental conversion. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
Before and after with the same trace id
<img width="710" alt="image" src="https://user-images.githubusercontent.com/12838032/165131868-97f6a16d-1538-4572-a9f3-316cebc764f2.png">
![Screen Shot 2022-04-25 at 10 16 01 AM](https://user-images.githubusercontent.com/12838032/165131908-e351c08c-8588-43d2-8d99-b7b4f8ed8031.png)

