### PR TITLE
Chore: uPlot 1.6.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -385,7 +385,7 @@
     "tether-drop": "https://github.com/torkelo/drop",
     "tinycolor2": "1.4.2",
     "tslib": "2.3.1",
-    "uplot": "1.6.19",
+    "uplot": "1.6.20",
     "uuid": "8.3.2",
     "vendor": "link:./public/vendor",
     "visjs-network": "4.25.0",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -38,7 +38,7 @@
     "regenerator-runtime": "0.13.9",
     "rxjs": "7.5.5",
     "tslib": "2.3.1",
-    "uplot": "1.6.19",
+    "uplot": "1.6.20",
     "xss": "1.0.11"
   },
   "devDependencies": {

--- a/packages/grafana-data/src/transformations/transformers/joinDataFrames.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinDataFrames.ts
@@ -230,7 +230,21 @@ export function outerJoinDataFrames(options: JoinOptions): DataFrame | undefined
 //--------------------------------------------------------------------------------
 
 // Copied from uplot
-export type AlignedData = [number[], ...Array<Array<number | null | undefined>>];
+export type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Uint8ClampedArray
+  | Float32Array
+  | Float64Array;
+
+export type AlignedData = [
+  xValues: number[] | TypedArray,
+  ...yValues: Array<Array<number | null | undefined> | TypedArray>
+];
 
 // nullModes
 const NULL_REMOVE = 0; // nulls are converted to undefined (e.g. for spanGaps: true)

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -90,7 +90,7 @@
     "slate-plain-serializer": "0.7.10",
     "tinycolor2": "1.4.2",
     "tslib": "2.3.1",
-    "uplot": "1.6.19",
+    "uplot": "1.6.20",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/public/app/plugins/panel/barchart/bars.ts
+++ b/public/app/plugins/panel/barchart/bars.ts
@@ -472,7 +472,7 @@ export function getConfig(opts: BarsOptions, theme: GrafanaTheme2) {
 
       // map per-bar colors
       for (let i = 1; i < u.data.length; i++) {
-        let colors = u.data[i].map((value, valueIdx) => {
+        let colors = (u.data[i] as Array<number | null>).map((value, valueIdx) => {
           if (value != null) {
             return getColor!(i, valueIdx, value);
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4035,7 +4035,7 @@ __metadata:
     tinycolor2: 1.4.2
     tslib: 2.3.1
     typescript: 4.4.4
-    uplot: 1.6.19
+    uplot: 1.6.20
     xss: 1.0.11
   languageName: unknown
   linkType: soft
@@ -4488,7 +4488,7 @@ __metadata:
     ts-loader: 8.0.11
     tslib: 2.3.1
     typescript: 4.4.4
-    uplot: 1.6.19
+    uplot: 1.6.20
     uuid: 8.3.2
     webpack: 5.72.0
     webpack-filter-warnings-plugin: 1.2.1
@@ -20842,7 +20842,7 @@ __metadata:
     ts-node: 10.7.0
     tslib: 2.3.1
     typescript: 4.4.4
-    uplot: 1.6.19
+    uplot: 1.6.20
     uuid: 8.3.2
     vendor: "link:./public/vendor"
     visjs-network: 4.25.0
@@ -36377,10 +36377,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uplot@npm:1.6.19":
-  version: 1.6.19
-  resolution: "uplot@npm:1.6.19"
-  checksum: 181cb158e920bc452940292f356eca4a75c31ebabbe9cd40b77e00a3ba90ac76e62e97fde9c06b45c4cd61e34734da0dbefb32c2689bf0d0c24b5d42aa38763a
+"uplot@npm:1.6.20":
+  version: 1.6.20
+  resolution: "uplot@npm:1.6.20"
+  checksum: 17ddacefbba2b0db0e919ad5ed85f43ebe40afbfced442bc821adbf6d84dc4f969ebf5754f913b316acf17f24ca18c3ca971181a530ea1fc91f45763f25cddaf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Unblocks https://github.com/grafana/grafana/pull/46288

one additional change to watch out for is that uPlot now defers `syncRect()` hooks until first mouse interaction after `setSize()` calls. [Element.getBoundingClientRect()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) was the top item in the perf profile during panel resizing since it fired hundreds of times and caused DOM reflow. the effect of deferring this is that any DOM elements from uPlot plugins that are positioned outside of the uPlot wrapping div (things in portals, like tooltips, popovers), will have stale coords. the only place i've found this to glitch is our `AnnotationEditorPlugin`, which positions the selection div overlay into a portal (we should refactor this), but this is only apparent when scrolling during an annotation edit, which is blocked anyhow. this bug happens before and after the uPlot update, so it's not new AFAICT. otherwise just test that resizing panels still maintains non-uplot dom in place.

i could not detect any obvious breakage otherwise in manual testing of `graph-ng` gdev dashboards.

@jalopez please test against #46288. :pray: 

https://user-images.githubusercontent.com/43234/166295005-086710bc-6a95-45d3-926c-ce848e3323ab.mp4