### PR TITLE
IconButton: IconButtons are now correctly aligned in Safari

### DIFF
--- a/packages/grafana-ui/src/components/Icon/Icon.tsx
+++ b/packages/grafana-ui/src/components/Icon/Icon.tsx
@@ -23,11 +23,11 @@ const getIconStyles = stylesFactory((theme: GrafanaTheme) => {
     container: css`
       label: Icon;
       display: inline-block;
+      line-height: 0;
     `,
     icon: css`
       vertical-align: middle;
       display: inline-block;
-      margin-bottom: ${theme.spacing.xxs};
       fill: currentColor;
     `,
     orange: css`

--- a/packages/grafana-ui/src/components/Icon/Icon.tsx
+++ b/packages/grafana-ui/src/components/Icon/Icon.tsx
@@ -20,6 +20,7 @@ export interface IconProps extends React.HTMLAttributes<HTMLDivElement> {
 
 const getIconStyles = stylesFactory((theme: GrafanaTheme) => {
   return {
+    // line-height: 0; is needed for correct icon alignment in Safari
     container: css`
       label: Icon;
       display: inline-block;

--- a/packages/grafana-ui/src/components/IconButton/IconButton.tsx
+++ b/packages/grafana-ui/src/components/IconButton/IconButton.tsx
@@ -154,7 +154,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme2, size: IconSize, variant: 
       }
     `,
     icon: css`
-      margin-bottom: 0;
       vertical-align: baseline;
       display: flex;
     `,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- our icons are `inline-block` at the moment. on safari this causes them to be misaligned as i think they're reserving space for the text content. by setting the `line-height` to 0 this makes the positioning consistent across the browsers
- for some reason our icons have a random `margin-bottom: 2px` which also causes some layout issues
  - can't centre icons properly when they're 2px higher than they should be

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/20999846/166924111-308557e9-fae2-4714-9fc2-47cbc84602ba.png)  | ![image](https://user-images.githubusercontent.com/20999846/166924027-d0e1ec8b-a50e-47ac-afdd-48f06b7d5e98.png) |

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #48499 

**Special notes for your reviewer**:

i've done a quick sniff test but it's obviously very hard to check every place that has icons 😱 