### PR TITLE
Trace to logs: Only show Loki and Splunk data sources in settings

### DIFF
--- a/public/app/core/components/TraceToLogs/TraceToLogsSettings.tsx
+++ b/public/app/core/components/TraceToLogs/TraceToLogsSettings.tsx
@@ -47,7 +47,10 @@ export function TraceToLogsSettings({ options, onOptionsChange }: Props) {
         <InlineField tooltip="The data source the trace is going to navigate to" label="Data source" labelWidth={26}>
           <DataSourcePicker
             inputId="trace-to-logs-data-source-picker"
-            logs
+            filter={(ds) => {
+              // Trace to logs only supports loki and splunk at the moment
+              return ds.type === 'loki' || ds.type === 'grafana-splunk-datasource';
+            }}
             current={options.jsonData.tracesToLogs?.datasourceUid}
             noDefault={true}
             width={40}


### PR DESCRIPTION
**What this PR does / why we need it**:
The logs filter on the data source picker displays all logs data sources, but trace to logs only supports Loki and Splunk. This update fixes that behavior. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #48722

**Special notes for your reviewer**:

