### PR TITLE
Docs: updates alerts to alerting in the TOC

### DIFF
--- a/docs/sources/alerting/_index.md
+++ b/docs/sources/alerting/_index.md
@@ -1,6 +1,6 @@
 +++
 aliases = ["/docs/grafana/latest/alerting/", "/docs/grafana/latest/alerting/unified-alerting/difference-old-new/"]
-title = "Alerts"
+title = "Alerting"
 weight = 114
 +++
 


### PR DESCRIPTION
As part of the docs refactoring project, this PR changes the 'alerts' TOC entry to 'alerting'.