### PR TITLE
Alerting: inject dashboardService in to AlertNG

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -49,6 +49,7 @@ func ProvideService(cfg *setting.Cfg, dataSourceCache datasources.CacheService, 
 		NotificationService: notificationService,
 		folderService:       folderService,
 		accesscontrol:       ac,
+		dashboardService:    dashboardService,
 	}
 
 	if ng.IsDisabled() {


### PR DESCRIPTION
**What this PR does / why we need it**:

A recent regression in https://github.com/grafana/grafana/pull/48971 would result in a segfault when unified alerting was enabled, rules were evaluated and alert states were changing.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x1018ff040]

goroutine 2338 [running]:
github.com/grafana/grafana/pkg/services/ngalert/state.(*Manager).annotateState(0x14001db0540, {0x103529fc8, 0x14000f18e40}, 0x140007463c0, 0x15?, {0x103529fc8?, 0x140024c8580?, 0x104f5f4c0?}, 0x2, 0x4)
	/Users/gilles/grafana/grafana/pkg/services/ngalert/state/manager.go:281 +0x8b0
created by github.com/grafana/grafana/pkg/services/ngalert/state.(*Manager).setNextState
	/Users/gilles/grafana/grafana/pkg/services/ngalert/state/manager.go:203 +0x7d4
```

**Special notes for your reviewer**:



