### PR TITLE
[v8.4.x] CI: Split `publish-packages` pipeline (#48414)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3104,7 +3104,7 @@ depends_on:
 - publish-docker-oss-public
 - publish-docker-enterprise-public
 kind: pipeline
-name: publish-packages
+name: publish-packages-oss
 node:
   type: no-parallel
 platform:
@@ -3136,6 +3136,36 @@ steps:
       from_secret: grafana_api_key
   image: grafana/grafana-ci-deploy:1.3.1
   name: store-packages-oss
+trigger:
+  event:
+  - promote
+  target:
+  - public
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+depends_on:
+- publish-artifacts-public
+- publish-docker-oss-public
+- publish-docker-enterprise-public
+kind: pipeline
+name: publish-packages-enterprise
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.9.41/grabpl
+  - chmod +x bin/grabpl
+  image: byrnedo/alpine-curl:0.1.8
+  name: grabpl
 - commands:
   - ./bin/grabpl store-packages --edition enterprise --packages-bucket grafana-downloads
     --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
@@ -4531,6 +4561,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: dac88338f1f0c0490658fff93f5a72c482b2fdbce64f116f864023536b383731
+hmac: 3963d585b24e256a484c1e14b5d9f220d11297ef277976f381ab866b27c1c223
 
 ...

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -419,18 +419,25 @@ def publish_packages_pipeline():
         'event': ['promote'],
         'target': ['public'],
     }
-    steps = [
+    oss_steps = [
         download_grabpl_step(),
         store_packages_step(edition='oss', ver_mode='release'),
+    ]
+
+    enterprise_steps = [
+        download_grabpl_step(),
         store_packages_step(edition='enterprise', ver_mode='release'),
+    ]
+    deps = [
+        'publish-artifacts-public',
+        'publish-docker-oss-public',
+        'publish-docker-enterprise-public'
     ]
 
     return [pipeline(
-        name='publish-packages', trigger=trigger, steps=steps, edition="all", depends_on=[
-            'publish-artifacts-public',
-            'publish-docker-oss-public',
-            'publish-docker-enterprise-public'
-        ]
+        name='publish-packages-oss', trigger=trigger, steps=oss_steps, edition="all", depends_on=deps
+    ), pipeline(
+        name='publish-packages-enterprise', trigger=trigger, steps=enterprise_steps, edition="all", depends_on=deps
     )]
 
 def publish_npm_pipelines(mode):


### PR DESCRIPTION
* Split publish packages pipeline

* Small refactoring

(cherry picked from commit a7a5476ac2c93778275f046aaf68e55d5112e8d0)

Backports #48414