### PR TITLE
ADX : Added `adxOnBehalfOf` feature gate

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1189,6 +1189,9 @@ cloudWatchDynamicLabels = true
 # New expandable navigation
 newNavigation = true
 
+# On-Behalf-Of functionality for ADX data source
+adxOnBehalfOf = true
+
 # feature1 = true
 # feature2 = false
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1189,9 +1189,6 @@ cloudWatchDynamicLabels = true
 # New expandable navigation
 newNavigation = true
 
-# On-Behalf-Of functionality for ADX data source
-adxOnBehalfOf = true
-
 # feature1 = true
 # feature2 = false
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -60,4 +60,5 @@ export interface FeatureToggles {
   traceToMetrics?: boolean;
   prometheusStreamingJSONParser?: boolean;
   validateDashboardsOnSave?: boolean;
+  adxOnBehalfOf?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -249,5 +249,10 @@ var (
 			State:           FeatureStateAlpha,
 			RequiresRestart: true,
 		},
+		{
+			Name:        "adxOnBehalfOf",
+			Description: "Enable the beta feature On-Behalf-Of in the ADX data source",
+			State:       FeatureStateBeta,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -182,4 +182,8 @@ const (
 	// FlagValidateDashboardsOnSave
 	// Validate dashboard JSON POSTed to api/dashboards/db
 	FlagValidateDashboardsOnSave = "validateDashboardsOnSave"
+
+	// FlagAdxOnBehalfOf
+	// Enable the beta feature On-Behalf-Of in the ADX data source
+	FlagAdxOnBehalfOf = "adxOnBehalfOf"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

We ran into a few issues with the OBO feature in ADX (in beta atow). 
This PR provides a feature gate `adxOnBehalfOf` to allow us to hide the toggle in ADX until issues are resolved.

First part of: https://github.com/grafana/azure-data-explorer-datasource/issues/359 

**Which issue(s) this PR fixes**:

First part of: https://github.com/grafana/azure-data-explorer-datasource/issues/359 

**Special notes for your reviewer**:

Next step is to use this feature gate in ADX code to hide the toggle and disable OBO if feature disabled.

