### PR TITLE
Loki: add cookie-handling functionality

### DIFF
--- a/pkg/tsdb/loki/api_mock.go
+++ b/pkg/tsdb/loki/api_mock.go
@@ -37,5 +37,5 @@ func makeMockedAPI(statusCode int, contentType string, responseBytes []byte, req
 		Transport: &mockedRoundTripper{statusCode: statusCode, contentType: contentType, responseBytes: responseBytes, requestCallback: requestCallback},
 	}
 
-	return newLokiAPI(&client, "http://localhost:9999", log.New("test"), "")
+	return newLokiAPI(&client, "http://localhost:9999", log.New("test"), nil)
 }

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -117,9 +117,7 @@ export class LokiDatasource
     this.languageProvider = new LanguageProvider(this);
     const settingsData = instanceSettings.jsonData || {};
     this.maxLines = parseInt(settingsData.maxLines ?? '0', 10) || DEFAULT_MAX_LINES;
-    const keepCookiesUsed = (settingsData.keepCookies ?? []).length > 0;
-    // only use backend-mode when keep-cookies is not used
-    this.useBackendMode = !keepCookiesUsed && (config.featureToggles.lokiBackendMode ?? false);
+    this.useBackendMode = config.featureToggles.lokiBackendMode ?? false;
   }
 
   _request(apiUrl: string, data?: any, options?: Partial<BackendSrvRequest>): Observable<Record<string, any>> {


### PR DESCRIPTION
in the Loki datasource config, there are two settings that require special care:
- "Forward OAuth identity"
- "Allowed cookies"

<img width="559" alt="auth" src="https://user-images.githubusercontent.com/51989/171361927-f85552cb-9ebb-4e9d-88cc-40db6fda21ed.png">

to handle those in the loki datasource, we need to take header-values given to us by Grafana, and send them "forward" to the Loki database:
- "Forward OAuth identity" needs the header named "Authorization"
- "Allowed cookies" needs the header named "Cookie"

we already handle the "Authorization" header, this pull-request adds support for the "Cookie" header too.

the following changes happened:
- `api.go`: until now it handled the `oauth` header-string only, now it has a `headers` attribute that is a `map[string]string`, so it can handle any header
- `loki.go`:
  - before we only extracted the `Authorization` header, now we extract the `Cookie` header too
  - before we did some extra work that is not needed: we checked the datasource's jsondata for the `oauthPassThru` field, and only extracted `Authorization` when it was enabled. this check is not needed, grafana does this check for us. so i removed a bunch of code that did this
- `auth_test.go`: adjusted to the changes in `loki.go`
- `datasource.ts`: because the "Allowed cookies" functionality did not work in the past in backend-mode, we switched to frontend-mode when the user used "Allowed cookies". this is not needed anymore.

### how to test:

because the code changed a lot, we should test both the "forward oauth" and the "allowed cookies" functionality.
NOTE:  you need a way to see the http request sent from grafana-server to the loki-database.

"forward oauth" test:
1. make a grafana setup where you can log in using oauth.
2. have two loki datasources, one has oauth-forward enabled, one has it disabled
3. we need to be in frontend-mode at this point, so add this to your `conf/custom.ini`:
    ```
    [feature_toggles]
    lokiBackendMode = false
    ```
4. choose the oauth-forward-enabled loki datasorce in explore, run a query. verify that an `Authorization` header is sent to Loki. this was not done by "us". in frontend-mode this is done by grafana itself. write down the value of the `Authorization` header that was sent to Loki.
5. now remove that part from `conf/custom.ini`, so we switch back to "backend mode"
6. repeat step [4], verify that the `Authorization` header is sent to Loki, and it's value is the same as previously.
7. now choose the oauth-forward-disabled loki datasource, run a query, verify that no `Authorization` header was sent.

"allowed cookies" test:
1. setup two cookies in your browser, the easiest way is to open the grafana explore page, then open the browser devtools javascript console, and run these two commands: `document.cookie="c1=v1"; document.cookie="c2=v2"`. you can verify in your browser-devtools that now, whenever you make a request to grafana, these two cookies are sent in the `Cookie` http-header to grafana.
2. have a loki datasource where the allowed-cookies setting has these two cookie-names. have a second loki datasource, that does not use allowed-cookies
3. choose the allowed-cookies loki datasource in explore, run a query, and verify that:
    - we send the `Cookie` header to the Loki database
    - the value of the `Cookie` header is exactly `c1=v1; c2=v2` or `c2=v2; c1=v1`
5. choose the not-allowed-cookies loki datasource in explore, run a query, and verify that the `Cookie` header is not sent to Loki