### PR TITLE
Alerting: Fix alert list panel showing firing alerts with no instances

### DIFF
--- a/public/app/plugins/panel/alertlist/AlertInstances.tsx
+++ b/public/app/plugins/panel/alertlist/AlertInstances.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
+import { noop } from 'lodash';
 import pluralize from 'pluralize';
-import React, { FC, useCallback, useMemo, useState } from 'react';
+import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { GrafanaTheme2, PanelProps } from '@grafana/data';
 import { Icon, useStyles2 } from '@grafana/ui';
@@ -31,12 +32,24 @@ export const AlertInstances: FC<Props> = ({ alerts, options }) => {
     [alerts, options]
   );
 
+  const hiddenInstances = alerts.length - filteredAlerts.length;
+
+  const uncollapsible = filteredAlerts.length > 0;
+  const toggleShowInstances = uncollapsible ? toggleDisplayInstances : noop;
+
+  useEffect(() => {
+    if (filteredAlerts.length === 0) {
+      setDisplayInstances(false);
+    }
+  }, [filteredAlerts]);
+
   return (
     <div>
       {options.groupMode === GroupMode.Default && (
-        <div className={styles.instance} onClick={() => toggleDisplayInstances()}>
-          <Icon name={displayInstances ? 'angle-down' : 'angle-right'} size={'md'} />
+        <div className={uncollapsible ? styles.clickable : ''} onClick={() => toggleShowInstances()}>
+          {uncollapsible && <Icon name={displayInstances ? 'angle-down' : 'angle-right'} size={'md'} />}
           <span>{`${filteredAlerts.length} ${pluralize('instance', filteredAlerts.length)}`}</span>
+          {hiddenInstances > 0 && <span>, {`${hiddenInstances} not shown`}</span>}
         </div>
       )}
       {displayInstances && <AlertInstancesTable instances={filteredAlerts} />}
@@ -45,7 +58,7 @@ export const AlertInstances: FC<Props> = ({ alerts, options }) => {
 };
 
 const getStyles = (_: GrafanaTheme2) => ({
-  instance: css`
+  clickable: css`
     cursor: pointer;
   `,
 });

--- a/public/app/plugins/panel/alertlist/AlertInstances.tsx
+++ b/public/app/plugins/panel/alertlist/AlertInstances.tsx
@@ -49,7 +49,7 @@ export const AlertInstances: FC<Props> = ({ alerts, options }) => {
         <div className={uncollapsible ? styles.clickable : ''} onClick={() => toggleShowInstances()}>
           {uncollapsible && <Icon name={displayInstances ? 'angle-down' : 'angle-right'} size={'md'} />}
           <span>{`${filteredAlerts.length} ${pluralize('instance', filteredAlerts.length)}`}</span>
-          {hiddenInstances > 0 && <span>, {`${hiddenInstances} not shown`}</span>}
+          {hiddenInstances > 0 && <span>, {`${hiddenInstances} hidden by filters`}</span>}
         </div>
       )}
       {displayInstances && <AlertInstancesTable instances={filteredAlerts} />}

--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -60,7 +60,7 @@ export function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
     [props, promRulesRequests]
   );
 
-  const noAlertsMessage = rules.length ? '' : 'No alerts';
+  const noAlertsMessage = rules.length === 0 ? 'No alerts matching filters' : undefined;
 
   if (
     !contextSrv.hasPermission(AccessControlAction.AlertingRuleRead) &&
@@ -122,15 +122,15 @@ function filterRules(props: PanelProps<UnifiedAlertListOptions>, rules: PromRule
       name.toLocaleLowerCase().includes(replacedName.toLocaleLowerCase())
     );
   }
-  if (Object.values(options.stateFilter).some((value) => value)) {
-    filteredRules = filteredRules.filter((rule) => {
-      return (
-        (options.stateFilter.firing && rule.rule.state === PromAlertingRuleState.Firing) ||
-        (options.stateFilter.pending && rule.rule.state === PromAlertingRuleState.Pending) ||
-        (options.stateFilter.inactive && rule.rule.state === PromAlertingRuleState.Inactive)
-      );
-    });
-  }
+
+  filteredRules = filteredRules.filter((rule) => {
+    return (
+      (options.stateFilter.firing && rule.rule.state === PromAlertingRuleState.Firing) ||
+      (options.stateFilter.pending && rule.rule.state === PromAlertingRuleState.Pending) ||
+      (options.stateFilter.inactive && rule.rule.state === PromAlertingRuleState.Inactive)
+    );
+  });
+
   if (options.alertInstanceLabelFilter) {
     const replacedLabelFilter = replaceVariables(options.alertInstanceLabelFilter);
     const matchers = parseMatchers(replacedLabelFilter);


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug where the alert list panel would show firing alerts with no instances. 

Additionally it clarifies that no alerts are shown that match the current set of filters and indicates how many instances are not being shown (because they are hidden by at least one of the alert state filters).

<img width="491" alt="Screenshot 2022-06-02 at 11 28 35" src="https://user-images.githubusercontent.com/868844/171602305-f68de4ba-ad77-4838-a66b-d403a87a07fd.png">
<img width="479" alt="Screenshot 2022-06-02 at 11 28 51" src="https://user-images.githubusercontent.com/868844/171602309-7144b905-0d29-49c0-9632-b0f7c54a3c3c.png">

**Special notes for your reviewer**:

