### PR TITLE
Alerting: Enable Unified Alerting for open source and enterprise

### DIFF
--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -1,8 +1,6 @@
 package migrations
 
 import (
-	"os"
-
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/ualert"
@@ -52,11 +50,6 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	addUserAuthTokenMigrations(mg)
 	addCacheMigration(mg)
 	addShortURLMigrations(mg)
-	// TODO Delete when unified alerting is enabled by default unconditionally (Grafana v9)
-	if err := ualert.CheckUnifiedAlertingEnabledByDefault(mg); err != nil { // this should always go before any other ualert migration
-		mg.Logger.Error("failed to determine the status of alerting engine. Enable either legacy or unified alerting explicitly and try again", "err", err)
-		os.Exit(1)
-	}
 	ualert.AddTablesMigrations(mg)
 	ualert.AddDashAlertMigration(mg)
 	addLibraryElementsMigrations(mg)

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -539,9 +539,10 @@ func TestAlertingEnabled(t *testing.T) {
 				require.NoError(t, err)
 				err = cfg.ReadUnifiedAlertingSettings(f)
 				require.NoError(t, err)
-				assert.Nil(t, cfg.UnifiedAlerting.Enabled)
+				assert.NotNil(t, cfg.UnifiedAlerting.Enabled)
+				assert.Equal(t, true, *cfg.UnifiedAlerting.Enabled)
 				assert.NotNil(t, AlertingEnabled)
-				assert.Equal(t, *AlertingEnabled, true)
+				assert.Equal(t, false, *AlertingEnabled)
 			},
 		},
 		{
@@ -557,9 +558,9 @@ func TestAlertingEnabled(t *testing.T) {
 				err = cfg.ReadUnifiedAlertingSettings(f)
 				require.NoError(t, err)
 				assert.NotNil(t, cfg.UnifiedAlerting.Enabled)
-				assert.Equal(t, *cfg.UnifiedAlerting.Enabled, false)
+				assert.Equal(t, true, *cfg.UnifiedAlerting.Enabled)
 				assert.NotNil(t, AlertingEnabled)
-				assert.Equal(t, *AlertingEnabled, true)
+				assert.Equal(t, false, *AlertingEnabled)
 			},
 		},
 		{
@@ -593,7 +594,7 @@ func TestAlertingEnabled(t *testing.T) {
 				err = cfg.ReadUnifiedAlertingSettings(f)
 				require.NoError(t, err)
 				assert.NotNil(t, cfg.UnifiedAlerting.Enabled)
-				assert.Equal(t, *cfg.UnifiedAlerting.Enabled, false)
+				assert.Equal(t, *cfg.UnifiedAlerting.Enabled, true)
 				assert.NotNil(t, AlertingEnabled)
 				assert.Equal(t, *AlertingEnabled, false)
 			},
@@ -610,7 +611,8 @@ func TestAlertingEnabled(t *testing.T) {
 				require.NoError(t, err)
 				err = cfg.ReadUnifiedAlertingSettings(f)
 				require.NoError(t, err)
-				assert.Nil(t, cfg.UnifiedAlerting.Enabled)
+				assert.NotNil(t, cfg.UnifiedAlerting.Enabled)
+				assert.True(t, *cfg.UnifiedAlerting.Enabled)
 				assert.Nil(t, AlertingEnabled)
 			},
 		},
@@ -627,9 +629,8 @@ func TestAlertingEnabled(t *testing.T) {
 				err = cfg.ReadUnifiedAlertingSettings(f)
 				require.NoError(t, err)
 				assert.NotNil(t, cfg.UnifiedAlerting.Enabled)
-				assert.Equal(t, *cfg.UnifiedAlerting.Enabled, false)
-				assert.NotNil(t, AlertingEnabled)
-				assert.Equal(t, *AlertingEnabled, true)
+				assert.True(t, *cfg.UnifiedAlerting.Enabled)
+				assert.Nil(t, AlertingEnabled)
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request enables unified alerting for both open source and enterprise Grafana unless disabled in configuration.

It is enabled in the following situations:

1. Neither old alerting or unified alerting have been configured (i.e. enabled is neither set for old alerting or unified alerting)
2. Old alerting is enabled but unified alerting has not been configured

The following table shows the outcomes of different settings:

| Alerting      | Unified Alerting | Outcome |
| ------------- | ---------------- | ------- |
| ""            | ""               | UA      |
| ""            | true             | UA      |
| ""            | false            | Legacy  |
| true          | ""               | UA      |
| true          | true             | Error   |
| true          | false            | Legacy  |
| false         | ""               | UA      |
| false         | true             | UA      |
| false         | false            | Disabled|