### PR TITLE
Shortcuts: Add shortcut to show shortcuts to the list of shortcuts

### DIFF
--- a/public/app/core/components/help/HelpModal.tsx
+++ b/public/app/core/components/help/HelpModal.tsx
@@ -10,6 +10,7 @@ const shortcuts = {
     { keys: ['g', 'p'], description: 'Go to Profile' },
     { keys: ['s', 'o'], description: 'Open search' },
     { keys: ['esc'], description: 'Exit edit/setting views' },
+    { keys: ['h'], description: 'Show all keyboards shortcuts' },
   ],
   Dashboard: [
     { keys: ['mod+s'], description: 'Save dashboard' },

--- a/public/app/core/components/help/HelpModal.tsx
+++ b/public/app/core/components/help/HelpModal.tsx
@@ -10,7 +10,7 @@ const shortcuts = {
     { keys: ['g', 'p'], description: 'Go to Profile' },
     { keys: ['s', 'o'], description: 'Open search' },
     { keys: ['esc'], description: 'Exit edit/setting views' },
-    { keys: ['h'], description: 'Show all keyboards shortcuts' },
+    { keys: ['h'], description: 'Show all keyboard shortcuts' },
   ],
   Dashboard: [
     { keys: ['mod+s'], description: 'Save dashboard' },


### PR DESCRIPTION
**What this PR does / why we need it**:
I didn't know that there was a shortcut to show all the shortcuts. It is documented in docs https://grafana.com/docs/grafana/latest/dashboards/shortcuts/, but I thought it would make sense to also add it to the list of shortcuts as it is shortcut. 

<img width="814" alt="image" src="https://user-images.githubusercontent.com/30407135/165706801-0ac9ddb2-d3f3-4a25-8728-bf554b403165.png">

![image](https://user-images.githubusercontent.com/30407135/165738783-a290e256-945e-43da-a014-86e8a4fb19aa.png)
