### PR TITLE
Logs: simpler nanoscecond timestamp handling

### DIFF
--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -364,9 +364,7 @@ export function logSeriesToLogsModel(logSeries: DataFrame[]): LogsModel | undefi
           series,
           timeField,
           labelsField,
-          timeNanosecondField: fieldCache.hasFieldWithNameAndType('tsNs', FieldType.time)
-            ? fieldCache.getFieldByName('tsNs')
-            : undefined,
+          timeNanosecondField: fieldCache.getFieldByName('tsNs'),
           stringField,
           logLevelField: fieldCache.getFieldByName('level'),
           idField: getIdField(fieldCache),

--- a/public/app/plugins/datasource/loki/backendResultTransformer.test.ts
+++ b/public/app/plugins/datasource/loki/backendResultTransformer.test.ts
@@ -62,7 +62,6 @@ describe('loki backendResultTransformer', () => {
         lokiQueryStatKey: 'Summary: total bytes processed',
       },
     };
-    expectedFrame.fields[3].type = FieldType.time;
 
     const expected: DataQueryResponse = { data: [expectedFrame] };
 

--- a/public/app/plugins/datasource/loki/backendResultTransformer.ts
+++ b/public/app/plugins/datasource/loki/backendResultTransformer.ts
@@ -28,28 +28,8 @@ function processStreamFrame(frame: DataFrame, query: LokiQuery | undefined): Dat
       lokiQueryStatKey: 'Summary: total bytes processed',
     },
   };
-  const newFrame = setFrameMeta(frame, meta);
 
-  const newFields = newFrame.fields.map((field) => {
-    switch (field.name) {
-      case 'tsNs': {
-        // we need to switch the field-type to be `time`
-        return {
-          ...field,
-          type: FieldType.time,
-        };
-      }
-      default: {
-        // no modification needed
-        return field;
-      }
-    }
-  });
-
-  return {
-    ...newFrame,
-    fields: newFields,
-  };
+  return setFrameMeta(frame, meta);
 }
 
 function processStreamsFrames(frames: DataFrame[], queryMap: Map<string, LokiQuery>): DataFrame[] {


### PR DESCRIPTION
when we handle logs-data, the datasource can give us nanosecond-precision timestamp. it does it by sending the timestamps as strings, in a field named "tsNs", but, it has to mark the field as having `type=time`. this has a couple problems:
1. it is not really a time-field, so if you load such data into a table-visualization, all the values will show up as `NaN` (not a number).
2. when a backend-datasource generates such fields in the go-code, there is no way to have it be strings, but marked as `time`, so you have to send them from the server to the browser as `type=string`, and then in the javascript code switch it to `type=time`. this complicates code.

with this pull-request, we just find the field based on the name, we do not require it to be `type=time`. this simplifies the code.

how to test:
1. run a loki datasource
2. we need to be sure the timestamp-field is still found, the only way to do it is to debug the javascript code:
    - open the browser dev-console, put a breakpoint at this line: https://github.com/grafana/grafana/blob/gabor/loki-simpler-nanosecond/public/app/core/logs_model.ts#L396
    - run a Loki query in explore
    - when the breakpoint is hit, check the value of the variable `tsNs`. it should not be `undefined`.
3. please do the check in [2] with both the `lokiBackendMode` feature flag enabled and disabled