### PR TITLE
Dashboards: Remove "delete dashboard" button for new dashboards

### DIFF
--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -212,6 +212,7 @@ export function getNewDashboardModelData(urlFolderId?: string | null): any {
     meta: {
       canStar: false,
       canShare: false,
+      canDelete: false,
       isNew: true,
       folderId: 0,
     },


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the "delete dashboard" button for new dashboards that haven't been created yet, as it doesn't really make sense and just fails if you try.
