### PR TITLE
CloudWatch: Enable support for dynamic labels with migrated alias patterns

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1165,7 +1165,7 @@ explore2Dashboard = true
 commandPalette = true
 
 # Use dynamic labels in CloudWatch datasource
-cloudWatchDynamicLabels = false
+cloudWatchDynamicLabels = true
 
 # New expandable navigation
 newNavigation = true


### PR DESCRIPTION
**What this PR does / why we need it**:
Support for [CloudWatch dynamic labels](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/graph-dynamic-labels.html), including the migration of legacy [alias patterns](https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/#alias), has been added in several different PRs described in [this](https://github.com/grafana/grafana/issues/48434) issue. So far, this feature has been hidden behind a feature flag called `cloudWatchDynamicLabels`. This PR enables this feature by default.  

For details on why we're doing this change, how it's implemented and all the different steps required for support this, refer to [this](https://github.com/grafana/grafana/issues/48434) issue.  

**Which issue(s) this PR fixes**:

Fixes #48513 

**Special notes for your reviewer**:
There's another [PR](https://github.com/grafana/deployment_tools/pull/31618) in the deployment_tools repo for enabling this feature by default in Grafana Cloud. 

# Release notice breaking change
* According to the dynamic labels documentation, you can use up to five dynamic values per label. There’s currently no such restriction in the alias pattern system, so if more than 5 patterns are being used the GetMetricData API will return an error. 
* Dynamic labels only allow ${LABEL} to be used once per query. There’s no such restriction in the alias pattern system, so in case more than 1 is being used the GetMetricData API will return an error. 
* When no alias is provided by the user, Grafana will no longer fallback with custom rules for naming the legend. 
* In case a search expression is being used and no data is returned, Grafana will no longer expand dimension values, for instance when using a multi-valued template variable or star wildcard `*` in the dimension value field. Ref https://github.com/grafana/grafana/issues/20729
* Time series might be displayed in a different order. Using for example the dynamic label `${PROP('MetricName')}`, might have the consequence that the time series are returned in a different order compared to when the alias pattern `{{metric}}` is used


