### PR TITLE
Alerting: populate cluster status for embedded alertmanager status endpoint

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -349,15 +349,11 @@ func (s *GettableStatus) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func NewGettableStatus(cfg *PostableApiAlertingConfig) *GettableStatus {
+func NewGettableStatus(cfg *PostableApiAlertingConfig, clusterStatus *amv2.ClusterStatus) *GettableStatus {
 	// In Grafana, the only field we support is Config.
-	cs := amv2.ClusterStatusStatusDisabled
 	na := "N/A"
 	return &GettableStatus{
-		Cluster: &amv2.ClusterStatus{
-			Status: &cs,
-			Peers:  []*amv2.PeerStatus{},
-		},
+		Cluster: clusterStatus,
 		VersionInfo: &amv2.VersionInfo{
 			Branch:    &na,
 			BuildDate: &na,


### PR DESCRIPTION
Currently, we do not populate the cluster status object when one requests the status of the embedded alertmanger. This PR populates the cluster status object when HA is enabled for the embedded alertmanager.

before with HA enabled:
```json
{
  "cluster": {
    "peers": [],
    "status": "disabled"
  },
  ...
}
```

with this fix:
```json
{
  "cluster": {
    "peers": [
      {
        "address": "10.244.0.56:9094",
        "name": "01G23225QWRDZ8GRWEYE063BS5"
      },
      {
        "address": "10.244.0.55:9094",
        "name": "01G2320YK6B648EJEF5D4N975C"
      },
      {
        "address": "10.244.0.57:9094",
        "name": "01G23228QF1DNMH3YCXN2ZV5EW"
      }
    ],
    "status": "ready"
  },
  ...
}
```

fixes #48581 