### PR TITLE
grafana-ui: Add checkbox value field

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -12,11 +12,12 @@ export interface CheckboxProps extends Omit<HTMLProps<HTMLInputElement>, 'value'
   label?: string;
   description?: string;
   value?: boolean;
-  internalValue?: string | number;
+  // htmlValue allows to specify the input "value" attribute
+  htmlValue?: string | number;
 }
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ label, description, value, internalValue, onChange, disabled, className, ...inputProps }, ref) => {
+  ({ label, description, value, htmlValue, onChange, disabled, className, ...inputProps }, ref) => {
     const handleOnChange = useCallback(
       (e: React.ChangeEvent<HTMLInputElement>) => {
         if (onChange) {
@@ -35,7 +36,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
           checked={value}
           disabled={disabled}
           onChange={handleOnChange}
-          value={internalValue}
+          value={htmlValue}
           {...inputProps}
           ref={ref}
         />

--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -12,10 +12,11 @@ export interface CheckboxProps extends Omit<HTMLProps<HTMLInputElement>, 'value'
   label?: string;
   description?: string;
   value?: boolean;
+  internalValue?: string | number;
 }
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ label, description, value, onChange, disabled, className, ...inputProps }, ref) => {
+  ({ label, description, value, internalValue, onChange, disabled, className, ...inputProps }, ref) => {
     const handleOnChange = useCallback(
       (e: React.ChangeEvent<HTMLInputElement>) => {
         if (onChange) {
@@ -34,6 +35,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
           checked={value}
           disabled={disabled}
           onChange={handleOnChange}
+          value={internalValue}
           {...inputProps}
           ref={ref}
         />


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the checkbox component to be able to use the `value` field (that can't be used currently because the `value` field is used to fill the `checked` field). 

This would allow me to have multiple checkboxes updating an array field, see the example [here](https://codesandbox.io/s/usecontroller-checkboxes-99ld4?file=/src/App.js:460-613).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

