### PR TITLE
Access Control: Remove unused option

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -56,18 +56,18 @@ func (a *api) getEvaluators(actionRead, actionWrite, scope string) (read, write 
 func (a *api) registerEndpoints() {
 	auth := accesscontrol.Middleware(a.ac)
 	disable := disableMiddleware(a.ac.IsDisabled())
-	uidSolver := solveUID(a.service.options.UidSolver)
 	inheritanceSolver := solveInheritedScopes(a.service.options.InheritedScopesSolver)
+
 	a.router.Group(fmt.Sprintf("/api/access-control/%s", a.service.options.Resource), func(r routing.RouteRegister) {
 		actionRead := fmt.Sprintf("%s.permissions:read", a.service.options.Resource)
 		actionWrite := fmt.Sprintf("%s.permissions:write", a.service.options.Resource)
 		scope := accesscontrol.Scope(a.service.options.Resource, a.service.options.ResourceAttribute, accesscontrol.Parameter(":resourceID"))
 		readEvaluator, writeEvaluator := a.getEvaluators(actionRead, actionWrite, scope)
 		r.Get("/description", auth(disable, accesscontrol.EvalPermission(actionRead)), routing.Wrap(a.getDescription))
-		r.Get("/:resourceID", inheritanceSolver, uidSolver, auth(disable, readEvaluator), routing.Wrap(a.getPermissions))
-		r.Post("/:resourceID/users/:userID", inheritanceSolver, uidSolver, auth(disable, writeEvaluator), routing.Wrap(a.setUserPermission))
-		r.Post("/:resourceID/teams/:teamID", inheritanceSolver, uidSolver, auth(disable, writeEvaluator), routing.Wrap(a.setTeamPermission))
-		r.Post("/:resourceID/builtInRoles/:builtInRole", inheritanceSolver, uidSolver, auth(disable, writeEvaluator), routing.Wrap(a.setBuiltinRolePermission))
+		r.Get("/:resourceID", inheritanceSolver, auth(disable, readEvaluator), routing.Wrap(a.getPermissions))
+		r.Post("/:resourceID/users/:userID", inheritanceSolver, auth(disable, writeEvaluator), routing.Wrap(a.setUserPermission))
+		r.Post("/:resourceID/teams/:teamID", inheritanceSolver, auth(disable, writeEvaluator), routing.Wrap(a.setTeamPermission))
+		r.Post("/:resourceID/builtInRoles/:builtInRole", inheritanceSolver, auth(disable, writeEvaluator), routing.Wrap(a.setBuiltinRolePermission))
 	})
 }
 

--- a/pkg/services/accesscontrol/resourcepermissions/api_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_test.go
@@ -528,13 +528,6 @@ var testInheritedScopeSolver = func(ctx context.Context, orgID int64, id string)
 	return nil, errors.New("not found")
 }
 
-var testSolver = func(ctx context.Context, orgID int64, uid string) (int64, error) {
-	if uid == "resourceUID" {
-		return 1, nil
-	}
-	return 0, errors.New("not found")
-}
-
 func getPermission(t *testing.T, server *web.Mux, resource, resourceID string) ([]resourcePermissionDTO, *httptest.ResponseRecorder) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/api/access-control/%s/%s", resource, resourceID), nil)
 	require.NoError(t, err)

--- a/pkg/services/accesscontrol/resourcepermissions/middleware.go
+++ b/pkg/services/accesscontrol/resourcepermissions/middleware.go
@@ -2,28 +2,12 @@ package resourcepermissions
 
 import (
 	"net/http"
-	"strconv"
 
 	"github.com/grafana/grafana/pkg/models"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
 )
-
-func solveUID(solve UidSolver) web.Handler {
-	return func(c *models.ReqContext) {
-		if solve != nil && util.IsValidShortUID(web.Params(c.Req)[":resourceID"]) {
-			params := web.Params(c.Req)
-			id, err := solve(c.Req.Context(), c.OrgId, params[":resourceID"])
-			if err != nil {
-				c.JsonApiErr(http.StatusNotFound, "Resource not found", err)
-				return
-			}
-			params[":resourceID"] = strconv.FormatInt(id, 10)
-			web.SetURLParams(c.Req, params)
-		}
-	}
-}
 
 // solveInheritedScopes will add the inherited scopes to the context param by prefix
 // Ex: params["folders:uid:"] = "folders:uid:BCeknZL7k"

--- a/pkg/services/accesscontrol/resourcepermissions/options.go
+++ b/pkg/services/accesscontrol/resourcepermissions/options.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 )
 
-type UidSolver func(ctx context.Context, orgID int64, uid string) (int64, error)
 type ResourceValidator func(ctx context.Context, orgID int64, resourceID string) error
 type InheritedScopesSolver func(ctx context.Context, orgID int64, resourceID string) ([]string, error)
 
@@ -38,8 +37,6 @@ type Options struct {
 	OnSetTeam func(session *sqlstore.DBSession, orgID, teamID int64, resourceID, permission string) error
 	// OnSetBuiltInRole if configured will be called each time a permission is set for a built-in role
 	OnSetBuiltInRole func(session *sqlstore.DBSession, orgID int64, builtInRole, resourceID, permission string) error
-	// UidSolver if configured will be used in a middleware to translate an uid to id for each request
-	UidSolver UidSolver
 	// InheritedScopesSolver if configured can generate additional scopes that will be used when fetching permissions for a resource
 	InheritedScopesSolver InheritedScopesSolver
 	// InheritedScopePrefixes if configured are used to create evaluators with the scopes returned by InheritedScopesSolver


### PR DESCRIPTION
**What this PR does / why we need it**:
We changed dashboard, folder and datasource permissions to be based on uid:s. We no longer have a need for the UIDSolver workaround in the api

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

