### PR TITLE
Draggable: only set drag handle props on the drag handle itself

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -110,7 +110,7 @@ exports[`no enzyme tests`] = {
     "public/app/core/components/QueryOperationRow/QueryOperationAction.test.tsx:3032694716": [
       [0, 19, 13, "RegExp match", "2409514259"]
     ],
-    "public/app/core/components/QueryOperationRow/QueryOperationRow.test.tsx:2026575657": [
+    "public/app/core/components/QueryOperationRow/QueryOperationRow.test.tsx:3743889097": [
       [0, 26, 13, "RegExp match", "2409514259"]
     ],
     "public/app/core/components/Select/MetricSelect.test.tsx:3351544014": [

--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.test.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.test.tsx
@@ -60,7 +60,7 @@ describe('QueryOperationRow', () => {
   describe('headerElement rendering', () => {
     it('should render headerElement provided as element', () => {
       const title = <div aria-label="test title">Test</div>;
-      const wrapper = shallow(
+      const wrapper = mount(
         <QueryOperationRow headerElement={title} id="test-id" index={0}>
           <div>Test</div>
         </QueryOperationRow>
@@ -72,7 +72,7 @@ describe('QueryOperationRow', () => {
 
     it('should render headerElement provided as function', () => {
       const title = () => <div aria-label="test title">Test</div>;
-      const wrapper = shallow(
+      const wrapper = mount(
         <QueryOperationRow headerElement={title} id="test-id" index={0}>
           <div>Test</div>
         </QueryOperationRow>
@@ -101,7 +101,7 @@ describe('QueryOperationRow', () => {
   describe('actions rendering', () => {
     it('should render actions provided as element', () => {
       const actions = <div aria-label="test actions">Test</div>;
-      const wrapper = shallow(
+      const wrapper = mount(
         <QueryOperationRow actions={actions} id="test-id" index={0}>
           <div>Test</div>
         </QueryOperationRow>
@@ -112,7 +112,7 @@ describe('QueryOperationRow', () => {
     });
     it('should render actions provided as function', () => {
       const actions = () => <div aria-label="test actions">Test</div>;
-      const wrapper = shallow(
+      const wrapper = mount(
         <QueryOperationRow actions={actions} id="test-id" index={0}>
           <div>Test</div>
         </QueryOperationRow>

--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import React, { useCallback, useState } from 'react';
-import { Draggable } from 'react-beautiful-dnd';
+import { Draggable, DraggableProvidedDragHandleProps } from 'react-beautiful-dnd';
 import { useUpdateEffect } from 'react-use';
 
 import { GrafanaTheme } from '@grafana/data';
@@ -93,7 +93,7 @@ export const QueryOperationRow: React.FC<QueryOperationRowProps> = ({
   const actionsElement = actions && ReactUtils.renderOrCallToRender(actions, renderPropArgs);
   const headerElementRendered = headerElement && ReactUtils.renderOrCallToRender(headerElement, renderPropArgs);
 
-  const rowHeader = (
+  const getRowHeader = (dragHandleProps?: DraggableProvidedDragHandleProps) => (
     <div className={styles.header}>
       <div className={styles.column}>
         <Icon
@@ -112,7 +112,14 @@ export const QueryOperationRow: React.FC<QueryOperationRowProps> = ({
       <div className={styles.column}>
         {actionsElement}
         {draggable && (
-          <Icon title="Drag and drop to reorder" name="draggabledots" size="lg" className={styles.dragIcon} />
+          <Icon
+            title="Drag and drop to reorder"
+            name="draggabledots"
+            size="lg"
+            className={styles.dragIcon}
+            onMouseMove={reportDragMousePosition}
+            {...dragHandleProps}
+          />
         )}
       </div>
     </div>
@@ -122,13 +129,10 @@ export const QueryOperationRow: React.FC<QueryOperationRowProps> = ({
     return (
       <Draggable draggableId={id} index={index}>
         {(provided) => {
-          const dragHandleProps = { ...provided.dragHandleProps, role: 'group' }; // replace the role="button" because it causes https://dequeuniversity.com/rules/axe/4.3/nested-interactive?application=msftAI
           return (
             <>
               <div ref={provided.innerRef} className={styles.wrapper} {...provided.draggableProps}>
-                <div {...dragHandleProps} onMouseMove={reportDragMousePosition}>
-                  {rowHeader}
-                </div>
+                <div>{getRowHeader(provided.dragHandleProps)}</div>
                 {isContentVisible && <div className={styles.content}>{children}</div>}
               </div>
             </>
@@ -140,7 +144,7 @@ export const QueryOperationRow: React.FC<QueryOperationRowProps> = ({
 
   return (
     <div className={styles.wrapper}>
-      {rowHeader}
+      {getRowHeader()}
       {isContentVisible && <div className={styles.content}>{children}</div>}
     </div>
   );

--- a/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRow.tsx
@@ -1,11 +1,13 @@
-import { css, cx } from '@emotion/css';
+import { css } from '@emotion/css';
 import React, { useCallback, useState } from 'react';
-import { Draggable, DraggableProvidedDragHandleProps } from 'react-beautiful-dnd';
+import { Draggable } from 'react-beautiful-dnd';
 import { useUpdateEffect } from 'react-use';
 
 import { GrafanaTheme } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
-import { Icon, ReactUtils, stylesFactory, useTheme } from '@grafana/ui';
+import { ReactUtils, stylesFactory, useTheme } from '@grafana/ui';
+
+import { QueryOperationRowHeader } from './QueryOperationRowHeader';
 
 interface QueryOperationRowProps {
   index: number;
@@ -93,38 +95,6 @@ export const QueryOperationRow: React.FC<QueryOperationRowProps> = ({
   const actionsElement = actions && ReactUtils.renderOrCallToRender(actions, renderPropArgs);
   const headerElementRendered = headerElement && ReactUtils.renderOrCallToRender(headerElement, renderPropArgs);
 
-  const getRowHeader = (dragHandleProps?: DraggableProvidedDragHandleProps) => (
-    <div className={styles.header}>
-      <div className={styles.column}>
-        <Icon
-          name={isContentVisible ? 'angle-down' : 'angle-right'}
-          className={styles.collapseIcon}
-          onClick={onRowToggle}
-        />
-        {title && (
-          <div className={styles.titleWrapper} onClick={onRowToggle} aria-label="Query operation row title">
-            <div className={cx(styles.title, disabled && styles.disabled)}>{titleElement}</div>
-          </div>
-        )}
-        {headerElementRendered}
-      </div>
-
-      <div className={styles.column}>
-        {actionsElement}
-        {draggable && (
-          <Icon
-            title="Drag and drop to reorder"
-            name="draggabledots"
-            size="lg"
-            className={styles.dragIcon}
-            onMouseMove={reportDragMousePosition}
-            {...dragHandleProps}
-          />
-        )}
-      </div>
-    </div>
-  );
-
   if (draggable) {
     return (
       <Draggable draggableId={id} index={index}>
@@ -132,7 +102,19 @@ export const QueryOperationRow: React.FC<QueryOperationRowProps> = ({
           return (
             <>
               <div ref={provided.innerRef} className={styles.wrapper} {...provided.draggableProps}>
-                <div>{getRowHeader(provided.dragHandleProps)}</div>
+                <div>
+                  <QueryOperationRowHeader
+                    actionsElement={actionsElement}
+                    disabled={disabled}
+                    draggable
+                    dragHandleProps={provided.dragHandleProps}
+                    headerElement={headerElementRendered}
+                    isContentVisible={isContentVisible}
+                    onRowToggle={onRowToggle}
+                    reportDragMousePosition={reportDragMousePosition}
+                    titleElement={titleElement}
+                  />
+                </div>
                 {isContentVisible && <div className={styles.content}>{children}</div>}
               </div>
             </>
@@ -144,7 +126,16 @@ export const QueryOperationRow: React.FC<QueryOperationRowProps> = ({
 
   return (
     <div className={styles.wrapper}>
-      {getRowHeader()}
+      <QueryOperationRowHeader
+        actionsElement={actionsElement}
+        disabled={disabled}
+        draggable={false}
+        headerElement={headerElementRendered}
+        isContentVisible={isContentVisible}
+        onRowToggle={onRowToggle}
+        reportDragMousePosition={reportDragMousePosition}
+        titleElement={titleElement}
+      />
       {isContentVisible && <div className={styles.content}>{children}</div>}
     </div>
   );
@@ -155,62 +146,9 @@ const getQueryOperationRowStyles = stylesFactory((theme: GrafanaTheme) => {
     wrapper: css`
       margin-bottom: ${theme.spacing.md};
     `,
-    header: css`
-      label: Header;
-      padding: ${theme.spacing.xs} ${theme.spacing.sm};
-      border-radius: ${theme.border.radius.sm};
-      background: ${theme.colors.bg2};
-      min-height: ${theme.spacing.formInputHeight}px;
-      display: grid;
-      grid-template-columns: minmax(100px, max-content) min-content;
-      align-items: center;
-      justify-content: space-between;
-      white-space: nowrap;
-
-      &:focus {
-        outline: none;
-      }
-    `,
-    column: css`
-      label: Column;
-      display: flex;
-      align-items: center;
-    `,
-    dragIcon: css`
-      cursor: grab;
-      color: ${theme.colors.textWeak};
-      &:hover {
-        color: ${theme.colors.text};
-      }
-    `,
-    collapseIcon: css`
-      color: ${theme.colors.textWeak};
-      cursor: pointer;
-      &:hover {
-        color: ${theme.colors.text};
-      }
-    `,
-    titleWrapper: css`
-      display: flex;
-      align-items: center;
-      flex-grow: 1;
-      cursor: pointer;
-      overflow: hidden;
-      margin-right: ${theme.spacing.sm};
-    `,
-    title: css`
-      font-weight: ${theme.typography.weight.semibold};
-      color: ${theme.colors.textBlue};
-      margin-left: ${theme.spacing.sm};
-      overflow: hidden;
-      text-overflow: ellipsis;
-    `,
     content: css`
       margin-top: ${theme.spacing.inlineFormMargin};
       margin-left: ${theme.spacing.lg};
-    `,
-    disabled: css`
-      color: ${theme.colors.textWeak};
     `,
   };
 });

--- a/public/app/core/components/QueryOperationRow/QueryOperationRowHeader.tsx
+++ b/public/app/core/components/QueryOperationRow/QueryOperationRowHeader.tsx
@@ -1,0 +1,123 @@
+import { css, cx } from '@emotion/css';
+import React, { MouseEventHandler } from 'react';
+import { DraggableProvidedDragHandleProps } from 'react-beautiful-dnd';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { Icon, useStyles2 } from '@grafana/ui';
+
+interface QueryOperationRowHeaderProps {
+  actionsElement?: React.ReactNode;
+  disabled?: boolean;
+  draggable: boolean;
+  dragHandleProps?: DraggableProvidedDragHandleProps;
+  headerElement?: React.ReactNode;
+  isContentVisible: boolean;
+  onRowToggle: () => void;
+  reportDragMousePosition: MouseEventHandler<HTMLDivElement>;
+  titleElement?: React.ReactNode;
+}
+
+export const QueryOperationRowHeader: React.FC<QueryOperationRowHeaderProps> = ({
+  actionsElement,
+  disabled,
+  draggable,
+  dragHandleProps,
+  headerElement,
+  isContentVisible,
+  onRowToggle,
+  reportDragMousePosition,
+  titleElement,
+}: QueryOperationRowHeaderProps) => {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.header}>
+      <div className={styles.column}>
+        <Icon
+          name={isContentVisible ? 'angle-down' : 'angle-right'}
+          className={styles.collapseIcon}
+          onClick={onRowToggle}
+        />
+        {titleElement && (
+          <div className={styles.titleWrapper} onClick={onRowToggle} aria-label="Query operation row title">
+            <div className={cx(styles.title, disabled && styles.disabled)}>{titleElement}</div>
+          </div>
+        )}
+        {headerElement}
+      </div>
+
+      <div className={styles.column}>
+        {actionsElement}
+        {draggable && (
+          <Icon
+            title="Drag and drop to reorder"
+            name="draggabledots"
+            size="lg"
+            className={styles.dragIcon}
+            onMouseMove={reportDragMousePosition}
+            {...dragHandleProps}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  header: css`
+    label: Header;
+    padding: ${theme.spacing(0.5, 0.5)};
+    border-radius: ${theme.shape.borderRadius(1)};
+    background: ${theme.colors.background.secondary};
+    min-height: ${theme.spacing(4)};
+    display: grid;
+    grid-template-columns: minmax(100px, max-content) min-content;
+    align-items: center;
+    justify-content: space-between;
+    white-space: nowrap;
+
+    &:focus {
+      outline: none;
+    }
+  `,
+  column: css`
+    label: Column;
+    display: flex;
+    align-items: center;
+  `,
+  dragIcon: css`
+    cursor: grab;
+    color: ${theme.colors.text.disabled};
+    margin: ${theme.spacing(0, 0.5)};
+    &:hover {
+      color: ${theme.colors.text};
+    }
+  `,
+  collapseIcon: css`
+    color: ${theme.colors.text.disabled};
+    cursor: pointer;
+    &:hover {
+      color: ${theme.colors.text};
+    }
+  `,
+  titleWrapper: css`
+    display: flex;
+    align-items: center;
+    flex-grow: 1;
+    cursor: pointer;
+    overflow: hidden;
+    margin-right: ${theme.spacing(0.5)};
+  `,
+  title: css`
+    font-weight: ${theme.typography.fontWeightBold};
+    color: ${theme.colors.text.link};
+    margin-left: ${theme.spacing(0.5)};
+    overflow: hidden;
+    text-overflow: ellipsis;
+  `,
+  disabled: css`
+    color: ${theme.colors.text.disabled};
+  `,
+});
+
+QueryOperationRowHeader.displayName = 'QueryOperationRowHeader';

--- a/public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx
@@ -131,15 +131,16 @@ const DraggableFieldName: React.FC<DraggableFieldProps> = ({
   return (
     <Draggable draggableId={fieldName} index={index}>
       {(provided) => (
-        <div
-          className="gf-form-inline"
-          ref={provided.innerRef}
-          {...provided.draggableProps}
-          {...provided.dragHandleProps}
-        >
+        <div className="gf-form-inline" ref={provided.innerRef} {...provided.draggableProps}>
           <div className="gf-form gf-form--grow">
             <div className="gf-form-label gf-form-label--justify-left width-30">
-              <Icon name="draggabledots" title="Drag and drop to reorder" size="lg" className={styles.draggable} />
+              <Icon
+                name="draggabledots"
+                title="Drag and drop to reorder"
+                size="lg"
+                className={styles.draggable}
+                {...provided.dragHandleProps}
+              />
               <IconButton
                 className={styles.toggle}
                 size="md"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- https://github.com/grafana/grafana/pull/49142 updated our version of `react-select`
  - this includes [this pr](https://github.com/JedWatson/react-select/pull/5134) which short circuits the `onControlMouseDown` function in `react-select` if `event.defaultPrevented = true`
- `react-beatiful-dnd` sets `event.preventDefault()` on it's drag handlers
- we were incorrectly spreading `dragHandleProps` onto elements that weren't the drag handles themselves, but instead the whole row.
- changed it to spread the props onto the correct elements.
  - this also makes it so that rows can no longer be dragged from anywhere, only the appropriate drag handle. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #49867 

**Special notes for your reviewer**:

