### PR TITLE
Alerting: Unescape label matcher values when migrating matchers

### DIFF
--- a/public/app/features/alerting/unified/utils/alertmanager.ts
+++ b/public/app/features/alerting/unified/utils/alertmanager.ts
@@ -117,6 +117,16 @@ export function matchersToString(matchers: Matcher[]) {
   return `{${combinedMatchers}}`;
 }
 
+// this function is used to unescape label values that are recorded in the "matchers" property as opposed to "object_matchers"
+// when we edit a Grafana managed rule that was migrated
+function unescapeMatcherValue(value: string) {
+  let trimmed = value.trim().replace(/\\"/g, '"');
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') && !trimmed.endsWith('\\"')) {
+    trimmed = trimmed.slice(1, trimmed.length - 1);
+  }
+  return trimmed.replace(/\\"/g, '"');
+}
+
 export const matcherFieldOptions: SelectableValue[] = [
   { label: MatcherOperator.equal, description: 'Equals', value: MatcherOperator.equal },
   { label: MatcherOperator.notEqual, description: 'Does not equal', value: MatcherOperator.notEqual },
@@ -146,7 +156,7 @@ export function parseMatcher(matcher: string): Matcher {
   }
   const [operator, idx] = operatorsFound[0];
   const name = trimmed.slice(0, idx).trim();
-  const value = trimmed.slice(idx + operator.length).trim();
+  const value = unescapeMatcherValue(trimmed.slice(idx + operator.length).trim());
   if (!name) {
     throw new Error(`Invalid matcher: ${trimmed}`);
   }


### PR DESCRIPTION
When alert rules are migrated, the `matchers` field is used. The value of each label matcher is also wrapped in double quotes.

When editing the notification policy afterwards we use the `object_matchers` property but do not remove the double quotes around the value.

A regression was introduced in https://github.com/grafana/grafana/pull/45334 in the attempt to fix another bug related to label matcher values.

This commit re-introduces the `unescapeMatcherValue` function that is called when updating Grafana managed alert rules with existing `matchers` instead of `object_matchers`.

Setting this to `draft` mode to has out some details with @gotjosh 
