### PR TITLE
PanelChrome: Fixes issue with padding not being applied as gridUnits

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -79,7 +79,7 @@ const getContentStyle = (
   headerHeight: number,
   height: number
 ) => {
-  const chromePadding = padding === 'md' ? theme.components.panel.padding : 0;
+  const chromePadding = (padding === 'md' ? theme.components.panel.padding : 0) * theme.spacing.gridSize;
   const panelBorder = 1 * 2;
   const innerWidth = width - chromePadding * 2 - panelBorder;
   const innerHeight = height - headerHeight - chromePadding * 2 - panelBorder;


### PR DESCRIPTION
This component is not used much internally yet, but used it in a branch and noticed the padding was not there.
It is not being multiplied by grid units 1 ended up as just 1px
