### PR TITLE
Manual backport: Adding a safety check to gracefully handle nil responses (#49653)

### DIFF
--- a/pkg/api/response/web_hack.go
+++ b/pkg/api/response/web_hack.go
@@ -42,7 +42,9 @@ func wrap_handler(h web.Handler) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
 			ctx := getReqCtx(r.Context())
 			res := handle(ctx)
-			res.WriteTo(ctx)
+			if res != nil {
+				res.WriteTo(ctx)
+			}
 		}
 	case handlerCtx:
 		return func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Replaces [this backport](https://github.com/grafana/grafana/pull/49693) which is messed up