### PR TITLE
Fix command palette casing

### DIFF
--- a/public/app/features/explore/ExploreActions.tsx
+++ b/public/app/features/explore/ExploreActions.tsx
@@ -30,7 +30,7 @@ export const ExploreActions: FC<Props> = ({ exploreIdLeft, exploreIdRight }: Pro
     if (splitted) {
       actionsArr.push({
         id: 'explore/run-query-left',
-        name: 'Run Query (Left)',
+        name: 'Run query (left)',
         keywords: 'query left',
         perform: () => {
           dispatch(runQueries(exploreIdLeft));
@@ -41,7 +41,7 @@ export const ExploreActions: FC<Props> = ({ exploreIdLeft, exploreIdRight }: Pro
         // we should always have the right exploreId if split
         actionsArr.push({
           id: 'explore/run-query-right',
-          name: 'Run Query (Right)',
+          name: 'Run query (right)',
           keywords: 'query right',
           perform: () => {
             dispatch(runQueries(exploreIdRight));
@@ -70,7 +70,7 @@ export const ExploreActions: FC<Props> = ({ exploreIdLeft, exploreIdRight }: Pro
     } else {
       actionsArr.push({
         id: 'explore/run-query',
-        name: 'Run Query',
+        name: 'Run query',
         keywords: 'query',
         perform: () => {
           dispatch(runQueries(exploreIdLeft));


### PR DESCRIPTION
During the UX session, it came up we should sentence case these actions and not title case. This updates the explore actions to be consistent.
