### PR TITLE
Azure Monitor: Add Resource Picker to Metrics Queries

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.test.tsx
@@ -28,7 +28,9 @@ describe('Azure Monitor QueryEditor', () => {
     };
 
     render(<QueryEditor query={mockQuery} datasource={mockDatasource} onChange={() => {}} onRunQuery={() => {}} />);
-    await waitFor(() => expect(screen.getByTestId('azure-monitor-metrics-query-editor')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId('azure-monitor-metrics-query-editor-with-resource-picker')).toBeInTheDocument()
+    );
   });
 
   it('renders the Logs query editor when the query type is Logs', async () => {
@@ -60,35 +62,14 @@ describe('Azure Monitor QueryEditor', () => {
 
   it('displays error messages from frontend Azure calls', async () => {
     const mockDatasource = createMockDatasource();
-    mockDatasource.azureMonitorDatasource.getSubscriptions = jest.fn().mockRejectedValue(invalidNamespaceError());
+    mockDatasource.azureMonitorDatasource.getMetricNamespaces = jest.fn().mockRejectedValue(invalidNamespaceError());
     render(
       <QueryEditor query={createMockQuery()} datasource={mockDatasource} onChange={() => {}} onRunQuery={() => {}} />
     );
-    await waitFor(() => expect(screen.getByTestId('azure-monitor-query-editor')).toBeInTheDocument());
-
-    expect(screen.getByText("The resource namespace 'grafanadev' is invalid.")).toBeInTheDocument();
-  });
-
-  it('renders the new query editor for metrics when enabled with a feature toggle', async () => {
-    const originalConfigValue = config.featureToggles.azureMonitorResourcePickerForMetrics;
-
-    // To do this irl go to custom.ini file and add resourcePickerForMetrics = true under [feature_toggles]
-    config.featureToggles.azureMonitorResourcePickerForMetrics = true;
-
-    const mockDatasource = createMockDatasource();
-    const mockQuery = {
-      ...createMockQuery(),
-      queryType: AzureQueryType.AzureMonitor,
-    };
-
-    render(<QueryEditor query={mockQuery} datasource={mockDatasource} onChange={() => {}} onRunQuery={() => {}} />);
-
     await waitFor(() =>
       expect(screen.getByTestId('azure-monitor-metrics-query-editor-with-resource-picker')).toBeInTheDocument()
     );
-
-    // reset config to not impact future tests
-    config.featureToggles.azureMonitorResourcePickerForMetrics = originalConfigValue;
+    expect(screen.getByText('An error occurred while requesting metadata from Azure Monitor')).toBeInTheDocument();
   });
 
   it('should render the experimental QueryHeader when feature toggle is enabled', async () => {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.tsx
@@ -16,7 +16,6 @@ import {
 import useLastError from '../../utils/useLastError';
 import ArgQueryEditor from '../ArgQueryEditor';
 import LogsQueryEditor from '../LogsQueryEditor';
-import MetricsQueryEditor from '../MetricsQueryEditor';
 import NewMetricsQueryEditor from '../NewMetricsQueryEditor/MetricsQueryEditor';
 import { QueryHeader } from '../QueryHeader';
 import { Space } from '../Space';
@@ -102,22 +101,9 @@ const EditorForQueryType: React.FC<EditorForQueryTypeProps> = ({
 }) => {
   switch (query.queryType) {
     case AzureQueryType.AzureMonitor:
-      if (config.featureToggles.azureMonitorResourcePickerForMetrics) {
-        return (
-          <NewMetricsQueryEditor
-            data={data}
-            query={query}
-            datasource={datasource}
-            onChange={onChange}
-            variableOptionGroup={variableOptionGroup}
-            setError={setError}
-          />
-        );
-      }
       return (
-        <MetricsQueryEditor
+        <NewMetricsQueryEditor
           data={data}
-          subscriptionId={subscriptionId}
           query={query}
           datasource={datasource}
           onChange={onChange}


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes feature toggle for the new Resource Picker for Azure Monitor Metrics Queries
<img width="523" alt="Screen Shot 2022-05-16 at 3 06 38 PM" src="https://user-images.githubusercontent.com/6620164/168664558-7d7816f2-cb29-4d2b-ba56-db25757f9eed.png">
<img width="915" alt="Screen Shot 2022-05-16 at 3 06 58 PM" src="https://user-images.githubusercontent.com/6620164/168664559-fac98b92-0c5d-4c38-a1d0-2b4958745f74.png">

**Which issue(s) this PR fixes**:

Closes https://github.com/grafana/grafana/issues/44439

**Special notes for your reviewer**:
Making another pr after Grafana 9 to remove old unused code, but keeping it for now just in case we need to revert back for some reason. 
