### PR TITLE
Alerting: Persist rule position in the group

### DIFF
--- a/pkg/services/ngalert/CHANGELOG.md
+++ b/pkg/services/ngalert/CHANGELOG.md
@@ -71,6 +71,7 @@ Scopes must have an order to ensure consistency and ease of search, this helps u
 - [FEATURE] Indicate whether contact point is provisioned when GETting Alertmanager configuration #48323
 - [FEATURE] Indicate whether alert rule is provisioned when GETting the rule #48458
 - [FEATURE] Alert rules with associated panels will take screenshots. #49293 #49338 #49374 #49377 #49378 #49379 #49381 #49385 #49439 #49445
+- [FEATURE] Persistent order of alert rules in a group #50051
 - [BUGFIX] Migration: ignore alerts that do not belong to any existing organization\dashboard #49192
 - [BUGFIX] Allow anonymous access to alerts #49203
 - [BUGFIX] RBAC: replace create\update\delete actions for notification policies by alert.notifications:write #49185

--- a/pkg/services/ngalert/api/api_prometheus.go
+++ b/pkg/services/ngalert/api/api_prometheus.go
@@ -191,7 +191,7 @@ func (srv PrometheusSrv) toRuleGroup(groupName string, folder *models.Folder, ru
 		Name: groupName,
 		File: folder.Title, // file is what Prometheus uses for provisioning, we replace it with namespace.
 	}
-
+	ngmodels.RulesGroup(rules).SortByGroupIndex()
 	for _, rule := range rules {
 		alertingRule := apimodels.AlertingRule{
 			State:       "inactive",

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -360,10 +360,10 @@ func (srv RulerSrv) updateAlertRulesInGroup(c *models.ReqContext, groupKey ngmod
 			return err
 		}
 
-		finalChanges = groupChanges
+		finalChanges = calculateAutomaticChanges(finalChanges)
 		logger.Debug("updating database with the authorized changes", "add", len(finalChanges.New), "update", len(finalChanges.New), "delete", len(finalChanges.Delete))
 
-		finalChanges = calculateAutomaticChanges(finalChanges)
+		
 
 		if len(finalChanges.Update) > 0 || len(finalChanges.New) > 0 {
 			updates := make([]store.UpdateRule, 0, len(finalChanges.Update))
@@ -448,50 +448,6 @@ func (srv RulerSrv) updateAlertRulesInGroup(c *models.ReqContext, groupKey ngmod
 	}
 
 	return response.JSON(http.StatusAccepted, util.DynMap{"message": "rule group updated successfully"})
-}
-
-// calculateAutomaticChanges scans all affected groups and creates either a noop update that will increment the version of each rule as well as re-index other groups.
-// this is needed to make sure that there are no any concurrent changes made to all affected groups.
-// Returns a copy of changes enriched with either noop or group index changes for all rules in
-func calculateAutomaticChanges(ch *changes) *changes {
-	updatingRules := make(map[ngmodels.AlertRuleKey]struct{}, len(ch.Delete)+len(ch.Update))
-	for _, update := range ch.Update {
-		updatingRules[update.Existing.GetKey()] = struct{}{}
-	}
-	for _, del := range ch.Delete {
-		updatingRules[del.GetKey()] = struct{}{}
-	}
-	var toUpdate []ruleUpdate
-	for groupKey, rules := range ch.AffectedGroups {
-		ngmodels.RulesGroup(rules).SortByGroupIndex()
-		idx := 1
-		for _, rule := range rules {
-			if _, ok := updatingRules[rule.GetKey()]; ok { // exclude rules that are going to be either updated or deleted
-				continue
-			}
-			upd := ruleUpdate{
-				Existing: rule,
-				New:      rule,
-			}
-			toUpdate = append(toUpdate, upd)
-			if groupKey == ch.GroupKey {
-				continue // do not reindex rules in the group that is being updated because all rules are already re-indexed
-			}
-			if rule.RuleGroupIndex != idx {
-				upd.New = ngmodels.CopyRule(rule)
-				upd.New.RuleGroupIndex = idx
-				upd.Diff = rule.Diff(upd.New, alertRuleFieldsToIgnoreInDiff...)
-			}
-			idx++
-		}
-	}
-	return &changes{
-		GroupKey:       ch.GroupKey,
-		AffectedGroups: ch.AffectedGroups,
-		New:            ch.New,
-		Update:         append(ch.Update, toUpdate...),
-		Delete:         ch.Delete,
-	}
 }
 
 func toGettableRuleGroupConfig(groupName string, rules []*ngmodels.AlertRule, namespaceID int64, provenanceRecords map[string]ngmodels.Provenance) apimodels.GettableRuleGroupConfig {
@@ -681,6 +637,51 @@ func calculateChanges(ctx context.Context, ruleStore store.RuleStore, groupKey n
 		Delete:         toDelete,
 		Update:         toUpdate,
 	}, nil
+}
+
+// calculateAutomaticChanges scans all affected groups and creates either a noop update that will increment the version of each rule as well as re-index other groups.
+// this is needed to make sure that there are no any concurrent changes made to all affected groups.
+// Returns a copy of changes enriched with either noop or group index changes for all rules in
+func calculateAutomaticChanges(ch *changes) *changes {
+	updatingRules := make(map[ngmodels.AlertRuleKey]struct{}, len(ch.Delete)+len(ch.Update))
+	for _, update := range ch.Update {
+		updatingRules[update.Existing.GetKey()] = struct{}{}
+	}
+	for _, del := range ch.Delete {
+		updatingRules[del.GetKey()] = struct{}{}
+	}
+	var toUpdate []ruleUpdate
+	for groupKey, rules := range ch.AffectedGroups {
+		if groupKey != ch.GroupKey {
+			ngmodels.RulesGroup(rules).SortByGroupIndex()
+		}
+		idx := 1
+		for _, rule := range rules {
+			if _, ok := updatingRules[rule.GetKey()]; ok { // exclude rules that are going to be either updated or deleted
+				continue
+			}
+			upd := ruleUpdate{
+				Existing: rule,
+				New:      rule,
+			}
+			if groupKey != ch.GroupKey {
+				if rule.RuleGroupIndex != idx {
+					upd.New = ngmodels.CopyRule(rule)
+					upd.New.RuleGroupIndex = idx
+					upd.Diff = rule.Diff(upd.New, alertRuleFieldsToIgnoreInDiff...)
+				}
+				idx++
+			}
+			toUpdate = append(toUpdate, upd)
+		}
+	}
+	return &changes{
+		GroupKey:       ch.GroupKey,
+		AffectedGroups: ch.AffectedGroups,
+		New:            ch.New,
+		Update:         append(ch.Update, toUpdate...),
+		Delete:         ch.Delete,
+	}
 }
 
 // alertRuleFieldsToIgnoreInDiff contains fields that the AlertRule.Diff should ignore

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -449,6 +449,7 @@ func (srv RulerSrv) updateAlertRulesInGroup(c *models.ReqContext, groupKey ngmod
 }
 
 func toGettableRuleGroupConfig(groupName string, rules []*ngmodels.AlertRule, namespaceID int64, provenanceRecords map[string]ngmodels.Provenance) apimodels.GettableRuleGroupConfig {
+	ngmodels.RulesGroup(rules).SortByGroupIndex()
 	ruleNodes := make([]apimodels.GettableExtendedRuleNode, 0, len(rules))
 	var interval time.Duration
 	if len(rules) > 0 {

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -360,10 +360,8 @@ func (srv RulerSrv) updateAlertRulesInGroup(c *models.ReqContext, groupKey ngmod
 			return err
 		}
 
-		finalChanges = calculateAutomaticChanges(finalChanges)
+		finalChanges = calculateAutomaticChanges(groupChanges)
 		logger.Debug("updating database with the authorized changes", "add", len(finalChanges.New), "update", len(finalChanges.New), "delete", len(finalChanges.Delete))
-
-		
 
 		if len(finalChanges.Update) > 0 || len(finalChanges.New) > 0 {
 			updates := make([]store.UpdateRule, 0, len(finalChanges.Update))

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -76,7 +76,7 @@ func TestCalculateChanges(t *testing.T) {
 			require.Equal(t, db, toDelete)
 		}
 		require.Contains(t, changes.AffectedGroups, groupKey)
-		require.Equal(t, inDatabase, changes.AffectedGroups[groupKey])
+		require.Equal(t, models.RulesGroup(inDatabase), changes.AffectedGroups[groupKey])
 	})
 
 	t.Run("should detect alerts that needs to be updated", func(t *testing.T) {
@@ -103,7 +103,7 @@ func TestCalculateChanges(t *testing.T) {
 		require.Empty(t, changes.New)
 
 		require.Contains(t, changes.AffectedGroups, groupKey)
-		require.Equal(t, inDatabase, changes.AffectedGroups[groupKey])
+		require.Equal(t, models.RulesGroup(inDatabase), changes.AffectedGroups[groupKey])
 	})
 
 	t.Run("should include only if there are changes ignoring specific fields", func(t *testing.T) {
@@ -867,7 +867,7 @@ func TestRouteGetRulesGroupConfig(t *testing.T) {
 func TestVerifyProvisionedRulesNotAffected(t *testing.T) {
 	orgID := rand.Int63()
 	group := models.GenerateGroupKey(orgID)
-	affectedGroups := make(map[models.AlertRuleGroupKey][]*models.AlertRule)
+	affectedGroups := make(map[models.AlertRuleGroupKey]models.RulesGroup)
 	var allRules []*models.AlertRule
 	{
 		rules := models.GenerateAlertRules(rand.Intn(3)+1, models.AlertRuleGen(withGroupKey(group)))
@@ -950,7 +950,7 @@ func TestCalculateAutomaticChanges(t *testing.T) {
 		// simulate adding new rules, updating a few existing and delete some from the same rule
 		ch := &changes{
 			GroupKey: group,
-			AffectedGroups: map[models.AlertRuleGroupKey][]*models.AlertRule{
+			AffectedGroups: map[models.AlertRuleGroupKey]models.RulesGroup{
 				group: copies,
 			},
 			New:    models.GenerateAlertRules(2, models.AlertRuleGen(withGroupKey(group))),
@@ -962,7 +962,7 @@ func TestCalculateAutomaticChanges(t *testing.T) {
 
 		require.NotEqual(t, ch, result)
 		require.Equal(t, ch.GroupKey, result.GroupKey)
-		require.Equal(t, map[models.AlertRuleGroupKey][]*models.AlertRule{
+		require.Equal(t, map[models.AlertRuleGroupKey]models.RulesGroup{
 			group: rules,
 		}, result.AffectedGroups)
 		require.Equal(t, ch.New, result.New)
@@ -1005,7 +1005,7 @@ func TestCalculateAutomaticChanges(t *testing.T) {
 		// simulate moving a rule from one group to another.
 		ch := &changes{
 			GroupKey: group,
-			AffectedGroups: map[models.AlertRuleGroupKey][]*models.AlertRule{
+			AffectedGroups: map[models.AlertRuleGroupKey]models.RulesGroup{
 				group:  rules,
 				group2: shuffled,
 			},

--- a/pkg/services/ngalert/api/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/api_ruler_validation.go
@@ -177,6 +177,7 @@ func validateRuleGroup(
 			}
 			uids[rule.UID] = idx
 		}
+		rule.RuleGroupIndex = idx + 1
 		result = append(result, rule)
 	}
 	return result, nil

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -107,7 +107,7 @@ func createAllCombinationsOfPermissions(permissions map[string][]string) []map[s
 	return permissionCombinations
 }
 
-func getDatasourceScopesForRules(rules []*models.AlertRule) []string {
+func getDatasourceScopesForRules(rules models.RulesGroup) []string {
 	scopesMap := map[string]struct{}{}
 	var result []string
 	for _, rule := range rules {
@@ -123,8 +123,8 @@ func getDatasourceScopesForRules(rules []*models.AlertRule) []string {
 	return result
 }
 
-func mapUpdates(updates []ruleUpdate, mapFunc func(ruleUpdate) *models.AlertRule) []*models.AlertRule {
-	result := make([]*models.AlertRule, 0, len(updates))
+func mapUpdates(updates []ruleUpdate, mapFunc func(ruleUpdate) *models.AlertRule) models.RulesGroup {
+	result := make(models.RulesGroup, 0, len(updates))
 	for _, update := range updates {
 		result = append(result, mapFunc(update))
 	}
@@ -172,7 +172,7 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 				rules2 := models.GenerateAlertRules(rand.Intn(4)+1, models.AlertRuleGen(withGroupKey(groupKey)))
 				return &changes{
 					GroupKey: groupKey,
-					AffectedGroups: map[models.AlertRuleGroupKey][]*models.AlertRule{
+					AffectedGroups: map[models.AlertRuleGroupKey]models.RulesGroup{
 						groupKey: append(rules, rules2...),
 					},
 					New:    nil,
@@ -208,7 +208,7 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 
 				return &changes{
 					GroupKey: groupKey,
-					AffectedGroups: map[models.AlertRuleGroupKey][]*models.AlertRule{
+					AffectedGroups: map[models.AlertRuleGroupKey]models.RulesGroup{
 						groupKey: append(rules, rules1...),
 					},
 					New:    nil,
@@ -252,7 +252,7 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 
 				return &changes{
 					GroupKey: targetGroupKey,
-					AffectedGroups: map[models.AlertRuleGroupKey][]*models.AlertRule{
+					AffectedGroups: map[models.AlertRuleGroupKey]models.RulesGroup{
 						groupKey: append(rules, rules1...),
 					},
 					New:    nil,
@@ -317,7 +317,7 @@ func TestAuthorizeRuleChanges(t *testing.T) {
 
 				return &changes{
 					GroupKey: targetGroupKey,
-					AffectedGroups: map[models.AlertRuleGroupKey][]*models.AlertRule{
+					AffectedGroups: map[models.AlertRuleGroupKey]models.RulesGroup{
 						groupKey:       sourceGroup,
 						targetGroupKey: targetGroup,
 					},

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -141,6 +142,9 @@ type SchedulableAlertRule struct {
 	OrgID           int64  `xorm:"org_id"`
 	IntervalSeconds int64
 	Version         int64
+	NamespaceUID    string `xorm:"namespace_uid"`
+	RuleGroup       string
+	RuleGroupIndex  int `xorm:"rule_group_idx"`
 }
 
 type LabelOption func(map[string]string)
@@ -395,4 +399,15 @@ func ValidateRuleGroupInterval(intervalSeconds, baseIntervalSeconds int64) error
 			ErrAlertRuleFailedValidation, time.Duration(intervalSeconds)*time.Second, baseIntervalSeconds)
 	}
 	return nil
+}
+
+type RulesGroup []*AlertRule
+
+func (g RulesGroup) SortByGroupIndex() {
+	sort.Slice(g, func(i, j int) bool {
+		if g[i].RuleGroupIndex == g[j].RuleGroupIndex {
+			return g[i].ID < g[j].ID
+		}
+		return g[i].RuleGroupIndex < g[j].RuleGroupIndex
+	})
 }

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -252,6 +252,7 @@ type AlertRuleVersion struct {
 	RuleUID          string `xorm:"rule_uid"`
 	RuleNamespaceUID string `xorm:"rule_namespace_uid"`
 	RuleGroup        string
+	RuleGroupIndex   int `xorm:"rule_group_idx"`
 	ParentVersion    int64
 	RestoredFrom     int64
 	Version          int64

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -125,6 +125,7 @@ type AlertRule struct {
 	DashboardUID    *string `xorm:"dashboard_uid"`
 	PanelID         *int64  `xorm:"panel_id"`
 	RuleGroup       string
+	RuleGroupIndex  int `xorm:"rule_group_idx"`
 	NoDataState     NoDataState
 	ExecErrState    ExecutionErrorState
 	// ideally this field should have been apimodels.ApiDuration

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -303,7 +303,7 @@ type ListAlertRulesQuery struct {
 	DashboardUID string
 	PanelID      int64
 
-	Result []*AlertRule
+	Result RulesGroup
 }
 
 type GetAlertRulesForSchedulingQuery struct {

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -354,6 +354,13 @@ func TestDiff(t *testing.T) {
 			assert.Equal(t, rule2.For, diff[0].Right.Interface())
 			difCnt++
 		}
+		if rule1.RuleGroupIndex != rule2.RuleGroupIndex {
+			diff := diffs.GetDiffsForField("RuleGroupIndex")
+			assert.Len(t, diff, 1)
+			assert.Equal(t, rule1.RuleGroupIndex, diff[0].Left.Interface())
+			assert.Equal(t, rule2.RuleGroupIndex, diff[0].Right.Interface())
+			difCnt++
+		}
 
 		require.Lenf(t, diffs, difCnt, "Got some unexpected diffs. Either add to ignore or add assert to it")
 

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/json"
 	"math/rand"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -543,5 +544,35 @@ func TestDiff(t *testing.T) {
 				t.Logf("rule1: %#v, rule2: %#v\ndiff: %v", rule1, rule2, diff)
 			}
 		})
+	})
+}
+
+func TestSortByGroupIndex(t *testing.T) {
+	t.Run("should sort rules by GroupIndex", func(t *testing.T) {
+		rules := GenerateAlertRules(rand.Intn(5)+5, AlertRuleGen(WithUniqueGroupIndex()))
+		rand.Shuffle(len(rules), func(i, j int) {
+			rules[i], rules[j] = rules[j], rules[i]
+		})
+		require.False(t, sort.SliceIsSorted(rules, func(i, j int) bool {
+			return rules[i].RuleGroupIndex < rules[j].RuleGroupIndex
+		}))
+		RulesGroup(rules).SortByGroupIndex()
+		require.True(t, sort.SliceIsSorted(rules, func(i, j int) bool {
+			return rules[i].RuleGroupIndex < rules[j].RuleGroupIndex
+		}))
+	})
+
+	t.Run("should sort by ID if same GroupIndex", func(t *testing.T) {
+		rules := GenerateAlertRules(rand.Intn(5)+5, AlertRuleGen(WithUniqueID(), WithGroupIndex(rand.Int())))
+		rand.Shuffle(len(rules), func(i, j int) {
+			rules[i], rules[j] = rules[j], rules[i]
+		})
+		require.False(t, sort.SliceIsSorted(rules, func(i, j int) bool {
+			return rules[i].ID < rules[j].ID
+		}))
+		RulesGroup(rules).SortByGroupIndex()
+		require.True(t, sort.SliceIsSorted(rules, func(i, j int) bool {
+			return rules[i].ID < rules[j].ID
+		}))
 	})
 }

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -125,6 +125,14 @@ func WithUniqueGroupIndex() AlertRuleMutator {
 	}
 }
 
+func WithSequentialGroupIndex() AlertRuleMutator {
+	idx := 1
+	return func(rule *AlertRule) {
+		rule.RuleGroupIndex = idx
+		idx++
+	}
+}
+
 func GenerateAlertQuery() AlertQuery {
 	f := rand.Intn(10) + 5
 	t := rand.Intn(f)

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -9,9 +9,11 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
+type AlertRuleMutator func(*AlertRule)
+
 // AlertRuleGen provides a factory function that generates a random AlertRule.
 // The mutators arguments allows changing fields of the resulting structure
-func AlertRuleGen(mutators ...func(*AlertRule)) func() *AlertRule {
+func AlertRuleGen(mutators ...AlertRuleMutator) func() *AlertRule {
 	return func() *AlertRule {
 		randNoDataState := func() NoDataState {
 			s := [...]NoDataState{
@@ -74,6 +76,7 @@ func AlertRuleGen(mutators ...func(*AlertRule)) func() *AlertRule {
 			DashboardUID:    dashUID,
 			PanelID:         panelID,
 			RuleGroup:       "TEST-GROUP-" + util.GenerateShortUID(),
+			RuleGroupIndex:  rand.Int(),
 			NoDataState:     randNoDataState(),
 			ExecErrState:    randErrState(),
 			For:             forInterval,
@@ -85,6 +88,40 @@ func AlertRuleGen(mutators ...func(*AlertRule)) func() *AlertRule {
 			mutator(rule)
 		}
 		return rule
+	}
+}
+
+func WithUniqueID() AlertRuleMutator {
+	usedID := make(map[int64]struct{})
+	return func(rule *AlertRule) {
+		for {
+			id := rand.Int63()
+			if _, ok := usedID[id]; !ok {
+				usedID[id] = struct{}{}
+				rule.ID = id
+				return
+			}
+		}
+	}
+}
+
+func WithGroupIndex(groupIndex int) AlertRuleMutator {
+	return func(rule *AlertRule) {
+		rule.RuleGroupIndex = groupIndex
+	}
+}
+
+func WithUniqueGroupIndex() AlertRuleMutator {
+	usedIdx := make(map[int]struct{})
+	return func(rule *AlertRule) {
+		for {
+			idx := rand.Int()
+			if _, ok := usedIdx[idx]; !ok {
+				usedIdx[idx] = struct{}{}
+				rule.RuleGroupIndex = idx
+				return
+			}
+		}
 	}
 }
 
@@ -155,6 +192,7 @@ func CopyRule(r *AlertRule) *AlertRule {
 		UID:             r.UID,
 		NamespaceUID:    r.NamespaceUID,
 		RuleGroup:       r.RuleGroup,
+		RuleGroupIndex:  r.RuleGroupIndex,
 		NoDataState:     r.NoDataState,
 		ExecErrState:    r.ExecErrState,
 		For:             r.For,

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -230,6 +230,7 @@ func (st DBstore) UpdateAlertRules(ctx context.Context, rules []UpdateRule) erro
 				RuleUID:          r.New.UID,
 				RuleNamespaceUID: r.New.NamespaceUID,
 				RuleGroup:        r.New.RuleGroup,
+				RuleGroupIndex:   r.New.RuleGroupIndex,
 				ParentVersion:    parentVersion,
 				Version:          r.New.Version + 1,
 				Created:          r.New.Updated,

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -284,7 +284,7 @@ func (st DBstore) ListAlertRules(ctx context.Context, query *ngmodels.ListAlertR
 			q = q.Where("rule_group = ?", query.RuleGroup)
 		}
 
-		q = q.OrderBy("id ASC")
+		q = q.Asc("namespace_uid", "rule_group", "rule_group_idx", "id")
 
 		alertRules := make([]*ngmodels.AlertRule, 0)
 		if err := q.Find(&alertRules); err != nil {
@@ -410,6 +410,7 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 			}
 			q = q.NotIn("org_id", excludeOrgs...)
 		}
+		q = q.Asc("namespace_uid", "rule_group", "rule_group_idx")
 		if err := q.Find(&alerts); err != nil {
 			return err
 		}

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -410,7 +410,7 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 			}
 			q = q.NotIn("org_id", excludeOrgs...)
 		}
-		q = q.Asc("namespace_uid", "rule_group", "rule_group_idx")
+		q = q.Asc("namespace_uid", "rule_group", "rule_group_idx", "id")
 		if err := q.Find(&alerts); err != nil {
 			return err
 		}

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -92,6 +92,8 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 	accesscontrol.AddManagedFolderAlertActionsMigration(mg)
 	accesscontrol.AddActionNameMigrator(mg)
 	addPlaylistUIDMigration(mg)
+
+	ualert.UpdateRuleGroupIndexMigration(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule.go
@@ -13,6 +13,7 @@ import (
 )
 
 type alertRule struct {
+	ID              int64 `xorm:"pk autoincr 'id'"`
 	OrgID           int64 `xorm:"org_id"`
 	Title           string
 	Condition       string
@@ -22,6 +23,7 @@ type alertRule struct {
 	UID             string `xorm:"uid"`
 	NamespaceUID    string `xorm:"namespace_uid"`
 	RuleGroup       string
+	RuleGroupIndex  int `xorm:"rule_group_idx"`
 	NoDataState     string
 	ExecErrState    string
 	For             duration
@@ -35,6 +37,7 @@ type alertRuleVersion struct {
 	RuleUID          string `xorm:"rule_uid"`
 	RuleNamespaceUID string `xorm:"rule_namespace_uid"`
 	RuleGroup        string
+	RuleGroupIndex   int `xorm:"rule_group_idx"`
 	ParentVersion    int64
 	RestoredFrom     int64
 	Version          int64
@@ -59,6 +62,7 @@ func (a *alertRule) makeVersion() *alertRuleVersion {
 		RuleUID:          a.UID,
 		RuleNamespaceUID: a.NamespaceUID,
 		RuleGroup:        a.RuleGroup,
+		RuleGroupIndex:   a.RuleGroupIndex,
 		ParentVersion:    0,
 		RestoredFrom:     0,
 		Version:          1,

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -241,6 +241,16 @@ func AddAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64)
 			Cols: []string{"org_id", "dashboard_uid", "panel_id"},
 		},
 	))
+
+	mg.AddMigration("add rule_group_idx column to alert_rule", migrator.NewAddColumnMigration(
+		migrator.Table{Name: "alert_rule"},
+		&migrator.Column{
+			Name:     "rule_group_idx",
+			Type:     migrator.DB_Int,
+			Nullable: false,
+			Default:  "1",
+		},
+	))
 }
 
 func AddAlertRuleVersionMigrations(mg *migrator.Migrator) {
@@ -284,6 +294,16 @@ func AddAlertRuleVersionMigrations(mg *migrator.Migrator) {
 
 	// add labels column
 	mg.AddMigration("add column labels to alert_rule_version", migrator.NewAddColumnMigration(alertRuleVersion, &migrator.Column{Name: "labels", Type: migrator.DB_Text, Nullable: true}))
+
+	mg.AddMigration("add rule_group_idx column to alert_rule_version", migrator.NewAddColumnMigration(
+		migrator.Table{Name: "alert_rule_version"},
+		&migrator.Column{
+			Name:     "rule_group_idx",
+			Type:     migrator.DB_Int,
+			Nullable: false,
+			Default:  "1",
+		},
+	))
 }
 
 func AddAlertmanagerConfigMigrations(mg *migrator.Migrator) {

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	pb "github.com/prometheus/alertmanager/silence/silencepb"
 	"xorm.io/xorm"
@@ -777,4 +778,85 @@ func (c createDefaultFoldersForAlertingMigration) Exec(sess *xorm.Session, migra
 
 func (c createDefaultFoldersForAlertingMigration) SQL(migrator.Dialect) string {
 	return "code migration"
+}
+
+// UpdateRuleGroupIndexMigration updates a new field rule_group_index for alert rules that belong to a group with more than 1 alert.
+func UpdateRuleGroupIndexMigration(mg *migrator.Migrator) {
+	if !mg.Cfg.UnifiedAlerting.IsEnabled() {
+		return
+	}
+	mg.AddMigration("update group index for alert rules", &updateRulesOrderInGroup{})
+}
+
+type updateRulesOrderInGroup struct {
+	migrator.MigrationBase
+}
+
+func (c updateRulesOrderInGroup) SQL(migrator.Dialect) string {
+	return "code migration"
+}
+
+func (c updateRulesOrderInGroup) Exec(sess *xorm.Session, migrator *migrator.Migrator) error {
+	var rows []*alertRule
+	if err := sess.Table(alertRule{}).Asc("id").Find(&rows); err != nil {
+		return fmt.Errorf("failed to read the list of alert rules: %w", err)
+	}
+
+	if len(rows) == 0 {
+		migrator.Logger.Debug("No rules to migrate.")
+		return nil
+	}
+
+	groups := map[ngmodels.AlertRuleGroupKey][]*alertRule{}
+
+	for _, row := range rows {
+		groupKey := ngmodels.AlertRuleGroupKey{
+			OrgID:        row.OrgID,
+			NamespaceUID: row.NamespaceUID,
+			RuleGroup:    row.RuleGroup,
+		}
+		groups[groupKey] = append(groups[groupKey], row)
+	}
+
+	toUpdate := make([]*alertRule, 0, len(rows))
+
+	for _, rules := range groups {
+		for i, rule := range rules {
+			if rule.RuleGroupIndex == i+1 {
+				continue
+			}
+			rule.RuleGroupIndex = i + 1
+			toUpdate = append(toUpdate, rule)
+		}
+	}
+
+	if len(toUpdate) == 0 {
+		migrator.Logger.Debug("No rules to upgrade group index")
+		return nil
+	}
+
+	updated := time.Now()
+	versions := make([]*alertRuleVersion, 0, len(toUpdate))
+
+	for _, rule := range toUpdate {
+		rule.Updated = updated
+		version := rule.makeVersion()
+		version.Version = rule.Version + 1
+		version.ParentVersion = rule.Version
+		rule.Version++
+		_, err := sess.ID(rule.ID).Cols("version", "updated", "rule_group_idx").Update(rule)
+		if err != nil {
+			migrator.Logger.Error("failed to update alert rule", "uid", rule.UID, "err", err)
+			return fmt.Errorf("unable to update alert rules with group index: %w", err)
+		}
+		migrator.Logger.Debug("updated group index for alert rule", "rule_uid", rule.UID)
+		versions = append(versions, version)
+	}
+
+	_, err := sess.Insert(&versions)
+	if err != nil {
+		migrator.Logger.Error("failed to insert changes to alert_rule_version", "err", err)
+		return fmt.Errorf("unable to update alert rules with group index: %w", err)
+	}
+	return nil
 }

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -38,6 +38,7 @@ var migTitle = "move dashboard alerts to unified alerting"
 var rmMigTitle = "remove unified alerting data"
 
 const clearMigrationEntryTitle = "clear migration entry %q"
+const codeMigration = "code migration"
 
 type MigrationError struct {
 	AlertId int64
@@ -228,7 +229,7 @@ type migration struct {
 }
 
 func (m *migration) SQL(dialect migrator.Dialect) string {
-	return "code migration"
+	return codeMigration
 }
 
 // nolint: gocyclo
@@ -512,7 +513,7 @@ type rmMigration struct {
 }
 
 func (m *rmMigration) SQL(dialect migrator.Dialect) string {
-	return "code migration"
+	return codeMigration
 }
 
 func (m *rmMigration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
@@ -711,7 +712,7 @@ func (u *upgradeNgAlerting) updateAlertmanagerFiles(orgId int64, migrator *migra
 }
 
 func (u *upgradeNgAlerting) SQL(migrator.Dialect) string {
-	return "code migration"
+	return codeMigration
 }
 
 // getAlertFolderNameFromDashboard generates a folder name for alerts that belong to a dashboard. Formats the string according to DASHBOARD_FOLDER format.
@@ -777,7 +778,7 @@ func (c createDefaultFoldersForAlertingMigration) Exec(sess *xorm.Session, migra
 }
 
 func (c createDefaultFoldersForAlertingMigration) SQL(migrator.Dialect) string {
-	return "code migration"
+	return codeMigration
 }
 
 // UpdateRuleGroupIndexMigration updates a new field rule_group_index for alert rules that belong to a group with more than 1 alert.
@@ -793,7 +794,7 @@ type updateRulesOrderInGroup struct {
 }
 
 func (c updateRulesOrderInGroup) SQL(migrator.Dialect) string {
-	return "code migration"
+	return codeMigration
 }
 
 func (c updateRulesOrderInGroup) Exec(sess *xorm.Session, migrator *migrator.Migrator) error {

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"testing"
 	"time"
@@ -17,6 +18,7 @@ import (
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func TestAlertRulePermissions(t *testing.T) {
@@ -717,6 +719,102 @@ func TestRulerRulesFilterByDashboard(t *testing.T) {
 		require.NoError(t, json.Unmarshal(b, &res))
 		require.Equal(t, "panel_id must be set with dashboard_uid", res["message"])
 	}
+}
+
+func TestRuleGroupSequence(t *testing.T) {
+	// Setup Grafana and its Database
+	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
+		DisableLegacyAlerting: true,
+		EnableUnifiedAlerting: true,
+		DisableAnonymous:      true,
+		AppModeProduction:     true,
+	})
+	grafanaListedAddr, store := testinfra.StartGrafana(t, dir, path)
+
+	// Create a user to make authenticated requests
+	createUser(t, store, models.CreateUserCommand{
+		DefaultOrgRole: string(models.ROLE_EDITOR),
+		Password:       "password",
+		Login:          "grafana",
+	})
+
+	client := newAlertingApiClient(grafanaListedAddr, "grafana", "password")
+	folder1Title := "folder1"
+	client.CreateFolder(t, util.GenerateShortUID(), folder1Title)
+
+	group1 := generateAlertRuleGroup(5, alertRuleGen())
+	group2 := generateAlertRuleGroup(5, alertRuleGen())
+
+	status, _ := client.PostRulesGroup(t, folder1Title, &group1)
+	require.Equal(t, http.StatusAccepted, status)
+	status, _ = client.PostRulesGroup(t, folder1Title, &group2)
+	require.Equal(t, http.StatusAccepted, status)
+
+	t.Run("should persist order of the rules in a group", func(t *testing.T) {
+		group1Get := client.GetRulesGroup(t, folder1Title, group1.Name)
+		assert.Equal(t, group1.Name, group1Get.Name)
+		assert.Equal(t, group1.Interval, group1Get.Interval)
+		assert.Len(t, group1Get.Rules, len(group1.Rules))
+		for i, getRule := range group1Get.Rules {
+			rule := group1.Rules[i]
+			assert.Equal(t, getRule.GrafanaManagedAlert.Title, rule.GrafanaManagedAlert.Title)
+			assert.NotEmpty(t, getRule.GrafanaManagedAlert.UID)
+		}
+
+		// now shuffle the rules
+		postableGroup1 := convertGettableRuleGroupToPostable(group1Get.GettableRuleGroupConfig)
+		rand.Shuffle(len(postableGroup1.Rules), func(i, j int) {
+			postableGroup1.Rules[i], postableGroup1.Rules[j] = postableGroup1.Rules[j], postableGroup1.Rules[i]
+		})
+		expectedUids := make([]string, 0, len(postableGroup1.Rules))
+		for _, rule := range postableGroup1.Rules {
+			expectedUids = append(expectedUids, rule.GrafanaManagedAlert.UID)
+		}
+		status, _ := client.PostRulesGroup(t, folder1Title, &postableGroup1)
+		require.Equal(t, http.StatusAccepted, status)
+
+		group1Get = client.GetRulesGroup(t, folder1Title, group1.Name)
+
+		require.Len(t, group1Get.Rules, len(postableGroup1.Rules))
+
+		actualUids := make([]string, 0, len(group1Get.Rules))
+		for _, getRule := range group1Get.Rules {
+			actualUids = append(actualUids, getRule.GrafanaManagedAlert.UID)
+		}
+		assert.Equal(t, expectedUids, actualUids)
+	})
+
+	t.Run("should be able to move a rule from another group in a specific position", func(t *testing.T) {
+		group1Get := client.GetRulesGroup(t, folder1Title, group1.Name)
+		group2Get := client.GetRulesGroup(t, folder1Title, group2.Name)
+
+		movedRule := convertGettableRuleToPostable(group2Get.Rules[3])
+		// now shuffle the rules
+		postableGroup1 := convertGettableRuleGroupToPostable(group1Get.GettableRuleGroupConfig)
+		postableGroup1.Rules = append(append(append([]apimodels.PostableExtendedRuleNode{}, postableGroup1.Rules[0:1]...), movedRule), postableGroup1.Rules[2:]...)
+		expectedUids := make([]string, 0, len(postableGroup1.Rules))
+		for _, rule := range postableGroup1.Rules {
+			expectedUids = append(expectedUids, rule.GrafanaManagedAlert.UID)
+		}
+		status, _ := client.PostRulesGroup(t, folder1Title, &postableGroup1)
+		require.Equal(t, http.StatusAccepted, status)
+
+		group1Get = client.GetRulesGroup(t, folder1Title, group1.Name)
+
+		require.Len(t, group1Get.Rules, len(postableGroup1.Rules))
+
+		actualUids := make([]string, 0, len(group1Get.Rules))
+		for _, getRule := range group1Get.Rules {
+			actualUids = append(actualUids, getRule.GrafanaManagedAlert.UID)
+		}
+		assert.Equal(t, expectedUids, actualUids)
+
+		group2Get = client.GetRulesGroup(t, folder1Title, group2.Name)
+		assert.Len(t, group2Get.Rules, len(group2.Rules)-1)
+		for _, rule := range group2Get.Rules {
+			require.NotEqual(t, movedRule.GrafanaManagedAlert.UID, rule.GrafanaManagedAlert.UID)
+		}
+	})
 }
 
 func newTestingRuleConfig(t *testing.T) apimodels.PostableRuleGroupConfig {

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -85,7 +85,7 @@ func getBody(t *testing.T, body io.ReadCloser) string {
 	return string(b)
 }
 
-func AlertRuleGen() func() apimodels.PostableExtendedRuleNode {
+func alertRuleGen() func() apimodels.PostableExtendedRuleNode {
 	return func() apimodels.PostableExtendedRuleNode {
 		return apimodels.PostableExtendedRuleNode{
 			ApiRuleNode: &apimodels.ApiRuleNode{
@@ -115,7 +115,7 @@ func AlertRuleGen() func() apimodels.PostableExtendedRuleNode {
 	}
 }
 
-func GenerateAlertRuleGroup(rulesCount int, gen func() apimodels.PostableExtendedRuleNode) apimodels.PostableRuleGroupConfig {
+func generateAlertRuleGroup(rulesCount int, gen func() apimodels.PostableExtendedRuleNode) apimodels.PostableRuleGroupConfig {
 	rules := make([]apimodels.PostableExtendedRuleNode, 0, rulesCount)
 	for i := 0; i < rulesCount; i++ {
 		rules = append(rules, gen())
@@ -127,10 +127,10 @@ func GenerateAlertRuleGroup(rulesCount int, gen func() apimodels.PostableExtende
 	}
 }
 
-func ConvertGettableRuleGroupToPostable(gettable apimodels.GettableRuleGroupConfig) apimodels.PostableRuleGroupConfig {
+func convertGettableRuleGroupToPostable(gettable apimodels.GettableRuleGroupConfig) apimodels.PostableRuleGroupConfig {
 	rules := make([]apimodels.PostableExtendedRuleNode, 0, len(gettable.Rules))
 	for _, rule := range gettable.Rules {
-		rules = append(rules, ConvertGettableRuleToPostable(rule))
+		rules = append(rules, convertGettableRuleToPostable(rule))
 	}
 	return apimodels.PostableRuleGroupConfig{
 		Name:     gettable.Name,
@@ -139,14 +139,14 @@ func ConvertGettableRuleGroupToPostable(gettable apimodels.GettableRuleGroupConf
 	}
 }
 
-func ConvertGettableRuleToPostable(gettable apimodels.GettableExtendedRuleNode) apimodels.PostableExtendedRuleNode {
+func convertGettableRuleToPostable(gettable apimodels.GettableExtendedRuleNode) apimodels.PostableExtendedRuleNode {
 	return apimodels.PostableExtendedRuleNode{
 		ApiRuleNode:         gettable.ApiRuleNode,
-		GrafanaManagedAlert: ConvertGettableGrafanaRuleToPostable(gettable.GrafanaManagedAlert),
+		GrafanaManagedAlert: convertGettableGrafanaRuleToPostable(gettable.GrafanaManagedAlert),
 	}
 }
 
-func ConvertGettableGrafanaRuleToPostable(gettable *apimodels.GettableGrafanaRule) *apimodels.PostableGrafanaRule {
+func convertGettableGrafanaRuleToPostable(gettable *apimodels.GettableGrafanaRule) *apimodels.PostableGrafanaRule {
 	if gettable == nil {
 		return nil
 	}

--- a/public/app/features/alerting/unified/utils/rulerClient.ts
+++ b/public/app/features/alerting/unified/utils/rulerClient.ts
@@ -216,11 +216,16 @@ export function getRulerClient(rulerConfig: RulerDataSourceConfig): RulerClient 
     // make sure our updated alert has the same UID as before
     copyGrafanaUID(existingRule, newRule);
 
-    // create the new array of rules we want to send to the group
-    const newRules = existingRule.group.rules
-      .filter((rule): rule is RulerGrafanaRuleDTO => isGrafanaRulerRule(rule))
-      .filter((rule) => rule.grafana_alert.uid !== existingRule.rule.grafana_alert.uid)
-      .concat(newRule as RulerGrafanaRuleDTO);
+    // create the new array of rules we want to send to the group. Keep the order of alerts in the group.
+    const newRules = existingRule.group.rules.map((rule) => {
+      if (!isGrafanaRulerRule(rule)) {
+        return rule;
+      }
+      if (rule.grafana_alert.uid === existingRule.rule.grafana_alert.uid) {
+        return newRule;
+      }
+      return rule;
+    });
 
     await setRulerRuleGroup(rulerConfig, existingRule.namespace, {
       name: existingRule.group.name,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The Grafana Alerting follows the design of Prometheus alerts: Grafana Alerting has a notion of alert groups but in opposite to Prometheus, Grafana does not handle groups of alerts the way Prometheus does. Although a rule belongs to a group it is treated as a single entity by the Grafana Alerting scheduler. The only place where group matters is API: if there are two rules in the same namespaces and they belong to the same group, the API will return them together.

For Grafana 9 (https://github.com/grafana/grafana/issues/48353) we are moving toward how Prometheus handles alert rules: e.g. alert rules that belong to the same group will be executed sequentially and in the pre-determined order.

This PR updates alerting API to maintain the correct order of the alert rules in a single group. 
- It introduces a new field in the database that would keep the index of a rule in the group
- updates rules POST API to use the position of the rule in the input array as a group index
- updates rules POST API to create either a noop update of all rules affected by the request. Also, if a rule is moved from one group to another, re-index the source group to make sure that the index is maintained properly.
- updates GET APIs to sort rules by group index (with fallback to ID)

**Which issue(s) this PR fixes**:
Related:  https://github.com/grafana/grafana/issues/48353 https://github.com/grafana/grafana/pull/49033