### PR TITLE
Plugins Catalog: Make tabs position consistent with other Grafana pages

### DIFF
--- a/public/app/features/plugins/admin/pages/PluginDetails.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.tsx
@@ -75,22 +75,25 @@ export default function PluginDetails({ match, queryParams }: Props): JSX.Elemen
   return (
     <Page>
       <PluginDetailsHeader currentUrl={`${url}?page=${pageId}`} parentUrl={parentUrl} plugin={plugin} />
+      {/* Tab navigation */}
+      <div>
+        <div className="page-container">
+          <TabsBar hideBorder>
+            {tabs.map((tab: PluginDetailsTab) => {
+              return (
+                <Tab
+                  key={tab.label}
+                  label={tab.label}
+                  href={tab.href}
+                  icon={tab.icon as IconName}
+                  active={tab.id === pageId}
+                />
+              );
+            })}
+          </TabsBar>
+        </div>
+      </div>
       <Page.Contents>
-        {/* Tab navigation */}
-        <TabsBar>
-          {tabs.map((tab: PluginDetailsTab) => {
-            return (
-              <Tab
-                key={tab.label}
-                label={tab.label}
-                href={tab.href}
-                icon={tab.icon as IconName}
-                active={tab.id === pageId}
-              />
-            );
-          })}
-        </TabsBar>
-
         {/* Active tab */}
         <TabContent className={styles.tabContent}>
           <PluginDetailsSignature plugin={plugin} className={styles.alert} />


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Whilst doing some v9 testing I spotted the tabs for PluginDetails page are inside the page "contents". This PR pulls them out so they are consistent with other pages across Grafana.

| Before | After |
| --- | --- |
| <img width="1678" alt="Screenshot 2022-06-01 at 13 06 59" src="https://user-images.githubusercontent.com/73201/171390962-75c7dddd-ca4f-4fd6-906b-8220600528af.png"> | <img width="1679" alt="Screenshot 2022-06-01 at 13 00 15" src="https://user-images.githubusercontent.com/73201/171390987-1d8e16b3-a6ef-4528-b704-d111bbd1b545.png"> |


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
This is a quick fix. A future PR will refactor this page and the page.header component.