### PR TITLE
QueryEditor: Set data source type in mixed query data source ref

### DIFF
--- a/public/app/features/query/components/QueryEditorRows.tsx
+++ b/public/app/features/query/components/QueryEditorRows.tsx
@@ -5,6 +5,7 @@ import {
   CoreApp,
   DataQuery,
   DataSourceInstanceSettings,
+  DataSourceRef,
   EventBusExtended,
   HistoryItem,
   PanelData,
@@ -60,13 +61,18 @@ export class QueryEditorRows extends PureComponent<Props> {
           return item;
         }
 
+        const dataSourceRef: DataSourceRef = {
+          type: dataSource.type,
+          uid: dataSource.uid,
+        };
+
         if (item.datasource) {
           const previous = getDataSourceSrv().getInstanceSettings(item.datasource);
 
           if (previous?.type === dataSource.type) {
             return {
               ...item,
-              datasource: { uid: dataSource.uid },
+              datasource: dataSourceRef,
             };
           }
         }
@@ -74,7 +80,7 @@ export class QueryEditorRows extends PureComponent<Props> {
         return {
           refId: item.refId,
           hide: item.hide,
-          datasource: { uid: dataSource.uid },
+          datasource: dataSourceRef,
         };
       })
     );


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes sure we set the data source _type_ for mixed data source queries. I think this is good housekeeping, but it also makes a feature I might look into later (importing dashboards that haven't explicitly been exported for sharing externally) easier.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

DataSourceRef is defined as 

```ts
export interface DataSourceRef {
  /** The plugin type-id */
  type?: string;

  /** Specific datasource instance */
  uid?: string;
}
```

On its face this seems way too lax (what data source would an empty object reference?), but I'm sure there's plenty of scenarios where this happens in practice....
