### PR TITLE
Dashboard: Implement keyed dashboard state

### DIFF
--- a/public/app/features/dashboard/components/DashboardPermissions/DashboardPermissions.tsx
+++ b/public/app/features/dashboard/components/DashboardPermissions/DashboardPermissions.tsx
@@ -12,19 +12,20 @@ import { DashboardAcl, PermissionLevel, NewDashboardAclItem } from 'app/types/ac
 import { checkFolderPermissions } from '../../../folders/state/actions';
 import { DashboardModel } from '../../state/DashboardModel';
 import {
-  getDashboardPermissions,
+  fetchDashboardPermissions,
   addDashboardPermission,
   removeDashboardPermission,
   updateDashboardPermission,
 } from '../../state/actions';
+import { selectCurrentDashboard } from '../../state/reducers';
 
 const mapStateToProps = (state: StoreState) => ({
-  permissions: state.dashboard.permissions,
+  permissions: selectCurrentDashboard(state.dashboards).permissions,
   canViewFolderPermissions: state.folder.canViewFolderPermissions,
 });
 
 const mapDispatchToProps = {
-  getDashboardPermissions,
+  fetchDashboardPermissions,
   addDashboardPermission,
   removeDashboardPermission,
   updateDashboardPermission,
@@ -53,7 +54,7 @@ export class DashboardPermissionsUnconnected extends PureComponent<Props, State>
   }
 
   componentDidMount() {
-    this.props.getDashboardPermissions(this.props.dashboard.id);
+    this.props.fetchDashboardPermissions(this.props.dashboard.key);
     if (this.props.dashboard.meta.folderUid) {
       this.props.checkFolderPermissions(this.props.dashboard.meta.folderUid);
     }
@@ -64,15 +65,15 @@ export class DashboardPermissionsUnconnected extends PureComponent<Props, State>
   };
 
   onRemoveItem = (item: DashboardAcl) => {
-    this.props.removeDashboardPermission(this.props.dashboard.id, item);
+    this.props.removeDashboardPermission({ key: this.props.dashboard.key, itemToDelete: item });
   };
 
   onPermissionChanged = (item: DashboardAcl, level: PermissionLevel) => {
-    this.props.updateDashboardPermission(this.props.dashboard.id, item, level);
+    this.props.updateDashboardPermission({ key: this.props.dashboard.key, itemToUpdate: item, level });
   };
 
   onAddPermission = (newItem: NewDashboardAclItem) => {
-    return this.props.addDashboardPermission(this.props.dashboard.id, newItem);
+    return this.props.addDashboardPermission({ key: this.props.dashboard.key, newItem });
   };
 
   onCancelAddPermission = () => {

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
@@ -52,8 +52,13 @@ describe('panelEditor actions', () => {
       const dispatchedActions = await thunkTester({
         panels: {},
         panelEditor: state,
-        dashboard: {
-          getModel: () => dashboard,
+        dashboards: {
+          byKey: {
+            home: {
+              getModel: () => dashboard,
+            },
+          },
+          currentKey: 'home',
         },
       })
         .givenThunk(exitPanelEditor)
@@ -88,8 +93,13 @@ describe('panelEditor actions', () => {
       const dispatchedActions = await thunkTester({
         panelEditor: state,
         panels: {},
-        dashboard: {
-          getModel: () => dashboard,
+        dashboards: {
+          byKey: {
+            home: {
+              getModel: () => dashboard,
+            },
+          },
+          currentKey: 'home',
         },
       })
         .givenThunk(exitPanelEditor)
@@ -124,8 +134,13 @@ describe('panelEditor actions', () => {
       const dispatchedActions = await thunkTester({
         panelEditor: state,
         panels: {},
-        dashboard: {
-          getModel: () => dashboard,
+        dashboards: {
+          byKey: {
+            home: {
+              getModel: () => dashboard,
+            },
+          },
+          currentKey: 'home',
         },
       })
         .givenThunk(exitPanelEditor)

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -1,6 +1,7 @@
 import { pick } from 'lodash';
 
 import store from 'app/core/store';
+import { selectCurrentDashboard } from 'app/features/dashboard/state/reducers';
 import { cleanUpPanelState, initPanelState } from 'app/features/panel/state/actions';
 import { panelModelAndPluginReady } from 'app/features/panel/state/reducers';
 import { ThunkResult } from 'app/types';
@@ -108,7 +109,7 @@ export function skipPanelUpdate(modifiedPanel: PanelModel, panelToUpdate: PanelM
 
 export function exitPanelEditor(): ThunkResult<void> {
   return async (dispatch, getStore) => {
-    const dashboard = getStore().dashboard.getModel();
+    const dashboard = selectCurrentDashboard(getStore().dashboards).getModel();
     const { getPanel, getSourcePanel, shouldDiscardChanges } = getStore().panelEditor;
     const panel = getPanel();
 

--- a/public/app/features/dashboard/components/VersionHistory/useDashboardRestore.tsx
+++ b/public/app/features/dashboard/components/VersionHistory/useDashboardRestore.tsx
@@ -8,6 +8,7 @@ import { useAppNotification } from 'app/core/copy/appNotification';
 import { StoreState } from 'app/types';
 
 import { DashboardModel } from '../../state';
+import { selectCurrentDashboard } from '../../state/reducers';
 
 import { historySrv } from './HistorySrv';
 
@@ -16,7 +17,7 @@ const restoreDashboard = async (version: number, dashboard: DashboardModel) => {
 };
 
 export const useDashboardRestore = (version: number) => {
-  const dashboard = useSelector((state: StoreState) => state.dashboard.getModel());
+  const dashboard = useSelector((state: StoreState) => selectCurrentDashboard(state.dashboards).getModel());
   const [state, onRestoreDashboard] = useAsyncFn(async () => await restoreDashboard(version, dashboard!), []);
   const notifyApp = useAppNotification();
 

--- a/public/app/features/dashboard/containers/DashboardPage.test.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.test.tsx
@@ -78,6 +78,7 @@ function getTestDashboard(overrides?: any, metaOverrides?: any): DashboardModel 
   const data = Object.assign(
     {
       title: 'My dashboard',
+      key: 'home',
       panels: [
         {
           id: 1,

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -32,6 +32,7 @@ import { liveTimer } from '../dashgrid/liveTimer';
 import { getTimeSrv } from '../services/TimeSrv';
 import { cleanUpDashboardAndVariables } from '../state/actions';
 import { initDashboard } from '../state/initDashboard';
+import { selectCurrentDashboard } from '../state/reducers';
 
 export interface DashboardPageRouteParams {
   uid?: string;
@@ -51,11 +52,14 @@ type DashboardPageRouteSearchParams = {
   refresh?: string;
 };
 
-export const mapStateToProps = (state: StoreState) => ({
-  initPhase: state.dashboard.initPhase,
-  initError: state.dashboard.initError,
-  dashboard: state.dashboard.getModel(),
-});
+export const mapStateToProps = (state: StoreState) => {
+  const dash = selectCurrentDashboard(state.dashboards);
+  return {
+    initPhase: dash.initPhase,
+    initError: dash.initError,
+    dashboard: dash.getModel(),
+  };
+};
 
 const mapDispatchToProps = {
   initDashboard,
@@ -107,7 +111,7 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
   }
 
   closeDashboard() {
-    this.props.cleanUpDashboardAndVariables();
+    this.props.dashboard && this.props.cleanUpDashboardAndVariables(this.props.dashboard.key);
     this.setState(this.getCleanState());
   }
 

--- a/public/app/features/dashboard/containers/SoloPanelPage.tsx
+++ b/public/app/features/dashboard/containers/SoloPanelPage.tsx
@@ -8,6 +8,7 @@ import { StoreState } from 'app/types';
 
 import { DashboardPanel } from '../dashgrid/DashboardPanel';
 import { initDashboard } from '../state/initDashboard';
+import { selectCurrentDashboard } from '../state/reducers';
 
 export interface DashboardPageRouteParams {
   uid?: string;
@@ -16,7 +17,7 @@ export interface DashboardPageRouteParams {
 }
 
 const mapStateToProps = (state: StoreState) => ({
-  dashboard: state.dashboard.getModel(),
+  dashboard: selectCurrentDashboard(state.dashboards).getModel(),
 });
 
 const mapDispatchToProps = {

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -67,6 +67,7 @@ export interface DashboardLink {
 }
 
 export class DashboardModel implements TimeModel {
+  key: string;
   id: any;
   uid: string;
   title: string;
@@ -124,6 +125,7 @@ export class DashboardModel implements TimeModel {
     appEventsSubscription: true,
     panelsAffectedByVariableChange: true,
     lastRefresh: true,
+    key: true,
   };
 
   constructor(data: any, meta?: DashboardMeta, private getVariablesFromState: GetVariables = getVariablesByKey) {
@@ -131,6 +133,7 @@ export class DashboardModel implements TimeModel {
       data = {};
     }
 
+    this.key = data.key;
     this.events = new EventBusSrv();
     this.id = data.id || null;
     this.uid = data.uid || null;

--- a/public/app/features/dashboard/state/initDashboard.test.ts
+++ b/public/app/features/dashboard/state/initDashboard.test.ts
@@ -115,8 +115,11 @@ function describeInitScenario(description: string, scenarioFn: ScenarioFn) {
         location: {
           query: {},
         },
-        dashboard: {
-          initPhase: DashboardInitPhase.Services,
+        dashboards: {
+          byKey: {
+            home: { initPhase: DashboardInitPhase.Services },
+          },
+          currentKey: 'home',
         },
         user: {},
         explore: {
@@ -180,7 +183,7 @@ describeInitScenario('Initializing new dashboard', (ctx) => {
 
   it('Should send action dashboardInitCompleted', () => {
     expect(ctx.actions[7].type).toBe(dashboardInitCompleted.type);
-    expect(ctx.actions[7].payload.title).toBe('New dashboard');
+    expect(ctx.actions[7].payload.dash.title).toBe('New dashboard');
   });
 
   it('Should initialize services', () => {
@@ -268,7 +271,7 @@ describeInitScenario('Initializing existing dashboard', (ctx) => {
 
 describeInitScenario('Initializing previously canceled dashboard initialization', (ctx) => {
   ctx.setup(() => {
-    ctx.storeState.dashboard.initPhase = DashboardInitPhase.Fetching;
+    ctx.storeState.dashboards.byKey['home'].initPhase = DashboardInitPhase.Fetching;
   });
 
   it('Should send action dashboardInitFetching', () => {

--- a/public/app/features/dashboard/state/initDashboard.test.ts
+++ b/public/app/features/dashboard/state/initDashboard.test.ts
@@ -117,9 +117,9 @@ function describeInitScenario(description: string, scenarioFn: ScenarioFn) {
         },
         dashboards: {
           byKey: {
-            home: { initPhase: DashboardInitPhase.Services },
+            [DASH_UID]: { initPhase: DashboardInitPhase.Services },
           },
-          currentKey: 'home',
+          currentKey: DASH_UID,
         },
         user: {},
         explore: {
@@ -254,7 +254,7 @@ describeInitScenario('Initializing existing dashboard', (ctx) => {
 
   it('Should send action dashboardInitCompleted', () => {
     expect(ctx.actions[8].type).toBe(dashboardInitCompleted.type);
-    expect(ctx.actions[8].payload.title).toBe('My cool dashboard');
+    expect(ctx.actions[8].payload.dash.title).toBe('My cool dashboard');
   });
 
   it('Should initialize services', () => {
@@ -271,7 +271,7 @@ describeInitScenario('Initializing existing dashboard', (ctx) => {
 
 describeInitScenario('Initializing previously canceled dashboard initialization', (ctx) => {
   ctx.setup(() => {
-    ctx.storeState.dashboards.byKey['home'].initPhase = DashboardInitPhase.Fetching;
+    ctx.storeState.dashboards.byKey[DASH_UID].initPhase = DashboardInitPhase.Fetching;
   });
 
   it('Should send action dashboardInitFetching', () => {
@@ -298,6 +298,8 @@ describeInitScenario('Initializing previously canceled dashboard initialization'
 describeInitScenario('Initializing snapshot dashboard', (ctx) => {
   ctx.setup(() => {
     ctx.args.urlUid = undefined;
+    ctx.args.urlSlug = 'snapshot-slug';
+    ctx.args.urlType = 'snapshot';
   });
 
   it('Should send action initVariablesTransaction with correct payload', () => {

--- a/public/app/features/dashboard/state/reducers.test.ts
+++ b/public/app/features/dashboard/state/reducers.test.ts
@@ -1,29 +1,37 @@
 import { DashboardInitPhase, DashboardState, OrgRole, PermissionLevel } from 'app/types';
 
 import { DashboardModel } from './DashboardModel';
+import { fetchDashboardPermissions } from './actions';
 import {
   dashboardInitCompleted,
   dashboardInitFailed,
   dashboardInitFetching,
-  loadDashboardPermissions,
   dashboardReducer,
+  initialDash,
   initialState,
 } from './reducers';
 
 describe('dashboard reducer', () => {
-  describe('loadDashboardPermissions', () => {
+  describe('fetchDashboardPermissions', () => {
     let state: DashboardState;
 
     beforeEach(() => {
-      const action = loadDashboardPermissions([
-        { id: 2, dashboardId: 1, role: OrgRole.Viewer, permission: PermissionLevel.View },
-        { id: 3, dashboardId: 1, role: OrgRole.Editor, permission: PermissionLevel.Edit },
-      ]);
-      state = dashboardReducer(initialState, action);
+      const action = fetchDashboardPermissions.fulfilled(
+        {
+          key: 'home',
+          dashboardAclDTOs: [
+            { id: 2, dashboardId: 1, role: OrgRole.Viewer, permission: PermissionLevel.View },
+            { id: 3, dashboardId: 1, role: OrgRole.Editor, permission: PermissionLevel.Edit },
+          ],
+        },
+        '',
+        ''
+      );
+      state = dashboardReducer({ currentKey: 'home', byKey: { home: { ...initialDash } } }, action);
     });
 
     it('should add permissions to state', async () => {
-      expect(state.permissions?.length).toBe(2);
+      expect(state.byKey['home'].permissions?.length).toBe(2);
     });
   });
 
@@ -31,20 +39,21 @@ describe('dashboard reducer', () => {
     let state: DashboardState;
 
     beforeEach(() => {
-      state = dashboardReducer(initialState, dashboardInitFetching());
+      state = dashboardReducer(initialState, dashboardInitFetching({ key: 'home' }));
       state = dashboardReducer(
         state,
-        dashboardInitCompleted(
-          new DashboardModel({
+        dashboardInitCompleted({
+          dash: new DashboardModel({
             title: 'My dashboard',
             panels: [{ id: 1 }, { id: 2 }],
-          })
-        )
+          }),
+          key: 'home',
+        })
       );
     });
 
     it('should set model', async () => {
-      expect(state.getModel()!.title).toBe('My dashboard');
+      expect(state.byKey['home'].getModel()!.title).toBe('My dashboard');
     });
   });
 
@@ -52,20 +61,20 @@ describe('dashboard reducer', () => {
     let state: DashboardState;
 
     beforeEach(() => {
-      state = dashboardReducer(initialState, dashboardInitFetching());
-      state = dashboardReducer(state, dashboardInitFailed({ message: 'Oh no', error: 'sad' }));
+      state = dashboardReducer(initialState, dashboardInitFetching({ key: 'home' }));
+      state = dashboardReducer(state, dashboardInitFailed({ message: 'Oh no', error: 'sad', key: 'home' }));
     });
 
     it('should set model', async () => {
-      expect(state.getModel()?.title).toBe('Dashboard init failed');
+      expect(state.byKey['home'].getModel()?.title).toBe('Dashboard init failed');
     });
 
     it('should set initError', async () => {
-      expect(state.initError?.message).toBe('Oh no');
+      expect(state.byKey['home'].initError?.message).toBe('Oh no');
     });
 
     it('should set phase failed', async () => {
-      expect(state.initPhase).toBe(DashboardInitPhase.Failed);
+      expect(state.byKey['home'].initPhase).toBe(DashboardInitPhase.Failed);
     });
   });
 });

--- a/public/app/features/datasources/DataSourceDashboards.tsx
+++ b/public/app/features/datasources/DataSourceDashboards.tsx
@@ -63,7 +63,7 @@ export class DataSourceDashboards extends PureComponent<Props> {
       });
     }
 
-    importDashboard(data, dashboard.title);
+    importDashboard({ data, dashboardTitle: dashboard.title });
   };
 
   onRemove = (dashboard: PluginDashboard) => {

--- a/public/app/features/variables/editor/actions.test.ts
+++ b/public/app/features/variables/editor/actions.test.ts
@@ -53,7 +53,9 @@ describe('switchToListMode', () => {
     jest.spyOn(selectors, 'getEditorVariables').mockReturnValue([]);
     jest.spyOn(inspectUtils, 'createUsagesNetwork').mockReturnValue({ usages: [], unUsed: [] });
     jest.spyOn(inspectUtils, 'transformUsagesToNetwork').mockReturnValue([]);
-    const mockGetState = jest.fn().mockReturnValue({ templating: initialKeyedVariablesState, dashboard: initialState });
+    const mockGetState = jest
+      .fn()
+      .mockReturnValue({ templating: initialKeyedVariablesState, dashboards: initialState });
     const mockDispatch = jest.fn();
 
     switchToListMode(null)(mockDispatch, mockGetState, undefined);

--- a/public/app/features/variables/editor/actions.ts
+++ b/public/app/features/variables/editor/actions.ts
@@ -1,6 +1,7 @@
 import { cloneDeep } from 'lodash';
 
 import { VariableType } from '@grafana/data';
+import { selectCurrentDashboard } from 'app/features/dashboard/state/reducers';
 
 import { ThunkResult } from '../../../types';
 import { variableAdapters } from '../adapters';
@@ -126,7 +127,7 @@ export const switchToListMode =
     dispatch(toKeyedAction(rootStateKey, clearIdInEditor()));
     const state = getState();
     const variables = getEditorVariables(rootStateKey, state);
-    const dashboard = state.dashboard.getModel();
+    const dashboard = selectCurrentDashboard(getState().dashboards).getModel();
     const { usages } = createUsagesNetwork(variables, dashboard);
     const usagesNetwork = transformUsagesToNetwork(usages);
 

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -14,6 +14,7 @@ import { notifyApp } from 'app/core/actions';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 import { DashboardModel } from 'app/features/dashboard/state';
+import { selectCurrentDashboard } from 'app/features/dashboard/state/reducers';
 import { store } from 'app/store/store';
 
 import { createErrorNotification } from '../../../core/copy/appNotification';
@@ -593,7 +594,7 @@ export const variableUpdated = (
 
     const variables = getVariablesByKey(rootStateKey, state);
     const g = createGraph(variables);
-    const panels = state.dashboard?.getModel()?.panels ?? [];
+    const panels = selectCurrentDashboard(state.dashboards ?? {}).getModel()?.panels ?? [];
     const event: VariablesChangedEvent = isAdHoc(variableInState)
       ? { refreshAll: true, panelIds: [] } // for adhoc variables we don't know which panels that will be impacted
       : { refreshAll: false, panelIds: getAllAffectedPanelIdsForVariableChange(variableInState.id, variables, panels) };
@@ -668,7 +669,7 @@ const timeRangeUpdated =
     const updatedOptions = updatedVariable.options;
 
     if (JSON.stringify(previousOptions) !== JSON.stringify(updatedOptions)) {
-      const dashboard = getState().dashboard.getModel();
+      const dashboard = selectCurrentDashboard(getState().dashboards).getModel();
       dashboard?.templateVariableValueUpdated();
     }
   };
@@ -677,7 +678,7 @@ export const templateVarsChangedInUrl =
   (key: string, vars: ExtendedUrlQueryMap, events: typeof appEvents = appEvents): ThunkResult<void> =>
   async (dispatch, getState) => {
     const update: Array<Promise<any>> = [];
-    const dashboard = getState().dashboard.getModel();
+    const dashboard = selectCurrentDashboard(getState().dashboards).getModel();
     for (const variable of getVariablesByKey(key, getState())) {
       const key = `var-${variable.name}`;
       if (!vars.hasOwnProperty(key)) {

--- a/public/app/features/variables/state/helpers.ts
+++ b/public/app/features/variables/state/helpers.ts
@@ -146,11 +146,11 @@ export const getVariableTestContext = <Model extends VariableModel>(
 
 export const getRootReducer = () =>
   combineReducers({
-    dashboard: dashboardReducer,
+    dashboards: dashboardReducer,
     templating: keyedVariablesReducer,
   });
 
-export type RootReducerType = { dashboard: DashboardState; templating: KeyedVariablesState };
+export type RootReducerType = { dashboards: DashboardState; templating: KeyedVariablesState };
 
 export const getTemplatingRootReducer = () =>
   combineReducers({

--- a/public/app/features/variables/state/onTimeRangeUpdated.test.ts
+++ b/public/app/features/variables/state/onTimeRangeUpdated.test.ts
@@ -1,4 +1,5 @@
 import { dateTime, TimeRange } from '@grafana/data';
+import { initialDash } from 'app/features/dashboard/state/reducers';
 
 import { reduxTester } from '../../../../test/core/redux/reduxTester';
 import { silenceConsoleOutput } from '../../../../test/core/utils/silenceConsoleOutput';
@@ -65,9 +66,16 @@ const getTestContext = (dashboard: DashboardModel) => {
   const startRefreshMock = jest.fn();
   dashboard.templateVariableValueUpdated = templateVariableValueUpdatedMock;
   dashboard.startRefresh = startRefreshMock;
-  const dashboardState = {
-    getModel: () => dashboard,
-  } as unknown as DashboardState;
+  dashboard.key = 'home';
+  const dashboardState: DashboardState = {
+    byKey: {
+      home: {
+        ...initialDash,
+        getModel: () => dashboard,
+      },
+    },
+    currentKey: 'home',
+  };
   const adapter = variableAdapters.get('interval');
   const templatingState = {
     variables: {
@@ -76,7 +84,7 @@ const getTestContext = (dashboard: DashboardModel) => {
     },
   };
   const preloadedState = {
-    dashboard: dashboardState,
+    dashboards: dashboardState,
     ...getPreloadedState(key, templatingState),
   } as unknown as RootReducerType;
 
@@ -227,5 +235,5 @@ describe('when onTimeRangeUpdated is dispatched', () => {
 });
 
 function getDashboardModel(): DashboardModel {
-  return new DashboardModel({ schemaVersion: 9999 }); // ignore any schema migrations
+  return new DashboardModel({ schemaVersion: 9999, key: 'home' }); // ignore any schema migrations
 }

--- a/public/app/features/variables/state/templateVarsChangedInUrl.test.ts
+++ b/public/app/features/variables/state/templateVarsChangedInUrl.test.ts
@@ -1,6 +1,6 @@
 import { DashboardState, StoreState } from '../../../types';
 import { DashboardModel } from '../../dashboard/state';
-import { initialState } from '../../dashboard/state/reducers';
+import { initialDash } from '../../dashboard/state/reducers';
 import { variableAdapters } from '../adapters';
 import { createConstantVariableAdapter } from '../constant/adapter';
 import { createCustomVariableAdapter } from '../custom/adapter';
@@ -35,19 +35,24 @@ async function getTestContext(urlQueryMap: ExtendedUrlQueryMap = {}, variable: V
 
   const templateVariableValueUpdatedMock = jest.fn();
   const startRefreshMock = jest.fn();
-  const dashboard: DashboardState = {
-    ...initialState,
-    getModel: () => {
-      dashboardModel.templateVariableValueUpdated = templateVariableValueUpdatedMock;
-      dashboardModel.startRefresh = startRefreshMock;
-      dashboardModel.templating = { list: [variable] };
-      return dashboardModel;
+  const dashboards: DashboardState = {
+    byKey: {
+      home: {
+        ...initialDash,
+        getModel: () => {
+          dashboardModel.templateVariableValueUpdated = templateVariableValueUpdatedMock;
+          dashboardModel.startRefresh = startRefreshMock;
+          dashboardModel.templating = { list: [variable] };
+          return dashboardModel;
+        },
+      },
     },
+    currentKey: 'home',
   };
 
   const variables: VariablesState = { variable };
   const state: Partial<StoreState> = {
-    dashboard,
+    dashboards,
     ...getPreloadedState(key, { variables }),
   };
   const getState = () => state as unknown as StoreState;

--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -93,9 +93,14 @@ export interface QueriesToUpdateOnDashboardLoad {
   queries: DataQuery[];
 }
 
-export interface DashboardState {
+export interface DashboardEntity {
   getModel: GetMutableDashboardModelFn;
   initPhase: DashboardInitPhase;
   initError: DashboardInitError | null;
   permissions: DashboardAcl[];
+}
+
+export interface DashboardState {
+  byKey: Record<string, DashboardEntity>;
+  currentKey: string | null;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
A first attempt at implementing keyed dashboard state.
Shouldn't change any behavior, but lays some groundwork for later work we might want to do around dashboard caching.

**Special notes for your reviewer**:

For most of the redux actions I've added a `key` param for specifying which state entry should be affected, but another option would be just to take the entry with `currentKey`. Also error handling within those actions is a bit repetitive right now so that's something I want to refine.