### PR TITLE
[v8.5.x] InfluxDB: Use backend for influxDB by default via feature toggle (#48453)

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1140,6 +1140,12 @@ enable =
 # The new prometheus visual query builder
 promQueryBuilder = true
 
+# The new loki visual query builder
+lokiQueryBuilder = true
+
+# InfluxDB backend migration
+influxdbBackendMigration = true
+
 # Experimental Explore to Dashboard workflow
 explore2Dashboard = true
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1140,9 +1140,6 @@ enable =
 # The new prometheus visual query builder
 promQueryBuilder = true
 
-# The new loki visual query builder
-lokiQueryBuilder = true
-
 # InfluxDB backend migration
 influxdbBackendMigration = true
 


### PR DESCRIPTION
manual backport PR of https://github.com/grafana/grafana/pull/48453

(cherry picked from commit 755ec3b469a15c585236527156d0451a5ff77d23)