### PR TITLE
Accessibility: Pressing escape in a Modal or DashboardSettings correctly closes the overlay

### DIFF
--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -55,6 +55,8 @@ export function Drawer({
   const { overlayProps } = useOverlay(
     {
       isDismissable: true,
+      isOpen,
+      onClose,
     },
     overlayRef
   );

--- a/packages/grafana-ui/src/components/Modal/Modal.test.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import { Modal } from './Modal';
@@ -21,5 +22,23 @@ describe('Modal', () => {
     expect(screen.getByLabelText('Some Title')).toBeInTheDocument();
 
     expect(screen.getByTestId('modal-content')).toBeInTheDocument();
+  });
+
+  it('pressing escape calls onDismiss correctly', async () => {
+    const onDismiss = jest.fn();
+
+    render(
+      <Modal title="Some Title" isOpen onDismiss={onDismiss}>
+        <div data-testid="modal-content">Content</div>
+      </Modal>
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByLabelText('Some Title')).toBeInTheDocument();
+    expect(screen.getByTestId('modal-content')).toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
+
+    expect(onDismiss).toHaveBeenCalled();
   });
 });

--- a/packages/grafana-ui/src/components/Modal/Modal.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.tsx
@@ -53,7 +53,7 @@ export function Modal(props: PropsWithChildren<Props>) {
   // Handle interacting outside the dialog and pressing
   // the Escape key to close the modal.
   const { overlayProps, underlayProps } = useOverlay(
-    { isKeyboardDismissDisabled: closeOnEscape, isOpen, onClose: onDismiss },
+    { isKeyboardDismissDisabled: !closeOnEscape, isOpen, onClose: onDismiss },
     ref
   );
 

--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
+
+import { locationService, setBackendSrv } from '@grafana/runtime';
+import { configureStore } from 'app/store/configureStore';
+
+import { DashboardModel } from '../../state';
+
+import { DashboardSettings } from './DashboardSettings';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  locationService: {
+    partial: jest.fn(),
+  },
+}));
+
+setBackendSrv({
+  get: jest.fn().mockResolvedValue({}),
+} as any);
+
+describe('DashboardSettings', () => {
+  it('pressing escape navigates away correctly', async () => {
+    jest.spyOn(locationService, 'partial');
+    const dashboard = new DashboardModel(
+      {
+        title: 'Foo',
+      },
+      {
+        folderId: 1,
+      }
+    );
+    const store = configureStore();
+    render(
+      <Provider store={store}>
+        <BrowserRouter>
+          <DashboardSettings editview="settings" dashboard={dashboard} />
+        </BrowserRouter>
+      </Provider>
+    );
+
+    expect(screen.getByText('Foo / Settings')).toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
+
+    expect(locationService.partial).toHaveBeenCalledWith({ editview: null });
+  });
+});

--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
@@ -49,7 +49,13 @@ const MakeEditable = (props: { onMakeEditable: () => any }) => (
 
 export function DashboardSettings({ dashboard, editview }: Props) {
   const ref = useRef<HTMLDivElement>(null);
-  const { overlayProps } = useOverlay({}, ref);
+  const { overlayProps } = useOverlay(
+    {
+      isOpen: true,
+      onClose,
+    },
+    ref
+  );
   const { dialogProps } = useDialog(
     {
       'aria-label': 'Dashboard settings',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- adds the correct `isOpen`/`onClose` parameters to some `useOverlay` calls. i think this was working by accident before and they've tightened up their props a bit 🤔 
- added some unit tests to hopefully prevent regressions in the future

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

see https://raintank-corp.slack.com/archives/CHKLEJ668/p1653385626576929 for context

**Special notes for your reviewer**:

