### PR TITLE
Docs: Clarify how PR titles should be formatted

### DIFF
--- a/contribute/create-pull-request.md
+++ b/contribute/create-pull-request.md
@@ -117,11 +117,14 @@ If you're unsure, see the existing [changelog](https://github.com/grafana/grafan
 
 ### Pull request titles
 
+The pull request title should be formatted according to `<Area>: <Summary>` (Both "Area" and "Summary" should start with a capital letter).
+
 The Grafana team _squashes_ all commits into one when we accept a pull request. The title of the pull request becomes the subject line of the squashed commit message. We still encourage contributors to write informative commit messages, as they becomes a part of the Git commit body.
 
 We use the pull request title when we generate change logs for releases. As such, we strive to make the title as informative as possible.
 
-Make sure that the title for your pull request uses the same format as the subject line in the commit message.
+**Example:**
+`Docs: Change url to URL in all documentation files`
 
 ## Configuration changes
 

--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -27,9 +27,14 @@ Before you can merge a pull request, it must have a review approval, and all the
 
 ### Format the pull request title
 
-The pull request title should be formatted according to `<Area>: <Summary>`. Keep the summary short and understandable for the community as a whole.
+The pull request title should be formatted according to `<Area>: <Summary>` (Both "Area" and "Summary" should start with a capital letter).
+
+Keep the summary short and understandable for the community as a whole.
 
 All commits in a pull request are squashed when merged and the pull request title will be the default subject line of the squashed commit message. It's also used for [changelog/release notes](#include-in-changelog-and-release-notes).
+
+**Example:**
+`Docs: Change url to URL in all documentation files`
 
 See [formatting guidelines](create-pull-request.md#formatting-guidelines) for more information.
 


### PR DESCRIPTION
### What changed?

Updated the contribution docs to make it more clear that in the PR titles both the "Area" and the "Summary" should be capitalised.

[Link to updated `merge-pull-request.md`](https://github.com/grafana/grafana/blob/leventebalogh/contribution-guidelines/contribute/merge-pull-request.md#format-the-pull-request-title)
[Link to updated `create-pull-request.md`](https://github.com/grafana/grafana/blob/leventebalogh/contribution-guidelines/contribute/create-pull-request.md#pull-request-titles)