### PR TITLE
Login: Fix mismatching label on auth_module in user list

### DIFF
--- a/pkg/services/login/authinfoservice/database/database.go
+++ b/pkg/services/login/authinfoservice/database/database.go
@@ -146,6 +146,17 @@ func (s *AuthInfoStore) SetAuthInfo(ctx context.Context, cmd *models.SetAuthInfo
 	})
 }
 
+// UpdateAuthInfo updates the auth info for the user with the latest date. Avoids overlapping entries hiding
+// the last used one (ex: LDAP->SAML->LDAP)
+func (s *AuthInfoStore) UpdateAuthInfoDate(ctx context.Context, authInfo *models.UserAuth) error {
+	authInfo.Created = GetTime()
+
+	return s.sqlStore.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		_, err := sess.Update(authInfo)
+		return err
+	})
+}
+
 func (s *AuthInfoStore) UpdateAuthInfo(ctx context.Context, cmd *models.UpdateAuthInfoCommand) error {
 	authUser := &models.UserAuth{
 		UserId:     cmd.UserId,

--- a/pkg/services/login/authinfoservice/database/database.go
+++ b/pkg/services/login/authinfoservice/database/database.go
@@ -151,8 +151,13 @@ func (s *AuthInfoStore) SetAuthInfo(ctx context.Context, cmd *models.SetAuthInfo
 func (s *AuthInfoStore) UpdateAuthInfoDate(ctx context.Context, authInfo *models.UserAuth) error {
 	authInfo.Created = GetTime()
 
+	cond := &models.UserAuth{
+		Id:         authInfo.Id,
+		UserId:     authInfo.UserId,
+		AuthModule: authInfo.AuthModule,
+	}
 	return s.sqlStore.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		_, err := sess.Update(authInfo)
+		_, err := sess.Update(authInfo, cond)
 		return err
 	})
 }

--- a/pkg/services/login/authinfoservice/service.go
+++ b/pkg/services/login/authinfoservice/service.go
@@ -158,14 +158,20 @@ func (s *Implementation) LookupAndUpdate(ctx context.Context, query *models.GetU
 		authInfo = ai
 	}
 
-	if authInfo == nil && query.AuthModule != "" {
-		cmd := &models.SetAuthInfoCommand{
-			UserId:     user.Id,
-			AuthModule: query.AuthModule,
-			AuthId:     query.AuthId,
-		}
-		if err := s.authInfoStore.SetAuthInfo(ctx, cmd); err != nil {
-			return nil, err
+	if query.AuthModule != "" {
+		if authInfo == nil {
+			cmd := &models.SetAuthInfoCommand{
+				UserId:     user.Id,
+				AuthModule: query.AuthModule,
+				AuthId:     query.AuthId,
+			}
+			if err := s.authInfoStore.SetAuthInfo(ctx, cmd); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := s.authInfoStore.UpdateAuthInfoDate(ctx, authInfo); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/services/login/authinfoservice/user_auth_test.go
+++ b/pkg/services/login/authinfoservice/user_auth_test.go
@@ -265,17 +265,22 @@ func TestUserAuth(t *testing.T) {
 			require.Nil(t, err)
 			require.Equal(t, user.Login, login)
 
+			// Get the latest entry by not supply an authmodule or authid
+			getAuthQuery := &models.GetAuthInfoQuery{
+				UserId: user.Id,
+			}
+
+			err = authInfoStore.GetAuthInfo(context.Background(), getAuthQuery)
+
+			require.Nil(t, err)
+			require.Equal(t, getAuthQuery.Result.AuthModule, "test2")
+
 			// Now reuse first auth module and make sure it's updated to the most recent
 			database.GetTime = time.Now
 			user, err = srv.LookupAndUpdate(context.Background(), queryOne)
 
 			require.Nil(t, err)
 			require.Equal(t, user.Login, login)
-
-			// Get the latest entry by not supply an authmodule or authid
-			getAuthQuery := &models.GetAuthInfoQuery{
-				UserId: user.Id,
-			}
 
 			err = authInfoStore.GetAuthInfo(context.Background(), getAuthQuery)
 

--- a/pkg/services/login/authinfoservice/user_auth_test.go
+++ b/pkg/services/login/authinfoservice/user_auth_test.go
@@ -277,7 +277,7 @@ func TestUserAuth(t *testing.T) {
 			require.Equal(t, "test2", getAuthQuery.Result.AuthModule)
 
 			// Now reuse first auth module and make sure it's updated to the most recent
-			database.GetTime = func() time.Time { return fixedTime.AddDate(0, 0, 0) }
+			database.GetTime = func() time.Time { return fixedTime }
 			user, err = srv.LookupAndUpdate(context.Background(), queryOne)
 
 			require.Nil(t, err)

--- a/pkg/services/login/userprotection.go
+++ b/pkg/services/login/userprotection.go
@@ -15,6 +15,7 @@ type Store interface {
 	GetAuthInfo(ctx context.Context, query *models.GetAuthInfoQuery) error
 	SetAuthInfo(ctx context.Context, cmd *models.SetAuthInfoCommand) error
 	UpdateAuthInfo(ctx context.Context, cmd *models.UpdateAuthInfoCommand) error
+	UpdateAuthInfoDate(ctx context.Context, authInfo *models.UserAuth) error
 	DeleteAuthInfo(ctx context.Context, cmd *models.DeleteAuthInfoCommand) error
 	GetUserById(ctx context.Context, id int64) (*models.User, error)
 	GetUserByLogin(ctx context.Context, login string) (*models.User, error)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- Changing between auth_modules with the same user caused the user display to display wrong information

![image](https://user-images.githubusercontent.com/8071073/169074680-20712f8f-1fb1-4bbd-bfa6-3756a85f06b3.png)

For example going from LDAP to SAML and back to LDAP would display the auth_module as SAML instead of LDAP.

This issue did not happen with oauth since it already had an update method that updated the `created` date.

This patch makes it so every auth_module login updates its auth info entry ensuring the latest is always selected. This causes all auth_modules to treat "Created" as a "Last Seen" column, which was already the case for oauth. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-enterprise/issues/3321 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->



**Other solutions considered**:

The most correct would be to only update user_auth (auth_info) when the auth_module changes, this would mean querying the DB for the latest auth info and then updating/creating the new auth info if it mismatches. 
There should be no functional implication in always updating the date 
