### PR TITLE
Transformations: Support complex objects in json parsing

### DIFF
--- a/public/app/features/transformers/extractFields/fieldExtractor.test.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractor.test.ts
@@ -14,6 +14,22 @@ describe('Extract fields from text', () => {
     `);
   });
 
+  it('Test complex json extraction', async () => {
+    const extractor = fieldExtractors.get(FieldExtractorID.JSON);
+    const out = extractor.parse('{"a":"1","b":2,"c":3,"d":{"e":4},"f":[5,6]}');
+
+    expect(out).toMatchInlineSnapshot(`
+      Object {
+        "a": "1",
+        "b": 2,
+        "c": 3,
+        "d.e": 4,
+        "f.0": 5,
+        "f.1": 6,
+      }
+    `);
+  });
+
   it('Test key-values with single/double quotes', async () => {
     const extractor = fieldExtractors.get(FieldExtractorID.KeyValues);
     const out = extractor.parse('a="1",   "b"=\'2\',c=3  x:y ;\r\nz="d and 4"');

--- a/public/app/features/transformers/extractFields/fieldExtractors.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractors.ts
@@ -14,10 +14,20 @@ const extJSON: FieldExtractor = {
   id: FieldExtractorID.JSON,
   name: 'JSON',
   description: 'Parse JSON string',
-  parse: (v: string) => {
-    return JSON.parse(v);
-  },
+  parse: parseJson,
 };
+
+function parseJson(raw: string): Record<string, any> {
+  const flatten = function (obj: Record<string, any>, path: string | null = null): Record<string, any> {
+    return Object.keys(obj).reduce((acc: Record<string, any>, key: string): Record<string, any> => {
+      const newPath = [path, key].filter(Boolean).join('.');
+      return typeof obj?.[key] === 'object'
+        ? { ...acc, ...flatten(obj[key], newPath) }
+        : { ...acc, [newPath]: obj[key] };
+    }, {});
+  };
+  return flatten(JSON.parse(raw));
+}
 
 function parseKeyValuePairs(raw: string): Record<string, string> {
   const buff: string[] = []; // array of characters


### PR DESCRIPTION
**What this PR does / why we need it:**

This PR extends the functionalities of the json field extractor transformation.
Objects are flattened prior to conversion.

E.g.: 

```json
{"a":{"b":1}}
```

becomes

```json
{"a.b":1} 
```

The change enables better support for arbitrary json data transmitted by datasources.

**Special notes for your reviewer:**

An additional test was added to verify proper flattening.
