### PR TITLE
Alerting: Failing to fetch rules to schedule from the database won't halt rule evaluation

### DIFF
--- a/pkg/services/ngalert/CHANGELOG.md
+++ b/pkg/services/ngalert/CHANGELOG.md
@@ -51,7 +51,7 @@ Scopes must have an order to ensure consistency and ease of search, this helps u
   - `grafana_alerting_ticker_interval_seconds`
 - [ENHANCEMENT] Create folder 'General Alerting' when Grafana starts from the scratch #48866
 - [ENHANCEMENT] Rule changes authorization logic to use UID folder scope instead of ID scope #48970
-- [ENHANCEMENT] Failures at a database-level won't halt rule evaluation #XXX
+- [ENHANCEMENT] Failures at a database-level won't halt rule evaluation #49857
 - [FEATURE] Indicate whether routes are provisioned when GETting Alertmanager configuration #47857
 - [FEATURE] Indicate whether contact point is provisioned when GETting Alertmanager configuration #48323
 - [FEATURE] Indicate whether alert rule is provisioned when GETting the rule #48458

--- a/pkg/services/ngalert/CHANGELOG.md
+++ b/pkg/services/ngalert/CHANGELOG.md
@@ -51,6 +51,7 @@ Scopes must have an order to ensure consistency and ease of search, this helps u
   - `grafana_alerting_ticker_interval_seconds`
 - [ENHANCEMENT] Create folder 'General Alerting' when Grafana starts from the scratch #48866
 - [ENHANCEMENT] Rule changes authorization logic to use UID folder scope instead of ID scope #48970
+- [ENHANCEMENT] Failures at a database-level won't halt rule evaluation #XXX
 - [FEATURE] Indicate whether routes are provisioned when GETting Alertmanager configuration #47857
 - [FEATURE] Indicate whether contact point is provisioned when GETting Alertmanager configuration #48323
 - [FEATURE] Indicate whether alert rule is provisioned when GETting the rule #48458

--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -2,6 +2,8 @@ package schedule
 
 import (
 	"context"
+	"crypto/sha256"
+	"fmt"
 	"time"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -16,10 +18,24 @@ func (sch *schedule) getAlertRules(ctx context.Context, disabledOrgs []int64) []
 	q := models.GetAlertRulesForSchedulingQuery{
 		ExcludeOrgIDs: disabledOrgs,
 	}
+
 	err := sch.ruleStore.GetAlertRulesForScheduling(ctx, &q)
 	if err != nil {
-		sch.log.Error("failed to fetch alert definitions", "err", err)
-		return nil
+		sch.log.Error("failed to fetch alert definitions - using cache", "err", err, "cached_rules", len(sch.currentRuleSet))
+		return sch.currentRuleSet
 	}
+
+	sch.CacheRuleSet(q.Result)
 	return q.Result
+}
+
+// CacheRuleSet caches the current rule set in memory to avoid database failures halting alert evaluations.
+func (sch *schedule) CacheRuleSet(result []*models.SchedulableAlertRule) {
+	h := sha256.New()
+	for i := range result {
+		_, _ = h.Write([]byte(fmt.Sprintf("%v", result[i])))
+	}
+
+	sch.currentRuleSet = result
+	sch.currentRuleSetHash = fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -97,6 +97,10 @@ type schedule struct {
 	adminConfigPollInterval time.Duration
 	disabledOrgs            map[int64]struct{}
 	minRuleInterval         time.Duration
+
+	// currentRuleSet holds the current set of rules we should schedule.
+	currentRuleSet     []*models.SchedulableAlertRule
+	currentRuleSetHash string
 }
 
 // SchedulerCfg is the scheduler configuration.


### PR DESCRIPTION
Grafana's alerting system should continue to run when failures at a database level are present. This change introduces a in-memory cache for the ready to schedule rules that we use when we're unable to fetch the newer versions from the database.

Partial solves #49855 but there's more to do.

I think we should do two more things (they can be separate PRs due to the urgency of Grafana 9) - if agreed, I'll move them to the main issue:

- [ ] Use the rules hash to determine whether we should update the cache or not
- [ ] Expose the hash as a metric (gauge in particular) to track changes to the ruleset over time.