### PR TITLE
Fix: Timeseries migration regex override

### DIFF
--- a/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
+++ b/public/app/plugins/panel/timeseries/__snapshots__/migrations.test.ts.snap
@@ -141,6 +141,21 @@ Object {
           },
         ],
       },
+      Object {
+        "matcher": Object {
+          "id": "byName",
+          "options": "B-series",
+        },
+        "properties": Array [
+          Object {
+            "id": "color",
+            "value": Object {
+              "fixedColor": "rgba(16, 72, 170, 0.77)",
+              "mode": "fixed",
+            },
+          },
+        ],
+      },
     ],
   },
   "options": Object {
@@ -192,6 +207,21 @@ Object {
             "id": "color",
             "value": Object {
               "fixedColor": "rgba(165, 72, 170, 0.77)",
+              "mode": "fixed",
+            },
+          },
+        ],
+      },
+      Object {
+        "matcher": Object {
+          "id": "byRegexp",
+          "options": "/.*Status: 2[0-9]+.*/i",
+        },
+        "properties": Array [
+          Object {
+            "id": "color",
+            "value": Object {
+              "fixedColor": "rgba(16, 72, 170, 0.77)",
               "mode": "fixed",
             },
           },

--- a/public/app/plugins/panel/timeseries/migrations.test.ts
+++ b/public/app/plugins/panel/timeseries/migrations.test.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash';
 
-import { PanelModel, FieldConfigSource } from '@grafana/data';
+import { PanelModel, FieldConfigSource, FieldMatcherID } from '@grafana/data';
 import { TooltipDisplayMode, SortOrder } from '@grafana/schema';
 
 import { graphPanelChangedHandler } from './migrations';
@@ -78,6 +78,8 @@ describe('Graph Migrations', () => {
     const panel = {} as PanelModel;
     panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
     expect(panel).toMatchSnapshot();
+    expect(panel.fieldConfig.overrides[0].matcher.id).toBe(FieldMatcherID.byRegexp);
+    expect(panel.fieldConfig.overrides[1].matcher.id).toBe(FieldMatcherID.byRegexp);
   });
 
   describe('legend', () => {
@@ -456,6 +458,11 @@ const customColor = {
       alias: 'A-series',
       color: 'rgba(165, 72, 170, 0.77)',
     },
+    {
+      $$hashKey: 'object:13',
+      alias: 'B-series',
+      color: 'rgba(16, 72, 170, 0.77)',
+    },
   ],
   spaceLength: 10,
   steppedLine: true,
@@ -513,6 +520,7 @@ const customColor = {
 
 const customColorRegex = cloneDeep(customColor);
 customColorRegex.seriesOverrides[0].alias = '/^A-/';
+customColorRegex.seriesOverrides[1].alias = '/.*Status: 2[0-9]+.*/i';
 
 const stairscase = {
   aliasColors: {},

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -119,7 +119,7 @@ export function flotToGraphOptions(angular: any): { fieldConfig: FieldConfigSour
       if (!seriesOverride.alias) {
         continue; // the matcher config
       }
-      const aliasIsRegex = seriesOverride.alias.startsWith('/') && seriesOverride.alias.endsWith('/');
+      const aliasIsRegex = /^([/~@;%#'])(.*?)\1([gimsuy]*)$/.test(seriesOverride.alias);
       const rule: ConfigOverrideRule = {
         matcher: {
           id: aliasIsRegex ? FieldMatcherID.byRegexp : FieldMatcherID.byName,


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr fixes https://github.com/grafana/support-escalations/issues/2699
