### PR TITLE
Variables: Fixes issue with null variables breaking the dropdown

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -166,7 +166,7 @@ export function mapToCurrent(picker: OptionsPickerState): VariableOption | undef
       continue;
     }
 
-    texts.push(option.text.toString());
+    texts.push(option.text?.toString());
     values.push(option.value.toString());
   }
 

--- a/public/app/features/variables/pickers/OptionsPicker/actions.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/actions.ts
@@ -166,7 +166,7 @@ export function mapToCurrent(picker: OptionsPickerState): VariableOption | undef
       continue;
     }
 
-    texts.push(option.text?.toString());
+    texts.push(option.text.toString());
     values.push(option.value.toString());
   }
 

--- a/public/app/features/variables/state/sharedReducer.ts
+++ b/public/app/features/variables/state/sharedReducer.ts
@@ -130,6 +130,7 @@ const sharedReducerSlice = createSlice({
       instanceState.current = current;
       instanceState.options = instanceState.options.map((option) => {
         option.value = ensureStringValues(option.value);
+        option.text = ensureStringValues(option.text);
         let selected = false;
         if (Array.isArray(current.value)) {
           for (let index = 0; index < current.value.length; index++) {


### PR DESCRIPTION
**What this PR does / why we need it**:

As per [Alexa's comment](https://github.com/grafana/grafana/issues/45676#issuecomment-1060920420) in the issue, I couldn't get the dashboard to "crash", but it is not possible to close the variable dropdown once you select a `null` variable. That is because there is no `text` associated to that value, so needed to make sure text i always initialised as a string.

**Which issue(s) this PR fixes**:

Fixes #45676 and escalation https://github.com/grafana/support-escalations/issues/2360

**Special notes for your reviewer**:

This only fixes the specific bug, we do need to think about how we actually deal with `null` values on the variables, for example what is shown in various labels. [This slack post](https://raintank-corp.slack.com/archives/C025WTVRBSN/p1651251838058169) explains my findings around this, also there is a feature request related to this: https://github.com/grafana/grafana/issues/5970