### PR TITLE
CI: Trigger `pr-test-*` pipelines on different cases

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -57,6 +57,7 @@ trigger:
     exclude:
     - docs/**
     - pkg/**
+    - packaging/*
     include: []
 type: docker
 volumes:
@@ -146,6 +147,9 @@ trigger:
     - docs/**
     include:
     - pkg/**
+    - packaging/*
+    - .drone.yml
+    - conf/*
 type: docker
 volumes:
 - host:
@@ -4715,6 +4719,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 4eea6c9f54b167ae04508a045f9aae5d7efd272abd650b2bdde427e6928db385
+hmac: 991694433d2e5972ad587d5d3d310980893c8c6db66529643ae52426fcc8e704
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -56,8 +56,11 @@ trigger:
   paths:
     exclude:
     - docs/**
+    - '*.md'
     - pkg/**
     - packaging/*
+    - go.sum
+    - go.mod
     include: []
 type: docker
 volumes:
@@ -145,11 +148,14 @@ trigger:
   paths:
     exclude:
     - docs/**
+    - '*.md'
     include:
     - pkg/**
     - packaging/*
     - .drone.yml
     - conf/*
+    - go.sum
+    - go.mod
 type: docker
 volumes:
 - host:
@@ -4719,6 +4725,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 991694433d2e5972ad587d5d3d310980893c8c6db66529643ae52426fcc8e704
+hmac: 78d89910f4e207c3975caef96c26558c8811846eabb95b16a1da2626462ed098
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -143,9 +143,9 @@ trigger:
   - pull_request
   paths:
     exclude:
-    - '*.md'
     - docs/**
-    - latest.json
+    include:
+    - pkg/**
 type: docker
 volumes:
 - host:
@@ -4715,6 +4715,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: fb64e50c271012ad1cc9b7ad7e7bd037736d6e3471d24f73774e8fd61472600c
+hmac: ff085ddc71068da845df1504632d1f41e54ff42b01df979c9cbea184d8289a5d
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -55,9 +55,9 @@ trigger:
   - pull_request
   paths:
     exclude:
-    - '*.md'
     - docs/**
-    - latest.json
+    - pkg/**
+    include: []
 type: docker
 volumes:
 - host:
@@ -4715,6 +4715,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: ff085ddc71068da845df1504632d1f41e54ff42b01df979c9cbea184d8289a5d
+hmac: 4eea6c9f54b167ae04508a045f9aae5d7efd272abd650b2bdde427e6928db385
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -58,7 +58,7 @@ trigger:
     - docs/**
     - '*.md'
     - pkg/**
-    - packaging/*
+    - packaging/**
     - go.sum
     - go.mod
     include: []
@@ -151,9 +151,9 @@ trigger:
     - '*.md'
     include:
     - pkg/**
-    - packaging/*
+    - packaging/**
     - .drone.yml
-    - conf/*
+    - conf/**
     - go.sum
     - go.mod
 type: docker
@@ -4725,6 +4725,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 78d89910f4e207c3975caef96c26558c8811846eabb95b16a1da2626462ed098
+hmac: f4586777ea98ff85fec51ae5bf344bf549871f73aab2b6ff6611ce979b5bbfa1
 
 ...

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -84,7 +84,7 @@ def pr_test_frontend():
         test_frontend_step(),
     ]
     return pipeline(
-        name='pr-test-frontend', edition="oss", trigger=get_pr_trigger(exclude_paths=['pkg/**', 'packaging/*']), services=[], steps=init_steps + test_steps,
+        name='pr-test-frontend', edition="oss", trigger=get_pr_trigger(exclude_paths=['pkg/**', 'packaging/*', 'go.sum', 'go.mod']), services=[], steps=init_steps + test_steps,
     )
 
 
@@ -104,7 +104,7 @@ def pr_test_backend():
         test_backend_integration_step(edition="oss"),
     ]
     return pipeline(
-        name='pr-test-backend', edition="oss", trigger=get_pr_trigger(include_paths=['pkg/**', 'packaging/*', '.drone.yml', 'conf/*']), services=[], steps=init_steps + test_steps,
+        name='pr-test-backend', edition="oss", trigger=get_pr_trigger(include_paths=['pkg/**', 'packaging/*', '.drone.yml', 'conf/*', 'go.sum', 'go.mod']), services=[], steps=init_steps + test_steps,
     )
 
 
@@ -163,7 +163,7 @@ def pr_pipelines(edition):
 
 
 def get_pr_trigger(include_paths=None, exclude_paths=None):
-    paths_ex = ['docs/**']
+    paths_ex = ['docs/**', '*.md']
     paths_in = []
     if include_paths:
         for path in include_paths:

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -84,7 +84,7 @@ def pr_test_frontend():
         test_frontend_step(),
     ]
     return pipeline(
-        name='pr-test-frontend', edition="oss", trigger=get_pr_trigger(exclude_paths=['pkg/**']), services=[], steps=init_steps + test_steps,
+        name='pr-test-frontend', edition="oss", trigger=get_pr_trigger(exclude_paths=['pkg/**', 'packaging/*']), services=[], steps=init_steps + test_steps,
     )
 
 
@@ -104,7 +104,7 @@ def pr_test_backend():
         test_backend_integration_step(edition="oss"),
     ]
     return pipeline(
-        name='pr-test-backend', edition="oss", trigger=get_pr_trigger(include_paths=['pkg/**']), services=[], steps=init_steps + test_steps,
+        name='pr-test-backend', edition="oss", trigger=get_pr_trigger(include_paths=['pkg/**', 'packaging/*', '.drone.yml', 'conf/*']), services=[], steps=init_steps + test_steps,
     )
 
 

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -84,7 +84,7 @@ def pr_test_frontend():
         test_frontend_step(),
     ]
     return pipeline(
-        name='pr-test-frontend', edition="oss", trigger=trigger, services=[], steps=init_steps + test_steps,
+        name='pr-test-frontend', edition="oss", trigger=get_pr_trigger(exclude_paths=['pkg/**']), services=[], steps=init_steps + test_steps,
     )
 
 

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -104,7 +104,7 @@ def pr_test_backend():
         test_backend_integration_step(edition="oss"),
     ]
     return pipeline(
-        name='pr-test-backend', edition="oss", trigger=trigger, services=[], steps=init_steps + test_steps,
+        name='pr-test-backend', edition="oss", trigger=get_pr_trigger(include_paths=['pkg/**']), services=[], steps=init_steps + test_steps,
     )
 
 
@@ -160,3 +160,24 @@ def pr_pipelines(edition):
             volumes=volumes,
         ), docs_pipelines(edition, ver_mode, trigger_docs())
     ]
+
+
+def get_pr_trigger(include_paths=None, exclude_paths=None):
+    paths_ex = ['docs/**']
+    paths_in = []
+    if include_paths:
+        for path in include_paths:
+            paths_in.extend([path])
+    if exclude_paths:
+        for path in exclude_paths:
+            paths_ex.extend([path])
+    return {
+        'event': [
+            'pull_request',
+        ],
+        'paths': {
+            'exclude': paths_ex,
+            'include': paths_in,
+        },
+    }
+

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -84,7 +84,7 @@ def pr_test_frontend():
         test_frontend_step(),
     ]
     return pipeline(
-        name='pr-test-frontend', edition="oss", trigger=get_pr_trigger(exclude_paths=['pkg/**', 'packaging/*', 'go.sum', 'go.mod']), services=[], steps=init_steps + test_steps,
+        name='pr-test-frontend', edition="oss", trigger=get_pr_trigger(exclude_paths=['pkg/**', 'packaging/**', 'go.sum', 'go.mod']), services=[], steps=init_steps + test_steps,
     )
 
 
@@ -104,7 +104,7 @@ def pr_test_backend():
         test_backend_integration_step(edition="oss"),
     ]
     return pipeline(
-        name='pr-test-backend', edition="oss", trigger=get_pr_trigger(include_paths=['pkg/**', 'packaging/*', '.drone.yml', 'conf/*', 'go.sum', 'go.mod']), services=[], steps=init_steps + test_steps,
+        name='pr-test-backend', edition="oss", trigger=get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod']), services=[], steps=init_steps + test_steps,
     )
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Triggers `pr-test-backend` and `pr-test-frontend` changes on different occasions.

# pr-test-backend
`pr-test-backend` gets triggered upon changes to:
* `pkg/**`
* `packaging/**`
* `.drone.yml`
* `conf/**`

# pr-test-frontend
`pr-test-frontend` gets triggered upon changes to everything except:
* `pkg/**`
* `packaging/**`
