### PR TITLE
Prometheus: Fix aligning of labels of exemplars after backend migration

### DIFF
--- a/pkg/tsdb/prometheus/buffered/time_series_query.go
+++ b/pkg/tsdb/prometheus/buffered/time_series_query.go
@@ -434,20 +434,39 @@ func vectorToDataFrames(vector model.Vector, query *PrometheusQuery, frames data
 	return frames
 }
 
-func exemplarToDataFrames(response []apiv1.ExemplarQueryResult, query *PrometheusQuery, frames data.Frames) data.Frames {
+// normalizeExemplars transforms the exemplar results into a single list of events. At the same time we make sure
+// that all exemplar events have the same labels which is important when converting to dataFrames so that we have
+// the same length of each field (each label will be a separate field). Exemplars can have different label either
+// because the exemplar event have different labels or because they are from different series.
+// Reason why we merge exemplars into single list even if they are from different series is that for example in case
+// of a histogram query, like histogram_quantile(0.99, sum(rate(traces_spanmetrics_duration_seconds_bucket[15s])) by (le))
+// Prometheus still returns all the exemplars for all the series of metric traces_spanmetrics_duration_seconds_bucket.
+// Which makes sense because each histogram bucket is separate series but we still want to show all the exemplars for
+// the metric and we don't specifically care which buckets they are from.
+// For non histogram queries or if you split by some label it would probably be nicer to then split also exemplars to
+// multiple frames (so they will have different symbols in the UI) but that would require understanding the query so it
+// is not implemented now.
+func normalizeExemplars(response []apiv1.ExemplarQueryResult) []ExemplarEvent {
 	// TODO: this preallocation is very naive.
 	// We should figure out a better approximation here.
 	events := make([]ExemplarEvent, 0, len(response)*2)
-	// Prometheus treats empty value as same as null, so `event.Labels` may not be consistent across `events`,
-	// leading errors like "frame has different field lengths, field 0 is len 5 but field 14 is len 2", need a fix.
+
+	// Get all the labels across all exemplars both from the examplars and their series labels. We will use this to make
+	// sure the resulting data frame has consistent number of values in each column.
 	eventLabels := make(map[string]struct{})
 	for _, exemplarData := range response {
+		// Check each exemplar labels as there isn't a guarantee they are consistent
 		for _, exemplar := range exemplarData.Exemplars {
 			for label := range exemplar.Labels {
 				eventLabels[string(label)] = struct{}{}
 			}
 		}
+
+		for label := range exemplarData.SeriesLabels {
+			eventLabels[string(label)] = struct{}{}
+		}
 	}
+
 	for _, exemplarData := range response {
 		for _, exemplar := range exemplarData.Exemplars {
 			event := ExemplarEvent{}
@@ -456,26 +475,35 @@ func exemplarToDataFrames(response []apiv1.ExemplarQueryResult, query *Prometheu
 			event.Value = float64(exemplar.Value)
 			event.Labels = make(map[string]string)
 
-			for label, value := range exemplar.Labels {
-				event.Labels[string(label)] = string(value)
+			// First sort the label key so that it is consistent (mainly for easier testing)
+			allLabels := make([]string, len(eventLabels))
+			i := 0
+			for key := range eventLabels {
+				allLabels[i] = key
+				i++
 			}
+			sort.Strings(allLabels)
 
-			for seriesLabel, seriesValue := range exemplarData.SeriesLabels {
-				event.Labels[string(seriesLabel)] = string(seriesValue)
-			}
-
-			if len(event.Labels) != len(eventLabels) {
-				// Fill event labels with empty value.
-				for label := range eventLabels {
-					if _, ok := event.Labels[label]; !ok {
-						event.Labels[label] = ""
-					}
+			// Fill in all the labels from eventLabels with values from exemplar labels or series labels or fill with
+			// empty string
+			for _, label := range allLabels {
+				if _, ok := exemplar.Labels[model.LabelName(label)]; ok {
+					event.Labels[label] = string(exemplar.Labels[model.LabelName(label)])
+				} else if _, ok := exemplarData.SeriesLabels[model.LabelName(label)]; ok {
+					event.Labels[label] = string(exemplarData.SeriesLabels[model.LabelName(label)])
+				} else {
+					event.Labels[label] = ""
 				}
 			}
 
 			events = append(events, event)
 		}
 	}
+	return events
+}
+
+func exemplarToDataFrames(response []apiv1.ExemplarQueryResult, query *PrometheusQuery, frames data.Frames) data.Frames {
+	events := normalizeExemplars(response)
 
 	// Sampling of exemplars
 	bucketedExemplars := make(map[string][]ExemplarEvent)

--- a/pkg/tsdb/prometheus/buffered/time_series_query.go
+++ b/pkg/tsdb/prometheus/buffered/time_series_query.go
@@ -477,7 +477,7 @@ func normalizeExemplars(response []apiv1.ExemplarQueryResult) []ExemplarEvent {
 
 			// Fill in all the labels from eventLabels with values from exemplar labels or series labels or fill with
 			// empty string
-			for label, _ := range eventLabels {
+			for label := range eventLabels {
 				if _, ok := exemplar.Labels[model.LabelName(label)]; ok {
 					event.Labels[label] = string(exemplar.Labels[model.LabelName(label)])
 				} else if _, ok := exemplarData.SeriesLabels[model.LabelName(label)]; ok {

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -336,7 +336,7 @@ export class PrometheusDatasource
       const metricName = this.languageProvider.histogramMetrics.find((m) => target.expr.includes(m));
       // Remove targets that weren't processed yet (in targets array they are after current target)
       const currentTargetIdx = request.targets.findIndex((t) => t.refId === target.refId);
-      const targets = request.targets.slice(0, currentTargetIdx);
+      const targets = request.targets.slice(0, currentTargetIdx).filter((t) => !t.hide);
 
       if (!metricName || (metricName && !targets.some((t) => t.expr.includes(metricName)))) {
         return true;


### PR DESCRIPTION
After backend migration the exemplar code could produce dataFrames with fields of different lengths resulting in an error:
```
grafana_1             | logger=context traceID=00000000000000000000000000000000 userId=1 orgId=1 uname=admin t=2022-05-05T20:35:32.38+0000 lvl=eror msg="Error writing to response" err="frame has different field lengths, field 0 is len 110 but field 9 is len 23"
```
and a "No Data" on the front end.

This should have been fixed in https://github.com/grafana/grafana/pull/46135 but it wasn't completely fixed due to my wrong suggestion.

This now correctly aligns all the exemplar labels and correctly fills empty values where needed.