### PR TITLE
Timeseries: Refresh data in OutsideRangePlugin

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/OutsideRangePlugin.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useRef } from 'react';
-import uPlot from 'uplot';
+import uPlot, { TypedArray } from 'uplot';
 
 import { TimeRange, AbsoluteTimeRange } from '@grafana/data';
 import { UPlotConfigBuilder, Button } from '@grafana/ui';
@@ -12,15 +12,18 @@ interface ThresholdControlsPluginProps {
 
 export const OutsideRangePlugin: React.FC<ThresholdControlsPluginProps> = ({ config, range, onChangeTimeRange }) => {
   const plotInstance = useRef<uPlot>();
+  const [timevalues, setTimeValues] = React.useState<number[] | TypedArray>([]);
 
   useLayoutEffect(() => {
     config.addHook('init', (u) => {
       plotInstance.current = u;
     });
+    config.addHook('setData', (u) => {
+      setTimeValues(plotInstance.current?.data?.[0] ?? []);
+    });
   }, [config]);
 
-  const timevalues = plotInstance.current?.data?.[0];
-  if (!timevalues || !plotInstance.current || timevalues.length < 2 || !onChangeTimeRange) {
+  if (timevalues.length < 2 || !onChangeTimeRange) {
     return null;
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This forces a refresh of data in the zoom to data popup on timeseries panels with the uPlot `setData` hook.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #49625 

**Special notes for your reviewer**:

