### PR TITLE
Chore: Transfer TimeSyncButton.test to testing-library

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -239,9 +239,6 @@ exports[`no enzyme tests`] = {
     "public/app/features/explore/SecondaryActions.test.tsx:1177396128": [
       [0, 19, 13, "RegExp match", "2409514259"]
     ],
-    "public/app/features/explore/TimeSyncButton.test.tsx:853739820": [
-      [0, 17, 13, "RegExp match", "2409514259"]
-    ],
     "public/app/features/folders/FolderSettingsPage.test.tsx:1109052730": [
       [0, 19, 13, "RegExp match", "2409514259"]
     ],

--- a/public/app/features/explore/TimeSyncButton.test.tsx
+++ b/public/app/features/explore/TimeSyncButton.test.tsx
@@ -1,20 +1,20 @@
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 
 import { TimeSyncButton } from './TimeSyncButton';
 
 const setup = (isSynced: boolean) => {
   const onClick = () => {};
-  return mount(<TimeSyncButton onClick={onClick} isSynced={isSynced} />);
+  return render(<TimeSyncButton onClick={onClick} isSynced={isSynced} />);
 };
 
 describe('TimeSyncButton', () => {
-  it('should change style when synced', () => {
-    const wrapper = setup(true);
-    expect(wrapper.find('button').props()['aria-label']).toEqual('Synced times');
+  it('should have the right name when isSynced = true', () => {
+    setup(true);
+    expect(screen.getByRole('button', { name: /synced times/i })).toBeInTheDocument();
   });
-  it('should not change style when not synced', () => {
-    const wrapper = setup(false);
-    expect(wrapper.find('button').props()['aria-label']).toEqual('Unsynced times');
+  it('should have the right name when isSynced = false', () => {
+    setup(false);
+    expect(screen.getByRole('button', { name: /unsynced times/i })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes #46201 