### PR TITLE
loki: do not use backend-mode when keepCookies is used

### DIFF
--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -57,6 +57,7 @@ export interface LokiOptions extends DataSourceJsonData {
   maxLines?: string;
   derivedFields?: DerivedFieldConfig[];
   alertmanager?: string;
+  keepCookies?: string[];
 }
 
 export interface LokiStats {


### PR DESCRIPTION
currently the grafana-backend-datasource api makes it impossible to implement the "allowed cookies" functionality. to be able to move forward with loki-backend-migration, we add a (hopefully temporary) check: if the user uses the allowed-cookies-functionality, do not use backend-mode.

how to test:
- make sure you have the `lokiBackendMode` feature flag enabled.
- make sure the loki datasource does not use the "allowed cookies' funcionality ( <img width="547" alt="img" src="https://user-images.githubusercontent.com/51989/169266045-23265ba2-adc8-4803-b818-0cd1e48902f1.png">
 )
- go to explore-mode
- open the browser-devtools, we will look at ajax-requests
- run a loki query
- make sure it does it in backend-mode: check the ajax-query, it should go to `/api/ds/query`
- now go to the datasource-config, add values to the allowed-cookies section, [save&test]
- go to explore-mode
- run a loki query
- make sure it does it in frontend-mode: check the ajax-query, it should go to `/api/datasources/proxy/...`
