### PR TITLE
Search: Add primary background for global search container

### DIFF
--- a/public/app/features/search/components/ActionRow.tsx
+++ b/public/app/features/search/components/ActionRow.tsx
@@ -77,7 +77,7 @@ export const ActionRow: FC<Props> = ({
 
 ActionRow.displayName = 'ActionRow';
 
-const getStyles = (theme: GrafanaTheme2) => {
+export const getStyles = (theme: GrafanaTheme2) => {
   return {
     actionRow: css`
       display: none;

--- a/public/app/features/search/components/ActionRow.tsx
+++ b/public/app/features/search/components/ActionRow.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/css';
 import React, { FC, ChangeEvent, FormEvent } from 'react';
 
-import { GrafanaTheme, SelectableValue } from '@grafana/data';
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { HorizontalGroup, RadioButtonGroup, stylesFactory, useTheme, Checkbox, InlineSwitch } from '@grafana/ui';
+import { HorizontalGroup, RadioButtonGroup, Checkbox, InlineSwitch, useStyles2 } from '@grafana/ui';
 import { SortPicker } from 'app/core/components/Select/SortPicker';
 import { TagFilter } from 'app/core/components/TagFilter/TagFilter';
 import { SearchSrv } from 'app/core/services/search_srv';
@@ -40,8 +40,7 @@ export const ActionRow: FC<Props> = ({
   hideLayout,
   showPreviews,
 }) => {
-  const theme = useTheme();
-  const styles = getStyles(theme);
+  const styles = useStyles2(getStyles);
   const previewsEnabled = config.featureToggles.dashboardPreviews;
 
   return (
@@ -78,21 +77,21 @@ export const ActionRow: FC<Props> = ({
 
 ActionRow.displayName = 'ActionRow';
 
-const getStyles = stylesFactory((theme: GrafanaTheme) => {
+const getStyles = (theme: GrafanaTheme2) => {
   return {
     actionRow: css`
       display: none;
 
-      @media only screen and (min-width: ${theme.breakpoints.md}) {
+      ${theme.breakpoints.up('md')} {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding: ${theme.spacing.lg} 0;
+        padding-bottom: ${theme.spacing(2)};
         width: 100%;
       }
     `,
     rowContainer: css`
-      margin-right: ${theme.spacing.md};
+      margin-right: ${theme.spacing(1)};
     `,
     checkboxWrapper: css`
       label {
@@ -100,4 +99,4 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       }
     `,
   };
-});
+};

--- a/public/app/features/search/components/DashboardSearch.tsx
+++ b/public/app/features/search/components/DashboardSearch.tsx
@@ -147,7 +147,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme2) => {
       height: 100%;
 
       ${theme.breakpoints.up('md')} {
-        padding: ${theme.spacing(4)};
+        padding: ${theme.spacing(3)};
       }
     `,
     closeBtn: css`
@@ -163,7 +163,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme2) => {
       display: flex;
       flex-direction: column;
       height: 100%;
-      padding-bottom: ${theme.spacing(3)};
+      padding: ${theme.spacing(2, 0, 3, 0)};
     `,
     input: css`
       box-sizing: border-box;

--- a/public/app/features/search/components/DashboardSearch.tsx
+++ b/public/app/features/search/components/DashboardSearch.tsx
@@ -140,6 +140,9 @@ const getStyles = stylesFactory((theme: GrafanaTheme2) => {
       max-width: 1400px;
       margin: 0 auto;
       padding: ${theme.spacing(2)};
+      background: ${theme.colors.background.primary};
+      border: 1px solid ${theme.components.panel.borderColor};
+      margin-top: ${theme.spacing(4)};
 
       height: 100%;
 

--- a/public/app/features/search/page/components/ActionRow.tsx
+++ b/public/app/features/search/page/components/ActionRow.tsx
@@ -99,16 +99,16 @@ export const ActionRow: FC<Props> = ({
 
 ActionRow.displayName = 'ActionRow';
 
-export const getStyles = (theme: GrafanaTheme2) => {
+const getStyles = (theme: GrafanaTheme2) => {
   return {
     actionRow: css`
       display: none;
 
-      @media only screen and (min-width: ${theme.v1.breakpoints.md}) {
+      ${theme.breakpoints.up('md')} {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        padding: ${theme.v1.spacing.lg} 0;
+        padding-bottom: ${theme.spacing(2)};
         width: 100%;
       }
     `,

--- a/public/app/features/search/page/components/ActionRow.tsx
+++ b/public/app/features/search/page/components/ActionRow.tsx
@@ -99,7 +99,7 @@ export const ActionRow: FC<Props> = ({
 
 ActionRow.displayName = 'ActionRow';
 
-const getStyles = (theme: GrafanaTheme2) => {
+export const getStyles = (theme: GrafanaTheme2) => {
   return {
     actionRow: css`
       display: none;

--- a/public/sass/theme.dark.generated.json
+++ b/public/sass/theme.dark.generated.json
@@ -152,6 +152,10 @@
     "menuTabs": {
       "height": 41
     },
+    "textHighlight": {
+      "text": "#000000",
+      "background": "#F5B73D"
+    },
     "horizontalDrawer": {
       "defaultHeight": 400
     }

--- a/public/sass/theme.light.generated.json
+++ b/public/sass/theme.light.generated.json
@@ -152,6 +152,10 @@
     "menuTabs": {
       "height": 41
     },
+    "textHighlight": {
+      "text": "#000000",
+      "background": "#FAD34A"
+    },
     "horizontalDrawer": {
       "defaultHeight": 400
     }


### PR DESCRIPTION
The SearchView component i used from both Manage dashboards and Global search view. But
on different backgrounds. This adds a primary background to the global view to make the
search result table be shown on the same background color on both.

Before global search: 
![Screenshot from 2022-05-24 11-21-28](https://user-images.githubusercontent.com/10999/169997860-f9c3abba-a239-434a-83bd-4eedb887b5cc.png)

Manage (browse):
![Screenshot from 2022-05-24 11-21-42](https://user-images.githubusercontent.com/10999/169997989-75094520-5a13-496a-a29a-e4b37796b03f.png)


Global search after change in PR:
* Adds primary background
* Adds panel border (which we also use for page containers)
* Adds some top margin 
* Align global search container margin to be same as for page container (3x grid units)
 
![Screenshot from 2022-05-24 11-24-44](https://user-images.githubusercontent.com/10999/169998535-c240f9aa-3149-4d50-bbb9-2a18d3973fce.png)


this PR also fixes the double upper spacing for ActionRow on the Manage/Browse page. 
Related #49468 