### PR TITLE
Alerting: check provenance of alert rules in current API

### DIFF
--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -410,7 +410,7 @@ func (srv RulerSrv) updateAlertRulesInGroup(c *models.ReqContext, namespace *mod
 		}
 
 		provisioningChanges := &changes{}
-		// new rules don't need to be chacked for provenance, just copy the whole slice
+		// New rules don't need to be checked for provenance, just copy the whole slice.
 		provisioningChanges.New = groupChanges.New
 		for _, rule := range groupChanges.Update {
 			if provenance, exists := provenances[rule.Existing.UID]; (exists && provenance == ngmodels.ProvenanceNone) || !exists {

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -88,12 +88,12 @@ func (srv RulerSrv) RouteDeleteAlertRules(c *models.ReqContext) response.Respons
 			return nil
 		}
 
-		deletableRulesFGAC, err := srv.accessableRulesFGAC(q.Result, hasAccess, logger)
+		deletableRulesFGAC, err := srv.accessibleRulesFGAC(q.Result, hasAccess, logger)
 		if err != nil {
 			return err
 		}
 
-		deletableRulesProvisioning, err := srv.accessableRulesProvisioning(q.Result, provenances, logger)
+		deletableRulesProvisioning, err := srv.accessibleRulesProvisioning(q.Result, provenances, logger)
 		if err != nil {
 			return err
 		}
@@ -126,9 +126,9 @@ func (srv RulerSrv) RouteDeleteAlertRules(c *models.ReqContext) response.Respons
 	return response.JSON(http.StatusAccepted, util.DynMap{"message": "rules deleted"})
 }
 
-// accessableRulesFGAC will return the rules that are accessable for the user
+// accessibleRulesFGAC will return the rules that are accessible for the user
 // while checking against FGAC. If none is accessible, an error will be returned.
-func (srv RulerSrv) accessableRulesFGAC(rules []*ngmodels.AlertRule, hasAccess func(evaluator accesscontrol.Evaluator) bool, logger *log.ConcreteLogger) (map[string]struct{}, error) {
+func (srv RulerSrv) accessibleRulesFGAC(rules []*ngmodels.AlertRule, hasAccess func(evaluator accesscontrol.Evaluator) bool, logger *log.ConcreteLogger) (map[string]struct{}, error) {
 	canDelete, cannotDelete := make(map[string]struct{}, 0), make([]string, 0)
 	for _, rule := range rules {
 		if authorizeDatasourceAccessForRule(rule, hasAccess) {
@@ -149,10 +149,10 @@ func (srv RulerSrv) accessableRulesFGAC(rules []*ngmodels.AlertRule, hasAccess f
 	return canDelete, nil
 }
 
-// accessableRulesProvisioning will return the rules that are accessable for
+// accessibleRulesProvisioning will return the rules that are accessible for
 // the user while checking against the provenance. If none is accessible, an
 // error will be returned.
-func (srv RulerSrv) accessableRulesProvisioning(rules []*ngmodels.AlertRule, provenances map[string]ngmodels.Provenance, logger *log.ConcreteLogger) (map[string]struct{}, error) {
+func (srv RulerSrv) accessibleRulesProvisioning(rules []*ngmodels.AlertRule, provenances map[string]ngmodels.Provenance, logger *log.ConcreteLogger) (map[string]struct{}, error) {
 	canDelete, cannotDelete := make(map[string]struct{}, 0), make([]string, 0)
 	for _, rule := range rules {
 		if provenance, exists := provenances[rule.UID]; (exists && provenance == ngmodels.ProvenanceNone) || !exists {

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -386,6 +386,7 @@ func (srv RulerSrv) RoutePostNameRulesConfig(c *models.ReqContext, ruleGroupConf
 
 // updateAlertRulesInGroup calculates changes (rules to add,update,delete), verifies that the user is authorized to do the calculated changes and updates database.
 // All operations are performed in a single transaction
+//nolint: gocyclo
 func (srv RulerSrv) updateAlertRulesInGroup(c *models.ReqContext, namespace *models.Folder, groupName string, rules []*ngmodels.AlertRule) response.Response {
 	var mergedChanges *changes
 	hasAccess := accesscontrol.HasAccess(srv.ac, c)

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -163,11 +163,11 @@ func (srv RulerSrv) accessibleRulesProvisioning(rules []*ngmodels.AlertRule, pro
 	}
 
 	if len(canDelete) == 0 {
-		return nil, fmt.Errorf("%w to delete rules because user is not authorized to access data sources used by the rules", ErrAuthorization)
+		return nil, fmt.Errorf("all rules have been provisioned and cannot be deleted through this api")
 	}
 
 	if len(cannotDelete) > 0 {
-		logger.Info("user cannot delete one or many alert rules because it does not have access to data sources. Those rules will be skipped", "expected", len(rules), "authorized", len(canDelete), "unauthorized", cannotDelete)
+		logger.Info("user cannot delete one or many alert rules because it does has a provenance set. Those rules will be skipped", "expected", len(rules), "provenance_none", len(canDelete), "provenance_set", cannotDelete)
 	}
 
 	return canDelete, nil

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -408,6 +408,7 @@ func (srv RulerSrv) updateAlertRulesInGroup(c *models.ReqContext, namespace *mod
 		}
 
 		// New rules don't need to be checked for provenance, just copy the whole slice.
+		finalChanges = &changes{}
 		finalChanges.New = authorizedChanges.New
 		for _, rule := range authorizedChanges.Update {
 			if provenance, exists := provenances[rule.Existing.UID]; (exists && provenance == ngmodels.ProvenanceNone) || !exists {

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -461,7 +461,7 @@ func (srv RulerSrv) updateAlertRulesInGroup(c *models.ReqContext, namespace *mod
 
 		// merged changes contains all changes that are allowed by FGAC and
 		// have not a provenace from a provisoning tool yet.
-		mergedChanges = mergeChanges(provisioningChanges, authorizedChanges)
+		mergedChanges = intersectChanges(provisioningChanges, authorizedChanges)
 
 		logger.Debug("updating database with the authorized changes", "add", len(mergedChanges.New), "update", len(mergedChanges.New), "delete", len(mergedChanges.Delete))
 
@@ -606,9 +606,9 @@ func (c *changes) isEmpty() bool {
 	return len(c.Update)+len(c.New)+len(c.Delete) == 0
 }
 
-// mergeChanges will return a new change set that contains all changes
-// that are in set a and set b.
-func mergeChanges(a, b *changes) *changes {
+// intersectChanges will return a new change set that contains all changes
+// that are in  both sets a and b.
+func intersectChanges(a, b *changes) *changes {
 	m := &changes{}
 outerNew:
 	for _, x := range a.New {

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -129,7 +129,7 @@ func (srv RulerSrv) RouteDeleteAlertRules(c *models.ReqContext) response.Respons
 // accessibleRulesFGAC will return the rules that are accessible for the user
 // while checking against FGAC. If none is accessible, an error will be returned.
 func (srv RulerSrv) accessibleRulesFGAC(rules []*ngmodels.AlertRule, hasAccess func(evaluator accesscontrol.Evaluator) bool, logger *log.ConcreteLogger) (map[string]struct{}, error) {
-	canDelete, cannotDelete := make(map[string]struct{}, 0), make([]string, 0)
+	canDelete, cannotDelete := make(map[string]struct{}), make([]string, 0)
 	for _, rule := range rules {
 		if authorizeDatasourceAccessForRule(rule, hasAccess) {
 			canDelete[rule.UID] = struct{}{}
@@ -153,7 +153,7 @@ func (srv RulerSrv) accessibleRulesFGAC(rules []*ngmodels.AlertRule, hasAccess f
 // the user while checking against the provenance. If none is accessible, an
 // error will be returned.
 func (srv RulerSrv) accessibleRulesProvisioning(rules []*ngmodels.AlertRule, provenances map[string]ngmodels.Provenance, logger *log.ConcreteLogger) (map[string]struct{}, error) {
-	canDelete, cannotDelete := make(map[string]struct{}, 0), make([]string, 0)
+	canDelete, cannotDelete := make(map[string]struct{}), make([]string, 0)
 	for _, rule := range rules {
 		if provenance, exists := provenances[rule.UID]; (exists && provenance == ngmodels.ProvenanceNone) || !exists {
 			canDelete[rule.UID] = struct{}{}

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -392,7 +392,8 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 
 			svc := createService(ac, ruleStore, scheduler)
 
-			svc.provenanceStore.SetProvenance(context.Background(), rulesInFolder[0], orgID, models.ProvenanceAPI)
+			err := svc.provenanceStore.SetProvenance(context.Background(), rulesInFolder[0], orgID, models.ProvenanceAPI)
+			require.NoError(t, err)
 
 			request := createRequestContext(orgID, models2.ROLE_EDITOR, map[string]string{
 				":Namespace": folder.Title,
@@ -461,7 +462,8 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 				ac := acMock.New().WithPermissions(createPermissionsForRules(rulesInFolder))
 				svc := createService(ac, ruleStore, scheduler)
 
-				svc.provenanceStore.SetProvenance(context.Background(), rulesInFolder[0], orgID, models.ProvenanceAPI)
+				err := svc.provenanceStore.SetProvenance(context.Background(), rulesInFolder[0], orgID, models.ProvenanceAPI)
+				require.NoError(t, err)
 
 				request := createRequestContext(orgID, "None", map[string]string{
 					":Namespace": folder.Title,

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -376,6 +376,31 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 			require.Equalf(t, 202, response.Status(), "Expected 202 but got %d: %v", response.Status(), string(response.Body()))
 			assertRulesDeleted(t, rulesInFolderInGroup, ruleStore, scheduler)
 		})
+		t.Run("editor shouldn't be able to delete provisioned rules", func(t *testing.T) {
+			ruleStore := store.NewFakeRuleStore(t)
+			orgID := rand.Int63()
+			folder := randFolder()
+			ruleStore.Folders[orgID] = append(ruleStore.Folders[orgID], folder)
+			rulesInFolder := models.GenerateAlertRules(rand.Intn(4)+2, models.AlertRuleGen(withOrgID(orgID), withNamespace(folder)))
+			ruleStore.PutRule(context.Background(), rulesInFolder...)
+			ruleStore.PutRule(context.Background(), models.GenerateAlertRules(rand.Intn(4)+2, models.AlertRuleGen(withOrgID(orgID)))...)
+
+			scheduler := &schedule.FakeScheduleService{}
+			scheduler.On("DeleteAlertRule", mock.Anything)
+
+			ac := acMock.New().WithDisabled()
+
+			svc := createService(ac, ruleStore, scheduler)
+
+			svc.provenanceStore.SetProvenance(context.Background(), rulesInFolder[0], orgID, models.ProvenanceAPI)
+
+			request := createRequestContext(orgID, models2.ROLE_EDITOR, map[string]string{
+				":Namespace": folder.Title,
+			})
+			response := svc.RouteDeleteAlertRules(request)
+			require.Equalf(t, 202, response.Status(), "Expected 202 but got %d: %v", response.Status(), string(response.Body()))
+			assertRulesDeleted(t, rulesInFolder[1:], ruleStore, scheduler)
+		})
 	})
 	t.Run("when fine-grained access is enabled", func(t *testing.T) {
 		t.Run("and user does not have access to any of data sources used by alert rules", func(t *testing.T) {
@@ -420,6 +445,31 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 				response := createService(ac, ruleStore, scheduler).RouteDeleteAlertRules(request)
 				require.Equalf(t, 202, response.Status(), "Expected 202 but got %d: %v", response.Status(), string(response.Body()))
 				assertRulesDeleted(t, rulesInFolder, ruleStore, scheduler)
+			})
+			t.Run("souldn't be able to delte provisioned rules", func(t *testing.T) {
+				ruleStore := store.NewFakeRuleStore(t)
+				orgID := rand.Int63()
+				folder := randFolder()
+				ruleStore.Folders[orgID] = append(ruleStore.Folders[orgID], folder)
+				rulesInFolder := models.GenerateAlertRules(rand.Intn(4)+2, models.AlertRuleGen(withOrgID(orgID), withNamespace(folder)))
+				ruleStore.PutRule(context.Background(), rulesInFolder...)
+				ruleStore.PutRule(context.Background(), models.GenerateAlertRules(rand.Intn(4)+2, models.AlertRuleGen(withOrgID(orgID)))...)
+
+				scheduler := &schedule.FakeScheduleService{}
+				scheduler.On("DeleteAlertRule", mock.Anything)
+
+				ac := acMock.New().WithPermissions(createPermissionsForRules(rulesInFolder))
+				svc := createService(ac, ruleStore, scheduler)
+
+				svc.provenanceStore.SetProvenance(context.Background(), rulesInFolder[0], orgID, models.ProvenanceAPI)
+
+				request := createRequestContext(orgID, "None", map[string]string{
+					":Namespace": folder.Title,
+				})
+
+				response := svc.RouteDeleteAlertRules(request)
+				require.Equalf(t, 202, response.Status(), "Expected 202 but got %d: %v", response.Status(), string(response.Body()))
+				assertRulesDeleted(t, rulesInFolder[1:], ruleStore, scheduler)
 			})
 		})
 		t.Run("and user has access to data sources of some of alert rules", func(t *testing.T) {

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -447,7 +447,7 @@ func TestRouteDeleteAlertRules(t *testing.T) {
 				require.Equalf(t, 202, response.Status(), "Expected 202 but got %d: %v", response.Status(), string(response.Body()))
 				assertRulesDeleted(t, rulesInFolder, ruleStore, scheduler)
 			})
-			t.Run("souldn't be able to delte provisioned rules", func(t *testing.T) {
+			t.Run("shouldn't be able to delete provisioned rules", func(t *testing.T) {
 				ruleStore := store.NewFakeRuleStore(t)
 				orgID := rand.Int63()
 				folder := randFolder()


### PR DESCRIPTION
This PR introduces a check for provenance when updating or deleting alert rules. If there is a provenance set, the alert rule won't be modified or deleted.