### PR TITLE
Alerting: Fix notification policies label matchers layout

### DIFF
--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesExpandedForm.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesExpandedForm.tsx
@@ -73,7 +73,7 @@ export const AmRoutesExpandedForm: FC<AmRoutesExpandedFormProps> = ({ onCancel, 
                       {fields.map((field, index) => {
                         const localPath = `object_matchers[${index}]`;
                         return (
-                          <HorizontalGroup key={field.id} align="flex-start">
+                          <HorizontalGroup key={field.id} align="flex-start" height="auto">
                             <Field
                               label="Label"
                               invalid={!!errors.object_matchers?.[index]?.name}


### PR DESCRIPTION
**What this PR does / why we need it**:

A regression in https://github.com/grafana/grafana/pull/47574 broke the label matchers layout for notification policies with more than one matcher.

**Before**

![image](https://user-images.githubusercontent.com/868844/169039714-72dcb8ac-6caf-43c7-8f92-30bc0832025f.png)

**After**

<img width="711" alt="image" src="https://user-images.githubusercontent.com/868844/169039803-f2efbdcc-8d6e-49ae-9c43-573cd980f8b7.png">

