### PR TITLE
move packages react to peer deps so grafana ui can be used in different react versions

### DIFF
--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -33,8 +33,6 @@
     "moment-timezone": "0.5.34",
     "ol": "6.14.1",
     "papaparse": "5.3.2",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
     "regenerator-runtime": "0.13.9",
     "rxjs": "7.5.5",
     "tslib": "2.4.0",
@@ -66,6 +64,8 @@
     "@types/testing-library__react-hooks": "^3.2.0",
     "@types/tinycolor2": "1.4.3",
     "history": "4.10.1",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "react-test-renderer": "17.0.2",
     "rimraf": "3.0.2",
     "rollup": "2.73.0",
@@ -74,5 +74,9 @@
     "sinon": "13.0.1",
     "tinycolor2": "1.4.2",
     "typescript": "4.6.4"
+  },
+  "peerDependencies": {
+    "react": ">= 16.8 || 17.x.x || 18.x.x",
+    "react-dom": ">= 16.8 || 17.x.x || 18.x.x"
   }
 }

--- a/packages/grafana-data/src/themes/createVisualizationColors.ts
+++ b/packages/grafana-data/src/themes/createVisualizationColors.ts
@@ -46,7 +46,7 @@ export function createVisualizationColors(colors: ThemeColors): ThemeVisualizati
 
   const byNameIndex: Record<string, string> = {};
 
-  for (const hue of hues) {
+  hues.forEach((hue) => {
     for (const shade of hue.shades) {
       byNameIndex[shade.name] = shade.color;
       if (shade.aliases) {
@@ -55,7 +55,7 @@ export function createVisualizationColors(colors: ThemeColors): ThemeVisualizati
         }
       }
     }
-  }
+  });
 
   // special colors
   byNameIndex['transparent'] = 'rgba(0,0,0,0)';

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -29,6 +29,10 @@
     "defaults",
     "not IE 11"
   ],
+  "peerDependencies": {
+    "react": ">= 16.8 || 17.x.x || 18.x.x",
+    "react-dom": ">= 16.8 || 17.x.x || 18.x.x"
+  },
   "dependencies": {
     "@emotion/css": "11.9.0",
     "@emotion/react": "11.9.0",
@@ -66,12 +70,10 @@
     "rc-drawer": "4.4.3",
     "rc-slider": "9.7.5",
     "rc-time-picker": "^3.7.3",
-    "react": "17.0.2",
     "react-beautiful-dnd": "13.1.0",
     "react-calendar": "3.7.0",
     "react-colorful": "5.5.1",
     "react-custom-scrollbars-2": "4.4.0",
-    "react-dom": "17.0.2",
     "react-dropzone": "12.0.4",
     "react-highlight-words": "0.18.0",
     "react-hook-form": "7.5.3",
@@ -162,7 +164,9 @@
     "postcss-loader": "6.2.1",
     "process": "^0.11.10",
     "raw-loader": "4.0.2",
+    "react": "17.0.2",
     "react-docgen-typescript-loader": "3.7.2",
+    "react-dom": "17.0.2",
     "react-test-renderer": "17.0.2",
     "rimraf": "3.0.2",
     "rollup": "2.73.0",

--- a/public/app/plugins/panel/barchart/bars.ts
+++ b/public/app/plugins/panel/barchart/bars.ts
@@ -12,8 +12,7 @@ import {
 } from '@grafana/schema';
 import { measureText, PlotTooltipInterpolator } from '@grafana/ui';
 import { formatTime } from '@grafana/ui/src/components/uPlot/config/UPlotAxisBuilder';
-
-import { preparePlotData2, StackingGroup } from '../../../../../packages/grafana-ui/src/components/uPlot/utils';
+import { preparePlotData2, StackingGroup } from '@grafana/ui/src/components/uPlot/utils';
 
 import { distribute, SPACE_BETWEEN } from './distribute';
 import { intersects, pointWithin, Quadtree, Rect } from './quadtree';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4402,6 +4402,9 @@ __metadata:
     typescript: 4.6.4
     uplot: 1.6.20
     xss: 1.0.11
+  peerDependencies:
+    react: ">= 16.8 || 17.x.x || 18.x.x"
+    react-dom: ">= 16.8 || 17.x.x || 18.x.x"
   languageName: unknown
   linkType: soft
 
@@ -4857,6 +4860,9 @@ __metadata:
     uuid: 8.3.2
     webpack: 5.72.0
     webpack-filter-warnings-plugin: 1.2.1
+  peerDependencies:
+    react: ">= 16.8 || 17.x.x || 18.x.x"
+    react-dom: ">= 16.8 || 17.x.x || 18.x.x"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Prior to this change, whenever we use @grafana/ui library outside grafana itself, we needed to have the same version of react that grafana/ui library (or override via resolutions). For react libraries, it is a common pattern to set react as peerDependency instead of a dependency, so apps using them can use the specific react version they want. E.g: https://github.com/react-dropzone/react-dropzone/blob/master/package.json

So this PR:
- For all packages, set react and react-dom as a peer dependency, allowing either latest 16.x versions (the ones including hooks), any 17 or any 18 version.
- Move actual dependencies to devDeps, so all plumbing for testing etc keeps working properly
