### PR TITLE
Navigation: Make the navigation toggle a clock

### DIFF
--- a/public/app/core/components/NavBar/Next/NavBarToggle.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarToggle.tsx
@@ -3,7 +3,7 @@ import classnames from 'classnames';
 import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { IconButton, useTheme2 } from '@grafana/ui';
+import { useTheme2 } from '@grafana/ui';
 
 export interface Props {
   className?: string;
@@ -15,26 +15,59 @@ export const NavBarToggle = ({ className, isExpanded, onClick }: Props) => {
   const theme = useTheme2();
   const styles = getStyles(theme);
 
+  const now = new Date();
+  const hour = now.getHours() % 12;
+  const minute = now.getMinutes();
+
+  const hourDegree = (hour / 12) * 360;
+  const minuteDegree = (minute / 60) * 360;
+
   return (
-    <IconButton
+    <div
       aria-label={isExpanded ? 'Close navigation menu' : 'Open navigation menu'}
-      name={isExpanded ? 'angle-left' : 'angle-right'}
       className={classnames(className, styles.icon)}
-      size="xl"
       onClick={onClick}
-    />
+    >
+      <div className={styles.hourHand} style={{ transform: `rotate(${hourDegree}deg)` }} />
+      <div className={styles.minuteHand} style={{ transform: `rotate(${minuteDegree}deg)` }} />
+    </div>
   );
 };
 
 NavBarToggle.displayName = 'NavBarToggle';
 
 const getStyles = (theme: GrafanaTheme2) => ({
+  hourHand: css({
+    width: 2,
+    height: 8,
+    display: 'inline-block',
+    background: '#000000ad',
+    position: 'absolute',
+    top: 'calc(50% - 8px)',
+    left: 'calc(50% - 1px)',
+    transformOrigin: 'bottom',
+  }),
+  minuteHand: css({
+    width: 2,
+    height: 5,
+    display: 'inline-block',
+    background: '#000000ad',
+    position: 'absolute',
+    top: 'calc(50% - 5px)',
+    left: 'calc(50% - 1px)',
+    transformOrigin: 'bottom',
+  }),
   icon: css({
+    width: 24,
+    height: 24,
     backgroundColor: theme.colors.background.secondary,
     border: `1px solid ${theme.colors.border.weak}`,
     borderRadius: '50%',
     marginRight: 0,
     zIndex: theme.zIndex.sidemenu + 1,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
 
     [theme.breakpoints.down('md')]: {
       display: 'none',


### PR DESCRIPTION
**What this PR does / why we need it**:

Ever been on a Grafana dashboard and wondered "What's the current time"? Well thankfully, the new navigation gives us a really neat opportunity to solve this. This PR turns the Open Nav button into a little clock so you can always see the current time right within Grafana!

![yMiLGF2cUq](https://user-images.githubusercontent.com/46142/166719512-7ffb024f-002d-44e3-a4f0-1c081749b906.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes every issue.

**Special notes for your reviewer**:

