### PR TITLE
loki: add feature-toggle check to live-mode

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -36,6 +36,7 @@ export interface FeatureToggles {
   showFeatureFlagsInUI?: boolean;
   publicDashboards?: boolean;
   lokiLive?: boolean;
+  lokiDataframeApi?: boolean;
   swaggerUi?: boolean;
   featureHighlights?: boolean;
   dashboardComments?: boolean;

--- a/pkg/plugins/manager/manager_integration_test.go
+++ b/pkg/plugins/manager/manager_integration_test.go
@@ -79,7 +79,7 @@ func TestPluginManager_int_init(t *testing.T) {
 	es := elasticsearch.ProvideService(hcp)
 	grap := graphite.ProvideService(hcp, tracer)
 	idb := influxdb.ProvideService(hcp)
-	lk := loki.ProvideService(hcp, tracer)
+	lk := loki.ProvideService(hcp, features, tracer)
 	otsdb := opentsdb.ProvideService(hcp)
 	pr := prometheus.ProvideService(hcp, cfg, features, tracer)
 	tmpo := tempo.ProvideService(hcp)

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -117,6 +117,11 @@ var (
 			State:       FeatureStateAlpha,
 		},
 		{
+			Name:        "lokiDataframeApi",
+			Description: "use experimental loki api for websocket streaming (early prototype)",
+			State:       FeatureStateAlpha,
+		},
+		{
 			Name:        "swaggerUi",
 			Description: "Serves swagger UI",
 			State:       FeatureStateBeta,

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -87,6 +87,10 @@ const (
 	// support websocket streaming for loki (early prototype)
 	FlagLokiLive = "lokiLive"
 
+	// FlagLokiDataframeApi
+	// use experimental loki api for websocket streaming (early prototype)
+	FlagLokiDataframeApi = "lokiDataframeApi"
+
 	// FlagSwaggerUi
 	// Serves swagger UI
 	FlagSwaggerUi = "swaggerUi"

--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -16,13 +16,15 @@ import (
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"go.opentelemetry.io/otel/attribute"
 )
 
 type Service struct {
-	im     instancemgmt.InstanceManager
-	plog   log.Logger
-	tracer tracing.Tracer
+	im       instancemgmt.InstanceManager
+	features featuremgmt.FeatureToggles
+	plog     log.Logger
+	tracer   tracing.Tracer
 }
 
 var (
@@ -31,11 +33,12 @@ var (
 	_ backend.CallResourceHandler = (*Service)(nil)
 )
 
-func ProvideService(httpClientProvider httpclient.Provider, tracer tracing.Tracer) *Service {
+func ProvideService(httpClientProvider httpclient.Provider, features featuremgmt.FeatureToggles, tracer tracing.Tracer) *Service {
 	return &Service{
-		im:     datasource.NewInstanceManager(newInstanceSettings(httpClientProvider)),
-		plog:   log.New("tsdb.loki"),
-		tracer: tracer,
+		im:       datasource.NewInstanceManager(newInstanceSettings(httpClientProvider)),
+		features: features,
+		plog:     log.New("tsdb.loki"),
+		tracer:   tracer,
 	}
 }
 


### PR DESCRIPTION
currently, if you enable the `lokiLive` feature-flag, the following happens:
1. in the loki datasource, you can normally choose 'ranged' and 'instant' query type. with the feature-flag enabled, you can also choose 'stream' . if you choose 'stream', it starts to stream the query-results continually.
2. the backend-code that does this streaming, has an extra feature: it checks for an experimental, unreleased mode in Loki, which returns grafana-formatted data. if that feature is detected, it will use it.

NOTE: these features are experimental, behind a feature-flag. they are unpolished, they might not work in some cases. that is ok.

this pull-request separates these two into two feature-flags:
- `lokiLive` enables [1]
- `lokiDataframeApi` enables [2], in a simpler way: if the feature-flag is `true`, it uses the new experimental api. if it is `false`, it uses the current api.

we need this because [1] has a much higher chance to get enabled-by-default than [2], so we need to control them separately.

the code:
- adds a new feature-flag
- adds the necessary code to the loki datasource to be able to check feature-flags
- adds the check for the new feature-flag


how to test:

1. you will need a way to see the http-requests going from grafana to loki
2. `make devenv sources=loki`
4. enable `lokiLive`, do not enable `lokiDataframeApi`
5. go to explore-mode, run the query`{place="moon"}`
6. now in `Options` switch `Type` to `Stream`
7. you should see a http-connection going from grafana-server to `/loki/api/v1/tail`
8. switch back to type=range
9. enable both the `lokiLive` and `lokiDataframeApi` feature-flags
10. go to explore, run the query `{place="moon"}`
11. in `Options` switch `Type` to `Stream`
12. you should see a http-connection going from grafana-server to `/loki/api/v2alpha/tail`
    - note: it will not work, that http-connection will fail. this is ok. we do not have a loki-version with that API available.