### PR TITLE
Search: exclude rows from search index

### DIFF
--- a/pkg/services/searchV2/bluge.go
+++ b/pkg/services/searchV2/bluge.go
@@ -190,6 +190,8 @@ func getDashboardPanelDocs(dash dashboard, location string) []*bluge.Document {
 		purl := url
 		if panel.Type != "row" {
 			purl = fmt.Sprintf("%s?viewPanel=%d", url, panel.ID)
+		} else {
+			continue // for now, we are excluding rows from the search index
 		}
 
 		doc := newSearchDocument(uid, panel.Title, panel.Description, purl).

--- a/pkg/services/searchV2/bluge.go
+++ b/pkg/services/searchV2/bluge.go
@@ -186,13 +186,12 @@ func getDashboardPanelDocs(dash dashboard, location string) []*bluge.Document {
 	var docs []*bluge.Document
 	url := fmt.Sprintf("/d/%s/%s", dash.uid, dash.slug)
 	for _, panel := range dash.info.Panels {
-		uid := dash.uid + "#" + strconv.FormatInt(panel.ID, 10)
-		purl := url
-		if panel.Type != "row" {
-			purl = fmt.Sprintf("%s?viewPanel=%d", url, panel.ID)
-		} else {
+		if panel.Type == "row" {
 			continue // for now, we are excluding rows from the search index
 		}
+
+		uid := dash.uid + "#" + strconv.FormatInt(panel.ID, 10)
+		purl := fmt.Sprintf("%s?viewPanel=%d", url, panel.ID)
 
 		doc := newSearchDocument(uid, panel.Title, panel.Description, purl).
 			AddField(bluge.NewKeywordField(documentFieldDSUID, dash.uid).StoreValue()).


### PR DESCRIPTION
This PR skips indexing rows so they do not show up in search results.

Once we have a more robust filtering UI, we will reevaluate keeping rows in the index.  (And ideally a good way to link to an open row!)