### PR TITLE
Fix: Use runuser instead of su for grafana-server startup

### DIFF
--- a/packaging/rpm/init.d/grafana-server
+++ b/packaging/rpm/init.d/grafana-server
@@ -92,7 +92,7 @@ case "$1" in
 
     # Start Daemon
     cd $GRAFANA_HOME
-    action $"Starting $DESC: ..." su -s /bin/sh -c "nohup ${DAEMON} ${DAEMON_OPTS} >> /dev/null 3>&1 &" $GRAFANA_USER 2> /dev/null
+    action $"Starting $DESC: ..." runuser -s /bin/sh -c "nohup ${DAEMON} ${DAEMON_OPTS} >> /dev/null 3>&1 &" $GRAFANA_USER 2> /dev/null
     return=$?
     if [ $return -eq 0 ]
     then


### PR DESCRIPTION
Fixes [#48881](https://github.com/grafana/grafana/issues/48881) where as of RHEL7.7+ / systemd-219-67 the usage of `su` is restricted resulting in `/etc/init.d/grafana-server` failing to start in such an environment.

```
"New main PID does not belong to service, and PID file is not owned by root. Refusing"
```

As per https://access.redhat.com/solutions/4420581 it is advised to use [runuser](https://man7.org/linux/man-pages/man1/runuser.1.html) instead of `su` as it is built from `su` source code but with the pam stack removed (see [blog post](https://danwalsh.livejournal.com/55588.html) from `runuser` co-author).

`runuser` is provided standard with the OS. This change has been verified working on versions prior (RHEL 7.6) and after (RHEL 7.9) RHEL 7.7 where this was introduced.