### PR TITLE
Search: remove broken keyboard nav

### DIFF
--- a/public/app/features/search/hooks/useDashboardSearch.ts
+++ b/public/app/features/search/hooks/useDashboardSearch.ts
@@ -1,13 +1,8 @@
 import { KeyboardEvent, useReducer } from 'react';
 import { useDebounce } from 'react-use';
 
-import { locationUtil } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
-
-import { MOVE_SELECTION_DOWN, MOVE_SELECTION_UP } from '../reducers/actionTypes';
 import { dashboardsSearchState, DashboardsSearchState, searchReducer } from '../reducers/dashboardSearch';
-import { DashboardQuery, DashboardSearchItemType, DashboardSection } from '../types';
-import { findSelected } from '../utils';
+import { DashboardQuery } from '../types';
 
 import { reportDashboardListViewed } from './useManageDashboards';
 import { useSearch } from './useSearch';
@@ -19,7 +14,6 @@ export const useDashboardSearch = (query: DashboardQuery, onCloseSearch: () => v
   const {
     state: { results, loading },
     onToggleSection,
-    dispatch,
   } = useSearch<DashboardsSearchState>(query, reducer, { queryParsing: true });
 
   useDebounce(
@@ -49,23 +43,6 @@ export const useDashboardSearch = (query: DashboardQuery, onCloseSearch: () => v
       case 'Escape':
         onCloseSearch();
         break;
-      case 'ArrowUp':
-        dispatch({ type: MOVE_SELECTION_UP });
-        break;
-      case 'ArrowDown':
-        dispatch({ type: MOVE_SELECTION_DOWN });
-        break;
-      case 'Enter':
-        const selectedItem = findSelected(results);
-        if (selectedItem) {
-          if (selectedItem.type === DashboardSearchItemType.DashFolder) {
-            onToggleSection(selectedItem as DashboardSection);
-          } else {
-            locationService.push(locationUtil.stripBaseFromUrl(selectedItem.url));
-            // Delay closing to prevent current page flicker
-            setTimeout(onCloseSearch, 0);
-          }
-        }
     }
   };
 

--- a/public/app/features/search/hooks/useManageDashboards.test.ts
+++ b/public/app/features/search/hooks/useManageDashboards.test.ts
@@ -25,7 +25,6 @@ describe('useManageDashboards', () => {
     const state: ManageDashboardsState = {
       results,
       loading: false,
-      selectedIndex: 0,
       initialLoading: false,
       allChecked: false,
     };

--- a/public/app/features/search/reducers/actionTypes.ts
+++ b/public/app/features/search/reducers/actionTypes.ts
@@ -2,8 +2,6 @@ export const FETCH_RESULTS = 'FETCH_RESULTS';
 export const TOGGLE_SECTION = 'TOGGLE_SECTION';
 export const FETCH_ITEMS = 'FETCH_ITEMS';
 export const FETCH_ITEMS_START = 'FETCH_ITEMS_START';
-export const MOVE_SELECTION_UP = 'MOVE_SELECTION_UP';
-export const MOVE_SELECTION_DOWN = 'MOVE_SELECTION_DOWN';
 export const SEARCH_START = 'SEARCH_START';
 
 // Manage dashboards

--- a/public/app/features/search/reducers/dashboardSearch.test.ts
+++ b/public/app/features/search/reducers/dashboardSearch.test.ts
@@ -1,6 +1,6 @@
 import { searchResults, sections } from '../testData';
 
-import { FETCH_ITEMS, FETCH_RESULTS, TOGGLE_SECTION, MOVE_SELECTION_DOWN, MOVE_SELECTION_UP } from './actionTypes';
+import { FETCH_ITEMS, FETCH_RESULTS, TOGGLE_SECTION } from './actionTypes';
 import { searchReducer as reducer, dashboardsSearchState } from './dashboardSearch';
 
 const defaultState = { selectedIndex: 0, loading: false, results: sections as any[], initialLoading: false };
@@ -47,48 +47,5 @@ describe('Dashboard Search reducer', () => {
       },
     });
     expect(newState.results[2].items).toEqual(items);
-  });
-
-  it('should handle MOVE_SELECTION_DOWN', () => {
-    const newState = reducer(defaultState, {
-      type: MOVE_SELECTION_DOWN,
-    });
-
-    expect(newState.selectedIndex).toEqual(1);
-    expect(newState.results[0].items[0].selected).toBeTruthy();
-
-    const newState2 = reducer(newState, {
-      type: MOVE_SELECTION_DOWN,
-    });
-
-    expect(newState2.selectedIndex).toEqual(2);
-    expect(newState2.results[1].selected).toBeTruthy();
-
-    // Shouldn't go over the visible results length - 1 (9)
-    const newState3 = reducer(
-      { ...defaultState, selectedIndex: 9 },
-      {
-        type: MOVE_SELECTION_DOWN,
-      }
-    );
-    expect(newState3.selectedIndex).toEqual(9);
-  });
-
-  it('should handle MOVE_SELECTION_UP', () => {
-    // shouldn't move beyond 0
-    const newState = reducer(defaultState, {
-      type: MOVE_SELECTION_UP,
-    });
-
-    expect(newState.selectedIndex).toEqual(0);
-
-    const newState2 = reducer(
-      { ...defaultState, selectedIndex: 3 },
-      {
-        type: MOVE_SELECTION_UP,
-      }
-    );
-    expect(newState2.selectedIndex).toEqual(2);
-    expect(newState2.results[1].selected).toBeTruthy();
   });
 });

--- a/public/app/features/search/reducers/dashboardSearch.ts
+++ b/public/app/features/search/reducers/dashboardSearch.ts
@@ -1,20 +1,11 @@
 import { DashboardSection, SearchAction } from '../types';
-import { getFlattenedSections, getLookupField, markSelected } from '../utils';
+import { getLookupField } from '../utils';
 
-import {
-  FETCH_ITEMS,
-  FETCH_RESULTS,
-  TOGGLE_SECTION,
-  MOVE_SELECTION_DOWN,
-  MOVE_SELECTION_UP,
-  SEARCH_START,
-  FETCH_ITEMS_START,
-} from './actionTypes';
+import { FETCH_ITEMS, FETCH_RESULTS, TOGGLE_SECTION, SEARCH_START, FETCH_ITEMS_START } from './actionTypes';
 
 export interface DashboardsSearchState {
   results: DashboardSection[];
   loading: boolean;
-  selectedIndex: number;
   /** Used for first time page load */
   initialLoading: boolean;
 }
@@ -23,7 +14,6 @@ export const dashboardsSearchState: DashboardsSearchState = {
   results: [],
   loading: true,
   initialLoading: true,
-  selectedIndex: 0,
 };
 
 export const searchReducer = (state: DashboardsSearchState, action: SearchAction) => {
@@ -77,31 +67,6 @@ export const searchReducer = (state: DashboardsSearchState, action: SearchAction
       }
       return state;
     }
-    case MOVE_SELECTION_DOWN: {
-      const flatIds = getFlattenedSections(state.results);
-      if (state.selectedIndex < flatIds.length - 1) {
-        const newIndex = state.selectedIndex + 1;
-        const selectedId = flatIds[newIndex];
-        return {
-          ...state,
-          selectedIndex: newIndex,
-          results: markSelected(state.results, selectedId),
-        };
-      }
-      return state;
-    }
-    case MOVE_SELECTION_UP:
-      if (state.selectedIndex > 0) {
-        const flatIds = getFlattenedSections(state.results);
-        const newIndex = state.selectedIndex - 1;
-        const selectedId = flatIds[newIndex];
-        return {
-          ...state,
-          selectedIndex: newIndex,
-          results: markSelected(state.results, selectedId),
-        };
-      }
-      return state;
     default:
       return state;
   }

--- a/public/app/features/search/utils.test.ts
+++ b/public/app/features/search/utils.test.ts
@@ -1,11 +1,9 @@
 import { sections, searchResults, checkedGeneralFolder, checkedOtherFolder, folderViewAllChecked } from './testData';
 import { SearchQueryParams } from './types';
 import {
-  findSelected,
   getCheckedDashboardsUids,
   getCheckedUids,
   getFlattenedSections,
-  markSelected,
   mergeReducers,
   parseRouteParams,
 } from './utils';
@@ -27,76 +25,6 @@ describe('Search utils', () => {
         '0-4072',
         '0-1',
       ]);
-    });
-
-    describe('markSelected', () => {
-      it('should correctly mark the section item without id as selected', () => {
-        const results = markSelected(sections as any, 'Recent');
-        //@ts-ignore
-        expect(results[1].selected).toBe(true);
-      });
-
-      it('should correctly mark the section item with id as selected', () => {
-        const results = markSelected(sections as any, '4074');
-        //@ts-ignore
-        expect(results[4].selected).toBe(true);
-      });
-
-      it('should mark all other sections as not selected', () => {
-        const results = markSelected(sections as any, 'Starred');
-        const newResults = markSelected(results as any, '0');
-        //@ts-ignore
-        expect(newResults[0].selected).toBeFalsy();
-        expect(newResults[5].selected).toBeTruthy();
-      });
-
-      it('should correctly mark an item of a section as selected', () => {
-        const results = markSelected(sections as any, '0-4072');
-        expect(results[5].items[1].selected).toBeTruthy();
-      });
-
-      it('should not mark an item as selected for non-expanded section', () => {
-        const results = markSelected(sections as any, 'Recent-4072');
-        expect(results[1].items[0].selected).toBeFalsy();
-      });
-
-      it('should mark all other items as not selected', () => {
-        const results = markSelected(sections as any, '0-4069');
-        const newResults = markSelected(results as any, '0-1');
-        //@ts-ignore
-        expect(newResults[5].items[0].selected).toBeFalsy();
-        expect(newResults[5].items[1].selected).toBeFalsy();
-        expect(newResults[5].items[2].selected).toBeTruthy();
-      });
-
-      it('should correctly select one of the same items in different sections', () => {
-        const results = markSelected(sections as any, 'Starred-1');
-        expect(results[0].items[0].selected).toBeTruthy();
-        // Same item in diff section
-        expect(results[5].items[2].selected).toBeFalsy();
-
-        // Switch order
-        const newResults = markSelected(sections as any, '0-1');
-        expect(newResults[0].items[0].selected).toBeFalsy();
-        // Same item in diff section
-        expect(newResults[5].items[2].selected).toBeTruthy();
-      });
-    });
-
-    describe('findSelected', () => {
-      it('should find selected section', () => {
-        const results = [...sections, { id: 'Test', selected: true }];
-
-        const found = findSelected(results);
-        expect(found?.id).toEqual('Test');
-      });
-
-      it('should find selected item', () => {
-        const results = [{ expanded: true, id: 'Test', items: [{ id: 1 }, { id: 2, selected: true }, { id: 3 }] }];
-
-        const found = findSelected(results);
-        expect(found?.id).toEqual(2);
-      });
     });
   });
 

--- a/public/app/features/search/utils.ts
+++ b/public/app/features/search/utils.ts
@@ -45,60 +45,13 @@ export const getVisibleItems = (sections: DashboardSection[]) => {
     return [];
   });
 };
+
 /**
  * Since Recent and Starred folders don't have id, title field is used as id
  * @param title - title field of the section
  */
 export const getLookupField = (title: string) => {
   return hasId(title) ? 'id' : 'title';
-};
-
-/**
- * Go through all the folders and items in expanded folders and toggle their selected
- * prop according to currently selected index. Used for item highlighting when navigating
- * the search results list using keyboard arrows
- * @param sections
- * @param selectedId
- */
-export const markSelected = (sections: DashboardSection[], selectedId: string) => {
-  return sections.map((result: DashboardSection) => {
-    const lookupField = getLookupField(selectedId);
-    result = { ...result, selected: String(result[lookupField]) === selectedId };
-
-    if (result.expanded && result.items.length) {
-      return {
-        ...result,
-        items: result.items.map((item) => {
-          const [sectionId, itemId] = selectedId.split('-');
-          const lookup = getLookupField(sectionId);
-          return { ...item, selected: String(item.id) === itemId && String(result[lookup]) === sectionId };
-        }),
-      };
-    }
-    return result;
-  });
-};
-
-/**
- * Find items with property 'selected' set true in a list of folders and their items.
- * Does recursive search in the items list.
- * @param sections
- */
-export const findSelected = (sections: any): DashboardSection | DashboardSectionItem | null => {
-  let found = null;
-  for (const section of sections) {
-    if (section.expanded && section.items.length) {
-      found = findSelected(section.items);
-    }
-    if (section.selected) {
-      found = section;
-    }
-    if (found) {
-      return found;
-    }
-  }
-
-  return null;
 };
 
 export const parseQuery = (query: string) => {


### PR DESCRIPTION
This PR removes the broken (for how long?!!!) keyboard navigation via reducers.  As we migrate and merge the search solution, I don't see any reason to keep this feature as is.

If we need the up/down/enter selection -- lets implement that against search results directly.