### PR TITLE
loki backend mode forward-oauth

### DIFF
--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -16,16 +16,23 @@ import (
 )
 
 type LokiAPI struct {
-	client *http.Client
-	url    string
-	log    log.Logger
+	client     *http.Client
+	url        string
+	log        log.Logger
+	oauthToken string
 }
 
-func newLokiAPI(client *http.Client, url string, log log.Logger) *LokiAPI {
-	return &LokiAPI{client: client, url: url, log: log}
+func newLokiAPI(client *http.Client, url string, log log.Logger, oauthToken string) *LokiAPI {
+	return &LokiAPI{client: client, url: url, log: log, oauthToken: oauthToken}
 }
 
-func makeDataRequest(ctx context.Context, lokiDsUrl string, query lokiQuery) (*http.Request, error) {
+func addOauthHeader(req *http.Request, oauthToken string) {
+	if oauthToken != "" {
+		req.Header.Set("Authorization", oauthToken)
+	}
+}
+
+func makeDataRequest(ctx context.Context, lokiDsUrl string, query lokiQuery, oauthToken string) (*http.Request, error) {
 	qs := url.Values{}
 	qs.Set("query", query.Expr)
 
@@ -77,6 +84,8 @@ func makeDataRequest(ctx context.Context, lokiDsUrl string, query lokiQuery) (*h
 	if err != nil {
 		return nil, err
 	}
+
+	addOauthHeader(req, oauthToken)
 
 	// NOTE:
 	// 1. we are missing "dynamic" http params, like OAuth data.
@@ -136,7 +145,7 @@ func makeLokiError(body io.ReadCloser) error {
 }
 
 func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery) (*loghttp.QueryResponse, error) {
-	req, err := makeDataRequest(ctx, api.url, query)
+	req, err := makeDataRequest(ctx, api.url, query, api.oauthToken)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +174,7 @@ func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery) (*loghttp.Qu
 	return &response, nil
 }
 
-func makeRawRequest(ctx context.Context, lokiDsUrl string, resourceURL string) (*http.Request, error) {
+func makeRawRequest(ctx context.Context, lokiDsUrl string, resourceURL string, oauthToken string) (*http.Request, error) {
 	lokiUrl, err := url.Parse(lokiDsUrl)
 	if err != nil {
 		return nil, err
@@ -176,11 +185,19 @@ func makeRawRequest(ctx context.Context, lokiDsUrl string, resourceURL string) (
 		return nil, err
 	}
 
-	return http.NewRequestWithContext(ctx, "GET", url.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url.String(), nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	addOauthHeader(req, oauthToken)
+
+	return req, nil
 }
 
 func (api *LokiAPI) RawQuery(ctx context.Context, resourceURL string) ([]byte, error) {
-	req, err := makeRawRequest(ctx, api.url, resourceURL)
+	req, err := makeRawRequest(ctx, api.url, resourceURL, api.oauthToken)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -87,13 +87,6 @@ func makeDataRequest(ctx context.Context, lokiDsUrl string, query lokiQuery, oau
 
 	addOauthHeader(req, oauthToken)
 
-	// NOTE:
-	// 1. we are missing "dynamic" http params, like OAuth data.
-	// this never worked before (and it is not needed for alerting scenarios),
-	// so it is not a regression.
-	// twe need to have that when we migrate to backend-queries.
-	//
-
 	if query.VolumeQuery {
 		req.Header.Set("X-Query-Tags", "Source=logvolhist")
 	}

--- a/pkg/tsdb/loki/api_mock.go
+++ b/pkg/tsdb/loki/api_mock.go
@@ -1,0 +1,41 @@
+package loki
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+type mockRequestCallback func(req *http.Request)
+
+type mockedRoundTripper struct {
+	statusCode      int
+	responseBytes   []byte
+	contentType     string
+	requestCallback mockRequestCallback
+}
+
+func (mockedRT *mockedRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	requestCallback := mockedRT.requestCallback
+	if requestCallback != nil {
+		requestCallback(req)
+	}
+
+	header := http.Header{}
+	header.Add("Content-Type", mockedRT.contentType)
+	return &http.Response{
+		StatusCode: mockedRT.statusCode,
+		Header:     header,
+		Body:       io.NopCloser(bytes.NewReader(mockedRT.responseBytes)),
+	}, nil
+}
+
+func makeMockedAPI(statusCode int, contentType string, responseBytes []byte, requestCallback mockRequestCallback) *LokiAPI {
+	client := http.Client{
+		Transport: &mockedRoundTripper{statusCode: statusCode, contentType: contentType, responseBytes: responseBytes, requestCallback: requestCallback},
+	}
+
+	return newLokiAPI(&client, "http://localhost:9999", log.New("test"), "")
+}

--- a/pkg/tsdb/loki/loki_bench_test.go
+++ b/pkg/tsdb/loki/loki_bench_test.go
@@ -17,7 +17,7 @@ func BenchmarkMatrixJson(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_, _ = runQuery(context.Background(), makeMockedAPI(http.StatusOK, "application/json", bytes), &lokiQuery{})
+		_, _ = runQuery(context.Background(), makeMockedAPI(http.StatusOK, "application/json", bytes, nil), &lokiQuery{})
 	}
 }
 

--- a/pkg/tsdb/loki/oauth_test.go
+++ b/pkg/tsdb/loki/oauth_test.go
@@ -1,0 +1,164 @@
+package loki
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/stretchr/testify/require"
+)
+
+type mockedRoundTripperForOauth struct {
+	requestCallback func(req *http.Request)
+	body            []byte
+}
+
+func (mockedRT *mockedRoundTripperForOauth) RoundTrip(req *http.Request) (*http.Response, error) {
+	mockedRT.requestCallback(req)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Body:       io.NopCloser(bytes.NewReader(mockedRT.body)),
+	}, nil
+}
+
+type mockedCallResourceResponseSenderForOauth struct {
+	Response *backend.CallResourceResponse
+}
+
+func (s *mockedCallResourceResponseSenderForOauth) Send(resp *backend.CallResourceResponse) error {
+	s.Response = resp
+	return nil
+}
+
+func makeMockedDsInfoForOauth(oauthPassThru bool, body []byte, requestCallback func(req *http.Request)) datasourceInfo {
+	client := http.Client{
+		Transport: &mockedRoundTripperForOauth{requestCallback: requestCallback, body: body},
+	}
+
+	return datasourceInfo{
+		HTTPClient:    &client,
+		OauthPassThru: oauthPassThru,
+	}
+}
+
+func TestOauthForwardIdentity(t *testing.T) {
+	tt := []struct {
+		name          string
+		oauthPassThru bool
+		headerGiven   bool
+		headerSent    bool
+	}{
+		{name: "when enabled and headers exist => add headers", oauthPassThru: true, headerGiven: true, headerSent: true},
+		{name: "when disabled and headers exist => do not add headers", oauthPassThru: false, headerGiven: true, headerSent: false},
+		{name: "when enabled and no headers exist => do not add headers", oauthPassThru: true, headerGiven: false, headerSent: false},
+		{name: "when disabled and no headers exist => do not add headers", oauthPassThru: false, headerGiven: false, headerSent: false},
+	}
+
+	authName := "Authorization"
+	authValue := "auth"
+
+	for _, test := range tt {
+		t.Run("QueryData: "+test.name, func(t *testing.T) {
+			response := []byte(`
+				{
+					"status": "success",
+					"data": {
+						"resultType": "streams",
+						"result": [
+							{
+								"stream": {},
+								"values": [
+									["1", "line1"]
+								]
+							}
+						]
+					}
+				}
+			`)
+
+			clientUsed := false
+			dsInfo := makeMockedDsInfoForOauth(test.oauthPassThru, response, func(req *http.Request) {
+				clientUsed = true
+				if test.headerSent {
+					require.Equal(t, authValue, req.Header.Get(authName))
+				} else {
+					require.Equal(t, "", req.Header.Get(authName))
+				}
+			})
+
+			req := backend.QueryDataRequest{
+				Headers: map[string]string{},
+				Queries: []backend.DataQuery{
+					{
+						RefID: "A",
+						JSON:  []byte("{}"),
+					},
+				},
+			}
+
+			if test.headerGiven {
+				req.Headers[authName] = authValue
+			}
+
+			tracer, err := tracing.InitializeTracerForTest()
+			require.NoError(t, err)
+
+			data, err := queryData(context.Background(), &req, &dsInfo, log.New("testlog"), tracer)
+			// we do a basic check that the result is OK
+			require.NoError(t, err)
+			require.Len(t, data.Responses, 1)
+			res := data.Responses["A"]
+			require.NoError(t, res.Error)
+			require.Len(t, res.Frames, 1)
+			require.Equal(t, "line1", res.Frames[0].Fields[2].At(0))
+
+			// we need to be sure the client-callback was triggered
+			require.True(t, clientUsed)
+		})
+	}
+
+	for _, test := range tt {
+		t.Run("CallResource: "+test.name, func(t *testing.T) {
+			response := []byte("mocked resource response")
+
+			clientUsed := false
+			dsInfo := makeMockedDsInfoForOauth(test.oauthPassThru, response, func(req *http.Request) {
+				clientUsed = true
+				if test.headerSent {
+					require.Equal(t, authValue, req.Header.Get(authName))
+				} else {
+					require.Equal(t, "", req.Header.Get(authName))
+				}
+			})
+
+			req := backend.CallResourceRequest{
+				Headers: map[string][]string{},
+				Method:  "GET",
+				URL:     "labels?",
+			}
+
+			if test.headerGiven {
+				req.Headers[authName] = []string{authValue}
+			}
+
+			sender := &mockedCallResourceResponseSenderForOauth{}
+
+			err := callResource(context.Background(), &req, sender, &dsInfo, log.New("testlog"))
+			// we do a basic check that the result is OK
+			require.NoError(t, err)
+			sent := sender.Response
+			require.NotNil(t, sent)
+			require.Equal(t, http.StatusOK, sent.Status)
+			require.Equal(t, response, sent.Body)
+
+			// we need to be sure the client-callback was triggered
+			require.True(t, clientUsed)
+		})
+	}
+}


### PR DESCRIPTION
for Loki backend mode, when in the datasource-config the "forward oauth identity" is enabled, we should send oauth info (if it exists) to Loki. this pull request implements the functionality for loki backend mode.

for documentation about what's happening here read this: https://grafana.com/docs/grafana/latest/developers/plugins/add-authentication-for-data-source-plugins/#forward-oauth-identity-for-the-logged-in-user
NOTE: we are not handling the X-id-token header because it's not needed.