### PR TITLE
Dashboard: Fix panel menu styling issues

### DIFF
--- a/public/sass/components/_dropdown.scss
+++ b/public/sass/components/_dropdown.scss
@@ -207,8 +207,8 @@
 // Right aligned dropdowns
 // ---------------------------
 .pull-right > .dropdown-menu {
-  left: 100% !important;
-  right: unset !important;
+  left: 100%;
+  right: unset;
 }
 
 // Allow for dropdowns to go bottom up (aka, dropup-menu)

--- a/public/sass/components/_dropdown.scss
+++ b/public/sass/components/_dropdown.scss
@@ -207,8 +207,8 @@
 // Right aligned dropdowns
 // ---------------------------
 .pull-right > .dropdown-menu {
-  right: 0;
-  left: auto;
+  left: 100% !important;
+  right: unset !important;
 }
 
 // Allow for dropdowns to go bottom up (aka, dropup-menu)
@@ -243,7 +243,6 @@
   left: 100%;
   margin-top: 0px;
   margin-left: -1px;
-  @include border-radius(0 6px 6px 6px);
 }
 .dropdown-submenu:hover > .dropdown-menu {
   display: block;
@@ -255,7 +254,6 @@
   bottom: 0;
   margin-top: 0;
   margin-bottom: -2px;
-  @include border-radius(5px 5px 5px 0);
 }
 // .dropdown-submenu > a::after {
 //   position: absolute;
@@ -284,7 +282,6 @@
     left: -100%;
     width: 100%;
     margin-left: 2px;
-    @include border-radius(6px 0 6px 6px);
   }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

 - Fixes padding on Panel Menu sub menus
    - There was conflicting `left`/`right` CSS properties that caused right-aligned sub menus to have zero width, which would default to the `min-width: 140px` which was just enough to make them look correct-ish
 - Removes border radius on Panel Menu sub menus

| Before | After |
|---|---|
| ![Before](https://user-images.githubusercontent.com/46142/170981794-bc9784e0-bf0c-4be0-9e74-49f73beffa56.png)| ![After](https://user-images.githubusercontent.com/46142/170981799-9149768f-2441-4dc6-978d-f91471b2216c.png)|





**Special notes for your reviewer**:

I tried to track down where else this is being used and it looks fine, but because its the old .scss styles I'm not sure if i caught everything...
