### PR TITLE
CI: Split `publish-packages` pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3147,7 +3147,7 @@ depends_on:
 - publish-docker-oss-public
 - publish-docker-enterprise-public
 kind: pipeline
-name: publish-packages
+name: publish-packages-oss
 node:
   type: no-parallel
 platform:
@@ -3179,6 +3179,36 @@ steps:
       from_secret: grafana_api_key
   image: grafana/grafana-ci-deploy:1.3.1
   name: store-packages-oss
+trigger:
+  event:
+  - promote
+  target:
+  - public
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+depends_on:
+- publish-artifacts-public
+- publish-docker-oss-public
+- publish-docker-enterprise-public
+kind: pipeline
+name: publish-packages-enterprise
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.9.41/grabpl
+  - chmod +x bin/grabpl
+  image: byrnedo/alpine-curl:0.1.8
+  name: grabpl
 - commands:
   - ./bin/grabpl store-packages --edition enterprise --packages-bucket grafana-downloads
     --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
@@ -4574,6 +4604,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 6f77e9f096880adceaf04b4235d20e1c73b26534da4965a797f30fb30ccbb114
+hmac: 045df48997fde9ae05050441a3635a97a8be4db7b8b0c748c367cee0fc3d2373
 
 ...

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -411,19 +411,16 @@ def publish_packages_pipeline():
         download_grabpl_step(),
         store_packages_step(edition='enterprise', ver_mode='release'),
     ]
+    deps = [
+        'publish-artifacts-public',
+        'publish-docker-oss-public',
+        'publish-docker-enterprise-public'
+    ]
 
     return [pipeline(
-        name='publish-packages-oss', trigger=trigger, steps=oss_steps, edition="all", depends_on=[
-            'publish-artifacts-public',
-            'publish-docker-oss-public',
-            'publish-docker-enterprise-public'
-        ]
+        name='publish-packages-oss', trigger=trigger, steps=oss_steps, edition="all", depends_on=deps
     ), pipeline(
-        name='publish-packages-enterprise', trigger=trigger, steps=enterprise_steps, edition="all", depends_on=[
-            'publish-artifacts-public',
-            'publish-docker-oss-public',
-            'publish-docker-enterprise-public'
-        ]
+        name='publish-packages-enterprise', trigger=trigger, steps=enterprise_steps, edition="all", depends_on=deps
     )]
 
 def publish_npm_pipelines(mode):

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -402,14 +402,24 @@ def publish_packages_pipeline():
         'event': ['promote'],
         'target': ['public'],
     }
-    steps = [
+    oss_steps = [
         download_grabpl_step(),
         store_packages_step(edition='oss', ver_mode='release'),
+    ]
+
+    enterprise_steps = [
+        download_grabpl_step(),
         store_packages_step(edition='enterprise', ver_mode='release'),
     ]
 
     return [pipeline(
-        name='publish-packages', trigger=trigger, steps=steps, edition="all", depends_on=[
+        name='publish-packages-oss', trigger=trigger, steps=oss_steps, edition="all", depends_on=[
+            'publish-artifacts-public',
+            'publish-docker-oss-public',
+            'publish-docker-enterprise-public'
+        ]
+    ), pipeline(
+        name='publish-packages-enterprise', trigger=trigger, steps=enterprise_steps, edition="all", depends_on=[
             'publish-artifacts-public',
             'publish-docker-oss-public',
             'publish-docker-enterprise-public'


### PR DESCRIPTION
**What this PR does / why we need it**:

Our Drone runners are running out of space when deb and rpm packages are being downloaded for both OSS and Enterprise. Splitting the pipelines will split the load, make the publishing faster and make the out-of-space error disappear.
