### PR TITLE
Canvas: Fix resize breaking certain constraints

### DIFF
--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -114,6 +114,7 @@ export class ElementState implements LayerElement {
         style.top = `${placement.top}px`;
         style.bottom = `${placement.bottom}px`;
         delete placement.height;
+        style.height = '';
         break;
       case VerticalConstraint.Center:
         placement.top = placement.top ?? 0;
@@ -129,6 +130,7 @@ export class ElementState implements LayerElement {
         style.top = `${placement.top}%`;
         style.bottom = `${placement.bottom}%`;
         delete placement.height;
+        style.height = '';
         break;
     }
 
@@ -153,6 +155,7 @@ export class ElementState implements LayerElement {
         style.left = `${placement.left}px`;
         style.right = `${placement.right}px`;
         delete placement.width;
+        style.width = '';
         break;
       case HorizontalConstraint.Center:
         placement.left = placement.left ?? 0;
@@ -168,6 +171,7 @@ export class ElementState implements LayerElement {
         style.left = `${placement.left}%`;
         style.right = `${placement.right}%`;
         delete placement.width;
+        style.width = '';
         break;
     }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Resize adds width / height style property to each element, which was not being cleared, breaking Top / Bottom + Left / Right + Scale constraints

Before

https://user-images.githubusercontent.com/22381771/170170691-4c584ad1-2e19-4ff5-90a5-02aa0eb9f22c.mov



After

https://user-images.githubusercontent.com/22381771/170170026-423f05e1-869d-4760-b71c-f49d4087faa9.mov



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #49548
