### PR TITLE
Azure Monitor: reset resource uri when resource changes

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.test.tsx
@@ -76,6 +76,123 @@ describe('Azure Monitor QueryEditor', () => {
     });
   });
 
+  it('should change the resource group when selected', async () => {
+    const mockDatasource = createMockDatasource();
+    const onChange = jest.fn();
+    const mockQuery = createMockQuery();
+    mockDatasource.getResourceGroups = jest.fn().mockResolvedValue([
+      { text: 'grafanastaging', value: 'grafanastaging' },
+      { text: 'Grafana Prod', value: 'grafanaprod' },
+    ]);
+    render(
+      <MetricsQueryEditor
+        subscriptionId="123"
+        query={createMockQuery()}
+        datasource={mockDatasource}
+        variableOptionGroup={variableOptionGroup}
+        onChange={onChange}
+        setError={() => {}}
+      />
+    );
+    await waitFor(() => expect(screen.getByTestId('azure-monitor-metrics-query-editor')).toBeInTheDocument());
+
+    const resourceGroup = await screen.findByLabelText('Resource group');
+    await selectOptionInTest(resourceGroup, 'Grafana Prod');
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...mockQuery,
+      azureMonitor: {
+        ...mockQuery.azureMonitor,
+        resourceUri: '',
+        resourceGroup: 'grafanaprod',
+        metricDefinition: undefined,
+        metricNamespace: undefined,
+        resourceName: undefined,
+        metricName: undefined,
+        aggregation: undefined,
+        timeGrain: '',
+        dimensionFilters: [],
+      },
+    });
+  });
+
+  it('should change the resource type when selected', async () => {
+    const mockDatasource = createMockDatasource();
+    const onChange = jest.fn();
+    const mockQuery = createMockQuery();
+    mockDatasource.getMetricDefinitions = jest.fn().mockResolvedValue([
+      { text: 'Virtual Machine', value: 'azure/vm' },
+      { text: 'Database', value: 'azure/db' },
+    ]);
+    render(
+      <MetricsQueryEditor
+        subscriptionId="123"
+        query={createMockQuery()}
+        datasource={mockDatasource}
+        variableOptionGroup={variableOptionGroup}
+        onChange={onChange}
+        setError={() => {}}
+      />
+    );
+    await waitFor(() => expect(screen.getByTestId('azure-monitor-metrics-query-editor')).toBeInTheDocument());
+
+    const resourceGroup = await screen.findByLabelText('Resource type');
+    await selectOptionInTest(resourceGroup, 'Virtual Machine');
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...mockQuery,
+      azureMonitor: {
+        ...mockQuery.azureMonitor,
+        resourceUri: '',
+        metricDefinition: 'azure/vm',
+        resourceName: undefined,
+        metricNamespace: undefined,
+        metricName: undefined,
+        aggregation: undefined,
+        timeGrain: '',
+        dimensionFilters: [],
+      },
+    });
+  });
+
+  it('should change the resource name when selected', async () => {
+    const mockDatasource = createMockDatasource();
+    const onChange = jest.fn();
+    const mockQuery = createMockQuery();
+    mockDatasource.getResourceNames = jest.fn().mockResolvedValue([
+      { text: 'ResourceName1', value: 'resource-name-1' },
+      { text: 'ResourceName2', value: 'resource-name-2' },
+    ]);
+    render(
+      <MetricsQueryEditor
+        subscriptionId="123"
+        query={createMockQuery()}
+        datasource={mockDatasource}
+        variableOptionGroup={variableOptionGroup}
+        onChange={onChange}
+        setError={() => {}}
+      />
+    );
+    await waitFor(() => expect(screen.getByTestId('azure-monitor-metrics-query-editor')).toBeInTheDocument());
+
+    const resourceGroup = await screen.findByLabelText('Resource name');
+    await selectOptionInTest(resourceGroup, 'ResourceName1');
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...mockQuery,
+      azureMonitor: {
+        ...mockQuery.azureMonitor,
+        resourceUri: '',
+        resourceName: 'resource-name-1',
+        metricNamespace: undefined,
+        metricName: undefined,
+        aggregation: undefined,
+        timeGrain: '',
+        dimensionFilters: [],
+      },
+    });
+  });
+
   it('should change the metric name when selected', async () => {
     const mockDatasource = createMockDatasource();
     const onChange = jest.fn();

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.test.ts
@@ -314,6 +314,7 @@ describe('AzureMonitor: updateSubscriptions', () => {
         azureMonitor: {
           dimensionFilters: [],
           timeGrain: '',
+          resourceUri: '',
         },
       },
     },
@@ -327,6 +328,7 @@ describe('AzureMonitor: updateSubscriptions', () => {
         azureMonitor: {
           dimensionFilters: [],
           timeGrain: '',
+          resourceUri: '',
         },
       },
     },
@@ -341,6 +343,7 @@ describe('AzureMonitor: updateSubscriptions', () => {
         azureMonitor: {
           dimensionFilters: [],
           timeGrain: '',
+          resourceUri: '',
         },
       },
     },

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/setQueryValue.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/setQueryValue.ts
@@ -25,6 +25,7 @@ export function setSubscriptionID(query: AzureMonitorQuery, subscriptionID: stri
     subscription: subscriptionID,
     azureMonitor: {
       ...query.azureMonitor,
+      resourceUri: '',
       resourceGroup: undefined,
       metricDefinition: undefined,
       metricNamespace: undefined,
@@ -46,6 +47,7 @@ export function setResourceGroup(query: AzureMonitorQuery, resourceGroup: string
     ...query,
     azureMonitor: {
       ...query.azureMonitor,
+      resourceUri: '',
       resourceGroup: resourceGroup,
       metricDefinition: undefined,
       metricNamespace: undefined,
@@ -68,6 +70,7 @@ export function setResourceType(query: AzureMonitorQuery, resourceType: string |
     ...query,
     azureMonitor: {
       ...query.azureMonitor,
+      resourceUri: '',
       metricDefinition: resourceType,
       resourceName: undefined,
       metricNamespace: undefined,
@@ -90,6 +93,7 @@ export function setResourceName(query: AzureMonitorQuery, resourceName: string |
     ...query,
     azureMonitor: {
       ...query.azureMonitor,
+      resourceUri: '',
       resourceName: resourceName,
       metricNamespace: undefined,
       metricName: undefined,


### PR DESCRIPTION
**What this PR does / why we need it**:
This resets the resource URI when the resource is changed in the query editor.

As a part of the work done in https://github.com/grafana/grafana/pull/47696 to migrate Azure Monitor queries to a new format, a `resourceUri` property was constructed and added to the query object. Since the current metrics query editor is not using the `resourceUri` property yet, it doesn't get reset when the resource changes. As a result, the code that performs the migration will return the same `resourceUri` as seen here https://github.com/grafana/grafana/blob/836f5c1f4a2f5a03b91121a2e80f23369f711e13/public/app/plugins/datasource/grafana-azure-monitor-datasource/utils/migrateQuery.ts#L143-L145 which may cause an error because the query may be requesting a metric that is not compatible with the resource specified by the `resourceUri`

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
This bug was discovered during a mob session for this ticket https://github.com/grafana/grafana/issues/47979#issuecomment-1105266219
