### PR TITLE
GrafanaUI: Fix color of links in error Tooltips in light theme

### DIFF
--- a/packages/grafana-ui/src/components/Forms/FieldValidationMessage.tsx
+++ b/packages/grafana-ui/src/components/Forms/FieldValidationMessage.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import React from 'react';
 
-import { colorManipulator, GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 
 import { stylesFactory, useTheme2 } from '../../themes';
 import { Icon } from '../Icon/Icon';
@@ -13,8 +13,6 @@ export interface FieldValidationMessageProps {
 }
 
 export const getFieldValidationMessageStyles = stylesFactory((theme: GrafanaTheme2) => {
-  const linkColor = colorManipulator.darken(theme.colors.error.contrastText, 0.15);
-
   const baseStyle = `
       font-size: ${theme.typography.size.sm};
       font-weight: ${theme.typography.fontWeightMedium};
@@ -26,11 +24,12 @@ export const getFieldValidationMessageStyles = stylesFactory((theme: GrafanaThem
       display: inline-block;
 
       a {
-        color: ${linkColor};
+        color: ${theme.colors.error.contrastText};
+        text-decoration: underline;
       }
 
       a:hover {
-        text-decoration: underline;
+        text-decoration: none;
       }
     `;
 

--- a/packages/grafana-ui/src/components/Forms/FieldValidationMessage.tsx
+++ b/packages/grafana-ui/src/components/Forms/FieldValidationMessage.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import React from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import { colorManipulator, GrafanaTheme2 } from '@grafana/data';
 
 import { stylesFactory, useTheme2 } from '../../themes';
 import { Icon } from '../Icon/Icon';
@@ -13,6 +13,8 @@ export interface FieldValidationMessageProps {
 }
 
 export const getFieldValidationMessageStyles = stylesFactory((theme: GrafanaTheme2) => {
+  const linkColor = colorManipulator.darken(theme.colors.error.contrastText, 0.15);
+
   const baseStyle = `
       font-size: ${theme.typography.size.sm};
       font-weight: ${theme.typography.fontWeightMedium};
@@ -22,6 +24,14 @@ export const getFieldValidationMessageStyles = stylesFactory((theme: GrafanaThem
       border-radius: ${theme.shape.borderRadius()};
       position: relative;
       display: inline-block;
+
+      a {
+        color: ${linkColor};
+      }
+
+      a:hover {
+        text-decoration: underline;
+      }
     `;
 
   return {

--- a/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
@@ -60,7 +60,9 @@ export const Tooltip = React.memo(({ children, theme, interactive, show, placeme
 Tooltip.displayName = 'Tooltip';
 
 function getStyles(theme: GrafanaTheme2) {
-  function buildTooltipTheme(tooltipBg: string, tooltipBorder: string, tooltipText: string) {
+  function buildTooltipTheme(tooltipBg: string, tooltipBorder: string, tooltipText: string, tooltipLink?: string) {
+    const linkColor = tooltipLink ?? colorManipulator.darken(tooltipText, 0.15);
+
     return css`
       background-color: ${tooltipBg};
       border-radius: 3px;
@@ -187,7 +189,7 @@ function getStyles(theme: GrafanaTheme2) {
       }
 
       a {
-        color: ${theme.colors.text.link};
+        color: ${linkColor};
       }
 
       a:hover {
@@ -199,7 +201,8 @@ function getStyles(theme: GrafanaTheme2) {
   const info = buildTooltipTheme(
     theme.components.tooltip.background,
     theme.components.tooltip.background,
-    theme.components.tooltip.text
+    theme.components.tooltip.text,
+    theme.colors.text.link
   );
   const error = buildTooltipTheme(theme.colors.error.main, theme.colors.error.main, theme.colors.error.contrastText);
 

--- a/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
@@ -60,9 +60,7 @@ export const Tooltip = React.memo(({ children, theme, interactive, show, placeme
 Tooltip.displayName = 'Tooltip';
 
 function getStyles(theme: GrafanaTheme2) {
-  function buildTooltipTheme(tooltipBg: string, tooltipBorder: string, tooltipText: string, tooltipLink?: string) {
-    const linkColor = tooltipLink ?? colorManipulator.darken(tooltipText, 0.15);
-
+  function buildTooltipTheme(tooltipBg: string, tooltipBorder: string, tooltipText: string) {
     return css`
       background-color: ${tooltipBg};
       border-radius: 3px;
@@ -189,11 +187,12 @@ function getStyles(theme: GrafanaTheme2) {
       }
 
       a {
-        color: ${linkColor};
+        color: ${tooltipText};
+        text-decoration: underline;
       }
 
       a:hover {
-        text-decoration: underline;
+        text-decoration: none;
       }
     `;
   }
@@ -201,8 +200,7 @@ function getStyles(theme: GrafanaTheme2) {
   const info = buildTooltipTheme(
     theme.components.tooltip.background,
     theme.components.tooltip.background,
-    theme.components.tooltip.text,
-    theme.colors.text.link
+    theme.components.tooltip.text
   );
   const error = buildTooltipTheme(theme.colors.error.main, theme.colors.error.main, theme.colors.error.contrastText);
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the link color in error tooltip, and in the input validation error tooltip (they're two different implementations), so they're consistent and readable.

Problem with fixing this is we haven't really defined what color links should be on `error` background - the theme/tokens don't cover this. So, I fixed this in the two component implementations. Links in the form validation error, and tooltips, will use the same text color, but will have the underline. When hovered, the link will disappear, similar to [mozilla protocol's link](https://protocol.mozilla.org/patterns/atoms/links.html).

| Before | After |
| --- | ---- |
| ![Before](https://user-images.githubusercontent.com/46142/169531995-0843a74a-31a7-4eef-bf0d-4e4557e05f0d.png)| ![After](https://user-images.githubusercontent.com/46142/169581400-20df65e0-a7e9-47e5-995b-69101517a1cf.png)|





**Which issue(s) this PR fixes**:


Fixes #49169

**Special notes for your reviewer**:

