### PR TITLE
Alerting: Indicate whether templates are provisioned

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -567,8 +567,9 @@ func (c *PostableUserConfig) UnmarshalYAML(value *yaml.Node) error {
 
 // swagger:model
 type GettableUserConfig struct {
-	TemplateFiles      map[string]string         `yaml:"template_files" json:"template_files"`
-	AlertmanagerConfig GettableApiAlertingConfig `yaml:"alertmanager_config" json:"alertmanager_config"`
+	TemplateFiles           map[string]string            `yaml:"template_files" json:"template_files"`
+	TemplateFileProvenances map[string]models.Provenance `yaml:"template_file_provenances,omitempty" json:"template_file_provenances,omitempty"`
+	AlertmanagerConfig      GettableApiAlertingConfig    `yaml:"alertmanager_config" json:"alertmanager_config"`
 
 	// amSimple stores a map[string]interface of the decoded alertmanager config.
 	// This enables circumventing the underlying alertmanager secret type

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -83,7 +83,7 @@ func (moa *MultiOrgAlertmanager) GetAlertmanagerConfiguration(ctx context.Contex
 	}
 
 	if moa.settings.IsFeatureToggleEnabled(featuremgmt.FlagAlertProvisioning) {
-		result.AlertmanagerConfig, err = moa.mergeProvenance(ctx, result.AlertmanagerConfig, org)
+		result, err = moa.mergeProvenance(ctx, result, org)
 		if err != nil {
 			return definitions.GettableUserConfig{}, err
 		}
@@ -126,25 +126,34 @@ func (moa *MultiOrgAlertmanager) ApplyAlertmanagerConfiguration(ctx context.Cont
 	return nil
 }
 
-func (moa *MultiOrgAlertmanager) mergeProvenance(ctx context.Context, config definitions.GettableApiAlertingConfig, org int64) (definitions.GettableApiAlertingConfig, error) {
-	if config.Route != nil {
-		provenance, err := moa.ProvStore.GetProvenance(ctx, config.Route, org)
+func (moa *MultiOrgAlertmanager) mergeProvenance(ctx context.Context, config definitions.GettableUserConfig, org int64) (definitions.GettableUserConfig, error) {
+	if config.AlertmanagerConfig.Route != nil {
+		provenance, err := moa.ProvStore.GetProvenance(ctx, config.AlertmanagerConfig.Route, org)
 		if err != nil {
-			return definitions.GettableApiAlertingConfig{}, err
+			return definitions.GettableUserConfig{}, err
 		}
-		config.Route.Provenance = provenance
+		config.AlertmanagerConfig.Route.Provenance = provenance
 	}
+
 	cp := definitions.EmbeddedContactPoint{}
 	cpProvs, err := moa.ProvStore.GetProvenances(ctx, org, cp.ResourceType())
 	if err != nil {
-		return definitions.GettableApiAlertingConfig{}, err
+		return definitions.GettableUserConfig{}, err
 	}
-	for _, receiver := range config.Receivers {
+	for _, receiver := range config.AlertmanagerConfig.Receivers {
 		for _, contactPoint := range receiver.GrafanaManagedReceivers {
 			if provenance, exists := cpProvs[contactPoint.UID]; exists {
 				contactPoint.Provenance = provenance
 			}
 		}
 	}
+
+	tmpl := definitions.MessageTemplate{}
+	tmplProvs, err := moa.ProvStore.GetProvenances(ctx, org, tmpl.ResourceType())
+	if err != nil {
+		return definitions.GettableUserConfig{}, nil
+	}
+	config.TemplateFileProvenances = tmplProvs
+
 	return config, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Extend the old GET AM Config route to show provisioning status for objects.

This one is a little unusual, since the set of templates in a config is represented as a `map[string]string`. So, instead of adding the field on each object as we have done before, we introduce a new `map[string]Provenance` that lives next to the current template set. This map is only present in the GET response.

**Which issue(s) this PR fixes**:

Rel https://github.com/grafana/grafana/issues/36153

**Special notes for your reviewer**:

