### PR TITLE
AuthProxy: Remove deprecated ldap_sync_ttl setting

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -582,8 +582,6 @@ enabled = false
 header_name = X-WEBAUTH-USER
 header_property = username
 auto_sign_up = true
-# Deprecated, use sync_ttl instead
-ldap_sync_ttl = 60
 sync_ttl = 60
 whitelist =
 headers =

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -49,12 +49,6 @@ const (
 	ApplicationName  = "Grafana"
 )
 
-// This constant corresponds to the default value for sync_ttl in .ini files
-// it is used for comparison and has to be kept in sync
-const (
-	authProxySyncTTL = 60
-)
-
 // zoneInfo names environment variable for setting the path to look for the timezone database in go
 const zoneInfo = "ZONEINFO"
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -49,7 +49,7 @@ const (
 	ApplicationName  = "Grafana"
 )
 
-// This constant corresponds to the default value for ldap_sync_ttl in .ini files
+// This constant corresponds to the default value for sync_ttl in .ini files
 // it is used for comparison and has to be kept in sync
 const (
 	authProxySyncTTL = 60
@@ -1332,15 +1332,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	cfg.AuthProxyAutoSignUp = authProxy.Key("auto_sign_up").MustBool(true)
 	cfg.AuthProxyEnableLoginToken = authProxy.Key("enable_login_token").MustBool(false)
 
-	ldapSyncVal := authProxy.Key("ldap_sync_ttl").MustInt()
-	syncVal := authProxy.Key("sync_ttl").MustInt()
-
-	if ldapSyncVal != authProxySyncTTL {
-		cfg.AuthProxySyncTTL = ldapSyncVal
-		cfg.Logger.Warn("[Deprecated] the configuration setting 'ldap_sync_ttl' is deprecated, please use 'sync_ttl' instead")
-	} else {
-		cfg.AuthProxySyncTTL = syncVal
-	}
+	cfg.AuthProxySyncTTL = authProxy.Key("sync_ttl").MustInt()
 
 	cfg.AuthProxyWhitelist = valueAsString(authProxy, "whitelist", "")
 

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -252,39 +252,6 @@ func TestLoadingSettings(t *testing.T) {
 		require.Equal(t, 2, cfg.AuthProxySyncTTL)
 	})
 
-	t.Run("Only ldap_sync_ttl should return the value ldap_sync_ttl", func(t *testing.T) {
-		cfg := NewCfg()
-		err := cfg.Load(CommandLineArgs{
-			HomePath: "../../",
-			Args:     []string{"cfg:auth.proxy.ldap_sync_ttl=5"},
-		})
-		require.Nil(t, err)
-
-		require.Equal(t, 5, cfg.AuthProxySyncTTL)
-	})
-
-	t.Run("ldap_sync should override ldap_sync_ttl that is default value", func(t *testing.T) {
-		cfg := NewCfg()
-		err := cfg.Load(CommandLineArgs{
-			HomePath: "../../",
-			Args:     []string{"cfg:auth.proxy.sync_ttl=5"},
-		})
-		require.Nil(t, err)
-
-		require.Equal(t, 5, cfg.AuthProxySyncTTL)
-	})
-
-	t.Run("ldap_sync should not override ldap_sync_ttl that is different from default value", func(t *testing.T) {
-		cfg := NewCfg()
-		err := cfg.Load(CommandLineArgs{
-			HomePath: "../../",
-			Args:     []string{"cfg:auth.proxy.ldap_sync_ttl=12", "cfg:auth.proxy.sync_ttl=5"},
-		})
-		require.Nil(t, err)
-
-		require.Equal(t, 12, cfg.AuthProxySyncTTL)
-	})
-
 	t.Run("Test reading string values from .ini file", func(t *testing.T) {
 		iniFile, err := ini.Load(path.Join(HomePath, "pkg/setting/testdata/invalid.ini"))
 		require.Nil(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
The `ldap_sync_ttl` got deprecated in grafana v6.5 by https://github.com/grafana/grafana/pull/20191

# Release notice breaking change
Drop support for deprecated setting ldap_sync_ttl under [auth.proxy]
Only sync_ttl  will work from now on