### PR TITLE
loki: more robust query-type switching

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -18,7 +18,8 @@ export interface Props {
 
 export const LokiQueryBuilderOptions = React.memo<Props>(({ query, onChange, onRunQuery }) => {
   const onQueryTypeChange = (value: LokiQueryType) => {
-    onChange({ ...query, queryType: value });
+    const { instant, range, ...rest } = query;
+    onChange({ ...rest, queryType: value });
     onRunQuery();
   };
 


### PR DESCRIPTION
NOTE: this does not happen in loki-backend-mode, so if that becomes enabled-by-default in grafana9, we do not need this PR.

is_ranged and is_instant in Loki queries was represented with two booleans in teh past, but now we migrated to a queryType field.

but, in some cases there can still be queries with the old boolean attributes.

we had a case where the user got in a situation where the query had: `{instant: true, ranged: false, queryType: "ranged"`.
and they could not escape from it by switching the query-type in the UI.

this pull-request adjusts the code so that when we switch the query-type, we remove the old-booleans (if they are there).

NOTE: this code was there in the past ( https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx#L62-L63 ), but maybe it was not added in the query-builder-version, not sure.

how to test:
1. go to explore-mode
2. run a metric query (you are in range-mode) (this applies to logs-query too but it's easier to test with metric queries because it's easy to see if we are ranged or instant)
3. modify the URL in the browser, add in a `,"instant":true,` part in the query, press ENTER. you will get instant-query-result, not ranged.
4. now switch the mode to instant and back to ranged, and run the query again
5. you should get a ranged query execution