### PR TITLE
gitlab oauth: account for role_attribute_path_strict

### DIFF
--- a/pkg/login/social/gitlab_oauth.go
+++ b/pkg/login/social/gitlab_oauth.go
@@ -2,6 +2,7 @@ package social
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -13,9 +14,10 @@ import (
 
 type SocialGitlab struct {
 	*SocialBase
-	allowedGroups     []string
-	apiUrl            string
-	roleAttributePath string
+	allowedGroups       []string
+	apiUrl              string
+	roleAttributePath   string
+	roleAttributeStrict bool
 }
 
 func (s *SocialGitlab) Type() int {
@@ -118,6 +120,9 @@ func (s *SocialGitlab) UserInfo(client *http.Client, token *oauth2.Token) (*Basi
 	role, err := s.extractRole(response.Body)
 	if err != nil {
 		s.log.Error("Failed to extract role", "error", err)
+	}
+	if s.roleAttributeStrict && !models.RoleType(role).IsValid() {
+		return nil, errors.New("invalid role")
 	}
 
 	userInfo := &BasicUserInfo{

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -130,10 +130,11 @@ func ProvideService(cfg *setting.Cfg) *SocialService {
 		// GitLab.
 		if name == "gitlab" {
 			ss.socialMap["gitlab"] = &SocialGitlab{
-				SocialBase:        newSocialBase(name, &config, info),
-				apiUrl:            info.ApiUrl,
-				allowedGroups:     util.SplitString(sec.Key("allowed_groups").String()),
-				roleAttributePath: info.RoleAttributePath,
+				SocialBase:          newSocialBase(name, &config, info),
+				apiUrl:              info.ApiUrl,
+				allowedGroups:       util.SplitString(sec.Key("allowed_groups").String()),
+				roleAttributePath:   info.RoleAttributePath,
+				roleAttributeStrict: info.RoleAttributeStrict,
 			}
 		}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
With https://github.com/grafana/grafana/pull/49147 we added support for an ENV override of `GF_AUTH_GITLAB_ROLE_ATTRIBUTE_PATH_STRICT`. 
This PR is aligning the backend to support this parameter: `gitlab_oauth` will handle  `role_attribute_path_strict` the same way `generic_oauth` and `okta_oauth` are.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/3407

**Special notes for your reviewer**:

