### PR TITLE
DataSource: Allow data source plugins to set query default values

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -348,6 +348,7 @@ abstract class DataSourceApi<
 
   /*
    * Optionally, use this method to set default values for a query
+   * @alpha -- experimental
    */
   getDefaultQuery?(app: CoreApp): Partial<TQuery>;
 }

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -215,6 +215,7 @@ abstract class DataSourceApi<
     this.type = instanceSettings.type;
     this.meta = instanceSettings.meta;
     this.uid = instanceSettings.uid;
+    this.defaultQuery = {};
   }
 
   /**
@@ -345,6 +346,8 @@ abstract class DataSourceApi<
     | StandardVariableSupport<DataSourceApi<TQuery, TOptions>>
     | CustomVariableSupport<DataSourceApi<TQuery, TOptions>>
     | DataSourceVariableSupport<DataSourceApi<TQuery, TOptions>>;
+
+  defaultQuery: Partial<TQuery>;
 }
 
 export interface MetadataInspectorProps<

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -215,7 +215,6 @@ abstract class DataSourceApi<
     this.type = instanceSettings.type;
     this.meta = instanceSettings.meta;
     this.uid = instanceSettings.uid;
-    this.defaultQuery = {};
   }
 
   /**
@@ -347,7 +346,10 @@ abstract class DataSourceApi<
     | CustomVariableSupport<DataSourceApi<TQuery, TOptions>>
     | DataSourceVariableSupport<DataSourceApi<TQuery, TOptions>>;
 
-  defaultQuery: Partial<TQuery>;
+  /*
+   * Optionally, use this method to set default values for a query
+   */
+  getDefaultQuery?(app: CoreApp): Partial<TQuery>;
 }
 
 export interface MetadataInspectorProps<

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -158,8 +158,8 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
   };
 
   onClickAddQueryRowButton = () => {
-    const { exploreId, queryKeys } = this.props;
-    this.props.addQueryRow(exploreId, queryKeys.length);
+    const { exploreId, queryKeys, datasourceInstance } = this.props;
+    this.props.addQueryRow(exploreId, queryKeys.length, datasourceInstance);
   };
 
   onMakeAbsoluteTime = () => {

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -5,6 +5,7 @@ import { mergeMap, throttleTime } from 'rxjs/operators';
 
 import {
   AbsoluteTimeRange,
+  CoreApp,
   DataQuery,
   DataQueryErrorType,
   DataQueryResponse,
@@ -213,10 +214,17 @@ export const clearCacheAction = createAction<ClearCachePayload>('explore/clearCa
 /**
  * Adds a query row after the row with the given index.
  */
-export function addQueryRow(exploreId: ExploreId, index: number): ThunkResult<void> {
+export function addQueryRow(
+  exploreId: ExploreId,
+  index: number,
+  datasource: DataSourceApi | undefined | null
+): ThunkResult<void> {
   return (dispatch, getState) => {
     const queries = getState().explore[exploreId]!.queries;
-    const query = generateEmptyQuery(queries, index);
+    const query = {
+      ...(datasource?.getDefaultQuery && datasource.getDefaultQuery(CoreApp.Explore)),
+      ...generateEmptyQuery(queries, index),
+    };
 
     dispatch(addQueryRowAction({ exploreId, index, query }));
   };

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -222,7 +222,7 @@ export function addQueryRow(
   return (dispatch, getState) => {
     const queries = getState().explore[exploreId]!.queries;
     const query = {
-      ...(datasource?.getDefaultQuery && datasource.getDefaultQuery(CoreApp.Explore)),
+      ...datasource?.getDefaultQuery?.(CoreApp.Explore),
       ...generateEmptyQuery(queries, index),
     };
 

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -138,7 +138,7 @@ export class QueryGroup extends PureComponent<Props, State> {
     const ds = !dsSettings?.meta.mixed ? dsSettings : defaultDataSource;
 
     return {
-      ...(this.state.dataSource?.getDefaultQuery && this.state.dataSource.getDefaultQuery(CoreApp.PanelEditor)),
+      ...this.state.dataSource?.getDefaultQuery?.(CoreApp.PanelEditor),
       datasource: { uid: ds?.uid, type: ds?.type },
     };
   }

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -3,6 +3,7 @@ import React, { PureComponent } from 'react';
 import { Unsubscribable } from 'rxjs';
 
 import {
+  CoreApp,
   DataQuery,
   DataSourceApi,
   DataSourceInstanceSettings,
@@ -137,7 +138,7 @@ export class QueryGroup extends PureComponent<Props, State> {
     const ds = !dsSettings?.meta.mixed ? dsSettings : defaultDataSource;
 
     return {
-      ...this.state.dataSource?.defaultQuery,
+      ...(this.state.dataSource?.getDefaultQuery && this.state.dataSource.getDefaultQuery(CoreApp.PanelEditor)),
       datasource: { uid: ds?.uid, type: ds?.type },
     };
   }

--- a/public/app/features/query/components/QueryGroup.tsx
+++ b/public/app/features/query/components/QueryGroup.tsx
@@ -137,6 +137,7 @@ export class QueryGroup extends PureComponent<Props, State> {
     const ds = !dsSettings?.meta.mixed ? dsSettings : defaultDataSource;
 
     return {
+      ...this.state.dataSource?.defaultQuery,
       datasource: { uid: ds?.uid, type: ds?.type },
     };
   }

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -33,6 +33,7 @@ import { AppNotificationTimeout } from 'app/types';
 
 import { CloudWatchAnnotationSupport } from './annotationSupport';
 import { SQLCompletionItemProvider } from './cloudwatch-sql/completion/CompletionItemProvider';
+import { DEFAULT_QUERY } from './components/MetricsQueryEditor/usePreparedMetricsQuery';
 import { ThrottlingErrorMessage } from './components/ThrottlingErrorMessage';
 import { isCloudWatchAnnotationQuery, isCloudWatchLogsQuery, isCloudWatchMetricsQuery } from './guards';
 import { CloudWatchLanguageProvider } from './language_provider';
@@ -131,6 +132,7 @@ export class CloudWatchDatasource
     this.metricMathCompletionItemProvider = new MetricMathCompletionItemProvider(this, this.templateSrv);
     this.variables = new CloudWatchVariableSupport(this);
     this.annotations = CloudWatchAnnotationSupport;
+    this.defaultQuery = DEFAULT_QUERY;
   }
 
   query(options: DataQueryRequest<CloudWatchQuery>): Observable<DataQueryResponse> {

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -33,7 +33,6 @@ import { AppNotificationTimeout } from 'app/types';
 
 import { CloudWatchAnnotationSupport } from './annotationSupport';
 import { SQLCompletionItemProvider } from './cloudwatch-sql/completion/CompletionItemProvider';
-import { DEFAULT_QUERY } from './components/MetricsQueryEditor/usePreparedMetricsQuery';
 import { ThrottlingErrorMessage } from './components/ThrottlingErrorMessage';
 import { isCloudWatchAnnotationQuery, isCloudWatchLogsQuery, isCloudWatchMetricsQuery } from './guards';
 import { CloudWatchLanguageProvider } from './language_provider';
@@ -132,7 +131,6 @@ export class CloudWatchDatasource
     this.metricMathCompletionItemProvider = new MetricMathCompletionItemProvider(this, this.templateSrv);
     this.variables = new CloudWatchVariableSupport(this);
     this.annotations = CloudWatchAnnotationSupport;
-    this.defaultQuery = DEFAULT_QUERY;
   }
 
   query(options: DataQueryRequest<CloudWatchQuery>): Observable<DataQueryResponse> {


### PR DESCRIPTION
**What this PR does / why we need it**:
It would be good if the datasource api provided a way for a datasource to set a default query that is applied whenever new query rows are added. That way we could get rid of boilerplate code in the editor and also prevent unnecessary rerenders that are triggered when a data source call `onChange` after setting default values. Curious to hear your thoughts on this approach. 


