### PR TITLE
Docs: Hide What’s new in Grafana alerting topic

### DIFF
--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Alerts"
 weight = 455
-aliases = ["/docs/grafana/latest/alerting/"]
+aliases = ["/docs/grafana/latest/alerting/", "/docs/grafana/latest/alerting/unified-alerting/difference-old-new/"]
 +++
 
 # Grafana alerts

--- a/docs/sources/alerting/difference-old-new.md
+++ b/docs/sources/alerting/difference-old-new.md
@@ -4,6 +4,7 @@ description = "What's New with Grafana alerts"
 keywords = ["grafana", "alerting", "guide"]
 aliases = ["/docs/grafana/latest/alerting/unified-alerting/difference-old-new/"]
 weight = 108
+draft = true
 +++
 
 # What's new in Grafana alerting


### PR DESCRIPTION
Based on a conversation with @gillesdemey.

Reason:
- Some information is not relevant anymore
- Relevant information was incorporated into other alerting topics