### PR TITLE
Dashboard Settings : Added back aria-labels into menu item links

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
@@ -6,6 +6,7 @@ import React, { useCallback, useMemo, useRef } from 'react';
 import { Link } from 'react-router-dom';
 
 import { GrafanaTheme2, locationUtil } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { locationService, reportInteraction } from '@grafana/runtime';
 import { Button, CustomScrollbar, Icon, IconName, PageToolbar, stylesFactory, useForceUpdate } from '@grafana/ui';
 import config from 'app/core/config';
@@ -165,6 +166,7 @@ export function DashboardSettings({ dashboard, editview }: Props) {
                 {pages.map((page) => (
                   <Link
                     onClick={() => reportInteraction(`Dashboard settings navigation to ${page.id}`)}
+                    aria-label={selectors.pages.Dashboard.Settings.General.sectionItems(page.title)}
                     to={(loc) => locationUtil.getUrlForPartial(loc, { editview: page.id })}
                     className={cx('dashboard-settings__nav-item', { active: page.id === editview })}
                     key={page.id}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

The `variables` part or the e2e `addDashboard` flow expects an aria label of `Dashboard settings section item Variables` to add a variable.
The aria-labels were removed in: #41407 so running the e2e tests in a Grafana 8.3+ container fails 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
I could very much be missing something, feel free to close with an explanation if there is an other way to run the e2e flows 😃 
