### PR TITLE
Docs: File name convention for docs?

### DIFF
--- a/docs/sources/dashboards/_index.md
+++ b/docs/sources/dashboards/_index.md
@@ -13,7 +13,7 @@ Dashboard snapshots are static . Queries and expressions cannot be re-executed f
 Before you begin, ensure that you have configured a data source. See also:
 
 - [Working with Grafana dashboard UI]({{< relref "./dashboard-ui/_index.md" >}})
-- [Dashboard folders]({{< relref "./dashboard-folders.md" >}})
+- [Dashboard folders]({{< relref "./dashboard_folders.md" >}})
 - [Create dashboard]({{< relref "./dashboard-create" >}})
 - [Manage dashboards]({{< relref "./dashboard-manage.md" >}})
 - [Annotations]({{< relref "./annotations.md" >}})
@@ -22,7 +22,7 @@ Before you begin, ensure that you have configured a data source. See also:
 - [Keyboard shortcuts]({{< relref "./shortcuts.md" >}})
 - [Reporting]({{< relref "./reporting.md" >}})
 - [Time range controls]({{< relref "./time-range-controls.md" >}})
-- [Dashboard version history]({{< relref "./dashboard-history.md" >}})
+- [Dashboard version history]({{< relref "./dashboard_history.md" >}})
 - [Dashboard export and import]({{< relref "./export-import.md" >}})
 - [Dashboard JSON model]({{< relref "./json-model.md" >}})
 - [Scripted dashboards]({{< relref "./scripted-dashboards.md" >}})


### PR DESCRIPTION

**What this PR does / why we need it**:
Fixes broken links, but it is probably better to standardise file names across all documentation.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:
I see that some of the docs use "-" to separate words in their file name, e.g. dashboard-create.md, and some use "\_", e.g. dashboard_folders.md and dashboard_history.md. This leads to files not linking to the documentation, e.g. \_index.md is expecting "\-" for the two files leading to the [links not working](https://grafana.com/docs/grafana/latest/dashboards/). I don’t see anything in [the guidelines](https://github.com/grafana/grafana/blob/8db35b9b0b2a35743b3fb6efd05d06d26e23717c/contribute/documentation/README.md) about a file name convention. At a quick glance "\-" seems to be more common, but there are many that use "\_".

This change was applied in [47985](https://github.com/grafana/grafana/pull/47985/files#diff-5660830aa0a145c000d6942931d2ef15431dcc10f32ed8e0ef945bfe5dd7ae0b) and reverted in [48143](https://github.com/grafana/grafana/pull/48143/files#diff-5660830aa0a145c000d6942931d2ef15431dcc10f32ed8e0ef945bfe5dd7ae0b)

Should there be a file name convention for docs?
Should images in the docs also have a file name convention?
For the issue in the _index.md, should the files names be updated with any references or should I submit a pull request for _index.md to be update?

I posted this in the [docs channel in Slack](https://grafana.slack.com/archives/CNCRV74GP/p1649761161045559) 3 weeks ago as the [contributing documentation requested](https://github.com/grafana/grafana/blob/main/contribute/documentation/README.md#join-our-community) and in [Community](https://community.grafana.com/t/file-name-convention-for-docs/64636) last week, but have not had a response yet.
