### PR TITLE
Loki: Fix unwrap parsing in query builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/experimental": "^0.0.2-canary.30",
     "@grafana/google-sdk": "0.0.3",
-    "@grafana/lezer-logql": "^0.0.11",
+    "@grafana/lezer-logql": "^0.0.12",
     "@grafana/runtime": "workspace:*",
     "@grafana/schema": "workspace:*",
     "@grafana/slate-react": "0.22.10-grafana",

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -220,6 +220,50 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
+  it('parses query with with unwrap and error filter', () => {
+    expect(
+      buildVisualQueryFromString('sum_over_time({app="frontend"} | logfmt | unwrap duration | __error__="" [1m])')
+    ).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [
+          { id: 'logfmt', params: [] },
+          { id: 'unwrap', params: ['duration'] },
+          { id: '__label_filter_no_errors', params: [] },
+          { id: 'sum_over_time', params: ['1m'] },
+        ],
+      })
+    );
+  });
+
+  it('parses query with with unwrap and label filter', () => {
+    expect(
+      buildVisualQueryFromString('sum_over_time({app="frontend"} | logfmt | unwrap duration | label="value" [1m])')
+    ).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [
+          { id: 'logfmt', params: [] },
+          { id: 'unwrap', params: ['duration'] },
+          { id: '__label_filter', params: ['label', '=', 'value'] },
+          { id: 'sum_over_time', params: ['1m'] },
+        ],
+      })
+    );
+  });
+
   it('returns error for query with unwrap and conversion operation', () => {
     const context = buildVisualQueryFromString(
       'sum_over_time({app="frontend"} | logfmt | unwrap duration(label) [5m])'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4011,14 +4011,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/lezer-logql@npm:^0.0.11":
-  version: 0.0.11
-  resolution: "@grafana/lezer-logql@npm:0.0.11"
+"@grafana/lezer-logql@npm:^0.0.12":
+  version: 0.0.12
+  resolution: "@grafana/lezer-logql@npm:0.0.12"
   dependencies:
     lezer: ^0.13.5
   peerDependencies:
     "@lezer/lr": ^0.15.8
-  checksum: 0427e59528ea5092e53a70b9b6be37b0ed29ca4c0ddf452cc192f8bd14d21a725ba1959b2e33e7567b42e4d0391cff4e4f36c249d7099a157d0f1e9093ba64e4
+  checksum: d28780b41a97b69a427390ef746e09a131e6a151be0894763e5cfe26fa16ae37fa5fe7409ea956f5e29974a5966162318a51bcd47422e9a3e609ca43340bbdcb
   languageName: node
   linkType: hard
 
@@ -19715,7 +19715,7 @@ __metadata:
     "@grafana/eslint-config": 3.0.0
     "@grafana/experimental": ^0.0.2-canary.30
     "@grafana/google-sdk": 0.0.3
-    "@grafana/lezer-logql": ^0.0.11
+    "@grafana/lezer-logql": ^0.0.12
     "@grafana/runtime": "workspace:*"
     "@grafana/schema": "workspace:*"
     "@grafana/slate-react": 0.22.10-grafana


### PR DESCRIPTION
**What this PR does / why we need it**:
In this PR, we are fixing parsing of `unwrap` with `duration` label. We are updating `@grafana/lezer-logql` version to `0.0.12` to include changes implemented in https://github.com/grafana/lezer-logql/pull/7. Moreover, we are updating parsin based on these changes. 

To test:

1. Specify this text query `sum(sum_over_time({job="grafana"} |= "error" | logfmt | unwrap duration | __error__="" [$__interval]))`
1. Move to builder mode

This should work. 

We are currently not supporting unwrap with conversion operator, so following query should still result in error: `sum(sum_over_time({job="grafana"} |= "error" | logfmt | unwrap duration(label) | __error__="" [$__interval]))`.

I have also added tests for these scenarios.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/49401

