### PR TITLE
Add new features to DiffReport and Diff

### DIFF
--- a/pkg/util/cmputil/reporter.go
+++ b/pkg/util/cmputil/reporter.go
@@ -98,4 +98,23 @@ func describeReflectValue(v reflect.Value) interface{} {
 	}
 	return v
 }
+
+// IsAddOperation returns true when
+//  - Left does not have value and Right has
+//  - the kind of Left and Right is either reflect.Slice or reflect.Map and the length of Left is less than length of Right
+// In all other cases it returns false.
+// NOTE: this is applicable to diff of Maps and Slices only
+func (d *Diff) IsAddOperation() bool {
+	return !d.Left.IsValid() && d.Right.IsValid() || (d.Left.Kind() == d.Right.Kind() && // cmp reports adding first element to a nil slice as creation of one and therefore Left is valid and it is nil and right is a new slice
+		(d.Left.Kind() == reflect.Slice || d.Left.Kind() == reflect.Map) && d.Left.Len() < d.Right.Len())
+}
+
+// IsDeleteOperation returns true when
+//  - Right does not have value and Left has
+//  - the kind of Left and Right is either reflect.Slice or reflect.Map and the length of Right is less than length of Left
+// In all other cases it returns false.
+// NOTE: this is applicable to diff of Maps and Slices only
+func (d *Diff) IsDeleteOperation() bool {
+	return d.Left.IsValid() && !d.Right.IsValid() || (d.Left.Kind() == d.Right.Kind() &&
+		(d.Left.Kind() == reflect.Slice || d.Left.Kind() == reflect.Map) && d.Left.Len() > d.Right.Len())
 }

--- a/pkg/util/cmputil/reporter.go
+++ b/pkg/util/cmputil/reporter.go
@@ -78,6 +78,15 @@ func (r DiffReport) String() string {
 	return b.String()
 }
 
+// Paths returns the slice of paths of the current DiffReport
+func (r DiffReport) Paths() []string {
+	var result = make([]string, len(r))
+	for _, diff := range r {
+		result = append(result, diff.Path)
+	}
+	return result
+}
+
 type Diff struct {
 	// Path to the field that has difference separated by period. Array index and key are designated by square brackets.
 	// For example, Annotations[12345].Data.Fields[0].ID

--- a/pkg/util/cmputil/reporter.go
+++ b/pkg/util/cmputil/reporter.go
@@ -87,15 +87,15 @@ type Diff struct {
 }
 
 func (d *Diff) String() string {
-	left := d.Left.String()
+	return fmt.Sprintf("%v:\n\t-: %+v\n\t+: %+v\n", d.Path, describeReflectValue(d.Left), describeReflectValue(d.Right))
+}
+
+func describeReflectValue(v reflect.Value) interface{} {
 	// invalid reflect.Value is produced when two collections (slices\maps) are compared and one misses value.
 	// This way go-cmp indicates that an element was added\removed from a list.
-	if !d.Left.IsValid() {
-		left = "<none>"
+	if !v.IsValid() {
+		return "<none>"
 	}
-	right := d.Right.String()
-	if !d.Right.IsValid() {
-		right = "<none>"
-	}
-	return fmt.Sprintf("%v:\n\t-: %+v\n\t+: %+v", d.Path, left, right)
+	return v
+}
 }

--- a/pkg/util/cmputil/reporter_test.go
+++ b/pkg/util/cmputil/reporter_test.go
@@ -34,8 +34,6 @@ func testStructDiff(left, right testStruct) DiffReport {
 	ops := make([]cmp.Option, 0, 4)
 	ops = append(ops, cmp.Reporter(&reporter))
 	cmp.Equal(left, right, ops...)
-	// TODO DO NOT COMMIT
-	println(reporter.Diffs.String())
 	return reporter.Diffs
 }
 

--- a/pkg/util/cmputil/reporter_test.go
+++ b/pkg/util/cmputil/reporter_test.go
@@ -1,0 +1,134 @@
+package cmputil
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ptr "github.com/xorcare/pointer"
+
+	"github.com/grafana/grafana/pkg/util"
+)
+
+type subStruct struct {
+	Data interface{}
+}
+
+type testStruct struct {
+	Number       float64
+	NumberPtr    *float64
+	Text         string
+	TextPtr      *string
+	Flag         bool
+	FlagPtr      *bool
+	Dict         map[float64]float64
+	Slice        []float64
+	SubStruct    subStruct
+	SubStructPtr *subStruct
+}
+
+func testStructDiff(left, right testStruct) DiffReport {
+	var reporter DiffReporter
+	ops := make([]cmp.Option, 0, 4)
+	ops = append(ops, cmp.Reporter(&reporter))
+	cmp.Equal(left, right, ops...)
+	// TODO DO NOT COMMIT
+	println(reporter.Diffs.String())
+	return reporter.Diffs
+}
+
+func TestIsAddedDeleted_Collections(t *testing.T) {
+	testCases := []struct {
+		name  string
+		left  testStruct
+		right testStruct
+		field string
+	}{
+		{
+			name: "nil vs non-empty slice",
+			left: testStruct{
+				Slice: nil,
+			},
+			right: testStruct{
+				Slice: []float64{rand.Float64()},
+			},
+			field: "Slice",
+		},
+		{
+			name: "empty vs non-empty slice",
+			left: testStruct{
+				Slice: []float64{},
+			},
+			right: testStruct{
+				Slice: []float64{rand.Float64()},
+			},
+			field: "Slice",
+		},
+		{
+			name: "nil vs non-empty map",
+			left: testStruct{
+				Dict: nil,
+			},
+			right: testStruct{
+				Dict: map[float64]float64{rand.Float64(): rand.Float64()},
+			},
+			field: "Slice",
+		},
+		{
+			name: "empty vs non-empty map",
+			left: testStruct{
+				Dict: map[float64]float64{},
+			},
+			right: testStruct{
+				Dict: map[float64]float64{rand.Float64(): rand.Float64()},
+			},
+			field: "Slice",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			left := testCase.left
+			right := testCase.right
+			field := testCase.field
+			t.Run("IsAddOperation=true, IsDeleted=false", func(t *testing.T) {
+				diff := testStructDiff(left, right)
+				require.Lenf(t, diff, 1, "diff was expected to have only one field %s but got %v", field, diff.String())
+				d := diff[0]
+				require.Truef(t, d.IsAddOperation(), "diff %v should be treated as Add operation but it wasn't", d)
+				require.Falsef(t, d.IsDeleteOperation(), "diff %v should not be treated as Delete operation but it was", d)
+			})
+			t.Run("IsDeleted=true, IsAddOperation=false", func(t *testing.T) {
+				diff := testStructDiff(right, left)
+				require.Lenf(t, diff, 1, "diff was expected to have only one field %s but got %v", field, diff.String())
+				d := diff[0]
+				require.Truef(t, d.IsDeleteOperation(), "diff %v should be treated as Delete operation but it wasn't", d)
+				require.Falsef(t, d.IsAddOperation(), "diff %v should not be treated as Delete operation but it was", d)
+			})
+		})
+	}
+
+	t.Run("IsAddOperation=false, IsDeleted=false if changes in struct fields", func(t *testing.T) {
+		left := testStruct{}
+		right := testStruct{
+			Number:    rand.Float64(),
+			NumberPtr: ptr.Float64(rand.Float64()),
+			Text:      util.GenerateShortUID(),
+			TextPtr:   ptr.String(util.GenerateShortUID()),
+			Flag:      true,
+			FlagPtr:   ptr.Bool(true),
+			SubStruct: subStruct{
+				Data: rand.Float64(),
+			},
+			SubStructPtr: &subStruct{Data: rand.Float64()},
+		}
+
+		diff := testStructDiff(left, right)
+		require.Len(t, diff, 8)
+		for _, d := range diff {
+			assert.Falsef(t, d.IsAddOperation(), "diff %v was not supposed to be Add operation", d.String())
+			assert.Falsef(t, d.IsDeleteOperation(), "diff %v was not supposed to be Delete operation", d.String())
+		}
+	})
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR adds some improvements to the cmputil.DiffReport 
- method `Paths` that returns all paths the report contains. This can be used in logging to omit the actual diff due to it's sensitive nature.

as well as cmputil.Diff:
- better String() implementation. The current implementation forcibly uses the String method of the reflect.Value. This is far from perfect because mostly it prints type instead of the actual value. This PR updates it to let formatter decide what representation should be.
- added `IsAddOperation` and `IsDeleteOperation` that simplifies detection of operation made on slices and maps. `cmp.Diff` reports the two following situations differently:
    1. Left = nil, Right = non-empty slice\map. The diff, in this case, looks like 
    ```
    	-: []
	+: [value]
    ```
    2. Left = empty, Right = non-empty.
    ```
	-: <invalid reflect.Value>
	+: value
    ```
    These methods provide a convenient way to detect both of these situations.
