### PR TITLE
Encryption: Add support for decrypting ciphertexts with algorithm metadata

### DIFF
--- a/pkg/services/encryption/ossencryption/ossencryption_test.go
+++ b/pkg/services/encryption/ossencryption/ossencryption_test.go
@@ -37,6 +37,32 @@ func TestEncryption(t *testing.T) {
 		_, err := svc.Decrypt(context.Background(), []byte(""), "1234")
 		require.Error(t, err)
 
-		assert.Equal(t, "unable to compute salt", err.Error())
+		assert.Equal(t, "unable to derive encryption algorithm", err.Error())
+	})
+
+	t.Run("decrypting ciphertext with aes-gcm as encryption algorithm should return error", func(t *testing.T) {
+		// Raw slice of bytes that corresponds to the following ciphertext:
+		// - 'grafana' as payload
+		// - '1234' as secret
+		// - 'aes-gcm' as encryption algorithm
+		// With no encryption algorithm metadata.
+		ciphertext := []byte{42, 89, 87, 86, 122, 76, 87, 100, 106, 98, 81, 42, 48, 99, 55, 50, 51, 48, 83, 66, 20, 99, 47, 238, 61, 44, 129, 125, 14, 37, 162, 230, 47, 31, 104, 70, 144, 223, 26, 51, 180, 17, 76, 52, 36, 93, 17, 203, 99, 158, 219, 102, 74, 173, 74}
+		_, err := svc.Decrypt(context.Background(), ciphertext, "1234")
+		require.Error(t, err)
+
+		assert.Equal(t, "unsupported encryption algorithm", err.Error())
+	})
+
+	t.Run("decrypting ciphertext with aes-cfb as encryption algorithm do not fail", func(t *testing.T) {
+		// Raw slice of bytes that corresponds to the following ciphertext:
+		// - 'grafana' as payload
+		// - '1234' as secret
+		// - 'aes-cfb' as encryption algorithm
+		// With no encryption algorithm metadata.
+		ciphertext := []byte{42, 89, 87, 86, 122, 76, 87, 78, 109, 89, 103, 42, 73, 71, 50, 57, 121, 110, 90, 109, 115, 23, 237, 13, 130, 188, 151, 118, 98, 103, 80, 209, 79, 143, 22, 122, 44, 40, 102, 41, 136, 16, 27}
+		decrypted, err := svc.Decrypt(context.Background(), ciphertext, "1234")
+		require.NoError(t, err)
+
+		assert.Equal(t, []byte("grafana"), decrypted)
 	})
 }


### PR DESCRIPTION
**Context**:

Some time ago we added support for other encryption algorithms (other than AES-CFB) as an Enterprise feature. Therefore, we needed to add an algorithm metadata into the resulting ciphertext to be able to choose the proper encryption algorithm at decryption time.

That was kind of breaking change because since that point, any secret encrypted with Enterprise binary wouldn't be able to be decrypted by OSS binary, which, at some point, was considered acceptable because:

- We don't have official support to downgrade from Enterprise binary to OSS one.
- As far as I know, there is (or was) a project to move everyone into the Enterprise binary (even if no license is used).

However, this has other implications (other than customers trying to downgrade), like for those developers not used to Enterprise that temporally switch it on/off on their development environment. Therefore, we agreed on adding support for the algorithm metadata as well in open source although GCM secrets will still be a break.

**What this PR does / why we need it**:

Add support for decrypting secrets with algorithm metadata (only AES-CFB, which is the encryption algorithm used by OSS and the one configured by default).

**Which issue(s) this PR fixes**:

I don't think there's an issue (or I haven't been able to find it) but we discussed internally multiple times, like [this recent Slack thread](https://raintank-corp.slack.com/archives/C028MCV4R7C/p1652881605764089).

**Special notes for your reviewer**:

I manually copy-pasted the bytes of some example secrets encrypted by Enterprise code base in order to test the compatibility when downgrading from Enterprise binary to OSS one.

Thanks!