### PR TITLE
transform: labels-to-field, add new mode

### DIFF
--- a/public/app/features/transformers/editors/LabelsToFieldsTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/LabelsToFieldsTransformerEditor.tsx
@@ -16,6 +16,7 @@ import { InlineField, InlineFieldRow, RadioButtonGroup, Select, FilterPill } fro
 const modes: Array<SelectableValue<LabelsToFieldsMode>> = [
   { value: LabelsToFieldsMode.Columns, label: 'Columns' },
   { value: LabelsToFieldsMode.Rows, label: 'Rows' },
+  { value: LabelsToFieldsMode.LabelField, label: 'LabelField' },
 ];
 
 export const LabelsAsFieldsTransformerEditor: React.FC<TransformerUIProps<LabelsToFieldsOptions>> = ({


### PR DESCRIPTION
(NOTE: maybe this is not needed. i was told we already have the "extract fields" transform that can do this)

we changed the dataframe-format for Loki, to be more efficient. it is a backward-incompatible change for grafana9.
the problem is, if you feed the Loki data into a table using the labels-to-fields transform, now it doesn't work.
this PR introduces a third-mode for the labels-to-fields transform, that handles the situation.

we are already mentioning data-format-change in the changelog's breaking-part, so we could then add some info like "if you use the labels-to-field transform, switch it to the third mode"

this is just a draft yet, so completely unoptimalized, no tests etc. but it works.

if you want to try it out, easiest is to use the test-datasource, it's raw-frames mode, and use this json-data:
```json
[
  {
    "schema": {
      "fields": [
        {
          "name": "labels",
          "type": "other"
        },
        {
          "name": "ts",
          "type": "time"
        },
        {
          "name": "line",
          "type": "string"
        }
      ]
    },
    "data": {
      "values": [
        [
          { "counter": "1", "level": "info", "loc": "moon" },
          { "counter": "2", "level": "error", "loc": "moon" }
        ],
        [1, 2],
        ["log line 1", "log line 2"]
      ]
    }
  }
]

```