### PR TITLE
InfluxDB: Removing influxDB backend migration feature flag

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1174,9 +1174,6 @@ promQueryBuilder = true
 # The new loki visual query builder
 lokiQueryBuilder = true
 
-# InfluxDB backend migration
-influxdbBackendMigration = true
-
 # Experimental Explore to Dashboard workflow
 explore2Dashboard = true
 


### PR DESCRIPTION
TLDR: revert https://github.com/grafana/grafana/pull/48453

Removing the `influxdbBackendMigration` feature toggle default value.

In G9.0.0-beta.1 and G8.5.4, we enabled `influxdbBackendMigration` feature flag ON by default. This may affect the users with browser access enabled. This PR turn it off the backend migration by default so users will get the default behaviour they used to get. 
