### PR TITLE
Variables: adds `reevaluate` and `onChangeVariable` datasource plugin APIs (proposal)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -314,7 +314,7 @@ exports[`no enzyme tests`] = {
     "public/app/plugins/datasource/loki/configuration/ConfigEditor.test.tsx:3658171175": [
       [0, 17, 13, "RegExp match", "2409514259"]
     ],
-    "public/app/plugins/datasource/loki/configuration/DebugSection.test.tsx:1551927716": [
+    "public/app/plugins/datasource/loki/configuration/DebugSection.test.tsx:2043792335": [
       [0, 17, 13, "RegExp match", "2409514259"]
     ],
     "public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx:3570129984": [

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -15,7 +15,7 @@ import { DataQuery } from './query';
 import { RawTimeRange, TimeRange } from './time';
 import { CustomVariableSupport, DataSourceVariableSupport, StandardVariableSupport } from './variables';
 
-import { DataSourceRef, WithAccessControlMetadata } from '.';
+import { DataSourceRef, VariableModel, WithAccessControlMetadata } from '.';
 
 export interface DataSourcePluginOptionsEditorProps<JSONData = DataSourceJsonData, SecureJSONData = {}> {
   options: DataSourceSettings<JSONData, SecureJSONData>;
@@ -282,6 +282,11 @@ abstract class DataSourceApi<
    * a deprecation warning which can be ignored for time being.
    */
   showContextToggle?(row?: LogRowModel): boolean;
+
+  /**
+   * Called when the value of a query variable for this datasource is changed.
+   */
+  onChangeVariable?(variable: VariableModel): void;
 
   /**
    * Variable query action.

--- a/packages/grafana-runtime/src/services/templateSrv.ts
+++ b/packages/grafana-runtime/src/services/templateSrv.ts
@@ -27,6 +27,11 @@ export interface TemplateSrv {
    * Update the current time range to be used when interpolating __from / __to variables.
    */
   updateTimeRange(timeRange: TimeRange): void;
+
+  /**
+   * Manually trigger reevaluation of a variable.
+   */
+  reevaluateVariable(variable: VariableModel): void;
 }
 
 let singletonInstance: TemplateSrv;

--- a/public/app/features/explore/utils/links.test.ts
+++ b/public/app/features/explore/utils/links.test.ts
@@ -28,6 +28,7 @@ describe('getFieldLinksForExplore', () => {
         return false;
       },
       updateTimeRange(timeRange: TimeRange) {},
+      reevaluateVariable() {},
     });
   });
 

--- a/public/app/features/templating/template_srv.mock.ts
+++ b/public/app/features/templating/template_srv.mock.ts
@@ -57,5 +57,7 @@ export class TemplateSrvMock implements TemplateSrv {
     return match !== null;
   }
 
+  reevaluateVariable(variable: VariableModel) {}
+
   updateTimeRange(timeRange: TimeRange) {}
 }

--- a/public/app/features/templating/template_srv.ts
+++ b/public/app/features/templating/template_srv.ts
@@ -3,12 +3,14 @@ import { escape, isString, property } from 'lodash';
 import { deprecationWarning, ScopedVars, TimeRange } from '@grafana/data';
 import { getDataSourceSrv, setTemplateSrv, TemplateSrv as BaseTemplateSrv } from '@grafana/runtime';
 
+import { dispatch } from '../../store/store';
 import { variableAdapters } from '../variables/adapters';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../variables/constants';
 import { isAdHoc } from '../variables/guard';
+import { updateOptions } from '../variables/state/actions';
 import { getFilteredVariables, getVariables, getVariableWithName } from '../variables/state/selectors';
 import { AdHocVariableFilter, AdHocVariableModel, VariableModel } from '../variables/types';
-import { variableRegex } from '../variables/utils';
+import { toKeyedVariableIdentifier, variableRegex } from '../variables/utils';
 
 import { FormatOptions, formatRegistry, FormatRegistryID } from './formatRegistry';
 
@@ -58,6 +60,10 @@ export class TemplateSrv implements BaseTemplateSrv {
 
   getVariables(): VariableModel[] {
     return this.dependencies.getVariables();
+  }
+
+  reevaluateVariable(variable: VariableModel) {
+    dispatch(updateOptions(toKeyedVariableIdentifier(variable), true));
   }
 
   updateIndex() {

--- a/public/app/features/variables/query/adapter.ts
+++ b/public/app/features/variables/query/adapter.ts
@@ -1,6 +1,7 @@
 import { cloneDeep } from 'lodash';
 
 import { dispatch } from '../../../store/store';
+import { getDatasourceSrv } from '../../plugins/datasource_srv';
 import { VariableAdapter } from '../adapters';
 import { ALL_VARIABLE_TEXT } from '../constants';
 import { optionPickerFactory } from '../pickers';
@@ -25,6 +26,14 @@ export const createQueryVariableAdapter = (): VariableAdapter<QueryVariableModel
       return containsVariable(variable.query, variable.datasource?.uid, variable.regex, variableToTest.name);
     },
     setValue: async (variable, option, emitChanges = false) => {
+      if (emitChanges) {
+        getDatasourceSrv()
+          .get(variable.datasource?.uid)
+          .then((datasource) => {
+            datasource.onChangeVariable?.(variable);
+          });
+      }
+
       await dispatch(setOptionAsCurrent(toKeyedVariableIdentifier(variable), option, emitChanges));
     },
     setValueFromUrl: async (variable, urlValue) => {

--- a/public/app/plugins/datasource/loki/configuration/DebugSection.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DebugSection.test.tsx
@@ -41,6 +41,7 @@ describe('DebugSection', () => {
         return false;
       },
       updateTimeRange(timeRange: TimeRange) {},
+      reevaluateVariable() {},
     });
   });
 


### PR DESCRIPTION
## Plugin Variables API Additions

This PR makes a couple additions to the datasource plugin API for variables to enable the following scenario. Here are the additions:

- `onChangeVariable` - This method can now be added to a plugin's DataSource class (i.e. the one that extends DataSourceApi). This allows plugins to be aware when a user changes a variable's value.
- `reevaluate` - This function on the template service allows plugin code to trigger reevaluation of a variable programmatically. 

## Scenario

I'm developing a datasource plugin where some dashboard variables can depend on one another as shown below.

![demo](https://user-images.githubusercontent.com/22484684/165165790-29a8e038-9260-4dad-96ef-f5245bdf0781.gif)

In this example you can see there is both a browser variable and version variable. When you select a certain browser the version options are reduced to show only versions which apply to this browser. The same is true in reverse as well. When you select a version only browsers that have that version should show in the browser dropdown. This type of pattern is a common occurance for the datasource plugin I'm developing. This PR makes supporting this pattern easier for plugin authors and users.

<details>

<summary><b>Current (less-than-ideal) workaround to enable this behavior</b></summary>
<br/>
Since Grafana doesn't support circular dependencies for variables I had to be a bit creative to get the above scenario to work as desired without changes to Grafana itself. There are two hidden dashboard variables here: a "context" variable and a "refresher" variable. The hidden "context" variable makes a query using both the browser and version to determine available options for the browser and version variables. The browser and version variables are dependent on the context variable so when it finishes its query they are automatically reevaluated and return the results the context query just returned but scoped to their specific type (browser or version). The hidden "refresher" variable is dependent on both the browser and version variables so when either of those have their values changed by the user it is aware of the change and can trigger a refresh of the "context" variable (it uses the location service to flip the "context" variable's value between A and B to force a refresh). Here's a diagram of the flow:

![diagram](https://user-images.githubusercontent.com/22484684/165165823-296eb0e6-0689-4a7b-b007-58e30bc32805.png)

Obviously the need to have a couple hidden "helper" variables here is less than ideal from a development perspective and especially from a user perspective. The API additions this PR proposes (`reevaluate` to programmatically force variable refreshes and `onChangeVariable` so the datasource plugin can be aware when a user makes a variable selection) would make the scenario described here possible without any "helper" variables required.

</details>

## Path Forward

The API changes here are purely additive so this shouldn't break any existing plugins. I still need to add/fix tests and docs. Since this PR merits some discussion on direction, however, I've decided to hold off adding those until Grafana confirms these API additions are acceptable.