### PR TITLE
UI/Card: Remove deprecated props

### DIFF
--- a/packages/grafana-ui/src/components/Card/Card.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.tsx
@@ -47,17 +47,7 @@ const CardContext = React.createContext<{
  *
  * @public
  */
-export const Card: CardInterface = ({
-  disabled,
-  href,
-  onClick,
-  children,
-  heading: deprecatedHeading,
-  description: deprecatedDescription,
-  isSelected,
-  className,
-  ...htmlProps
-}) => {
+export const Card: CardInterface = ({ disabled, href, onClick, children, isSelected, className, ...htmlProps }) => {
   const hasHeadingComponent = useMemo(
     () =>
       React.Children.toArray(children).some(
@@ -81,8 +71,6 @@ export const Card: CardInterface = ({
     >
       <CardContext.Provider value={{ href, onClick: onCardClick, disabled, isSelected }}>
         {!hasHeadingComponent && <Heading />}
-        {deprecatedHeading && <Heading>{deprecatedHeading}</Heading>}
-        {deprecatedDescription && <Description>{deprecatedDescription}</Description>}
         {children}
       </CardContext.Provider>
     </CardContainer>
@@ -93,9 +81,6 @@ interface ChildProps {
   className?: string;
   disabled?: boolean;
   children?: React.ReactNode;
-
-  /** @deprecated Use `className` to add new styles */
-  styles?: ReturnType<typeof getCardStyles>;
 }
 
 /** Main heading for the card */

--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -313,12 +313,11 @@ const DatasourceNotFound = ({ index, onUpdateDatasource, onRemoveQuery, model }:
   return (
     <EmptyQueryWrapper>
       <QueryOperationRow title={refId} draggable index={index} id={refId} isOpen>
-        <Card
-          heading="This datasource has been removed"
-          description={
-            'The datasource for this query was not found, it was either removed or is not installed correctly.'
-          }
-        >
+        <Card>
+          <Card.Heading>This datasource has been removed</Card.Heading>
+          <Card.Description>
+            The datasource for this query was not found, it was either removed or is not installed correctly.
+          </Card.Description>
           <Card.Figure>
             <Icon name="question-circle" />
           </Card.Figure>


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove support for deprecated `heading` and `description` props.

# Release notice breaking change
Removes support for deprecated `heading` and `description` props. Moving forward, the `Card.Heading` and `Card.Description` components should be used.