### PR TITLE
Command Palette - use same focus overlay as modals, override monaco keybinding for prometheus

### DIFF
--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { FocusScope } from '@react-aria/focus';
 import {
   KBarAnimator,
   KBarPortal,
@@ -78,8 +79,10 @@ export const CommandPalette = () => {
     <KBarPortal>
       <KBarPositioner className={styles.positioner}>
         <KBarAnimator className={styles.animator}>
-          <KBarSearch className={styles.search} />
-          <RenderResults />
+          <FocusScope contain>
+            <KBarSearch className={styles.search} />
+            <RenderResults />
+          </FocusScope>
         </KBarAnimator>
       </KBarPositioner>
     </KBarPortal>

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { useKBar } from 'kbar';
 import { promLanguageDefinition } from 'monaco-promql';
 import React, { useRef, useEffect } from 'react';
 import { useLatest } from 'react-use';
@@ -94,6 +95,8 @@ const MonacoQueryField = (props: Props) => {
 
   const theme = useTheme2();
   const styles = getStyles(theme);
+
+  const { query } = useKBar();
 
   useEffect(() => {
     // when we unmount, we unregister the autocomplete-function, if it was registered
@@ -198,6 +201,10 @@ const MonacoQueryField = (props: Props) => {
           // FIXME: maybe move this functionality into CodeEditor?
           editor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, () => {
             onRunQueryRef.current(editor.getValue());
+          });
+
+          editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK, function () {
+            query.toggle();
           });
         }}
       />

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/css';
-import { useKBar } from 'kbar';
 import { promLanguageDefinition } from 'monaco-promql';
 import React, { useRef, useEffect } from 'react';
 import { useLatest } from 'react-use';
@@ -95,8 +94,6 @@ const MonacoQueryField = (props: Props) => {
 
   const theme = useTheme2();
   const styles = getStyles(theme);
-
-  const { query } = useKBar();
 
   useEffect(() => {
     // when we unmount, we unregister the autocomplete-function, if it was registered
@@ -203,8 +200,11 @@ const MonacoQueryField = (props: Props) => {
             onRunQueryRef.current(editor.getValue());
           });
 
+          /* Something in this configuration of monaco doesn't bubble up [mod]+K, which the 
+          command palette uses. Pass the event out of monaco manually
+          */
           editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK, function () {
-            query.toggle();
+            global.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
           });
         }}
       />


### PR DESCRIPTION
**What this PR does / why we need it**:
We noticed a few editors had issues with the command palette. Some would keep focus when it was pulled up, so you could continue to type in the background. Others wouldn't bubble up the keypress so the command palette wouldn't display.

**Which issue(s) this PR fixes**:

Fixes #48088

**Special notes for your reviewer**: Reviewing will be best done listening to 'Deorro - Focus feat. Lena Leon' because dealing with this problem has had this song stuck in my head the last few days. 