### PR TITLE
Loki: enable backend-mode

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -93,6 +93,7 @@ var (
 			Description:  "Loki datasource works as backend datasource",
 			State:        FeatureStateAlpha,
 			FrontendOnly: true,
+			Expression:   "true", // Enabled by default
 		},
 		{
 			Name:        "prometheus_azure_auth",


### PR DESCRIPTION
we adjust the `lokiBackendMode` feauture flag to be enabled by default.

how to test:
1. make sure you do not have the `lokiBackendMode` feature flag enabled
2. open the browser dev-tools
3. run a loki query
4. check the ajax-request that was sent. it should have the form `/api/ds/query`
5. now add a line to your config that disables the feature-flag, for example:
    ```ini
    [feature_toggles]
    lokiBackendMode = false
    ```
6. repeat the test. the ajax-request should have teh form `/api/datasources/proxy/`