### PR TITLE
Canvas: Implement minimum element size + center constraint UX

### DIFF
--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -83,6 +83,9 @@ export class ElementState implements LayerElement {
 
     const style: React.CSSProperties = {
       position: 'absolute',
+      // Minimum element size is 10x10
+      minWidth: '10px',
+      minHeight: '10px',
     };
 
     const translate = ['0px', '0px'];

--- a/public/app/plugins/panel/canvas/editor/ConstraintSelectionBox.tsx
+++ b/public/app/plugins/panel/canvas/editor/ConstraintSelectionBox.tsx
@@ -50,6 +50,7 @@ export const ConstraintSelectionBox = ({
       height="75.000000pt"
       viewBox="0 0 228.000000 228.000000"
       preserveAspectRatio="xMidYMid meet"
+      style={{ marginBottom: '4.8px' }}
     >
       <g transform="translate(0.000000,228.000000) scale(0.100000,-0.100000)" fill="#000000" stroke="none">
         <path


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Implement a minimum element size (10x10) as a stop gap for #48231


https://user-images.githubusercontent.com/22381771/169444152-b31dede2-30d9-4ce8-bdb6-6c38474b8b7e.mov


Also center constraint UX which was slightly off center 😬 

Before
<img width="195" alt="Constraint before" src="https://user-images.githubusercontent.com/22381771/169444240-3b44e49f-153e-472b-856b-57f6d9da123b.png">

After
<img width="200" alt="Constraint After" src="https://user-images.githubusercontent.com/22381771/169444255-9a4dea9b-0c9f-4f2c-b5d7-b2fa3218bbd8.png">

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #49290
Fixes #49289

