### PR TITLE
Alerting: Allow serving images from custom url path

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/rule-types/GrafanaManagedAlert.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/rule-types/GrafanaManagedAlert.tsx
@@ -15,7 +15,7 @@ const GrafanaManagedRuleType: FC<SharedProps> = ({ selected = false, disabled, o
           Transform data with expressions.
         </span>
       }
-      image="/public/img/grafana_icon.svg"
+      image="public/img/grafana_icon.svg"
       selected={selected}
       disabled={disabled}
       value={RuleFormType.grafana}

--- a/public/app/features/alerting/unified/components/rule-editor/rule-types/MimirOrLokiAlert.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/rule-types/MimirOrLokiAlert.tsx
@@ -21,7 +21,7 @@ const MimirFlavoredType: FC<Props> = ({ selected = false, disabled = false, onCl
             Expressions are not supported.
           </span>
         }
-        image="/public/img/alerting/mimir_logo.svg"
+        image="public/img/alerting/mimir_logo.svg"
         selected={selected}
         disabled={disabled}
         value={RuleFormType.cloudAlerting}

--- a/public/app/features/alerting/unified/components/rule-editor/rule-types/MimirOrLokiRecordingRule.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/rule-types/MimirOrLokiRecordingRule.tsx
@@ -17,7 +17,7 @@ const RecordingRuleType: FC<SharedProps> = ({ selected = false, disabled = false
             Should be combined with an alert rule.
           </span>
         }
-        image="/public/img/alerting/mimir_logo_recording.svg"
+        image="public/img/alerting/mimir_logo_recording.svg"
         selected={selected}
         disabled={disabled}
         value={RuleFormType.cloudRecording}


### PR DESCRIPTION
**What this PR does / why we need it**:

When Grafana was running under a custom sub path some images were not displayed properly.

**Which issue(s) this PR fixes**:

Fixes #48901

**Special notes for your reviewer**:

Manually tested with `serve_from_sub_path = true` and a custom pathUrl in `root_url`
