### PR TITLE
use NaN if condition value is nil

### DIFF
--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -3,6 +3,7 @@ package state
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -223,7 +224,11 @@ func (a *State) GetLastEvaluationValuesForCondition() map[string]float64 {
 
 	for refID, value := range lastResult.Values {
 		if strings.Contains(refID, lastResult.Condition) {
-			r[refID] = *value
+			if value != nil {
+				r[refID] = *value
+				continue
+			}
+			r[refID] = math.NaN()
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR fixes method `GetLastEvaluationValuesForCondition` to not panic if value reference is nil. 

It's not perfectly clear where nil comes from but according to 
https://github.com/grafana/grafana/blob/a578cf0f7cd25fe80e26a1b23f381c2fa3fb1b41/pkg/expr/classic/classic.go#L110
it can be an indicator of NoData.

I was able to reproduce this panic.
1. The datasource should return null value for at least one dimension\series. For example CloudWatch data source when there is no value for a metric in the time range
2. Option `Alert state if no data or all values are null` should be set to `Alerting`