### PR TITLE
Docs: Set base branch to 8.5 release branch for docs publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: publish_docs
 on:
   push:
     branches:
-    - main
+    - v8.5.x
     paths:
     - 'docs/sources/**'
     - 'packages/grafana-*/**'


### PR DESCRIPTION
Follow up with missing step from https://github.com/grafana/grafana/pull/48198