### PR TITLE
[v9.0.x] loki: handle ad hoc filters in backend mode (#50135)

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1058,6 +1058,15 @@ describe('isMetricsQuery', () => {
   });
 });
 
+describe('applyTemplateVariables', () => {
+  it('should add the adhoc filter to the query', () => {
+    const ds = createLokiDSForTests();
+    const spy = jest.spyOn(ds, 'addAdHocFilters');
+    ds.applyTemplateVariables({ expr: '{test}', refId: 'A' }, {});
+    expect(spy).toHaveBeenCalledWith('{test}');
+  });
+});
+
 function assertAdHocFilters(query: string, expectedResults: string, ds: LokiDatasource) {
   const lokiQuery: LokiQuery = { refId: 'A', expr: query };
   const result = ds.addAdHocFilters(lokiQuery.expr);

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -889,10 +889,12 @@ export class LokiDatasource
     // We want to interpolate these variables on backend
     const { __interval, __interval_ms, ...rest } = scopedVars;
 
+    const exprWithAdHoc = this.addAdHocFilters(target.expr);
+
     return {
       ...target,
       legendFormat: this.templateSrv.replace(target.legendFormat, rest),
-      expr: this.templateSrv.replace(target.expr, rest, this.interpolateQueryExpr),
+      expr: this.templateSrv.replace(exprWithAdHoc, rest, this.interpolateQueryExpr),
     };
   }
 


### PR DESCRIPTION
(cherry picked from commit 6011c373aeb641a96ac162e0f0071d8e030a8f26)

manual backport of https://github.com/grafana/grafana/pull/50135 .