### PR TITLE
Access control: Fix permission query for older postgres version

### DIFF
--- a/pkg/services/accesscontrol/database/resource_permissions.go
+++ b/pkg/services/accesscontrol/database/resource_permissions.go
@@ -13,30 +13,27 @@ import (
 )
 
 type flatResourcePermission struct {
-	ID       int64 `xorm:"id"`
-	RoleName string
-	Action   string
-	// Scope is what is stored in the database
-	Scope string
-	// ResourceScope is what we ask for
-	ResourceScope string
-	UserId        int64
-	UserLogin     string
-	UserEmail     string
-	TeamId        int64
-	TeamEmail     string
-	Team          string
-	BuiltInRole   string
-	Created       time.Time
-	Updated       time.Time
+	ID          int64 `xorm:"id"`
+	RoleName    string
+	Action      string
+	Scope       string
+	UserId      int64
+	UserLogin   string
+	UserEmail   string
+	TeamId      int64
+	TeamEmail   string
+	Team        string
+	BuiltInRole string
+	Created     time.Time
+	Updated     time.Time
 }
 
-func (p *flatResourcePermission) IsManaged() bool {
-	return strings.HasPrefix(p.RoleName, accesscontrol.ManagedRolePrefix) && !p.IsInherited()
+func (p *flatResourcePermission) IsManaged(scope string) bool {
+	return strings.HasPrefix(p.RoleName, accesscontrol.ManagedRolePrefix) && !p.IsInherited(scope)
 }
 
-func (p *flatResourcePermission) IsInherited() bool {
-	return p.Scope != p.ResourceScope
+func (p *flatResourcePermission) IsInherited(scope string) bool {
+	return p.Scope != scope
 }
 
 func (s *AccessControlStore) SetUserResourcePermission(
@@ -210,7 +207,8 @@ func (s *AccessControlStore) setResourcePermission(
 	`
 
 	var current []accesscontrol.Permission
-	if err := sess.SQL(rawSQL, role.ID, accesscontrol.Scope(cmd.Resource, cmd.ResourceAttribute, cmd.ResourceID)).Find(&current); err != nil {
+	scope := accesscontrol.Scope(cmd.Resource, cmd.ResourceAttribute, cmd.ResourceID)
+	if err := sess.SQL(rawSQL, role.ID, scope).Find(&current); err != nil {
 		return nil, err
 	}
 
@@ -247,7 +245,7 @@ func (s *AccessControlStore) setResourcePermission(
 		return nil, err
 	}
 
-	permission := flatPermissionsToResourcePermission(permissions)
+	permission := flatPermissionsToResourcePermission(scope, permissions)
 	if permission == nil {
 		return &accesscontrol.ResourcePermission{}, nil
 	}
@@ -288,7 +286,6 @@ func (s *AccessControlStore) getResourcePermissions(sess *sqlstore.DBSession, or
 	SELECT
 		p.*,
 		r.name as role_name,
-		? as resource_scope,
 	`
 
 	userSelect := rawSelect + `
@@ -343,7 +340,6 @@ func (s *AccessControlStore) getResourcePermissions(sess *sqlstore.DBSession, or
 	scope := accesscontrol.Scope(query.Resource, query.ResourceAttribute, query.ResourceID)
 
 	args := []interface{}{
-		scope,
 		orgID,
 		orgID,
 		accesscontrol.Scope(query.Resource, "*"),
@@ -398,13 +394,13 @@ func (s *AccessControlStore) getResourcePermissions(sess *sqlstore.DBSession, or
 	var result []accesscontrol.ResourcePermission
 	users, teams, builtins := groupPermissionsByAssignment(queryResults)
 	for _, p := range users {
-		result = append(result, flatPermissionsToResourcePermissions(p)...)
+		result = append(result, flatPermissionsToResourcePermissions(scope, p)...)
 	}
 	for _, p := range teams {
-		result = append(result, flatPermissionsToResourcePermissions(p)...)
+		result = append(result, flatPermissionsToResourcePermissions(scope, p)...)
 	}
 	for _, p := range builtins {
-		result = append(result, flatPermissionsToResourcePermissions(p)...)
+		result = append(result, flatPermissionsToResourcePermissions(scope, p)...)
 	}
 
 	return result, nil
@@ -428,10 +424,10 @@ func groupPermissionsByAssignment(permissions []flatResourcePermission) (map[int
 	return users, teams, builtins
 }
 
-func flatPermissionsToResourcePermissions(permissions []flatResourcePermission) []accesscontrol.ResourcePermission {
+func flatPermissionsToResourcePermissions(scope string, permissions []flatResourcePermission) []accesscontrol.ResourcePermission {
 	var managed, provisioned []flatResourcePermission
 	for _, p := range permissions {
-		if p.IsManaged() {
+		if p.IsManaged(scope) {
 			managed = append(managed, p)
 		} else {
 			provisioned = append(provisioned, p)
@@ -439,17 +435,17 @@ func flatPermissionsToResourcePermissions(permissions []flatResourcePermission) 
 	}
 
 	var result []accesscontrol.ResourcePermission
-	if g := flatPermissionsToResourcePermission(managed); g != nil {
+	if g := flatPermissionsToResourcePermission(scope, managed); g != nil {
 		result = append(result, *g)
 	}
-	if g := flatPermissionsToResourcePermission(provisioned); g != nil {
+	if g := flatPermissionsToResourcePermission(scope, provisioned); g != nil {
 		result = append(result, *g)
 	}
 
 	return result
 }
 
-func flatPermissionsToResourcePermission(permissions []flatResourcePermission) *accesscontrol.ResourcePermission {
+func flatPermissionsToResourcePermission(scope string, permissions []flatResourcePermission) *accesscontrol.ResourcePermission {
 	if len(permissions) == 0 {
 		return nil
 	}
@@ -474,7 +470,7 @@ func flatPermissionsToResourcePermission(permissions []flatResourcePermission) *
 		BuiltInRole: first.BuiltInRole,
 		Created:     first.Created,
 		Updated:     first.Updated,
-		IsManaged:   first.IsManaged(),
+		IsManaged:   first.IsManaged(scope),
 	}
 }
 
@@ -582,7 +578,6 @@ func (s *AccessControlStore) getResourcePermissionsByIds(sess *sqlstore.DBSessio
 	rawSql := `
 	SELECT
 		p.*,
-		? as resource_scope,
 		ur.user_id AS user_id,
 		u.login AS user_login,
 		u.email AS user_email,
@@ -602,7 +597,6 @@ func (s *AccessControlStore) getResourcePermissionsByIds(sess *sqlstore.DBSessio
 	`
 
 	args := make([]interface{}, 0, len(ids)+1)
-	args = append(args, accesscontrol.Scope(resource, resourceAttribute, resourceID))
 	for _, id := range ids {
 		args = append(args, id)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Query in access control prevented users from setting team members on postgres version > 10.

Instead of injecting the scope we ask for we can just pass it to the functions to compare them

**Which issue(s) this PR fixes**:
Fixes #48158

**Special notes for your reviewer**:

