### PR TITLE
CloudWatch: Fix variable query tag migration

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/migration.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/migration.test.ts
@@ -223,6 +223,15 @@ describe('migration', () => {
           expect(query.dimensionFilters).toBe('{"InstanceId":"$instance_id"}');
         });
       });
+      describe('when resource_arns query is used', () => {
+        it('should parse the query', () => {
+          const query = migrateVariableQuery('resource_arns(us-east-1,rds:db,{"environment":["$environment"]})');
+          expect(query.queryType).toBe(VariableQueryType.ResourceArns);
+          expect(query.region).toBe('us-east-1');
+          expect(query.resourceType).toBe('rds:db');
+          expect(query.tags).toBe('{"environment":["$environment"]}');
+        });
+      });
     });
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/migrations.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations.ts
@@ -149,7 +149,7 @@ export function migrateVariableQuery(rawQuery: string | VariableQuery): Variable
     newQuery.queryType = VariableQueryType.ResourceArns;
     newQuery.region = resourceARNsQuery[1];
     newQuery.resourceType = resourceARNsQuery[2];
-    newQuery.tags = JSON.parse(resourceARNsQuery[3]) || '';
+    newQuery.tags = resourceARNsQuery[3] || '';
     return newQuery;
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Stops double-parsing tags in variable queries. (In 8.5.x it gets stored as a string so it should stay a string when migrating)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #48586 

**Special notes for your reviewer**:
This was part of a commit that accidentally didn't get backported, so it's now being put on v8.5.x separately.