### PR TITLE
util: Improve performance of strings.SplitString

### DIFF
--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -3,7 +3,6 @@ package util
 import (
 	"fmt"
 	"math"
-	"regexp"
 	"strings"
 	"time"
 	"unicode"
@@ -34,7 +33,7 @@ func SplitString(str string) []string {
 		return []string{}
 	}
 
-	return regexp.MustCompile("[, ]+").Split(str, -1)
+	return strings.Fields(strings.ReplaceAll(str, ",", " "))
 }
 
 // GetAgeString returns a string representing certain time from years to minutes.

--- a/pkg/util/strings_test.go
+++ b/pkg/util/strings_test.go
@@ -58,6 +58,53 @@ func TestSplitString(t *testing.T) {
 	}
 }
 
+func BenchmarkSplitString(b *testing.B) {
+	b.Run("empty input", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			SplitString("")
+		}
+	})
+	b.Run("single string", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			SplitString("test")
+		}
+	})
+	b.Run("space-separated", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			SplitString("test1 test2 test3")
+		}
+	})
+	b.Run("comma-separated", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			SplitString("test1,test2,test3")
+		}
+	})
+	b.Run("comma-separated with spaces", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			SplitString("test1 , test2 test3")
+		}
+	})
+	b.Run("mixed commas and spaces", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			SplitString("test1 , test2 test3,test4")
+		}
+	})
+	b.Run("very long mixed", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			SplitString("test1 , test2 test3,test4, test5 test6 test7,test8 test9 test10" +
+				" test11 test12 test13,test14 test15 test16,test17 test18 test19,test20 test21 test22" +
+				" test23,test24 test25 test26,test27 test28 test29,test30 test31 test32" +
+				" test33,test34 test35 test36,test37 test38 test39,test40 test41 test42" +
+				" test43,test44 test45 test46,test47 test48 test49,test50 test51 test52" +
+				" test53,test54 test55 test56,test57 test58 test59,test60 test61 test62" +
+				" test63,test64 test65 test66,test67 test68 test69,test70 test71 test72" +
+				" test73,test74 test75 test76,test77 test78 test79,test80 test81 test82" +
+				" test83,test84 test85 test86,test87 test88 test89,test90 test91 test92" +
+				" test93,test94 test95 test96,test97 test98 test99,test100 ")
+		}
+	})
+}
+
 func TestDateAge(t *testing.T) {
 	assert.Equal(t, "?", GetAgeString(time.Time{})) // base case
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces the regexp with calls to `strings.ReplaceAll` and `strings.Fields` for simplicity and improved performance (~90% faster & ~95% fewer allocations). I've also added some benchmarks to measure it .

This isn't strictly necessary, but came up when we were looking at some tangentially-related code in the Hosted Grafana API.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

I ran the benchmarks against the old implementation, and again against the new, and then compared with `benchstat`. Here are the results:

```console
$ benchstat -geomean old.txt new.txt
name                                        old time/op    new time/op    delta
SplitString/empty_input                       1.29ns ± 1%    1.29ns ± 0%     ~     (p=0.343 n=4+4)
SplitString/empty_input-4                     1.29ns ± 1%    1.29ns ± 0%     ~     (p=0.343 n=4+4)
SplitString/empty_input-16                    1.29ns ± 0%    1.29ns ± 0%     ~     (p=0.629 n=4+4)
SplitString/single_string                      888ns ± 1%      39ns ± 0%  -95.66%  (p=0.029 n=4+4)
SplitString/single_string-4                    871ns ± 1%      38ns ± 0%  -95.62%  (p=0.029 n=4+4)
SplitString/single_string-16                   894ns ± 4%      38ns ± 0%  -95.72%  (p=0.029 n=4+4)
SplitString/space-separated                   1.46µs ± 0%    0.09µs ± 0%  -94.01%  (p=0.029 n=4+4)
SplitString/space-separated-4                 1.44µs ± 0%    0.09µs ± 0%  -94.00%  (p=0.029 n=4+4)
SplitString/space-separated-16                1.45µs ± 1%    0.09µs ± 1%  -94.01%  (p=0.029 n=4+4)
SplitString/comma-separated                   1.47µs ± 1%    0.15µs ± 1%  -90.14%  (p=0.029 n=4+4)
SplitString/comma-separated-4                 1.43µs ± 0%    0.14µs ± 0%  -90.02%  (p=0.029 n=4+4)
SplitString/comma-separated-16                1.45µs ± 1%    0.14µs ± 1%  -90.04%  (p=0.029 n=4+4)
SplitString/comma-separated_with_spaces       1.51µs ± 1%    0.14µs ± 0%  -90.92%  (p=0.029 n=4+4)
SplitString/comma-separated_with_spaces-4     1.48µs ± 1%    0.14µs ± 3%  -90.80%  (p=0.029 n=4+4)
SplitString/comma-separated_with_spaces-16    1.50µs ± 3%    0.13µs ± 0%  -91.02%  (p=0.029 n=4+4)
SplitString/mixed_commas_and_spaces           1.70µs ± 1%    0.16µs ± 0%  -90.75%  (p=0.029 n=4+4)
SplitString/mixed_commas_and_spaces-4         1.67µs ± 1%    0.15µs ± 0%  -90.69%  (p=0.029 n=4+4)
SplitString/mixed_commas_and_spaces-16        1.68µs ± 1%    0.16µs ± 0%  -90.75%  (p=0.029 n=4+4)
SplitString/very_long_mixed                   22.8µs ± 0%     1.8µs ± 1%  -92.11%  (p=0.029 n=4+4)
SplitString/very_long_mixed-4                 22.3µs ± 0%     1.7µs ± 0%  -92.20%  (p=0.029 n=4+4)
SplitString/very_long_mixed-16                22.5µs ± 0%     1.8µs ± 1%  -92.19%  (p=0.029 n=4+4)
[Geo mean]                                     752ns           81ns       -89.22%

name                                        old alloc/op   new alloc/op   delta
SplitString/empty_input                        0.00B          0.00B          ~     (all equal)
SplitString/empty_input-4                      0.00B          0.00B          ~     (all equal)
SplitString/empty_input-16                     0.00B          0.00B          ~     (all equal)
SplitString/single_string                       888B ± 0%       16B ± 0%  -98.20%  (p=0.029 n=4+4)
SplitString/single_string-4                     894B ± 0%       16B ± 0%  -98.21%  (p=0.029 n=4+4)
SplitString/single_string-16                    900B ± 0%       16B ± 0%  -98.22%  (p=0.029 n=4+4)
SplitString/space-separated                   1.24kB ± 0%    0.05kB ± 0%  -96.13%  (p=0.029 n=4+4)
SplitString/space-separated-4                 1.25kB ± 0%    0.05kB ± 0%  -96.15%  (p=0.029 n=4+4)
SplitString/space-separated-16                1.26kB ± 0%    0.05kB ± 0%  -96.18%  (p=0.029 n=4+4)
SplitString/comma-separated                   1.24kB ± 0%    0.07kB ± 0%  -94.19%  (p=0.029 n=4+4)
SplitString/comma-separated-4                 1.25kB ± 0%    0.07kB ± 0%  -94.23%  (p=0.029 n=4+4)
SplitString/comma-separated-16                1.26kB ± 0%    0.07kB ± 0%  -94.26%  (p=0.029 n=4+4)
SplitString/comma-separated_with_spaces       1.24kB ± 0%    0.07kB ± 0%  -94.19%  (p=0.029 n=4+4)
SplitString/comma-separated_with_spaces-4     1.25kB ± 0%    0.07kB ± 0%  -94.23%  (p=0.029 n=4+4)
SplitString/comma-separated_with_spaces-16    1.26kB ± 0%    0.07kB ± 0%  -94.27%  (p=0.029 n=4+4)
SplitString/mixed_commas_and_spaces           1.30kB ± 0%    0.10kB ± 0%  -92.64%  (p=0.029 n=4+4)
SplitString/mixed_commas_and_spaces-4         1.31kB ± 0%    0.10kB ± 0%  -92.69%  (p=0.029 n=4+4)
SplitString/mixed_commas_and_spaces-16        1.32kB ± 0%    0.10kB ± 0%  -92.72%  (p=0.029 n=4+4)
SplitString/very_long_mixed                   15.4kB ± 0%     2.5kB ± 0%  -83.74%  (p=0.029 n=4+4)
SplitString/very_long_mixed-4                 15.4kB ± 0%     2.5kB ± 0%  -83.83%  (p=0.029 n=4+4)
SplitString/very_long_mixed-16                15.5kB ± 0%     2.5kB ± 0%  -83.88%  (p=0.029 n=4+4)
[Geo mean]                                    1.81kB         0.10kB       -94.52%

name                                        old allocs/op  new allocs/op  delta
SplitString/empty_input                         0.00           0.00          ~     (all equal)
SplitString/empty_input-4                       0.00           0.00          ~     (all equal)
SplitString/empty_input-16                      0.00           0.00          ~     (all equal)
SplitString/single_string                       12.0 ± 0%       1.0 ± 0%  -91.67%  (p=0.029 n=4+4)
SplitString/single_string-4                     12.0 ± 0%       1.0 ± 0%  -91.67%  (p=0.029 n=4+4)
SplitString/single_string-16                    12.0 ± 0%       1.0 ± 0%  -91.67%  (p=0.029 n=4+4)
SplitString/space-separated                     16.0 ± 0%       1.0 ± 0%  -93.75%  (p=0.029 n=4+4)
SplitString/space-separated-4                   16.0 ± 0%       1.0 ± 0%  -93.75%  (p=0.029 n=4+4)
SplitString/space-separated-16                  16.0 ± 0%       1.0 ± 0%  -93.75%  (p=0.029 n=4+4)
SplitString/comma-separated                     16.0 ± 0%       2.0 ± 0%  -87.50%  (p=0.029 n=4+4)
SplitString/comma-separated-4                   16.0 ± 0%       2.0 ± 0%  -87.50%  (p=0.029 n=4+4)
SplitString/comma-separated-16                  16.0 ± 0%       2.0 ± 0%  -87.50%  (p=0.029 n=4+4)
SplitString/comma-separated_with_spaces         16.0 ± 0%       2.0 ± 0%  -87.50%  (p=0.029 n=4+4)
SplitString/comma-separated_with_spaces-4       16.0 ± 0%       2.0 ± 0%  -87.50%  (p=0.029 n=4+4)
SplitString/comma-separated_with_spaces-16      16.0 ± 0%       2.0 ± 0%  -87.50%  (p=0.029 n=4+4)
SplitString/mixed_commas_and_spaces             17.0 ± 0%       2.0 ± 0%  -88.24%  (p=0.029 n=4+4)
SplitString/mixed_commas_and_spaces-4           17.0 ± 0%       2.0 ± 0%  -88.24%  (p=0.029 n=4+4)
SplitString/mixed_commas_and_spaces-16          17.0 ± 0%       2.0 ± 0%  -88.24%  (p=0.029 n=4+4)
SplitString/very_long_mixed                      118 ± 0%         2 ± 0%  -98.31%  (p=0.029 n=4+4)
SplitString/very_long_mixed-4                    118 ± 0%         2 ± 0%  -98.31%  (p=0.029 n=4+4)
SplitString/very_long_mixed-16                   118 ± 0%         2 ± 0%  -98.31%  (p=0.029 n=4+4)
[Geo mean]                                      21.5            1.6       -92.61%
```

Note: I ran the benchmarks with this command:

```console
$ go test -count=4 -cpu=1,4,16 -benchmem -run=^$ -bench ^BenchmarkSplitString$ github.com/grafana/grafana/pkg/util
```

Signed-off-by: Dave Henderson <dave.henderson@grafana.com>