### PR TITLE
AzureAd Oauth: Fix strictMode to reject users without an assigned role

### DIFF
--- a/pkg/login/social/azuread_oauth.go
+++ b/pkg/login/social/azuread_oauth.go
@@ -124,6 +124,10 @@ func extractEmail(claims azureClaims) string {
 
 func extractRole(claims azureClaims, autoAssignRole string, strictMode bool) models.RoleType {
 	if len(claims.Roles) == 0 {
+		if strictMode {
+			return models.RoleType("")
+		}
+
 		return models.RoleType(autoAssignRole)
 	}
 

--- a/pkg/login/social/azuread_oauth_test.go
+++ b/pkg/login/social/azuread_oauth_test.go
@@ -296,6 +296,22 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name: "Fetch empty role when strict attribute role is true and no role claims returned",
+			fields: fields{
+				roleAttributeStrict: true,
+			},
+			claims: &azureClaims{
+				Email:             "me@example.com",
+				PreferredUsername: "",
+				Roles:             []string{},
+				Groups:            []string{},
+				Name:              "My Name",
+				ID:                "1234",
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: kyschouv <kyschouv@microsoft.com>

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: Fixes strict mode on AzureAD OAuth to reject users who do not have an assigned role in the AAD application, rather than granting them the `auto_assign_org_role`.

**Which issue(s) this PR fixes**: #40186

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #40186


