### PR TITLE
Search: remove dev-mode from the feature flag

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -67,10 +67,9 @@ var (
 			FrontendOnly: true,
 		},
 		{
-			Name:            "panelTitleSearch",
-			Description:     "Search for dashboards using panel title",
-			State:           FeatureStateAlpha,
-			RequiresDevMode: true, // only supported in dev mode right now
+			Name:        "panelTitleSearch",
+			Description: "Search for dashboards using panel title",
+			State:       FeatureStateAlpha,
 		},
 		{
 			Name:         "tempoSearch",


### PR DESCRIPTION
Removing dev-mode from the `panelTitleSearch` feature flag after the recent round of testing, so that we can test out the feature on HG. The feature remains in `alpha` state 