### PR TITLE
Alerting: Allow disabling override timings for notification policies

### DIFF
--- a/public/app/features/alerting/unified/AmRoutes.test.tsx
+++ b/public/app/features/alerting/unified/AmRoutes.test.tsx
@@ -646,6 +646,7 @@ const clickSelectOption = async (selectElement: HTMLElement, optionText: string)
 const updateTiming = async (selectElement: HTMLElement, value: string, timeUnit: string): Promise<void> => {
   const input = byRole('textbox').get(selectElement);
   const select = byRole('combobox').get(selectElement);
+  await userEvent.clear(input);
   await userEvent.type(input, value);
   await userEvent.click(select);
   await selectOptionInTest(selectElement, timeUnit);

--- a/public/app/features/alerting/unified/AmRoutes.tsx
+++ b/public/app/features/alerting/unified/AmRoutes.tsx
@@ -49,7 +49,7 @@ const AmRoutes: FC = () => {
   } = (alertManagerSourceName && amConfigs[alertManagerSourceName]) || initialAsyncRequestState;
 
   const config = result?.alertmanager_config;
-  const [rootRoute, id2ExistingRoute] = useMemo(() => amRouteToFormAmRoute(config?.route), [config?.route]);
+  const [rootRoute, id2ExistingRoute] = useMemo(() => amRouteToFormAmRoute(config?.route, true), [config?.route]);
 
   const receivers = stringsToSelectableValues(
     (config?.receivers ?? []).map((receiver: Receiver) => receiver.name)

--- a/public/app/features/alerting/unified/AmRoutes.tsx
+++ b/public/app/features/alerting/unified/AmRoutes.tsx
@@ -49,7 +49,7 @@ const AmRoutes: FC = () => {
   } = (alertManagerSourceName && amConfigs[alertManagerSourceName]) || initialAsyncRequestState;
 
   const config = result?.alertmanager_config;
-  const [rootRoute, id2ExistingRoute] = useMemo(() => amRouteToFormAmRoute(config?.route, true), [config?.route]);
+  const [rootRoute, id2ExistingRoute] = useMemo(() => amRouteToFormAmRoute(config?.route), [config?.route]);
 
   const receivers = stringsToSelectableValues(
     (config?.receivers ?? []).map((receiver: Receiver) => receiver.name)

--- a/public/app/features/alerting/unified/components/amroutes/AmRootRouteForm.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRootRouteForm.tsx
@@ -113,12 +113,7 @@ export const AmRootRouteForm: FC<AmRootRouteFormProps> = ({
                 <div className={cx(styles.container, styles.timingContainer)}>
                   <InputControl
                     render={({ field, fieldState: { invalid } }) => (
-                      <Input
-                        {...field}
-                        className={styles.smallInput}
-                        invalid={invalid}
-                        placeholder={'Default 30 seconds'}
-                      />
+                      <Input {...field} className={styles.smallInput} invalid={invalid} placeholder={'30'} />
                     )}
                     control={control}
                     name="groupWaitValue"
@@ -154,12 +149,7 @@ export const AmRootRouteForm: FC<AmRootRouteFormProps> = ({
                 <div className={cx(styles.container, styles.timingContainer)}>
                   <InputControl
                     render={({ field, fieldState: { invalid } }) => (
-                      <Input
-                        {...field}
-                        className={styles.smallInput}
-                        invalid={invalid}
-                        placeholder={'Default 5 minutes'}
-                      />
+                      <Input {...field} className={styles.smallInput} invalid={invalid} placeholder={'5'} />
                     )}
                     control={control}
                     name="groupIntervalValue"
@@ -195,7 +185,7 @@ export const AmRootRouteForm: FC<AmRootRouteFormProps> = ({
                 <div className={cx(styles.container, styles.timingContainer)}>
                   <InputControl
                     render={({ field, fieldState: { invalid } }) => (
-                      <Input {...field} className={styles.smallInput} invalid={invalid} placeholder="Default 4 hours" />
+                      <Input {...field} className={styles.smallInput} invalid={invalid} placeholder="4" />
                     )}
                     control={control}
                     name="repeatIntervalValue"

--- a/public/app/features/alerting/unified/components/amroutes/AmRootRouteForm.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRootRouteForm.tsx
@@ -36,7 +36,7 @@ export const AmRootRouteForm: FC<AmRootRouteFormProps> = ({
   const [groupByOptions, setGroupByOptions] = useState(stringsToSelectableValues(routes.groupBy));
 
   return (
-    <Form defaultValues={routes} onSubmit={onSave}>
+    <Form defaultValues={{ ...routes, overrideTimings: true }} onSubmit={onSave}>
       {({ control, errors, setValue }) => (
         <>
           <Field label="Default contact point" invalid={!!errors.receiver} error={errors.receiver?.message}>

--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesExpandedForm.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesExpandedForm.tsx
@@ -214,7 +214,6 @@ export const AmRoutesExpandedForm: FC<AmRoutesExpandedFormProps> = ({ onCancel, 
                           {...field}
                           className={formStyles.smallInput}
                           invalid={invalid}
-                          placeholder="Time"
                           aria-label="Group wait value"
                         />
                       )}
@@ -255,7 +254,6 @@ export const AmRoutesExpandedForm: FC<AmRoutesExpandedFormProps> = ({ onCancel, 
                           {...field}
                           className={formStyles.smallInput}
                           invalid={invalid}
-                          placeholder="Time"
                           aria-label="Group interval value"
                         />
                       )}
@@ -296,7 +294,6 @@ export const AmRoutesExpandedForm: FC<AmRoutesExpandedFormProps> = ({ onCancel, 
                           {...field}
                           className={formStyles.smallInput}
                           invalid={invalid}
-                          placeholder="Time"
                           aria-label="Repeat interval value"
                         />
                       )}

--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesExpandedForm.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesExpandedForm.tsx
@@ -168,7 +168,10 @@ export const AmRoutesExpandedForm: FC<AmRoutesExpandedFormProps> = ({ onCancel, 
             />
           </Field>
           {overrideGrouping && (
-            <Field label="Group by" description="Group alerts when you receive a notification based on labels.">
+            <Field
+              label="Group by"
+              description="Group alerts when you receive a notification based on labels. If empty it will be inherited from the parent policy."
+            >
               <InputControl
                 render={({ field: { onChange, ref, ...field } }) => (
                   <MultiSelect
@@ -199,7 +202,7 @@ export const AmRoutesExpandedForm: FC<AmRoutesExpandedFormProps> = ({ onCancel, 
             <>
               <Field
                 label="Group wait"
-                description="The waiting time until the initial notification is sent for a new group created by an incoming alert."
+                description="The waiting time until the initial notification is sent for a new group created by an incoming alert. If empty it will be inherited from the parent policy."
                 invalid={!!errors.groupWaitValue}
                 error={errors.groupWaitValue?.message}
               >
@@ -240,7 +243,7 @@ export const AmRoutesExpandedForm: FC<AmRoutesExpandedFormProps> = ({ onCancel, 
               </Field>
               <Field
                 label="Group interval"
-                description="The waiting time to send a batch of new alerts for that group after the first notification was sent."
+                description="The waiting time to send a batch of new alerts for that group after the first notification was sent. If empty it will be inherited from the parent policy."
                 invalid={!!errors.groupIntervalValue}
                 error={errors.groupIntervalValue?.message}
               >

--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesExpandedForm.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesExpandedForm.tsx
@@ -45,15 +45,12 @@ export const AmRoutesExpandedForm: FC<AmRoutesExpandedFormProps> = ({ onCancel, 
   const styles = useStyles2(getStyles);
   const formStyles = useStyles2(getFormStyles);
   const [overrideGrouping, setOverrideGrouping] = useState(routes.groupBy.length > 0);
-  const [overrideTimings, setOverrideTimings] = useState(
-    !!routes.groupWaitValue || !!routes.groupIntervalValue || !!routes.repeatIntervalValue
-  );
   const [groupByOptions, setGroupByOptions] = useState(stringsToSelectableValues(routes.groupBy));
   const muteTimingOptions = useMuteTimingOptions();
 
   return (
     <Form defaultValues={routes} onSubmit={onSave}>
-      {({ control, register, errors, setValue }) => (
+      {({ control, register, errors, setValue, watch }) => (
         <>
           {/* @ts-ignore-check: react-hook-form made me do this */}
           <input type="hidden" {...register('id')} />
@@ -196,13 +193,9 @@ export const AmRoutesExpandedForm: FC<AmRoutesExpandedFormProps> = ({ onCancel, 
             </Field>
           )}
           <Field label="Override general timings">
-            <Switch
-              id="override-timings-toggle"
-              value={overrideTimings}
-              onChange={() => setOverrideTimings((overrideTimings) => !overrideTimings)}
-            />
+            <Switch id="override-timings-toggle" {...register('overrideTimings')} />
           </Field>
-          {overrideTimings && (
+          {watch().overrideTimings && (
             <>
               <Field
                 label="Group wait"

--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.test.ts
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesTable.test.ts
@@ -11,6 +11,7 @@ const defaultAmRoute: FormAmRoute = {
   continue: false,
   receiver: '',
   groupBy: [],
+  overrideTimings: false,
   groupWaitValue: '',
   groupWaitValueType: '',
   groupIntervalValue: '',

--- a/public/app/features/alerting/unified/types/amroutes.ts
+++ b/public/app/features/alerting/unified/types/amroutes.ts
@@ -6,6 +6,7 @@ export interface FormAmRoute {
   continue: boolean;
   receiver: string;
   groupBy: string[];
+  overrideTimings: boolean;
   groupWaitValue: string;
   groupWaitValueType: string;
   groupIntervalValue: string;

--- a/public/app/features/alerting/unified/utils/amroutes.ts
+++ b/public/app/features/alerting/unified/utils/amroutes.ts
@@ -87,15 +87,15 @@ export const amRouteToFormAmRoute = (
 
   const [groupWaitValue, groupWaitValueType] = intervalToValueAndType(
     route.group_wait,
-    isRoot ? ['30', 's'] : defaultValueAndType
+    isRoot ? ['', 's'] : defaultValueAndType
   );
   const [groupIntervalValue, groupIntervalValueType] = intervalToValueAndType(
     route.group_interval,
-    isRoot ? ['5', 'm'] : defaultValueAndType
+    isRoot ? ['', 'm'] : defaultValueAndType
   );
   const [repeatIntervalValue, repeatIntervalValueType] = intervalToValueAndType(
     route.repeat_interval,
-    isRoot ? ['4', 'h'] : defaultValueAndType
+    isRoot ? ['', 'h'] : defaultValueAndType
   );
 
   const id = String(Math.random());

--- a/public/app/features/alerting/unified/utils/amroutes.ts
+++ b/public/app/features/alerting/unified/utils/amroutes.ts
@@ -77,30 +77,14 @@ export const emptyRoute: FormAmRoute = {
 };
 
 //returns route, and a record mapping id to existing route route
-interface AmRouteToFormAmRouteOptions {
-  isRoot: boolean;
-}
-
-export const amRouteToFormAmRoute = (
-  route: Route | undefined,
-  { isRoot }: AmRouteToFormAmRouteOptions
-): [FormAmRoute, Record<string, Route>] => {
+export const amRouteToFormAmRoute = (route: Route | undefined): [FormAmRoute, Record<string, Route>] => {
   if (!route || Object.keys(route).length === 0) {
     return [emptyRoute, {}];
   }
 
-  const [groupWaitValue, groupWaitValueType] = intervalToValueAndType(
-    route.group_wait,
-    isRoot ? ['', 's'] : defaultValueAndType
-  );
-  const [groupIntervalValue, groupIntervalValueType] = intervalToValueAndType(
-    route.group_interval,
-    isRoot ? ['', 'm'] : defaultValueAndType
-  );
-  const [repeatIntervalValue, repeatIntervalValueType] = intervalToValueAndType(
-    route.repeat_interval,
-    isRoot ? ['', 'h'] : defaultValueAndType
-  );
+  const [groupWaitValue, groupWaitValueType] = intervalToValueAndType(route.group_wait, ['', 's']);
+  const [groupIntervalValue, groupIntervalValueType] = intervalToValueAndType(route.group_interval, ['', 'm']);
+  const [repeatIntervalValue, repeatIntervalValueType] = intervalToValueAndType(route.repeat_interval, ['', 'h']);
 
   const id = String(Math.random());
   const id2route = {
@@ -108,7 +92,7 @@ export const amRouteToFormAmRoute = (
   };
   const formRoutes: FormAmRoute[] = [];
   route.routes?.forEach((subRoute) => {
-    const [subFormRoute, subId2Route] = amRouteToFormAmRoute(subRoute, { isRoot: false });
+    const [subFormRoute, subId2Route] = amRouteToFormAmRoute(subRoute);
     formRoutes.push(subFormRoute);
     Object.assign(id2route, subId2Route);
   });

--- a/public/app/features/alerting/unified/utils/amroutes.ts
+++ b/public/app/features/alerting/unified/utils/amroutes.ts
@@ -77,9 +77,13 @@ export const emptyRoute: FormAmRoute = {
 };
 
 //returns route, and a record mapping id to existing route route
+interface AmRouteToFormAmRouteOptions {
+  isRoot: boolean;
+}
+
 export const amRouteToFormAmRoute = (
   route: Route | undefined,
-  isRoot: boolean
+  { isRoot }: AmRouteToFormAmRouteOptions
 ): [FormAmRoute, Record<string, Route>] => {
   if (!route || Object.keys(route).length === 0) {
     return [emptyRoute, {}];
@@ -104,7 +108,7 @@ export const amRouteToFormAmRoute = (
   };
   const formRoutes: FormAmRoute[] = [];
   route.routes?.forEach((subRoute) => {
-    const [subFormRoute, subId2Route] = amRouteToFormAmRoute(subRoute, false);
+    const [subFormRoute, subId2Route] = amRouteToFormAmRoute(subRoute, { isRoot: false });
     formRoutes.push(subFormRoute);
     Object.assign(id2route, subId2Route);
   });

--- a/public/app/features/alerting/unified/utils/amroutes.ts
+++ b/public/app/features/alerting/unified/utils/amroutes.ts
@@ -11,7 +11,7 @@ import { matcherToMatcherField, parseMatcher } from './alertmanager';
 import { GRAFANA_RULES_SOURCE_NAME } from './datasource';
 import { parseInterval, timeOptions } from './time';
 
-const defaultValueAndType: [string, string] = ['', timeOptions[0].value];
+const defaultValueAndType: [string, string] = ['', ''];
 
 const matchersToArrayFieldMatchers = (
   matchers: Record<string, string> | undefined,
@@ -29,9 +29,12 @@ const matchersToArrayFieldMatchers = (
     [] as MatcherFieldValue[]
   );
 
-const intervalToValueAndType = (strValue: string | undefined): [string, string] => {
+const intervalToValueAndType = (
+  strValue: string | undefined,
+  defaultValue?: typeof defaultValueAndType
+): [string, string] => {
   if (!strValue) {
-    return defaultValueAndType;
+    return defaultValue ?? defaultValueAndType;
   }
 
   const [value, valueType] = strValue ? parseInterval(strValue) : [undefined, undefined];
@@ -63,6 +66,7 @@ export const emptyRoute: FormAmRoute = {
   routes: [],
   continue: false,
   receiver: '',
+  overrideTimings: false,
   groupWaitValue: '',
   groupWaitValueType: timeOptions[0].value,
   groupIntervalValue: '',
@@ -73,14 +77,26 @@ export const emptyRoute: FormAmRoute = {
 };
 
 //returns route, and a record mapping id to existing route route
-export const amRouteToFormAmRoute = (route: Route | undefined): [FormAmRoute, Record<string, Route>] => {
+export const amRouteToFormAmRoute = (
+  route: Route | undefined,
+  isRoot: boolean
+): [FormAmRoute, Record<string, Route>] => {
   if (!route || Object.keys(route).length === 0) {
     return [emptyRoute, {}];
   }
 
-  const [groupWaitValue, groupWaitValueType] = intervalToValueAndType(route.group_wait);
-  const [groupIntervalValue, groupIntervalValueType] = intervalToValueAndType(route.group_interval);
-  const [repeatIntervalValue, repeatIntervalValueType] = intervalToValueAndType(route.repeat_interval);
+  const [groupWaitValue, groupWaitValueType] = intervalToValueAndType(
+    route.group_wait,
+    isRoot ? ['30', 's'] : defaultValueAndType
+  );
+  const [groupIntervalValue, groupIntervalValueType] = intervalToValueAndType(
+    route.group_interval,
+    isRoot ? ['5', 'm'] : defaultValueAndType
+  );
+  const [repeatIntervalValue, repeatIntervalValueType] = intervalToValueAndType(
+    route.repeat_interval,
+    isRoot ? ['4', 'h'] : defaultValueAndType
+  );
 
   const id = String(Math.random());
   const id2route = {
@@ -88,7 +104,7 @@ export const amRouteToFormAmRoute = (route: Route | undefined): [FormAmRoute, Re
   };
   const formRoutes: FormAmRoute[] = [];
   route.routes?.forEach((subRoute) => {
-    const [subFormRoute, subId2Route] = amRouteToFormAmRoute(subRoute);
+    const [subFormRoute, subId2Route] = amRouteToFormAmRoute(subRoute, false);
     formRoutes.push(subFormRoute);
     Object.assign(id2route, subId2Route);
   });
@@ -111,6 +127,7 @@ export const amRouteToFormAmRoute = (route: Route | undefined): [FormAmRoute, Re
       continue: route.continue ?? false,
       receiver: route.receiver ?? '',
       groupBy: route.group_by ?? [],
+      overrideTimings: [groupWaitValue, groupIntervalValue, repeatIntervalValue].some(Boolean),
       groupWaitValue,
       groupWaitValueType,
       groupIntervalValue,
@@ -130,6 +147,26 @@ export const formAmRouteToAmRoute = (
   id2ExistingRoute: Record<string, Route>
 ): Route => {
   const existing: Route | undefined = id2ExistingRoute[formAmRoute.id];
+
+  const {
+    overrideTimings,
+    groupWaitValue,
+    groupWaitValueType,
+    groupIntervalValue,
+    groupIntervalValueType,
+    repeatIntervalValue,
+    repeatIntervalValueType,
+  } = formAmRoute;
+
+  const overrideGroupWait = overrideTimings && groupWaitValue;
+  const group_wait = overrideGroupWait ? `${groupWaitValue}${groupWaitValueType}` : undefined;
+
+  const overrideGroupInterval = overrideTimings && groupIntervalValue;
+  const group_interval = overrideGroupInterval ? `${groupIntervalValue}${groupIntervalValueType}` : undefined;
+
+  const overrideRepeatInterval = overrideTimings && repeatIntervalValue;
+  const repeat_interval = overrideRepeatInterval ? `${repeatIntervalValue}${repeatIntervalValueType}` : undefined;
+
   const amRoute: Route = {
     ...(existing ?? {}),
     continue: formAmRoute.continue,
@@ -137,17 +174,11 @@ export const formAmRouteToAmRoute = (
     object_matchers: formAmRoute.object_matchers.length
       ? formAmRoute.object_matchers.map((matcher) => [matcher.name, matcher.operator, matcher.value])
       : undefined,
-    match: undefined,
-    match_re: undefined,
-    group_wait: formAmRoute.groupWaitValue
-      ? `${formAmRoute.groupWaitValue}${formAmRoute.groupWaitValueType}`
-      : undefined,
-    group_interval: formAmRoute.groupIntervalValue
-      ? `${formAmRoute.groupIntervalValue}${formAmRoute.groupIntervalValueType}`
-      : undefined,
-    repeat_interval: formAmRoute.repeatIntervalValue
-      ? `${formAmRoute.repeatIntervalValue}${formAmRoute.repeatIntervalValueType}`
-      : undefined,
+    match: undefined, // DEPRECATED: Use matchers
+    match_re: undefined, // DEPRECATED: Use matchers
+    group_wait,
+    group_interval,
+    repeat_interval,
     routes: formAmRoute.routes.map((subRoute) =>
       formAmRouteToAmRoute(alertManagerSourceName, subRoute, id2ExistingRoute)
     ),


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, disabling the `override general timings` switch would not remove the configured timing option overrides for a notification policy.

This PR does the following:

1. Allows removing the overrides by disabling the toggle
2. Explicitly displays the defaults for the root policy

<img width="539" alt="image" src="https://user-images.githubusercontent.com/868844/166714643-8a59d394-e5ab-4226-bf02-5787c3345736.png">

**Which issue(s) this PR fixes**:

Fixes #48505

**Special notes for your reviewer**:

