### PR TITLE
FileUpload: clicking the `Upload file` button now opens the modal correctly

### DIFF
--- a/packages/grafana-ui/src/components/FileUpload/FileUpload.test.tsx
+++ b/packages/grafana-ui/src/components/FileUpload/FileUpload.test.tsx
@@ -1,4 +1,5 @@
 import { render, waitFor, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
@@ -10,6 +11,19 @@ describe('FileUpload', () => {
     render(<FileUpload onFileUpload={() => {}} />);
     expect(screen.getByRole('button', { name: 'Upload file' })).toBeInTheDocument();
     expect(screen.queryByLabelText('File name')).toBeNull();
+  });
+
+  it('clicking the button should trigger the input', async () => {
+    const mockInputOnClick = jest.fn();
+    const { getByTestId } = render(<FileUpload onFileUpload={() => {}} />);
+    const button = screen.getByRole('button', { name: 'Upload file' });
+    const input = getByTestId(selectors.components.FileUpload.inputField);
+
+    // attach a click listener to the input
+    input.onclick = mockInputOnClick;
+
+    await userEvent.click(button);
+    expect(mockInputOnClick).toHaveBeenCalled();
   });
 
   it('should display uploaded file name', async () => {

--- a/packages/grafana-ui/src/components/FileUpload/FileUpload.test.tsx
+++ b/packages/grafana-ui/src/components/FileUpload/FileUpload.test.tsx
@@ -8,7 +8,7 @@ import { FileUpload } from './FileUpload';
 describe('FileUpload', () => {
   it('should render upload button with default text and no file name', () => {
     render(<FileUpload onFileUpload={() => {}} />);
-    expect(screen.getByText('Upload file')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Upload file' })).toBeInTheDocument();
     expect(screen.queryByLabelText('File name')).toBeNull();
   });
 

--- a/packages/grafana-ui/src/components/FileUpload/FileUpload.tsx
+++ b/packages/grafana-ui/src/components/FileUpload/FileUpload.tsx
@@ -1,5 +1,6 @@
 import { css, cx } from '@emotion/css';
 import React, { FC, FormEvent, useCallback, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -31,6 +32,7 @@ export const FileUpload: FC<Props> = ({
 }) => {
   const style = useStyles2(getStyles(size));
   const [fileName, setFileName] = useState('');
+  const id = uuidv4();
 
   const onChange = useCallback(
     (event: FormEvent<HTMLInputElement>) => {
@@ -47,14 +49,14 @@ export const FileUpload: FC<Props> = ({
     <>
       <input
         type="file"
-        id="fileUpload"
+        id={id}
         className={style.fileUpload}
         onChange={onChange}
         multiple={false}
         accept={accept}
         data-testid={selectors.components.FileUpload.inputField}
       />
-      <label htmlFor="fileUpload" className={cx(style.labelWrapper, className)}>
+      <label role="button" htmlFor={id} className={cx(style.labelWrapper, className)}>
         <Icon name="upload" className={style.icon} />
         {children}
       </label>

--- a/packages/grafana-ui/src/components/FileUpload/FileUpload.tsx
+++ b/packages/grafana-ui/src/components/FileUpload/FileUpload.tsx
@@ -54,7 +54,7 @@ export const FileUpload: FC<Props> = ({
         accept={accept}
         data-testid={selectors.components.FileUpload.inputField}
       />
-      <label className={cx(style.labelWrapper, className)}>
+      <label htmlFor="fileUpload" className={cx(style.labelWrapper, className)}>
         <Icon name="upload" className={style.icon} />
         {children}
       </label>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- `FileUpload` currently does nothing when clicked in main
- this was broken in https://github.com/grafana/grafana/pull/47497
- associates the label with the input so that clicking the label triggers the input correctly

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Follow on from https://github.com/grafana/grafana/pull/47497

**Special notes for your reviewer**:

