### PR TITLE
CI: Add s3fs to grafana-ci-deploy docker image

### DIFF
--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -15,25 +15,24 @@ RUN curl -fLO https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.t
 
 RUN git clone https://github.com/aptly-dev/aptly $GOPATH/src/github.com/aptly-dev/aptly
 RUN cd $GOPATH/src/github.com/aptly-dev/aptly && \
-    # pin aptly to a specific commit after 1.3.0 that contains gpg2 support
-    git reset --hard a64807efdaf5e380bfa878c71bc88eae10d62be1 && \
     make install
 
 FROM debian:testing-20210111-slim
 
 # Use ARG so as not to persist environment variable in image
 ARG DEBIAN_FRONTEND=noninteractive \
-  GOOGLE_SDK_VERSION=325.0.0 \
-  GOOGLE_SDK_CHECKSUM=374f960c9f384f88b6fc190b268ceac5dcad777301390107af63782bfb5ecbc7
+  GOOGLE_SDK_VERSION=385.0.0 \
+  GOOGLE_SDK_CHECKSUM=cd1839e9343e32f64645f2d3c269340a9c50d0c77d85c9a0a44cd9de2103879e
 
+# Pin pip3 to version 20.0.2 to address https://github.com/pypa/pip/issues/11070
 # Need procps for pkill utility, which is used by the build pipeline tool to restart the GPG agent
-RUN apt update && apt install -yq curl python3-pip procps && pip3 install -U awscli crcmod && \
+RUN apt update && apt install -yq curl python3-pip procps && pip3 install -U pip==20.0.2 && pip3 install -U awscli crcmod && \
     curl -fLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
     echo "${GOOGLE_SDK_CHECKSUM} google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz" | sha256sum --check --status && \
     tar xzf google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz -C /opt && \
     rm google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
     apt update && \
-    apt install -y createrepo-c expect && \
+    apt install -y createrepo-c expect s3fs && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     ln -s /opt/google-cloud-sdk/bin/gsutil /usr/bin/gsutil && \

--- a/scripts/build/ci-deploy/build-deploy.sh
+++ b/scripts/build/ci-deploy/build-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-_version="1.3.1"
+_version="1.3.2"
 _tag="grafana/grafana-ci-deploy:${_version}"
 
 docker build -t $_tag .


### PR DESCRIPTION
Add `s3fs` to `grafana-ci-deploy` docker image for further usage for publishing packages.

As a side effect, upgrade `aptly` and `google-cloud-sdk` to the actual versions.