### PR TITLE
AzureAD: Fallback to no groups if user does not have permission to query groups from azure 

### DIFF
--- a/pkg/login/social/azuread_oauth.go
+++ b/pkg/login/social/azuread_oauth.go
@@ -213,7 +213,8 @@ func extractGroups(client *http.Client, claims azureClaims, token *oauth2.Token)
 
 	if res.StatusCode != http.StatusOK {
 		if res.StatusCode == http.StatusForbidden {
-			logger.Error("AzureAD OAuth: failed to fetch user groups. Token need User.Read and GroupMember.Read.All permission")
+			logger.Warn("AzureAD OAuh: failed to fetch user groups. Token need GroupMember.Read.All permission")
+			return []string{}, nil
 		}
 		return nil, errors.New("error fetching groups")
 	}

--- a/pkg/login/social/azuread_oauth.go
+++ b/pkg/login/social/azuread_oauth.go
@@ -213,7 +213,7 @@ func extractGroups(client *http.Client, claims azureClaims, token *oauth2.Token)
 
 	if res.StatusCode != http.StatusOK {
 		if res.StatusCode == http.StatusForbidden {
-			logger.Warn("AzureAD OAuh: failed to fetch user groups. Token need GroupMember.Read.All permission")
+			logger.Warn("AzureAD OAuh: Token need GroupMember.Read.All permission to fetch all groups")
 			return []string{}, nil
 		}
 		return nil, errors.New("error fetching groups")


### PR DESCRIPTION
**What this PR does / why we need it**:
In #43470 support for fetching user groups from azure was added. This is needed when a user is member of more then 200 groups. But this also broke backward comparability.

To fix this we should try to query for the groups but only log if we don't have the permissions. The user should still get access to grafana and not a 500 error

**Which issue(s) this PR fixes**:

Fixes #49339

**Special notes for your reviewer**:

