### PR TITLE
Preferences: Fix updating of preferences for Navbar and Query History

### DIFF
--- a/pkg/api/dtos/prefs.go
+++ b/pkg/api/dtos/prefs.go
@@ -25,8 +25,8 @@ type UpdatePrefsCmd struct {
 	// Enum: utc,browser
 	Timezone     string                         `json:"timezone"`
 	WeekStart    string                         `json:"weekStart"`
-	Navbar       *pref.NavbarPreference        `json:"navbar,omitempty"`
-	QueryHistory *pref.QueryHistoryPreference `json:"queryHistory,omitempty"`
+	Navbar       *pref.NavbarPreference         `json:"navbar,omitempty"`
+	QueryHistory *pref.QueryHistoryPreference   `json:"queryHistory,omitempty"`
 }
 
 // swagger:model

--- a/pkg/api/dtos/prefs.go
+++ b/pkg/api/dtos/prefs.go
@@ -23,10 +23,10 @@ type UpdatePrefsCmd struct {
 	HomeDashboardID  int64   `json:"homeDashboardId"`
 	HomeDashboardUID *string `json:"homeDashboardUID,omitempty"`
 	// Enum: utc,browser
-	Timezone     string                         `json:"timezone"`
-	WeekStart    string                         `json:"weekStart"`
-	Navbar       *pref.NavbarPreference         `json:"navbar,omitempty"`
-	QueryHistory *pref.QueryHistoryPreference   `json:"queryHistory,omitempty"`
+	Timezone     string                       `json:"timezone"`
+	WeekStart    string                       `json:"weekStart"`
+	Navbar       *pref.NavbarPreference       `json:"navbar,omitempty"`
+	QueryHistory *pref.QueryHistoryPreference `json:"queryHistory,omitempty"`
 }
 
 // swagger:model

--- a/pkg/api/dtos/prefs.go
+++ b/pkg/api/dtos/prefs.go
@@ -1,7 +1,6 @@
 package dtos
 
 import (
-	"github.com/grafana/grafana/pkg/models"
 	pref "github.com/grafana/grafana/pkg/services/preference"
 )
 
@@ -26,8 +25,8 @@ type UpdatePrefsCmd struct {
 	// Enum: utc,browser
 	Timezone     string                         `json:"timezone"`
 	WeekStart    string                         `json:"weekStart"`
-	Navbar       *models.NavbarPreference       `json:"navbar,omitempty"`
-	QueryHistory *models.QueryHistoryPreference `json:"queryHistory,omitempty"`
+	Navbar       *pref.NavbarPreference        `json:"navbar,omitempty"`
+	QueryHistory *pref.QueryHistoryPreference `json:"queryHistory,omitempty"`
 }
 
 // swagger:model

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -120,6 +120,8 @@ func (hs *HTTPServer) updatePreferencesFor(ctx context.Context, orgID, userID, t
 		Timezone:        dtoCmd.Timezone,
 		WeekStart:       dtoCmd.WeekStart,
 		HomeDashboardID: dtoCmd.HomeDashboardID,
+		QueryHistory: 	 dtoCmd.QueryHistory,
+		Navbar:					 dtoCmd.Navbar,
 	}
 
 	if err := hs.preferenceService.Save(ctx, &saveCmd); err != nil {

--- a/pkg/api/preferences.go
+++ b/pkg/api/preferences.go
@@ -120,8 +120,8 @@ func (hs *HTTPServer) updatePreferencesFor(ctx context.Context, orgID, userID, t
 		Timezone:        dtoCmd.Timezone,
 		WeekStart:       dtoCmd.WeekStart,
 		HomeDashboardID: dtoCmd.HomeDashboardID,
-		QueryHistory: 	 dtoCmd.QueryHistory,
-		Navbar:					 dtoCmd.Navbar,
+		QueryHistory:    dtoCmd.QueryHistory,
+		Navbar:          dtoCmd.Navbar,
 	}
 
 	if err := hs.preferenceService.Save(ctx, &saveCmd); err != nil {

--- a/pkg/services/preference/model.go
+++ b/pkg/services/preference/model.go
@@ -9,7 +9,6 @@ import (
 	pref "github.com/grafana/grafana/pkg/services/preference"
 )
 
-
 var ErrPrefNotFound = errors.New("preference not found")
 
 type Preference struct {

--- a/pkg/services/preference/model.go
+++ b/pkg/services/preference/model.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"time"
+
+	pref "github.com/grafana/grafana/pkg/services/preference"
 )
+
 
 var ErrPrefNotFound = errors.New("preference not found")
 
@@ -47,8 +50,8 @@ type SavePreferenceCommand struct {
 	Timezone         string                  `json:"timezone,omitempty"`
 	WeekStart        string                  `json:"weekStart,omitempty"`
 	Theme            string                  `json:"theme,omitempty"`
-	Navbar           *NavbarPreference       `json:"navbar,omitempty"`
-	QueryHistory     *QueryHistoryPreference `json:"queryHistory,omitempty"`
+	Navbar           *pref.NavbarPreference       `json:"navbar,omitempty"`
+	QueryHistory     *pref.QueryHistoryPreference `json:"queryHistory,omitempty"`
 }
 
 type PatchPreferenceCommand struct {
@@ -61,8 +64,8 @@ type PatchPreferenceCommand struct {
 	Timezone         *string                 `json:"timezone,omitempty"`
 	WeekStart        *string                 `json:"weekStart,omitempty"`
 	Theme            *string                 `json:"theme,omitempty"`
-	Navbar           *NavbarPreference       `json:"navbar,omitempty"`
-	QueryHistory     *QueryHistoryPreference `json:"queryHistory,omitempty"`
+	Navbar           *pref.NavbarPreference       `json:"navbar,omitempty"`
+	QueryHistory     *pref.QueryHistoryPreference `json:"queryHistory,omitempty"`
 }
 
 type NavLink struct {
@@ -72,18 +75,11 @@ type NavLink struct {
 	Target string `json:"target,omitempty"`
 }
 
-type NavbarPreference struct {
-	SavedItems []NavLink `json:"savedItems"`
-}
-
 type PreferenceJSONData struct {
-	Navbar       NavbarPreference       `json:"navbar"`
-	QueryHistory QueryHistoryPreference `json:"queryHistory"`
+	Navbar       pref.NavbarPreference       `json:"navbar"`
+	QueryHistory pref.QueryHistoryPreference `json:"queryHistory"`
 }
 
-type QueryHistoryPreference struct {
-	HomeTab string `json:"homeTab"`
-}
 
 func (j *PreferenceJSONData) FromDB(data []byte) error {
 	dec := json.NewDecoder(bytes.NewBuffer(data))

--- a/pkg/services/preference/model.go
+++ b/pkg/services/preference/model.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"time"
-
-	pref "github.com/grafana/grafana/pkg/services/preference"
 )
 
 var ErrPrefNotFound = errors.New("preference not found")
@@ -49,8 +47,8 @@ type SavePreferenceCommand struct {
 	Timezone         string                  `json:"timezone,omitempty"`
 	WeekStart        string                  `json:"weekStart,omitempty"`
 	Theme            string                  `json:"theme,omitempty"`
-	Navbar           *pref.NavbarPreference       `json:"navbar,omitempty"`
-	QueryHistory     *pref.QueryHistoryPreference `json:"queryHistory,omitempty"`
+	Navbar           *NavbarPreference       `json:"navbar,omitempty"`
+	QueryHistory     *QueryHistoryPreference `json:"queryHistory,omitempty"`
 }
 
 type PatchPreferenceCommand struct {
@@ -63,8 +61,8 @@ type PatchPreferenceCommand struct {
 	Timezone         *string                 `json:"timezone,omitempty"`
 	WeekStart        *string                 `json:"weekStart,omitempty"`
 	Theme            *string                 `json:"theme,omitempty"`
-	Navbar           *pref.NavbarPreference       `json:"navbar,omitempty"`
-	QueryHistory     *pref.QueryHistoryPreference `json:"queryHistory,omitempty"`
+	Navbar           *NavbarPreference       `json:"navbar,omitempty"`
+	QueryHistory     *QueryHistoryPreference `json:"queryHistory,omitempty"`
 }
 
 type NavLink struct {
@@ -74,11 +72,18 @@ type NavLink struct {
 	Target string `json:"target,omitempty"`
 }
 
-type PreferenceJSONData struct {
-	Navbar       pref.NavbarPreference       `json:"navbar"`
-	QueryHistory pref.QueryHistoryPreference `json:"queryHistory"`
+type NavbarPreference struct {
+	SavedItems []NavLink `json:"savedItems"`
 }
 
+type PreferenceJSONData struct {
+	Navbar       NavbarPreference       `json:"navbar"`
+	QueryHistory QueryHistoryPreference `json:"queryHistory"`
+}
+
+type QueryHistoryPreference struct {
+	HomeTab string `json:"homeTab"`
+}
 
 func (j *PreferenceJSONData) FromDB(data []byte) error {
 	dec := json.NewDecoder(bytes.NewBuffer(data))


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/grafana/grafana/pull/47506 we have added updating of query history preferences using PATCH method. However, when user if in their user preferences, we are using PUT method to override all settings and it was missing handling for preferences of query history (and navbar). This causes a bug where query history home tab settings are removed if a user saves any preferences using User Preferences panel.

I was fixing Query history part, but noticed that the same probably happens for navbar settings, so I updated that as well. @ashharrison90 could you please have a look if it make sense.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/49322

**Special notes for your reviewer**:

How to reproduce:
1. Got to Explore ->  Query History 
2. Change Query history tab settings
3. Go to User -> Preferences
4. Change any preferences e.g. timezone (queryHistory is passed in the payload)
5. When the page is reloaded /preferences/ endpoint contains empty (default) queryHistory entry
