### PR TITLE
Cloudwatch: Set time zone offset in GMD request

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch_query.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_query.go
@@ -9,23 +9,24 @@ import (
 )
 
 type cloudWatchQuery struct {
-	RefId            string
-	Region           string
-	Id               string
-	Namespace        string
-	MetricName       string
-	Statistic        string
-	Expression       string
-	SqlExpression    string
-	ReturnData       bool
-	Dimensions       map[string][]string
-	Period           int
-	Alias            string
-	Label            string
-	MatchExact       bool
-	UsedExpression   string
-	MetricQueryType  metricQueryType
-	MetricEditorMode metricEditorMode
+	RefId             string
+	Region            string
+	Id                string
+	Namespace         string
+	MetricName        string
+	Statistic         string
+	Expression        string
+	SqlExpression     string
+	ReturnData        bool
+	Dimensions        map[string][]string
+	Period            int
+	Alias             string
+	Label             string
+	MatchExact        bool
+	UsedExpression    string
+	TimezoneUTCOffset string
+	MetricQueryType   metricQueryType
+	MetricEditorMode  metricEditorMode
 }
 
 func (q *cloudWatchQuery) getGMDAPIMode() gmdApiMode {

--- a/pkg/tsdb/cloudwatch/metric_data_input_builder_test.go
+++ b/pkg/tsdb/cloudwatch/metric_data_input_builder_test.go
@@ -1,0 +1,44 @@
+package cloudwatch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricDataInputBuilder(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name                 string
+		timezoneUTCOffset    string
+		expectedLabelOptions *cloudwatch.LabelOptions
+		featureEnabled       bool
+	}{
+		{name: "when timezoneUTCOffset is provided and feature is enabled", timezoneUTCOffset: "+1234", expectedLabelOptions: &cloudwatch.LabelOptions{Timezone: aws.String("+1234")}, featureEnabled: true},
+		{name: "when timezoneUTCOffset is not provided and feature is enabled", timezoneUTCOffset: "", expectedLabelOptions: nil, featureEnabled: true},
+		{name: "when timezoneUTCOffset is provided and feature is disabled", timezoneUTCOffset: "+1234", expectedLabelOptions: nil, featureEnabled: false},
+		{name: "when timezoneUTCOffset is not provided and feature is disabled", timezoneUTCOffset: "", expectedLabelOptions: nil, featureEnabled: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			executor := newExecutor(nil, newTestConfig(), &fakeSessionCache{}, featuremgmt.WithFeatures(featuremgmt.FlagCloudWatchDynamicLabels, tc.featureEnabled))
+			query := getBaseQuery()
+			query.TimezoneUTCOffset = tc.timezoneUTCOffset
+
+			from := now.Add(time.Hour * -2)
+			to := now.Add(time.Hour * -1)
+			mdi, err := executor.buildMetricDataInput(from, to, []*cloudWatchQuery{query})
+
+			assert.NoError(t, err)
+			require.NotNil(t, mdi)
+			assert.Equal(t, tc.expectedLabelOptions, mdi.LabelOptions)
+		})
+	}
+}

--- a/pkg/tsdb/cloudwatch/request_parser.go
+++ b/pkg/tsdb/cloudwatch/request_parser.go
@@ -201,6 +201,8 @@ func parseRequestQuery(model *simplejson.Json, refId string, startTime time.Time
 	label := model.Get("label").MustString()
 	returnData := !model.Get("hide").MustBool(false)
 	queryType := model.Get("type").MustString()
+	timezoneUTCOffset := model.Get("timezoneUTCOffset").MustString("")
+
 	if queryType == "" {
 		// If no type is provided we assume we are called by alerting service, which requires to return data!
 		// Note, this is sort of a hack, but the official Grafana interfaces do not carry the information
@@ -221,23 +223,24 @@ func parseRequestQuery(model *simplejson.Json, refId string, startTime time.Time
 	}
 
 	return &cloudWatchQuery{
-		RefId:            refId,
-		Region:           region,
-		Id:               id,
-		Namespace:        namespace,
-		MetricName:       metricName,
-		Statistic:        statistic,
-		Expression:       expression,
-		ReturnData:       returnData,
-		Dimensions:       dimensions,
-		Period:           period,
-		Alias:            alias,
-		Label:            label,
-		MatchExact:       matchExact,
-		UsedExpression:   "",
-		MetricQueryType:  metricQueryType,
-		MetricEditorMode: metricEditorModeValue,
-		SqlExpression:    sqlExpression,
+		RefId:             refId,
+		Region:            region,
+		Id:                id,
+		Namespace:         namespace,
+		MetricName:        metricName,
+		Statistic:         statistic,
+		Expression:        expression,
+		ReturnData:        returnData,
+		Dimensions:        dimensions,
+		Period:            period,
+		Alias:             alias,
+		Label:             label,
+		MatchExact:        matchExact,
+		UsedExpression:    "",
+		MetricQueryType:   metricQueryType,
+		MetricEditorMode:  metricEditorModeValue,
+		SqlExpression:     sqlExpression,
+		TimezoneUTCOffset: timezoneUTCOffset,
 	}, nil
 }
 

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -19,7 +19,6 @@ import {
   rangeUtil,
   ScopedVars,
   TimeRange,
-  timeZoneAbbrevation,
 } from '@grafana/data';
 import { DataSourceWithBackend, FetchError, getBackendSrv, toDataQueryResponse } from '@grafana/runtime';
 import { RowContextOptions } from '@grafana/ui/src/components/Logs/LogRowContextProvider';

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -12,24 +12,25 @@ import {
   DataSourceInstanceSettings,
   DataSourceWithLogsContextSupport,
   dateMath,
+  dateTimeFormat,
   FieldType,
   LoadingState,
   LogRowModel,
   rangeUtil,
   ScopedVars,
   TimeRange,
+  timeZoneAbbrevation,
 } from '@grafana/data';
 import { DataSourceWithBackend, FetchError, getBackendSrv, toDataQueryResponse } from '@grafana/runtime';
 import { RowContextOptions } from '@grafana/ui/src/components/Logs/LogRowContextProvider';
 import { notifyApp } from 'app/core/actions';
+import { config } from 'app/core/config';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { getTimeSrv, TimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_srv';
 import { VariableWithMultiSupport } from 'app/features/variables/types';
 import { store } from 'app/store/store';
 import { AppNotificationTimeout } from 'app/types';
-
-import config from '../../../core/config';
 
 import { CloudWatchAnnotationSupport } from './annotationSupport';
 import { SQLCompletionItemProvider } from './cloudwatch-sql/completion/CompletionItemProvider';
@@ -290,11 +291,17 @@ export class CloudWatchDatasource
     metricQueries: CloudWatchMetricsQuery[],
     options: DataQueryRequest<CloudWatchQuery>
   ): Observable<DataQueryResponse> => {
+    const timezoneUTCOffset = dateTimeFormat(Date.now(), {
+      timeZone: options.timezone,
+      format: 'Z',
+    }).replace(':', '');
+
     const validMetricsQueries = metricQueries.filter(this.filterQuery).map((q: CloudWatchMetricsQuery): MetricQuery => {
       const migratedQuery = migrateMetricQuery(q);
       const migratedAndIterpolatedQuery = this.replaceMetricQueryVars(migratedQuery, options);
 
       return {
+        timezoneUTCOffset,
         intervalMs: options.intervalMs,
         maxDataPoints: options.maxDataPoints,
         ...migratedAndIterpolatedQuery,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR sets the time zone UTC offset in the GMD API request. The Timezone value affects a metric response label only if you have a time-based dynamic expression in the label, for example `${MIN_TIME_RELATIVE}`. The timezone offset if calculated based on the time zone that was specified in the dashboard's [time range picker](https://grafana.com/docs/grafana/latest/dashboards/time-range-controls/#dashboard-time-settings).

This is currently hidden behind a feature flag, but will be enabled by default in 9.0.0. 

**Which issue(s) this PR fixes**:

Fixes #48797
Part of https://github.com/grafana/grafana/issues/48434

**Special notes for your reviewer**:

