### PR TITLE
Explore: Reset Graph overrides if underlying series changes

### DIFF
--- a/public/app/features/explore/ExploreGraph.tsx
+++ b/public/app/features/explore/ExploreGraph.tsx
@@ -75,12 +75,8 @@ export function ExploreGraph({
 
   const previousData = usePrevious(data);
   const structureChangesRef = useRef(0);
-
-  if (data && previousData && !compareArrayValues(previousData, data, compareDataFrameStructures)) {
-    structureChangesRef.current++;
-  }
-
   const structureRev = baseStructureRev + structureChangesRef.current;
+  const prevStructureRev = usePrevious(structureRev);
 
   const [fieldConfig, setFieldConfig] = useState<FieldConfigSource>({
     defaults: {
@@ -95,6 +91,14 @@ export function ExploreGraph({
     },
     overrides: [],
   });
+
+  if (data && previousData && !compareArrayValues(previousData, data, compareDataFrameStructures)) {
+    structureChangesRef.current++;
+
+    if (prevStructureRev === structureRev) {
+      setFieldConfig({ ...fieldConfig, overrides: [] });
+    }
+  }
 
   const style = useStyles2(getStyles);
   const timeRange = {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Resets Graph series overrides in Explore when query(ies) return a different dataframe structure (ie. when a query returns a different set of series).

Currently if a user decides to show only some series (which actually mean hiding every series except for the selected ones), and triggers another query run that returns a different set of series, they would all be hidden. Given that the legend styles for hidden series is very subtle this could be confusing as the page would show a panel with no data even if the legend would show all the series. More details in the linked issue.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #48265


