### PR TITLE
DataSource: Fix secure json data reset on datasource update

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -360,7 +360,7 @@ func (hs *HTTPServer) fillWithSecureJSONData(ctx context.Context, cmd *models.Up
 
 	for k, v := range decrypted {
 		if _, ok := cmd.SecureJsonData[k]; !ok {
-			cmd.SecureJsonData[k] = string(v)
+			cmd.SecureJsonData[k] = v
 		}
 	}
 

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -353,13 +353,14 @@ func (hs *HTTPServer) fillWithSecureJSONData(ctx context.Context, cmd *models.Up
 		return models.ErrDatasourceIsReadOnly
 	}
 
-	for k, v := range ds.SecureJsonData {
+	decrypted, err := hs.DataSourcesService.DecryptedValues(ctx, ds)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range decrypted {
 		if _, ok := cmd.SecureJsonData[k]; !ok {
-			decrypted, err := hs.SecretsService.Decrypt(ctx, v)
-			if err != nil {
-				return err
-			}
-			cmd.SecureJsonData[k] = string(decrypted)
+			cmd.SecureJsonData[k] = string(v)
 		}
 	}
 

--- a/pkg/services/datasources/service/datasource_service.go
+++ b/pkg/services/datasources/service/datasource_service.go
@@ -214,7 +214,7 @@ func (s *Service) UpdateDataSource(ctx context.Context, cmd *models.UpdateDataSo
 		}
 	}
 
-	if len(cmd.SecureJsonData) > 0 {
+	if len(cmd.SecureJsonData) != 0 {
 		secret, err := json.Marshal(cmd.SecureJsonData)
 		if err != nil {
 			return err

--- a/pkg/services/datasources/service/datasource_service.go
+++ b/pkg/services/datasources/service/datasource_service.go
@@ -572,6 +572,10 @@ func (s *Service) fillWithSecureJSONData(ctx context.Context, cmd *models.Update
 		return err
 	}
 
+	if cmd.SecureJsonData == nil {
+		cmd.SecureJsonData = make(map[string]string)
+	}
+
 	for k, v := range decrypted {
 		if _, ok := cmd.SecureJsonData[k]; !ok {
 			cmd.SecureJsonData[k] = v

--- a/pkg/services/datasources/service/datasource_service.go
+++ b/pkg/services/datasources/service/datasource_service.go
@@ -192,10 +192,6 @@ func (s *Service) DeleteDataSource(ctx context.Context, cmd *models.DeleteDataSo
 
 func (s *Service) UpdateDataSource(ctx context.Context, cmd *models.UpdateDataSourceCommand) error {
 	var err error
-	secret, err := json.Marshal(cmd.SecureJsonData)
-	if err != nil {
-		return err
-	}
 
 	query := &models.GetDataSourceQuery{
 		Id:    cmd.Id,
@@ -218,7 +214,18 @@ func (s *Service) UpdateDataSource(ctx context.Context, cmd *models.UpdateDataSo
 		}
 	}
 
-	return s.SecretsStore.Set(ctx, cmd.OrgId, cmd.Name, secretType, string(secret))
+	if len(cmd.SecureJsonData) > 0 {
+		secret, err := json.Marshal(cmd.SecureJsonData)
+		if err != nil {
+			return err
+		}
+		err = s.SecretsStore.Set(ctx, cmd.OrgId, cmd.Name, secretType, string(secret))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (s *Service) GetDefaultDataSource(ctx context.Context, query *models.GetDefaultDataSourceQuery) error {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR fixes an issue introduced by #45804 that happens when clicking Save to update a Data Source without changing any secure json data information.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #48525

**Special notes for your reviewer**:

