### PR TITLE
Chore: Add additional wait for e2e addPanel flow

### DIFF
--- a/packages/grafana-e2e/src/flows/configurePanel.ts
+++ b/packages/grafana-e2e/src/flows/configurePanel.ts
@@ -103,6 +103,9 @@ export const configurePanel = (config: PartialAddPanelConfig | PartialEditPanelC
     e2e().intercept(chartData.method, chartData.route).as('chartData');
 
     if (dataSourceName) {
+      // @todo instead wait for '@pluginModule' if not already loaded
+      e2e().wait(2000);
+
       selectOption({
         container: e2e.components.DataSourcePicker.container(),
         optionText: dataSourceName,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

My e2e sometimes fails when going through the addPanel flow. This is because the query editor of the pre-selected data source finally loads _before_ selecting the targed data source. This causes that the data source selector gets re-rendered, so cypress returns this error:

![Screenshot from 2022-05-25 12-23-49](https://user-images.githubusercontent.com/4025665/170246056-5fae0fe5-98e5-4887-a8e6-a16b05be3ec7.png)

There is no generic way to wait for the query editor to finish loading so I am replicating the solution of some lines below, waiting 2 seconds.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

