### PR TITLE
Alerting: Update RBAC for alert rules to consider access to rule as access to group it belongs

### DIFF
--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -166,9 +166,6 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 
 	groupedRules := make(map[ngmodels.AlertRuleGroupKey][]*ngmodels.AlertRule)
 	for _, rule := range alertRuleQuery.Result {
-		if !authorizeDatasourceAccessForRule(rule, hasAccess) {
-			continue
-		}
 		key := rule.GetGroupKey()
 		rulesInGroup := groupedRules[key]
 		rulesInGroup = append(rulesInGroup, rule)
@@ -179,6 +176,9 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *models.ReqContext) response.Res
 		folder := namespaceMap[groupKey.NamespaceUID]
 		if folder == nil {
 			srv.log.Warn("query returned rules that belong to folder the user does not have access to. All rules that belong to that namespace will not be added to the response", "folder_uid", groupKey.NamespaceUID)
+			continue
+		}
+		if !authorizeAccessToRuleGroup(rules, hasAccess) {
 			continue
 		}
 		ruleResponse.Data.RuleGroups = append(ruleResponse.Data.RuleGroups, srv.toRuleGroup(groupKey.RuleGroup, folder, rules, labelOptions))

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -64,6 +64,7 @@ func TestCalculateChanges(t *testing.T) {
 		changes, err := calculateChanges(context.Background(), fakeStore, groupKey, make([]*models.AlertRule, 0))
 		require.NoError(t, err)
 
+		require.Equal(t, groupKey, changes.GroupKey)
 		require.Empty(t, changes.New)
 		require.Empty(t, changes.Update)
 		require.Len(t, changes.Delete, len(inDatabaseMap))
@@ -72,6 +73,8 @@ func TestCalculateChanges(t *testing.T) {
 			db := inDatabaseMap[toDelete.UID]
 			require.Equal(t, db, toDelete)
 		}
+		require.Contains(t, changes.AffectedGroups, groupKey)
+		require.Equal(t, inDatabase, changes.AffectedGroups[groupKey])
 	})
 
 	t.Run("should detect alerts that needs to be updated", func(t *testing.T) {
@@ -85,6 +88,7 @@ func TestCalculateChanges(t *testing.T) {
 		changes, err := calculateChanges(context.Background(), fakeStore, groupKey, submitted)
 		require.NoError(t, err)
 
+		require.Equal(t, groupKey, changes.GroupKey)
 		require.Len(t, changes.Update, len(inDatabase))
 		for _, upsert := range changes.Update {
 			require.NotNil(t, upsert.Existing)
@@ -95,6 +99,9 @@ func TestCalculateChanges(t *testing.T) {
 		}
 		require.Empty(t, changes.Delete)
 		require.Empty(t, changes.New)
+
+		require.Contains(t, changes.AffectedGroups, groupKey)
+		require.Equal(t, inDatabase, changes.AffectedGroups[groupKey])
 	})
 
 	t.Run("should include only if there are changes ignoring specific fields", func(t *testing.T) {
@@ -187,7 +194,8 @@ func TestCalculateChanges(t *testing.T) {
 	})
 
 	t.Run("should be able to find alerts by UID in other group/namespace", func(t *testing.T) {
-		inDatabaseMap, inDatabase := models.GenerateUniqueAlertRules(rand.Intn(10)+10, models.AlertRuleGen(withOrgID(orgId)))
+		sourceGroupKey := models.GenerateGroupKey(orgId)
+		inDatabaseMap, inDatabase := models.GenerateUniqueAlertRules(rand.Intn(10)+10, models.AlertRuleGen(withGroupKey(sourceGroupKey)))
 
 		fakeStore := store.NewFakeRuleStore(t)
 		fakeStore.PutRule(context.Background(), inDatabase...)
@@ -206,6 +214,7 @@ func TestCalculateChanges(t *testing.T) {
 		changes, err := calculateChanges(context.Background(), fakeStore, groupKey, submitted)
 		require.NoError(t, err)
 
+		require.Equal(t, groupKey, changes.GroupKey)
 		require.Empty(t, changes.Delete)
 		require.Empty(t, changes.New)
 		require.Len(t, changes.Update, len(submitted))
@@ -216,6 +225,11 @@ func TestCalculateChanges(t *testing.T) {
 			require.Equal(t, submittedMap[update.Existing.UID], update.New)
 			require.NotEmpty(t, update.Diff)
 		}
+
+		require.Contains(t, changes.AffectedGroups, sourceGroupKey)
+		require.NotContains(t, changes.AffectedGroups, groupKey) // because there is no such group in database yet
+
+		require.Len(t, changes.AffectedGroups[sourceGroupKey], len(inDatabase))
 	})
 
 	t.Run("should fail when submitted rule has UID that does not exist in db", func(t *testing.T) {
@@ -251,7 +265,7 @@ func TestCalculateChanges(t *testing.T) {
 		expectedErr := errors.New("TEST ERROR")
 		fakeStore.Hook = func(cmd interface{}) error {
 			switch cmd.(type) {
-			case models.GetAlertRuleByUIDQuery:
+			case models.GetAlertRulesGroupByRuleUIDQuery:
 				return expectedErr
 			}
 			return nil
@@ -261,7 +275,7 @@ func TestCalculateChanges(t *testing.T) {
 		submitted := models.AlertRuleGen(withOrgID(orgId), simulateSubmitted)()
 
 		_, err := calculateChanges(context.Background(), fakeStore, groupKey, []*models.AlertRule{submitted})
-		require.Error(t, err, expectedErr)
+		require.ErrorIs(t, err, expectedErr)
 	})
 }
 

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -216,6 +216,16 @@ func authorizeDatasourceAccessForRule(rule *ngmodels.AlertRule, evaluator func(e
 	return true
 }
 
+// authorizeAccessToRuleGroup checks all rules against authorizeDatasourceAccessForRule and exits on the first negative result
+func authorizeAccessToRuleGroup(rules []*ngmodels.AlertRule, evaluator func(evaluator ac.Evaluator) bool) bool {
+	for _, rule := range rules {
+		if !authorizeDatasourceAccessForRule(rule, evaluator) {
+			return false
+		}
+	}
+	return true
+}
+
 // authorizeRuleChanges analyzes changes in the rule group, and checks whether the changes are authorized.
 // NOTE: if there are rules for deletion, and the user does not have access to data sources that a rule uses, the rule is removed from the list.
 // If the user is not authorized to perform the changes the function returns ErrAuthorization with a description of what action is not authorized.

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -188,26 +188,24 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 
 			groupChanges := testCase.changes()
 
-			result, err := authorizeRuleChanges(groupChanges, func(evaluator ac.Evaluator) bool {
+			err := authorizeRuleChanges(groupChanges, func(evaluator ac.Evaluator) bool {
 				response := evaluator.Evaluate(make(map[string][]string))
 				require.False(t, response)
 				executed = true
 				return false
 			})
-			require.Nil(t, result)
 			require.Error(t, err)
 			require.Truef(t, executed, "evaluation function is expected to be called but it was not.")
 
 			permissions := testCase.permissions(groupChanges)
 			executed = false
-			result, err = authorizeRuleChanges(groupChanges, func(evaluator ac.Evaluator) bool {
+			err = authorizeRuleChanges(groupChanges, func(evaluator ac.Evaluator) bool {
 				response := evaluator.Evaluate(permissions)
 				require.Truef(t, response, "provided permissions [%v] is not enough for requested permissions [%s]", testCase.permissions, evaluator.GoString())
 				executed = true
 				return true
 			})
 			require.NoError(t, err)
-			require.Equal(t, groupChanges, result)
 			require.Truef(t, executed, "evaluation function is expected to be called but it was not.")
 		})
 	}
@@ -356,12 +354,12 @@ func TestAuthorizeRuleDelete(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			groupChanges := testCase.changes()
 			permissions := testCase.permissions(groupChanges)
-			result, err := authorizeRuleChanges(groupChanges, func(evaluator ac.Evaluator) bool {
+			err := authorizeRuleChanges(groupChanges, func(evaluator ac.Evaluator) bool {
 				response := evaluator.Evaluate(permissions)
 				return response
 			})
 
-			testCase.assert(t, groupChanges, result, err)
+			testCase.assert(t, groupChanges, err)
 		})
 	}
 }

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -266,7 +266,7 @@ type GetAlertRuleByUIDQuery struct {
 	Result *AlertRule
 }
 
-// GetAlertRulesGroupByRuleUIDQuery is the query for retrieving/deleting a group of alerts by UID of a rule that belongs to that group
+// GetAlertRulesGroupByRuleUIDQuery is the query for retrieving a group of alerts by UID of a rule that belongs to that group
 type GetAlertRulesGroupByRuleUIDQuery struct {
 	UID   string
 	OrgID int64

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -266,6 +266,14 @@ type GetAlertRuleByUIDQuery struct {
 	Result *AlertRule
 }
 
+// GetAlertRulesGroupByRuleUIDQuery is the query for retrieving/deleting a group of alerts by UID of a rule that belongs to that group
+type GetAlertRulesGroupByRuleUIDQuery struct {
+	UID   string
+	OrgID int64
+
+	Result []*AlertRule
+}
+
 // ListAlertRulesQuery is the query for listing alert rules
 type ListAlertRulesQuery struct {
 	OrgID         int64

--- a/pkg/services/ngalert/store/testing.go
+++ b/pkg/services/ngalert/store/testing.go
@@ -152,6 +152,37 @@ func (f *FakeRuleStore) GetAlertRuleByUID(_ context.Context, q *models.GetAlertR
 	return nil
 }
 
+func (f *FakeRuleStore) GetAlertRulesGroupByRuleUID(_ context.Context, q *models.GetAlertRulesGroupByRuleUIDQuery) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	f.RecordedOps = append(f.RecordedOps, *q)
+	if err := f.Hook(*q); err != nil {
+		return err
+	}
+	rules, ok := f.Rules[q.OrgID]
+	if !ok {
+		return nil
+	}
+
+	var selected *models.AlertRule
+	for _, rule := range rules {
+		if rule.UID == q.UID {
+			selected = rule
+			break
+		}
+	}
+	if selected == nil {
+		return nil
+	}
+
+	for _, rule := range rules {
+		if rule.GetGroupKey() == selected.GetGroupKey() {
+			q.Result = append(q.Result, rule)
+		}
+	}
+	return nil
+}
+
 // For now, we're not implementing namespace filtering.
 func (f *FakeRuleStore) GetAlertRulesForScheduling(_ context.Context, q *models.GetAlertRulesForSchedulingQuery) error {
 	f.mtx.Lock()


### PR DESCRIPTION
**What this PR does / why we need it**:
The Grafana Alerting follows the design of Prometheus alerts: Grafana Alerting has a notion of alert groups but in opposite to Prometheus, Grafana does not handle groups of alerts the way Prometheus does. Although a rule belongs to a group it is treated as a single entity by the Grafana Alerting scheduler. The only place where group matters is API: if there are two rules in the same namespaces and they belong to the same group, the API will return them together. 
The same conception of rule independence is implemented in RBAC: if there is a group of several alert rules in a namespace that use different data sources then the user will see only those alerts in the group in which data source is available to the user. Other alert rules will not be accessible to the user at all.

For Grafana 9 (https://github.com/grafana/grafana/issues/48353) we are moving toward how Prometheus handles alert rules: e.g. alert rules that belong to the same group will be executed sequentially and in the pre-determined order.

Therefore, the current RBAC model will not work anymore because otherwise, it will not be possible to hide inaccessible rules and maintain the correct order when that user submits changes back.

Currently, in order to access a rule user should have the following permissions:
1. have permission (CRUD) to access rules in a folder\namespace
2. have permission to query all data sources the rule uses.

This PR updates rule APIs and adds 3rd criteria:
3. have permission to query all data sources of all rules in the group to which the rule belongs.


**Which issue(s) this PR fixes**:
Related: https://github.com/grafana/grafana/issues/48353