### PR TITLE
CloudWatch: Add multi-value template variable support for log group names in logs query builder

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -179,8 +179,8 @@ exports[`no enzyme tests`] = {
     "public/app/plugins/datasource/cloudwatch/components/ConfigEditor.test.tsx:1224072551": [
       [0, 19, 13, "RegExp match", "2409514259"]
     ],
-    "public/app/plugins/datasource/cloudwatch/components/LogsQueryField.test.tsx:2097436158": [
-      [1, 19, 13, "RegExp match", "2409514259"]
+    "public/app/plugins/datasource/cloudwatch/components/LogsQueryField.test.tsx:1501504663": [
+      [2, 19, 13, "RegExp match", "2409514259"]
     ],
     "public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.test.tsx:3481855642": [
       [0, 26, 13, "RegExp match", "2409514259"]

--- a/public/app/plugins/datasource/cloudwatch/__mocks__/CloudWatchDataSource.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/CloudWatchDataSource.ts
@@ -149,3 +149,45 @@ export const dimensionVariable: CustomVariableModel = {
   ],
   multi: false,
 };
+
+export const logGroupNamesVariable: CustomVariableModel = {
+  ...initialCustomVariableModelState,
+  id: 'groups',
+  name: 'groups',
+  current: {
+    value: ['templatedGroup-1', 'templatedGroup-2'],
+    text: ['templatedGroup-1', 'templatedGroup-2'],
+    selected: true,
+  },
+  options: [
+    { value: 'templatedGroup-1', text: 'templatedGroup-1', selected: true },
+    { value: 'templatedGroup-2', text: 'templatedGroup-2', selected: true },
+  ],
+  multi: true,
+};
+
+export const regionVariable: CustomVariableModel = {
+  ...initialCustomVariableModelState,
+  id: 'region',
+  name: 'region',
+  current: {
+    value: 'templatedRegion',
+    text: 'templatedRegion',
+    selected: true,
+  },
+  options: [{ value: 'templatedRegion', text: 'templatedRegion', selected: true }],
+  multi: false,
+};
+
+export const expressionVariable: CustomVariableModel = {
+  ...initialCustomVariableModelState,
+  id: 'fields',
+  name: 'fields',
+  current: {
+    value: 'templatedField',
+    text: 'templatedField',
+    selected: true,
+  },
+  options: [{ value: 'templatedField', text: 'templatedField', selected: true }],
+  multi: false,
+};

--- a/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/LogsQueryField.tsx
@@ -27,6 +27,7 @@ import { CloudWatchLanguageProvider } from '../language_provider';
 import syntax from '../syntax';
 import { CloudWatchJsonData, CloudWatchLogsQuery, CloudWatchQuery } from '../types';
 import { getStatsGroups } from '../utils/query/getStatsGroups';
+import { appendTemplateVariables } from '../utils/utils';
 
 import QueryHeader from './QueryHeader';
 
@@ -310,7 +311,7 @@ export class CloudWatchLogsQueryField extends React.PureComponent<CloudWatchLogs
               <MultiSelect
                 aria-label="Log Groups"
                 allowCustomValue={allowCustomValue}
-                options={unionBy(availableLogGroups, selectedLogGroups, 'value')}
+                options={appendTemplateVariables(datasource, unionBy(availableLogGroups, selectedLogGroups, 'value'))}
                 value={selectedLogGroups}
                 onChange={(v) => {
                   this.setSelectedLogGroups(v);

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -233,6 +233,7 @@ export class CloudWatchDatasource
               options,
               this.timeSrv.timeRange(),
               this.replace.bind(this),
+              this.getVariableValue.bind(this),
               this.getActualRegion.bind(this),
               this.tracingDataSourceUid
             );
@@ -648,9 +649,12 @@ export class CloudWatchDatasource
         for (const fieldName of fieldsToReplace) {
           if (query.hasOwnProperty(fieldName)) {
             if (Array.isArray(anyQuery[fieldName])) {
-              anyQuery[fieldName] = anyQuery[fieldName].map((val: string) =>
-                this.replace(val, options.scopedVars, true, fieldName)
-              );
+              anyQuery[fieldName] = anyQuery[fieldName].flatMap((val: string) => {
+                if (fieldName === 'logGroupNames') {
+                  return this.getVariableValue(val, options.scopedVars || {});
+                }
+                return this.replace(val, options.scopedVars, true, fieldName);
+              });
             } else {
               anyQuery[fieldName] = this.replace(anyQuery[fieldName], options.scopedVars, true, fieldName);
             }

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
@@ -52,6 +52,7 @@ describe('addDataLinksToLogsResponse', () => {
       mockOptions,
       { ...time, raw: time },
       (s) => s ?? '',
+      (v) => [v] ?? [],
       (r) => r,
       'xrayUid'
     );

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -16,10 +16,12 @@ export async function addDataLinksToLogsResponse(
   request: DataQueryRequest<CloudWatchQuery>,
   range: TimeRange,
   replaceFn: ReplaceFn,
+  getVariableValueFn: (value: string, scopedVars: ScopedVars) => string[],
   getRegion: (region: string) => string,
   tracingDatasourceUid?: string
 ): Promise<void> {
   const replace = (target: string, fieldName?: string) => replaceFn(target, request.scopedVars, true, fieldName);
+  const getVariableValue = (target: string) => getVariableValueFn(target, request.scopedVars);
 
   for (const dataFrame of response.data as DataFrame[]) {
     const curTarget = request.targets.find((target) => target.refId === dataFrame.refId) as CloudWatchLogsQuery;
@@ -35,7 +37,7 @@ export async function addDataLinksToLogsResponse(
       } else {
         // Right now we add generic link to open the query in xray console to every field so it shows in the logs row
         // details. Unfortunately this also creates link for all values inside table which look weird.
-        field.config.links = [createAwsConsoleLink(curTarget, range, interpolatedRegion, replace)];
+        field.config.links = [createAwsConsoleLink(curTarget, range, interpolatedRegion, replace, getVariableValue)];
       }
     }
   }
@@ -65,10 +67,11 @@ function createAwsConsoleLink(
   target: CloudWatchLogsQuery,
   range: TimeRange,
   region: string,
-  replace: (target: string, fieldName?: string) => string
+  replace: (target: string, fieldName?: string) => string,
+  getVariableValue: (value: string) => string[]
 ) {
   const interpolatedExpression = target.expression ? replace(target.expression) : '';
-  const interpolatedGroups = target.logGroupNames?.map((logGroup: string) => replace(logGroup, 'log groups')) ?? [];
+  const interpolatedGroups = target.logGroupNames?.flatMap(getVariableValue) ?? [];
 
   const urlProps: AwsUrl = {
     end: range.to.toISOString(),


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support in the frontend for multi-value template variables. The backend already supports it.

Currently on the frontend, the `logGroupNames` field in the query is an array of strings. Each value in the array is a log group name. When using a multi-value template variable, all of the selected values are joined in a single string. E.g. if you had the values `log-group-name-1` and `log-group-name-2`, it would be:

```js
logGroupNames: ["log-group-name-1,log-group-name-2"],
```

This PR uses `getVariableValue` to get the variable values and splits them so each individual log group name correctly passed in the query to the backend.

```js
logGroupNames: ["log-group-name-1", "log-group-name-2"],
```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #49540

**Special notes for your reviewer**:
If you want to test this, you'll have to manually enter the variable into the Log groups field.

<img width="357" alt="Screen Shot 2022-05-26 at 12 33 30 PM" src="https://user-images.githubusercontent.com/19530599/170563515-d2a727fe-6b54-4e44-8bd2-08b31830149f.png">