### PR TITLE
SSE: Change help from CTA to secondary action

### DIFF
--- a/public/app/features/expressions/components/Math.tsx
+++ b/public/app/features/expressions/components/Math.tsx
@@ -41,7 +41,7 @@ export const Math: FC<Props> = ({ labelWidth, onChange, query }) => {
       >
         <>
           <TextArea value={query.expression} onChange={onExpressionChange} rows={5} placeholder={mathPlaceholder} />
-          <Button color="primary" size="sm" onClick={() => toggleShowHelp()}>
+          <Button variant="secondary" size="sm" onClick={toggleShowHelp}>
             {showHelp === false ? 'Show' : 'Hide'} help
           </Button>
         </>


### PR DESCRIPTION
**What this PR does / why we need it**:
The show/hide help button had the cta button color which felt a bit off. Using the `secondary` variant instead.

Before
![image](https://user-images.githubusercontent.com/946275/169521989-bd5ed6ab-9ce9-41a7-8170-88f4e375ea8c.png)


After
![image](https://user-images.githubusercontent.com/946275/169521898-c2c1eb8e-a7bb-4a3b-9f63-00ec30d1b553.png)

Fixes #

**Special notes for your reviewer**:

