### PR TITLE
Search (SQL): support dashboardUID query parameter

### DIFF
--- a/pkg/api/search.go
+++ b/pkg/api/search.go
@@ -39,6 +39,8 @@ func (hs *HTTPServer) Search(c *models.ReqContext) response.Response {
 		}
 	}
 
+	dbUIDs := c.QueryStrings("dashboardUID")
+
 	folderIDs := make([]int64, 0)
 	for _, id := range c.QueryStrings("folderIds") {
 		folderID, err := strconv.ParseInt(id, 10, 64)
@@ -47,19 +49,24 @@ func (hs *HTTPServer) Search(c *models.ReqContext) response.Response {
 		}
 	}
 
+	if len(dbIDs) > 0 && len(dbUIDs) > 0 {
+		return response.Error(400, "search supports UIDs or IDs, not both", nil)
+	}
+
 	searchQuery := search.Query{
-		Title:        query,
-		Tags:         tags,
-		SignedInUser: c.SignedInUser,
-		Limit:        limit,
-		Page:         page,
-		IsStarred:    starred == "true",
-		OrgId:        c.OrgId,
-		DashboardIds: dbIDs,
-		Type:         dashboardType,
-		FolderIds:    folderIDs,
-		Permission:   permission,
-		Sort:         sort,
+		Title:         query,
+		Tags:          tags,
+		SignedInUser:  c.SignedInUser,
+		Limit:         limit,
+		Page:          page,
+		IsStarred:     starred == "true",
+		OrgId:         c.OrgId,
+		DashboardIds:  dbIDs,
+		DashboardUIDs: dbUIDs,
+		Type:          dashboardType,
+		FolderIds:     folderIDs,
+		Permission:    permission,
+		Sort:          sort,
 	}
 
 	err := hs.SearchService.SearchHandler(c.Req.Context(), &searchQuery)

--- a/pkg/models/search.go
+++ b/pkg/models/search.go
@@ -20,18 +20,19 @@ type SortOptionFilter interface {
 }
 
 type FindPersistedDashboardsQuery struct {
-	Title        string
-	OrgId        int64
-	SignedInUser *SignedInUser
-	IsStarred    bool
-	DashboardIds []int64
-	Type         string
-	FolderIds    []int64
-	Tags         []string
-	Limit        int64
-	Page         int64
-	Permission   PermissionType
-	Sort         SortOption
+	Title         string
+	OrgId         int64
+	SignedInUser  *SignedInUser
+	IsStarred     bool
+	DashboardIds  []int64
+	DashboardUIDs []string
+	Type          string
+	FolderIds     []int64
+	Tags          []string
+	Limit         int64
+	Page          int64
+	Permission    PermissionType
+	Sort          SortOption
 
 	Filters []interface{}
 

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -964,8 +964,10 @@ func (d *DashboardStore) FindDashboards(ctx context.Context, query *models.FindP
 		filters = append(filters, searchstore.TagsFilter{Tags: query.Tags})
 	}
 
-	if len(query.DashboardIds) > 0 {
-		filters = append(filters, searchstore.DashboardFilter{IDs: query.DashboardIds})
+	if len(query.DashboardUIDs) > 0 {
+		filters = append(filters, searchstore.DashboardFilter{UIDs: query.DashboardUIDs})
+	} else if len(query.DashboardIds) > 0 {
+		filters = append(filters, searchstore.DashboardIDFilter{IDs: query.DashboardIds})
 	}
 
 	if query.IsStarred {

--- a/pkg/services/search/service.go
+++ b/pkg/services/search/service.go
@@ -27,18 +27,19 @@ func ProvideService(cfg *setting.Cfg, sqlstore *sqlstore.SQLStore, starService s
 }
 
 type Query struct {
-	Title        string
-	Tags         []string
-	OrgId        int64
-	SignedInUser *models.SignedInUser
-	Limit        int64
-	Page         int64
-	IsStarred    bool
-	Type         string
-	DashboardIds []int64
-	FolderIds    []int64
-	Permission   models.PermissionType
-	Sort         string
+	Title         string
+	Tags          []string
+	OrgId         int64
+	SignedInUser  *models.SignedInUser
+	Limit         int64
+	Page          int64
+	IsStarred     bool
+	Type          string
+	DashboardUIDs []string
+	DashboardIds  []int64
+	FolderIds     []int64
+	Permission    models.PermissionType
+	Sort          string
 
 	Result models.HitList
 }
@@ -58,16 +59,17 @@ type SearchService struct {
 
 func (s *SearchService) SearchHandler(ctx context.Context, query *Query) error {
 	dashboardQuery := models.FindPersistedDashboardsQuery{
-		Title:        query.Title,
-		SignedInUser: query.SignedInUser,
-		IsStarred:    query.IsStarred,
-		DashboardIds: query.DashboardIds,
-		Type:         query.Type,
-		FolderIds:    query.FolderIds,
-		Tags:         query.Tags,
-		Limit:        query.Limit,
-		Page:         query.Page,
-		Permission:   query.Permission,
+		Title:         query.Title,
+		SignedInUser:  query.SignedInUser,
+		IsStarred:     query.IsStarred,
+		DashboardUIDs: query.DashboardUIDs,
+		DashboardIds:  query.DashboardIds,
+		Type:          query.Type,
+		FolderIds:     query.FolderIds,
+		Tags:          query.Tags,
+		Limit:         query.Limit,
+		Page:          query.Page,
+		Permission:    query.Permission,
 	}
 
 	if sortOpt, exists := s.sortOptions[query.Sort]; exists {

--- a/pkg/services/sqlstore/searchstore/filters.go
+++ b/pkg/services/sqlstore/searchstore/filters.go
@@ -95,12 +95,20 @@ func (f FolderFilter) Where() (string, []interface{}) {
 	return sqlIDin("dashboard.folder_id", f.IDs)
 }
 
-type DashboardFilter struct {
+type DashboardIDFilter struct {
 	IDs []int64
 }
 
-func (f DashboardFilter) Where() (string, []interface{}) {
+func (f DashboardIDFilter) Where() (string, []interface{}) {
 	return sqlIDin("dashboard.id", f.IDs)
+}
+
+type DashboardFilter struct {
+	UIDs []string
+}
+
+func (f DashboardFilter) Where() (string, []interface{}) {
+	return sqlUIDin("dashboard.uid", f.UIDs)
 }
 
 type TagsFilter struct {
@@ -145,6 +153,21 @@ func sqlIDin(column string, ids []int64) (string, []interface{}) {
 
 	params := []interface{}{}
 	for _, id := range ids {
+		params = append(params, id)
+	}
+	return fmt.Sprintf("%s IN %s", column, sqlArray), params
+}
+
+func sqlUIDin(column string, uids []string) (string, []interface{}) {
+	length := len(uids)
+	if length < 1 {
+		return "", nil
+	}
+
+	sqlArray := "(?" + strings.Repeat(",?", length-1) + ")"
+
+	params := []interface{}{}
+	for _, id := range uids {
 		params = append(params, id)
 	}
 	return fmt.Sprintf("%s IN %s", column, sqlArray), params

--- a/public/app/features/search/service/sql.ts
+++ b/public/app/features/search/service/sql.ts
@@ -16,11 +16,9 @@ interface APIQuery {
   page?: number;
   type?: string;
   // DashboardIds []int64
+  dashboardUID?: string[];
   folderIds?: number[];
   sort?: string;
-
-  // NEW!!!! TODO TODO: needs backend support?
-  dashboardUIDs?: string[];
 }
 
 // Internal object to hold folderId
@@ -57,8 +55,7 @@ export class SQLSearcher implements GrafanaSearcher {
     }
 
     if (query.uid) {
-      q.query = query.uid.join(', '); // TODO! this will return nothing
-      q.dashboardUIDs = query.uid;
+      q.dashboardUID = query.uid;
     } else if (query.location?.length) {
       let info = this.locationInfo[query.location];
       if (!info) {


### PR DESCRIPTION
The current SQL based search API allows filtering by *id*, but not *uid* -- the whole API should be replaced with the new more powerful search engine... but in the meantime, we are trying to power the new internal id unaware UI with the current sql backend.

This PR adds a `dashboardUID` parameter that behaves the as the `dashboardID` parameter.  Now the new UI works!

<img width="767" alt="image" src="https://user-images.githubusercontent.com/705951/171689088-0c93c1ca-c76b-44dd-a27a-ebc14d775f1d.png">


