### PR TITLE
Run tini as PID 1 for Grafana containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ ENV PATH="/usr/share/grafana/bin:$PATH" \
 
 WORKDIR $GF_PATHS_HOME
 
-RUN apk add --no-cache ca-certificates bash tzdata musl-utils
+RUN apk add --no-cache ca-certificates bash tzdata musl-utils tini
 RUN apk add --no-cache openssl ncurses-libs ncurses-terminfo-base --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk upgrade ncurses-libs ncurses-terminfo-base --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk info -vv | sort
@@ -93,4 +93,4 @@ EXPOSE 3000
 COPY ./packaging/docker/run.sh /run.sh
 
 USER grafana
-ENTRYPOINT [ "/run.sh" ]
+ENTRYPOINT [ "/sbin/tini", "--", "/run.sh" ]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -59,7 +59,7 @@ WORKDIR $GF_PATHS_HOME
 COPY conf conf
 
 # curl should be part of the image
-RUN apt-get update && apt-get install -y ca-certificates curl
+RUN apt-get update && apt-get install -y ca-certificates curl tini
 
 RUN mkdir -p "$GF_PATHS_HOME/.aws" && \
   addgroup --system --gid $GF_GID grafana && \
@@ -84,4 +84,4 @@ COPY --from=js-builder /usr/src/app/tools tools
 COPY packaging/docker/run.sh /
 
 USER grafana
-ENTRYPOINT [ "/run.sh" ]
+ENTRYPOINT [ "/usr/bin/tini", "--", "/run.sh" ]

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -26,7 +26,7 @@ ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bi
 
 WORKDIR $GF_PATHS_HOME
 
-RUN apk add --no-cache ca-certificates bash tzdata && \
+RUN apk add --no-cache ca-certificates bash tzdata tini && \
     apk add --no-cache musl-utils
 
 RUN apk add --no-cache openssl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
@@ -73,4 +73,4 @@ EXPOSE 3000
 COPY ./run.sh /run.sh
 
 USER "$GF_UID"
-ENTRYPOINT [ "/run.sh" ]
+ENTRYPOINT [ "/sbin/tini", "--", "/run.sh" ]

--- a/packaging/docker/ubuntu.Dockerfile
+++ b/packaging/docker/ubuntu.Dockerfile
@@ -28,7 +28,7 @@ WORKDIR $GF_PATHS_HOME
 
 # Install dependencies
 # We need curl in the image
-RUN apt-get update && apt-get install -y ca-certificates curl tzdata && \
+RUN apt-get update && apt-get install -y ca-certificates curl tzdata tini && \
     apt-get autoremove -y && rm -rf /var/lib/apt/lists/*;
 
 COPY --from=grafana-builder /tmp/grafana "$GF_PATHS_HOME"
@@ -56,4 +56,4 @@ RUN export GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
 COPY ./run.sh /run.sh
 
 USER "$GF_UID"
-ENTRYPOINT [ "/run.sh" ]
+ENTRYPOINT [ "/usr/bin/tini", "--", "/run.sh" ]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Grafana containers have an `ENTRYPOINT` of a shell script which causes weird issues such as broken signal propagation and orphaned processes within a containerized environment.
See: https://hynek.me/articles/docker-signals/ for details.

This PR runs `tini` as the init process. There are other options but this one seems preferred considering that Docker has incorporated it via [Moby](https://github.com/moby/moby/blob/6b9b445af6c7908992632cff6c30cbf6a4c617ac/daemon/info_unix.go).

You'll typically see issues where there's leaked container shims or SIGTERM signals are not being propagated (container takes a long time to stop).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

