### PR TITLE
Docs: clarifies viewer can edit prose

### DIFF
--- a/docs/sources/administration/manage-users-and-permissions/manage-dashboard-permissions/_index.md
+++ b/docs/sources/administration/manage-users-and-permissions/manage-dashboard-permissions/_index.md
@@ -60,7 +60,7 @@ Grant dashboard permissions when you want to restrict or enhance dashboard acces
 
 ## Enable viewers to preview dashboards and use Explore
 
-By default, the viewer organization role does not allow viewers to create dashboards or use the Explore feature. However, by modifying a configuration setting you can allow viewers to create and preview (but not save) dashboards, and use the Explore feature.
+By default, the viewer organization role does not allow viewers to create dashboards or use the Explore feature. However, by modifying a configuration setting, you can allow viewers to edit a panel and make changes to a dashboard but not save those changes. This setting also enables viewers to use the Explore feature.
 
 This modification is useful for public Grafana installations where you want anonymous users to be able to edit panels and queries but not save or create new dashboards.
 

--- a/docs/sources/administration/manage-users-and-permissions/manage-dashboard-permissions/_index.md
+++ b/docs/sources/administration/manage-users-and-permissions/manage-dashboard-permissions/_index.md
@@ -58,7 +58,7 @@ Grant dashboard permissions when you want to restrict or enhance dashboard acces
 1. Select the user or team.
 1. Select the permission and click **Save**.
 
-## Enable viewers to preview dashboards and use Explore
+## Enable viewers to edit (but not save) dashboards and use Explore
 
 By default, the viewer organization role does not allow viewers to create dashboards or use the Explore feature. However, by modifying a configuration setting, you can allow viewers to edit a panel and make changes to a dashboard but not save those changes. This setting also enables viewers to use the Explore feature.
 


### PR DESCRIPTION
This PR clarifies wording about permissions granted to viewers when modifying the viewer_can_edit config.