### PR TITLE
Alerting: Add GetImages to ImageStore

### DIFF
--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -27,6 +27,10 @@ func (f *FakeConfigStore) GetImage(ctx context.Context, token string) (*models.I
 	return nil, models.ErrImageNotFound
 }
 
+func (f *FakeConfigStore) GetImages(ctx context.Context, tokens []string) ([]models.Image, error) {
+	return nil, models.ErrImageNotFound
+}
+
 func NewFakeConfigStore(t *testing.T, configs map[int64]*models.AlertConfiguration) FakeConfigStore {
 	t.Helper()
 

--- a/pkg/services/ngalert/store/image_test.go
+++ b/pkg/services/ngalert/store/image_test.go
@@ -5,7 +5,6 @@ package store_test
 
 import (
 	"context"
-	"sort"
 	"testing"
 	"time"
 
@@ -94,12 +93,6 @@ func TestIntegrationSaveAndGetImage(t *testing.T) {
 	}
 }
 
-type imagesByID []models.Image
-
-func (s imagesByID) Len() int           { return len(s) }
-func (s imagesByID) Less(i, j int) bool { return s[i].ID < s[j].ID }
-func (s imagesByID) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-
 func TestIntegrationGetImages(t *testing.T) {
 	mockTimeNow()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -122,9 +115,7 @@ func TestIntegrationGetImages(t *testing.T) {
 	// GetImages should return both images
 	imgs, err = dbstore.GetImages(ctx, []string{img1.Token, img2.Token})
 	require.NoError(t, err)
-	v := imagesByID(imgs)
-	sort.Sort(v)
-	assert.Equal(t, imagesByID{img1, img2}, v)
+	assert.ElementsMatch(t, []models.Image{img1, img2}, imgs)
 
 	// GetImages should return the first image
 	imgs, err = dbstore.GetImages(ctx, []string{img1.Token})


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `GetImages` to `ImageStore` so we can retrieve all images for an alert notification at the same time.
