### PR TITLE
Tempo: trim whitespace from trace id query

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -252,7 +252,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     options: DataQueryRequest<TempoQuery>,
     targets: TempoQuery[]
   ): Observable<DataQueryResponse> {
-    const validTargets = targets.filter((t) => t.query);
+    const validTargets = targets.filter((t) => t.query).map((t) => ({ ...t, query: t.query.trim() }));
     if (!validTargets.length) {
       return EMPTY;
     }


### PR DESCRIPTION
**What this PR does / why we need it**:
Trims whitespace from trace id queries, for example, if the user copies a trace id and accidentally selects additional whitespace. 

**Which issue(s) this PR fixes**:
Fixes #

Relates to https://github.com/grafana/tempo/issues/846

**Special notes for your reviewer**:

Before (unable to parse whitespace)
![Screen Shot 2022-05-16 at 7 30 27 AM](https://user-images.githubusercontent.com/12838032/168604642-c917e4d3-c198-4e8b-9edf-a540d213f5f0.png)

After
![Screen Shot 2022-05-16 at 7 30 09 AM](https://user-images.githubusercontent.com/12838032/168604649-464a36df-6a37-4051-a204-8e10863cb577.png)

