### PR TITLE
Query History: Enable new query history by default

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -938,7 +938,7 @@ enabled = true
 #################################### Query History #############################
 [query_history]
 # Enable the Query history
-enabled = false
+enabled = true
 
 #################################### Internal Grafana Metrics ############
 # Metrics available at HTTP URL /metrics and /metrics/plugins/:pluginId

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -903,7 +903,7 @@
 #################################### Query History #############################
 [query_history]
 # Enable the Query history
-;enabled = false
+;enabled = true
 
 #################################### Internal Grafana Metrics ##########################
 # Metrics available at HTTP URL /metrics and /metrics/plugins/:pluginId
@@ -968,7 +968,7 @@
 
 # This is a configuration for OTLP exporter with GRPC protocol
 [tracing.opentelemetry.otlp]
-# otlp destination (ex localhost:4317) 
+# otlp destination (ex localhost:4317)
 ; address = localhost:4317
 # Propagation specifies the text map propagation format: w3c, jaeger
 ; propagation = w3c

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -1381,7 +1381,7 @@ Configures Query history in Explore.
 
 ### enabled
 
-Enable or disable the Query history. Default is `disabled`.
+Enable or disable the Query history. Default is `enabled`.
 
 ## [metrics]
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This is to enable new query history that is being worked on here https://github.com/grafana/grafana/issues/44327 for beta testing. There are still smaller tweaks we are thinking about adding but it has all the features implemented.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to #44327

**Special notes for your reviewer**:

Details on how to test migration multiple times: https://github.com/grafana/grafana/pull/48572

Query history should work as before with minor changes to filtering and settings:
* Retention period cannot be changed. It's fixed at 14 weeks. (Previously it was defined by the user at maximum 14 weeks but could have been shorter to reduce space usage, which was important with local storage, but shouldn't be a problem with backend database. Also we may decide to allow configuring this option but at organization level).
* Query history cannot be cleared. (It was needed only for local storage as it has limited space when the user was running out of space)
* Results cannot be sorted by data source. (Not supported by the API, it's not really needed because it's easy to filter by data source)
* The behavior for filtering only for the active data source is simplified -> the filter for data sources is always visible but pre-populated with the currently active data source.

To *disable* new query history add the following entry to custom.ini:

```
[query_history]
enabled = false
```

When new query history is disabled it should work exactly as before with all the features required for local storage (like changing retention period and clearing all the entries). Entries are not removed from local storage is it's possible to opt-out after the migration and keep using local storage (though new entries won't be migrated when query history is re-enabled).