### PR TITLE
TimeSeries: insert null values at each missing interval

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.test.ts
+++ b/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.test.ts
@@ -59,9 +59,9 @@ describe('nullInsertThreshold Transformer', () => {
 
     const result = applyNullInsertThreshold(df);
 
-    expect(result.fields[0].values.toArray()).toStrictEqual([1, 2, 3, 4, 10]);
-    expect(result.fields[1].values.toArray()).toStrictEqual([4, null, 6, null, 8]);
-    expect(result.fields[2].values.toArray()).toStrictEqual(['a', null, 'b', null, 'c']);
+    expect(result.fields[0].values.toArray()).toStrictEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(result.fields[1].values.toArray()).toStrictEqual([4, null, 6, null, null, null, null, null, null, 8]);
+    expect(result.fields[2].values.toArray()).toStrictEqual(['a', null, 'b', null, null, null, null, null, null, 'c']);
   });
 
   test('should insert nulls at +threshold between adjacent > threshold: 2', () => {
@@ -93,9 +93,9 @@ describe('nullInsertThreshold Transformer', () => {
 
     const result = applyNullInsertThreshold(df);
 
-    expect(result.fields[0].values.toArray()).toStrictEqual([1, 2, 3, 4, 10]);
-    expect(result.fields[1].values.toArray()).toStrictEqual([4, null, 6, null, 8]);
-    expect(result.fields[2].values.toArray()).toStrictEqual(['a', null, 'b', null, 'c']);
+    expect(result.fields[0].values.toArray()).toStrictEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(result.fields[1].values.toArray()).toStrictEqual([4, null, 6, null, null, null, null, null, null, 8]);
+    expect(result.fields[2].values.toArray()).toStrictEqual(['a', null, 'b', null, null, null, null, null, null, 'c']);
   });
 
   test('should insert trailing null at end +interval when timeRange.to.valueOf() exceeds threshold', () => {
@@ -110,9 +110,21 @@ describe('nullInsertThreshold Transformer', () => {
 
     const result = applyNullInsertThreshold(df, null, 13);
 
-    expect(result.fields[0].values.toArray()).toStrictEqual([1, 2, 3, 4, 10, 11]);
-    expect(result.fields[1].values.toArray()).toStrictEqual([4, null, 6, null, 8, null]);
-    expect(result.fields[2].values.toArray()).toStrictEqual(['a', null, 'b', null, 'c', null]);
+    expect(result.fields[0].values.toArray()).toStrictEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    expect(result.fields[1].values.toArray()).toStrictEqual([4, null, 6, null, null, null, null, null, null, 8, null]);
+    expect(result.fields[2].values.toArray()).toStrictEqual([
+      'a',
+      null,
+      'b',
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      'c',
+      null,
+    ]);
 
     // should work for frames with 1 datapoint
     const df2 = new MutableDataFrame({


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/49030

![Peek 2022-05-16 17-13](https://user-images.githubusercontent.com/43234/168691062-a12b3e32-8167-4eac-b984-bb0b23dce800.gif)

this is also a prerequisite for a followup PR that will fix `No value` in TimeSeries:

![image](https://user-images.githubusercontent.com/43234/168686984-9f594338-9718-408d-91a2-146ba87eaf92.png)
