### PR TITLE
Chore: Add PR Check action enforcing changelog decision

### DIFF
--- a/.github/pr-checks.json
+++ b/.github/pr-checks.json
@@ -7,12 +7,43 @@
     "failure": "Milestone not set"
   },
   {
-    "type": "check-backport",
+    "type": "check-label",
     "title": "Backport Check",
-    "backportEnabled": "Backport enabled",
-    "backportSkipped": "Backport skipped",
-    "failure": "Backport decision needed",
-    "targetUrl": "https://github.com/grafana/grafana/blob/main/contribute/merge-pull-request.md#should-the-pull-request-be-backported",
-    "skipLabels": [ "backport", "no-backport"]
+    "labels": {
+      "exists": "Backport enabled",
+      "notExists": "Backport decision needed",
+      "matches": [
+        "backport v*"
+      ]
+    },
+    "skip": {
+      "message": "Backport skipped",
+      "matches": [
+        "backport",
+        "no-backport"
+      ]
+    },
+    "targetUrl": "https://github.com/grafana/grafana/blob/main/contribute/merge-pull-request.md#should-the-pull-request-be-backported"
+  },
+  {
+    "type": "check-changelog",
+    "title": "Changelog Check",
+    "labels": {
+      "exists": "Changelog enabled",
+      "notExists": "Changelog decision needed",
+      "matches": [
+        "add to changelog"
+      ]
+    },
+    "breakingChangeLabels": [
+      "breaking change"
+    ],
+    "skip": {
+      "message": "Changelog skipped",
+      "matches": [
+        "no-changelog"
+      ]
+    },
+    "targetUrl": "https://github.com/grafana/grafana/blob/main/contribute/merge-pull-request.md#include-in-changelog-and-release-notes"
   }
 ]

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,9 +5,10 @@ on:
       - opened
       - reopened
       - synchronize
-      - ready_for_review      
+      - ready_for_review
       - labeled
       - unlabeled
+      - edited
   issues:
     types:
       - milestoned

--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -43,11 +43,31 @@ This makes it easier to track what changes go into a certain release. Without th
 
 At Grafana we generate the [changelog](https://github.com/grafana/grafana/blob/main/CHANGELOG.md) and [release notes](https://grafana.com/docs/grafana/latest/release-notes/) based on merged pull requests. Including changes in the changelog/release notes is very important to provide a somewhat complete picture of what changes a Grafana release actually includes.
 
-Exactly what changes should be added to the changelog is hard to answer but some general guidance would be any change that you think would be interesting for the community as a whole. Use your best judgement and/or ask other maintainers for advice.
-
 There's a GitHub action available in the repository named [Update changelog](https://github.com/grafana/grafana/blob/main/.github/workflows/update-changelog.yml) that can manually be triggered to re-generate the changelog and release notes for any release.
 
-To include a pull request in the changelog/release notes the general rule of thumb is that a milestone should be assigned and labeled with `add to changelog`.
+Exactly what changes should be added to the changelog is hard to answer but here's some general guidance:
+
+- Include any bug fix in general.
+- Include any change that you think would be interesting for the community as a whole.
+- Skip larger features divided in multiple pull requests since they might go into the release blog post/What's New article.
+- Use your best judgement and/or ask other maintainers for advice.
+- Including a change in error rather than skipping one that should have been there is better.
+- Always keep [Format the pull request title](#format-the-pull-request-title) in mind.
+
+An active decision to include change in changelog/release notes needs to be taken for every pull request. There's a pull request check named **Changelog Check** that will enforce this. By adding/removing labels on the pull request or updating the pull request title/description the check will be re-evaluated.
+
+#### Skip changelog
+
+If you don't want to include your change in changelog/release notes you need to add a label named **no-changelog** to the pull request.
+
+#### Include in changelog/release notes
+
+To include a pull request in the changelog/release notes you need to add a label named `add to changelog` to the pull request. Then additional validation rules is checked:
+
+- Title need to be formatted according to [Format the pull request title](#format-the-pull-request-title)
+- Description needs to include a breaking change notice if change is labeled to be a breaking change, see Breaking changes below for more information.
+
+Not complying with above rules can make the **Changelog Check** fail with validation errors.
 
 The changelog/release notes are divided into sections and here's a description of how you make a pull request show up in a certain section.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a PR check action enforcing changelog decision. In addition:
- Changes the backport-check to a label-check
- Update of the Merge a pull request guideline
- Added a `no-changelog` label to the respository

**Which issue(s) this PR fixes**:
Ref https://github.com/grafana/grafana-github-actions/pull/92
Closes https://github.com/grafana/grafana-release/issues/146

**Special notes for your reviewer**:

