### PR TITLE
Chore: convert `Typeahead` test to RTL

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -26,9 +26,6 @@ exports[`no enzyme tests`] = {
     "packages/grafana-ui/src/components/Typeahead/PartialHighlighter.test.tsx:1751923376": [
       [0, 31, 13, "RegExp match", "2409514259"]
     ],
-    "packages/grafana-ui/src/components/Typeahead/Typeahead.test.tsx:972524250": [
-      [0, 17, 13, "RegExp match", "2409514259"]
-    ],
     "packages/grafana-ui/src/slate-plugins/braces.test.tsx:1440546721": [
       [0, 19, 13, "RegExp match", "2409514259"]
     ],

--- a/packages/grafana-ui/src/components/Typeahead/Typeahead.test.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/Typeahead.test.tsx
@@ -1,57 +1,45 @@
-import { mount } from 'enzyme';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { CompletionItemGroup, CompletionItemKind } from '../../types';
+import { CompletionItemGroup } from '../../types';
 
-import { Typeahead, State } from './Typeahead';
-import { TypeaheadItem } from './TypeaheadItem';
+import { Typeahead } from './Typeahead';
 
 describe('Typeahead', () => {
-  const completionItemGroups = [{ label: 'my group', items: [{ label: 'first item' }] }];
+  const completionItemGroups: CompletionItemGroup[] = [{ label: 'my group', items: [{ label: 'first item' }] }];
+
   describe('when closed', () => {
     it('renders nothing when no items given', () => {
-      const component = mount(<Typeahead origin="test" groupedItems={[]} />);
-      expect(component.find('.typeahead')).toHaveLength(0);
+      render(<Typeahead origin="test" groupedItems={[]} />);
+      expect(screen.queryByTestId('typeahead')).not.toBeInTheDocument();
     });
+
     it('renders nothing when items given', () => {
-      const component = mount(<Typeahead origin="test" groupedItems={completionItemGroups} />);
-      expect(component.find('.typeahead')).toHaveLength(0);
+      render(<Typeahead origin="test" groupedItems={completionItemGroups} />);
+      expect(screen.queryByTestId('typeahead')).not.toBeInTheDocument();
     });
   });
+
   describe('when open', () => {
     it('renders given items and nothing is selected', () => {
-      const component = mount(<Typeahead origin="test" groupedItems={completionItemGroups} isOpen />);
-      expect(component.find('.typeahead')).toHaveLength(1);
-      const items = component.find(TypeaheadItem);
+      render(<Typeahead origin="test" groupedItems={completionItemGroups} isOpen />);
+      expect(screen.getByTestId('typeahead')).toBeInTheDocument();
+
+      const items = screen.getAllByRole('listitem');
       expect(items).toHaveLength(2);
-      expect(items.get(0).props.item.kind).toEqual(CompletionItemKind.GroupTitle);
-      expect(items.get(0).props.isSelected).toBeFalsy();
-      expect(items.get(1).props.item.label).toEqual('first item');
-      expect(items.get(1).props.isSelected).toBeFalsy();
+      expect(items[0]).toHaveTextContent('my group');
+      expect(items[1]).toHaveTextContent('first item');
     });
-  });
-  it('selected the first non-group item on moving to first item', () => {
-    const component = mount(<Typeahead origin="test" groupedItems={completionItemGroups} isOpen />);
-    expect(component.find('.typeahead')).toHaveLength(1);
-    let items = component.find(TypeaheadItem);
 
-    expect(items).toHaveLength(2);
-    expect((component.state() as State).typeaheadIndex).toBe(null);
-    (component.instance() as Typeahead).moveMenuIndex(1);
-    expect((component.state() as State).typeaheadIndex).toBe(1);
-    component.setProps({});
-    items = component.find(TypeaheadItem);
-    expect(items.get(0).props.isSelected).toBeFalsy();
-    expect(items.get(1).props.isSelected).toBeTruthy();
-  });
-  it('can be rendered properly even if the size of items is large', () => {
-    const completionItemGroups: CompletionItemGroup[] = [{ label: 'my group', items: [] }];
-    const itemsSize = 1000000;
-    for (let i = 0; i < itemsSize; i++) {
-      completionItemGroups[0].items.push({ label: 'item' + i });
-    }
+    it('can be rendered properly even if the size of items is large', () => {
+      const completionItemGroups: CompletionItemGroup[] = [{ label: 'my group', items: [] }];
+      const itemsSize = 1000000;
+      for (let i = 0; i < itemsSize; i++) {
+        completionItemGroups[0].items.push({ label: 'item' + i });
+      }
 
-    const component = mount(<Typeahead origin="test" groupedItems={completionItemGroups} isOpen />);
-    expect(component.find('.typeahead')).toHaveLength(1);
+      render(<Typeahead origin="test" groupedItems={completionItemGroups} isOpen />);
+      expect(screen.getByTestId('typeahead')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
+++ b/packages/grafana-ui/src/components/Typeahead/Typeahead.tsx
@@ -162,7 +162,7 @@ export class Typeahead extends React.PureComponent<Props, State> {
 
     return (
       <Portal origin={origin} isOpen={isOpen} style={this.menuPosition}>
-        <ul className="typeahead">
+        <ul className="typeahead" data-testid="typeahead">
           <FixedSizeList
             ref={this.listRef}
             itemCount={allItems.length}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- converts the `Typeahead` test to RTL

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/49507

**Special notes for your reviewer**:

i don't think there is a real equivalent for calling the component method directly as we've done in the `selected the first non-group item on moving to first item` test, we'd have to test this in the slate editor itself.