### PR TITLE
Alerting: Add templated subject config to email notifier

### DIFF
--- a/pkg/services/ngalert/notifier/available_channels.go
+++ b/pkg/services/ngalert/notifier/available_channels.go
@@ -190,6 +190,14 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 					Element:      alerting.ElementTypeTextArea,
 					PropertyName: "message",
 				},
+				{ // New in 9.0.
+					Label:        "Subject",
+					Element:      alerting.ElementTypeInput,
+					InputType:    alerting.InputTypeText,
+					Description:  "Templated subject of the email",
+					PropertyName: "subject",
+					Placeholder:  `{{ template "default.title" . }}`,
+				},
 			},
 		},
 		{

--- a/pkg/services/ngalert/notifier/channels/email.go
+++ b/pkg/services/ngalert/notifier/channels/email.go
@@ -24,6 +24,7 @@ type EmailNotifier struct {
 	Addresses   []string
 	SingleEmail bool
 	Message     string
+	Subject     string
 	log         log.Logger
 	ns          notifications.EmailSender
 	images      ImageStore
@@ -35,6 +36,7 @@ type EmailConfig struct {
 	SingleEmail bool
 	Addresses   []string
 	Message     string
+	Subject     string
 }
 
 func EmailFactory(fc FactoryConfig) (NotificationChannel, error) {
@@ -59,6 +61,7 @@ func NewEmailConfig(config *NotificationChannelConfig) (*EmailConfig, error) {
 		NotificationChannelConfig: config,
 		SingleEmail:               config.Settings.Get("singleEmail").MustBool(false),
 		Message:                   config.Settings.Get("message").MustString(),
+		Subject:                   config.Settings.Get("subject").MustString(DefaultMessageTitleEmbed),
 		Addresses:                 addresses,
 	}, nil
 }
@@ -77,6 +80,7 @@ func NewEmailNotifier(config *EmailConfig, ns notifications.EmailSender, images 
 		Addresses:   config.Addresses,
 		SingleEmail: config.SingleEmail,
 		Message:     config.Message,
+		Subject:     config.Subject,
 		log:         log.New("alerting.notifier.email"),
 		ns:          ns,
 		images:      images,
@@ -89,7 +93,7 @@ func (en *EmailNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 	var tmplErr error
 	tmpl, data := TmplText(ctx, en.tmpl, as, en.log, &tmplErr)
 
-	title := tmpl(DefaultMessageTitleEmbed)
+	subject := tmpl(en.Subject)
 
 	alertPageURL := en.tmpl.ExternalURL.String()
 	ruleURL := en.tmpl.ExternalURL.String()
@@ -106,9 +110,9 @@ func (en *EmailNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 
 	cmd := &models.SendEmailCommandSync{
 		SendEmailCommand: models.SendEmailCommand{
-			Subject: title,
+			Subject: subject,
 			Data: map[string]interface{}{
-				"Title":             title,
+				"Title":             subject,
 				"Message":           tmpl(en.Message),
 				"Status":            data.Status,
 				"Alerts":            data.Alerts,

--- a/pkg/services/ngalert/notifier/channels/email_test.go
+++ b/pkg/services/ngalert/notifier/channels/email_test.go
@@ -232,7 +232,7 @@ func TestEmailNotifierIntegration(t *testing.T) {
 				},
 			},
 			subjectTmpl: `This notification is {{ .Status }}!`,
-			expSubject: "This notification is firing!",
+			expSubject:  "This notification is firing!",
 			expSnippets: []string{},
 		},
 	}

--- a/pkg/services/ngalert/notifier/channels/email_test.go
+++ b/pkg/services/ngalert/notifier/channels/email_test.go
@@ -117,6 +117,7 @@ func TestEmailNotifierIntegration(t *testing.T) {
 		name        string
 		alerts      []*types.Alert
 		messageTmpl string
+		subjectTmpl string
 		expSubject  string
 		expSnippets []string
 	}{
@@ -220,11 +221,25 @@ func TestEmailNotifierIntegration(t *testing.T) {
 				"&lt;li&gt;Firing: AlwaysFiring at warning &lt;/li&gt;",
 			},
 		},
+		{
+			name: "single alert with templated subject",
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "AlwaysFiring", "severity": "warning"},
+						Annotations: model.LabelSet{"runbook_url": "http://fix.me", "__dashboardUid__": "abc", "__panelId__": "5"},
+					},
+				},
+			},
+			subjectTmpl: `This notification is {{ .Status }}!`,
+			expSubject: "This notification is firing!",
+			expSnippets: []string{},
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			emailNotifier := createSut(t, c.messageTmpl, emailTmpl, ns)
+			emailNotifier := createSut(t, c.messageTmpl, c.subjectTmpl, emailTmpl, ns)
 
 			ok, err := emailNotifier.Notify(context.Background(), c.alerts...)
 			require.NoError(t, err)
@@ -271,7 +286,7 @@ func createCoreEmailService(t *testing.T) *notifications.NotificationService {
 	return ns
 }
 
-func createSut(t *testing.T, messageTmpl string, emailTmpl *template.Template, ns notifications.EmailSender) *EmailNotifier {
+func createSut(t *testing.T, messageTmpl string, subjectTmpl string, emailTmpl *template.Template, ns notifications.EmailSender) *EmailNotifier {
 	t.Helper()
 
 	json := `{
@@ -282,6 +297,11 @@ func createSut(t *testing.T, messageTmpl string, emailTmpl *template.Template, n
 	if messageTmpl != "" {
 		settingsJSON.Set("message", messageTmpl)
 	}
+
+	if subjectTmpl != "" {
+		settingsJSON.Set("subject", subjectTmpl)
+	}
+
 	require.NoError(t, err)
 	cfg, err := NewEmailConfig(&NotificationChannelConfig{
 		Name:     "ops",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a new templated config to the email notifier for the subject of the email. This is part of a larger standardization of templated message fields in notifiers: https://github.com/grafana/grafana/issues/49716

**Which issue(s) this PR fixes**:

Partial: https://github.com/grafana/grafana/issues/49716

**Special notes for your reviewer**:

New Field:

![Screenshot from 2022-05-26 18-52-35](https://user-images.githubusercontent.com/8484471/170592604-adbaddc7-8cd8-49b1-b09f-7086afd2b584.png)

Templated Subject:

<img src="https://user-images.githubusercontent.com/8484471/170592617-a3345fdb-91d8-4c6c-9584-de88ef6b22b7.png" width="500" height="400">
