### PR TITLE
Loki: Add back frontend-mode metadata queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1002,7 +1002,7 @@ describe('LokiDatasource', () => {
   describe('importing queries', () => {
     it('keeps all labels when no labels are loaded', async () => {
       const ds = createLokiDSForTests();
-      ds.getResource = () => Promise.resolve({ data: [] });
+      fetchMock.mockImplementation(() => of(createFetchResponse({ data: [] })));
       const queries = await ds.importFromAbstractQueries([
         {
           refId: 'A',
@@ -1017,9 +1017,7 @@ describe('LokiDatasource', () => {
 
     it('filters out non existing labels', async () => {
       const ds = createLokiDSForTests();
-      ds.getResource = () => {
-        return Promise.resolve({ data: ['foo'] });
-      };
+      fetchMock.mockImplementation(() => of(createFetchResponse({ data: ['foo'] })));
       const queries = await ds.importFromAbstractQueries([
         {
           refId: 'A',

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -464,8 +464,15 @@ export class LokiDatasource
     if (url.startsWith('/')) {
       throw new Error(`invalid metadata request url: ${url}`);
     }
-    const res = await this.getResource(url, params);
-    return res.data || [];
+
+    if (this.useBackendMode) {
+      const res = await this.getResource(url, params);
+      return res.data || [];
+    } else {
+      const lokiURL = `${LOKI_ENDPOINT}/${url}`;
+      const res = await lastValueFrom(this._request(lokiURL, params, { hideFromInspector: true }));
+      return res.data.data || [];
+    }
   }
 
   async metricFindQuery(query: string) {


### PR DESCRIPTION
currently, when running metadata queries in loki (get list of labels, get list of label-values etc.), those always run in backend-mode.

but, it seems maybe we will have to keep the frontend-mode-code available for longer, i made sure metadata-requests can run in frontend-mode too.

how to test:
1. make sure you have the `lokiBackendMode` feature flag disabled
2. open the browser-devtools
3. go to explore-mode, choose a loki datasource
4. open the log-browser
5. choose a label-name and a label value
6. click show logs
7. now look at the ajax-requests sent: mixed with the query-requests, there should be 3 ajax requests (ending with :`labels`, `values`, `series`),  and they should all have the form: `/api/datasources/proxy/...`
8. now enable the `lokiBackendMode` feature flag
9. repeat the test. the ajax requsts should all have the form: `/api/datasources/${number}/resources/...`