### PR TITLE
[Option 2] QueryGroup: support scrolling while data updates

### DIFF
--- a/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
+++ b/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
@@ -20,6 +20,7 @@ interface Props {
   hideVerticalTrack?: boolean;
   scrollRefCallback?: RefCallback<HTMLDivElement>;
   scrollTop?: number;
+  scrollToBottom?: boolean; // when changed to true, it will scroll to the bootom
   setScrollTop?: (position: ScrollbarPosition) => void;
   autoHeightMin?: number | string;
   updateAfterMountMs?: number;
@@ -41,6 +42,7 @@ export const CustomScrollbar: FC<Props> = ({
   scrollRefCallback,
   updateAfterMountMs,
   scrollTop,
+  scrollToBottom,
   children,
 }) => {
   const ref = useRef<Scrollbars & { view: HTMLDivElement }>(null);
@@ -77,6 +79,15 @@ export const CustomScrollbar: FC<Props> = ({
       }
     }, updateAfterMountMs);
   }, [updateAfterMountMs]);
+
+  useEffect(() => {
+    if (!scrollToBottom) {
+      return;
+    }
+    setTimeout(() => {
+      ref.current?.scrollToBottom();
+    }, 100);
+  }, [ref, scrollToBottom]);
 
   function renderTrack(className: string, hideTrack: boolean | undefined, passedProps: any) {
     if (passedProps.style && hideTrack) {


### PR DESCRIPTION
The current query editor behavior while streaming is pretty rough.  This is what happens with scrolling:

https://user-images.githubusercontent.com/705951/165413007-a4a4363f-f3e9-49d9-a595-93630d978954.mp4


This PR makes it so we actually scroll to the bottom, but I confess that it feels weird: 

https://user-images.githubusercontent.com/705951/165411378-f872a607-47a4-434a-9664-efaa145c4cf7.mp4


