### PR TITLE
CSRF: Configurable Header 

### DIFF
--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -308,6 +308,9 @@
 # Controls if old angular plugins are supported or not. This will be disabled by default in Grafana v9.
 ;angular_support_enabled = true
 
+# Controls the header to check for original Host when behind a reverse proxy. Used in CSRF checks
+;proxy_forwarded_host_header = X-Forwarded-Host
+
 [security.encryption]
 # Defines the time-to-live (TTL) for decrypted data encryption keys stored in memory (cache).
 # Please note that small values may cause performance issues due to a high frequency decryption operations.

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -495,7 +495,7 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 	}
 
 	m.Use(middleware.Recovery(hs.Cfg))
-	m.UseMiddleware(middleware.CSRF(hs.Cfg.LoginCookieName, hs.log))
+	m.UseMiddleware(middleware.CSRF(hs.Cfg.LoginCookieName, hs.Cfg.ProxyForwardedHostHeader, hs.log))
 
 	hs.mapStatic(m, hs.Cfg.StaticRootPath, "build", "public/build")
 	hs.mapStatic(m, hs.Cfg.StaticRootPath, "", "public", "/public/views/swagger.html")

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -90,6 +90,7 @@ var (
 	CookieSecure           bool
 	CookieSameSiteDisabled bool
 	CookieSameSiteMode     http.SameSite
+	ProxyForwardedHostHeader string
 
 	// Snapshots
 	ExternalSnapshotUrl   string
@@ -263,6 +264,7 @@ type Cfg struct {
 	// CSPTemplate contains the Content Security Policy template.
 	CSPTemplate           string
 	AngularSupportEnabled bool
+	ProxyForwardedHostHeader string
 
 	TempDataLifetime                 time.Duration
 	PluginsEnableAlpha               bool
@@ -1239,6 +1241,8 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	for _, hostAndIP := range util.SplitString(securityStr) {
 		DataProxyWhiteList[hostAndIP] = true
 	}
+
+	cfg.ProxyForwardedHostHeader = valueAsString(security, "proxy_forwarded_host_header", "")
 
 	// admin
 	cfg.DisableInitAdminCreation = security.Key("disable_initial_admin_creation").MustBool(false)


### PR DESCRIPTION
This PR allows setting an override to the default Host header used in CSRF checks.

The intention here is to make Grafana easier to deploy behind existing reverse-proxy setups. Currently Grafana imposes restrictions on the design of internal routing by insisting that the Host header is the same as the Origin.

Behind typical reverse proxies, the host header is changed and used for internal routing, but an additional header such as `X-Forwarded-Host` may be used to record the original `Host` header before it enters the routing stack.

If left empty, then the CSRF check continues to be made using the `Host` header as before

This PR addresses the issues described in https://github.com/grafana/grafana/issues/46321 (and others). Grafana returned 403 errors origin not allowed when used behind a (reverse) proxy server that does not support PreserveHostHeader like for example Apache or Nginx.

This PR might also make the workarounds documented for Traefik, Nginx and Apache obsolete as all of them should use or at least support X-Forwarded-Host, too.

**Which issue(s) this PR fixes:**

Fixes https://github.com/grafana/grafana/issues/46321

**Special notes for your reviewer:**

This PR adds a setting
```
[security]
proxy_forwarded_host_header = X-Forwarded-Host
```
that will override the default usage of the `Host` header to check against the origin.

This has been largely inspired by https://github.com/grafana/grafana/pull/46418

CC: @sebader @heoelri
