### PR TITLE
AccessControl: Remove unused error from evaluator Evaluate

### DIFF
--- a/pkg/services/accesscontrol/evaluator_test.go
+++ b/pkg/services/accesscontrol/evaluator_test.go
@@ -52,8 +52,7 @@ func TestPermission_Evaluate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			ok, err := test.evaluator.Evaluate(test.permissions)
-			assert.NoError(t, err)
+			ok := test.evaluator.Evaluate(test.permissions)
 			assert.Equal(t, test.expected, ok)
 		})
 	}
@@ -123,8 +122,7 @@ func TestPermission_Inject(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			injected, err := test.evaluator.MutateScopes(context.TODO(), ScopeInjector(test.params))
 			assert.NoError(t, err)
-			ok, err := injected.Evaluate(test.permissions)
-			assert.NoError(t, err)
+			ok := injected.Evaluate(test.permissions)
 			assert.Equal(t, test.expected, ok)
 		})
 	}
@@ -172,8 +170,7 @@ func TestAll_Evaluate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			ok, err := test.evaluator.Evaluate(test.permissions)
-			assert.NoError(t, err)
+			ok := test.evaluator.Evaluate(test.permissions)
 			assert.Equal(t, test.expected, ok)
 		})
 	}
@@ -236,7 +233,7 @@ func TestAll_Inject(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			injected, err := test.evaluator.MutateScopes(context.TODO(), ScopeInjector(test.params))
 			assert.NoError(t, err)
-			ok, err := injected.Evaluate(test.permissions)
+			ok := injected.Evaluate(test.permissions)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expected, ok)
 		})
@@ -283,8 +280,7 @@ func TestAny_Evaluate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			ok, err := test.evaluator.Evaluate(test.permissions)
-			assert.NoError(t, err)
+			ok := test.evaluator.Evaluate(test.permissions)
 			assert.Equal(t, test.expected, ok)
 		})
 	}
@@ -347,7 +343,7 @@ func TestAny_Inject(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			injected, err := test.evaluator.MutateScopes(context.TODO(), ScopeInjector(test.params))
 			assert.NoError(t, err)
-			ok, err := injected.Evaluate(test.permissions)
+			ok := injected.Evaluate(test.permissions)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expected, ok)
 		})
@@ -409,8 +405,7 @@ func TestEval(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			ok, err := test.evaluator.Evaluate(test.permissions)
-			assert.NoError(t, err)
+			ok := test.evaluator.Evaluate(test.permissions)
 			assert.Equal(t, test.expected, ok)
 		})
 	}

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -103,7 +103,7 @@ func (m *Mock) Evaluate(ctx context.Context, user *models.SignedInUser, evaluato
 	if err != nil {
 		return false, err
 	}
-	return resolvedEvaluator.Evaluate(accesscontrol.GroupScopesByAction(permissions))
+	return resolvedEvaluator.Evaluate(accesscontrol.GroupScopesByAction(permissions)), nil
 }
 
 // GetUserPermissions returns user permissions.

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
@@ -98,7 +98,7 @@ func (ac *OSSAccessControlService) Evaluate(ctx context.Context, user *models.Si
 	if err != nil {
 		return false, err
 	}
-	return resolvedEvaluator.Evaluate(user.Permissions[user.OrgId])
+	return resolvedEvaluator.Evaluate(user.Permissions[user.OrgId]), nil
 }
 
 // GetUserRoles returns user permissions based on built-in roles

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -189,9 +189,8 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 			groupChanges := testCase.changes()
 
 			result, err := authorizeRuleChanges(groupChanges, func(evaluator ac.Evaluator) bool {
-				response, err := evaluator.Evaluate(make(map[string][]string))
+				response := evaluator.Evaluate(make(map[string][]string))
 				require.False(t, response)
-				require.NoError(t, err)
 				executed = true
 				return false
 			})
@@ -202,9 +201,8 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 			permissions := testCase.permissions(groupChanges)
 			executed = false
 			result, err = authorizeRuleChanges(groupChanges, func(evaluator ac.Evaluator) bool {
-				response, err := evaluator.Evaluate(permissions)
+				response := evaluator.Evaluate(permissions)
 				require.Truef(t, response, "provided permissions [%v] is not enough for requested permissions [%s]", testCase.permissions, evaluator.GoString())
-				require.NoError(t, err)
 				executed = true
 				return true
 			})
@@ -359,8 +357,7 @@ func TestAuthorizeRuleDelete(t *testing.T) {
 			groupChanges := testCase.changes()
 			permissions := testCase.permissions(groupChanges)
 			result, err := authorizeRuleChanges(groupChanges, func(evaluator ac.Evaluator) bool {
-				response, err := evaluator.Evaluate(permissions)
-				require.NoError(t, err)
+				response := evaluator.Evaluate(permissions)
 				return response
 			})
 
@@ -401,9 +398,8 @@ func TestCheckDatasourcePermissionsForRule(t *testing.T) {
 		executed := 0
 
 		eval := authorizeDatasourceAccessForRule(rule, func(evaluator ac.Evaluator) bool {
-			response, err := evaluator.Evaluate(permissions)
+			response := evaluator.Evaluate(permissions)
 			require.Truef(t, response, "provided permissions [%v] is not enough for requested permissions [%s]", permissions, evaluator.GoString())
-			require.NoError(t, err)
 			executed++
 			return true
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove unused error from the Evaluate function. For all implementations of the evaluator this value is always nil

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/3332
