### PR TITLE
Explore: Use Dashboard permissions in Explore To Dashboard

### DIFF
--- a/public/app/features/explore/AddToDashboard/AddToDashboardModal.tsx
+++ b/public/app/features/explore/AddToDashboard/AddToDashboardModal.tsx
@@ -7,7 +7,7 @@ import { locationUtil, SelectableValue } from '@grafana/data';
 import { config, locationService, reportInteraction } from '@grafana/runtime';
 import { Alert, Button, Field, InputControl, Modal, RadioButtonGroup } from '@grafana/ui';
 import { DashboardPicker } from 'app/core/components/Select/DashboardPicker';
-import { contextSrv } from 'app/core/core';
+import { contextSrv } from 'app/core/services/context_srv';
 import { removeDashboardToFetchFromLocalStorage } from 'app/features/dashboard/state/initDashboard';
 import { ExploreId, AccessControlAction } from 'app/types';
 

--- a/public/app/features/explore/AddToDashboard/AddToDashboardModal.tsx
+++ b/public/app/features/explore/AddToDashboard/AddToDashboardModal.tsx
@@ -7,8 +7,9 @@ import { locationUtil, SelectableValue } from '@grafana/data';
 import { config, locationService, reportInteraction } from '@grafana/runtime';
 import { Alert, Button, Field, InputControl, Modal, RadioButtonGroup } from '@grafana/ui';
 import { DashboardPicker } from 'app/core/components/Select/DashboardPicker';
+import { contextSrv } from 'app/core/core';
 import { removeDashboardToFetchFromLocalStorage } from 'app/features/dashboard/state/initDashboard';
-import { ExploreId } from 'app/types';
+import { ExploreId, AccessControlAction } from 'app/types';
 
 import { getExploreItemSelector } from '../state/selectors';
 
@@ -18,17 +19,6 @@ enum SaveTarget {
   NewDashboard = 'new-dashboard',
   ExistingDashboard = 'existing-dashboard',
 }
-
-const SAVE_TARGETS: Array<SelectableValue<SaveTarget>> = [
-  {
-    label: 'New dashboard',
-    value: SaveTarget.NewDashboard,
-  },
-  {
-    label: 'Existing dashboard',
-    value: SaveTarget.ExistingDashboard,
-  },
-];
 
 interface SaveTargetDTO {
   saveTarget: SaveTarget;
@@ -82,7 +72,27 @@ export const AddToDashboardModal = ({ onClose, exploreId }: Props) => {
   } = useForm<FormDTO>({
     defaultValues: { saveTarget: SaveTarget.NewDashboard },
   });
-  const saveTarget = watch('saveTarget');
+
+  const canCreateDashboard = contextSrv.hasAccess(AccessControlAction.DashboardsCreate, contextSrv.isEditor);
+  const canWriteDashboard = contextSrv.hasAccess(AccessControlAction.DashboardsWrite, contextSrv.isEditor);
+
+  const saveTargets: Array<SelectableValue<SaveTarget>> = [];
+  if (canCreateDashboard) {
+    saveTargets.push({
+      label: 'New dashboard',
+      value: SaveTarget.NewDashboard,
+    });
+  }
+  if (canWriteDashboard) {
+    saveTargets.push({
+      label: 'Existing dashboard',
+      value: SaveTarget.ExistingDashboard,
+    });
+  }
+
+  const saveTarget = saveTargets.length > 1 ? watch('saveTarget') : saveTargets[0].value;
+
+  const modalTitle = `Add panel to ${saveTargets.length > 1 ? 'dashboard' : saveTargets[0].label!.toLowerCase()}`;
 
   const onSubmit = async (openInNewTab: boolean, data: FormDTO) => {
     setSubmissionError(undefined);
@@ -139,17 +149,19 @@ export const AddToDashboardModal = ({ onClose, exploreId }: Props) => {
   }, []);
 
   return (
-    <Modal title="Add panel to dashboard" onDismiss={onClose} isOpen>
+    <Modal title={modalTitle} onDismiss={onClose} isOpen>
       <form>
-        <InputControl
-          control={control}
-          render={({ field: { ref, ...field } }) => (
-            <Field label="Target dashboard" description="Choose where to add the panel.">
-              <RadioButtonGroup options={SAVE_TARGETS} {...field} id="e2d-save-target" />
-            </Field>
-          )}
-          name="saveTarget"
-        />
+        {saveTargets.length > 1 && (
+          <InputControl
+            control={control}
+            render={({ field: { ref, ...field } }) => (
+              <Field label="Target dashboard" description="Choose where to add the panel.">
+                <RadioButtonGroup options={saveTargets} {...field} id="e2d-save-target" />
+              </Field>
+            )}
+            name="saveTarget"
+          />
+        )}
 
         {saveTarget === SaveTarget.ExistingDashboard &&
           (() => {

--- a/public/app/features/explore/AddToDashboard/index.test.tsx
+++ b/public/app/features/explore/AddToDashboard/index.test.tsx
@@ -31,6 +31,12 @@ const setup = (children: ReactNode, queries: DataQuery[] = [{ refId: 'A' }]) => 
   return render(<Provider store={store}>{children}</Provider>);
 };
 
+jest.mock('app/core/core', () => ({
+  contextSrv: {
+    hasAccess: () => true,
+  },
+}));
+
 const openModal = async () => {
   await userEvent.click(screen.getByRole('button', { name: /add to dashboard/i }));
 

--- a/public/app/features/explore/AddToDashboard/index.test.tsx
+++ b/public/app/features/explore/AddToDashboard/index.test.tsx
@@ -6,6 +6,7 @@ import { Provider } from 'react-redux';
 import { DataQuery } from '@grafana/data';
 import { locationService, setEchoSrv } from '@grafana/runtime';
 import { backendSrv } from 'app/core/services/backend_srv';
+import { contextSrv } from 'app/core/services/context_srv';
 import { Echo } from 'app/core/services/echo/Echo';
 import * as initDashboard from 'app/features/dashboard/state/initDashboard';
 import { DashboardSearchItemType } from 'app/features/search/types';
@@ -31,16 +32,16 @@ const setup = (children: ReactNode, queries: DataQuery[] = [{ refId: 'A' }]) => 
   return render(<Provider store={store}>{children}</Provider>);
 };
 
-jest.mock('app/core/core', () => ({
-  contextSrv: {
-    hasAccess: () => true,
-  },
-}));
+jest.mock('app/core/services/context_srv');
 
-const openModal = async () => {
+const mocks = {
+  contextSrv: jest.mocked(contextSrv),
+};
+
+const openModal = async (nameOverride?: string) => {
   await userEvent.click(screen.getByRole('button', { name: /add to dashboard/i }));
 
-  expect(await screen.findByRole('dialog', { name: 'Add panel to dashboard' })).toBeInTheDocument();
+  expect(await screen.findByRole('dialog', { name: nameOverride || 'Add panel to dashboard' })).toBeInTheDocument();
 };
 
 describe('AddToDashboardButton', () => {
@@ -70,6 +71,7 @@ describe('AddToDashboardButton', () => {
 
     beforeEach(() => {
       jest.spyOn(api, 'setDashboardInLocalStorage').mockReturnValue(addToDashboardResponse);
+      mocks.contextSrv.hasAccess.mockImplementation(() => true);
     });
 
     afterEach(() => {
@@ -277,7 +279,43 @@ describe('AddToDashboardButton', () => {
     });
   });
 
+  describe('Permissions', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('Should only show existing dashboard option with no access to create', async () => {
+      mocks.contextSrv.hasAccess.mockImplementation((action) => {
+        if (action === 'dashboards:create') {
+          return false;
+        } else {
+          return true;
+        }
+      });
+      setup(<AddToDashboard exploreId={ExploreId.left} />);
+      await openModal('Add panel to existing dashboard');
+      expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+    });
+
+    it('Should only show new dashboard option with no access to write', async () => {
+      mocks.contextSrv.hasAccess.mockImplementation((action) => {
+        if (action === 'dashboards:write') {
+          return false;
+        } else {
+          return true;
+        }
+      });
+      setup(<AddToDashboard exploreId={ExploreId.left} />);
+      await openModal('Add panel to new dashboard');
+      expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Error handling', () => {
+    beforeEach(() => {
+      mocks.contextSrv.hasAccess.mockImplementation(() => true);
+    });
+
     afterEach(() => {
       jest.restoreAllMocks();
     });

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -97,6 +97,12 @@ jest.mock('@grafana/runtime/src/services/dataSourceSrv', () => {
   };
 });
 
+jest.mock('app/core/core', () => ({
+  contextSrv: {
+    hasAccess: () => true,
+  },
+}));
+
 // for the AutoSizer component to have a width
 jest.mock('react-virtualized-auto-sizer', () => {
   return ({ children }: AutoSizerProps) => children({ height: 1, width: 1 });

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -11,7 +11,9 @@ import {
   ToolbarButton,
   ToolbarButtonRow,
 } from '@grafana/ui';
+import { contextSrv } from 'app/core/core';
 import { createAndCopyShortLink } from 'app/core/utils/shortLinks';
+import { AccessControlAction } from 'app/types';
 import { ExploreId } from 'app/types/explore';
 import { StoreState } from 'app/types/store';
 
@@ -120,6 +122,10 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
     const showSmallDataSourcePicker = (splitted ? containerWidth < 700 : containerWidth < 800) || false;
     const showSmallTimePicker = splitted || containerWidth < 1210;
 
+    const showExploreToDashboard =
+      contextSrv.hasAccess(AccessControlAction.DashboardsCreate, contextSrv.isEditor) ||
+      contextSrv.hasAccess(AccessControlAction.DashboardsWrite, contextSrv.isEditor);
+
     return (
       <div ref={topOfViewRef}>
         <PageToolbar
@@ -158,7 +164,7 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
               </ToolbarButton>
             )}
 
-            {config.featureToggles.explore2Dashboard && (
+            {config.featureToggles.explore2Dashboard && showExploreToDashboard && (
               <Suspense fallback={null}>
                 <AddToDashboard exploreId={exploreId} />
               </Suspense>

--- a/public/app/features/explore/Wrapper.test.tsx
+++ b/public/app/features/explore/Wrapper.test.tsx
@@ -50,6 +50,7 @@ jest.mock('app/core/core', () => {
   return {
     contextSrv: {
       hasPermission: () => true,
+      hasAccess: () => true,
     },
     appEvents: {
       subscribe: () => {},

--- a/public/app/features/explore/spec/interpolation.test.tsx
+++ b/public/app/features/explore/spec/interpolation.test.tsx
@@ -14,6 +14,12 @@ jest.mock('@grafana/runtime', () => ({
   getBackendSrv: () => ({ fetch }),
 }));
 
+jest.mock('app/core/core', () => ({
+  contextSrv: {
+    hasAccess: () => true,
+  },
+}));
+
 jest.mock('react-virtualized-auto-sizer', () => {
   return {
     __esModule: true,

--- a/public/app/features/explore/spec/queryHistory.test.tsx
+++ b/public/app/features/explore/spec/queryHistory.test.tsx
@@ -45,6 +45,12 @@ jest.mock('@grafana/runtime', () => ({
   getBackendSrv: () => ({ fetch: fetchMock, post: postMock, get: getMock }),
 }));
 
+jest.mock('app/core/core', () => ({
+  contextSrv: {
+    hasAccess: () => true,
+  },
+}));
+
 jest.mock('app/core/services/PreferencesService', () => ({
   PreferencesService: function () {
     return {


### PR DESCRIPTION
**What this PR does / why we need it**:
Users would need permission to create or edit dashboards in order to perform an explore to dashboard workflow.

This is a client side only permissions system, which can be worked around, but if a user does this, they will be blocked after clicking the button they were not supposed to see. So they could possibly edit the source to see the button, but they ultimately would be blocked from performing the action.

**Which issue(s) this PR fixes**:
Fixes #49498

**Special notes for your reviewer**:
Not sure what we would want in this modal with the toggle gone. I change the title if there is only one selection, but I am not sure if that is enough.
![Screen Shot 2022-05-24 at 2 58 59 PM](https://user-images.githubusercontent.com/1533128/170122431-3624a507-bf3d-4102-9f70-162361c5d180.png)

![Screen Shot 2022-05-24 at 2 58 30 PM](https://user-images.githubusercontent.com/1533128/170122421-adc266f6-6277-4606-ab67-eec6d8d18c00.png)

