### PR TITLE
devenv: Fix data source uid for default gdev-testdata

### DIFF
--- a/devenv/dev-dashboards/e2e-repeats/Repeating-a-row-with-a-non-repeating-panel-and-horizontal-repeating-panel.json
+++ b/devenv/dev-dashboards/e2e-repeats/Repeating-a-row-with-a-non-repeating-panel-and-horizontal-repeating-panel.json
@@ -33,7 +33,7 @@
       "collapsed": false,
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "gridPos": {
         "h": 1,

--- a/devenv/dev-dashboards/home.json
+++ b/devenv/dev-dashboards/home.json
@@ -31,7 +31,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "gridPos": {
         "h": 26,
@@ -58,7 +58,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "gridPos": {
         "h": 13,
@@ -89,7 +89,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "gridPos": {
         "h": 13,
@@ -122,7 +122,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "gridPos": {
         "h": 26,
@@ -155,7 +155,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "gridPos": {
         "h": 13,
@@ -188,7 +188,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "gridPos": {
         "h": 13,

--- a/devenv/dev-dashboards/panel-barchart/barchart-autosizing.json
+++ b/devenv/dev-dashboards/panel-barchart/barchart-autosizing.json
@@ -31,7 +31,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {
@@ -112,7 +112,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "description": "Should be smaller given the longer value",
       "fieldConfig": {
@@ -195,7 +195,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {
@@ -276,7 +276,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {
@@ -438,7 +438,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {
@@ -520,7 +520,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "description": "",
       "fieldConfig": {

--- a/devenv/dev-dashboards/panel-candlestick/candlestick.json
+++ b/devenv/dev-dashboards/panel-candlestick/candlestick.json
@@ -31,7 +31,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {
@@ -179,7 +179,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {
@@ -268,7 +268,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {
@@ -357,7 +357,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {

--- a/devenv/dev-dashboards/panel-geomap/geomap_multi-layers.json
+++ b/devenv/dev-dashboards/panel-geomap/geomap_multi-layers.json
@@ -31,7 +31,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {
@@ -324,7 +324,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {

--- a/devenv/dev-dashboards/panel-geomap/panel-geomap.json
+++ b/devenv/dev-dashboards/panel-geomap/panel-geomap.json
@@ -31,7 +31,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {
@@ -129,7 +129,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {
@@ -231,7 +231,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {
@@ -325,7 +325,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {

--- a/devenv/dev-dashboards/panel-timeline/timeline-demo.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-demo.json
@@ -31,7 +31,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {
@@ -133,7 +133,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {
@@ -239,7 +239,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "description": "Should show gaps",
       "fieldConfig": {
@@ -345,7 +345,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {

--- a/devenv/dev-dashboards/panel-timeline/timeline-modes.json
+++ b/devenv/dev-dashboards/panel-timeline/timeline-modes.json
@@ -31,7 +31,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {
@@ -213,7 +213,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {
@@ -290,7 +290,7 @@
     {
       "datasource": {
         "type": "testdata",
-        "uid": "3fuUBUNGz"
+        "uid": "PD8C576611E62080A"
       },
       "fieldConfig": {
         "defaults": {


### PR DESCRIPTION
These dashboards stopped working after https://github.com/grafana/grafana/pull/48976

changed the uid. In all my local dev environments gdev-testdata has uid PD8C576611E62080A,
not sure how that value is derived as we do not set uid in the provisioning file for gdev-testdata.

