### PR TITLE
Data: Remove deprecated types and functions from valueMappings

### DIFF
--- a/packages/grafana-data/src/utils/index.ts
+++ b/packages/grafana-data/src/utils/index.ts
@@ -23,12 +23,4 @@ export { DocsId } from './docs';
 export { makeClassES5Compatible } from './makeClassES5Compatible';
 export { anyToNumber } from './anyToNumber';
 export { withLoadingIndicator, WithLoadingIndicatorOptions } from './withLoadingIndicator';
-export {
-  getMappedValue,
-  convertOldAngularValueMappings,
-  LegacyValueMapping,
-  LegacyValueMap,
-  LegacyRangeMap,
-  LegacyBaseMap,
-  LegacyMappingType,
-} from './valueMappings';
+export { convertOldAngularValueMappings, LegacyMappingType } from './valueMappings';

--- a/packages/grafana-data/src/utils/valueMappings.ts
+++ b/packages/grafana-data/src/utils/valueMappings.ts
@@ -127,77 +127,6 @@ export enum LegacyMappingType {
 }
 
 /**
- * @deprecated use MappingType instead
- * @internal
- */
-export interface LegacyBaseMap {
-  id: number; // this could/should just be the array index
-  text: string; // the final display value
-  type: LegacyMappingType;
-}
-
-/**
- * @deprecated use ValueMapping instead
- * @internal
- */
-export type LegacyValueMapping = LegacyValueMap | LegacyRangeMap;
-
-/**
- * @deprecated use ValueMap instead
- * @internal
- */
-export interface LegacyValueMap extends LegacyBaseMap {
-  value: string;
-}
-
-/**
- * @deprecated use RangeMap instead
- * @internal
- */
-export interface LegacyRangeMap extends LegacyBaseMap {
-  from: string;
-  to: string;
-}
-
-/**
- * @deprecated use getValueMappingResult instead
- * @internal
- */
-export function getMappedValue(valueMappings: LegacyValueMapping[], value: any): LegacyValueMapping {
-  const emptyResult = { type: LegacyMappingType.ValueToText, value: '', text: '', from: '', to: '', id: 0 };
-  if (!valueMappings?.length) {
-    return emptyResult;
-  }
-
-  const upgraded: ValueMapping[] = [];
-  for (const vm of valueMappings) {
-    if (isValueMapping(vm)) {
-      upgraded.push(vm);
-      continue;
-    }
-    upgraded.push(upgradeOldAngularValueMapping(vm));
-  }
-
-  if (!upgraded?.length) {
-    return emptyResult;
-  }
-
-  const result = getValueMappingResult(upgraded, value);
-  if (!result) {
-    return emptyResult;
-  }
-
-  return {
-    type: LegacyMappingType.ValueToText,
-    value: result.text,
-    text: result.text ?? '',
-    from: '',
-    to: '',
-    id: result.index ?? 0,
-  };
-}
-
-/**
  * @alpha
  * Converts the old Angular value mappings to new react style
  */
@@ -308,12 +237,4 @@ function upgradeOldAngularValueMapping(old: any, thresholds?: ThresholdsConfig):
   }
 
   return newMappings[0];
-}
-
-function isValueMapping(map: any): map is ValueMapping {
-  if (!map) {
-    return false;
-  }
-
-  return map.hasOwnProperty('options') && typeof map.options === 'object';
 }


### PR DESCRIPTION
# Release notice breaking change
Removes the deprecated `LegacyBaseMap`, `LegacyValueMapping`, `LegacyValueMap`, and `LegacyRangeMap` types, and `getMappedValue` function from grafana-data. Migration is as follows:
| Old  | New |
| ------------- | ------------- |
| `LegacyBaseMap`  | `MappingType`  |
| `LegacyValueMapping`  | `ValueMapping`  |
| `LegacyValueMap`  | `ValueMap`  |
| `LegacyRangeMap`  | `RangeMap` |
| `getMappedValue`  | `getValueMappingResult` |