### PR TITLE
Make clear that the two example templates must be used together

### DIFF
--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -125,6 +125,13 @@ Template to render entire notification message:
 {{ end }}
 ```
 
+After you save these two templates, use `mymessage` in the notification message field:
+
+```
+Alert summary:
+{{ template "mymessage" . }}
+```
+
 ### HTML in message templates
 
 HTML in alerting message templates is escaped. We do not support rendering of HTML in the resulting notification.

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -81,7 +81,7 @@ You can use any of the following built-in template options to embed custom templ
 
 ### Custom template examples
 
-Here are a few examples of how to use custom templates.
+Here's an examples of how to use custom templates.
 
 Template to render a single alert:
 
@@ -125,7 +125,7 @@ Template to render entire notification message:
 {{ end }}
 ```
 
-After you save these two templates, use `mymessage` in the notification message field:
+After saving these two templates, use `mymessage` in the notification message field:
 
 ```
 Alert summary:

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -81,7 +81,7 @@ You can use any of the following built-in template options to embed custom templ
 
 ### Custom template examples
 
-Here's an examples of how to use custom templates.
+Here's an example of how to use a custom template. You can also use the default template included in the setup.
 
 Template to render a single alert:
 

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -83,7 +83,7 @@ You can use any of the following built-in template options to embed custom templ
 
 Here's an example of how to use a custom template. You can also use the default template included in the setup.
 
-Template to render a single alert:
+Step 1: Configure a template to render a single alert.
 
 ```
 {{ define "myalert" }}
@@ -110,7 +110,7 @@ Template to render a single alert:
 {{ end }}
 ```
 
-Template to render entire notification message:
+Step 2: Configure a template to render entire notification message.
 
 ```
 {{ define "mymessage" }}
@@ -125,7 +125,7 @@ Template to render entire notification message:
 {{ end }}
 ```
 
-After saving these two templates, use `mymessage` in the notification message field:
+Step 3: Add `mymessage` in the notification message field.
 
 ```
 Alert summary:

--- a/docs/sources/alerting/unified-alerting/message-templating/_index.md
+++ b/docs/sources/alerting/unified-alerting/message-templating/_index.md
@@ -79,7 +79,7 @@ You can use any of the following built-in template options to embed custom templ
 | `default.message`       | Provides a formatted summary of firing and resolved alerts.   |
 | `teams.default.message` | Similar to `default.messsage`, formatted for Microsoft Teams. |
 
-### Custom template examples
+### Example of a custom template
 
 Here's an example of how to use a custom template. You can also use the default template included in the setup.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a little enhancement over our current docs for message templating.

We've had escalations about our [example of custom templates](https://grafana.com/docs/grafana/latest/alerting/unified-alerting/message-templating/#custom-template-examples) not working. Customers tried to use them as standalone templates, when in reality they should be use together as one depends on the other.

When the notification message fails to parse, customers think that there's something wrong with the example templates. This can be solved by adding an extra step in the docs implying that these templates are meant to be used together.

**Which issue(s) this PR fixes**:

https://github.com/grafana/grafana/issues/47023
