### PR TITLE
Variables: allow Regex tooltip links to be clickable

### DIFF
--- a/public/app/features/variables/editor/VariableTextField.tsx
+++ b/public/app/features/variables/editor/VariableTextField.tsx
@@ -14,6 +14,7 @@ interface VariableTextFieldProps {
   labelWidth?: number;
   grow?: boolean;
   onBlur?: (event: FormEvent<HTMLInputElement>) => void;
+  interactive?: boolean;
 }
 
 export function VariableTextField({
@@ -28,9 +29,10 @@ export function VariableTextField({
   onBlur,
   tooltip,
   grow,
+  interactive,
 }: PropsWithChildren<VariableTextFieldProps>): ReactElement {
   return (
-    <InlineField label={name} labelWidth={labelWidth ?? 12} tooltip={tooltip} grow={grow}>
+    <InlineField interactive={interactive} label={name} labelWidth={labelWidth ?? 12} tooltip={tooltip} grow={grow}>
       <Input
         type="text"
         id={name}

--- a/public/app/features/variables/query/QueryVariableEditor.tsx
+++ b/public/app/features/variables/query/QueryVariableEditor.tsx
@@ -201,6 +201,7 @@ export class QueryVariableEditorUnConnected extends PureComponent<Props, State> 
               onChange={this.onRegExChange}
               onBlur={this.onRegExBlur}
               labelWidth={20}
+              interactive={true}
               tooltip={
                 <div>
                   Optional, if you want to extract part of a series name or metric node segment. Named capture groups


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `interactive` prop to `VariableTextField` in `QueryVariableEditor` to allow the link in the tooltip to be clicked.

![pass-regex-tooltip](https://user-images.githubusercontent.com/1048831/166062983-3cdc3214-94ab-44d2-8781-991f59eeae6c.gif)

**Which issue(s) this PR fixes**:

Fixes #48558