### PR TITLE
Alerting: Reject provisioning of syntactically invalid templates

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
@@ -2,6 +2,7 @@ package definitions
 
 import (
 	"fmt"
+	"html/template"
 	"regexp"
 	"strings"
 
@@ -72,6 +73,11 @@ func (t *MessageTemplate) Validate() error {
 	}
 	if t.Template == "" {
 		return fmt.Errorf("template must have content")
+	}
+
+	_, err := template.New("").Parse(t.Template)
+	if err != nil {
+		return fmt.Errorf("invalid template: %w", err)
 	}
 
 	content := strings.TrimSpace(t.Template)

--- a/pkg/services/ngalert/provisioning/templates_test.go
+++ b/pkg/services/ngalert/provisioning/templates_test.go
@@ -228,6 +228,42 @@ func TestTemplateService(t *testing.T) {
 
 			require.Equal(t, tmpl.Template, result.Template)
 		})
+
+		t.Run("rejects syntactically invalid template", func(t *testing.T) {
+			sut := createTemplateServiceSut()
+			tmpl := definitions.MessageTemplate{
+				Name:     "name",
+				Template: "{{ .MyField }",
+			}
+			sut.config.(*MockAMConfigStore).EXPECT().
+				getsConfig(models.AlertConfiguration{
+					AlertmanagerConfiguration: defaultConfig,
+				})
+			sut.config.(*MockAMConfigStore).EXPECT().saveSucceeds()
+			sut.prov.(*MockProvisioningStore).EXPECT().saveSucceeds()
+
+			_, err := sut.SetTemplate(context.Background(), 1, tmpl)
+
+			require.ErrorIs(t, err, ErrValidation)
+		})
+
+		t.Run("does not reject template with unknown field", func(t *testing.T) {
+			sut := createTemplateServiceSut()
+			tmpl := definitions.MessageTemplate{
+				Name:     "name",
+				Template: "{{ .NotAField }}",
+			}
+			sut.config.(*MockAMConfigStore).EXPECT().
+				getsConfig(models.AlertConfiguration{
+					AlertmanagerConfiguration: defaultConfig,
+				})
+			sut.config.(*MockAMConfigStore).EXPECT().saveSucceeds()
+			sut.prov.(*MockProvisioningStore).EXPECT().saveSucceeds()
+
+			_, err := sut.SetTemplate(context.Background(), 1, tmpl)
+
+			require.NoError(t, err)
+		})
 	})
 
 	t.Run("deleting templates", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Reject invalid/malformed templates. Doesn't validate fields, just syntax.

**Which issue(s) this PR fixes**:

Rel https://github.com/grafana/grafana/issues/36153 

**Special notes for your reviewer**:

n/a