### PR TITLE
I18n: Add locale to user preference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ debug.test
 /packaging/**/*.deb
 /packaging/**/*.tar.gz
 /packaging/**/*.tar.gz.sha256
+pkg/cmd/grafana-server/__debug_bin
 
 # Ignore OSX indexing
 .DS_Store
@@ -165,4 +166,3 @@ public/locales/_build/
 public/locales/**/*.js
 
 deployment_tools_config.json
-

--- a/pkg/api/dtos/prefs.go
+++ b/pkg/api/dtos/prefs.go
@@ -10,6 +10,7 @@ type Prefs struct {
 	HomeDashboardUID string                      `json:"homeDashboardUID,omitempty"`
 	Timezone         string                      `json:"timezone"`
 	WeekStart        string                      `json:"weekStart"`
+	Locale           string                      `json:"locale"`
 	Navbar           pref.NavbarPreference       `json:"navbar,omitempty"`
 	QueryHistory     pref.QueryHistoryPreference `json:"queryHistory,omitempty"`
 }
@@ -27,6 +28,7 @@ type UpdatePrefsCmd struct {
 	WeekStart    string                       `json:"weekStart"`
 	Navbar       *pref.NavbarPreference       `json:"navbar,omitempty"`
 	QueryHistory *pref.QueryHistoryPreference `json:"queryHistory,omitempty"`
+	Locale       string                       `json:"locale"`
 }
 
 // swagger:model
@@ -39,6 +41,7 @@ type PatchPrefsCmd struct {
 	// Enum: utc,browser
 	Timezone         *string                      `json:"timezone,omitempty"`
 	WeekStart        *string                      `json:"weekStart,omitempty"`
+	Locale           *string                      `json:"locale,omitempty"`
 	Navbar           *pref.NavbarPreference       `json:"navbar,omitempty"`
 	QueryHistory     *pref.QueryHistoryPreference `json:"queryHistory,omitempty"`
 	HomeDashboardUID *string                      `json:"homeDashboardUID,omitempty"`

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -80,6 +80,7 @@ func (hs *HTTPServer) getPreferencesFor(ctx context.Context, orgID, userID, team
 	}
 
 	if preference.JSONData != nil {
+		dto.Locale = preference.JSONData.Locale
 		dto.Navbar = preference.JSONData.Navbar
 		dto.QueryHistory = preference.JSONData.QueryHistory
 	}
@@ -117,6 +118,7 @@ func (hs *HTTPServer) updatePreferencesFor(ctx context.Context, orgID, userID, t
 		OrgID:           orgID,
 		TeamID:          teamId,
 		Theme:           dtoCmd.Theme,
+		Locale:          dtoCmd.Locale,
 		Timezone:        dtoCmd.Timezone,
 		WeekStart:       dtoCmd.WeekStart,
 		HomeDashboardID: dtoCmd.HomeDashboardID,
@@ -165,6 +167,7 @@ func (hs *HTTPServer) patchPreferencesFor(ctx context.Context, orgID, userID, te
 		Timezone:        dtoCmd.Timezone,
 		WeekStart:       dtoCmd.WeekStart,
 		HomeDashboardID: dtoCmd.HomeDashboardID,
+		Locale:          dtoCmd.Locale,
 		Navbar:          dtoCmd.Navbar,
 		QueryHistory:    dtoCmd.QueryHistory,
 	}

--- a/pkg/services/preference/model.go
+++ b/pkg/services/preference/model.go
@@ -47,6 +47,7 @@ type SavePreferenceCommand struct {
 	Timezone         string                  `json:"timezone,omitempty"`
 	WeekStart        string                  `json:"weekStart,omitempty"`
 	Theme            string                  `json:"theme,omitempty"`
+	Locale           string                  `json:"locale,omitempty"`
 	Navbar           *NavbarPreference       `json:"navbar,omitempty"`
 	QueryHistory     *QueryHistoryPreference `json:"queryHistory,omitempty"`
 }
@@ -61,6 +62,7 @@ type PatchPreferenceCommand struct {
 	Timezone         *string                 `json:"timezone,omitempty"`
 	WeekStart        *string                 `json:"weekStart,omitempty"`
 	Theme            *string                 `json:"theme,omitempty"`
+	Locale           *string                 `json:"locale,omitempty"`
 	Navbar           *NavbarPreference       `json:"navbar,omitempty"`
 	QueryHistory     *QueryHistoryPreference `json:"queryHistory,omitempty"`
 }
@@ -77,6 +79,7 @@ type NavbarPreference struct {
 }
 
 type PreferenceJSONData struct {
+	Locale       string                 `json:"locale"`
 	Navbar       NavbarPreference       `json:"navbar"`
 	QueryHistory QueryHistoryPreference `json:"queryHistory"`
 }

--- a/pkg/services/preference/prefimpl/pref.go
+++ b/pkg/services/preference/prefimpl/pref.go
@@ -82,6 +82,7 @@ func (s *Service) Save(ctx context.Context, cmd *pref.SavePreferenceCommand) err
 	})
 	if err != nil {
 		if errors.Is(err, pref.ErrPrefNotFound) {
+			// TODO: need to set Locale preference here
 			preference := &pref.Preference{
 				UserID:          cmd.UserID,
 				OrgID:           cmd.OrgID,
@@ -92,6 +93,9 @@ func (s *Service) Save(ctx context.Context, cmd *pref.SavePreferenceCommand) err
 				Theme:           cmd.Theme,
 				Created:         time.Now(),
 				Updated:         time.Now(),
+				JSONData: &pref.PreferenceJSONData{
+					Locale: cmd.Locale,
+				},
 			}
 			_, err = s.store.Insert(ctx, preference)
 			if err != nil {
@@ -106,9 +110,14 @@ func (s *Service) Save(ctx context.Context, cmd *pref.SavePreferenceCommand) err
 	preference.Theme = cmd.Theme
 	preference.Updated = time.Now()
 	preference.Version += 1
-	preference.JSONData = &pref.PreferenceJSONData{}
 	preference.HomeDashboardID = cmd.HomeDashboardID
 
+	if preference.JSONData == nil {
+		preference.JSONData = &pref.PreferenceJSONData{}
+	}
+	if cmd.Locale != "" {
+		preference.JSONData.Locale = cmd.Locale
+	}
 	if cmd.Navbar != nil {
 		preference.JSONData.Navbar = *cmd.Navbar
 	}
@@ -139,6 +148,13 @@ func (s *Service) Patch(ctx context.Context, cmd *pref.PatchPreferenceCommand) e
 		}
 	} else {
 		exists = true
+	}
+
+	if cmd.Locale != nil {
+		if preference.JSONData == nil {
+			preference.JSONData = &pref.PreferenceJSONData{}
+		}
+		preference.JSONData.Locale = *cmd.Locale
 	}
 
 	if cmd.Navbar != nil {

--- a/pkg/services/preference/prefimpl/pref.go
+++ b/pkg/services/preference/prefimpl/pref.go
@@ -82,7 +82,6 @@ func (s *Service) Save(ctx context.Context, cmd *pref.SavePreferenceCommand) err
 	})
 	if err != nil {
 		if errors.Is(err, pref.ErrPrefNotFound) {
-			// TODO: need to set Locale preference here
 			preference := &pref.Preference{
 				UserID:          cmd.UserID,
 				OrgID:           cmd.OrgID,
@@ -111,13 +110,10 @@ func (s *Service) Save(ctx context.Context, cmd *pref.SavePreferenceCommand) err
 	preference.Updated = time.Now()
 	preference.Version += 1
 	preference.HomeDashboardID = cmd.HomeDashboardID
+	preference.JSONData = &pref.PreferenceJSONData{
+		Locale: cmd.Locale,
+	}
 
-	if preference.JSONData == nil {
-		preference.JSONData = &pref.PreferenceJSONData{}
-	}
-	if cmd.Locale != "" {
-		preference.JSONData.Locale = cmd.Locale
-	}
 	if cmd.Navbar != nil {
 		preference.JSONData.Navbar = *cmd.Navbar
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Starts to add locale preference. Future PRs will add this to Org preferences and also the custom.ini config.

Because this is optional in the UI, we're not adding this particular part behind a feature flag, despite the UI for this being feature flagged (when its added)

**Which issue(s) this PR fixes**:


Part of #49424