### PR TITLE
Alerting: Add Screenshot URLs to Pagerduty Notifier

### DIFF
--- a/pkg/services/ngalert/notifier/channels/pagerduty.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty.go
@@ -243,10 +243,6 @@ type pagerDutyLink struct {
 	Text string `json:"text"`
 }
 
-type pagerDutyImages struct {
-	Images []pagerDutyImage `json:"images"`
-}
-
 type pagerDutyImage struct {
 	Src string `json:"src"`
 }

--- a/pkg/services/ngalert/notifier/channels/pagerduty.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty.go
@@ -39,6 +39,7 @@ type PagerdutyNotifier struct {
 	tmpl          *template.Template
 	log           log.Logger
 	ns            notifications.WebhookSender
+	images        ImageStore
 }
 
 type PagerdutyConfig struct {
@@ -59,7 +60,7 @@ func PagerdutyFactory(fc FactoryConfig) (NotificationChannel, error) {
 			Cfg:    *fc.Config,
 		}
 	}
-	return NewPagerdutyNotifier(cfg, fc.NotificationService, fc.Template), nil
+	return NewPagerdutyNotifier(cfg, fc.NotificationService, fc.ImageStore, fc.Template), nil
 }
 
 func NewPagerdutyConfig(config *NotificationChannelConfig, decryptFunc GetDecryptedValueFn) (*PagerdutyConfig, error) {
@@ -79,7 +80,7 @@ func NewPagerdutyConfig(config *NotificationChannelConfig, decryptFunc GetDecryp
 }
 
 // NewPagerdutyNotifier is the constructor for the PagerDuty notifier
-func NewPagerdutyNotifier(config *PagerdutyConfig, ns notifications.WebhookSender, t *template.Template) *PagerdutyNotifier {
+func NewPagerdutyNotifier(config *PagerdutyConfig, ns notifications.WebhookSender, images ImageStore, t *template.Template) *PagerdutyNotifier {
 	return &PagerdutyNotifier{
 		Base: NewBase(&models.AlertNotification{
 			Uid:                   config.UID,
@@ -103,6 +104,7 @@ func NewPagerdutyNotifier(config *PagerdutyConfig, ns notifications.WebhookSende
 		tmpl:      t,
 		log:       log.New("alerting.notifier." + config.Name),
 		ns:        ns,
+		images:    images,
 	}
 }
 
@@ -184,6 +186,19 @@ func (pn *PagerdutyNotifier) buildPagerdutyMessage(ctx context.Context, alerts m
 		},
 	}
 
+	imgToken := getTokenFromAnnotations(as[0].Annotations)
+	timeoutCtx, cancel := context.WithTimeout(ctx, ImageStoreTimeout)
+	imgURL, err := pn.images.GetURL(timeoutCtx, imgToken)
+	cancel()
+	if err != nil {
+		if !errors.Is(err, ErrImagesUnavailable) {
+			// Ignore errors. Don't log "ImageUnavailable", which means the storage doesn't exist.
+			pn.log.Warn("failed to retrieve image url from store", "error", err)
+		}
+	} else {
+		msg.Images = append(msg.Images, pagerDutyImage{Src: imgURL})
+	}
+
 	if len(msg.Payload.Summary) > 1024 {
 		// This is the Pagerduty limit.
 		msg.Payload.Summary = msg.Payload.Summary[:1021] + "..."
@@ -215,11 +230,20 @@ type pagerDutyMessage struct {
 	Client      string           `json:"client,omitempty"`
 	ClientURL   string           `json:"client_url,omitempty"`
 	Links       []pagerDutyLink  `json:"links,omitempty"`
+	Images      []pagerDutyImage `json:"images,omitempty"`
 }
 
 type pagerDutyLink struct {
 	HRef string `json:"href"`
 	Text string `json:"text"`
+}
+
+type pagerDutyImages struct {
+	Images []pagerDutyImage `json:"images"`
+}
+
+type pagerDutyImage struct {
+	Src string `json:"src"`
 }
 
 type pagerDutyPayload struct {

--- a/pkg/services/ngalert/notifier/channels/pagerduty_test.go
+++ b/pkg/services/ngalert/notifier/channels/pagerduty_test.go
@@ -149,7 +149,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")
 			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
-			pn := NewPagerdutyNotifier(cfg, webhookSender, tmpl)
+			pn := NewPagerdutyNotifier(cfg, webhookSender, &UnavailableImageStore{}, tmpl)
 			ok, err := pn.Notify(ctx, c.alerts...)
 			if c.expMsgError != nil {
 				require.False(t, ok)


### PR DESCRIPTION
PagerDuty takes an "images" array of objects, and we attach an image URL for each alert that we can fetch one for.