### PR TITLE
Tracing: Fix trace links in traces panel

### DIFF
--- a/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanLinks.tsx
+++ b/packages/jaeger-ui-components/src/TraceTimelineViewer/SpanLinks.tsx
@@ -18,12 +18,15 @@ const renderMenuItems = (links: SpanLinks, styles: ReturnType<typeof getStyles>,
             <MenuItem
               key={i}
               label="Logs for this span"
-              onClick={(e) => {
-                if (link.onClick) {
-                  link.onClick(e);
-                }
-                closeMenu();
-              }}
+              onClick={
+                link.onClick
+                  ? (event) => {
+                      event?.preventDefault();
+                      link.onClick!(event);
+                      closeMenu();
+                    }
+                  : undefined
+              }
               url={link.href}
               className={styles.menuItem}
             />
@@ -36,12 +39,15 @@ const renderMenuItems = (links: SpanLinks, styles: ReturnType<typeof getStyles>,
             <MenuItem
               key={i}
               label={link.title ?? 'Metrics for this span'}
-              onClick={(e) => {
-                if (link.onClick) {
-                  link.onClick(e);
-                }
-                closeMenu();
-              }}
+              onClick={
+                link.onClick
+                  ? (event) => {
+                      event?.preventDefault();
+                      link.onClick!(event);
+                      closeMenu();
+                    }
+                  : undefined
+              }
               url={link.href}
               className={styles.menuItem}
             />
@@ -54,12 +60,15 @@ const renderMenuItems = (links: SpanLinks, styles: ReturnType<typeof getStyles>,
             <MenuItem
               key={i}
               label={link.title ?? 'View linked span'}
-              onClick={(e) => {
-                if (link.onClick) {
-                  link.onClick(e);
-                }
-                closeMenu();
-              }}
+              onClick={
+                link.onClick
+                  ? (event) => {
+                      event?.preventDefault();
+                      link.onClick!(event);
+                      closeMenu();
+                    }
+                  : undefined
+              }
               url={link.href}
               className={styles.menuItem}
             />


### PR DESCRIPTION
**What this PR does / why we need it**:
In Explore, span links have an onClick property which calls a splitOpenFn which opens another explore pane with the linked query. In the traces panel, splitOpenFn is undefined, so the links should fall back to the href to navigate. 

For this to work, onClick needs to be undefined but before it was still closing the menu. This changes it to be undefined if the link.onClick method is undefined. It's not a problem that we aren't closing the menu if onClick is undefined because the user will navigate away from the page with the menu open when clicking the link.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
To test:
1. Run any tempo instance
2. Add trace to metrics (needs `traceToMetrics` feature flag enabled)
3. Get a trace id from tempo search in Explore
4. Create a Traces Panel, select the tempo datasource, select the trace id query, and run the query with the id from 2
5. Clicking any link from the span links menu should navigate to the selected link
