### PR TITLE
DataFrame: move interval null insertion to datasources

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/utils.ts
+++ b/packages/grafana-ui/src/components/GraphNG/utils.ts
@@ -8,7 +8,6 @@ import {
 } from '@grafana/schema';
 
 import { FIXED_UNIT } from './GraphNG';
-import { applyNullInsertThreshold } from './nullInsertThreshold';
 import { nullToUndefThreshold } from './nullToUndefThreshold';
 import { XYFieldMatchers } from './types';
 
@@ -43,9 +42,6 @@ function applySpanNullsThresholds(frame: DataFrame) {
 }
 
 export function preparePlotFrame(frames: DataFrame[], dimFields: XYFieldMatchers, timeRange?: TimeRange | null) {
-  // apply null insertions at interval
-  frames = frames.map((frame) => applyNullInsertThreshold(frame, null, timeRange?.to.valueOf()));
-
   let numBarSeries = 0;
 
   frames.forEach((frame) => {

--- a/packages/grafana-ui/src/components/Sparkline/utils.ts
+++ b/packages/grafana-ui/src/components/Sparkline/utils.ts
@@ -1,8 +1,6 @@
 import { DataFrame, FieldConfig, FieldSparkline, IndexVector } from '@grafana/data';
 import { GraphFieldConfig } from '@grafana/schema';
 
-import { applyNullInsertThreshold } from '../GraphNG/nullInsertThreshold';
-
 /** @internal
  * Given a sparkline config returns a DataFrame ready to be turned into Plot data set
  **/
@@ -13,7 +11,7 @@ export function preparePlotFrame(sparkline: FieldSparkline, config?: FieldConfig
     ...config,
   };
 
-  return applyNullInsertThreshold({
+  return {
     refId: 'sparkline',
     fields: [
       sparkline.x ?? IndexVector.newField(length),
@@ -23,5 +21,5 @@ export function preparePlotFrame(sparkline: FieldSparkline, config?: FieldConfig
       },
     ],
     length,
-  });
+  };
 }

--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -23,6 +23,7 @@ import {
   DataFrameType,
 } from '@grafana/data';
 import { FetchResponse, getDataSourceSrv, getTemplateSrv } from '@grafana/runtime';
+import { applyNullInsertThreshold } from '@grafana/ui/src/components/GraphNG/nullInsertThreshold';
 
 import { renderLegendFormat } from './legend';
 import {
@@ -109,7 +110,8 @@ export function transformV2(
   // Everything else is processed as time_series result and graph preferredVisualisationType
   const otherFrames = framesWithoutTableHeatmapsAndExemplars.map((dataFrame) => {
     const df = {
-      ...dataFrame,
+      // insert null values omitted intervals
+      ...applyNullInsertThreshold(dataFrame, null, request.range?.to.valueOf()),
       meta: {
         ...dataFrame.meta,
         preferredVisualisationType: 'graph',

--- a/public/app/plugins/panel/graph/data_processor.ts
+++ b/public/app/plugins/panel/graph/data_processor.ts
@@ -11,7 +11,6 @@ import {
   TimeRange,
 } from '@grafana/data';
 import { colors } from '@grafana/ui';
-import { applyNullInsertThreshold } from '@grafana/ui/src/components/GraphNG/nullInsertThreshold';
 import config from 'app/core/config';
 import TimeSeries from 'app/core/time_series2';
 
@@ -38,9 +37,6 @@ export class DataProcessor {
       if (!timeField) {
         continue;
       }
-
-      series = applyNullInsertThreshold(series, timeField.name);
-      timeField = getTimeField(series).timeField!; // use updated length
 
       for (let j = 0; j < series.fields.length; j++) {
         const field = series.fields[j];


### PR DESCRIPTION
this moves the null insertion into the datasources' JS, as it was pre-8.4.0.

this allows "null as \<whatever\>" and follow-up calcs to work in missing intervals in time-sparse raw data responses.

related to https://github.com/grafana/grafana/pull/49118