### PR TITLE
Heatmap: add feature toggle to automatically switch to new plugin.

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -60,4 +60,5 @@ export interface FeatureToggles {
   azureMonitorExperimentalUI?: boolean;
   traceToMetrics?: boolean;
   prometheusStreamingJSONParser?: boolean;
+  useNewHeatmapPanel?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -248,5 +248,11 @@ var (
 			Description: "Enable streaming JSON parser for Prometheus datasource",
 			State:       FeatureStateAlpha,
 		},
+		{
+			Name:            "useNewHeatmapPanel",
+			Description:     "Swaps the current (angular) heatmap for a new react one.  This aims to be builtin for 9.0",
+			State:           FeatureStateAlpha,
+			RequiresDevMode: true, // Still dev mode until we are confident with the saved options and migrations
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -182,4 +182,8 @@ const (
 	// FlagPrometheusStreamingJSONParser
 	// Enable streaming JSON parser for Prometheus datasource
 	FlagPrometheusStreamingJSONParser = "prometheusStreamingJSONParser"
+
+	// FlagUseNewHeatmapPanel
+	// Swaps the current (angular) heatmap for a new react one.  This aims to be builtin for 9.0
+	FlagUseNewHeatmapPanel = "useNewHeatmapPanel"
 )

--- a/public/app/features/plugins/built_in_plugins.ts
+++ b/public/app/features/plugins/built_in_plugins.ts
@@ -112,7 +112,7 @@ const builtInPlugins: any = {
   'app/plugins/panel/dashlist/module': dashListPanel,
   'app/plugins/panel/alertlist/module': alertListPanel,
   'app/plugins/panel/annolist/module': annoListPanel,
-  'app/plugins/panel/heatmap/module': heatmapPanel,
+  'app/plugins/panel/heatmap/module': true ? heatmapPanelNG : heatmapPanel,
   'app/plugins/panel/heatmap-new/module': heatmapPanelNG,
   'app/plugins/panel/table/module': tablePanel,
   'app/plugins/panel/table-old/module': tableOldPanel,

--- a/public/app/features/plugins/built_in_plugins.ts
+++ b/public/app/features/plugins/built_in_plugins.ts
@@ -40,6 +40,7 @@ const tempoPlugin = async () =>
 const alertmanagerPlugin = async () =>
   await import(/* webpackChunkName: "alertmanagerPlugin" */ 'app/plugins/datasource/alertmanager/module');
 
+import { config } from '@grafana/runtime';
 import * as alertGroupsPanel from 'app/plugins/panel/alertGroups/module';
 import * as alertListPanel from 'app/plugins/panel/alertlist/module';
 import * as annoListPanel from 'app/plugins/panel/annolist/module';
@@ -112,7 +113,7 @@ const builtInPlugins: any = {
   'app/plugins/panel/dashlist/module': dashListPanel,
   'app/plugins/panel/alertlist/module': alertListPanel,
   'app/plugins/panel/annolist/module': annoListPanel,
-  'app/plugins/panel/heatmap/module': true ? heatmapPanelNG : heatmapPanel,
+  'app/plugins/panel/heatmap/module': config.featureToggles.useNewHeatmapPanel ? heatmapPanelNG : heatmapPanel,
   'app/plugins/panel/heatmap-new/module': heatmapPanelNG,
   'app/plugins/panel/table/module': tablePanel,
   'app/plugins/panel/table-old/module': tableOldPanel,


### PR DESCRIPTION
I'm not sure if this is too much magic... but it seems to work :) 🪄 🧙 

This feature toggle will let us swap the some cloud instances to the new panel before simply replacing the heatmap panel in main.

We do not want to maintain both old+new heatmaps in v9 -- but also need a bit more validation and testing before we make the hard switch.