### PR TITLE
Alerting: Change method on endpoint to provision routes

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -53,7 +53,7 @@ func (srv *ProvisioningSrv) RouteGetPolicyTree(c *models.ReqContext) response.Re
 	return response.JSON(http.StatusOK, policies)
 }
 
-func (srv *ProvisioningSrv) RoutePostPolicyTree(c *models.ReqContext, tree apimodels.Route) response.Response {
+func (srv *ProvisioningSrv) RoutePutPolicyTree(c *models.ReqContext, tree apimodels.Route) response.Response {
 	err := srv.policies.UpdatePolicyTree(c.Req.Context(), c.OrgId, tree, alerting_models.ProvenanceAPI)
 	if errors.Is(err, store.ErrNoAlertmanagerConfiguration) {
 		return ErrResp(http.StatusNotFound, err, "")

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -26,24 +26,24 @@ func TestProvisioningApi(t *testing.T) {
 		require.Equal(t, 200, response.Status())
 	})
 
-	t.Run("successful POST policies returns 202", func(t *testing.T) {
+	t.Run("successful PUT policies returns 202", func(t *testing.T) {
 		sut := createProvisioningSrvSut()
 		rc := createTestRequestCtx()
 		tree := apimodels.Route{}
 
-		response := sut.RoutePostPolicyTree(&rc, tree)
+		response := sut.RoutePutPolicyTree(&rc, tree)
 
 		require.Equal(t, 202, response.Status())
 	})
 
 	t.Run("when new policy tree is invalid", func(t *testing.T) {
-		t.Run("POST policies returns 400", func(t *testing.T) {
+		t.Run("PUT policies returns 400", func(t *testing.T) {
 			sut := createProvisioningSrvSut()
 			sut.policies = &fakeRejectingNotificationPolicyService{}
 			rc := createTestRequestCtx()
 			tree := apimodels.Route{}
 
-			response := sut.RoutePostPolicyTree(&rc, tree)
+			response := sut.RoutePutPolicyTree(&rc, tree)
 
 			require.Equal(t, 400, response.Status())
 			expBody := `{"error":"invalid object specification: invalid policy tree","message":"invalid object specification: invalid policy tree"}`
@@ -86,13 +86,13 @@ func TestProvisioningApi(t *testing.T) {
 			require.Contains(t, string(response.Body()), "something went wrong")
 		})
 
-		t.Run("POST policies returns 500", func(t *testing.T) {
+		t.Run("PUT policies returns 500", func(t *testing.T) {
 			sut := createProvisioningSrvSut()
 			sut.policies = &fakeFailingNotificationPolicyService{}
 			rc := createTestRequestCtx()
 			tree := apimodels.Route{}
 
-			response := sut.RoutePostPolicyTree(&rc, tree)
+			response := sut.RoutePutPolicyTree(&rc, tree)
 
 			require.Equal(t, 500, response.Status())
 			require.NotEmpty(t, response.Body())

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -186,7 +186,7 @@ func (api *API) authorize(method, path string) web.Handler {
 		http.MethodGet + "/api/provisioning/templates/{name}":
 		return middleware.ReqSignedIn
 
-	case http.MethodPost + "/api/provisioning/policies",
+	case http.MethodPut + "/api/provisioning/policies",
 		http.MethodPost + "/api/provisioning/contact-points",
 		http.MethodPut + "/api/provisioning/contact-points",
 		http.MethodDelete + "/api/provisioning/contact-points/{ID}",

--- a/pkg/services/ngalert/api/forked_provisioning.go
+++ b/pkg/services/ngalert/api/forked_provisioning.go
@@ -23,8 +23,8 @@ func (f *ForkedProvisioningApi) forkRouteGetPolicyTree(ctx *models.ReqContext) r
 	return f.svc.RouteGetPolicyTree(ctx)
 }
 
-func (f *ForkedProvisioningApi) forkRoutePostPolicyTree(ctx *models.ReqContext, route apimodels.Route) response.Response {
-	return f.svc.RoutePostPolicyTree(ctx, route)
+func (f *ForkedProvisioningApi) forkRoutePutPolicyTree(ctx *models.ReqContext, route apimodels.Route) response.Response {
+	return f.svc.RoutePutPolicyTree(ctx, route)
 }
 
 func (f *ForkedProvisioningApi) forkRouteGetContactpoints(ctx *models.ReqContext) response.Response {

--- a/pkg/services/ngalert/api/generated_base_api_provisioning.go
+++ b/pkg/services/ngalert/api/generated_base_api_provisioning.go
@@ -27,8 +27,8 @@ type ProvisioningApiForkingService interface {
 	RouteGetTemplate(*models.ReqContext) response.Response
 	RouteGetTemplates(*models.ReqContext) response.Response
 	RoutePostContactpoints(*models.ReqContext) response.Response
-	RoutePostPolicyTree(*models.ReqContext) response.Response
 	RoutePutContactpoints(*models.ReqContext) response.Response
+	RoutePutPolicyTree(*models.ReqContext) response.Response
 	RoutePutTemplate(*models.ReqContext) response.Response
 }
 
@@ -64,20 +64,20 @@ func (f *ForkedProvisioningApi) RoutePostContactpoints(ctx *models.ReqContext) r
 	return f.forkRoutePostContactpoints(ctx, conf)
 }
 
-func (f *ForkedProvisioningApi) RoutePostPolicyTree(ctx *models.ReqContext) response.Response {
-	conf := apimodels.Route{}
-	if err := web.Bind(ctx.Req, &conf); err != nil {
-		return response.Error(http.StatusBadRequest, "bad request data", err)
-	}
-	return f.forkRoutePostPolicyTree(ctx, conf)
-}
-
 func (f *ForkedProvisioningApi) RoutePutContactpoints(ctx *models.ReqContext) response.Response {
 	conf := apimodels.EmbeddedContactPoint{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 	return f.forkRoutePutContactpoints(ctx, conf)
+}
+
+func (f *ForkedProvisioningApi) RoutePutPolicyTree(ctx *models.ReqContext) response.Response {
+	conf := apimodels.Route{}
+	if err := web.Bind(ctx.Req, &conf); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+	return f.forkRoutePutPolicyTree(ctx, conf)
 }
 
 func (f *ForkedProvisioningApi) RoutePutTemplate(ctx *models.ReqContext) response.Response {
@@ -160,16 +160,6 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingServi
 				m,
 			),
 		)
-		group.Post(
-			toMacaronPath("/api/provisioning/policies"),
-			api.authorize(http.MethodPost, "/api/provisioning/policies"),
-			metrics.Instrument(
-				http.MethodPost,
-				"/api/provisioning/policies",
-				srv.RoutePostPolicyTree,
-				m,
-			),
-		)
 		group.Put(
 			toMacaronPath("/api/provisioning/contact-points"),
 			api.authorize(http.MethodPut, "/api/provisioning/contact-points"),
@@ -177,6 +167,16 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingServi
 				http.MethodPut,
 				"/api/provisioning/contact-points",
 				srv.RoutePutContactpoints,
+				m,
+			),
+		)
+		group.Put(
+			toMacaronPath("/api/provisioning/policies"),
+			api.authorize(http.MethodPut, "/api/provisioning/policies"),
+			metrics.Instrument(
+				http.MethodPut,
+				"/api/provisioning/policies",
+				srv.RoutePutPolicyTree,
 				m,
 			),
 		)

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_policies.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_policies.go
@@ -8,7 +8,7 @@ package definitions
 //       200: Route
 //       400: ValidationError
 
-// swagger:route POST /api/provisioning/policies provisioning RoutePostPolicyTree
+// swagger:route PUT /api/provisioning/policies provisioning RoutePutPolicyTree
 //
 // Sets the notification policy tree.
 //
@@ -19,7 +19,7 @@ package definitions
 //       202: Accepted
 //       400: ValidationError
 
-// swagger:parameters RoutePostPolicyTree
+// swagger:parameters RoutePutPolicyTree
 type Policytree struct {
 	// in:body
 	Body Route

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -3115,7 +3115,6 @@
    "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertGroup": {
-   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -3137,7 +3136,9 @@
     "labels",
     "receiver"
    ],
-   "type": "object"
+   "type": "object",
+   "x-go-name": "AlertGroup",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertGroups": {
    "items": {
@@ -3524,7 +3525,6 @@
    "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "postableSilence": {
-   "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3564,10 +3564,11 @@
     "matchers",
     "startsAt"
    ],
-   "type": "object"
+   "type": "object",
+   "x-go-name": "PostableSilence",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "receiver": {
-   "description": "Receiver receiver",
    "properties": {
     "name": {
      "description": "name",
@@ -3578,7 +3579,9 @@
    "required": [
     "name"
    ],
-   "type": "object"
+   "type": "object",
+   "x-go-name": "Receiver",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "silence": {
    "description": "Silence silence",
@@ -4927,11 +4930,11 @@
      "provisioning"
     ]
    },
-   "post": {
+   "put": {
     "consumes": [
      "application/json"
     ],
-    "operationId": "RoutePostPolicyTree",
+    "operationId": "RoutePutPolicyTree",
     "parameters": [
      {
       "in": "body",

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1252,7 +1252,7 @@
           }
         }
       },
-      "post": {
+      "put": {
         "consumes": [
           "application/json"
         ],
@@ -1260,7 +1260,7 @@
           "provisioning"
         ],
         "summary": "Sets the notification policy tree.",
-        "operationId": "RoutePostPolicyTree",
+        "operationId": "RoutePutPolicyTree",
         "parameters": [
           {
             "name": "Body",
@@ -5096,7 +5096,6 @@
       "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
     },
     "alertGroup": {
-      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -5119,6 +5118,8 @@
           "$ref": "#/definitions/receiver"
         }
       },
+      "x-go-name": "AlertGroup",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/alertGroup"
     },
     "alertGroups": {
@@ -5511,7 +5512,6 @@
       "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
     },
     "postableSilence": {
-      "description": "PostableSilence postable silence",
       "type": "object",
       "required": [
         "comment",
@@ -5552,10 +5552,11 @@
           "x-go-name": "StartsAt"
         }
       },
+      "x-go-name": "PostableSilence",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/postableSilence"
     },
     "receiver": {
-      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "name"
@@ -5567,6 +5568,8 @@
           "x-go-name": "Name"
         }
       },
+      "x-go-name": "Receiver",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/receiver"
     },
     "silence": {

--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -96,8 +96,8 @@ func TestProvisioning(t *testing.T) {
 			require.Equal(t, 200, resp.StatusCode)
 		})
 
-		t.Run("un-authenticated POST should 401", func(t *testing.T) {
-			req := createTestRequest("POST", url, "", body)
+		t.Run("un-authenticated PUT should 401", func(t *testing.T) {
+			req := createTestRequest("PUT", url, "", body)
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
@@ -106,8 +106,8 @@ func TestProvisioning(t *testing.T) {
 			require.Equal(t, 401, resp.StatusCode)
 		})
 
-		t.Run("viewer POST should 403", func(t *testing.T) {
-			req := createTestRequest("POST", url, "viewer", body)
+		t.Run("viewer PUT should 403", func(t *testing.T) {
+			req := createTestRequest("PUT", url, "viewer", body)
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
@@ -116,8 +116,8 @@ func TestProvisioning(t *testing.T) {
 			require.Equal(t, 403, resp.StatusCode)
 		})
 
-		t.Run("editor POST should succeed", func(t *testing.T) {
-			req := createTestRequest("POST", url, "editor", body)
+		t.Run("editor PUT should succeed", func(t *testing.T) {
+			req := createTestRequest("PUT", url, "editor", body)
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
@@ -126,8 +126,8 @@ func TestProvisioning(t *testing.T) {
 			require.Equal(t, 202, resp.StatusCode)
 		})
 
-		t.Run("admin POST should succeed", func(t *testing.T) {
-			req := createTestRequest("POST", url, "admin", body)
+		t.Run("admin PUT should succeed", func(t *testing.T) {
+			req := createTestRequest("PUT", url, "admin", body)
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This is a really small PR that changes POST /provisioning/routes to PUT /provisioning/routes. No semantic changes, just the method.

This is because the route semantically behaves like a PUT, since it is a full replacement of a path-identified resource on the server.

This is in compliance with our design guide, and IETF RFC 7231: https://datatracker.ietf.org/doc/html/rfc7231#section-4.3.4

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Rel: https://github.com/grafana/grafana/issues/36153

**Special notes for your reviewer**:

