### PR TITLE
AccessControl: Enforce user check when enterprise accesscontrol is on

### DIFF
--- a/pkg/services/sqlstore/org_test.go
+++ b/pkg/services/sqlstore/org_test.go
@@ -203,7 +203,13 @@ func TestAccountDataAccess(t *testing.T) {
 					err = sqlStore.UpdateOrgUser(context.Background(), &updateCmd)
 					require.NoError(t, err)
 
-					orgUsersQuery := models.GetOrgUsersQuery{OrgId: ac1.OrgId}
+					orgUsersQuery := models.GetOrgUsersQuery{
+						OrgId: ac1.OrgId,
+						User: &models.SignedInUser{
+							OrgId:       ac1.OrgId,
+							Permissions: map[int64]map[string][]string{ac1.OrgId: {accesscontrol.ActionOrgUsersRead: {accesscontrol.ScopeUsersAll}}},
+						},
+					}
 					err = sqlStore.GetOrgUsers(context.Background(), &orgUsersQuery)
 					require.NoError(t, err)
 
@@ -233,7 +239,13 @@ func TestAccountDataAccess(t *testing.T) {
 				})
 
 				t.Run("Can get organization users", func(t *testing.T) {
-					query := models.GetOrgUsersQuery{OrgId: ac1.OrgId}
+					query := models.GetOrgUsersQuery{
+						OrgId: ac1.OrgId,
+						User: &models.SignedInUser{
+							OrgId:       ac1.OrgId,
+							Permissions: map[int64]map[string][]string{ac1.OrgId: {accesscontrol.ActionOrgUsersRead: {accesscontrol.ScopeUsersAll}}},
+						},
+					}
 					err := sqlStore.GetOrgUsers(context.Background(), &query)
 
 					require.NoError(t, err)
@@ -245,6 +257,10 @@ func TestAccountDataAccess(t *testing.T) {
 					query := models.GetOrgUsersQuery{
 						OrgId: ac1.OrgId,
 						Query: "ac1",
+						User: &models.SignedInUser{
+							OrgId:       ac1.OrgId,
+							Permissions: map[int64]map[string][]string{ac1.OrgId: {accesscontrol.ActionOrgUsersRead: {accesscontrol.ScopeUsersAll}}},
+						},
 					}
 					err := sqlStore.GetOrgUsers(context.Background(), &query)
 
@@ -258,6 +274,10 @@ func TestAccountDataAccess(t *testing.T) {
 						OrgId: ac1.OrgId,
 						Query: "ac",
 						Limit: 1,
+						User: &models.SignedInUser{
+							OrgId:       ac1.OrgId,
+							Permissions: map[int64]map[string][]string{ac1.OrgId: {accesscontrol.ActionOrgUsersRead: {accesscontrol.ScopeUsersAll}}},
+						},
 					}
 					err := sqlStore.GetOrgUsers(context.Background(), &query)
 
@@ -338,7 +358,13 @@ func TestAccountDataAccess(t *testing.T) {
 					err = sqlStore.AddOrgUser(context.Background(), &orgUserCmd)
 					require.NoError(t, err)
 
-					query := models.GetOrgUsersQuery{OrgId: ac1.OrgId}
+					query := models.GetOrgUsersQuery{
+						OrgId: ac1.OrgId,
+						User: &models.SignedInUser{
+							OrgId:       ac1.OrgId,
+							Permissions: map[int64]map[string][]string{ac1.OrgId: {accesscontrol.ActionOrgUsersRead: {accesscontrol.ScopeUsersAll}}},
+						},
+					}
 					err = sqlStore.GetOrgUsers(context.Background(), &query)
 					require.NoError(t, err)
 					// require.Equal(t, len(query.Result), 3)

--- a/pkg/services/sqlstore/org_users.go
+++ b/pkg/services/sqlstore/org_users.go
@@ -109,6 +109,9 @@ func (ss *SQLStore) GetOrgUsers(ctx context.Context, query *models.GetOrgUsersQu
 		whereConditions = append(whereConditions, fmt.Sprintf("%s.is_service_account = ?", ss.Dialect.Quote("user")))
 		whereParams = append(whereParams, ss.Dialect.BooleanStr(false))
 
+		if query.User == nil {
+			ss.log.Warn("Query User not set.")
+		}
 		if ss.Cfg.IsEnterprise && !accesscontrol.IsDisabled(ss.Cfg) {
 			acFilter, err := accesscontrol.Filter(query.User, "org_user.user_id", "users:id:", accesscontrol.ActionOrgUsersRead)
 			if err != nil {

--- a/pkg/services/sqlstore/org_users.go
+++ b/pkg/services/sqlstore/org_users.go
@@ -109,7 +109,7 @@ func (ss *SQLStore) GetOrgUsers(ctx context.Context, query *models.GetOrgUsersQu
 		whereConditions = append(whereConditions, fmt.Sprintf("%s.is_service_account = ?", ss.Dialect.Quote("user")))
 		whereParams = append(whereParams, ss.Dialect.BooleanStr(false))
 
-		if ss.Cfg.IsEnterprise && !accesscontrol.IsDisabled(ss.Cfg) && query.User != nil {
+		if ss.Cfg.IsEnterprise && !accesscontrol.IsDisabled(ss.Cfg) {
 			acFilter, err := accesscontrol.Filter(query.User, "org_user.user_id", "users:id:", accesscontrol.ActionOrgUsersRead)
 			if err != nil {
 				return err

--- a/pkg/services/sqlstore/org_users.go
+++ b/pkg/services/sqlstore/org_users.go
@@ -110,7 +110,7 @@ func (ss *SQLStore) GetOrgUsers(ctx context.Context, query *models.GetOrgUsersQu
 		whereParams = append(whereParams, ss.Dialect.BooleanStr(false))
 
 		if query.User == nil {
-			ss.log.Warn("Query User not set.")
+			ss.log.Warn("Query user not set for filtering.")
 		}
 		if ss.Cfg.IsEnterprise && !accesscontrol.IsDisabled(ss.Cfg) {
 			acFilter, err := accesscontrol.Filter(query.User, "org_user.user_id", "users:id:", accesscontrol.ActionOrgUsersRead)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Seems like we have a left over from a [previous fix](https://github.com/grafana/grafana/pull/44389) enabling to skip the accesscontrol check should the user not be specified in `getOrgUsers`.
This PR intends to remove this bypass to ensure we always check users permissions.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

