### PR TITLE
Bind command palette specific overrides and reset when no longer relevant

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -49,7 +49,7 @@ export class KeybindingSrv {
     this.bind('t r', () => toggleTheme(true));
   }
 
-  private globalEsc() {
+  globalEsc() {
     const anyDoc = document as any;
     const activeElement = anyDoc.activeElement;
 

--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -65,8 +65,9 @@ export const CommandPalette = () => {
     }
 
     return () => {
-      keybindingSrv.reset();
-      keybindingSrv.initGlobals();
+      keybindingSrv.bindGlobal('esc', () => {
+        keybindingSrv.globalEsc();
+      });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showing]);

--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -33,8 +33,7 @@ import getGlobalActions from './actions/global.static.actions';
 export const CommandPalette = () => {
   const styles = useStyles2(getSearchStyles);
   const [actions, setActions] = useState<Action[]>([]);
-  const { notHidden, query, showing } = useKBar((state) => ({
-    notHidden: state.visualState !== VisualState.hidden,
+  const { query, showing } = useKBar((state) => ({
     showing: state.visualState === VisualState.showing,
   }));
   const isNotLogin = locationService.getLocation().pathname !== '/login';
@@ -43,12 +42,6 @@ export const CommandPalette = () => {
     return {
       navBarTree: state.navBarTree,
     };
-  });
-
-  keybindingSrv.bind('esc', () => {
-    if (notHidden) {
-      query.setVisualState(VisualState.animatingOut);
-    }
   });
 
   useEffect(() => {
@@ -65,7 +58,17 @@ export const CommandPalette = () => {
   useEffect(() => {
     if (showing) {
       reportInteraction('commandPalette_opened');
+
+      keybindingSrv.bindGlobal('esc', () => {
+        query.setVisualState(VisualState.animatingOut);
+      });
     }
+
+    return () => {
+      keybindingSrv.reset();
+      keybindingSrv.initGlobals();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showing]);
 
   useRegisterActions(actions, [actions]);


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes issue where ESC keybindings no longer functioned due to being overridden by feature specific keybinding. We do override it, but then reset it back to the original function when the command palette is closed.

There is an alternative PR that will just remove the keybinding and not enable the command palette by default at #48220

Chatting with @Elfo404 about this - one thing to consider is picking one of two options

- we want `KeybindingSrv` to be the one way Grafana should register key bindings always
- `KeybindingSrv` is more for permanent keybindings and transitory keybindings like the 'command palette' and the 'dashboard save drawer' use normal `eventListener` type handlers as a layer on top. This is not reflected in this PR but can be done if we would like that approach

Another option is to have multiple instantiations of `MouseTrap` to support scoped keybindings. See the comment here https://github.com/ccampbell/mousetrap/issues/4#issuecomment-145755876. So with this, we would declare an instance of mousetrap in `KeybindingSrv`, export it, and bind and unbind to that. CommandPalette would have another instance with its escape binding, then pause the instance exported in `KeybindingSrv` when the command palette showed and unpause it when it was hidden. I didn't implement this because it would be a bunch of edits to `KeybindingSrv`, and I'd rather get some opinions before diving in. 