### PR TITLE
live: Use Exclude instead of Omit on generated types

### DIFF
--- a/pkg/services/live/pipeline/config.go
+++ b/pkg/services/live/pipeline/config.go
@@ -34,7 +34,7 @@ type ChannelRule struct {
 }
 
 type ConverterConfig struct {
-	Type                      string                     `json:"type" ts_type:"Omit<keyof ConverterConfig, 'type'>"`
+	Type                      string                     `json:"type" ts_type:"Exclude<keyof ConverterConfig, 'type'>"`
 	AutoJsonConverterConfig   *AutoJsonConverterConfig   `json:"jsonAuto,omitempty"`
 	ExactJsonConverterConfig  *ExactJsonConverterConfig  `json:"jsonExact,omitempty"`
 	AutoInfluxConverterConfig *AutoInfluxConverterConfig `json:"influxAuto,omitempty"`
@@ -50,7 +50,7 @@ type KeepFieldsFrameProcessorConfig struct {
 }
 
 type FrameProcessorConfig struct {
-	Type                      string                          `json:"type" ts_type:"Omit<keyof FrameProcessorConfig, 'type'>"`
+	Type                      string                          `json:"type" ts_type:"Exclude<keyof FrameProcessorConfig, 'type'>"`
 	DropFieldsProcessorConfig *DropFieldsFrameProcessorConfig `json:"dropFields,omitempty"`
 	KeepFieldsProcessorConfig *KeepFieldsFrameProcessorConfig `json:"keepFields,omitempty"`
 	MultipleProcessorConfig   *MultipleFrameProcessorConfig   `json:"multiple,omitempty"`
@@ -83,7 +83,7 @@ type MultipleSubscriberConfig struct {
 }
 
 type SubscriberConfig struct {
-	Type                     string                    `json:"type" ts_type:"Omit<keyof SubscriberConfig, 'type'>"`
+	Type                     string                    `json:"type" ts_type:"Exclude<keyof SubscriberConfig, 'type'>"`
 	MultipleSubscriberConfig *MultipleSubscriberConfig `json:"multiple,omitempty"`
 }
 
@@ -93,13 +93,13 @@ type RedirectDataOutputConfig struct {
 }
 
 type DataOutputterConfig struct {
-	Type                     string                    `json:"type" ts_type:"Omit<keyof DataOutputterConfig, 'type'>"`
+	Type                     string                    `json:"type" ts_type:"Exclude<keyof DataOutputterConfig, 'type'>"`
 	RedirectDataOutputConfig *RedirectDataOutputConfig `json:"redirect,omitempty"`
 	LokiOutputConfig         *LokiOutputConfig         `json:"loki,omitempty"`
 }
 
 type FrameOutputterConfig struct {
-	Type                    string                     `json:"type" ts_type:"Omit<keyof FrameOutputterConfig, 'type'>"`
+	Type                    string                     `json:"type" ts_type:"Exclude<keyof FrameOutputterConfig, 'type'>"`
 	ManagedStreamConfig     *ManagedStreamOutputConfig `json:"managedStream,omitempty"`
 	MultipleOutputterConfig *MultipleOutputterConfig   `json:"multiple,omitempty"`
 	RedirectOutputConfig    *RedirectOutputConfig      `json:"redirect,omitempty"`
@@ -122,7 +122,7 @@ type NumberCompareFrameConditionConfig struct {
 }
 
 type FrameConditionCheckerConfig struct {
-	Type                           string                               `json:"type" ts_type:"Omit<keyof FrameConditionCheckerConfig, 'type'>"`
+	Type                           string                               `json:"type" ts_type:"Exclude<keyof FrameConditionCheckerConfig, 'type'>"`
 	MultipleConditionCheckerConfig *MultipleFrameConditionCheckerConfig `json:"multiple,omitempty"`
 	NumberCompareConditionConfig   *NumberCompareFrameConditionConfig   `json:"numberCompare,omitempty"`
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

@ryantxu and i were talking about codegen/type relations, and he pointed to the file changed in this PR and its generated counterpart as an example for a point he was making. I started poking at it, and got confused. Looking at the Go string constants used for these values, it _seems_ like the goal of using `Omit` here is to have the `type` field on each of these structs be a union of all the names of the containing type, except the `type` field itself.

However, that's not what using `Omit` here does. (Honestly i'm not even sure what it does - i think it creates a type with all the properties on a ...string? idk. [Playground wasn't really much help](https://www.typescriptlang.org/play?#code/PQKgBAIg9mB2UBcwGMAWBDWBzApgGjAVQEsBnFKAExzDLF1hwCd0EdKwAzJqAWzADiUADaYsYUgiYBXZAnIhgAKCU4AHgAcoTJMVhsmndMhoBhDLEbCAgtKLmcyANamosTsXEBvJWDA9hHAB+AC4JKT0sAG4lAF9VTW1dfWYjEzBzTCtbezcPb18JaQAjUmQmYmLgsMzLHBs7VAdnV3dPGL8NEuEyVFCMi2zG5pc89riErR1aFMNjMwtcABkoLAB5Oy6EVvywHz8PesoAOXReHDDJCuwOlEH6y4ibifUp5IM0mgAlHF5EHAA6hU2BsEFsdp49oVpMRKI9rtFCqQzhpAgBZYjCHqkRxuSikMKwaS8KpMGLxV5JGYfeZgAAqqCYOFIqBElFB4LGBQOxCOp3O8MitzQWQe4QR5MmVL0NPSx2JpNcvA06CZADEWOdWpRiAhiG4IdyuLzhCczhdxULClANILnn4AG7oYTSC1EknMSWU6Yy1K0tHSYR61E4DXm7W6-WwEbMQ1QvzIPGRtx0gCeGgtVytCaTercBLAYa1uajMaYhoA2gBdL2JH2zT6FzU4CN56OoRxOWNc+OEdMWta8XUAHi7qagnCb4ZLBo7zm7bSwBAA5Ah+8uAHy3XiB4OBfoBoPEENFlsz9udhf5W7uxV8FVM-ryj3l++q0PN1ulrm1t7Uv3pF+bjOhydhxvsFCwDqbb9KeQEXvOr6LrcUCbHYsHNqBCAGIav7Sg2tI-DqTJyFh4GFCKdTCHaiIUnW7wATQh57jgWE4T2EGoWCdgFqebFXp41Z4fWspMZg6C4JQADKUg4GcZEcXRf6+nM6R8Wh2ECUaa4ZmEg4jmOE5Tuc-FIfkK46Tgm7buJkkyUyZwHrZ7D2XJvAKchhQ7keIYHrux6BKZuGFEyxGOAg-REcQJEIB514Ueezr9PBIEacFfhEEyLJsv0DJZayppxeMfhMn8bBArq1RgD8ZWAsCrFpT+hTCFATjEP0KxtUViIJosOArFgyV9QN3XCQxqlMf5J7NgACjwJikKQ2jkZ083MktTC8bNa2LctXJCS89H-hNYAANI4DgGhqia+KnnNUALRtK3Gny5oFlm2AHUp+GiZAPBXTdpB3TtT0cYUhymvyzI0V9UoiYxxk4Pdj17YuvaWXpQ4IKOODjpOwMPetqPmWAq7rluhSUP911HKQ-QQNTgMEyjZnFWAXaXTTpp02E52c0z22E7trM9WA3ksX5PmBMzRMi2Nx2NgAUktsBwW4DrMOxaNeN98MnTkUAAJLuC6aitBrOhab23Dmmq2i8KwNHyypjYAKJqMYCDKwa6ua1bEEQ-iYRc5QsPeuNjZLOgVTCL2sDmk7hROi6mZPLRcMR7SIdxwnlr2n2ulwAqnpJ86rqJ34ogxzzYBRzHB05ou-Q687BHpAb3vRr7lsi9bN10seNdeGAFZjjRVbBzdYCxK3v3m37vcQRjYD6djhmTvPPeGhZ5O3AAVirBv9B3Kub1r8V+Afbju57-Q33Indn1ptx6JwptH2EBvG2-0hm9359syvqrZs-RO5q1gBbAB6dw4K1pJ1Yg3VewwjhHnaBR0XaEXYNFcKEBWDoEQRBSiVhE660zukXBCB8EaSgejfsmMDK4yMhQqh3FNIix3hmayIUsExUijwnBeDRrNVau1MI8ChGkNgekZiAUcBSRKGUCod5tZIgUeUSozACzyNKOo5R+Qw7oLbjQbRiiNGL0KMvVeOM8ZgBMborSHCrIUz8OLWRksWJ2KUc-Q6ykjEDFFMIL4gY5E4GwpEcgEF0CNCGgEnITQmp+FIGorxm1+ieLMZWGslNBEaRrswoK+0smN0gcwZK-9vEHEFizGuMthaZNuDbEyuSMLmgKYuAxvi573ECcE3sKo2GwArhIUJepsAFlqFYIJgQpIjPCZKDOBcaB0jAAAXhXljaxRkn7sNJpZLhMDLL0ldqssA7tkAumoJsje5Sdlk04RTA5-Z6QACYTkAAp14ZBuYaAAlDEBZTomBgAAI5hGWWs5cAB3Vgy4AWqnZjUb5PY1lLzobs9ceA4hAA).)

In any case, i think what's desired here is `Exclude`, not `Omit`, so i've put up this PR in case that's correct.

I don't know what to run in order to re-execute codegen and produce the TS (might i request [something like this](https://github.com/grafana/grafana/blob/main/pkg/coremodel/dashboard/coremodel_gen.go#L3) in the generated file header?). Also, idk if this'll fail in CI due to the desync between generated code and the inputs, but it should. i wrote [this](https://github.com/grafana/grafana/blob/main/pkg/codegen/diffwrite.go) to help with that, see e.g. usage [here](https://github.com/grafana/grafana/blob/main/pkg/framework/coremodel/gen.go#L63-L93).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

