### PR TITLE
CommandPalette: Make dashboard nav work when under grafana is under sub path

### DIFF
--- a/public/app/features/commandPalette/actions/dashboard.nav.actions.ts
+++ b/public/app/features/commandPalette/actions/dashboard.nav.actions.ts
@@ -1,5 +1,6 @@
 import { Action } from 'kbar';
 
+import { locationUtil } from '@grafana/data';
 import { locationService, getBackendSrv } from '@grafana/runtime';
 
 async function getDashboardNav(parentId: string): Promise<Action[]> {
@@ -12,7 +13,7 @@ async function getDashboardNav(parentId: string): Promise<Action[]> {
       id: `go/dashboard/${item.url}`,
       name: `Go to dashboard ${item.title}`,
       perform: () => {
-        locationService.push(item.url);
+        locationService.push(locationUtil.stripBaseFromUrl(item.url));
       },
     }));
 


### PR DESCRIPTION
Fixes so command palette dashboard nav is working when grafana is under a subpath

Fixes #48707 