### PR TITLE
WIP: loki backend-mode live-streaming

### DIFF
--- a/pkg/tsdb/loki/streaming.go
+++ b/pkg/tsdb/loki/streaming.go
@@ -132,7 +132,7 @@ func (s *Service) RunStream(ctx context.Context, req *backend.RunStreamRequest, 
 
 			frame := &data.Frame{}
 			if !lokiDataframeApi {
-				frame, err = lokiBytesToLabeledFrame(message)
+				frame, err = lokiBytesToLabeledFrame(message, lokiQuery{Expr: query.Expr})
 			} else {
 				err = json.Unmarshal(message, &frame)
 			}

--- a/pkg/tsdb/loki/streaming_frame.go
+++ b/pkg/tsdb/loki/streaming_frame.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	jsoniter "github.com/json-iterator/go"
 )
 
 type lokiResponse struct {
@@ -17,25 +18,42 @@ type lokiStream struct {
 	Values [][2]string `json:"values"`
 }
 
-func lokiBytesToLabeledFrame(msg []byte) (*data.Frame, error) {
+func labelsToRawJson(labels data.Labels) (json.RawMessage, error) {
+	// data.Labels when converted to JSON keep the fields sorted
+	bytes, err := jsoniter.Marshal(labels)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.RawMessage(bytes), nil
+}
+
+func lokiBytesToLabeledFrame(msg []byte, query lokiQuery) (*data.Frame, error) {
 	rsp := &lokiResponse{}
 	err := json.Unmarshal(msg, rsp)
 	if err != nil {
 		return nil, err
 	}
 
-	labelField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
+	labelField := data.NewFieldFromFieldType(data.FieldTypeJSON, 0)
 	timeField := data.NewFieldFromFieldType(data.FieldTypeTime, 0)
+	timeNsField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 	lineField := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 
-	labelField.Name = "__labels" // for now, avoid automatically spreading this by labels
+	labelField.Name = "labels"
 	timeField.Name = "Time"
+	timeNsField.Name = "tsNs"
 	lineField.Name = "Line"
 
 	for _, stream := range rsp.Streams {
-		label := stream.Stream.String() // TODO -- make it match prom labels!
+		label, err := labelsToRawJson(stream.Stream)
+		if err != nil {
+			return nil, err
+		}
+
 		for _, value := range stream.Values {
-			n, err := strconv.ParseInt(value[0], 10, 64)
+			tsNs := value[0]
+			n, err := strconv.ParseInt(tsNs, 10, 64)
 			if err != nil {
 				continue
 			}
@@ -44,9 +62,15 @@ func lokiBytesToLabeledFrame(msg []byte) (*data.Frame, error) {
 
 			labelField.Append(label)
 			timeField.Append(ts)
+			timeNsField.Append(tsNs)
 			lineField.Append(line)
 		}
 	}
 
-	return data.NewFrame("", labelField, timeField, lineField), nil
+	frame := data.NewFrame("", labelField, timeField, lineField, timeNsField)
+	err = adjustFrame(frame, &query)
+	if err != nil {
+		return nil, err
+	}
+	return frame, nil
 }

--- a/pkg/tsdb/loki/streaming_frame_test.go
+++ b/pkg/tsdb/loki/streaming_frame_test.go
@@ -27,7 +27,7 @@ func TestLokiFramer(t *testing.T) {
 			   ]}
 			]}`)
 
-		frame, err := lokiBytesToLabeledFrame(msg)
+		frame, err := lokiBytesToLabeledFrame(msg, lokiQuery{Expr: ""})
 		require.NoError(t, err)
 
 		lines := frame.Fields[2]

--- a/public/app/plugins/datasource/loki/streaming.ts
+++ b/public/app/plugins/datasource/loki/streaming.ts
@@ -1,6 +1,6 @@
 import { map, Observable, defer, mergeMap } from 'rxjs';
 
-import { DataFrameJSON, DataQueryRequest, DataQueryResponse, LiveChannelScope, LoadingState } from '@grafana/data';
+import { DataFrameJSON, DataQueryResponse, LiveChannelScope, LoadingState, TimeRange } from '@grafana/data';
 import { getGrafanaLiveSrv } from '@grafana/runtime';
 import { StreamingDataFrame } from 'app/features/live/data/StreamingDataFrame';
 
@@ -25,16 +25,11 @@ export async function getLiveStreamKey(query: LokiQuery): Promise<string> {
 export function doLokiChannelStream(
   query: LokiQuery,
   ds: LokiDatasource,
-  options: DataQueryRequest<LokiQuery>
+  range: TimeRange,
+  maxLength: number
 ): Observable<DataQueryResponse> {
   // maximum time to keep values
-  const range = options.range;
   const maxDelta = range.to.valueOf() - range.from.valueOf() + 1000;
-  let maxLength = options.maxDataPoints ?? 1000;
-  if (maxLength > 100) {
-    // for small buffers, keep them small
-    maxLength *= 2;
-  }
 
   let frame: StreamingDataFrame | undefined = undefined;
   const updateFrame = (msg: any) => {


### PR DESCRIPTION
WorkInProgress

when runnig a loki query in explore, you can press the [▶️Live] button to start live-streaming your logs.
this PR realizes this using "backed mode"

NOTE: there are big gaps in how-to-do-auth-things here:
- the first big question is: there are some http-modes that need per-user auth-data (forward-oauth-identity, allowedCookies)... these do not play well with the typical pub-sub-ish approach we prefer for streaming-backend-plugins... what to do there? should we just not do it if the feature is used? some other approach?
    - if we want to do them:
        - how to get additional info, like oauth-header and allowed-cookies (https://github.com/grafana/grafana-plugin-sdk-go/issues/509)
- whether it's possible to take the grafana-provided `httpClient`, and somehow "use" it in the outgoing websocket-connection
