### PR TITLE
CI: Reorder dependencies for npm release steps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3114,7 +3114,7 @@ steps:
 - commands:
   - ./bin/grabpl artifacts npm retrieve --tag v${TAG}
   depends_on:
-  - grabpl
+  - yarn-install
   environment:
     GCP_KEY:
       from_secret: gcp_key
@@ -4574,6 +4574,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 7ca5d844d600cf20dd0f568ab2753aa82a57a159a7b9dcf0435fe87003d9447e
+hmac: 6f77e9f096880adceaf04b4235d20e1c73b26534da4965a797f30fb30ccbb114
 
 ...

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -82,7 +82,7 @@ def retrieve_npm_packages_step():
         'name': 'retrieve-npm-packages',
         'image': publish_image,
         'depends_on': [
-            'grabpl',
+            'yarn-install',
         ],
         'environment': {
             'GCP_KEY': from_secret('gcp_key'),


### PR DESCRIPTION
**What this PR does / why we need it**:

`release-npm-packages` needs `package.json` to run yarn commands. This step depended on `retrieve-npm-packages` which depended on `grabpl`, so `release-npm-packages` ran before `yarn-install` step and caused failures.
Now, `retrieve-npm-packages` will depend on `yarn-install` to avoid this problem.
