### PR TITLE
Alerting: Attach image URLs to Google Chat notifications.

### DIFF
--- a/pkg/services/ngalert/notifier/channels/googlechat.go
+++ b/pkg/services/ngalert/notifier/channels/googlechat.go
@@ -140,8 +140,7 @@ func (gcn *GoogleChatNotifier) Notify(ctx context.Context, as ...*types.Alert) (
 			},
 		},
 	}
-	screenshots := gcn.buildScreenshotCard(ctx, as)
-	if screenshots != nil {
+	if screenshots := gcn.buildScreenshotCard(ctx, as); screenshots != nil {
 		res.Cards = append(res.Cards, *screenshots)
 	}
 

--- a/pkg/services/ngalert/notifier/channels/googlechat_test.go
+++ b/pkg/services/ngalert/notifier/channels/googlechat_test.go
@@ -329,10 +329,11 @@ func TestGoogleChatNotifier(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+			imageStore := &UnavailableImageStore{}
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")
 			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
-			pn := NewGoogleChatNotifier(cfg, webhookSender, tmpl)
+			pn := NewGoogleChatNotifier(cfg, imageStore, webhookSender, tmpl)
 			ok, err := pn.Notify(ctx, c.alerts...)
 			if c.expMsgError != nil {
 				require.False(t, ok)


### PR DESCRIPTION
**What this PR does / why we need it**:

If an image is attached to an alert notification and the notification is routed to Google Chat, we now build a new card containing the screenshots. Each screenshot is annotated with the corresponding alert's state and name.

Much like MSTeams (https://github.com/grafana/grafana/pull/49385), Googlechat expects a link to an image hosted elsewhere, and doesn't seem to have a multipart API for uploading the image with the screenshot. So, we just key off the URL only, which is also what Teams does.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

