### PR TITLE
Loki: Enable new visual query builder by default

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1137,6 +1137,9 @@ enable =
 # The new prometheus visual query builder
 promQueryBuilder = true
 
+# The new loki visual query builder
+lokiQueryBuilder = true
+
 # Experimental Explore to Dashboard workflow
 explore2Dashboard = true
 


### PR DESCRIPTION
This PR enables visual query builder for Loki by default in 9.0 release and on main. 