### PR TITLE
Search: Center FolderSection spinner

### DIFF
--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -130,7 +130,7 @@ export const FolderSection: FC<SectionHeaderProps> = ({
   const renderResults = () => {
     if (!results.value?.length) {
       if (results.loading) {
-        return <Spinner />;
+        return <Spinner className={styles.spinner} />;
       }
 
       return (
@@ -254,6 +254,11 @@ const getSectionHeaderStyles = stylesFactory((theme: GrafanaTheme, selected = fa
     content: css`
       padding-top: 0px;
       padding-bottom: 0px;
+    `,
+    spinner: css`
+      display: grid;
+      place-content: center;
+      padding-bottom: 1rem;
     `,
   };
 });


### PR DESCRIPTION
**What this PR does / why we need it**:
Before:
<img width="849" alt="image" src="https://user-images.githubusercontent.com/45561153/170051414-add10345-f136-46c4-ad09-1ffa3d82ee0c.png">

After:
<img width="853" alt="image" src="https://user-images.githubusercontent.com/45561153/170051240-e44d2e06-fe88-41ab-94d6-d63f860c32a1.png">

**Special notes for your reviewer**:
I almost wonder if we need both this spinner that I've repositioned and the one aligned to the right 🤔 
