### PR TITLE
Alerting: Attach screenshot data to Unified Alerting notifications.

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
@@ -85,7 +85,7 @@ func (e *EmbeddedContactPoint) Valid(decryptFunc channels.GetDecryptedValueFn) e
 	cfg, _ := channels.NewFactoryConfig(&channels.NotificationChannelConfig{
 		Settings: e.Settings,
 		Type:     e.Type,
-	}, nil, decryptFunc, nil)
+	}, nil, decryptFunc, nil, nil)
 	if _, err := factory(cfg); err != nil {
 		return err
 	}

--- a/pkg/services/ngalert/image/service.go
+++ b/pkg/services/ngalert/image/service.go
@@ -96,6 +96,8 @@ func (s *ScreenshotImageService) NewImage(ctx context.Context, r *ngmodels.Alert
 		DashboardUID: *r.DashboardUID,
 		PanelID:      *r.PanelID,
 	})
+	// TODO: Check for screenshot upload failures. These images should still be
+	// stored because we have a local disk path that could be useful.
 	if err != nil {
 		return nil, fmt.Errorf("failed to take screenshot: %w", err)
 	}

--- a/pkg/services/ngalert/notifier/channels/factory.go
+++ b/pkg/services/ngalert/notifier/channels/factory.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"net/url"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/services/notifications"
@@ -22,7 +21,7 @@ type FactoryConfig struct {
 
 // A specialization of store.ImageStore, to avoid an import loop.
 type ImageStore interface {
-	GetURL(ctx context.Context, token string) (*url.URL, error)
+	GetURL(ctx context.Context, token string) (string, error)
 	GetData(ctx context.Context, token string) (io.ReadCloser, error)
 }
 
@@ -36,11 +35,16 @@ func NewFactoryConfig(config *NotificationChannelConfig, notificationService not
 	if config.SecureSettings == nil {
 		config.SecureSettings = map[string][]byte{}
 	}
+
+	if imageStore == nil {
+		imageStore = &UnavailableImageStore{}
+	}
 	return FactoryConfig{
 		Config:              config,
 		NotificationService: notificationService,
 		DecryptFunc:         decryptFunc,
 		Template:            template,
+		ImageStore:          imageStore,
 	}, nil
 }
 

--- a/pkg/services/ngalert/notifier/channels/factory.go
+++ b/pkg/services/ngalert/notifier/channels/factory.go
@@ -23,11 +23,11 @@ type FactoryConfig struct {
 // A specialization of store.ImageStore, to avoid an import loop.
 type ImageStore interface {
 	GetURL(ctx context.Context, token string) (*url.URL, error)
-	GetData(ctx context.Context, token string) (io.Reader, error)
+	GetData(ctx context.Context, token string) (io.ReadCloser, error)
 }
 
 func NewFactoryConfig(config *NotificationChannelConfig, notificationService notifications.Service,
-	decryptFunc GetDecryptedValueFn, template *template.Template) (FactoryConfig, error) {
+	decryptFunc GetDecryptedValueFn, template *template.Template, imageStore ImageStore) (FactoryConfig, error) {
 	if config.Settings == nil {
 		return FactoryConfig{}, errors.New("no settings supplied")
 	}

--- a/pkg/services/ngalert/notifier/channels/factory.go
+++ b/pkg/services/ngalert/notifier/channels/factory.go
@@ -1,7 +1,10 @@
 package channels
 
 import (
+	"context"
 	"errors"
+	"io"
+	"net/url"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/services/notifications"
@@ -12,7 +15,15 @@ type FactoryConfig struct {
 	Config              *NotificationChannelConfig
 	NotificationService notifications.Service
 	DecryptFunc         GetDecryptedValueFn
-	Template            *template.Template
+	ImageStore          ImageStore
+	// Used to retrieve image URLs for messages, or data for uploads.
+	Template *template.Template
+}
+
+// A specialization of store.ImageStore, to avoid an import loop.
+type ImageStore interface {
+	GetURL(ctx context.Context, token string) (*url.URL, error)
+	GetData(ctx context.Context, token string) (io.Reader, error)
 }
 
 func NewFactoryConfig(config *NotificationChannelConfig, notificationService notifications.Service,

--- a/pkg/services/ngalert/notifier/channels/slack.go
+++ b/pkg/services/ngalert/notifier/channels/slack.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
+	"mime/multipart"
 	"net"
 	"net/http"
 	"net/url"
@@ -16,6 +18,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/template"
@@ -28,8 +31,10 @@ var SlackAPIEndpoint = "https://slack.com/api/chat.postMessage"
 // alert notification to Slack.
 type SlackNotifier struct {
 	*Base
-	log  log.Logger
-	tmpl *template.Template
+	log           log.Logger
+	tmpl          *template.Template
+	images        ImageStore
+	webhookSender notifications.WebhookSender
 
 	URL            *url.URL
 	Username       string
@@ -60,19 +65,21 @@ type SlackConfig struct {
 }
 
 func SlackFactory(fc FactoryConfig) (NotificationChannel, error) {
-	cfg, err := NewSlackConfig(fc.Config, fc.DecryptFunc)
+	cfg, err := NewSlackConfig(fc)
 	if err != nil {
 		return nil, receiverInitError{
 			Reason: err.Error(),
 			Cfg:    *fc.Config,
 		}
 	}
-	return NewSlackNotifier(cfg, fc.Template), nil
+	return NewSlackNotifier(cfg, fc.ImageStore, fc.NotificationService, fc.Template), nil
 }
 
-func NewSlackConfig(config *NotificationChannelConfig, decryptFunc GetDecryptedValueFn) (*SlackConfig, error) {
-	endpointURL := config.Settings.Get("endpointUrl").MustString(SlackAPIEndpoint)
-	slackURL := decryptFunc(context.Background(), config.SecureSettings, "url", config.Settings.Get("url").MustString())
+func NewSlackConfig(factoryConfig FactoryConfig) (*SlackConfig, error) {
+	channelConfig := factoryConfig.Config
+	decryptFunc := factoryConfig.DecryptFunc
+	endpointURL := channelConfig.Settings.Get("endpointUrl").MustString(SlackAPIEndpoint)
+	slackURL := decryptFunc(context.Background(), channelConfig.SecureSettings, "url", channelConfig.Settings.Get("url").MustString())
 	if slackURL == "" {
 		slackURL = endpointURL
 	}
@@ -80,19 +87,19 @@ func NewSlackConfig(config *NotificationChannelConfig, decryptFunc GetDecryptedV
 	if err != nil {
 		return nil, fmt.Errorf("invalid URL %q", slackURL)
 	}
-	recipient := strings.TrimSpace(config.Settings.Get("recipient").MustString())
+	recipient := strings.TrimSpace(channelConfig.Settings.Get("recipient").MustString())
 	if recipient == "" && apiURL.String() == SlackAPIEndpoint {
 		return nil, errors.New("recipient must be specified when using the Slack chat API")
 	}
-	mentionChannel := config.Settings.Get("mentionChannel").MustString()
+	mentionChannel := channelConfig.Settings.Get("mentionChannel").MustString()
 	if mentionChannel != "" && mentionChannel != "here" && mentionChannel != "channel" {
 		return nil, fmt.Errorf("invalid value for mentionChannel: %q", mentionChannel)
 	}
-	token := decryptFunc(context.Background(), config.SecureSettings, "token", config.Settings.Get("token").MustString())
+	token := decryptFunc(context.Background(), channelConfig.SecureSettings, "token", channelConfig.Settings.Get("token").MustString())
 	if token == "" && apiURL.String() == SlackAPIEndpoint {
 		return nil, errors.New("token must be specified when using the Slack chat API")
 	}
-	mentionUsersStr := config.Settings.Get("mentionUsers").MustString()
+	mentionUsersStr := channelConfig.Settings.Get("mentionUsers").MustString()
 	mentionUsers := []string{}
 	for _, u := range strings.Split(mentionUsersStr, ",") {
 		u = strings.TrimSpace(u)
@@ -100,7 +107,7 @@ func NewSlackConfig(config *NotificationChannelConfig, decryptFunc GetDecryptedV
 			mentionUsers = append(mentionUsers, u)
 		}
 	}
-	mentionGroupsStr := config.Settings.Get("mentionGroups").MustString()
+	mentionGroupsStr := channelConfig.Settings.Get("mentionGroups").MustString()
 	mentionGroups := []string{}
 	for _, g := range strings.Split(mentionGroupsStr, ",") {
 		g = strings.TrimSpace(g)
@@ -109,23 +116,27 @@ func NewSlackConfig(config *NotificationChannelConfig, decryptFunc GetDecryptedV
 		}
 	}
 	return &SlackConfig{
-		NotificationChannelConfig: config,
-		Recipient:                 strings.TrimSpace(config.Settings.Get("recipient").MustString()),
-		MentionChannel:            config.Settings.Get("mentionChannel").MustString(),
+		NotificationChannelConfig: channelConfig,
+		Recipient:                 strings.TrimSpace(channelConfig.Settings.Get("recipient").MustString()),
+		MentionChannel:            channelConfig.Settings.Get("mentionChannel").MustString(),
 		MentionUsers:              mentionUsers,
 		MentionGroups:             mentionGroups,
 		URL:                       apiURL,
-		Username:                  config.Settings.Get("username").MustString("Grafana"),
-		IconEmoji:                 config.Settings.Get("icon_emoji").MustString(),
-		IconURL:                   config.Settings.Get("icon_url").MustString(),
+		Username:                  channelConfig.Settings.Get("username").MustString("Grafana"),
+		IconEmoji:                 channelConfig.Settings.Get("icon_emoji").MustString(),
+		IconURL:                   channelConfig.Settings.Get("icon_url").MustString(),
 		Token:                     token,
-		Text:                      config.Settings.Get("text").MustString(`{{ template "default.message" . }}`),
-		Title:                     config.Settings.Get("title").MustString(DefaultMessageTitleEmbed),
+		Text:                      channelConfig.Settings.Get("text").MustString(`{{ template "default.message" . }}`),
+		Title:                     channelConfig.Settings.Get("title").MustString(DefaultMessageTitleEmbed),
 	}, nil
 }
 
 // NewSlackNotifier is the constructor for the Slack notifier
-func NewSlackNotifier(config *SlackConfig, t *template.Template) *SlackNotifier {
+func NewSlackNotifier(config *SlackConfig,
+	images ImageStore,
+	webhookSender notifications.WebhookSender,
+	t *template.Template,
+) *SlackNotifier {
 	return &SlackNotifier{
 		Base: NewBase(&models.AlertNotification{
 			Uid:                   config.UID,
@@ -145,6 +156,8 @@ func NewSlackNotifier(config *SlackConfig, t *template.Template) *SlackNotifier 
 		Token:          config.Token,
 		Text:           config.Text,
 		Title:          config.Title,
+		images:         images,
+		webhookSender:  webhookSender,
 		log:            log.New("alerting.notifier.slack"),
 		tmpl:           t,
 	}
@@ -165,6 +178,7 @@ type attachment struct {
 	Title      string              `json:"title,omitempty"`
 	TitleLink  string              `json:"title_link,omitempty"`
 	Text       string              `json:"text"`
+	ImageURL   string              `json:"image_url"`
 	Fallback   string              `json:"fallback"`
 	Fields     []config.SlackField `json:"fields,omitempty"`
 	Footer     string              `json:"footer"`
@@ -174,8 +188,8 @@ type attachment struct {
 }
 
 // Notify sends an alert notification to Slack.
-func (sn *SlackNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, error) {
-	msg, err := sn.buildSlackMessage(ctx, as)
+func (sn *SlackNotifier) Notify(ctx context.Context, alerts ...*types.Alert) (bool, error) {
+	msg, err := sn.buildSlackMessage(ctx, alerts)
 	if err != nil {
 		return false, fmt.Errorf("build slack message: %w", err)
 	}
@@ -205,7 +219,38 @@ func (sn *SlackNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 	if err := sendSlackRequest(request, sn.log); err != nil {
 		return false, err
 	}
-	return true, nil
+
+	// Try to upload if we have an image path but no image URL. This uploads the file
+	// immediately after the message. A bit of a hack, but it doesn't require the
+	// user to have an image host set up.
+	// TODO: how many image files should we upload? In what order? Should we
+	// assume the alerts array is already sorted?
+	// TODO: We need a refactoring so we don't do two database reads for the same data.
+	// TODO: Should we process all alerts' annotations? We can only have on image.
+	// TODO: Should we guard out-of-bounds errors here? Callers should prevent that from happening, imo
+	imgToken := getTokenFromAnnotations(alerts[0].Annotations)
+	dbContext, cancel := context.WithTimeout(ctx, ImageStoreTimeout)
+	imgData, err := sn.images.GetData(dbContext, imgToken)
+	cancel()
+	if err != nil {
+		if !errors.Is(err, ErrImagesUnavailable) {
+			// Ignore errors. Don't log "ImageUnavailable", which means the storage doesn't exist.
+			sn.log.Warn("Error reading screenshot data from ImageStore: %v", err)
+		}
+		return true, nil
+	} else {
+		defer func() {
+			// Nothing for us to do.
+			_ = imgData.Close()
+		}()
+
+		err = sn.slackFileUpload(ctx, imgData, sn.Recipient, sn.Token)
+		if err != nil {
+			sn.log.Warn("Error reading screenshot data from ImageStore: %v", err)
+		}
+
+		return true, nil
+	}
 }
 
 // sendSlackRequest sends a request to the Slack API.
@@ -275,11 +320,26 @@ func (sn *SlackNotifier) buildSlackMessage(ctx context.Context, as []*types.Aler
 
 	ruleURL := joinUrlPath(sn.tmpl.ExternalURL.String(), "/alerting/list", sn.log)
 
+	// TODO: Should we process all alerts' annotations? We can only have on image.
+	// TODO: Should we guard out-of-bounds errors here? Callers should prevent that from happening, imo
+	imgToken := getTokenFromAnnotations(as[0].Annotations)
+	timeoutCtx, cancel := context.WithTimeout(ctx, ImageStoreTimeout)
+	imgURL, err := sn.images.GetURL(timeoutCtx, imgToken)
+	cancel()
+	if err != nil {
+		if !errors.Is(err, ErrImagesUnavailable) {
+			// Ignore errors. Don't log "ImageUnavailable", which means the storage doesn't exist.
+			sn.log.Warn("failed to retrieve image url from store", "error", err)
+		}
+	}
+
 	req := &slackMessage{
 		Channel:   tmpl(sn.Recipient),
 		Username:  tmpl(sn.Username),
 		IconEmoji: tmpl(sn.IconEmoji),
 		IconURL:   tmpl(sn.IconURL),
+		// TODO: We should use the Block Kit API instead:
+		// https://api.slack.com/messaging/composing/layouts#when-to-use-attachments
 		Attachments: []attachment{
 			{
 				Color:      getAlertStatusColor(alerts.Status()),
@@ -287,6 +347,7 @@ func (sn *SlackNotifier) buildSlackMessage(ctx context.Context, as []*types.Aler
 				Fallback:   tmpl(sn.Title),
 				Footer:     "Grafana v" + setting.BuildVersion,
 				FooterIcon: FooterIconURL,
+				ImageURL:   imgURL,
 				Ts:         time.Now().Unix(),
 				TitleLink:  ruleURL,
 				Text:       tmpl(sn.Text),
@@ -338,4 +399,60 @@ func (sn *SlackNotifier) buildSlackMessage(ctx context.Context, as []*types.Aler
 
 func (sn *SlackNotifier) SendResolved() bool {
 	return !sn.GetDisableResolveMessage()
+}
+
+func (sn *SlackNotifier) slackFileUpload(ctx context.Context, data io.Reader, recipient, token string) error {
+	sn.log.Info("Uploading to slack via file.upload API")
+	headers, uploadBody, err := sn.generateSlackBody(data, token, recipient)
+	if err != nil {
+		return err
+	}
+	cmd := &models.SendWebhookSync{
+		Url: "https://slack.com/api/files.upload", Body: uploadBody.String(), HttpHeader: headers, HttpMethod: "POST",
+	}
+	if err := sn.webhookSender.SendWebhookSync(ctx, cmd); err != nil {
+		sn.log.Error("Failed to upload slack image", "error", err, "webhook", "file.upload")
+		return err
+	}
+	return nil
+}
+
+func (sn *SlackNotifier) generateSlackBody(data io.Reader, token string, recipient string) (map[string]string, bytes.Buffer, error) {
+	// Slack requires all POSTs to files.upload to present
+	// an "application/x-www-form-urlencoded" encoded querystring
+	// See https://api.slack.com/methods/files.upload
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+	defer func() {
+		if err := w.Close(); err != nil {
+			// Shouldn't matter since we already close w explicitly on the non-error path
+			sn.log.Warn("Failed to close multipart writer", "err", err)
+		}
+	}()
+
+	// TODO: perhaps we should pass the filename through to here to use the local name.
+	// https://github.com/grafana/grafana/issues/49375
+	fw, err := w.CreateFormFile("file", fmt.Sprintf("screenshot-%v", rand.Intn(2e6)))
+	if err != nil {
+		return nil, b, err
+	}
+	if _, err := io.Copy(fw, data); err != nil {
+		return nil, b, err
+	}
+	// Add the authorization token
+	if err := w.WriteField("token", token); err != nil {
+		return nil, b, err
+	}
+	// Add the channel(s) to POST to
+	if err := w.WriteField("channels", recipient); err != nil {
+		return nil, b, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, b, fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+	headers := map[string]string{
+		"Content-Type":  w.FormDataContentType(),
+		"Authorization": "auth_token=\"" + token + "\"",
+	}
+	return headers, b, nil
 }

--- a/pkg/services/ngalert/notifier/channels/utils.go
+++ b/pkg/services/ngalert/notifier/channels/utils.go
@@ -25,6 +25,9 @@ const (
 	FooterIconURL      = "https://grafana.com/assets/img/fav32.png"
 	ColorAlertFiring   = "#D63232"
 	ColorAlertResolved = "#36a64f"
+
+	// ImageStoreTimeout should be used by all callers for calles to `Images`
+	ImageStoreTimeout time.Duration = 500 * time.Millisecond
 )
 
 var (

--- a/pkg/services/ngalert/notifier/channels/utils.go
+++ b/pkg/services/ngalert/notifier/channels/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -16,6 +17,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/util"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -32,8 +34,26 @@ const (
 
 var (
 	// Provides current time. Can be overwritten in tests.
-	timeNow = time.Now
+	timeNow              = time.Now
+	ErrImagesUnavailable = errors.New("alert screenshots are unavailable")
 )
+
+func getTokenFromAnnotations(annotations model.LabelSet) string {
+	if value, ok := annotations[models.ScreenshotTokenAnnotation]; ok {
+		return string(value)
+	}
+	return ""
+}
+
+type UnavailableImageStore struct{}
+
+func (n *UnavailableImageStore) GetURL(ctx context.Context, token string) (string, error) {
+	return "", ErrImagesUnavailable
+}
+
+func (n *UnavailableImageStore) GetData(ctx context.Context, token string) (io.ReadCloser, error) {
+	return nil, ErrImagesUnavailable
+}
 
 type receiverInitError struct {
 	Reason string

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -44,7 +44,7 @@ type MultiOrgAlertmanager struct {
 	peer         ClusterPeer
 	settleCancel context.CancelFunc
 
-	configStore store.AlertingStore
+	configStore AlertingStore
 	orgStore    store.OrgStore
 	kvStore     kvstore.KVStore
 
@@ -54,7 +54,7 @@ type MultiOrgAlertmanager struct {
 	ns      notifications.Service
 }
 
-func NewMultiOrgAlertmanager(cfg *setting.Cfg, configStore store.AlertingStore, orgStore store.OrgStore,
+func NewMultiOrgAlertmanager(cfg *setting.Cfg, configStore AlertingStore, orgStore store.OrgStore,
 	kvStore kvstore.KVStore, provStore provisioning.ProvisioningStore, decryptFn channels.GetDecryptedValueFn,
 	m *metrics.MultiOrgAlertmanager, ns notifications.Service, l log.Logger, s secrets.Service,
 ) (*MultiOrgAlertmanager, error) {

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -20,8 +19,8 @@ type FakeConfigStore struct {
 	configs map[int64]*models.AlertConfiguration
 }
 
-func (f *FakeConfigStore) GetURL(ctx context.Context, token string) (*url.URL, error) {
-	return nil, store.ErrImageNotFound
+func (f *FakeConfigStore) GetURL(ctx context.Context, token string) (string, error) {
+	return "", store.ErrImageNotFound
 }
 
 // Returns an io.ReadCloser that reads out the image data for the provided

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -5,6 +5,8 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
+	"io"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -16,6 +18,16 @@ import (
 
 type FakeConfigStore struct {
 	configs map[int64]*models.AlertConfiguration
+}
+
+func (f *FakeConfigStore) GetURL(ctx context.Context, token string) (*url.URL, error) {
+	return nil, store.ErrImageNotFound
+}
+
+// Returns an io.ReadCloser that reads out the image data for the provided
+// token, if available. May return ErrImageNotFound.
+func (f *FakeConfigStore) GetData(ctx context.Context, token string) (io.ReadCloser, error) {
+	return nil, store.ErrImageNotFound
 }
 
 func NewFakeConfigStore(t *testing.T, configs map[int64]*models.AlertConfiguration) FakeConfigStore {

--- a/pkg/services/ngalert/store/image.go
+++ b/pkg/services/ngalert/store/image.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/url"
+	"os"
 	"time"
 
 	"github.com/gofrs/uuid"
@@ -36,6 +39,12 @@ type ImageStore interface {
 
 	// Saves the image or returns an error.
 	SaveImage(ctx context.Context, img *Image) error
+
+	GetURL(ctx context.Context, token string) (*url.URL, error)
+
+	// Returns an io.ReadCloser that reads out the image data for the provided
+	// token, if available. May return ErrImageNotFound.
+	GetData(ctx context.Context, token string) (io.ReadCloser, error)
 }
 
 func (st DBstore) GetImage(ctx context.Context, token string) (*Image, error) {
@@ -81,6 +90,35 @@ func (st DBstore) SaveImage(ctx context.Context, img *Image) error {
 		}
 		return nil
 	})
+}
+
+func (st *DBstore) GetURL(ctx context.Context, token string) (*url.URL, error) {
+	img, err := st.GetImage(ctx, token)
+	if err != nil {
+		return &url.URL{}, err
+	}
+	return url.Parse(img.URL)
+}
+
+func (st *DBstore) GetData(ctx context.Context, token string) (io.ReadCloser, error) {
+	// TODO: Should we support getting data from image.URL? One could configure
+	// the system to upload to S3 while still reading data for notifiers like
+	// Slack that take multipart uploads.
+	img, err := st.GetImage(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(img.Path) == 0 {
+		return nil, ErrImageNotFound
+	}
+
+	f, err := os.Open(img.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	return f, nil
 }
 
 //nolint:unused

--- a/pkg/services/ngalert/store/image.go
+++ b/pkg/services/ngalert/store/image.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"time"
 
@@ -40,7 +39,7 @@ type ImageStore interface {
 	// Saves the image or returns an error.
 	SaveImage(ctx context.Context, img *Image) error
 
-	GetURL(ctx context.Context, token string) (*url.URL, error)
+	GetURL(ctx context.Context, token string) (string, error)
 
 	// Returns an io.ReadCloser that reads out the image data for the provided
 	// token, if available. May return ErrImageNotFound.
@@ -92,12 +91,12 @@ func (st DBstore) SaveImage(ctx context.Context, img *Image) error {
 	})
 }
 
-func (st *DBstore) GetURL(ctx context.Context, token string) (*url.URL, error) {
+func (st *DBstore) GetURL(ctx context.Context, token string) (string, error) {
 	img, err := st.GetImage(ctx, token)
 	if err != nil {
-		return &url.URL{}, err
+		return "", err
 	}
-	return url.Parse(img.URL)
+	return img.URL, nil
 }
 
 func (st *DBstore) GetData(ctx context.Context, token string) (io.ReadCloser, error) {

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -475,7 +475,7 @@ func (m *migration) validateAlertmanagerConfig(orgID int64, config *PostableUser
 			if !exists {
 				return fmt.Errorf("notifier %s is not supported", gr.Type)
 			}
-			factoryConfig, err := channels.NewFactoryConfig(cfg, nil, decryptFunc, nil)
+			factoryConfig, err := channels.NewFactoryConfig(cfg, nil, decryptFunc, nil, nil)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Attaches either an image URL for screenshots that have been uploaded to an external image hosting service, if configured. Uploads screenshot images to notification channels that support image uploads, like Slack, if configured.
