### PR TITLE
license: Make coremodels all Apache v2

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -17,6 +17,8 @@ packages/grafana-toolkit/
 packages/grafana-ui/
 packages/jaeger-ui-components/
 packaging/
+pkg/coremodel/
+pkg/framework/coremodel/
 grafana-mixin/
 cue/
 ```


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This marks all individual coremodels, and the framework for consuming them, as Apache v2. This is necessary in order to allow external libs in Go/CUE/etc. to also be Apache 2.

This isn't anything new - it's the same idea as marking e.g. `@grafana-schema` as Apache 2. (Which i guess we do by keeping separate LICENSE files in their roots) Just keeping up with the new places that the code is now living.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

