### PR TITLE
TimeRange: Fixes updating time range from url and browser history

### DIFF
--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -169,14 +169,9 @@ export class TimeSrv {
       }
     }
 
-    let paramsJSON: Record<string, string> = {};
-    params.forEach(function (value, key) {
-      paramsJSON[key] = value;
-    });
-
     // but if refresh explicitly set then use that
     this.refresh = getRefreshFromUrl({
-      params: paramsJSON,
+      urlRefresh: params.get('refresh'),
       currentRefresh: this.refresh,
       refreshIntervals: Array.isArray(this.timeModel?.timepicker?.refresh_intervals)
         ? this.timeModel?.timepicker?.refresh_intervals
@@ -203,7 +198,7 @@ export class TimeSrv {
       if (from !== urlRange.from || to !== urlRange.to) {
         // issue update
         this.initTimeFromUrl();
-        this.setTime(this.time, true);
+        this.setTime(this.time, false);
       }
     } else if (this.timeHasChangedSinceLoad()) {
       this.setTime(this.timeAtLoad, true);

--- a/public/app/features/dashboard/utils/getRefreshFromUrl.test.ts
+++ b/public/app/features/dashboard/utils/getRefreshFromUrl.test.ts
@@ -3,13 +3,12 @@ import { getRefreshFromUrl } from './getRefreshFromUrl';
 describe('getRefreshFromUrl', () => {
   describe('when refresh is not part of params', () => {
     it('then it should return current refresh value', () => {
-      const params = {};
       const currentRefresh = false;
       const minRefreshInterval = '5s';
       const isAllowedIntervalFn = () => false;
 
       const actual = getRefreshFromUrl({
-        params,
+        urlRefresh: null,
         currentRefresh,
         minRefreshInterval,
         isAllowedIntervalFn,
@@ -22,14 +21,13 @@ describe('getRefreshFromUrl', () => {
   describe('when refresh is part of params', () => {
     describe('and refresh is an existing and valid interval', () => {
       it('then it should return the refresh value', () => {
-        const params = { refresh: '10s' };
         const currentRefresh = '';
         const minRefreshInterval = '5s';
         const isAllowedIntervalFn = () => true;
         const refreshIntervals = ['5s', '10s', '30s'];
 
         const actual = getRefreshFromUrl({
-          params,
+          urlRefresh: '10s',
           currentRefresh,
           minRefreshInterval,
           isAllowedIntervalFn,
@@ -61,7 +59,7 @@ describe('getRefreshFromUrl', () => {
       'when called with refresh:{$refresh}, isAllowedInterval:{$isAllowedInterval}, minRefreshInterval:{$minRefreshInterval}, refreshIntervals:{$refreshIntervals} then it should return: $expected',
       ({ refresh, isAllowedInterval, minRefreshInterval, refreshIntervals, expected }) => {
         const actual = getRefreshFromUrl({
-          params: { refresh },
+          urlRefresh: refresh,
           currentRefresh: 'currentRefresh',
           minRefreshInterval,
           isAllowedIntervalFn: () => isAllowedInterval,

--- a/public/app/features/dashboard/utils/getRefreshFromUrl.ts
+++ b/public/app/features/dashboard/utils/getRefreshFromUrl.ts
@@ -1,7 +1,7 @@
 import { defaultIntervals } from '@grafana/ui';
 
 interface Args {
-  params: Record<string, string>;
+  urlRefresh: string | null;
   currentRefresh: string | boolean | undefined;
   isAllowedIntervalFn: (interval: string) => boolean;
   minRefreshInterval: string;
@@ -13,18 +13,18 @@ interface Args {
 // try to find the first refresh interval that matches the minRefreshInterval (min_refresh_interval in ini)
 // or just take the first interval.
 export function getRefreshFromUrl({
-  params,
+  urlRefresh,
   currentRefresh,
   isAllowedIntervalFn,
   minRefreshInterval,
   refreshIntervals = defaultIntervals,
 }: Args): string | boolean | undefined {
-  if (!params.refresh) {
+  if (!urlRefresh) {
     return currentRefresh;
   }
 
-  const isAllowedInterval = isAllowedIntervalFn(params.refresh);
-  const isExistingInterval = refreshIntervals.find((interval) => interval === params.refresh);
+  const isAllowedInterval = isAllowedIntervalFn(urlRefresh);
+  const isExistingInterval = refreshIntervals.find((interval) => interval === urlRefresh);
 
   if (!isAllowedInterval || !isExistingInterval) {
     const minRefreshIntervalInIntervals = minRefreshInterval
@@ -35,5 +35,5 @@ export function getRefreshFromUrl({
     return minRefreshIntervalInIntervals ?? lowestRefreshInterval ?? currentRefresh;
   }
 
-  return params.refresh || currentRefresh;
+  return urlRefresh || currentRefresh;
 }


### PR DESCRIPTION
Fixes #48652


PR #45020 inverted the boolean parameter fromRouteUpdate in call to setTime but did not invert the place
where it was called.

Also included some code simplification as I was struggling understanding why we built a object with all
url params when the function getUrlRefresh only needed a single url property.


