### PR TITLE
loki: handle ad hoc filters in backend mode

### DIFF
--- a/devenv/docker/blocks/loki/data/data.js
+++ b/devenv/docker/blocks/loki/data/data.js
@@ -125,8 +125,8 @@ async function main() {
     await sleep(getNextSineWaveSleepDuration());
     const timestampMs = new Date().getTime();
     const item = getRandomLogItem(step + 1)
-    lokiSendLogLine(timestampMs, JSON.stringify(item), {place:'moon'});
-    lokiSendLogLine(timestampMs, logFmtLine(item), {place:'luna'});
+    lokiSendLogLine(timestampMs, JSON.stringify(item), {place:'moon', source: 'data'});
+    lokiSendLogLine(timestampMs, logFmtLine(item), {place:'luna', source: 'data'});
   }
 }
 

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1058,6 +1058,15 @@ describe('isMetricsQuery', () => {
   });
 });
 
+describe('applyTemplateVariables', () => {
+  it('should add the adhoc filter to the query', () => {
+    const ds = createLokiDSForTests();
+    const spy = jest.spyOn(ds, 'addAdHocFilters');
+    ds.applyTemplateVariables({ expr: '{test}', refId: 'A' }, {});
+    expect(spy).toHaveBeenCalledWith('{test}');
+  });
+});
+
 function assertAdHocFilters(query: string, expectedResults: string, ds: LokiDatasource) {
   const lokiQuery: LokiQuery = { refId: 'A', expr: query };
   const result = ds.addAdHocFilters(lokiQuery.expr);

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -887,10 +887,12 @@ export class LokiDatasource
     // We want to interpolate these variables on backend
     const { __interval, __interval_ms, ...rest } = scopedVars;
 
+    const exprWithAdHoc = this.addAdHocFilters(target.expr);
+
     return {
       ...target,
       legendFormat: this.templateSrv.replace(target.legendFormat, rest),
-      expr: this.templateSrv.replace(target.expr, rest, this.interpolateQueryExpr),
+      expr: this.templateSrv.replace(exprWithAdHoc, rest, this.interpolateQueryExpr),
     };
   }
 


### PR DESCRIPTION
ad hoc filters did not work in backend mode, this pull request fixes that.

how to test:

1. `make devenv sources=loki`
2. create a dashboard-panel, choose the logs-visualization
3. choose the loki data source, run this query: `{source="data"}`
4. set the line-limit to 6lines
5. at this point you should see both json-formatted log lines and logfmt-formatted log lines
6. [save]
7. go to the dashboard-settings, Variables, New, Name=`adhoc`, Type=`Ad hoc filters`, Options/Data source =  your_loki_data_source
8. [update] , [save dashboard]
9. go back to the panel
10. at the top-left corner, you will get a button named `adhoc`, click on it, and you can choose label-names and label-values. set it to `place=moon`, and you should see only json-formatted lines.
11. switch it to `place=luna`, and you should see only logfmt-formatted lines.