### PR TITLE
devenv: elastic: fixed docker-compose syntax

### DIFF
--- a/devenv/docker/blocks/elastic/docker-compose.yaml
+++ b/devenv/docker/blocks/elastic/docker-compose.yaml
@@ -17,8 +17,4 @@
       - elasticsearch
     # elastic starts slowly, the first couple start of data.js
     # might fail, so we auto-restart it on failure.
-    deploy:
-      restart_policy:
-        condition: on-failure
-        delay: 5s
-        max_attempts: 20 # should be enough
+    restart: "on-failure"


### PR DESCRIPTION
when running `make devenv sources=elastic`, i get a warning: `WARNING: The following deploy sub-keys are not supported and have been ignored: restart_policy.delay`

it seems the `devenv sources=...` commands seem to use a docker-compose version that only supports older syntax. i updated the docker-compose file for `elastic` to be in the older format.

how to test:
1. run `make devenv sources=elastic`. you should not get the warning message
2. go to explore-mode, choose the `gdev-elasticsearch` datasource, you should see logs