### PR TITLE
logs: do not show the labels-field used by loki

### DIFF
--- a/packages/grafana-ui/src/components/Logs/logParser.ts
+++ b/packages/grafana-ui/src/components/Logs/logParser.ts
@@ -65,9 +65,18 @@ const getDerivedFields = memoizeOne(
     return (
       row.dataFrame.fields
         .map((field, index) => ({ ...field, index }))
-        // Remove Id which we use for react key and entry field which we are showing as the log message. Also remove hidden fields.
         .filter(
-          (field, index) => !('id' === field.name || row.entryFieldIndex === index || field.config.custom?.hidden)
+          // remove some fields
+          (field, index) =>
+            !(
+              'id' === field.name || //  id-field is used internally
+              row.entryFieldIndex === index || // the log-message field
+              field.config.custom?.hidden ||
+              // NOTE: this is an experimental custom-frame-type, please do not use in your code.
+              // we will get this custom-frame-type into the "real" frame-type list soon,
+              // but the name might change, so please do not use it until then.
+              (row.dataFrame.meta?.custom?.frameType === 'LabeledTimeValues' && field.name === 'labels')
+            )
         )
         // Filter out fields without values. For example in elastic the fields are parsed from the document which can
         // have different structure per row and so the dataframe is pretty sparse.


### PR DESCRIPTION
WORK IN PROGRESS

the loki dataframe-format for logs uses a separate dataframe-field to store logs. if we do nothing, this field will show up in the logs-visualization in the "detected fields" section. we do not want that. this pull request filters it out.

NOTE: we are using an experimental marker to mark such dataframes. we hope we can get a "real" frame-type for this format at some point.

how to test:
1. go to explore-mode
2. run a loki query
3. click on a log-line to see detected fields
4. you should not set a field named `labels` there