### PR TITLE
Metrics: Remove support for using summaries instead of histogram for HTTP instrumentation

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -36,7 +36,6 @@ export interface FeatureToggles {
   influxdbBackendMigration?: boolean;
   newNavigation?: boolean;
   showFeatureFlagsInUI?: boolean;
-  disable_http_request_histogram?: boolean;
   publicDashboards?: boolean;
   lokiLive?: boolean;
   swaggerUi?: boolean;

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -24,12 +24,6 @@ var (
 	// MProxyStatus is a metric proxy http response status
 	MProxyStatus *prometheus.CounterVec
 
-	// MHttpRequestTotal is a metric http request counter
-	MHttpRequestTotal *prometheus.CounterVec
-
-	// MHttpRequestSummary is a metric http request summary
-	MHttpRequestSummary *prometheus.SummaryVec
-
 	// MApiUserSignUpStarted is a metric amount of users who started the signup flow
 	MApiUserSignUpStarted prometheus.Counter
 
@@ -225,23 +219,6 @@ func init() {
 			Help:      "proxy http response status",
 			Namespace: ExporterName,
 		}, []string{"code"}, httpStatusCodes...)
-
-	MHttpRequestTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "http_request_total",
-			Help: "http request counter",
-		},
-		[]string{"handler", "statuscode", "method"},
-	)
-
-	MHttpRequestSummary = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Name:       "http_request_duration_milliseconds",
-			Help:       "http request summary",
-			Objectives: objectiveMap,
-		},
-		[]string{"handler", "statuscode", "method"},
-	)
 
 	MApiUserSignUpStarted = newCounterStartingAtZero(prometheus.CounterOpts{
 		Name:      "api_user_signup_started_total",
@@ -615,8 +592,6 @@ func initMetricVars() {
 		MPageStatus,
 		MApiStatus,
 		MProxyStatus,
-		MHttpRequestTotal,
-		MHttpRequestSummary,
 		MApiUserSignUpStarted,
 		MApiUserSignUpCompleted,
 		MApiUserSignUpInvite,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -118,11 +118,6 @@ var (
 			RequiresDevMode: true,
 		},
 		{
-			Name:        "disable_http_request_histogram",
-			Description: "Do not create histograms for http requests",
-			State:       FeatureStateAlpha,
-		},
-		{
 			Name:            "publicDashboards",
 			Description:     "enables public access to dashboards",
 			State:           FeatureStateAlpha,

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -87,10 +87,6 @@ const (
 	// Show feature flags in the settings UI
 	FlagShowFeatureFlagsInUI = "showFeatureFlagsInUI"
 
-	// FlagDisableHttpRequestHistogram
-	// Do not create histograms for http requests
-	FlagDisableHttpRequestHistogram = "disable_http_request_histogram"
-
 	// FlagPublicDashboards
 	// enables public access to dashboards
 	FlagPublicDashboards = "publicDashboards"

--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -18,14 +18,13 @@ import (
 
 func TestFeatureToggleFiles(t *testing.T) {
 	legacyNames := map[string]bool{
-		"httpclientprovider_azure_auth":  true,
-		"service-accounts":               true,
-		"database_metrics":               true,
-		"live-config":                    true,
-		"live-pipeline":                  true,
-		"live-service-web-worker":        true,
-		"prometheus_azure_auth":          true,
-		"disable_http_request_histogram": true,
+		"httpclientprovider_azure_auth": true,
+		"service-accounts":              true,
+		"database_metrics":              true,
+		"live-config":                   true,
+		"live-pipeline":                 true,
+		"live-service-web-worker":       true,
+		"prometheus_azure_auth":         true,
 	}
 
 	t.Run("verify files", func(t *testing.T) {


### PR DESCRIPTION
Removes the option to instrument HTTP request in Grafana using summaries instead of histograms. 

ref https://github.com/grafana/grafana/issues/47509

# Release notice breaking change

Removes the option to instrument HTTP request in Grafana using summaries instead of histograms. 