### PR TITLE
Canvas: Layer actions / constraint change not adhering to inline editing state

### DIFF
--- a/public/app/features/canvas/runtime/group.tsx
+++ b/public/app/features/canvas/runtime/group.tsx
@@ -77,7 +77,7 @@ export class GroupState extends ElementState {
   reinitializeMoveable() {
     // Need to first clear current selection and then re-init moveable with slight delay
     this.scene.clearCurrentSelection();
-    setTimeout(() => this.scene.initMoveable(true), 100);
+    setTimeout(() => this.scene.initMoveable(true, this.scene.isEditingEnabled), 100);
   }
 
   // ??? or should this be on the element directly?

--- a/public/app/features/canvas/runtime/scene.tsx
+++ b/public/app/features/canvas/runtime/scene.tsx
@@ -52,6 +52,7 @@ export class Scene {
   moveable?: Moveable;
   div?: HTMLDivElement;
   currentLayer?: GroupState;
+  isEditingEnabled?: boolean;
 
   constructor(cfg: CanvasGroupOptions, enableEditing: boolean, public onSave: (cfg: CanvasGroupOptions) => void) {
     this.root = this.load(cfg, enableEditing);
@@ -85,6 +86,8 @@ export class Scene {
       this,
       this.save // callback when changes are made
     );
+
+    this.isEditingEnabled = enableEditing;
 
     setTimeout(() => {
       if (this.div) {
@@ -165,7 +168,7 @@ export class Scene {
     if (updateMoveable) {
       setTimeout(() => {
         if (this.div) {
-          this.initMoveable(true);
+          this.initMoveable(true, this.isEditingEnabled);
         }
       }, 100);
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Layer element actions (duplicate, remove, re-order) and constraint on change was not adhering to inline editing state. (i.e. if inline editing state was turned off, doing one of those actions would re-enable inline editing)

Before

https://user-images.githubusercontent.com/22381771/165652373-e1b0cb2c-baee-4238-b8b3-b2a184c80cc4.mov

https://user-images.githubusercontent.com/22381771/165652521-66cbad68-159c-4952-8482-e559a09ab71e.mov

After

https://user-images.githubusercontent.com/22381771/165652596-83133e48-bccc-4084-a184-cc6cfb6237e2.mov




**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #48389

