### PR TITLE
Alerting: Add image_urls to OpsGenie notification details.

### DIFF
--- a/pkg/services/ngalert/notifier/channels/opsgenie.go
+++ b/pkg/services/ngalert/notifier/channels/opsgenie.go
@@ -220,16 +220,18 @@ func (on *OpsgenieNotifier) buildOpsgenieMessage(ctx context.Context, alerts mod
 
 			dbContext, cancel := context.WithTimeout(ctx, ImageStoreTimeout)
 			imgURL, err := on.images.GetURL(dbContext, imgToken)
+			cancel()
+
 			if err != nil {
 				if !errors.Is(err, ErrImagesUnavailable) {
 					// Ignore errors. Don't log "ImageUnavailable", which means the storage doesn't exist.
 					on.log.Warn("Error reading screenshot data from ImageStore: %v", err)
 				}
-			} else {
+			} else if len(imgURL) != 0 {
 				images = append(images, imgURL)
 			}
-			cancel()
 		}
+
 		if len(images) != 0 {
 			details.Set("image_urls", images)
 		}

--- a/pkg/services/ngalert/notifier/channels/opsgenie.go
+++ b/pkg/services/ngalert/notifier/channels/opsgenie.go
@@ -40,6 +40,7 @@ type OpsgenieNotifier struct {
 	tmpl             *template.Template
 	log              log.Logger
 	ns               notifications.WebhookSender
+	images           ImageStore
 }
 
 type OpsgenieConfig struct {
@@ -59,7 +60,7 @@ func OpsgenieFactory(fc FactoryConfig) (NotificationChannel, error) {
 			Cfg:    *fc.Config,
 		}
 	}
-	return NewOpsgenieNotifier(cfg, fc.NotificationService, fc.Template, fc.DecryptFunc), nil
+	return NewOpsgenieNotifier(cfg, fc.NotificationService, fc.ImageStore, fc.Template, fc.DecryptFunc), nil
 }
 
 func NewOpsgenieConfig(config *NotificationChannelConfig, decryptFunc GetDecryptedValueFn) (*OpsgenieConfig, error) {
@@ -84,7 +85,7 @@ func NewOpsgenieConfig(config *NotificationChannelConfig, decryptFunc GetDecrypt
 }
 
 // NewOpsgenieNotifier is the constructor for the Opsgenie notifier
-func NewOpsgenieNotifier(config *OpsgenieConfig, ns notifications.WebhookSender, t *template.Template, fn GetDecryptedValueFn) *OpsgenieNotifier {
+func NewOpsgenieNotifier(config *OpsgenieConfig, ns notifications.WebhookSender, images ImageStore, t *template.Template, fn GetDecryptedValueFn) *OpsgenieNotifier {
 	return &OpsgenieNotifier{
 		Base: NewBase(&models.AlertNotification{
 			Uid:                   config.UID,
@@ -101,6 +102,7 @@ func NewOpsgenieNotifier(config *OpsgenieConfig, ns notifications.WebhookSender,
 		tmpl:             t,
 		log:              log.New("alerting.notifier." + config.Name),
 		ns:               ns,
+		images:           images,
 	}
 }
 
@@ -207,6 +209,29 @@ func (on *OpsgenieNotifier) buildOpsgenieMessage(ctx context.Context, alerts mod
 	if on.sendDetails() {
 		for k, v := range lbls {
 			details.Set(k, v)
+		}
+
+		images := []string{}
+		for i := range as {
+			imgToken := getTokenFromAnnotations(as[i].Annotations)
+			if len(imgToken) == 0 {
+				continue
+			}
+
+			dbContext, cancel := context.WithTimeout(ctx, ImageStoreTimeout)
+			imgURL, err := on.images.GetURL(dbContext, imgToken)
+			if err != nil {
+				if !errors.Is(err, ErrImagesUnavailable) {
+					// Ignore errors. Don't log "ImageUnavailable", which means the storage doesn't exist.
+					on.log.Warn("Error reading screenshot data from ImageStore: %v", err)
+				}
+			} else {
+				images = append(images, imgURL)
+			}
+			cancel()
+		}
+		if len(images) != 0 {
+			details.Set("image_urls", images)
 		}
 	}
 

--- a/pkg/services/ngalert/notifier/channels/opsgenie_test.go
+++ b/pkg/services/ngalert/notifier/channels/opsgenie_test.go
@@ -184,7 +184,7 @@ func TestOpsgenieNotifier(t *testing.T) {
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")
 			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
-			pn := NewOpsgenieNotifier(cfg, webhookSender, tmpl, decryptFn)
+			pn := NewOpsgenieNotifier(cfg, webhookSender, &UnavailableImageStore{}, tmpl, decryptFn)
 			ok, err := pn.Notify(ctx, c.alerts...)
 			if c.expMsgError != nil {
 				require.False(t, ok)


### PR DESCRIPTION
Adds an array of `image_urls` to the ops genier `details` field in a message, if image urls are available.

```json
{
  "message": "Alert with Images!",
  "details": {
    "image_urls": ["http://www.example.com"]
  }
}
```