### PR TITLE
Access Control: Move access control middlewares to domain package

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/database"
-	acmiddleware "github.com/grafana/grafana/pkg/services/accesscontrol/middleware"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/auth"
@@ -421,7 +420,7 @@ func setupHTTPServerWithCfgDb(t *testing.T, useFakeAccessControl, enableAccessCo
 		c.Map(initCtx)
 	})
 
-	m.Use(acmiddleware.LoadPermissionsMiddleware(hs.AccessControl))
+	m.Use(accesscontrol.LoadPermissionsMiddleware(hs.AccessControl))
 
 	// Register all routes
 	hs.registerRoutes()

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -28,7 +28,6 @@ import (
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/plugincontext"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	acmiddleware "github.com/grafana/grafana/pkg/services/accesscontrol/middleware"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/cleanup"
 	"github.com/grafana/grafana/pkg/services/comments"
@@ -511,7 +510,7 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 
 	m.Use(hs.ContextHandler.Middleware)
 	m.Use(middleware.OrgRedirect(hs.Cfg, hs.SQLStore))
-	m.Use(acmiddleware.LoadPermissionsMiddleware(hs.AccessControl))
+	m.Use(accesscontrol.LoadPermissionsMiddleware(hs.AccessControl))
 
 	// needs to be after context handler
 	if hs.Cfg.EnforceDomain {

--- a/pkg/services/accesscontrol/middleware.go
+++ b/pkg/services/accesscontrol/middleware.go
@@ -1,35 +1,20 @@
-package middleware
+package accesscontrol
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
 )
 
-func authorize(c *models.ReqContext, ac accesscontrol.AccessControl, user *models.SignedInUser, evaluator accesscontrol.Evaluator) {
-	injected, err := evaluator.MutateScopes(c.Req.Context(), accesscontrol.ScopeInjector(buildScopeParams(c)))
-	if err != nil {
-		c.JsonApiErr(http.StatusInternalServerError, "Internal server error", err)
-		return
-	}
-
-	hasAccess, err := ac.Evaluate(c.Req.Context(), user, injected)
-	if !hasAccess || err != nil {
-		Deny(c, injected, err)
-		return
-	}
-}
-
-func Middleware(ac accesscontrol.AccessControl) func(web.Handler, accesscontrol.Evaluator) web.Handler {
-	return func(fallback web.Handler, evaluator accesscontrol.Evaluator) web.Handler {
+func Middleware(ac AccessControl) func(web.Handler, Evaluator) web.Handler {
+	return func(fallback web.Handler, evaluator Evaluator) web.Handler {
 		if ac.IsDisabled() {
 			return fallback
 		}
@@ -40,7 +25,24 @@ func Middleware(ac accesscontrol.AccessControl) func(web.Handler, accesscontrol.
 	}
 }
 
-func Deny(c *models.ReqContext, evaluator accesscontrol.Evaluator, err error) {
+func authorize(c *models.ReqContext, ac AccessControl, user *models.SignedInUser, evaluator Evaluator) {
+	injected, err := evaluator.MutateScopes(c.Req.Context(), ScopeInjector(ScopeParams{
+		OrgID:     c.OrgId,
+		URLParams: web.Params(c.Req),
+	}))
+	if err != nil {
+		c.JsonApiErr(http.StatusInternalServerError, "Internal server error", err)
+		return
+	}
+
+	hasAccess, err := ac.Evaluate(c.Req.Context(), user, injected)
+	if !hasAccess || err != nil {
+		deny(c, injected.GoString(), err)
+		return
+	}
+}
+
+func deny(c *models.ReqContext, permissions string, err error) {
 	id := newID()
 	if err != nil {
 		c.Logger.Error("Error from access control system", "error", err, "accessErrorID", id)
@@ -49,7 +51,7 @@ func Deny(c *models.ReqContext, evaluator accesscontrol.Evaluator, err error) {
 			"Access denied",
 			"userID", c.UserId,
 			"accessErrorID", id,
-			"permissions", evaluator.GoString(),
+			"permissions", permissions,
 		)
 	}
 
@@ -65,7 +67,7 @@ func Deny(c *models.ReqContext, evaluator accesscontrol.Evaluator, err error) {
 	// internal server error or access denied.
 	c.JSON(http.StatusForbidden, map[string]string{
 		"title":         "Access denied", // the component needs to pick this up
-		"message":       fmt.Sprintf("You'll need additional permissions to perform this action. Permissions needed: %s", evaluator.String()),
+		"message":       fmt.Sprintf("You'll need additional permissions to perform this action. Permissions needed: %s", permissions),
 		"accessErrorId": id,
 	})
 }
@@ -82,17 +84,13 @@ func newID() string {
 	return "ACE" + id
 }
 
-func buildScopeParams(c *models.ReqContext) accesscontrol.ScopeParams {
-	return accesscontrol.ScopeParams{
-		OrgID:     c.OrgId,
-		URLParams: web.Params(c.Req),
-	}
+type OrgIDGetter func(c *models.ReqContext) (int64, error)
+type userCache interface {
+	GetSignedInUserWithCacheCtx(ctx context.Context, query *models.GetSignedInUserQuery) error
 }
 
-type OrgIDGetter func(c *models.ReqContext) (int64, error)
-
-func AuthorizeInOrgMiddleware(ac accesscontrol.AccessControl, db sqlstore.Store) func(web.Handler, OrgIDGetter, accesscontrol.Evaluator) web.Handler {
-	return func(fallback web.Handler, getTargetOrg OrgIDGetter, evaluator accesscontrol.Evaluator) web.Handler {
+func AuthorizeInOrgMiddleware(ac AccessControl, cache userCache) func(web.Handler, OrgIDGetter, Evaluator) web.Handler {
+	return func(fallback web.Handler, getTargetOrg OrgIDGetter, evaluator Evaluator) web.Handler {
 		if ac.IsDisabled() {
 			return fallback
 		}
@@ -102,17 +100,17 @@ func AuthorizeInOrgMiddleware(ac accesscontrol.AccessControl, db sqlstore.Store)
 			userCopy := *(c.SignedInUser)
 			orgID, err := getTargetOrg(c)
 			if err != nil {
-				Deny(c, nil, fmt.Errorf("failed to get target org: %w", err))
+				deny(c, "", fmt.Errorf("failed to get target org: %w", err))
 				return
 			}
-			if orgID == accesscontrol.GlobalOrgID {
+			if orgID == GlobalOrgID {
 				userCopy.OrgId = orgID
 				userCopy.OrgName = ""
 				userCopy.OrgRole = ""
 			} else {
 				query := models.GetSignedInUserQuery{UserId: c.UserId, OrgId: orgID}
-				if err := db.GetSignedInUserWithCacheCtx(c.Req.Context(), &query); err != nil {
-					Deny(c, nil, fmt.Errorf("failed to authenticate user in target org: %w", err))
+				if err := cache.GetSignedInUserWithCacheCtx(c.Req.Context(), &query); err != nil {
+					deny(c, "", fmt.Errorf("failed to authenticate user in target org: %w", err))
 					return
 				}
 				userCopy.OrgId = query.Result.OrgId
@@ -122,7 +120,7 @@ func AuthorizeInOrgMiddleware(ac accesscontrol.AccessControl, db sqlstore.Store)
 
 			authorize(c, ac, &userCopy, evaluator)
 
-			// Set the signed in user permissions in that org
+			// Set the sign-ed in user permissions in that org
 			c.SignedInUser.Permissions = userCopy.Permissions
 		}
 	}
@@ -140,27 +138,17 @@ func UseOrgFromContextParams(c *models.ReqContext) (int64, error) {
 }
 
 func UseGlobalOrg(c *models.ReqContext) (int64, error) {
-	return accesscontrol.GlobalOrgID, nil
+	return GlobalOrgID, nil
 }
 
-// Disable returns http 404 if shouldDisable is set to true
-func Disable(shouldDisable bool) web.Handler {
-	return func(c *models.ReqContext) {
-		if shouldDisable {
-			c.Resp.WriteHeader(http.StatusNotFound)
-			return
-		}
-	}
-}
-
-func LoadPermissionsMiddleware(ac accesscontrol.AccessControl) web.Handler {
+func LoadPermissionsMiddleware(ac AccessControl) web.Handler {
 	return func(c *models.ReqContext) {
 		if ac.IsDisabled() {
 			return
 		}
 
 		permissions, err := ac.GetUserPermissions(c.Req.Context(), c.SignedInUser,
-			accesscontrol.Options{ReloadCache: false})
+			Options{ReloadCache: false})
 		if err != nil {
 			c.JsonApiErr(http.StatusForbidden, "", err)
 			return
@@ -169,6 +157,6 @@ func LoadPermissionsMiddleware(ac accesscontrol.AccessControl) web.Handler {
 		if c.SignedInUser.Permissions == nil {
 			c.SignedInUser.Permissions = make(map[int64]map[string][]string)
 		}
-		c.SignedInUser.Permissions[c.OrgId] = accesscontrol.GroupScopesByAction(permissions)
+		c.SignedInUser.Permissions[c.OrgId] = GroupScopesByAction(permissions)
 	}
 }

--- a/pkg/services/accesscontrol/middleware_test.go
+++ b/pkg/services/accesscontrol/middleware_test.go
@@ -1,24 +1,25 @@
-package accesscontrol
+package accesscontrol_test
 
 import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/web"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 type middlewareTestCase struct {
 	desc           string
 	expectFallback bool
 	expectEndpoint bool
-	evaluator      Evaluator
-	ac             AccessControl
+	evaluator      accesscontrol.Evaluator
+	ac             accesscontrol.AccessControl
 }
 
 func TestMiddleware(t *testing.T) {
@@ -32,18 +33,18 @@ func TestMiddleware(t *testing.T) {
 		{
 			desc: "should pass middleware for correct permissions",
 			ac: mock.New().WithPermissions(
-				[]*Permission{{Action: "users:read", Scope: "users:*"}},
+				[]*accesscontrol.Permission{{Action: "users:read", Scope: "users:*"}},
 			),
-			evaluator:      EvalPermission("users:read", "users:*"),
+			evaluator:      accesscontrol.EvalPermission("users:read", "users:*"),
 			expectFallback: false,
 			expectEndpoint: true,
 		},
 		{
 			desc: "should not reach endpoint when missing permissions",
 			ac: mock.New().WithPermissions(
-				[]*Permission{{Action: "users:read", Scope: "users:1"}},
+				[]*accesscontrol.Permission{{Action: "users:read", Scope: "users:1"}},
 			),
-			evaluator:      EvalPermission("users:read", "users:*"),
+			evaluator:      accesscontrol.EvalPermission("users:read", "users:*"),
 			expectFallback: false,
 			expectEndpoint: false,
 		},
@@ -60,7 +61,7 @@ func TestMiddleware(t *testing.T) {
 			server.UseMiddleware(web.Renderer("../../public/views", "[[", "]]"))
 
 			server.Use(contextProvider())
-			server.Use(Middleware(test.ac)(fallback, test.evaluator))
+			server.Use(accesscontrol.Middleware(test.ac)(fallback, test.evaluator))
 
 			endpointCalled := false
 			server.Get("/", func(c *models.ReqContext) {

--- a/pkg/services/accesscontrol/middleware_test.go
+++ b/pkg/services/accesscontrol/middleware_test.go
@@ -1,4 +1,4 @@
-package middleware
+package accesscontrol
 
 import (
 	"net/http"
@@ -10,7 +10,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 )
 
@@ -18,8 +17,8 @@ type middlewareTestCase struct {
 	desc           string
 	expectFallback bool
 	expectEndpoint bool
-	evaluator      accesscontrol.Evaluator
-	ac             accesscontrol.AccessControl
+	evaluator      Evaluator
+	ac             AccessControl
 }
 
 func TestMiddleware(t *testing.T) {
@@ -33,18 +32,18 @@ func TestMiddleware(t *testing.T) {
 		{
 			desc: "should pass middleware for correct permissions",
 			ac: mock.New().WithPermissions(
-				[]*accesscontrol.Permission{{Action: "users:read", Scope: "users:*"}},
+				[]*Permission{{Action: "users:read", Scope: "users:*"}},
 			),
-			evaluator:      accesscontrol.EvalPermission("users:read", "users:*"),
+			evaluator:      EvalPermission("users:read", "users:*"),
 			expectFallback: false,
 			expectEndpoint: true,
 		},
 		{
 			desc: "should not reach endpoint when missing permissions",
 			ac: mock.New().WithPermissions(
-				[]*accesscontrol.Permission{{Action: "users:read", Scope: "users:1"}},
+				[]*Permission{{Action: "users:read", Scope: "users:1"}},
 			),
-			evaluator:      accesscontrol.EvalPermission("users:read", "users:*"),
+			evaluator:      EvalPermission("users:read", "users:*"),
 			expectFallback: false,
 			expectEndpoint: false,
 		},

--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/middleware"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -55,7 +54,7 @@ func (a *api) getEvaluators(actionRead, actionWrite, scope string) (read, write 
 }
 
 func (a *api) registerEndpoints() {
-	auth := middleware.Middleware(a.ac)
+	auth := accesscontrol.Middleware(a.ac)
 	disable := disableMiddleware(a.ac.IsDisabled())
 	uidSolver := solveUID(a.service.options.UidSolver)
 	inheritanceSolver := solveInheritedScopes(a.service.options.InheritedScopesSolver)

--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -56,9 +56,9 @@ func (a *api) getEvaluators(actionRead, actionWrite, scope string) (read, write 
 
 func (a *api) registerEndpoints() {
 	auth := middleware.Middleware(a.ac)
+	disable := disableMiddleware(a.ac.IsDisabled())
 	uidSolver := solveUID(a.service.options.UidSolver)
 	inheritanceSolver := solveInheritedScopes(a.service.options.InheritedScopesSolver)
-	disable := middleware.Disable(a.ac.IsDisabled())
 	a.router.Group(fmt.Sprintf("/api/access-control/%s", a.service.options.Resource), func(r routing.RouteRegister) {
 		actionRead := fmt.Sprintf("%s.permissions:read", a.service.options.Resource)
 		actionWrite := fmt.Sprintf("%s.permissions:write", a.service.options.Resource)

--- a/pkg/services/accesscontrol/resourcepermissions/middleware.go
+++ b/pkg/services/accesscontrol/resourcepermissions/middleware.go
@@ -43,3 +43,12 @@ func solveInheritedScopes(solve InheritedScopesSolver) web.Handler {
 		}
 	}
 }
+
+func disableMiddleware(shouldDisable bool) web.Handler {
+	return func(c *models.ReqContext) {
+		if shouldDisable {
+			c.Resp.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}
+}

--- a/pkg/services/dashboardimport/api/api.go
+++ b/pkg/services/dashboardimport/api/api.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	acmiddleware "github.com/grafana/grafana/pkg/services/accesscontrol/middleware"
 	"github.com/grafana/grafana/pkg/services/dashboardimport"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -36,7 +35,7 @@ func New(dashboardImportService dashboardimport.Service, quotaService QuotaServi
 }
 
 func (api *ImportDashboardAPI) RegisterAPIEndpoints(routeRegister routing.RouteRegister) {
-	authorize := acmiddleware.Middleware(api.ac)
+	authorize := accesscontrol.Middleware(api.ac)
 	routeRegister.Group("/api/dashboards", func(route routing.RouteRegister) {
 		route.Post(
 			"/import",

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/models"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
-	acmiddleware "github.com/grafana/grafana/pkg/services/accesscontrol/middleware"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -23,7 +22,7 @@ var (
 
 //nolint:gocyclo
 func (api *API) authorize(method, path string) web.Handler {
-	authorize := acmiddleware.Middleware(api.AccessControl)
+	authorize := ac.Middleware(api.AccessControl)
 	var eval ac.Evaluator = nil
 
 	// Most routes follow this general authorization approach as a fallback. Exceptions are overridden directly in the below block.

--- a/pkg/services/serviceaccounts/api/api.go
+++ b/pkg/services/serviceaccounts/api/api.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	acmiddleware "github.com/grafana/grafana/pkg/services/accesscontrol/middleware"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts/database"
@@ -53,7 +52,7 @@ func (api *ServiceAccountsAPI) RegisterAPIEndpoints(
 		return
 	}
 
-	auth := acmiddleware.Middleware(api.accesscontrol)
+	auth := accesscontrol.Middleware(api.accesscontrol)
 	api.RouterRegister.Group("/api/serviceaccounts", func(serviceAccountsRoute routing.RouteRegister) {
 		serviceAccountsRoute.Get("/search", auth(middleware.ReqOrgAdmin,
 			accesscontrol.EvalPermission(serviceaccounts.ActionRead)), routing.Wrap(api.SearchOrgServiceAccountsWithPaging))


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove access control middleware sub package and place them in access control root

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

