### PR TITLE
Azure OAuth: silent fail on getting groups

### DIFF
--- a/pkg/login/social/azuread_oauth.go
+++ b/pkg/login/social/azuread_oauth.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -214,9 +215,11 @@ func extractGroups(client *http.Client, claims azureClaims, token *oauth2.Token)
 	if res.StatusCode != http.StatusOK {
 		if res.StatusCode == http.StatusForbidden {
 			logger.Warn("AzureAD OAuh: Token need GroupMember.Read.All permission to fetch all groups")
-			return []string{}, nil
+		} else {
+			body, _ := io.ReadAll(res.Body)
+			logger.Warn("AzureAD OAuh: could not fetch user groups", "code", res.StatusCode, "body", string(body))
 		}
-		return nil, errors.New("error fetching groups")
+		return []string{}, nil
 	}
 
 	var body getAzureGroupResponse


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR intends to prevent azure authentication from failing should fetching the user's groups fail.
Users will be authenticated but the groups info used by team sync won't be available. A message logging the status code and the body has been added to help future debugging.

**Which issue(s) this PR fixes**:

Relates to https://github.com/grafana/support-escalations/issues/2534
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer**:

