### PR TITLE
DashboardAPI: convert internal ids to uids

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -391,6 +391,9 @@ func (hs *HTTPServer) registerRoutes() {
 			dashboardRoute.Get("/home", routing.Wrap(hs.GetHomeDashboard))
 			dashboardRoute.Get("/tags", hs.GetDashboardTags)
 
+			// Deprecated: used to convert internal IDs to UIDs
+			dashboardRoute.Get("/ids/:ids", authorize(reqSignedIn, ac.EvalPermission(dashboards.ActionDashboardsRead)), hs.GetDashboardUIDs)
+
 			// Deprecated: use /uid/:uid API instead.
 			dashboardRoute.Group("/id/:dashboardId", func(dashIdRoute routing.RouteRegister) {
 				dashIdRoute.Get("/versions", authorize(reqSignedIn, ac.EvalPermission(dashboards.ActionDashboardsWrite)), routing.Wrap(hs.GetDashboardVersions))


### PR DESCRIPTION
The frontend currently has a few places that save a list of internal IDs ([recent history ](https://github.com/grafana/grafana/blob/dash-ids-to-uids-api/public/app/core/services/impression_srv.ts#L6) for example) -- this PR introduces a new API that will help the frontend migrate from internal IDs to UIDs by explicitly converting them and then calling a better API.

http://localhost:3000/api/dashboards/ids/55,56,57
```
[
"ei4Hwg5Mk",
"0FoXlRcGk",
"i3Bj9k5Gz"
]
```