### PR TITLE
AccessControl: Let users with data source create permissions list non-core plugins  

### DIFF
--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -38,7 +38,7 @@ func (hs *HTTPServer) GetPluginList(c *models.ReqContext) response.Response {
 	// When using access control anyone that can create a data source should be able to list all data sources installed
 	// Fallback to only letting admins list non-core plugins
 	hasAccess := accesscontrol.HasAccess(hs.AccessControl, c)
-	if !hasAccess(accesscontrol.ReqOrgAdmin, accesscontrol.EvalPermission(datasources.ActionCreate)) {
+	if !hasAccess(accesscontrol.ReqOrgAdmin, accesscontrol.EvalPermission(datasources.ActionCreate)) || c.HasRole(models.ROLE_ADMIN) {
 		coreFilter = "1"
 	}
 

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -13,6 +13,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/datasources"
+
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
@@ -32,8 +35,10 @@ func (hs *HTTPServer) GetPluginList(c *models.ReqContext) response.Response {
 	embeddedFilter := c.Query("embedded")
 	coreFilter := c.Query("core")
 
-	// For users with viewer role we only return core plugins
-	if !c.HasRole(models.ROLE_ADMIN) {
+	// When using access control anyone that can create a data source should be able to list all data sources installed
+	// Fallback to only letting admins list non-core plugins
+	hasAccess := accesscontrol.HasAccess(hs.AccessControl, c)
+	if !hasAccess(accesscontrol.ReqOrgAdmin, accesscontrol.EvalPermission(datasources.ActionCreate)) {
 		coreFilter = "1"
 	}
 

--- a/pkg/services/datasources/accesscontrol.go
+++ b/pkg/services/datasources/accesscontrol.go
@@ -37,7 +37,6 @@ var (
 	NewPageAccess = accesscontrol.EvalAll(
 		accesscontrol.EvalPermission(ActionRead),
 		accesscontrol.EvalPermission(ActionCreate),
-		accesscontrol.EvalPermission(ActionWrite),
 	)
 
 	// EditPageAccess is used to protect the "Configure > Data sources > Edit" page access

--- a/public/app/features/datasources/DataSourcesListPage.tsx
+++ b/public/app/features/datasources/DataSourcesListPage.tsx
@@ -60,9 +60,7 @@ export class DataSourcesListPage extends PureComponent<Props> {
     const { dataSources, dataSourcesCount, navModel, layoutMode, searchQuery, setDataSourcesSearchQuery, hasFetched } =
       this.props;
 
-    const canCreateDataSource =
-      contextSrv.hasPermission(AccessControlAction.DataSourcesCreate) &&
-      contextSrv.hasPermission(AccessControlAction.DataSourcesWrite);
+    const canCreateDataSource = contextSrv.hasPermission(AccessControlAction.DataSourcesCreate);
 
     const linkButton = {
       href: 'datasources/new',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
With access control a user can have the permissions to create new data sources. In this case we should allow them to list non-core plugins (not only restrict that to admins).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

https://github.com/grafana/support-escalations/issues/2561

**Special notes for your reviewer**:
* Also removed the restriction on the create page needing the write permission
