### PR TITLE
CloudWatch: migrate variable query dimension filter

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.test.ts
@@ -78,6 +78,7 @@ describe('variableQueryMigrations', () => {
         region: 'us-east-1',
         metricName: '',
         dimensionKey: '',
+        dimensionFilters: '{"InstanceId":"$instanceid"}',
         ec2Filters: '{"environment":["$environment"]}',
         instanceID: '',
         attributeName: 'rds:db',
@@ -88,6 +89,7 @@ describe('variableQueryMigrations', () => {
       const query = migrateVariableQuery(oldQuery);
       expect(query.region).toBe('us-east-1');
       expect(query.attributeName).toBe('rds:db');
+      expect(query.dimensionFilters).toStrictEqual({ InstanceId: '$instanceid' });
       expect(query.ec2Filters).toStrictEqual({ environment: ['$environment'] });
       expect(query.resourceType).toBe('elasticloadbalancing:loadbalancer');
       expect(query.tags).toStrictEqual({ 'elasticbeanstalk:environment-name': ['myApp-dev', 'myApp-prod'] });

--- a/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.test.ts
@@ -71,28 +71,56 @@ describe('variableQueryMigrations', () => {
     });
   });
   describe('when OldVariableQuery is used', () => {
-    it('should parse the query', () => {
+    const baseOldQuery: OldVariableQuery = {
+      queryType: VariableQueryType.Regions,
+      namespace: '',
+      region: 'us-east-1',
+      metricName: '',
+      dimensionKey: '',
+      dimensionFilters: '',
+      ec2Filters: '',
+      instanceID: '',
+      attributeName: '',
+      resourceType: '',
+      tags: '',
+      refId: '',
+    };
+    it('should parse ec2 query', () => {
       const oldQuery: OldVariableQuery = {
+        ...baseOldQuery,
         queryType: VariableQueryType.EC2InstanceAttributes,
-        namespace: '',
-        region: 'us-east-1',
-        metricName: '',
-        dimensionKey: '',
-        dimensionFilters: '{"InstanceId":"$instanceid"}',
         ec2Filters: '{"environment":["$environment"]}',
-        instanceID: '',
         attributeName: 'rds:db',
-        resourceType: 'elasticloadbalancing:loadbalancer',
-        tags: '{"elasticbeanstalk:environment-name":["myApp-dev","myApp-prod"]}',
-        refId: '',
       };
       const query = migrateVariableQuery(oldQuery);
       expect(query.region).toBe('us-east-1');
       expect(query.attributeName).toBe('rds:db');
-      expect(query.dimensionFilters).toStrictEqual({ InstanceId: '$instanceid' });
       expect(query.ec2Filters).toStrictEqual({ environment: ['$environment'] });
+    });
+    it('should parse resource arn query', () => {
+      const oldQuery: OldVariableQuery = {
+        ...baseOldQuery,
+        queryType: VariableQueryType.ResourceArns,
+        resourceType: 'elasticloadbalancing:loadbalancer',
+        tags: '{"elasticbeanstalk:environment-name":["myApp-dev","myApp-prod"]}',
+      };
+      const query = migrateVariableQuery(oldQuery);
+      expect(query.region).toBe('us-east-1');
       expect(query.resourceType).toBe('elasticloadbalancing:loadbalancer');
       expect(query.tags).toStrictEqual({ 'elasticbeanstalk:environment-name': ['myApp-dev', 'myApp-prod'] });
+    });
+    it('should parse dimension values query', () => {
+      const oldQuery: OldVariableQuery = {
+        ...baseOldQuery,
+        queryType: VariableQueryType.DimensionValues,
+        metricName: 'foo',
+        dimensionKey: 'bar',
+        dimensionFilters: '{"InstanceId":"$instanceid"}',
+      };
+      const query = migrateVariableQuery(oldQuery);
+      expect(query.metricName).toBe('foo');
+      expect(query.dimensionKey).toBe('bar');
+      expect(query.dimensionFilters).toStrictEqual({ InstanceId: '$instanceid' });
     });
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.ts
@@ -18,7 +18,7 @@ export function migrateVariableQuery(rawQuery: string | VariableQuery | OldVaria
     newQuery.ec2Filters = {};
     newQuery.tags = {};
 
-    if (rawQuery.ec2Filters !== '') {
+    if (rawQuery.dimensionFilters !== '') {
       try {
         newQuery.dimensionFilters = JSON.parse(rawQuery.dimensionFilters);
       } catch {

--- a/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.ts
@@ -13,10 +13,18 @@ export function migrateVariableQuery(rawQuery: string | VariableQuery | OldVaria
 
   // rawQuery is OldVariableQuery
   if (typeof rawQuery !== 'string') {
-    const newQuery: VariableQuery = omit(rawQuery, ['ec2Filters', 'tags']);
+    const newQuery: VariableQuery = omit(rawQuery, ['dimensionFilters', 'ec2Filters', 'tags']);
+    newQuery.dimensionFilters = {};
     newQuery.ec2Filters = {};
     newQuery.tags = {};
 
+    if (rawQuery.ec2Filters !== '') {
+      try {
+        newQuery.dimensionFilters = JSON.parse(rawQuery.dimensionFilters);
+      } catch {
+        throw new Error(`unable to migrate poorly formed filters: ${rawQuery.dimensionFilters}`);
+      }
+    }
     if (rawQuery.ec2Filters !== '') {
       try {
         newQuery.ec2Filters = JSON.parse(rawQuery.ec2Filters);

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -384,7 +384,7 @@ export interface OldVariableQuery extends DataQuery {
   region: string;
   metricName: string;
   dimensionKey: string;
-  dimensionFilters?: Dimensions;
+  dimensionFilters: string;
   ec2Filters: string;
   instanceID: string;
   attributeName: string;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Adds a migration between the [string `dimensionFilters`](https://github.com/grafana/grafana/blob/f790be606dfb7d3b5ffa26e59f24057c8ba8ba58/public/app/plugins/datasource/cloudwatch/types.ts#L389) field in v8.5.x and the new dimensions `dimensionFilters` field in v9.0.0
It wasn't included before because the dimensions field type change was intended to be backported to v8.5.0, where the new `VariableQuery` type was introduced, in which case a migration wouldn't have been needed.
**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #48205 

**Special notes for your reviewer**:

