### PR TITLE
Alerting: Endpoints for provisioning mute timings

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -180,3 +180,15 @@ func (srv *ProvisioningSrv) RouteGetMuteTimings(c *models.ReqContext) response.R
 	}
 	return response.JSON(http.StatusOK, timings)
 }
+
+func (srv *ProvisioningSrv) RoutePostMuteTiming(c *models.ReqContext, mt apimodels.MuteTimeInterval) response.Response {
+	return ErrResp(http.StatusInternalServerError, nil, "not implemented")
+}
+
+func (srv *ProvisioningSrv) RoutePutMuteTiming(c *models.ReqContext, mt apimodels.MuteTimeInterval) response.Response {
+	return ErrResp(http.StatusInternalServerError, nil, "not implemented")
+}
+
+func (srv *ProvisioningSrv) RouteDeleteMuteTiming(c *models.ReqContext) response.Response {
+	return ErrResp(http.StatusInternalServerError, nil, "not implemented")
+}

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -16,6 +16,9 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
+const namePathParam = ":name"
+const idPathParam = ":ID"
+
 type ProvisioningSrv struct {
 	log                 log.Logger
 	policies            NotificationPolicyService
@@ -94,7 +97,7 @@ func (srv *ProvisioningSrv) RoutePostContactPoint(c *models.ReqContext, cp apimo
 }
 
 func (srv *ProvisioningSrv) RoutePutContactPoint(c *models.ReqContext, cp apimodels.EmbeddedContactPoint) response.Response {
-	id := web.Params(c.Req)[":ID"]
+	id := pathParam(c, idPathParam)
 	cp.UID = id
 	err := srv.contactPointService.UpdateContactPoint(c.Req.Context(), c.OrgId, cp, alerting_models.ProvenanceAPI)
 	if err != nil {
@@ -104,7 +107,7 @@ func (srv *ProvisioningSrv) RoutePutContactPoint(c *models.ReqContext, cp apimod
 }
 
 func (srv *ProvisioningSrv) RouteDeleteContactPoint(c *models.ReqContext) response.Response {
-	cpID := web.Params(c.Req)[":ID"]
+	cpID := pathParam(c, idPathParam)
 	err := srv.contactPointService.DeleteContactPoint(c.Req.Context(), c.OrgId, cpID)
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "")
@@ -125,19 +128,19 @@ func (srv *ProvisioningSrv) RouteGetTemplates(c *models.ReqContext) response.Res
 }
 
 func (srv *ProvisioningSrv) RouteGetTemplate(c *models.ReqContext) response.Response {
-	id := web.Params(c.Req)[":name"]
+	name := pathParam(c, namePathParam)
 	templates, err := srv.templates.GetTemplates(c.Req.Context(), c.OrgId)
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "")
 	}
-	if tmpl, ok := templates[id]; ok {
-		return response.JSON(http.StatusOK, apimodels.MessageTemplate{Name: id, Template: tmpl})
+	if tmpl, ok := templates[name]; ok {
+		return response.JSON(http.StatusOK, apimodels.MessageTemplate{Name: name, Template: tmpl})
 	}
 	return response.Empty(http.StatusNotFound)
 }
 
 func (srv *ProvisioningSrv) RoutePutTemplate(c *models.ReqContext, body apimodels.MessageTemplateContent) response.Response {
-	name := web.Params(c.Req)[":name"]
+	name := pathParam(c, namePathParam)
 	tmpl := apimodels.MessageTemplate{
 		Name:       name,
 		Template:   body.Template,
@@ -154,7 +157,7 @@ func (srv *ProvisioningSrv) RoutePutTemplate(c *models.ReqContext, body apimodel
 }
 
 func (srv *ProvisioningSrv) RouteDeleteTemplate(c *models.ReqContext) response.Response {
-	name := web.Params(c.Req)[":name"]
+	name := pathParam(c, namePathParam)
 	err := srv.templates.DeleteTemplate(c.Req.Context(), c.OrgId, name)
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "")
@@ -163,7 +166,7 @@ func (srv *ProvisioningSrv) RouteDeleteTemplate(c *models.ReqContext) response.R
 }
 
 func (srv *ProvisioningSrv) RouteGetMuteTiming(c *models.ReqContext) response.Response {
-	name := web.Params(c.Req)[":name"]
+	name := pathParam(c, namePathParam)
 	timings, err := srv.muteTimings.GetMuteTimings(c.Req.Context(), c.OrgId)
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "")
@@ -196,7 +199,7 @@ func (srv *ProvisioningSrv) RoutePostMuteTiming(c *models.ReqContext, mt apimode
 }
 
 func (srv *ProvisioningSrv) RoutePutMuteTiming(c *models.ReqContext, mt apimodels.MuteTimeInterval) response.Response {
-	name := web.Params(c.Req)[":name"]
+	name := pathParam(c, namePathParam)
 	mt.Name = name
 	updated, err := srv.muteTimings.UpdateMuteTiming(c.Req.Context(), mt, c.OrgId)
 	if err != nil {
@@ -212,10 +215,14 @@ func (srv *ProvisioningSrv) RoutePutMuteTiming(c *models.ReqContext, mt apimodel
 }
 
 func (srv *ProvisioningSrv) RouteDeleteMuteTiming(c *models.ReqContext) response.Response {
-	name := web.Params(c.Req)[":name"]
+	name := pathParam(c, namePathParam)
 	err := srv.muteTimings.DeleteMuteTiming(c.Req.Context(), name, c.OrgId)
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "")
 	}
 	return response.JSON(http.StatusNoContent, nil)
+}
+
+func pathParam(c *models.ReqContext, param string) string {
+	return web.Params(c.Req)[param]
 }

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -43,7 +43,7 @@ type NotificationPolicyService interface {
 }
 
 type MuteTimingService interface {
-	GetMuteTimings(ctx context.Context, orgID int64) ([]apimodels.MuteTiming, error)
+	GetMuteTimings(ctx context.Context, orgID int64) ([]apimodels.MuteTimeInterval, error)
 }
 
 func (srv *ProvisioningSrv) RouteGetPolicyTree(c *models.ReqContext) response.Response {

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -192,7 +192,10 @@ func (api *API) authorize(method, path string) web.Handler {
 		http.MethodPut + "/api/provisioning/contact-points/{ID}",
 		http.MethodDelete + "/api/provisioning/contact-points/{ID}",
 		http.MethodPut + "/api/provisioning/templates/{name}",
-		http.MethodDelete + "/api/provisioning/templates/{name}":
+		http.MethodDelete + "/api/provisioning/templates/{name}",
+		http.MethodPost + "/api/provisioning/mute-timings",
+		http.MethodPut + "/api/provisioning/mute-timings/{name}",
+		http.MethodDelete + "/api/provisioning/mute-timings/{name}":
 		return middleware.ReqEditorRole
 	}
 

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -46,7 +46,7 @@ func TestAuthorize(t *testing.T) {
 		}
 		paths[p] = methods
 	}
-	require.Len(t, paths, 36)
+	require.Len(t, paths, 38)
 
 	ac := acmock.New()
 	api := &API{AccessControl: ac}

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -46,7 +46,7 @@ func TestAuthorize(t *testing.T) {
 		}
 		paths[p] = methods
 	}
-	require.Len(t, paths, 38)
+	require.Len(t, paths, 36)
 
 	ac := acmock.New()
 	api := &API{AccessControl: ac}

--- a/pkg/services/ngalert/api/forked_provisioning.go
+++ b/pkg/services/ngalert/api/forked_provisioning.go
@@ -66,3 +66,15 @@ func (f *ForkedProvisioningApi) forkRouteGetMuteTiming(ctx *models.ReqContext) r
 func (f *ForkedProvisioningApi) forkRouteGetMuteTimings(ctx *models.ReqContext) response.Response {
 	return f.svc.RouteGetMuteTimings(ctx)
 }
+
+func (f *ForkedProvisioningApi) forkRoutePostMuteTiming(ctx *models.ReqContext, mt apimodels.MuteTimeInterval) response.Response {
+	return f.svc.RoutePostMuteTiming(ctx, mt)
+}
+
+func (f *ForkedProvisioningApi) forkRoutePutMuteTiming(ctx *models.ReqContext, mt apimodels.MuteTimeInterval) response.Response {
+	return f.svc.RoutePutMuteTiming(ctx, mt)
+}
+
+func (f *ForkedProvisioningApi) forkRouteDeleteMuteTiming(ctx *models.ReqContext) response.Response {
+	return f.svc.RouteDeleteMuteTiming(ctx)
+}

--- a/pkg/services/ngalert/api/generated_base_api_provisioning.go
+++ b/pkg/services/ngalert/api/generated_base_api_provisioning.go
@@ -21,6 +21,7 @@ import (
 
 type ProvisioningApiForkingService interface {
 	RouteDeleteContactpoints(*models.ReqContext) response.Response
+	RouteDeleteMuteTiming(*models.ReqContext) response.Response
 	RouteDeleteTemplate(*models.ReqContext) response.Response
 	RouteGetContactpoints(*models.ReqContext) response.Response
 	RouteGetMuteTiming(*models.ReqContext) response.Response
@@ -29,13 +30,19 @@ type ProvisioningApiForkingService interface {
 	RouteGetTemplate(*models.ReqContext) response.Response
 	RouteGetTemplates(*models.ReqContext) response.Response
 	RoutePostContactpoints(*models.ReqContext) response.Response
+	RoutePostMuteTiming(*models.ReqContext) response.Response
 	RoutePutContactpoint(*models.ReqContext) response.Response
+	RoutePutMuteTiming(*models.ReqContext) response.Response
 	RoutePutPolicyTree(*models.ReqContext) response.Response
 	RoutePutTemplate(*models.ReqContext) response.Response
 }
 
 func (f *ForkedProvisioningApi) RouteDeleteContactpoints(ctx *models.ReqContext) response.Response {
 	return f.forkRouteDeleteContactpoints(ctx)
+}
+
+func (f *ForkedProvisioningApi) RouteDeleteMuteTiming(ctx *models.ReqContext) response.Response {
+	return f.forkRouteDeleteMuteTiming(ctx)
 }
 
 func (f *ForkedProvisioningApi) RouteDeleteTemplate(ctx *models.ReqContext) response.Response {
@@ -74,12 +81,28 @@ func (f *ForkedProvisioningApi) RoutePostContactpoints(ctx *models.ReqContext) r
 	return f.forkRoutePostContactpoints(ctx, conf)
 }
 
+func (f *ForkedProvisioningApi) RoutePostMuteTiming(ctx *models.ReqContext) response.Response {
+	conf := apimodels.MuteTimeInterval{}
+	if err := web.Bind(ctx.Req, &conf); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+	return f.forkRoutePostMuteTiming(ctx, conf)
+}
+
 func (f *ForkedProvisioningApi) RoutePutContactpoint(ctx *models.ReqContext) response.Response {
 	conf := apimodels.EmbeddedContactPoint{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 	return f.forkRoutePutContactpoint(ctx, conf)
+}
+
+func (f *ForkedProvisioningApi) RoutePutMuteTiming(ctx *models.ReqContext) response.Response {
+	conf := apimodels.MuteTimeInterval{}
+	if err := web.Bind(ctx.Req, &conf); err != nil {
+		return response.Error(http.StatusBadRequest, "bad request data", err)
+	}
+	return f.forkRoutePutMuteTiming(ctx, conf)
 }
 
 func (f *ForkedProvisioningApi) RoutePutPolicyTree(ctx *models.ReqContext) response.Response {
@@ -107,6 +130,16 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingServi
 				http.MethodDelete,
 				"/api/provisioning/contact-points/{ID}",
 				srv.RouteDeleteContactpoints,
+				m,
+			),
+		)
+		group.Delete(
+			toMacaronPath("/api/provisioning/mute-timings/{name}"),
+			api.authorize(http.MethodDelete, "/api/provisioning/mute-timings/{name}"),
+			metrics.Instrument(
+				http.MethodDelete,
+				"/api/provisioning/mute-timings/{name}",
+				srv.RouteDeleteMuteTiming,
 				m,
 			),
 		)
@@ -190,6 +223,16 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingServi
 				m,
 			),
 		)
+		group.Post(
+			toMacaronPath("/api/provisioning/mute-timings"),
+			api.authorize(http.MethodPost, "/api/provisioning/mute-timings"),
+			metrics.Instrument(
+				http.MethodPost,
+				"/api/provisioning/mute-timings",
+				srv.RoutePostMuteTiming,
+				m,
+			),
+		)
 		group.Put(
 			toMacaronPath("/api/provisioning/contact-points/{ID}"),
 			api.authorize(http.MethodPut, "/api/provisioning/contact-points/{ID}"),
@@ -197,6 +240,16 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingServi
 				http.MethodPut,
 				"/api/provisioning/contact-points/{ID}",
 				srv.RoutePutContactpoint,
+				m,
+			),
+		)
+		group.Put(
+			toMacaronPath("/api/provisioning/mute-timings/{name}"),
+			api.authorize(http.MethodPut, "/api/provisioning/mute-timings/{name}"),
+			metrics.Instrument(
+				http.MethodPut,
+				"/api/provisioning/mute-timings/{name}",
+				srv.RoutePutMuteTiming,
 				m,
 			),
 		)

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -1439,26 +1439,9 @@
    "type": "object",
    "x-go-package": "github.com/prometheus/alertmanager/config"
   },
-  "MuteTiming": {
-   "properties": {
-    "name": {
-     "type": "string",
-     "x-go-name": "Name"
-    },
-    "time_intervals": {
-     "items": {
-      "$ref": "#/definitions/TimeInterval"
-     },
-     "type": "array",
-     "x-go-name": "TimeIntervals"
-    }
-   },
-   "type": "object",
-   "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
-  },
   "MuteTimings": {
    "items": {
-    "$ref": "#/definitions/MuteTiming"
+    "$ref": "#/definitions/MuteTimeInterval"
    },
    "type": "array",
    "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -3198,12 +3181,11 @@
    "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertGroups": {
+   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
-   "type": "array",
-   "x-go-name": "AlertGroups",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "array"
   },
   "alertStatus": {
    "description": "AlertStatus alert status",
@@ -3385,11 +3367,12 @@
    "type": "object"
   },
   "gettableAlerts": {
-   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
-   "type": "array"
+   "type": "array",
+   "x-go-name": "GettableAlerts",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "gettableSilence": {
    "description": "GettableSilence gettable silence",
@@ -3447,12 +3430,11 @@
    "type": "object"
   },
   "gettableSilences": {
+   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
-   "type": "array",
-   "x-go-name": "GettableSilences",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "array"
   },
   "labelSet": {
    "additionalProperties": {
@@ -3581,6 +3563,7 @@
    "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "postableSilence": {
+   "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3620,9 +3603,7 @@
     "matchers",
     "startsAt"
    ],
-   "type": "object",
-   "x-go-name": "PostableSilence",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "object"
   },
   "receiver": {
    "properties": {

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -3181,11 +3181,12 @@
    "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
-   "type": "array"
+   "type": "array",
+   "x-go-name": "AlertGroups",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertStatus": {
    "description": "AlertStatus alert status",
@@ -3367,15 +3368,13 @@
    "type": "object"
   },
   "gettableAlerts": {
+   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
-   "type": "array",
-   "x-go-name": "GettableAlerts",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "array"
   },
   "gettableSilence": {
-   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3427,14 +3426,17 @@
     "status",
     "updatedAt"
    ],
-   "type": "object"
+   "type": "object",
+   "x-go-name": "GettableSilence",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "gettableSilences": {
-   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
-   "type": "array"
+   "type": "array",
+   "x-go-name": "GettableSilences",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "labelSet": {
    "additionalProperties": {
@@ -3606,6 +3608,7 @@
    "type": "object"
   },
   "receiver": {
+   "description": "Receiver receiver",
    "properties": {
     "name": {
      "description": "name",
@@ -3616,9 +3619,7 @@
    "required": [
     "name"
    ],
-   "type": "object",
-   "x-go-name": "Receiver",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "object"
   },
   "silence": {
    "description": "Silence silence",

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -850,6 +850,19 @@ func checkTimeInterval(r *Route, timeIntervals map[string]struct{}) error {
 	return nil
 }
 
+type MuteTimeInterval struct {
+	config.MuteTimeInterval
+	Provenance models.Provenance `json:"provenance,omitempty"`
+}
+
+func (mt *MuteTimeInterval) ResourceType() string {
+	return "muteTimeInterval"
+}
+
+func (mt *MuteTimeInterval) ResourceID() string {
+	return mt.MuteTimeInterval.Name
+}
+
 type PostableApiAlertingConfig struct {
 	Config `yaml:",inline"`
 

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -850,6 +850,7 @@ func checkTimeInterval(r *Route, timeIntervals map[string]struct{}) error {
 	return nil
 }
 
+// swagger:model
 type MuteTimeInterval struct {
 	config.MuteTimeInterval
 	Provenance models.Provenance `json:"provenance,omitempty"`

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
@@ -106,7 +106,7 @@ func (mt *MuteTimeInterval) Validate() error {
 	if err != nil {
 		return err
 	}
-	if err = yaml.Unmarshal(s, mt.MuteTimeInterval); err != nil {
+	if err = yaml.Unmarshal(s, &(mt.MuteTimeInterval)); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
@@ -1,7 +1,5 @@
 package definitions
 
-import prometheus "github.com/prometheus/alertmanager/config"
-
 // swagger:route GET /api/provisioning/mute-timings provisioning RouteGetMuteTimings
 //
 // Get all the mute timings.
@@ -15,20 +13,52 @@ import prometheus "github.com/prometheus/alertmanager/config"
 // Get a mute timing.
 //
 //     Responses:
-//       200: MuteTiming
+//       200: MuteTimeInterval
 //       400: ValidationError
 
-// swagger:model
-type MuteTiming struct {
-	prometheus.MuteTimeInterval
-}
+// swagger:route POST /api/provisioning/mute-timings provisioning RoutePostMuteTiming
+//
+// Create a new mute timing.
+//
+//     Consumes:
+//     - application/json
+//
+//     Responses:
+//       201: MuteTimeInterval
+//       400: ValidationError
+
+// swagger:route PUT /api/provisioning/mute-timings/{name} provisioning RoutePutMuteTiming
+//
+// Replace an existing mute timing.
+//
+//     Consumes:
+//     - application/json
+//
+//     Responses:
+//       200: MuteTimeInterval
+//       400: ValidationError
+
+// swagger:route DELETE /api/provisioning/mute-timings/{name} provisioning RouteDeleteMuteTiming
+//
+// Delete a mute timing.
+//
+//     Responses:
+//       204: Accepted
+
+// swagger:route
 
 // swagger:model
-type MuteTimings []MuteTiming
+type MuteTimings []MuteTimeInterval
 
 // swagger:parameters RouteGetTemplate RouteGetMuteTiming
 type RouteGetMuteTimingParam struct {
 	// Template Name
 	// in:path
 	Name string `json:"name"`
+}
+
+// swagger:parameters RoutePostMuteTiming RoutePutMuteTiming
+type MuteTimingPayload struct {
+	// in:body
+	Body MuteTimeInterval
 }

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_mute_timings.go
@@ -43,14 +43,14 @@ package definitions
 // Delete a mute timing.
 //
 //     Responses:
-//       204: Accepted
+//       204: Ack
 
 // swagger:route
 
 // swagger:model
 type MuteTimings []MuteTimeInterval
 
-// swagger:parameters RouteGetTemplate RouteGetMuteTiming
+// swagger:parameters RouteGetTemplate RouteGetMuteTiming RoutePutMuteTiming RouteDeleteMuteTiming
 type RouteGetMuteTimingParam struct {
 	// Template Name
 	// in:path

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
@@ -1,11 +1,6 @@
 package definitions
 
 import (
-	"fmt"
-	"html/template"
-	"regexp"
-	"strings"
-
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
@@ -76,35 +71,4 @@ func (t *MessageTemplate) ResourceType() string {
 
 func (t *MessageTemplate) ResourceID() string {
 	return t.Name
-}
-
-func (t *MessageTemplate) Validate() error {
-	if t.Name == "" {
-		return fmt.Errorf("template must have a name")
-	}
-	if t.Template == "" {
-		return fmt.Errorf("template must have content")
-	}
-
-	_, err := template.New("").Parse(t.Template)
-	if err != nil {
-		return fmt.Errorf("invalid template: %w", err)
-	}
-
-	content := strings.TrimSpace(t.Template)
-	found, err := regexp.MatchString(`\{\{\s*define`, content)
-	if err != nil {
-		return fmt.Errorf("failed to match regex: %w", err)
-	}
-	if !found {
-		lines := strings.Split(content, "\n")
-		for i, s := range lines {
-			lines[i] = "  " + s
-		}
-		content = strings.Join(lines, "\n")
-		content = fmt.Sprintf("{{ define \"%s\" }}\n%s\n{{ end }}", t.Name, content)
-	}
-	t.Template = content
-
-	return nil
 }

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -1439,26 +1439,9 @@
    "type": "object",
    "x-go-package": "github.com/prometheus/alertmanager/config"
   },
-  "MuteTiming": {
-   "properties": {
-    "name": {
-     "type": "string",
-     "x-go-name": "Name"
-    },
-    "time_intervals": {
-     "items": {
-      "$ref": "#/definitions/TimeInterval"
-     },
-     "type": "array",
-     "x-go-name": "TimeIntervals"
-    }
-   },
-   "type": "object",
-   "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
-  },
   "MuteTimings": {
    "items": {
-    "$ref": "#/definitions/MuteTiming"
+    "$ref": "#/definitions/MuteTimeInterval"
    },
    "type": "array",
    "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -2940,6 +2923,7 @@
    "x-go-package": "github.com/prometheus/alertmanager/timeinterval"
   },
   "URL": {
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -2972,9 +2956,9 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "URL is a custom URL type that allows validation at configuration load time.",
+   "title": "A URL represents a parsed URL (technically, a URI reference).",
    "type": "object",
-   "x-go-package": "github.com/prometheus/common/config"
+   "x-go-package": "net/url"
   },
   "Userinfo": {
    "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -3171,7 +3155,6 @@
    "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertGroup": {
-   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -3193,7 +3176,9 @@
     "labels",
     "receiver"
    ],
-   "type": "object"
+   "type": "object",
+   "x-go-name": "AlertGroup",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertGroups": {
    "description": "AlertGroups alert groups",
@@ -3383,11 +3368,12 @@
    "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "gettableAlerts": {
-   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
-   "type": "array"
+   "type": "array",
+   "x-go-name": "GettableAlerts",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "gettableSilence": {
    "description": "GettableSilence gettable silence",
@@ -3445,11 +3431,12 @@
    "type": "object"
   },
   "gettableSilences": {
-   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
-   "type": "array"
+   "type": "array",
+   "x-go-name": "GettableSilences",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "labelSet": {
    "additionalProperties": {
@@ -5005,9 +4992,54 @@
     "tags": [
      "provisioning"
     ]
+   },
+   "post": {
+    "consumes": [
+     "application/json"
+    ],
+    "operationId": "RoutePostMuteTiming",
+    "parameters": [
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/MuteTimeInterval"
+      }
+     }
+    ],
+    "responses": {
+     "201": {
+      "description": "MuteTimeInterval",
+      "schema": {
+       "$ref": "#/definitions/MuteTimeInterval"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Create a new mute timing.",
+    "tags": [
+     "provisioning"
+    ]
    }
   },
   "/api/provisioning/mute-timings/{name}": {
+   "delete": {
+    "operationId": "RouteDeleteMuteTiming",
+    "responses": {
+     "204": {
+      "$ref": "#/responses/Accepted"
+     }
+    },
+    "summary": "Delete a mute timing.",
+    "tags": [
+     "provisioning"
+    ]
+   },
    "get": {
     "operationId": "RouteGetMuteTiming",
     "parameters": [
@@ -5022,9 +5054,9 @@
     ],
     "responses": {
      "200": {
-      "description": "MuteTiming",
+      "description": "MuteTimeInterval",
       "schema": {
-       "$ref": "#/definitions/MuteTiming"
+       "$ref": "#/definitions/MuteTimeInterval"
       }
      },
      "400": {
@@ -5035,6 +5067,39 @@
      }
     },
     "summary": "Get a mute timing.",
+    "tags": [
+     "provisioning"
+    ]
+   },
+   "put": {
+    "consumes": [
+     "application/json"
+    ],
+    "operationId": "RoutePutMuteTiming",
+    "parameters": [
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/MuteTimeInterval"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "MuteTimeInterval",
+      "schema": {
+       "$ref": "#/definitions/MuteTimeInterval"
+      }
+     },
+     "400": {
+      "description": "ValidationError",
+      "schema": {
+       "$ref": "#/definitions/ValidationError"
+      }
+     }
+    },
+    "summary": "Replace an existing mute timing.",
     "tags": [
      "provisioning"
     ]

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -2923,7 +2923,6 @@
    "x-go-package": "github.com/prometheus/alertmanager/timeinterval"
   },
   "URL": {
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -2956,9 +2955,9 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object",
-   "x-go-package": "net/url"
+   "x-go-package": "github.com/prometheus/common/config"
   },
   "Userinfo": {
    "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -3155,6 +3154,7 @@
    "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertGroup": {
+   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -3176,16 +3176,15 @@
     "labels",
     "receiver"
    ],
-   "type": "object",
-   "x-go-name": "AlertGroup",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "object"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
-   "type": "array"
+   "type": "array",
+   "x-go-name": "AlertGroups",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertStatus": {
    "description": "AlertStatus alert status",
@@ -3368,12 +3367,11 @@
    "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "gettableAlerts": {
+   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
-   "type": "array",
-   "x-go-name": "GettableAlerts",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "array"
   },
   "gettableSilence": {
    "description": "GettableSilence gettable silence",
@@ -5030,9 +5028,22 @@
   "/api/provisioning/mute-timings/{name}": {
    "delete": {
     "operationId": "RouteDeleteMuteTiming",
+    "parameters": [
+     {
+      "description": "Template Name",
+      "in": "path",
+      "name": "name",
+      "required": true,
+      "type": "string",
+      "x-go-name": "Name"
+     }
+    ],
     "responses": {
      "204": {
-      "$ref": "#/responses/Accepted"
+      "description": "Ack",
+      "schema": {
+       "$ref": "#/definitions/Ack"
+      }
      }
     },
     "summary": "Delete a mute timing.",
@@ -5077,6 +5088,14 @@
     ],
     "operationId": "RoutePutMuteTiming",
     "parameters": [
+     {
+      "description": "Template Name",
+      "in": "path",
+      "name": "name",
+      "required": true,
+      "type": "string",
+      "x-go-name": "Name"
+     },
      {
       "in": "body",
       "name": "Body",

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1274,6 +1274,39 @@
             }
           }
         }
+      },
+      "post": {
+        "consumes": [
+          "application/json"
+        ],
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Create a new mute timing.",
+        "operationId": "RoutePostMuteTiming",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/MuteTimeInterval"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "MuteTimeInterval",
+            "schema": {
+              "$ref": "#/definitions/MuteTimeInterval"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
       }
     },
     "/api/provisioning/mute-timings/{name}": {
@@ -1295,9 +1328,9 @@
         ],
         "responses": {
           "200": {
-            "description": "MuteTiming",
+            "description": "MuteTimeInterval",
             "schema": {
-              "$ref": "#/definitions/MuteTiming"
+              "$ref": "#/definitions/MuteTimeInterval"
             }
           },
           "400": {
@@ -1305,6 +1338,51 @@
             "schema": {
               "$ref": "#/definitions/ValidationError"
             }
+          }
+        }
+      },
+      "put": {
+        "consumes": [
+          "application/json"
+        ],
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Replace an existing mute timing.",
+        "operationId": "RoutePutMuteTiming",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/MuteTimeInterval"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "MuteTimeInterval",
+            "schema": {
+              "$ref": "#/definitions/MuteTimeInterval"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "provisioning"
+        ],
+        "summary": "Delete a mute timing.",
+        "operationId": "RouteDeleteMuteTiming",
+        "responses": {
+          "204": {
+            "$ref": "#/responses/Accepted"
           }
         }
       }
@@ -3544,27 +3622,10 @@
       },
       "x-go-package": "github.com/prometheus/alertmanager/config"
     },
-    "MuteTiming": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "time_intervals": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/TimeInterval"
-          },
-          "x-go-name": "TimeIntervals"
-        }
-      },
-      "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
-    },
     "MuteTimings": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/MuteTiming"
+        "$ref": "#/definitions/MuteTimeInterval"
       },
       "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
     },
@@ -5045,8 +5106,9 @@
       "x-go-package": "github.com/prometheus/alertmanager/timeinterval"
     },
     "URL": {
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "URL is a custom URL type that allows validation at configuration load time.",
+      "title": "A URL represents a parsed URL (technically, a URI reference).",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -5079,7 +5141,7 @@
           "$ref": "#/definitions/Userinfo"
         }
       },
-      "x-go-package": "github.com/prometheus/common/config"
+      "x-go-package": "net/url"
     },
     "Userinfo": {
       "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -5276,7 +5338,6 @@
       "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
     },
     "alertGroup": {
-      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -5299,6 +5360,8 @@
           "$ref": "#/definitions/receiver"
         }
       },
+      "x-go-name": "AlertGroup",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/alertGroup"
     },
     "alertGroups": {
@@ -5491,11 +5554,12 @@
       "$ref": "#/definitions/gettableAlert"
     },
     "gettableAlerts": {
-      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableAlert"
       },
+      "x-go-name": "GettableAlerts",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/gettableAlerts"
     },
     "gettableSilence": {
@@ -5555,11 +5619,12 @@
       "$ref": "#/definitions/gettableSilence"
     },
     "gettableSilences": {
-      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
       },
+      "x-go-name": "GettableSilences",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/gettableSilences"
     },
     "labelSet": {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1352,6 +1352,14 @@
         "operationId": "RoutePutMuteTiming",
         "parameters": [
           {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Template Name",
+            "name": "name",
+            "in": "path",
+            "required": true
+          },
+          {
             "name": "Body",
             "in": "body",
             "schema": {
@@ -1380,9 +1388,22 @@
         ],
         "summary": "Delete a mute timing.",
         "operationId": "RouteDeleteMuteTiming",
+        "parameters": [
+          {
+            "type": "string",
+            "x-go-name": "Name",
+            "description": "Template Name",
+            "name": "name",
+            "in": "path",
+            "required": true
+          }
+        ],
         "responses": {
           "204": {
-            "$ref": "#/responses/Accepted"
+            "description": "Ack",
+            "schema": {
+              "$ref": "#/definitions/Ack"
+            }
           }
         }
       }
@@ -5106,9 +5127,8 @@
       "x-go-package": "github.com/prometheus/alertmanager/timeinterval"
     },
     "URL": {
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "title": "URL is a custom URL type that allows validation at configuration load time.",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -5141,7 +5161,7 @@
           "$ref": "#/definitions/Userinfo"
         }
       },
-      "x-go-package": "net/url"
+      "x-go-package": "github.com/prometheus/common/config"
     },
     "Userinfo": {
       "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -5338,6 +5358,7 @@
       "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
     },
     "alertGroup": {
+      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -5360,16 +5381,15 @@
           "$ref": "#/definitions/receiver"
         }
       },
-      "x-go-name": "AlertGroup",
-      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/alertGroup"
     },
     "alertGroups": {
-      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "$ref": "#/definitions/alertGroup"
       },
+      "x-go-name": "AlertGroups",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/alertGroups"
     },
     "alertStatus": {
@@ -5554,12 +5574,11 @@
       "$ref": "#/definitions/gettableAlert"
     },
     "gettableAlerts": {
+      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableAlert"
       },
-      "x-go-name": "GettableAlerts",
-      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/gettableAlerts"
     },
     "gettableSilence": {

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -10,7 +10,6 @@ import (
 	"github.com/prometheus/alertmanager/config"
 )
 
-// MuteTimingService is a golang API for handling mute timings.
 type MuteTimingService struct {
 	config AMConfigStore
 	prov   ProvisioningStore

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -163,7 +163,7 @@ func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, name string,
 	for i, existing := range revision.cfg.AlertmanagerConfig.MuteTimeIntervals {
 		if name == existing.Name {
 			intervals := revision.cfg.AlertmanagerConfig.MuteTimeIntervals
-			intervals = append(intervals[:i], intervals[i+1:]...)
+			revision.cfg.AlertmanagerConfig.MuteTimeIntervals = append(intervals[:i], intervals[i+1:]...)
 		}
 	}
 

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -28,8 +28,8 @@ func NewMuteTimingService(config AMConfigStore, prov ProvisioningStore, xact Tra
 }
 
 // GetMuteTimings returns a slice of all mute timings within the specified org.
-func (m *MuteTimingService) GetMuteTimings(ctx context.Context, orgID int64) ([]definitions.MuteTimeInterval, error) {
-	rev, err := getLastConfiguration(ctx, orgID, m.config)
+func (svc *MuteTimingService) GetMuteTimings(ctx context.Context, orgID int64) ([]definitions.MuteTimeInterval, error) {
+	rev, err := getLastConfiguration(ctx, orgID, svc.config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -2,11 +2,15 @@ package provisioning
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/prometheus/alertmanager/config"
 )
 
+// MuteTimingService is a golang API for handling mute timings.
 type MuteTimingService struct {
 	config AMConfigStore
 	prov   ProvisioningStore
@@ -23,19 +27,167 @@ func NewMuteTimingService(config AMConfigStore, prov ProvisioningStore, xact Tra
 	}
 }
 
-func (m *MuteTimingService) GetMuteTimings(ctx context.Context, orgID int64) ([]definitions.MuteTiming, error) {
+// GetMuteTimings returns a slice of all mute timings within the specified org.
+func (m *MuteTimingService) GetMuteTimings(ctx context.Context, orgID int64) ([]definitions.MuteTimeInterval, error) {
 	rev, err := getLastConfiguration(ctx, orgID, m.config)
 	if err != nil {
 		return nil, err
 	}
 
 	if rev.cfg.AlertmanagerConfig.MuteTimeIntervals == nil {
-		return []definitions.MuteTiming{}, nil
+		return []definitions.MuteTimeInterval{}, nil
 	}
 
-	result := make([]definitions.MuteTiming, 0, len(rev.cfg.AlertmanagerConfig.MuteTimeIntervals))
+	result := make([]definitions.MuteTimeInterval, 0, len(rev.cfg.AlertmanagerConfig.MuteTimeIntervals))
 	for _, interval := range rev.cfg.AlertmanagerConfig.MuteTimeIntervals {
-		result = append(result, definitions.MuteTiming{MuteTimeInterval: interval})
+		result = append(result, definitions.MuteTimeInterval{MuteTimeInterval: interval})
 	}
 	return result, nil
+}
+
+// CreateMuteTiming adds a new mute timing within the specified org. The created mute timing is returned.
+func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt definitions.MuteTimeInterval, orgID int64) (*definitions.MuteTimeInterval, error) {
+	if err := mt.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrValidation, err.Error())
+	}
+
+	revision, err := getLastConfiguration(ctx, orgID, svc.config)
+	if err != nil {
+		return nil, err
+	}
+
+	if revision.cfg.AlertmanagerConfig.MuteTimeIntervals == nil {
+		revision.cfg.AlertmanagerConfig.MuteTimeIntervals = []config.MuteTimeInterval{}
+	}
+	for _, existing := range revision.cfg.AlertmanagerConfig.MuteTimeIntervals {
+		if mt.Name == existing.Name {
+			return nil, fmt.Errorf("%w: %s", ErrValidation, "a mute timing with this name already exists")
+		}
+	}
+	revision.cfg.AlertmanagerConfig.MuteTimeIntervals = append(revision.cfg.AlertmanagerConfig.MuteTimeIntervals, mt.MuteTimeInterval)
+
+	serialized, err := serializeAlertmanagerConfig(*revision.cfg)
+	if err != nil {
+		return nil, err
+	}
+	cmd := models.SaveAlertmanagerConfigurationCmd{
+		AlertmanagerConfiguration: string(serialized),
+		ConfigurationVersion:      revision.version,
+		FetchedConfigurationHash:  revision.concurrencyToken,
+		Default:                   false,
+		OrgID:                     orgID,
+	}
+	err = svc.xact.InTransaction(ctx, func(ctx context.Context) error {
+		err = svc.config.UpdateAlertmanagerConfiguration(ctx, &cmd)
+		if err != nil {
+			return err
+		}
+		err = svc.prov.SetProvenance(ctx, &mt, orgID, mt.Provenance)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &mt, nil
+}
+
+// UpdateMuteTiming replaces an existing mute timing within the specified org. The replaced mute timing is returned. If the mute timing does not exist, nil is returned and no action is taken.
+func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitions.MuteTimeInterval, orgID int64) (*definitions.MuteTimeInterval, error) {
+	if err := mt.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrValidation, err.Error())
+	}
+
+	revision, err := getLastConfiguration(ctx, orgID, svc.config)
+	if err != nil {
+		return nil, err
+	}
+
+	if revision.cfg.AlertmanagerConfig.MuteTimeIntervals == nil {
+		return nil, nil
+	}
+	updated := false
+	for i, existing := range revision.cfg.AlertmanagerConfig.MuteTimeIntervals {
+		if mt.Name == existing.Name {
+			revision.cfg.AlertmanagerConfig.MuteTimeIntervals[i] = mt.MuteTimeInterval
+			updated = true
+			break
+		}
+	}
+	if !updated {
+		return nil, nil
+	}
+
+	serialized, err := serializeAlertmanagerConfig(*revision.cfg)
+	if err != nil {
+		return nil, err
+	}
+	cmd := models.SaveAlertmanagerConfigurationCmd{
+		AlertmanagerConfiguration: string(serialized),
+		ConfigurationVersion:      revision.version,
+		FetchedConfigurationHash:  revision.concurrencyToken,
+		Default:                   false,
+		OrgID:                     orgID,
+	}
+	err = svc.xact.InTransaction(ctx, func(ctx context.Context) error {
+		err = svc.config.UpdateAlertmanagerConfiguration(ctx, &cmd)
+		if err != nil {
+			return err
+		}
+		err = svc.prov.SetProvenance(ctx, &mt, orgID, mt.Provenance)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &mt, err
+}
+
+// DeleteMuteTiming deletes the mute timing with the given name in the given org. If the mute timing does not exist, no error is returned.
+func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, name string, orgID int64) error {
+	revision, err := getLastConfiguration(ctx, orgID, svc.config)
+	if err != nil {
+		return err
+	}
+
+	if revision.cfg.AlertmanagerConfig.MuteTimeIntervals == nil {
+		return nil
+	}
+	for i, existing := range revision.cfg.AlertmanagerConfig.MuteTimeIntervals {
+		if name == existing.Name {
+			intervals := revision.cfg.AlertmanagerConfig.MuteTimeIntervals
+			intervals = append(intervals[:i], intervals[i+1:]...)
+		}
+	}
+
+	serialized, err := serializeAlertmanagerConfig(*revision.cfg)
+	if err != nil {
+		return err
+	}
+	cmd := models.SaveAlertmanagerConfigurationCmd{
+		AlertmanagerConfiguration: string(serialized),
+		ConfigurationVersion:      revision.version,
+		FetchedConfigurationHash:  revision.concurrencyToken,
+		Default:                   false,
+		OrgID:                     orgID,
+	}
+	return svc.xact.InTransaction(ctx, func(ctx context.Context) error {
+		err = svc.config.UpdateAlertmanagerConfiguration(ctx, &cmd)
+		if err != nil {
+			return err
+		}
+		target := definitions.MuteTimeInterval{MuteTimeInterval: config.MuteTimeInterval{Name: name}}
+		err := svc.prov.DeleteProvenance(ctx, &target, orgID)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds endpoints for provisioning mute timings:
`POST /api/provisioning/mute-timings`
`PUT /api/provisioning/mute-timings{name}`
`DELETE /api/provisioning/mute-timings{name}`

**Which issue(s) this PR fixes**:

Rel https://github.com/grafana/grafana/issues/36153

**Special notes for your reviewer**:

