### PR TITLE
Storage: use `FlagStorageLocalUpload` for HTTP API

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -217,8 +217,10 @@ func (hs *HTTPServer) registerRoutes() {
 				orgRoute.Get("/list/*", routing.Wrap(hs.StorageService.List))
 				orgRoute.Get("/read/*", routing.Wrap(hs.StorageService.Read))
 
-				orgRoute.Delete("/delete/*", reqSignedIn, routing.Wrap(hs.StorageService.Delete))
-				orgRoute.Post("/upload", reqSignedIn, routing.Wrap(hs.StorageService.Upload))
+				if hs.Features.IsEnabled(featuremgmt.FlagStorageLocalUpload) {
+					orgRoute.Delete("/delete/*", reqSignedIn, routing.Wrap(hs.StorageService.Delete))
+					orgRoute.Post("/upload", reqSignedIn, routing.Wrap(hs.StorageService.Upload))
+				}
 			})
 		}
 


### PR DESCRIPTION
The storage is already hidden behind a feature flag but we have no reason to expose the HTTP without the flag enabled: https://github.com/grafana/grafana/blob/900d9bf9a1650274354206e3cee64d9cfed94da2/pkg/services/store/service.go#L71