### PR TITLE
Save Drawer: reduce the number of diff elements we show

### DIFF
--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDiff.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDiff.tsx
@@ -64,7 +64,7 @@ export const SaveDashboardDiff = ({ diff, oldValue, newValue }: SaveDashboardDif
 
       {value.showDiffs && <div className={styles.spacer}>{value.diffs}</div>}
 
-      <h4>JSON Diff</h4>
+      <h4>JSON Model</h4>
       <DiffViewer oldValue={value.oldJSON} newValue={value.newJSON} />
     </div>
   );

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDiff.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDiff.tsx
@@ -45,7 +45,7 @@ export const SaveDashboardDiff = ({ diff, oldValue, newValue }: SaveDashboardDif
       schemaChange,
       diffs,
       count,
-      showDiffs: count < 10, // overwhelming if too many changes
+      showDiffs: count < 15, // overwhelming if too many changes
     };
   }, [diff, oldValue, newValue]);
 

--- a/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDiff.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/SaveDashboardDiff.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { useAsync } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -22,12 +22,30 @@ export const SaveDashboardDiff = ({ diff, oldValue, newValue }: SaveDashboardDif
   const loader = useAsync(async () => {
     const oldJSON = JSON.stringify(oldValue ?? {}, null, 2);
     const newJSON = JSON.stringify(newValue ?? {}, null, 2);
+
+    // Schema changes will have MANY changes that the user will not understand
+    let schemaChange: ReactElement | undefined = undefined;
+    const diffs: ReactElement[] = [];
+    let count = 0;
+    if (diff) {
+      for (const [key, changes] of Object.entries(diff)) {
+        // this takes a long time for large diffs (so this is async)
+        const g = <DiffGroup diffs={changes} key={key} title={key} />;
+        if (key === 'schemaVersion') {
+          schemaChange = g;
+        } else {
+          diffs.push(g);
+        }
+        count += changes.length;
+      }
+    }
     return {
       oldJSON,
       newJSON,
-      diffs: Object.entries(diff ?? []).map(([key, diffs]) => (
-        <DiffGroup diffs={diffs} key={key} title={key} /> // this takes a long time for large diffs
-      )),
+      schemaChange,
+      diffs,
+      count,
+      showDiffs: count < 10, // overwhelming if too many changes
     };
   }, [diff, oldValue, newValue]);
 
@@ -36,13 +54,15 @@ export const SaveDashboardDiff = ({ diff, oldValue, newValue }: SaveDashboardDif
     return <Spinner />;
   }
 
-  if (!value.diffs.length) {
+  if (value.count < 1) {
     return <div>No changes in this dashboard</div>;
   }
 
   return (
     <div>
-      <div className={styles.spacer}>{value.diffs}</div>
+      {value.schemaChange && <div className={styles.spacer}>{value.schemaChange}</div>}
+
+      {value.showDiffs && <div className={styles.spacer}>{value.diffs}</div>}
 
       <h4>JSON Diff</h4>
       <DiffViewer oldValue={value.oldJSON} newValue={value.newJSON} />


### PR DESCRIPTION
In an effort to make the diff view a bit more understandable, this PR limits the "user friendly" formatting to 15 changes, and will always show the JSON diff.

When there are many changes the non-json view can be misleading.

Similarly -- saving with changes to the schemaVersion explode the actual changeset.  


| Before | After |
| --- | ----------- |
| <img width="789" alt="image" src="https://user-images.githubusercontent.com/705951/165417836-63ac66b9-abde-4010-8727-b8e21217952f.png"> | <img width="790" alt="image" src="https://user-images.githubusercontent.com/705951/165417731-12f746c2-5f3a-4e0c-a89a-3e20087cac81.png"> |




