### PR TITLE
Chore: do not run husky hooks on backend-only changes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# Ignore husky hooks if no frontend code has been changed
+git diff --cached --name-only | grep -v --quiet "^pkg/" || exit 0
+
 . "$(dirname "$0")/_/husky.sh"
 
 yarn run precommit


### PR DESCRIPTION
This is a lame approach to disable husky when only backend files have been changed in a commit.