### PR TITLE
Azure Monitor: Include datasource ref when interpolating variables

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/query.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/query.ts
@@ -1,18 +1,30 @@
 import { AzureMonitorQuery, AzureQueryType } from '../types';
 
-export default function createMockQuery(): AzureMonitorQuery {
+export default function createMockQuery(overrides?: Partial<AzureMonitorQuery>): AzureMonitorQuery {
   return {
+    queryType: AzureQueryType.AzureMonitor,
+    refId: 'A',
+    subscription: '99999999-cccc-bbbb-aaaa-9106972f9572',
+    subscriptions: ['99999999-cccc-bbbb-aaaa-9106972f9572'],
+    datasource: {
+      type: 'grafana-azure-monitor-datasource',
+      uid: 'AAAAA11111BBBBB22222CCCC',
+    },
+    ...overrides,
+
     azureLogAnalytics: {
       query:
         '//change this example to create your own time series query\n<table name>                                                              //the table to query (e.g. Usage, Heartbeat, Perf)\n| where $__timeFilter(TimeGenerated)                                      //this is a macro used to show the full chart’s time range, choose the datetime column here\n| summarize count() by <group by column>, bin(TimeGenerated, $__interval) //change “group by column” to a column in your table, such as “Computer”. The $__interval macro is used to auto-select the time grain. Can also use 1h, 5m etc.\n| order by TimeGenerated asc',
       resultFormat: 'time_series',
       workspace: 'e3fe4fde-ad5e-4d60-9974-e2f3562ffdf2',
       resource: 'test-resource',
+      ...overrides?.azureLogAnalytics,
     },
 
     azureResourceGraph: {
       query: 'Resources | summarize count()',
       resultFormat: 'table',
+      ...overrides?.azureResourceGraph,
     },
 
     azureMonitor: {
@@ -32,15 +44,7 @@ export default function createMockQuery(): AzureMonitorQuery {
       alias: '',
       // timeGrains: [],
       top: '10',
-    },
-
-    queryType: AzureQueryType.AzureMonitor,
-    refId: 'A',
-    subscription: '99999999-cccc-bbbb-aaaa-9106972f9572',
-    subscriptions: ['99999999-cccc-bbbb-aaaa-9106972f9572'],
-    datasource: {
-      type: 'grafana-azure-monitor-datasource',
-      uid: 'AAAAA11111BBBBB22222CCCC',
+      ...overrides?.azureMonitor,
     },
   };
 }

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.test.ts
@@ -21,7 +21,9 @@ describe('Azure Monitor Datasource', () => {
 
     it('should include a datasource ref when interpolating queries', () => {
       const ds = new Datasource(createMockInstanceSetttings());
-      const queries = [createMockQuery()];
+      const query = createMockQuery();
+      delete query.datasource;
+      const queries = [query];
 
       const interpolatedQueries = ds.interpolateVariablesInQueries(queries, {});
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.test.ts
@@ -1,0 +1,35 @@
+import { createMockInstanceSetttings } from './__mocks__/instanceSettings';
+import createMockQuery from './__mocks__/query';
+import Datasource from './datasource';
+
+describe('Azure Monitor Datasource', () => {
+  describe('interpolateVariablesInQueries()', () => {
+    it('should interpolate variables in the queries', () => {
+      const ds = new Datasource(createMockInstanceSetttings());
+      const queries = [createMockQuery({ azureMonitor: { resourceGroup: '$resourceGroup' } })];
+
+      const interpolatedQueries = ds.interpolateVariablesInQueries(queries, {
+        resourceGroup: { text: 'the-resource-group', value: 'the-resource-group' },
+      });
+
+      expect(interpolatedQueries).toContainEqual(
+        expect.objectContaining({
+          azureMonitor: expect.objectContaining({ resourceGroup: 'the-resource-group' }),
+        })
+      );
+    });
+
+    it('should include a datasource ref when interpolating queries', () => {
+      const ds = new Datasource(createMockInstanceSetttings());
+      const queries = [createMockQuery()];
+
+      const interpolatedQueries = ds.interpolateVariablesInQueries(queries, {});
+
+      expect(interpolatedQueries).toContainEqual(
+        expect.objectContaining({
+          datasource: expect.objectContaining({ type: 'azuremonitor', uid: 'abc' }),
+        })
+      );
+    });
+  });
+});

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
@@ -203,7 +203,10 @@ export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDa
       }
 
       const ds = this.pseudoDatasource[query.queryType];
-      return ds?.applyTemplateVariables(query, scopedVars) ?? query;
+      return {
+        datasource: ds?.getRef(),
+        ...(ds?.applyTemplateVariables(query, scopedVars) ?? query),
+      };
     });
 
     return mapped;


### PR DESCRIPTION
**What this PR does / why we need it**:
When recorded queries are created, it calls the `interpolateVariablesInQueries` function of the datasource. It expects a datasource ref to be included in the query.

This PR adds the datasource ref to the query when variables are interpolated.

**Which issue(s) this PR fixes**:

Fixes #48877

**Special notes for your reviewer**: