### PR TITLE
Alerting: Remove feature flag for unified alerting

### DIFF
--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -97,17 +97,8 @@ func (u *UnifiedAlertingSettings) IsEnabled() bool {
 
 func (cfg *Cfg) readUnifiedAlertingEnabledSetting(section *ini.Section) (*bool, error) {
 	enabled, err := section.Key("enabled").Bool()
-	// the unified alerting is not enabled by default. First, check the feature flag
+	// the unified alerting is not enabled by default
 	if err != nil {
-		// TODO: Remove in Grafana v9
-		if cfg.IsFeatureToggleEnabled("ngalert") {
-			cfg.Logger.Warn("ngalert feature flag is deprecated: use unified alerting enabled setting instead")
-			enabled = true
-			// feature flag overrides the legacy alerting setting.
-			legacyAlerting := false
-			AlertingEnabled = &legacyAlerting
-			return &enabled, nil
-		}
 		if IsEnterprise {
 			enabled = false
 			if AlertingEnabled == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the feature flag for unified alerting in Grafana 9.0.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

