### PR TITLE
loki: better resource-call urls

### DIFF
--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -98,11 +98,12 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	if req.Method != "GET" {
 		return fmt.Errorf("invalid resource method: %s", req.Method)
 	}
-	if (!strings.HasPrefix(url, "/loki/api/v1/labels?")) &&
-		(!strings.HasPrefix(url, "/loki/api/v1/label/")) && // the `/label/$label_name/values` form
-		(!strings.HasPrefix(url, "/loki/api/v1/series?")) {
+	if (!strings.HasPrefix(url, "labels?")) &&
+		(!strings.HasPrefix(url, "label/")) && // the `/label/$label_name/values` form
+		(!strings.HasPrefix(url, "series?")) {
 		return fmt.Errorf("invalid resource URL: %s", url)
 	}
+	lokiURL := fmt.Sprintf("/loki/api/v1/%s", url)
 
 	dsInfo, err := s.getDSInfo(req.PluginContext)
 	if err != nil {
@@ -110,7 +111,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 	}
 
 	api := newLokiAPI(dsInfo.HTTPClient, dsInfo.URL, s.plog)
-	bytes, err := api.RawQuery(ctx, url)
+	bytes, err := api.RawQuery(ctx, lokiURL)
 
 	if err != nil {
 		return err

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1000,7 +1000,7 @@ describe('LokiDatasource', () => {
   describe('importing queries', () => {
     it('keeps all labels when no labels are loaded', async () => {
       const ds = createLokiDSForTests();
-      fetchMock.mockImplementation(() => of(createFetchResponse({ data: [] })));
+      ds.getResource = () => Promise.resolve({ data: [] });
       const queries = await ds.importFromAbstractQueries([
         {
           refId: 'A',
@@ -1015,7 +1015,9 @@ describe('LokiDatasource', () => {
 
     it('filters out non existing labels', async () => {
       const ds = createLokiDSForTests();
-      fetchMock.mockImplementation(() => of(createFetchResponse({ data: ['foo'] })));
+      ds.getResource = () => {
+        return Promise.resolve({ data: ['foo'] });
+      };
       const queries = await ds.importFromAbstractQueries([
         {
           refId: 'A',

--- a/public/app/plugins/datasource/loki/language_provider.test.ts
+++ b/public/app/plugins/datasource/loki/language_provider.test.ts
@@ -95,7 +95,7 @@ describe('Language completion provider', () => {
       const fetchSeries = languageProvider.fetchSeries;
       const requestSpy = jest.spyOn(languageProvider, 'request');
       fetchSeries('{job="grafana"}');
-      expect(requestSpy).toHaveBeenCalledWith('/loki/api/v1/series', {
+      expect(requestSpy).toHaveBeenCalledWith('series', {
         end: 1560163909000,
         'match[]': '{job="grafana"}',
         start: 1560153109000,
@@ -116,7 +116,7 @@ describe('Language completion provider', () => {
       const requestSpy = jest.spyOn(languageProvider, 'request').mockResolvedValue([]);
       fetchSeriesLabels('$stream');
       expect(requestSpy).toHaveBeenCalled();
-      expect(requestSpy).toHaveBeenCalledWith('/loki/api/v1/series', {
+      expect(requestSpy).toHaveBeenCalledWith('series', {
         end: 1,
         'match[]': 'interpolated-stream',
         start: 0,
@@ -259,7 +259,7 @@ describe('Request URL', () => {
 
     const instance = new LanguageProvider(datasourceWithLabels);
     instance.fetchLabels();
-    const expectedUrl = '/loki/api/v1/labels';
+    const expectedUrl = 'labels';
     expect(datasourceSpy).toHaveBeenCalledWith(expectedUrl, rangeParams);
   });
 });

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -364,7 +364,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
    * Fetches all label keys
    */
   async fetchLabels(): Promise<string[]> {
-    const url = '/loki/api/v1/labels';
+    const url = 'labels';
     const timeRange = this.datasource.getTimeRangeParams();
     this.labelFetchTs = Date.now().valueOf();
 
@@ -393,7 +393,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
    */
   fetchSeriesLabels = async (match: string): Promise<Record<string, string[]>> => {
     const interpolatedMatch = this.datasource.interpolateString(match);
-    const url = '/loki/api/v1/series';
+    const url = 'series';
     const { start, end } = this.datasource.getTimeRangeParams();
 
     const cacheKey = this.generateCacheKey(url, start, end, interpolatedMatch);
@@ -415,7 +415,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
    * @param match
    */
   fetchSeries = async (match: string): Promise<Array<Record<string, string>>> => {
-    const url = '/loki/api/v1/series';
+    const url = 'series';
     const { start, end } = this.datasource.getTimeRangeParams();
     const params = { 'match[]': match, start, end };
     return await this.request(url, params);
@@ -440,7 +440,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
 
   async fetchLabelValues(key: string): Promise<string[]> {
     const interpolatedKey = this.datasource.interpolateString(key);
-    const url = `/loki/api/v1/label/${interpolatedKey}/values`;
+    const url = `label/${interpolatedKey}/values`;
     const rangeParams = this.datasource.getTimeRangeParams();
     const { start, end } = rangeParams;
 

--- a/public/app/plugins/datasource/loki/mocks.ts
+++ b/public/app/plugins/datasource/loki/mocks.ts
@@ -2,7 +2,7 @@ import { DataSourceSettings } from '@grafana/data';
 
 import { createDatasourceSettings } from '../../../features/datasources/mocks';
 
-import { LokiDatasource, LOKI_ENDPOINT } from './datasource';
+import { LokiDatasource } from './datasource';
 import { LokiOptions } from './types';
 
 interface Labels {
@@ -18,10 +18,10 @@ interface SeriesForSelector {
 }
 
 export function makeMockLokiDatasource(labelsAndValues: Labels, series?: SeriesForSelector): LokiDatasource {
-  const lokiLabelsAndValuesEndpointRegex = /^\/loki\/api\/v1\/label\/(\w*)\/values/;
-  const lokiSeriesEndpointRegex = /^\/loki\/api\/v1\/series/;
+  const lokiLabelsAndValuesEndpointRegex = /^label\/(\w*)\/values/;
+  const lokiSeriesEndpointRegex = /^series/;
 
-  const lokiLabelsEndpoint = `${LOKI_ENDPOINT}/labels`;
+  const lokiLabelsEndpoint = 'labels';
   const rangeMock = {
     start: 1560153109000,
     end: 1560163909000,


### PR DESCRIPTION
NOTE: the old-version of the code still supported frontend-mode (it was checking the backend-mode-feature-flag). to simplify the code, i just removed that and now metadata-requests are always backend-mode requests. (other queries still respect the feature-flag)

we had a problem, where metadata-requests created ajax-requests like `/api/datasources/number/resources//loki/api/v1/labels`

(note the `//` ).

on my local computer this worked fine, but in other environments, the `//` got somehow replaced by `/`. i don't know if that's a valid transformation, but i think not having that strange `//` in the URL will make this more robust.

how to test:
1. go to explore, choose a loki datasource
2. open the logs-panel, click on a label-name, then click on a label-value. make sure it works.