### PR TITLE
PanelEditor: Fixes issue with Table view and multi data frames

### DIFF
--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -145,7 +145,7 @@ export class TablePanel extends Component<Props> {
 
       return (
         <div className={tableStyles.wrapper}>
-          {this.renderTable(data.series[currentIndex], width, height - inputHeight + padding)}
+          {this.renderTable(data.series[currentIndex], width, height - inputHeight - padding)}
           <div className={tableStyles.selectWrapper}>
             <Select options={names} value={names[currentIndex]} onChange={this.onChangeTableSelection} />
           </div>


### PR DESCRIPTION
**What this PR does / why we need it**:

In the PanelEditor, if you have multiple data frames and toggle the "Table view" switch, the dropdown to choose data frames is not correctly positioned in the table. This PR fixes that.

| Before | After |
| --- | --- |
| <img width="585" alt="Screenshot 2022-05-30 at 17 43 15" src="https://user-images.githubusercontent.com/100691367/171033670-824587b9-3dd6-4c2a-bf21-40bf70a00a4a.png"> | <img width="587" alt="Screenshot 2022-05-30 at 17 42 52" src="https://user-images.githubusercontent.com/100691367/171033653-4bde1425-d2a4-47d8-b651-476e03b2018f.png"> |

**Which issue(s) this PR fixes**:

Fixes #49145

