### PR TITLE
Tooltip: Fix links not legible in Tooltips when using light theme

### DIFF
--- a/packages/grafana-data/src/themes/createComponents.ts
+++ b/packages/grafana-data/src/themes/createComponents.ts
@@ -75,8 +75,8 @@ export function createComponents(colors: ThemeColors, shadows: ThemeShadows): Th
       background: input.background,
     },
     tooltip: {
-      background: colors.mode === 'light' ? '#555' : '#35383e',
-      text: colors.mode === 'light' ? '#FFF' : colors.text.primary,
+      background: colors.background.secondary,
+      text: colors.text.primary,
     },
     dashboard: {
       background: colors.background.canvas,

--- a/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
@@ -188,6 +188,9 @@ function getStyles(theme: GrafanaTheme2) {
 
       a {
         color: ${theme.colors.text.link};
+      }
+
+      a:hover {
         text-decoration: underline;
       }
     `;

--- a/public/sass/_variables.dark.generated.scss
+++ b/public/sass/_variables.dark.generated.scss
@@ -291,9 +291,9 @@ $tooltipLinkColor: $link-color;
 $tooltipExternalLinkColor: $external-link-color;
 $graph-tooltip-bg: $dark-1;
 
-$tooltipBackground: #35383e;
+$tooltipBackground: #22252b;
 $tooltipColor: rgb(204, 204, 220);
-$tooltipArrowColor: #35383e;
+$tooltipArrowColor: #22252b;
 $tooltipBackgroundError: #D10E5C;
 $tooltipShadow: 0px 4px 8px rgba(24, 26, 27, 0.75);
 

--- a/public/sass/_variables.light.generated.scss
+++ b/public/sass/_variables.light.generated.scss
@@ -282,9 +282,9 @@ $alert-warning-bg: #FAD34A;
 $alert-info-bg: #FAD34A;
 
 // Tooltips and popovers
-$tooltipBackground: #555;
-$tooltipColor: #FFF;
-$tooltipArrowColor: #555;
+$tooltipBackground: #F4F5F5;
+$tooltipColor: rgba(36, 41, 46, 1);
+$tooltipArrowColor: #F4F5F5;
 $tooltipBackgroundError: #E0226E;
 $tooltipShadow: 0px 4px 8px rgba(24, 26, 27, 0.2);
 

--- a/public/sass/components/_panel_header.scss
+++ b/public/sass/components/_panel_header.scss
@@ -161,14 +161,6 @@ $panel-header-no-title-zindex: 1;
 }
 
 .panel-info-content {
-  a {
-    color: $gray-6;
-
-    &:hover {
-      color: darken($white, 10%);
-    }
-  }
-
   code {
     white-space: normal;
     word-wrap: break-word;


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes the tooltip to use the `background.secondary` color to  make links legible and match the visualisation tooltips.

I also removed the old .scss styles that was affecting the tooltip and gave links a hover effect within Tooltip.

I'm not totally convinced this is the right approach (changing tooltips to light in Light theme, or this particular color), but thought I would propose in PR and we can iterate from there.

Light theme:  
![1936_2022-05-05-10-47_chrome](https://user-images.githubusercontent.com/46142/166900640-ea36534e-fe55-404e-88d4-a7154e38d54c.png)

Dark theme:  
![1935_2022-05-05-10-45_NVIDIA_Share](https://user-images.githubusercontent.com/46142/166900657-39b4ec60-534a-4994-b295-d889fe2807fc.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #48692

**Special notes for your reviewer**:

I'm unsure whether to backport this or not? It fixes a bug, but changing tooltip colors seems a smidge bigger than we usually put in backports?