### PR TITLE
Access control: fix a typo for folder actions

### DIFF
--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -71,7 +71,7 @@ export enum AccessControlAction {
   DashboardsDelete = 'dashboards:delete',
   DashboardsCreate = 'dashboards:create',
   DashboardsPermissionsRead = 'dashboards.permissions:read',
-  DashboardsPermissionsWrite = 'dashboards.permissions:read',
+  DashboardsPermissionsWrite = 'dashboards.permissions:write',
 
   FoldersRead = 'folders:read',
   FoldersWrite = 'folders:write',

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -74,11 +74,11 @@ export enum AccessControlAction {
   DashboardsPermissionsWrite = 'dashboards.permissions:read',
 
   FoldersRead = 'folders:read',
-  FoldersWrite = 'folders:read',
+  FoldersWrite = 'folders:write',
   FoldersDelete = 'folders:delete',
   FoldersCreate = 'folders:create',
   FoldersPermissionsRead = 'folders.permissions:read',
-  FoldersPermissionsWrite = 'folders.permissions:read',
+  FoldersPermissionsWrite = 'folders.permissions:write',
 
   // Alerting rules
   AlertingRuleCreate = 'alert.rules:create',


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a typo for folder RBAC actions.
