### PR TITLE
Settings: Use Grafana Azure SDK to pass Azure env vars for external plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/gosimple/slug v1.9.0
 	github.com/grafana/cuetsy v0.0.1
 	github.com/grafana/grafana-aws-sdk v0.10.3
-	github.com/grafana/grafana-azure-sdk-go v1.1.0
+	github.com/grafana/grafana-azure-sdk-go v1.2.0
 	github.com/grafana/grafana-plugin-sdk-go v0.134.0
 	github.com/grafana/loki v1.6.2-0.20211015002020-7832783b1caa
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1444,8 +1444,8 @@ github.com/grafana/go-mssqldb v0.0.0-20210326084033-d0ce3c521036 h1:GplhUk6Xes5J
 github.com/grafana/go-mssqldb v0.0.0-20210326084033-d0ce3c521036/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/grafana/grafana-aws-sdk v0.10.3 h1:nqjK8NfrUyUcAtSjGxnt17ZKjeOMCi62MNKFNagjG6g=
 github.com/grafana/grafana-aws-sdk v0.10.3/go.mod h1:vFIOHEnY1u5nY0/tge1IHQjPuG6DRKr2ISf/HikUdjE=
-github.com/grafana/grafana-azure-sdk-go v1.1.0 h1:Gh0fjs7jr4Lp5y+4cjn48U+MQaJeV8i9m1ds/1xszto=
-github.com/grafana/grafana-azure-sdk-go v1.1.0/go.mod h1:rgrnK9m6CgKlgx4rH3FFP/6dTdyRO6LYC2mVZov35yo=
+github.com/grafana/grafana-azure-sdk-go v1.2.0 h1:f/7BjCHGIU0JYOsLIt4oJztDy0fOPBRHB5R0Xe9++ew=
+github.com/grafana/grafana-azure-sdk-go v1.2.0/go.mod h1:rgrnK9m6CgKlgx4rH3FFP/6dTdyRO6LYC2mVZov35yo=
 github.com/grafana/grafana-google-sdk-go v0.0.0-20211104130251-b190293eaf58 h1:2ud7NNM7LrGPO4x0NFR8qLq68CqI4SmB7I2yRN2w9oE=
 github.com/grafana/grafana-google-sdk-go v0.0.0-20211104130251-b190293eaf58/go.mod h1:Vo2TKWfDVmNTELBUM+3lkrZvFtBws0qSZdXhQxRdJrE=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=

--- a/pkg/plugins/manager/loader/initializer/initializer.go
+++ b/pkg/plugins/manager/loader/initializer/initializer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
+	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
@@ -66,7 +67,7 @@ func (i *Initializer) envVars(plugin *plugins.Plugin) []string {
 	}
 
 	hostEnv = append(hostEnv, i.awsEnvVars()...)
-	hostEnv = append(hostEnv, i.azureEnvVars()...)
+	hostEnv = append(hostEnv, azsettings.WriteToEnvStr(i.cfg.Azure)...)
 	return getPluginSettings(plugin.ID, i.cfg).asEnvVar("GF_PLUGIN", hostEnv)
 }
 
@@ -77,24 +78,6 @@ func (i *Initializer) awsEnvVars() []string {
 	}
 	if len(i.cfg.AWSAllowedAuthProviders) > 0 {
 		variables = append(variables, awsds.AllowedAuthProvidersEnvVarKeyName+"="+strings.Join(i.cfg.AWSAllowedAuthProviders, ","))
-	}
-
-	return variables
-}
-
-func (i *Initializer) azureEnvVars() []string {
-	var variables []string
-
-	if i.cfg.Azure != nil {
-		if i.cfg.Azure.Cloud != "" {
-			variables = append(variables, "AZURE_CLOUD="+i.cfg.Azure.Cloud)
-		}
-		if i.cfg.Azure.ManagedIdentityClientId != "" {
-			variables = append(variables, "AZURE_MANAGED_IDENTITY_CLIENT_ID="+i.cfg.Azure.ManagedIdentityClientId)
-		}
-		if i.cfg.Azure.ManagedIdentityEnabled {
-			variables = append(variables, "AZURE_MANAGED_IDENTITY_ENABLED=true")
-		}
 	}
 
 	return variables

--- a/pkg/plugins/manager/loader/initializer/initializer_test.go
+++ b/pkg/plugins/manager/loader/initializer/initializer_test.go
@@ -146,10 +146,6 @@ func TestInitializer_getAWSEnvironmentVariables(t *testing.T) {
 
 }
 
-func TestInitializer_getAzureEnvironmentVariables(t *testing.T) {
-
-}
-
 func TestInitializer_handleModuleDefaults(t *testing.T) {
 
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR uses Grafana Azure SDK ([github.com/grafana/grafana-azure-sdk-go/azsettings/env.go](https://github.com/grafana/grafana-azure-sdk-go/blob/e8d4106df2fc474a8b7f55dd3b82f92868d9ed27/azsettings/env.go#L37)) to transform Azure settings stored in `cfg.Azure` into a set of environment variables understandable by external Azure plugins.

This allows to encapsulate the settings schema into the SDK and make coordinated changes to both reader and writer.

#### Which issue(s) this PR fixes:

Related: https://github.com/grafana/azure-data-explorer-datasource/issues/357

#### Special notes for your reviewer:

While Grafana has been passing Azure env vars in `azureEnvVars()` for some period of time, there are no external plugins which actually used them, so there is no risk of breaking change.

# Release notice breaking change

Environment variables passed from Grafana to external Azure plugins have been renamed:
* `AZURE_CLOUD` renamed to `GFAZPL_AZURE_CLOUD` 
* `AZURE_MANAGED_IDENTITY_ENABLED` renamed to `GFAZPL_MANAGED_IDENTITY_ENABLED`
* `AZURE_MANAGED_IDENTITY_CLIENT_ID` renamed to `GFAZPL_MANAGED_IDENTITY_CLIENT_ID`

There are no known plugins which were relying on these variables. Moving forward plugins should read Azure settings only via Grafana Azure SDK which properly handles old and new environment variables.