### PR TITLE
Tempo: NativeSearch code simplification and cleanup

### DIFF
--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.test.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.test.tsx
@@ -57,9 +57,9 @@ describe('NativeSearch', () => {
       <NativeSearch datasource={{} as TempoDatasource} query={mockQuery} onChange={jest.fn()} onRunQuery={jest.fn()} />
     );
 
-    const asyncServiceSelect = screen.getByRole('combobox', { name: 'select-service-name' });
+    const select = screen.getByRole('combobox', { name: 'select-service-name' });
 
-    await user.click(asyncServiceSelect);
+    await user.click(select);
     const loader = screen.getByText('Loading options...');
 
     expect(loader).toBeInTheDocument();
@@ -89,13 +89,13 @@ describe('NativeSearch', () => {
       />
     );
 
-    const asyncServiceSelect = await screen.findByRole('combobox', { name: 'select-service-name' });
+    const select = await screen.findByRole('combobox', { name: 'select-service-name' });
 
-    expect(asyncServiceSelect).toBeInTheDocument();
-    await user.click(asyncServiceSelect);
+    expect(select).toBeInTheDocument();
+    await user.click(select);
     jest.advanceTimersByTime(1000);
 
-    await user.type(asyncServiceSelect, 'd');
+    await user.type(select, 'd');
     const driverOption = await screen.findByText('driver');
     await user.click(driverOption);
 
@@ -107,16 +107,16 @@ describe('NativeSearch', () => {
       <NativeSearch datasource={{} as TempoDatasource} query={mockQuery} onChange={() => {}} onRunQuery={() => {}} />
     );
 
-    const asyncServiceSelect = await screen.findByRole('combobox', { name: 'select-service-name' });
-    await user.click(asyncServiceSelect);
+    const select = await screen.findByRole('combobox', { name: 'select-service-name' });
+    await user.click(select);
     jest.advanceTimersByTime(1000);
-    expect(asyncServiceSelect).toBeInTheDocument();
+    expect(select).toBeInTheDocument();
 
-    await user.type(asyncServiceSelect, 'd');
+    await user.type(select, 'd');
     var option = await screen.findByText('driver');
     expect(option).toBeDefined();
 
-    await user.type(asyncServiceSelect, 'a');
+    await user.type(select, 'a');
     option = await screen.findByText('No options found');
     expect(option).toBeDefined();
   });

--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.test.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.test.tsx
@@ -35,6 +35,7 @@ const mockQuery = {
   queryType: 'nativeSearch',
   key: 'Q-595a9bbc-2a25-49a7-9249-a52a0a475d83-0',
   serviceName: 'driver',
+  spanName: 'customer',
 } as TempoQuery;
 
 describe('NativeSearch', () => {
@@ -56,7 +57,7 @@ describe('NativeSearch', () => {
       <NativeSearch datasource={{} as TempoDatasource} query={mockQuery} onChange={jest.fn()} onRunQuery={jest.fn()} />
     );
 
-    const asyncServiceSelect = screen.getByRole('combobox', { name: 'select-span-name' });
+    const asyncServiceSelect = screen.getByRole('combobox', { name: 'select-service-name' });
 
     await user.click(asyncServiceSelect);
     const loader = screen.getByText('Loading options...');
@@ -76,7 +77,7 @@ describe('NativeSearch', () => {
       queryType: 'nativeSearch',
       refId: 'A',
       serviceName: 'driver',
-      spanName: 'driver',
+      spanName: 'customer',
     };
 
     render(
@@ -88,12 +89,13 @@ describe('NativeSearch', () => {
       />
     );
 
-    const asyncServiceSelect = await screen.findByRole('combobox', { name: 'select-span-name' });
+    const asyncServiceSelect = await screen.findByRole('combobox', { name: 'select-service-name' });
 
     expect(asyncServiceSelect).toBeInTheDocument();
     await user.click(asyncServiceSelect);
     jest.advanceTimersByTime(1000);
 
+    await user.type(asyncServiceSelect, 'd');
     const driverOption = await screen.findByText('driver');
     await user.click(driverOption);
 
@@ -105,19 +107,16 @@ describe('NativeSearch', () => {
       <NativeSearch datasource={{} as TempoDatasource} query={mockQuery} onChange={() => {}} onRunQuery={() => {}} />
     );
 
-    const asyncServiceSelect = await screen.findByRole('combobox', { name: 'select-span-name' });
-
-    expect(asyncServiceSelect).toBeInTheDocument();
+    const asyncServiceSelect = await screen.findByRole('combobox', { name: 'select-service-name' });
     await user.click(asyncServiceSelect);
     jest.advanceTimersByTime(1000);
+    expect(asyncServiceSelect).toBeInTheDocument();
 
     await user.type(asyncServiceSelect, 'd');
-    jest.advanceTimersByTime(1000);
     var option = await screen.findByText('driver');
     expect(option).toBeDefined();
 
     await user.type(asyncServiceSelect, 'a');
-    jest.advanceTimersByTime(1000);
     option = await screen.findByText('No options found');
     expect(option).toBeDefined();
   });

--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
@@ -89,12 +89,10 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
   useEffect(() => {
     const fetchOptions = async () => {
       try {
-        await languageProvider.start();
         const services = await loadOptions('serviceName');
         setServiceOptions(services);
         const spans = await loadOptions('spanName');
         setSpanOptions(spans);
-        setHasSyntaxLoaded(true);
       } catch (error) {
         // Display message if Tempo is connected but search 404's
         if (error?.status === 404) {
@@ -102,11 +100,22 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
         } else {
           dispatch(notifyApp(createErrorNotification('Error', error)));
         }
-        setHasSyntaxLoaded(true);
       }
     };
     fetchOptions();
   }, [languageProvider, loadOptions]);
+
+  useEffect(() => {
+    const fetchTags = async () => {
+      try {
+        await languageProvider.start();
+        setHasSyntaxLoaded(true);
+      } catch (error) {
+        dispatch(notifyApp(createErrorNotification('Error', error)));
+      }
+    };
+    fetchTags();
+  }, [languageProvider]);
 
   const onTypeahead = async (typeahead: TypeaheadInput): Promise<TypeaheadOutput> => {
     return await languageProvider.provideCompletionItems(typeahead);

--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
@@ -15,7 +15,6 @@ import {
   BracesPlugin,
   TypeaheadInput,
   TypeaheadOutput,
-  AsyncSelect,
   Alert,
   useStyles2,
   fuzzyMatch,
@@ -71,7 +70,7 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
     spanName: false,
   });
 
-  async function fetchOptionsCallback(name: string, lp: TempoLanguageProvider, query = '') {
+  async function loadOptions(name: string, lp: TempoLanguageProvider, query = '') {
     const lpName = name === 'serviceName' ? 'service.name' : 'name';
     setIsLoading((prevValue) => ({ ...prevValue, [name]: true }));
 
@@ -94,7 +93,7 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
   const loadOptionsOfType = useCallback(
     (name: string) => {
       setIsLoading((prevValue) => ({ ...prevValue, [name]: true }));
-      return fetchOptionsCallback(name, languageProvider);
+      return loadOptions(name, languageProvider);
     },
     [languageProvider]
   );
@@ -108,9 +107,9 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
     const fetchOptions = async () => {
       try {
         await languageProvider.start();
-        const services = await fetchOptionsCallback('serviceName', languageProvider);
+        const services = await loadOptions('serviceName', languageProvider);
         setServiceOptions(services);
-        const spans = await fetchOptionsCallback('spanName', languageProvider);
+        const spans = await loadOptions('spanName', languageProvider);
         setSpanOptions(spans);
         setHasSyntaxLoaded(true);
       } catch (error) {

--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
@@ -51,12 +51,6 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
   const styles = useStyles2(getStyles);
   const languageProvider = useMemo(() => new TempoLanguageProvider(datasource), [datasource]);
   const [hasSyntaxLoaded, setHasSyntaxLoaded] = useState(false);
-  const [asyncServiceNameValue, setAsyncServiceNameValue] = useState<SelectableValue<any>>({
-    value: '',
-  });
-  const [asyncSpanNameValue, setAsyncSpanNameValue] = useState<SelectableValue<any>>({
-    value: '',
-  });
   const [serviceOptions, setServiceOptions] = useState<Array<SelectableValue<string>>>();
   const [spanOptions, setSpanOptions] = useState<Array<SelectableValue<string>>>();
   const [error, setError] = useState(null);
@@ -146,11 +140,8 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
                 loadOptions('serviceName');
               }}
               isLoading={isLoading.serviceName}
-              value={asyncServiceNameValue.value}
+              value={serviceOptions?.find((v) => v?.value === query.serviceName) || undefined}
               onChange={(v) => {
-                setAsyncServiceNameValue({
-                  value: v,
-                });
                 onChange({
                   ...query,
                   serviceName: v?.value || undefined,
@@ -172,9 +163,8 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
                 loadOptions('spanName');
               }}
               isLoading={isLoading.spanName}
-              value={asyncSpanNameValue.value}
+              value={spanOptions?.find((v) => v?.value === query.spanName) || undefined}
               onChange={(v) => {
-                setAsyncSpanNameValue({ value: v });
                 onChange({
                   ...query,
                   spanName: v?.value || undefined,

--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
@@ -89,9 +89,8 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
   useEffect(() => {
     const fetchOptions = async () => {
       try {
-        const services = await loadOptions('serviceName');
+        const [services, spans] = await Promise.all([loadOptions('serviceName'), loadOptions('spanName')]);
         setServiceOptions(services);
-        const spans = await loadOptions('spanName');
         setSpanOptions(spans);
       } catch (error) {
         // Display message if Tempo is connected but search 404's


### PR DESCRIPTION
**What this PR does / why we need it**:

This simplifies Tempo's NativeSearch functionality.

**How to test**:

Tempo's NativeSearch should work the same as before.