### PR TITLE
Transformations: Add an All Unique Values Reducer

### DIFF
--- a/packages/grafana-data/src/transformations/fieldReducer.test.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.test.ts
@@ -97,6 +97,15 @@ describe('Stats Calculators', () => {
     expect(stats.delta).toEqual(300);
   });
 
+  it('should calculate unique values', () => {
+    const stats = reduceField({
+      field: createField('x', [1, 2, 2, 3, 1]),
+      reducers: [ReducerID.allUniqueValues],
+    });
+
+    expect(stats.allUniqueValues).toEqual([1, 2, 3]);
+  });
+
   it('consistently check allIsNull/allIsZero', () => {
     const empty = createField('x');
     const allNull = createField('x', [null, null, null, null]);

--- a/packages/grafana-data/src/transformations/fieldReducer.test.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.test.ts
@@ -100,10 +100,10 @@ describe('Stats Calculators', () => {
   it('should calculate unique values', () => {
     const stats = reduceField({
       field: createField('x', [1, 2, 2, 3, 1]),
-      reducers: [ReducerID.allUniqueValues],
+      reducers: [ReducerID.uniqueValues],
     });
 
-    expect(stats.allUniqueValues).toEqual([1, 2, 3]);
+    expect(stats.uniqueValues).toEqual([1, 2, 3]);
   });
 
   it('consistently check allIsNull/allIsZero', () => {

--- a/packages/grafana-data/src/transformations/fieldReducer.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.ts
@@ -25,7 +25,7 @@ export enum ReducerID {
   allIsZero = 'allIsZero',
   allIsNull = 'allIsNull',
   allValues = 'allValues',
-  allUniqueValues = 'allUniqueValues',
+  uniqueValues = 'uniqueValues',
 }
 
 // Internal function

--- a/packages/grafana-data/src/transformations/fieldReducer.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.ts
@@ -239,12 +239,12 @@ export const fieldReducers = new Registry<FieldReducerInfo>(() => [
     reduce: (field: Field) => ({ allValues: field.values.toArray() }),
   },
   {
-    id: ReducerID.allUniqueValues,
+    id: ReducerID.uniqueValues,
     name: 'All unique values',
     description: 'Returns an array with all unique values',
     standard: false,
     reduce: (field: Field) => ({
-      allUniqueValues: [...new Set(field.values.toArray())],
+      uniqueValues: [...new Set(field.values.toArray())],
     }),
   },
 ]);

--- a/packages/grafana-data/src/transformations/fieldReducer.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.ts
@@ -244,7 +244,7 @@ export const fieldReducers = new Registry<FieldReducerInfo>(() => [
     description: 'Returns an array with all unique values',
     standard: false,
     reduce: (field: Field) => ({
-      allUniqueValues: field.values.toArray().filter((n, i) => field.values.toArray().indexOf(n) === i),
+      allUniqueValues: [...new Set(field.values.toArray())],
     }),
   },
 ]);

--- a/packages/grafana-data/src/transformations/fieldReducer.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.ts
@@ -25,6 +25,7 @@ export enum ReducerID {
   allIsZero = 'allIsZero',
   allIsNull = 'allIsNull',
   allValues = 'allValues',
+  allUniqueValues = 'allUniqueValues',
 }
 
 // Internal function
@@ -236,6 +237,15 @@ export const fieldReducers = new Registry<FieldReducerInfo>(() => [
     description: 'Returns an array with all values',
     standard: false,
     reduce: (field: Field) => ({ allValues: field.values.toArray() }),
+  },
+  {
+    id: ReducerID.allUniqueValues,
+    name: 'All unique values',
+    description: 'Returns an array with all unique values',
+    standard: false,
+    reduce: (field: Field) => ({
+      allUniqueValues: field.values.toArray().filter((n, i) => field.values.toArray().indexOf(n) === i),
+    }),
   },
 ]);
 


### PR DESCRIPTION
In the Group by transformation (and all other transformations that use reducers), there is an "All Values" calculation, and it would be useful to add a "All unique values" calculation. So if "All values" returns this array:

[1, 2, 3, 1, 2]

"All Unique Values" would return only:

[1, 2, 3]