### PR TITLE
Tracing: Add config for multiple named trace to metrics queries

### DIFF
--- a/docs/sources/datasources/jaeger.md
+++ b/docs/sources/datasources/jaeger.md
@@ -44,9 +44,13 @@ This is a configuration for the [trace to logs feature]({{< relref "../explore/t
 
 > **Note:** This feature is behind the `traceToMetrics` feature toggle.
 
-To configure trace to metrics, select the target Prometheus data source and enter the desired query.
+To configure trace to metrics, select the target Prometheus data source and create any desired linked queries.
 
 -- **Data source -** Target data source.
+
+Each linked query consists of:
+
+-- **Link Label -** (Optional) Descriptive label for the linked query.
 -- **Query -** Query that runs when navigating from a trace to the metrics data source.
 
 ### Node Graph

--- a/docs/sources/datasources/tempo.md
+++ b/docs/sources/datasources/tempo.md
@@ -43,9 +43,13 @@ This is a configuration for the [trace to logs feature]({{< relref "../explore/t
 
 > **Note:** This feature is behind the `traceToMetrics` feature toggle.
 
-To configure trace to metrics, select the target Prometheus data source and enter the desired query.
+To configure trace to metrics, select the target Prometheus data source and create any desired linked queries.
 
 -- **Data source -** Target data source.
+
+Each linked query consists of:
+
+-- **Link Label -** (Optional) Descriptive label for the linked query.
 -- **Query -** Query that runs when navigating from a trace to the metrics data source.
 
 ### Service Graph

--- a/docs/sources/datasources/zipkin.md
+++ b/docs/sources/datasources/zipkin.md
@@ -44,9 +44,13 @@ This is a configuration for the [trace to logs feature]({{< relref "../explore/t
 
 > **Note:** This feature is behind the `traceToMetrics` feature toggle.
 
-To configure trace to metrics, select the target Prometheus data source and enter the desired query.
+To configure trace to metrics, select the target Prometheus data source and create any desired linked queries.
 
 -- **Data source -** Target data source.
+
+Each linked query consists of:
+
+-- **Link Label -** (Optional) Descriptive label for the linked query.
 -- **Query -** Query that runs when navigating from a trace to the metrics data source.
 
 ### Node Graph

--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanLinks.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanLinks.tsx
@@ -35,7 +35,7 @@ const renderMenuItems = (links: SpanLinks, styles: ReturnType<typeof getStyles>,
           {links.metricLinks.map((link, i) => (
             <MenuItem
               key={i}
-              label="Metrics for this span"
+              label={link.title ?? 'Metrics for this span'}
               onClick={(e) => {
                 if (link.onClick) {
                   link.onClick(e);

--- a/public/app/core/components/TraceToMetrics/TraceToMetricsSettings.tsx
+++ b/public/app/core/components/TraceToMetrics/TraceToMetricsSettings.tsx
@@ -12,6 +12,11 @@ import { Button, InlineField, InlineFieldRow, Input, useStyles } from '@grafana/
 
 export interface TraceToMetricsOptions {
   datasourceUid?: string;
+  queries: TraceToMetricQuery[];
+}
+
+export interface TraceToMetricQuery {
+  name?: string;
   query: string;
 }
 
@@ -66,27 +71,76 @@ export function TraceToMetricsSettings({ options, onOptionsChange }: Props) {
         ) : null}
       </InlineFieldRow>
 
-      <InlineFieldRow>
-        <InlineField
-          label="Query"
-          labelWidth={26}
-          tooltip="The Prometheus query that will run when navigating from a trace to metrics"
-          grow
-        >
-          <Input
+      {options.jsonData.tracesToMetrics?.queries?.map((query, i) => (
+        <div key={i} className={styles.queryRow}>
+          <InlineField label="Name" labelWidth={10}>
+            <Input
+              label="Name"
+              type="text"
+              allowFullScreen
+              value={query.name}
+              onChange={(e) => {
+                let newQueries = options.jsonData.tracesToMetrics?.queries.slice() ?? [];
+                newQueries[i].name = e.currentTarget.value;
+                updateDatasourcePluginJsonDataOption({ onOptionsChange, options }, 'tracesToMetrics', {
+                  ...options.jsonData.tracesToMetrics,
+                  queries: newQueries,
+                });
+              }}
+            />
+          </InlineField>
+          <InlineField
             label="Query"
-            type="text"
-            allowFullScreen
-            value={options.jsonData.tracesToMetrics?.query}
-            onChange={(e) => {
+            labelWidth={10}
+            tooltip="The Prometheus query that will run when navigating from a trace to metrics"
+            grow
+          >
+            <Input
+              label="Query"
+              type="text"
+              allowFullScreen
+              value={query.query}
+              onChange={(e) => {
+                let newQueries = options.jsonData.tracesToMetrics?.queries.slice() ?? [];
+                newQueries[i].query = e.currentTarget.value;
+                updateDatasourcePluginJsonDataOption({ onOptionsChange, options }, 'tracesToMetrics', {
+                  ...options.jsonData.tracesToMetrics,
+                  queries: newQueries,
+                });
+              }}
+            />
+          </InlineField>
+
+          <Button
+            variant="destructive"
+            title="Remove query"
+            icon="times"
+            type="button"
+            onClick={() => {
+              let newQueries = options.jsonData.tracesToMetrics?.queries.slice();
+              newQueries?.splice(i, 1);
               updateDatasourcePluginJsonDataOption({ onOptionsChange, options }, 'tracesToMetrics', {
                 ...options.jsonData.tracesToMetrics,
-                query: e.currentTarget.value,
+                queries: newQueries,
               });
             }}
           />
-        </InlineField>
-      </InlineFieldRow>
+        </div>
+      ))}
+
+      <Button
+        variant="secondary"
+        icon="plus"
+        type="button"
+        onClick={() => {
+          updateDatasourcePluginJsonDataOption({ onOptionsChange, options }, 'tracesToMetrics', {
+            ...options.jsonData.tracesToMetrics,
+            queries: [...(options.jsonData.tracesToMetrics?.queries ?? []), { query: '' }],
+          });
+        }}
+      >
+        Add query
+      </Button>
     </div>
   );
 }
@@ -99,5 +153,8 @@ const getStyles = (theme: GrafanaTheme) => ({
   row: css`
     label: row;
     align-items: baseline;
+  `,
+  queryRow: css`
+    display: flex;
   `,
 });

--- a/public/app/core/components/TraceToMetrics/TraceToMetricsSettings.tsx
+++ b/public/app/core/components/TraceToMetrics/TraceToMetricsSettings.tsx
@@ -73,9 +73,9 @@ export function TraceToMetricsSettings({ options, onOptionsChange }: Props) {
 
       {options.jsonData.tracesToMetrics?.queries?.map((query, i) => (
         <div key={i} className={styles.queryRow}>
-          <InlineField label="Name" labelWidth={10}>
+          <InlineField label="Link Label" labelWidth={10}>
             <Input
-              label="Name"
+              label="Link Label"
               type="text"
               allowFullScreen
               value={query.name}
@@ -130,6 +130,7 @@ export function TraceToMetricsSettings({ options, onOptionsChange }: Props) {
 
       <Button
         variant="secondary"
+        title="Add query"
         icon="plus"
         type="button"
         onClick={() => {

--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -411,7 +411,7 @@ describe('createSpanLinkFactory', () => {
       expect(linkDef).toBeDefined();
       expect(linkDef!.href).toBe(
         `/explore?left=${encodeURIComponent(
-          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"prom1","queries":[{"expr":"customQuery","refId":""}],"panelsState":{}}'
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"prom1","queries":[{"expr":"customQuery","refId":"A"}],"panelsState":{}}'
         )}`
       );
     });
@@ -454,7 +454,7 @@ describe('createSpanLinkFactory', () => {
       expect(namedLink!.title).toBe('Named Query');
       expect(namedLink!.href).toBe(
         `/explore?left=${encodeURIComponent(
-          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"prom1","queries":[{"expr":"customQuery","refId":""}],"panelsState":{}}'
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"prom1","queries":[{"expr":"customQuery","refId":"A"}],"panelsState":{}}'
         )}`
       );
 
@@ -463,7 +463,7 @@ describe('createSpanLinkFactory', () => {
       expect(defaultLink!.title).toBe('defaultQuery');
       expect(defaultLink!.href).toBe(
         `/explore?left=${encodeURIComponent(
-          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"prom1","queries":[{"expr":"histogram_quantile(0.5, sum(rate(tempo_spanmetrics_latency_bucket{operation=\\"operation\\"}[5m])) by (le))","refId":""}],"panelsState":{}}'
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"prom1","queries":[{"expr":"histogram_quantile(0.5, sum(rate(tempo_spanmetrics_latency_bucket{operation=\\"operation\\"}[5m])) by (le))","refId":"A"}],"panelsState":{}}'
         )}`
       );
 
@@ -472,7 +472,7 @@ describe('createSpanLinkFactory', () => {
       expect(unnamedQuery!.title).toBeUndefined();
       expect(unnamedQuery!.href).toBe(
         `/explore?left=${encodeURIComponent(
-          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"prom1","queries":[{"expr":"no_name_here","refId":""}],"panelsState":{}}'
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"prom1","queries":[{"expr":"no_name_here","refId":"A"}],"panelsState":{}}'
         )}`
       );
     });

--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -394,13 +394,13 @@ describe('createSpanLinkFactory', () => {
       setTemplateSrv(new TemplateSrv());
     });
 
-    it('returns query with span', () => {
+    it('returns single query with span', () => {
       const splitOpenFn = jest.fn();
       const createLink = createSpanLinkFactory({
         splitOpenFn,
         traceToMetricsOptions: {
           datasourceUid: 'prom1',
-          query: 'customQuery',
+          queries: [{ query: 'customQuery' }],
         },
       });
       expect(createLink).toBeDefined();
@@ -416,7 +416,7 @@ describe('createSpanLinkFactory', () => {
       );
     });
 
-    it('uses default query if no query specified', () => {
+    it('returns nothing if no queries specified', () => {
       const splitOpenFn = jest.fn();
       const createLink = createSpanLinkFactory({
         splitOpenFn,
@@ -427,12 +427,52 @@ describe('createSpanLinkFactory', () => {
       expect(createLink).toBeDefined();
 
       const links = createLink!(createTraceSpan());
-      const linkDef = links?.metricLinks?.[0];
+      expect(links?.metricLinks).toBeUndefined();
+    });
 
-      expect(linkDef).toBeDefined();
-      expect(linkDef!.href).toBe(
+    it('returns multiple queries including default', () => {
+      const splitOpenFn = jest.fn();
+      const createLink = createSpanLinkFactory({
+        splitOpenFn,
+        traceToMetricsOptions: {
+          datasourceUid: 'prom1',
+          queries: [
+            { name: 'Named Query', query: 'customQuery' },
+            { name: 'defaultQuery', query: '' },
+            { query: 'no_name_here' },
+          ],
+        } as TraceToMetricsOptions,
+      });
+      expect(createLink).toBeDefined();
+
+      const links = createLink!(createTraceSpan());
+      expect(links?.metricLinks).toBeDefined();
+      expect(links?.metricLinks).toHaveLength(3);
+
+      const namedLink = links?.metricLinks?.[0];
+      expect(namedLink).toBeDefined();
+      expect(namedLink!.title).toBe('Named Query');
+      expect(namedLink!.href).toBe(
+        `/explore?left=${encodeURIComponent(
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"prom1","queries":[{"expr":"customQuery","refId":""}],"panelsState":{}}'
+        )}`
+      );
+
+      const defaultLink = links?.metricLinks?.[1];
+      expect(defaultLink).toBeDefined();
+      expect(defaultLink!.title).toBe('defaultQuery');
+      expect(defaultLink!.href).toBe(
         `/explore?left=${encodeURIComponent(
           '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"prom1","queries":[{"expr":"histogram_quantile(0.5, sum(rate(tempo_spanmetrics_latency_bucket{operation=\\"operation\\"}[5m])) by (le))","refId":""}],"panelsState":{}}'
+        )}`
+      );
+
+      const unnamedQuery = links?.metricLinks?.[2];
+      expect(unnamedQuery).toBeDefined();
+      expect(unnamedQuery!.title).toBeUndefined();
+      expect(unnamedQuery!.href).toBe(
+        `/explore?left=${encodeURIComponent(
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"prom1","queries":[{"expr":"no_name_here","refId":""}],"panelsState":{}}'
         )}`
       );
     });

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -149,41 +149,44 @@ function legacyCreateSpanLinkFactory(
     }
 
     // Get metrics links
-    if (metricsDataSourceSettings && traceToMetricsOptions) {
+    if (metricsDataSourceSettings && traceToMetricsOptions?.queries) {
       const defaultQuery = `histogram_quantile(0.5, sum(rate(tempo_spanmetrics_latency_bucket{operation="${span.operationName}"}[5m])) by (le))`;
-      const dataLink: DataLink<PromQuery> = {
-        title: metricsDataSourceSettings.name,
-        url: '',
-        internal: {
-          datasourceUid: metricsDataSourceSettings.uid,
-          datasourceName: metricsDataSourceSettings.name,
-          query: {
-            expr: traceToMetricsOptions.query ?? defaultQuery,
-            refId: '',
+
+      links.metricLinks = [];
+      for (const query of traceToMetricsOptions.queries) {
+        const dataLink: DataLink<PromQuery> = {
+          title: metricsDataSourceSettings.name,
+          url: '',
+          internal: {
+            datasourceUid: metricsDataSourceSettings.uid,
+            datasourceName: metricsDataSourceSettings.name,
+            query: {
+              expr: query.query || defaultQuery,
+              refId: '',
+            },
           },
-        },
-      };
+        };
 
-      const link = mapInternalLinkToExplore({
-        link: dataLink,
-        internalLink: dataLink.internal!,
-        scopedVars: {},
-        range: getTimeRangeFromSpan(span, {
-          startMs: 0,
-          endMs: 0,
-        }),
-        field: {} as Field,
-        onClickFn: splitOpenFn,
-        replaceVariables: getTemplateSrv().replace.bind(getTemplateSrv()),
-      });
+        const link = mapInternalLinkToExplore({
+          link: dataLink,
+          internalLink: dataLink.internal!,
+          scopedVars: {},
+          range: getTimeRangeFromSpan(span, {
+            startMs: 0,
+            endMs: 0,
+          }),
+          field: {} as Field,
+          onClickFn: splitOpenFn,
+          replaceVariables: getTemplateSrv().replace.bind(getTemplateSrv()),
+        });
 
-      links.metricLinks = [
-        {
+        links.metricLinks.push({
+          title: query?.name,
           href: link.href,
           onClick: link.onClick,
           content: <Icon name="chart-line" title="Explore metrics for this span" />,
-        },
-      ];
+        });
+      }
     }
 
     // Get trace links

--- a/public/app/features/explore/TraceView/createSpanLink.tsx
+++ b/public/app/features/explore/TraceView/createSpanLink.tsx
@@ -162,7 +162,7 @@ function legacyCreateSpanLinkFactory(
             datasourceName: metricsDataSourceSettings.name,
             query: {
               expr: query.query || defaultQuery,
-              refId: '',
+              refId: 'A',
             },
           },
         };


### PR DESCRIPTION
Fixes #
Adds support for writing multiple trace to metrics queries. Also adds the option to name the query. 

**Special notes for your reviewer**:
To test:
- Configure 0, 1, and n queries in a tempo datasource
- Make sure the correct links are present in the span links menu

![Screen Shot 2022-05-16 at 7 07 22 AM](https://user-images.githubusercontent.com/12838032/168601837-a8c9c42a-c7c5-4cbe-b933-ddada4630b56.png)