### PR TITLE
Search: Constrain folder view

### DIFF
--- a/public/app/features/search/page/SearchPage.tsx
+++ b/public/app/features/search/page/SearchPage.tsx
@@ -162,6 +162,7 @@ export default function SearchPage() {
         className={css`
           display: flex;
           flex-direction: column;
+          overflow: hidden;
         `}
       >
         <Input
@@ -215,6 +216,7 @@ export default function SearchPage() {
 const getStyles = (theme: GrafanaTheme2) => ({
   searchInput: css`
     margin-bottom: 6px;
+    min-height: ${theme.spacing(4)};
   `,
   unsupported: css`
     padding: 10px;

--- a/public/app/features/search/page/components/FolderView.tsx
+++ b/public/app/features/search/page/components/FolderView.tsx
@@ -78,6 +78,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     wrapper: css`
       display: flex;
       flex-direction: column;
+      overflow: auto;
 
       > ul {
         list-style: none;


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevents folder view from overflowing the page.

Closes #49042
