### PR TITLE
Loki: backend-mode: add "limit" dataframe meta attribute

### DIFF
--- a/public/app/plugins/datasource/loki/backendResultTransformer.test.ts
+++ b/public/app/plugins/datasource/loki/backendResultTransformer.test.ts
@@ -91,6 +91,37 @@ describe('loki backendResultTransformer', () => {
     expect(result).toEqual(expected);
   });
 
+  it('applies maxLines correctly', () => {
+    const response: DataQueryResponse = { data: [cloneDeep(inputFrame)] };
+
+    const frame1: DataFrame = transformBackendResult(
+      response,
+      [
+        {
+          refId: 'A',
+          expr: LOKI_EXPR,
+        },
+      ],
+      []
+    ).data[0];
+
+    expect(frame1.meta?.limit).toBeUndefined();
+
+    const frame2 = transformBackendResult(
+      response,
+      [
+        {
+          refId: 'A',
+          expr: LOKI_EXPR,
+          maxLines: 42,
+        },
+      ],
+      []
+    ).data[0];
+
+    expect(frame2.meta?.limit).toBe(42);
+  });
+
   it('processed derived fields correctly', () => {
     const input: DataFrame = {
       length: 1,

--- a/public/app/plugins/datasource/loki/backendResultTransformer.ts
+++ b/public/app/plugins/datasource/loki/backendResultTransformer.ts
@@ -27,6 +27,7 @@ function processStreamFrame(
 ): DataFrame {
   const meta: QueryResultMeta = {
     preferredVisualisationType: 'logs',
+    limit: query?.maxLines,
     searchWords: query !== undefined ? getHighlighterExpressionsFromQuery(formatQuery(query.expr)) : undefined,
     custom: {
       // used by logs_model


### PR DESCRIPTION
when you run a logs-query in grafana, in explore-mode, then above the results you will see lines like:
`Line limit: 1000 (55 returned)`
or `Line limit 100 reached...`

the way we generate these is that in the logs-dataframe, the `limit` metadata-value has to be set to the value of the "max amount of lines" that we sent in the loki-query: https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/data.ts#L81

this pull request does this for loki backend-mode queries.

how to test:
1. make sure you have the `lokiBackendMode` feature flag enabled
2. set a line-limit in the loki-query-editor that you will not reach
3. run a query
4. verify you get a message of type `Line limit: X (Y returned)`
5. now adjust the line-limit to a value that you will reach
6. run the query
7. verify you get a message of type `Line Limit X reached, ...`