### PR TITLE
Provisioning: Change datasource provisioning to use datasource service

### DIFF
--- a/pkg/services/provisioning/datasources/datasources.go
+++ b/pkg/services/provisioning/datasources/datasources.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/provisioning/utils"
 
 	"github.com/grafana/grafana/pkg/models"
@@ -25,8 +26,8 @@ var (
 
 // Provision scans a directory for provisioning config files
 // and provisions the datasource in those files.
-func Provision(ctx context.Context, configDirectory string, store Store, orgStore utils.OrgStore) error {
-	dc := newDatasourceProvisioner(log.New("provisioning.datasources"), store, orgStore)
+func Provision(ctx context.Context, configDirectory string, service datasources.DataSourceService, orgStore utils.OrgStore) error {
+	dc := newDatasourceProvisioner(log.New("provisioning.datasources"), service, orgStore)
 	return dc.applyChanges(ctx, configDirectory)
 }
 
@@ -35,14 +36,14 @@ func Provision(ctx context.Context, configDirectory string, store Store, orgStor
 type DatasourceProvisioner struct {
 	log         log.Logger
 	cfgProvider *configReader
-	store       Store
+	service     datasources.DataSourceService
 }
 
-func newDatasourceProvisioner(log log.Logger, store Store, orgStore utils.OrgStore) DatasourceProvisioner {
+func newDatasourceProvisioner(log log.Logger, service datasources.DataSourceService, orgStore utils.OrgStore) DatasourceProvisioner {
 	return DatasourceProvisioner{
 		log:         log,
 		cfgProvider: &configReader{log: log, orgStore: orgStore},
-		store:       store,
+		service:     service,
 	}
 }
 
@@ -53,7 +54,7 @@ func (dc *DatasourceProvisioner) apply(ctx context.Context, cfg *configs) error 
 
 	for _, ds := range cfg.Datasources {
 		cmd := &models.GetDataSourceQuery{OrgId: ds.OrgID, Name: ds.Name}
-		err := dc.store.GetDataSource(ctx, cmd)
+		err := dc.service.GetDataSource(ctx, cmd)
 		if err != nil && !errors.Is(err, models.ErrDataSourceNotFound) {
 			return err
 		}
@@ -61,13 +62,13 @@ func (dc *DatasourceProvisioner) apply(ctx context.Context, cfg *configs) error 
 		if errors.Is(err, models.ErrDataSourceNotFound) {
 			insertCmd := createInsertCommand(ds)
 			dc.log.Info("inserting datasource from configuration ", "name", insertCmd.Name, "uid", insertCmd.Uid)
-			if err := dc.store.AddDataSource(ctx, insertCmd); err != nil {
+			if err := dc.service.AddDataSource(ctx, insertCmd); err != nil {
 				return err
 			}
 		} else {
 			updateCmd := createUpdateCommand(ds, cmd.Result.Id)
 			dc.log.Debug("updating datasource from configuration", "name", updateCmd.Name, "uid", updateCmd.Uid)
-			if err := dc.store.UpdateDataSource(ctx, updateCmd); err != nil {
+			if err := dc.service.UpdateDataSource(ctx, updateCmd); err != nil {
 				return err
 			}
 		}
@@ -94,7 +95,7 @@ func (dc *DatasourceProvisioner) applyChanges(ctx context.Context, configPath st
 func (dc *DatasourceProvisioner) deleteDatasources(ctx context.Context, dsToDelete []*deleteDatasourceConfig) error {
 	for _, ds := range dsToDelete {
 		cmd := &models.DeleteDataSourceCommand{OrgID: ds.OrgID, Name: ds.Name}
-		if err := dc.store.DeleteDataSource(ctx, cmd); err != nil {
+		if err := dc.service.DeleteDataSource(ctx, cmd); err != nil {
 			return err
 		}
 

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -77,7 +77,7 @@ func NewProvisioningServiceImpl() *ProvisioningServiceImpl {
 func newProvisioningServiceImpl(
 	newDashboardProvisioner dashboards.DashboardProvisionerFactory,
 	provisionNotifiers func(context.Context, string, notifiers.Manager, notifiers.SQLStore, encryption.Internal, *notifications.NotificationService) error,
-	provisionDatasources func(context.Context, string, datasources.Store, utils.OrgStore) error,
+	provisionDatasources func(context.Context, string, datasourceservice.DataSourceService, utils.OrgStore) error,
 	provisionPlugins func(context.Context, string, plugins.Store, plugifaces.Store, pluginsettings.Service) error,
 ) *ProvisioningServiceImpl {
 	return &ProvisioningServiceImpl{
@@ -100,7 +100,7 @@ type ProvisioningServiceImpl struct {
 	newDashboardProvisioner      dashboards.DashboardProvisionerFactory
 	dashboardProvisioner         dashboards.DashboardProvisioner
 	provisionNotifiers           func(context.Context, string, notifiers.Manager, notifiers.SQLStore, encryption.Internal, *notifications.NotificationService) error
-	provisionDatasources         func(context.Context, string, datasources.Store, utils.OrgStore) error
+	provisionDatasources         func(context.Context, string, datasourceservice.DataSourceService, utils.OrgStore) error
 	provisionPlugins             func(context.Context, string, plugins.Store, plugifaces.Store, pluginsettings.Service) error
 	mutex                        sync.Mutex
 	dashboardProvisioningService dashboardservice.DashboardProvisioningService


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR makes the datasource provisioning use the datasource service instead of the SQL store directly.

This is needed after: #45804

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes an issue with provisioning not using the Unified Secrets table.

**Special notes for your reviewer**:

