### PR TITLE
Loki: use metadataRequest in testDatasource

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -688,44 +688,35 @@ export class LokiDatasource
     };
   };
 
-  testDatasource() {
+  testDatasource(): Promise<{ status: string; message: string }> {
     // Consider only last 10 minutes otherwise request takes too long
-    const startMs = Date.now() - 10 * 60 * 1000;
-    const start = `${startMs}000000`; // API expects nanoseconds
-    return lastValueFrom(
-      this._request(`${LOKI_ENDPOINT}/label`, { start }).pipe(
-        map((res) => {
-          const values: any[] = res?.data?.data || res?.data?.values || [];
-          const testResult =
-            values.length > 0
-              ? { status: 'success', message: 'Data source connected and labels found.' }
-              : {
-                  status: 'error',
-                  message:
-                    'Data source connected, but no labels received. Verify that Loki and Promtail is configured properly.',
-                };
-          return testResult;
-        }),
-        catchError((err: any) => {
-          let message = 'Loki: ';
-          if (err.statusText) {
-            message += err.statusText;
-          } else {
-            message += 'Cannot connect to Loki';
-          }
+    const nowMs = Date.now();
+    const params = {
+      start: (nowMs - 10 * 60 * 1000) * NS_IN_MS,
+      end: nowMs * NS_IN_MS,
+    };
 
-          if (err.status) {
-            message += `. ${err.status}`;
-          }
-
-          if (err.data && err.data.message) {
-            message += `. ${err.data.message}`;
-          } else if (err.data) {
-            message += `. ${err.data}`;
-          }
-          return of({ status: 'error', message: message });
-        })
-      )
+    return this.metadataRequest('labels', params).then(
+      (values) => {
+        return values.length > 0
+          ? { status: 'success', message: 'Data source connected and labels found.' }
+          : {
+              status: 'error',
+              message:
+                'Data source connected, but no labels received. Verify that Loki and Promtail is configured properly.',
+            };
+      },
+      (err) => {
+        // we did a resource-call that failed.
+        // the only info we have, if exists, is err.data.message
+        // (when in development-mode, err.data.error exists too, but not in production-mode)
+        // things like err.status & err.statusText does not help,
+        // because those will only describe how the request between browser<>server failed
+        const info: string = err?.data?.message ?? '';
+        const infoInParentheses = info !== '' ? ` (${info})` : '';
+        const message = `Unable to fetch labels from Loki${infoInParentheses}, please check the server logs for more details`;
+        return { status: 'error', message: message };
+      }
     );
   }
 


### PR DESCRIPTION
we adjust the code that runs when you press `[save &test]` on a loki datasource's config page, to be compatible with loki's backend-mode.

the functionality is to fetch label-names from Loki, and if we get labels, it's a success, all other cases are error.
we refactor the code to use `datasource.metadataRequest()`. 

how to test:

1. (it does not matter if you have backend-mode enabled or disabled, the same code-path happens either way)
1. go to a loki datasource's config page
2. make sure a loki datasource is configured
3. press [save&test]
4. you should get a success message
5. now turn off the loki database
6. press [save&test] again
7. you should get an error message