### PR TITLE
Alerting: Remove disabled flag for data source when migrating alerts

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -160,6 +160,8 @@ func migrateAlertRuleQueries(data []alertQuery) ([]alertQuery, error) {
 		if err != nil {
 			return nil, err
 		}
+		// remove hidden tag from the query (if exists)
+		delete(fixedData, "hide")
 		fixedData = fixGraphiteReferencedSubQueries(fixedData)
 		updatedModel, err := json.Marshal(fixedData)
 		if err != nil {

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
@@ -25,6 +25,11 @@ func TestMigrateAlertRuleQueries(t *testing.T) {
 			input:    simplejson.NewFromAny(map[string]interface{}{"target": "ahalfquery"}),
 			expected: `{"target":"ahalfquery"}`,
 		},
+		{
+			name:     "when query was hidden, it removes the flag",
+			input:    simplejson.NewFromAny(map[string]interface{}{"hide": true}),
+			expected: `{}`,
+		},
 	}
 
 	for _, tt := range tc {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
In legacy alerting, the query could be hidden from panel but used in alert rules. After migration user will see a confusing "Disabled" on the query panel. It is harmless and does not affect the evaluation results but can confuse users 

![image](https://user-images.githubusercontent.com/25988953/166061787-610e6a87-e8b0-4505-a12e-fed45e108a2e.png)

There is a field `hide` in the query model that is responsible for the presentation. This PR resets that flag.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

