### PR TITLE
Alerting: Add legacy indicator to navbar

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -526,7 +526,7 @@ func (hs *HTTPServer) buildLegacyAlertNavLinks() []*dtos.NavLink {
 		{
 			Text:       "Alerting",
 			SubTitle:   "Alert rules and notifications",
-			Id:         "alerting",
+			Id:         "alerting-legacy",
 			Icon:       "bell",
 			Url:        hs.Cfg.AppSubURL + "/alerting/list",
 			Children:   alertChildNavs,

--- a/public/app/core/components/NavBar/Next/NavBarItem.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarItem.tsx
@@ -68,11 +68,6 @@ const NavBarItem = ({
 
   const translationKey = link.id && menuItemTranslations[link.id];
   const linkText = translationKey ? i18n._(translationKey) : link.text;
-  if (link.id === 'alerting-legacy') {
-    console.log(translationKey);
-    console.log(link.text);
-    console.log(linkText);
-  }
 
   if (!showMenu) {
     return (

--- a/public/app/core/components/NavBar/Next/NavBarItem.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarItem.tsx
@@ -68,6 +68,11 @@ const NavBarItem = ({
 
   const translationKey = link.id && menuItemTranslations[link.id];
   const linkText = translationKey ? i18n._(translationKey) : link.text;
+  if (link.id === 'alerting-legacy') {
+    console.log(translationKey);
+    console.log(link.text);
+    console.log(linkText);
+  }
 
   if (!showMenu) {
     return (

--- a/public/app/core/components/NavBar/Next/NavBarNext.tsx
+++ b/public/app/core/components/NavBar/Next/NavBarNext.tsx
@@ -70,7 +70,6 @@ export const NavBarNext = React.memo(() => {
   if (kiosk !== KioskMode.Off) {
     return null;
   }
-
   return (
     <div className={styles.navWrapper}>
       <nav className={cx(styles.sidemenu, 'sidemenu')} data-testid="sidemenu" aria-label="Main menu">

--- a/public/app/core/components/NavBar/navBarItem-translations.ts
+++ b/public/app/core/components/NavBar/navBarItem-translations.ts
@@ -26,6 +26,7 @@ const TRANSLATED_MENU_ITEMS: Record<string, MessageDescriptor> = {
   explore: defineMessage({ id: 'nav.explore', message: 'Explore' }),
 
   alerting: defineMessage({ id: 'nav.alerting', message: 'Alerting' }),
+  'alerting-legacy': defineMessage({ id: 'nav.alerting-legacy', message: 'Alerting (legacy)' }),
   'alert-list': defineMessage({ id: 'nav.alerting-list', message: 'Alert rules' }),
   receivers: defineMessage({ id: 'nav.alerting-receivers', message: 'Contact points' }),
   'am-routes': defineMessage({ id: 'nav.alerting-am-routes', message: 'Notification policies' }),

--- a/public/locales/en/messages.po
+++ b/public/locales/en/messages.po
@@ -39,6 +39,10 @@ msgid "nav.alerting-groups"
 msgstr "Groups"
 
 #: public/app/core/components/NavBar/navBarItem-translations.ts
+msgid "nav.alerting-legacy"
+msgstr "Alerting (legacy)"
+
+#: public/app/core/components/NavBar/navBarItem-translations.ts
 msgid "nav.alerting-list"
 msgstr "Alert rules"
 

--- a/public/locales/es/messages.po
+++ b/public/locales/es/messages.po
@@ -39,6 +39,10 @@ msgid "nav.alerting-groups"
 msgstr ""
 
 #: public/app/core/components/NavBar/navBarItem-translations.ts
+msgid "nav.alerting-legacy"
+msgstr ""
+
+#: public/app/core/components/NavBar/navBarItem-translations.ts
 msgid "nav.alerting-list"
 msgstr ""
 

--- a/public/locales/fr/messages.po
+++ b/public/locales/fr/messages.po
@@ -39,6 +39,10 @@ msgid "nav.alerting-groups"
 msgstr ""
 
 #: public/app/core/components/NavBar/navBarItem-translations.ts
+msgid "nav.alerting-legacy"
+msgstr ""
+
+#: public/app/core/components/NavBar/navBarItem-translations.ts
 msgid "nav.alerting-list"
 msgstr ""
 

--- a/public/locales/pseudo-LOCALE/messages.po
+++ b/public/locales/pseudo-LOCALE/messages.po
@@ -39,6 +39,10 @@ msgid "nav.alerting-groups"
 msgstr ""
 
 #: public/app/core/components/NavBar/navBarItem-translations.ts
+msgid "nav.alerting-legacy"
+msgstr ""
+
+#: public/app/core/components/NavBar/navBarItem-translations.ts
 msgid "nav.alerting-list"
 msgstr ""
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds an indicator that a user is using Grafana legacy alerting to the navbar.

![image](https://user-images.githubusercontent.com/946275/170068034-8bf6eae0-0ce6-4ed5-bce5-fa08bd639b62.png)


**Which issue(s) this PR fixes**:

Fixes #47880

**Special notes for your reviewer**:

