### PR TITLE
Dashboards: Use home dashboard from org again

### DIFF
--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -409,7 +409,7 @@ func (hs *HTTPServer) postDashboard(c *models.ReqContext, cmd models.SaveDashboa
 
 // GetHomeDashboard returns the home dashboard.
 func (hs *HTTPServer) GetHomeDashboard(c *models.ReqContext) response.Response {
-	prefsQuery := pref.GetPreferenceWithDefaultsQuery{UserID: c.SignedInUser.UserId}
+	prefsQuery := pref.GetPreferenceWithDefaultsQuery{OrgID: c.OrgId, UserID: c.SignedInUser.UserId}
 	homePage := hs.Cfg.HomePage
 
 	preference, err := hs.preferenceService.GetWithDefaults(c.Req.Context(), &prefsQuery)

--- a/pkg/services/preference/prefimpl/pref.go
+++ b/pkg/services/preference/prefimpl/pref.go
@@ -100,12 +100,14 @@ func (s *Service) Save(ctx context.Context, cmd *pref.SavePreferenceCommand) err
 		}
 		return err
 	}
+
 	preference.Timezone = cmd.Timezone
 	preference.WeekStart = cmd.WeekStart
 	preference.Theme = cmd.Theme
 	preference.Updated = time.Now()
 	preference.Version += 1
 	preference.JSONData = &pref.PreferenceJSONData{}
+	preference.HomeDashboardID = cmd.HomeDashboardID
 
 	if cmd.Navbar != nil {
 		preference.JSONData.Navbar = *cmd.Navbar


### PR DESCRIPTION
Fixes regression where home dashboard is not loaded from org.