### PR TITLE
UsageStats: fixed elasticsearch version number to semver

### DIFF
--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -261,14 +261,12 @@ func (s *Service) collectElasticStats(ctx context.Context) (map[string]interface
 		s.log.Error("Failed to get elasticsearch json data", "error", err)
 		return nil, err
 	}
-
 	for _, data := range esDataSourcesQuery.Result {
-		esVersion, err := data.JsonData.Get("esVersion").Int()
+		esVersion, err := data.JsonData.Get("esVersion").String()
 		if err != nil {
 			continue
 		}
-
-		statName := fmt.Sprintf("stats.ds.elasticsearch.v%d.count", esVersion)
+		statName := fmt.Sprintf("stats.ds.elasticsearch.v%s.count", strings.ReplaceAll(esVersion, ".", "_"))
 
 		count, _ := m[statName].(int64)
 

--- a/pkg/infra/usagestats/statscollector/service_test.go
+++ b/pkg/infra/usagestats/statscollector/service_test.go
@@ -121,6 +121,24 @@ func TestFeatureUsageStats(t *testing.T) {
 
 func TestCollectingUsageStats(t *testing.T) {
 	sqlStore := mockstore.NewSQLStoreMock()
+	sqlStore.ExpectedDataSources = []*datasources.DataSource{
+		{
+			JsonData: simplejson.NewFromAny(map[string]interface{}{
+				"esVersion": "2.0.0",
+			}),
+		},
+		{
+			JsonData: simplejson.NewFromAny(map[string]interface{}{
+				"esVersion": "2.0.0",
+			}),
+		},
+		{
+			JsonData: simplejson.NewFromAny(map[string]interface{}{
+				"esVersion": "70.1.1",
+			}),
+		},
+	}
+
 	s := createService(t, &setting.Cfg{
 		ReportingEnabled:     true,
 		BuildVersion:         "5.0.0",
@@ -130,7 +148,8 @@ func TestCollectingUsageStats(t *testing.T) {
 		AuthProxyEnabled:     true,
 		Packaging:            "deb",
 		ReportingDistributor: "hosted-grafana",
-	}, sqlStore)
+	}, sqlStore,
+		withDatasources(mockDatasourceService{datasources: sqlStore.ExpectedDataSources}))
 
 	s.startTime = time.Now().Add(-1 * time.Minute)
 

--- a/pkg/infra/usagestats/statscollector/service_test.go
+++ b/pkg/infra/usagestats/statscollector/service_test.go
@@ -198,6 +198,9 @@ func TestCollectingUsageStats(t *testing.T) {
 	assert.EqualValues(t, 3, metrics["stats.active_data_keys.count"])
 	assert.EqualValues(t, 5, metrics["stats.public_dashboards.count"])
 
+	assert.EqualValues(t, 2, metrics["stats.ds."+datasources.DS_ES+".v2_0_0.count"])
+	assert.EqualValues(t, 1, metrics["stats.ds."+datasources.DS_ES+".v70_1_1.count"])
+
 	assert.InDelta(t, int64(65), metrics["stats.uptime"], 6)
 }
 

--- a/pkg/services/sqlstore/mockstore/mockstore.go
+++ b/pkg/services/sqlstore/mockstore/mockstore.go
@@ -423,11 +423,12 @@ func (m SQLStoreMock) GetDataSource(ctx context.Context, query *datasources.GetD
 }
 
 func (m *SQLStoreMock) GetDataSources(ctx context.Context, query *datasources.GetDataSourcesQuery) error {
-	query.Result = m.ExpectedDatasources
+	query.Result = m.ExpectedDataSources
 	return m.ExpectedError
 }
 
 func (m *SQLStoreMock) GetDataSourcesByType(ctx context.Context, query *datasources.GetDataSourcesByTypeQuery) error {
+	query.Result = m.ExpectedDataSources
 	return m.ExpectedError
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Versions on datasources were changed from plain numbers to a semver-ish approach. This was forgotten in the UsageStats module and accordingly is fixed in this PR.

**Which issue(s) this PR fixes**:
 Fixes #45977

**Special notes for your reviewer**:
I changed the origin of `GetDataSourcesByType` from the `sqlstore` to the `datasources` field. The datasource itself will wrap the `GetDataSourcesByType` call to the SQLStore and it is also used in the prometheus_flavor: https://github.com/grafana/grafana/blob/main/pkg/infra/usagestats/statscollector/prometheus_flavor.go#L28
