### PR TITLE
backend: add PlaylistUIDs to Playlist; remove playlist IDs from API

### DIFF
--- a/docs/sources/developers/http_api/playlist.md
+++ b/docs/sources/developers/http_api/playlist.md
@@ -51,7 +51,7 @@ Content-Type: application/json
 
 ## Get one playlist
 
-`GET /api/playlists/:id`
+`GET /api/playlists/:uid`
 
 **Example Request**:
 
@@ -74,7 +74,7 @@ Content-Type: application/json
   "items": [
     {
       "id": 1,
-      "playlistId": 1,
+      "playlistUid": 1,
       "type": "dashboard_by_id",
       "value": "3",
       "order": 1,
@@ -82,7 +82,7 @@ Content-Type: application/json
     },
     {
       "id": 2,
-      "playlistId": 1,
+      "playlistUid": 1,
       "type": "dashboard_by_tag",
       "value": "myTag",
       "order": 2,
@@ -94,7 +94,7 @@ Content-Type: application/json
 
 ## Get Playlist items
 
-`GET /api/playlists/:id/items`
+`GET /api/playlists/:uid/items`
 
 **Example Request**:
 
@@ -112,7 +112,7 @@ Content-Type: application/json
 [
   {
     "id": 1,
-    "playlistId": 1,
+    "playlistUid": 1,
     "type": "dashboard_by_id",
     "value": "3",
     "order": 1,
@@ -120,7 +120,7 @@ Content-Type: application/json
   },
   {
     "id": 2,
-    "playlistId": 1,
+    "playlistUid": 1,
     "type": "dashboard_by_tag",
     "value": "myTag",
     "order": 2,
@@ -131,7 +131,7 @@ Content-Type: application/json
 
 ## Get Playlist dashboards
 
-`GET /api/playlists/:id/dashboards`
+`GET /api/playlists/:uid/dashboards`
 
 **Example Request**:
 
@@ -206,7 +206,7 @@ Content-Type: application/json
 
 ## Update a playlist
 
-`PUT /api/playlists/:id`
+`PUT /api/playlists/:uid`
 
 **Example Request**:
 
@@ -220,14 +220,14 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
     "interval": "5m",
     "items": [
       {
-        "playlistId": 1,
+        "playlistUid": 1,
         "type": "dashboard_by_id",
         "value": "3",
         "order": 1,
         "title":"my third dashboard"
       },
       {
-        "playlistId": 1,
+        "playlistUid": 1,
         "type": "dashboard_by_tag",
         "value": "myTag",
         "order": 2,
@@ -250,7 +250,7 @@ Content-Type: application/json
   "items": [
     {
       "id": 1,
-      "playlistId": 1,
+      "playlistUid": 1,
       "type": "dashboard_by_id",
       "value": "3",
       "order": 1,
@@ -258,7 +258,7 @@ Content-Type: application/json
     },
     {
       "id": 2,
-      "playlistId": 1,
+      "playlistUid": 1,
       "type": "dashboard_by_tag",
       "value": "myTag",
       "order": 2,
@@ -270,7 +270,7 @@ Content-Type: application/json
 
 ## Delete a playlist
 
-`DELETE /api/playlists/:id`
+`DELETE /api/playlists/:uid`
 
 **Example Request**:
 

--- a/docs/sources/developers/http_api/playlist.md
+++ b/docs/sources/developers/http_api/playlist.md
@@ -42,7 +42,7 @@ HTTP/1.1 200
 Content-Type: application/json
 [
   {
-    "id": 1,
+    "uid": "1",
     "name": "my playlist",
     "interval": "5m"
   }
@@ -67,14 +67,14 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 HTTP/1.1 200
 Content-Type: application/json
 {
-  "id" : 1,
+  "uid" : "1",
   "name": "my playlist",
   "interval": "5m",
   "orgId": "my org",
   "items": [
     {
       "id": 1,
-      "playlistUid": 1,
+      "playlistUid": "1",
       "type": "dashboard_by_id",
       "value": "3",
       "order": 1,
@@ -82,7 +82,7 @@ Content-Type: application/json
     },
     {
       "id": 2,
-      "playlistUid": 1,
+      "playlistUid": "1",
       "type": "dashboard_by_tag",
       "value": "myTag",
       "order": 2,
@@ -112,7 +112,7 @@ Content-Type: application/json
 [
   {
     "id": 1,
-    "playlistUid": 1,
+    "playlistUid": "1",
     "type": "dashboard_by_id",
     "value": "3",
     "order": 1,
@@ -120,7 +120,7 @@ Content-Type: application/json
   },
   {
     "id": 2,
-    "playlistUid": 1,
+    "playlistUid": "1",
     "type": "dashboard_by_tag",
     "value": "myTag",
     "order": 2,
@@ -198,7 +198,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 HTTP/1.1 200
 Content-Type: application/json
   {
-    "id": 1,
+    "uid": "1",
     "name": "my playlist",
     "interval": "5m"
   }
@@ -220,14 +220,14 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
     "interval": "5m",
     "items": [
       {
-        "playlistUid": 1,
+        "playlistUid": "1",
         "type": "dashboard_by_id",
         "value": "3",
         "order": 1,
         "title":"my third dashboard"
       },
       {
-        "playlistUid": 1,
+        "playlistUid": "1",
         "type": "dashboard_by_tag",
         "value": "myTag",
         "order": 2,
@@ -243,14 +243,14 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 HTTP/1.1 200
 Content-Type: application/json
 {
-  "id" : 1,
+  "uid" : "1",
   "name": "my playlist",
   "interval": "5m",
   "orgId": "my org",
   "items": [
     {
       "id": 1,
-      "playlistUid": 1,
+      "playlistUid": "1",
       "type": "dashboard_by_id",
       "value": "3",
       "order": 1,
@@ -258,7 +258,7 @@ Content-Type: application/json
     },
     {
       "id": 2,
-      "playlistUid": 1,
+      "playlistUid": "1",
       "type": "dashboard_by_tag",
       "value": "myTag",
       "order": 2,

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -438,11 +438,11 @@ func (hs *HTTPServer) registerRoutes() {
 		// Playlist
 		apiRoute.Group("/playlists", func(playlistRoute routing.RouteRegister) {
 			playlistRoute.Get("/", routing.Wrap(hs.SearchPlaylists))
-			playlistRoute.Get("/:id", hs.ValidateOrgPlaylist, routing.Wrap(hs.GetPlaylist))
-			playlistRoute.Get("/:id/items", hs.ValidateOrgPlaylist, routing.Wrap(hs.GetPlaylistItems))
-			playlistRoute.Get("/:id/dashboards", hs.ValidateOrgPlaylist, routing.Wrap(hs.GetPlaylistDashboards))
-			playlistRoute.Delete("/:id", reqEditorRole, hs.ValidateOrgPlaylist, routing.Wrap(hs.DeletePlaylist))
-			playlistRoute.Put("/:id", reqEditorRole, hs.ValidateOrgPlaylist, routing.Wrap(hs.UpdatePlaylist))
+			playlistRoute.Get("/:uid", hs.ValidateOrgPlaylist, routing.Wrap(hs.GetPlaylist))
+			playlistRoute.Get("/:uid/items", hs.ValidateOrgPlaylist, routing.Wrap(hs.GetPlaylistItems))
+			playlistRoute.Get("/:uid/dashboards", hs.ValidateOrgPlaylist, routing.Wrap(hs.GetPlaylistDashboards))
+			playlistRoute.Delete("/:uid", reqEditorRole, hs.ValidateOrgPlaylist, routing.Wrap(hs.DeletePlaylist))
+			playlistRoute.Put("/:uid", reqEditorRole, hs.ValidateOrgPlaylist, routing.Wrap(hs.UpdatePlaylist))
 			playlistRoute.Post("/", reqEditorRole, routing.Wrap(hs.CreatePlaylist))
 		})
 

--- a/pkg/api/playlist.go
+++ b/pkg/api/playlist.go
@@ -11,13 +11,9 @@ import (
 )
 
 func (hs *HTTPServer) ValidateOrgPlaylist(c *models.ReqContext) {
-	id, err := strconv.ParseInt(web.Params(c.Req)[":id"], 10, 64)
-	if err != nil {
-		c.JsonApiErr(http.StatusBadRequest, "id is invalid", nil)
-		return
-	}
-	query := models.GetPlaylistByIdQuery{Id: id}
-	err = hs.SQLStore.GetPlaylist(c.Req.Context(), &query)
+	uid := web.Params(c.Req)[":uid"]
+	query := models.GetPlaylistByUidQuery{Uid: uid}
+	err := hs.SQLStore.GetPlaylist(c.Req.Context(), &query)
 
 	if err != nil {
 		c.JsonApiErr(404, "Playlist not found", err)
@@ -58,20 +54,17 @@ func (hs *HTTPServer) SearchPlaylists(c *models.ReqContext) response.Response {
 }
 
 func (hs *HTTPServer) GetPlaylist(c *models.ReqContext) response.Response {
-	id, err := strconv.ParseInt(web.Params(c.Req)[":id"], 10, 64)
-	if err != nil {
-		return response.Error(http.StatusBadRequest, "id is invalid", err)
-	}
-	cmd := models.GetPlaylistByIdQuery{Id: id}
+	uid := web.Params(c.Req)[":uid"]
+	cmd := models.GetPlaylistByUidQuery{Uid: uid}
 
 	if err := hs.SQLStore.GetPlaylist(c.Req.Context(), &cmd); err != nil {
 		return response.Error(500, "Playlist not found", err)
 	}
 
-	playlistDTOs, _ := hs.LoadPlaylistItemDTOs(c.Req.Context(), id)
+	playlistDTOs, _ := hs.LoadPlaylistItemDTOs(c.Req.Context(), uid)
 
 	dto := &models.PlaylistDTO{
-		Id:       cmd.Result.Id,
+		Uid:      cmd.Result.Uid,
 		Name:     cmd.Result.Name,
 		Interval: cmd.Result.Interval,
 		OrgId:    cmd.Result.OrgId,
@@ -81,8 +74,8 @@ func (hs *HTTPServer) GetPlaylist(c *models.ReqContext) response.Response {
 	return response.JSON(http.StatusOK, dto)
 }
 
-func (hs *HTTPServer) LoadPlaylistItemDTOs(ctx context.Context, id int64) ([]models.PlaylistItemDTO, error) {
-	playlistitems, err := hs.LoadPlaylistItems(ctx, id)
+func (hs *HTTPServer) LoadPlaylistItemDTOs(ctx context.Context, uid string) ([]models.PlaylistItemDTO, error) {
+	playlistitems, err := hs.LoadPlaylistItems(ctx, uid)
 
 	if err != nil {
 		return nil, err
@@ -92,20 +85,20 @@ func (hs *HTTPServer) LoadPlaylistItemDTOs(ctx context.Context, id int64) ([]mod
 
 	for _, item := range playlistitems {
 		playlistDTOs = append(playlistDTOs, models.PlaylistItemDTO{
-			Id:         item.Id,
-			PlaylistId: item.PlaylistId,
-			Type:       item.Type,
-			Value:      item.Value,
-			Order:      item.Order,
-			Title:      item.Title,
+			Id:          item.Id,
+			PlaylistUid: item.PlaylistUid,
+			Type:        item.Type,
+			Value:       item.Value,
+			Order:       item.Order,
+			Title:       item.Title,
 		})
 	}
 
 	return playlistDTOs, nil
 }
 
-func (hs *HTTPServer) LoadPlaylistItems(ctx context.Context, id int64) ([]models.PlaylistItem, error) {
-	itemQuery := models.GetPlaylistItemsByIdQuery{PlaylistId: id}
+func (hs *HTTPServer) LoadPlaylistItems(ctx context.Context, uid string) ([]models.PlaylistItem, error) {
+	itemQuery := models.GetPlaylistItemsByUidQuery{PlaylistUid: uid}
 	if err := hs.SQLStore.GetPlaylistItem(ctx, &itemQuery); err != nil {
 		return nil, err
 	}
@@ -114,12 +107,9 @@ func (hs *HTTPServer) LoadPlaylistItems(ctx context.Context, id int64) ([]models
 }
 
 func (hs *HTTPServer) GetPlaylistItems(c *models.ReqContext) response.Response {
-	id, err := strconv.ParseInt(web.Params(c.Req)[":id"], 10, 64)
-	if err != nil {
-		return response.Error(http.StatusBadRequest, "id is invalid", err)
-	}
+	uid := web.Params(c.Req)[":uid"]
 
-	playlistDTOs, err := hs.LoadPlaylistItemDTOs(c.Req.Context(), id)
+	playlistDTOs, err := hs.LoadPlaylistItemDTOs(c.Req.Context(), uid)
 
 	if err != nil {
 		return response.Error(500, "Could not load playlist items", err)
@@ -129,12 +119,9 @@ func (hs *HTTPServer) GetPlaylistItems(c *models.ReqContext) response.Response {
 }
 
 func (hs *HTTPServer) GetPlaylistDashboards(c *models.ReqContext) response.Response {
-	playlistID, err := strconv.ParseInt(web.Params(c.Req)[":id"], 10, 64)
-	if err != nil {
-		return response.Error(http.StatusBadRequest, "id is invalid", err)
-	}
+	playlistUID := web.Params(c.Req)[":uid"]
 
-	playlists, err := hs.LoadPlaylistDashboards(c.Req.Context(), c.OrgId, c.SignedInUser, playlistID)
+	playlists, err := hs.LoadPlaylistDashboards(c.Req.Context(), c.OrgId, c.SignedInUser, playlistUID)
 	if err != nil {
 		return response.Error(500, "Could not load dashboards", err)
 	}
@@ -186,7 +173,7 @@ func (hs *HTTPServer) UpdatePlaylist(c *models.ReqContext) response.Response {
 		return response.Error(500, "Failed to save playlist", err)
 	}
 
-	playlistDTOs, err := hs.LoadPlaylistItemDTOs(c.Req.Context(), cmd.Id)
+	playlistDTOs, err := hs.LoadPlaylistItemDTOs(c.Req.Context(), cmd.Uid)
 	if err != nil {
 		return response.Error(500, "Failed to save playlist", err)
 	}

--- a/pkg/api/playlist.go
+++ b/pkg/api/playlist.go
@@ -54,7 +54,7 @@ func (hs *HTTPServer) SearchPlaylists(c *models.ReqContext) response.Response {
 
 func (hs *HTTPServer) GetPlaylist(c *models.ReqContext) response.Response {
 	uid := web.Params(c.Req)[":uid"]
-	cmd := models.GetPlaylistByUidQuery{Uid: uid}
+	cmd := models.GetPlaylistByUidQuery{Uid: uid, OrgId: c.OrgId}
 
 	if err := hs.SQLStore.GetPlaylist(c.Req.Context(), &cmd); err != nil {
 		return response.Error(500, "Playlist not found", err)

--- a/pkg/api/playlist.go
+++ b/pkg/api/playlist.go
@@ -84,12 +84,11 @@ func (hs *HTTPServer) LoadPlaylistItemDTOs(ctx context.Context, uid string, orgI
 
 	for _, item := range playlistitems {
 		playlistDTOs = append(playlistDTOs, models.PlaylistItemDTO{
-			Id:          item.Id,
-			PlaylistUid: item.PlaylistUid,
-			Type:        item.Type,
-			Value:       item.Value,
-			Order:       item.Order,
-			Title:       item.Title,
+			Id:    item.Id,
+			Type:  item.Type,
+			Value: item.Value,
+			Order: item.Order,
+			Title: item.Title,
 		})
 	}
 

--- a/pkg/api/playlist.go
+++ b/pkg/api/playlist.go
@@ -11,7 +11,7 @@ import (
 
 func (hs *HTTPServer) ValidateOrgPlaylist(c *models.ReqContext) {
 	uid := web.Params(c.Req)[":uid"]
-	query := models.GetPlaylistByUidQuery{Uid: uid, OrgId: c.OrgId}
+	query := models.GetPlaylistByUidQuery{UID: uid, OrgId: c.OrgId}
 	err := hs.SQLStore.GetPlaylist(c.Req.Context(), &query)
 
 	if err != nil {
@@ -54,7 +54,7 @@ func (hs *HTTPServer) SearchPlaylists(c *models.ReqContext) response.Response {
 
 func (hs *HTTPServer) GetPlaylist(c *models.ReqContext) response.Response {
 	uid := web.Params(c.Req)[":uid"]
-	cmd := models.GetPlaylistByUidQuery{Uid: uid, OrgId: c.OrgId}
+	cmd := models.GetPlaylistByUidQuery{UID: uid, OrgId: c.OrgId}
 
 	if err := hs.SQLStore.GetPlaylist(c.Req.Context(), &cmd); err != nil {
 		return response.Error(500, "Playlist not found", err)
@@ -64,7 +64,7 @@ func (hs *HTTPServer) GetPlaylist(c *models.ReqContext) response.Response {
 
 	dto := &models.PlaylistDTO{
 		Id:       cmd.Result.Id,
-		Uid:      cmd.Result.Uid,
+		UID:      cmd.Result.UID,
 		Name:     cmd.Result.Name,
 		Interval: cmd.Result.Interval,
 		OrgId:    cmd.Result.OrgId,
@@ -98,7 +98,7 @@ func (hs *HTTPServer) LoadPlaylistItemDTOs(ctx context.Context, uid string, orgI
 }
 
 func (hs *HTTPServer) LoadPlaylistItems(ctx context.Context, uid string, orgId int64) ([]models.PlaylistItem, error) {
-	itemQuery := models.GetPlaylistItemsByUidQuery{PlaylistUid: uid, OrgId: orgId}
+	itemQuery := models.GetPlaylistItemsByUidQuery{PlaylistUID: uid, OrgId: orgId}
 	if err := hs.SQLStore.GetPlaylistItem(ctx, &itemQuery); err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (hs *HTTPServer) GetPlaylistDashboards(c *models.ReqContext) response.Respo
 func (hs *HTTPServer) DeletePlaylist(c *models.ReqContext) response.Response {
 	uid := web.Params(c.Req)[":uid"]
 
-	cmd := models.DeletePlaylistCommand{Uid: uid, OrgId: c.OrgId}
+	cmd := models.DeletePlaylistCommand{UID: uid, OrgId: c.OrgId}
 	if err := hs.SQLStore.DeletePlaylist(c.Req.Context(), &cmd); err != nil {
 		return response.Error(500, "Failed to delete playlist", err)
 	}
@@ -160,13 +160,13 @@ func (hs *HTTPServer) UpdatePlaylist(c *models.ReqContext) response.Response {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 	cmd.OrgId = c.OrgId
-	cmd.Uid = web.Params(c.Req)[":uid"]
+	cmd.UID = web.Params(c.Req)[":uid"]
 
 	if err := hs.SQLStore.UpdatePlaylist(c.Req.Context(), &cmd); err != nil {
 		return response.Error(500, "Failed to save playlist", err)
 	}
 
-	playlistDTOs, err := hs.LoadPlaylistItemDTOs(c.Req.Context(), cmd.Uid, c.OrgId)
+	playlistDTOs, err := hs.LoadPlaylistItemDTOs(c.Req.Context(), cmd.UID, c.OrgId)
 	if err != nil {
 		return response.Error(500, "Failed to save playlist", err)
 	}

--- a/pkg/api/playlist.go
+++ b/pkg/api/playlist.go
@@ -63,6 +63,7 @@ func (hs *HTTPServer) GetPlaylist(c *models.ReqContext) response.Response {
 	playlistDTOs, _ := hs.LoadPlaylistItemDTOs(c.Req.Context(), uid, c.OrgId)
 
 	dto := &models.PlaylistDTO{
+		Id:       cmd.Result.Id,
 		Uid:      cmd.Result.Uid,
 		Name:     cmd.Result.Name,
 		Interval: cmd.Result.Interval,
@@ -84,11 +85,12 @@ func (hs *HTTPServer) LoadPlaylistItemDTOs(ctx context.Context, uid string, orgI
 
 	for _, item := range playlistitems {
 		playlistDTOs = append(playlistDTOs, models.PlaylistItemDTO{
-			Id:    item.Id,
-			Type:  item.Type,
-			Value: item.Value,
-			Order: item.Order,
-			Title: item.Title,
+			Id:         item.Id,
+			PlaylistId: item.PlaylistId,
+			Type:       item.Type,
+			Value:      item.Value,
+			Order:      item.Order,
+			Title:      item.Title,
 		})
 	}
 

--- a/pkg/api/playlist.go
+++ b/pkg/api/playlist.go
@@ -11,7 +11,7 @@ import (
 
 func (hs *HTTPServer) ValidateOrgPlaylist(c *models.ReqContext) {
 	uid := web.Params(c.Req)[":uid"]
-	query := models.GetPlaylistByUidQuery{Uid: uid}
+	query := models.GetPlaylistByUidQuery{Uid: uid, OrgId: c.OrgId}
 	err := hs.SQLStore.GetPlaylist(c.Req.Context(), &query)
 
 	if err != nil {
@@ -60,7 +60,7 @@ func (hs *HTTPServer) GetPlaylist(c *models.ReqContext) response.Response {
 		return response.Error(500, "Playlist not found", err)
 	}
 
-	playlistDTOs, _ := hs.LoadPlaylistItemDTOs(c.Req.Context(), uid)
+	playlistDTOs, _ := hs.LoadPlaylistItemDTOs(c.Req.Context(), uid, c.OrgId)
 
 	dto := &models.PlaylistDTO{
 		Uid:      cmd.Result.Uid,
@@ -73,8 +73,8 @@ func (hs *HTTPServer) GetPlaylist(c *models.ReqContext) response.Response {
 	return response.JSON(http.StatusOK, dto)
 }
 
-func (hs *HTTPServer) LoadPlaylistItemDTOs(ctx context.Context, uid string) ([]models.PlaylistItemDTO, error) {
-	playlistitems, err := hs.LoadPlaylistItems(ctx, uid)
+func (hs *HTTPServer) LoadPlaylistItemDTOs(ctx context.Context, uid string, orgId int64) ([]models.PlaylistItemDTO, error) {
+	playlistitems, err := hs.LoadPlaylistItems(ctx, uid, orgId)
 
 	if err != nil {
 		return nil, err
@@ -96,8 +96,8 @@ func (hs *HTTPServer) LoadPlaylistItemDTOs(ctx context.Context, uid string) ([]m
 	return playlistDTOs, nil
 }
 
-func (hs *HTTPServer) LoadPlaylistItems(ctx context.Context, uid string) ([]models.PlaylistItem, error) {
-	itemQuery := models.GetPlaylistItemsByUidQuery{PlaylistUid: uid}
+func (hs *HTTPServer) LoadPlaylistItems(ctx context.Context, uid string, orgId int64) ([]models.PlaylistItem, error) {
+	itemQuery := models.GetPlaylistItemsByUidQuery{PlaylistUid: uid, OrgId: orgId}
 	if err := hs.SQLStore.GetPlaylistItem(ctx, &itemQuery); err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (hs *HTTPServer) LoadPlaylistItems(ctx context.Context, uid string) ([]mode
 func (hs *HTTPServer) GetPlaylistItems(c *models.ReqContext) response.Response {
 	uid := web.Params(c.Req)[":uid"]
 
-	playlistDTOs, err := hs.LoadPlaylistItemDTOs(c.Req.Context(), uid)
+	playlistDTOs, err := hs.LoadPlaylistItemDTOs(c.Req.Context(), uid, c.OrgId)
 
 	if err != nil {
 		return response.Error(500, "Could not load playlist items", err)
@@ -165,7 +165,7 @@ func (hs *HTTPServer) UpdatePlaylist(c *models.ReqContext) response.Response {
 		return response.Error(500, "Failed to save playlist", err)
 	}
 
-	playlistDTOs, err := hs.LoadPlaylistItemDTOs(c.Req.Context(), cmd.Uid)
+	playlistDTOs, err := hs.LoadPlaylistItemDTOs(c.Req.Context(), cmd.Uid, c.OrgId)
 	if err != nil {
 		return response.Error(500, "Failed to save playlist", err)
 	}

--- a/pkg/api/playlist.go
+++ b/pkg/api/playlist.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"net/http"
-	"strconv"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/models"
@@ -130,12 +129,9 @@ func (hs *HTTPServer) GetPlaylistDashboards(c *models.ReqContext) response.Respo
 }
 
 func (hs *HTTPServer) DeletePlaylist(c *models.ReqContext) response.Response {
-	id, err := strconv.ParseInt(web.Params(c.Req)[":id"], 10, 64)
-	if err != nil {
-		return response.Error(http.StatusBadRequest, "id is invalid", err)
-	}
+	uid := web.Params(c.Req)[":uid"]
 
-	cmd := models.DeletePlaylistCommand{Id: id, OrgId: c.OrgId}
+	cmd := models.DeletePlaylistCommand{Uid: uid, OrgId: c.OrgId}
 	if err := hs.SQLStore.DeletePlaylist(c.Req.Context(), &cmd); err != nil {
 		return response.Error(500, "Failed to delete playlist", err)
 	}
@@ -163,11 +159,7 @@ func (hs *HTTPServer) UpdatePlaylist(c *models.ReqContext) response.Response {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 	cmd.OrgId = c.OrgId
-	var err error
-	cmd.Id, err = strconv.ParseInt(web.Params(c.Req)[":id"], 10, 64)
-	if err != nil {
-		return response.Error(http.StatusBadRequest, "id is invalid", err)
-	}
+	cmd.Uid = web.Params(c.Req)[":uid"]
 
 	if err := hs.SQLStore.UpdatePlaylist(c.Req.Context(), &cmd); err != nil {
 		return response.Error(500, "Failed to save playlist", err)

--- a/pkg/api/playlist_play.go
+++ b/pkg/api/playlist_play.go
@@ -65,8 +65,8 @@ func (hs *HTTPServer) populateDashboardsByTag(ctx context.Context, orgID int64, 
 	return result
 }
 
-func (hs *HTTPServer) LoadPlaylistDashboards(ctx context.Context, orgID int64, signedInUser *models.SignedInUser, playlistID int64) (dtos.PlaylistDashboardsSlice, error) {
-	playlistItems, _ := hs.LoadPlaylistItems(ctx, playlistID)
+func (hs *HTTPServer) LoadPlaylistDashboards(ctx context.Context, orgID int64, signedInUser *models.SignedInUser, playlistUID string) (dtos.PlaylistDashboardsSlice, error) {
+	playlistItems, _ := hs.LoadPlaylistItems(ctx, playlistUID)
 
 	dashboardByIDs := make([]int64, 0)
 	dashboardByTag := make([]string, 0)

--- a/pkg/api/playlist_play.go
+++ b/pkg/api/playlist_play.go
@@ -66,7 +66,7 @@ func (hs *HTTPServer) populateDashboardsByTag(ctx context.Context, orgID int64, 
 }
 
 func (hs *HTTPServer) LoadPlaylistDashboards(ctx context.Context, orgID int64, signedInUser *models.SignedInUser, playlistUID string) (dtos.PlaylistDashboardsSlice, error) {
-	playlistItems, _ := hs.LoadPlaylistItems(ctx, playlistUID)
+	playlistItems, _ := hs.LoadPlaylistItems(ctx, playlistUID, orgID)
 
 	dashboardByIDs := make([]int64, 0)
 	dashboardByTag := make([]string, 0)

--- a/pkg/models/playlist.go
+++ b/pkg/models/playlist.go
@@ -6,19 +6,20 @@ import (
 
 // Typed errors
 var (
-	ErrPlaylistNotFound = errors.New("Playlist not found")
+	ErrPlaylistNotFound                = errors.New("Playlist not found")
+	ErrPlaylistFailedGenerateUniqueUid = errors.New("failed to generate unique playlist UID")
 )
 
 // Playlist model
 type Playlist struct {
-	Id       int64  `json:"id"`
+	Uid      string `json:"uid"`
 	Name     string `json:"name"`
 	Interval string `json:"interval"`
 	OrgId    int64  `json:"-"`
 }
 
 type PlaylistDTO struct {
-	Id       int64             `json:"id"`
+	Uid      string            `json:"uid"`
 	Name     string            `json:"name"`
 	Interval string            `json:"interval"`
 	OrgId    int64             `json:"-"`
@@ -26,21 +27,21 @@ type PlaylistDTO struct {
 }
 
 type PlaylistItemDTO struct {
-	Id         int64  `json:"id"`
-	PlaylistId int64  `json:"playlistid"`
-	Type       string `json:"type"`
-	Title      string `json:"title"`
-	Value      string `json:"value"`
-	Order      int    `json:"order"`
+	Id          int64  `json:"id"`
+	PlaylistUid string `json:"playlistuid"`
+	Type        string `json:"type"`
+	Title       string `json:"title"`
+	Value       string `json:"value"`
+	Order       int    `json:"order"`
 }
 
 type PlaylistItem struct {
-	Id         int64
-	PlaylistId int64
-	Type       string
-	Value      string
-	Order      int
-	Title      string
+	Id          int64
+	PlaylistUid string
+	Type        string
+	Value       string
+	Order       int
+	Title       string
 }
 
 type Playlists []*Playlist
@@ -51,7 +52,7 @@ type Playlists []*Playlist
 
 type UpdatePlaylistCommand struct {
 	OrgId    int64             `json:"-"`
-	Id       int64             `json:"id"`
+	Uid      string            `json:"uid"`
 	Name     string            `json:"name" binding:"Required"`
 	Interval string            `json:"interval"`
 	Items    []PlaylistItemDTO `json:"items"`
@@ -69,7 +70,7 @@ type CreatePlaylistCommand struct {
 }
 
 type DeletePlaylistCommand struct {
-	Id    int64
+	Uid   string
 	OrgId int64
 }
 
@@ -85,12 +86,12 @@ type GetPlaylistsQuery struct {
 	Result Playlists
 }
 
-type GetPlaylistByIdQuery struct {
-	Id     int64
+type GetPlaylistByUidQuery struct {
+	Uid    string
 	Result *Playlist
 }
 
-type GetPlaylistItemsByIdQuery struct {
-	PlaylistId int64
-	Result     *[]PlaylistItem
+type GetPlaylistItemsByUidQuery struct {
+	PlaylistUid string
+	Result      *[]PlaylistItem
 }

--- a/pkg/models/playlist.go
+++ b/pkg/models/playlist.go
@@ -38,13 +38,12 @@ type PlaylistItemDTO struct {
 }
 
 type PlaylistItem struct {
-	Id          int64
-	PlaylistUid string
-	PlaylistId  int
-	Type        string
-	Value       string
-	Order       int
-	Title       string
+	Id         int64
+	PlaylistId int
+	Type       string
+	Value      string
+	Order      int
+	Title      string
 }
 
 type Playlists []*Playlist

--- a/pkg/models/playlist.go
+++ b/pkg/models/playlist.go
@@ -12,6 +12,7 @@ var (
 
 // Playlist model
 type Playlist struct {
+	Id       int    `json:"id"`
 	Uid      string `json:"uid"`
 	Name     string `json:"name"`
 	Interval string `json:"interval"`
@@ -19,6 +20,7 @@ type Playlist struct {
 }
 
 type PlaylistDTO struct {
+	Id       int               `json:"id"`
 	Uid      string            `json:"uid"`
 	Name     string            `json:"name"`
 	Interval string            `json:"interval"`
@@ -38,6 +40,7 @@ type PlaylistItemDTO struct {
 type PlaylistItem struct {
 	Id          int64
 	PlaylistUid string
+	PlaylistId  int
 	Type        string
 	Value       string
 	Order       int

--- a/pkg/models/playlist.go
+++ b/pkg/models/playlist.go
@@ -91,10 +91,12 @@ type GetPlaylistsQuery struct {
 
 type GetPlaylistByUidQuery struct {
 	Uid    string
+	OrgId  int64
 	Result *Playlist
 }
 
 type GetPlaylistItemsByUidQuery struct {
 	PlaylistUid string
+	OrgId       int64
 	Result      *[]PlaylistItem
 }

--- a/pkg/models/playlist.go
+++ b/pkg/models/playlist.go
@@ -12,7 +12,7 @@ var (
 
 // Playlist model
 type Playlist struct {
-	Id       int    `json:"id"`
+	Id       int64  `json:"id"`
 	Uid      string `json:"uid"`
 	Name     string `json:"name"`
 	Interval string `json:"interval"`
@@ -20,7 +20,7 @@ type Playlist struct {
 }
 
 type PlaylistDTO struct {
-	Id       int               `json:"id"`
+	Id       int64             `json:"id"`
 	Uid      string            `json:"uid"`
 	Name     string            `json:"name"`
 	Interval string            `json:"interval"`
@@ -29,17 +29,17 @@ type PlaylistDTO struct {
 }
 
 type PlaylistItemDTO struct {
-	Id          int64  `json:"id"`
-	PlaylistUid string `json:"playlistuid"`
-	Type        string `json:"type"`
-	Title       string `json:"title"`
-	Value       string `json:"value"`
-	Order       int    `json:"order"`
+	Id         int64  `json:"id"`
+	PlaylistId int64  `json:"playlistid"`
+	Type       string `json:"type"`
+	Title      string `json:"title"`
+	Value      string `json:"value"`
+	Order      int    `json:"order"`
 }
 
 type PlaylistItem struct {
 	Id         int64
-	PlaylistId int
+	PlaylistId int64
 	Type       string
 	Value      string
 	Order      int

--- a/pkg/models/playlist.go
+++ b/pkg/models/playlist.go
@@ -13,7 +13,7 @@ var (
 // Playlist model
 type Playlist struct {
 	Id       int64  `json:"id"`
-	Uid      string `json:"uid"`
+	UID      string `json:"uid" xorm:"uid"`
 	Name     string `json:"name"`
 	Interval string `json:"interval"`
 	OrgId    int64  `json:"-"`
@@ -21,7 +21,7 @@ type Playlist struct {
 
 type PlaylistDTO struct {
 	Id       int64             `json:"id"`
-	Uid      string            `json:"uid"`
+	UID      string            `json:"uid"`
 	Name     string            `json:"name"`
 	Interval string            `json:"interval"`
 	OrgId    int64             `json:"-"`
@@ -54,7 +54,7 @@ type Playlists []*Playlist
 
 type UpdatePlaylistCommand struct {
 	OrgId    int64             `json:"-"`
-	Uid      string            `json:"uid"`
+	UID      string            `json:"uid"`
 	Name     string            `json:"name" binding:"Required"`
 	Interval string            `json:"interval"`
 	Items    []PlaylistItemDTO `json:"items"`
@@ -72,7 +72,7 @@ type CreatePlaylistCommand struct {
 }
 
 type DeletePlaylistCommand struct {
-	Uid   string
+	UID   string
 	OrgId int64
 }
 
@@ -89,13 +89,13 @@ type GetPlaylistsQuery struct {
 }
 
 type GetPlaylistByUidQuery struct {
-	Uid    string
+	UID    string
 	OrgId  int64
 	Result *Playlist
 }
 
 type GetPlaylistItemsByUidQuery struct {
-	PlaylistUid string
+	PlaylistUID string
 	OrgId       int64
 	Result      *[]PlaylistItem
 }

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -91,6 +91,7 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	accesscontrol.AddManagedPermissionsMigration(mg, accesscontrol.ManagedPermissionsMigrationID)
 	accesscontrol.AddManagedFolderAlertActionsMigration(mg)
 	accesscontrol.AddActionNameMigrator(mg)
+	addPlaylistUIDMigration(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/playlist_mig.go
+++ b/pkg/services/sqlstore/migrations/playlist_mig.go
@@ -43,4 +43,33 @@ func addPlaylistMigrations(mg *Migrator) {
 		{Name: "value", Type: DB_Text, Nullable: false},
 		{Name: "title", Type: DB_Text, Nullable: false},
 	}))
+
+	// Replacing auto-incremented playlistIDs with string UIDs
+	mg.AddMigration("Add UID column to playlist", NewAddColumnMigration(playlistV2, &Column{
+		Name: "uid", Type: DB_NVarchar, Length: 80, Nullable: false,
+	}))
+
+	// copy the (string representation of) existing IDs into the new uid column.
+	mg.AddMigration("Update uid column values in playlist", NewRawSQLMigration("").
+		SQLite("UPDATE playlist SET uid=printf('%09d',id) WHERE uid IS NULL;").
+		Postgres("UPDATE playlist SET uid=lpad('' || id::text,9,'0') WHERE uid IS NULL;").
+		Mysql("UPDATE playlist SET uid=lpad(id,9,'0') WHERE uid IS NULL;"))
+
+	mg.AddMigration("Add index for uid in playlist", NewAddIndexMigration(playlistV2, &Index{
+		Cols: []string{"uid"}, Type: IndexType,
+	}))
+
+	// TODO(?): drop ID column, index
+
+	mg.AddMigration("Add playlistUID column to playlistItems", NewAddColumnMigration(playlistItemV2, &Column{
+		Name: "playlist_uid", Type: DB_NVarchar, Length: 80, Nullable: false,
+	}))
+
+	// copy the string representation of existing IDs into the new uid column.
+	mg.AddMigration("Update uid column values in playlist", NewRawSQLMigration("").
+		SQLite("UPDATE playlist_item SET playlist_uid=printf('%09d',playlist_id) WHERE uid IS NULL;").
+		Postgres("UPDATE playlist_item SET playlist_uid=lpad('' || playlist_id::text,9,'0') WHERE uid IS NULL;").
+		Mysql("UPDATE playlist_item SET playlist_uid=lpad(playlist_id,9,'0') WHERE uid IS NULL;"))
+
+	// TODO(?): drop playlist_id column
 }

--- a/pkg/services/sqlstore/migrations/playlist_mig.go
+++ b/pkg/services/sqlstore/migrations/playlist_mig.go
@@ -6,18 +6,8 @@ func addPlaylistMigrations(mg *Migrator) {
 	mg.AddMigration("Drop old table playlist table", NewDropTableMigration("playlist"))
 	mg.AddMigration("Drop old table playlist_item table", NewDropTableMigration("playlist_item"))
 
-	playlistV2 := Table{
-		Name: "playlist",
-		Columns: []*Column{
-			{Name: "id", Type: DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
-			{Name: "name", Type: DB_NVarchar, Length: 255, Nullable: false},
-			{Name: "interval", Type: DB_NVarchar, Length: 255, Nullable: false},
-			{Name: "org_id", Type: DB_BigInt, Nullable: false},
-		},
-	}
-
 	// create table
-	mg.AddMigration("create playlist table v2", NewAddTableMigration(playlistV2))
+	mg.AddMigration("create playlist table v2", NewAddTableMigration(playlistV2()))
 
 	playlistItemV2 := Table{
 		Name: "playlist_item",
@@ -43,19 +33,33 @@ func addPlaylistMigrations(mg *Migrator) {
 		{Name: "value", Type: DB_Text, Nullable: false},
 		{Name: "title", Type: DB_Text, Nullable: false},
 	}))
+}
 
+func addPlaylistUIDMigration(mg *Migrator) {
 	// Replacing auto-incremented playlistIDs with string UIDs
-	mg.AddMigration("Add UID column to playlist", NewAddColumnMigration(playlistV2, &Column{
+	mg.AddMigration("Add UID column to playlist", NewAddColumnMigration(playlistV2(), &Column{
 		Name: "uid", Type: DB_NVarchar, Length: 80, Nullable: false, Default: "0",
 	}))
 
 	// copy the (string representation of) existing IDs into the new uid column.
 	mg.AddMigration("Update uid column values in playlist", NewRawSQLMigration("").
-		SQLite("UPDATE playlist SET uid=printf('%d',id) WHERE uid IS NULL;").
-		Postgres("UPDATE playlist SET uid=id::text WHERE uid IS NULL;").
-		Mysql("UPDATE playlist SET uid=id WHERE uid IS NULL;"))
+		SQLite("UPDATE playlist SET uid=printf('%d',id);").
+		Postgres("UPDATE playlist SET uid=id::text;").
+		Mysql("UPDATE playlist SET uid=id;"))
 
-	mg.AddMigration("Add index for uid in playlist", NewAddIndexMigration(playlistV2, &Index{
+	mg.AddMigration("Add index for uid in playlist", NewAddIndexMigration(playlistV2(), &Index{
 		Cols: []string{"org_id", "uid"}, Type: UniqueIndex,
 	}))
+}
+
+func playlistV2() Table {
+	return Table{
+		Name: "playlist",
+		Columns: []*Column{
+			{Name: "id", Type: DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
+			{Name: "name", Type: DB_NVarchar, Length: 255, Nullable: false},
+			{Name: "interval", Type: DB_NVarchar, Length: 255, Nullable: false},
+			{Name: "org_id", Type: DB_BigInt, Nullable: false},
+		},
+	}
 }

--- a/pkg/services/sqlstore/migrations/playlist_mig.go
+++ b/pkg/services/sqlstore/migrations/playlist_mig.go
@@ -56,7 +56,8 @@ func addPlaylistMigrations(mg *Migrator) {
 		Mysql("UPDATE playlist SET uid=lpad(id,9,'0') WHERE uid IS NULL;"))
 
 	mg.AddMigration("Add index for uid in playlist", NewAddIndexMigration(playlistV2, &Index{
-		Cols: []string{"uid"}, Type: IndexType,
+		// reviewer question: should this be []string{"org_id", "uid"} instead?
+		Cols: []string{"uid"}, Type: UniqueIndex,
 	}))
 
 	// TODO(?): drop ID column, index

--- a/pkg/services/sqlstore/migrations/playlist_mig.go
+++ b/pkg/services/sqlstore/migrations/playlist_mig.go
@@ -46,7 +46,7 @@ func addPlaylistMigrations(mg *Migrator) {
 
 	// Replacing auto-incremented playlistIDs with string UIDs
 	mg.AddMigration("Add UID column to playlist", NewAddColumnMigration(playlistV2, &Column{
-		Name: "uid", Type: DB_NVarchar, Length: 80, Nullable: false,
+		Name: "uid", Type: DB_NVarchar, Length: 80, Nullable: false, Default: "0",
 	}))
 
 	// copy the (string representation of) existing IDs into the new uid column.
@@ -58,14 +58,4 @@ func addPlaylistMigrations(mg *Migrator) {
 	mg.AddMigration("Add index for uid in playlist", NewAddIndexMigration(playlistV2, &Index{
 		Cols: []string{"org_id", "uid"}, Type: UniqueIndex,
 	}))
-
-	mg.AddMigration("Add playlistUID column to playlistItems", NewAddColumnMigration(playlistItemV2, &Column{
-		Name: "playlist_uid", Type: DB_NVarchar, Length: 80, Nullable: false,
-	}))
-
-	// copy the string representation of existing IDs into the new uid column.
-	mg.AddMigration("Update uid column values in playlist_item", NewRawSQLMigration("").
-		SQLite("UPDATE playlist_item SET playlist_uid=printf('%d',playlist_id) WHERE playlist_uid IS NULL;").
-		Postgres("UPDATE playlist_item SET playlist_uid=playlist_id::text WHERE playlist_uid IS NULL;").
-		Mysql("UPDATE playlist_item SET playlist_uid=playlist_id WHERE playlist_uid IS NULL;"))
 }

--- a/pkg/services/sqlstore/migrations/playlist_mig.go
+++ b/pkg/services/sqlstore/migrations/playlist_mig.go
@@ -51,9 +51,9 @@ func addPlaylistMigrations(mg *Migrator) {
 
 	// copy the (string representation of) existing IDs into the new uid column.
 	mg.AddMigration("Update uid column values in playlist", NewRawSQLMigration("").
-		SQLite("UPDATE playlist SET uid=printf('%09d',id) WHERE uid IS NULL;").
-		Postgres("UPDATE playlist SET uid=lpad('' || id::text,9,'0') WHERE uid IS NULL;").
-		Mysql("UPDATE playlist SET uid=lpad(id,9,'0') WHERE uid IS NULL;"))
+		SQLite("UPDATE playlist SET uid=printf('%d',id) WHERE uid IS NULL;").
+		Postgres("UPDATE playlist SET uid=id::text WHERE uid IS NULL;").
+		Mysql("UPDATE playlist SET uid=id WHERE uid IS NULL;"))
 
 	mg.AddMigration("Add index for uid in playlist", NewAddIndexMigration(playlistV2, &Index{
 		Cols: []string{"org_id", "uid"}, Type: UniqueIndex,
@@ -65,7 +65,7 @@ func addPlaylistMigrations(mg *Migrator) {
 
 	// copy the string representation of existing IDs into the new uid column.
 	mg.AddMigration("Update uid column values in playlist_item", NewRawSQLMigration("").
-		SQLite("UPDATE playlist_item SET playlist_uid=printf('%09d',playlist_id) WHERE playlist_uid IS NULL;").
-		Postgres("UPDATE playlist_item SET playlist_uid=lpad('' || playlist_id::text,9,'0') WHERE playlist_uid IS NULL;").
-		Mysql("UPDATE playlist_item SET playlist_uid=lpad(playlist_id,9,'0') WHERE playlist_uid IS NULL;"))
+		SQLite("UPDATE playlist_item SET playlist_uid=printf('%d',playlist_id) WHERE playlist_uid IS NULL;").
+		Postgres("UPDATE playlist_item SET playlist_uid=playlist_id::text WHERE playlist_uid IS NULL;").
+		Mysql("UPDATE playlist_item SET playlist_uid=playlist_id WHERE playlist_uid IS NULL;"))
 }

--- a/pkg/services/sqlstore/migrations/playlist_mig.go
+++ b/pkg/services/sqlstore/migrations/playlist_mig.go
@@ -56,11 +56,8 @@ func addPlaylistMigrations(mg *Migrator) {
 		Mysql("UPDATE playlist SET uid=lpad(id,9,'0') WHERE uid IS NULL;"))
 
 	mg.AddMigration("Add index for uid in playlist", NewAddIndexMigration(playlistV2, &Index{
-		// reviewer question: should this be []string{"org_id", "uid"} instead?
-		Cols: []string{"uid"}, Type: UniqueIndex,
+		Cols: []string{"org_id", "uid"}, Type: UniqueIndex,
 	}))
-
-	// TODO(?): drop ID column, index
 
 	mg.AddMigration("Add playlistUID column to playlistItems", NewAddColumnMigration(playlistItemV2, &Column{
 		Name: "playlist_uid", Type: DB_NVarchar, Length: 80, Nullable: false,
@@ -71,6 +68,4 @@ func addPlaylistMigrations(mg *Migrator) {
 		SQLite("UPDATE playlist_item SET playlist_uid=printf('%09d',playlist_id) WHERE playlist_uid IS NULL;").
 		Postgres("UPDATE playlist_item SET playlist_uid=lpad('' || playlist_id::text,9,'0') WHERE playlist_uid IS NULL;").
 		Mysql("UPDATE playlist_item SET playlist_uid=lpad(playlist_id,9,'0') WHERE playlist_uid IS NULL;"))
-
-	// TODO(?): drop playlist_id column
 }

--- a/pkg/services/sqlstore/migrations/playlist_mig.go
+++ b/pkg/services/sqlstore/migrations/playlist_mig.go
@@ -67,10 +67,10 @@ func addPlaylistMigrations(mg *Migrator) {
 	}))
 
 	// copy the string representation of existing IDs into the new uid column.
-	mg.AddMigration("Update uid column values in playlist", NewRawSQLMigration("").
-		SQLite("UPDATE playlist_item SET playlist_uid=printf('%09d',playlist_id) WHERE uid IS NULL;").
-		Postgres("UPDATE playlist_item SET playlist_uid=lpad('' || playlist_id::text,9,'0') WHERE uid IS NULL;").
-		Mysql("UPDATE playlist_item SET playlist_uid=lpad(playlist_id,9,'0') WHERE uid IS NULL;"))
+	mg.AddMigration("Update uid column values in playlist_item", NewRawSQLMigration("").
+		SQLite("UPDATE playlist_item SET playlist_uid=printf('%09d',playlist_id) WHERE playlist_uid IS NULL;").
+		Postgres("UPDATE playlist_item SET playlist_uid=lpad('' || playlist_id::text,9,'0') WHERE playlist_uid IS NULL;").
+		Mysql("UPDATE playlist_item SET playlist_uid=lpad(playlist_id,9,'0') WHERE playlist_uid IS NULL;"))
 
 	// TODO(?): drop playlist_id column
 }

--- a/pkg/services/sqlstore/mockstore/mockstore.go
+++ b/pkg/services/sqlstore/mockstore/mockstore.go
@@ -355,7 +355,7 @@ func (m *SQLStoreMock) UpdatePlaylist(ctx context.Context, cmd *models.UpdatePla
 	return m.ExpectedError
 }
 
-func (m *SQLStoreMock) GetPlaylist(ctx context.Context, query *models.GetPlaylistByIdQuery) error {
+func (m *SQLStoreMock) GetPlaylist(ctx context.Context, query *models.GetPlaylistByUidQuery) error {
 	return m.ExpectedError
 }
 
@@ -367,7 +367,7 @@ func (m *SQLStoreMock) SearchPlaylists(ctx context.Context, query *models.GetPla
 	return m.ExpectedError
 }
 
-func (m *SQLStoreMock) GetPlaylistItem(ctx context.Context, query *models.GetPlaylistItemsByIdQuery) error {
+func (m *SQLStoreMock) GetPlaylistItem(ctx context.Context, query *models.GetPlaylistItemsByUidQuery) error {
 	return m.ExpectedError
 }
 

--- a/pkg/services/sqlstore/playlist.go
+++ b/pkg/services/sqlstore/playlist.go
@@ -4,14 +4,13 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 func (ss *SQLStore) CreatePlaylist(ctx context.Context, cmd *models.CreatePlaylistCommand) error {
 	return ss.WithTransactionalDbSession(ctx, func(sess *DBSession) error {
 		uid, err := generateAndValidateNewPlaylistUid(sess, cmd.OrgId)
 		if err != nil {
-			return errutil.Wrapf(err, "Failed to generate UID for playlist %q", cmd.Name)
+			return err
 		}
 
 		playlist := models.Playlist{

--- a/pkg/services/sqlstore/playlist.go
+++ b/pkg/services/sqlstore/playlist.go
@@ -18,7 +18,7 @@ func (ss *SQLStore) CreatePlaylist(ctx context.Context, cmd *models.CreatePlayli
 			Name:     cmd.Name,
 			Interval: cmd.Interval,
 			OrgId:    cmd.OrgId,
-			Uid:      uid,
+			UID:      uid,
 		}
 
 		_, err = sess.Insert(&playlist)
@@ -47,13 +47,13 @@ func (ss *SQLStore) CreatePlaylist(ctx context.Context, cmd *models.CreatePlayli
 func (ss *SQLStore) UpdatePlaylist(ctx context.Context, cmd *models.UpdatePlaylistCommand) error {
 	return ss.WithTransactionalDbSession(ctx, func(sess *DBSession) error {
 		playlist := models.Playlist{
-			Uid:      cmd.Uid,
+			UID:      cmd.UID,
 			OrgId:    cmd.OrgId,
 			Name:     cmd.Name,
 			Interval: cmd.Interval,
 		}
 
-		existingPlaylist := models.Playlist{Uid: cmd.Uid, OrgId: cmd.OrgId}
+		existingPlaylist := models.Playlist{UID: cmd.UID, OrgId: cmd.OrgId}
 		_, err := sess.Get(&existingPlaylist)
 		if err != nil {
 			return err
@@ -62,7 +62,7 @@ func (ss *SQLStore) UpdatePlaylist(ctx context.Context, cmd *models.UpdatePlayli
 
 		cmd.Result = &models.PlaylistDTO{
 			Id:       playlist.Id,
-			Uid:      playlist.Uid,
+			UID:      playlist.UID,
 			OrgId:    playlist.OrgId,
 			Name:     playlist.Name,
 			Interval: playlist.Interval,
@@ -98,12 +98,12 @@ func (ss *SQLStore) UpdatePlaylist(ctx context.Context, cmd *models.UpdatePlayli
 }
 
 func (ss *SQLStore) GetPlaylist(ctx context.Context, query *models.GetPlaylistByUidQuery) error {
-	if query.Uid == "" || query.OrgId == 0 {
+	if query.UID == "" || query.OrgId == 0 {
 		return models.ErrCommandValidationFailed
 	}
 
 	return ss.WithDbSession(ctx, func(sess *DBSession) error {
-		playlist := models.Playlist{Uid: query.Uid, OrgId: query.OrgId}
+		playlist := models.Playlist{UID: query.UID, OrgId: query.OrgId}
 		_, err := sess.Get(&playlist)
 		query.Result = &playlist
 
@@ -112,19 +112,19 @@ func (ss *SQLStore) GetPlaylist(ctx context.Context, query *models.GetPlaylistBy
 }
 
 func (ss *SQLStore) DeletePlaylist(ctx context.Context, cmd *models.DeletePlaylistCommand) error {
-	if cmd.Uid == "" || cmd.OrgId == 0 {
+	if cmd.UID == "" || cmd.OrgId == 0 {
 		return models.ErrCommandValidationFailed
 	}
 
 	return ss.WithTransactionalDbSession(ctx, func(sess *DBSession) error {
-		playlist := models.Playlist{Uid: cmd.Uid, OrgId: cmd.OrgId}
+		playlist := models.Playlist{UID: cmd.UID, OrgId: cmd.OrgId}
 		_, err := sess.Get(&playlist)
 		if err != nil {
 			return err
 		}
 
 		var rawPlaylistSQL = "DELETE FROM playlist WHERE uid = ? and org_id = ?"
-		_, err = sess.Exec(rawPlaylistSQL, cmd.Uid, cmd.OrgId)
+		_, err = sess.Exec(rawPlaylistSQL, cmd.UID, cmd.OrgId)
 		if err != nil {
 			return err
 		}
@@ -160,12 +160,12 @@ func (ss *SQLStore) SearchPlaylists(ctx context.Context, query *models.GetPlayli
 
 func (ss *SQLStore) GetPlaylistItem(ctx context.Context, query *models.GetPlaylistItemsByUidQuery) error {
 	return ss.WithDbSession(ctx, func(sess *DBSession) error {
-		if query.PlaylistUid == "" || query.OrgId == 0 {
+		if query.PlaylistUID == "" || query.OrgId == 0 {
 			return models.ErrCommandValidationFailed
 		}
 
 		// get the playlist Id
-		get := &models.GetPlaylistByUidQuery{Uid: query.PlaylistUid, OrgId: query.OrgId}
+		get := &models.GetPlaylistByUidQuery{UID: query.PlaylistUID, OrgId: query.OrgId}
 		err := ss.GetPlaylist(ctx, get)
 		if err != nil {
 			return err
@@ -186,7 +186,7 @@ func generateAndValidateNewPlaylistUid(sess *DBSession, orgId int64) (string, er
 	for i := 0; i < 3; i++ {
 		uid := generateNewUid()
 
-		playlist := models.Playlist{OrgId: orgId, Uid: uid}
+		playlist := models.Playlist{OrgId: orgId, UID: uid}
 		exists, err := sess.Get(&playlist)
 		if err != nil {
 			return "", err

--- a/pkg/services/sqlstore/playlist.go
+++ b/pkg/services/sqlstore/playlist.go
@@ -57,7 +57,7 @@ func (ss *SQLStore) UpdatePlaylist(ctx context.Context, cmd *models.UpdatePlayli
 			Interval: cmd.Interval,
 		}
 
-		existingPlaylist := sess.Where("uid = ? AND org_id = ?", cmd.Uid, cmd.OrgId).Find(playlist)
+		existingPlaylist := sess.Where("uid = ? AND org_id = ?", cmd.Uid, cmd.OrgId).Find(models.Playlist{})
 		if existingPlaylist == nil {
 			return models.ErrPlaylistNotFound
 		}
@@ -94,9 +94,6 @@ func (ss *SQLStore) UpdatePlaylist(ctx context.Context, cmd *models.UpdatePlayli
 		}
 
 		_, err = sess.Insert(&playlistItems)
-		if err != nil {
-			panic(err)
-		}
 		return err
 	})
 }

--- a/pkg/services/sqlstore/playlist.go
+++ b/pkg/services/sqlstore/playlist.go
@@ -166,9 +166,15 @@ func (ss *SQLStore) GetPlaylistItem(ctx context.Context, query *models.GetPlayli
 			return models.ErrCommandValidationFailed
 		}
 
-		var playlistItems = make([]models.PlaylistItem, 0)
-		err := sess.Where("playlist_uid=? and org_id = ?", query.PlaylistUid, query.OrgId).Find(&playlistItems)
+		// get the playlist Id
+		get := &models.GetPlaylistByUidQuery{Uid: query.PlaylistUid, OrgId: query.OrgId}
+		err := ss.GetPlaylist(ctx, get)
+		if err != nil {
+			return err
+		}
 
+		var playlistItems = make([]models.PlaylistItem, 0)
+		err = sess.Where("playlist_id=?", get.Result.Id).Find(&playlistItems)
 		query.Result = &playlistItems
 
 		return err

--- a/pkg/services/sqlstore/playlist_test.go
+++ b/pkg/services/sqlstore/playlist_test.go
@@ -23,10 +23,10 @@ func TestIntegrationPlaylistDataAccess(t *testing.T) {
 		cmd := models.CreatePlaylistCommand{Name: "NYC office", Interval: "10m", OrgId: 1, Items: items}
 		err := ss.CreatePlaylist(context.Background(), &cmd)
 		require.NoError(t, err)
-		uid := cmd.Result.Uid
+		uid := cmd.Result.UID
 
 		t.Run("Can get playlist items", func(t *testing.T) {
-			get := &models.GetPlaylistItemsByUidQuery{PlaylistUid: uid, OrgId: 1}
+			get := &models.GetPlaylistItemsByUidQuery{PlaylistUID: uid, OrgId: 1}
 			err = ss.GetPlaylistItem(context.Background(), get)
 			require.NoError(t, err)
 			require.Equal(t, len(*get.Result), len(items))
@@ -37,25 +37,25 @@ func TestIntegrationPlaylistDataAccess(t *testing.T) {
 				{Title: "influxdb", Value: "influxdb", Type: "dashboard_by_tag"},
 				{Title: "Backend response times", Value: "2", Type: "dashboard_by_id"},
 			}
-			query := models.UpdatePlaylistCommand{Name: "NYC office ", OrgId: 1, Uid: uid, Interval: "10s", Items: items}
+			query := models.UpdatePlaylistCommand{Name: "NYC office ", OrgId: 1, UID: uid, Interval: "10s", Items: items}
 			err = ss.UpdatePlaylist(context.Background(), &query)
 			require.NoError(t, err)
 		})
 
 		t.Run("Can remove playlist", func(t *testing.T) {
-			deleteQuery := models.DeletePlaylistCommand{Uid: uid, OrgId: 1}
+			deleteQuery := models.DeletePlaylistCommand{UID: uid, OrgId: 1}
 			err = ss.DeletePlaylist(context.Background(), &deleteQuery)
 			require.NoError(t, err)
 
-			getQuery := models.GetPlaylistByUidQuery{Uid: uid, OrgId: 1}
+			getQuery := models.GetPlaylistByUidQuery{UID: uid, OrgId: 1}
 			err = ss.GetPlaylist(context.Background(), &getQuery)
 			require.NoError(t, err)
-			require.Equal(t, uid, getQuery.Result.Uid, "playlist should've been removed")
+			require.Equal(t, uid, getQuery.Result.UID, "playlist should've been removed")
 		})
 	})
 
 	t.Run("Delete playlist that doesn't exist", func(t *testing.T) {
-		deleteQuery := models.DeletePlaylistCommand{Uid: "654312", OrgId: 1}
+		deleteQuery := models.DeletePlaylistCommand{UID: "654312", OrgId: 1}
 		err := ss.DeletePlaylist(context.Background(), &deleteQuery)
 		require.NoError(t, err)
 	})
@@ -66,7 +66,7 @@ func TestIntegrationPlaylistDataAccess(t *testing.T) {
 			cmd  models.DeletePlaylistCommand
 		}{
 			{desc: "none", cmd: models.DeletePlaylistCommand{}},
-			{desc: "no OrgId", cmd: models.DeletePlaylistCommand{Uid: "1"}},
+			{desc: "no OrgId", cmd: models.DeletePlaylistCommand{UID: "1"}},
 			{desc: "no Uid", cmd: models.DeletePlaylistCommand{OrgId: 1}},
 		}
 

--- a/pkg/services/sqlstore/playlist_test.go
+++ b/pkg/services/sqlstore/playlist_test.go
@@ -2,10 +2,12 @@ package sqlstore
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/models"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/models"
 )
 
 func TestIntegrationPlaylistDataAccess(t *testing.T) {
@@ -23,30 +25,34 @@ func TestIntegrationPlaylistDataAccess(t *testing.T) {
 		err := ss.CreatePlaylist(context.Background(), &cmd)
 		require.NoError(t, err)
 
+		uid := cmd.Result.Uid
+		id := cmd.Result.Id
+		fmt.Printf("uid: %s, id: %d\n", uid, id)
+
 		t.Run("Can update playlist", func(t *testing.T) {
 			items := []models.PlaylistItemDTO{
 				{Title: "influxdb", Value: "influxdb", Type: "dashboard_by_tag"},
 				{Title: "Backend response times", Value: "2", Type: "dashboard_by_id"},
 			}
-			query := models.UpdatePlaylistCommand{Name: "NYC office ", OrgId: 1, Id: 1, Interval: "10s", Items: items}
+			query := models.UpdatePlaylistCommand{Name: "NYC office ", OrgId: 1, Uid: uid, Interval: "10s", Items: items}
 			err = ss.UpdatePlaylist(context.Background(), &query)
 			require.NoError(t, err)
 		})
 
 		t.Run("Can remove playlist", func(t *testing.T) {
-			deleteQuery := models.DeletePlaylistCommand{Id: 1, OrgId: 1}
+			deleteQuery := models.DeletePlaylistCommand{Uid: uid, OrgId: 1}
 			err = ss.DeletePlaylist(context.Background(), &deleteQuery)
 			require.NoError(t, err)
 
-			getQuery := models.GetPlaylistByIdQuery{Id: 1}
+			getQuery := models.GetPlaylistByUidQuery{Uid: uid}
 			err = ss.GetPlaylist(context.Background(), &getQuery)
 			require.NoError(t, err)
-			require.Equal(t, int64(0), getQuery.Result.Id, "playlist should've been removed")
+			require.Equal(t, uid, getQuery.Result.Uid, "playlist should've been removed")
 		})
 	})
 
 	t.Run("Delete playlist that doesn't exist", func(t *testing.T) {
-		deleteQuery := models.DeletePlaylistCommand{Id: 1, OrgId: 1}
+		deleteQuery := models.DeletePlaylistCommand{Uid: "654312", OrgId: 1}
 		err := ss.DeletePlaylist(context.Background(), &deleteQuery)
 		require.NoError(t, err)
 	})
@@ -57,8 +63,8 @@ func TestIntegrationPlaylistDataAccess(t *testing.T) {
 			cmd  models.DeletePlaylistCommand
 		}{
 			{desc: "none", cmd: models.DeletePlaylistCommand{}},
-			{desc: "no OrgId", cmd: models.DeletePlaylistCommand{Id: 1}},
-			{desc: "no Id", cmd: models.DeletePlaylistCommand{OrgId: 1}},
+			{desc: "no OrgId", cmd: models.DeletePlaylistCommand{Uid: "1"}},
+			{desc: "no Uid", cmd: models.DeletePlaylistCommand{OrgId: 1}},
 		}
 
 		for _, tc := range testCases {

--- a/pkg/services/sqlstore/playlist_test.go
+++ b/pkg/services/sqlstore/playlist_test.go
@@ -2,7 +2,6 @@ package sqlstore
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,10 +23,7 @@ func TestIntegrationPlaylistDataAccess(t *testing.T) {
 		cmd := models.CreatePlaylistCommand{Name: "NYC office", Interval: "10m", OrgId: 1, Items: items}
 		err := ss.CreatePlaylist(context.Background(), &cmd)
 		require.NoError(t, err)
-
 		uid := cmd.Result.Uid
-		id := cmd.Result.Id
-		fmt.Printf("uid: %s, id: %d\n", uid, id)
 
 		t.Run("Can update playlist", func(t *testing.T) {
 			items := []models.PlaylistItemDTO{
@@ -44,7 +40,7 @@ func TestIntegrationPlaylistDataAccess(t *testing.T) {
 			err = ss.DeletePlaylist(context.Background(), &deleteQuery)
 			require.NoError(t, err)
 
-			getQuery := models.GetPlaylistByUidQuery{Uid: uid}
+			getQuery := models.GetPlaylistByUidQuery{Uid: uid, OrgId: 1}
 			err = ss.GetPlaylist(context.Background(), &getQuery)
 			require.NoError(t, err)
 			require.Equal(t, uid, getQuery.Result.Uid, "playlist should've been removed")

--- a/pkg/services/sqlstore/playlist_test.go
+++ b/pkg/services/sqlstore/playlist_test.go
@@ -25,6 +25,13 @@ func TestIntegrationPlaylistDataAccess(t *testing.T) {
 		require.NoError(t, err)
 		uid := cmd.Result.Uid
 
+		t.Run("Can get playlist items", func(t *testing.T) {
+			get := &models.GetPlaylistItemsByUidQuery{PlaylistUid: uid, OrgId: 1}
+			err = ss.GetPlaylistItem(context.Background(), get)
+			require.NoError(t, err)
+			require.Equal(t, len(*get.Result), len(items))
+		})
+
 		t.Run("Can update playlist", func(t *testing.T) {
 			items := []models.PlaylistItemDTO{
 				{Title: "influxdb", Value: "influxdb", Type: "dashboard_by_tag"},

--- a/pkg/services/sqlstore/store.go
+++ b/pkg/services/sqlstore/store.go
@@ -75,10 +75,10 @@ type Store interface {
 	InTransaction(ctx context.Context, fn func(ctx context.Context) error) error
 	CreatePlaylist(ctx context.Context, cmd *models.CreatePlaylistCommand) error
 	UpdatePlaylist(ctx context.Context, cmd *models.UpdatePlaylistCommand) error
-	GetPlaylist(ctx context.Context, query *models.GetPlaylistByIdQuery) error
+	GetPlaylist(ctx context.Context, query *models.GetPlaylistByUidQuery) error
 	DeletePlaylist(ctx context.Context, cmd *models.DeletePlaylistCommand) error
 	SearchPlaylists(ctx context.Context, query *models.GetPlaylistsQuery) error
-	GetPlaylistItem(ctx context.Context, query *models.GetPlaylistItemsByIdQuery) error
+	GetPlaylistItem(ctx context.Context, query *models.GetPlaylistItemsByUidQuery) error
 	GetAlertById(ctx context.Context, query *models.GetAlertByIdQuery) error
 	GetAllAlertQueryHandler(ctx context.Context, query *models.GetAllAlertsQuery) error
 	HandleAlertsQuery(ctx context.Context, query *models.GetAlertsQuery) error

--- a/public/app/features/playlist/PlaylistEditPage.test.tsx
+++ b/public/app/features/playlist/PlaylistEditPage.test.tsx
@@ -19,12 +19,12 @@ jest.mock('../../core/components/TagFilter/TagFilter', () => ({
   },
 }));
 
-async function getTestContext({ name, interval, items }: Partial<Playlist> = {}) {
+async function getTestContext({ name, interval, items, uid }: Partial<Playlist> = {}) {
   jest.clearAllMocks();
-  const playlist = { name, items, interval } as unknown as Playlist;
+  const playlist = { name, items, interval, uid } as unknown as Playlist;
   const queryParams = {};
   const route: any = {};
-  const match: any = { params: { id: 1 } };
+  const match: any = { params: { uid: 'foo' } };
   const location: any = {};
   const history: any = {};
   const navModel: any = {
@@ -37,6 +37,7 @@ async function getTestContext({ name, interval, items }: Partial<Playlist> = {})
     name: 'Test Playlist',
     interval: '5s',
     items: [{ title: 'First item', type: 'dashboard_by_id', order: 1, value: '1' }],
+    uid: 'foo',
   });
   const { rerender } = render(
     <PlaylistEditPage
@@ -76,7 +77,7 @@ describe('PlaylistEditPage', () => {
       await userEvent.type(screen.getByRole('textbox', { name: /playlist interval/i }), '10s');
       fireEvent.submit(screen.getByRole('button', { name: /save/i }));
       await waitFor(() => expect(putMock).toHaveBeenCalledTimes(1));
-      expect(putMock).toHaveBeenCalledWith('/api/playlists/1', {
+      expect(putMock).toHaveBeenCalledWith('/api/playlists/foo', {
         name: 'A Name',
         interval: '10s',
         items: [{ title: 'First item', type: 'dashboard_by_id', order: 1, value: '1' }],

--- a/public/app/features/playlist/PlaylistEditPage.tsx
+++ b/public/app/features/playlist/PlaylistEditPage.tsx
@@ -21,16 +21,16 @@ interface ConnectedProps {
 }
 
 export interface RouteParams {
-  id: number;
+  uid: string;
 }
 
 interface Props extends ConnectedProps, GrafanaRouteComponentProps<RouteParams> {}
 
 export const PlaylistEditPage: FC<Props> = ({ navModel, match }) => {
   const styles = useStyles2(getPlaylistStyles);
-  const { playlist, loading } = usePlaylist(match.params.id);
+  const { playlist, loading } = usePlaylist(match.params.uid);
   const onSubmit = async (playlist: Playlist) => {
-    await updatePlaylist(match.params.id, playlist);
+    await updatePlaylist(match.params.uid, playlist);
     locationService.push('/playlists');
   };
 

--- a/public/app/features/playlist/PlaylistForm.test.tsx
+++ b/public/app/features/playlist/PlaylistForm.test.tsx
@@ -12,9 +12,9 @@ jest.mock('../../core/components/TagFilter/TagFilter', () => ({
   },
 }));
 
-function getTestContext({ name, interval, items }: Partial<Playlist> = {}) {
+function getTestContext({ name, interval, items, uid }: Partial<Playlist> = {}) {
   const onSubmitMock = jest.fn();
-  const playlist = { name, items, interval } as unknown as Playlist;
+  const playlist = { name, items, interval, uid } as unknown as Playlist;
   const { rerender } = render(<PlaylistForm onSubmit={onSubmitMock} playlist={playlist} />);
 
   return { onSubmitMock, playlist, rerender };
@@ -28,6 +28,7 @@ const playlist: Playlist = {
     { title: 'Middle item', type: 'dashboard_by_id', order: 2, value: '2' },
     { title: 'Last item', type: 'dashboard_by_tag', order: 2, value: 'Last item' },
   ],
+  uid: 'foo',
 };
 
 function rows() {

--- a/public/app/features/playlist/PlaylistForm.test.tsx
+++ b/public/app/features/playlist/PlaylistForm.test.tsx
@@ -136,7 +136,15 @@ describe('PlaylistForm', () => {
 
       await userEvent.click(screen.getByRole('button', { name: /save/i }));
       expect(onSubmitMock).toHaveBeenCalledTimes(1);
-      expect(onSubmitMock).toHaveBeenCalledWith(playlist);
+      expect(onSubmitMock).toHaveBeenCalledWith({
+        name: 'A test playlist',
+        interval: '10m',
+        items: [
+          { title: 'First item', type: 'dashboard_by_id', order: 1, value: '1' },
+          { title: 'Middle item', type: 'dashboard_by_id', order: 2, value: '2' },
+          { title: 'Last item', type: 'dashboard_by_tag', order: 2, value: 'Last item' },
+        ],
+      });
     });
 
     describe('and name is missing', () => {

--- a/public/app/features/playlist/PlaylistPage.test.tsx
+++ b/public/app/features/playlist/PlaylistPage.test.tsx
@@ -69,6 +69,7 @@ describe('PlaylistPage', () => {
             { title: 'Middle item', type: 'dashboard_by_id', order: 2, value: '2' },
             { title: 'Last item', type: 'dashboard_by_tag', order: 2, value: 'Last item' },
           ],
+          uid: 'playlist-0',
         },
       ]);
       const { getByText } = getTestContext();

--- a/public/app/features/playlist/PlaylistPage.tsx
+++ b/public/app/features/playlist/PlaylistPage.tsx
@@ -52,7 +52,7 @@ export const PlaylistPage: FC<PlaylistPageProps> = ({ navModel }) => {
     if (!playlistToDelete) {
       return;
     }
-    deletePlaylist(playlistToDelete.id).finally(() => {
+    deletePlaylist(playlistToDelete.uid).finally(() => {
       setForcePlaylistsFetch(forcePlaylistsFetch + 1);
       setPlaylistToDelete(undefined);
     });

--- a/public/app/features/playlist/PlaylistPageList.tsx
+++ b/public/app/features/playlist/PlaylistPageList.tsx
@@ -21,7 +21,7 @@ export const PlaylistPageList = ({ playlists, setStartPlaylist, setPlaylistToDel
   return (
     <ul className={styles.list}>
       {playlists!.map((playlist: PlaylistDTO) => (
-        <li className={styles.listItem} key={playlist.id.toString()}>
+        <li className={styles.listItem} key={playlist.uid}>
           <Card>
             <Card.Heading>
               {playlist.name}
@@ -33,7 +33,7 @@ export const PlaylistPageList = ({ playlists, setStartPlaylist, setPlaylistToDel
                     iconSize="lg"
                     onClick={() => {
                       showModal(ShareModal, {
-                        playlistId: playlist.id,
+                        playlistUid: playlist.uid,
                         onDismiss: hideModal,
                       });
                     }}
@@ -47,12 +47,12 @@ export const PlaylistPageList = ({ playlists, setStartPlaylist, setPlaylistToDel
               </Button>
               {contextSrv.isEditor && (
                 <>
-                  <LinkButton key="edit" variant="secondary" href={`/playlists/edit/${playlist.id}`} icon="cog">
+                  <LinkButton key="edit" variant="secondary" href={`/playlists/edit/${playlist.uid}`} icon="cog">
                     Edit playlist
                   </LinkButton>
                   <Button
                     disabled={false}
-                    onClick={() => setPlaylistToDelete({ id: playlist.id, name: playlist.name })}
+                    onClick={() => setPlaylistToDelete({ id: playlist.id, uid: playlist.uid, name: playlist.name })}
                     icon="trash-alt"
                     variant="destructive"
                   >

--- a/public/app/features/playlist/PlaylistSrv.test.ts
+++ b/public/app/features/playlist/PlaylistSrv.test.ts
@@ -29,7 +29,7 @@ setStore(
 const dashboards = [{ url: '/dash1' }, { url: '/dash2' }];
 
 function createPlaylistSrv(): PlaylistSrv {
-  locationService.push('/playlists/1');
+  locationService.push('/playlists/foo');
   return new PlaylistSrv();
 }
 
@@ -66,9 +66,9 @@ describe('PlaylistSrv', () => {
     getMock.mockImplementation(
       jest.fn((url) => {
         switch (url) {
-          case '/api/playlists/1':
+          case '/api/playlists/foo':
             return Promise.resolve({ interval: '1s' });
-          case '/api/playlists/1/dashboards':
+          case '/api/playlists/foo/dashboards':
             return Promise.resolve(dashboards);
           default:
             throw new Error(`Unexpected url=${url}`);
@@ -88,7 +88,7 @@ describe('PlaylistSrv', () => {
   });
 
   it('runs all dashboards in cycle and reloads page after 3 cycles', async () => {
-    await srv.start(1);
+    await srv.start('foo');
 
     for (let i = 0; i < 6; i++) {
       srv.next();
@@ -99,7 +99,7 @@ describe('PlaylistSrv', () => {
   });
 
   it('keeps the refresh counter value after restarting', async () => {
-    await srv.start(1);
+    await srv.start('foo');
 
     // 1 complete loop
     for (let i = 0; i < 3; i++) {
@@ -107,7 +107,7 @@ describe('PlaylistSrv', () => {
     }
 
     srv.stop();
-    await srv.start(1);
+    await srv.start('foo');
 
     // Another 2 loops
     for (let i = 0; i < 4; i++) {
@@ -119,7 +119,7 @@ describe('PlaylistSrv', () => {
   });
 
   it('Should stop playlist when navigating away', async () => {
-    await srv.start(1);
+    await srv.start('foo');
 
     locationService.push('/datasources');
 
@@ -127,7 +127,7 @@ describe('PlaylistSrv', () => {
   });
 
   it('storeUpdated should not stop playlist when navigating to next dashboard', async () => {
-    await srv.start(1);
+    await srv.start('foo');
 
     srv.next();
 

--- a/public/app/features/playlist/PlaylistSrv.ts
+++ b/public/app/features/playlist/PlaylistSrv.ts
@@ -68,7 +68,7 @@ export class PlaylistSrv {
     }
   }
 
-  start(playlistId: number) {
+  start(playlistUid: string) {
     this.stop();
 
     this.startUrl = window.location.href;
@@ -79,10 +79,10 @@ export class PlaylistSrv {
     this.locationListenerUnsub = locationService.getHistory().listen(this.locationUpdated);
 
     return getBackendSrv()
-      .get(`/api/playlists/${playlistId}`)
+      .get(`/api/playlists/${playlistUid}`)
       .then((playlist: any) => {
         return getBackendSrv()
-          .get(`/api/playlists/${playlistId}/dashboards`)
+          .get(`/api/playlists/${playlistUid}/dashboards`)
           .then((dashboards: any) => {
             this.dashboards = dashboards;
             this.interval = rangeUtil.intervalToMs(playlist.interval);

--- a/public/app/features/playlist/PlaylistStartPage.tsx
+++ b/public/app/features/playlist/PlaylistStartPage.tsx
@@ -4,10 +4,10 @@ import { GrafanaRouteComponentProps } from '../../core/navigation/types';
 
 import { playlistSrv } from './PlaylistSrv';
 
-interface Props extends GrafanaRouteComponentProps<{ id: string }> {}
+interface Props extends GrafanaRouteComponentProps<{ uid: string }> {}
 
 export const PlaylistStartPage: FC<Props> = ({ match }) => {
-  playlistSrv.start(parseInt(match.params.id, 10));
+  playlistSrv.start(match.params.uid);
   return null;
 };
 

--- a/public/app/features/playlist/ShareModal.tsx
+++ b/public/app/features/playlist/ShareModal.tsx
@@ -9,11 +9,11 @@ import { buildBaseUrl } from '../dashboard/components/ShareModal/utils';
 import { PlaylistMode } from './types';
 
 interface ShareModalProps {
-  playlistId: number;
+  playlistUid: string;
   onDismiss: () => void;
 }
 
-export const ShareModal = ({ playlistId, onDismiss }: ShareModalProps) => {
+export const ShareModal = ({ playlistUid, onDismiss }: ShareModalProps) => {
   const [mode, setMode] = useState<PlaylistMode>(false);
   const [autoFit, setAutofit] = useState(false);
 
@@ -35,7 +35,7 @@ export const ShareModal = ({ playlistId, onDismiss }: ShareModalProps) => {
     params.autofitpanels = true;
   }
 
-  const shareUrl = urlUtil.renderUrl(`${buildBaseUrl()}/play/${playlistId}`, params);
+  const shareUrl = urlUtil.renderUrl(`${buildBaseUrl()}/play/${playlistUid}`, params);
 
   return (
     <Modal isOpen={true} title="Share playlist" onDismiss={onDismiss}>

--- a/public/app/features/playlist/StartModal.tsx
+++ b/public/app/features/playlist/StartModal.tsx
@@ -29,7 +29,7 @@ export const StartModal: FC<StartModalProps> = ({ playlist, onDismiss }) => {
     if (autoFit) {
       params.autofitpanels = true;
     }
-    locationService.push(urlUtil.renderUrl(`/playlists/play/${playlist.id}`, params));
+    locationService.push(urlUtil.renderUrl(`/playlists/play/${playlist.uid}`, params));
   };
 
   return (

--- a/public/app/features/playlist/api.ts
+++ b/public/app/features/playlist/api.ts
@@ -10,16 +10,16 @@ export async function createPlaylist(playlist: Playlist) {
   await withErrorHandling(() => getBackendSrv().post('/api/playlists', playlist));
 }
 
-export async function updatePlaylist(id: number, playlist: Playlist) {
-  await withErrorHandling(() => getBackendSrv().put(`/api/playlists/${id}`, playlist));
+export async function updatePlaylist(uid: string, playlist: Playlist) {
+  await withErrorHandling(() => getBackendSrv().put(`/api/playlists/${uid}`, playlist));
 }
 
-export async function deletePlaylist(id: number) {
-  await withErrorHandling(() => getBackendSrv().delete(`/api/playlists/${id}`), 'Playlist deleted');
+export async function deletePlaylist(uid: string) {
+  await withErrorHandling(() => getBackendSrv().delete(`/api/playlists/${uid}`), 'Playlist deleted');
 }
 
-export async function getPlaylist(id: number): Promise<Playlist> {
-  const result: Playlist = await getBackendSrv().get(`/api/playlists/${id}`);
+export async function getPlaylist(uid: string): Promise<Playlist> {
+  const result: Playlist = await getBackendSrv().get(`/api/playlists/${uid}`);
   return result;
 }
 

--- a/public/app/features/playlist/types.ts
+++ b/public/app/features/playlist/types.ts
@@ -2,6 +2,7 @@ export interface PlaylistDTO {
   id: number;
   name: string;
   startUrl?: string;
+  uid: string;
 }
 
 export type PlaylistMode = boolean | 'tv';
@@ -17,6 +18,7 @@ export interface Playlist {
   name: string;
   interval: string;
   items?: PlaylistItem[];
+  uid: string;
 }
 
 export interface PlaylistItem {

--- a/public/app/features/playlist/usePlaylist.tsx
+++ b/public/app/features/playlist/usePlaylist.tsx
@@ -3,22 +3,22 @@ import { useEffect, useState } from 'react';
 import { getPlaylist } from './api';
 import { Playlist } from './types';
 
-export function usePlaylist(playlistId?: number) {
-  const [playlist, setPlaylist] = useState<Playlist>({ items: [], interval: '5m', name: '' });
+export function usePlaylist(playlistUid?: string) {
+  const [playlist, setPlaylist] = useState<Playlist>({ items: [], interval: '5m', name: '', uid: '' });
   const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
     const initPlaylist = async () => {
-      if (!playlistId) {
+      if (!playlistUid) {
         setLoading(false);
         return;
       }
-      const list = await getPlaylist(playlistId);
+      const list = await getPlaylist(playlistUid);
       setPlaylist(list);
       setLoading(false);
     };
     initPlaylist();
-  }, [playlistId]);
+  }, [playlistUid]);
 
   return { playlist, loading };
 }

--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -371,7 +371,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
-      path: '/playlists/play/:id',
+      path: '/playlists/play/:uid',
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "PlaylistStartPage"*/ 'app/features/playlist/PlaylistStartPage')
       ),
@@ -383,7 +383,7 @@ export function getAppRoutes(): RouteDescriptor[] {
       ),
     },
     {
-      path: '/playlists/edit/:id',
+      path: '/playlists/edit/:uid',
       component: SafeDynamicImport(
         () => import(/* webpackChunkName: "PlaylistEditPage"*/ 'app/features/playlist/PlaylistEditPage')
       ),


### PR DESCRIPTION
Take two! I'm sorry about closing and re-opening this PR. I addressed all the remaining feedback from #48524 but it's still very inconvenient to loose the comment threads ☹️ 

This PR adds UIDs to playlists and removes playlistID from the playlist API. This is a deliberately breaking change, since playlists aren't widely used we're okay with breaking the APIs instead of the usual deprecation & removal process.

Note that playlistIDs have not been removed, and (in the sqlstore) we grab the playlistID from the UID when grabbing playlistItems.

This PR is blocked requiring front end work; it breaks Playlist functionality in the UI.

Addresses https://github.com/grafana/grafana/issues/48336