### PR TITLE
Rename built-in roles to basic roles in the role picker

### DIFF
--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -188,7 +188,7 @@ export const RolePickerMenu = ({
         <CustomScrollbar autoHide={false} autoHeightMax={`${MENU_MAX_HEIGHT}px`} hideHorizontalTrack hideVerticalTrack>
           {showBuiltInRole && (
             <div className={customStyles.menuSection}>
-              <div className={customStyles.groupHeader}>Built-in roles</div>
+              <div className={customStyles.groupHeader}>Basic roles</div>
               <RadioButtonGroup
                 className={customStyles.builtInRoleSelector}
                 options={BuiltinRoleOption}


### PR DESCRIPTION
**What this PR does / why we need it**:

We are calling Admin, Editor and Viewer "Basic roles" now, this PR updates the header in the role picker. 
