### PR TITLE
Canvas: Fix selecto breaking on enter / exit panel edit mode

### DIFF
--- a/public/app/plugins/panel/canvas/CanvasPanel.tsx
+++ b/public/app/plugins/panel/canvas/CanvasPanel.tsx
@@ -122,10 +122,6 @@ export class CanvasPanel extends Component<Props, State> {
       this.scene.updateSize(nextProps.width, nextProps.height);
       this.scene.updateData(nextProps.data);
       changed = true;
-
-      if (this.props.options.inlineEditing) {
-        this.scene.selecto?.destroy();
-      }
     }
 
     return changed;

--- a/public/app/plugins/panel/canvas/CanvasPanel.tsx
+++ b/public/app/plugins/panel/canvas/CanvasPanel.tsx
@@ -113,15 +113,18 @@ export class CanvasPanel extends Component<Props, State> {
     }
 
     // After editing, the options are valid, but the scene was in a different panel or inline editing mode has changed
-    const shouldUpdateSceneAndPanel =
-      (this.needsReload && this.props.options !== nextProps.options) ||
-      this.props.options.inlineEditing !== nextProps.options.inlineEditing;
-    if (shouldUpdateSceneAndPanel) {
+    const shouldUpdateSceneAndPanel = this.needsReload && this.props.options !== nextProps.options;
+    const inlineEditingSwitched = this.props.options.inlineEditing !== nextProps.options.inlineEditing;
+    if (shouldUpdateSceneAndPanel || inlineEditingSwitched) {
       this.needsReload = false;
       this.scene.load(nextProps.options.root, nextProps.options.inlineEditing);
       this.scene.updateSize(nextProps.width, nextProps.height);
       this.scene.updateData(nextProps.data);
       changed = true;
+
+      if (inlineEditingSwitched && this.props.options.inlineEditing) {
+        this.scene.selecto?.destroy();
+      }
     }
 
     return changed;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Selecto was breaking when exiting (and sometimes entering) panel edit mode, requiring refreshing the page to fix issue. Also cleans up issue when toggling inline editing mode breaking selecto functionality (in both panel edit / dashboard contexts)

Before

https://user-images.githubusercontent.com/22381771/165647947-f268be11-9490-4bcb-96be-81fffc17e39f.mov



After


https://user-images.githubusercontent.com/22381771/165649942-4ff5f7db-b1f4-4318-b0e7-ad40cd8732e0.mov





<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #48386
Fixes #48388

