### PR TITLE
Loki: dataframes: do not set field.config.DisplayName

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -369,7 +369,7 @@ describe('LokiDatasource', () => {
         const dataFrame = result.data[0] as DataFrame;
         const fieldCache = new FieldCache(dataFrame);
 
-        expect(fieldCache.getFieldByName('line')?.values.get(0)).toBe('hello');
+        expect(fieldCache.getFieldByName('Line')?.values.get(0)).toBe('hello');
         expect(dataFrame.meta?.limit).toBe(20);
         expect(dataFrame.meta?.searchWords).toEqual(['foo']);
       });

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -765,7 +765,7 @@ export class LokiDatasource
     const splitKeys: string[] = tagKeys.split(',').filter((v: string) => v !== '');
 
     for (const frame of data) {
-      const view = new DataFrameView<{ ts: string; line: string; labels: Labels }>(frame);
+      const view = new DataFrameView<{ Time: string; Line: string; labels: Labels }>(frame);
 
       view.forEach((row) => {
         const { labels } = row;
@@ -791,9 +791,9 @@ export class LokiDatasource
         const tags = Array.from(new Set(maybeDuplicatedTags));
 
         annotations.push({
-          time: new Date(row.ts).valueOf(),
+          time: new Date(row.Time).valueOf(),
           title: renderLegendFormat(titleFormat, labels),
-          text: renderLegendFormat(textFormat, labels) || row.line,
+          text: renderLegendFormat(textFormat, labels) || row.Line,
           tags,
         });
       });

--- a/public/app/plugins/datasource/loki/live_streams.test.ts
+++ b/public/app/plugins/datasource/loki/live_streams.test.ts
@@ -48,10 +48,10 @@ describe('Live Stream Tests', () => {
         const view = new DataFrameView(val[0]);
         const last = { ...view.get(view.length - 1) };
         expect(last).toEqual({
-          ts: '2019-08-28T20:50:40.118Z',
+          Time: '2019-08-28T20:50:40.118Z',
           tsNs: '1567025440118944705',
           id: '25d81461-a66f-53ff-98d5-e39515af4735_A',
-          line: 'Kittens',
+          Line: 'Kittens',
           labels: { filename: '/var/log/sntpc.log' },
         });
       },
@@ -148,8 +148,8 @@ describe('Live Stream Tests', () => {
       const firstLog = { ...view.get(0) };
       const secondLog = { ...view.get(1) };
 
-      expect(firstLog.line).toBe('Kittens');
-      expect(secondLog.line).toBe('Doggos');
+      expect(firstLog.Line).toBe('Kittens');
+      expect(secondLog.Line).toBe('Doggos');
       expect(retries).toBe(2);
     });
   });

--- a/public/app/plugins/datasource/loki/live_streams.ts
+++ b/public/app/plugins/datasource/loki/live_streams.ts
@@ -33,10 +33,10 @@ export class LiveStreams {
 
     const data = new CircularDataFrame({ capacity: target.size });
     data.addField({ name: 'labels', type: FieldType.other }); // The labels for each line
-    data.addField({ name: 'ts', type: FieldType.time, config: { displayName: 'Time' } });
-    data.addField({ name: 'line', type: FieldType.string }).labels = parseLabels(target.query);
+    data.addField({ name: 'Time', type: FieldType.time, config: {} });
+    data.addField({ name: 'Line', type: FieldType.string }).labels = parseLabels(target.query);
     data.addField({ name: 'id', type: FieldType.string });
-    data.addField({ name: 'tsNs', type: FieldType.time, config: { displayName: 'Time ns' } });
+    data.addField({ name: 'tsNs', type: FieldType.time, config: {} });
     data.meta = { ...data.meta, preferredVisualisationType: 'logs' };
     data.refId = target.refId;
 

--- a/public/app/plugins/datasource/loki/result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.test.ts
@@ -242,7 +242,7 @@ describe('loki result transformer', () => {
 
 describe('enhanceDataFrame', () => {
   it('adds links to fields', () => {
-    const df = new MutableDataFrame({ fields: [{ name: 'line', values: ['nothing', 'trace1=1234', 'trace2=foo'] }] });
+    const df = new MutableDataFrame({ fields: [{ name: 'Line', values: ['nothing', 'trace1=1234', 'trace2=foo'] }] });
     ResultTransformer.enhanceDataFrame(df, {
       derivedFields: [
         {

--- a/public/app/plugins/datasource/loki/result_transformer.ts
+++ b/public/app/plugins/datasource/loki/result_transformer.ts
@@ -92,9 +92,9 @@ function constructDataFrame(
     refId,
     fields: [
       { name: 'labels', type: FieldType.other, config: {}, values: labels },
-      { name: 'ts', type: FieldType.time, config: { displayName: 'Time' }, values: times }, // Time
-      { name: 'line', type: FieldType.string, config: {}, values: lines }, // Line - needs to be the first field with string type
-      { name: 'tsNs', type: FieldType.time, config: { displayName: 'Time ns' }, values: timesNs }, // Time
+      { name: 'Time', type: FieldType.time, config: {}, values: times }, // Time
+      { name: 'Line', type: FieldType.string, config: {}, values: lines }, // Line - needs to be the first field with string type
+      { name: 'tsNs', type: FieldType.time, config: {}, values: timesNs }, // Time
       { name: 'id', type: FieldType.string, config: {}, values: uids },
     ],
     length: times.length,
@@ -391,9 +391,9 @@ export const enhanceDataFrame = (dataFrame: DataFrame, config: LokiOptions | nul
   const newFields = Object.values(derivedFieldsGrouped).map(fieldFromDerivedFieldConfig);
 
   const view = new DataFrameView(dataFrame);
-  view.forEach((row: { line: string }) => {
+  view.forEach((row: { Line: string }) => {
     for (const field of newFields) {
-      const logMatch = row.line.match(derivedFieldsGrouped[field.name][0].matcherRegex);
+      const logMatch = row.Line.match(derivedFieldsGrouped[field.name][0].matcherRegex);
       field.values.add(logMatch && logMatch[1]);
     }
   });


### PR DESCRIPTION
this pull request does two things for the frontend-mode:
1. makes sure we are not setting the `dataframe.field.config.displayName` property. the datasource should not do that. 
2. make sure the field-names in frontend-mode are the same as in backend-mode


to achieve it:
1. for the time-field, removes `displayName`, and sets a good `name`
2. for the tsNs-field, removes `displayName` (we cannot change the `name` because it has to be exactly `tsNs`.. but this field is not really meant to be visible to end users, so that's probably OK)
3. for the line-field, we change it's `name` from `Line` to `line` to make it the same as the backend-mode.
4. we adjust the rest of the code to handle this change


how to test:
1. make sure you do not have the `lokiBackendMode` flag set
2. run a loki logs query, make sure the results look ok in general
3. press the [⏯️ Live] button, it should show log lines