### PR TITLE
Levitate: use a custom breaking change label

### DIFF
--- a/.github/workflows/detect-breaking-changes-report.yml
+++ b/.github/workflows/detect-breaking-changes-report.yml
@@ -61,7 +61,7 @@ jobs:
           const script = require('./.github/workflows/scripts/json-file-to-job-output.js');
           await script({ core, filePath });
 
-    - name: Check if "breaking change" label exists
+    - name: Check if "breaking change (bot-assigned)" label exists
       id: does-label-exist
       uses: actions/github-script@v6
       env:
@@ -74,7 +74,7 @@ jobs:
             repo: context.repo.repo,
           });
           const labels = data.map(({ name }) => name);
-          const doesExist = labels.includes('breaking change');
+          const doesExist = labels.includes('breaking change (bot-assigned)');
 
           return doesExist ? 1 : 0;
 
@@ -117,7 +117,7 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_LEVITATE_WEBHOOK_URL }}
 
-    - name: Add "breaking change" label
+    - name: Add "breaking change (bot-assigned)" label
       if: ${{ steps.levitate-run.outputs.exit_code == 1 && steps.does-label-exist.outputs.result == 0 }}
       uses: actions/github-script@v6
       env:
@@ -129,10 +129,10 @@ jobs:
             issue_number: process.env.PR_NUMBER,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            labels: ['breaking change']
+            labels: ['breaking change (bot-assigned) (']
           })
 
-    - name: Remove "breaking change" label
+    - name: Remove "breaking change (bot-assigned)" label
       if: ${{ steps.levitate-run.outputs.exit_code == 0 && steps.does-label-exist.outputs.result == 1 }}
       uses: actions/github-script@v6
       env:
@@ -144,7 +144,7 @@ jobs:
             issue_number: process.env.PR_NUMBER,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            name: 'breaking change'
+            name: 'breaking change (bot-assigned)'
           })
 
     # This is very weird, the actual request goes through (comes back with a 201), but does not assign the team.

--- a/.github/workflows/detect-breaking-changes-report.yml
+++ b/.github/workflows/detect-breaking-changes-report.yml
@@ -61,7 +61,7 @@ jobs:
           const script = require('./.github/workflows/scripts/json-file-to-job-output.js');
           await script({ core, filePath });
 
-    - name: Check if "breaking change (bot-assigned)" label exists
+    - name: Check if "levitate breaking change" label exists
       id: does-label-exist
       uses: actions/github-script@v6
       env:
@@ -74,7 +74,7 @@ jobs:
             repo: context.repo.repo,
           });
           const labels = data.map(({ name }) => name);
-          const doesExist = labels.includes('breaking change (bot-assigned)');
+          const doesExist = labels.includes('levitate breaking change');
 
           return doesExist ? 1 : 0;
 
@@ -117,7 +117,7 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_LEVITATE_WEBHOOK_URL }}
 
-    - name: Add "breaking change (bot-assigned)" label
+    - name: Add "levitate breaking change" label
       if: ${{ steps.levitate-run.outputs.exit_code == 1 && steps.does-label-exist.outputs.result == 0 }}
       uses: actions/github-script@v6
       env:
@@ -129,10 +129,10 @@ jobs:
             issue_number: process.env.PR_NUMBER,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            labels: ['breaking change (bot-assigned) (']
+            labels: ['levitate breaking change']
           })
 
-    - name: Remove "breaking change (bot-assigned)" label
+    - name: Remove "levitate breaking change" label
       if: ${{ steps.levitate-run.outputs.exit_code == 0 && steps.does-label-exist.outputs.result == 1 }}
       uses: actions/github-script@v6
       env:
@@ -144,7 +144,7 @@ jobs:
             issue_number: process.env.PR_NUMBER,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            name: 'breaking change (bot-assigned)'
+            name: 'levitate breaking change'
           })
 
     # This is very weird, the actual request goes through (comes back with a 201), but does not assign the team.


### PR DESCRIPTION
**Related Slack thread:** https://raintank-corp.slack.com/archives/C01C4K8DETW/p1650894475948409

### What changed?
Changed Levitate to work with a label called `breaking change (bot assigned)` instead of `breaking change`.

This is quick fix for Levitate aggressively assigning / removing the `breaking change` label after someone has added / removed it manually.

We are planning this to be an interim fix until we implement the bit more complex logic for checking who edited the label, and based on that decide in the Levitate workflow if we should add / remove it.

**Sorry the issues and difficulties this has caused.**