### PR TITLE
Notification history: limit persisted notifications to 25

### DIFF
--- a/public/app/core/reducers/appNotification.ts
+++ b/public/app/core/reducers/appNotification.ts
@@ -3,6 +3,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { config } from '@grafana/runtime';
 import { AppNotification, AppNotificationSeverity, AppNotificationsState } from 'app/types/';
 
+const MAX_STORED_NOTIFICATIONS = 25;
 export const STORAGE_KEY = 'notifications';
 export const NEW_NOTIFS_KEY = `${STORAGE_KEY}/lastRead`;
 type StoredNotification = Omit<AppNotification, 'component'>;
@@ -111,6 +112,8 @@ function serializeNotifications(notifs: Record<string, StoredNotification>) {
 
   const reducedNotifs = Object.values(notifs)
     .filter(isAtLeastWarning)
+    .sort((a, b) => b.timestamp - a.timestamp)
+    .slice(0, MAX_STORED_NOTIFICATIONS)
     .reduce<Record<string, StoredNotification>>((prev, cur) => {
       prev[cur.id] = {
         id: cur.id,
@@ -125,5 +128,11 @@ function serializeNotifications(notifs: Record<string, StoredNotification>) {
 
       return prev;
     }, {});
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(reducedNotifs));
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(reducedNotifs));
+  } catch (err) {
+    console.error('Unable to persist notifications to local storage');
+    console.error(err);
+  }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

 - Limits stored notifications to 25 most recent
 - Wrap `localStorage.setItem` in try/catch so if it does fail for whatever reason, we don't crash all of grafana

**Which issue(s) this PR fixes**:

For https://github.com/grafana/grafana/issues/49110

**Special notes for your reviewer**:

Not super convinced this is the right approach! Instead, I guess we could stringify each notification and count it's length and set a max characters limit (as a proxy for bytes)? Not sure if the complexity is worth it. Eager for other's thoughts!!

