### PR TITLE
AccessControl: Use `RBACBuiltInRoleAssignmentEnabled` in the frontend instead of FeatureToggle

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -163,6 +163,7 @@ export interface GrafanaConfig {
   verifyEmailEnabled: boolean;
   oauth: OAuthSettings;
   rbacEnabled: boolean;
+  rbacBuiltInRoleAssignmentEnabled: boolean;
   disableUserSignUp: boolean;
   loginHint: string;
   passwordHint: string;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -58,6 +58,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   verifyEmailEnabled = false;
   oauth: OAuthSettings = {};
   rbacEnabled = true;
+  rbacBuiltInRoleAssignmentEnabled = true;
   disableUserSignUp = false;
   loginHint = '';
   passwordHint = '';

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -58,7 +58,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   verifyEmailEnabled = false;
   oauth: OAuthSettings = {};
   rbacEnabled = true;
-  rbacBuiltInRoleAssignmentEnabled = true;
+  rbacBuiltInRoleAssignmentEnabled = false;
   disableUserSignUp = false;
   loginHint = '';
   passwordHint = '';

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -106,6 +106,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"verifyEmailEnabled":                  setting.VerifyEmailEnabled,
 		"sigV4AuthEnabled":                    setting.SigV4AuthEnabled,
 		"rbacEnabled":                         hs.Cfg.RBACEnabled,
+		"rbacBuiltInRoleAssignmentEnabled":    hs.Cfg.RBACBuiltInRoleAssignmentEnabled,
 		"exploreEnabled":                      setting.ExploreEnabled,
 		"helpEnabled":                         setting.HelpEnabled,
 		"profileEnabled":                      setting.ProfileEnabled,

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -112,7 +112,7 @@ export class ContextSrv {
     return config.rbacEnabled;
   }
 
-  accessControlBuiltinRefactorEnabled(): boolean {
+  accessControlBuiltInRoleAssignmentEnabled(): boolean {
     return config.rbacBuiltInRoleAssignmentEnabled;
   }
 

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -113,7 +113,7 @@ export class ContextSrv {
   }
 
   accessControlBuiltinRefactorEnabled(): boolean {
-    return Boolean(config.featureToggles['accesscontrol-builtins']);
+    return config.rbacBuiltInRoleAssignmentEnabled;
   }
 
   licensedAccessControlEnabled(): boolean {

--- a/public/app/features/serviceaccounts/state/actions.ts
+++ b/public/app/features/serviceaccounts/state/actions.ts
@@ -32,7 +32,7 @@ export function fetchACOptions(): ThunkResult<void> {
         dispatch(acOptionsLoaded(options));
       }
       if (
-        !contextSrv.accessControlBuiltinRefactorEnabled() &&
+        contextSrv.accessControlBuiltInRoleAssignmentEnabled() &&
         contextSrv.licensedAccessControlEnabled() &&
         contextSrv.hasPermission(AccessControlAction.ActionBuiltinRolesList)
       ) {

--- a/public/app/features/users/UsersTable.tsx
+++ b/public/app/features/users/UsersTable.tsx
@@ -31,7 +31,7 @@ const UsersTable: FC<Props> = (props) => {
         }
 
         if (
-          !contextSrv.accessControlBuiltinRefactorEnabled() &&
+          contextSrv.accessControlBuiltInRoleAssignmentEnabled() &&
           contextSrv.hasPermission(AccessControlAction.ActionBuiltinRolesList)
         ) {
           const builtInRoles = await fetchBuiltinRoles(orgId);


### PR DESCRIPTION
**What this PR does / why we need it**:

With the feature flag removal, we introduced a new config option to enable built-in role assignment. This PR contains the associated frontend changes. Otherwise the accesscontrol endpoints for listing built-in role assignments result in a 404.

![built-in-role-listing-failing](https://user-images.githubusercontent.com/5232696/169340871-b8a5a7dc-eb59-49c1-8c3f-1812d965ce83.gif)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

We will actually end up removing the listing of builtin role assignments from the role picker. This PR is a quick fix.