### PR TITLE
Build: Introduce webpack manifest plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,9 @@ pkg/cmd/grafana-server/__debug_bin
 ## CI places the packages in a different location
 /npm-artifacts/*.tgz
 
+# Ignore frontend build manifest
+manifest.json
+
 # Ignore go local build dependencies
 /scripts/go/bin/**
 

--- a/package.json
+++ b/package.json
@@ -243,6 +243,7 @@
     "webpack-bundle-analyzer": "4.5.0",
     "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.9.3",
+    "webpack-manifest-plugin": "5.0.0",
     "webpack-merge": "5.8.0"
   },
   "dependencies": {

--- a/scripts/webpack/webpack.prod.js
+++ b/scripts/webpack/webpack.prod.js
@@ -82,7 +82,10 @@ module.exports = (env = {}) =>
         chunksSortMode: 'none',
       }),
       new HTMLWebpackCSSChunks(),
-      new WebpackManifestPlugin(),
+      new WebpackManifestPlugin({
+        fileName: path.join(process.cwd(), 'manifest.json'),
+        filter: (file) => !file.name.endsWith('.map'),
+      }),
       function () {
         this.hooks.done.tap('Done', function (stats) {
           if (stats.compilation.errors && stats.compilation.errors.length) {

--- a/scripts/webpack/webpack.prod.js
+++ b/scripts/webpack/webpack.prod.js
@@ -5,6 +5,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const path = require('path');
 const TerserPlugin = require('terser-webpack-plugin');
+const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const { merge } = require('webpack-merge');
 
 const HTMLWebpackCSSChunks = require('./plugins/HTMLWebpackCSSChunks');
@@ -81,6 +82,7 @@ module.exports = (env = {}) =>
         chunksSortMode: 'none',
       }),
       new HTMLWebpackCSSChunks(),
+      new WebpackManifestPlugin(),
       function () {
         this.hooks.done.tap('Done', function (stats) {
           if (stats.compilation.errors && stats.compilation.errors.length) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22056,6 +22056,7 @@ __metadata:
     webpack-bundle-analyzer: 4.5.0
     webpack-cli: 4.10.0
     webpack-dev-server: 4.9.3
+    webpack-manifest-plugin: 5.0.0
     webpack-merge: 5.8.0
     whatwg-fetch: 3.6.2
   languageName: unknown
@@ -34722,7 +34723,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-list-map@npm:^2.0.0":
+"source-list-map@npm:^2.0.0, source-list-map@npm:^2.0.1":
   version: 2.0.1
   resolution: "source-list-map@npm:2.0.1"
   checksum: 806efc6f75e7cd31e4815e7a3aaf75a45c704871ea4075cb2eb49882c6fca28998f44fc5ac91adb6de03b2882ee6fb02f951fdc85e6a22b338c32bfe19557938
@@ -37973,6 +37974,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webpack-manifest-plugin@npm:5.0.0":
+  version: 5.0.0
+  resolution: "webpack-manifest-plugin@npm:5.0.0"
+  dependencies:
+    tapable: ^2.0.0
+    webpack-sources: ^2.2.0
+  peerDependencies:
+    webpack: ^5.47.0
+  checksum: 864d68f90870e194074756e71caf3df36b777d687a50286ba27eb1958480642b125c2cf47a2787beac52eba4b1ccf1fe8141f017c81f1e87e953481f852a7c48
+  languageName: node
+  linkType: hard
+
 "webpack-merge@npm:5.8.0, webpack-merge@npm:^5.7.3":
   version: 5.8.0
   resolution: "webpack-merge@npm:5.8.0"
@@ -37990,6 +38003,16 @@ __metadata:
     source-list-map: ^2.0.0
     source-map: ~0.6.1
   checksum: 37463dad8d08114930f4bc4882a9602941f07c9f0efa9b6bc78738cd936275b990a596d801ef450d022bb005b109b9f451dd087db2f3c9baf53e8e22cf388f79
+  languageName: node
+  linkType: hard
+
+"webpack-sources@npm:^2.2.0":
+  version: 2.3.1
+  resolution: "webpack-sources@npm:2.3.1"
+  dependencies:
+    source-list-map: ^2.0.1
+    source-map: ^0.6.1
+  checksum: 6fd67f2274a84c5f51ad89767112ec8b47727134bf0f2ba0cff458c970f18966939a24128bdbddba621cd66eeb2bef0552642a9333cd8e54514f7b2a71776346
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Some Grafana services rely on the webpack `[hash]` in filenames from compiled frontend assets to understand if uploads completed successfully. After merging #47625 these services encountered build issues. This PR introduces the Webpack manifest plugin to output the names of all compiled assets to a json file for easier consumption.

Currently the output is placed in `public/build/manifest.json` and contains:

```json5
{
  "app.js": "public/build/app.b226142f7f31e5cfcb2a.js",
  "dark.css": "public/build/grafana.dark.4aa093e77b236c135586.css",
  "dark.js": "public/build/dark.13d60784ae3ab488dee4.js",
  "light.css": "public/build/grafana.light.c2aab27160e4d8b58a67.css",
  "light.js": "public/build/light.ab5bef8058f32ad84c7d.js",
  "runtime.js": "public/build/runtime.aa21ce3cd2876d911a33.js",
  //... all other js (chunks and entries), css and html output from webpack
}
```

The entries in this json file can be filtered and the file itself can be placed in another directory if necessary. @hairyhenderson @filewalkwithme let me know what works best for you.
