### PR TITLE
Usage stats: Divide collection into multiple functions to isolate failures

### DIFF
--- a/pkg/infra/usagestats/service/usage_stats.go
+++ b/pkg/infra/usagestats/service/usage_stats.go
@@ -48,10 +48,13 @@ func (uss *UsageStats) GetUsageReport(ctx context.Context) (usagestats.Report, e
 }
 
 func (uss *UsageStats) gatherMetrics(ctx context.Context, metrics map[string]interface{}) {
+	totC, errC := 0, 0
 	for _, fn := range uss.externalMetrics {
 		fnMetrics, err := fn(ctx)
+		totC++
 		if err != nil {
 			uss.log.Error("Failed to fetch external metrics", "error", err)
+			errC++
 			continue
 		}
 
@@ -59,6 +62,8 @@ func (uss *UsageStats) gatherMetrics(ctx context.Context, metrics map[string]int
 			metrics[name] = value
 		}
 	}
+	metrics["stats.usagestats.debug.collect.total.count"] = totC
+	metrics["stats.usagestats.debug.collect.error.count"] = errC
 }
 
 func (uss *UsageStats) RegisterMetricsFunc(fn usagestats.MetricsFunc) {

--- a/pkg/infra/usagestats/service/usage_stats_test.go
+++ b/pkg/infra/usagestats/service/usage_stats_test.go
@@ -178,6 +178,7 @@ func TestRegisterMetrics(t *testing.T) {
 
 	uss.gatherMetrics(context.Background(), metrics)
 	assert.Equal(t, 1, metrics[goodMetricName])
+	metricsCount := len(metrics)
 
 	t.Run("do not add metrics that return an error when fetched", func(t *testing.T) {
 		const badMetricName = "stats.test_external_metric_error.count"
@@ -192,7 +193,8 @@ func TestRegisterMetrics(t *testing.T) {
 
 		require.Nil(t, extErrorMetric, "Invalid metric should not be added")
 		assert.Equal(t, 1, extMetric)
-		assert.Len(t, metrics, 3, "Expected only one available metric")
+		assert.Len(t, metrics, metricsCount, "Expected same number of metrics before and after collecting bad metric")
+		assert.EqualValues(t, 1, metrics["stats.usagestats.debug.collect.error.count"])
 	})
 }
 

--- a/pkg/infra/usagestats/statscollector/concurrent_users.go
+++ b/pkg/infra/usagestats/statscollector/concurrent_users.go
@@ -56,3 +56,24 @@ FROM (select count(1) as tokens from user_auth_token group by user_id) uat;`
 	s.concurrentUserStatsCache.memoized = time.Now()
 	return s.concurrentUserStatsCache.stats, nil
 }
+
+func (s *Service) collectConcurrentUsers(ctx context.Context) (map[string]interface{}, error) {
+	m := map[string]interface{}{}
+
+	// Get concurrent users stats as histogram
+	concurrentUsersStats, err := s.concurrentUsers(ctx)
+	if err != nil {
+		s.log.Error("Failed to get concurrent users stats", "error", err)
+		return nil, err
+	}
+
+	// Histogram is cumulative and metric name has a postfix of le_"<upper inclusive bound>"
+	m["stats.auth_token_per_user_le_3"] = concurrentUsersStats.BucketLE3
+	m["stats.auth_token_per_user_le_6"] = concurrentUsersStats.BucketLE6
+	m["stats.auth_token_per_user_le_9"] = concurrentUsersStats.BucketLE9
+	m["stats.auth_token_per_user_le_12"] = concurrentUsersStats.BucketLE12
+	m["stats.auth_token_per_user_le_15"] = concurrentUsersStats.BucketLE15
+	m["stats.auth_token_per_user_le_inf"] = concurrentUsersStats.BucketLEInf
+
+	return m, nil
+}

--- a/pkg/infra/usagestats/statscollector/concurrent_users_test.go
+++ b/pkg/infra/usagestats/statscollector/concurrent_users_test.go
@@ -23,7 +23,7 @@ func TestConcurrentUsersMetrics(t *testing.T) {
 
 	createConcurrentTokens(t, sqlStore)
 
-	stats, err := s.collect(context.Background())
+	stats, err := s.collectConcurrentUsers(context.Background())
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(1), stats["stats.auth_token_per_user_le_3"])

--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
@@ -18,7 +20,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 type Service struct {
@@ -40,7 +41,7 @@ type Service struct {
 }
 
 func ProvideService(
-	usagestats usagestats.Service,
+	us usagestats.Service,
 	cfg *setting.Cfg,
 	store sqlstore.Store,
 	social social.Service,
@@ -54,7 +55,7 @@ func ProvideService(
 		sqlstore:           store,
 		plugins:            plugins,
 		social:             social,
-		usageStats:         usagestats,
+		usageStats:         us,
 		features:           features,
 		datasources:        datasourceService,
 		httpClientProvider: httpClientProvider,
@@ -63,7 +64,19 @@ func ProvideService(
 		log:       log.New("infra.usagestats.collector"),
 	}
 
-	usagestats.RegisterMetricsFunc(s.collect)
+	collectors := []usagestats.MetricsFunc{
+		s.collectSystemStats,
+		s.collectConcurrentUsers,
+		s.collectDatasourceStats,
+		s.collectDatasourceAccess,
+		s.collectElasticStats,
+		s.collectAlertNotifierStats,
+		s.collectPrometheusFlavors,
+		s.collectAdditionalMetrics,
+	}
+	for _, c := range collectors {
+		us.RegisterMetricsFunc(c)
+	}
 
 	return s
 }
@@ -89,7 +102,7 @@ func (s *Service) Run(ctx context.Context) error {
 	}
 }
 
-func (s *Service) collect(ctx context.Context) (map[string]interface{}, error) {
+func (s *Service) collectSystemStats(ctx context.Context) (map[string]interface{}, error) {
 	m := map[string]interface{}{}
 
 	statsQuery := models.GetSystemStatsQuery{}
@@ -158,7 +171,66 @@ func (s *Service) collect(ctx context.Context) (map[string]interface{}, error) {
 	}
 
 	m["stats.avg_auth_token_per_user.count"] = avgAuthTokensPerUser
+	m["stats.packaging."+s.cfg.Packaging+".count"] = 1
+	m["stats.distributor."+s.cfg.ReportingDistributor+".count"] = 1
 
+	// Add stats about auth configuration
+	authTypes := map[string]bool{}
+	authTypes["anonymous"] = s.cfg.AnonymousEnabled
+	authTypes["basic_auth"] = s.cfg.BasicAuthEnabled
+	authTypes["ldap"] = s.cfg.LDAPEnabled
+	authTypes["auth_proxy"] = s.cfg.AuthProxyEnabled
+
+	for provider, enabled := range s.social.GetOAuthProviders() {
+		authTypes["oauth_"+provider] = enabled
+	}
+
+	for authType, enabled := range authTypes {
+		enabledValue := 0
+		if enabled {
+			enabledValue = 1
+		}
+		m["stats.auth_enabled."+authType+".count"] = enabledValue
+	}
+
+	m["stats.uptime"] = int64(time.Since(s.startTime).Seconds())
+
+	featureUsageStats := s.features.GetUsageStats(ctx)
+	for k, v := range featureUsageStats {
+		m[k] = v
+	}
+
+	return m, nil
+}
+
+func (s *Service) collectAdditionalMetrics(ctx context.Context) (map[string]interface{}, error) {
+	m := map[string]interface{}{}
+	for _, usageStatProvider := range s.usageStatProviders {
+		stats := usageStatProvider.GetUsageStats(ctx)
+		for k, v := range stats {
+			m[k] = v
+		}
+	}
+	return m, nil
+}
+
+func (s *Service) collectAlertNotifierStats(ctx context.Context) (map[string]interface{}, error) {
+	m := map[string]interface{}{}
+	// get stats about alert notifier usage
+	anStats := models.GetAlertNotifierUsageStatsQuery{}
+	if err := s.sqlstore.GetAlertNotifiersUsageStats(ctx, &anStats); err != nil {
+		s.log.Error("Failed to get alert notification stats", "error", err)
+		return nil, err
+	}
+
+	for _, stats := range anStats.Result {
+		m["stats.alert_notifiers."+stats.Type+".count"] = stats.Count
+	}
+	return m, nil
+}
+
+func (s *Service) collectDatasourceStats(ctx context.Context) (map[string]interface{}, error) {
+	m := map[string]interface{}{}
 	dsStats := models.GetDataSourceStatsQuery{}
 	if err := s.sqlstore.GetDataSourceStats(ctx, &dsStats); err != nil {
 		s.log.Error("Failed to get datasource stats", "error", err)
@@ -178,6 +250,11 @@ func (s *Service) collect(ctx context.Context) (map[string]interface{}, error) {
 	}
 	m["stats.ds.other.count"] = dsOtherCount
 
+	return m, nil
+}
+
+func (s *Service) collectElasticStats(ctx context.Context) (map[string]interface{}, error) {
+	m := map[string]interface{}{}
 	esDataSourcesQuery := models.GetDataSourcesByTypeQuery{Type: models.DS_ES}
 	if err := s.sqlstore.GetDataSourcesByType(ctx, &esDataSourcesQuery); err != nil {
 		s.log.Error("Failed to get elasticsearch json data", "error", err)
@@ -196,24 +273,17 @@ func (s *Service) collect(ctx context.Context) (map[string]interface{}, error) {
 
 		m[statName] = count + 1
 	}
+	return m, nil
+}
 
-	m["stats.packaging."+s.cfg.Packaging+".count"] = 1
-	m["stats.distributor."+s.cfg.ReportingDistributor+".count"] = 1
+func (s *Service) collectDatasourceAccess(ctx context.Context) (map[string]interface{}, error) {
+	m := map[string]interface{}{}
 
 	// fetch datasource access stats
 	dsAccessStats := models.GetDataSourceAccessStatsQuery{}
 	if err := s.sqlstore.GetDataSourceAccessStats(ctx, &dsAccessStats); err != nil {
 		s.log.Error("Failed to get datasource access stats", "error", err)
 		return nil, err
-	}
-
-	variants, err := s.detectPrometheusVariants(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	for variant, count := range variants {
-		m["stats.ds.prometheus.flavor."+variant+".count"] = count
 	}
 
 	// send access counters for each data source
@@ -238,66 +308,6 @@ func (s *Service) collect(ctx context.Context) (map[string]interface{}, error) {
 	for access, count := range dsAccessOtherCount {
 		m["stats.ds_access.other."+access+".count"] = count
 	}
-
-	// get stats about alert notifier usage
-	anStats := models.GetAlertNotifierUsageStatsQuery{}
-	if err := s.sqlstore.GetAlertNotifiersUsageStats(ctx, &anStats); err != nil {
-		s.log.Error("Failed to get alert notification stats", "error", err)
-		return nil, err
-	}
-
-	for _, stats := range anStats.Result {
-		m["stats.alert_notifiers."+stats.Type+".count"] = stats.Count
-	}
-
-	// Add stats about auth configuration
-	authTypes := map[string]bool{}
-	authTypes["anonymous"] = s.cfg.AnonymousEnabled
-	authTypes["basic_auth"] = s.cfg.BasicAuthEnabled
-	authTypes["ldap"] = s.cfg.LDAPEnabled
-	authTypes["auth_proxy"] = s.cfg.AuthProxyEnabled
-
-	for provider, enabled := range s.social.GetOAuthProviders() {
-		authTypes["oauth_"+provider] = enabled
-	}
-
-	for authType, enabled := range authTypes {
-		enabledValue := 0
-		if enabled {
-			enabledValue = 1
-		}
-		m["stats.auth_enabled."+authType+".count"] = enabledValue
-	}
-
-	// Get concurrent users stats as histogram
-	concurrentUsersStats, err := s.concurrentUsers(ctx)
-	if err != nil {
-		s.log.Error("Failed to get concurrent users stats", "error", err)
-		return nil, err
-	}
-
-	// Histogram is cumulative and metric name has a postfix of le_"<upper inclusive bound>"
-	m["stats.auth_token_per_user_le_3"] = concurrentUsersStats.BucketLE3
-	m["stats.auth_token_per_user_le_6"] = concurrentUsersStats.BucketLE6
-	m["stats.auth_token_per_user_le_9"] = concurrentUsersStats.BucketLE9
-	m["stats.auth_token_per_user_le_12"] = concurrentUsersStats.BucketLE12
-	m["stats.auth_token_per_user_le_15"] = concurrentUsersStats.BucketLE15
-	m["stats.auth_token_per_user_le_inf"] = concurrentUsersStats.BucketLEInf
-
-	m["stats.uptime"] = int64(time.Since(s.startTime).Seconds())
-
-	featureUsageStats := s.features.GetUsageStats(ctx)
-	for k, v := range featureUsageStats {
-		m[k] = v
-	}
-
-	for _, usageStatProvider := range s.usageStatProviders {
-		stats := usageStatProvider.GetUsageStats(ctx)
-		for k, v := range stats {
-			m[k] = v
-		}
-	}
-
 	return m, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR improves the resiliency of the usage stats report by creating several collectors that each are capable of failing in at most one way. In addition, there are minor improvements to debugging of usage stats themselves and the Prometheus flavor detection specifically.

**Which issue(s) this PR fixes**:

Reduces effect of grafana/grafana-enterprise#3373

**Special notes for your reviewer**:

The diff looks more intimidating than it actually is. I have not deleted any metrics, and only added two new ones (plus a Prometheus flavor for HTTP network _errors_ [defined here as when there's no HTTP server, so a 4xx/5xx wouldn't be an error here]). Almost all of the "removed" code is still there.