### PR TITLE
Chore: Remove Wrap

### DIFF
--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,7 +18,6 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/util/errutil"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -276,7 +276,7 @@ func (hs *HTTPServer) loginUserWithUser(user *models.User, c *models.ReqContext)
 	ctx := context.WithValue(c.Req.Context(), models.RequestURIKey{}, c.Req.RequestURI)
 	userToken, err := hs.AuthTokenService.CreateToken(ctx, user, ip, c.Req.UserAgent())
 	if err != nil {
-		return errutil.Wrap("failed to create auth token", err)
+		return fmt.Errorf("%v: %w", "failed to create auth token", err)
 	}
 	c.UserToken = userToken
 

--- a/pkg/api/plugin_resource.go
+++ b/pkg/api/plugin_resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
-	"github.com/grafana/grafana/pkg/util/errutil"
 	"github.com/grafana/grafana/pkg/util/proxyutil"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -174,7 +173,7 @@ func (hs *HTTPServer) flushStream(stream callResourceClientResponseStream, w htt
 		}
 		if err != nil {
 			if processedStreams == 0 {
-				return errutil.Wrap("failed to receive response from resource call", err)
+				return fmt.Errorf("%v: %w", "failed to receive response from resource call", err)
 			}
 
 			hs.log.Error("Failed to receive response from resource call", "err", err)

--- a/pkg/cmd/grafana-cli/commands/commands.go
+++ b/pkg/cmd/grafana-cli/commands/commands.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/fatih/color"
@@ -14,7 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/util/errutil"
 	"github.com/urfave/cli/v2"
 )
 
@@ -24,12 +24,12 @@ func runRunnerCommand(command func(commandLine utils.CommandLine, runner runner.
 
 		cfg, err := initCfg(cmd)
 		if err != nil {
-			return errutil.Wrap("failed to load configuration", err)
+			return fmt.Errorf("%v: %w", "failed to load configuration", err)
 		}
 
 		r, err := runner.Initialize(cfg)
 		if err != nil {
-			return errutil.Wrap("failed to initialize runner", err)
+			return fmt.Errorf("%v: %w", "failed to initialize runner", err)
 		}
 
 		if err := command(cmd, r); err != nil {
@@ -47,17 +47,17 @@ func runDbCommand(command func(commandLine utils.CommandLine, sqlStore *sqlstore
 
 		cfg, err := initCfg(cmd)
 		if err != nil {
-			return errutil.Wrap("failed to load configuration", err)
+			return fmt.Errorf("%v: %w", "failed to load configuration", err)
 		}
 
 		tracer, err := tracing.ProvideService(cfg)
 		if err != nil {
-			return errutil.Wrap("failed to initialize tracer service", err)
+			return fmt.Errorf("%v: %w", "failed to initialize tracer service", err)
 		}
 
 		sqlStore, err := sqlstore.ProvideService(cfg, nil, &migrations.OSSMigrations{}, tracer)
 		if err != nil {
-			return errutil.Wrap("failed to initialize SQL store", err)
+			return fmt.Errorf("%v: %w", "failed to initialize SQL store", err)
 		}
 
 		if err := command(cmd, sqlStore); err != nil {

--- a/pkg/cmd/grafana-cli/commands/datamigrations/encrypt_datasource_passwords.go
+++ b/pkg/cmd/grafana-cli/commands/datamigrations/encrypt_datasource_passwords.go
@@ -3,6 +3,7 @@ package datamigrations
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/fatih/color"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
@@ -89,7 +90,7 @@ func updateRows(session *sqlstore.DBSession, rows []map[string][]byte, passwordF
 
 		data, err := json.Marshal(newSecureJSONData)
 		if err != nil {
-			return 0, errutil.Wrap("marshaling newSecureJsonData failed", err)
+			return 0, fmt.Errorf("%v: %w", "marshaling newSecureJsonData failed", err)
 		}
 
 		newRow := map[string]interface{}{"secure_json_data": data, passwordFieldName: ""}

--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -117,7 +117,7 @@ func InstallPlugin(pluginName, version string, c utils.CommandLine, client utils
 	// Create temp file for downloading zip file
 	tmpFile, err := ioutil.TempFile("", "*.zip")
 	if err != nil {
-		return errutil.Wrap("failed to create temporary file", err)
+		return fmt.Errorf("%v: %w", "failed to create temporary file", err)
 	}
 	defer func() {
 		if err := os.Remove(tmpFile.Name()); err != nil {
@@ -130,16 +130,16 @@ func InstallPlugin(pluginName, version string, c utils.CommandLine, client utils
 		if err := tmpFile.Close(); err != nil {
 			logger.Warn("Failed to close file", "err", err)
 		}
-		return errutil.Wrap("failed to download plugin archive", err)
+		return fmt.Errorf("%v: %w", "failed to download plugin archive", err)
 	}
 	err = tmpFile.Close()
 	if err != nil {
-		return errutil.Wrap("failed to close tmp file", err)
+		return fmt.Errorf("%v: %w", "failed to close tmp file", err)
 	}
 
 	err = extractFiles(tmpFile.Name(), pluginName, pluginFolder, isInternal)
 	if err != nil {
-		return errutil.Wrap("failed to extract plugin archive", err)
+		return fmt.Errorf("%v: %w", "failed to extract plugin archive", err)
 	}
 
 	logger.Infof("%s Installed %s successfully \n", color.GreenString("✔"), pluginName)
@@ -275,7 +275,7 @@ func extractFiles(archiveFile string, pluginName string, dstDir string, allowSym
 		// We can ignore gosec G304 here since it makes sense to give all users read access
 		// nolint:gosec
 		if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
-			return errutil.Wrap("failed to create directory to extract plugin files", err)
+			return fmt.Errorf("%v: %w", "failed to create directory to extract plugin files", err)
 		}
 
 		if isSymlink(zf) {
@@ -291,7 +291,7 @@ func extractFiles(archiveFile string, pluginName string, dstDir string, allowSym
 		}
 
 		if err := extractFile(zf, dstPath); err != nil {
-			return errutil.Wrap("failed to extract file", err)
+			return fmt.Errorf("%v: %w", "failed to extract file", err)
 		}
 	}
 
@@ -306,11 +306,11 @@ func extractSymlink(file *zip.File, filePath string) error {
 	// symlink target is the contents of the file
 	src, err := file.Open()
 	if err != nil {
-		return errutil.Wrap("failed to extract file", err)
+		return fmt.Errorf("%v: %w", "failed to extract file", err)
 	}
 	buf := new(bytes.Buffer)
 	if _, err := io.Copy(buf, src); err != nil {
-		return errutil.Wrap("failed to copy symlink contents", err)
+		return fmt.Errorf("%v: %w", "failed to copy symlink contents", err)
 	}
 	if err := os.Symlink(strings.TrimSpace(buf.String()), filePath); err != nil {
 		return errutil.Wrapf(err, "failed to make symbolic link for %v", filePath)
@@ -340,7 +340,7 @@ func extractFile(file *zip.File, filePath string) (err error) {
 			return fmt.Errorf("file %q is in use - please stop Grafana, install the plugin and restart Grafana", filePath)
 		}
 
-		return errutil.Wrap("failed to open file", err)
+		return fmt.Errorf("%v: %w", "failed to open file", err)
 	}
 	defer func() {
 		err = dst.Close()
@@ -348,7 +348,7 @@ func extractFile(file *zip.File, filePath string) (err error) {
 
 	src, err := file.Open()
 	if err != nil {
-		return errutil.Wrap("failed to extract file", err)
+		return fmt.Errorf("%v: %w", "failed to extract file", err)
 	}
 	defer func() {
 		err = src.Close()

--- a/pkg/cmd/grafana-cli/services/api_client.go
+++ b/pkg/cmd/grafana-cli/services/api_client.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/models"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 type GrafanaComClient struct {
@@ -28,10 +27,10 @@ func (client *GrafanaComClient) GetPlugin(pluginId, repoUrl string) (models.Plug
 	body, err := sendRequestGetBytes(HttpClient, repoUrl, "repo", pluginId)
 	if err != nil {
 		if errors.Is(err, ErrNotFoundError) {
-			return models.Plugin{}, errutil.Wrap(
+			return models.Plugin{}, fmt.Errorf("%v: %w",
 				fmt.Sprintf("Failed to find requested plugin, check if the plugin_id (%s) is correct", pluginId), err)
 		}
-		return models.Plugin{}, errutil.Wrap("Failed to send request", err)
+		return models.Plugin{}, fmt.Errorf("%v: %w", "Failed to send request", err)
 	}
 
 	var data models.Plugin
@@ -52,11 +51,11 @@ func (client *GrafanaComClient) DownloadFile(pluginName string, tmpFile *os.File
 		// nolint:gosec
 		f, err := os.Open(url)
 		if err != nil {
-			return errutil.Wrap("Failed to read plugin archive", err)
+			return fmt.Errorf("%v: %w", "Failed to read plugin archive", err)
 		}
 		_, err = io.Copy(tmpFile, f)
 		if err != nil {
-			return errutil.Wrap("Failed to copy plugin archive", err)
+			return fmt.Errorf("%v: %w", "Failed to copy plugin archive", err)
 		}
 		return nil
 	}
@@ -93,7 +92,7 @@ func (client *GrafanaComClient) DownloadFile(pluginName string, tmpFile *os.File
 	// slow network. As this is CLI operation hanging is not a big of an issue as user can just abort.
 	bodyReader, err := sendRequest(HttpClientNoTimeout, url)
 	if err != nil {
-		return errutil.Wrap("Failed to send request", err)
+		return fmt.Errorf("%v: %w", "Failed to send request", err)
 	}
 	defer func() {
 		if err := bodyReader.Close(); err != nil {
@@ -104,7 +103,7 @@ func (client *GrafanaComClient) DownloadFile(pluginName string, tmpFile *os.File
 	w := bufio.NewWriter(tmpFile)
 	h := sha256.New()
 	if _, err = io.Copy(w, io.TeeReader(bodyReader, h)); err != nil {
-		return errutil.Wrap("failed to compute SHA256 checksum", err)
+		return fmt.Errorf("%v: %w", "failed to compute SHA256 checksum", err)
 	}
 	if err := w.Flush(); err != nil {
 		return fmt.Errorf("failed to write to %q: %w", tmpFile.Name(), err)
@@ -120,7 +119,7 @@ func (client *GrafanaComClient) ListAllPlugins(repoUrl string) (models.PluginRep
 
 	if err != nil {
 		logger.Info("Failed to send request", "error", err)
-		return models.PluginRepo{}, errutil.Wrap("Failed to send request", err)
+		return models.PluginRepo{}, fmt.Errorf("%v: %w", "Failed to send request", err)
 	}
 
 	var data models.PluginRepo

--- a/pkg/cmd/grafana-cli/utils/grafana_path.go
+++ b/pkg/cmd/grafana-cli/utils/grafana_path.go
@@ -1,11 +1,11 @@
 package utils
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/grafana/grafana/pkg/cmd/grafana-cli/logger"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 func GetGrafanaPluginDir(currentOS string) string {
@@ -22,7 +22,7 @@ func GetGrafanaPluginDir(currentOS string) string {
 func getGrafanaRoot() (string, error) {
 	ex, err := os.Executable()
 	if err != nil {
-		return "", errutil.Wrap("failed to get executable path", err)
+		return "", fmt.Errorf("%v: %w", "failed to get executable path", err)
 	}
 	exPath := filepath.Dir(ex)
 	_, last := filepath.Split(exPath)

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins/adapters"
-	"github.com/grafana/grafana/pkg/util/errutil"
 
 	"gonum.org/v1/gonum/graph/simple"
 )
@@ -200,7 +199,7 @@ func (s *Service) buildDSNode(dp *simple.DirectedGraph, rn *rawNode, req *Reques
 func (dn *DSNode) Execute(ctx context.Context, vars mathexp.Vars, s *Service) (mathexp.Results, error) {
 	dsInstanceSettings, err := adapters.ModelToInstanceSettings(dn.datasource, s.decryptSecureJsonDataFn(ctx))
 	if err != nil {
-		return mathexp.Results{}, errutil.Wrap("failed to convert datasource instance settings", err)
+		return mathexp.Results{}, fmt.Errorf("%v: %w", "failed to convert datasource instance settings", err)
 	}
 	pc := backend.PluginContext{
 		OrgID:                      dn.orgID,

--- a/pkg/infra/remotecache/redis_storage.go
+++ b/pkg/infra/remotecache/redis_storage.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/go-redis/redis/v8"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 const redisCacheType = "redis"
@@ -43,13 +42,13 @@ func parseRedisConnStr(connStr string) (*redis.Options, error) {
 		case "db":
 			i, err := strconv.Atoi(connVal)
 			if err != nil {
-				return nil, errutil.Wrap("value for db in redis connection string must be a number", err)
+				return nil, fmt.Errorf("%v: %w", "value for db in redis connection string must be a number", err)
 			}
 			options.DB = i
 		case "pool_size":
 			i, err := strconv.Atoi(connVal)
 			if err != nil {
-				return nil, errutil.Wrap("value for pool_size in redis connection string must be a number", err)
+				return nil, fmt.Errorf("%v: %w", "value for pool_size in redis connection string must be a number", err)
 			}
 			options.PoolSize = i
 		case "ssl":

--- a/pkg/login/ldap_login.go
+++ b/pkg/login/ldap_login.go
@@ -3,6 +3,7 @@ package login
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
@@ -10,7 +11,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/multildap"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 // getLDAPConfig gets LDAP config
@@ -36,7 +36,7 @@ var loginUsingLDAP = func(ctx context.Context, query *models.LoginUserQuery, log
 
 	config, err := getLDAPConfig(query.Cfg)
 	if err != nil {
-		return true, errutil.Wrap("Failed to get LDAP config", err)
+		return true, fmt.Errorf("%v: %w", "Failed to get LDAP config", err)
 	}
 
 	externalUser, err := newLDAP(config.Servers).Login(query)

--- a/pkg/login/social/common.go
+++ b/pkg/login/social/common.go
@@ -83,7 +83,7 @@ func (s *SocialBase) searchJSONForAttr(attributePath string, data []byte) (inter
 
 	var buf interface{}
 	if err := json.Unmarshal(data, &buf); err != nil {
-		return "", errutil.Wrap("failed to unmarshal user info JSON response", err)
+		return "", fmt.Errorf("%v: %w", "failed to unmarshal user info JSON response", err)
 	}
 
 	val, err := jmespath.Search(attributePath, buf)

--- a/pkg/login/social/generic_oauth.go
+++ b/pkg/login/social/generic_oauth.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/util/errutil"
 	"golang.org/x/oauth2"
 )
 
@@ -388,7 +387,7 @@ func (s *SocialGenericOAuth) FetchPrivateEmail(client *http.Client) (string, err
 	response, err := s.httpGet(client, fmt.Sprintf(s.apiUrl+"/emails"))
 	if err != nil {
 		s.log.Error("Error getting email address", "url", s.apiUrl+"/emails", "error", err)
-		return "", errutil.Wrap("Error getting email address", err)
+		return "", fmt.Errorf("%v: %w", "Error getting email address", err)
 	}
 
 	var records []Record
@@ -402,7 +401,7 @@ func (s *SocialGenericOAuth) FetchPrivateEmail(client *http.Client) (string, err
 		err = json.Unmarshal(response.Body, &data)
 		if err != nil {
 			s.log.Error("Error decoding email addresses response", "raw_json", string(response.Body), "error", err)
-			return "", errutil.Wrap("Error decoding email addresses response", err)
+			return "", fmt.Errorf("%v: %w", "Error decoding email addresses response", err)
 		}
 
 		records = data.Values

--- a/pkg/plugins/backendplugin/grpcplugin/client_v2.go
+++ b/pkg/plugins/backendplugin/grpcplugin/client_v2.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/pluginextensionv2"
-	"github.com/grafana/grafana/pkg/util/errutil"
 	"github.com/hashicorp/go-plugin"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -143,7 +142,7 @@ func (c *ClientV2) QueryData(ctx context.Context, req *backend.QueryDataRequest)
 			return nil, backendplugin.ErrMethodNotImplemented
 		}
 
-		return nil, errutil.Wrap("Failed to query data", err)
+		return nil, fmt.Errorf("%v: %w", "Failed to query data", err)
 	}
 
 	return backend.FromProto().QueryDataResponse(protoResp)
@@ -161,7 +160,7 @@ func (c *ClientV2) CallResource(ctx context.Context, req *backend.CallResourceRe
 			return backendplugin.ErrMethodNotImplemented
 		}
 
-		return errutil.Wrap("Failed to call resource", err)
+		return fmt.Errorf("%v: %w", "Failed to call resource", err)
 	}
 
 	for {
@@ -175,7 +174,7 @@ func (c *ClientV2) CallResource(ctx context.Context, req *backend.CallResourceRe
 				return nil
 			}
 
-			return errutil.Wrap("failed to receive call resource response", err)
+			return fmt.Errorf("%v: %w", "failed to receive call resource response", err)
 		}
 
 		if err := sender.Send(backend.FromProto().CallResourceResponse(protoResp)); err != nil {
@@ -217,7 +216,7 @@ func (c *ClientV2) RunStream(ctx context.Context, req *backend.RunStreamRequest,
 		if status.Code(err) == codes.Unimplemented {
 			return backendplugin.ErrMethodNotImplemented
 		}
-		return errutil.Wrap("Failed to call resource", err)
+		return fmt.Errorf("%v: %w", "Failed to call resource", err)
 	}
 
 	for {

--- a/pkg/plugins/manager/client.go
+++ b/pkg/plugins/manager/client.go
@@ -3,12 +3,12 @@ package manager
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/instrumentation"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 func (m *PluginManager) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
@@ -32,7 +32,7 @@ func (m *PluginManager) QueryData(ctx context.Context, req *backend.QueryDataReq
 			return nil, err
 		}
 
-		return nil, errutil.Wrap("failed to query data", err)
+		return nil, fmt.Errorf("%v: %w", "failed to query data", err)
 	}
 
 	for refID, res := range resp.Responses {
@@ -106,7 +106,7 @@ func (m *PluginManager) CheckHealth(ctx context.Context, req *backend.CheckHealt
 			return nil, err
 		}
 
-		return nil, errutil.Wrap("failed to check plugin health", backendplugin.ErrHealthCheckFailed)
+		return nil, fmt.Errorf("%v: %w", "failed to check plugin health", backendplugin.ErrHealthCheckFailed)
 	}
 
 	return resp, nil

--- a/pkg/plugins/manager/installer/installer.go
+++ b/pkg/plugins/manager/installer/installer.go
@@ -137,7 +137,7 @@ func (i *Installer) Install(ctx context.Context, pluginID, version, pluginsDir, 
 	// Create temp file for downloading zip file
 	tmpFile, err := ioutil.TempFile("", "*.zip")
 	if err != nil {
-		return errutil.Wrap("failed to create temporary file", err)
+		return fmt.Errorf("%v: %w", "failed to create temporary file", err)
 	}
 	defer func() {
 		if err := os.Remove(tmpFile.Name()); err != nil {
@@ -150,16 +150,16 @@ func (i *Installer) Install(ctx context.Context, pluginID, version, pluginsDir, 
 		if err := tmpFile.Close(); err != nil {
 			i.log.Warn("Failed to close file", "err", err)
 		}
-		return errutil.Wrap("failed to download plugin archive", err)
+		return fmt.Errorf("%v: %w", "failed to download plugin archive", err)
 	}
 	err = tmpFile.Close()
 	if err != nil {
-		return errutil.Wrap("failed to close tmp file", err)
+		return fmt.Errorf("%v: %w", "failed to close tmp file", err)
 	}
 
 	err = i.extractFiles(tmpFile.Name(), pluginID, pluginsDir, isInternal)
 	if err != nil {
-		return errutil.Wrap("failed to extract plugin archive", err)
+		return fmt.Errorf("%v: %w", "failed to extract plugin archive", err)
 	}
 
 	res, _ := toPluginDTO(pluginsDir, pluginID)
@@ -203,7 +203,7 @@ func (i *Installer) DownloadFile(pluginID string, tmpFile *os.File, url string, 
 		// nolint:gosec
 		f, err := os.Open(url)
 		if err != nil {
-			return errutil.Wrap("Failed to read plugin archive", err)
+			return fmt.Errorf("%v: %w", "Failed to read plugin archive", err)
 		}
 		defer func() {
 			if err := f.Close(); err != nil {
@@ -212,7 +212,7 @@ func (i *Installer) DownloadFile(pluginID string, tmpFile *os.File, url string, 
 		}()
 		_, err = io.Copy(tmpFile, f)
 		if err != nil {
-			return errutil.Wrap("Failed to copy plugin archive", err)
+			return fmt.Errorf("%v: %w", "Failed to copy plugin archive", err)
 		}
 		return nil
 	}
@@ -260,7 +260,7 @@ func (i *Installer) DownloadFile(pluginID string, tmpFile *os.File, url string, 
 	w := bufio.NewWriter(tmpFile)
 	h := sha256.New()
 	if _, err = io.Copy(w, io.TeeReader(bodyReader, h)); err != nil {
-		return errutil.Wrap("failed to compute SHA256 checksum", err)
+		return fmt.Errorf("%v: %w", "failed to compute SHA256 checksum", err)
 	}
 	if err := w.Flush(); err != nil {
 		return fmt.Errorf("failed to write to %q: %w", tmpFile.Name(), err)
@@ -571,7 +571,7 @@ func (i *Installer) extractFiles(archiveFile string, pluginID string, dest strin
 		// We can ignore gosec G304 here since it makes sense to give all users read access
 		// nolint:gosec
 		if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
-			return errutil.Wrap("failed to create directory to extract plugin files", err)
+			return fmt.Errorf("%v: %w", "failed to create directory to extract plugin files", err)
 		}
 
 		if isSymlink(zf) {
@@ -587,7 +587,7 @@ func (i *Installer) extractFiles(archiveFile string, pluginID string, dest strin
 		}
 
 		if err := extractFile(zf, dstPath); err != nil {
-			return errutil.Wrap("failed to extract file", err)
+			return fmt.Errorf("%v: %w", "failed to extract file", err)
 		}
 	}
 
@@ -602,11 +602,11 @@ func extractSymlink(file *zip.File, filePath string) error {
 	// symlink target is the contents of the file
 	src, err := file.Open()
 	if err != nil {
-		return errutil.Wrap("failed to extract file", err)
+		return fmt.Errorf("%v: %w", "failed to extract file", err)
 	}
 	buf := new(bytes.Buffer)
 	if _, err := io.Copy(buf, src); err != nil {
-		return errutil.Wrap("failed to copy symlink contents", err)
+		return fmt.Errorf("%v: %w", "failed to copy symlink contents", err)
 	}
 	if err := os.Symlink(strings.TrimSpace(buf.String()), filePath); err != nil {
 		return errutil.Wrapf(err, "failed to make symbolic link for %v", filePath)
@@ -636,7 +636,7 @@ func extractFile(file *zip.File, filePath string) (err error) {
 			return fmt.Errorf("file %q is in use - please stop Grafana, install the plugin and restart Grafana", filePath)
 		}
 
-		return errutil.Wrap("failed to open file", err)
+		return fmt.Errorf("%v: %w", "failed to open file", err)
 	}
 	defer func() {
 		err = dst.Close()
@@ -644,7 +644,7 @@ func extractFile(file *zip.File, filePath string) (err error) {
 
 	src, err := file.Open()
 	if err != nil {
-		return errutil.Wrap("failed to extract file", err)
+		return fmt.Errorf("%v: %w", "failed to extract file", err)
 	}
 	defer func() {
 		err = src.Close()

--- a/pkg/plugins/manager/signature/manifest.go
+++ b/pkg/plugins/manager/signature/manifest.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 // Soon we can fetch keys from:
@@ -85,18 +84,18 @@ func readPluginManifest(body []byte) (*pluginManifest, error) {
 	var manifest pluginManifest
 	err := json.Unmarshal(block.Plaintext, &manifest)
 	if err != nil {
-		return nil, errutil.Wrap("Error parsing manifest JSON", err)
+		return nil, fmt.Errorf("%v: %w", "Error parsing manifest JSON", err)
 	}
 
 	keyring, err := openpgp.ReadArmoredKeyRing(bytes.NewBufferString(publicKeyText))
 	if err != nil {
-		return nil, errutil.Wrap("failed to parse public key", err)
+		return nil, fmt.Errorf("%v: %w", "failed to parse public key", err)
 	}
 
 	if _, err := openpgp.CheckDetachedSignature(keyring,
 		bytes.NewBuffer(block.Bytes),
 		block.ArmoredSignature.Body); err != nil {
-		return nil, errutil.Wrap("failed to check signature", err)
+		return nil, fmt.Errorf("%v: %w", "failed to check signature", err)
 	}
 
 	return &manifest, nil

--- a/pkg/plugins/plugincontext/plugincontext.go
+++ b/pkg/plugins/plugincontext/plugincontext.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -15,7 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/adapters"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/pluginsettings"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 func ProvideService(cacheService *localcache.CacheService, pluginStore plugins.Store,
@@ -57,7 +57,7 @@ func (p *Provider) GetWithDataSource(ctx context.Context, pluginID string, user 
 
 	datasourceSettings, err := adapters.ModelToInstanceSettings(ds, p.decryptSecureJsonDataFn(ctx))
 	if err != nil {
-		return pCtx, exists, errutil.Wrap("Failed to convert datasource", err)
+		return pCtx, exists, fmt.Errorf("%v: %w", "Failed to convert datasource", err)
 	}
 	pCtx.DataSourceInstanceSettings = datasourceSettings
 
@@ -82,12 +82,12 @@ func (p *Provider) pluginContext(ctx context.Context, pluginID string, user *mod
 		// models.ErrPluginSettingNotFound is expected if there's no row found for plugin setting in database (if non-app plugin).
 		// If it's not this expected error something is wrong with cache or database and we return the error to the client.
 		if !errors.Is(err, models.ErrPluginSettingNotFound) {
-			return backend.PluginContext{}, false, errutil.Wrap("Failed to get plugin settings", err)
+			return backend.PluginContext{}, false, fmt.Errorf("%v: %w", "Failed to get plugin settings", err)
 		}
 	} else {
 		jsonData, err = json.Marshal(ps.JSONData)
 		if err != nil {
-			return backend.PluginContext{}, false, errutil.Wrap("Failed to unmarshal plugin json data", err)
+			return backend.PluginContext{}, false, fmt.Errorf("%v: %w", "Failed to unmarshal plugin json data", err)
 		}
 		decryptedSecureJSONData = p.pluginSettingsService.DecryptedValues(ps)
 		updated = ps.Updated

--- a/pkg/services/alerting/conditions/query.go
+++ b/pkg/services/alerting/conditions/query.go
@@ -215,7 +215,7 @@ func (c *QueryCondition) executeQuery(context *alerting.EvalContext, timeRange l
 		if useDataframes { // convert the dataframes to plugins.DataTimeSeries
 			frames, err := v.Dataframes.Decoded()
 			if err != nil {
-				return nil, errutil.Wrap("request handler failed to unmarshal arrow dataframes from bytes", err)
+				return nil, fmt.Errorf("%v: %w", "request handler failed to unmarshal arrow dataframes from bytes", err)
 			}
 
 			for _, frame := range frames {

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 var (
@@ -429,7 +428,7 @@ func (dr *DashboardServiceImpl) deleteDashboard(ctx context.Context, dashboardId
 	if validateProvisionedDashboard {
 		provisionedData, err := dr.GetProvisionedDashboardDataByDashboardID(dashboardId)
 		if err != nil {
-			return errutil.Wrap("failed to check if dashboard is provisioned", err)
+			return fmt.Errorf("%v: %w", "failed to check if dashboard is provisioned", err)
 		}
 
 		if provisionedData != nil {

--- a/pkg/services/ldap/settings.go
+++ b/pkg/services/ldap/settings.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 // Config holds list of connections to LDAP
@@ -123,18 +122,18 @@ func readConfig(configFile string) (*Config, error) {
 	// We can ignore the gosec G304 warning on this one because `filename` comes from grafana configuration file
 	fileBytes, err := ioutil.ReadFile(configFile)
 	if err != nil {
-		return nil, errutil.Wrap("Failed to load LDAP config file", err)
+		return nil, fmt.Errorf("%v: %w", "Failed to load LDAP config file", err)
 	}
 
 	// interpolate full toml string (it can contain ENV variables)
 	stringContent, err := setting.ExpandVar(string(fileBytes))
 	if err != nil {
-		return nil, errutil.Wrap("Failed to expand variables", err)
+		return nil, fmt.Errorf("%v: %w", "Failed to expand variables", err)
 	}
 
 	_, err = toml.Decode(stringContent, result)
 	if err != nil {
-		return nil, errutil.Wrap("Failed to load LDAP config file", err)
+		return nil, fmt.Errorf("%v: %w", "Failed to load LDAP config file", err)
 	}
 
 	if len(result.Servers) == 0 {
@@ -145,11 +144,11 @@ func readConfig(configFile string) (*Config, error) {
 	for _, server := range result.Servers {
 		err = assertNotEmptyCfg(server.SearchFilter, "search_filter")
 		if err != nil {
-			return nil, errutil.Wrap("Failed to validate SearchFilter section", err)
+			return nil, fmt.Errorf("%v: %w", "Failed to validate SearchFilter section", err)
 		}
 		err = assertNotEmptyCfg(server.SearchBaseDNs, "search_base_dns")
 		if err != nil {
-			return nil, errutil.Wrap("Failed to validate SearchBaseDNs section", err)
+			return nil, fmt.Errorf("%v: %w", "Failed to validate SearchBaseDNs section", err)
 		}
 
 		for _, groupMap := range server.Groups {

--- a/pkg/services/live/liveplugin/plugin.go
+++ b/pkg/services/live/liveplugin/plugin.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/live/orgchannel"
 	"github.com/grafana/grafana/pkg/services/live/pipeline"
-	"github.com/grafana/grafana/pkg/util/errutil"
 
 	"github.com/centrifugal/centrifuge"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -80,7 +79,7 @@ func (g *ContextGetter) GetPluginContext(ctx context.Context, user *models.Signe
 
 	ds, err := g.dataSourceCache.GetDatasourceByUID(ctx, datasourceUID, user, skipCache)
 	if err != nil {
-		return backend.PluginContext{}, false, errutil.Wrap("Failed to get datasource", err)
+		return backend.PluginContext{}, false, fmt.Errorf("%v: %w", "Failed to get datasource", err)
 	}
 	return g.pluginContextProvider.GetWithDataSource(ctx, pluginID, user, ds)
 }

--- a/pkg/services/provisioning/dashboards/dashboard.go
+++ b/pkg/services/provisioning/dashboards/dashboard.go
@@ -40,12 +40,12 @@ func New(ctx context.Context, configDirectory string, provisioner dashboards.Das
 	cfgReader := &configReader{path: configDirectory, log: logger, orgStore: orgStore}
 	configs, err := cfgReader.readConfig(ctx)
 	if err != nil {
-		return nil, errutil.Wrap("Failed to read dashboards config", err)
+		return nil, fmt.Errorf("%v: %w", "Failed to read dashboards config", err)
 	}
 
 	fileReaders, err := getFileReaders(configs, logger, provisioner, dashboardStore)
 	if err != nil {
-		return nil, errutil.Wrap("Failed to initialize file readers", err)
+		return nil, fmt.Errorf("%v: %w", "Failed to initialize file readers", err)
 	}
 
 	d := &Provisioner{

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -2,6 +2,7 @@ package provisioning
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"sync"
 
@@ -21,7 +22,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/provisioning/utils"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 func ProvideService(cfg *setting.Cfg, sqlStore *sqlstore.SQLStore, pluginStore plugifaces.Store,
@@ -161,7 +161,7 @@ func (ps *ProvisioningServiceImpl) Run(ctx context.Context) error {
 func (ps *ProvisioningServiceImpl) ProvisionDatasources(ctx context.Context) error {
 	datasourcePath := filepath.Join(ps.Cfg.ProvisioningPath, "datasources")
 	if err := ps.provisionDatasources(ctx, datasourcePath, ps.datasourceService, ps.SQLStore); err != nil {
-		err = errutil.Wrap("Datasource provisioning error", err)
+		err = fmt.Errorf("%v: %w", "Datasource provisioning error", err)
 		ps.log.Error("Failed to provision data sources", "error", err)
 		return err
 	}
@@ -171,7 +171,7 @@ func (ps *ProvisioningServiceImpl) ProvisionDatasources(ctx context.Context) err
 func (ps *ProvisioningServiceImpl) ProvisionPlugins(ctx context.Context) error {
 	appPath := filepath.Join(ps.Cfg.ProvisioningPath, "plugins")
 	if err := ps.provisionPlugins(ctx, appPath, ps.SQLStore, ps.pluginStore, ps.pluginsSettings); err != nil {
-		err = errutil.Wrap("app provisioning error", err)
+		err = fmt.Errorf("%v: %w", "app provisioning error", err)
 		ps.log.Error("Failed to provision plugins", "error", err)
 		return err
 	}
@@ -181,7 +181,7 @@ func (ps *ProvisioningServiceImpl) ProvisionPlugins(ctx context.Context) error {
 func (ps *ProvisioningServiceImpl) ProvisionNotifications(ctx context.Context) error {
 	alertNotificationsPath := filepath.Join(ps.Cfg.ProvisioningPath, "notifiers")
 	if err := ps.provisionNotifiers(ctx, alertNotificationsPath, ps.alertingService, ps.SQLStore, ps.EncryptionService, ps.NotificationService); err != nil {
-		err = errutil.Wrap("Alert notification provisioning error", err)
+		err = fmt.Errorf("%v: %w", "Alert notification provisioning error", err)
 		ps.log.Error("Failed to provision alert notifications", "error", err)
 		return err
 	}
@@ -192,7 +192,7 @@ func (ps *ProvisioningServiceImpl) ProvisionDashboards(ctx context.Context) erro
 	dashboardPath := filepath.Join(ps.Cfg.ProvisioningPath, "dashboards")
 	dashProvisioner, err := ps.newDashboardProvisioner(ctx, dashboardPath, ps.dashboardProvisioningService, ps.SQLStore, ps.dashboardService)
 	if err != nil {
-		return errutil.Wrap("Failed to create provisioner", err)
+		return fmt.Errorf("%v: %w", "Failed to create provisioner", err)
 	}
 
 	ps.mutex.Lock()
@@ -205,7 +205,7 @@ func (ps *ProvisioningServiceImpl) ProvisionDashboards(ctx context.Context) erro
 	if err != nil {
 		// If we fail to provision with the new provisioner, the mutex will unlock and the polling will restart with the
 		// old provisioner as we did not switch them yet.
-		return errutil.Wrap("Failed to provision dashboards", err)
+		return fmt.Errorf("%v: %w", "Failed to provision dashboards", err)
 	}
 	ps.dashboardProvisioner = dashProvisioner
 	return nil

--- a/pkg/services/provisioning/values/values.go
+++ b/pkg/services/provisioning/values/values.go
@@ -39,7 +39,10 @@ func (val *IntValue) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	val.Raw = interpolated.raw
 	val.value, err = strconv.Atoi(interpolated.value)
-	return fmt.Errorf("%v: %w", "cannot convert value int", err)
+	if err != nil {
+		return fmt.Errorf("%v: %w", "cannot convert value int", err)
+	}
+	return err
 }
 
 // Value returns the wrapped int value

--- a/pkg/services/provisioning/values/values.go
+++ b/pkg/services/provisioning/values/values.go
@@ -18,8 +18,6 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/setting"
-
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 // IntValue represents a string value in a YAML
@@ -41,7 +39,7 @@ func (val *IntValue) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	val.Raw = interpolated.raw
 	val.value, err = strconv.Atoi(interpolated.value)
-	return errutil.Wrap("cannot convert value int", err)
+	return fmt.Errorf("%v: %w", "cannot convert value int", err)
 }
 
 // Value returns the wrapped int value

--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -74,7 +74,7 @@ func (mg *Migrator) GetMigrationLog() (map[string]MigrationLog, error) {
 
 	exists, err := mg.DBEngine.IsTableExist(new(MigrationLog))
 	if err != nil {
-		return nil, errutil.Wrap("failed to check table existence", err)
+		return nil, fmt.Errorf("%v: %w", "failed to check table existence", err)
 	}
 	if !exists {
 		return logMap, nil
@@ -169,7 +169,7 @@ func (mg *Migrator) run() (err error) {
 			return err
 		})
 		if err != nil {
-			return errutil.Wrap(fmt.Sprintf("migration failed (id = %s)", m.Id()), err)
+			return fmt.Errorf("%v: %w", fmt.Sprintf("migration failed (id = %s)", m.Id()), err)
 		}
 	}
 

--- a/pkg/services/sqlstore/migrator/mysql_dialect.go
+++ b/pkg/services/sqlstore/migrator/mysql_dialect.go
@@ -144,13 +144,13 @@ func (db *MySQLDialect) CleanDB() error {
 		switch table.Name {
 		default:
 			if _, err := sess.Exec("set foreign_key_checks = 0"); err != nil {
-				return errutil.Wrap("failed to disable foreign key checks", err)
+				return fmt.Errorf("%v: %w", "failed to disable foreign key checks", err)
 			}
 			if _, err := sess.Exec("drop table " + table.Name + " ;"); err != nil {
 				return errutil.Wrapf(err, "failed to delete table %q", table.Name)
 			}
 			if _, err := sess.Exec("set foreign_key_checks = 1"); err != nil {
-				return errutil.Wrap("failed to disable foreign key checks", err)
+				return fmt.Errorf("%v: %w", "failed to disable foreign key checks", err)
 			}
 		}
 	}

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -133,11 +133,11 @@ func (db *PostgresDialect) CleanDB() error {
 	defer sess.Close()
 
 	if _, err := sess.Exec("DROP SCHEMA public CASCADE;"); err != nil {
-		return errutil.Wrap("failed to drop schema public", err)
+		return fmt.Errorf("%v: %w", "failed to drop schema public", err)
 	}
 
 	if _, err := sess.Exec("CREATE SCHEMA public;"); err != nil {
-		return errutil.Wrap("failed to create schema public", err)
+		return fmt.Errorf("%v: %w", "failed to create schema public", err)
 	}
 
 	return nil

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -95,7 +95,7 @@ func newSQLStore(cfg *setting.Cfg, cacheService *localcache.CacheService, engine
 	}
 
 	if err := ss.initEngine(engine); err != nil {
-		return nil, errutil.Wrap("failed to connect to database", err)
+		return nil, fmt.Errorf("%v: %w", "failed to connect to database", err)
 	}
 
 	ss.Dialect = migrator.NewDialect(ss.engine)

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -22,7 +22,6 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/azlog"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/macros"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 // AzureLogAnalyticsDatasource calls the Azure Log Analytics API's
@@ -227,7 +226,7 @@ func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, dsInfo 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		azlog.Debug("Failed to create request", "error", err)
-		return nil, errutil.Wrap("failed to create request", err)
+		return nil, fmt.Errorf("%v: %w", "failed to create request", err)
 	}
 	req.URL.Path = "/"
 	req.Header.Set("Content-Type", "application/json")

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -23,7 +23,6 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/resourcegraph"
 	azTime "github.com/grafana/grafana/pkg/tsdb/azuremonitor/time"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 // AzureMonitorDatasource calls the Azure Monitor API - one of the four API's supported
@@ -231,7 +230,7 @@ func (e *AzureMonitorDatasource) createRequest(ctx context.Context, dsInfo types
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		azlog.Debug("Failed to create request", "error", err)
-		return nil, errutil.Wrap("Failed to create request", err)
+		return nil, fmt.Errorf("%v: %w", "Failed to create request", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 

--- a/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
+++ b/pkg/tsdb/azuremonitor/resourcegraph/azure-resource-graph-datasource.go
@@ -23,7 +23,6 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/loganalytics"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/macros"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/types"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 // AzureResourceGraphResponse is the json response object from the Azure Resource Graph Analytics API.
@@ -229,7 +228,7 @@ func (e *AzureResourceGraphDatasource) createRequest(ctx context.Context, dsInfo
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(reqBody))
 	if err != nil {
 		azlog.Debug("Failed to create request", "error", err)
-		return nil, errutil.Wrap("failed to create request", err)
+		return nil, fmt.Errorf("%v: %w", "failed to create request", err)
 	}
 	req.URL.Path = "/"
 	req.Header.Set("Content-Type", "application/json")

--- a/pkg/tsdb/cloudwatch/annotation_query.go
+++ b/pkg/tsdb/cloudwatch/annotation_query.go
@@ -2,6 +2,7 @@ package cloudwatch
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -9,7 +10,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 type annotationEvent struct {
@@ -49,7 +49,7 @@ func (e *cloudWatchExecutor) executeAnnotationQuery(pluginCtx backend.PluginCont
 		}
 		resp, err := cli.DescribeAlarms(params)
 		if err != nil {
-			return nil, errutil.Wrap("failed to call cloudwatch:DescribeAlarms", err)
+			return nil, fmt.Errorf("%v: %w", "failed to call cloudwatch:DescribeAlarms", err)
 		}
 		alarmNames = filterAlarms(resp, namespace, metricName, dimensions, statistic, period)
 	} else {
@@ -79,7 +79,7 @@ func (e *cloudWatchExecutor) executeAnnotationQuery(pluginCtx backend.PluginCont
 		}
 		resp, err := cli.DescribeAlarmsForMetric(params)
 		if err != nil {
-			return nil, errutil.Wrap("failed to call cloudwatch:DescribeAlarmsForMetric", err)
+			return nil, fmt.Errorf("%v: %w", "failed to call cloudwatch:DescribeAlarmsForMetric", err)
 		}
 		for _, alarm := range resp.MetricAlarms {
 			alarmNames = append(alarmNames, alarm.AlarmName)
@@ -96,7 +96,7 @@ func (e *cloudWatchExecutor) executeAnnotationQuery(pluginCtx backend.PluginCont
 		}
 		resp, err := cli.DescribeAlarmHistory(params)
 		if err != nil {
-			return nil, errutil.Wrap("failed to call cloudwatch:DescribeAlarmHistory", err)
+			return nil, fmt.Errorf("%v: %w", "failed to call cloudwatch:DescribeAlarmHistory", err)
 		}
 		for _, history := range resp.AlarmHistoryItems {
 			annotations = append(annotations, &annotationEvent{

--- a/pkg/tsdb/cloudwatch/metric_find_query.go
+++ b/pkg/tsdb/cloudwatch/metric_find_query.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/infra/metrics"
-	"github.com/grafana/grafana/pkg/util/errutil"
 )
 
 type suggestData struct {
@@ -140,7 +139,7 @@ func (e *cloudWatchExecutor) handleGetMetrics(pluginCtx backend.PluginContext, p
 	} else {
 		var err error
 		if namespaceMetrics, err = e.getMetricsForCustomMetrics(region, namespace, pluginCtx); err != nil {
-			return nil, errutil.Wrap("unable to call AWS API", err)
+			return nil, fmt.Errorf("%v: %w", "unable to call AWS API", err)
 		}
 	}
 	sort.Strings(namespaceMetrics)
@@ -222,7 +221,7 @@ func (e *cloudWatchExecutor) handleGetDimensionKeys(pluginCtx backend.PluginCont
 				region, input)
 
 			if err != nil {
-				return nil, errutil.Wrap("unable to call AWS API", err)
+				return nil, fmt.Errorf("%v: %w", "unable to call AWS API", err)
 			}
 
 			dupCheck := make(map[string]bool)
@@ -250,7 +249,7 @@ func (e *cloudWatchExecutor) handleGetDimensionKeys(pluginCtx backend.PluginCont
 	} else {
 		var err error
 		if dimensionValues, err = e.getDimensionsForCustomMetrics(region, namespace, pluginCtx); err != nil {
-			return nil, errutil.Wrap("unable to call AWS API", err)
+			return nil, fmt.Errorf("%v: %w", "unable to call AWS API", err)
 		}
 	}
 	sort.Strings(dimensionValues)

--- a/pkg/tsdb/sqleng/sql_engine.go
+++ b/pkg/tsdb/sqleng/sql_engine.go
@@ -18,7 +18,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
-	"github.com/grafana/grafana/pkg/util/errutil"
 	"xorm.io/core"
 	"xorm.io/xorm"
 )
@@ -823,13 +822,13 @@ func convertNullableFloat32ToEpochMS(origin *data.Field, newField *data.Field) {
 func convertSQLTimeColumnsToEpochMS(frame *data.Frame, qm *dataQueryModel) error {
 	if qm.timeIndex != -1 {
 		if err := convertSQLTimeColumnToEpochMS(frame, qm.timeIndex); err != nil {
-			return errutil.Wrap("failed to convert time column", err)
+			return fmt.Errorf("%v: %w", "failed to convert time column", err)
 		}
 	}
 
 	if qm.timeEndIndex != -1 {
 		if err := convertSQLTimeColumnToEpochMS(frame, qm.timeEndIndex); err != nil {
-			return errutil.Wrap("failed to convert timeend column", err)
+			return fmt.Errorf("%v: %w", "failed to convert timeend column", err)
 		}
 	}
 


### PR DESCRIPTION
Replace `errutil.Wrap()` with `fmt.Errorf()`. Will remove the original `Wrap`, `Wrapf`, and references of `Wrapf` in next PR.

All three PRs needed to remove Wrap and Wrapf:

- [x] #50048
- [x] #50128
- [x] [#3424](https://github.com/grafana/grafana-enterprise/pull/3424)