### PR TITLE
48044 keep only one panel menu opened

### DIFF
--- a/packages/grafana-ui/src/components/ClickOutsideWrapper/ClickOutsideWrapper.tsx
+++ b/packages/grafana-ui/src/components/ClickOutsideWrapper/ClickOutsideWrapper.tsx
@@ -47,10 +47,10 @@ export class ClickOutsideWrapper extends PureComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (this.props.setHandlers) {
-      this.setHandlers();
-    } else {
-      if (prevProps.setHandlers) {
+    if (this.props.setHandlers !== prevProps.setHandlers) {
+      if (this.props.setHandlers) {
+        this.setHandlers();
+      } else {
         this.removeHandlers();
       }
     }

--- a/packages/grafana-ui/src/components/ClickOutsideWrapper/ClickOutsideWrapper.tsx
+++ b/packages/grafana-ui/src/components/ClickOutsideWrapper/ClickOutsideWrapper.tsx
@@ -15,6 +15,8 @@ export interface Props {
    * https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener. Defaults to false.
    */
   useCapture?: boolean;
+  setHandlers?: boolean;
+  className?: string;
 }
 
 interface State {
@@ -26,6 +28,8 @@ export class ClickOutsideWrapper extends PureComponent<Props, State> {
     includeButtonPress: true,
     parent: typeof window !== 'undefined' ? window : null,
     useCapture: false,
+    setHandlers: false,
+    className: null,
   };
   myRef = createRef<HTMLDivElement>();
   state = {
@@ -33,6 +37,26 @@ export class ClickOutsideWrapper extends PureComponent<Props, State> {
   };
 
   componentDidMount() {
+    if (this.props.setHandlers) {
+      this.setHandlers();
+    }
+  }
+
+  componentWillUnmount() {
+    this.removeHandlers();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.props.setHandlers) {
+      this.setHandlers();
+    } else {
+      if (prevProps.setHandlers) {
+        this.removeHandlers();
+      }
+    }
+  }
+
+  setHandlers() {
     this.props.parent.addEventListener('click', this.onOutsideClick, this.props.useCapture);
     if (this.props.includeButtonPress) {
       // Use keyup since keydown already has an event listener on window
@@ -40,7 +64,7 @@ export class ClickOutsideWrapper extends PureComponent<Props, State> {
     }
   }
 
-  componentWillUnmount() {
+  removeHandlers() {
     this.props.parent.removeEventListener('click', this.onOutsideClick, this.props.useCapture);
     if (this.props.includeButtonPress) {
       this.props.parent.removeEventListener('keyup', this.onOutsideClick, this.props.useCapture);
@@ -56,6 +80,10 @@ export class ClickOutsideWrapper extends PureComponent<Props, State> {
   };
 
   render() {
-    return <div ref={this.myRef}>{this.props.children}</div>;
+    return (
+      <div ref={this.myRef} className={this.props.className}>
+        {this.props.children}
+      </div>
+    );
   }
 }

--- a/packages/grafana-ui/src/components/ClickOutsideWrapper/ClickOutsideWrapper.tsx
+++ b/packages/grafana-ui/src/components/ClickOutsideWrapper/ClickOutsideWrapper.tsx
@@ -28,7 +28,7 @@ export class ClickOutsideWrapper extends PureComponent<Props, State> {
     includeButtonPress: true,
     parent: typeof window !== 'undefined' ? window : null,
     useCapture: false,
-    setHandlers: false,
+    setHandlers: true,
     className: null,
   };
   myRef = createRef<HTMLDivElement>();

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -554,18 +554,6 @@ export class PanelChrome extends PureComponent<Props, State> {
         className={containerClassNames}
         aria-label={selectors.components.Panels.Panel.containerByTitle(panel.title)}
       >
-        <PanelHeader
-          panel={panel}
-          dashboard={dashboard}
-          title={panel.title}
-          description={panel.description}
-          links={panel.links}
-          error={errorMessage}
-          isEditing={isEditing}
-          isViewing={isViewing}
-          alertState={alertState}
-          data={data}
-        />
         <ErrorBoundary
           dependencies={[data, plugin, panel.getOptions()]}
           onError={this.onPanelError}
@@ -578,6 +566,21 @@ export class PanelChrome extends PureComponent<Props, State> {
             return this.renderPanel(width, height);
           }}
         </ErrorBoundary>
+
+        <PanelHeader
+          /* Panel header should follow the content because in some cases(i.e. hidden title) it will be absolutely
+          positioned and covers content */
+          panel={panel}
+          dashboard={dashboard}
+          title={panel.title}
+          description={panel.description}
+          links={panel.links}
+          error={errorMessage}
+          isEditing={isEditing}
+          isViewing={isViewing}
+          alertState={alertState}
+          data={data}
+        />
       </section>
     );
   }

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeader.tsx
@@ -3,7 +3,7 @@ import React, { FC } from 'react';
 
 import { DataLink, GrafanaTheme2, PanelData } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Icon, useStyles2 } from '@grafana/ui';
+import { ClickOutsideWrapper, Icon, useStyles2 } from '@grafana/ui';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getPanelLinksSupplier } from 'app/features/panel/panellinks/linkSuppliers';
@@ -48,7 +48,12 @@ export const PanelHeader: FC<Props> = ({ panel, error, isViewing, isEditing, dat
         <PanelHeaderMenuTrigger data-testid={selectors.components.Panels.Panel.title(title)}>
           {({ closeMenu, panelMenuOpen }) => {
             return (
-              <div className="panel-title">
+              <ClickOutsideWrapper
+                onClick={closeMenu}
+                parent={document}
+                className="panel-title"
+                setHandlers={panelMenuOpen}
+              >
                 <PanelHeaderNotices frames={data.series} panelId={panel.id} />
                 {alertState ? (
                   <Icon
@@ -60,13 +65,13 @@ export const PanelHeader: FC<Props> = ({ panel, error, isViewing, isEditing, dat
                 ) : null}
                 <h2 className={styles.titleText}>{title}</h2>
                 <Icon name="angle-down" className="panel-menu-toggle" />
-                <PanelHeaderMenuWrapper panel={panel} dashboard={dashboard} show={panelMenuOpen} onClose={closeMenu} />
+                {panelMenuOpen ? <PanelHeaderMenuWrapper panel={panel} dashboard={dashboard} /> : null}
                 {data.request && data.request.timeInfo && (
                   <span className="panel-time-info">
                     <Icon name="clock-nine" size="sm" /> {data.request.timeInfo}
                   </span>
                 )}
-              </div>
+              </ClickOutsideWrapper>
             );
           }}
         </PanelHeaderMenuTrigger>

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenuTrigger.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenuTrigger.tsx
@@ -20,8 +20,6 @@ export const PanelHeaderMenuTrigger: FC<Props> = ({ children, ...divProps }) => 
         return;
       }
 
-      event.stopPropagation();
-
       setPanelMenuOpen(!panelMenuOpen);
     },
     [clickCoordinates, panelMenuOpen, setPanelMenuOpen]

--- a/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenuWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelHeader/PanelHeaderMenuWrapper.tsx
@@ -1,7 +1,5 @@
 import React, { FC } from 'react';
 
-import { ClickOutsideWrapper } from '@grafana/ui';
-
 import { DashboardModel, PanelModel } from '../../state';
 
 import { PanelHeaderMenu } from './PanelHeaderMenu';
@@ -10,22 +8,14 @@ import { PanelHeaderMenuProvider } from './PanelHeaderMenuProvider';
 interface Props {
   panel: PanelModel;
   dashboard: DashboardModel;
-  show: boolean;
-  onClose: () => void;
 }
 
-export const PanelHeaderMenuWrapper: FC<Props> = ({ show, onClose, panel, dashboard }) => {
-  if (!show) {
-    return null;
-  }
-
+export const PanelHeaderMenuWrapper: FC<Props> = ({ panel, dashboard }) => {
   return (
-    <ClickOutsideWrapper onClick={onClose} parent={document}>
-      <PanelHeaderMenuProvider panel={panel} dashboard={dashboard}>
-        {({ items }) => {
-          return <PanelHeaderMenu items={items} />;
-        }}
-      </PanelHeaderMenuProvider>
-    </ClickOutsideWrapper>
+    <PanelHeaderMenuProvider panel={panel} dashboard={dashboard}>
+      {({ items }) => {
+        return <PanelHeaderMenu items={items} />;
+      }}
+    </PanelHeaderMenuProvider>
   );
 };

--- a/public/sass/components/_panel_header.scss
+++ b/public/sass/components/_panel_header.scss
@@ -1,6 +1,7 @@
 $panel-header-no-title-zindex: 1;
 
 .panel-header {
+  order: -1;
   &:hover {
     transition: background-color 0.1s ease-in-out;
     background-color: $panel-header-hover-bg;
@@ -12,7 +13,7 @@ $panel-header-no-title-zindex: 1;
     position: absolute;
     left: min(50px, 10%); // allows space for interaction in the corders
     right: min(50px, 10%);
-    z-index: $panel-header-z-index;
+    order: 1;
 
     &:hover {
       left: 0;


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Fixes [#37436](https://github.com/grafana/grafana/issues/37436)

**Special notes for your reviewer**:

This PR fixes multiple simultaneos opened panel menus that lead to various UI bugs. Keeping only one opened menu is a good widely used practice in UI/UX.
