### PR TITLE
CI: Run docs pipeline only upon changes to root markdown files

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -57,6 +57,7 @@ trigger:
     exclude:
     - '*.md'
     - docs/**
+    - latest.json
 type: docker
 volumes:
 - host:
@@ -144,6 +145,7 @@ trigger:
     exclude:
     - '*.md'
     - docs/**
+    - latest.json
 type: docker
 volumes:
 - host:
@@ -380,6 +382,7 @@ trigger:
     exclude:
     - '*.md'
     - docs/**
+    - latest.json
 type: docker
 volumes:
 - host:
@@ -463,6 +466,7 @@ trigger:
     exclude:
     - '*.md'
     - docs/**
+    - latest.json
 type: docker
 volumes:
 - host:
@@ -558,6 +562,7 @@ trigger:
     - '*.md'
     - docs/**
     - packages/**
+    - latest.json
 type: docker
 volumes:
 - host:
@@ -4609,6 +4614,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 616a95611b439ac35d5c059cca803728b8ae21b230240fe6a459fbcd31f8d567
+hmac: 6be0c058bd66d0282afe37bd5af923f345ca71ec0fd874514ae08f759e23adfd
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -55,6 +55,7 @@ trigger:
   - pull_request
   paths:
     exclude:
+    - '*.md'
     - docs/**
 type: docker
 volumes:
@@ -141,6 +142,7 @@ trigger:
   - pull_request
   paths:
     exclude:
+    - '*.md'
     - docs/**
 type: docker
 volumes:
@@ -376,6 +378,7 @@ trigger:
   - pull_request
   paths:
     exclude:
+    - '*.md'
     - docs/**
 type: docker
 volumes:
@@ -458,6 +461,7 @@ trigger:
   - pull_request
   paths:
     exclude:
+    - '*.md'
     - docs/**
 type: docker
 volumes:
@@ -551,6 +555,7 @@ trigger:
   - pull_request
   paths:
     include:
+    - '*.md'
     - docs/**
     - packages/**
 type: docker
@@ -4604,6 +4609,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 045df48997fde9ae05050441a3635a97a8be4db7b8b0c748c367cee0fc3d2373
+hmac: 616a95611b439ac35d5c059cca803728b8ae21b230240fe6a459fbcd31f8d567
 
 ...

--- a/scripts/drone/pipelines/docs.star
+++ b/scripts/drone/pipelines/docs.star
@@ -69,6 +69,7 @@ def trigger_docs():
                 '*.md',
                 'docs/**',
                 'packages/**',
+                'latest.json',
             ],
         },
     }

--- a/scripts/drone/pipelines/docs.star
+++ b/scripts/drone/pipelines/docs.star
@@ -66,6 +66,7 @@ def trigger_docs():
         ],
         'paths': {
             'include': [
+                '*.md',
                 'docs/**',
                 'packages/**',
             ],

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -62,6 +62,7 @@ trigger = {
     ],
     'paths': {
         'exclude': [
+            '*.md',
             'docs/**',
         ],
     },

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -64,6 +64,7 @@ trigger = {
         'exclude': [
             '*.md',
             'docs/**',
+            'latest.json',
         ],
     },
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the `pr-docs` pipeline runs only on changes under `docs/**` dir.
This PR adds the ability to run this pipeline on markdown files in the root directory.
