### PR TITLE
Ayy1: Cannot save single dashboard link

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/LinksSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/LinksSettings.test.tsx
@@ -146,6 +146,7 @@ describe('LinksSettings', () => {
     expect(screen.queryByText('Type')).toBeInTheDocument();
     expect(screen.queryByText('Title')).toBeInTheDocument();
     expect(screen.queryByText('With tags')).toBeInTheDocument();
+    expect(screen.queryByText('Apply')).toBeInTheDocument();
 
     expect(screen.queryByText('Url')).not.toBeInTheDocument();
     expect(screen.queryByText('Tooltip')).not.toBeInTheDocument();
@@ -153,8 +154,8 @@ describe('LinksSettings', () => {
 
     await userEvent.click(screen.getByText('Dashboards'));
     expect(screen.queryAllByText('Dashboards')).toHaveLength(2);
-    expect(screen.queryByText('Link')).toBeVisible();
 
+    expect(screen.queryByText('Link')).toBeVisible();
     await userEvent.click(screen.getByText('Link'));
 
     expect(screen.queryByText('URL')).toBeInTheDocument();
@@ -163,9 +164,7 @@ describe('LinksSettings', () => {
 
     await userEvent.clear(screen.getByRole('textbox', { name: /title/i }));
     await userEvent.type(screen.getByRole('textbox', { name: /title/i }), 'New Dashboard Link');
-    await userEvent.click(
-      within(screen.getByRole('heading', { name: /dashboard links edit/i })).getByText(/dashboard links/i)
-    );
+    await userEvent.click(screen.getByText('Apply'));
 
     expect(getTableBodyRows().length).toBe(links.length + 1);
     expect(within(getTableBody()).queryByText('New Dashboard Link')).toBeInTheDocument();
@@ -173,9 +172,7 @@ describe('LinksSettings', () => {
     await userEvent.click(screen.getAllByText(links[0].type)[0]);
     await userEvent.clear(screen.getByRole('textbox', { name: /title/i }));
     await userEvent.type(screen.getByRole('textbox', { name: /title/i }), 'The first dashboard link');
-    await userEvent.click(
-      within(screen.getByRole('heading', { name: /dashboard links edit/i })).getByText(/dashboard links/i)
-    );
+    await userEvent.click(screen.getByText('Apply'));
 
     expect(within(getTableBody()).queryByText(links[0].title)).not.toBeInTheDocument();
     expect(within(getTableBody()).queryByText('The first dashboard link')).toBeInTheDocument();

--- a/public/app/features/dashboard/components/LinksSettings/LinkSettingsEdit.tsx
+++ b/public/app/features/dashboard/components/LinksSettings/LinkSettingsEdit.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { CollapsableSection, TagsInput, Select, Field, Input, Checkbox } from '@grafana/ui';
+import { CollapsableSection, TagsInput, Select, Field, Input, Checkbox, Button } from '@grafana/ui';
 
 import { DashboardLink, DashboardModel } from '../../state/DashboardModel';
 
@@ -41,18 +41,18 @@ type LinkSettingsEditProps = {
   onGoBack: () => void;
 };
 
-export const LinkSettingsEdit: React.FC<LinkSettingsEditProps> = ({ editLinkIdx, dashboard }) => {
+export const LinkSettingsEdit: React.FC<LinkSettingsEditProps> = ({ editLinkIdx, dashboard, onGoBack }) => {
   const [linkSettings, setLinkSettings] = useState(editLinkIdx !== null ? dashboard.links[editLinkIdx] : newLink);
 
-  const onUpdate = (link: DashboardLink) => {
+  const onUpdate = () => {
     const links = [...dashboard.links];
-    links.splice(editLinkIdx, 1, link);
+    links.splice(editLinkIdx, 1, linkSettings);
     dashboard.links = links;
-    setLinkSettings(link);
+    onGoBack();
   };
 
   const onTagsChange = (tags: any[]) => {
-    onUpdate({ ...linkSettings, tags: tags });
+    setLinkSettings({ ...linkSettings, tags: tags });
   };
 
   const onTypeChange = (selectedItem: SelectableValue) => {
@@ -66,16 +66,16 @@ export const LinkSettingsEdit: React.FC<LinkSettingsEditProps> = ({ editLinkIdx,
       update.tags = [];
     }
 
-    onUpdate(update);
+    setLinkSettings(update);
   };
 
   const onIconChange = (selectedItem: SelectableValue) => {
-    onUpdate({ ...linkSettings, icon: selectedItem.value });
+    setLinkSettings({ ...linkSettings, icon: selectedItem.value });
   };
 
   const onChange = (ev: React.FocusEvent<HTMLInputElement>) => {
     const target = ev.currentTarget;
-    onUpdate({
+    setLinkSettings({
       ...linkSettings,
       [target.name]: target.type === 'checkbox' ? target.checked : target.value,
     });
@@ -142,6 +142,7 @@ export const LinkSettingsEdit: React.FC<LinkSettingsEditProps> = ({ editLinkIdx,
           />
         </Field>
       </CollapsableSection>
+      <Button onClick={onUpdate}>Apply</Button>
     </div>
   );
 };


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #46498

**Special notes for your reviewer**: 
An `Apply` button was added which saves the Link and navigates back to the `Dashboard Links`.
It changes the existing functionality which saved every field of a Link immediately when it is editing and the button need to be clicked to apply the changes.

Alternative: #49075