### PR TITLE
Alerting: Parse Loki BuildInfo response

### DIFF
--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -27,6 +27,7 @@ export enum PromApplication {
   Cortex = 'Cortex',
   Mimir = 'Mimir',
   Prometheus = 'Prometheus',
+  Loki = 'Loki',
 }
 
 export interface PromBuildInfoResponse {


### PR DESCRIPTION
Loki returns a BuildInfo response from its API, much like Mimir, which
allows us to list its alerting rules in the Grafana UI. However, the
structure of the Loki response is different. This PR accounts for that
difference by examining the returned responses for both the shape of the
Loki and Mimir-type responses.

Fixes #48627

Signed-off-by: Joe Blubaugh <joe.blubaugh@grafana.com>