### PR TITLE
Alerting: Use UID scope for folders authorization

### DIFF
--- a/pkg/services/ngalert/CHANGELOG.md
+++ b/pkg/services/ngalert/CHANGELOG.md
@@ -49,6 +49,7 @@ Scopes must have an order to ensure consistency and ease of search, this helps u
   - `grafana_alerting_ticker_last_consumed_tick_timestamp_seconds`
   - `grafana_alerting_ticker_next_tick_timestamp_seconds`
   - `grafana_alerting_ticker_interval_seconds`
+- [ENHANCEMENT] Rule changes authorization logic to use UID folder scope instead of ID scope #48970
 - [FEATURE] Indicate whether routes are provisioned when GETting Alertmanager configuration #47857
 - [FEATURE] Indicate whether contact point is provisioned when GETting Alertmanager configuration #48323
 - [FEATURE] Indicate whether alert rule is provisioned when GETting the rule #48458

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strconv"
 
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/middleware"
@@ -226,7 +225,7 @@ func authorizeRuleChanges(namespace *models.Folder, change *changes, evaluator f
 		Delete: change.Delete,
 	}
 
-	namespaceScope := dashboards.ScopeFoldersProvider.GetResourceScope(strconv.FormatInt(namespace.Id, 10))
+	namespaceScope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(namespace.Uid)
 	if len(change.Delete) > 0 {
 		var allowedToDelete []*ngmodels.AlertRule
 		for _, rule := range change.Delete {

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 
 	"github.com/go-openapi/loads"
@@ -71,7 +70,7 @@ func TestAuthorize(t *testing.T) {
 
 func TestAuthorizeRuleChanges(t *testing.T) {
 	namespace := randFolder()
-	namespaceIdScope := dashboards.ScopeFoldersProvider.GetResourceScope(strconv.FormatInt(namespace.Id, 10))
+	namespaceIdScope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(namespace.Uid)
 
 	testCases := []struct {
 		name        string
@@ -215,7 +214,7 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 
 func TestAuthorizeRuleDelete(t *testing.T) {
 	namespace := randFolder()
-	namespaceIdScope := dashboards.ScopeFoldersProvider.GetResourceScope(strconv.FormatInt(namespace.Id, 10))
+	namespaceScope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(namespace.Uid)
 
 	getScopes := func(rules []*models.AlertRule) []string {
 		var scopes []string
@@ -245,7 +244,7 @@ func TestAuthorizeRuleDelete(t *testing.T) {
 			permissions: func(c *changes) map[string][]string {
 				return map[string][]string{
 					ac.ActionAlertingRuleDelete: {
-						namespaceIdScope,
+						namespaceScope,
 					},
 					datasources.ActionQuery: getScopes(c.Delete),
 				}
@@ -267,7 +266,7 @@ func TestAuthorizeRuleDelete(t *testing.T) {
 			permissions: func(c *changes) map[string][]string {
 				return map[string][]string{
 					ac.ActionAlertingRuleDelete: {
-						namespaceIdScope,
+						namespaceScope,
 					},
 					datasources.ActionQuery: {
 						getScopes(c.Delete[:1])[0],
@@ -291,7 +290,7 @@ func TestAuthorizeRuleDelete(t *testing.T) {
 			permissions: func(c *changes) map[string][]string {
 				return map[string][]string{
 					ac.ActionAlertingRuleDelete: {
-						namespaceIdScope,
+						namespaceScope,
 					},
 				}
 			},
@@ -313,10 +312,10 @@ func TestAuthorizeRuleDelete(t *testing.T) {
 			permissions: func(c *changes) map[string][]string {
 				return map[string][]string{
 					ac.ActionAlertingRuleDelete: {
-						namespaceIdScope,
+						namespaceScope,
 					},
 					ac.ActionAlertingRuleCreate: {
-						namespaceIdScope,
+						namespaceScope,
 					},
 					datasources.ActionQuery: getScopes(c.New),
 				}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
After that code was implemented there was a decision to use UID scope as the default. To support ID scopes there is a resolver
https://github.com/grafana/grafana/blob/2738d1c5570271ace05978e4dba43ba5f989bca8/pkg/services/dashboards/accesscontrol.go#L59-L83 which does a look up by the ID to get UID.

 This PR updates alert rule changes authorization logic to use the default scope type to avoid conversion from ID to UID, and therefore additional db query cycles.