### PR TITLE
Table: Reorder panel options

### DIFF
--- a/e2e/panels-suite/panelEdit_base.spec.ts
+++ b/e2e/panels-suite/panelEdit_base.spec.ts
@@ -102,7 +102,7 @@ e2e.scenario({
     e2e.components.PanelEditor.DataPane.content().should('be.visible');
 
     // Field & Overrides tabs (need to switch to React based vis, i.e. Table)
-    e2e.components.PanelEditor.OptionsPane.fieldLabel('Header and footer Show header').should('be.visible');
+    e2e.components.PanelEditor.OptionsPane.fieldLabel('Table Show table header').should('be.visible');
     e2e.components.PanelEditor.OptionsPane.fieldLabel('Table Column width').should('be.visible');
   },
 });

--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -15,6 +15,8 @@ import { tableMigrationHandler, tablePanelChangedHandler } from './migrations';
 import { PanelOptions, defaultPanelOptions, defaultPanelFieldConfig } from './models.gen';
 import { TableSuggestionsSupplier } from './suggestions';
 
+const footerCategory = 'Table footer';
+
 export const plugin = new PanelPlugin<PanelOptions, TableFieldOptions>(TablePanel)
   .setPanelChangeHandler(tablePanelChangedHandler)
   .setMigrationHandler(tableMigrationHandler)
@@ -110,21 +112,18 @@ export const plugin = new PanelPlugin<PanelOptions, TableFieldOptions>(TablePane
     builder
       .addBooleanSwitch({
         path: 'showHeader',
-        category: ['Header and footer'],
-        name: 'Show header',
-        description: "To display table's header or not to display",
+        name: 'Show table header',
         defaultValue: defaultPanelOptions.showHeader,
       })
       .addBooleanSwitch({
         path: 'footer.show',
-        category: ['Header and footer'],
-        name: 'Show Footer',
-        description: "To display table's footer or not to display",
+        category: [footerCategory],
+        name: 'Show table footer',
         defaultValue: defaultPanelOptions.footer?.show,
       })
       .addCustomEditor({
         id: 'footer.reducer',
-        category: ['Header and footer'],
+        category: [footerCategory],
         path: 'footer.reducer',
         name: 'Calculation',
         description: 'Choose a reducer function / calculation',
@@ -134,7 +133,7 @@ export const plugin = new PanelPlugin<PanelOptions, TableFieldOptions>(TablePane
       })
       .addMultiSelect({
         path: 'footer.fields',
-        category: ['Header and footer'],
+        category: [footerCategory],
         name: 'Fields',
         description: 'Select the fields that should be calculated',
         settings: {
@@ -161,7 +160,6 @@ export const plugin = new PanelPlugin<PanelOptions, TableFieldOptions>(TablePane
       })
       .addCustomEditor({
         id: 'footer.enablePagination',
-        category: ['Header and footer'],
         path: 'footer.enablePagination',
         name: 'Enable pagination',
         editor: PaginationEditor,


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes table panel options as discussed in slack. Moved Show header and Pagination to the main Table category. And rename the Header and Footer category to "Table footer". Also removed the descriptions from show header and show footer.

![Screenshot 2022-06-01 at 11 21 53](https://user-images.githubusercontent.com/13729989/171372239-e9763a85-3dfd-492c-a2cb-0d39d70ed17a.png)

