### PR TITLE
Prometheus: Predefined scopes for Azure authentication

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -18,7 +18,6 @@ export interface FeatureToggles {
 
   trimDefaults?: boolean;
   disableEnvelopeEncryption?: boolean;
-  httpclientprovider_azure_auth?: boolean;
   serviceAccounts?: boolean;
   database_metrics?: boolean;
   dashboardPreviews?: boolean;
@@ -33,6 +32,7 @@ export interface FeatureToggles {
   tempoServiceGraph?: boolean;
   lokiBackendMode?: boolean;
   prometheus_azure_auth?: boolean;
+  prometheusAzureOverrideAudience?: boolean;
   influxdbBackendMigration?: boolean;
   newNavigation?: boolean;
   showFeatureFlagsInUI?: boolean;

--- a/pkg/services/datasources/service/datasource_service_test.go
+++ b/pkg/services/datasources/service/datasource_service_test.go
@@ -561,7 +561,7 @@ func TestService_HTTPClientOptions(t *testing.T) {
 
 	t.Run("Azure authentication", func(t *testing.T) {
 		t.Run("given feature flag enabled", func(t *testing.T) {
-			features := featuremgmt.WithFeatures(featuremgmt.FlagHttpclientproviderAzureAuth)
+			features := featuremgmt.WithFeatures(featuremgmt.FlagPrometheusAzureAuth)
 
 			t.Run("should set Azure middleware when JsonData contains valid credentials", func(t *testing.T) {
 				t.Cleanup(func() { ds.JsonData = emptyJsonData; ds.SecureJsonData = emptySecureJsonData })
@@ -571,7 +571,6 @@ func TestService_HTTPClientOptions(t *testing.T) {
 					"azureCredentials": map[string]interface{}{
 						"authType": "msi",
 					},
-					"azureEndpointResourceId": "https://api.example.com/abd5c4ce-ca73-41e9-9cb2-bed39aa2adb5",
 				})
 
 				secretsStore := kvstore.SetupTestService(t)

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -19,11 +19,6 @@ var (
 			State:       FeatureStateStable,
 		},
 		{
-			Name:        "httpclientprovider_azure_auth",
-			Description: "Experimental. Allow datasources to configure Azure authentication directly via JsonData",
-			State:       FeatureStateBeta,
-		},
-		{
 			Name:        "serviceAccounts",
 			Description: "support service accounts",
 			State:       FeatureStateBeta,
@@ -98,6 +93,11 @@ var (
 		{
 			Name:        "prometheus_azure_auth",
 			Description: "Experimental. Azure authentication for Prometheus datasource",
+			State:       FeatureStateBeta,
+		},
+		{
+			Name:        "prometheusAzureOverrideAudience",
+			Description: "Experimental. Allow override default AAD audience for Azure Prometheus endpoint",
 			State:       FeatureStateBeta,
 		},
 		{

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -15,10 +15,6 @@ const (
 	// Disable envelope encryption (emergency only)
 	FlagDisableEnvelopeEncryption = "disableEnvelopeEncryption"
 
-	// FlagHttpclientproviderAzureAuth
-	// Experimental. Allow datasources to configure Azure authentication directly via JsonData
-	FlagHttpclientproviderAzureAuth = "httpclientprovider_azure_auth"
-
 	// FlagServiceAccounts
 	// support service accounts
 	FlagServiceAccounts = "serviceAccounts"
@@ -74,6 +70,10 @@ const (
 	// FlagPrometheusAzureAuth
 	// Experimental. Azure authentication for Prometheus datasource
 	FlagPrometheusAzureAuth = "prometheus_azure_auth"
+
+	// FlagPrometheusAzureOverrideAudience
+	// Experimental. Allow override default AAD audience for Azure Prometheus endpoint
+	FlagPrometheusAzureOverrideAudience = "prometheusAzureOverrideAudience"
 
 	// FlagInfluxdbBackendMigration
 	// Query InfluxDB InfluxQL without the proxy

--- a/pkg/tsdb/prometheus/buffered/promclient/provider_azure_test.go
+++ b/pkg/tsdb/prometheus/buffered/promclient/provider_azure_test.go
@@ -3,8 +3,10 @@ package promclient
 import (
 	"testing"
 
+	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/assert"
@@ -12,7 +14,9 @@ import (
 )
 
 func TestConfigureAzureAuthentication(t *testing.T) {
-	cfg := &setting.Cfg{}
+	cfg := &setting.Cfg{
+		Azure: &azsettings.AzureSettings{},
+	}
 	settings := backend.DataSourceInstanceSettings{}
 
 	t.Run("given feature flag enabled", func(t *testing.T) {
@@ -24,7 +28,6 @@ func TestConfigureAzureAuthentication(t *testing.T) {
 				"azureCredentials": map[string]interface{}{
 					"authType": "msi",
 				},
-				"azureEndpointResourceId": "https://api.example.com/abd5c4ce-ca73-41e9-9cb2-bed39aa2adb5",
 			}
 
 			var p = NewProvider(settings, jsonData, nil, cfg, features, nil)

--- a/public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx
@@ -1,7 +1,7 @@
-import React, { FunctionComponent, useMemo } from 'react';
+import React, { FunctionComponent, FormEvent, useMemo, useState } from 'react';
 
 import { config } from '@grafana/runtime';
-import { InlineFormLabel, Input } from '@grafana/ui';
+import { InlineField, InlineFieldRow, InlineSwitch, Input } from '@grafana/ui';
 import { HttpSettingsBaseProps } from '@grafana/ui/src/components/DataSourceSettings/types';
 
 import { KnownAzureClouds, AzureCredentials } from './AzureCredentials';
@@ -11,10 +11,36 @@ import { AzureCredentialsForm } from './AzureCredentialsForm';
 export const AzureAuthSettings: FunctionComponent<HttpSettingsBaseProps> = (props: HttpSettingsBaseProps) => {
   const { dataSourceConfig, onChange } = props;
 
+  const [overrideAudienceAllowed] = useState<boolean>(
+    config.featureToggles.prometheusAzureOverrideAudience || !!dataSourceConfig.jsonData.azureEndpointResourceId
+  );
+  const [overrideAudienceChecked, setOverrideAudienceChecked] = useState<boolean>(
+    !!dataSourceConfig.jsonData.azureEndpointResourceId
+  );
+
   const credentials = useMemo(() => getCredentials(dataSourceConfig), [dataSourceConfig]);
 
   const onCredentialsChange = (credentials: AzureCredentials): void => {
     onChange(updateCredentials(dataSourceConfig, credentials));
+  };
+
+  const onOverrideAudienceChange = (ev: FormEvent<HTMLInputElement>): void => {
+    setOverrideAudienceChecked(ev.currentTarget.checked);
+    if (!ev.currentTarget.checked) {
+      onChange({
+        ...dataSourceConfig,
+        jsonData: { ...dataSourceConfig.jsonData, azureEndpointResourceId: undefined },
+      });
+    }
+  };
+
+  const onResourceIdChange = (ev: FormEvent<HTMLInputElement>): void => {
+    if (overrideAudienceChecked) {
+      onChange({
+        ...dataSourceConfig,
+        jsonData: { ...dataSourceConfig.jsonData, azureEndpointResourceId: ev.currentTarget.value },
+      });
+    }
   };
 
   return (
@@ -26,26 +52,29 @@ export const AzureAuthSettings: FunctionComponent<HttpSettingsBaseProps> = (prop
         azureCloudOptions={KnownAzureClouds}
         onCredentialsChange={onCredentialsChange}
       />
-      <h6>Azure Configuration</h6>
-      <div className="gf-form-group">
-        <div className="gf-form-inline">
-          <div className="gf-form">
-            <InlineFormLabel className="width-12">AAD resource ID</InlineFormLabel>
-            <div className="width-15">
-              <Input
-                className="width-30"
-                value={dataSourceConfig.jsonData.azureEndpointResourceId || ''}
-                onChange={(event) =>
-                  onChange({
-                    ...dataSourceConfig,
-                    jsonData: { ...dataSourceConfig.jsonData, azureEndpointResourceId: event.currentTarget.value },
-                  })
-                }
-              />
-            </div>
+      {overrideAudienceAllowed && (
+        <>
+          <h6>Azure Configuration</h6>
+          <div className="gf-form-group">
+            <InlineFieldRow>
+              <InlineField labelWidth={26} label="Override AAD audience">
+                <InlineSwitch value={overrideAudienceChecked} onChange={onOverrideAudienceChange} />
+              </InlineField>
+            </InlineFieldRow>
+            {overrideAudienceChecked && (
+              <InlineFieldRow>
+                <InlineField labelWidth={26} label="Resource ID">
+                  <Input
+                    className="width-30"
+                    value={dataSourceConfig.jsonData.azureEndpointResourceId || ''}
+                    onChange={onResourceIdChange}
+                  />
+                </InlineField>
+              </InlineFieldRow>
+            )}
           </div>
-        </div>
-      </div>
+        </>
+      )}
     </>
   );
 };

--- a/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/ConfigEditor.tsx
@@ -18,7 +18,7 @@ export const ConfigEditor = (props: Props) => {
   const alertmanagers = getAllAlertmanagerDataSources();
 
   const azureAuthSettings = {
-    azureAuthSupported: config.featureToggles['prometheus_azure_auth'] ?? false,
+    azureAuthSupported: !!config.featureToggles.prometheus_azure_auth,
     getAzureAuthEnabled: (config: DataSourceSettings<any, any>): boolean => hasCredentials(config),
     setAzureAuthEnabled: (config: DataSourceSettings<any, any>, enabled: boolean) =>
       enabled ? setDefaultCredentials(config) : resetCredentials(config),


### PR DESCRIPTION
**What this PR does / why we need it**:

Prometheus datasource has support for Azure authentication and besides normal configuration of endpoint URL it also requires configuration of OAuth audience (AAD resource ID).

Configuration of OAuth audience should not be required from end users. This PR replaces the manual configuration of OAuth audience with automatic selection based on Azure cloud (same logic as in Azure Monitor).

Manual configuration of OAuth audience (override of default) is still possible in two cases:
1. When `prometheusAzureOverrideAudience` feature flag is enabled (e.g. for testing purposes).
2. When existing datasource already has the OAuth audience configured, so it will continue to work until user explicitly removes it (for backwards compatibility).


![image](https://user-images.githubusercontent.com/1131253/170191881-665385d0-c2be-413a-9dde-e21bba4d2bbc.png)

**Which issue(s) this PR fixes**:

Related to #35857

**Special notes for your reviewer**:

`datasource_service.go` has Azure authentication logic which is exclusively used by Prometheus templating queries and needed as long as templating queries go through `datasource_service.go` rather than Prometheus backend `promclient.Provider` (tracked by #48790)

Azure authentication is Prometheus datasource is still an experimental feature under the flag `prometheus_azure_auth` and can tolerate breaking changes.