### PR TITLE
Release: downgrade to centos 7 in verify repo as 8 doesn't work

### DIFF
--- a/scripts/verify-repo-update/Dockerfile.rpm
+++ b/scripts/verify-repo-update/Dockerfile.rpm
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM centos:7
 
 ARG REPO_CONFIG=grafana.repo.oss
 ARG PACKAGE=grafana


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Centos 8 doesn't have a valid mirrorlist for some reason. Downgrading to 7 as that works.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

