### PR TITLE
Cloudwatch: Pass label in deep link

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch_query_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_query_test.go
@@ -9,27 +9,107 @@ import (
 )
 
 func TestCloudWatchQuery(t *testing.T) {
-	t.Run("Deeplink is not generated for MetricQueryTypeQuery", func(t *testing.T) {
-		startTime := time.Now()
-		endTime := startTime.Add(2 * time.Hour)
-		query := &cloudWatchQuery{
-			RefId:      "A",
-			Region:     "us-east-1",
-			Expression: "",
-			Statistic:  "Average",
-			Period:     300,
-			Id:         "id1",
-			MatchExact: true,
-			Dimensions: map[string][]string{
-				"InstanceId": {"i-12345678"},
+	t.Run("Deeplink", func(t *testing.T) {
+		t.Run("is not generated for MetricQueryTypeQuery", func(t *testing.T) {
+			startTime := time.Now()
+			endTime := startTime.Add(2 * time.Hour)
+			query := &cloudWatchQuery{
+				RefId:      "A",
+				Region:     "us-east-1",
+				Expression: "",
+				Statistic:  "Average",
+				Period:     300,
+				Id:         "id1",
+				MatchExact: true,
+				Dimensions: map[string][]string{
+					"InstanceId": {"i-12345678"},
+				},
+				MetricQueryType:  MetricQueryTypeQuery,
+				MetricEditorMode: MetricEditorModeBuilder,
+			}
+
+			deepLink, err := query.buildDeepLink(startTime, endTime, false)
+			require.NoError(t, err)
+			assert.Empty(t, deepLink)
+		})
+
+		testCases := map[string]struct {
+			linkContainsSubstring string
+			query                 *cloudWatchQuery
+			featureEnabled        bool
+		}{"includes label in case dynamic label is enabled and its a metric stat query": {
+			query: &cloudWatchQuery{
+				RefId:      "A",
+				Region:     "us-east-1",
+				Expression: "",
+				Statistic:  "Average",
+				Period:     300,
+				Id:         "id1",
+				MatchExact: true,
+				Label:      "${PROP('Namespace')}",
+				Dimensions: map[string][]string{
+					"InstanceId": {"i-12345678"},
+				},
+				MetricQueryType:  MetricQueryTypeSearch,
+				MetricEditorMode: MetricEditorModeBuilder,
 			},
-			MetricQueryType:  MetricQueryTypeQuery,
-			MetricEditorMode: MetricEditorModeBuilder,
+			featureEnabled: true,
+			// decoded: label: ${PROP('Namespace')}
+			linkContainsSubstring: "label%22%3A%22%24%7BPROP%28%27Namespace%27%29%7D%22%7D%5D%5D%7D",
+		},
+			"does not include label in case dynamic label is diabled": {
+				query: &cloudWatchQuery{
+					RefId:      "A",
+					Region:     "us-east-1",
+					Expression: "",
+					Statistic:  "Average",
+					Period:     300,
+					Id:         "id1",
+					MatchExact: true,
+					Label:      "${PROP('Namespace')}",
+					Dimensions: map[string][]string{
+						"InstanceId": {"i-12345678"},
+					},
+					MetricQueryType:  MetricQueryTypeSearch,
+					MetricEditorMode: MetricEditorModeBuilder,
+				},
+				featureEnabled: true,
+				// decoded: label: ${PROP('Namespace')}
+				linkContainsSubstring: "label%22%3A%22%24%7BPROP%28%27Namespace%27%29%7D%22%7D%5D%5D%7D",
+			},
+			"includes label in case dynamic label is enabled and its a math expression query": {
+				query: &cloudWatchQuery{
+					RefId:      "A",
+					Region:     "us-east-1",
+					Expression: "",
+					Statistic:  "Average",
+					Period:     300,
+					Id:         "id1",
+					MatchExact: true,
+					Label:      "${PROP('Namespace')}",
+					Dimensions: map[string][]string{
+						"InstanceId": {"i-12345678"},
+					},
+					MetricQueryType:  MetricQueryTypeSearch,
+					MetricEditorMode: MetricEditorModeBuilder,
+				},
+				featureEnabled: true,
+				// decoded: label: ${PROP('Namespace')}
+				linkContainsSubstring: "label%22%3A%22%24%7BPROP%28%27Namespace%27%29%7D%22%7D%5D%5D%7D",
+			},
 		}
 
-		deepLink, err := query.buildDeepLink(startTime, endTime)
-		require.NoError(t, err)
-		assert.Empty(t, deepLink)
+		for name, tc := range testCases {
+			t.Run(name, func(t *testing.T) {
+				startTime := time.Now()
+				endTime := startTime.Add(2 * time.Hour)
+
+				deepLink, err := tc.query.buildDeepLink(startTime, endTime, tc.featureEnabled)
+				require.NoError(t, err)
+
+				assert.Contains(t, deepLink, tc.linkContainsSubstring)
+			})
+		}
 	})
 
 	t.Run("SEARCH(someexpression) was specified in the query editor", func(t *testing.T) {

--- a/pkg/tsdb/cloudwatch/response_parser.go
+++ b/pkg/tsdb/cloudwatch/response_parser.go
@@ -118,7 +118,7 @@ func buildDataFrames(startTime time.Time, endTime time.Time, aggregatedResponse 
 	for _, metric := range aggregatedResponse.Metrics {
 		label := *metric.Label
 
-		deepLink, err := query.buildDeepLink(startTime, endTime)
+		deepLink, err := query.buildDeepLink(startTime, endTime, dynamicLabelEnabled)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/tsdb/cloudwatch/types.go
+++ b/pkg/tsdb/cloudwatch/types.go
@@ -25,13 +25,13 @@ type cloudWatchLink struct {
 
 type metricExpression struct {
 	Expression string `json:"expression"`
-	Label      string `json:"label"`
+	Label      string `json:"label,omitempty"`
 }
 
 type metricStatMeta struct {
 	Stat   string `json:"stat"`
 	Period int    `json:"period"`
-	Label  string `json:"label"`
+	Label  string `json:"label,omitempty"`
 }
 
 type metricQueryType uint32

--- a/pkg/tsdb/cloudwatch/types.go
+++ b/pkg/tsdb/cloudwatch/types.go
@@ -25,11 +25,13 @@ type cloudWatchLink struct {
 
 type metricExpression struct {
 	Expression string `json:"expression"`
+	Label      string `json:"label"`
 }
 
 type metricStatMeta struct {
 	Stat   string `json:"stat"`
 	Period int    `json:"period"`
+	Label  string `json:"label"`
 }
 
 type metricQueryType uint32


### PR DESCRIPTION

**What this PR does / why we need it**:

In case the dynamic label feature is enabled and the label field is set, it should be included in the deep link from Grafana to the CloudWatch console.

**Which issue(s) this PR fixes**:

Fixes #49158
Part of https://github.com/grafana/grafana/issues/48434
