### PR TITLE
CloudWatch: migrate old variable queries with empty array

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.test.ts
@@ -35,16 +35,11 @@ describe('variableQueryMigrations', () => {
           expect(query.dimensionFilters).toStrictEqual({});
         });
       });
-      describe('and filter param is empty array', () => {
+      describe('and filter value is an empty array', () => {
         it('should leave an empty filter', () => {
           const query = migrateVariableQuery(
             'dimension_values(us-east-1,AWS/RDS,CPUUtilization,DBInstanceIdentifier, [])'
           );
-          expect(query.queryType).toBe(VariableQueryType.DimensionValues);
-          expect(query.region).toBe('us-east-1');
-          expect(query.namespace).toBe('AWS/RDS');
-          expect(query.metricName).toBe('CPUUtilization');
-          expect(query.dimensionKey).toBe('DBInstanceIdentifier');
           expect(query.dimensionFilters).toStrictEqual({});
         });
       });
@@ -75,9 +70,6 @@ describe('variableQueryMigrations', () => {
     });
     it('should parse a empty array for tags', () => {
       const query = migrateVariableQuery('resource_arns(eu-west-1,elasticloadbalancing:loadbalancer, [])');
-      expect(query.queryType).toBe(VariableQueryType.ResourceArns);
-      expect(query.region).toBe('eu-west-1');
-      expect(query.resourceType).toBe('elasticloadbalancing:loadbalancer');
       expect(query.tags).toStrictEqual({});
     });
   });
@@ -91,9 +83,6 @@ describe('variableQueryMigrations', () => {
     });
     it('should parse an empty array for filters', () => {
       const query = migrateVariableQuery('ec2_instance_attribute(us-east-1,rds:db,[])');
-      expect(query.queryType).toBe(VariableQueryType.EC2InstanceAttributes);
-      expect(query.region).toBe('us-east-1');
-      expect(query.attributeName).toBe('rds:db');
       expect(query.ec2Filters).toStrictEqual({});
     });
   });

--- a/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.test.ts
@@ -35,6 +35,19 @@ describe('variableQueryMigrations', () => {
           expect(query.dimensionFilters).toStrictEqual({});
         });
       });
+      describe('and filter param is empty array', () => {
+        it('should leave an empty filter', () => {
+          const query = migrateVariableQuery(
+            'dimension_values(us-east-1,AWS/RDS,CPUUtilization,DBInstanceIdentifier, [])'
+          );
+          expect(query.queryType).toBe(VariableQueryType.DimensionValues);
+          expect(query.region).toBe('us-east-1');
+          expect(query.namespace).toBe('AWS/RDS');
+          expect(query.metricName).toBe('CPUUtilization');
+          expect(query.dimensionKey).toBe('DBInstanceIdentifier');
+          expect(query.dimensionFilters).toStrictEqual({});
+        });
+      });
       describe('and filter param is defined by user', () => {
         it('should use the user defined filter', () => {
           const query = migrateVariableQuery(
@@ -60,6 +73,13 @@ describe('variableQueryMigrations', () => {
       expect(query.resourceType).toBe('elasticloadbalancing:loadbalancer');
       expect(query.tags).toStrictEqual({ 'elasticbeanstalk:environment-name': ['myApp-dev', 'myApp-prod'] });
     });
+    it('should parse a empty array for tags', () => {
+      const query = migrateVariableQuery('resource_arns(eu-west-1,elasticloadbalancing:loadbalancer, [])');
+      expect(query.queryType).toBe(VariableQueryType.ResourceArns);
+      expect(query.region).toBe('eu-west-1');
+      expect(query.resourceType).toBe('elasticloadbalancing:loadbalancer');
+      expect(query.tags).toStrictEqual({});
+    });
   });
   describe('when ec2_instance_attribute query is used', () => {
     it('should parse the query', () => {
@@ -68,6 +88,13 @@ describe('variableQueryMigrations', () => {
       expect(query.region).toBe('us-east-1');
       expect(query.attributeName).toBe('rds:db');
       expect(query.ec2Filters).toStrictEqual({ environment: ['$environment'] });
+    });
+    it('should parse an empty array for filters', () => {
+      const query = migrateVariableQuery('ec2_instance_attribute(us-east-1,rds:db,[])');
+      expect(query.queryType).toBe(VariableQueryType.EC2InstanceAttributes);
+      expect(query.region).toBe('us-east-1');
+      expect(query.attributeName).toBe('rds:db');
+      expect(query.ec2Filters).toStrictEqual({});
     });
   });
   describe('when OldVariableQuery is used', () => {

--- a/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.ts
@@ -18,21 +18,21 @@ export function migrateVariableQuery(rawQuery: string | VariableQuery | OldVaria
     newQuery.ec2Filters = {};
     newQuery.tags = {};
 
-    if (rawQuery.dimensionFilters !== '') {
+    if (rawQuery.dimensionFilters !== '' && rawQuery.ec2Filters !== '[]') {
       try {
         newQuery.dimensionFilters = JSON.parse(rawQuery.dimensionFilters);
       } catch {
         throw new Error(`unable to migrate poorly formed filters: ${rawQuery.dimensionFilters}`);
       }
     }
-    if (rawQuery.ec2Filters !== '') {
+    if (rawQuery.ec2Filters !== '' && rawQuery.ec2Filters !== '[]') {
       try {
         newQuery.ec2Filters = JSON.parse(rawQuery.ec2Filters);
       } catch {
         throw new Error(`unable to migrate poorly formed filters: ${rawQuery.ec2Filters}`);
       }
     }
-    if (rawQuery.tags !== '') {
+    if (rawQuery.tags !== '' && rawQuery.tags !== '[]') {
       try {
         newQuery.tags = JSON.parse(rawQuery.tags);
       } catch {
@@ -93,7 +93,7 @@ export function migrateVariableQuery(rawQuery: string | VariableQuery | OldVaria
     newQuery.metricName = dimensionValuesQuery[3];
     newQuery.dimensionKey = dimensionValuesQuery[4];
     newQuery.dimensionFilters = {};
-    if (!!dimensionValuesQuery[6]) {
+    if (!!dimensionValuesQuery[6] && dimensionValuesQuery[6] !== '[]') {
       try {
         newQuery.dimensionFilters = JSON.parse(dimensionValuesQuery[6]);
       } catch {
@@ -116,7 +116,7 @@ export function migrateVariableQuery(rawQuery: string | VariableQuery | OldVaria
     newQuery.queryType = VariableQueryType.EC2InstanceAttributes;
     newQuery.region = ec2InstanceAttributeQuery[1];
     newQuery.attributeName = ec2InstanceAttributeQuery[2];
-    if (ec2InstanceAttributeQuery[3]) {
+    if (ec2InstanceAttributeQuery[3] && ec2InstanceAttributeQuery[3] !== '[]') {
       try {
         newQuery.ec2Filters = JSON.parse(ec2InstanceAttributeQuery[3]);
       } catch {
@@ -131,7 +131,7 @@ export function migrateVariableQuery(rawQuery: string | VariableQuery | OldVaria
     newQuery.queryType = VariableQueryType.ResourceArns;
     newQuery.region = resourceARNsQuery[1];
     newQuery.resourceType = resourceARNsQuery[2];
-    if (resourceARNsQuery[3]) {
+    if (resourceARNsQuery[3] && resourceARNsQuery[3] !== '[]') {
       try {
         newQuery.tags = JSON.parse(resourceARNsQuery[3]);
       } catch {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The text variable queries  in versions < 8.5 supported passing in `[]` for no tags, so this pr adds those to the migration.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #49181

**Special notes for your reviewer**:

