### PR TITLE
loki: added two new functions

### DIFF
--- a/public/app/plugins/datasource/loki/syntax.ts
+++ b/public/app/plugins/datasource/loki/syntax.ts
@@ -123,6 +123,18 @@ export const RANGE_VEC_FUNCTIONS = [
     documentation: 'The maximum of all values in the specified interval. Only available in Loki 2.0+.',
   },
   {
+    insertText: 'first_over_time',
+    label: 'first_over_time',
+    detail: 'first_over_time(range-vector)',
+    documentation: 'The first of all values in the specified interval. Only available in Loki 2.3+.',
+  },
+  {
+    insertText: 'last_over_time',
+    label: 'last_over_time',
+    detail: 'last_over_time(range-vector)',
+    documentation: 'The last of all values in the specified interval. Only available in Loki 2.3+.',
+  },
+  {
     insertText: 'sum_over_time',
     label: 'sum_over_time',
     detail: 'sum_over_time(range-vector)',


### PR DESCRIPTION
this pull request adds support for two more loki functions.
this is important because our "is this query a metric query or not" relies on finding these functions, so currently if you run a query with `last_over_time`, we will think it is a logs-producing query.

how to test:
1. go to explore, choose a loki datasource, and start writing "first". you should get an autocomplete offer for the function "first_over_time", together with help-text.
2. repeat the same for "last_over_time"