### PR TITLE
[v8.5.x] AccessControl: Grant data source reader to all users when running oss 

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -94,6 +94,11 @@ func (hs *HTTPServer) declareFixedRoles() error {
 		Grants: []string{string(models.ROLE_ADMIN)},
 	}
 
+	// when running oss or enterprise without a license all users should be able to query data sources
+	if !hs.License.FeatureEnabled("accesscontrol.enforcement") {
+		datasourcesReaderRole.Grants = []string{string(models.ROLE_VIEWER)}
+	}
+
 	datasourcesWriterRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
 			Version:     3,
@@ -130,21 +135,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 					Action: datasources.ActionIDRead,
 					Scope:  datasources.ScopeAll,
 				},
-			},
-		},
-		Grants: []string{string(models.ROLE_VIEWER)},
-	}
-
-	datasourcesCompatibilityReaderRole := ac.RoleRegistration{
-		Role: ac.RoleDTO{
-			Version:     3,
-			Name:        "fixed:datasources:compatibility:querier",
-			DisplayName: "Data source compatibility querier",
-			Description: "Only used for open source compatibility. Query data sources.",
-			Group:       "Infrequently used",
-			Permissions: []ac.Permission{
-				{Action: datasources.ActionQuery},
-				{Action: datasources.ActionRead},
 			},
 		},
 		Grants: []string{string(models.ROLE_VIEWER)},
@@ -419,8 +409,8 @@ func (hs *HTTPServer) declareFixedRoles() error {
 	}
 
 	return hs.AccessControl.DeclareFixedRoles(
-		provisioningWriterRole, datasourcesReaderRole, datasourcesWriterRole, datasourcesIdReaderRole,
-		datasourcesCompatibilityReaderRole, orgReaderRole, orgWriterRole,
+		provisioningWriterRole, datasourcesReaderRole, datasourcesWriterRole,
+		datasourcesIdReaderRole, orgReaderRole, orgWriterRole,
 		orgMaintainerRole, teamsCreatorRole, teamsWriterRole, datasourcesExplorerRole,
 		annotationsReaderRole, dashboardAnnotationsWriterRole, annotationsWriterRole,
 		dashboardsCreatorRole, dashboardsReaderRole, dashboardsWriterRole,

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -32,6 +32,7 @@ import (
 	dashboardservice "github.com/grafana/grafana/pkg/services/dashboards/manager"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ldap"
+	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/services/login/loginservice"
 	"github.com/grafana/grafana/pkg/services/login/logintest"
 	"github.com/grafana/grafana/pkg/services/quota"
@@ -370,6 +371,7 @@ func setupHTTPServerWithCfgDb(t *testing.T, useFakeAccessControl, enableAccessCo
 		QuotaService:       &quota.QuotaService{Cfg: cfg},
 		RouteRegister:      routeRegister,
 		SQLStore:           store,
+		License:            &licensing.OSSLicensingService{},
 		searchUsersService: searchusers.ProvideUsersService(db, filters.ProvideOSSSearchUserFilter()),
 		dashboardService:   dashboardservice.ProvideDashboardService(cfg, dashboardsStore, nil, features, accesscontrolmock.NewPermissionsServicesMock()),
 	}


### PR DESCRIPTION
Manual Backport https://github.com/grafana/grafana/commit/1796a1d27724a2e3818b83f37221a4a99642b451 from https://github.com/grafana/grafana/pull/49514
