### PR TITLE
Explore: simplify support for multiple query editors

### DIFF
--- a/docs/sources/developers/plugins/add-query-editor-help.md
+++ b/docs/sources/developers/plugins/add-query-editor-help.md
@@ -27,7 +27,6 @@ By adding a help component to your plugin, you can for example create "cheat she
    export const plugin = new DataSourcePlugin<DataSource, MyQuery, MyDataSourceOptions>(DataSource)
      .setConfigEditor(ConfigEditor)
      .setQueryEditor(QueryEditor)
-     .setExploreQueryField(ExploreQueryEditor)
      .setQueryEditorHelp(QueryEditorHelp);
    ```
 

--- a/docs/sources/developers/plugins/add-support-for-explore-queries.md
+++ b/docs/sources/developers/plugins/add-support-for-explore-queries.md
@@ -15,7 +15,7 @@ Your data source supports Explore by default and uses the existing query editor 
 
 ## Add an Explore-specific query editor
 
-If you want to extend Explore functionality for your data source, you can define an Explore-specific query editor.
+To extend Explore functionality for your data source, you can define an Explore-specific query editor.
 
 1. Create a file `ExploreQueryEditor.tsx` in the `src` directory of your plugin, with the following content:
 

--- a/docs/sources/developers/plugins/add-support-for-explore-queries.md
+++ b/docs/sources/developers/plugins/add-support-for-explore-queries.md
@@ -10,7 +10,8 @@ This guide assumes that you're already familiar with how to [Build a data source
 
 With Explore, users can make ad-hoc queries without the use of a dashboard. This is useful when users want to troubleshoot or to learn more about the data.
 
-Your data source already supports Explore by default, and will use the existing query editor for the data source.
+Your data source supports Explore by default and uses the existing query editor for the data source.
+
 
 ## Add an Explore-specific query editor
 
@@ -33,7 +34,7 @@ If you want to offer extended Explore functionality for your data source, you ca
    };
    ```
 
-1. Modify your base query editor in `QueryEditor.tsx` to render the Explore-specific one when using Explore. For example:
+1. Modify your base query editor in `QueryEditor.tsx` to render the Explore-specific query editor. For example:
 
    ```ts
    // [...]

--- a/docs/sources/developers/plugins/add-support-for-explore-queries.md
+++ b/docs/sources/developers/plugins/add-support-for-explore-queries.md
@@ -10,11 +10,11 @@ This guide assumes that you're already familiar with how to [Build a data source
 
 With Explore, users can make ad-hoc queries without the use of a dashboard. This is useful when users want to troubleshoot or to learn more about the data.
 
-Your data source already supports Explore by default, and will use the existing query editor for the data source. If you want to offer extended Explore functionality for your data source however, you can define a Explore-specific query editor.
+Your data source already supports Explore by default, and will use the existing query editor for the data source.
 
-## Add a query editor for Explore
+## Add an Explore-specific query editor
 
-The query editor for Explore is similar to the query editor for the data source itself. In fact, you'll probably reuse the same components for both query editors.
+If you want to offer extended Explore functionality for your data source, you can define an Explore-specific query editor.
 
 1. Create a file `ExploreQueryEditor.tsx` in the `src` directory of your plugin, with the following content:
 
@@ -26,60 +26,31 @@ The query editor for Explore is similar to the query editor for the data source 
    import { DataSource } from './DataSource';
    import { MyQuery, MyDataSourceOptions } from './types';
 
-   export type Props = QueryEditorProps<DataSource, MyQuery, MyDataSourceOptions>;
+   type Props = QueryEditorProps<DataSource, MyQuery, MyDataSourceOptions>;
 
    export default (props: Props) => {
-     return <h2>My query editor</h2>;
+     return <h2>My Explore-specific query editor</h2>;
    };
    ```
 
-1. Configure the plugin to use the `ExploreQueryEditor`.
+1. Modify your base query editor in `QueryEditor.tsx` to render the Explore-specific one when using Explore. For example:
 
    ```ts
+   // [...]
+   import { CoreApp } from '@grafana/data';
    import ExploreQueryEditor from './ExploreQueryEditor';
-   ```
 
-   ```ts
-   export const plugin = new DataSourcePlugin<DataSource, MyQuery, MyDataSourceOptions>(DataSource)
-     .setConfigEditor(ConfigEditor)
-     .setQueryEditor(QueryEditor)
-     .setExploreQueryField(ExploreQueryEditor);
-   ```
+   type Props = QueryEditorProps<DataSource, MyQuery, MyDataSourceOptions>;
 
-1. Add a `QueryField` to `ExploreQueryEditor`.
-
-   ```ts
-   import { QueryField } from '@grafana/ui';
-   ```
-
-   ```ts
    export default (props: Props) => {
-     const { query } = props;
+     const { app } = props;
 
-     const onQueryChange = (value: string, override?: boolean) => {
-       const { query, onChange, onRunQuery } = props;
-
-       if (onChange) {
-         // Update the query whenever the query field changes.
-         onChange({ ...query, queryText: value });
-
-         // Run the query on Enter.
-         if (override && onRunQuery) {
-           onRunQuery();
-         }
-       }
-     };
-
-     return (
-       <QueryField
-         portalOrigin="mock-origin"
-         onChange={onQueryChange}
-         onRunQuery={props.onRunQuery}
-         onBlur={props.onBlur}
-         query={query.queryText || ''}
-         placeholder="Enter a query"
-       />
-     );
+     switch (app) {
+       case CoreApp.Explore:
+         return <ExploreQueryEditor {...props} />;
+       default:
+         return <div>My base query editor</div>;
+     }
    };
    ```
 

--- a/docs/sources/developers/plugins/add-support-for-explore-queries.md
+++ b/docs/sources/developers/plugins/add-support-for-explore-queries.md
@@ -15,7 +15,7 @@ Your data source supports Explore by default and uses the existing query editor 
 
 ## Add an Explore-specific query editor
 
-If you want to offer extended Explore functionality for your data source, you can define an Explore-specific query editor.
+If you want to extend Explore functionality for your data source, you can define an Explore-specific query editor.
 
 1. Create a file `ExploreQueryEditor.tsx` in the `src` directory of your plugin, with the following content:
 

--- a/docs/sources/developers/plugins/add-support-for-explore-queries.md
+++ b/docs/sources/developers/plugins/add-support-for-explore-queries.md
@@ -12,7 +12,6 @@ With Explore, users can make ad-hoc queries without the use of a dashboard. This
 
 Your data source supports Explore by default and uses the existing query editor for the data source.
 
-
 ## Add an Explore-specific query editor
 
 To extend Explore functionality for your data source, you can define an Explore-specific query editor.

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -65,16 +65,19 @@ export class DataSourcePlugin<
     return this;
   }
 
+  /** @deprecated Use `setQueryEditor` instead. When using Explore `props.app` is equal to `CoreApp.Explore` */
   setExploreQueryField(ExploreQueryField: ComponentType<QueryEditorProps<DSType, TQuery, TOptions>>) {
     this.components.ExploreQueryField = ExploreQueryField;
     return this;
   }
 
+  /** @deprecated Use `setQueryEditor` instead. */
   setExploreMetricsQueryField(ExploreQueryField: ComponentType<QueryEditorProps<DSType, TQuery, TOptions>>) {
     this.components.ExploreMetricsQueryField = ExploreQueryField;
     return this;
   }
 
+  /** @deprecated Use `setQueryEditor` instead. */
   setExploreLogsQueryField(ExploreQueryField: ComponentType<QueryEditorProps<DSType, TQuery, TOptions>>) {
     this.components.ExploreLogsQueryField = ExploreQueryField;
     return this;
@@ -151,8 +154,11 @@ export interface DataSourcePluginComponents<
   AnnotationsQueryCtrl?: any;
   VariableQueryEditor?: any;
   QueryEditor?: ComponentType<QueryEditorProps<DSType, TQuery, TOptions>>;
+  /** @deprecated it will be removed in a future release and `QueryEditor` will be used instead. */
   ExploreQueryField?: ComponentType<QueryEditorProps<DSType, TQuery, TOptions>>;
+  /** @deprecated it will be removed in a future release and `QueryEditor` will be used instead. */
   ExploreMetricsQueryField?: ComponentType<QueryEditorProps<DSType, TQuery, TOptions>>;
+  /** @deprecated it will be removed in a future release and `QueryEditor` will be used instead. */
   ExploreLogsQueryField?: ComponentType<QueryEditorProps<DSType, TQuery, TOptions>>;
   QueryEditorHelp?: ComponentType<QueryEditorHelpProps<TQuery>>;
   ConfigEditor?: ComponentType<DataSourcePluginOptionsEditorProps<TOptions, TSecureOptions>>;

--- a/public/app/plugins/datasource/cloudwatch/module.tsx
+++ b/public/app/plugins/datasource/cloudwatch/module.tsx
@@ -2,7 +2,6 @@ import { DataSourcePlugin } from '@grafana/data';
 
 import { ConfigEditor } from './components/ConfigEditor';
 import LogsCheatSheet from './components/LogsCheatSheet';
-import { CloudWatchLogsQueryEditor } from './components/LogsQueryEditor';
 import { MetaInspector } from './components/MetaInspector';
 import { PanelQueryEditor } from './components/PanelQueryEditor';
 import { CloudWatchDatasource } from './datasource';
@@ -14,6 +13,4 @@ export const plugin = new DataSourcePlugin<CloudWatchDatasource, CloudWatchQuery
   .setQueryEditorHelp(LogsCheatSheet)
   .setConfigEditor(ConfigEditor)
   .setQueryEditor(PanelQueryEditor)
-  .setMetadataInspector(MetaInspector)
-  .setExploreMetricsQueryField(PanelQueryEditor)
-  .setExploreLogsQueryField(CloudWatchLogsQueryEditor);
+  .setMetadataInspector(MetaInspector);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Deprecates `setExplore*QueryField` plugins configuration options in favor of a unified API using only `setQueryEditor` and updates CloudWatch to remove usage of those deprecated settings.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #48175 

**Special notes for your reviewer**:
I didn't want the whole company for a review 🙏 

# Deprecation notice

`setExploreQueryField`, `setExploreMetricsQueryField` and `setExploreLogsQueryField` are now deprecated and will be removed in a future release. If you need to set a different query editor for Explore, conditionally render based on `props.app` in your regular query editor. Please refer to https://grafana.com/docs/grafana/latest/developers/plugins/add-support-for-explore-queries/ for more informations.
