### PR TITLE
backend/sqlstore: move GetDashboards to Dashboard Service

### DIFF
--- a/pkg/api/playlist_play.go
+++ b/pkg/api/playlist_play.go
@@ -16,7 +16,7 @@ func (hs *HTTPServer) populateDashboardsByID(ctx context.Context, dashboardByIDs
 
 	if len(dashboardByIDs) > 0 {
 		dashboardQuery := models.GetDashboardsQuery{DashboardIds: dashboardByIDs}
-		if err := hs.SQLStore.GetDashboards(ctx, &dashboardQuery); err != nil {
+		if err := hs.dashboardService.GetDashboards(ctx, &dashboardQuery); err != nil {
 			return result, err
 		}
 

--- a/pkg/services/dashboards/dashboard.go
+++ b/pkg/services/dashboards/dashboard.go
@@ -18,6 +18,7 @@ type DashboardService interface {
 	BuildSaveDashboardCommand(ctx context.Context, dto *SaveDashboardDTO, shouldValidateAlerts bool, validateProvisionedDashboard bool) (*models.SaveDashboardCommand, error)
 	DeleteDashboard(ctx context.Context, dashboardId int64, orgId int64) error
 	GetDashboard(ctx context.Context, query *models.GetDashboardQuery) error
+	GetDashboards(ctx context.Context, query *models.GetDashboardsQuery) error
 	GetDashboardUIDById(ctx context.Context, query *models.GetDashboardRefByIdQuery) error
 	GetPublicDashboardConfig(ctx context.Context, orgId int64, dashboardUid string) (*models.PublicDashboardConfig, error)
 	ImportDashboard(ctx context.Context, dto *SaveDashboardDTO) (*models.Dashboard, error)
@@ -45,13 +46,14 @@ type DashboardProvisioningService interface {
 	UnprovisionDashboard(ctx context.Context, dashboardID int64) error
 }
 
-//go:generate mockery --name Store --structname FakeDashboardStore --inpackage --filename database_mock.go
+//go:generate mockery --name Store --structname FakeDashboardStore --inpackage --filename store_mock.go
 // Store is a dashboard store.
 type Store interface {
 	DeleteDashboard(ctx context.Context, cmd *models.DeleteDashboardCommand) error
 	DeleteOrphanedProvisionedDashboards(ctx context.Context, cmd *models.DeleteOrphanedProvisionedDashboardsCommand) error
 	GetDashboard(ctx context.Context, query *models.GetDashboardQuery) error
 	GetDashboardUIDById(ctx context.Context, query *models.GetDashboardRefByIdQuery) error
+	GetDashboards(ctx context.Context, query *models.GetDashboardsQuery) error
 	// GetDashboardsByPluginID retrieves dashboards identified by plugin.
 	GetDashboardsByPluginID(ctx context.Context, query *models.GetDashboardsByPluginIdQuery) error
 	GetProvisionedDashboardData(name string) ([]*models.DashboardProvisioning, error)

--- a/pkg/services/dashboards/dashboard_service_mock.go
+++ b/pkg/services/dashboards/dashboard_service_mock.go
@@ -73,3 +73,7 @@ func (s *FakeDashboardService) GetDashboard(ctx context.Context, cmd *models.Get
 func (s *FakeDashboardService) GetDashboardUIDById(ctx context.Context, query *models.GetDashboardRefByIdQuery) error {
 	return nil
 }
+
+func (s *FakeDashboardService) GetDashboards(ctx context.Context, query *models.GetDashboardsQuery) error {
+	return nil
+}

--- a/pkg/services/dashboards/database/database_provisioning_test.go
+++ b/pkg/services/dashboards/database/database_provisioning_test.go
@@ -78,7 +78,7 @@ func TestDashboardProvisioningTest(t *testing.T) {
 			require.Nil(t, err)
 
 			query := &models.GetDashboardsQuery{DashboardIds: []int64{anotherDash.Id}}
-			err = sqlStore.GetDashboards(context.Background(), query)
+			err = dashboardStore.GetDashboards(context.Background(), query)
 			require.Nil(t, err)
 			require.NotNil(t, query.Result)
 
@@ -86,7 +86,7 @@ func TestDashboardProvisioningTest(t *testing.T) {
 			require.Nil(t, dashboardStore.DeleteOrphanedProvisionedDashboards(context.Background(), deleteCmd))
 
 			query = &models.GetDashboardsQuery{DashboardIds: []int64{dash.Id, anotherDash.Id}}
-			err = sqlStore.GetDashboards(context.Background(), query)
+			err = dashboardStore.GetDashboards(context.Background(), query)
 			require.Nil(t, err)
 
 			require.Equal(t, 1, len(query.Result))

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -127,6 +127,19 @@ func TestDashboardDataAccess(t *testing.T) {
 		require.Equal(t, err, models.ErrDashboardIdentifierNotSet)
 	})
 
+	t.Run("Should be able to get dashboards by IDs & UIDs", func(t *testing.T) {
+		setup()
+		query := models.GetDashboardsQuery{DashboardIds: []int64{savedDash.Id, savedDash2.Id}}
+		err := dashboardStore.GetDashboards(context.Background(), &query)
+		require.NoError(t, err)
+		assert.Equal(t, len(query.Result), 2)
+
+		query = models.GetDashboardsQuery{DashboardUIds: []string{savedDash.Uid, savedDash2.Uid}}
+		err = dashboardStore.GetDashboards(context.Background(), &query)
+		require.NoError(t, err)
+		assert.Equal(t, len(query.Result), 2)
+	})
+
 	t.Run("Should be able to delete dashboard", func(t *testing.T) {
 		setup()
 		dash := insertTestDashboard(t, dashboardStore, "delete me", 1, 0, false, "delete this")

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -518,3 +518,7 @@ func (dr *DashboardServiceImpl) GetDashboard(ctx context.Context, query *models.
 func (dr *DashboardServiceImpl) GetDashboardUIDById(ctx context.Context, query *models.GetDashboardRefByIdQuery) error {
 	return dr.dashboardStore.GetDashboardUIDById(ctx, query)
 }
+
+func (dr *DashboardServiceImpl) GetDashboards(ctx context.Context, query *models.GetDashboardsQuery) error {
+	return dr.dashboardStore.GetDashboards(ctx, query)
+}

--- a/pkg/services/dashboards/store_mock.go
+++ b/pkg/services/dashboards/store_mock.go
@@ -72,6 +72,20 @@ func (_m *FakeDashboardStore) GetDashboardUIDById(ctx context.Context, query *mo
 	return r0
 }
 
+// GetDashboards provides a mock function with given fields: ctx, query
+func (_m *FakeDashboardStore) GetDashboards(ctx context.Context, query *models.GetDashboardsQuery) error {
+	ret := _m.Called(ctx, query)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *models.GetDashboardsQuery) error); ok {
+		r0 = rf(ctx, query)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetDashboardsByPluginID provides a mock function with given fields: ctx, query
 func (_m *FakeDashboardStore) GetDashboardsByPluginID(ctx context.Context, query *models.GetDashboardsByPluginIdQuery) error {
 	ret := _m.Called(ctx, query)

--- a/pkg/services/sqlstore/dashboard.go
+++ b/pkg/services/sqlstore/dashboard.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"xorm.io/xorm"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/grafana/pkg/models"
@@ -197,26 +195,6 @@ func (ss *SQLStore) GetDashboardTags(ctx context.Context, query *models.GetDashb
 		query.Result = make([]*models.DashboardTagCloudItem, 0)
 		sess := dbSession.SQL(sql, query.OrgId)
 		err := sess.Find(&query.Result)
-		return err
-	})
-}
-
-func (ss *SQLStore) GetDashboards(ctx context.Context, query *models.GetDashboardsQuery) error {
-	return ss.WithDbSession(ctx, func(dbSession *DBSession) error {
-		if len(query.DashboardIds) == 0 && len(query.DashboardUIds) == 0 {
-			return models.ErrCommandValidationFailed
-		}
-
-		var dashboards = make([]*models.Dashboard, 0)
-		var session *xorm.Session
-		if len(query.DashboardIds) > 0 {
-			session = dbSession.In("id", query.DashboardIds)
-		} else {
-			session = dbSession.In("uid", query.DashboardUIds)
-		}
-
-		err := session.Find(&dashboards)
-		query.Result = dashboards
 		return err
 	})
 }

--- a/pkg/services/sqlstore/store.go
+++ b/pkg/services/sqlstore/store.go
@@ -98,7 +98,6 @@ type Store interface {
 	RemoveOrgUser(ctx context.Context, cmd *models.RemoveOrgUserCommand) error
 	GetDashboardTags(ctx context.Context, query *models.GetDashboardTagsQuery) error
 	SearchDashboards(ctx context.Context, query *models.FindPersistedDashboardsQuery) error
-	GetDashboards(ctx context.Context, query *models.GetDashboardsQuery) error
 	GetDataSource(ctx context.Context, query *models.GetDataSourceQuery) error
 	GetDataSources(ctx context.Context, query *models.GetDataSourcesQuery) error
 	GetDataSourcesByType(ctx context.Context, query *models.GetDataSourcesByTypeQuery) error


### PR DESCRIPTION
I also did some mild file renaming to try and get the dashboards package closer in line with the sqlstore split design doc.

Note that this PR is currently targeting another branch and will be updated to target main when #49170 is merged.