### PR TITLE
Alerting: automatically select last expression

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/ConditionField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/ConditionField.tsx
@@ -39,7 +39,7 @@ export const ConditionField: FC = () => {
     if (lastExpression) {
       setValue('condition', lastExpression.refId, { shouldValidate: true });
     }
-  }, [expressions, queries, setValue]);
+  }, [expressions, setValue]);
 
   // reset condition if option no longer exists or if it is unset, but there are options available
   useEffect(() => {
@@ -51,7 +51,7 @@ export const ConditionField: FC = () => {
     } else if (!condition && lastExpression) {
       setValue('condition', lastExpression.refId, { shouldValidate: true });
     }
-  }, [condition, expressions, options, queries, setValue]);
+  }, [condition, expressions, options, setValue]);
 
   return (
     <Field

--- a/public/app/features/alerting/unified/components/rule-editor/ConditionField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/ConditionField.tsx
@@ -29,9 +29,20 @@ export const ConditionField: FC = () => {
     [queries]
   );
 
+  const expressions = useMemo(() => {
+    return queries.filter((query) => query.datasourceUid === ExpressionDatasourceUID);
+  }, [queries]);
+
+  // automatically use the last expression when new expressions have been added
+  useEffect(() => {
+    const lastExpression = last(expressions);
+    if (lastExpression) {
+      setValue('condition', lastExpression.refId, { shouldValidate: true });
+    }
+  }, [expressions, queries, setValue]);
+
   // reset condition if option no longer exists or if it is unset, but there are options available
   useEffect(() => {
-    const expressions = queries.filter((query) => query.datasourceUid === ExpressionDatasourceUID);
     const lastExpression = last(expressions);
     const conditionExists = options.find(({ value }) => value === condition);
 
@@ -40,7 +51,7 @@ export const ConditionField: FC = () => {
     } else if (!condition && lastExpression) {
       setValue('condition', lastExpression.refId, { shouldValidate: true });
     }
-  }, [condition, options, queries, setValue]);
+  }, [condition, expressions, options, queries, setValue]);
 
   return (
     <Field


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR will make sure the last expression is used when adding additional expressions in to the pipeline. This prevents confusion about alert creation and previewing because it would – before the introduction of this PR – always use expression `B`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

