### PR TITLE
CloudMonitor: Correctly encode default project response

### DIFF
--- a/pkg/tsdb/cloudmonitoring/resource_handler.go
+++ b/pkg/tsdb/cloudmonitoring/resource_handler.go
@@ -41,7 +41,12 @@ func (s *Service) getGCEDefaultProject() func(rw http.ResponseWriter, req *http.
 			writeResponse(rw, http.StatusBadRequest, fmt.Sprintf("unexpected error %v", err))
 			return
 		}
-		encoded, _ := json.Marshal(project)
+
+		encoded, err := json.Marshal(project)
+		if err != nil {
+			writeResponse(rw, http.StatusBadRequest, fmt.Sprintf("error retrieving default project %v", err))
+			return
+		}
 		writeResponseBytes(rw, http.StatusOK, encoded)
 	}
 }

--- a/pkg/tsdb/cloudmonitoring/resource_handler.go
+++ b/pkg/tsdb/cloudmonitoring/resource_handler.go
@@ -41,7 +41,8 @@ func getGCEDefaultProject(rw http.ResponseWriter, req *http.Request) {
 		writeResponse(rw, http.StatusBadRequest, fmt.Sprintf("unexpected error %v", err))
 		return
 	}
-	writeResponse(rw, http.StatusOK, project)
+	encoded, _ := json.Marshal(project)
+	writeResponseBytes(rw, http.StatusOK, encoded)
 }
 
 func (s *Service) handleResourceReq(subDataSource string, responseFn processResponse) func(rw http.ResponseWriter, req *http.Request) {

--- a/pkg/tsdb/cloudmonitoring/resource_handler_test.go
+++ b/pkg/tsdb/cloudmonitoring/resource_handler_test.go
@@ -3,6 +3,7 @@ package cloudmonitoring
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -304,6 +305,6 @@ func Test_getGCEDefaultProject(t *testing.T) {
 		},
 	}
 
-	assert.HTTPSuccess(t, s.getGCEDefaultProject(), "GET", "/gceDefaultProject", nil)
-	assert.HTTPBodyContains(t, s.getGCEDefaultProject(), "GET", "/gceDefaultProject", nil, project)
+	assert.HTTPSuccess(t, s.getGCEDefaultProject, "GET", "/gceDefaultProject", nil)
+	assert.HTTPBodyContains(t, s.getGCEDefaultProject, "GET", "/gceDefaultProject", nil, fmt.Sprintf("\"%v\"", project))
 }

--- a/pkg/tsdb/cloudmonitoring/resource_handler_test.go
+++ b/pkg/tsdb/cloudmonitoring/resource_handler_test.go
@@ -1,6 +1,7 @@
 package cloudmonitoring
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -284,4 +286,24 @@ func Test_processData_functions(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_getGCEDefaultProject(t *testing.T) {
+	project := "test-project"
+	s := Service{
+		im: &fakeInstance{
+			services: map[string]datasourceService{
+				cloudMonitor: {
+					url:    routes[cloudMonitor].url,
+					client: &http.Client{},
+				},
+			},
+		},
+		gceDefaultProjectGetter: func(ctx context.Context) (string, error) {
+			return project, nil
+		},
+	}
+
+	assert.HTTPSuccess(t, s.getGCEDefaultProject(), "GET", "/gceDefaultProject", nil)
+	assert.HTTPBodyContains(t, s.getGCEDefaultProject(), "GET", "/gceDefaultProject", nil, project)
 }


### PR DESCRIPTION

**What this PR does / why we need it**:

Correctly encodes the response of `getGCEDefaultProject` to prevent invalid JSON being returned which then gets parsed as an empty object. 
 
**Which issue(s) this PR fixes**:

Fixes #48907 

**Special notes for your reviewer**:

Tested in GCP by creating an instance and installing Grafana locally. The Cloud Monitoring datasource was then setup to use the `GCE Default Service Account` authentication method (which was the affected method). The fix was also tested as above.
