### PR TITLE
Alerting: fix layout with long words / numbers

### DIFF
--- a/public/app/features/alerting/unified/components/AnnotationDetailsField.tsx
+++ b/public/app/features/alerting/unified/components/AnnotationDetailsField.tsx
@@ -34,15 +34,22 @@ export const AnnotationDetailsField: FC<Props> = ({ annotationKey, value }) => {
 
 const AnnotationValue: FC<Props> = ({ annotationKey, value }) => {
   const styles = useStyles(getStyles);
-  if (wellableAnnotationKeys.includes(annotationKey)) {
-    return <Well>{value}</Well>;
-  } else if (value && value.startsWith('http')) {
+
+  const needsWell = wellableAnnotationKeys.includes(annotationKey);
+  const needsLink = value && value.startsWith('http');
+
+  if (needsWell) {
+    return <Well className={styles.well}>{value}</Well>;
+  }
+
+  if (needsLink) {
     return (
       <a href={value} target="__blank" className={styles.link}>
         {value}
       </a>
     );
   }
+
   return <>{value}</>;
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Long words or numbers would break the alert instances layout and float the controls

**Before**
![image](https://user-images.githubusercontent.com/868844/171141367-a6cad7a1-3866-45b8-82ab-9d15a4863fb5.png)

**after**
<img width="1318" alt="image" src="https://user-images.githubusercontent.com/868844/171141854-8b62c8b1-d5d2-427f-ab8b-239b8b57efaa.png">
