### PR TITLE
Redshift: Add feature flag for experimental UI

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -58,4 +58,5 @@ export interface FeatureToggles {
   validateDashboardsOnSave?: boolean;
   prometheusWideSeries?: boolean;
   canvasPanelNesting?: boolean;
+  redshiftExperimentalUI?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -238,5 +238,12 @@ var (
 			State:        FeatureStateAlpha,
 			FrontendOnly: true,
 		},
+		{
+			Name:            "redshiftExperimentalUI",
+			Description:     "Use grafana-experimental UI in the Redshift plugin",
+			State:           FeatureStateAlpha,
+			RequiresDevMode: true,
+			FrontendOnly:    true,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -174,4 +174,8 @@ const (
 	// FlagCanvasPanelNesting
 	// Allow elements nesting
 	FlagCanvasPanelNesting = "canvasPanelNesting"
+
+	// FlagRedshiftExperimentalUI
+	// Use grafana-experimental UI in the Redshift plugin
+	FlagRedshiftExperimentalUI = "redshiftExperimentalUI"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Needed in https://github.com/grafana/redshift-datasource/issues/108. As the feature flag name suggests, this flag can be used not only for the autocomplete feature, but also for future work migrating the redshift plugin to exerimental ui. 


