### PR TITLE
[v8.5.x] Azure Monitor: Include datasource ref when interpolating variables

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/query.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/__mocks__/query.ts
@@ -1,7 +1,17 @@
 import { AzureMonitorQuery, AzureQueryType } from '../types';
 
-export default function createMockQuery(): AzureMonitorQuery {
+export default function createMockQuery(overrides?: Partial<AzureMonitorQuery>): AzureMonitorQuery {
   return {
+    queryType: AzureQueryType.AzureMonitor,
+    refId: 'A',
+    subscription: '99999999-cccc-bbbb-aaaa-9106972f9572',
+    subscriptions: ['99999999-cccc-bbbb-aaaa-9106972f9572'],
+    datasource: {
+      type: 'grafana-azure-monitor-datasource',
+      uid: 'AAAAA11111BBBBB22222CCCC',
+    },
+    ...overrides,
+
     appInsights: undefined, // The actualy shape of this at runtime disagrees with the ts interface
 
     azureLogAnalytics: {
@@ -10,11 +20,13 @@ export default function createMockQuery(): AzureMonitorQuery {
       resultFormat: 'time_series',
       workspace: 'e3fe4fde-ad5e-4d60-9974-e2f3562ffdf2',
       resource: 'test-resource',
+      ...overrides?.azureLogAnalytics,
     },
 
     azureResourceGraph: {
       query: 'Resources | summarize count()',
       resultFormat: 'table',
+      ...overrides?.azureResourceGraph,
     },
 
     azureMonitor: {
@@ -32,20 +44,12 @@ export default function createMockQuery(): AzureMonitorQuery {
       alias: '',
       // timeGrains: [],
       top: '10',
+      ...overrides?.azureMonitor,
     },
 
     insightsAnalytics: {
       query: '',
       resultFormat: 'time_series',
-    },
-
-    queryType: AzureQueryType.AzureMonitor,
-    refId: 'A',
-    subscription: '99999999-cccc-bbbb-aaaa-9106972f9572',
-    subscriptions: ['99999999-cccc-bbbb-aaaa-9106972f9572'],
-    datasource: {
-      type: 'grafana-azure-monitor-datasource',
-      uid: 'AAAAA11111BBBBB22222CCCC',
     },
   };
 }

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.test.ts
@@ -1,0 +1,37 @@
+import { createMockInstanceSetttings } from './__mocks__/instanceSettings';
+import createMockQuery from './__mocks__/query';
+import Datasource from './datasource';
+
+describe('Azure Monitor Datasource', () => {
+  describe('interpolateVariablesInQueries()', () => {
+    it('should interpolate variables in the queries', () => {
+      const ds = new Datasource(createMockInstanceSetttings());
+      const queries = [createMockQuery({ azureMonitor: { resourceGroup: '$resourceGroup' } })];
+
+      const interpolatedQueries = ds.interpolateVariablesInQueries(queries, {
+        resourceGroup: { text: 'the-resource-group', value: 'the-resource-group' },
+      });
+
+      expect(interpolatedQueries).toContainEqual(
+        expect.objectContaining({
+          azureMonitor: expect.objectContaining({ resourceGroup: 'the-resource-group' }),
+        })
+      );
+    });
+
+    it('should include a datasource ref when interpolating queries', () => {
+      const ds = new Datasource(createMockInstanceSetttings());
+      const query = createMockQuery();
+      delete query.datasource;
+      const queries = [query];
+
+      const interpolatedQueries = ds.interpolateVariablesInQueries(queries, {});
+
+      expect(interpolatedQueries).toContainEqual(
+        expect.objectContaining({
+          datasource: expect.objectContaining({ type: 'azuremonitor', uid: 'abc' }),
+        })
+      );
+    });
+  });
+});

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
@@ -290,7 +290,10 @@ export default class Datasource extends DataSourceApi<AzureMonitorQuery, AzureDa
       }
 
       const ds = this.pseudoDatasource[query.queryType];
-      return ds?.applyTemplateVariables(query, scopedVars) ?? query;
+      return {
+        datasource: ds?.getRef(),
+        ...(ds?.applyTemplateVariables(query, scopedVars) ?? query),
+      };
     });
 
     return mapped;


### PR DESCRIPTION
Backport 7156935d1226b0076537d476f7ef1c4d9240d65b from #49543
