### PR TITLE
Query History: Hide query history when anonymous user uses Explore

### DIFF
--- a/public/app/core/history/richHistoryStorageProvider.ts
+++ b/public/app/core/history/richHistoryStorageProvider.ts
@@ -1,5 +1,5 @@
 import { config } from '@grafana/runtime';
-import { contextSrv } from 'app/core/services/context_srv';
+import { contextSrv } from 'app/core/core';
 
 import { SortOrder } from '../utils/richHistoryTypes';
 

--- a/public/app/core/history/richHistoryStorageProvider.ts
+++ b/public/app/core/history/richHistoryStorageProvider.ts
@@ -1,4 +1,5 @@
 import { config } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
 
 import { SortOrder } from '../utils/richHistoryTypes';
 
@@ -19,6 +20,7 @@ interface RichHistorySupportedFeatures {
   clearHistory: boolean;
   onlyActiveDataSource: boolean;
   changeRetention: boolean;
+  queryHistoryAvailable: boolean;
 }
 
 export const supportedFeatures = (): RichHistorySupportedFeatures => {
@@ -29,6 +31,7 @@ export const supportedFeatures = (): RichHistorySupportedFeatures => {
         clearHistory: false,
         onlyActiveDataSource: false,
         changeRetention: false,
+        queryHistoryAvailable: contextSrv.isSignedIn,
       }
     : {
         availableFilters: [SortOrder.Descending, SortOrder.Ascending, SortOrder.DatasourceAZ, SortOrder.DatasourceZA],
@@ -36,5 +39,6 @@ export const supportedFeatures = (): RichHistorySupportedFeatures => {
         clearHistory: true,
         onlyActiveDataSource: true,
         changeRetention: true,
+        queryHistoryAvailable: true,
       };
 };

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -11,6 +11,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Collapse, CustomScrollbar, ErrorBoundaryAlert, Themeable2, withTheme2 } from '@grafana/ui';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR, FilterItem } from '@grafana/ui/src/components/Table/types';
 import appEvents from 'app/core/app_events';
+import { contextSrv } from 'app/core/services/context_srv';
 import { getNodeGraphDataFrames } from 'app/plugins/panel/nodeGraph/utils';
 import { StoreState } from 'app/types';
 import { AbsoluteTimeEvent } from 'app/types/events';
@@ -347,6 +348,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
     const styles = getStyles(theme);
     const showPanels = queryResponse && queryResponse.state !== LoadingState.NotStarted;
     const showRichHistory = openDrawer === ExploreDrawer.RichHistory;
+    const richHistoryRowButtonHidden = !contextSrv.isSignedIn;
     const showQueryInspector = openDrawer === ExploreDrawer.QueryInspector;
     const showNoData =
       queryResponse.state === LoadingState.Done &&
@@ -375,6 +377,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
                 // We cannot show multiple traces at the same time right now so we do not show add query button.
                 //TODO:unification
                 addQueryRowButtonHidden={false}
+                richHistoryRowButtonHidden={richHistoryRowButtonHidden}
                 richHistoryButtonActive={showRichHistory}
                 queryInspectorButtonActive={showQueryInspector}
                 onClickAddQueryRowButton={this.onClickAddQueryRowButton}

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -11,7 +11,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Collapse, CustomScrollbar, ErrorBoundaryAlert, Themeable2, withTheme2 } from '@grafana/ui';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR, FilterItem } from '@grafana/ui/src/components/Table/types';
 import appEvents from 'app/core/app_events';
-import { contextSrv } from 'app/core/services/context_srv';
+import { supportedFeatures } from 'app/core/history/richHistoryStorageProvider';
 import { getNodeGraphDataFrames } from 'app/plugins/panel/nodeGraph/utils';
 import { StoreState } from 'app/types';
 import { AbsoluteTimeEvent } from 'app/types/events';
@@ -348,7 +348,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
     const styles = getStyles(theme);
     const showPanels = queryResponse && queryResponse.state !== LoadingState.NotStarted;
     const showRichHistory = openDrawer === ExploreDrawer.RichHistory;
-    const richHistoryRowButtonHidden = !contextSrv.isSignedIn;
+    const richHistoryRowButtonHidden = !supportedFeatures().queryHistoryAvailable;
     const showQueryInspector = openDrawer === ExploreDrawer.QueryInspector;
     const showNoData =
       queryResponse.state === LoadingState.Done &&

--- a/public/app/features/explore/SecondaryActions.test.tsx
+++ b/public/app/features/explore/SecondaryActions.test.tsx
@@ -20,10 +20,11 @@ describe('SecondaryActions', () => {
     expect(screen.getByRole('button', { name: /Query inspector button/i })).toBeInTheDocument();
   });
 
-  it('should not render add row button if addQueryRowButtonHidden=true', () => {
+  it('should not render hidden elements', () => {
     render(
       <SecondaryActions
         addQueryRowButtonHidden={true}
+        richHistoryRowButtonHidden={true}
         onClickAddQueryRowButton={noop}
         onClickRichHistoryButton={noop}
         onClickQueryInspectorButton={noop}
@@ -31,7 +32,7 @@ describe('SecondaryActions', () => {
     );
 
     expect(screen.queryByRole('button', { name: /Add row button/i })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Rich history button/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Rich history button/i })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Query inspector button/i })).toBeInTheDocument();
   });
 

--- a/public/app/features/explore/SecondaryActions.tsx
+++ b/public/app/features/explore/SecondaryActions.tsx
@@ -7,6 +7,7 @@ import { Button, HorizontalGroup, useTheme2 } from '@grafana/ui';
 type Props = {
   addQueryRowButtonDisabled?: boolean;
   addQueryRowButtonHidden?: boolean;
+  richHistoryRowButtonHidden?: boolean;
   richHistoryButtonActive?: boolean;
   queryInspectorButtonActive?: boolean;
 
@@ -39,15 +40,17 @@ export function SecondaryActions(props: Props) {
             Add query
           </Button>
         )}
-        <Button
-          variant="secondary"
-          aria-label="Rich history button"
-          className={cx({ ['explore-active-button']: props.richHistoryButtonActive })}
-          onClick={props.onClickRichHistoryButton}
-          icon="history"
-        >
-          Query history
-        </Button>
+        {!props.richHistoryRowButtonHidden && (
+          <Button
+            variant="secondary"
+            aria-label="Rich history button"
+            className={cx({ ['explore-active-button']: props.richHistoryButtonActive })}
+            onClick={props.onClickRichHistoryButton}
+            icon="history"
+          >
+            Query history
+          </Button>
+        )}
         <Button
           variant="secondary"
           aria-label="Query inspector button"

--- a/public/app/features/explore/spec/queryHistory.test.tsx
+++ b/public/app/features/explore/spec/queryHistory.test.tsx
@@ -52,6 +52,7 @@ jest.mock('@grafana/runtime', () => ({
 jest.mock('app/core/core', () => ({
   contextSrv: {
     hasAccess: () => true,
+    isSignedIn: true,
   },
 }));
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #49895

**Special notes for your reviewer**:

Query History button will be hidden when the following config is used:

```
[query_history]
enabled = true

[auth]
disable_login_form = true

[auth.anonymous]
enabled = true
org_name = Main Org.
org_role = Admin
```

Note: this applies only to new query history, so with the config entry:

```
[query_history]
enabled = false
```

the button will still show up.