### PR TITLE
documentation: don't put migrations behind feature flags

### DIFF
--- a/contribute/architecture/backend/database.md
+++ b/contribute/architecture/backend/database.md
@@ -99,6 +99,8 @@ To add a migration:
 - In the `AddMigrations` function, find the `addXxxMigration` function for the service you want to create a migration for.
 - At the end of the `addXxxMigration` function, register your migration:
 
+> **NOTE:** Putting migrations behind feature flags is no longer recommended as it may cause the migration skip integration testing.
+
 [Example](https://github.com/grafana/grafana/blob/00d0640b6e778ddaca021670fe851fe00982acf2/pkg/services/sqlstore/migrations/migrations.go#L55-L70)
 
 ### Implement `DatabaseMigrator`

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -13,6 +13,9 @@ import (
 // 1. Never change a migration that is committed and pushed to main
 // 2. Always add new migrations (to change or undo previous migrations)
 // 3. Some migrations are not yet written (rename column, table, drop table, index etc)
+// 4. Putting migrations behind feature flags is no longer recommended as broken
+//    migrations may not be caught by integration tests unless feature flags are
+//    specifically added
 
 type OSSMigrations struct {
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Update documentation to explicitly state we should not be putting migrations behind feature flags as broken migrations will not be caught by ci/cd

ref: 

https://github.com/grafana/grafana/pull/48470#discussion_r862706949
https://github.com/grafana/grafana/pull/47709#discussion_r858952114
