### PR TITLE
Query History: Track query history migration failures

### DIFF
--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -131,7 +131,12 @@ export enum LocalStorageMigrationStatus {
   NotNeeded = 'not-needed',
 }
 
-export async function migrateQueryHistoryFromLocalStorage(): Promise<LocalStorageMigrationStatus> {
+export interface LocalStorageMigrationResult {
+  status: LocalStorageMigrationStatus;
+  error?: Error;
+}
+
+export async function migrateQueryHistoryFromLocalStorage(): Promise<LocalStorageMigrationResult> {
   const richHistoryLocalStorage = new RichHistoryLocalStorage();
   const richHistoryRemoteStorage = new RichHistoryRemoteStorage();
 
@@ -145,14 +150,14 @@ export async function migrateQueryHistoryFromLocalStorage(): Promise<LocalStorag
       to: 14,
     });
     if (richHistory.length === 0) {
-      return LocalStorageMigrationStatus.NotNeeded;
+      return { status: LocalStorageMigrationStatus.NotNeeded };
     }
     await richHistoryRemoteStorage.migrate(richHistory);
     dispatch(notifyApp(createSuccessNotification('Query history successfully migrated from local storage')));
-    return LocalStorageMigrationStatus.Successful;
+    return { status: LocalStorageMigrationStatus.Successful };
   } catch (error) {
     dispatch(notifyApp(createWarningNotification(`Query history migration failed. ${error.message}`)));
-    return LocalStorageMigrationStatus.Failed;
+    return { status: LocalStorageMigrationStatus.Failed, error };
   }
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This is to track errors thrown when query history migration failed. Grafana will produce the following log error:

```
ERROR[05-25|08:39:01] TypeError: window.triggerError is not a function logger=frontend url="http://localhost:3000/explore?orgId=1&left=%7B%22datasource%22:%22gdev-loki%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%22%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D" user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/101.0.0.0 Safari/537.36" event_id=12f94f0345b54c439f2ab09f88c0d132 original_timestamp=2022-05-25T06:39:01.127Z stacktrace="TypeError: window.triggerError is not a function\n  at async (http://localhost:3000/public/build/app.js?857c6676c958bf9b32ef:152587:31)\n  at migrateQueryHistoryFromLocalStorage (http://localhost:3000/public/build/app.js?857c6676c958bf9b32ef:123961:12)" context_explore_event=QueryHistoryMigrationFailed user_email=admin@localhost user_id=1
```

Important fields: `logger=frontend ... context_explore_event=QueryHistoryMigrationFailed`

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #49559

**Special notes for your reviewer**:

How to test it?

Trigger an error from within try/catch in`migrateQueryHistoryFromLocalStorage()`, for example calling an undefined function, or just throwing an error:

```typescript
export async function migrateQueryHistoryFromLocalStorage(): Promise<LocalStorageMigrationResult> {
  const richHistoryLocalStorage = new RichHistoryLocalStorage();
  const richHistoryRemoteStorage = new RichHistoryRemoteStorage();

  try {
    const { richHistory } = await richHistoryLocalStorage.getRichHistory({ ... });
    if (richHistory.length === 0) {
      return { status: LocalStorageMigrationStatus.NotNeeded };
    }
    // @ts-ignore
    window.triggerError(); // <-------------------------- TRIGGER ERROR MANUALLY
    await richHistoryRemoteStorage.migrate(richHistory);
    dispatch(notifyApp(createSuccessNotification('Query history successfully migrated from local storage')));
    return { status: LocalStorageMigrationStatus.Successful };
  } catch (error) {
    dispatch(notifyApp(createWarningNotification(`Query history migration failed. ${error.message}`)));
    return { status: LocalStorageMigrationStatus.Failed, error };
  }
}
```