### PR TITLE
GeomapPanel: Add base types to data layer options

### DIFF
--- a/packages/grafana-data/src/geo/layer.ts
+++ b/packages/grafana-data/src/geo/layer.ts
@@ -104,9 +104,9 @@ export interface MapLayerRegistryItem<TConfig = MapLayerOptions> extends Registr
   showLocation?: boolean;
 
   /**
-   * Show transparency controls in UI (for non-basemaps)
+   * Hide transparency controls in UI
    */
-  showOpacity?: boolean;
+  hideOpacity?: boolean;
 
   /**
    * Function that configures transformation and returns a transformer

--- a/packages/grafana-ui/src/components/Slider/Slider.tsx
+++ b/packages/grafana-ui/src/components/Slider/Slider.tsx
@@ -1,7 +1,7 @@
 import { cx } from '@emotion/css';
 import { Global } from '@emotion/react';
 import SliderComponent from 'rc-slider';
-import React, { useState, useCallback, ChangeEvent, FunctionComponent, FocusEvent } from 'react';
+import React, { useState, useCallback, ChangeEvent, FunctionComponent, FocusEvent, useEffect } from 'react';
 
 import { useTheme2 } from '../../themes/ThemeContext';
 import { Input } from '../Input/Input';
@@ -30,6 +30,13 @@ export const Slider: FunctionComponent<SliderProps> = ({
   const styles = getStyles(theme, isHorizontal, Boolean(marks));
   const SliderWithTooltip = SliderComponent;
   const [sliderValue, setSliderValue] = useState<number>(value ?? min);
+
+  // Check for a difference between prop value and internal state
+  useEffect(() => {
+    if (value != null && value !== sliderValue) {
+      setSliderValue(value);
+    }
+  }, [value, sliderValue]);
 
   const onSliderChange = useCallback(
     (v: number) => {

--- a/packages/grafana-ui/src/components/Slider/Slider.tsx
+++ b/packages/grafana-ui/src/components/Slider/Slider.tsx
@@ -1,7 +1,7 @@
 import { cx } from '@emotion/css';
 import { Global } from '@emotion/react';
 import SliderComponent from 'rc-slider';
-import React, { useState, useCallback, ChangeEvent, FunctionComponent, FocusEvent, useEffect } from 'react';
+import React, { useState, useCallback, ChangeEvent, FunctionComponent, FocusEvent } from 'react';
 
 import { useTheme2 } from '../../themes/ThemeContext';
 import { Input } from '../Input/Input';
@@ -30,13 +30,6 @@ export const Slider: FunctionComponent<SliderProps> = ({
   const styles = getStyles(theme, isHorizontal, Boolean(marks));
   const SliderWithTooltip = SliderComponent;
   const [sliderValue, setSliderValue] = useState<number>(value ?? min);
-
-  // Check for a difference between prop value and internal state
-  useEffect(() => {
-    if (value != null && value !== sliderValue) {
-      setSliderValue(value);
-    }
-  }, [value, sliderValue]);
 
   const onSliderChange = useCallback(
     (v: number) => {

--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -503,6 +503,9 @@ export class GeomapPanel extends Component<Props, State> {
 
     const handler = await item.create(map, options, config.theme2);
     const layer = handler.init();
+    if (options.opacity != null) {
+      layer.setOpacity(1 - options.opacity);
+    }
 
     if (!options.name) {
       options.name = this.getNextLayerName();

--- a/public/app/plugins/panel/geomap/editor/LayersEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/LayersEditor.tsx
@@ -7,10 +7,8 @@ import { AddLayerButton } from 'app/core/components/Layers/AddLayerButton';
 import { LayerDragDropList } from 'app/core/components/Layers/LayerDragDropList';
 
 import { GeomapInstanceState } from '../GeomapPanel';
-import { geomapLayerRegistry } from '../layers/registry';
+import { getLayersOptions } from '../layers/registry';
 import { GeomapPanelOptions, MapLayerState } from '../types';
-
-import { dataLayerFilter } from './layerEditor';
 
 type LayersEditorProps = StandardEditorProps<any, any, GeomapPanelOptions, GeomapInstanceState>;
 
@@ -61,7 +59,7 @@ export const LayersEditor = (props: LayersEditorProps) => {
       <Container>
         <AddLayerButton
           onChange={(v) => actions.addlayer(v.value!)}
-          options={geomapLayerRegistry.selectOptions(undefined, dataLayerFilter).options}
+          options={getLayersOptions(false).options}
           label={'Add layer'}
         />
       </Container>

--- a/public/app/plugins/panel/geomap/editor/layerEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/layerEditor.tsx
@@ -1,14 +1,13 @@
 import { get as lodashGet, isEqual } from 'lodash';
 
-import { FrameGeometrySourceMode, MapLayerOptions, MapLayerRegistryItem, PluginState } from '@grafana/data';
+import { FrameGeometrySourceMode, MapLayerOptions } from '@grafana/data';
 import { NestedPanelOptions, NestedValueAccess } from '@grafana/data/src/utils/OptionsUIBuilders';
-import { hasAlphaPanels } from 'app/core/config';
 import { setOptionImmutably } from 'app/features/dashboard/components/PanelEditor/utils';
 import { addLocationFields } from 'app/features/geo/editor/locationEditor';
 
 import { FrameSelectionEditor } from '../layers/data/FrameSelectionEditor';
 import { defaultMarkersConfig } from '../layers/data/markersLayer';
-import { DEFAULT_BASEMAP_CONFIG, geomapLayerRegistry } from '../layers/registry';
+import { DEFAULT_BASEMAP_CONFIG, geomapLayerRegistry, getLayersOptions } from '../layers/registry';
 import { MapLayerState } from '../types';
 
 export interface LayerEditorOptions {
@@ -62,12 +61,11 @@ export function getLayerEditor(opts: LayerEditorOptions): NestedPanelOptions<Map
       const { handler, options } = opts.state;
       const layer = geomapLayerRegistry.getIfExists(options?.type);
 
-      const layerTypes = geomapLayerRegistry.selectOptions(
-        //TODO: sort data layer base map types appropriately
+      const layerTypes = getLayersOptions(
+        opts.basemaps,
         options?.type // the selected value
-          ? [options.type] // as an array
-          : [DEFAULT_BASEMAP_CONFIG.type],
-        opts.basemaps ? baseMapFilter : dataLayerFilter
+          ? options.type
+          : DEFAULT_BASEMAP_CONFIG.type
       );
 
       builder.addSelect({
@@ -126,21 +124,4 @@ export function getLayerEditor(opts: LayerEditorOptions): NestedPanelOptions<Map
       }
     },
   };
-}
-
-function baseMapFilter(layer: MapLayerRegistryItem): boolean {
-  if (!layer.isBaseMap) {
-    return false;
-  }
-  if (layer.state === PluginState.alpha) {
-    return hasAlphaPanels;
-  }
-  return true;
-}
-
-export function dataLayerFilter(layer: MapLayerRegistryItem): boolean {
-  if (layer.state === PluginState.alpha) {
-    return hasAlphaPanels;
-  }
-  return true;
 }

--- a/public/app/plugins/panel/geomap/editor/layerEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/layerEditor.tsx
@@ -63,6 +63,7 @@ export function getLayerEditor(opts: LayerEditorOptions): NestedPanelOptions<Map
       const layer = geomapLayerRegistry.getIfExists(options?.type);
 
       const layerTypes = geomapLayerRegistry.selectOptions(
+        //TODO: sort data layer base map types appropriately
         options?.type // the selected value
           ? [options.type] // as an array
           : [DEFAULT_BASEMAP_CONFIG.type],
@@ -103,11 +104,19 @@ export function getLayerEditor(opts: LayerEditorOptions): NestedPanelOptions<Map
       if (handler.registerOptionsUI) {
         handler.registerOptionsUI(builder);
       }
-      if (layer.showOpacity) {
-        // TODO -- add opacity check
-      }
-
       if (!isEqual(opts.category, ['Base layer'])) {
+        if (layer.showOpacity) {
+          builder.addSliderInput({
+            path: 'opacity',
+            name: 'Opacity',
+            defaultValue: 1,
+            settings: {
+              min: 0,
+              max: 1,
+              step: 0.1,
+            },
+          });
+        }
         builder.addBooleanSwitch({
           path: 'tooltip',
           name: 'Display tooltip',
@@ -130,9 +139,6 @@ function baseMapFilter(layer: MapLayerRegistryItem): boolean {
 }
 
 export function dataLayerFilter(layer: MapLayerRegistryItem): boolean {
-  if (layer.isBaseMap) {
-    return false;
-  }
   if (layer.state === PluginState.alpha) {
     return hasAlphaPanels;
   }

--- a/public/app/plugins/panel/geomap/editor/layerEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/layerEditor.tsx
@@ -103,7 +103,7 @@ export function getLayerEditor(opts: LayerEditorOptions): NestedPanelOptions<Map
         handler.registerOptionsUI(builder);
       }
       if (!isEqual(opts.category, ['Base layer'])) {
-        if (layer.showOpacity) {
+        if (!layer.hideOpacity) {
           builder.addSliderInput({
             path: 'opacity',
             name: 'Opacity',

--- a/public/app/plugins/panel/geomap/layers/basemaps/carto.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/carto.ts
@@ -27,6 +27,7 @@ export const carto: MapLayerRegistryItem<CartoConfig> = {
   name: 'CARTO reference map',
   isBaseMap: true,
   defaultOptions: defaultCartoConfig,
+  showOpacity: true,
 
   /**
    * Function that configures transformation and returns a transformer

--- a/public/app/plugins/panel/geomap/layers/basemaps/carto.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/carto.ts
@@ -25,6 +25,7 @@ export const defaultCartoConfig: CartoConfig = {
 export const carto: MapLayerRegistryItem<CartoConfig> = {
   id: 'carto',
   name: 'CARTO reference map',
+  description: 'Add map from CARTO database',
   isBaseMap: true,
   defaultOptions: defaultCartoConfig,
   showOpacity: true,

--- a/public/app/plugins/panel/geomap/layers/basemaps/carto.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/carto.ts
@@ -28,7 +28,6 @@ export const carto: MapLayerRegistryItem<CartoConfig> = {
   description: 'Add map from CARTO database',
   isBaseMap: true,
   defaultOptions: defaultCartoConfig,
-  showOpacity: true,
 
   /**
    * Function that configures transformation and returns a transformer

--- a/public/app/plugins/panel/geomap/layers/basemaps/carto.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/carto.ts
@@ -24,8 +24,8 @@ export const defaultCartoConfig: CartoConfig = {
 
 export const carto: MapLayerRegistryItem<CartoConfig> = {
   id: 'carto',
-  name: 'CARTO reference map',
-  description: 'Add map from CARTO database',
+  name: 'CARTO basemap',
+  description: 'Add layer CARTO Raster basemaps',
   isBaseMap: true,
   defaultOptions: defaultCartoConfig,
 

--- a/public/app/plugins/panel/geomap/layers/basemaps/esri.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/esri.ts
@@ -57,6 +57,7 @@ export interface ESRIXYZConfig extends XYZConfig {
 export const esriXYZTiles: MapLayerRegistryItem<ESRIXYZConfig> = {
   id: 'esri-xyz',
   name: 'ArcGIS MapServer',
+  description: 'Add map from Arc geographic information system',
   isBaseMap: true,
   showOpacity: true,
 

--- a/public/app/plugins/panel/geomap/layers/basemaps/esri.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/esri.ts
@@ -58,6 +58,7 @@ export const esriXYZTiles: MapLayerRegistryItem<ESRIXYZConfig> = {
   id: 'esri-xyz',
   name: 'ArcGIS MapServer',
   isBaseMap: true,
+  showOpacity: true,
 
   create: async (map: Map, options: MapLayerOptions<ESRIXYZConfig>, theme: GrafanaTheme2) => {
     const cfg = { ...options.config };

--- a/public/app/plugins/panel/geomap/layers/basemaps/esri.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/esri.ts
@@ -59,7 +59,6 @@ export const esriXYZTiles: MapLayerRegistryItem<ESRIXYZConfig> = {
   name: 'ArcGIS MapServer',
   description: 'Add map from Arc geographic information system',
   isBaseMap: true,
-  showOpacity: true,
 
   create: async (map: Map, options: MapLayerOptions<ESRIXYZConfig>, theme: GrafanaTheme2) => {
     const cfg = { ...options.config };

--- a/public/app/plugins/panel/geomap/layers/basemaps/esri.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/esri.ts
@@ -57,7 +57,7 @@ export interface ESRIXYZConfig extends XYZConfig {
 export const esriXYZTiles: MapLayerRegistryItem<ESRIXYZConfig> = {
   id: 'esri-xyz',
   name: 'ArcGIS MapServer',
-  description: 'Add map from Arc geographic information system',
+  description: 'Add layer from an ESRI ArcGIS MapServer',
   isBaseMap: true,
 
   create: async (map: Map, options: MapLayerOptions<ESRIXYZConfig>, theme: GrafanaTheme2) => {

--- a/public/app/plugins/panel/geomap/layers/basemaps/generic.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/generic.ts
@@ -21,6 +21,7 @@ export const xyzTiles: MapLayerRegistryItem<XYZConfig> = {
   id: 'xyz',
   name: 'XYZ Tile layer',
   isBaseMap: true,
+  showOpacity: true,
 
   create: async (map: Map, options: MapLayerOptions<XYZConfig>, theme: GrafanaTheme2) => ({
     init: () => {

--- a/public/app/plugins/panel/geomap/layers/basemaps/generic.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/generic.ts
@@ -20,6 +20,7 @@ export const defaultXYZConfig: XYZConfig = {
 export const xyzTiles: MapLayerRegistryItem<XYZConfig> = {
   id: 'xyz',
   name: 'XYZ Tile layer',
+  description: 'Add map from custom source',
   isBaseMap: true,
   showOpacity: true,
 

--- a/public/app/plugins/panel/geomap/layers/basemaps/generic.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/generic.ts
@@ -22,7 +22,6 @@ export const xyzTiles: MapLayerRegistryItem<XYZConfig> = {
   name: 'XYZ Tile layer',
   description: 'Add map from custom source',
   isBaseMap: true,
-  showOpacity: true,
 
   create: async (map: Map, options: MapLayerOptions<XYZConfig>, theme: GrafanaTheme2) => ({
     init: () => {

--- a/public/app/plugins/panel/geomap/layers/basemaps/generic.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/generic.ts
@@ -20,7 +20,7 @@ export const defaultXYZConfig: XYZConfig = {
 export const xyzTiles: MapLayerRegistryItem<XYZConfig> = {
   id: 'xyz',
   name: 'XYZ Tile layer',
-  description: 'Add map from custom source',
+  description: 'Add map from a generic tile layer',
   isBaseMap: true,
 
   create: async (map: Map, options: MapLayerOptions<XYZConfig>, theme: GrafanaTheme2) => ({

--- a/public/app/plugins/panel/geomap/layers/basemaps/osm.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/osm.ts
@@ -8,6 +8,7 @@ export const standard: MapLayerRegistryItem = {
   id: 'osm-standard',
   name: 'Open Street Map',
   isBaseMap: true,
+  showOpacity: true,
 
   /**
    * Function that configures transformation and returns a transformer

--- a/public/app/plugins/panel/geomap/layers/basemaps/osm.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/osm.ts
@@ -7,6 +7,7 @@ import { MapLayerRegistryItem, MapLayerOptions } from '@grafana/data';
 export const standard: MapLayerRegistryItem = {
   id: 'osm-standard',
   name: 'Open Street Map',
+  description: 'Add map from a collaborative free geographic world database',
   isBaseMap: true,
   showOpacity: true,
 

--- a/public/app/plugins/panel/geomap/layers/basemaps/osm.ts
+++ b/public/app/plugins/panel/geomap/layers/basemaps/osm.ts
@@ -9,7 +9,6 @@ export const standard: MapLayerRegistryItem = {
   name: 'Open Street Map',
   description: 'Add map from a collaborative free geographic world database',
   isBaseMap: true,
-  showOpacity: true,
 
   /**
    * Function that configures transformation and returns a transformer

--- a/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
+++ b/public/app/plugins/panel/geomap/layers/data/markersLayer.tsx
@@ -53,6 +53,7 @@ export const markersLayer: MapLayerRegistryItem<MarkersConfig> = {
   description: 'Use markers to render each data point',
   isBaseMap: false,
   showLocation: true,
+  hideOpacity: true,
 
   /**
    * Function that configures transformation and returns a transformer


### PR DESCRIPTION
What this PR does / why we need it:
Adds base layer types to data layer type selection, including controls for opacity of these data layers. This adds support for OpenSeaMap (and beyond) at the data layer level.

After
(Add XYZ Tile Layer)
![Jun-01-2022 17-47-02](https://user-images.githubusercontent.com/60050885/171524508-2634eab9-93bf-44fd-b932-c9e89c62756d.gif)
(Add ArcGIS MapServer and adjust its opacity)
![Jun-01-2022 17-47-34](https://user-images.githubusercontent.com/60050885/171524519-13311354-be03-426b-99eb-b678125818ea.gif)

Which issue(s) this PR fixes:

Fixes #47812

