### PR TITLE
Chore: Add Usage stats providers registry

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/infra/tracing"
-	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/database"
@@ -396,8 +395,7 @@ func setupHTTPServerWithCfgDb(t *testing.T, useFakeAccessControl, enableAccessCo
 		require.NoError(t, err)
 		hs.teamPermissionsService = teamPermissionService
 	} else {
-		ac, errInitAc := ossaccesscontrol.ProvideService(hs.Features, &usagestats.UsageStatsMock{T: t},
-			database.ProvideService(db), routing.NewRouteRegister())
+		ac, errInitAc := ossaccesscontrol.ProvideService(hs.Features, database.ProvideService(db), routing.NewRouteRegister())
 		require.NoError(t, errInitAc)
 		hs.AccessControl = ac
 		// Perform role registration

--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/login/social"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
+	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
@@ -34,6 +35,7 @@ type Service struct {
 	startTime                time.Time
 	concurrentUserStatsCache memoConcurrentUserStats
 	promFlavorCache          memoPrometheusFlavor
+	usageStatProviders       []registry.ProvidesUsageStats
 }
 
 func ProvideService(
@@ -63,6 +65,12 @@ func ProvideService(
 	usagestats.RegisterMetricsFunc(s.collect)
 
 	return s
+}
+
+// RegisterProviders is called only once - during Grafana start up
+func (s *Service) RegisterProviders(usageStatProviders []registry.ProvidesUsageStats) {
+	s.log.Info("registering usage stat providers", "usage_stat_providers_len", len(usageStatProviders))
+	s.usageStatProviders = usageStatProviders
 }
 
 func (s *Service) Run(ctx context.Context) error {
@@ -278,6 +286,13 @@ func (s *Service) collect(ctx context.Context) (map[string]interface{}, error) {
 	featureUsageStats := s.features.GetUsageStats(ctx)
 	for k, v := range featureUsageStats {
 		m[k] = v
+	}
+
+	for _, usageStatProvider := range s.usageStatProviders {
+		stats := usageStatProvider.GetUsageStats(ctx)
+		for k, v := range stats {
+			m[k] = v
+		}
 	}
 
 	return m, nil

--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -69,7 +69,7 @@ func ProvideService(
 
 // RegisterProviders is called only once - during Grafana start up
 func (s *Service) RegisterProviders(usageStatProviders []registry.ProvidesUsageStats) {
-	s.log.Info("registering usage stat providers", "usage_stat_providers_len", len(usageStatProviders))
+	s.log.Info("registering usage stat providers", "usageStatsProvidersLen", len(usageStatProviders))
 	s.usageStatProviders = usageStatProviders
 }
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -37,6 +37,7 @@ type UsageStatsProvidersRegistry interface {
 // ProvidesUsageStats is an interface for services that share their usage stats
 type ProvidesUsageStats interface {
 	// GetUsageStats is called on a schedule by the UsageStatsService
+	// Any errors occurring during usage stats collection should be collected and logged within the provider.
 	GetUsageStats(ctx context.Context) map[string]interface{}
 }
 

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -29,6 +29,17 @@ type BackgroundService interface {
 	Run(ctx context.Context) error
 }
 
+// UsageStatsProvidersRegistry provides services sharing their usage stats
+type UsageStatsProvidersRegistry interface {
+	GetServices() []ProvidesUsageStats
+}
+
+// ProvidesUsageStats is an interface for services that share their usage stats
+type ProvidesUsageStats interface {
+	// GetUsageStats is called on a schedule by the UsageStatsService
+	GetUsageStats(ctx context.Context) map[string]interface{}
+}
+
 // DatabaseMigrator allows the caller to add migrations to
 // the migrator passed as argument
 type DatabaseMigrator interface {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/grafana/grafana/pkg/infra/usagestats/statscollector"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 
 	"github.com/grafana/grafana/pkg/api"
@@ -41,7 +42,9 @@ type Options struct {
 // New returns a new instance of Server.
 func New(opts Options, cfg *setting.Cfg, httpServer *api.HTTPServer, roleRegistry accesscontrol.RoleRegistry,
 	provisioningService provisioning.ProvisioningService, backgroundServiceProvider registry.BackgroundServiceRegistry,
+	usageStatsProvidersRegistry registry.UsageStatsProvidersRegistry, statsCollectorService *statscollector.Service,
 ) (*Server, error) {
+	statsCollectorService.RegisterProviders(usageStatsProvidersRegistry.GetServices())
 	s, err := newServer(opts, cfg, httpServer, roleRegistry, provisioningService, backgroundServiceProvider)
 	if err != nil {
 		return nil, err

--- a/pkg/server/usagestatssvcs/usage_stats_providers_registry.go
+++ b/pkg/server/usagestatssvcs/usage_stats_providers_registry.go
@@ -1,0 +1,26 @@
+package usagestatssvcs
+
+import (
+	"github.com/grafana/grafana/pkg/registry"
+	"github.com/grafana/grafana/pkg/services/thumbs"
+)
+
+func ProvideUsageStatsProvidersRegistry(
+	thumbsService thumbs.Service,
+) registry.UsageStatsProvidersRegistry {
+	return NewUsageStatsProvidersRegistry(
+		thumbsService,
+	)
+}
+
+type UsageStatsProvidersRegistry struct {
+	Services []registry.ProvidesUsageStats
+}
+
+func NewUsageStatsProvidersRegistry(services ...registry.ProvidesUsageStats) *UsageStatsProvidersRegistry {
+	return &UsageStatsProvidersRegistry{services}
+}
+
+func (r *UsageStatsProvidersRegistry) GetServices() []registry.ProvidesUsageStats {
+	return r.Services
+}

--- a/pkg/server/usagestatssvcs/usage_stats_providers_registry.go
+++ b/pkg/server/usagestatssvcs/usage_stats_providers_registry.go
@@ -2,14 +2,17 @@ package usagestatssvcs
 
 import (
 	"github.com/grafana/grafana/pkg/registry"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/thumbs"
 )
 
 func ProvideUsageStatsProvidersRegistry(
 	thumbsService thumbs.Service,
-) registry.UsageStatsProvidersRegistry {
+	accesscontrol accesscontrol.AccessControl,
+) *UsageStatsProvidersRegistry {
 	return NewUsageStatsProvidersRegistry(
 		thumbsService,
+		accesscontrol,
 	)
 }
 

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -34,6 +34,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/manager"
 	"github.com/grafana/grafana/pkg/plugins/manager/loader"
 	"github.com/grafana/grafana/pkg/plugins/plugincontext"
+	"github.com/grafana/grafana/pkg/server/usagestatssvcs"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/auth/jwt"
 	"github.com/grafana/grafana/pkg/services/cleanup"
@@ -250,6 +251,7 @@ var wireBasicSet = wire.NewSet(
 	cmreg.ProvideRegistry,
 	cuectx.ProvideCUEContext,
 	cuectx.ProvideThemaLibrary,
+	usagestatssvcs.ProvideUsageStatsProvidersRegistry,
 )
 
 var wireSet = wire.NewSet(

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -34,7 +34,6 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/manager"
 	"github.com/grafana/grafana/pkg/plugins/manager/loader"
 	"github.com/grafana/grafana/pkg/plugins/plugincontext"
-	"github.com/grafana/grafana/pkg/server/usagestatssvcs"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/auth/jwt"
 	"github.com/grafana/grafana/pkg/services/cleanup"
@@ -251,7 +250,6 @@ var wireBasicSet = wire.NewSet(
 	cmreg.ProvideRegistry,
 	cuectx.ProvideCUEContext,
 	cuectx.ProvideThemaLibrary,
-	usagestatssvcs.ProvideUsageStatsProvidersRegistry,
 )
 
 var wireSet = wire.NewSet(

--- a/pkg/server/wireexts_oss.go
+++ b/pkg/server/wireexts_oss.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/manager/signature"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/server/backgroundsvcs"
+	"github.com/grafana/grafana/pkg/server/usagestatssvcs"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	acdb "github.com/grafana/grafana/pkg/services/accesscontrol/database"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
@@ -82,6 +83,8 @@ var wireExtsBasicSet = wire.NewSet(
 	wire.Bind(new(permissions.DatasourcePermissionsService), new(*permissions.OSSDatasourcePermissionsService)),
 	ossaccesscontrol.ProvidePermissionsServices,
 	wire.Bind(new(accesscontrol.PermissionsServices), new(*ossaccesscontrol.PermissionsServices)),
+	usagestatssvcs.ProvideUsageStatsProvidersRegistry,
+	wire.Bind(new(registry.UsageStatsProvidersRegistry), new(*usagestatssvcs.UsageStatsProvidersRegistry)),
 )
 
 var wireExtsSet = wire.NewSet(

--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/registry"
 )
 
 type Options struct {
@@ -13,6 +14,8 @@ type Options struct {
 }
 
 type AccessControl interface {
+	registry.ProvidesUsageStats
+
 	// Evaluate evaluates access to the given resources.
 	Evaluate(ctx context.Context, user *models.SignedInUser, evaluator Evaluator) (bool, error)
 

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -65,6 +65,10 @@ func New() *Mock {
 	return mock
 }
 
+func (m Mock) GetUsageStats(ctx context.Context) map[string]interface{} {
+	return make(map[string]interface{})
+}
+
 func (m Mock) WithPermissions(permissions []*accesscontrol.Permission) *Mock {
 	m.permissions = permissions
 	return &m

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/database"
@@ -134,19 +133,13 @@ func TestUsageMetrics(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			usagestatsmock := &usagestats.UsageStatsMock{T: t}
-
-			_, errInitAc := ProvideService(
+			s, errInitAc := ProvideService(
 				featuremgmt.WithFeatures("accesscontrol", tt.enabled),
-				usagestatsmock,
 				database.ProvideService(sqlstore.InitTestDB(t)),
 				routing.NewRouteRegister(),
 			)
 			require.NoError(t, errInitAc)
-			report, err := usagestatsmock.GetUsageReport(context.Background())
-			assert.Nil(t, err)
-
-			assert.Equal(t, tt.expectedValue, report.Metrics["stats.oss.accesscontrol.enabled.count"])
+			assert.Equal(t, tt.expectedValue, s.GetUsageStats(context.Background())["stats.oss.accesscontrol.enabled.count"])
 		})
 	}
 }

--- a/pkg/services/thumbs/dummy.go
+++ b/pkg/services/thumbs/dummy.go
@@ -11,6 +11,10 @@ import (
 // When the feature flag is not enabled we just implement a dummy service
 type dummyService struct{}
 
+func (ds *dummyService) GetUsageStats(ctx context.Context) map[string]interface{} {
+	return make(map[string]interface{})
+}
+
 func (ds *dummyService) GetImage(c *models.ReqContext) {
 	c.JSON(400, map[string]string{"error": "invalid size"})
 }

--- a/pkg/services/thumbs/service.go
+++ b/pkg/services/thumbs/service.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/serverlock"
-	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -52,7 +51,6 @@ type thumbService struct {
 	store                      sqlstore.Store
 	crawlLockServiceActionName string
 	log                        log.Logger
-	usageStatsService          usagestats.Service
 	canRunCrawler              bool
 	settings                   setting.DashboardPreviewsSettings
 }

--- a/pkg/services/thumbs/service.go
+++ b/pkg/services/thumbs/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/registry"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/live"
@@ -25,6 +26,7 @@ import (
 )
 
 type Service interface {
+	registry.ProvidesUsageStats
 	Run(ctx context.Context) error
 	Enabled() bool
 	GetImage(c *models.ReqContext)
@@ -65,7 +67,7 @@ type crawlerScheduleOptions struct {
 	auth             CrawlerAuth
 }
 
-func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, lockService *serverlock.ServerLockService, renderService rendering.Service, gl *live.GrafanaLive, store *sqlstore.SQLStore, authSetupService CrawlerAuthSetupService, usageStatsService usagestats.Service) Service {
+func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, lockService *serverlock.ServerLockService, renderService rendering.Service, gl *live.GrafanaLive, store *sqlstore.SQLStore, authSetupService CrawlerAuthSetupService) Service {
 	if !features.IsEnabled(featuremgmt.FlagDashboardPreviews) {
 		return &dummyService{}
 	}
@@ -81,7 +83,6 @@ func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, lockS
 		canRunCrawler = false
 	}
 	t := &thumbService{
-		usageStatsService:          usageStatsService,
 		renderingService:           renderService,
 		renderer:                   newSimpleCrawler(renderService, gl, thumbnailRepo, cfg, cfg.DashboardPreviews),
 		thumbnailRepo:              thumbnailRepo,
@@ -104,26 +105,23 @@ func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles, lockS
 		},
 	}
 
-	t.registerUsageStats()
 	return t
 }
 
-func (hs *thumbService) registerUsageStats() {
-	hs.usageStatsService.RegisterMetricsFunc(func(ctx context.Context) (map[string]interface{}, error) {
-		s := hs.getDashboardPreviewsSetupSettings(ctx)
+func (hs *thumbService) GetUsageStats(ctx context.Context) map[string]interface{} {
+	s := hs.getDashboardPreviewsSetupSettings(ctx)
 
-		stats := make(map[string]interface{})
+	stats := make(map[string]interface{})
 
-		if s.SystemRequirements.Met {
-			stats["stats.dashboard_previews.system_req_met.count"] = 1
-		}
+	if s.SystemRequirements.Met {
+		stats["stats.dashboard_previews.system_req_met.count"] = 1
+	}
 
-		if s.ThumbnailsExist {
-			stats["stats.dashboard_previews.thumbnails_exist.count"] = 1
-		}
+	if s.ThumbnailsExist {
+		stats["stats.dashboard_previews.thumbnails_exist.count"] = 1
+	}
 
-		return stats, nil
-	})
+	return stats
 }
 
 func (hs *thumbService) Enabled() bool {


### PR DESCRIPTION
This PR adds a usage stats providers registry to eliminate problems with cyclical dependencies (https://github.com/grafana/grafana/pull/48350#discussion_r859781981) and to make it easier to serve usage stats in general.

This PR also refactors two services to serve as examples: `thumbs` (oss only) and `accesscontrol` (oss+ent)