### PR TITLE
DashList: Handle long dashboard titles more gracefully

### DIFF
--- a/public/app/plugins/panel/dashlist/styles.ts
+++ b/public/app/plugins/panel/dashlist/styles.ts
@@ -48,6 +48,8 @@ export const getStyles = (theme: GrafanaTheme2) => ({
 
   dashlistLinkBody: css`
     flex-grow: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
   `,
 
   dashlistItem: css`


### PR DESCRIPTION
**What this PR does / why we need it**:
Before:
<img width="793" alt="image" src="https://user-images.githubusercontent.com/45561153/169967964-32ea7030-a3c3-4c91-971e-12084c2b1a89.png">

After:
<img width="797" alt="image" src="https://user-images.githubusercontent.com/45561153/169967211-98a5291b-1a42-4e4a-bf01-2ab06757d9b3.png">

