### PR TITLE
TimeSeries: update frame.length when syncing bar widths

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/GraphNG/utils.test.ts
@@ -499,7 +499,7 @@ describe('GraphNG utils', () => {
             ],
           },
         ],
-        "length": 10,
+        "length": 12,
       }
     `);
   });

--- a/packages/grafana-ui/src/components/GraphNG/utils.ts
+++ b/packages/grafana-ui/src/components/GraphNG/utils.ts
@@ -13,7 +13,9 @@ import { nullToUndefThreshold } from './nullToUndefThreshold';
 import { XYFieldMatchers } from './types';
 
 function isVisibleBarField(f: Field) {
-  return f.config.custom?.drawStyle === GraphDrawStyle.Bars && !f.config.custom?.hideFrom?.viz;
+  return (
+    f.type === FieldType.number && f.config.custom?.drawStyle === GraphDrawStyle.Bars && !f.config.custom?.hideFrom?.viz
+  );
 }
 
 // will mutate the DataFrame's fields' values
@@ -105,6 +107,8 @@ export function preparePlotFrame(frames: DataFrame[], dimFields: XYFieldMatchers
           vals.push(undefined, undefined);
         }
       });
+
+      alignedFrame.length += 2;
     }
 
     return alignedFrame;


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/47834

This is a follow-up patch for #48030, which didn't work when stacking. (see https://github.com/grafana/grafana/issues/47834#issuecomment-1108914981)

<details><summary>stacked-barwidth.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "target": {
          "limit": 100,
          "matchAny": false,
          "tags": [],
          "type": "dashboard"
        },
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 245,
  "links": [],
  "liveNow": false,
  "panels": [
    {
      "datasource": {
        "type": "testdata",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "drawStyle": "bars",
            "fillOpacity": 20,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "normal"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": null
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 18,
        "w": 24,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom"
        },
        "tooltip": {
          "mode": "single",
          "sort": "none"
        }
      },
      "targets": [
        {
          "csvContent": "time,sum\n1650672000000,19.834",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "A",
          "scenarioId": "csv_content"
        },
        {
          "csvContent": "time,sum\n1650067200000,31.7555\n1650153600000,37.980000000000004\n1650240000000,44.521\n1650326400000,34.182\n1650412800000,35.659\n1650499200000,37.980000000000004\n1650585600000,31.333500000000004\n1650672000000,null",
          "datasource": {
            "type": "testdata",
            "uid": "PD8C576611E62080A"
          },
          "refId": "B",
          "scenarioId": "csv_content"
        }
      ],
      "title": "Panel Title",
      "type": "timeseries"
    }
  ],
  "schemaVersion": 36,
  "style": "dark",
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "2022-04-09T10:14:48.248Z",
    "to": "2022-04-30T14:30:14.564Z"
  },
  "timepicker": {},
  "timezone": "",
  "title": "bars-uniform-width",
  "uid": "8xywyaw7k",
  "version": 2,
  "weekStart": ""
}
```
</details>