### PR TITLE
Add role_attribute_path and role_attribute_path_strict to auth.gitlab

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -477,6 +477,8 @@ token_url = https://gitlab.com/oauth/token
 api_url = https://gitlab.com/api/v4
 allowed_domains =
 allowed_groups =
+role_attribute_path =
+role_attribute_strict = false
 
 #################################### Google Auth #########################
 [auth.google]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
adds 2 parameters from auth.generic to auth.gitlab module since they are not recognized when added as environment variables.

**Which issue(s) this PR fixes**:

 The intention is to fix https://github.com/grafana/grafana/issues/48637

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/48637

**Special notes for your reviewer**: 

hoping that it's as simple as this, as suggested by https://community.grafana.com/t/grafana-gitlab-oauth-env-variable-not-recognized/65039/2 but I must acknowledge that I didn't go through the whole grafana code.

