### PR TITLE
AccessControl: Remove action to manage plugin

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -632,7 +632,7 @@ func (hs *HTTPServer) buildAdminNavLinks(c *models.ReqContext) []*dtos.NavLink {
 		})
 	}
 
-	if hs.Cfg.PluginAdminEnabled && hasAccess(ac.ReqGrafanaAdmin, ac.EvalPermission(ac.ActionPluginsManage)) {
+	if hs.Cfg.PluginAdminEnabled && ac.ReqGrafanaAdmin(c) {
 		adminNavLinks = append(adminNavLinks, &dtos.NavLink{
 			Text: "Plugins", Id: "admin-plugins", Url: hs.Cfg.AppSubURL + "/admin/plugins", Icon: "plug",
 		})

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -327,9 +327,6 @@ const (
 	// Datasources actions
 	ActionDatasourcesExplore = "datasources:explore"
 
-	// Plugin actions
-	ActionPluginsManage = "plugins:manage"
-
 	// Global Scopes
 	ScopeGlobalUsersAll = "global.users:*"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I noticed we had a action `plugins:manage` that is not documented, assigned to any fixed roles by default and does not protect endpoints to manage plugins.

The only use of this actions was to check if the /admin/plugins nav should be added

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

