### PR TITLE
Table: Fix reset filter on resize

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -183,6 +183,7 @@ export const Table: FC<Props> = memo((props: Props) => {
       disableResizing: !resizable,
       stateReducer: stateReducer,
       initialState: getInitialState(initialSortBy, memoizedColumns),
+      autoResetFilters: false,
       sortTypes: {
         number: sortNumber, // the builtin number type on react-table does not handle NaN values
         'alphanumeric-insensitive': sortCaseInsensitive, // should be replace with the builtin string when react-table is upgraded, see https://github.com/tannerlinsley/react-table/pull/3235


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr disables the [autoResetFilters](https://react-table.tanstack.com/docs/api/useFilters#table-options) for the table panel which fixes #46562 but this is still not persisted in grafana level. The question is if we should do that or not?

**Which issue(s) this PR fixes**:

Fixes #46562

**Special notes for your reviewer**:

