### PR TITLE
Alerting: Prevent query wrapper recreation on drag/drop

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryRows.tsx
@@ -256,7 +256,7 @@ export class QueryRows extends PureComponent<Props, State> {
                   return (
                     <QueryWrapper
                       index={index}
-                      key={`${query.refId}-${index}`}
+                      key={query.refId}
                       dsSettings={dsSettings}
                       data={data}
                       query={query}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR prevents query editor loosing its state during drag & drop operation

**Which issue(s) this PR fixes**:
Fixes #48094 

**Special notes for your reviewer**:

