### PR TITLE
CI: add s3fs

### DIFF
--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -39,7 +39,7 @@ RUN apt update && apt install -yq curl python3-pip procps && pip3 install -U pip
     ln -s /opt/google-cloud-sdk/bin/gsutil /usr/bin/gsutil && \
     ln -s /opt/google-cloud-sdk/bin/gcloud /usr/bin/gcloud && \
     mkdir -p /deb-repo /rpm-repo && \
-    ln -s /usr/bin/createrepo_c /usr/bin/createrepo \
+    ln -s /usr/bin/createrepo_c /usr/bin/createrepo && \
     curl -L -O https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v${GCSFUSE_VERSION}/gcsfuse_${GCSFUSE_VERSION}_amd64.deb && \
     dpkg --install gcsfuse_${GCSFUSE_VERSION}_amd64.deb && \
     rm -Rf gcsfuse_${GCSFUSE_VERSION}_amd64.deb

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:testing-20210111-slim
+FROM debian:bullseye-slim
 
 # Use ARG so as not to persist environment variable in image
-ARG GOVERSION=1.17.8 \
-  GO_CHECKSUM=980e65a863377e69fd9b67df9d8395fd8e93858e7a24c9f55803421e453f4f99 \
-  DEBIAN_FRONTEND=noninteractive
+ARG GOVERSION=1.18.1 \
+  GO_CHECKSUM=b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334 \
+  DEBIAN_FRONTEND=interactive
 
 ENV PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go
@@ -15,30 +15,32 @@ RUN curl -fLO https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.t
 
 RUN git clone https://github.com/aptly-dev/aptly $GOPATH/src/github.com/aptly-dev/aptly
 RUN cd $GOPATH/src/github.com/aptly-dev/aptly && \
-    # pin aptly to a specific commit after 1.3.0 that contains gpg2 support
-    git reset --hard a64807efdaf5e380bfa878c71bc88eae10d62be1 && \
     make install
 
 FROM debian:testing-20210111-slim
 
 # Use ARG so as not to persist environment variable in image
 ARG DEBIAN_FRONTEND=noninteractive \
-  GOOGLE_SDK_VERSION=325.0.0 \
-  GOOGLE_SDK_CHECKSUM=374f960c9f384f88b6fc190b268ceac5dcad777301390107af63782bfb5ecbc7
+  GOOGLE_SDK_VERSION=384.0.1 \
+  GOOGLE_SDK_CHECKSUM=437539933ce68aed7147bd03173d53e1c3d69c0694c107bc25e5f8309f29ccb8 \
+  GCSFUSE_VERSION=0.41.1
 
 # Need procps for pkill utility, which is used by the build pipeline tool to restart the GPG agent
 RUN apt update && apt install -yq curl python3-pip procps && pip3 install -U awscli crcmod && \
-    curl -fLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
-    echo "${GOOGLE_SDK_CHECKSUM} google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz" | sha256sum --check --status && \
-    tar xzf google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz -C /opt && \
-    rm google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
+    curl -fLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
+    echo "${GOOGLE_SDK_CHECKSUM} google-cloud-cli-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz" | sha256sum --check --status && \
+    tar xzf google-cloud-cli-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz -C /opt && \
+    rm google-cloud-cli-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
     apt update && \
-    apt install -y createrepo-c expect && \
+    apt install -y createrepo-c expect fuse && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     ln -s /opt/google-cloud-sdk/bin/gsutil /usr/bin/gsutil && \
     ln -s /opt/google-cloud-sdk/bin/gcloud /usr/bin/gcloud && \
     mkdir -p /deb-repo /rpm-repo && \
-    ln -s /usr/bin/createrepo_c /usr/bin/createrepo
+    ln -s /usr/bin/createrepo_c /usr/bin/createrepo \
+    curl -L -O https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v${GCSFUSE_VERSION}/gcsfuse_${GCSFUSE_VERSION}_amd64.deb && \
+    dpkg --install gcsfuse_${GCSFUSE_VERSION}_amd64.deb && \
+    rm -Rf gcsfuse_${GCSFUSE_VERSION}_amd64.deb
 
 COPY --from=0 /go/bin/aptly /usr/local/bin/aptly

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -21,8 +21,8 @@ FROM debian:testing-20210111-slim
 
 # Use ARG so as not to persist environment variable in image
 ARG DEBIAN_FRONTEND=noninteractive \
-  GOOGLE_SDK_VERSION=325.0.0 \
-  GOOGLE_SDK_CHECKSUM=374f960c9f384f88b6fc190b268ceac5dcad777301390107af63782bfb5ecbc7 \
+  GOOGLE_SDK_VERSION=385.0.0 \
+  GOOGLE_SDK_CHECKSUM=cd1839e9343e32f64645f2d3c269340a9c50d0c77d85c9a0a44cd9de2103879e \
   GCSFUSE_VERSION=0.41.1
 
 # Need procps for pkill utility, which is used by the build pipeline tool to restart the GPG agent

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -22,8 +22,7 @@ FROM debian:testing-20210111-slim
 # Use ARG so as not to persist environment variable in image
 ARG DEBIAN_FRONTEND=noninteractive \
   GOOGLE_SDK_VERSION=385.0.0 \
-  GOOGLE_SDK_CHECKSUM=cd1839e9343e32f64645f2d3c269340a9c50d0c77d85c9a0a44cd9de2103879e \
-  GCSFUSE_VERSION=0.41.1
+  GOOGLE_SDK_CHECKSUM=cd1839e9343e32f64645f2d3c269340a9c50d0c77d85c9a0a44cd9de2103879e
 
 # Need procps for pkill utility, which is used by the build pipeline tool to restart the GPG agent
 # Pin pip3 to version 20.0.2 to address https://github.com/pypa/pip/issues/11070
@@ -33,15 +32,12 @@ RUN apt update && apt install -yq curl python3-pip procps && pip3 install -U pip
     tar xzf google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz -C /opt && \
     rm google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
     apt update && \
-    apt install -y createrepo-c expect fuse && \
+    apt install -y createrepo-c expect s3fs && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     ln -s /opt/google-cloud-sdk/bin/gsutil /usr/bin/gsutil && \
     ln -s /opt/google-cloud-sdk/bin/gcloud /usr/bin/gcloud && \
     mkdir -p /deb-repo /rpm-repo && \
-    ln -s /usr/bin/createrepo_c /usr/bin/createrepo && \
-    curl -L -O https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v${GCSFUSE_VERSION}/gcsfuse_${GCSFUSE_VERSION}_amd64.deb && \
-    dpkg --install gcsfuse_${GCSFUSE_VERSION}_amd64.deb && \
-    rm -Rf gcsfuse_${GCSFUSE_VERSION}_amd64.deb
+    ln -s /usr/bin/createrepo_c /usr/bin/createrepo
 
 COPY --from=0 /go/bin/aptly /usr/local/bin/aptly

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -21,17 +21,17 @@ FROM debian:testing-20210111-slim
 
 # Use ARG so as not to persist environment variable in image
 ARG DEBIAN_FRONTEND=noninteractive \
-  GOOGLE_SDK_VERSION=384.0.1 \
-  GOOGLE_SDK_CHECKSUM=437539933ce68aed7147bd03173d53e1c3d69c0694c107bc25e5f8309f29ccb8 \
+  GOOGLE_SDK_VERSION=325.0.0 \
+  GOOGLE_SDK_CHECKSUM=374f960c9f384f88b6fc190b268ceac5dcad777301390107af63782bfb5ecbc7 \
   GCSFUSE_VERSION=0.41.1
 
 # Need procps for pkill utility, which is used by the build pipeline tool to restart the GPG agent
 # Pin pip3 to version 20.0.2 to address https://github.com/pypa/pip/issues/11070
 RUN apt update && apt install -yq curl python3-pip procps && pip3 install -U pip==20.0.2 && pip3 install -U awscli crcmod && \
-    curl -fLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
-    echo "${GOOGLE_SDK_CHECKSUM} google-cloud-cli-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz" | sha256sum --check --status && \
-    tar xzf google-cloud-cli-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz -C /opt && \
-    rm google-cloud-cli-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
+    curl -fLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
+    echo "${GOOGLE_SDK_CHECKSUM} google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz" | sha256sum --check --status && \
+    tar xzf google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz -C /opt && \
+    rm google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
     apt update && \
     apt install -y createrepo-c expect fuse && \
     apt-get autoremove -y && \

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:bullseye-slim
+FROM debian:testing-20210111-slim
 
 # Use ARG so as not to persist environment variable in image
-ARG GOVERSION=1.18.1 \
-  GO_CHECKSUM=b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334 \
-  DEBIAN_FRONTEND=interactive
+ARG GOVERSION=1.17.8 \
+  GO_CHECKSUM=980e65a863377e69fd9b67df9d8395fd8e93858e7a24c9f55803421e453f4f99 \
+  DEBIAN_FRONTEND=noninteractive
 
 ENV PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go
@@ -26,7 +26,8 @@ ARG DEBIAN_FRONTEND=noninteractive \
   GCSFUSE_VERSION=0.41.1
 
 # Need procps for pkill utility, which is used by the build pipeline tool to restart the GPG agent
-RUN apt update && apt install -yq curl python3-pip procps && pip3 install -U awscli crcmod && \
+# Pin pip3 to version 20.0.2 to address https://github.com/pypa/pip/issues/11070
+RUN apt update && apt install -yq curl python3-pip procps && pip3 install -U pip==20.0.2 && pip3 install -U awscli crcmod && \
     curl -fLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
     echo "${GOOGLE_SDK_CHECKSUM} google-cloud-cli-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz" | sha256sum --check --status && \
     tar xzf google-cloud-cli-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz -C /opt && \

--- a/scripts/build/ci-deploy/build-deploy.sh
+++ b/scripts/build/ci-deploy/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.3.1"
+_version="1.4.0"
 _tag="grafana/grafana-ci-deploy:${_version}"
 
 docker build -t $_tag .

--- a/scripts/build/ci-deploy/build-deploy.sh
+++ b/scripts/build/ci-deploy/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.4.0"
+_version="1.3.2"
 _tag="grafana/grafana-ci-deploy:${_version}"
 
 docker build -t $_tag .


### PR DESCRIPTION
Add `gcsfuse` to `grafana-ci-deploy` docker image for further usage for publishing packages.

As a side effect, upgrade `aptly`, `google-cloud-sdk` to the actual versions.