### PR TITLE
Alerting: Add Image URLs to Microsoft Teams notifier.

### DIFF
--- a/pkg/services/ngalert/notifier/channels/teams_test.go
+++ b/pkg/services/ngalert/notifier/channels/teams_test.go
@@ -220,7 +220,7 @@ func TestTeamsNotifier(t *testing.T) {
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")
 			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
-			pn := NewTeamsNotifier(cfg, webhookSender, tmpl)
+			pn := NewTeamsNotifier(cfg, webhookSender, &UnavailableImageStore{}, tmpl)
 			ok, err := pn.Notify(ctx, c.alerts...)
 			if c.expMsgError != nil {
 				require.False(t, ok)


### PR DESCRIPTION
If there are screenshot images with URLs, they will be attached to the
Microsoft teams notification in the first sections, as a slice of image
objects.