### PR TITLE
CloudWatch: Change aggregateResponse to return slice instead of map

### DIFF
--- a/pkg/tsdb/cloudwatch/query_row_response.go
+++ b/pkg/tsdb/cloudwatch/query_row_response.go
@@ -27,9 +27,9 @@ func newQueryRowResponse() queryRowResponse {
 }
 
 func (q *queryRowResponse) addMetricDataResult(mdr *cloudwatch.MetricDataResult, partialDataSet map[string]*cloudwatch.MetricDataResult) {
-	if metricDataResult, ok := partialDataSet[*mdr.Label]; ok {
-		metricDataResult.Timestamps = append(metricDataResult.Timestamps, mdr.Timestamps...)
-		metricDataResult.Values = append(metricDataResult.Values, mdr.Values...)
+	if partialData, ok := partialDataSet[*mdr.Label]; ok {
+		partialData.Timestamps = append(partialData.Timestamps, mdr.Timestamps...)
+		partialData.Values = append(partialData.Values, mdr.Values...)
 		q.StatusCode = *mdr.StatusCode
 		if *mdr.StatusCode != "PartialData" {
 			delete(partialDataSet, *mdr.Label)

--- a/pkg/tsdb/cloudwatch/query_row_response.go
+++ b/pkg/tsdb/cloudwatch/query_row_response.go
@@ -4,8 +4,8 @@ import "github.com/aws/aws-sdk-go/service/cloudwatch"
 
 // queryRowResponse represents the GetMetricData response for a query row in the query editor.
 type queryRowResponse struct {
+	partialDataSet         map[string]*cloudwatch.MetricDataResult
 	ErrorCodes             map[string]bool
-	Labels                 []string
 	HasArithmeticError     bool
 	ArithmeticErrorMessage string
 	Metrics                []*cloudwatch.MetricDataResult
@@ -22,7 +22,6 @@ func newQueryRowResponse() queryRowResponse {
 			maxMatchingResultsExceeded: false},
 		HasArithmeticError:     false,
 		ArithmeticErrorMessage: "",
-		Labels:                 []string{},
 		Metrics:                []*cloudwatch.MetricDataResult{},
 	}
 }
@@ -38,7 +37,6 @@ func (q *queryRowResponse) addMetricDataResult(mdr *cloudwatch.MetricDataResult)
 		return
 	}
 
-	q.Labels = append(q.Labels, *mdr.Label)
 	q.Metrics = append(q.Metrics, mdr)
 	q.StatusCode = *mdr.StatusCode
 	if *mdr.StatusCode == "PartialData" {

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -62,7 +62,6 @@ func aggregateResponse(getMetricDataOutputs []*cloudwatch.GetMetricDataOutput) m
 		}
 		for _, r := range gmdo.MetricDataResults {
 			id := *r.Id
-			label := *r.Label
 
 			response := newQueryRowResponse()
 			if _, exists := responseByID[id]; exists {
@@ -75,11 +74,7 @@ func aggregateResponse(getMetricDataOutputs []*cloudwatch.GetMetricDataOutput) m
 				}
 			}
 
-			if _, exists := response.Metrics[label]; !exists {
-				response.addMetricDataResult(r)
-			} else {
-				response.appendTimeSeries(r)
-			}
+			response.addMetricDataResult(r)
 
 			for code := range errorCodes {
 				if _, exists := response.ErrorCodes[code]; exists {
@@ -120,8 +115,8 @@ func getLabels(cloudwatchLabel string, query *cloudWatchQuery) data.Labels {
 func buildDataFrames(startTime time.Time, endTime time.Time, aggregatedResponse queryRowResponse,
 	query *cloudWatchQuery, dynamicLabelEnabled bool) (data.Frames, error) {
 	frames := data.Frames{}
-	for _, label := range aggregatedResponse.Labels {
-		metric := aggregatedResponse.Metrics[label]
+	for _, metric := range aggregatedResponse.Metrics {
+		label := *metric.Label
 
 		deepLink, err := query.buildDeepLink(startTime, endTime)
 		if err != nil {

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -54,6 +54,7 @@ func aggregateResponse(getMetricDataOutputs []*cloudwatch.GetMetricDataOutput) m
 		maxQueryResultsExceeded:    false,
 		maxMatchingResultsExceeded: false,
 	}
+	var partialDataSet = make(map[string]*cloudwatch.MetricDataResult)
 	for _, gmdo := range getMetricDataOutputs {
 		for _, message := range gmdo.Messages {
 			if _, exists := errorCodes[*message.Code]; exists {
@@ -74,7 +75,7 @@ func aggregateResponse(getMetricDataOutputs []*cloudwatch.GetMetricDataOutput) m
 				}
 			}
 
-			response.addMetricDataResult(r)
+			response.addMetricDataResult(r, partialDataSet)
 
 			for code := range errorCodes {
 				if _, exists := response.ErrorCodes[code]; exists {

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -54,7 +54,6 @@ func aggregateResponse(getMetricDataOutputs []*cloudwatch.GetMetricDataOutput) m
 		maxQueryResultsExceeded:    false,
 		maxMatchingResultsExceeded: false,
 	}
-	var partialDataSet = make(map[string]*cloudwatch.MetricDataResult)
 	for _, gmdo := range getMetricDataOutputs {
 		for _, message := range gmdo.Messages {
 			if _, exists := errorCodes[*message.Code]; exists {
@@ -75,7 +74,7 @@ func aggregateResponse(getMetricDataOutputs []*cloudwatch.GetMetricDataOutput) m
 				}
 			}
 
-			response.addMetricDataResult(r, partialDataSet)
+			response.addMetricDataResult(r)
 
 			for code := range errorCodes {
 				if _, exists := response.ErrorCodes[code]; exists {

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -38,7 +38,9 @@ func TestCloudWatchResponseParser(t *testing.T) {
 			assert.Len(t, aggregatedResponse[idA].Metrics, 2)
 		})
 		t.Run("should have points for label1 taken from both getMetricDataOutputs", func(t *testing.T) {
-			assert.Len(t, aggregatedResponse[idA].Metrics["label1"].Values, 10)
+			require.NotNil(t, *aggregatedResponse[idA].Metrics[0].Label)
+			require.Equal(t, "label1", *aggregatedResponse[idA].Metrics[0].Label)
+			assert.Len(t, aggregatedResponse[idA].Metrics[0].Values, 10)
 		})
 		t.Run("should have statuscode 'Complete'", func(t *testing.T) {
 			assert.Equal(t, "Complete", aggregatedResponse[idA].StatusCode)
@@ -96,8 +98,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 		timestamp := time.Unix(0, 0)
 		response := &queryRowResponse{
 			Labels: []string{"lb1", "lb2"},
-			Metrics: map[string]*cloudwatch.MetricDataResult{
-				"lb1": {
+			Metrics: []*cloudwatch.MetricDataResult{
+				{
 					Id:    aws.String("id1"),
 					Label: aws.String("lb1"),
 					Timestamps: []*time.Time{
@@ -112,7 +114,7 @@ func TestCloudWatchResponseParser(t *testing.T) {
 					},
 					StatusCode: aws.String("Complete"),
 				},
-				"lb2": {
+				{
 					Id:    aws.String("id2"),
 					Label: aws.String("lb2"),
 					Timestamps: []*time.Time{
@@ -161,8 +163,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 		timestamp := time.Unix(0, 0)
 		response := &queryRowResponse{
 			Labels: []string{"lb1 Sum", "lb2 Average"},
-			Metrics: map[string]*cloudwatch.MetricDataResult{
-				"lb1 Sum": {
+			Metrics: []*cloudwatch.MetricDataResult{
+				{
 					Id:    aws.String("id1"),
 					Label: aws.String("lb1 Sum"),
 					Timestamps: []*time.Time{
@@ -177,7 +179,7 @@ func TestCloudWatchResponseParser(t *testing.T) {
 					},
 					StatusCode: aws.String("Complete"),
 				},
-				"lb2 Average": {
+				{
 					Id:    aws.String("id2"),
 					Label: aws.String("lb2 Average"),
 					Timestamps: []*time.Time{
@@ -225,8 +227,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 		timestamp := time.Unix(0, 0)
 		response := &queryRowResponse{
 			Labels: []string{"lb3", "lb4"},
-			Metrics: map[string]*cloudwatch.MetricDataResult{
-				"lb3": {
+			Metrics: []*cloudwatch.MetricDataResult{
+				{
 					Id:    aws.String("lb3"),
 					Label: aws.String("lb3"),
 					Timestamps: []*time.Time{
@@ -241,7 +243,7 @@ func TestCloudWatchResponseParser(t *testing.T) {
 					},
 					StatusCode: aws.String("Complete"),
 				},
-				"lb4": {
+				{
 					Id:    aws.String("lb4"),
 					Label: aws.String("lb4"),
 					Timestamps: []*time.Time{
@@ -285,8 +287,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 		timestamp := time.Unix(0, 0)
 		response := &queryRowResponse{
 			Labels: []string{"lb3"},
-			Metrics: map[string]*cloudwatch.MetricDataResult{
-				"lb3": {
+			Metrics: []*cloudwatch.MetricDataResult{
+				{
 					Id:    aws.String("lb3"),
 					Label: aws.String("lb3"),
 					Timestamps: []*time.Time{
@@ -325,8 +327,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 		timestamp := time.Unix(0, 0)
 		response := &queryRowResponse{
 			Labels: []string{"lb3"},
-			Metrics: map[string]*cloudwatch.MetricDataResult{
-				"lb3": {
+			Metrics: []*cloudwatch.MetricDataResult{
+				{
 					Id:    aws.String("lb3"),
 					Label: aws.String("lb3"),
 					Timestamps: []*time.Time{
@@ -368,8 +370,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 		timestamp := time.Unix(0, 0)
 		response := &queryRowResponse{
 			Labels: []string{"lb3"},
-			Metrics: map[string]*cloudwatch.MetricDataResult{
-				"lb3": {
+			Metrics: []*cloudwatch.MetricDataResult{
+				{
 					Id:    aws.String("lb3"),
 					Label: aws.String("lb3"),
 					Timestamps: []*time.Time{
@@ -413,8 +415,8 @@ func TestCloudWatchResponseParser(t *testing.T) {
 		timestamp := time.Unix(0, 0)
 		response := &queryRowResponse{
 			Labels: []string{"lb"},
-			Metrics: map[string]*cloudwatch.MetricDataResult{
-				"lb": {
+			Metrics: []*cloudwatch.MetricDataResult{
+				{
 					Id:    aws.String("id1"),
 					Label: aws.String("lb"),
 					Timestamps: []*time.Time{
@@ -464,8 +466,9 @@ func TestCloudWatchResponseParser(t *testing.T) {
 	t.Run("buildDataFrames should use response label as frame name when dynamic label is enabled", func(t *testing.T) {
 		response := &queryRowResponse{
 			Labels: []string{"some response label"},
-			Metrics: map[string]*cloudwatch.MetricDataResult{
-				"some response label": {
+			Metrics: []*cloudwatch.MetricDataResult{
+				{
+					Label:      aws.String("some response label"),
 					Timestamps: []*time.Time{},
 					Values:     []*float64{aws.Float64(10)},
 					StatusCode: aws.String("Complete"),

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -74,7 +74,7 @@ func TestCloudWatchResponseParser(t *testing.T) {
 	})
 
 	t.Run("when aggregating multi-outputs response", func(t *testing.T) {
-		getMetricDataOutputs, err := loadGetMetricDataOutputsFromFile("./test-data/multi-metric-same-label-output.json")
+		getMetricDataOutputs, err := loadGetMetricDataOutputsFromFile("./test-data/single-output-multiple-metric-data-results.json")
 		require.NoError(t, err)
 		aggregatedResponse := aggregateResponse(getMetricDataOutputs)
 		idA := "a"

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -73,6 +73,25 @@ func TestCloudWatchResponseParser(t *testing.T) {
 		})
 	})
 
+	t.Run("when aggregating multi-outputs response", func(t *testing.T) {
+		getMetricDataOutputs, err := loadGetMetricDataOutputsFromFile("./test-data/multi-metric-same-label-output.json")
+		require.NoError(t, err)
+		aggregatedResponse := aggregateResponse(getMetricDataOutputs)
+		idA := "a"
+		t.Run("should have one label", func(t *testing.T) {
+			assert.Len(t, aggregatedResponse[idA].Labels, 1)
+			assert.Len(t, aggregatedResponse[idA].Metrics, 1)
+		})
+		t.Run("should have points for label1 taken from both MetricDataResults", func(t *testing.T) {
+			require.NotNil(t, *aggregatedResponse[idA].Metrics[0].Label)
+			require.Equal(t, "label1", *aggregatedResponse[idA].Metrics[0].Label)
+			assert.Len(t, aggregatedResponse[idA].Metrics[0].Values, 6)
+		})
+		t.Run("should have statuscode 'Complete'", func(t *testing.T) {
+			assert.Equal(t, "Complete", aggregatedResponse[idA].StatusCode)
+		})
+	})
+
 	t.Run("when aggregating response and error codes are in first GetMetricDataOutput", func(t *testing.T) {
 		getMetricDataOutputs, err := loadGetMetricDataOutputsFromFile("./test-data/multiple-outputs2.json")
 		require.NoError(t, err)

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -34,7 +34,6 @@ func TestCloudWatchResponseParser(t *testing.T) {
 		aggregatedResponse := aggregateResponse(getMetricDataOutputs)
 		idA := "a"
 		t.Run("should have two labels", func(t *testing.T) {
-			assert.Len(t, aggregatedResponse[idA].Labels, 2)
 			assert.Len(t, aggregatedResponse[idA].Metrics, 2)
 		})
 		t.Run("should have points for label1 taken from both getMetricDataOutputs", func(t *testing.T) {
@@ -79,7 +78,6 @@ func TestCloudWatchResponseParser(t *testing.T) {
 		aggregatedResponse := aggregateResponse(getMetricDataOutputs)
 		idA := "a"
 		t.Run("should have one label", func(t *testing.T) {
-			assert.Len(t, aggregatedResponse[idA].Labels, 1)
 			assert.Len(t, aggregatedResponse[idA].Metrics, 1)
 		})
 		t.Run("should have points for label1 taken from both MetricDataResults", func(t *testing.T) {
@@ -116,7 +114,6 @@ func TestCloudWatchResponseParser(t *testing.T) {
 	t.Run("Expand dimension value using exact match", func(t *testing.T) {
 		timestamp := time.Unix(0, 0)
 		response := &queryRowResponse{
-			Labels: []string{"lb1", "lb2"},
 			Metrics: []*cloudwatch.MetricDataResult{
 				{
 					Id:    aws.String("id1"),
@@ -181,7 +178,6 @@ func TestCloudWatchResponseParser(t *testing.T) {
 	t.Run("Expand dimension value using substring", func(t *testing.T) {
 		timestamp := time.Unix(0, 0)
 		response := &queryRowResponse{
-			Labels: []string{"lb1 Sum", "lb2 Average"},
 			Metrics: []*cloudwatch.MetricDataResult{
 				{
 					Id:    aws.String("id1"),
@@ -245,7 +241,6 @@ func TestCloudWatchResponseParser(t *testing.T) {
 	t.Run("Expand dimension value using wildcard", func(t *testing.T) {
 		timestamp := time.Unix(0, 0)
 		response := &queryRowResponse{
-			Labels: []string{"lb3", "lb4"},
 			Metrics: []*cloudwatch.MetricDataResult{
 				{
 					Id:    aws.String("lb3"),
@@ -305,7 +300,6 @@ func TestCloudWatchResponseParser(t *testing.T) {
 	t.Run("Expand dimension value when no values are returned and a multi-valued template variable is used", func(t *testing.T) {
 		timestamp := time.Unix(0, 0)
 		response := &queryRowResponse{
-			Labels: []string{"lb3"},
 			Metrics: []*cloudwatch.MetricDataResult{
 				{
 					Id:    aws.String("lb3"),
@@ -345,7 +339,6 @@ func TestCloudWatchResponseParser(t *testing.T) {
 	t.Run("Expand dimension value when no values are returned and a multi-valued template variable and two single-valued dimensions are used", func(t *testing.T) {
 		timestamp := time.Unix(0, 0)
 		response := &queryRowResponse{
-			Labels: []string{"lb3"},
 			Metrics: []*cloudwatch.MetricDataResult{
 				{
 					Id:    aws.String("lb3"),
@@ -388,7 +381,6 @@ func TestCloudWatchResponseParser(t *testing.T) {
 	t.Run("Should only expand certain fields when using SQL queries", func(t *testing.T) {
 		timestamp := time.Unix(0, 0)
 		response := &queryRowResponse{
-			Labels: []string{"lb3"},
 			Metrics: []*cloudwatch.MetricDataResult{
 				{
 					Id:    aws.String("lb3"),
@@ -433,7 +425,6 @@ func TestCloudWatchResponseParser(t *testing.T) {
 	t.Run("Parse cloudwatch response", func(t *testing.T) {
 		timestamp := time.Unix(0, 0)
 		response := &queryRowResponse{
-			Labels: []string{"lb"},
 			Metrics: []*cloudwatch.MetricDataResult{
 				{
 					Id:    aws.String("id1"),
@@ -484,7 +475,6 @@ func TestCloudWatchResponseParser(t *testing.T) {
 
 	t.Run("buildDataFrames should use response label as frame name when dynamic label is enabled", func(t *testing.T) {
 		response := &queryRowResponse{
-			Labels: []string{"some response label"},
 			Metrics: []*cloudwatch.MetricDataResult{
 				{
 					Label:      aws.String("some response label"),

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -57,7 +57,7 @@ func TestCloudWatchResponseParser(t *testing.T) {
 		})
 	})
 
-	t.Run("when aggregating response for query id b", func(t *testing.T) {
+	t.Run("when aggregating multi-outputs response with PartialData and ArithmeticError", func(t *testing.T) {
 		getMetricDataOutputs, err := loadGetMetricDataOutputsFromFile("./test-data/multiple-outputs-query-b.json")
 		require.NoError(t, err)
 		aggregatedResponse := aggregateResponse(getMetricDataOutputs)

--- a/pkg/tsdb/cloudwatch/response_parser_test.go
+++ b/pkg/tsdb/cloudwatch/response_parser_test.go
@@ -57,7 +57,7 @@ func TestCloudWatchResponseParser(t *testing.T) {
 		})
 	})
 
-	t.Run("when aggregating multi-outputs response with PartialData and ArithmeticError", func(t *testing.T) {
+	t.Run("when aggregating response for query id b", func(t *testing.T) {
 		getMetricDataOutputs, err := loadGetMetricDataOutputsFromFile("./test-data/multiple-outputs-query-b.json")
 		require.NoError(t, err)
 		aggregatedResponse := aggregateResponse(getMetricDataOutputs)

--- a/pkg/tsdb/cloudwatch/test-data/single-output-multiple-metric-data-results.json
+++ b/pkg/tsdb/cloudwatch/test-data/single-output-multiple-metric-data-results.json
@@ -1,0 +1,40 @@
+[
+  {
+    "Messages": null,
+    "MetricDataResults": [
+      {
+        "Id": "a",
+        "Label": "label1",
+        "Messages": null,
+        "StatusCode": "PartialData",
+        "Timestamps": [
+          "2021-01-15T19:44:00Z",
+          "2021-01-15T19:59:00Z",
+          "2021-01-15T20:14:00Z",
+          "2021-01-15T20:29:00Z",
+          "2021-01-15T20:44:00Z"
+        ],
+        "Values": [
+          0.1333395078879982,
+          0.244268469636633,
+          0.15574387947267768,
+          0.14447563659125626,
+          0.15519743138527173
+        ]
+      },
+      {
+        "Id": "a",
+        "Label": "label1",
+        "Messages": null,
+        "StatusCode": "Complete",
+        "Timestamps": [
+          "2021-01-15T19:44:00Z"
+        ],
+        "Values": [
+          0.1333395078879982
+        ]
+      }
+    ],
+    "NextToken": null
+  }
+]

--- a/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricsQueryEditor/MetricsQueryEditor.tsx
@@ -140,7 +140,6 @@ export const MetricsQueryEditor = (props: Props) => {
           >
             <Input
               id={`${query.refId}-cloudwatch-metric-query-editor-label`}
-              placeholder="auto"
               onBlur={onRunQuery}
               value={preparedQuery.label ?? ''}
               onChange={(event: ChangeEvent<HTMLInputElement>) =>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
@sunker noticed that GetMetricData response labels are not necessarily unique anymore [when users can provide their own labels](https://github.com/grafana/grafana/pull/48574). However, while [parsing](https://github.com/grafana/grafana/blob/main/pkg/tsdb/cloudwatch/response_parser.go#L78-L82) the response we assume that all returned metrics have unique labels and when they don't we'll put the result of them in the same frame.

Instead of using a `map` to represent metrics with `label` as a key, this PR changes the metrics to a slice of data frames.
When a result from GetMetricData is considered unique/distinct, its metrics are appended to this slice of data frames.
When a result from GetMetricData is a *continuation* of metrics for an existing metric, as is the case when a previous result has a status of `PartialData`, then its timestamps and values are appended to the existing entry.

Broken behavior (before):
![Screen Shot 2022-05-06 at 20 32 43](https://user-images.githubusercontent.com/4163034/167197737-2924ad06-b694-4d7a-bd12-f69bcb368615.png)

Expected behavior (this PR):
![Screen Shot 2022-05-06 at 20 33 29](https://user-images.githubusercontent.com/4163034/167197747-ea2d0747-efb4-4c1f-b691-89d6a7cc4b40.png)



<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->
