### PR TITLE
Explore Split Logs - use unique IDs and save state vals to unique place

### DIFF
--- a/public/app/features/explore/Logs.test.tsx
+++ b/public/app/features/explore/Logs.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
 import { LoadingState, LogLevel, LogRowModel, MutableDataFrame, toUtc } from '@grafana/data';
+import { ExploreId } from 'app/types';
 
 import { Logs } from './Logs';
 
@@ -15,6 +16,7 @@ describe('Logs', () => {
 
     return render(
       <Logs
+        exploreId={ExploreId.left}
         logRows={rows}
         timeZone={'utc'}
         width={50}

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -35,6 +35,7 @@ import {
 import { RowContextOptions } from '@grafana/ui/src/components/Logs/LogRowContextProvider';
 import { dedupLogRows, filterLogLevels } from 'app/core/logs_model';
 import store from 'app/core/store';
+import { ExploreId } from 'app/types/explore';
 
 import { ExploreGraph } from './ExploreGraph';
 import { LogsMetaRow } from './LogsMetaRow';
@@ -62,6 +63,7 @@ interface Props extends Themeable2 {
   timeZone: TimeZone;
   scanning?: boolean;
   scanRange?: RawTimeRange;
+  exploreId: ExploreId;
   showContextToggle?: (row?: LogRowModel) => boolean;
   onChangeTime: (range: AbsoluteTimeRange) => void;
   onClickFilterLabel?: (key: string, value: string) => void;
@@ -93,10 +95,10 @@ class UnthemedLogs extends PureComponent<Props, State> {
   topLogsRef = createRef<HTMLDivElement>();
 
   state: State = {
-    showLabels: store.getBool(SETTINGS_KEYS.showLabels, false),
-    showTime: store.getBool(SETTINGS_KEYS.showTime, true),
-    wrapLogMessage: store.getBool(SETTINGS_KEYS.wrapLogMessage, true),
-    prettifyLogMessage: store.getBool(SETTINGS_KEYS.prettifyLogMessage, false),
+    showLabels: store.getBool(`${SETTINGS_KEYS.showLabels}_${this.props.exploreId}`, false),
+    showTime: store.getBool(`${SETTINGS_KEYS.showTime}_${this.props.exploreId}`, true),
+    wrapLogMessage: store.getBool(`${SETTINGS_KEYS.wrapLogMessage}_${this.props.exploreId}`, true),
+    prettifyLogMessage: store.getBool(`${SETTINGS_KEYS.prettifyLogMessage}_${this.props.exploreId}`, false),
     dedupStrategy: LogsDedupStrategy.none,
     hiddenLogLevels: [],
     logsSortOrder: store.get(SETTINGS_KEYS.logsSortOrder) || LogsSortOrder.Descending,
@@ -141,45 +143,49 @@ class UnthemedLogs extends PureComponent<Props, State> {
 
   onChangeLabels = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { target } = event;
+    const { exploreId } = this.props;
     if (target) {
       const showLabels = target.checked;
       this.setState({
         showLabels,
       });
-      store.set(SETTINGS_KEYS.showLabels, showLabels);
+      store.set(`${SETTINGS_KEYS.showLabels}_${exploreId}`, showLabels);
     }
   };
 
   onChangeTime = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { target } = event;
+    const { exploreId } = this.props;
     if (target) {
       const showTime = target.checked;
       this.setState({
         showTime,
       });
-      store.set(SETTINGS_KEYS.showTime, showTime);
+      store.set(`${SETTINGS_KEYS.showTime}_${exploreId}`, showTime);
     }
   };
 
   onChangewrapLogMessage = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { target } = event;
+    const { exploreId } = this.props;
     if (target) {
       const wrapLogMessage = target.checked;
       this.setState({
         wrapLogMessage,
       });
-      store.set(SETTINGS_KEYS.wrapLogMessage, wrapLogMessage);
+      store.set(`${SETTINGS_KEYS.wrapLogMessage}_${exploreId}`, wrapLogMessage);
     }
   };
 
   onChangePrettifyLogMessage = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { target } = event;
+    const { exploreId } = this.props;
     if (target) {
       const prettifyLogMessage = target.checked;
       this.setState({
         prettifyLogMessage,
       });
-      store.set(SETTINGS_KEYS.prettifyLogMessage, prettifyLogMessage);
+      store.set(`${SETTINGS_KEYS.prettifyLogMessage}_${exploreId}`, prettifyLogMessage);
     }
   };
 
@@ -271,6 +277,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
       logsQueries,
       clearCache,
       addResultsToCache,
+      exploreId,
     } = this.props;
 
     const {
@@ -324,7 +331,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
                 onChange={this.onChangeTime}
                 className={styles.horizontalInlineSwitch}
                 transparent
-                id="show-time"
+                id={`show-time_${exploreId}`}
               />
             </InlineField>
             <InlineField label="Unique labels" className={styles.horizontalInlineLabel} transparent>
@@ -333,7 +340,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
                 onChange={this.onChangeLabels}
                 className={styles.horizontalInlineSwitch}
                 transparent
-                id="unique-labels"
+                id={`unique-labels_${exploreId}`}
               />
             </InlineField>
             <InlineField label="Wrap lines" className={styles.horizontalInlineLabel} transparent>
@@ -342,7 +349,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
                 onChange={this.onChangewrapLogMessage}
                 className={styles.horizontalInlineSwitch}
                 transparent
-                id="wrap-lines"
+                id={`wrap-lines_${exploreId}`}
               />
             </InlineField>
             <InlineField label="Prettify JSON" className={styles.horizontalInlineLabel} transparent>
@@ -351,7 +358,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
                 onChange={this.onChangePrettifyLogMessage}
                 className={styles.horizontalInlineSwitch}
                 transparent
-                id="prettify"
+                id={`prettify_${exploreId}`}
               />
             </InlineField>
             <InlineField label="Dedup" className={styles.horizontalInlineLabel} transparent>

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -95,10 +95,10 @@ class UnthemedLogs extends PureComponent<Props, State> {
   topLogsRef = createRef<HTMLDivElement>();
 
   state: State = {
-    showLabels: store.getBool(`${SETTINGS_KEYS.showLabels}_${this.props.exploreId}`, false),
-    showTime: store.getBool(`${SETTINGS_KEYS.showTime}_${this.props.exploreId}`, true),
-    wrapLogMessage: store.getBool(`${SETTINGS_KEYS.wrapLogMessage}_${this.props.exploreId}`, true),
-    prettifyLogMessage: store.getBool(`${SETTINGS_KEYS.prettifyLogMessage}_${this.props.exploreId}`, false),
+    showLabels: store.getBool(SETTINGS_KEYS.showLabels, false),
+    showTime: store.getBool(SETTINGS_KEYS.showTime, true),
+    wrapLogMessage: store.getBool(SETTINGS_KEYS.wrapLogMessage, true),
+    prettifyLogMessage: store.getBool(SETTINGS_KEYS.prettifyLogMessage, false),
     dedupStrategy: LogsDedupStrategy.none,
     hiddenLogLevels: [],
     logsSortOrder: store.get(SETTINGS_KEYS.logsSortOrder) || LogsSortOrder.Descending,
@@ -143,49 +143,45 @@ class UnthemedLogs extends PureComponent<Props, State> {
 
   onChangeLabels = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { target } = event;
-    const { exploreId } = this.props;
     if (target) {
       const showLabels = target.checked;
       this.setState({
         showLabels,
       });
-      store.set(`${SETTINGS_KEYS.showLabels}_${exploreId}`, showLabels);
+      store.set(SETTINGS_KEYS.showLabels, showLabels);
     }
   };
 
   onChangeTime = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { target } = event;
-    const { exploreId } = this.props;
     if (target) {
       const showTime = target.checked;
       this.setState({
         showTime,
       });
-      store.set(`${SETTINGS_KEYS.showTime}_${exploreId}`, showTime);
+      store.set(SETTINGS_KEYS.showTime, showTime);
     }
   };
 
   onChangewrapLogMessage = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { target } = event;
-    const { exploreId } = this.props;
     if (target) {
       const wrapLogMessage = target.checked;
       this.setState({
         wrapLogMessage,
       });
-      store.set(`${SETTINGS_KEYS.wrapLogMessage}_${exploreId}`, wrapLogMessage);
+      store.set(SETTINGS_KEYS.wrapLogMessage, wrapLogMessage);
     }
   };
 
   onChangePrettifyLogMessage = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { target } = event;
-    const { exploreId } = this.props;
     if (target) {
       const prettifyLogMessage = target.checked;
       this.setState({
         prettifyLogMessage,
       });
-      store.set(`${SETTINGS_KEYS.prettifyLogMessage}_${exploreId}`, prettifyLogMessage);
+      store.set(SETTINGS_KEYS.prettifyLogMessage, prettifyLogMessage);
     }
   };
 

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -127,6 +127,7 @@ class LogsContainer extends PureComponent<LogsContainerProps> {
         <LogsCrossFadeTransition visible={!isLive}>
           <Collapse label="Logs" loading={loading} isOpen className={styleOverridesForStickyNavigation}>
             <Logs
+              exploreId={exploreId}
               logRows={logRows}
               logsMeta={logsMeta}
               logsSeries={logsSeries}


### PR DESCRIPTION
**What this PR does / why we need it**:
Ids for some switches end up not being unique, and toggling them toggles the wrong side of the split. I also save them to their own state locations.

**Which issue(s) this PR fixes**:
Fixes #48296

