### PR TITLE
Alerting: scheduler to use short version of model for alert rule

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -113,7 +113,7 @@ type AlertRule struct {
 	Labels      map[string]string
 }
 
-type AlertRuleShort struct {
+type SchedulableAlertRule struct {
 	UID             string `xorm:"uid"`
 	OrgID           int64  `xorm:"org_id"`
 	IntervalSeconds int64

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -113,6 +113,13 @@ type AlertRule struct {
 	Labels      map[string]string
 }
 
+type AlertRuleShort struct {
+	UID             string `xorm:"uid"`
+	OrgID           int64  `xorm:"org_id"`
+	IntervalSeconds int64
+	Version         int64
+}
+
 type LabelOption func(map[string]string)
 
 func WithoutInternalLabels() LabelOption {
@@ -166,6 +173,11 @@ func (k AlertRuleKey) String() string {
 
 // GetKey returns the alert definitions identifier
 func (alertRule *AlertRule) GetKey() AlertRuleKey {
+	return AlertRuleKey{OrgID: alertRule.OrgID, UID: alertRule.UID}
+}
+
+// GetKey returns the alert definitions identifier
+func (alertRule *AlertRuleShort) GetKey() AlertRuleKey {
 	return AlertRuleKey{OrgID: alertRule.OrgID, UID: alertRule.UID}
 }
 
@@ -240,6 +252,12 @@ type ListAlertRulesQuery struct {
 	PanelID      int64
 
 	Result []*AlertRule
+}
+
+type GetAlertRulesForSchedulingQuery struct {
+	ExcludeOrgIDs []int64
+
+	Result []*AlertRuleShort
 }
 
 // ListNamespaceAlertRulesQuery is the query for listing namespace alert rules

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -177,7 +177,7 @@ func (alertRule *AlertRule) GetKey() AlertRuleKey {
 }
 
 // GetKey returns the alert definitions identifier
-func (alertRule *AlertRuleShort) GetKey() AlertRuleKey {
+func (alertRule *SchedulableAlertRule) GetKey() AlertRuleKey {
 	return AlertRuleKey{OrgID: alertRule.OrgID, UID: alertRule.UID}
 }
 
@@ -257,7 +257,7 @@ type ListAlertRulesQuery struct {
 type GetAlertRulesForSchedulingQuery struct {
 	ExcludeOrgIDs []int64
 
-	Result []*AlertRuleShort
+	Result []*SchedulableAlertRule
 }
 
 // ListNamespaceAlertRulesQuery is the query for listing namespace alert rules

--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -7,14 +7,14 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-func (sch *schedule) getAlertRules(ctx context.Context, disabledOrgs []int64) []*models.AlertRule {
+func (sch *schedule) getAlertRules(ctx context.Context, disabledOrgs []int64) []*models.AlertRuleShort {
 	start := time.Now()
 	defer func() {
 		sch.metrics.GetAlertRulesDuration.Observe(time.Since(start).Seconds())
 	}()
 
-	q := models.ListAlertRulesQuery{
-		ExcludeOrgs: disabledOrgs,
+	q := models.GetAlertRulesForSchedulingQuery{
+		ExcludeOrgIDs: disabledOrgs,
 	}
 	err := sch.ruleStore.GetAlertRulesForScheduling(ctx, &q)
 	if err != nil {

--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-func (sch *schedule) getAlertRules(ctx context.Context, disabledOrgs []int64) []*models.AlertRuleShort {
+func (sch *schedule) getAlertRules(ctx context.Context, disabledOrgs []int64) []*models.SchedulableAlertRule {
 	start := time.Now()
 	defer func() {
 		sch.metrics.GetAlertRulesDuration.Observe(time.Since(start).Seconds())

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -347,7 +347,7 @@ func (st DBstore) GetNamespaceByTitle(ctx context.Context, namespace string, org
 // GetAlertRulesForScheduling returns a short version of all alert rules except those that belong to an excluded list of organizations
 func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodels.GetAlertRulesForSchedulingQuery) error {
 	return st.SQLStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		alerts := make([]*ngmodels.AlertRuleShort, 0)
+		alerts := make([]*ngmodels.SchedulableAlertRule, 0)
 		q := sess.Table("alert_rule")
 		if len(query.ExcludeOrgIDs) > 0 {
 			excludeOrgs := make([]interface{}, 0, len(query.ExcludeOrgIDs))

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -37,7 +37,7 @@ type RuleStore interface {
 	DeleteAlertRulesByUID(ctx context.Context, orgID int64, ruleUID ...string) error
 	DeleteAlertInstancesByRuleUID(ctx context.Context, orgID int64, ruleUID string) error
 	GetAlertRuleByUID(ctx context.Context, query *ngmodels.GetAlertRuleByUIDQuery) error
-	GetAlertRulesForScheduling(ctx context.Context, query *ngmodels.ListAlertRulesQuery) error
+	GetAlertRulesForScheduling(ctx context.Context, query *ngmodels.GetAlertRulesForSchedulingQuery) error
 	ListAlertRules(ctx context.Context, query *ngmodels.ListAlertRulesQuery) error
 	// GetRuleGroups returns the unique rule groups across all organizations.
 	GetRuleGroups(ctx context.Context, query *ngmodels.ListRuleGroupsQuery) error
@@ -344,16 +344,19 @@ func (st DBstore) GetNamespaceByTitle(ctx context.Context, namespace string, org
 	return folder, nil
 }
 
-// GetAlertRulesForScheduling returns alert rule info (identifier, interval, version state)
-// that is useful for it's scheduling.
-func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodels.ListAlertRulesQuery) error {
+// GetAlertRulesForScheduling returns a short version of all alert rules except those that belong to an excluded list of organizations
+func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodels.GetAlertRulesForSchedulingQuery) error {
 	return st.SQLStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		alerts := make([]*ngmodels.AlertRule, 0)
-		q := "SELECT uid, org_id, interval_seconds, version FROM alert_rule"
-		if len(query.ExcludeOrgs) > 0 {
-			q = fmt.Sprintf("%s WHERE org_id NOT IN (%s)", q, strings.Join(strings.Split(strings.Trim(fmt.Sprint(query.ExcludeOrgs), "[]"), " "), ","))
+		alerts := make([]*ngmodels.AlertRuleShort, 0)
+		q := sess.Table("alert_rule")
+		if len(query.ExcludeOrgIDs) > 0 {
+			excludeOrgs := make([]interface{}, 0, len(query.ExcludeOrgIDs))
+			for _, orgID := range query.ExcludeOrgIDs {
+				excludeOrgs = append(excludeOrgs, orgID)
+			}
+			q = q.NotIn("org_id", excludeOrgs...)
 		}
-		if err := sess.SQL(q).Find(&alerts); err != nil {
+		if err := q.Find(&alerts); err != nil {
 			return err
 		}
 		query.Result = alerts

--- a/pkg/services/ngalert/store/testing.go
+++ b/pkg/services/ngalert/store/testing.go
@@ -153,7 +153,7 @@ func (f *FakeRuleStore) GetAlertRuleByUID(_ context.Context, q *models.GetAlertR
 }
 
 // For now, we're not implementing namespace filtering.
-func (f *FakeRuleStore) GetAlertRulesForScheduling(_ context.Context, q *models.ListAlertRulesQuery) error {
+func (f *FakeRuleStore) GetAlertRulesForScheduling(_ context.Context, q *models.GetAlertRulesForSchedulingQuery) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.RecordedOps = append(f.RecordedOps, *q)
@@ -161,7 +161,14 @@ func (f *FakeRuleStore) GetAlertRulesForScheduling(_ context.Context, q *models.
 		return err
 	}
 	for _, rules := range f.Rules {
-		q.Result = append(q.Result, rules...)
+		for _, rule := range rules {
+			q.Result = append(q.Result, &models.AlertRuleShort{
+				UID:             rule.UID,
+				OrgID:           rule.OrgID,
+				IntervalSeconds: rule.IntervalSeconds,
+				Version:         rule.Version,
+			})
+		}
 	}
 	return nil
 }

--- a/pkg/services/ngalert/store/testing.go
+++ b/pkg/services/ngalert/store/testing.go
@@ -162,7 +162,7 @@ func (f *FakeRuleStore) GetAlertRulesForScheduling(_ context.Context, q *models.
 	}
 	for _, rules := range f.Rules {
 		for _, rule := range rules {
-			q.Result = append(q.Result, &models.AlertRuleShort{
+			q.Result = append(q.Result, &models.SchedulableAlertRule{
 				UID:             rule.UID,
 				OrgID:           rule.OrgID,
 				IntervalSeconds: rule.IntervalSeconds,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The interface of the DbStore.GetAlertRulesForScheduling is very deceiving as it declares that the result is a collection of `AlertRule` models whereas in the reality the model is not fully populated. This can lead to a false assumption about the field values during the processing rules in the scheduler.
This PR creates a new model AlertRuleShort (better ideas a welcome) and changes the result of this method to return only fields that actually populated.