### PR TITLE
Loki: Fix uncaught errors if `labelKey` contains special characters

### DIFF
--- a/public/app/plugins/datasource/loki/language_provider.test.ts
+++ b/public/app/plugins/datasource/loki/language_provider.test.ts
@@ -184,29 +184,6 @@ describe('Language completion provider', () => {
       expect(result.context).toBe('context-labels');
       expect(result.suggestions).toEqual([{ items: [{ label: 'label2' }], label: 'Labels' }]);
     });
-
-    it('returns facetted label suggestions when invalid labelKey is given', async () => {
-      const datasource = makeMockLokiDatasource({ label1: [], label2: [] });
-      const provider = await getLanguageProvider(datasource);
-
-      // test values from issue #49122
-      const input = createTypeaheadInput('|= `\\"invalidlabelkey\\": "+1"`', '\\', '= `\\"invalidlabelkey');
-      const getLabelValuesSpy = jest.spyOn(provider, 'getLabelValues');
-      const result = await provider.provideCompletionItems(input);
-
-      expect(getLabelValuesSpy).not.toHaveBeenCalled();
-
-      expect(result.context).toBe('context-labels');
-      expect(result.suggestions).toEqual([
-        {
-          items: [
-            { label: 'label1', filterText: '"label1"' },
-            { label: 'label2', filterText: '"label2"' },
-          ],
-          label: 'Labels',
-        },
-      ]);
-    });
   });
 
   describe('label suggestions', () => {

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -276,7 +276,9 @@ export default class LokiLanguageProvider extends LanguageProvider {
       selector = EMPTY_SELECTOR;
     }
 
-    if (!labelKey && selector === EMPTY_SELECTOR) {
+    // In some occasions the labelKey will contain special characters. In that
+    // case, we assume the labelKey as invalid.
+    if ((!labelKey || /^\w*$/.test(labelKey) === false) && selector === EMPTY_SELECTOR) {
       // start task gets all labels
       await this.start();
       const allLabels = this.getLabelKeys();
@@ -439,7 +441,8 @@ export default class LokiLanguageProvider extends LanguageProvider {
   }
 
   async fetchLabelValues(key: string): Promise<string[]> {
-    const interpolatedKey = this.datasource.interpolateString(key);
+    const interpolatedKey = encodeURIComponent(this.datasource.interpolateString(key));
+
     const url = `label/${interpolatedKey}/values`;
     const rangeParams = this.datasource.getTimeRangeParams();
     const { start, end } = rangeParams;

--- a/public/app/plugins/datasource/loki/language_provider.ts
+++ b/public/app/plugins/datasource/loki/language_provider.ts
@@ -276,9 +276,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
       selector = EMPTY_SELECTOR;
     }
 
-    // In some occasions the labelKey will contain special characters. In that
-    // case, we assume the labelKey as invalid.
-    if ((!labelKey || /^\w*$/.test(labelKey) === false) && selector === EMPTY_SELECTOR) {
+    if (!labelKey && selector === EMPTY_SELECTOR) {
       // start task gets all labels
       await this.start();
       const allLabels = this.getLabelKeys();

--- a/public/app/plugins/datasource/loki/mocks.ts
+++ b/public/app/plugins/datasource/loki/mocks.ts
@@ -18,7 +18,8 @@ interface SeriesForSelector {
 }
 
 export function makeMockLokiDatasource(labelsAndValues: Labels, series?: SeriesForSelector): LokiDatasource {
-  const lokiLabelsAndValuesEndpointRegex = /^label\/(\w*)\/values/;
+  // added % to allow urlencoded labelKeys. Note, that this is not confirm with Loki, as loki does not allow specialcharacters in labelKeys, but needed for tests.
+  const lokiLabelsAndValuesEndpointRegex = /^label\/([%\w]*)\/values/;
   const lokiSeriesEndpointRegex = /^series/;
 
   const lokiLabelsEndpoint = 'labels';


### PR DESCRIPTION


**What this PR does / why we need it**:

#49122 describes an edge case, where adding quotes in a string with backticks would lead to a request to get labels. The `labelKey` in that case would contain special character (`\`) which will be interpolated as a pathseparator in the `fetchLabelValues` method. This is why I added URL encoding using `encodeURIComponent` to that part.

However, the querybuilder would still erroneously how the autocomplete for labels:

I fixed that by checking if the given `labelKey` in `getLabelCompletionItems` contains special characters. After the fix, `getLabelCompletionItems` handles `labelKey`s with special characters as if there was no `labelKey` given.

**Which issue(s) this PR fixes**:

Fixes #49122

**Special notes for your reviewer**:

Testing as from #49122:
1. Go to Grafana Explore.
2. Select any Loki data source.
3. Paste this query:
```
{environment="prod", service="something"}
|= `"abc_to": "+11111111111"`
```
4. Change it to this (add backslash):
```
{environment="prod", service="something"}
|= `\"abc_to": "+11111111111"`
```
5. Change it to this (add backslash at the end) - without the fix a error would appear:
```
{environment="prod", service="something"}
|= `\"abc_to\": "+11111111111"`
```

#### Video without the fix:

https://user-images.githubusercontent.com/8092184/171153360-7354d05d-462e-4ae1-8cf4-da105bb37299.mov

#### Video with the fix:

https://user-images.githubusercontent.com/8092184/171153509-8dc09b5e-0ffa-4f6d-9842-ceaebc9b6ea9.mov



