### PR TITLE
Access control: Fix listing data sources for org admins

### DIFF
--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -38,7 +38,7 @@ func (hs *HTTPServer) GetPluginList(c *models.ReqContext) response.Response {
 	// When using access control anyone that can create a data source should be able to list all data sources installed
 	// Fallback to only letting admins list non-core plugins
 	hasAccess := accesscontrol.HasAccess(hs.AccessControl, c)
-	if !hasAccess(accesscontrol.ReqOrgAdmin, accesscontrol.EvalPermission(datasources.ActionCreate)) || c.HasRole(models.ROLE_ADMIN) {
+	if !hasAccess(accesscontrol.ReqOrgAdmin, accesscontrol.EvalPermission(datasources.ActionCreate)) {
 		coreFilter = "1"
 	}
 

--- a/pkg/api/plugins.go
+++ b/pkg/api/plugins.go
@@ -38,7 +38,7 @@ func (hs *HTTPServer) GetPluginList(c *models.ReqContext) response.Response {
 	// When using access control anyone that can create a data source should be able to list all data sources installed
 	// Fallback to only letting admins list non-core plugins
 	hasAccess := accesscontrol.HasAccess(hs.AccessControl, c)
-	if !hasAccess(accesscontrol.ReqOrgAdmin, accesscontrol.EvalPermission(datasources.ActionCreate)) {
+	if !hasAccess(accesscontrol.ReqOrgAdmin, accesscontrol.EvalPermission(datasources.ActionCreate)) && !c.HasRole(models.ROLE_ADMIN) {
 		coreFilter = "1"
 	}
 


### PR DESCRIPTION
This PR fixes regression introduced by #48897 - org admin user cannot list non-core data sources.