### PR TITLE
Heatmap (new): exemplars tooltip stub

### DIFF
--- a/public/app/plugins/panel/heatmap-new/HeatmapHoverView.tsx
+++ b/public/app/plugins/panel/heatmap-new/HeatmapHoverView.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 
-import { Field, FieldType, formattedValueToString, getFieldDisplayName, LinkModel } from '@grafana/data';
+import { DataFrameView, Field, FieldType, formattedValueToString, getFieldDisplayName, LinkModel } from '@grafana/data';
 import { LinkButton, VerticalGroup } from '@grafana/ui';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 
@@ -62,7 +62,6 @@ export const HeatmapHoverView = ({ data, hover, showHistogram }: Props) => {
   const xBucketMax = xBucketMin + data.xBucketSize;
 
   const count = countVals?.[hover.index];
-  const exemplarIndex = data.exemplarsMappings?.lookup; //?.[hover.index];
 
   const visibleFields = data.heatmap?.fields.filter((f) => !Boolean(f.config.custom?.hideFrom?.tooltip));
   const links: Array<LinkModel<Field>> = [];
@@ -154,6 +153,30 @@ export const HeatmapHoverView = ({ data, hover, showHistogram }: Props) => {
     [hover.index]
   );
 
+  const renderExemplars = () => {
+    const exemplarIndex = data.exemplarsMappings?.lookup; //?.[hover.index];
+    if (!exemplarIndex || !data.exemplars) {
+      return null;
+    }
+
+    const ids = exemplarIndex[hover.index];
+    if (ids) {
+      const view = new DataFrameView(data.exemplars);
+      return (
+        <ul>
+          {ids.map((id) => (
+            <li key={id}>
+              <pre>{JSON.stringify(view.get(id), null, 2)}</pre>
+            </li>
+          ))}
+        </ul>
+      );
+    }
+
+    // should not show anything... but for debugging
+    return <div>EXEMPLARS: {JSON.stringify(exemplarIndex)}</div>;
+  };
+
   return (
     <>
       <div>
@@ -176,7 +199,7 @@ export const HeatmapHoverView = ({ data, hover, showHistogram }: Props) => {
           {getFieldDisplayName(countField!, data.heatmap)}: {count}
         </div>
       </div>
-      {exemplarIndex && <div>EXEMPLARS: {JSON.stringify(exemplarIndex)}</div>}
+      {renderExemplars()}
       {links.length > 0 && (
         <VerticalGroup>
           {links.map((link, i) => (

--- a/public/app/plugins/panel/heatmap-new/HeatmapHoverView.tsx
+++ b/public/app/plugins/panel/heatmap-new/HeatmapHoverView.tsx
@@ -62,6 +62,7 @@ export const HeatmapHoverView = ({ data, hover, showHistogram }: Props) => {
   const xBucketMax = xBucketMin + data.xBucketSize;
 
   const count = countVals?.[hover.index];
+  const exemplarIndex = data.exemplarsMappings?.lookup; //?.[hover.index];
 
   const visibleFields = data.heatmap?.fields.filter((f) => !Boolean(f.config.custom?.hideFrom?.tooltip));
   const links: Array<LinkModel<Field>> = [];
@@ -175,6 +176,7 @@ export const HeatmapHoverView = ({ data, hover, showHistogram }: Props) => {
           {getFieldDisplayName(countField!, data.heatmap)}: {count}
         </div>
       </div>
+      {exemplarIndex && <div>EXEMPLARS: {JSON.stringify(exemplarIndex)}</div>}
       {links.length > 0 && (
         <VerticalGroup>
           {links.map((link, i) => (

--- a/public/app/plugins/panel/heatmap-new/fields.test.ts
+++ b/public/app/plugins/panel/heatmap-new/fields.test.ts
@@ -1,6 +1,6 @@
 import { createTheme, ArrayVector, DataFrameType, FieldType } from '@grafana/data';
 
-import { BucketLayout, getAnnotationMapping, HEATMAP_NOT_SCANLINES_ERROR } from './fields';
+import { BucketLayout, getExemplarsMapping, HEATMAP_NOT_SCANLINES_ERROR } from './fields';
 import { PanelOptions } from './models.gen';
 
 const theme = createTheme();
@@ -16,7 +16,7 @@ describe('Heatmap data', () => {
 
 describe('creating a heatmap data mapping', () => {
   describe('generates a simple data mapping with orderly data', () => {
-    const mapping = getAnnotationMapping(
+    const mapping = getExemplarsMapping(
       {
         heatmap: {
           name: 'test',
@@ -139,7 +139,7 @@ describe('creating a heatmap data mapping', () => {
       // In this case, we are just finding proper values, but don't care if a values
       // exists in the bucket in the original data or not. Therefore, we should see
       // a value mapped into the second mapping bucket containing the value '8'.
-      const mapping = getAnnotationMapping(heatmap, rawData);
+      const mapping = getExemplarsMapping(heatmap, rawData);
       expect(mapping.lookup.length).toEqual(3);
       expect(mapping.lookup[0]).toEqual([1, 4]);
       expect(mapping.lookup[1]).toEqual([8]);
@@ -148,7 +148,7 @@ describe('creating a heatmap data mapping', () => {
   });
 
   describe('Handles a larger data set that will not fill all buckets', () => {
-    const mapping = getAnnotationMapping(
+    const mapping = getExemplarsMapping(
       {
         heatmap: {
           name: 'test',
@@ -276,7 +276,7 @@ describe('creating a heatmap data mapping', () => {
 
     it('Will not process heatmap buckets', () => {
       expect(() =>
-        getAnnotationMapping(
+        getExemplarsMapping(
           {
             ...heatmap,
             heatmap: {
@@ -291,7 +291,7 @@ describe('creating a heatmap data mapping', () => {
       ).toThrow(HEATMAP_NOT_SCANLINES_ERROR);
 
       expect(() =>
-        getAnnotationMapping(
+        getExemplarsMapping(
           {
             ...heatmap,
             heatmap: {
@@ -306,7 +306,7 @@ describe('creating a heatmap data mapping', () => {
       ).toThrow(HEATMAP_NOT_SCANLINES_ERROR);
 
       expect(() =>
-        getAnnotationMapping(
+        getExemplarsMapping(
           {
             ...heatmap,
             heatmap: {


### PR DESCRIPTION
This refactors the general "annotations" subject to be exemplars specific, it also stubs out how to 

https://user-images.githubusercontent.com/705951/167072778-5186ac23-61e4-43e0-88ed-fcf287f2b720.mp4

Here is a test dashboard that will show the above:
[heatmap with exemplars-1651815177268.json.txt](https://github.com/grafana/grafana/files/8637780/heatmap.with.exemplars-1651815177268.json.txt)

NOTE:
1. The current structure does not send tooltip events for cells that match exemplars, but do *not* have values.  In this example the bottom left should always have a value
