### PR TITLE
A11y: Fix remaining focus issues with Switch

### DIFF
--- a/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
@@ -2,9 +2,9 @@ import React, { useMemo } from 'react';
 
 import { DataSourceInstanceSettings, DataSourceJsonData, DataSourcePluginOptionsEditorProps } from '@grafana/data';
 
+import { InlineSwitch } from '../../components/Switch/Switch';
 import { InlineField } from '../Forms/InlineField';
 import { InlineFieldRow } from '../Forms/InlineFieldRow';
-import { Switch } from '../Forms/Legacy/Switch/Switch';
 import { Select } from '../Select/Select';
 
 interface Props<T> extends Pick<DataSourcePluginOptionsEditorProps<T>, 'options' | 'onOptionsChange'> {
@@ -37,17 +37,17 @@ export function AlertingSettings<T extends AlertingConfig>({
       <div className="gf-form-group">
         <div className="gf-form-inline">
           <div className="gf-form">
-            <Switch
-              label="Manage alerts via Alerting UI"
-              labelClass="width-13"
-              checked={options.jsonData.manageAlerts !== false}
-              onChange={(event) =>
-                onOptionsChange({
-                  ...options,
-                  jsonData: { ...options.jsonData, manageAlerts: event!.currentTarget.checked },
-                })
-              }
-            />
+            <InlineField labelWidth={26} label="Manage alerts via Alerting UI">
+              <InlineSwitch
+                value={options.jsonData.manageAlerts !== false}
+                onChange={(event) =>
+                  onOptionsChange({
+                    ...options,
+                    jsonData: { ...options.jsonData, manageAlerts: event!.currentTarget.checked },
+                  })
+                }
+              />
+            </InlineField>
           </div>
         </div>
         <InlineFieldRow>

--- a/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
@@ -7,10 +7,11 @@ import { selectors } from '@grafana/e2e-selectors';
 import { useTheme } from '../../themes';
 import { FormField } from '../FormField/FormField';
 import { InlineFormLabel } from '../FormLabel/FormLabel';
+import { InlineField } from '../Forms/InlineField';
 import { Input } from '../Forms/Legacy/Input/Input';
-import { Switch } from '../Forms/Legacy/Switch/Switch';
 import { Icon } from '../Icon/Icon';
 import { Select } from '../Select/Select';
+import { InlineSwitch } from '../Switch/Switch';
 import { TagsInput } from '../TagsInput/TagsInput';
 
 import { BasicAuthSettings } from './BasicAuthSettings';
@@ -58,6 +59,8 @@ const HttpAccessHelp = () => (
     </p>
   </div>
 );
+
+const LABEL_WIDTH = 26;
 
 export const DataSourceHttpSettings: React.FC<HttpSettingsProps> = (props) => {
   const {
@@ -208,53 +211,64 @@ export const DataSourceHttpSettings: React.FC<HttpSettingsProps> = (props) => {
         <h3 className="page-heading">Auth</h3>
         <div className="gf-form-group">
           <div className="gf-form-inline">
-            <Switch
-              label="Basic auth"
-              labelClass="width-13"
-              checked={dataSourceConfig.basicAuth}
-              onChange={(event) => {
-                onSettingsChange({ basicAuth: event!.currentTarget.checked });
-              }}
-            />
-            <Switch
+            <InlineField label="Basic auth" labelWidth={LABEL_WIDTH}>
+              <InlineSwitch
+                id="http-settings-basic-auth"
+                checked={dataSourceConfig.basicAuth}
+                onChange={(event) => {
+                  onSettingsChange({ basicAuth: event!.currentTarget.checked });
+                }}
+              />
+            </InlineField>
+
+            <InlineField
               label="With Credentials"
-              labelClass="width-13"
-              checked={dataSourceConfig.withCredentials}
-              onChange={(event) => {
-                onSettingsChange({ withCredentials: event!.currentTarget.checked });
-              }}
               tooltip="Whether credentials such as cookies or auth headers should be sent with cross-site requests."
-            />
+              labelWidth={LABEL_WIDTH}
+            >
+              <InlineSwitch
+                id="http-settings-with-credentials"
+                checked={dataSourceConfig.withCredentials}
+                onChange={(event) => {
+                  onSettingsChange({ withCredentials: event!.currentTarget.checked });
+                }}
+              />
+            </InlineField>
           </div>
 
           {azureAuthSettings?.azureAuthSupported && (
             <div className="gf-form-inline">
-              <Switch
+              <InlineField
                 label="Azure Authentication"
-                labelClass="width-13"
-                checked={azureAuthEnabled}
-                onChange={(event) => {
-                  onSettingsChange(
-                    azureAuthSettings.setAzureAuthEnabled(dataSourceConfig, event!.currentTarget.checked)
-                  );
-                }}
                 tooltip="Use Azure authentication for Azure endpoint."
-              />
+                labelWidth={LABEL_WIDTH}
+              >
+                <InlineSwitch
+                  id="http-settings-azure-auth"
+                  checked={azureAuthEnabled}
+                  onChange={(event) => {
+                    onSettingsChange(
+                      azureAuthSettings.setAzureAuthEnabled(dataSourceConfig, event!.currentTarget.checked)
+                    );
+                  }}
+                />
+              </InlineField>
             </div>
           )}
 
           {sigV4AuthToggleEnabled && (
             <div className="gf-form-inline">
-              <Switch
-                label="SigV4 auth"
-                labelClass="width-13"
-                checked={dataSourceConfig.jsonData.sigV4Auth || false}
-                onChange={(event) => {
-                  onSettingsChange({
-                    jsonData: { ...dataSourceConfig.jsonData, sigV4Auth: event!.currentTarget.checked },
-                  });
-                }}
-              />
+              <InlineField label="SigV4 auth" labelWidth={LABEL_WIDTH}>
+                <InlineSwitch
+                  id="http-settings-sigv4-auth"
+                  checked={dataSourceConfig.jsonData.sigV4Auth || false}
+                  onChange={(event) => {
+                    onSettingsChange({
+                      jsonData: { ...dataSourceConfig.jsonData, sigV4Auth: event!.currentTarget.checked },
+                    });
+                  }}
+                />
+              </InlineField>
             </div>
           )}
 

--- a/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.tsx
@@ -214,7 +214,7 @@ export const DataSourceHttpSettings: React.FC<HttpSettingsProps> = (props) => {
             <InlineField label="Basic auth" labelWidth={LABEL_WIDTH}>
               <InlineSwitch
                 id="http-settings-basic-auth"
-                checked={dataSourceConfig.basicAuth}
+                value={dataSourceConfig.basicAuth}
                 onChange={(event) => {
                   onSettingsChange({ basicAuth: event!.currentTarget.checked });
                 }}
@@ -228,7 +228,7 @@ export const DataSourceHttpSettings: React.FC<HttpSettingsProps> = (props) => {
             >
               <InlineSwitch
                 id="http-settings-with-credentials"
-                checked={dataSourceConfig.withCredentials}
+                value={dataSourceConfig.withCredentials}
                 onChange={(event) => {
                   onSettingsChange({ withCredentials: event!.currentTarget.checked });
                 }}
@@ -245,7 +245,7 @@ export const DataSourceHttpSettings: React.FC<HttpSettingsProps> = (props) => {
               >
                 <InlineSwitch
                   id="http-settings-azure-auth"
-                  checked={azureAuthEnabled}
+                  value={azureAuthEnabled}
                   onChange={(event) => {
                     onSettingsChange(
                       azureAuthSettings.setAzureAuthEnabled(dataSourceConfig, event!.currentTarget.checked)
@@ -261,7 +261,7 @@ export const DataSourceHttpSettings: React.FC<HttpSettingsProps> = (props) => {
               <InlineField label="SigV4 auth" labelWidth={LABEL_WIDTH}>
                 <InlineSwitch
                   id="http-settings-sigv4-auth"
-                  checked={dataSourceConfig.jsonData.sigV4Auth || false}
+                  value={dataSourceConfig.jsonData.sigV4Auth || false}
                   onChange={(event) => {
                     onSettingsChange({
                       jsonData: { ...dataSourceConfig.jsonData, sigV4Auth: event!.currentTarget.checked },

--- a/packages/grafana-ui/src/components/DataSourceSettings/HttpProxySettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/HttpProxySettings.tsx
@@ -18,14 +18,14 @@ export const HttpProxySettings: React.FC<HttpSettingsBaseProps> = ({
         <InlineField label="TLS Client Auth" labelWidth={LABEL_WIDTH}>
           <InlineSwitch
             id="http-settings-tls-client-auth"
-            checked={dataSourceConfig.jsonData.tlsAuth || false}
+            value={dataSourceConfig.jsonData.tlsAuth || false}
             onChange={(event) => onChange({ ...dataSourceConfig.jsonData, tlsAuth: event!.currentTarget.checked })}
           />
         </InlineField>
         <InlineField label="With CA Cert" tooltip="Needed for verifying self-signed TLS Certs" labelWidth={LABEL_WIDTH}>
           <InlineSwitch
             id="http-settings-ca-cert"
-            checked={dataSourceConfig.jsonData.tlsAuthWithCACert || false}
+            value={dataSourceConfig.jsonData.tlsAuthWithCACert || false}
             onChange={(event) =>
               onChange({ ...dataSourceConfig.jsonData, tlsAuthWithCACert: event!.currentTarget.checked })
             }
@@ -36,7 +36,7 @@ export const HttpProxySettings: React.FC<HttpSettingsBaseProps> = ({
         <InlineField label="Skip TLS Verify" labelWidth={LABEL_WIDTH}>
           <InlineSwitch
             id="http-settings-skip-tls-verify"
-            checked={dataSourceConfig.jsonData.tlsSkipVerify || false}
+            value={dataSourceConfig.jsonData.tlsSkipVerify || false}
             onChange={(event) =>
               onChange({ ...dataSourceConfig.jsonData, tlsSkipVerify: event!.currentTarget.checked })
             }
@@ -52,7 +52,7 @@ export const HttpProxySettings: React.FC<HttpSettingsBaseProps> = ({
           >
             <InlineSwitch
               id="http-settings-forward-oauth"
-              checked={dataSourceConfig.jsonData.oauthPassThru || false}
+              value={dataSourceConfig.jsonData.oauthPassThru || false}
               onChange={(event) =>
                 onChange({ ...dataSourceConfig.jsonData, oauthPassThru: event!.currentTarget.checked })
               }

--- a/packages/grafana-ui/src/components/DataSourceSettings/HttpProxySettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/HttpProxySettings.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 
-import { Switch } from '../Forms/Legacy/Switch/Switch';
+import { InlineField } from '../Forms/InlineField';
+import { InlineSwitch } from '../Switch/Switch';
 
 import { HttpSettingsBaseProps } from './types';
+
+const LABEL_WIDTH = 26;
 
 export const HttpProxySettings: React.FC<HttpSettingsBaseProps> = ({
   dataSourceConfig,
@@ -12,42 +15,49 @@ export const HttpProxySettings: React.FC<HttpSettingsBaseProps> = ({
   return (
     <>
       <div className="gf-form-inline">
-        <Switch
-          label="TLS Client Auth"
-          labelClass="width-13"
-          checked={dataSourceConfig.jsonData.tlsAuth || false}
-          onChange={(event) => onChange({ ...dataSourceConfig.jsonData, tlsAuth: event!.currentTarget.checked })}
-        />
-
-        <Switch
-          label="With CA Cert"
-          labelClass="width-13"
-          checked={dataSourceConfig.jsonData.tlsAuthWithCACert || false}
-          onChange={(event) =>
-            onChange({ ...dataSourceConfig.jsonData, tlsAuthWithCACert: event!.currentTarget.checked })
-          }
-          tooltip="Needed for verifying self-signed TLS Certs"
-        />
+        <InlineField label="TLS Client Auth" labelWidth={LABEL_WIDTH}>
+          <InlineSwitch
+            id="http-settings-tls-client-auth"
+            checked={dataSourceConfig.jsonData.tlsAuth || false}
+            onChange={(event) => onChange({ ...dataSourceConfig.jsonData, tlsAuth: event!.currentTarget.checked })}
+          />
+        </InlineField>
+        <InlineField label="With CA Cert" tooltip="Needed for verifying self-signed TLS Certs" labelWidth={LABEL_WIDTH}>
+          <InlineSwitch
+            id="http-settings-ca-cert"
+            checked={dataSourceConfig.jsonData.tlsAuthWithCACert || false}
+            onChange={(event) =>
+              onChange({ ...dataSourceConfig.jsonData, tlsAuthWithCACert: event!.currentTarget.checked })
+            }
+          />
+        </InlineField>
       </div>
       <div className="gf-form-inline">
-        <Switch
-          label="Skip TLS Verify"
-          labelClass="width-13"
-          checked={dataSourceConfig.jsonData.tlsSkipVerify || false}
-          onChange={(event) => onChange({ ...dataSourceConfig.jsonData, tlsSkipVerify: event!.currentTarget.checked })}
-        />
+        <InlineField label="Skip TLS Verify" labelWidth={LABEL_WIDTH}>
+          <InlineSwitch
+            id="http-settings-skip-tls-verify"
+            checked={dataSourceConfig.jsonData.tlsSkipVerify || false}
+            onChange={(event) =>
+              onChange({ ...dataSourceConfig.jsonData, tlsSkipVerify: event!.currentTarget.checked })
+            }
+          />
+        </InlineField>
       </div>
       {showForwardOAuthIdentityOption && (
         <div className="gf-form-inline">
-          <Switch
+          <InlineField
             label="Forward OAuth Identity"
-            labelClass="width-13"
-            checked={dataSourceConfig.jsonData.oauthPassThru || false}
-            onChange={(event) =>
-              onChange({ ...dataSourceConfig.jsonData, oauthPassThru: event!.currentTarget.checked })
-            }
             tooltip="Forward the user's upstream OAuth identity to the data source (Their access token gets passed along)."
-          />
+            labelWidth={LABEL_WIDTH}
+          >
+            <InlineSwitch
+              id="http-settings-forward-oauth"
+              checked={dataSourceConfig.jsonData.oauthPassThru || false}
+              onChange={(event) =>
+                onChange({ ...dataSourceConfig.jsonData, oauthPassThru: event!.currentTarget.checked })
+              }
+            />
+          </InlineField>
         </div>
       )}
     </>

--- a/public/app/features/dashboard/components/PanelEditor/getPanelFrameOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getPanelFrameOptions.tsx
@@ -57,7 +57,7 @@ export function getPanelFrameCategory(props: OptionPaneRenderProps): OptionsPane
           return (
             <Switch
               value={panel.transparent}
-              id="Transparent background"
+              id="transparent-background"
               onChange={(e) => onPanelConfigChange('transparent', e.currentTarget.checked)}
             />
           );

--- a/public/app/features/datasources/settings/BasicSettings.tsx
+++ b/public/app/features/datasources/settings/BasicSettings.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import { selectors } from '@grafana/e2e-selectors';
 import { InlineField, InlineSwitch, Input } from '@grafana/ui';
 
 export interface Props {
@@ -27,6 +28,7 @@ const BasicSettings: FC<Props> = ({ dataSourceName, isDefault, onDefaultChange, 
               placeholder="Name"
               onChange={(event) => onNameChange(event.currentTarget.value)}
               required
+              aria-label={selectors.pages.DataSource.name}
             />
           </InlineField>
         </div>

--- a/public/app/features/datasources/settings/BasicSettings.tsx
+++ b/public/app/features/datasources/settings/BasicSettings.tsx
@@ -34,7 +34,7 @@ const BasicSettings: FC<Props> = ({ dataSourceName, isDefault, onDefaultChange, 
         <InlineField label="Default" labelWidth={8}>
           <InlineSwitch
             id="basic-settings-default"
-            checked={isDefault}
+            value={isDefault}
             onChange={(event: React.FormEvent<HTMLInputElement>) => {
               onDefaultChange(event.currentTarget.checked);
             }}

--- a/public/app/features/datasources/settings/BasicSettings.tsx
+++ b/public/app/features/datasources/settings/BasicSettings.tsx
@@ -1,9 +1,6 @@
 import React, { FC } from 'react';
 
-import { selectors } from '@grafana/e2e-selectors';
-import { InlineFormLabel, LegacyForms } from '@grafana/ui';
-
-const { Input, Switch } = LegacyForms;
+import { InlineField, InlineSwitch, Input } from '@grafana/ui';
 
 export interface Props {
   dataSourceName: string;
@@ -16,33 +13,33 @@ const BasicSettings: FC<Props> = ({ dataSourceName, isDefault, onDefaultChange, 
   return (
     <div className="gf-form-group" aria-label="Datasource settings page basic settings">
       <div className="gf-form-inline">
-        <div className="gf-form max-width-30" style={{ marginRight: '3px' }}>
-          <InlineFormLabel
-            tooltip={
-              'The name is used when you select the data source in panels. The default data source is ' +
-              'preselected in new panels.'
-            }
+        <div className="gf-form max-width-30">
+          <InlineField
+            label="Name"
+            tooltip="The name is used when you select the data source in panels. The default data source is
+              'preselected in new panels."
+            grow
           >
-            Name
-          </InlineFormLabel>
-          <Input
-            className="gf-form-input max-width-23"
-            type="text"
-            value={dataSourceName}
-            placeholder="Name"
-            onChange={(event) => onNameChange(event.target.value)}
-            required
-            aria-label={selectors.pages.DataSource.name}
-          />
+            <Input
+              id="basic-settings-name"
+              type="text"
+              value={dataSourceName}
+              placeholder="Name"
+              onChange={(event) => onNameChange(event.currentTarget.value)}
+              required
+            />
+          </InlineField>
         </div>
-        <Switch
-          label="Default"
-          checked={isDefault}
-          onChange={(event) => {
-            // @ts-ignore
-            onDefaultChange(event.target.checked);
-          }}
-        />
+
+        <InlineField label="Default" labelWidth={8}>
+          <InlineSwitch
+            id="basic-settings-default"
+            checked={isDefault}
+            onChange={(event: React.FormEvent<HTMLInputElement>) => {
+              onDefaultChange(event.currentTarget.checked);
+            }}
+          />
+        </InlineField>
       </div>
     </div>
   );

--- a/public/app/features/datasources/settings/__snapshots__/BasicSettings.test.tsx.snap
+++ b/public/app/features/datasources/settings/__snapshots__/BasicSettings.test.tsx.snap
@@ -10,32 +10,33 @@ exports[`Render should render component 1`] = `
   >
     <div
       className="gf-form max-width-30"
-      style={
-        Object {
-          "marginRight": "3px",
-        }
-      }
     >
-      <FormLabel
-        tooltip="The name is used when you select the data source in panels. The default data source is preselected in new panels."
+      <InlineField
+        grow={true}
+        label="Name"
+        tooltip="The name is used when you select the data source in panels. The default data source is
+              'preselected in new panels."
       >
-        Name
-      </FormLabel>
-      <Input
-        aria-label="Data source settings page name input field"
-        className="gf-form-input max-width-23"
-        onChange={[Function]}
-        placeholder="Name"
-        required={true}
-        type="text"
-        value="Graphite"
-      />
+        <Input
+          id="basic-settings-name"
+          onChange={[Function]}
+          placeholder="Name"
+          required={true}
+          type="text"
+          value="Graphite"
+        />
+      </InlineField>
     </div>
-    <Switch
-      checked={false}
+    <InlineField
       label="Default"
-      onChange={[Function]}
-    />
+      labelWidth={8}
+    >
+      <Switch
+        checked={false}
+        id="basic-settings-default"
+        onChange={[Function]}
+      />
+    </InlineField>
   </div>
 </div>
 `;

--- a/public/app/features/datasources/settings/__snapshots__/BasicSettings.test.tsx.snap
+++ b/public/app/features/datasources/settings/__snapshots__/BasicSettings.test.tsx.snap
@@ -32,9 +32,9 @@ exports[`Render should render component 1`] = `
       labelWidth={8}
     >
       <Switch
-        checked={false}
         id="basic-settings-default"
         onChange={[Function]}
+        value={false}
       />
     </InlineField>
   </div>

--- a/public/app/features/datasources/settings/__snapshots__/BasicSettings.test.tsx.snap
+++ b/public/app/features/datasources/settings/__snapshots__/BasicSettings.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`Render should render component 1`] = `
               'preselected in new panels."
       >
         <Input
+          aria-label="Data source settings page name input field"
           id="basic-settings-name"
           onChange={[Function]}
           placeholder="Name"

--- a/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/PromSettings.tsx
@@ -6,12 +6,19 @@ import {
   SelectableValue,
   updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
-import { EventsWithValidation, InlineFormLabel, LegacyForms, regexValidation } from '@grafana/ui';
+import {
+  InlineField,
+  InlineSwitch,
+  EventsWithValidation,
+  InlineFormLabel,
+  LegacyForms,
+  regexValidation,
+} from '@grafana/ui';
 
 import { PromOptions } from '../types';
 
 import { ExemplarsSettings } from './ExemplarsSettings';
-const { Select, Input, FormField, Switch } = LegacyForms;
+const { Select, Input, FormField } = LegacyForms;
 
 const httpOptions = [
   { value: 'POST', label: 'POST' },
@@ -90,13 +97,16 @@ export const PromSettings = (props: Props) => {
       <h3 className="page-heading">Misc</h3>
       <div className="gf-form-group">
         <div className="gf-form">
-          <Switch
-            checked={options.jsonData.disableMetricsLookup ?? false}
+          <InlineField
+            labelWidth={28}
             label="Disable metrics lookup"
-            labelClass="width-14"
-            onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'disableMetricsLookup')}
             tooltip="Checking this option will disable the metrics chooser and metric/label support in the query field's autocomplete. This helps if you have performance issues with bigger Prometheus instances."
-          />
+          >
+            <InlineSwitch
+              value={options.jsonData.disableMetricsLookup ?? false}
+              onChange={onUpdateDatasourceJsonDataOptionChecked(props, 'disableMetricsLookup')}
+            />
+          </InlineField>
         </div>
         <div className="gf-form-inline">
           <div className="gf-form max-width-30">

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/QueryHeaderSwitch.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/QueryHeaderSwitch.tsx
@@ -12,7 +12,8 @@ export interface Props extends Omit<HTMLProps<HTMLInputElement>, 'value' | 'ref'
 }
 
 export function QueryHeaderSwitch({ label, ...inputProps }: Props) {
-  const switchIdRef = useRef(uniqueId(`switch-${label}`));
+  const dashedLabel = label.replace(' ', '-');
+  const switchIdRef = useRef(uniqueId(`switch-${dashedLabel}`));
   const styles = useStyles2(getStyles);
 
   return (


### PR DESCRIPTION
**What this PR does / why we need it**:

@Elfo404 started looking into #46472 and created #46252.  That PR looks like it solves most of the problems combined with gradual adoption of `InlineSwitch` in other places :trophy: I grepped around and checked all the other places where we use the basic `Switch` to verify keyboard navigation via `tab` worked correctly and recorded my results below.

Rows marked :ok: don't need to be updated since the component in question gets focused just fine.

| Component | Updated | Notes |
| :-- | -- | :-- |
| `basicSettings` | :heavy_check_mark: | |
| `httpproxysettings` | :heavy_check_mark: | |
| `datasourcehttp` | :heavy_check_mark: | |
|`./public/app/plugins/panel/table/PaginationEditor.tsx`|:ok:| |
|`./public/app/plugins/datasource/grafana/components/AnnotationQueryEditor.tsx`|:ok:| |
|`./public/app/plugins/datasource/prometheus/querybuilder/shared/QueryHeaderSwitch.tsx`|:ok:| |
|`./public/app/features/query/components/QueryGroupOptions.tsx`|:ok:| |
|`./public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx`|:ok:| |
|`./public/app/features/dashboard/components/SaveDashboard/forms/SaveDashboardAsForm.tsx`|:x:| Not sure how this ever gets rendered. `isNew` seems to be true everytime?|
|`./public/app/features/dashboard/components/PanelEditor/getPanelFrameOptions.tsx`|:ok:| |
|`./public/app/features/dashboard/components/ShareModal/ShareExport.tsx`|:ok:| |
|`./public/app/features/dashboard/components/ShareModal/ShareEmbed.tsx`|:ok:| |
|`./public/app/features/inspector/InspectDataOptions.tsx`|:ok:| |
|`./public/app/features/dashboard/components/ShareModal/ShareLink.tsx`|:ok:| |


**Which issue(s) this PR fixes**:

Fixes #46472

**Special notes for your reviewer**:
Most uses of `Switch` are in dashboard settings or panel settings. One good place to check keyboard a11y is setting up a Prometheus or Loki datasource with the various authentication options presented as switches. Another good one is sharing a dashboard or modifying its settings. Here's an example from basic datasource settings (note that the default switch can be tabbed too):
![tab-switch](https://user-images.githubusercontent.com/1048831/165815155-e7520f9f-7305-4eec-a0dc-3752df93bdd1.gif)

