### PR TITLE
Loki: Do not produce histogram for instant queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -25,7 +25,7 @@ import { CustomVariableModel } from '../../../features/variables/types';
 
 import { isMetricsQuery, LokiDatasource, RangeQueryOptions } from './datasource';
 import { makeMockLokiDatasource } from './mocks';
-import { LokiQuery, LokiResponse, LokiResultType } from './types';
+import { LokiQuery, LokiQueryType, LokiResponse, LokiResultType } from './types';
 
 jest.mock('@grafana/runtime', () => ({
   // @ts-ignore
@@ -996,6 +996,15 @@ describe('LokiDatasource', () => {
       });
 
       expect(ds.getLogsVolumeDataProvider(options)).toBeDefined();
+    });
+
+    it('does not create provider if there is only an instant logs query', () => {
+      const ds = createLokiDSForTests();
+      const options = getQueryOptions<LokiQuery>({
+        targets: [{ expr: '{label=value', refId: 'A', queryType: LokiQueryType.Instant }],
+      });
+
+      expect(ds.getLogsVolumeDataProvider(options)).not.toBeDefined();
     });
   });
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -141,22 +141,28 @@ export class LokiDatasource
   }
 
   getLogsVolumeDataProvider(request: DataQueryRequest<LokiQuery>): Observable<DataQueryResponse> | undefined {
-    const isLogsVolumeAvailable = request.targets.some((target) => target.expr && !isMetricsQuery(target.expr));
+    const isQuerySuitable = (query: LokiQuery) => {
+      const normalized = getNormalizedLokiQuery(query);
+      const { expr } = normalized;
+      // it has to be a logs-producing range-query
+      return expr && !isMetricsQuery(expr) && normalized.queryType === LokiQueryType.Range;
+    };
+
+    const isLogsVolumeAvailable = request.targets.some(isQuerySuitable);
+
     if (!isLogsVolumeAvailable) {
       return undefined;
     }
 
     const logsVolumeRequest = cloneDeep(request);
-    logsVolumeRequest.targets = logsVolumeRequest.targets
-      .filter((target) => target.expr && !isMetricsQuery(target.expr))
-      .map((target) => {
-        return {
-          ...target,
-          instant: false,
-          volumeQuery: true,
-          expr: `sum by (level) (count_over_time(${target.expr}[$__interval]))`,
-        };
-      });
+    logsVolumeRequest.targets = logsVolumeRequest.targets.filter(isQuerySuitable).map((target) => {
+      return {
+        ...target,
+        instant: false,
+        volumeQuery: true,
+        expr: `sum by (level) (count_over_time(${target.expr}[$__interval]))`,
+      };
+    });
 
     return queryLogsVolume(this, logsVolumeRequest, {
       extractLevel,


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/49749

in the Loki datasource, when you use an instant-query, that is only really useful for metric (numbers-producing) queries. for logs-producing queries, range-queries are the way to go. still, logs-producing instant-queries can happen, and it causes problems for the log-volume-histogram.
this pull-request modifes the log-volume-histogram so that it ignores instant-queries.

how to test:
1. use a loki datasource
2. go to explore
3. run a logs-producing range query. verify that you see a histogram
4. run a logs-producing instant query. verify that you do not see a histogram