### PR TITLE
Login: Fix AuthInfo update process

### DIFF
--- a/pkg/services/login/authinfoservice/database/database.go
+++ b/pkg/services/login/authinfoservice/database/database.go
@@ -157,7 +157,7 @@ func (s *AuthInfoStore) UpdateAuthInfoDate(ctx context.Context, authInfo *models
 		AuthModule: authInfo.AuthModule,
 	}
 	return s.sqlStore.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		_, err := sess.Update(authInfo, cond)
+		_, err := sess.Cols("created").Update(authInfo, cond)
 		return err
 	})
 }

--- a/pkg/services/login/authinfoservice/database/database.go
+++ b/pkg/services/login/authinfoservice/database/database.go
@@ -146,8 +146,8 @@ func (s *AuthInfoStore) SetAuthInfo(ctx context.Context, cmd *models.SetAuthInfo
 	})
 }
 
-// UpdateAuthInfo updates the auth info for the user with the latest date. Avoids overlapping entries hiding
-// the last used one (ex: LDAP->SAML->LDAP)
+// UpdateAuthInfoDate updates the auth info for the user with the latest date.
+// Avoids overlapping entries hiding the last used one (ex: LDAP->SAML->LDAP).
 func (s *AuthInfoStore) UpdateAuthInfoDate(ctx context.Context, authInfo *models.UserAuth) error {
 	authInfo.Created = GetTime()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In https://github.com/grafana/grafana/pull/49177 new changes were added in order to update the `created` column of a given `UserAuth` entry to keep it as the most recent entry when switching between different auth modules (e.g. LDAP->SAML->LDAP).

However, as the code added is relying on XORM (see the `UpdateAuthInfoDate` method), it's not only the `created` column what gets updated but the whole entity. That's causing an issue because at that point, the `OAuthXXX` fields in the given struct aren't encrypted/encoded, but they should (compare it to the `UpdateAuthInfo` method, for instance).

Therefore, the fix basically uses the `Cols(...)` method from the XORM (as suggested [here](https://xorm.io/docs/chapter-06/readme/)) to specifically set which columns (`created` only) should be updated.

I tested it locally and it seems to be working: when using that method it only updates the columns referred, even if other fields have non-zero values, which seems to be enough.

**Which issue(s) this PR fixes**:

Related with https://github.com/grafana/grafana-enterprise/issues/3353

It's also related with https://ops.grafana.net/a/grafana-incident-app/incidents/123

**Special notes for your reviewer**:

See from the docs referred above that there are different strategies to only update a single column. We could even just write a simple SQL statement. However, I decided to use `Cols(...)` method because apparently it's quite common in the code base. But I'm completely open for feedback and alternative proposals, of course!

Also, note that in the [incident](https://ops.grafana.net/a/grafana-incident-app/incidents/123) channel we mentioned that the value stored into the database that we used to reproduce it was encoded but not encrypted, and also truncated. So, I'm still not sure if this is the only change needed to fix https://github.com/grafana/grafana-enterprise/issues/3353 completely.

I guess that situation could be the result of multiple encrypt/decrypt and encode/decode operations with a non-expected input, but I'd say in those situations an error should happen (like the one mentioned in the incident: `illegal base64 data at input byte 90`) instead. **So, an extra pair of 👀  and a fresh 🧠  plenty of ideas will be extremely appreciated here**. 

**Other solutions considered**:

Alternatively, we could somehow merge `UpdateAuthInfo` and `UpdateAuthInfoDate` (the latter would just update the `Created` field and pass it to the former) to ensure those fields are encrypted & encoded before updating the database, but that'd add an extra overhead (encryption & encoding one) and could cause side-effects (other columns modifications) that I guess are not desired when calling the `UpdateAuthInfoDate` method.

Finally, credits for @undef1nd because she's who actually caught it 🙌🏻 
