### PR TITLE
Search: add icon for row and singlestat panels

### DIFF
--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -301,7 +301,7 @@ function makeTypeColumn(
                     txt = 'Row';
                     icon = `public/img/icons/unicons/bars.svg`;
                     break;
-                  case 'singlestat': // auto-migratino
+                  case 'singlestat': // auto-migration
                     txt = 'Singlestat';
                     icon = `public/app/plugins/panel/stat/img/icn-singlestat-panel.svg`;
                     break;

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -296,7 +296,18 @@ function makeTypeColumn(
                 }
                 txt = info.name;
               } else {
-                icon = `public/img/icons/unicons/question.svg`; // plugin not found
+                switch (type) {
+                  case 'row':
+                    txt = 'Row';
+                    icon = `public/img/icons/unicons/bars.svg`;
+                    break;
+                  case 'singlestat': // auto-migratino
+                    txt = 'Singlestat';
+                    icon = `public/app/plugins/panel/stat/img/icn-singlestat-panel.svg`;
+                    break;
+                  default:
+                    icon = `public/img/icons/unicons/question.svg`; // plugin not found
+                }
               }
             }
             break;


### PR DESCRIPTION
The logic to show panel icon loads it from a plugin, but "row" and "singlestat" are not real plugins.  This PR manually replaces them with reasonable values

<img width="542" alt="image" src="https://user-images.githubusercontent.com/705951/170283168-585cade9-a91d-4c81-9866-56a64c902c7c.png">
