### PR TITLE
Alerting: Add version segment to all provisioning routes

### DIFF
--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -179,6 +179,7 @@ func (api *API) authorize(method, path string) web.Handler {
 		return middleware.ReqOrgAdmin
 
 	// Grafana-only Provisioning Read Paths
+<<<<<<< HEAD
 	case http.MethodGet + "/api/provisioning/policies",
 		http.MethodGet + "/api/provisioning/contact-points",
 		http.MethodGet + "/api/provisioning/templates",
@@ -201,6 +202,22 @@ func (api *API) authorize(method, path string) web.Handler {
 		http.MethodPut + "/api/provisioning/alert-rules/{UID}",
 		http.MethodDelete + "/api/provisioning/alert-rules/{UID}",
 		http.MethodPut + "/api/provisioning/folder/{FolderUID}/rule-groups/{Group}":
+=======
+	case http.MethodGet + "/api/provisioning/v1/policies",
+		http.MethodGet + "/api/provisioning/v1/contact-points",
+		http.MethodGet + "/api/provisioning/v1/templates",
+		http.MethodGet + "/api/provisioning/v1/templates/{name}",
+		http.MethodGet + "/api/provisioning/v1/mute-timings",
+		http.MethodGet + "/api/provisioning/v1/mute-timings/{name}":
+		return middleware.ReqSignedIn
+
+	case http.MethodPut + "/api/provisioning/v1/policies",
+		http.MethodPost + "/api/provisioning/v1/contact-points",
+		http.MethodPut + "/api/provisioning/v1/contact-points/{ID}",
+		http.MethodDelete + "/api/provisioning/v1/contact-points/{ID}",
+		http.MethodPut + "/api/provisioning/v1/templates/{name}",
+		http.MethodDelete + "/api/provisioning/v1/templates/{name}":
+>>>>>>> 8211e8193e (Add version segment to all provisioning routes)
 		return middleware.ReqEditorRole
 	}
 

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -179,45 +179,28 @@ func (api *API) authorize(method, path string) web.Handler {
 		return middleware.ReqOrgAdmin
 
 	// Grafana-only Provisioning Read Paths
-<<<<<<< HEAD
-	case http.MethodGet + "/api/provisioning/policies",
-		http.MethodGet + "/api/provisioning/contact-points",
-		http.MethodGet + "/api/provisioning/templates",
-		http.MethodGet + "/api/provisioning/templates/{name}",
-		http.MethodGet + "/api/provisioning/mute-timings",
-		http.MethodGet + "/api/provisioning/mute-timings/{name}",
-		http.MethodGet + "/api/provisioning/alert-rules/{UID}":
+	case http.MethodGet + "/api/v1/provisioning/policies",
+		http.MethodGet + "/api/v1/provisioning/contact-points",
+		http.MethodGet + "/api/v1/provisioning/templates",
+		http.MethodGet + "/api/v1/provisioning/templates/{name}",
+		http.MethodGet + "/api/v1/provisioning/mute-timings",
+		http.MethodGet + "/api/v1/provisioning/mute-timings/{name}",
+		http.MethodGet + "/api/v1/provisioning/alert-rules/{UID}":
 		return middleware.ReqSignedIn
 
-	case http.MethodPut + "/api/provisioning/policies",
-		http.MethodPost + "/api/provisioning/contact-points",
-		http.MethodPut + "/api/provisioning/contact-points/{UID}",
-		http.MethodDelete + "/api/provisioning/contact-points/{UID}",
-		http.MethodPut + "/api/provisioning/templates/{name}",
-		http.MethodDelete + "/api/provisioning/templates/{name}",
-		http.MethodPost + "/api/provisioning/mute-timings",
-		http.MethodPut + "/api/provisioning/mute-timings/{name}",
-		http.MethodDelete + "/api/provisioning/mute-timings/{name}",
-		http.MethodPost + "/api/provisioning/alert-rules",
-		http.MethodPut + "/api/provisioning/alert-rules/{UID}",
-		http.MethodDelete + "/api/provisioning/alert-rules/{UID}",
-		http.MethodPut + "/api/provisioning/folder/{FolderUID}/rule-groups/{Group}":
-=======
-	case http.MethodGet + "/api/provisioning/v1/policies",
-		http.MethodGet + "/api/provisioning/v1/contact-points",
-		http.MethodGet + "/api/provisioning/v1/templates",
-		http.MethodGet + "/api/provisioning/v1/templates/{name}",
-		http.MethodGet + "/api/provisioning/v1/mute-timings",
-		http.MethodGet + "/api/provisioning/v1/mute-timings/{name}":
-		return middleware.ReqSignedIn
-
-	case http.MethodPut + "/api/provisioning/v1/policies",
-		http.MethodPost + "/api/provisioning/v1/contact-points",
-		http.MethodPut + "/api/provisioning/v1/contact-points/{ID}",
-		http.MethodDelete + "/api/provisioning/v1/contact-points/{ID}",
-		http.MethodPut + "/api/provisioning/v1/templates/{name}",
-		http.MethodDelete + "/api/provisioning/v1/templates/{name}":
->>>>>>> 8211e8193e (Add version segment to all provisioning routes)
+	case http.MethodPut + "/api/v1/provisioning/policies",
+		http.MethodPost + "/api/v1/provisioning/contact-points",
+		http.MethodPut + "/api/v1/provisioning/contact-points/{UID}",
+		http.MethodDelete + "/api/v1/provisioning/contact-points/{UID}",
+		http.MethodPut + "/api/v1/provisioning/templates/{name}",
+		http.MethodDelete + "/api/v1/provisioning/templates/{name}",
+		http.MethodPost + "/api/v1/provisioning/mute-timings",
+		http.MethodPut + "/api/v1/provisioning/mute-timings/{name}",
+		http.MethodDelete + "/api/v1/provisioning/mute-timings/{name}",
+		http.MethodPost + "/api/v1/provisioning/alert-rules",
+		http.MethodPut + "/api/v1/provisioning/alert-rules/{UID}",
+		http.MethodDelete + "/api/v1/provisioning/alert-rules/{UID}",
+		http.MethodPut + "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}":
 		return middleware.ReqEditorRole
 	}
 

--- a/pkg/services/ngalert/api/generated_base_api_provisioning.go
+++ b/pkg/services/ngalert/api/generated_base_api_provisioning.go
@@ -141,6 +141,7 @@ func (f *ForkedProvisioningApi) RoutePutTemplate(ctx *models.ReqContext) respons
 func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingService, m *metrics.API) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Delete(
+<<<<<<< HEAD
 			toMacaronPath("/api/provisioning/alert-rules/{UID}"),
 			api.authorize(http.MethodDelete, "/api/provisioning/alert-rules/{UID}"),
 			metrics.Instrument(
@@ -156,11 +157,19 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingServi
 			metrics.Instrument(
 				http.MethodDelete,
 				"/api/provisioning/contact-points/{UID}",
+=======
+			toMacaronPath("/api/provisioning/v1/contact-points/{ID}"),
+			api.authorize(http.MethodDelete, "/api/provisioning/v1/contact-points/{ID}"),
+			metrics.Instrument(
+				http.MethodDelete,
+				"/api/provisioning/v1/contact-points/{ID}",
+>>>>>>> 8211e8193e (Add version segment to all provisioning routes)
 				srv.RouteDeleteContactpoints,
 				m,
 			),
 		)
 		group.Delete(
+<<<<<<< HEAD
 			toMacaronPath("/api/provisioning/mute-timings/{name}"),
 			api.authorize(http.MethodDelete, "/api/provisioning/mute-timings/{name}"),
 			metrics.Instrument(
@@ -173,14 +182,19 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingServi
 		group.Delete(
 			toMacaronPath("/api/provisioning/templates/{name}"),
 			api.authorize(http.MethodDelete, "/api/provisioning/templates/{name}"),
+=======
+			toMacaronPath("/api/provisioning/v1/templates/{name}"),
+			api.authorize(http.MethodDelete, "/api/provisioning/v1/templates/{name}"),
+>>>>>>> 8211e8193e (Add version segment to all provisioning routes)
 			metrics.Instrument(
 				http.MethodDelete,
-				"/api/provisioning/templates/{name}",
+				"/api/provisioning/v1/templates/{name}",
 				srv.RouteDeleteTemplate,
 				m,
 			),
 		)
 		group.Get(
+<<<<<<< HEAD
 			toMacaronPath("/api/provisioning/alert-rules/{UID}"),
 			api.authorize(http.MethodGet, "/api/provisioning/alert-rules/{UID}"),
 			metrics.Instrument(
@@ -193,64 +207,69 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingServi
 		group.Get(
 			toMacaronPath("/api/provisioning/contact-points"),
 			api.authorize(http.MethodGet, "/api/provisioning/contact-points"),
+=======
+			toMacaronPath("/api/provisioning/v1/contact-points"),
+			api.authorize(http.MethodGet, "/api/provisioning/v1/contact-points"),
+>>>>>>> 8211e8193e (Add version segment to all provisioning routes)
 			metrics.Instrument(
 				http.MethodGet,
-				"/api/provisioning/contact-points",
+				"/api/provisioning/v1/contact-points",
 				srv.RouteGetContactpoints,
 				m,
 			),
 		)
 		group.Get(
-			toMacaronPath("/api/provisioning/mute-timings/{name}"),
-			api.authorize(http.MethodGet, "/api/provisioning/mute-timings/{name}"),
+			toMacaronPath("/api/provisioning/v1/mute-timings/{name}"),
+			api.authorize(http.MethodGet, "/api/provisioning/v1/mute-timings/{name}"),
 			metrics.Instrument(
 				http.MethodGet,
-				"/api/provisioning/mute-timings/{name}",
+				"/api/provisioning/v1/mute-timings/{name}",
 				srv.RouteGetMuteTiming,
 				m,
 			),
 		)
 		group.Get(
-			toMacaronPath("/api/provisioning/mute-timings"),
-			api.authorize(http.MethodGet, "/api/provisioning/mute-timings"),
+			toMacaronPath("/api/provisioning/v1/mute-timings"),
+			api.authorize(http.MethodGet, "/api/provisioning/v1/mute-timings"),
 			metrics.Instrument(
 				http.MethodGet,
-				"/api/provisioning/mute-timings",
+				"/api/provisioning/v1/mute-timings",
 				srv.RouteGetMuteTimings,
 				m,
 			),
 		)
 		group.Get(
-			toMacaronPath("/api/provisioning/policies"),
-			api.authorize(http.MethodGet, "/api/provisioning/policies"),
+			toMacaronPath("/api/provisioning/v1/policies"),
+			api.authorize(http.MethodGet, "/api/provisioning/v1/policies"),
 			metrics.Instrument(
 				http.MethodGet,
-				"/api/provisioning/policies",
+				"/api/provisioning/v1/policies",
 				srv.RouteGetPolicyTree,
 				m,
 			),
 		)
 		group.Get(
-			toMacaronPath("/api/provisioning/templates/{name}"),
-			api.authorize(http.MethodGet, "/api/provisioning/templates/{name}"),
+			toMacaronPath("/api/provisioning/v1/templates/{name}"),
+			api.authorize(http.MethodGet, "/api/provisioning/v1/templates/{name}"),
 			metrics.Instrument(
 				http.MethodGet,
-				"/api/provisioning/templates/{name}",
+				"/api/provisioning/v1/templates/{name}",
 				srv.RouteGetTemplate,
 				m,
 			),
 		)
 		group.Get(
-			toMacaronPath("/api/provisioning/templates"),
-			api.authorize(http.MethodGet, "/api/provisioning/templates"),
+			toMacaronPath("/api/provisioning/v1/templates"),
+			api.authorize(http.MethodGet, "/api/provisioning/v1/templates"),
 			metrics.Instrument(
 				http.MethodGet,
-				"/api/provisioning/templates",
+				"/api/provisioning/v1/templates",
 				srv.RouteGetTemplates,
 				m,
 			),
 		)
 		group.Post(
+<<<<<<< HEAD
 			toMacaronPath("/api/provisioning/alert-rules"),
 			api.authorize(http.MethodPost, "/api/provisioning/alert-rules"),
 			metrics.Instrument(
@@ -263,9 +282,13 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingServi
 		group.Post(
 			toMacaronPath("/api/provisioning/contact-points"),
 			api.authorize(http.MethodPost, "/api/provisioning/contact-points"),
+=======
+			toMacaronPath("/api/provisioning/v1/contact-points"),
+			api.authorize(http.MethodPost, "/api/provisioning/v1/contact-points"),
+>>>>>>> 8211e8193e (Add version segment to all provisioning routes)
 			metrics.Instrument(
 				http.MethodPost,
-				"/api/provisioning/contact-points",
+				"/api/provisioning/v1/contact-points",
 				srv.RoutePostContactpoints,
 				m,
 			),
@@ -301,16 +324,25 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingServi
 			),
 		)
 		group.Put(
+<<<<<<< HEAD
 			toMacaronPath("/api/provisioning/contact-points/{UID}"),
 			api.authorize(http.MethodPut, "/api/provisioning/contact-points/{UID}"),
 			metrics.Instrument(
 				http.MethodPut,
 				"/api/provisioning/contact-points/{UID}",
+=======
+			toMacaronPath("/api/provisioning/v1/contact-points/{ID}"),
+			api.authorize(http.MethodPut, "/api/provisioning/v1/contact-points/{ID}"),
+			metrics.Instrument(
+				http.MethodPut,
+				"/api/provisioning/v1/contact-points/{ID}",
+>>>>>>> 8211e8193e (Add version segment to all provisioning routes)
 				srv.RoutePutContactpoint,
 				m,
 			),
 		)
 		group.Put(
+<<<<<<< HEAD
 			toMacaronPath("/api/provisioning/mute-timings/{name}"),
 			api.authorize(http.MethodPut, "/api/provisioning/mute-timings/{name}"),
 			metrics.Instrument(
@@ -323,19 +355,23 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingServi
 		group.Put(
 			toMacaronPath("/api/provisioning/policies"),
 			api.authorize(http.MethodPut, "/api/provisioning/policies"),
+=======
+			toMacaronPath("/api/provisioning/v1/policies"),
+			api.authorize(http.MethodPut, "/api/provisioning/v1/policies"),
+>>>>>>> 8211e8193e (Add version segment to all provisioning routes)
 			metrics.Instrument(
 				http.MethodPut,
-				"/api/provisioning/policies",
+				"/api/provisioning/v1/policies",
 				srv.RoutePutPolicyTree,
 				m,
 			),
 		)
 		group.Put(
-			toMacaronPath("/api/provisioning/templates/{name}"),
-			api.authorize(http.MethodPut, "/api/provisioning/templates/{name}"),
+			toMacaronPath("/api/provisioning/v1/templates/{name}"),
+			api.authorize(http.MethodPut, "/api/provisioning/v1/templates/{name}"),
 			metrics.Instrument(
 				http.MethodPut,
-				"/api/provisioning/templates/{name}",
+				"/api/provisioning/v1/templates/{name}",
 				srv.RoutePutTemplate,
 				m,
 			),

--- a/pkg/services/ngalert/api/generated_base_api_provisioning.go
+++ b/pkg/services/ngalert/api/generated_base_api_provisioning.go
@@ -141,76 +141,58 @@ func (f *ForkedProvisioningApi) RoutePutTemplate(ctx *models.ReqContext) respons
 func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingService, m *metrics.API) {
 	api.RouteRegister.Group("", func(group routing.RouteRegister) {
 		group.Delete(
-<<<<<<< HEAD
-			toMacaronPath("/api/provisioning/alert-rules/{UID}"),
-			api.authorize(http.MethodDelete, "/api/provisioning/alert-rules/{UID}"),
+			toMacaronPath("/api/v1/provisioning/alert-rules/{UID}"),
+			api.authorize(http.MethodDelete, "/api/v1/provisioning/alert-rules/{UID}"),
 			metrics.Instrument(
 				http.MethodDelete,
-				"/api/provisioning/alert-rules/{UID}",
+				"/api/v1/provisioning/alert-rules/{UID}",
 				srv.RouteDeleteAlertRule,
 				m,
 			),
 		)
 		group.Delete(
-			toMacaronPath("/api/provisioning/contact-points/{UID}"),
-			api.authorize(http.MethodDelete, "/api/provisioning/contact-points/{UID}"),
+			toMacaronPath("/api/v1/provisioning/contact-points/{UID}"),
+			api.authorize(http.MethodDelete, "/api/v1/provisioning/contact-points/{UID}"),
 			metrics.Instrument(
 				http.MethodDelete,
-				"/api/provisioning/contact-points/{UID}",
-=======
-			toMacaronPath("/api/provisioning/v1/contact-points/{ID}"),
-			api.authorize(http.MethodDelete, "/api/provisioning/v1/contact-points/{ID}"),
-			metrics.Instrument(
-				http.MethodDelete,
-				"/api/provisioning/v1/contact-points/{ID}",
->>>>>>> 8211e8193e (Add version segment to all provisioning routes)
+				"/api/v1/provisioning/contact-points/{UID}",
 				srv.RouteDeleteContactpoints,
 				m,
 			),
 		)
 		group.Delete(
-<<<<<<< HEAD
-			toMacaronPath("/api/provisioning/mute-timings/{name}"),
-			api.authorize(http.MethodDelete, "/api/provisioning/mute-timings/{name}"),
+			toMacaronPath("/api/v1/provisioning/mute-timings/{name}"),
+			api.authorize(http.MethodDelete, "/api/v1/provisioning/mute-timings/{name}"),
 			metrics.Instrument(
 				http.MethodDelete,
-				"/api/provisioning/mute-timings/{name}",
+				"/api/v1/provisioning/mute-timings/{name}",
 				srv.RouteDeleteMuteTiming,
 				m,
 			),
 		)
 		group.Delete(
-			toMacaronPath("/api/provisioning/templates/{name}"),
-			api.authorize(http.MethodDelete, "/api/provisioning/templates/{name}"),
-=======
-			toMacaronPath("/api/provisioning/v1/templates/{name}"),
-			api.authorize(http.MethodDelete, "/api/provisioning/v1/templates/{name}"),
->>>>>>> 8211e8193e (Add version segment to all provisioning routes)
+			toMacaronPath("/api/v1/provisioning/templates/{name}"),
+			api.authorize(http.MethodDelete, "/api/v1/provisioning/templates/{name}"),
 			metrics.Instrument(
 				http.MethodDelete,
-				"/api/provisioning/v1/templates/{name}",
+				"/api/v1/provisioning/templates/{name}",
 				srv.RouteDeleteTemplate,
 				m,
 			),
 		)
 		group.Get(
-<<<<<<< HEAD
-			toMacaronPath("/api/provisioning/alert-rules/{UID}"),
-			api.authorize(http.MethodGet, "/api/provisioning/alert-rules/{UID}"),
+			toMacaronPath("/api/v1/provisioning/alert-rules/{UID}"),
+			api.authorize(http.MethodGet, "/api/v1/provisioning/alert-rules/{UID}"),
 			metrics.Instrument(
 				http.MethodGet,
-				"/api/provisioning/alert-rules/{UID}",
+				"/api/v1/provisioning/alert-rules/{UID}",
 				srv.RouteGetAlertRule,
 				m,
 			),
 		)
 		group.Get(
-			toMacaronPath("/api/provisioning/contact-points"),
-			api.authorize(http.MethodGet, "/api/provisioning/contact-points"),
-=======
 			toMacaronPath("/api/provisioning/v1/contact-points"),
 			api.authorize(http.MethodGet, "/api/provisioning/v1/contact-points"),
->>>>>>> 8211e8193e (Add version segment to all provisioning routes)
 			metrics.Instrument(
 				http.MethodGet,
 				"/api/provisioning/v1/contact-points",
@@ -219,159 +201,141 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingServi
 			),
 		)
 		group.Get(
-			toMacaronPath("/api/provisioning/v1/mute-timings/{name}"),
-			api.authorize(http.MethodGet, "/api/provisioning/v1/mute-timings/{name}"),
+			toMacaronPath("/api/v1/provisioning/mute-timings/{name}"),
+			api.authorize(http.MethodGet, "/api/v1/provisioning/mute-timings/{name}"),
 			metrics.Instrument(
 				http.MethodGet,
-				"/api/provisioning/v1/mute-timings/{name}",
+				"/api/v1/provisioning/mute-timings/{name}",
 				srv.RouteGetMuteTiming,
 				m,
 			),
 		)
 		group.Get(
-			toMacaronPath("/api/provisioning/v1/mute-timings"),
-			api.authorize(http.MethodGet, "/api/provisioning/v1/mute-timings"),
+			toMacaronPath("/api/v1/provisioning/mute-timings"),
+			api.authorize(http.MethodGet, "/api/v1/provisioning/mute-timings"),
 			metrics.Instrument(
 				http.MethodGet,
-				"/api/provisioning/v1/mute-timings",
+				"/api/v1/provisioning/mute-timings",
 				srv.RouteGetMuteTimings,
 				m,
 			),
 		)
 		group.Get(
-			toMacaronPath("/api/provisioning/v1/policies"),
-			api.authorize(http.MethodGet, "/api/provisioning/v1/policies"),
+			toMacaronPath("/api/v1/provisioning/policies"),
+			api.authorize(http.MethodGet, "/api/v1/provisioning/policies"),
 			metrics.Instrument(
 				http.MethodGet,
-				"/api/provisioning/v1/policies",
+				"/api/v1/provisioning/policies",
 				srv.RouteGetPolicyTree,
 				m,
 			),
 		)
 		group.Get(
-			toMacaronPath("/api/provisioning/v1/templates/{name}"),
-			api.authorize(http.MethodGet, "/api/provisioning/v1/templates/{name}"),
+			toMacaronPath("/api/v1/provisioning/templates/{name}"),
+			api.authorize(http.MethodGet, "/api/v1/provisioning/templates/{name}"),
 			metrics.Instrument(
 				http.MethodGet,
-				"/api/provisioning/v1/templates/{name}",
+				"/api/v1/provisioning/templates/{name}",
 				srv.RouteGetTemplate,
 				m,
 			),
 		)
 		group.Get(
-			toMacaronPath("/api/provisioning/v1/templates"),
-			api.authorize(http.MethodGet, "/api/provisioning/v1/templates"),
+			toMacaronPath("/api/v1/provisioning/templates"),
+			api.authorize(http.MethodGet, "/api/v1/provisioning/templates"),
 			metrics.Instrument(
 				http.MethodGet,
-				"/api/provisioning/v1/templates",
+				"/api/v1/provisioning/templates",
 				srv.RouteGetTemplates,
 				m,
 			),
 		)
 		group.Post(
-<<<<<<< HEAD
-			toMacaronPath("/api/provisioning/alert-rules"),
-			api.authorize(http.MethodPost, "/api/provisioning/alert-rules"),
+			toMacaronPath("/api/v1/provisioning/alert-rules"),
+			api.authorize(http.MethodPost, "/api/v1/provisioning/alert-rules"),
 			metrics.Instrument(
 				http.MethodPost,
-				"/api/provisioning/alert-rules",
+				"/api/v1/provisioning/alert-rules",
 				srv.RoutePostAlertRule,
 				m,
 			),
 		)
 		group.Post(
-			toMacaronPath("/api/provisioning/contact-points"),
-			api.authorize(http.MethodPost, "/api/provisioning/contact-points"),
-=======
-			toMacaronPath("/api/provisioning/v1/contact-points"),
-			api.authorize(http.MethodPost, "/api/provisioning/v1/contact-points"),
->>>>>>> 8211e8193e (Add version segment to all provisioning routes)
+			toMacaronPath("/api/v1/provisioning/contact-points"),
+			api.authorize(http.MethodPost, "/api/v1/provisioning/contact-points"),
 			metrics.Instrument(
 				http.MethodPost,
-				"/api/provisioning/v1/contact-points",
+				"/api/v1/provisioning/contact-points",
 				srv.RoutePostContactpoints,
 				m,
 			),
 		)
 		group.Post(
-			toMacaronPath("/api/provisioning/mute-timings"),
-			api.authorize(http.MethodPost, "/api/provisioning/mute-timings"),
+			toMacaronPath("/api/v1/provisioning/mute-timings"),
+			api.authorize(http.MethodPost, "/api/v1/provisioning/mute-timings"),
 			metrics.Instrument(
 				http.MethodPost,
-				"/api/provisioning/mute-timings",
+				"/api/v1/provisioning/mute-timings",
 				srv.RoutePostMuteTiming,
 				m,
 			),
 		)
 		group.Put(
-			toMacaronPath("/api/provisioning/alert-rules/{UID}"),
-			api.authorize(http.MethodPut, "/api/provisioning/alert-rules/{UID}"),
+			toMacaronPath("/api/v1/provisioning/alert-rules/{UID}"),
+			api.authorize(http.MethodPut, "/api/v1/provisioning/alert-rules/{UID}"),
 			metrics.Instrument(
 				http.MethodPut,
-				"/api/provisioning/alert-rules/{UID}",
+				"/api/v1/provisioning/alert-rules/{UID}",
 				srv.RoutePutAlertRule,
 				m,
 			),
 		)
 		group.Put(
-			toMacaronPath("/api/provisioning/folder/{FolderUID}/rule-groups/{Group}"),
-			api.authorize(http.MethodPut, "/api/provisioning/folder/{FolderUID}/rule-groups/{Group}"),
+			toMacaronPath("/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}"),
+			api.authorize(http.MethodPut, "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}"),
 			metrics.Instrument(
 				http.MethodPut,
-				"/api/provisioning/folder/{FolderUID}/rule-groups/{Group}",
+				"/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}",
 				srv.RoutePutAlertRuleGroup,
 				m,
 			),
 		)
 		group.Put(
-<<<<<<< HEAD
-			toMacaronPath("/api/provisioning/contact-points/{UID}"),
-			api.authorize(http.MethodPut, "/api/provisioning/contact-points/{UID}"),
+			toMacaronPath("/api/v1/provisioning/contact-points/{UID}"),
+			api.authorize(http.MethodPut, "/api/v1/provisioning/contact-points/{UID}"),
 			metrics.Instrument(
 				http.MethodPut,
-				"/api/provisioning/contact-points/{UID}",
-=======
-			toMacaronPath("/api/provisioning/v1/contact-points/{ID}"),
-			api.authorize(http.MethodPut, "/api/provisioning/v1/contact-points/{ID}"),
-			metrics.Instrument(
-				http.MethodPut,
-				"/api/provisioning/v1/contact-points/{ID}",
->>>>>>> 8211e8193e (Add version segment to all provisioning routes)
+				"/api/v1/provisioning/contact-points/{UID}",
 				srv.RoutePutContactpoint,
 				m,
 			),
 		)
 		group.Put(
-<<<<<<< HEAD
-			toMacaronPath("/api/provisioning/mute-timings/{name}"),
-			api.authorize(http.MethodPut, "/api/provisioning/mute-timings/{name}"),
+			toMacaronPath("/api/v1/provisioning/mute-timings/{name}"),
+			api.authorize(http.MethodPut, "/api/v1/provisioning/mute-timings/{name}"),
 			metrics.Instrument(
 				http.MethodPut,
-				"/api/provisioning/mute-timings/{name}",
+				"/api/v1/provisioning/mute-timings/{name}",
 				srv.RoutePutMuteTiming,
 				m,
 			),
 		)
 		group.Put(
-			toMacaronPath("/api/provisioning/policies"),
-			api.authorize(http.MethodPut, "/api/provisioning/policies"),
-=======
-			toMacaronPath("/api/provisioning/v1/policies"),
-			api.authorize(http.MethodPut, "/api/provisioning/v1/policies"),
->>>>>>> 8211e8193e (Add version segment to all provisioning routes)
+			toMacaronPath("/api/v1/provisioning/policies"),
+			api.authorize(http.MethodPut, "/api/v1/provisioning/policies"),
 			metrics.Instrument(
 				http.MethodPut,
-				"/api/provisioning/v1/policies",
+				"/api/v1/provisioning/policies",
 				srv.RoutePutPolicyTree,
 				m,
 			),
 		)
 		group.Put(
-			toMacaronPath("/api/provisioning/v1/templates/{name}"),
-			api.authorize(http.MethodPut, "/api/provisioning/v1/templates/{name}"),
+			toMacaronPath("/api/v1/provisioning/templates/{name}"),
+			api.authorize(http.MethodPut, "/api/v1/provisioning/templates/{name}"),
 			metrics.Instrument(
 				http.MethodPut,
-				"/api/provisioning/v1/templates/{name}",
+				"/api/v1/provisioning/templates/{name}",
 				srv.RoutePutTemplate,
 				m,
 			),

--- a/pkg/services/ngalert/api/generated_base_api_provisioning.go
+++ b/pkg/services/ngalert/api/generated_base_api_provisioning.go
@@ -191,11 +191,11 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingServi
 			),
 		)
 		group.Get(
-			toMacaronPath("/api/provisioning/v1/contact-points"),
-			api.authorize(http.MethodGet, "/api/provisioning/v1/contact-points"),
+			toMacaronPath("/api/v1/provisioning/contact-points"),
+			api.authorize(http.MethodGet, "/api/v1/provisioning/contact-points"),
 			metrics.Instrument(
 				http.MethodGet,
-				"/api/provisioning/v1/contact-points",
+				"/api/v1/provisioning/contact-points",
 				srv.RouteGetContactpoints,
 				m,
 			),

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -6,7 +6,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-// swagger:route GET /api/provisioning/alert-rules/{UID} provisioning RouteGetAlertRule
+// swagger:route GET /api/v1/provisioning/alert-rules/{UID} provisioning RouteGetAlertRule
 //
 // Get a specific alert rule by UID.
 //
@@ -14,7 +14,7 @@ import (
 //       200: AlertRule
 //       400: ValidationError
 
-// swagger:route POST /api/provisioning/alert-rules provisioning RoutePostAlertRule
+// swagger:route POST /api/v1/provisioning/alert-rules provisioning RoutePostAlertRule
 //
 // Create a new alert rule.
 //
@@ -22,7 +22,7 @@ import (
 //       201: AlertRule
 //       400: ValidationError
 
-// swagger:route PUT /api/provisioning/alert-rules/{UID} provisioning RoutePutAlertRule
+// swagger:route PUT /api/v1/provisioning/alert-rules/{UID} provisioning RoutePutAlertRule
 //
 // Update an existing alert rule.
 //
@@ -33,7 +33,7 @@ import (
 //       200: AlertRule
 //       400: ValidationError
 
-// swagger:route DELETE /api/provisioning/alert-rules/{UID} provisioning RouteDeleteAlertRule
+// swagger:route DELETE /api/v1/provisioning/alert-rules/{UID} provisioning RouteDeleteAlertRule
 //
 // Delete a specific alert rule by UID.
 //
@@ -110,7 +110,7 @@ func NewAlertRule(rule models.AlertRule, provenance models.Provenance) AlertRule
 	}
 }
 
-// swagger:route PUT /api/provisioning/folder/{FolderUID}/rule-groups/{Group} provisioning RoutePutAlertRuleGroup
+// swagger:route PUT /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group} provisioning RoutePutAlertRuleGroup
 //
 // Update the interval of a rule group.
 //

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels"
 )
 
-// swagger:route GET /api/provisioning/contact-points provisioning RouteGetContactpoints
+// swagger:route GET /api/provisioning/v1/contact-points provisioning RouteGetContactpoints
 //
 // Get all the contact points.
 //
@@ -15,7 +15,7 @@ import (
 //       200: Route
 //       400: ValidationError
 
-// swagger:route POST /api/provisioning/contact-points provisioning RoutePostContactpoints
+// swagger:route POST /api/provisioning/v1/contact-points provisioning RoutePostContactpoints
 //
 // Create a contact point.
 //
@@ -26,7 +26,7 @@ import (
 //       202: Ack
 //       400: ValidationError
 
-// swagger:route PUT /api/provisioning/contact-points/{UID} provisioning RoutePutContactpoint
+// swagger:route PUT /api/provisioning/v1/contact-points/{UID} provisioning RoutePutContactpoint
 //
 // Update an existing contact point.
 //
@@ -37,7 +37,7 @@ import (
 //       202: Ack
 //       400: ValidationError
 
-// swagger:route DELETE /api/provisioning/contact-points/{UID} provisioning RouteDeleteContactpoints
+// swagger:route DELETE /api/provisioning/v1/contact-points/{UID} provisioning RouteDeleteContactpoints
 //
 // Delete a contact point.
 //

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
@@ -7,7 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels"
 )
 
-// swagger:route GET /api/provisioning/v1/contact-points provisioning RouteGetContactpoints
+// swagger:route GET /api/v1/provisioning/contact-points provisioning RouteGetContactpoints
 //
 // Get all the contact points.
 //

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
@@ -15,7 +15,7 @@ import (
 //       200: Route
 //       400: ValidationError
 
-// swagger:route POST /api/provisioning/v1/contact-points provisioning RoutePostContactpoints
+// swagger:route POST /api/v1/provisioning/contact-points provisioning RoutePostContactpoints
 //
 // Create a contact point.
 //
@@ -26,7 +26,7 @@ import (
 //       202: Ack
 //       400: ValidationError
 
-// swagger:route PUT /api/provisioning/v1/contact-points/{UID} provisioning RoutePutContactpoint
+// swagger:route PUT /api/v1/provisioning/contact-points/{UID} provisioning RoutePutContactpoint
 //
 // Update an existing contact point.
 //
@@ -37,7 +37,7 @@ import (
 //       202: Ack
 //       400: ValidationError
 
-// swagger:route DELETE /api/provisioning/v1/contact-points/{UID} provisioning RouteDeleteContactpoints
+// swagger:route DELETE /api/v1/provisioning/contact-points/{UID} provisioning RouteDeleteContactpoints
 //
 // Delete a contact point.
 //

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
@@ -1,6 +1,6 @@
 package definitions
 
-// swagger:route GET /api/provisioning/mute-timings provisioning RouteGetMuteTimings
+// swagger:route GET /api/provisioning/v1/mute-timings provisioning RouteGetMuteTimings
 //
 // Get all the mute timings.
 //
@@ -8,7 +8,7 @@ package definitions
 //       200: MuteTimings
 //       400: ValidationError
 
-// swagger:route GET /api/provisioning/mute-timings/{name} provisioning RouteGetMuteTiming
+// swagger:route GET /api/provisioning/v1/mute-timings/{name} provisioning RouteGetMuteTiming
 //
 // Get a mute timing.
 //

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
@@ -1,6 +1,6 @@
 package definitions
 
-// swagger:route GET /api/provisioning/v1/mute-timings provisioning RouteGetMuteTimings
+// swagger:route GET /api/v1/provisioning/mute-timings provisioning RouteGetMuteTimings
 //
 // Get all the mute timings.
 //
@@ -8,7 +8,7 @@ package definitions
 //       200: MuteTimings
 //       400: ValidationError
 
-// swagger:route GET /api/provisioning/v1/mute-timings/{name} provisioning RouteGetMuteTiming
+// swagger:route GET /api/v1/provisioning/mute-timings/{name} provisioning RouteGetMuteTiming
 //
 // Get a mute timing.
 //
@@ -16,7 +16,7 @@ package definitions
 //       200: MuteTimeInterval
 //       400: ValidationError
 
-// swagger:route POST /api/provisioning/mute-timings provisioning RoutePostMuteTiming
+// swagger:route POST /api/v1/provisioning/mute-timings provisioning RoutePostMuteTiming
 //
 // Create a new mute timing.
 //
@@ -27,7 +27,7 @@ package definitions
 //       201: MuteTimeInterval
 //       400: ValidationError
 
-// swagger:route PUT /api/provisioning/mute-timings/{name} provisioning RoutePutMuteTiming
+// swagger:route PUT /api/v1/provisioning/mute-timings/{name} provisioning RoutePutMuteTiming
 //
 // Replace an existing mute timing.
 //
@@ -38,7 +38,7 @@ package definitions
 //       200: MuteTimeInterval
 //       400: ValidationError
 
-// swagger:route DELETE /api/provisioning/mute-timings/{name} provisioning RouteDeleteMuteTiming
+// swagger:route DELETE /api/v1/provisioning/mute-timings/{name} provisioning RouteDeleteMuteTiming
 //
 // Delete a mute timing.
 //

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_policies.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_policies.go
@@ -1,6 +1,6 @@
 package definitions
 
-// swagger:route GET /api/provisioning/policies provisioning RouteGetPolicyTree
+// swagger:route GET /api/provisioning/v1/policies provisioning RouteGetPolicyTree
 //
 // Get the notification policy tree.
 //
@@ -8,7 +8,7 @@ package definitions
 //       200: Route
 //       400: ValidationError
 
-// swagger:route PUT /api/provisioning/policies provisioning RoutePutPolicyTree
+// swagger:route PUT /api/provisioning/v1/policies provisioning RoutePutPolicyTree
 //
 // Sets the notification policy tree.
 //

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_policies.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_policies.go
@@ -1,6 +1,6 @@
 package definitions
 
-// swagger:route GET /api/provisioning/v1/policies provisioning RouteGetPolicyTree
+// swagger:route GET /api/v1/provisioning/policies provisioning RouteGetPolicyTree
 //
 // Get the notification policy tree.
 //
@@ -8,7 +8,7 @@ package definitions
 //       200: Route
 //       400: ValidationError
 
-// swagger:route PUT /api/provisioning/v1/policies provisioning RoutePutPolicyTree
+// swagger:route PUT /api/v1/provisioning/policies provisioning RoutePutPolicyTree
 //
 // Sets the notification policy tree.
 //

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
@@ -4,7 +4,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-// swagger:route GET /api/provisioning/templates provisioning RouteGetTemplates
+// swagger:route GET /api/provisioning/v1/templates provisioning RouteGetTemplates
 //
 // Get all message templates.
 //
@@ -12,7 +12,7 @@ import (
 //       200: MessageTemplate
 //       400: ValidationError
 
-// swagger:route GET /api/provisioning/templates/{name} provisioning RouteGetTemplate
+// swagger:route GET /api/provisioning/v1/templates/{name} provisioning RouteGetTemplate
 //
 // Get a message template.
 //
@@ -20,7 +20,7 @@ import (
 //       200: MessageTemplate
 //       404: NotFound
 
-// swagger:route PUT /api/provisioning/templates/{name} provisioning RoutePutTemplate
+// swagger:route PUT /api/provisioning/v1/templates/{name} provisioning RoutePutTemplate
 //
 // Updates an existing template.
 //
@@ -31,7 +31,7 @@ import (
 //       202: Ack
 //       400: ValidationError
 
-// swagger:route DELETE /api/provisioning/templates/{name} provisioning RouteDeleteTemplate
+// swagger:route DELETE /api/provisioning/v1/templates/{name} provisioning RouteDeleteTemplate
 //
 // Delete a template.
 //

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
@@ -4,7 +4,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-// swagger:route GET /api/provisioning/v1/templates provisioning RouteGetTemplates
+// swagger:route GET /api/v1/provisioning/templates provisioning RouteGetTemplates
 //
 // Get all message templates.
 //
@@ -12,7 +12,7 @@ import (
 //       200: MessageTemplate
 //       400: ValidationError
 
-// swagger:route GET /api/provisioning/v1/templates/{name} provisioning RouteGetTemplate
+// swagger:route GET /api/v1/provisioning/templates/{name} provisioning RouteGetTemplate
 //
 // Get a message template.
 //
@@ -20,7 +20,7 @@ import (
 //       200: MessageTemplate
 //       404: NotFound
 
-// swagger:route PUT /api/provisioning/v1/templates/{name} provisioning RoutePutTemplate
+// swagger:route PUT /api/v1/provisioning/templates/{name} provisioning RoutePutTemplate
 //
 // Updates an existing template.
 //
@@ -31,7 +31,7 @@ import (
 //       202: Ack
 //       400: ValidationError
 
-// swagger:route DELETE /api/provisioning/v1/templates/{name} provisioning RouteDeleteTemplate
+// swagger:route DELETE /api/v1/provisioning/templates/{name} provisioning RouteDeleteTemplate
 //
 // Delete a template.
 //

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -3016,6 +3016,7 @@
    "x-go-package": "github.com/prometheus/alertmanager/timeinterval"
   },
   "URL": {
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -3048,9 +3049,9 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "URL is a custom URL type that allows validation at configuration load time.",
+   "title": "A URL represents a parsed URL (technically, a URI reference).",
    "type": "object",
-   "x-go-package": "github.com/prometheus/common/config"
+   "x-go-package": "net/url"
   },
   "Userinfo": {
    "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -3247,6 +3248,7 @@
    "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertGroup": {
+   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -3268,9 +3270,7 @@
     "labels",
     "receiver"
    ],
-   "type": "object",
-   "x-go-name": "AlertGroup",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "object"
   },
   "alertGroups": {
    "description": "AlertGroups alert groups",
@@ -3397,7 +3397,6 @@
    "$ref": "#/definitions/Duration"
   },
   "gettableAlert": {
-   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -3456,17 +3455,19 @@
     "status",
     "updatedAt"
    ],
-   "type": "object"
+   "type": "object",
+   "x-go-name": "GettableAlert",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "gettableAlerts": {
-   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
-   "type": "array"
+   "type": "array",
+   "x-go-name": "GettableAlerts",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "gettableSilence": {
-   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3518,14 +3519,17 @@
     "status",
     "updatedAt"
    ],
-   "type": "object"
+   "type": "object",
+   "x-go-name": "GettableSilence",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "gettableSilences": {
-   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
-   "type": "array"
+   "type": "array",
+   "x-go-name": "GettableSilences",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "labelSet": {
    "additionalProperties": {
@@ -3654,6 +3658,7 @@
    "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "postableSilence": {
+   "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3693,12 +3698,9 @@
     "matchers",
     "startsAt"
    ],
-   "type": "object",
-   "x-go-name": "PostableSilence",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "object"
   },
   "receiver": {
-   "description": "Receiver receiver",
    "properties": {
     "name": {
      "description": "name",
@@ -3709,7 +3711,9 @@
    "required": [
     "name"
    ],
-   "type": "object"
+   "type": "object",
+   "x-go-name": "Receiver",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "silence": {
    "description": "Silence silence",
@@ -4928,135 +4932,6 @@
     ]
    }
   },
-  "/api/provisioning/alert-rules": {
-   "post": {
-    "operationId": "RoutePostAlertRule",
-    "parameters": [
-     {
-      "in": "body",
-      "name": "Body",
-      "schema": {
-       "$ref": "#/definitions/AlertRule"
-      }
-     }
-    ],
-    "responses": {
-     "201": {
-      "description": "AlertRule",
-      "schema": {
-       "$ref": "#/definitions/AlertRule"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Create a new alert rule.",
-    "tags": [
-     "provisioning"
-    ]
-   }
-  },
-  "/api/provisioning/alert-rules/{UID}": {
-   "delete": {
-    "operationId": "RouteDeleteAlertRule",
-    "parameters": [
-     {
-      "in": "path",
-      "name": "UID",
-      "required": true,
-      "type": "string"
-     }
-    ],
-    "responses": {
-     "204": {
-      "description": " The alert rule was deleted successfully."
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Delete a specific alert rule by UID.",
-    "tags": [
-     "provisioning"
-    ]
-   },
-   "get": {
-    "operationId": "RouteGetAlertRule",
-    "parameters": [
-     {
-      "in": "path",
-      "name": "UID",
-      "required": true,
-      "type": "string"
-     }
-    ],
-    "responses": {
-     "200": {
-      "description": "AlertRule",
-      "schema": {
-       "$ref": "#/definitions/AlertRule"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Get a specific alert rule by UID.",
-    "tags": [
-     "provisioning"
-    ]
-   },
-   "put": {
-    "consumes": [
-     "application/json"
-    ],
-    "operationId": "RoutePutAlertRule",
-    "parameters": [
-     {
-      "in": "path",
-      "name": "UID",
-      "required": true,
-      "type": "string"
-     },
-     {
-      "in": "body",
-      "name": "Body",
-      "schema": {
-       "$ref": "#/definitions/AlertRule"
-      }
-     }
-    ],
-    "responses": {
-     "200": {
-      "description": "AlertRule",
-      "schema": {
-       "$ref": "#/definitions/AlertRule"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Update an existing alert rule.",
-    "tags": [
-     "provisioning"
-    ]
-   }
-  },
-  "/api/provisioning/contact-points": {
   "/api/provisioning/v1/contact-points": {
    "get": {
     "operationId": "RouteGetContactpoints",
@@ -5075,422 +4950,6 @@
      }
     },
     "summary": "Get all the contact points.",
-    "tags": [
-     "provisioning"
-    ]
-   },
-   "post": {
-    "consumes": [
-     "application/json"
-    ],
-    "operationId": "RoutePostContactpoints",
-    "parameters": [
-     {
-      "in": "body",
-      "name": "Body",
-      "schema": {
-       "$ref": "#/definitions/EmbeddedContactPoint"
-      }
-     }
-    ],
-    "responses": {
-     "202": {
-      "description": "Ack",
-      "schema": {
-       "$ref": "#/definitions/Ack"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Create a contact point.",
-    "tags": [
-     "provisioning"
-    ]
-   }
-  },
-  "/api/provisioning/v1/contact-points/{ID}": {
-   "delete": {
-    "consumes": [
-     "application/json"
-    ],
-    "operationId": "RouteDeleteContactpoints",
-    "parameters": [
-     {
-      "description": "ContactPointUID should be the contact point UID identifier",
-      "in": "path",
-      "name": "UID",
-      "required": true,
-      "type": "string"
-     }
-    ],
-    "responses": {
-     "202": {
-      "description": "Ack",
-      "schema": {
-       "$ref": "#/definitions/Ack"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Delete a contact point.",
-    "tags": [
-     "provisioning"
-    ]
-   },
-   "put": {
-    "consumes": [
-     "application/json"
-    ],
-    "operationId": "RoutePutContactpoint",
-    "parameters": [
-     {
-      "description": "ContactPointUID should be the contact point UID identifier",
-      "in": "path",
-      "name": "UID",
-      "required": true,
-      "type": "string"
-     },
-     {
-      "in": "body",
-      "name": "Body",
-      "schema": {
-       "$ref": "#/definitions/EmbeddedContactPoint"
-      }
-     }
-    ],
-    "responses": {
-     "202": {
-      "description": "Ack",
-      "schema": {
-       "$ref": "#/definitions/Ack"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Update an existing contact point.",
-    "tags": [
-     "provisioning"
-    ]
-   }
-  },
-  "/api/provisioning/v1/mute-timings": {
-   "get": {
-    "operationId": "RouteGetMuteTimings",
-    "responses": {
-     "200": {
-      "description": "MuteTimings",
-      "schema": {
-       "$ref": "#/definitions/MuteTimings"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Get all the mute timings.",
-    "tags": [
-     "provisioning"
-    ]
-   },
-   "post": {
-    "consumes": [
-     "application/json"
-    ],
-    "operationId": "RoutePostMuteTiming",
-    "parameters": [
-     {
-      "in": "body",
-      "name": "Body",
-      "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
-      }
-     }
-    ],
-    "responses": {
-     "201": {
-      "description": "MuteTimeInterval",
-      "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Create a new mute timing.",
-    "tags": [
-     "provisioning"
-    ]
-   }
-  },
-  "/api/provisioning/v1/mute-timings/{name}": {
-   "get": {
-    "operationId": "RouteGetMuteTiming",
-    "parameters": [
-     {
-      "description": "Template Name",
-      "in": "path",
-      "name": "name",
-      "required": true,
-      "type": "string",
-      "x-go-name": "Name"
-     }
-    ],
-    "responses": {
-     "200": {
-      "description": "MuteTimeInterval",
-      "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Get a mute timing.",
-    "tags": [
-     "provisioning"
-    ]
-   },
-   "put": {
-    "consumes": [
-     "application/json"
-    ],
-    "operationId": "RoutePutMuteTiming",
-    "parameters": [
-     {
-      "description": "Template Name",
-      "in": "path",
-      "name": "name",
-      "required": true,
-      "type": "string",
-      "x-go-name": "Name"
-     },
-     {
-      "in": "body",
-      "name": "Body",
-      "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
-      }
-     }
-    ],
-    "responses": {
-     "200": {
-      "description": "MuteTimeInterval",
-      "schema": {
-       "$ref": "#/definitions/MuteTimeInterval"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Replace an existing mute timing.",
-    "tags": [
-     "provisioning"
-    ]
-   }
-  },
-  "/api/provisioning/v1/policies": {
-   "get": {
-    "operationId": "RouteGetPolicyTree",
-    "responses": {
-     "200": {
-      "description": "Route",
-      "schema": {
-       "$ref": "#/definitions/Route"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Get the notification policy tree.",
-    "tags": [
-     "provisioning"
-    ]
-   },
-   "put": {
-    "consumes": [
-     "application/json"
-    ],
-    "operationId": "RoutePutPolicyTree",
-    "parameters": [
-     {
-      "in": "body",
-      "name": "Body",
-      "schema": {
-       "$ref": "#/definitions/Route"
-      }
-     }
-    ],
-    "responses": {
-     "202": {
-      "description": "Ack",
-      "schema": {
-       "$ref": "#/definitions/Ack"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Sets the notification policy tree.",
-    "tags": [
-     "provisioning"
-    ]
-   }
-  },
-  "/api/provisioning/v1/templates": {
-   "get": {
-    "operationId": "RouteGetTemplates",
-    "responses": {
-     "200": {
-      "description": "MessageTemplate",
-      "schema": {
-       "$ref": "#/definitions/MessageTemplate"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Get all message templates.",
-    "tags": [
-     "provisioning"
-    ]
-   }
-  },
-  "/api/provisioning/v1/templates/{name}": {
-   "delete": {
-    "operationId": "RouteDeleteTemplate",
-    "parameters": [
-     {
-      "description": "Template Name",
-      "in": "path",
-      "name": "name",
-      "required": true,
-      "type": "string",
-      "x-go-name": "Name"
-     }
-    ],
-    "responses": {
-     "204": {
-      "description": "Ack",
-      "schema": {
-       "$ref": "#/definitions/Ack"
-      }
-     }
-    },
-    "summary": "Delete a template.",
-    "tags": [
-     "provisioning"
-    ]
-   },
-   "get": {
-    "operationId": "RouteGetTemplate",
-    "parameters": [
-     {
-      "description": "Template Name",
-      "in": "path",
-      "name": "name",
-      "required": true,
-      "type": "string",
-      "x-go-name": "Name"
-     }
-    ],
-    "responses": {
-     "200": {
-      "description": "MessageTemplate",
-      "schema": {
-       "$ref": "#/definitions/MessageTemplate"
-      }
-     },
-     "404": {
-      "description": "NotFound",
-      "schema": {
-       "$ref": "#/definitions/NotFound"
-      }
-     }
-    },
-    "summary": "Get a message template.",
-    "tags": [
-     "provisioning"
-    ]
-   },
-   "put": {
-    "consumes": [
-     "application/json"
-    ],
-    "operationId": "RoutePutTemplate",
-    "parameters": [
-     {
-      "description": "Template Name",
-      "in": "path",
-      "name": "name",
-      "required": true,
-      "type": "string",
-      "x-go-name": "Name"
-     },
-     {
-      "in": "body",
-      "name": "Body",
-      "schema": {
-       "$ref": "#/definitions/MessageTemplateContent"
-      }
-     }
-    ],
-    "responses": {
-     "202": {
-      "description": "Ack",
-      "schema": {
-       "$ref": "#/definitions/Ack"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Updates an existing template.",
     "tags": [
      "provisioning"
     ]
@@ -6038,6 +5497,624 @@
     "summary": "Get the discovered and dropped Alertmanagers of the user's organization based on the specified configuration.",
     "tags": [
      "configuration"
+    ]
+   }
+  },
+  "/api/v1/provisioning/alert-rules": {
+   "post": {
+    "operationId": "RoutePostAlertRule",
+    "parameters": [
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/AlertRule"
+      }
+     }
+    ],
+    "responses": {
+     "201": {
+      "description": "AlertRule",
+      "schema": {
+       "$ref": "#/definitions/AlertRule"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Create a new alert rule.",
+    "tags": [
+     "provisioning"
+    ]
+   }
+  },
+  "/api/v1/provisioning/alert-rules/{UID}": {
+   "delete": {
+    "operationId": "RouteDeleteAlertRule",
+    "parameters": [
+     {
+      "in": "path",
+      "name": "UID",
+      "required": true,
+      "type": "string"
+     }
+    ],
+    "responses": {
+     "204": {
+      "description": " The alert rule was deleted successfully."
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Delete a specific alert rule by UID.",
+    "tags": [
+     "provisioning"
+    ]
+   },
+   "get": {
+    "operationId": "RouteGetAlertRule",
+    "parameters": [
+     {
+      "in": "path",
+      "name": "UID",
+      "required": true,
+      "type": "string"
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "AlertRule",
+      "schema": {
+       "$ref": "#/definitions/AlertRule"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Get a specific alert rule by UID.",
+    "tags": [
+     "provisioning"
+    ]
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "operationId": "RoutePutAlertRule",
+    "parameters": [
+     {
+      "in": "path",
+      "name": "UID",
+      "required": true,
+      "type": "string"
+     },
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/AlertRule"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "AlertRule",
+      "schema": {
+       "$ref": "#/definitions/AlertRule"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Update an existing alert rule.",
+    "tags": [
+     "provisioning"
+    ]
+   }
+  },
+  "/api/v1/provisioning/contact-points": {
+   "post": {
+    "consumes": [
+     "application/json"
+    ],
+    "operationId": "RoutePostContactpoints",
+    "parameters": [
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/EmbeddedContactPoint"
+      }
+     }
+    ],
+    "responses": {
+     "202": {
+      "description": "Ack",
+      "schema": {
+       "$ref": "#/definitions/Ack"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Create a contact point.",
+    "tags": [
+     "provisioning"
+    ]
+   }
+  },
+  "/api/v1/provisioning/contact-points/{UID}": {
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "operationId": "RouteDeleteContactpoints",
+    "parameters": [
+     {
+      "description": "ContactPointUID should be the contact point UID identifier",
+      "in": "path",
+      "name": "UID",
+      "required": true,
+      "type": "string"
+     }
+    ],
+    "responses": {
+     "202": {
+      "description": "Ack",
+      "schema": {
+       "$ref": "#/definitions/Ack"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Delete a contact point.",
+    "tags": [
+     "provisioning"
+    ]
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "operationId": "RoutePutContactpoint",
+    "parameters": [
+     {
+      "description": "ContactPointUID should be the contact point UID identifier",
+      "in": "path",
+      "name": "UID",
+      "required": true,
+      "type": "string"
+     },
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/EmbeddedContactPoint"
+      }
+     }
+    ],
+    "responses": {
+     "202": {
+      "description": "Ack",
+      "schema": {
+       "$ref": "#/definitions/Ack"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Update an existing contact point.",
+    "tags": [
+     "provisioning"
+    ]
+   }
+  },
+  "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "operationId": "RoutePutAlertRuleGroup",
+    "parameters": [
+     {
+      "in": "path",
+      "name": "FolderUID",
+      "required": true,
+      "type": "string"
+     },
+     {
+      "in": "path",
+      "name": "Group",
+      "required": true,
+      "type": "string"
+     },
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/AlertRuleGroup"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "AlertRuleGroup",
+      "schema": {
+       "$ref": "#/definitions/AlertRuleGroup"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Update the interval of a rule group.",
+    "tags": [
+     "provisioning"
+    ]
+   }
+  },
+  "/api/v1/provisioning/mute-timings": {
+   "get": {
+    "operationId": "RouteGetMuteTimings",
+    "responses": {
+     "200": {
+      "description": "MuteTimings",
+      "schema": {
+       "$ref": "#/definitions/MuteTimings"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Get all the mute timings.",
+    "tags": [
+     "provisioning"
+    ]
+   },
+   "post": {
+    "consumes": [
+     "application/json"
+    ],
+    "operationId": "RoutePostMuteTiming",
+    "parameters": [
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/MuteTimeInterval"
+      }
+     }
+    ],
+    "responses": {
+     "201": {
+      "description": "MuteTimeInterval",
+      "schema": {
+       "$ref": "#/definitions/MuteTimeInterval"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Create a new mute timing.",
+    "tags": [
+     "provisioning"
+    ]
+   }
+  },
+  "/api/v1/provisioning/mute-timings/{name}": {
+   "delete": {
+    "operationId": "RouteDeleteMuteTiming",
+    "parameters": [
+     {
+      "description": "Template Name",
+      "in": "path",
+      "name": "name",
+      "required": true,
+      "type": "string",
+      "x-go-name": "Name"
+     }
+    ],
+    "responses": {
+     "204": {
+      "description": "Ack",
+      "schema": {
+       "$ref": "#/definitions/Ack"
+      }
+     }
+    },
+    "summary": "Delete a mute timing.",
+    "tags": [
+     "provisioning"
+    ]
+   },
+   "get": {
+    "operationId": "RouteGetMuteTiming",
+    "parameters": [
+     {
+      "description": "Template Name",
+      "in": "path",
+      "name": "name",
+      "required": true,
+      "type": "string",
+      "x-go-name": "Name"
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "MuteTimeInterval",
+      "schema": {
+       "$ref": "#/definitions/MuteTimeInterval"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Get a mute timing.",
+    "tags": [
+     "provisioning"
+    ]
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "operationId": "RoutePutMuteTiming",
+    "parameters": [
+     {
+      "description": "Template Name",
+      "in": "path",
+      "name": "name",
+      "required": true,
+      "type": "string",
+      "x-go-name": "Name"
+     },
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/MuteTimeInterval"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "MuteTimeInterval",
+      "schema": {
+       "$ref": "#/definitions/MuteTimeInterval"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Replace an existing mute timing.",
+    "tags": [
+     "provisioning"
+    ]
+   }
+  },
+  "/api/v1/provisioning/policies": {
+   "get": {
+    "operationId": "RouteGetPolicyTree",
+    "responses": {
+     "200": {
+      "description": "Route",
+      "schema": {
+       "$ref": "#/definitions/Route"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Get the notification policy tree.",
+    "tags": [
+     "provisioning"
+    ]
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "operationId": "RoutePutPolicyTree",
+    "parameters": [
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/Route"
+      }
+     }
+    ],
+    "responses": {
+     "202": {
+      "description": "Ack",
+      "schema": {
+       "$ref": "#/definitions/Ack"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Sets the notification policy tree.",
+    "tags": [
+     "provisioning"
+    ]
+   }
+  },
+  "/api/v1/provisioning/templates": {
+   "get": {
+    "operationId": "RouteGetTemplates",
+    "responses": {
+     "200": {
+      "description": "MessageTemplate",
+      "schema": {
+       "$ref": "#/definitions/MessageTemplate"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Get all message templates.",
+    "tags": [
+     "provisioning"
+    ]
+   }
+  },
+  "/api/v1/provisioning/templates/{name}": {
+   "delete": {
+    "operationId": "RouteDeleteTemplate",
+    "parameters": [
+     {
+      "description": "Template Name",
+      "in": "path",
+      "name": "name",
+      "required": true,
+      "type": "string",
+      "x-go-name": "Name"
+     }
+    ],
+    "responses": {
+     "204": {
+      "description": "Ack",
+      "schema": {
+       "$ref": "#/definitions/Ack"
+      }
+     }
+    },
+    "summary": "Delete a template.",
+    "tags": [
+     "provisioning"
+    ]
+   },
+   "get": {
+    "operationId": "RouteGetTemplate",
+    "parameters": [
+     {
+      "description": "Template Name",
+      "in": "path",
+      "name": "name",
+      "required": true,
+      "type": "string",
+      "x-go-name": "Name"
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "MessageTemplate",
+      "schema": {
+       "$ref": "#/definitions/MessageTemplate"
+      }
+     },
+     "404": {
+      "description": "NotFound",
+      "schema": {
+       "$ref": "#/definitions/NotFound"
+      }
+     }
+    },
+    "summary": "Get a message template.",
+    "tags": [
+     "provisioning"
+    ]
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "operationId": "RoutePutTemplate",
+    "parameters": [
+     {
+      "description": "Template Name",
+      "in": "path",
+      "name": "name",
+      "required": true,
+      "type": "string",
+      "x-go-name": "Name"
+     },
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/MessageTemplateContent"
+      }
+     }
+    ],
+    "responses": {
+     "202": {
+      "description": "Ack",
+      "schema": {
+       "$ref": "#/definitions/Ack"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Updates an existing template.",
+    "tags": [
+     "provisioning"
     ]
    }
   },

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -3248,7 +3248,6 @@
    "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertGroup": {
-   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -3270,7 +3269,9 @@
     "labels",
     "receiver"
    ],
-   "type": "object"
+   "type": "object",
+   "x-go-name": "AlertGroup",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertGroups": {
    "description": "AlertGroups alert groups",
@@ -3397,6 +3398,7 @@
    "$ref": "#/definitions/Duration"
   },
   "gettableAlert": {
+   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -3455,9 +3457,7 @@
     "status",
     "updatedAt"
    ],
-   "type": "object",
-   "x-go-name": "GettableAlert",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "object"
   },
   "gettableAlerts": {
    "items": {
@@ -3468,6 +3468,7 @@
    "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "gettableSilence": {
+   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3519,17 +3520,14 @@
     "status",
     "updatedAt"
    ],
-   "type": "object",
-   "x-go-name": "GettableSilence",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "object"
   },
   "gettableSilences": {
+   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
-   "type": "array",
-   "x-go-name": "GettableSilences",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "array"
   },
   "labelSet": {
    "additionalProperties": {
@@ -3701,6 +3699,7 @@
    "type": "object"
   },
   "receiver": {
+   "description": "Receiver receiver",
    "properties": {
     "name": {
      "description": "name",
@@ -3711,9 +3710,7 @@
    "required": [
     "name"
    ],
-   "type": "object",
-   "x-go-name": "Receiver",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "object"
   },
   "silence": {
    "description": "Silence silence",
@@ -4932,29 +4929,6 @@
     ]
    }
   },
-  "/api/provisioning/v1/contact-points": {
-   "get": {
-    "operationId": "RouteGetContactpoints",
-    "responses": {
-     "200": {
-      "description": "Route",
-      "schema": {
-       "$ref": "#/definitions/Route"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Get all the contact points.",
-    "tags": [
-     "provisioning"
-    ]
-   }
-  },
   "/api/ruler/grafana/api/v1/rules": {
    "get": {
     "description": "List rule groups",
@@ -5629,6 +5603,27 @@
    }
   },
   "/api/v1/provisioning/contact-points": {
+   "get": {
+    "operationId": "RouteGetContactpoints",
+    "responses": {
+     "200": {
+      "description": "Route",
+      "schema": {
+       "$ref": "#/definitions/Route"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Get all the contact points.",
+    "tags": [
+     "provisioning"
+    ]
+   },
    "post": {
     "consumes": [
      "application/json"

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -3466,6 +3466,7 @@
    "type": "array"
   },
   "gettableSilence": {
+   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3517,9 +3518,7 @@
     "status",
     "updatedAt"
    ],
-   "type": "object",
-   "x-go-name": "GettableSilence",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "object"
   },
   "gettableSilences": {
    "description": "GettableSilences gettable silences",
@@ -5058,6 +5057,7 @@
    }
   },
   "/api/provisioning/contact-points": {
+  "/api/provisioning/v1/contact-points": {
    "get": {
     "operationId": "RouteGetContactpoints",
     "responses": {
@@ -5113,7 +5113,7 @@
     ]
    }
   },
-  "/api/provisioning/contact-points/{UID}": {
+  "/api/provisioning/v1/contact-points/{ID}": {
    "delete": {
     "consumes": [
      "application/json"
@@ -5188,54 +5188,7 @@
     ]
    }
   },
-  "/api/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
-   "put": {
-    "consumes": [
-     "application/json"
-    ],
-    "operationId": "RoutePutAlertRuleGroup",
-    "parameters": [
-     {
-      "in": "path",
-      "name": "FolderUID",
-      "required": true,
-      "type": "string"
-     },
-     {
-      "in": "path",
-      "name": "Group",
-      "required": true,
-      "type": "string"
-     },
-     {
-      "in": "body",
-      "name": "Body",
-      "schema": {
-       "$ref": "#/definitions/AlertRuleGroup"
-      }
-     }
-    ],
-    "responses": {
-     "200": {
-      "description": "AlertRuleGroup",
-      "schema": {
-       "$ref": "#/definitions/AlertRuleGroup"
-      }
-     },
-     "400": {
-      "description": "ValidationError",
-      "schema": {
-       "$ref": "#/definitions/ValidationError"
-      }
-     }
-    },
-    "summary": "Update the interval of a rule group.",
-    "tags": [
-     "provisioning"
-    ]
-   }
-  },
-  "/api/provisioning/mute-timings": {
+  "/api/provisioning/v1/mute-timings": {
    "get": {
     "operationId": "RouteGetMuteTimings",
     "responses": {
@@ -5291,32 +5244,7 @@
     ]
    }
   },
-  "/api/provisioning/mute-timings/{name}": {
-   "delete": {
-    "operationId": "RouteDeleteMuteTiming",
-    "parameters": [
-     {
-      "description": "Template Name",
-      "in": "path",
-      "name": "name",
-      "required": true,
-      "type": "string",
-      "x-go-name": "Name"
-     }
-    ],
-    "responses": {
-     "204": {
-      "description": "Ack",
-      "schema": {
-       "$ref": "#/definitions/Ack"
-      }
-     }
-    },
-    "summary": "Delete a mute timing.",
-    "tags": [
-     "provisioning"
-    ]
-   },
+  "/api/provisioning/v1/mute-timings/{name}": {
    "get": {
     "operationId": "RouteGetMuteTiming",
     "parameters": [
@@ -5390,7 +5318,7 @@
     ]
    }
   },
-  "/api/provisioning/policies": {
+  "/api/provisioning/v1/policies": {
    "get": {
     "operationId": "RouteGetPolicyTree",
     "responses": {
@@ -5446,7 +5374,7 @@
     ]
    }
   },
-  "/api/provisioning/templates": {
+  "/api/provisioning/v1/templates": {
    "get": {
     "operationId": "RouteGetTemplates",
     "responses": {
@@ -5469,7 +5397,7 @@
     ]
    }
   },
-  "/api/provisioning/templates/{name}": {
+  "/api/provisioning/v1/templates/{name}": {
    "delete": {
     "operationId": "RouteDeleteTemplate",
     "parameters": [

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1251,6 +1251,7 @@
       }
     },
     "/api/provisioning/contact-points": {
+    "/api/provisioning/v1/contact-points": {
       "get": {
         "tags": [
           "provisioning"
@@ -1306,7 +1307,7 @@
         }
       }
     },
-    "/api/provisioning/contact-points/{UID}": {
+    "/api/provisioning/v1/contact-points/{ID}": {
       "put": {
         "consumes": [
           "application/json"
@@ -1428,7 +1429,7 @@
         }
       }
     },
-    "/api/provisioning/mute-timings": {
+    "/api/provisioning/v1/mute-timings": {
       "get": {
         "tags": [
           "provisioning"
@@ -1484,7 +1485,7 @@
         }
       }
     },
-    "/api/provisioning/mute-timings/{name}": {
+    "/api/provisioning/v1/mute-timings/{name}": {
       "get": {
         "tags": [
           "provisioning"
@@ -1583,7 +1584,7 @@
         }
       }
     },
-    "/api/provisioning/policies": {
+    "/api/provisioning/v1/policies": {
       "get": {
         "tags": [
           "provisioning"
@@ -1639,7 +1640,7 @@
         }
       }
     },
-    "/api/provisioning/templates": {
+    "/api/provisioning/v1/templates": {
       "get": {
         "tags": [
           "provisioning"
@@ -1662,7 +1663,7 @@
         }
       }
     },
-    "/api/provisioning/templates/{name}": {
+    "/api/provisioning/v1/templates/{name}": {
       "get": {
         "tags": [
           "provisioning"
@@ -5849,6 +5850,7 @@
       "$ref": "#/definitions/gettableAlerts"
     },
     "gettableSilence": {
+      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -5901,8 +5903,6 @@
           "x-go-name": "UpdatedAt"
         }
       },
-      "x-go-name": "GettableSilence",
-      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/gettableSilence"
     },
     "gettableSilences": {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1122,135 +1122,6 @@
         }
       }
     },
-    "/api/provisioning/alert-rules": {
-      "post": {
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Create a new alert rule.",
-        "operationId": "RoutePostAlertRule",
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/AlertRule"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "AlertRule",
-            "schema": {
-              "$ref": "#/definitions/AlertRule"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      }
-    },
-    "/api/provisioning/alert-rules/{UID}": {
-      "get": {
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Get a specific alert rule by UID.",
-        "operationId": "RouteGetAlertRule",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "UID",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "AlertRule",
-            "schema": {
-              "$ref": "#/definitions/AlertRule"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      },
-      "put": {
-        "consumes": [
-          "application/json"
-        ],
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Update an existing alert rule.",
-        "operationId": "RoutePutAlertRule",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "UID",
-            "in": "path",
-            "required": true
-          },
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/AlertRule"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "AlertRule",
-            "schema": {
-              "$ref": "#/definitions/AlertRule"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Delete a specific alert rule by UID.",
-        "operationId": "RouteDeleteAlertRule",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "UID",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": " The alert rule was deleted successfully."
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      }
-    },
-    "/api/provisioning/contact-points": {
     "/api/provisioning/v1/contact-points": {
       "get": {
         "tags": [
@@ -1269,494 +1140,6 @@
             "description": "ValidationError",
             "schema": {
               "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      },
-      "post": {
-        "consumes": [
-          "application/json"
-        ],
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Create a contact point.",
-        "operationId": "RoutePostContactpoints",
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/EmbeddedContactPoint"
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Ack",
-            "schema": {
-              "$ref": "#/definitions/Ack"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      }
-    },
-    "/api/provisioning/v1/contact-points/{ID}": {
-      "put": {
-        "consumes": [
-          "application/json"
-        ],
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Update an existing contact point.",
-        "operationId": "RoutePutContactpoint",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "ContactPointUID should be the contact point UID identifier",
-            "name": "UID",
-            "in": "path",
-            "required": true
-          },
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/EmbeddedContactPoint"
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Ack",
-            "schema": {
-              "$ref": "#/definitions/Ack"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      },
-      "delete": {
-        "consumes": [
-          "application/json"
-        ],
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Delete a contact point.",
-        "operationId": "RouteDeleteContactpoints",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "ContactPointUID should be the contact point UID identifier",
-            "name": "UID",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Ack",
-            "schema": {
-              "$ref": "#/definitions/Ack"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      }
-    },
-    "/api/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
-      "put": {
-        "consumes": [
-          "application/json"
-        ],
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Update the interval of a rule group.",
-        "operationId": "RoutePutAlertRuleGroup",
-        "parameters": [
-          {
-            "type": "string",
-            "name": "FolderUID",
-            "in": "path",
-            "required": true
-          },
-          {
-            "type": "string",
-            "name": "Group",
-            "in": "path",
-            "required": true
-          },
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/AlertRuleGroup"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "AlertRuleGroup",
-            "schema": {
-              "$ref": "#/definitions/AlertRuleGroup"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      }
-    },
-    "/api/provisioning/v1/mute-timings": {
-      "get": {
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Get all the mute timings.",
-        "operationId": "RouteGetMuteTimings",
-        "responses": {
-          "200": {
-            "description": "MuteTimings",
-            "schema": {
-              "$ref": "#/definitions/MuteTimings"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      },
-      "post": {
-        "consumes": [
-          "application/json"
-        ],
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Create a new mute timing.",
-        "operationId": "RoutePostMuteTiming",
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "MuteTimeInterval",
-            "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      }
-    },
-    "/api/provisioning/v1/mute-timings/{name}": {
-      "get": {
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Get a mute timing.",
-        "operationId": "RouteGetMuteTiming",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "Template Name",
-            "name": "name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "MuteTimeInterval",
-            "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      },
-      "put": {
-        "consumes": [
-          "application/json"
-        ],
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Replace an existing mute timing.",
-        "operationId": "RoutePutMuteTiming",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "Template Name",
-            "name": "name",
-            "in": "path",
-            "required": true
-          },
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "MuteTimeInterval",
-            "schema": {
-              "$ref": "#/definitions/MuteTimeInterval"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Delete a mute timing.",
-        "operationId": "RouteDeleteMuteTiming",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "Template Name",
-            "name": "name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Ack",
-            "schema": {
-              "$ref": "#/definitions/Ack"
-            }
-          }
-        }
-      }
-    },
-    "/api/provisioning/v1/policies": {
-      "get": {
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Get the notification policy tree.",
-        "operationId": "RouteGetPolicyTree",
-        "responses": {
-          "200": {
-            "description": "Route",
-            "schema": {
-              "$ref": "#/definitions/Route"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      },
-      "put": {
-        "consumes": [
-          "application/json"
-        ],
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Sets the notification policy tree.",
-        "operationId": "RoutePutPolicyTree",
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/Route"
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Ack",
-            "schema": {
-              "$ref": "#/definitions/Ack"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      }
-    },
-    "/api/provisioning/v1/templates": {
-      "get": {
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Get all message templates.",
-        "operationId": "RouteGetTemplates",
-        "responses": {
-          "200": {
-            "description": "MessageTemplate",
-            "schema": {
-              "$ref": "#/definitions/MessageTemplate"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      }
-    },
-    "/api/provisioning/v1/templates/{name}": {
-      "get": {
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Get a message template.",
-        "operationId": "RouteGetTemplate",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "Template Name",
-            "name": "name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "MessageTemplate",
-            "schema": {
-              "$ref": "#/definitions/MessageTemplate"
-            }
-          },
-          "404": {
-            "description": "NotFound",
-            "schema": {
-              "$ref": "#/definitions/NotFound"
-            }
-          }
-        }
-      },
-      "put": {
-        "consumes": [
-          "application/json"
-        ],
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Updates an existing template.",
-        "operationId": "RoutePutTemplate",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "Template Name",
-            "name": "name",
-            "in": "path",
-            "required": true
-          },
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/MessageTemplateContent"
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Ack",
-            "schema": {
-              "$ref": "#/definitions/Ack"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Delete a template.",
-        "operationId": "RouteDeleteTemplate",
-        "parameters": [
-          {
-            "type": "string",
-            "x-go-name": "Name",
-            "description": "Template Name",
-            "name": "name",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Ack",
-            "schema": {
-              "$ref": "#/definitions/Ack"
             }
           }
         }
@@ -2302,6 +1685,624 @@
             "description": "GettableAlertmanagers",
             "schema": {
               "$ref": "#/definitions/GettableAlertmanagers"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/provisioning/alert-rules": {
+      "post": {
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Create a new alert rule.",
+        "operationId": "RoutePostAlertRule",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/AlertRule"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "AlertRule",
+            "schema": {
+              "$ref": "#/definitions/AlertRule"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/provisioning/alert-rules/{UID}": {
+      "get": {
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Get a specific alert rule by UID.",
+        "operationId": "RouteGetAlertRule",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "UID",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AlertRule",
+            "schema": {
+              "$ref": "#/definitions/AlertRule"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      },
+      "put": {
+        "consumes": [
+          "application/json"
+        ],
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Update an existing alert rule.",
+        "operationId": "RoutePutAlertRule",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "UID",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/AlertRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AlertRule",
+            "schema": {
+              "$ref": "#/definitions/AlertRule"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Delete a specific alert rule by UID.",
+        "operationId": "RouteDeleteAlertRule",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "UID",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": " The alert rule was deleted successfully."
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/provisioning/contact-points": {
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Create a contact point.",
+        "operationId": "RoutePostContactpoints",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/EmbeddedContactPoint"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Ack",
+            "schema": {
+              "$ref": "#/definitions/Ack"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/provisioning/contact-points/{UID}": {
+      "put": {
+        "consumes": [
+          "application/json"
+        ],
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Update an existing contact point.",
+        "operationId": "RoutePutContactpoint",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ContactPointUID should be the contact point UID identifier",
+            "name": "UID",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/EmbeddedContactPoint"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Ack",
+            "schema": {
+              "$ref": "#/definitions/Ack"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "consumes": [
+          "application/json"
+        ],
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Delete a contact point.",
+        "operationId": "RouteDeleteContactpoints",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ContactPointUID should be the contact point UID identifier",
+            "name": "UID",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Ack",
+            "schema": {
+              "$ref": "#/definitions/Ack"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
+      "put": {
+        "consumes": [
+          "application/json"
+        ],
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Update the interval of a rule group.",
+        "operationId": "RoutePutAlertRuleGroup",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "FolderUID",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "Group",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/AlertRuleGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AlertRuleGroup",
+            "schema": {
+              "$ref": "#/definitions/AlertRuleGroup"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/provisioning/mute-timings": {
+      "get": {
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Get all the mute timings.",
+        "operationId": "RouteGetMuteTimings",
+        "responses": {
+          "200": {
+            "description": "MuteTimings",
+            "schema": {
+              "$ref": "#/definitions/MuteTimings"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Create a new mute timing.",
+        "operationId": "RoutePostMuteTiming",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/MuteTimeInterval"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "MuteTimeInterval",
+            "schema": {
+              "$ref": "#/definitions/MuteTimeInterval"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/provisioning/mute-timings/{name}": {
+      "get": {
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Get a mute timing.",
+        "operationId": "RouteGetMuteTiming",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Template Name",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "MuteTimeInterval",
+            "schema": {
+              "$ref": "#/definitions/MuteTimeInterval"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      },
+      "put": {
+        "consumes": [
+          "application/json"
+        ],
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Replace an existing mute timing.",
+        "operationId": "RoutePutMuteTiming",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Template Name",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/MuteTimeInterval"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "MuteTimeInterval",
+            "schema": {
+              "$ref": "#/definitions/MuteTimeInterval"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Delete a mute timing.",
+        "operationId": "RouteDeleteMuteTiming",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Template Name",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Ack",
+            "schema": {
+              "$ref": "#/definitions/Ack"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/provisioning/policies": {
+      "get": {
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Get the notification policy tree.",
+        "operationId": "RouteGetPolicyTree",
+        "responses": {
+          "200": {
+            "description": "Route",
+            "schema": {
+              "$ref": "#/definitions/Route"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      },
+      "put": {
+        "consumes": [
+          "application/json"
+        ],
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Sets the notification policy tree.",
+        "operationId": "RoutePutPolicyTree",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Route"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Ack",
+            "schema": {
+              "$ref": "#/definitions/Ack"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/provisioning/templates": {
+      "get": {
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Get all message templates.",
+        "operationId": "RouteGetTemplates",
+        "responses": {
+          "200": {
+            "description": "MessageTemplate",
+            "schema": {
+              "$ref": "#/definitions/MessageTemplate"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/provisioning/templates/{name}": {
+      "get": {
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Get a message template.",
+        "operationId": "RouteGetTemplate",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Template Name",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "MessageTemplate",
+            "schema": {
+              "$ref": "#/definitions/MessageTemplate"
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "schema": {
+              "$ref": "#/definitions/NotFound"
+            }
+          }
+        }
+      },
+      "put": {
+        "consumes": [
+          "application/json"
+        ],
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Updates an existing template.",
+        "operationId": "RoutePutTemplate",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Template Name",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/MessageTemplateContent"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Ack",
+            "schema": {
+              "$ref": "#/definitions/Ack"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Delete a template.",
+        "operationId": "RouteDeleteTemplate",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Template Name",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Ack",
+            "schema": {
+              "$ref": "#/definitions/Ack"
             }
           }
         }
@@ -5396,8 +5397,9 @@
       "x-go-package": "github.com/prometheus/alertmanager/timeinterval"
     },
     "URL": {
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "URL is a custom URL type that allows validation at configuration load time.",
+      "title": "A URL represents a parsed URL (technically, a URI reference).",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -5430,7 +5432,7 @@
           "$ref": "#/definitions/Userinfo"
         }
       },
-      "x-go-package": "github.com/prometheus/common/config"
+      "x-go-package": "net/url"
     },
     "Userinfo": {
       "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -5627,6 +5629,7 @@
       "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
     },
     "alertGroup": {
+      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -5649,8 +5652,6 @@
           "$ref": "#/definitions/receiver"
         }
       },
-      "x-go-name": "AlertGroup",
-      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/alertGroup"
     },
     "alertGroups": {
@@ -5779,7 +5780,6 @@
       "$ref": "#/definitions/Duration"
     },
     "gettableAlert": {
-      "description": "GettableAlert gettable alert",
       "type": "object",
       "required": [
         "labels",
@@ -5839,18 +5839,20 @@
           "x-go-name": "UpdatedAt"
         }
       },
+      "x-go-name": "GettableAlert",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/gettableAlert"
     },
     "gettableAlerts": {
-      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableAlert"
       },
+      "x-go-name": "GettableAlerts",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/gettableAlerts"
     },
     "gettableSilence": {
-      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -5903,14 +5905,17 @@
           "x-go-name": "UpdatedAt"
         }
       },
+      "x-go-name": "GettableSilence",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/gettableSilence"
     },
     "gettableSilences": {
-      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
       },
+      "x-go-name": "GettableSilences",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/gettableSilences"
     },
     "labelSet": {
@@ -6040,6 +6045,7 @@
       "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
     },
     "postableSilence": {
+      "description": "PostableSilence postable silence",
       "type": "object",
       "required": [
         "comment",
@@ -6080,12 +6086,9 @@
           "x-go-name": "StartsAt"
         }
       },
-      "x-go-name": "PostableSilence",
-      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/postableSilence"
     },
     "receiver": {
-      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "name"
@@ -6097,6 +6100,8 @@
           "x-go-name": "Name"
         }
       },
+      "x-go-name": "Receiver",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/receiver"
     },
     "silence": {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1122,29 +1122,6 @@
         }
       }
     },
-    "/api/provisioning/v1/contact-points": {
-      "get": {
-        "tags": [
-          "provisioning"
-        ],
-        "summary": "Get all the contact points.",
-        "operationId": "RouteGetContactpoints",
-        "responses": {
-          "200": {
-            "description": "Route",
-            "schema": {
-              "$ref": "#/definitions/Route"
-            }
-          },
-          "400": {
-            "description": "ValidationError",
-            "schema": {
-              "$ref": "#/definitions/ValidationError"
-            }
-          }
-        }
-      }
-    },
     "/api/ruler/grafana/api/v1/rules": {
       "get": {
         "description": "List rule groups",
@@ -1819,6 +1796,27 @@
       }
     },
     "/api/v1/provisioning/contact-points": {
+      "get": {
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Get all the contact points.",
+        "operationId": "RouteGetContactpoints",
+        "responses": {
+          "200": {
+            "description": "Route",
+            "schema": {
+              "$ref": "#/definitions/Route"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      },
       "post": {
         "consumes": [
           "application/json"
@@ -5629,7 +5627,6 @@
       "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
     },
     "alertGroup": {
-      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -5652,6 +5649,8 @@
           "$ref": "#/definitions/receiver"
         }
       },
+      "x-go-name": "AlertGroup",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/alertGroup"
     },
     "alertGroups": {
@@ -5780,6 +5779,7 @@
       "$ref": "#/definitions/Duration"
     },
     "gettableAlert": {
+      "description": "GettableAlert gettable alert",
       "type": "object",
       "required": [
         "labels",
@@ -5839,8 +5839,6 @@
           "x-go-name": "UpdatedAt"
         }
       },
-      "x-go-name": "GettableAlert",
-      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/gettableAlert"
     },
     "gettableAlerts": {
@@ -5853,6 +5851,7 @@
       "$ref": "#/definitions/gettableAlerts"
     },
     "gettableSilence": {
+      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -5905,17 +5904,14 @@
           "x-go-name": "UpdatedAt"
         }
       },
-      "x-go-name": "GettableSilence",
-      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/gettableSilence"
     },
     "gettableSilences": {
+      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
       },
-      "x-go-name": "GettableSilences",
-      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/gettableSilences"
     },
     "labelSet": {
@@ -6089,6 +6085,7 @@
       "$ref": "#/definitions/postableSilence"
     },
     "receiver": {
+      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "name"
@@ -6100,8 +6097,6 @@
           "x-go-name": "Name"
         }
       },
-      "x-go-name": "Receiver",
-      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/receiver"
     },
     "silence": {

--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -46,7 +46,7 @@ func TestProvisioning(t *testing.T) {
 	})
 
 	t.Run("when provisioning notification policies", func(t *testing.T) {
-		url := fmt.Sprintf("http://%s/api/provisioning/policies", grafanaListedAddr)
+		url := fmt.Sprintf("http://%s/api/provisioning/v1/policies", grafanaListedAddr)
 		body := `
 		{
 			"receiver": "grafana-default-email",
@@ -138,7 +138,7 @@ func TestProvisioning(t *testing.T) {
 	})
 
 	t.Run("when provisioning contactpoints", func(t *testing.T) {
-		url := fmt.Sprintf("http://%s/api/provisioning/contact-points", grafanaListedAddr)
+		url := fmt.Sprintf("http://%s/api/provisioning/v1/contact-points", grafanaListedAddr)
 		body := `
 		{
 			"name": "my-contact-point",
@@ -231,7 +231,7 @@ func TestProvisioning(t *testing.T) {
 	})
 
 	t.Run("when provisioning templates", func(t *testing.T) {
-		url := fmt.Sprintf("http://%s/api/provisioning/templates", grafanaListedAddr)
+		url := fmt.Sprintf("http://%s/api/provisioning/v1/templates", grafanaListedAddr)
 
 		t.Run("un-authenticated GET should 401", func(t *testing.T) {
 			req := createTestRequest("GET", url, "", "")
@@ -275,7 +275,7 @@ func TestProvisioning(t *testing.T) {
 	})
 
 	t.Run("when provisioning mute timings", func(t *testing.T) {
-		url := fmt.Sprintf("http://%s/api/provisioning/mute-timings", grafanaListedAddr)
+		url := fmt.Sprintf("http://%s/api/provisioning/v1/mute-timings", grafanaListedAddr)
 
 		t.Run("un-authenticated GET should 401", func(t *testing.T) {
 			req := createTestRequest("GET", url, "", "")

--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -46,7 +46,7 @@ func TestProvisioning(t *testing.T) {
 	})
 
 	t.Run("when provisioning notification policies", func(t *testing.T) {
-		url := fmt.Sprintf("http://%s/api/provisioning/v1/policies", grafanaListedAddr)
+		url := fmt.Sprintf("http://%s/api/v1/provisioning/policies", grafanaListedAddr)
 		body := `
 		{
 			"receiver": "grafana-default-email",
@@ -138,7 +138,7 @@ func TestProvisioning(t *testing.T) {
 	})
 
 	t.Run("when provisioning contactpoints", func(t *testing.T) {
-		url := fmt.Sprintf("http://%s/api/provisioning/v1/contact-points", grafanaListedAddr)
+		url := fmt.Sprintf("http://%s/api/v1/provisioning/contact-points", grafanaListedAddr)
 		body := `
 		{
 			"name": "my-contact-point",
@@ -231,7 +231,7 @@ func TestProvisioning(t *testing.T) {
 	})
 
 	t.Run("when provisioning templates", func(t *testing.T) {
-		url := fmt.Sprintf("http://%s/api/provisioning/v1/templates", grafanaListedAddr)
+		url := fmt.Sprintf("http://%s/api/v1/provisioning/templates", grafanaListedAddr)
 
 		t.Run("un-authenticated GET should 401", func(t *testing.T) {
 			req := createTestRequest("GET", url, "", "")
@@ -275,7 +275,7 @@ func TestProvisioning(t *testing.T) {
 	})
 
 	t.Run("when provisioning mute timings", func(t *testing.T) {
-		url := fmt.Sprintf("http://%s/api/provisioning/v1/mute-timings", grafanaListedAddr)
+		url := fmt.Sprintf("http://%s/api/v1/provisioning/mute-timings", grafanaListedAddr)
 
 		t.Run("un-authenticated GET should 401", func(t *testing.T) {
 			req := createTestRequest("GET", url, "", "")


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a version segment to the URL for provisioning endpoints.

This lets us be more structured about backwards compatibility, and easily communicate breakages to users.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Rel https://github.com/grafana/grafana/issues/36153

**Special notes for your reviewer**:

