### PR TITLE
loki: backend-mode: apply default max-lines if not set in the UI

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -173,10 +173,13 @@ export class LokiDatasource
     };
 
     if (this.useBackendMode) {
-      // we "fix" the loki queries to have `.queryType` and not have `.instant` and `.range`
+      const queries = request.targets
+        .map(getNormalizedLokiQuery) // "fix" the `.queryType` prop
+        .map((q) => ({ ...q, maxLines: q.maxLines || this.maxLines })); // set maxLines if not set
+
       const fixedRequest = {
         ...request,
-        targets: request.targets.map(getNormalizedLokiQuery),
+        targets: queries,
       };
 
       const streamQueries = fixedRequest.targets.filter((q) => q.queryType === LokiQueryType.Stream);


### PR DESCRIPTION
in the query loki query editor you can specify a "line limit" option. when it is set, we tell Loki to send us only that many log-lines in the result (this setting does not do anything when the response is metric, when it is a graph).

in backend-mode we did not handle correctly the case when the "line limit" is not specified.

it should look at the datasource's configuration, at the "Maximum lines" setting, and use that. if that's also not specified, it should use 1000.

how to test:
1. make sure you have the "lokiBackendMode" feature flag enabled
2. go to grafana-dashboards, create a new dashboard, with a new panel, choose logs-visualization, and enter a loki query that produces logs.
3. open the browser-dev-tools, and look at the ajax-requests that will be sent. we are looking at the "queries" array, it's first item's `maxLines` value.
4. we will do multiple tests, i will write them down as three values:
  - first is the value that should be set in the data-source's "Maximum lines" property
  - second is the value that should be set in the loki query editor's `line limit` property
  - third is the value that should appear in the ajax-request's JSON's`maxLines` property
5. the test cases:
    - empty, empty, 1000
    - empty, 0, 1000
    - empty, 7, 7
    - 42, empty, 42
    - 42, 0, 42
    - 42, 7, 7
