### PR TITLE
SearchV2 - Fix starred dashboards for new organizations error

### DIFF
--- a/pkg/api/stars.go
+++ b/pkg/api/stars.go
@@ -27,10 +27,11 @@ func (hs *HTTPServer) GetStars(c *models.ReqContext) response.Response {
 			OrgId: c.OrgId,
 		}
 		err := hs.dashboardService.GetDashboard(c.Req.Context(), query)
-		if err != nil {
-			return response.Error(500, "Failed to get dashboard", err)
+
+		// sometimes we don't find the dashboard because it belongs to a different OrgId that the user is in
+		if err == nil {
+			uids = append(uids, query.Result.Uid)
 		}
-		uids = append(uids, query.Result.Uid)
 	}
 	return response.JSON(200, uids)
 }

--- a/pkg/api/stars.go
+++ b/pkg/api/stars.go
@@ -28,7 +28,7 @@ func (hs *HTTPServer) GetStars(c *models.ReqContext) response.Response {
 		}
 		err := hs.dashboardService.GetDashboard(c.Req.Context(), query)
 
-		// sometimes we don't find the dashboard because it belongs to a different OrgId that the user is in
+		// Grafana admin users may have starred dashboards in multiple orgs.  This will avoid returning errors when the dashboard is in another org
 		if err == nil {
 			uids = append(uids, query.Result.Uid)
 		}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

On the new search page, we were getting an error on the `api/user/stars` endpoint when switching organizations

After this PR


https://user-images.githubusercontent.com/239999/170338502-9d291fea-94e2-4391-9e6e-0f7e00885c3d.mp4



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #49613

**Special notes for your reviewer**:
I am not a backender feel free to remove this solution if it doesn't work 🙈 