### PR TITLE
Transforms: Labels to fields, fix label picker layout

### DIFF
--- a/public/app/features/transformers/editors/LabelsToFieldsTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/LabelsToFieldsTransformerEditor.tsx
@@ -11,6 +11,7 @@ import {
   LabelsToFieldsMode,
   LabelsToFieldsOptions,
 } from '@grafana/data/src/transformations/transformers/labelsToFields';
+import { Stack } from '@grafana/experimental';
 import { InlineField, InlineFieldRow, RadioButtonGroup, Select, FilterPill } from '@grafana/ui';
 
 const modes: Array<SelectableValue<LabelsToFieldsMode>> = [
@@ -79,7 +80,7 @@ export const LabelsAsFieldsTransformerEditor: React.FC<TransformerUIProps<Labels
       </InlineFieldRow>
       <InlineFieldRow>
         <InlineField label={'Labels'} labelWidth={labelWidth}>
-          <>
+          <Stack gap={1} wrap>
             {labelNames.map((o, i) => {
               const label = o.label!;
               return (
@@ -91,7 +92,7 @@ export const LabelsAsFieldsTransformerEditor: React.FC<TransformerUIProps<Labels
                 />
               );
             })}
-          </>
+          </Stack>
         </InlineField>
       </InlineFieldRow>
       {options.mode !== LabelsToFieldsMode.Rows && (


### PR DESCRIPTION
Fixes issue with labels layout with the Labels to fields transform

Before:
![Screenshot from 2022-05-20 09-58-21](https://user-images.githubusercontent.com/10999/169482743-60ca9ea1-14a0-4bca-b5ed-9d4233c0430d.png)

After:
![Screenshot from 2022-05-20 10-02-39](https://user-images.githubusercontent.com/10999/169482805-168fe63f-1562-426c-b2af-6a80bf206629.png)

