### PR TITLE
Plugins: Add new XYZ data layer type to GeoMap plugin

### DIFF
--- a/docs/sources/visualizations/geomap.md
+++ b/docs/sources/visualizations/geomap.md
@@ -36,6 +36,7 @@ There are four-layer types to choose from in the Geomap visualization.
 - **Marker** renders a marker at each data point.
 - **Heatmap** visualizes a heatmap of the data.
 - **GeoJSON** renders static data from a geojson file.
+- **XYZ** renders a custom tile server defined by the user.
 
 ### Layer Controls
 
@@ -105,6 +106,13 @@ The GeoJSON layer allows you to select and load a static GeoJSON file from the f
   - **Color** configures the color of the style for the current rule
   - **Opacity** configures the transparency level for the current rule
 - **Add style rule** creates additional style rules.
+
+### XYZ layer
+
+The XYZ layer allows you to add an overlay to the base layer from a custom xyz tile server. Set a valid tile server `url`, with {z}/{x}/{y} for this option in order to properly load an overlay. Example: https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png
+
+- **URL** sets the tile server to be used.
+- **Attribution** sets the attribution for the used tile server.
 
 ## Base layer
 

--- a/public/app/plugins/panel/geomap/layers/data/index.ts
+++ b/public/app/plugins/panel/geomap/layers/data/index.ts
@@ -1,9 +1,10 @@
 import { markersLayer } from './markersLayer';
 import { geojsonLayer } from './geojsonLayer';
 import { heatmapLayer } from './heatMap';
+import { xyzLayer } from './xyzLayer';
 import { lastPointTracker } from './lastPointTracker';
 
 /**
  * Registry for layer handlers
  */
-export const dataLayers = [markersLayer, heatmapLayer, lastPointTracker, geojsonLayer];
+export const dataLayers = [markersLayer, heatmapLayer, lastPointTracker, geojsonLayer, xyzLayer];

--- a/public/app/plugins/panel/geomap/layers/data/xyzLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/xyzLayer.tsx
@@ -1,0 +1,65 @@
+import {
+  // FieldType,
+  // getFieldColorModeForField,
+  // GrafanaTheme2,
+  MapLayerOptions,
+  MapLayerRegistryItem,
+  // PanelData,
+} from '@grafana/data';
+import Map from 'ol/Map';
+// import * as layer from 'ol/layer';
+import TileLayer from 'ol/layer/Tile';
+import XYZ from 'ol/source/XYZ';
+
+// Configuration options for XYZ overlays
+export interface XYZConfig {
+  url: string;
+  attribution: string;
+}
+
+const sampleURL = 'https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png';
+export const defaultXYZConfig: XYZConfig = {
+  url: sampleURL + '/tile/{z}/{y}/{x}',
+  attribution: `Map data: &copy; <a href="http://www.openseamap.org">OpenSeaMap</a> contributors`,
+};
+
+export const xyzLayer: MapLayerRegistryItem<XYZConfig> = {
+  id: 'xyzlayer',
+  name: 'XYZ Data Layer',
+  description: 'Adds an xyz map overlay to the map',
+  isBaseMap: false,
+
+  create: async (map: Map, options: MapLayerOptions<XYZConfig>) => ({
+    init: () => {
+      const cfg = { ...options.config };
+      if (!cfg.url) {
+        cfg.url = defaultXYZConfig.url;
+        cfg.attribution = cfg.attribution ?? defaultXYZConfig.attribution;
+      }
+      return new TileLayer({
+        source: new XYZ({
+          url: cfg.url,
+          attributions: cfg.attribution, // singular?
+        }),
+      });
+    },
+    registerOptionsUI: (builder) => {
+      builder
+        .addTextInput({
+          path: 'config.url',
+          name: 'URL template',
+          description: 'Must include {x}, {y} or {-y}, and {z} placeholders',
+          settings: {
+            placeholder: defaultXYZConfig.url,
+          },
+        })
+        .addTextInput({
+          path: 'config.attribution',
+          name: 'Attribution',
+          settings: {
+            placeholder: defaultXYZConfig.attribution,
+          },
+        });
+    },
+  })
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a new data layer type, XYZ layer, to the GeoMap plugin. Some tile servers like OpenSeaMap render tiles that can be used as overlays. Adding this new data layer type makes it possible to use these tile servers.

**Which issue(s) this PR fixes**:

- Fixes #47812