### PR TITLE
Storage: store uploaded files in SQL rather than on the disk

### DIFF
--- a/pkg/services/store/config.go
+++ b/pkg/services/store/config.go
@@ -32,7 +32,8 @@ type StorageGitConfig struct {
 }
 
 type StorageSQLConfig struct {
-	// no custom settings
+	// SQLStorage will prefix all paths with orgId for isolation between orgs
+	orgId int64
 }
 
 type StorageS3Config struct {

--- a/pkg/services/store/service_test.go
+++ b/pkg/services/store/service_test.go
@@ -10,11 +10,16 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/experimental"
+	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/testdatasource"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	dummyUser = &models.SignedInUser{OrgId: 1}
 )
 
 func TestListFiles(t *testing.T) {
@@ -34,14 +39,16 @@ func TestListFiles(t *testing.T) {
 		}).setReadOnly(true).setBuiltin(true),
 	}
 
-	store := newStandardStorageService(roots)
-	frame, err := store.List(context.Background(), nil, "public/testdata")
+	store := newStandardStorageService(roots, func(orgId int64) []storageRuntime {
+		return make([]storageRuntime, 0)
+	})
+	frame, err := store.List(context.Background(), dummyUser, "public/testdata")
 	require.NoError(t, err)
 
 	err = experimental.CheckGoldenFrame(path.Join("testdata", "public_testdata.golden.txt"), frame, true)
 	require.NoError(t, err)
 
-	file, err := store.Read(context.Background(), nil, "public/testdata/js_libraries.csv")
+	file, err := store.Read(context.Background(), dummyUser, "public/testdata/js_libraries.csv")
 	require.NoError(t, err)
 	require.NotNil(t, file)
 
@@ -61,7 +68,7 @@ func TestUpload(t *testing.T) {
 		Value: map[string][]string{},
 		File:  map[string][]*multipart.FileHeader{},
 	}
-	res, err := s.Upload(context.Background(), nil, testForm)
+	res, err := s.Upload(context.Background(), dummyUser, testForm)
 	require.NoError(t, err)
 	assert.Equal(t, res.path, "upload")
 }

--- a/pkg/services/store/storage_sql.go
+++ b/pkg/services/store/storage_sql.go
@@ -1,0 +1,82 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/infra/filestorage"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+)
+
+const rootStorageTypeSQL = "sql"
+
+type rootStorageSQL struct {
+	baseStorageRuntime
+
+	settings *StorageSQLConfig
+}
+
+// getDbRootFolder creates a DB path prefix for a given storage name and orgId.
+// example:
+//   orgId: 5
+//   storageName: "upload"
+//     => prefix: "/5/upload/"
+func getDbStoragePathPrefix(orgId int64, storageName string) string {
+	return filestorage.Join(fmt.Sprintf("%d", orgId), storageName+filestorage.Delimiter)
+}
+
+func newSQLStorage(prefix string, name string, cfg *StorageSQLConfig, sql *sqlstore.SQLStore) *rootStorageSQL {
+	if cfg == nil {
+		cfg = &StorageSQLConfig{}
+	}
+
+	meta := RootStorageMeta{
+		Config: RootStorageConfig{
+			Type:   rootStorageTypeSQL,
+			Prefix: prefix,
+			Name:   name,
+			SQL:    cfg,
+		},
+	}
+
+	if prefix == "" {
+		meta.Notice = append(meta.Notice, data.Notice{
+			Severity: data.NoticeSeverityError,
+			Text:     "Missing prefix",
+		})
+	}
+
+	s := &rootStorageSQL{}
+	s.store = filestorage.NewDbStorage(
+		grafanaStorageLogger,
+		sql, nil, getDbStoragePathPrefix(cfg.orgId, prefix))
+
+	meta.Ready = true
+	s.meta = meta
+	s.settings = cfg
+	return s
+}
+
+func (s *rootStorageSQL) Write(ctx context.Context, cmd *WriteValueRequest) (*WriteValueResponse, error) {
+	byteAray := []byte(cmd.Body)
+
+	path := cmd.Path
+	if !strings.HasPrefix(path, filestorage.Delimiter) {
+		path = filestorage.Delimiter + path
+	}
+	err := s.store.Upsert(ctx, &filestorage.UpsertFileCommand{
+		Path:     path,
+		Contents: byteAray,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &WriteValueResponse{Code: 200}, nil
+}
+
+func (s *rootStorageSQL) Sync() error {
+	return nil // already in sync
+}

--- a/pkg/services/store/storage_sql_test.go
+++ b/pkg/services/store/storage_sql_test.go
@@ -1,0 +1,27 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetDbStoragePathPrefix(t *testing.T) {
+	tests := []struct {
+		orgId       int64
+		storageName string
+		expected    string
+	}{
+		{
+			orgId:       124,
+			storageName: "long-storage-name",
+			expected:    "/124/long-storage-name/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("orgId: %d, storageName: %s", tt.orgId, tt.storageName), func(t *testing.T) {
+			assert.Equal(t, tt.expected, getDbStoragePathPrefix(tt.orgId, tt.storageName))
+		})
+	}
+}

--- a/pkg/services/store/tree.go
+++ b/pkg/services/store/tree.go
@@ -2,66 +2,117 @@ package store
 
 import (
 	"context"
+	"sync"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/infra/filestorage"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 )
 
 type nestedTree struct {
-	roots  []storageRuntime
-	lookup map[string]filestorage.FileStorage
+	rootsByOrgId map[int64][]storageRuntime
+	lookup       map[int64]map[string]filestorage.FileStorage
+
+	orgInitMutex          sync.Mutex
+	initializeOrgStorages func(orgId int64) []storageRuntime
 }
 
 var (
 	_ storageTree = (*nestedTree)(nil)
 )
 
+func asNameToFileStorageMap(storages []storageRuntime) map[string]filestorage.FileStorage {
+	lookup := make(map[string]filestorage.FileStorage)
+	for _, storage := range storages {
+		lookup[storage.Meta().Config.Prefix] = storage.Store()
+	}
+	return lookup
+}
+
 func (t *nestedTree) init() {
-	t.lookup = make(map[string]filestorage.FileStorage, len(t.roots))
-	for _, root := range t.roots {
-		t.lookup[root.Meta().Config.Prefix] = root.Store()
+	t.orgInitMutex.Lock()
+	defer t.orgInitMutex.Unlock()
+
+	t.lookup = make(map[int64]map[string]filestorage.FileStorage, len(t.rootsByOrgId))
+
+	for orgId, storages := range t.rootsByOrgId {
+		t.lookup[orgId] = asNameToFileStorageMap(storages)
 	}
 }
 
-func (t *nestedTree) getRoot(path string) (filestorage.FileStorage, string) {
+func (t *nestedTree) assureOrgIsInitialized(orgId int64) {
+	t.orgInitMutex.Lock()
+	defer t.orgInitMutex.Unlock()
+	if _, ok := t.rootsByOrgId[orgId]; !ok {
+		orgStorages := t.initializeOrgStorages(orgId)
+		t.rootsByOrgId[orgId] = orgStorages
+		t.lookup[orgId] = asNameToFileStorageMap(orgStorages)
+	}
+}
+
+func (t *nestedTree) getRoot(orgId int64, path string) (filestorage.FileStorage, string) {
+	t.assureOrgIsInitialized(orgId)
+
 	if path == "" {
 		return nil, ""
 	}
 
 	rootKey, path := splitFirstSegment(path)
-	root, ok := t.lookup[rootKey]
-	if !ok || root == nil {
-		return nil, path // not found or not ready
+	root, ok := t.lookup[orgId][rootKey]
+	if ok && root != nil {
+		return root, filestorage.Delimiter + path
 	}
-	return root, filestorage.Delimiter + path
+
+	if orgId != ac.GlobalOrgID {
+		globalRoot, ok := t.lookup[ac.GlobalOrgID][rootKey]
+		if ok && globalRoot != nil {
+			return globalRoot, filestorage.Delimiter + path
+		}
+	}
+
+	return nil, path // not found or not ready
 }
 
-func (t *nestedTree) GetFile(ctx context.Context, path string) (*filestorage.File, error) {
+func (t *nestedTree) GetFile(ctx context.Context, orgId int64, path string) (*filestorage.File, error) {
 	if path == "" {
 		return nil, nil // not found
 	}
 
-	root, path := t.getRoot(path)
+	root, path := t.getRoot(orgId, path)
 	if root == nil {
 		return nil, nil // not found (or not ready)
 	}
 	return root.Get(ctx, path)
 }
 
-func (t *nestedTree) ListFolder(ctx context.Context, path string) (*data.Frame, error) {
+func (t *nestedTree) ListFolder(ctx context.Context, orgId int64, path string) (*data.Frame, error) {
 	if path == "" || path == "/" {
-		count := len(t.roots)
+		t.assureOrgIsInitialized(orgId)
+
+		count := len(t.rootsByOrgId[ac.GlobalOrgID])
+		if orgId != ac.GlobalOrgID {
+			count += len(t.rootsByOrgId[orgId])
+		}
+
 		title := data.NewFieldFromFieldType(data.FieldTypeString, count)
 		names := data.NewFieldFromFieldType(data.FieldTypeString, count)
 		mtype := data.NewFieldFromFieldType(data.FieldTypeString, count)
 		title.Name = "title"
 		names.Name = "name"
 		mtype.Name = "mediaType"
-		for i, f := range t.roots {
+		for i, f := range t.rootsByOrgId[ac.GlobalOrgID] {
 			names.Set(i, f.Meta().Config.Prefix)
 			title.Set(i, f.Meta().Config.Name)
 			mtype.Set(i, "directory")
 		}
+		if orgId != ac.GlobalOrgID {
+			for i, f := range t.rootsByOrgId[orgId] {
+				names.Set(i, f.Meta().Config.Prefix)
+				title.Set(i, f.Meta().Config.Name)
+				mtype.Set(i, "directory")
+			}
+		}
+
 		frame := data.NewFrame("", names, title, mtype)
 		frame.SetMeta(&data.FrameMeta{
 			Type: data.FrameTypeDirectoryListing,
@@ -69,7 +120,7 @@ func (t *nestedTree) ListFolder(ctx context.Context, path string) (*data.Frame, 
 		return frame, nil
 	}
 
-	root, path := t.getRoot(path)
+	root, path := t.getRoot(orgId, path)
 	if root == nil {
 		return nil, nil // not found (or not ready)
 	}

--- a/pkg/services/store/types.go
+++ b/pkg/services/store/types.go
@@ -29,8 +29,8 @@ type WriteValueResponse struct {
 }
 
 type storageTree interface {
-	GetFile(ctx context.Context, path string) (*filestorage.File, error)
-	ListFolder(ctx context.Context, path string) (*data.Frame, error)
+	GetFile(ctx context.Context, orgId int64, path string) (*filestorage.File, error)
+	ListFolder(ctx context.Context, orgId int64, path string) (*data.Frame, error)
 }
 
 //-------------------------------------------


### PR DESCRIPTION
Two changes:

- [x] Modify  `StorageService` so that it supports storage-per-organization. 
   - storages with per-org setup are initialized/created lazily  
- [x] Migrate from `storage_disk` to `storage_sql`