### PR TITLE
Alerting: Add Go error message to warning log for screenshots.

### DIFF
--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -250,7 +250,8 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 		st.log.Warn("Error generating a screenshot for an alert instance.",
 			"alert_rule", alertRule.UID,
 			"dashboard", alertRule.DashboardUID,
-			"panel", alertRule.PanelID)
+			"panel", alertRule.PanelID,
+			"error", err)
 	}
 
 	st.set(currentState)

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -247,11 +247,11 @@ func (st *Manager) setNextState(ctx context.Context, alertRule *ngModels.AlertRu
 
 	err := st.maybeTakeScreenshot(ctx, alertRule, currentState, oldState)
 	if err != nil {
-		st.log.Warn("Error generating a screenshot for an alert instance.",
+		st.log.Warn("failed to generate a screenshot for an alert instance",
 			"alert_rule", alertRule.UID,
 			"dashboard", alertRule.DashboardUID,
 			"panel", alertRule.PanelID,
-			"error", err)
+			"err", err)
 	}
 
 	st.set(currentState)


### PR DESCRIPTION
Makes debugging problems with alert screenshotting easier.

