### PR TITLE
AccessControl: check if user can create in folder on dashboard move

### DIFF
--- a/pkg/services/dashboards/manager/dashboard_service.go
+++ b/pkg/services/dashboards/manager/dashboard_service.go
@@ -110,8 +110,8 @@ func (dr *DashboardServiceImpl) BuildSaveDashboardCommand(ctx context.Context, d
 	}
 
 	if isParentFolderChanged {
-		folderGuardian := guardian.New(ctx, dash.FolderId, dto.OrgId, dto.User)
-		if canSave, err := folderGuardian.CanSave(); err != nil || !canSave {
+		guard := guardian.New(ctx, dash.Id, dto.OrgId, dto.User)
+		if canCreate, err := guard.CanCreate(dash.FolderId, dash.IsFolder); err != nil || !canCreate {
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/services/dashboards/manager/dashboard_service_test.go
+++ b/pkg/services/dashboards/manager/dashboard_service_test.go
@@ -23,7 +23,10 @@ func TestDashboardService(t *testing.T) {
 	t.Run("Dashboard service tests", func(t *testing.T) {
 		fakeStore := m.FakeDashboardStore{}
 		defer fakeStore.AssertExpectations(t)
+		cfg := setting.NewCfg()
+		cfg.IsFeatureToggleEnabled = func(key string) bool { return false }
 		service := &DashboardServiceImpl{
+			cfg:                cfg,
 			log:                log.New("test.logger"),
 			dashboardStore:     &fakeStore,
 			dashAlertExtractor: &dummyDashAlertExtractor{},

--- a/pkg/services/guardian/guardian.go
+++ b/pkg/services/guardian/guardian.go
@@ -88,8 +88,22 @@ func (g *dashboardGuardianImpl) CanDelete() (bool, error) {
 	return g.CanSave()
 }
 
-func (g *dashboardGuardianImpl) CanCreate(_ int64, _ bool) (bool, error) {
-	// when using dashboard guardian without access control a user can create a dashboard if they can save it
+func (g *dashboardGuardianImpl) CanCreate(folderID int64, isFolder bool) (bool, error) {
+	if isFolder {
+		return g.CanSave()
+	}
+
+	dashId := g.dashId
+	cachedAcl := g.acl
+	// set dash id to folder id that user tries to create dashboard in
+	g.acl = nil
+	g.dashId = folderID
+
+	// reset to dash id and acl after check
+	defer func() {
+		g.acl = cachedAcl
+		g.dashId = dashId
+	}()
 	return g.CanSave()
 }
 

--- a/pkg/services/guardian/guardian.go
+++ b/pkg/services/guardian/guardian.go
@@ -88,22 +88,8 @@ func (g *dashboardGuardianImpl) CanDelete() (bool, error) {
 	return g.CanSave()
 }
 
-func (g *dashboardGuardianImpl) CanCreate(folderID int64, isFolder bool) (bool, error) {
-	if isFolder {
-		return g.CanSave()
-	}
-
-	dashId := g.dashId
-	cachedAcl := g.acl
-	// set dash id to folder id that user tries to create dashboard in
-	g.acl = nil
-	g.dashId = folderID
-
-	// reset to dash id and acl after check
-	defer func() {
-		g.acl = cachedAcl
-		g.dashId = dashId
-	}()
+func (g *dashboardGuardianImpl) CanCreate(_ int64, isFolder bool) (bool, error) {
+	// when using dashboard guardian without access control a user can create a dashboard if they can save it
 	return g.CanSave()
 }
 


### PR DESCRIPTION
in that folder

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When moving a dashboard to a new folder we should check if user has the permissions to create / add a dashboard in that folder and not just check if a user can save a dashboard in that folder

This i required to fix tests in the enable RBAC by default pr https://github.com/grafana/grafana/pull/48813

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

