### PR TITLE
Geomap: show delete button

### DIFF
--- a/public/app/core/components/Layers/LayerDragDropList.tsx
+++ b/public/app/core/components/Layers/LayerDragDropList.tsx
@@ -16,7 +16,7 @@ type LayerDragDropListProps<T extends LayerElement> = {
   onSelect: (element: T) => any;
   onDelete: (element: T) => any;
   onDuplicate?: (element: T) => any;
-  isFrame: (element: T) => boolean;
+  showActions: (element: T) => boolean;
   selection?: string[]; // list of unique ids (names)
   excludeBaseLayer?: boolean;
   onNameChange: (element: T, newName: string) => any;
@@ -30,7 +30,7 @@ export const LayerDragDropList = <T extends LayerElement>({
   onSelect,
   onDelete,
   onDuplicate,
-  isFrame,
+  showActions,
   selection,
   excludeBaseLayer,
   onNameChange,
@@ -74,7 +74,7 @@ export const LayerDragDropList = <T extends LayerElement>({
                         />
                         <div className={style.textWrapper}>&nbsp; {getLayerInfo(element)}</div>
 
-                        {isFrame(element) && (
+                        {showActions(element) && (
                           <>
                             {onDuplicate ? (
                               <IconButton
@@ -93,15 +93,15 @@ export const LayerDragDropList = <T extends LayerElement>({
                               onClick={() => onDelete(element)}
                               surface="header"
                             />
-                            {layers.length > shouldRenderDragIconLengthThreshold && (
-                              <Icon
-                                title="Drag and drop to reorder"
-                                name="draggabledots"
-                                size="lg"
-                                className={style.dragIcon}
-                              />
-                            )}
                           </>
+                        )}
+                        {layers.length > shouldRenderDragIconLengthThreshold && (
+                          <Icon
+                            title="Drag and drop to reorder"
+                            name="draggabledots"
+                            size="lg"
+                            className={style.dragIcon}
+                          />
                         )}
                       </div>
                     )}

--- a/public/app/plugins/panel/canvas/editor/LayerElementListEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/LayerElementListEditor.tsx
@@ -215,8 +215,8 @@ export class LayerElementListEditor extends PureComponent<Props> {
       element.onChange({ ...element.options, name });
     };
 
-    const isFrame = (element: ElementState) => {
-      return element instanceof FrameState;
+    const showActions = (element: ElementState) => {
+      return !(element instanceof FrameState);
     };
 
     const verifyLayerNameUniqueness = (nameToVerify: string) => {
@@ -252,7 +252,7 @@ export class LayerElementListEditor extends PureComponent<Props> {
           getLayerInfo={getLayerInfo}
           onNameChange={onNameChange}
           verifyLayerNameUniqueness={verifyLayerNameUniqueness}
-          isFrame={isFrame}
+          showActions={showActions}
           layers={layer.elements}
           selection={selection}
         />

--- a/public/app/plugins/panel/geomap/editor/LayersEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/LayersEditor.tsx
@@ -5,7 +5,6 @@ import { StandardEditorProps } from '@grafana/data';
 import { Container } from '@grafana/ui';
 import { AddLayerButton } from 'app/core/components/Layers/AddLayerButton';
 import { LayerDragDropList } from 'app/core/components/Layers/LayerDragDropList';
-import { FrameState } from 'app/features/canvas/runtime/frame';
 
 import { GeomapInstanceState } from '../GeomapPanel';
 import { geomapLayerRegistry } from '../layers/registry';
@@ -55,10 +54,6 @@ export const LayersEditor = (props: LayersEditorProps) => {
     element.onChange({ ...element.options, name });
   };
 
-  const isFrame = (element: MapLayerState<any>) => {
-    return element instanceof FrameState;
-  };
-
   const selection = selected ? [layers[selected]?.getName()] : [];
 
   return (
@@ -74,12 +69,12 @@ export const LayersEditor = (props: LayersEditorProps) => {
 
       <LayerDragDropList
         layers={layers}
+        showActions={() => layers.length > 2} // 2 because base layer is not counted!
         getLayerInfo={getLayerInfo}
         onDragEnd={onDragEnd}
         onSelect={onSelect}
         onDelete={onDelete}
         selection={selection}
-        isFrame={isFrame}
         excludeBaseLayer
         onNameChange={onNameChange}
         verifyLayerNameUniqueness={actions.canRename}


### PR DESCRIPTION
It looks like the recent canvas refactoring broke geomap delete function.  This updates the logic so we show the buttons again.  The previous behavior has not been in a released version, so we do not need changelog/fix etc

![2022-05-17_15-34-16 (1)](https://user-images.githubusercontent.com/705951/168923370-b1adfc13-7075-46ea-8c8e-131c1fea55c6.gif)
