### PR TITLE
InlineLabel: Remove deprecated props

### DIFF
--- a/packages/grafana-ui/src/components/Forms/InlineLabel.tsx
+++ b/packages/grafana-ui/src/components/Forms/InlineLabel.tsx
@@ -17,12 +17,6 @@ export interface Props extends Omit<LabelProps, 'css' | 'description' | 'categor
   width?: number | 'auto';
   /** Make labels's background transparent */
   transparent?: boolean;
-  /** @deprecated */
-  /** This prop is deprecated and is not used anymore */
-  isFocused?: boolean;
-  /** @deprecated */
-  /** This prop is deprecated and is not used anymore */
-  isInvalid?: boolean;
   /** Make tooltip interactive */
   interactive?: boolean;
   /** @beta */


### PR DESCRIPTION
# Release notice breaking change
Removed the deprecated `isFocused` and `isInvalid` props from the `InlineLabel` component. These props haven't done anything for a while, so migration is just a matter of removing the props.