### PR TITLE
Plugins: Fix Azure Devops plugin link and plugins list order

### DIFF
--- a/public/app/features/datasources/state/buildCategories.test.ts
+++ b/public/app/features/datasources/state/buildCategories.test.ts
@@ -52,7 +52,10 @@ describe('buildCategories', () => {
   });
 
   it('should add enterprise phantom plugins', () => {
-    expect(categories[3].title).toBe('Enterprise plugins');
-    expect(categories[3].plugins.length).toBe(17);
+    const enterprisePluginsCategory = categories[3];
+    expect(enterprisePluginsCategory.title).toBe('Enterprise plugins');
+    expect(enterprisePluginsCategory.plugins.length).toBe(17);
+    expect(enterprisePluginsCategory.plugins[0].name).toBe('AppDynamics');
+    expect(enterprisePluginsCategory.plugins[enterprisePluginsCategory.plugins.length - 1].name).toBe('Wavefront');
   });
 });

--- a/public/app/features/datasources/state/buildCategories.ts
+++ b/public/app/features/datasources/state/buildCategories.ts
@@ -88,7 +88,7 @@ function sortPlugins(plugins: DataSourcePluginMeta[]) {
       return 1;
     }
 
-    return a.name > b.name ? -1 : 1;
+    return a.name > b.name ? 1 : -1;
   });
 }
 
@@ -191,7 +191,7 @@ function getEnterprisePhantomPlugins(): DataSourcePluginMeta[] {
       imgUrl: 'public/img/plugins/signalfx-logo.svg',
     }),
     getPhantomPlugin({
-      id: 'grafana-azure-devops-datasource',
+      id: 'grafana-azuredevops-datasource',
       description: 'Azure Devops datasource',
       name: 'Azure Devops',
       imgUrl: 'public/img/plugins/azure-devops.png',


### PR DESCRIPTION
**What this PR does / why we need it**:

* Fixes the link azure devops datasource in plugins/datasources list page
* Sort the plugins list by their name a-z instead z-a.