### PR TITLE
AccessControl: Pass current org id to UsersTable

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -200,7 +200,7 @@ exports[`no enzyme tests`] = {
     "public/app/features/teams/TeamSettings.test.tsx:2043271249": [
       [0, 19, 13, "RegExp match", "2409514259"]
     ],
-    "public/app/features/users/UsersListPage.test.tsx:3908145117": [
+    "public/app/features/users/UsersListPage.test.tsx:2518052139": [
       [0, 19, 13, "RegExp match", "2409514259"]
     ],
     "public/app/features/users/UsersTable.test.tsx:263958312": [

--- a/public/app/features/users/UsersListPage.test.tsx
+++ b/public/app/features/users/UsersListPage.test.tsx
@@ -12,6 +12,12 @@ jest.mock('../../core/app_events', () => ({
   emit: jest.fn(),
 }));
 
+jest.mock('app/core/services/context_srv', () => ({
+  contextSrv: {
+    user: { orgId: 1 },
+  },
+}));
+
 const setup = (propOverrides?: object) => {
   const props: Props = {
     navModel: {

--- a/public/app/features/users/UsersListPage.tsx
+++ b/public/app/features/users/UsersListPage.tsx
@@ -5,6 +5,7 @@ import { renderMarkdown } from '@grafana/data';
 import { HorizontalGroup, Pagination, VerticalGroup } from '@grafana/ui';
 import Page from 'app/core/components/Page/Page';
 import { getNavModel } from 'app/core/selectors/navModel';
+import { contextSrv } from 'app/core/services/context_srv';
 import { OrgUser, OrgRole, StoreState } from 'app/types';
 
 import InviteesTable from '../invites/InviteesTable';
@@ -106,6 +107,7 @@ export class UsersListPage extends PureComponent<Props, State> {
         <VerticalGroup spacing="md">
           <UsersTable
             users={paginatedUsers}
+            orgId={contextSrv.user.orgId}
             onRoleChange={(role, user) => this.onRoleChange(role, user)}
             onRemoveUser={(user) => this.props.removeUser(user.userId)}
           />

--- a/public/app/features/users/__snapshots__/UsersListPage.test.tsx.snap
+++ b/public/app/features/users/__snapshots__/UsersListPage.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`Render should render List page 1`] = `
       <UsersTable
         onRemoveUser={[Function]}
         onRoleChange={[Function]}
+        orgId={1}
         users={Array []}
       />
       <HorizontalGroup


### PR DESCRIPTION
**What this PR does / why we need it**:
RolePicker will only fetch roles for a user if orgId is passed to it and it was missing in the UserTable. This resulted in Org user page not displaying any assigned roles for users

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

