### PR TITLE
Search: Reduce unnecessary child component re-rendering

### DIFF
--- a/public/app/features/search/hooks/useSearchQuery.ts
+++ b/public/app/features/search/hooks/useSearchQuery.ts
@@ -25,20 +25,20 @@ export const useSearchQuery = (defaults: Partial<DashboardQuery>) => {
   const initialState = { ...defaultQuery, ...defaults, ...queryParams };
   const [query, dispatch] = useReducer(queryReducer, initialState);
 
-  const onQueryChange = (query: string) => {
+  const onQueryChange = useCallback((query: string) => {
     dispatch({ type: QUERY_CHANGE, payload: query });
     updateLocation({ query });
-  };
+  }, []);
 
-  const onTagFilterChange = (tags: string[]) => {
+  const onTagFilterChange = useCallback((tags: string[]) => {
     dispatch({ type: SET_TAGS, payload: tags });
     updateLocation({ tag: tags });
-  };
+  }, []);
 
-  const onDatasourceChange = (datasource?: string) => {
+  const onDatasourceChange = useCallback((datasource?: string) => {
     dispatch({ type: DATASOURCE_CHANGE, payload: datasource });
     updateLocation({ datasource });
-  };
+  }, []);
 
   const onTagAdd = useCallback(
     (tag: string) => {
@@ -48,30 +48,30 @@ export const useSearchQuery = (defaults: Partial<DashboardQuery>) => {
     [query.tag]
   );
 
-  const onClearFilters = () => {
+  const onClearFilters = useCallback(() => {
     dispatch({ type: CLEAR_FILTERS });
     updateLocation(defaultQueryParams);
-  };
+  }, []);
 
-  const onStarredFilterChange = (e: FormEvent<HTMLInputElement>) => {
+  const onStarredFilterChange = useCallback((e: FormEvent<HTMLInputElement>) => {
     const starred = (e.target as HTMLInputElement).checked;
     dispatch({ type: TOGGLE_STARRED, payload: starred });
     updateLocation({ starred: starred || null });
-  };
+  }, []);
 
-  const onSortChange = (sort: SelectableValue | null) => {
+  const onSortChange = useCallback((sort: SelectableValue | null) => {
     dispatch({ type: TOGGLE_SORT, payload: sort });
     updateLocation({ sort: sort?.value, layout: SearchLayout.List });
-  };
+  }, []);
 
-  const onLayoutChange = (layout: SearchLayout) => {
+  const onLayoutChange = useCallback((layout: SearchLayout) => {
     dispatch({ type: LAYOUT_CHANGE, payload: layout });
     if (layout === SearchLayout.Folders) {
       updateLocation({ layout, sort: null });
       return;
     }
     updateLocation({ layout });
-  };
+  }, []);
 
   return {
     query,

--- a/public/app/features/search/page/SearchPage.tsx
+++ b/public/app/features/search/page/SearchPage.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useAsync, useDebounce } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
@@ -31,9 +31,8 @@ const node: NavModelItem = {
 
 export default function SearchPage() {
   const styles = useStyles2(getStyles);
-  const { query, onQueryChange, onTagFilterChange, onDatasourceChange, onSortChange, onLayoutChange } = useSearchQuery(
-    {}
-  );
+  const { query, onQueryChange, onTagFilterChange, onTagAdd, onDatasourceChange, onSortChange, onLayoutChange } =
+    useSearchQuery({});
   const [showManage, setShowManage] = useState(false); // grid vs list view
 
   const [searchSelection, setSearchSelection] = useState(newSearchSelection());
@@ -62,6 +61,17 @@ export default function SearchPage() {
 
   useDebounce(() => onQueryChange(inputValue), 200, [inputValue]);
 
+  const toggleSelection = useCallback(
+    (kind: string, uid: string) => {
+      const current = searchSelection.isSelected(kind, uid);
+      if (kind === 'folder') {
+        // ??? also select all children?
+      }
+      setSearchSelection(updateSearchSelection(searchSelection, !current, kind, [uid]));
+    },
+    [searchSelection]
+  );
+
   if (!config.featureToggles.panelTitleSearch) {
     return <div className={styles.unsupported}>Unsupported</div>;
   }
@@ -74,18 +84,6 @@ export default function SearchPage() {
       ds_uid: query.datasource,
     };
     return getGrafanaSearcher().tags(q);
-  };
-
-  const onTagSelected = (tag: string) => {
-    onTagFilterChange([...new Set(query.tag as string[]).add(tag)]);
-  };
-
-  const toggleSelection = (kind: string, uid: string) => {
-    const current = searchSelection.isSelected(kind, uid);
-    if (kind === 'folder') {
-      // ??? also select all children?
-    }
-    setSearchSelection(updateSearchSelection(searchSelection, !current, kind, [uid]));
   };
 
   // function to update items when dashboards or folders are moved or deleted
@@ -130,7 +128,7 @@ export default function SearchPage() {
 
     const selection = showManage ? searchSelection.isSelected : undefined;
     if (layout === SearchLayout.Folders) {
-      return <FolderView selection={selection} selectionToggle={toggleSelection} onTagSelected={onTagSelected} />;
+      return <FolderView selection={selection} selectionToggle={toggleSelection} onTagSelected={onTagAdd} />;
     }
 
     return (
@@ -143,7 +141,7 @@ export default function SearchPage() {
               selectionToggle: toggleSelection,
               width: width,
               height: height,
-              onTagSelected: onTagSelected,
+              onTagSelected: onTagAdd,
               onDatasourceChange: query.datasource ? onDatasourceChange : undefined,
             };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement callback and component memoization to prevent child components constantly re-rendering when the search query is being typed.

**Special notes for your reviewer**:
The diff github generated for `SearchResultsTable.tsx` is super messy for whatever reason, but it's really just wrapping `React.memo` around the component

Related: #48819