### PR TITLE
Alerting: Fix test intermittency caused by port conflicts

### DIFF
--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"regexp"
 	"strings"
@@ -922,13 +923,13 @@ type mockNotificationChannel struct {
 }
 
 func newMockNotificationChannel(t *testing.T, grafanaListedAddr string) *mockNotificationChannel {
-	lastDigit := grafanaListedAddr[len(grafanaListedAddr)-1] - 48
-	lastDigit = (lastDigit + 1) % 10
-	newAddr := fmt.Sprintf("%s%01d", grafanaListedAddr[:len(grafanaListedAddr)-1], lastDigit)
+	// Spin up a separate webserver to receive notifications emitted by Grafana.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
 
 	nc := &mockNotificationChannel{
 		server: &http.Server{
-			Addr: newAddr,
+			Addr: listener.Addr().String(),
 		},
 		receivedNotifications: make(map[string][]string),
 		t:                     t,
@@ -936,7 +937,8 @@ func newMockNotificationChannel(t *testing.T, grafanaListedAddr string) *mockNot
 
 	nc.server.Handler = nc
 	go func() {
-		require.Equal(t, http.ErrServerClosed, nc.server.ListenAndServe())
+		err := nc.server.Serve(listener)
+		require.Equal(t, http.ErrServerClosed, err.Error())
 	}()
 
 	return nc

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -938,7 +938,7 @@ func newMockNotificationChannel(t *testing.T, grafanaListedAddr string) *mockNot
 	nc.server.Handler = nc
 	go func() {
 		err := nc.server.Serve(listener)
-		require.Equal(t, http.ErrServerClosed, err.Error())
+		require.EqualError(t, nc.server.ListenAndServe(), http.ErrServerClosed.Error())
 	}()
 
 	return nc

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -937,8 +937,7 @@ func newMockNotificationChannel(t *testing.T, grafanaListedAddr string) *mockNot
 
 	nc.server.Handler = nc
 	go func() {
-		err := nc.server.Serve(listener)
-		require.EqualError(t, nc.server.ListenAndServe(), http.ErrServerClosed.Error())
+		require.EqualError(t, nc.server.Serve(listener), http.ErrServerClosed.Error())
 	}()
 
 	return nc


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Some of our integration/e2e tests will spin up webservers alongside Grafana for intercepting notifications.

These webservers previously worked by taking Grafana's port, incrementing it by one, and using that as the new address. They had no mechanism for re-rolling or discovering an open port if that failed. The result is that tests using this can intermittently fail, if the generated port has a conflict on the current machine.

Instead, outsource this work to Go. Let it find an open port for us, that is definitely free of conflict, and more likely to succeed deterministically in different environments.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #48546

**Special notes for your reviewer**:

