### PR TITLE
Service accounts: doc fixes

### DIFF
--- a/docs/sources/administration/service-accounts/add-service-account-token.md
+++ b/docs/sources/administration/service-accounts/add-service-account-token.md
@@ -14,7 +14,7 @@ You can create a service account token using the Grafana UI or via the API. For 
 ## Before you begin
 
 - Ensure you have added the `serviceAccounts` feature toggle to Grafana. For more information about adding the feature toggle, refer to [Enable service accounts]({{< relref "./enable-service-accounts.md#">}}).
-- Ensure you have permission to create and edit service accounts. By default, organization administrator role is required to create and edit service accounts. For more information about user permissions, refer to [About users and permissions]({{< relref "../manage-users-and-permissions/about-users-and-permissions.md#">}}).
+- Ensure you have permission to create and edit service accounts. By default, the organization administrator role is required to create and edit service accounts. For more information about user permissions, refer to [About users and permissions]({{< relref "../manage-users-and-permissions/about-users-and-permissions.md#">}}).
 
 ## To add a token to a service account
 

--- a/docs/sources/administration/service-accounts/add-service-account-token.md
+++ b/docs/sources/administration/service-accounts/add-service-account-token.md
@@ -15,12 +15,11 @@ You can create a service account token using the Grafana UI or via the API. For 
 ## Before you begin
 
 - Ensure you have added the `serviceAccounts` feature toggle to Grafana. For more information about adding the feature toggle, refer to [Enable service accounts]({{< relref "./enable-service-accounts.md#">}}).
-- Ensure you have permission to create and edit service accounts. For more information about user roles, refer to [About users and permissions]({{< relref "../manage-users-and-permissions/about-users-and-permissions.md#">}}).
-- [Create a service account in Grafana]({{< relref "./create-service-account.md#">}}).
+- Ensure you have permission to create and edit service accounts. By default, organization administrator role is required to create and edit service accounts. For more information about user permissions, refer to [About users and permissions]({{< relref "../manage-users-and-permissions/about-users-and-permissions.md#">}}).
 
-**To add a token to a service account:**
+## To add a token to a service account
 
-1. Sign in to Grafana and hover your cursor over the organization icon in the sidebar.
+1. Sign in to Grafana and hover your cursor over **Configuration** (the gear icon) in the sidebar.
 1. Click **Service accounts**.
 1. Click the service account to which you want to add a token.
 1. Click **Add token**.

--- a/docs/sources/administration/service-accounts/add-service-account-token.md
+++ b/docs/sources/administration/service-accounts/add-service-account-token.md
@@ -18,7 +18,7 @@ You can create a service account token using the Grafana UI or via the API. For 
 
 ## To add a token to a service account
 
-1. Sign in to Grafana and hover your cursor over **Configuration** (the gear icon) in the sidebar.
+1. Sign in to Grafana, then hover your cursor over **Configuration** (the gear icon) in the sidebar.
 1. Click **Service accounts**.
 1. Click the service account to which you want to add a token.
 1. Click **Add token**.

--- a/docs/sources/administration/service-accounts/create-service-account.md
+++ b/docs/sources/administration/service-accounts/create-service-account.md
@@ -16,7 +16,7 @@ For more information about creating service accounts via the API, refer to [Crea
 ## Before you begin
 
 - Ensure you have added the feature toggle for service accounts `serviceAccounts`. For more information about adding the feature toggle, refer to [Enable service accounts]({{< relref "./enable-service-accounts.md#">}}).
-- Ensure you have permission to create and edit service accounts. By default, organization administrator role is required to create and edit service accounts. For more information about user permissions, refer to [About users and permissions]({{< relref "../manage-users-and-permissions/about-users-and-permissions.md#">}}).
+- Ensure you have permission to create and edit service accounts. By default, the organization administrator role is required to create and edit service accounts. For more information about user permissions, refer to [About users and permissions]({{< relref "../manage-users-and-permissions/about-users-and-permissions.md#">}}).
 
 ## To create a service account
 

--- a/docs/sources/administration/service-accounts/create-service-account.md
+++ b/docs/sources/administration/service-accounts/create-service-account.md
@@ -16,11 +16,11 @@ For more information about creating service accounts via the API, refer to [Crea
 ## Before you begin
 
 - Ensure you have added the feature toggle for service accounts `serviceAccounts`. For more information about adding the feature toggle, refer to [Enable service accounts]({{< relref "./enable-service-accounts.md#">}}).
-- Ensure you have permission to create and edit service accounts. For more information about user permissions, refer to [About users and permissions]({{< relref "../manage-users-and-permissions/about-users-and-permissions.md#">}}).
+- Ensure you have permission to create and edit service accounts. By default, organization administrator role is required to create and edit service accounts. For more information about user permissions, refer to [About users and permissions]({{< relref "../manage-users-and-permissions/about-users-and-permissions.md#">}}).
 
-**To create a service account:**
+## To create a service account
 
-1. Sign in to Grafana and hover your cursor over the organization icon in the sidebar.
+1. Sign in to Grafana and hover your cursor over **Configuration** (the gear icon) in the sidebar.
 1. Click **Service accounts**.
 1. Click **New service account**.
 1. Enter a **Display name**.

--- a/docs/sources/administration/service-accounts/enable-service-accounts.md
+++ b/docs/sources/administration/service-accounts/enable-service-accounts.md
@@ -10,7 +10,7 @@ keywords:
 
 # Enable service accounts in Grafana
 
-Service accounts are available behind the `service-accounts` feature toggle available in Grafana 9.0+.
+Service accounts are available behind the `serviceAccounts` feature toggle available in Grafana 8.5+.
 
 You can enable service accounts by:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Clarifies service account documentation to make this feature easier to use.

**Which issue(s) this PR fixes**:

Related to https://github.com/grafana/support-escalations/issues/2454

