### PR TITLE
Alerting: Remove Image Upload code from Slack notifier.

### DIFF
--- a/pkg/services/ngalert/notifier/channels/slack_test.go
+++ b/pkg/services/ngalert/notifier/channels/slack_test.go
@@ -39,14 +39,6 @@ func TestSlackNotifier(t *testing.T) {
 				Token: "test-with-url",
 				URL:   "https://www.example.com/image.jpg",
 			},
-			{
-				Token: "test-with-path-not-found",
-				Path:  "usr/home/nouser/noway.jpg",
-			},
-			{
-				Token: "test-with-path-found",
-				Path:  f.Name(), // Has the full path because of how CreateTemp works.
-			},
 		},
 	}
 
@@ -173,78 +165,6 @@ func TestSlackNotifier(t *testing.T) {
 			expMsgError: nil,
 		},
 		{
-			name: "Image URL with path but no file creates message with no error",
-			settings: `{
-				"token": "1234",
-				"image_upload_url": "https://www.webhook.com",
-				"recipient": "#testchannel",
-				"icon_emoji": ":emoji:"
-			}`,
-			alerts: []*types.Alert{
-				{
-					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertScreenshotToken__": "test-with-path-not-found"},
-					},
-				},
-			},
-			expMsg: &slackMessage{
-				Channel:   "#testchannel",
-				Username:  "Grafana",
-				IconEmoji: ":emoji:",
-				Attachments: []attachment{
-					{
-						Title:      "[FIRING:1]  (val1)",
-						TitleLink:  "http://localhost/alerting/list",
-						Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
-						Fallback:   "[FIRING:1]  (val1)",
-						Fields:     nil,
-						Footer:     "Grafana v" + setting.BuildVersion,
-						FooterIcon: "https://grafana.com/assets/img/fav32.png",
-						Color:      "#D63232",
-						Ts:         0,
-					},
-				},
-			},
-			expMsgError: nil,
-		},
-		{
-			name: "Image URL with path and file creates message and uploads image",
-			settings: `{
-				"token": "1234",
-				"recipient": "#testchannel",
-				"icon_emoji": ":emoji:"
-			}`,
-			alerts: []*types.Alert{
-				{
-					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertScreenshotToken__": "test-with-path-found"},
-					},
-				},
-			},
-			expMsg: &slackMessage{
-				Channel:   "#testchannel",
-				Username:  "Grafana",
-				IconEmoji: ":emoji:",
-				Attachments: []attachment{
-					{
-						Title:      "[FIRING:1]  (val1)",
-						TitleLink:  "http://localhost/alerting/list",
-						Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
-						Fallback:   "[FIRING:1]  (val1)",
-						Fields:     nil,
-						Footer:     "Grafana v" + setting.BuildVersion,
-						FooterIcon: "https://grafana.com/assets/img/fav32.png",
-						Color:      "#D63232",
-						Ts:         0,
-					},
-				},
-			},
-			expMsgError:   nil,
-			expWebhookURL: SlackImageAPIEndpoint,
-		},
-		{
 			name: "Correct config with multiple alerts and template",
 			settings: `{
 				"token": "1234",
@@ -333,43 +253,6 @@ func TestSlackNotifier(t *testing.T) {
 				},
 			},
 			expMsgError: nil,
-		},
-		{
-			name: "Custom image upload URL",
-			settings: `{
-				"token": "1234",
-				"recipient": "#testchannel",
-				"icon_emoji": ":emoji:",
-				"imageUploadUrl": "https://custom-domain.upload"
-			}`,
-			alerts: []*types.Alert{
-				{
-					Alert: model.Alert{
-						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertScreenshotToken__": "test-with-path-found"},
-					},
-				},
-			},
-			expMsg: &slackMessage{
-				Channel:   "#testchannel",
-				Username:  "Grafana",
-				IconEmoji: ":emoji:",
-				Attachments: []attachment{
-					{
-						Title:      "[FIRING:1]  (val1)",
-						TitleLink:  "http://localhost/alerting/list",
-						Text:       "**Firing**\n\nValue: [no value]\nLabels:\n - alertname = alert1\n - lbl1 = val1\nAnnotations:\n - ann1 = annv1\nSilence: http://localhost/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1\nDashboard: http://localhost/d/abcd\nPanel: http://localhost/d/abcd?viewPanel=efgh\n",
-						Fallback:   "[FIRING:1]  (val1)",
-						Fields:     nil,
-						Footer:     "Grafana v" + setting.BuildVersion,
-						FooterIcon: "https://grafana.com/assets/img/fav32.png",
-						Color:      "#D63232",
-						Ts:         0,
-					},
-				},
-			},
-			expMsgError:   nil,
-			expWebhookURL: "https://custom-domain.upload",
 		},
 	}
 


### PR DESCRIPTION
The image file upload code as it is now simply doesn't work - it's
missing several important steps in the file upload process. There is
more information in the fixed issue as to the steps required.

After this change, screenshots will still be attached to slack messages
when external image storage is used with Grafana (an S3 bucket, for
example).

Fixes #50056