### PR TITLE
AngularSupport: Update description for angular_support_enabled config option

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -305,7 +305,7 @@ content_security_policy = false
 # $ROOT_PATH is server.root_url without the protocol.
 content_security_policy_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
 
-# Controls if old angular plugins are supported or not. This will be disabled by default in Grafana v9.
+# Controls if old angular plugins are supported or not. This will be disabled by default in future release
 angular_support_enabled = true
 
 [security.encryption]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -305,7 +305,7 @@
 # $ROOT_PATH is server.root_url without the protocol.
 ;content_security_policy_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
 
-# Controls if old angular plugins are supported or not. This will be disabled by default in Grafana v9.
+# Controls if old angular plugins are supported or not. This will be disabled by default in future release
 ;angular_support_enabled = true
 
 [security.encryption]

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -602,7 +602,7 @@ Set Content Security Policy template used when adding the Content-Security-Polic
 
 ### angular_support_enabled
 
-This currently defaults to `true` but will in future release default to `false`. When set to false the angular framework and support components will not be loaded. This means that
+This currently defaults to `true` but will default to `false` in a future release. When set to false the angular framework and support components will not be loaded. This means that
 all plugins and core features that depend on angular support will stop working.
 
 Current core features that will stop working:

--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -602,7 +602,7 @@ Set Content Security Policy template used when adding the Content-Security-Polic
 
 ### angular_support_enabled
 
-This currently defaults to `true` but will in Grafana v9 default to `false`. When set to false the angular framework and support components will not be loaded. This means that
+This currently defaults to `true` but will in future release default to `false`. When set to false the angular framework and support components will not be loaded. This means that
 all plugins and core features that depend on angular support will stop working.
 
 Current core features that will stop working:

--- a/docs/sources/developers/angular_deprecation.md
+++ b/docs/sources/developers/angular_deprecation.md
@@ -15,7 +15,7 @@ AngularJS is an old frontend framework that stopped active development many year
 
 ## When will angular plugins stop working?
 
-In Grafana version 9 coming in June 2022, all angular plugins will stop working unless a new server configuration option is turned on. If you still depend on community or internally developed plugins that require AngularJS then you will have to turn this option on.
+We hope to migrate the last features of core Grafana later this year. Then the setting enable_angular_support can be disable by default. This will make all angular plugins stop working. If you still depend on community or internally developed plugins that require AngularJS then you will have to turn this option on.
 
 This is a good time to start working on migrating plugins to React.
 

--- a/docs/sources/developers/angular_deprecation.md
+++ b/docs/sources/developers/angular_deprecation.md
@@ -15,7 +15,7 @@ AngularJS is an old frontend framework that stopped active development many year
 
 ## When will angular plugins stop working?
 
-We hope to migrate the last features of core Grafana later this year. Then the setting enable_angular_support can be disable by default. This will make all angular plugins stop working. If you still depend on community or internally developed plugins that require AngularJS then you will have to turn this option on.
+We hope to migrate the last remaining angular code in core Grafana later this year. Then the setting enable_angular_support can be disable by default. This will make all angular plugins stop working. If you still depend on community or internally developed plugins that require AngularJS then you will have to enable this option.
 
 This is a good time to start working on migrating plugins to React.
 

--- a/docs/sources/developers/angular_deprecation.md
+++ b/docs/sources/developers/angular_deprecation.md
@@ -7,7 +7,7 @@ weight = 500
 
 # Angular support deprecation
 
-Angular plugin support is deprecated, and it will be removed in a future release. There are still many community plugins that depend on Grafana’s angular plugin support for them to work. The same is true for many internal (private) plugins developed over the years by Grafana users. Grafana version 9 will have a server configuration option, global for the whole instance, that will control if angular plugin support is available or not. By default, angular plugin support will be disabled.
+Angular plugin support is deprecated, and it will be removed in a future release. There are still many community plugins that depend on Grafana’s angular plugin support for them to work. The same is true for many internal (private) plugins developed over the years by Grafana users. Grafana version 9 will have a server configuration option, global for the whole instance, that will control if angular plugin support is available or not. By default angular support is still enabled but this will soon change as we complete the migration of all angular code in the core product.
 
 ## Why are we deprecating angular support?
 


### PR DESCRIPTION
Since we still have some small parts to migrate we cannot disable angular in v9 so updating the description of this
setting.
