### PR TITLE
Alerting: Keep private annotations across evaluations

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -74,12 +74,6 @@ const (
 	OkErrState       ExecutionErrorState = "OK"
 )
 
-// InternalLabelNameSet are labels that grafana automatically include as part of the labelset.
-var InternalLabelNameSet = map[string]struct{}{
-	RuleUIDLabel:      {},
-	NamespaceUIDLabel: {},
-}
-
 const (
 	RuleUIDLabel      = "__alert_rule_uid__"
 	NamespaceUIDLabel = "__alert_rule_namespace_uid__"
@@ -87,6 +81,15 @@ const (
 	// Annotations are actually a set of labels, so technically this is the label name of an annotation.
 	DashboardUIDAnnotation = "__dashboardUid__"
 	PanelIDAnnotation      = "__panelId__"
+)
+
+var (
+	// InternalLabelNameSet are labels that grafana automatically include as part of the labelset.
+	InternalLabelNameSet = map[string]struct{}{
+		RuleUIDLabel:      {},
+		NamespaceUIDLabel: {},
+	}
+	InternalAnnotationNameSet = map[string]struct{}{}
 )
 
 // AlertRule is the model for alert rules in unified alerting.


### PR DESCRIPTION
**What this PR does / why we need it**:

Each time an alert rule is evaluated all annotations from the previous evaluation are discarded, even if those annotations are private annotations created while processing the state. This means that, unlike labels, annotations cannot be used to keep state across evaluations.

**Which issue(s) this PR fixes**:

This pull request changes the state package so private annotations are maintained across evaluations unless a private annotation with the same name is present, in which case the annotation is updated.

Fixes #

**Special notes for your reviewer**:

