### PR TITLE
Loki: Improve unpack parser handling

### DIFF
--- a/public/app/plugins/datasource/loki/syntax.ts
+++ b/public/app/plugins/datasource/loki/syntax.ts
@@ -72,6 +72,13 @@ export const PIPE_PARSERS: CompletionItem[] = [
     insertText: 'pattern',
     documentation: 'Extracting labels from the log line using pattern parser. Only available in Loki 2.3+.',
   },
+  {
+    label: 'unpack',
+    insertText: 'unpack',
+    detail: 'unpack identifier',
+    documentation:
+      'Parses a JSON log line, unpacking all embedded labels in the pack stage. A special property "_entry" will also be used to replace the original log line. Only available in Loki 2.2+.',
+  },
 ];
 
 export const PIPE_OPERATORS: CompletionItem[] = [
@@ -81,13 +88,6 @@ export const PIPE_OPERATORS: CompletionItem[] = [
     detail: 'unwrap identifier',
     documentation:
       'Take labels and use the values as sample data for metric aggregations. Only available in Loki 2.0+.',
-  },
-  {
-    label: 'unpack',
-    insertText: 'unpack',
-    detail: 'unpack identifier',
-    documentation:
-      'Parses a JSON log line, unpacking all embedded labels in the pack stage. A special property "_entry" will also be used to replace the original log line. Only available in Loki 2.0+.',
   },
   {
     label: 'label_format',


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/48820

imagine we have loki-data with labels `{section="main"}`. the log-lines itself are built with the https://grafana.com/docs/loki/latest/clients/promtail/stages/pack/ thing, meaning they are in JSON-format for example 
```json
{
    "component":"thing",
    "level": "error",
    "_entity": "bad thing happened with the main component"
}
```

if you query this with `{section="main"} | json`, or `{section="main"} | unpack`, the JSON-data will be parsed and the resulting data will have 3 labels (`section`, `component`, `level`).

when in grafana-explore-mode, you click on such a log-line, and click on the [+] symbol next to let's say `component`, then:
- if your query is `{section="main"} | json`, then it will become `{section="main"} | json | component="thing"`
- if your query is `{section="main"} | unpack`, then it will become `{section="main", component="thing} | unpack`

the unpack-line is incorrect, because there is no "real" label named `component`, it is inside the json-log-line.

we have code that decides whether we should add filters to the end of the query (like done for `json`) or into the stream-selector (like done incorrectly for `unpack), which ends up calling `queryHasPipeParser` at https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/loki/query_utils.ts#L67-L71

this function uses the `PIPE_PARSERS` list, but `unpack` is currently in the `PIPE_OPERATORS` list instead, so it is not taken into account.

my pull request moves `unpack` from the `PIPE_OPERATORS` section to the `PIPE_PARSERS` section.

(i also adjusted the `available in version 2.0` to `available in version 2.2`, because it was added there to Loki)

how to test:
- you need data in loki that has the shape i described above
- write a query of form `{....} | unpack`
- click on the [+] next to a label-name that was parsed out from the JSON
- the query should become `{....} | unpack | label="value"`