### PR TITLE
Datasource: Remove deprecated max_idle_connections_per_host setting

### DIFF
--- a/docs/sources/administration/configuration.md
+++ b/docs/sources/administration/configuration.md
@@ -434,12 +434,6 @@ For more details check the [Transport.MaxConnsPerHost](https://golang.org/pkg/ne
 
 The maximum number of idle connections that Grafana will maintain. Default is `100`. For more details check the [Transport.MaxIdleConns](https://golang.org/pkg/net/http/#Transport.MaxIdleConns) documentation.
 
-### max_idle_connections_per_host
-
-[Deprecated - use max_idle_connections instead]
-
-The maximum number of idle connections per host that Grafana will maintain. Default is `2`. For more details check the [Transport.MaxIdleConnsPerHost](https://golang.org/pkg/net/http/#Transport.MaxIdleConnsPerHost) documentation.
-
 ### idle_conn_timeout_seconds
 
 The length of time that Grafana maintains idle connections before closing them. Default is `90` seconds. For more details check the [Transport.IdleConnTimeout](https://golang.org/pkg/net/http/#Transport.IdleConnTimeout) documentation.

--- a/pkg/setting/setting_data_proxy.go
+++ b/pkg/setting/setting_data_proxy.go
@@ -23,10 +23,5 @@ func readDataProxySettings(iniFile *ini.File, cfg *Cfg) error {
 		cfg.DataProxyRowLimit = defaultDataProxyRowLimit
 	}
 
-	if val, err := dataproxy.Key("max_idle_connections_per_host").Int(); err == nil {
-		cfg.Logger.Warn("[Deprecated] the configuration setting 'max_idle_connections_per_host' is deprecated, please use 'max_idle_connections' instead")
-		cfg.DataProxyMaxIdleConns = val
-	}
-
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes support for deprecated `[dataproxy].max_idle_connections_per_host` setting. `max_idle_connections` should be used instead.

**Which issue(s) this PR fixes**:
Ref #47509 

**Special notes for your reviewer**:

# Release notice breaking change

Removes support for deprecated dataproxy.max_idle_connections_per_host setting. Please use max_idle_connections instead.