### PR TITLE
Variables: Fixes issue with data source variables not updating queries with variable

### DIFF
--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -101,36 +101,30 @@ export class AppWrapper extends React.Component<AppWrapperProps, AppWrapperState
           <ErrorBoundaryAlert style="page">
             <ConfigContext.Provider value={config}>
               <ThemeProvider>
-                <KBarProvider
-                  actions={[]}
-                  options={{ enableHistory: true, callbacks: { onSelectAction: commandPaletteActionSelected } }}
-                >
-                  <ModalsProvider>
-                    <GlobalStyles />
-                    {config.featureToggles.commandPalette && <CommandPalette />}
-                    <div className="grafana-app">
-                      <Router history={locationService.getHistory()}>
-                        {ready && <>{newNavigationEnabled ? <NavBarNext /> : <NavBar />}</>}
-                        <main className="main-view">
-                          {pageBanners.map((Banner, index) => (
-                            <Banner key={index.toString()} />
-                          ))}
+                <ModalsProvider>
+                  <GlobalStyles />
+                  <div className="grafana-app">
+                    <Router history={locationService.getHistory()}>
+                      {ready && <>{newNavigationEnabled ? <NavBarNext /> : <NavBar />}</>}
+                      <main className="main-view">
+                        {pageBanners.map((Banner, index) => (
+                          <Banner key={index.toString()} />
+                        ))}
 
-                          <AngularRoot />
-                          <AppNotificationList />
-                          <SearchWrapper />
-                          {ready && this.renderRoutes()}
-                          {bodyRenderHooks.map((Hook, index) => (
-                            <Hook key={index.toString()} />
-                          ))}
-                        </main>
-                      </Router>
-                    </div>
-                    <LiveConnectionWarning />
-                    <ModalRoot />
-                    <PortalContainer />
-                  </ModalsProvider>
-                </KBarProvider>
+                        <AngularRoot />
+                        <AppNotificationList />
+                        <SearchWrapper />
+                        {ready && this.renderRoutes()}
+                        {bodyRenderHooks.map((Hook, index) => (
+                          <Hook key={index.toString()} />
+                        ))}
+                      </main>
+                    </Router>
+                  </div>
+                  <LiveConnectionWarning />
+                  <ModalRoot />
+                  <PortalContainer />
+                </ModalsProvider>
               </ThemeProvider>
             </ConfigContext.Provider>
           </ErrorBoundaryAlert>

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -101,30 +101,36 @@ export class AppWrapper extends React.Component<AppWrapperProps, AppWrapperState
           <ErrorBoundaryAlert style="page">
             <ConfigContext.Provider value={config}>
               <ThemeProvider>
-                <ModalsProvider>
-                  <GlobalStyles />
-                  <div className="grafana-app">
-                    <Router history={locationService.getHistory()}>
-                      {ready && <>{newNavigationEnabled ? <NavBarNext /> : <NavBar />}</>}
-                      <main className="main-view">
-                        {pageBanners.map((Banner, index) => (
-                          <Banner key={index.toString()} />
-                        ))}
+                <KBarProvider
+                  actions={[]}
+                  options={{ enableHistory: true, callbacks: { onSelectAction: commandPaletteActionSelected } }}
+                >
+                  <ModalsProvider>
+                    <GlobalStyles />
+                    {config.featureToggles.commandPalette && <CommandPalette />}
+                    <div className="grafana-app">
+                      <Router history={locationService.getHistory()}>
+                        {ready && <>{newNavigationEnabled ? <NavBarNext /> : <NavBar />}</>}
+                        <main className="main-view">
+                          {pageBanners.map((Banner, index) => (
+                            <Banner key={index.toString()} />
+                          ))}
 
-                        <AngularRoot />
-                        <AppNotificationList />
-                        <SearchWrapper />
-                        {ready && this.renderRoutes()}
-                        {bodyRenderHooks.map((Hook, index) => (
-                          <Hook key={index.toString()} />
-                        ))}
-                      </main>
-                    </Router>
-                  </div>
-                  <LiveConnectionWarning />
-                  <ModalRoot />
-                  <PortalContainer />
-                </ModalsProvider>
+                          <AngularRoot />
+                          <AppNotificationList />
+                          <SearchWrapper />
+                          {ready && this.renderRoutes()}
+                          {bodyRenderHooks.map((Hook, index) => (
+                            <Hook key={index.toString()} />
+                          ))}
+                        </main>
+                      </Router>
+                    </div>
+                    <LiveConnectionWarning />
+                    <ModalRoot />
+                    <PortalContainer />
+                  </ModalsProvider>
+                </KBarProvider>
               </ThemeProvider>
             </ConfigContext.Provider>
           </ErrorBoundaryAlert>

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -104,7 +104,8 @@ export class QueryGroup extends PureComponent<Props, State> {
     const currentDS = dsSettings ? await getDataSourceSrv().get(dsSettings.uid) : undefined;
     const nextDS = await getDataSourceSrv().get(newSettings.uid);
 
-    const queries = await updateQueries(nextDS, this.state.queries, currentDS);
+    // We need to pass in newSettings.uid as well here as that can be a variable expression and we want to store that in the query model not the current ds variable value
+    const queries = await updateQueries(nextDS, newSettings.uid, this.state.queries, currentDS);
 
     const dataSource = await this.dataSourceSrv.get(newSettings.name);
     this.onChange({

--- a/public/app/features/query/state/updateQueries.test.ts
+++ b/public/app/features/query/state/updateQueries.test.ts
@@ -44,6 +44,7 @@ describe('updateQueries', () => {
   it('Should update all queries except expression query when changing data source with same type', async () => {
     const updated = await updateQueries(
       newUidSameTypeDS,
+      'new-uid-same-type',
       [
         {
           refId: 'A',
@@ -64,9 +65,29 @@ describe('updateQueries', () => {
     expect(updated[1].datasource).toEqual(ExpressionDatasourceRef);
   });
 
+  it('Should update all to uid string passed in even when different from real current ds uid', async () => {
+    const updated = await updateQueries(
+      newUidSameTypeDS,
+      '${ds}',
+      [
+        {
+          refId: 'A',
+          datasource: {
+            uid: 'old-uid',
+            type: 'old-type',
+          },
+        },
+      ],
+      oldUidDS
+    );
+
+    expect(updated[0].datasource).toEqual({ type: 'old-type', uid: '${ds}' });
+  });
+
   it('Should clear queries when changing type', async () => {
     const updated = await updateQueries(
       newUidDS,
+      'new-uid',
       [
         {
           refId: 'A',
@@ -93,6 +114,7 @@ describe('updateQueries', () => {
   it('Should preserve query data source when changing to mixed', async () => {
     const updated = await updateQueries(
       mixedDS,
+      'mixed',
       [
         {
           refId: 'A',
@@ -119,6 +141,7 @@ describe('updateQueries', () => {
   it('should change nothing mixed updated to mixed', async () => {
     const updated = await updateQueries(
       mixedDS,
+      'mixed',
       [
         {
           refId: 'A',
@@ -192,7 +215,12 @@ describe('updateQueries with import', () => {
         },
       ];
 
-      const updated = await updateQueries(newUidDSWithAbstract as any, queries, oldUidDSWithAbstract as any);
+      const updated = await updateQueries(
+        newUidDSWithAbstract as any,
+        (newUidDSWithAbstract as any).uid,
+        queries,
+        oldUidDSWithAbstract as any
+      );
 
       expect(exportSpy).toBeCalledWith(queries);
       expect(importSpy).toBeCalledWith(queries.map((q) => ({ ...q, exported: true })));
@@ -262,7 +290,12 @@ describe('updateQueries with import', () => {
         },
       ];
 
-      const updated = await updateQueries(newUidDSWithAbstract as any, queries, oldUidDSWithAbstract as any);
+      const updated = await updateQueries(
+        newUidDSWithAbstract as any,
+        (newUidDSWithAbstract as any).uid,
+        queries,
+        oldUidDSWithAbstract as any
+      );
 
       expect(updated.length).toEqual(1);
       expect(updated[0].datasource).toEqual({ type: 'new-type', uid: 'new-uid' });
@@ -311,7 +344,7 @@ describe('updateQueries with import', () => {
         },
       ];
 
-      const updated = await updateQueries(newUidDSWithImport, queries, oldUidDS);
+      const updated = await updateQueries(newUidDSWithImport, newUidDSWithImport.uid, queries, oldUidDS);
 
       expect(importSpy).toBeCalledWith(queries, { uid: 'old-uid', type: 'old-type', meta: { id: 'old-type' } });
 
@@ -374,7 +407,7 @@ describe('updateQueries with import', () => {
         },
       ];
 
-      const updated = await updateQueries(newUidDSWithImport, queries, oldUidDS);
+      const updated = await updateQueries(newUidDSWithImport, 'new-uid', queries, oldUidDS);
 
       expect(updated.length).toEqual(1);
       expect(updated[0].datasource).toEqual({ type: 'new-type', uid: 'new-uid' });

--- a/public/app/features/query/state/updateQueries.ts
+++ b/public/app/features/query/state/updateQueries.ts
@@ -3,11 +3,12 @@ import { isExpressionReference } from '@grafana/runtime/src/utils/DataSourceWith
 
 export async function updateQueries(
   nextDS: DataSourceApi,
+  nextDSUidOrVariableExpression: string,
   queries: DataQuery[],
   currentDS?: DataSourceApi
 ): Promise<DataQuery[]> {
   let nextQueries = queries;
-  const datasource = { type: nextDS.type, uid: nextDS.uid };
+  const datasource = { type: nextDS.type, uid: nextDSUidOrVariableExpression };
 
   // we are changing data source type
   if (currentDS?.meta.id !== nextDS.meta.id) {


### PR DESCRIPTION
Fixes #49456

the change in https://github.com/grafana/grafana/pull/47435 missed that the old solution the DataSourceSettings.uid could be a variable expression , but when we get a DataSourceAPI that is not the case. Very easy mistake to make as this bit is very complex and unintutive.


Related: https://github.com/grafana/support-escalations/issues/2688
