### PR TITLE
transforms: mark extract-fields transform as stable

### DIFF
--- a/public/app/features/transformers/extractFields/ExtractFieldsTransformerEditor.tsx
+++ b/public/app/features/transformers/extractFields/ExtractFieldsTransformerEditor.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import {
   DataTransformerID,
   FieldNamePickerConfigSettings,
-  PluginState,
   SelectableValue,
   StandardEditorsRegistryItem,
   TransformerRegistryItem,

--- a/public/app/features/transformers/extractFields/ExtractFieldsTransformerEditor.tsx
+++ b/public/app/features/transformers/extractFields/ExtractFieldsTransformerEditor.tsx
@@ -91,5 +91,4 @@ export const extractFieldsTransformRegistryItem: TransformerRegistryItem<Extract
   transformation: extractFieldsTransformer,
   name: 'Extract fields',
   description: `Parse fields from content (JSON, labels, etc)`,
-  state: PluginState.alpha,
 };


### PR DESCRIPTION
the Extract Fields transform was added in grafana8.3.0, i think/hope we can now mark it as stable.

(this transform will be probably used more with grafana9, where we changed the loki-dataframe-format, so instead of labels-to-fields, extract-fields can be used)