### PR TITLE
Alerting: Make alertmanager datasource stable (#49485)

### DIFF
--- a/pkg/tests/api/plugins/data/expectedListResp.json
+++ b/pkg/tests/api/plugins/data/expectedListResp.json
@@ -36,6 +36,47 @@
     "signatureOrg": ""
   },
   {
+    "name": "Alertmanager",
+    "type": "datasource",
+    "id": "alertmanager",
+    "enabled": true,
+    "pinned": false,
+    "info": {
+      "author": {
+        "name": "Prometheus alertmanager",
+        "url": "https://grafana.com"
+      },
+      "description": "",
+      "links": [
+        {
+          "name": "Learn more",
+          "url": "https://prometheus.io/docs/alerting/latest/alertmanager/"
+        }
+      ],
+      "logos": {
+        "small": "public/app/plugins/datasource/alertmanager/img/logo.svg",
+        "large": "public/app/plugins/datasource/alertmanager/img/logo.svg"
+      },
+      "build": {},
+      "screenshots": null,
+      "version": "",
+      "updated": ""
+    },
+    "dependencies": {
+      "grafanaDependency": "",
+      "grafanaVersion": "*",
+      "plugins": []
+    },
+    "latestVersion": "",
+    "hasUpdate": false,
+    "defaultNavUrl": "/plugins/alertmanager/",
+    "category": "",
+    "state": "",
+    "signature": "internal",
+    "signatureType": "",
+    "signatureOrg": ""
+  },
+  {
     "name": "Annotations list",
     "type": "panel",
     "id": "annolist",

--- a/public/app/plugins/datasource/alertmanager/plugin.json
+++ b/public/app/plugins/datasource/alertmanager/plugin.json
@@ -3,7 +3,6 @@
   "name": "Alertmanager",
   "id": "alertmanager",
   "metrics": false,
-  "state": "alpha",
   "routes": [
     {
       "method": "POST",


### PR DESCRIPTION
Manual back-port from https://github.com/grafana/grafana/pull/49485

(cherry picked from commit 86871807d27a155e044d7c6fb6608efdc2f2974e)
