### PR TITLE
Chore: rename integration tests to match the pattern

### DIFF
--- a/pkg/infra/filestorage/fs_integration_test.go
+++ b/pkg/infra/filestorage/fs_integration_test.go
@@ -1,4 +1,3 @@
-
 package filestorage
 
 import (

--- a/pkg/infra/filestorage/fs_integration_test.go
+++ b/pkg/infra/filestorage/fs_integration_test.go
@@ -149,7 +149,7 @@ func runTests(createCases func() []fsTestCase, t *testing.T) {
 	}
 }
 
-func TestFsStorage(t *testing.T) {
+func TestIntegrationFsStorage(t *testing.T) {
 	//skipTest := true
 	emptyContents := make([]byte, 0)
 	pngImage, _ := base64.StdEncoding.DecodeString(pngImageBase64)

--- a/pkg/infra/filestorage/fs_integration_test.go
+++ b/pkg/infra/filestorage/fs_integration_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package filestorage
 

--- a/pkg/infra/filestorage/test_utils.go
+++ b/pkg/infra/filestorage/test_utils.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package filestorage
 

--- a/pkg/infra/filestorage/test_utils.go
+++ b/pkg/infra/filestorage/test_utils.go
@@ -1,4 +1,3 @@
-
 package filestorage
 
 import (
@@ -135,7 +134,6 @@ type queryListFiles struct {
 
 type queryListFoldersInput struct {
 	path    string
-	paging  *Paging
 	options *ListOptions
 }
 
@@ -252,7 +250,6 @@ func runChecks(t *testing.T, stepName string, path string, output interface{}, c
 	default:
 		t.Fatalf("unrecognized output %s", interfaceName(output))
 	}
-
 }
 
 func formatPathStructure(files []*File) string {
@@ -275,7 +272,7 @@ func handleQuery(t *testing.T, ctx context.Context, query interface{}, queryName
 		file, err := fs.Get(ctx, inputPath)
 		require.NoError(t, err, "%s: should be able to get file %s", queryName, inputPath)
 
-		if q.checks != nil && len(q.checks) > 0 {
+		if len(q.checks) > 0 {
 			require.NotNil(t, file, "%s %s", queryName, inputPath)
 			require.Equal(t, strings.ToLower(inputPath), strings.ToLower(file.FullPath), "%s %s", queryName, inputPath)
 			runChecks(t, queryName, inputPath, file, q.checks)
@@ -358,5 +355,4 @@ func executeTestStep(t *testing.T, ctx context.Context, step interface{}, stepNu
 	default:
 		t.Fatalf("unrecognized step %s", name)
 	}
-
 }

--- a/pkg/infra/filestorage/test_utils.go
+++ b/pkg/infra/filestorage/test_utils.go
@@ -196,7 +196,7 @@ func handleCommand(t *testing.T, ctx context.Context, cmd interface{}, cmdName s
 }
 
 func runChecks(t *testing.T, stepName string, path string, output interface{}, checks []interface{}) {
-	if checks == nil || len(checks) == 0 {
+	if len(checks) == 0 {
 		return
 	}
 
@@ -284,7 +284,7 @@ func handleQuery(t *testing.T, ctx context.Context, query interface{}, queryName
 		resp, err := fs.List(ctx, inputPath, q.input.paging, q.input.options)
 		require.NoError(t, err, "%s: should be able to list files in %s", queryName, inputPath)
 		require.NotNil(t, resp)
-		if q.list != nil && len(q.list) > 0 {
+		if len(q.list) > 0 {
 			runChecks(t, queryName, inputPath, *resp, q.list)
 		} else {
 			require.NotNil(t, resp, "%s %s", queryName, inputPath)

--- a/pkg/infra/kvstore/kvstore_test.go
+++ b/pkg/infra/kvstore/kvstore_test.go
@@ -39,7 +39,7 @@ func (t *TestCase) Value() string {
 	return fmt.Sprintf("%d:%s:%s:%d", t.OrgId, t.Namespace, t.Key, t.Revision)
 }
 
-func TestKVStore(t *testing.T) {
+func TestIntegrationKVStore(t *testing.T) {
 	kv := createTestableKVStore(t)
 
 	ctx := context.Background()

--- a/pkg/infra/kvstore/kvstore_test.go
+++ b/pkg/infra/kvstore/kvstore_test.go
@@ -1,4 +1,3 @@
-
 package kvstore
 
 import (
@@ -6,11 +5,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createTestableKVStore(t *testing.T) KVStore {

--- a/pkg/infra/kvstore/kvstore_test.go
+++ b/pkg/infra/kvstore/kvstore_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package kvstore
 

--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestServerLok(t *testing.T) {
+func TestIntegrationServerLok(t *testing.T) {
 	sl := createTestableServerLock(t)
 
 	counter := 0

--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -1,4 +1,3 @@
-
 package serverlock
 
 import (

--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package serverlock
 

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEngineTimeouts(t *testing.T) {
+func TestIntegrationEngineTimeouts(t *testing.T) {
 	usMock := &usagestats.UsageStatsMock{T: t}
 	tracer, err := tracing.InitializeTracerForTest()
 	require.NoError(t, err)

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package alerting
 

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -1,4 +1,3 @@
-
 package alerting
 
 import (
@@ -79,7 +78,7 @@ func (handler *FakeCommonTimeoutHandler) Eval(evalContext *EvalContext) {
 	url := srv.URL + path
 	res, err := sendRequest(evalContext.Ctx, url, handler.TransportTimeoutDuration)
 	if res != nil {
-		defer res.Body.Close()
+		defer func() { _ = res.Body.Close() }()
 	}
 
 	if err != nil {
@@ -104,7 +103,7 @@ func (handler *FakeCommonTimeoutHandler) handle(evalContext *EvalContext) error 
 	url := srv.URL + path
 	res, err := sendRequest(evalContext.Ctx, url, handler.TransportTimeoutDuration)
 	if res != nil {
-		defer res.Body.Close()
+		defer func() { _ = res.Body.Close() }()
 	}
 
 	if err != nil {

--- a/pkg/services/dashboards/database/database_dashboard_test.go
+++ b/pkg/services/dashboards/database/database_dashboard_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func TestDashboardDataAccess(t *testing.T) {
+func TestIntegrationDashboardDataAccess(t *testing.T) {
 	var sqlStore *sqlstore.SQLStore
 	var savedFolder, savedDash, savedDash2 *models.Dashboard
 	var dashboardStore *DashboardStore
@@ -407,7 +407,7 @@ func TestDashboardDataAccess(t *testing.T) {
 	})
 }
 
-func TestDashboardDataAccessGivenPluginWithImportedDashboards(t *testing.T) {
+func TestIntegrationDashboardDataAccessGivenPluginWithImportedDashboards(t *testing.T) {
 	sqlStore := sqlstore.InitTestDB(t)
 	dashboardStore := ProvideDashboardStore(sqlStore)
 	pluginId := "test-app"
@@ -426,7 +426,7 @@ func TestDashboardDataAccessGivenPluginWithImportedDashboards(t *testing.T) {
 	require.Equal(t, len(query.Result), 2)
 }
 
-func TestDashboard_SortingOptions(t *testing.T) {
+func TestIntegrationDashboard_SortingOptions(t *testing.T) {
 	sqlStore := sqlstore.InitTestDB(t)
 	dashboardStore := ProvideDashboardStore(sqlStore)
 
@@ -459,7 +459,7 @@ func TestDashboard_SortingOptions(t *testing.T) {
 
 }
 
-func TestDashboard_Filter(t *testing.T) {
+func TestIntegrationDashboard_Filter(t *testing.T) {
 	sqlStore := sqlstore.InitTestDB(t)
 	dashboardStore := ProvideDashboardStore(sqlStore)
 	insertTestDashboard(t, dashboardStore, "Alfa", 1, 0, false)

--- a/pkg/services/dashboards/database/database_dashboard_test.go
+++ b/pkg/services/dashboards/database/database_dashboard_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package database
 

--- a/pkg/services/dashboards/database/database_dashboard_test.go
+++ b/pkg/services/dashboards/database/database_dashboard_test.go
@@ -1,4 +1,3 @@
-
 package database
 
 import (
@@ -219,7 +218,7 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 
 		require.Equal(t, len(query.Result), 0)
 
-		sqlStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+		_ = sqlStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 			var existingRuleID int64
 			exists, err := sess.Table("alert_rule").Where("namespace_uid = (SELECT uid FROM dashboard WHERE id = ?)", savedFolder.Id).Cols("id").Get(&existingRuleID)
 			require.NoError(t, err)
@@ -454,7 +453,6 @@ func TestIntegrationDashboard_SortingOptions(t *testing.T) {
 	require.Len(t, dashboards, 2)
 	assert.Equal(t, dashB.Id, dashboards[0].ID)
 	assert.Equal(t, dashA.Id, dashboards[1].ID)
-
 }
 
 func TestIntegrationDashboard_Filter(t *testing.T) {
@@ -486,7 +484,7 @@ func TestIntegrationDashboard_Filter(t *testing.T) {
 }
 
 func insertTestRule(t *testing.T, sqlStore *sqlstore.SQLStore, foderOrgID int64, folderUID string) {
-	sqlStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+	_ = sqlStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
 		type alertQuery struct {
 			RefID         string
 			DatasourceUID string

--- a/pkg/services/dashboards/database/database_dashboard_test.go
+++ b/pkg/services/dashboards/database/database_dashboard_test.go
@@ -480,7 +480,6 @@ func TestIntegrationDashboard_Filter(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, dashboards, 1)
 	assert.Equal(t, dashB.Id, dashboards[0].ID)
-
 }
 
 func insertTestRule(t *testing.T, sqlStore *sqlstore.SQLStore, foderOrgID int64, folderUID string) {

--- a/pkg/services/dashboards/database/database_folder_test.go
+++ b/pkg/services/dashboards/database/database_folder_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 )
 
-func TestDashboardFolderDataAccess(t *testing.T) {
+func TestIntegrationDashboardFolderDataAccess(t *testing.T) {
 	t.Run("Testing DB", func(t *testing.T) {
 		var sqlStore *sqlstore.SQLStore
 		var folder, dashInRoot, childDash *models.Dashboard

--- a/pkg/services/dashboards/database/database_folder_test.go
+++ b/pkg/services/dashboards/database/database_folder_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package database
 

--- a/pkg/services/dashboards/database/database_folder_test.go
+++ b/pkg/services/dashboards/database/database_folder_test.go
@@ -1,15 +1,13 @@
-
 package database
 
 import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationDashboardFolderDataAccess(t *testing.T) {

--- a/pkg/services/dashboards/database/database_provisioning_test.go
+++ b/pkg/services/dashboards/database/database_provisioning_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDashboardProvisioningTest(t *testing.T) {
+func TestIntegrationDashboardProvisioningTest(t *testing.T) {
 	sqlStore := sqlstore.InitTestDB(t)
 	dashboardStore := ProvideDashboardStore(sqlStore)
 

--- a/pkg/services/dashboards/database/database_provisioning_test.go
+++ b/pkg/services/dashboards/database/database_provisioning_test.go
@@ -1,4 +1,3 @@
-
 package database
 
 import (
@@ -6,11 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/services/sqlstore"
-
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
-
+	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/services/dashboards/database/database_provisioning_test.go
+++ b/pkg/services/dashboards/database/database_provisioning_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package database
 

--- a/pkg/services/dashboards/database/permissions/database_acl_test.go
+++ b/pkg/services/dashboards/database/permissions/database_acl_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDashboardAclDataAccess(t *testing.T) {
+func TestIntegrationDashboardAclDataAccess(t *testing.T) {
 	var sqlStore *sqlstore.SQLStore
 	var currentUser models.User
 	var savedFolder, childDash *models.Dashboard

--- a/pkg/services/dashboards/database/permissions/database_acl_test.go
+++ b/pkg/services/dashboards/database/permissions/database_acl_test.go
@@ -1,17 +1,15 @@
-
 package permissions
 
 import (
 	"context"
-	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/services/dashboards/database"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/grafana/grafana/pkg/setting"
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
-
+	"github.com/grafana/grafana/pkg/services/dashboards/database"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
 )
 
@@ -86,7 +84,6 @@ func TestIntegrationDashboardAclDataAccess(t *testing.T) {
 	})
 
 	t.Run("Given a dashboard folder and a user", func(t *testing.T) {
-
 		t.Run("Given dashboard folder permission", func(t *testing.T) {
 			setup(t)
 			err := updateDashboardAcl(t, dashboardStore, savedFolder.Id, models.DashboardAcl{

--- a/pkg/services/dashboards/database/permissions/database_acl_test.go
+++ b/pkg/services/dashboards/database/permissions/database_acl_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package permissions
 

--- a/pkg/services/dashboards/manager/dashboard_service_integration_test.go
+++ b/pkg/services/dashboards/manager/dashboard_service_integration_test.go
@@ -1,4 +1,3 @@
-
 package service
 
 import (

--- a/pkg/services/dashboards/manager/dashboard_service_integration_test.go
+++ b/pkg/services/dashboards/manager/dashboard_service_integration_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package service
 

--- a/pkg/services/dashboards/manager/dashboard_service_integration_test.go
+++ b/pkg/services/dashboards/manager/dashboard_service_integration_test.go
@@ -23,7 +23,7 @@ import (
 
 const testOrgID int64 = 1
 
-func TestIntegratedDashboardService(t *testing.T) {
+func TestIntegrationIntegratedDashboardService(t *testing.T) {
 	t.Run("Given saved folders and dashboards in organization A", func(t *testing.T) {
 		// Basic validation tests
 

--- a/pkg/services/dashboards/manager/dashboard_service_test.go
+++ b/pkg/services/dashboards/manager/dashboard_service_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func TestDashboardService(t *testing.T) {
+func TestIntegrationDashboardService(t *testing.T) {
 	t.Run("Dashboard service tests", func(t *testing.T) {
 		fakeStore := m.FakeDashboardStore{}
 		defer fakeStore.AssertExpectations(t)

--- a/pkg/services/dashboards/manager/dashboard_service_test.go
+++ b/pkg/services/dashboards/manager/dashboard_service_test.go
@@ -184,7 +184,6 @@ func TestIntegrationDashboardService(t *testing.T) {
 		})
 
 		t.Run("Given non provisioned dashboard", func(t *testing.T) {
-
 			t.Run("DeleteProvisionedDashboard should delete the dashboard", func(t *testing.T) {
 				args := &models.DeleteDashboardCommand{OrgId: 1, Id: 1, ForceDeleteFolderRules: false}
 				fakeStore.On("DeleteDashboard", mock.Anything, args).Return(nil).Once()

--- a/pkg/services/dashboards/manager/dashboard_service_test.go
+++ b/pkg/services/dashboards/manager/dashboard_service_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package service
 

--- a/pkg/services/dashboards/manager/dashboard_service_test.go
+++ b/pkg/services/dashboards/manager/dashboard_service_test.go
@@ -1,4 +1,3 @@
-
 package service
 
 import (
@@ -202,8 +201,4 @@ func TestIntegrationDashboardService(t *testing.T) {
 			})
 		})
 	})
-}
-
-type Result struct {
-	deleteWasCalled bool
 }

--- a/pkg/services/dashboards/manager/folder_service_test.go
+++ b/pkg/services/dashboards/manager/folder_service_test.go
@@ -1,4 +1,3 @@
-
 package service
 
 import (

--- a/pkg/services/dashboards/manager/folder_service_test.go
+++ b/pkg/services/dashboards/manager/folder_service_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package service
 

--- a/pkg/services/dashboards/manager/folder_service_test.go
+++ b/pkg/services/dashboards/manager/folder_service_test.go
@@ -26,7 +26,7 @@ import (
 var orgID = int64(1)
 var user = &models.SignedInUser{UserId: 1}
 
-func TestProvideFolderService(t *testing.T) {
+func TestIntegrationProvideFolderService(t *testing.T) {
 	t.Run("should register scope resolvers", func(t *testing.T) {
 		store := &dashboards.FakeDashboardStore{}
 		cfg := setting.NewCfg()
@@ -46,7 +46,7 @@ func TestProvideFolderService(t *testing.T) {
 	})
 }
 
-func TestFolderService(t *testing.T) {
+func TestIntegrationFolderService(t *testing.T) {
 	t.Run("Folder service tests", func(t *testing.T) {
 		store := &dashboards.FakeDashboardStore{}
 		cfg := setting.NewCfg()

--- a/pkg/services/live/database/tests/storage_test.go
+++ b/pkg/services/live/database/tests/storage_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLiveMessage(t *testing.T) {
+func TestIntegrationLiveMessage(t *testing.T) {
 	storage := SetupTestStorage(t)
 
 	getQuery := &models.GetLiveMessageQuery{

--- a/pkg/services/live/database/tests/storage_test.go
+++ b/pkg/services/live/database/tests/storage_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package tests
 

--- a/pkg/services/live/database/tests/storage_test.go
+++ b/pkg/services/live/database/tests/storage_test.go
@@ -1,4 +1,3 @@
-
 package tests
 
 import (
@@ -6,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/models"
-
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/services/ngalert/store/alertmanager_test.go
+++ b/pkg/services/ngalert/store/alertmanager_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAlertManagerHash(t *testing.T) {
+func TestIntegrationAlertManagerHash(t *testing.T) {
 	sqlStore := sqlstore.InitTestDB(t)
 	store := &DBstore{
 		SQLStore: sqlStore,

--- a/pkg/services/ngalert/store/alertmanager_test.go
+++ b/pkg/services/ngalert/store/alertmanager_test.go
@@ -1,4 +1,3 @@
-
 package store
 
 import (

--- a/pkg/services/ngalert/store/alertmanager_test.go
+++ b/pkg/services/ngalert/store/alertmanager_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package store
 

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package store_test
 

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -1,28 +1,16 @@
-
 package store_test
 
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests"
 
 	"github.com/stretchr/testify/require"
 )
 
 const baseIntervalSeconds = 10
-
-func mockTimeNow() {
-	var timeSeed int64
-	store.TimeNow = func() time.Time {
-		fakeNow := time.Unix(timeSeed, 0).UTC()
-		timeSeed++
-		return fakeNow
-	}
-}
 
 func TestIntegrationAlertInstanceOperations(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -26,7 +26,7 @@ func mockTimeNow() {
 	}
 }
 
-func TestAlertInstanceOperations(t *testing.T) {
+func TestIntegrationAlertInstanceOperations(t *testing.T) {
 	ctx := context.Background()
 	_, dbstore := tests.SetupTestEnv(t, baseIntervalSeconds)
 

--- a/pkg/services/preference/prefimpl/store_test.go
+++ b/pkg/services/preference/prefimpl/store_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPreferencesDataAccess(t *testing.T) {
+func TestIntegrationPreferencesDataAccess(t *testing.T) {
 	ss := sqlstore.InitTestDB(t)
 	prefStore := sqlStore{db: ss}
 	orgNavbarPreferences := pref.NavbarPreference{

--- a/pkg/services/preference/prefimpl/store_test.go
+++ b/pkg/services/preference/prefimpl/store_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package prefimpl
 

--- a/pkg/services/preference/prefimpl/store_test.go
+++ b/pkg/services/preference/prefimpl/store_test.go
@@ -1,4 +1,3 @@
-
 package prefimpl
 
 import (

--- a/pkg/services/queryhistory/queryhistory_create_test.go
+++ b/pkg/services/queryhistory/queryhistory_create_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateQueryInQueryHistory(t *testing.T) {
+func TestIntegrationCreateQueryInQueryHistory(t *testing.T) {
 	testScenario(t, "When users tries to create query in query history it should succeed",
 		func(t *testing.T, sc scenarioContext) {
 			command := CreateQueryInQueryHistoryCommand{

--- a/pkg/services/queryhistory/queryhistory_create_test.go
+++ b/pkg/services/queryhistory/queryhistory_create_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package queryhistory
 

--- a/pkg/services/queryhistory/queryhistory_create_test.go
+++ b/pkg/services/queryhistory/queryhistory_create_test.go
@@ -1,4 +1,3 @@
-
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_delete_stale_test.go
+++ b/pkg/services/queryhistory/queryhistory_delete_stale_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeleteStaleQueryFromQueryHistory(t *testing.T) {
+func TestIntegrationDeleteStaleQueryFromQueryHistory(t *testing.T) {
 	testScenarioWithQueryInQueryHistory(t, "Stale query history can be deleted",
 		func(t *testing.T, sc scenarioContext) {
 			olderThan := time.Now().Unix() + 60

--- a/pkg/services/queryhistory/queryhistory_delete_stale_test.go
+++ b/pkg/services/queryhistory/queryhistory_delete_stale_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package queryhistory
 

--- a/pkg/services/queryhistory/queryhistory_delete_stale_test.go
+++ b/pkg/services/queryhistory/queryhistory_delete_stale_test.go
@@ -1,4 +1,3 @@
-
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_delete_test.go
+++ b/pkg/services/queryhistory/queryhistory_delete_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeleteQueryFromQueryHistory(t *testing.T) {
+func TestIntegrationDeleteQueryFromQueryHistory(t *testing.T) {
 	testScenarioWithQueryInQueryHistory(t, "When users tries to delete query in query history that does not exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			resp := sc.service.deleteHandler(sc.reqContext)

--- a/pkg/services/queryhistory/queryhistory_delete_test.go
+++ b/pkg/services/queryhistory/queryhistory_delete_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package queryhistory
 

--- a/pkg/services/queryhistory/queryhistory_delete_test.go
+++ b/pkg/services/queryhistory/queryhistory_delete_test.go
@@ -1,4 +1,3 @@
-
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_enforce_limit_test.go
+++ b/pkg/services/queryhistory/queryhistory_enforce_limit_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEnforceRowLimitInQueryHistory(t *testing.T) {
+func TestIntegrationEnforceRowLimitInQueryHistory(t *testing.T) {
 	testScenarioWithQueryInQueryHistory(t, "Enforce limit for query_history",
 		func(t *testing.T, sc scenarioContext) {
 			limit := 0

--- a/pkg/services/queryhistory/queryhistory_enforce_limit_test.go
+++ b/pkg/services/queryhistory/queryhistory_enforce_limit_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package queryhistory
 

--- a/pkg/services/queryhistory/queryhistory_enforce_limit_test.go
+++ b/pkg/services/queryhistory/queryhistory_enforce_limit_test.go
@@ -1,4 +1,3 @@
-
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_migrate_test.go
+++ b/pkg/services/queryhistory/queryhistory_migrate_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMigrateQueriesToQueryHistory(t *testing.T) {
+func TestIntegrationMigrateQueriesToQueryHistory(t *testing.T) {
 	testScenario(t, "When users tries to migrate 1 query in query history it should succeed",
 		func(t *testing.T, sc scenarioContext) {
 			command := MigrateQueriesToQueryHistoryCommand{

--- a/pkg/services/queryhistory/queryhistory_migrate_test.go
+++ b/pkg/services/queryhistory/queryhistory_migrate_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package queryhistory
 

--- a/pkg/services/queryhistory/queryhistory_migrate_test.go
+++ b/pkg/services/queryhistory/queryhistory_migrate_test.go
@@ -1,4 +1,3 @@
-
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_patch_test.go
+++ b/pkg/services/queryhistory/queryhistory_patch_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPatchQueryCommentInQueryHistory(t *testing.T) {
+func TestIntegrationPatchQueryCommentInQueryHistory(t *testing.T) {
 	testScenarioWithQueryInQueryHistory(t, "When user tries to patch comment of query in query history that does not exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			resp := sc.service.patchCommentHandler(sc.reqContext)

--- a/pkg/services/queryhistory/queryhistory_patch_test.go
+++ b/pkg/services/queryhistory/queryhistory_patch_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package queryhistory
 

--- a/pkg/services/queryhistory/queryhistory_patch_test.go
+++ b/pkg/services/queryhistory/queryhistory_patch_test.go
@@ -1,4 +1,3 @@
-
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetQueriesFromQueryHistory(t *testing.T) {
+func TestIntegrationGetQueriesFromQueryHistory(t *testing.T) {
 	testScenario(t, "When users tries to get query in empty query history, it should return empty result",
 		func(t *testing.T, sc scenarioContext) {
 			sc.reqContext.Req.Form.Add("datasourceUid", "test")

--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package queryhistory
 

--- a/pkg/services/queryhistory/queryhistory_search_test.go
+++ b/pkg/services/queryhistory/queryhistory_search_test.go
@@ -1,4 +1,3 @@
-
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_star_test.go
+++ b/pkg/services/queryhistory/queryhistory_star_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStarQueryInQueryHistory(t *testing.T) {
+func TestIntegrationStarQueryInQueryHistory(t *testing.T) {
 	testScenarioWithQueryInQueryHistory(t, "When users tries to star query in query history that does not exists, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			resp := sc.service.starHandler(sc.reqContext)

--- a/pkg/services/queryhistory/queryhistory_star_test.go
+++ b/pkg/services/queryhistory/queryhistory_star_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package queryhistory
 

--- a/pkg/services/queryhistory/queryhistory_star_test.go
+++ b/pkg/services/queryhistory/queryhistory_star_test.go
@@ -1,4 +1,3 @@
-
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_test.go
+++ b/pkg/services/queryhistory/queryhistory_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package queryhistory
 

--- a/pkg/services/queryhistory/queryhistory_test.go
+++ b/pkg/services/queryhistory/queryhistory_test.go
@@ -1,4 +1,3 @@
-
 package queryhistory
 
 import (

--- a/pkg/services/queryhistory/queryhistory_unstar_test.go
+++ b/pkg/services/queryhistory/queryhistory_unstar_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnstarQueryInQueryHistory(t *testing.T) {
+func TestIntegrationUnstarQueryInQueryHistory(t *testing.T) {
 	testScenarioWithQueryInQueryHistory(t, "When users tries to unstar query in query history that does not exists, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			resp := sc.service.starHandler(sc.reqContext)

--- a/pkg/services/queryhistory/queryhistory_unstar_test.go
+++ b/pkg/services/queryhistory/queryhistory_unstar_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package queryhistory
 

--- a/pkg/services/queryhistory/queryhistory_unstar_test.go
+++ b/pkg/services/queryhistory/queryhistory_unstar_test.go
@@ -1,4 +1,3 @@
-
 package queryhistory
 
 import (

--- a/pkg/services/sqlstore/alert_notification_test.go
+++ b/pkg/services/sqlstore/alert_notification_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAlertNotificationSQLAccess(t *testing.T) {
+func TestIntegrationAlertNotificationSQLAccess(t *testing.T) {
 	var sqlStore *SQLStore
 	setup := func() { sqlStore = InitTestDB(t) }
 

--- a/pkg/services/sqlstore/alert_notification_test.go
+++ b/pkg/services/sqlstore/alert_notification_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (
@@ -10,7 +9,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
-
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/services/sqlstore/alert_notification_test.go
+++ b/pkg/services/sqlstore/alert_notification_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/alert_test.go
+++ b/pkg/services/sqlstore/alert_test.go
@@ -28,7 +28,7 @@ func resetTimeNow() {
 	timeNow = time.Now
 }
 
-func TestAlertingDataAccess(t *testing.T) {
+func TestIntegrationAlertingDataAccess(t *testing.T) {
 	mockTimeNow()
 	defer resetTimeNow()
 
@@ -262,7 +262,7 @@ func TestAlertingDataAccess(t *testing.T) {
 	})
 }
 
-func TestPausingAlerts(t *testing.T) {
+func TestIntegrationPausingAlerts(t *testing.T) {
 	mockTimeNow()
 	defer resetTimeNow()
 

--- a/pkg/services/sqlstore/alert_test.go
+++ b/pkg/services/sqlstore/alert_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (
@@ -8,7 +7,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
-
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/services/sqlstore/alert_test.go
+++ b/pkg/services/sqlstore/alert_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/annotation_test.go
+++ b/pkg/services/sqlstore/annotation_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore_test
 

--- a/pkg/services/sqlstore/annotation_test.go
+++ b/pkg/services/sqlstore/annotation_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore_test
 
 import (

--- a/pkg/services/sqlstore/annotation_test.go
+++ b/pkg/services/sqlstore/annotation_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 )
 
-func TestAnnotations(t *testing.T) {
+func TestIntegrationAnnotations(t *testing.T) {
 	sql := sqlstore.InitTestDB(t)
 	repo := sqlstore.NewSQLAnnotationRepo(sql)
 
@@ -338,7 +338,7 @@ func TestAnnotations(t *testing.T) {
 	})
 }
 
-func TestAnnotationListingWithRBAC(t *testing.T) {
+func TestIntegrationAnnotationListingWithRBAC(t *testing.T) {
 	sql := sqlstore.InitTestDB(t, sqlstore.InitTestDBOpt{FeatureFlags: []string{featuremgmt.FlagAccesscontrol}})
 	repo := sqlstore.NewSQLAnnotationRepo(sql)
 	dashboardStore := dashboardstore.ProvideDashboardStore(sql)

--- a/pkg/services/sqlstore/apikey_test.go
+++ b/pkg/services/sqlstore/apikey_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (
@@ -7,11 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationApiKeyDataAccess(t *testing.T) {

--- a/pkg/services/sqlstore/apikey_test.go
+++ b/pkg/services/sqlstore/apikey_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/apikey_test.go
+++ b/pkg/services/sqlstore/apikey_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestApiKeyDataAccess(t *testing.T) {
+func TestIntegrationApiKeyDataAccess(t *testing.T) {
 	mockTimeNow()
 	defer resetTimeNow()
 
@@ -124,7 +124,7 @@ func TestApiKeyDataAccess(t *testing.T) {
 	})
 }
 
-func TestApiKeyErrors(t *testing.T) {
+func TestIntegrationApiKeyErrors(t *testing.T) {
 	mockTimeNow()
 	defer resetTimeNow()
 
@@ -160,7 +160,7 @@ type getApiKeysTestCase struct {
 	expectedNumKeys int
 }
 
-func TestSQLStore_GetAPIKeys(t *testing.T) {
+func TestIntegrationSQLStore_GetAPIKeys(t *testing.T) {
 	tests := []getApiKeysTestCase{
 		{
 			desc: "expect all keys for wildcard scope",

--- a/pkg/services/sqlstore/dashboard_snapshot_test.go
+++ b/pkg/services/sqlstore/dashboard_snapshot_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDashboardSnapshotDBAccess(t *testing.T) {
+func TestIntegrationDashboardSnapshotDBAccess(t *testing.T) {
 	sqlstore := InitTestDB(t)
 
 	origSecret := setting.SecretKey
@@ -144,7 +144,7 @@ func TestDashboardSnapshotDBAccess(t *testing.T) {
 	})
 }
 
-func TestDeleteExpiredSnapshots(t *testing.T) {
+func TestIntegrationDeleteExpiredSnapshots(t *testing.T) {
 	sqlstore := InitTestDB(t)
 
 	t.Run("Testing dashboard snapshots clean up", func(t *testing.T) {

--- a/pkg/services/sqlstore/dashboard_snapshot_test.go
+++ b/pkg/services/sqlstore/dashboard_snapshot_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/dashboard_snapshot_test.go
+++ b/pkg/services/sqlstore/dashboard_snapshot_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/dashboard_thumbs_test.go
+++ b/pkg/services/sqlstore/dashboard_thumbs_test.go
@@ -14,7 +14,7 @@ import (
 var theme = models.ThemeDark
 var kind = models.ThumbnailKindDefault
 
-func TestSqlStorage(t *testing.T) {
+func TestIntegrationSqlStorage(t *testing.T) {
 
 	var sqlStore *SQLStore
 	var savedFolder *models.Dashboard

--- a/pkg/services/sqlstore/dashboard_thumbs_test.go
+++ b/pkg/services/sqlstore/dashboard_thumbs_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/dashboard_thumbs_test.go
+++ b/pkg/services/sqlstore/dashboard_thumbs_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (
@@ -13,7 +12,6 @@ var theme = models.ThemeDark
 var kind = models.ThumbnailKindDefault
 
 func TestIntegrationSqlStorage(t *testing.T) {
-
 	var sqlStore *SQLStore
 	var savedFolder *models.Dashboard
 

--- a/pkg/services/sqlstore/dashboard_version_test.go
+++ b/pkg/services/sqlstore/dashboard_version_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/dashboard_version_test.go
+++ b/pkg/services/sqlstore/dashboard_version_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/dashboard_version_test.go
+++ b/pkg/services/sqlstore/dashboard_version_test.go
@@ -77,7 +77,7 @@ func updateTestDashboard(t *testing.T, sqlStore *SQLStore, dashboard *models.Das
 	require.NoError(t, err)
 }
 
-func TestGetDashboardVersion(t *testing.T) {
+func TestIntegrationGetDashboardVersion(t *testing.T) {
 	sqlStore := InitTestDB(t)
 
 	t.Run("Get a Dashboard ID and version ID", func(t *testing.T) {
@@ -118,7 +118,7 @@ func TestGetDashboardVersion(t *testing.T) {
 	})
 }
 
-func TestGetDashboardVersions(t *testing.T) {
+func TestIntegrationGetDashboardVersions(t *testing.T) {
 	sqlStore := InitTestDB(t)
 	savedDash := insertTestDashboard(t, sqlStore, "test dash 43", 1, 0, false, "diff-all")
 
@@ -151,7 +151,7 @@ func TestGetDashboardVersions(t *testing.T) {
 	})
 }
 
-func TestDeleteExpiredVersions(t *testing.T) {
+func TestIntegrationDeleteExpiredVersions(t *testing.T) {
 	versionsToKeep := 5
 	versionsToWrite := 10
 	setting.DashboardVersionsToKeep = versionsToKeep

--- a/pkg/services/sqlstore/datasource_test.go
+++ b/pkg/services/sqlstore/datasource_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDataAccess(t *testing.T) {
+func TestIntegrationDataAccess(t *testing.T) {
 	defaultAddDatasourceCommand := models.AddDataSourceCommand{
 		OrgId:  10,
 		Name:   "nisse",
@@ -431,7 +431,7 @@ func TestDataAccess(t *testing.T) {
 	})
 }
 
-func TestGetDefaultDataSource(t *testing.T) {
+func TestIntegrationGetDefaultDataSource(t *testing.T) {
 	InitTestDB(t)
 
 	t.Run("should return error if there is no default datasource", func(t *testing.T) {

--- a/pkg/services/sqlstore/datasource_test.go
+++ b/pkg/services/sqlstore/datasource_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/datasource_test.go
+++ b/pkg/services/sqlstore/datasource_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/health_test.go
+++ b/pkg/services/sqlstore/health_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetDBHealthQuery(t *testing.T) {
+func TestIntegrationGetDBHealthQuery(t *testing.T) {
 	store := InitTestDB(t)
 
 	query := models.GetDBHealthQuery{}

--- a/pkg/services/sqlstore/health_test.go
+++ b/pkg/services/sqlstore/health_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/health_test.go
+++ b/pkg/services/sqlstore/health_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/login_attempt_test.go
+++ b/pkg/services/sqlstore/login_attempt_test.go
@@ -18,7 +18,7 @@ func mockTime(mock time.Time) time.Time {
 	return mock
 }
 
-func TestLoginAttempts(t *testing.T) {
+func TestIntegrationLoginAttempts(t *testing.T) {
 	var beginningOfTime, timePlusOneMinute, timePlusTwoMinutes time.Time
 	var sqlStore *SQLStore
 	user := "user"

--- a/pkg/services/sqlstore/login_attempt_test.go
+++ b/pkg/services/sqlstore/login_attempt_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/login_attempt_test.go
+++ b/pkg/services/sqlstore/login_attempt_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/org_test.go
+++ b/pkg/services/sqlstore/org_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (
@@ -422,6 +421,7 @@ func insertTestDashboard(t *testing.T, sqlStore *SQLStore, title string, orgId i
 
 		return nil
 	})
+	require.NoError(t, err)
 
 	return dash
 }

--- a/pkg/services/sqlstore/org_test.go
+++ b/pkg/services/sqlstore/org_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/org_test.go
+++ b/pkg/services/sqlstore/org_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAccountDataAccess(t *testing.T) {
+func TestIntegrationAccountDataAccess(t *testing.T) {
 	t.Run("Testing Account DB Access", func(t *testing.T) {
 		sqlStore := InitTestDB(t)
 

--- a/pkg/services/sqlstore/playlist_test.go
+++ b/pkg/services/sqlstore/playlist_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPlaylistDataAccess(t *testing.T) {
+func TestIntegrationPlaylistDataAccess(t *testing.T) {
 	ss := InitTestDB(t)
 
 	t.Run("Can create playlist", func(t *testing.T) {

--- a/pkg/services/sqlstore/playlist_test.go
+++ b/pkg/services/sqlstore/playlist_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/playlist_test.go
+++ b/pkg/services/sqlstore/playlist_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/plugin_setting_test.go
+++ b/pkg/services/sqlstore/plugin_setting_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPluginSettings(t *testing.T) {
+func TestIntegrationPluginSettings(t *testing.T) {
 	store := InitTestDB(t)
 
 	t.Run("Existing plugin settings", func(t *testing.T) {

--- a/pkg/services/sqlstore/plugin_setting_test.go
+++ b/pkg/services/sqlstore/plugin_setting_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/plugin_setting_test.go
+++ b/pkg/services/sqlstore/plugin_setting_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/quota_test.go
+++ b/pkg/services/sqlstore/quota_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestQuotaCommandsAndQueries(t *testing.T) {
+func TestIntegrationQuotaCommandsAndQueries(t *testing.T) {
 	sqlStore := InitTestDB(t)
 	userId := int64(1)
 	orgId := int64(0)

--- a/pkg/services/sqlstore/quota_test.go
+++ b/pkg/services/sqlstore/quota_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/quota_test.go
+++ b/pkg/services/sqlstore/quota_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/sqlbuilder_test.go
+++ b/pkg/services/sqlstore/sqlbuilder_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSQLBuilder(t *testing.T) {
+func TestIntegrationSQLBuilder(t *testing.T) {
 	t.Run("WriteDashboardPermissionFilter", func(t *testing.T) {
 		t.Run("user ACL", func(t *testing.T) {
 			test(t,

--- a/pkg/services/sqlstore/sqlbuilder_test.go
+++ b/pkg/services/sqlstore/sqlbuilder_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/sqlbuilder_test.go
+++ b/pkg/services/sqlstore/sqlbuilder_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -77,7 +77,7 @@ var sqlStoreTestCases = []sqlStoreTest{
 	},
 }
 
-func TestSQLConnectionString(t *testing.T) {
+func TestIntegrationSQLConnectionString(t *testing.T) {
 	for _, testCase := range sqlStoreTestCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			sqlstore := &SQLStore{}

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/stars_test.go
+++ b/pkg/services/sqlstore/stars_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/stars_test.go
+++ b/pkg/services/sqlstore/stars_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/stars_test.go
+++ b/pkg/services/sqlstore/stars_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUserStarsDataAccess(t *testing.T) {
+func TestIntegrationUserStarsDataAccess(t *testing.T) {
 	t.Run("Testing User Stars Data Access", func(t *testing.T) {
 		sqlStore := InitTestDB(t)
 

--- a/pkg/services/sqlstore/stats_integration_test.go
+++ b/pkg/services/sqlstore/stats_integration_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/stats_integration_test.go
+++ b/pkg/services/sqlstore/stats_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIntegration_GetAdminStats(t *testing.T) {
+func TestIntegrationIntegration_GetAdminStats(t *testing.T) {
 	sqlStore := InitTestDB(t)
 
 	query := models.GetAdminStatsQuery{}

--- a/pkg/services/sqlstore/stats_integration_test.go
+++ b/pkg/services/sqlstore/stats_integration_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/stats_test.go
+++ b/pkg/services/sqlstore/stats_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStatsDataAccess(t *testing.T) {
+func TestIntegrationStatsDataAccess(t *testing.T) {
 	sqlStore := InitTestDB(t)
 	populateDB(t, sqlStore)
 

--- a/pkg/services/sqlstore/stats_test.go
+++ b/pkg/services/sqlstore/stats_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/stats_test.go
+++ b/pkg/services/sqlstore/stats_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/tags_test.go
+++ b/pkg/services/sqlstore/tags_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSavingTags(t *testing.T) {
+func TestIntegrationSavingTags(t *testing.T) {
 	ss := InitTestDB(t)
 
 	tagPairs := []*models.Tag{

--- a/pkg/services/sqlstore/tags_test.go
+++ b/pkg/services/sqlstore/tags_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/tags_test.go
+++ b/pkg/services/sqlstore/tags_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/team_test.go
+++ b/pkg/services/sqlstore/team_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/team_test.go
+++ b/pkg/services/sqlstore/team_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (
@@ -426,7 +425,6 @@ func TestIntegrationSQLStore_GetTeamMembers_ACFilter(t *testing.T) {
 
 	// Seed 2 teams with 2 members
 	setup := func(store *SQLStore) {
-
 		team1, errCreateTeam := store.CreateTeam("group1 name", "test1@example.org", testOrgID)
 		require.NoError(t, errCreateTeam)
 		team2, errCreateTeam := store.CreateTeam("group2 name", "test2@example.org", testOrgID)

--- a/pkg/services/sqlstore/team_test.go
+++ b/pkg/services/sqlstore/team_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
-func TestTeamCommandsAndQueries(t *testing.T) {
+func TestIntegrationTeamCommandsAndQueries(t *testing.T) {
 	t.Run("Testing Team commands & queries", func(t *testing.T) {
 		sqlStore := InitTestDB(t)
 
@@ -349,7 +349,7 @@ func TestTeamCommandsAndQueries(t *testing.T) {
 	})
 }
 
-func TestSQLStore_SearchTeams(t *testing.T) {
+func TestIntegrationSQLStore_SearchTeams(t *testing.T) {
 	type searchTeamsTestCase struct {
 		desc             string
 		query            *models.SearchTeamsQuery
@@ -422,7 +422,7 @@ func TestSQLStore_SearchTeams(t *testing.T) {
 
 // TestSQLStore_GetTeamMembers_ACFilter tests the accesscontrol filtering of
 // team members based on the signed in user permissions
-func TestSQLStore_GetTeamMembers_ACFilter(t *testing.T) {
+func TestIntegrationSQLStore_GetTeamMembers_ACFilter(t *testing.T) {
 	testOrgID := int64(2)
 	userIds := make([]int64, 4)
 

--- a/pkg/services/sqlstore/temp_user_test.go
+++ b/pkg/services/sqlstore/temp_user_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTempUserCommandsAndQueries(t *testing.T) {
+func TestIntegrationTempUserCommandsAndQueries(t *testing.T) {
 	ss := InitTestDB(t)
 	cmd := models.CreateTempUserCommand{
 		OrgId:  2256,

--- a/pkg/services/sqlstore/temp_user_test.go
+++ b/pkg/services/sqlstore/temp_user_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/temp_user_test.go
+++ b/pkg/services/sqlstore/temp_user_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/transactions_test.go
+++ b/pkg/services/sqlstore/transactions_test.go
@@ -15,7 +15,7 @@ import (
 
 var ErrProvokedError = errors.New("testing error")
 
-func TestTransaction(t *testing.T) {
+func TestIntegrationTransaction(t *testing.T) {
 	ss := InitTestDB(t)
 
 	cmd := &models.AddApiKeyCommand{Key: "secret-key", Name: "key", OrgId: 1}
@@ -56,7 +56,7 @@ func TestTransaction(t *testing.T) {
 	})
 }
 
-func TestReuseSessionWithTransaction(t *testing.T) {
+func TestIntegrationReuseSessionWithTransaction(t *testing.T) {
 	ss := InitTestDB(t)
 
 	t.Run("top level transaction", func(t *testing.T) {

--- a/pkg/services/sqlstore/transactions_test.go
+++ b/pkg/services/sqlstore/transactions_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (

--- a/pkg/services/sqlstore/transactions_test.go
+++ b/pkg/services/sqlstore/transactions_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUserDataAccess(t *testing.T) {
+func TestIntegrationUserDataAccess(t *testing.T) {
 
 	ss := InitTestDB(t)
 

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -1,4 +1,3 @@
-
 package sqlstore
 
 import (
@@ -12,7 +11,6 @@ import (
 )
 
 func TestIntegrationUserDataAccess(t *testing.T) {
-
 	ss := InitTestDB(t)
 
 	t.Run("Testing DB - creates and loads user", func(t *testing.T) {

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package sqlstore
 

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -335,7 +335,6 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 	ss = InitTestDB(t)
 
 	t.Run("Testing DB - enable all users", func(t *testing.T) {
-
 		users := createFiveTestUsers(t, ss, func(i int) *models.CreateUserCommand {
 			return &models.CreateUserCommand{
 				Email:      fmt.Sprint("user", i, "@test.com"),
@@ -423,7 +422,6 @@ func TestIntegrationUserDataAccess(t *testing.T) {
 	})
 
 	t.Run("Testing DB - grafana admin users", func(t *testing.T) {
-
 		ss = InitTestDB(t)
 
 		createUserCmd := models.CreateUserCommand{

--- a/pkg/services/store/entity_events_test.go
+++ b/pkg/services/store/entity_events_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEntityEventsService(t *testing.T) {
+func TestIntegrationEntityEventsService(t *testing.T) {
 	var ctx context.Context
 	var service EntityEventsService
 
@@ -136,7 +136,7 @@ func TestEntityEventsService(t *testing.T) {
 	})
 }
 
-func TestCreateDatabaseEntityId(t *testing.T) {
+func TestIntegrationCreateDatabaseEntityId(t *testing.T) {
 	tests := []struct {
 		name       string
 		entityType EntityType

--- a/pkg/services/store/entity_events_test.go
+++ b/pkg/services/store/entity_events_test.go
@@ -1,4 +1,3 @@
-
 package store
 
 import (
@@ -76,6 +75,7 @@ func TestIntegrationEntityEventsService(t *testing.T) {
 		})
 		require.NoError(t, err)
 		firstEv, err := service.GetLastEvent(ctx)
+		require.NoError(t, err)
 		firstEvId := firstEv.Id
 
 		err = service.SaveEvent(ctx, SaveEventCmd{

--- a/pkg/services/store/entity_events_test.go
+++ b/pkg/services/store/entity_events_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package store
 

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -28,7 +28,7 @@ import (
 // There is also a datasource and dashboard provisioned by devenv scripts that you can
 // use to verify that the generated data are visualized as expected, see
 // devenv/README.md for setup instructions.
-func TestMySQL(t *testing.T) {
+func TestIntegrationMySQL(t *testing.T) {
 	// change to true to run the MySQL tests
 	runMySQLTests := false
 	// runMySqlTests := true

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -1,4 +1,3 @@
-
 package mysql
 
 import (

--- a/pkg/tsdb/mysql/mysql_test.go
+++ b/pkg/tsdb/mysql/mysql_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package mysql
 

--- a/pkg/tsdb/postgres/postgres_test.go
+++ b/pkg/tsdb/postgres/postgres_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 // Test generateConnectionString.
-func TestGenerateConnectionString(t *testing.T) {
+func TestIntegrationGenerateConnectionString(t *testing.T) {
 	cfg := setting.NewCfg()
 	cfg.DataPath = t.TempDir()
 
@@ -172,7 +172,7 @@ func TestGenerateConnectionString(t *testing.T) {
 // There is also a datasource and dashboard provisioned by devenv scripts that you can
 // use to verify that the generated data are visualized as expected, see
 // devenv/README.md for setup instructions.
-func TestPostgres(t *testing.T) {
+func TestIntegrationPostgres(t *testing.T) {
 	// change to true to run the PostgreSQL tests
 	const runPostgresTests = false
 

--- a/pkg/tsdb/postgres/postgres_test.go
+++ b/pkg/tsdb/postgres/postgres_test.go
@@ -1,4 +1,3 @@
-
 package postgres
 
 import (
@@ -15,11 +14,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/sqleng"
+	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"xorm.io/xorm"
-
-	_ "github.com/lib/pq"
 )
 
 // Test generateConnectionString.

--- a/pkg/tsdb/postgres/postgres_test.go
+++ b/pkg/tsdb/postgres/postgres_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-// +build integration
 
 package postgres
 


### PR DESCRIPTION
This is a WIP attempt to make backend integration tests behave like normal tests.

1. All integration tests are renamed to match `TestIntegrationXXX(*tesing.T)`
2. All integration build tags are removed
3. All linter errors in those files are fixed (previously linter has been skipping them)
4. ???