### PR TITLE
Devenv: Fix fake data gen to target mysql server

### DIFF
--- a/devenv/docker/blocks/mysql/docker-compose.yaml
+++ b/devenv/docker/blocks/mysql/docker-compose.yaml
@@ -12,5 +12,6 @@
   fake-mysql-data:
     image: grafana/fake-data-gen
     environment:
+      FD_SERVER: mysql
       FD_DATASOURCE: mysql
       FD_PORT: 3306


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
I did not see any data in the mysql devenv source when running `make devenv sources=mysql`. Investigating a bit I noticed the fake data generator threw a bunch of `randomWalk:  ConnectionError [SequelizeConnectionError]: connect ETIMEDOUT`. Providing `FD_SERVER` to the `fake-mysql-data` container solved the issue.

![image](https://user-images.githubusercontent.com/5232696/169996093-0a63f8b3-de9d-47b1-9156-3b320ada8452.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

