### PR TITLE
elastic: config: hide access-mode selector when not needed

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { Alert, DataSourceHttpSettings } from '@grafana/ui';
@@ -15,6 +15,12 @@ import { coerceOptions, isValidOptions } from './utils';
 export type Props = DataSourcePluginOptionsEditorProps<ElasticsearchOptions>;
 
 export const ConfigEditor = (props: Props) => {
+  // we decide on whether to show access options or not at the point when the config page opens.
+  // whatever happens while the page is open, this decision does not change.
+  // (we do this to avoid situations where you switch access-mode and suddenly
+  // the access-mode-select-box vanishes)
+  const showAccessOptions = useRef(props.options.access === 'direct');
+
   const { options: originalOptions, onOptionsChange } = props;
   const options = coerceOptions(originalOptions);
 
@@ -45,7 +51,7 @@ export const ConfigEditor = (props: Props) => {
       <DataSourceHttpSettings
         defaultUrl="http://localhost:9200"
         dataSourceConfig={options}
-        showAccessOptions
+        showAccessOptions={showAccessOptions.current}
         onChange={onOptionsChange}
         sigV4AuthToggleEnabled={config.sigV4AuthEnabled}
       />


### PR DESCRIPTION
in the Elasticsearch datasource, the user can switch the access mode between `browser` and `server`.
`browser` does not work anymore.

we want to allow the user to switch from `browser` to `server`, so we need to show the select-box for this.

but, if the user has been on the `server` setting, there is no need to show the select-box anymore.

this pull request does just that.

normally we would simply put an `IF` around the select-box, like `if mode === browser`, but that would do strange things, like:
- let's say the user has `browser` selected
- the user switches to `server`
- suddenly the whole select-box vanishes

for this reason, we calculate the should-we-show-the-select-box boolean value when the config-page opens, and stay with the decision while the page is open. 

how to test:
1. have an elastic datasource that has the mode `server` already selected
2. go to the datasource config page
3. make sure the access-mode selection is not shown
4. make sure the page work: change some value and [save&test] it, then reload the page and verify the changes were persisted
5. now you need an elastic datasource that has the mode `browser` already selected
    - this can be hard to do with this PR, so i recommend:
        - change this line https://github.com/grafana/grafana/blob/gabor/elastic-hide-access/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.tsx#L54 , replace it with `showAccessOptions={true}`
        - create an elastic datasource or modify an existing one so that it has `browser` mode selected, save it
        - now revert the code-change
6. go to the datasource config page
7. verify that you see the access-mode selector
8. verify you can change the value
9. change the value to `server`
10. press [save&test] button, verify that you still see the access-mode selector
11. go back to the list-of-datasources page
12. open the datsource-config page again
13. verify you do not see the access-mode-selector anymore