### PR TITLE
CloudWatch: migrate old variable queries with empty array (#49197)

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/migration.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/migration.test.ts
@@ -210,6 +210,16 @@ describe('migration', () => {
           expect(query.dimensionFilters).toBe('');
         });
       });
+
+      describe('and filter value is an empty array', () => {
+        it('should leave an empty filter', () => {
+          const query = migrateVariableQuery(
+            'dimension_values(us-east-1,AWS/RDS,CPUUtilization,DBInstanceIdentifier, [])'
+          );
+          expect(query.dimensionFilters).toBe('');
+        });
+      });
+
       describe('and filter param is defined by user', () => {
         it('should use the user defined filter', () => {
           const query = migrateVariableQuery(
@@ -223,14 +233,35 @@ describe('migration', () => {
           expect(query.dimensionFilters).toBe('{"InstanceId":"$instance_id"}');
         });
       });
-      describe('when resource_arns query is used', () => {
-        it('should parse the query', () => {
-          const query = migrateVariableQuery('resource_arns(us-east-1,rds:db,{"environment":["$environment"]})');
-          expect(query.queryType).toBe(VariableQueryType.ResourceArns);
-          expect(query.region).toBe('us-east-1');
-          expect(query.resourceType).toBe('rds:db');
-          expect(query.tags).toBe('{"environment":["$environment"]}');
-        });
+    });
+
+    describe('when resource_arns query is used', () => {
+      it('should parse the query', () => {
+        const query = migrateVariableQuery('resource_arns(us-east-1,rds:db,{"environment":["$environment"]})');
+        expect(query.queryType).toBe(VariableQueryType.ResourceArns);
+        expect(query.region).toBe('us-east-1');
+        expect(query.resourceType).toBe('rds:db');
+        expect(query.tags).toBe('{"environment":["$environment"]}');
+      });
+
+      it('should parse a empty array for tags', () => {
+        const query = migrateVariableQuery('resource_arns(us-east-1,rds:db, [])');
+        expect(query.tags).toBe('');
+      });
+    });
+
+    describe('when ec2_instance_attribute query is used', () => {
+      it('should parse the query', () => {
+        const query = migrateVariableQuery('ec2_instance_attribute(us-east-1,rds:db,{"environment":["$environment"]})');
+        expect(query.queryType).toBe(VariableQueryType.EC2InstanceAttributes);
+        expect(query.region).toBe('us-east-1');
+        expect(query.attributeName).toBe('rds:db');
+        expect(query.ec2Filters).toBe('{"environment":["$environment"]}');
+      });
+
+      it('should parse an empty array for filters', () => {
+        const query = migrateVariableQuery('ec2_instance_attribute(us-east-1,rds:db,[])');
+        expect(query.ec2Filters).toBe('');
       });
     });
   });

--- a/public/app/plugins/datasource/cloudwatch/migrations.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations.ts
@@ -124,6 +124,9 @@ export function migrateVariableQuery(rawQuery: string | VariableQuery): Variable
     newQuery.metricName = dimensionValuesQuery[3];
     newQuery.dimensionKey = dimensionValuesQuery[4];
     newQuery.dimensionFilters = dimensionValuesQuery[6] || '';
+    if (newQuery.dimensionFilters === '[]') {
+      newQuery.dimensionFilters = '';
+    }
     return newQuery;
   }
 
@@ -141,6 +144,9 @@ export function migrateVariableQuery(rawQuery: string | VariableQuery): Variable
     newQuery.region = ec2InstanceAttributeQuery[1];
     newQuery.attributeName = ec2InstanceAttributeQuery[2];
     newQuery.ec2Filters = ec2InstanceAttributeQuery[3] || '';
+    if (newQuery.ec2Filters === '[]') {
+      newQuery.ec2Filters = '';
+    }
     return newQuery;
   }
 
@@ -150,6 +156,9 @@ export function migrateVariableQuery(rawQuery: string | VariableQuery): Variable
     newQuery.region = resourceARNsQuery[1];
     newQuery.resourceType = resourceARNsQuery[2];
     newQuery.tags = resourceARNsQuery[3] || '';
+    if (newQuery.tags === '[]') {
+      newQuery.tags = '';
+    }
     return newQuery;
   }
 

--- a/public/app/plugins/datasource/cloudwatch/variables.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.test.ts
@@ -74,11 +74,24 @@ describe('variables', () => {
       expect(getDimensionValues).not.toBeCalled();
       expect(result).toEqual([]);
     });
+
     it('should run if values are set', async () => {
       const result = await variables.execute(query);
       expect(getDimensionValues).toBeCalledWith(query.region, query.namespace, query.metricName, query.dimensionKey, {
         a: 'b',
       });
+      expect(result).toEqual([{ text: 'e', value: 'e', expandable: true }]);
+    });
+
+    it('should replace empty array filters with empty object', async () => {
+      const result = await variables.execute({ ...query, dimensionFilters: '[]' });
+      expect(getDimensionValues).toBeCalledWith(
+        query.region,
+        query.namespace,
+        query.metricName,
+        query.dimensionKey,
+        {}
+      );
       expect(result).toEqual([{ text: 'e', value: 'e', expandable: true }]);
     });
   });
@@ -129,6 +142,12 @@ describe('variables', () => {
       expect(getEc2InstanceAttribute).toBeCalledWith(query.region, query.attributeName, { env: ['b'] });
       expect(result).toEqual([{ text: 'g', value: 'g', expandable: true }]);
     });
+
+    it('should replace empty array filters with empty object', async () => {
+      const result = await variables.execute({ ...query, ec2Filters: '[]' });
+      expect(getEc2InstanceAttribute).toBeCalledWith(query.region, query.attributeName, {});
+      expect(result).toEqual([{ text: 'g', value: 'g', expandable: true }]);
+    });
   });
 
   describe('resource arns', () => {
@@ -152,6 +171,12 @@ describe('variables', () => {
     it('should run if instance id set', async () => {
       const result = await variables.execute(query);
       expect(getResourceARNs).toBeCalledWith(query.region, query.resourceType, { a: ['InstanceId', 'InstanceType'] });
+      expect(result).toEqual([{ text: 'h', value: 'h', expandable: true }]);
+    });
+
+    it('should replace empty array tags with empty object', async () => {
+      const result = await variables.execute({ ...query, tags: '[]' });
+      expect(getResourceARNs).toBeCalledWith(query.region, query.resourceType, {});
       expect(result).toEqual([{ text: 'h', value: 'h', expandable: true }]);
     });
   });

--- a/public/app/plugins/datasource/cloudwatch/variables.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.ts
@@ -96,7 +96,7 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
       return [];
     }
     var filterJson = {};
-    if (dimensionFilters) {
+    if (dimensionFilters && dimensionFilters !== '[]') {
       filterJson = JSON.parse(dimensionFilters);
     }
     const keys = await this.datasource.getDimensionValues(region, namespace, metricName, dimensionKey, filterJson);
@@ -124,7 +124,7 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
       return [];
     }
     var filterJson = {};
-    if (ec2Filters) {
+    if (ec2Filters && ec2Filters !== '[]') {
       filterJson = JSON.parse(this.templateSrv.replace(ec2Filters));
     }
     const values = await this.datasource.getEc2InstanceAttribute(region, attributeName, filterJson);
@@ -140,7 +140,7 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
       return [];
     }
     var tagJson = {};
-    if (tags) {
+    if (tags && tags !== '[]') {
       tagJson = JSON.parse(this.templateSrv.replace(tags));
     }
     const keys = await this.datasource.getResourceARNs(region, resourceType, tagJson);


### PR DESCRIPTION
(cherry picked from commit 66220758b30ebbb9f0b9594defd7bba0273c7eaf)

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Allows `[]` to be passed as a filterJSON to variableQueries. Due to changes this is functionally a completely different commit that should be reviewed again

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #49197 

**Special notes for your reviewer**:

