### PR TITLE
Alerting: Fix alert creation form layout when errors occur

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DetailsStep.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import classNames from 'classnames';
 import React, { FC } from 'react';
 import { useFormContext } from 'react-hook-form';
 
@@ -75,7 +76,7 @@ export const DetailsStep: FC = () => {
         dataSourceName && <GroupAndNamespaceFields rulesSourceName={dataSourceName} />}
 
       {ruleFormType === RuleFormType.grafana && (
-        <div className={styles.flexRow}>
+        <div className={classNames([styles.flexRow, styles.alignBaseline])}>
           <Field
             label={
               <Label htmlFor="folder" description={'Select a folder to store your rule.'}>
@@ -137,6 +138,9 @@ export const DetailsStep: FC = () => {
 };
 
 const getStyles = (theme: GrafanaTheme2) => ({
+  alignBaseline: css`
+    align-items: baseline;
+  `,
   formInput: css`
     width: 330px;
     & + & {


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a small layout issue when errors occurred in the alert creation.

**Before**
![image](https://user-images.githubusercontent.com/868844/171627919-9dcdbd5a-b9bb-4b74-bcf7-7c3dc9654df2.png)


**After**
![image](https://user-images.githubusercontent.com/868844/171627934-c47ce24f-d649-45b8-bbbd-c314382447e0.png)

