### PR TITLE
PanelEditor: Add spacing between variables

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -509,6 +509,7 @@ export const getStyles = stylesFactory((theme: GrafanaTheme2, props: Props) => {
       display: flex;
       flex-grow: 1;
       flex-wrap: wrap;
+      gap: ${theme.spacing(1, 2)};
     `,
     panelWrapper: css`
       flex: 1 1 0;


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a gap between variables when in the Panel Edit view, to match the Dashboard page

**Before**

![image](https://user-images.githubusercontent.com/46142/166709985-d7ffbb7b-30ba-45f8-a47a-aa5185d0e60c.png)


**After**

![1918_2022-05-04-15-59_chrome](https://user-images.githubusercontent.com/46142/166710046-b47f5ae2-60c9-45bf-894d-f44e6e8fb23e.png)

Relies on https://github.com/grafana/grafana/pull/48717