### PR TITLE
Search: scroll to the top after a query changes

### DIFF
--- a/public/app/features/search/page/components/SearchResultsTable.tsx
+++ b/public/app/features/search/page/components/SearchResultsTable.tsx
@@ -46,10 +46,8 @@ export const SearchResultsTable = React.memo(
     const styles = useStyles2(getStyles);
     const tableStyles = useStyles2(getTableStyles);
 
-    // We create a reference for the InfiniteLoader
     const infiniteLoaderRef = useRef<InfiniteLoader>(null);
     const listRef = useRef<FixedSizeList>(null);
-    const hasMountedRef = useRef(false);
 
     const memoizedData = useMemo(() => {
       if (!response?.view?.dataFrame.fields.length) {
@@ -61,16 +59,14 @@ export const SearchResultsTable = React.memo(
       return Array(response.totalRows).fill(0);
     }, [response]);
 
+    // Scroll to the top and clear loader cache when the query results change
     useEffect(() => {
-      // We only need to reset cached items when "sortOrder" changes.
-      // This effect will run on mount too; there's no need to reset in that case.
-      if (hasMountedRef.current && infiniteLoaderRef.current) {
+      if (infiniteLoaderRef.current) {
         infiniteLoaderRef.current.resetloadMoreItemsCache();
       }
       if (listRef.current) {
         listRef.current.scrollTo(0);
       }
-      hasMountedRef.current = true;
     }, [memoizedData]);
 
     // React-table column definitions
@@ -155,7 +151,7 @@ export const SearchResultsTable = React.memo(
             itemCount={rows.length}
             loadMoreItems={response.loadMoreItems}
           >
-            {({ onItemsRendered, ref }) => (
+            {({ onItemsRendered }) => (
               <FixedSizeList
                 ref={listRef}
                 onItemsRendered={onItemsRendered}


### PR DESCRIPTION
With the infinite loader and virtualized list, we currently have the not-great bug that if you query after scrolling, the view stays in its scrolled location.  This PR will reset the view to the top whenever query results change.

![2022-05-23_14-01-53 (1)](https://user-images.githubusercontent.com/705951/169905653-8009828a-892e-40d0-84bd-ebe980678795.gif)
