### PR TITLE
ClipboardButton: Simplify callbacks

### DIFF
--- a/packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.tsx
+++ b/packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.tsx
@@ -8,7 +8,7 @@ export interface Props extends ButtonProps {
   /** Callback when the text has been successfully copied */
   onClipboardCopy?(copiedText: string): void;
   /** Callback when there was an error copying the text */
-  onClipboardError?(copiedText: string): void;
+  onClipboardError?(copiedText: string, error: unknown): void;
 }
 
 export function ClipboardButton({ onClipboardCopy, onClipboardError, children, getText, ...buttonProps }: Props) {
@@ -19,8 +19,8 @@ export function ClipboardButton({ onClipboardCopy, onClipboardError, children, g
     try {
       await copyText(textToCopy, buttonRef);
       onClipboardCopy?.(textToCopy);
-    } catch {
-      onClipboardError?.(textToCopy);
+    } catch (e) {
+      onClipboardError?.(textToCopy, e);
     }
   }, [getText, onClipboardCopy, onClipboardError]);
 

--- a/packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.tsx
+++ b/packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.tsx
@@ -2,41 +2,25 @@ import React, { useCallback, useRef } from 'react';
 
 import { Button, ButtonProps } from '../Button';
 
-/** @deprecated Will be removed in next major release */
-interface ClipboardEvent {
-  action: string;
-  text: string;
-  trigger: Element;
-  clearSelection(): void;
-}
-
 export interface Props extends ButtonProps {
   /** A function that returns text to be copied */
   getText(): string;
   /** Callback when the text has been successfully copied */
-  onClipboardCopy?(e: ClipboardEvent): void;
+  onClipboardCopy?(copiedText: string): void;
   /** Callback when there was an error copying the text */
-  onClipboardError?(e: ClipboardEvent): void;
+  onClipboardError?(copiedText: string): void;
 }
-
-const dummyClearFunc = () => {};
 
 export function ClipboardButton({ onClipboardCopy, onClipboardError, children, getText, ...buttonProps }: Props) {
   const buttonRef = useRef<null | HTMLButtonElement>(null);
   const copyTextCallback = useCallback(async () => {
     const textToCopy = getText();
-    // Can be removed in 9.x
-    const dummyEvent: ClipboardEvent = {
-      action: 'copy',
-      clearSelection: dummyClearFunc,
-      text: textToCopy,
-      trigger: buttonRef.current!,
-    };
+
     try {
       await copyText(textToCopy, buttonRef);
-      onClipboardCopy?.(dummyEvent);
+      onClipboardCopy?.(textToCopy);
     } catch {
-      onClipboardError?.(dummyEvent);
+      onClipboardError?.(textToCopy);
     }
   }, [getText, onClipboardCopy, onClipboardError]);
 

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsActionButtons.tsx
@@ -203,8 +203,8 @@ export const RuleDetailsActionButtons: FC<Props> = ({ rule, rulesSource }) => {
           onClipboardCopy={() => {
             notifyApp.success('URL copied!');
           }}
-          onClipboardError={(e) => {
-            notifyApp.error('Error while copying URL', e.text);
+          onClipboardError={(copiedText) => {
+            notifyApp.error('Error while copying URL', copiedText);
           }}
           className={style.button}
           size="sm"


### PR DESCRIPTION
**What this PR does / why we need it**:
Earlier in the year we changed the implementation of `ClipboardButton`, but to maintain compatibility with the previous version we had to keep the callback interface which was more complicated than strictly necessary. This PR breaks that backwards compatibility in service of a simpler API.

# Release notice breaking change
`onClipboardCopy` and `onClipboardError` APIs have been changed such that the callback's argument is just the text that's been copied rather than the old `ClipboardEvent` interface.
Migration should just be a matter of going from

```tsx
<ClipboardButton
  {/*other props... */}
  onClipboardCopy={(e) => {
    console.log(`Text "${e.text}" was copied!`);
  }}
/>
```

to

```tsx
<ClipboardButton
  {/* other props... */}
  onClipboardCopy={(copiedText) => {
    console.log(`Text "${copiedText}" was copied!`);
  }}
/>
```
