### PR TITLE
Alerting: Add provenance guard to config api

### DIFF
--- a/pkg/services/ngalert/api/api_alertmanager_guards.go
+++ b/pkg/services/ngalert/api/api_alertmanager_guards.go
@@ -1,0 +1,138 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util/cmputil"
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+func (srv AlertmanagerSrv) provenanceGuard(currentConfig apimodels.GettableUserConfig, newConfig apimodels.PostableUserConfig) error {
+	var reporter cmputil.DiffReporter
+	ops := make([]cmp.Option, 0, 4)
+	// json.RawMessage is a slice of bytes and therefore cmp's default behavior is to compare it by byte, which is not really useful
+	var jsonCmp = cmp.Transformer("", func(in json.RawMessage) string {
+		return string(in)
+	})
+	matcherComparer := cmp.Comparer(func(a, b labels.Matcher) bool {
+		if a.Name != b.Name {
+			return false
+		}
+		if a.Value != b.Value {
+			return false
+		}
+		if a.Type != b.Type {
+			return false
+		}
+		return true
+	})
+	ops = append(ops, cmp.Reporter(&reporter), matcherComparer, jsonCmp, cmpopts.EquateEmpty())
+	routesEqual := cmp.Equal(currentConfig.AlertmanagerConfig.Route, newConfig.AlertmanagerConfig.Route, ops...)
+	if !routesEqual && currentConfig.AlertmanagerConfig.Route.Provenance != ngmodels.ProvenanceNone {
+		srv.log.Debug("diff route", "equal", routesEqual)
+		for _, path := range reporter.Diffs.Paths() {
+			srv.log.Debug("diff paths", "path", path)
+		}
+		return errors.New("policies were provisioned and cannot be changed through the UI")
+	}
+	reporter = cmputil.DiffReporter{}
+	ops = make([]cmp.Option, 0, 4)
+	ops = append(ops, cmp.Reporter(&reporter), matcherComparer, jsonCmp, cmpopts.EquateEmpty())
+	templatesEqual := cmp.Equal(currentConfig.TemplateFiles, newConfig.TemplateFiles, ops...)
+	if !templatesEqual {
+		for _, path := range reporter.Diffs.Paths() {
+			if prov, ok := currentConfig.TemplateFileProvenances[path]; ok {
+				if prov != ngmodels.ProvenanceNone {
+					return errors.New("template '" + path + "' was provisioned and cannot be changed through the UI")
+				}
+			}
+		}
+	}
+	if err := validateContactPoints(currentConfig.AlertmanagerConfig.Receivers, newConfig.AlertmanagerConfig.Receivers); err != nil {
+		return err
+	}
+	// reporter = cmputil.DiffReporter{}
+	// ops = make([]cmp.Option, 0, 4)
+	// ops = append(ops, cmp.Reporter(&reporter), matcherComparer, jsonCmp, cmpopts.EquateEmpty())
+	// contactPointsEqual := cmp.Equal(currentConfig.AlertmanagerConfig.Receivers, newConfig.AlertmanagerConfig.Receivers, ops...)
+	// if !contactPointsEqual {
+	// 	for _, path := range reporter.Diffs.Paths() {
+	// 		srv.log.Debug("cp not equal", "path", path)
+	// 	}
+	// }
+	return nil
+}
+
+func validateContactPoints(current []*apimodels.GettableApiReceiver, new []*apimodels.PostableApiReceiver) error {
+	// todo check if provisioned was deleted
+	for _, existingReceiver := range current {
+		for _, existingContactPoint := range existingReceiver.GrafanaManagedReceivers {
+			found, edited := false, false
+		outer:
+			for _, postedReceiver := range new {
+				fmt.Printf("######## START (%s, %s) ##########\n", existingContactPoint.Name, existingContactPoint.Type)
+				for _, postedContactPoint := range postedReceiver.GrafanaManagedReceivers {
+					if existingContactPoint.UID != postedContactPoint.UID {
+						continue
+					}
+					found = true
+					if existingContactPoint.DisableResolveMessage != postedContactPoint.DisableResolveMessage {
+						edited = true
+					}
+					fmt.Printf("######## (edited == %t) checked resolved \n", edited)
+					if existingContactPoint.Name != postedContactPoint.Name {
+						edited = true
+					}
+					fmt.Printf("######## (edited == %t) checked name \n", edited)
+					if existingContactPoint.Type != postedContactPoint.Type {
+						edited = true
+					}
+					fmt.Printf("######## (edited == %t) checked type \n", edited)
+					for key := range existingContactPoint.SecureFields {
+						if value, present := postedContactPoint.SecureSettings[key]; present && value != "" {
+							edited = true
+							break // it's enough to know that something was edited
+						}
+					}
+					fmt.Printf("######## (edited == %t) checked secure \n", edited)
+					existingSettings, err := existingContactPoint.Settings.Map()
+					if err != nil {
+						return err
+					}
+					newSettings, err := postedContactPoint.Settings.Map()
+					if err != nil {
+						return err
+					}
+					for key, val := range existingSettings {
+						if newVal, present := newSettings[key]; present {
+							if val != newVal {
+								edited = true
+								break // it's enough to know that something was edited
+							}
+						} else {
+							edited = true
+							break // it's enough to know that something was edited
+						}
+					}
+					fmt.Printf("######## (edited == %t) checked settings \n", edited)
+					fmt.Printf("######## END (found:%t, edited:%t) ##########\n", found, edited)
+					if edited && existingContactPoint.Provenance != ngmodels.ProvenanceNone {
+						return errors.New("contact point '" + existingContactPoint.Name + "' was provisioned and cannot be changed through the UI")
+					}
+					break outer
+				}
+				fmt.Printf("######## END (found:%t, edited:%t) ##########\n", found, edited)
+			}
+			if !found && existingContactPoint.Provenance != ngmodels.ProvenanceNone {
+				return errors.New("contact point '" + existingContactPoint.Name + "' was provisioned and cannot be changed through the UI")
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/services/ngalert/api/api_alertmanager_guards.go
+++ b/pkg/services/ngalert/api/api_alertmanager_guards.go
@@ -8,6 +8,7 @@ import (
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/util/cmputil"
+	amConfig "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
 )
 
@@ -65,61 +66,56 @@ func checkTemplates(currentConfig apimodels.GettableUserConfig, newConfig apimod
 }
 
 func checkContactPoints(currReceivers []*apimodels.GettableApiReceiver, newReceivers []*apimodels.PostableApiReceiver) error {
+	currentCPs := make(map[string]*apimodels.GettableGrafanaReceiver)
+	newCPs := make(map[string]*apimodels.PostableGrafanaReceiver)
 	for _, existingReceiver := range currReceivers {
 		for _, existingContactPoint := range existingReceiver.GrafanaManagedReceivers {
 			if existingContactPoint.Provenance == ngmodels.ProvenanceNone {
 				continue // we are only interested in non none
 			}
-			found, edited := false, false
-		outer:
-			for _, postedReceiver := range newReceivers {
-				for _, postedContactPoint := range postedReceiver.GrafanaManagedReceivers {
-					if existingContactPoint.UID != postedContactPoint.UID {
-						continue
-					}
-					found = true
-					if existingContactPoint.DisableResolveMessage != postedContactPoint.DisableResolveMessage {
-						edited = true
-					}
-					if existingContactPoint.Name != postedContactPoint.Name {
-						edited = true
-					}
-					if existingContactPoint.Type != postedContactPoint.Type {
-						edited = true
-					}
-					for key := range existingContactPoint.SecureFields {
-						if value, present := postedContactPoint.SecureSettings[key]; present && value != "" {
-							edited = true
-							break // it's enough to know that something was edited
-						}
-					}
-					existingSettings, err := existingContactPoint.Settings.Map()
-					if err != nil {
-						return err
-					}
-					newSettings, err := postedContactPoint.Settings.Map()
-					if err != nil {
-						return err
-					}
-					for key, val := range existingSettings {
-						if newVal, present := newSettings[key]; present {
-							if val != newVal {
-								edited = true
-								break // it's enough to know that something was edited
-							}
-						} else {
-							edited = true
-							break // it's enough to know that something was edited
-						}
-					}
-					if edited {
-						return fmt.Errorf("cannot save provisioned contact point '%s'", existingContactPoint.Name)
-					}
-					break outer
-				}
+			currentCPs[existingContactPoint.UID] = existingContactPoint
+		}
+	}
+	for _, postedReceiver := range newReceivers {
+		for _, postedContactPoint := range postedReceiver.GrafanaManagedReceivers {
+			newCPs[postedContactPoint.UID] = postedContactPoint
+		}
+	}
+	for uid, contactPoint := range currentCPs {
+		postedContactPoint, present := newCPs[uid]
+		if !present {
+			return fmt.Errorf("cannot delete provisioned contact point '%s'", contactPoint.Name)
+		}
+		editErr := fmt.Errorf("cannot save provisioned contact point '%s'", contactPoint.Name)
+		if contactPoint.DisableResolveMessage != postedContactPoint.DisableResolveMessage {
+			return editErr
+		}
+		if contactPoint.Name != postedContactPoint.Name {
+			return editErr
+		}
+		if contactPoint.Type != postedContactPoint.Type {
+			return editErr
+		}
+		for key := range contactPoint.SecureFields {
+			if value, present := postedContactPoint.SecureSettings[key]; present && value != "" {
+				return editErr
 			}
-			if !found {
-				return fmt.Errorf("cannot delete provisioned contact point '%s'", existingContactPoint.Name)
+		}
+		existingSettings, err := contactPoint.Settings.Map()
+		if err != nil {
+			return err
+		}
+		newSettings, err := postedContactPoint.Settings.Map()
+		if err != nil {
+			return err
+		}
+		for key, val := range existingSettings {
+			if newVal, present := newSettings[key]; present {
+				if val != newVal {
+					return editErr
+				}
+			} else {
+				return editErr
 			}
 		}
 	}
@@ -127,6 +123,8 @@ func checkContactPoints(currReceivers []*apimodels.GettableApiReceiver, newRecei
 }
 
 func checkMuteTimes(currentConfig apimodels.GettableUserConfig, newConfig apimodels.PostableUserConfig) error {
+	currentMTs := make(map[string]amConfig.MuteTimeInterval)
+	newMTs := make(map[string]amConfig.MuteTimeInterval)
 	for _, muteTime := range currentConfig.AlertmanagerConfig.MuteTimeIntervals {
 		provenance := ngmodels.ProvenanceNone
 		if prov, present := currentConfig.AlertmanagerConfig.MuteTimeProvenances[muteTime.Name]; present {
@@ -135,22 +133,21 @@ func checkMuteTimes(currentConfig apimodels.GettableUserConfig, newConfig apimod
 		if provenance == ngmodels.ProvenanceNone {
 			continue // we are only interested in non none
 		}
-		found := false
-		for _, newMuteTime := range newConfig.AlertmanagerConfig.MuteTimeIntervals {
-			if newMuteTime.Name != muteTime.Name {
-				continue
-			}
-			found = true
-			reporter := cmputil.DiffReporter{}
-			ops := []cmp.Option{cmp.Reporter(&reporter), cmpopts.EquateEmpty()}
-			timesEqual := cmp.Equal(muteTime.TimeIntervals, newMuteTime.TimeIntervals, ops...)
-			if !timesEqual {
-				return fmt.Errorf("cannot save provisioned mute time '%s'", muteTime.Name)
-			}
-			break
+		currentMTs[muteTime.Name] = muteTime
+	}
+	for _, newMuteTime := range newConfig.AlertmanagerConfig.MuteTimeIntervals {
+		newMTs[newMuteTime.Name] = newMuteTime
+	}
+	for name, muteTime := range currentMTs {
+		postedMT, present := newMTs[name]
+		if !present {
+			return fmt.Errorf("cannot delete provisioned mute time '%s'", name)
 		}
-		if !found {
-			return fmt.Errorf("cannot delete provisioned mute time '%s'", muteTime.Name)
+		reporter := cmputil.DiffReporter{}
+		ops := []cmp.Option{cmp.Reporter(&reporter), cmpopts.EquateEmpty()}
+		timesEqual := cmp.Equal(muteTime.TimeIntervals, postedMT.TimeIntervals, ops...)
+		if !timesEqual {
+			return fmt.Errorf("cannot save provisioned mute time '%s'", muteTime.Name)
 		}
 	}
 	return nil

--- a/pkg/services/ngalert/api/api_alertmanager_guards.go
+++ b/pkg/services/ngalert/api/api_alertmanager_guards.go
@@ -50,12 +50,12 @@ func checkTemplates(currentConfig apimodels.GettableUserConfig, newConfig apimod
 			}
 			found = true
 			if template != newTemplate && provenance != ngmodels.ProvenanceNone {
-				return fmt.Errorf("template '%s' was provisioned and cannot be changed through the UI", name)
+				return fmt.Errorf("cannot save provisioned template '%s'", name)
 			}
 			break // we found the template and we can proceed
 		}
 		if !found && provenance != ngmodels.ProvenanceNone {
-			return fmt.Errorf("template '%s' was provisioned and cannot be changed through the UI", name)
+			return fmt.Errorf("cannot delete provisioned template '%s'", name)
 		}
 	}
 	return nil
@@ -107,13 +107,13 @@ func checkContactPoints(current []*apimodels.GettableApiReceiver, new []*apimode
 						}
 					}
 					if edited && existingContactPoint.Provenance != ngmodels.ProvenanceNone {
-						return fmt.Errorf("contact point '%s' was provisioned and cannot be changed through the UI", existingContactPoint.Name)
+						return fmt.Errorf("cannot save provisioned contact point '%s'", existingContactPoint.Name)
 					}
 					break outer
 				}
 			}
 			if !found && existingContactPoint.Provenance != ngmodels.ProvenanceNone {
-				return fmt.Errorf("contact point '%s' was provisioned and cannot be changed through the UI", existingContactPoint.Name)
+				return fmt.Errorf("cannot delete provisioned contact point '%s'", existingContactPoint.Name)
 			}
 		}
 	}
@@ -136,12 +136,12 @@ func checkMuteTimes(currentConfig apimodels.GettableUserConfig, newConfig apimod
 			ops := []cmp.Option{cmp.Reporter(&reporter), cmpopts.EquateEmpty()}
 			timesEqual := cmp.Equal(muteTime.TimeIntervals, newMuteTime.TimeIntervals, ops...)
 			if !timesEqual && provenance != ngmodels.ProvenanceNone {
-				return fmt.Errorf("mute time '%s' was provisioned and cannot be changed through the UI", muteTime.Name)
+				return fmt.Errorf("cannot save provisioned mute time '%s'", muteTime.Name)
 			}
 			break
 		}
 		if !found && provenance != ngmodels.ProvenanceNone {
-			return fmt.Errorf("mute time '%s' was provisioned and cannot be changed through the UI", muteTime.Name)
+			return fmt.Errorf("cannot delete provisioned mute time '%s'", muteTime.Name)
 		}
 	}
 	return nil

--- a/pkg/services/ngalert/api/api_alertmanager_guards.go
+++ b/pkg/services/ngalert/api/api_alertmanager_guards.go
@@ -30,8 +30,8 @@ func (srv AlertmanagerSrv) provenanceGuard(currentConfig apimodels.GettableUserC
 
 func checkRoutes(currentConfig apimodels.GettableUserConfig, newConfig apimodels.PostableUserConfig) error {
 	reporter := cmputil.DiffReporter{}
-	ops := []cmp.Option{cmp.Reporter(&reporter), cmpopts.EquateEmpty(), cmpopts.IgnoreUnexported(labels.Matcher{})}
-	routesEqual := cmp.Equal(currentConfig.AlertmanagerConfig.Route, newConfig.AlertmanagerConfig.Route, ops...)
+	options := []cmp.Option{cmp.Reporter(&reporter), cmpopts.EquateEmpty(), cmpopts.IgnoreUnexported(labels.Matcher{})}
+	routesEqual := cmp.Equal(currentConfig.AlertmanagerConfig.Route, newConfig.AlertmanagerConfig.Route, options...)
 	if !routesEqual && currentConfig.AlertmanagerConfig.Route.Provenance != ngmodels.ProvenanceNone {
 		return fmt.Errorf("policies were provisioned and cannot be changed through the UI")
 	}
@@ -144,8 +144,8 @@ func checkMuteTimes(currentConfig apimodels.GettableUserConfig, newConfig apimod
 			return fmt.Errorf("cannot delete provisioned mute time '%s'", name)
 		}
 		reporter := cmputil.DiffReporter{}
-		ops := []cmp.Option{cmp.Reporter(&reporter), cmpopts.EquateEmpty()}
-		timesEqual := cmp.Equal(muteTime.TimeIntervals, postedMT.TimeIntervals, ops...)
+		options := []cmp.Option{cmp.Reporter(&reporter), cmpopts.EquateEmpty()}
+		timesEqual := cmp.Equal(muteTime.TimeIntervals, postedMT.TimeIntervals, options...)
 		if !timesEqual {
 			return fmt.Errorf("cannot save provisioned mute time '%s'", muteTime.Name)
 		}

--- a/pkg/services/ngalert/api/api_alertmanager_guards.go
+++ b/pkg/services/ngalert/api/api_alertmanager_guards.go
@@ -64,15 +64,15 @@ func checkTemplates(currentConfig apimodels.GettableUserConfig, newConfig apimod
 	return nil
 }
 
-func checkContactPoints(current []*apimodels.GettableApiReceiver, new []*apimodels.PostableApiReceiver) error {
-	for _, existingReceiver := range current {
+func checkContactPoints(currReceivers []*apimodels.GettableApiReceiver, newReceivers []*apimodels.PostableApiReceiver) error {
+	for _, existingReceiver := range currReceivers {
 		for _, existingContactPoint := range existingReceiver.GrafanaManagedReceivers {
 			if existingContactPoint.Provenance == ngmodels.ProvenanceNone {
 				continue // we are only interested in non none
 			}
 			found, edited := false, false
 		outer:
-			for _, postedReceiver := range new {
+			for _, postedReceiver := range newReceivers {
 				for _, postedContactPoint := range postedReceiver.GrafanaManagedReceivers {
 					if existingContactPoint.UID != postedContactPoint.UID {
 						continue

--- a/pkg/services/ngalert/api/api_alertmanager_guards_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_guards_test.go
@@ -1,0 +1,1 @@
+package api

--- a/pkg/services/ngalert/api/api_alertmanager_guards_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_guards_test.go
@@ -1,1 +1,589 @@
 package api
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	amConfig "github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/pkg/labels"
+	"github.com/prometheus/alertmanager/timeinterval"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckRoute(t *testing.T) {
+	tests := []struct {
+		name          string
+		shouldErr     bool
+		currentConfig definitions.GettableUserConfig
+		newConfig     definitions.PostableUserConfig
+	}{
+		{
+			name:          "equal configs should not error",
+			shouldErr:     false,
+			currentConfig: gettableRoute(t, models.ProvenanceAPI),
+			newConfig:     postableRoute(t, models.ProvenanceAPI),
+		},
+		{
+			name:          "editing a non provisioned object should not fail",
+			shouldErr:     false,
+			currentConfig: gettableRoute(t, models.ProvenanceNone),
+			newConfig: func() definitions.PostableUserConfig {
+				cfg := postableRoute(t, models.ProvenanceNone)
+				cfg.AlertmanagerConfig.Route.Matchers[0].Value = "123"
+				return cfg
+			}(),
+		},
+		{
+			name:          "editing a provisioned object should fail",
+			shouldErr:     true,
+			currentConfig: gettableRoute(t, models.ProvenanceAPI),
+			newConfig: func() definitions.PostableUserConfig {
+				cfg := postableRoute(t, models.ProvenanceAPI)
+				cfg.AlertmanagerConfig.Route.Matchers[0].Value = "123"
+				return cfg
+			}(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := checkRoutes(test.currentConfig, test.newConfig)
+			if test.shouldErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func gettableRoute(t *testing.T, provenance models.Provenance) definitions.GettableUserConfig {
+	t.Helper()
+	return definitions.GettableUserConfig{
+		AlertmanagerConfig: definitions.GettableApiAlertingConfig{
+			Config: definitions.Config{
+				Route: &definitions.Route{
+					Provenance: provenance,
+					Continue:   true,
+					GroupBy: []model.LabelName{
+						"...",
+					},
+					Matchers: amConfig.Matchers{
+						{
+							Name:  "a",
+							Type:  labels.MatchEqual,
+							Value: "b",
+						},
+					},
+					Routes: []*definitions.Route{
+						{
+							Matchers: amConfig.Matchers{
+								{
+									Name:  "x",
+									Type:  labels.MatchNotEqual,
+									Value: "y",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func postableRoute(t *testing.T, provenace models.Provenance) definitions.PostableUserConfig {
+	t.Helper()
+	return definitions.PostableUserConfig{
+		AlertmanagerConfig: definitions.PostableApiAlertingConfig{
+			Config: definitions.Config{
+				Route: &definitions.Route{
+					Provenance: provenace,
+					Continue:   true,
+					GroupBy: []model.LabelName{
+						"...",
+					},
+					Matchers: amConfig.Matchers{
+						{
+							Name:  "a",
+							Type:  labels.MatchEqual,
+							Value: "b",
+						},
+					},
+					Routes: []*definitions.Route{
+						{
+							Matchers: amConfig.Matchers{
+								{
+									Name:  "x",
+									Type:  labels.MatchNotEqual,
+									Value: "y",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestCheckTemplates(t *testing.T) {
+	tests := []struct {
+		name          string
+		shouldErr     bool
+		currentConfig definitions.GettableUserConfig
+		newConfig     definitions.PostableUserConfig
+	}{
+		{
+			name:          "equal configs should not error",
+			shouldErr:     false,
+			currentConfig: gettableTemplates(t, "test-1", models.ProvenanceAPI),
+			newConfig:     postableTemplate(t, "test-1"),
+		},
+		{
+			name:          "removing a non provisioned object should not fail",
+			shouldErr:     false,
+			currentConfig: gettableTemplates(t, "test-1", models.ProvenanceNone),
+			newConfig:     definitions.PostableUserConfig{},
+		},
+		{
+			name:          "removing a provisioned object should fail",
+			shouldErr:     true,
+			currentConfig: gettableTemplates(t, "test-1", models.ProvenanceAPI),
+			newConfig:     definitions.PostableUserConfig{},
+		},
+		{
+			name:          "adding a non provisioned object should not fail",
+			shouldErr:     false,
+			currentConfig: gettableTemplates(t, "test-1", models.ProvenanceAPI),
+			newConfig:     postableTemplate(t, "test-1", "test-2"),
+		},
+		{
+			name:          "editing a non provisioned object should not fail",
+			shouldErr:     false,
+			currentConfig: gettableTemplates(t, "test-1", models.ProvenanceNone),
+			newConfig: func() definitions.PostableUserConfig {
+				cfg := postableTemplate(t, "test-1")
+				cfg.TemplateFiles["test-1"] = "some updated value"
+				return cfg
+			}(),
+		},
+		{
+			name:          "editing a provisioned object should fail",
+			shouldErr:     true,
+			currentConfig: gettableTemplates(t, "test-1", models.ProvenanceAPI),
+			newConfig: func() definitions.PostableUserConfig {
+				cfg := postableTemplate(t, "test-1")
+				cfg.TemplateFiles["test-1"] = "some updated value"
+				return cfg
+			}(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := checkTemplates(test.currentConfig, test.newConfig)
+			if test.shouldErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func gettableTemplates(t *testing.T, name string, provenance models.Provenance) definitions.GettableUserConfig {
+	t.Helper()
+	return definitions.GettableUserConfig{
+		TemplateFiles: map[string]string{
+			name: "some-template",
+		},
+		TemplateFileProvenances: map[string]models.Provenance{
+			name: provenance,
+		},
+	}
+}
+
+func postableTemplate(t *testing.T, names ...string) definitions.PostableUserConfig {
+	t.Helper()
+	files := map[string]string{}
+	for _, name := range names {
+		files[name] = "some-template"
+	}
+	return definitions.PostableUserConfig{
+		TemplateFiles: files,
+	}
+}
+
+func TestCheckContactPoints(t *testing.T) {
+	tests := []struct {
+		name          string
+		shouldErr     bool
+		currentConfig []*definitions.GettableApiReceiver
+		newConfig     []*definitions.PostableApiReceiver
+	}{
+		{
+			name:      "equal configs should not error",
+			shouldErr: false,
+			currentConfig: []*definitions.GettableApiReceiver{
+				defaultGettableReceiver(t, "test-1", models.ProvenanceAPI),
+			},
+			newConfig: []*definitions.PostableApiReceiver{
+				defaultPostableReceiver(t, "test-1"),
+			},
+		},
+		{
+			name:      "removing a non provisioned object should not fail",
+			shouldErr: false,
+			currentConfig: []*definitions.GettableApiReceiver{
+				defaultGettableReceiver(t, "test-1", models.ProvenanceNone),
+			},
+			newConfig: []*definitions.PostableApiReceiver{},
+		},
+		{
+			name:      "removing a provisioned object should fail",
+			shouldErr: true,
+			currentConfig: []*definitions.GettableApiReceiver{
+				defaultGettableReceiver(t, "test-1", models.ProvenanceAPI),
+			},
+			newConfig: []*definitions.PostableApiReceiver{},
+		},
+		{
+			name:      "adding a non provisioned object should not fail",
+			shouldErr: false,
+			currentConfig: []*definitions.GettableApiReceiver{
+				defaultGettableReceiver(t, "test-1", models.ProvenanceAPI),
+			},
+			newConfig: []*definitions.PostableApiReceiver{
+				defaultPostableReceiver(t, "test-1"),
+				defaultPostableReceiver(t, "test-2"),
+			},
+		},
+		{
+			name:      "editing a non provisioned object should not fail",
+			shouldErr: false,
+			currentConfig: []*definitions.GettableApiReceiver{
+				defaultGettableReceiver(t, "test-1", models.ProvenanceNone),
+			},
+			newConfig: []*definitions.PostableApiReceiver{
+				func() *definitions.PostableApiReceiver {
+					receiver := defaultPostableReceiver(t, "test-1")
+					receiver.GrafanaManagedReceivers[0].SecureSettings = map[string]string{
+						"url": "newUrl",
+					}
+					return receiver
+				}(),
+			},
+		},
+		{
+			name:      "editing a provisioned object should fail",
+			shouldErr: true,
+			currentConfig: []*definitions.GettableApiReceiver{
+				defaultGettableReceiver(t, "test-1", models.ProvenanceAPI),
+			},
+			newConfig: []*definitions.PostableApiReceiver{
+				func() *definitions.PostableApiReceiver {
+					receiver := defaultPostableReceiver(t, "test-1")
+					receiver.GrafanaManagedReceivers[0].SecureSettings = map[string]string{
+						"url": "newUrl",
+					}
+					return receiver
+				}(),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := checkContactPoints(test.currentConfig, test.newConfig)
+			if test.shouldErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func defaultGettableReceiver(t *testing.T, uid string, provenance models.Provenance) *definitions.GettableApiReceiver {
+	t.Helper()
+	return &definitions.GettableApiReceiver{
+		GettableGrafanaReceivers: definitions.GettableGrafanaReceivers{
+			GrafanaManagedReceivers: []*definitions.GettableGrafanaReceiver{
+				{
+					UID:                   "123",
+					Name:                  "yeah",
+					Type:                  "slack",
+					DisableResolveMessage: true,
+					Provenance:            provenance,
+					SecureFields: map[string]bool{
+						"url": true,
+					},
+					Settings: simplejson.NewFromAny(map[string]interface{}{
+						"hello": "world",
+					}),
+				},
+			},
+		},
+	}
+}
+
+func defaultPostableReceiver(t *testing.T, uid string) *definitions.PostableApiReceiver {
+	t.Helper()
+	return &definitions.PostableApiReceiver{
+		PostableGrafanaReceivers: definitions.PostableGrafanaReceivers{
+			GrafanaManagedReceivers: []*definitions.PostableGrafanaReceiver{
+				{
+					UID:                   "123",
+					Name:                  "yeah",
+					Type:                  "slack",
+					DisableResolveMessage: true,
+					Settings: simplejson.NewFromAny(map[string]interface{}{
+						"hello": "world",
+					}),
+				},
+			},
+		},
+	}
+}
+
+func TestCheckMuteTimes(t *testing.T) {
+	tests := []struct {
+		name          string
+		shouldErr     bool
+		currentConfig definitions.GettableUserConfig
+		newConfig     definitions.PostableUserConfig
+	}{
+		{
+			name:      "equal configs should not error",
+			shouldErr: false,
+			currentConfig: gettableMuteIntervals(t,
+				[]amConfig.MuteTimeInterval{
+					{
+						Name:          "test-1",
+						TimeIntervals: defaultInterval(t),
+					},
+					{
+						Name:          "test-2",
+						TimeIntervals: defaultInterval(t),
+					},
+				},
+				map[string]models.Provenance{
+					"test-1": models.ProvenanceNone,
+				}),
+			newConfig: postableMuteIntervals(t,
+				[]amConfig.MuteTimeInterval{
+					{
+						Name:          "test-1",
+						TimeIntervals: defaultInterval(t),
+					},
+					{
+						Name:          "test-2",
+						TimeIntervals: defaultInterval(t),
+					},
+				}),
+		},
+		{
+			name:      "removing a non provisioned object should not fail",
+			shouldErr: false,
+			currentConfig: gettableMuteIntervals(t,
+				[]amConfig.MuteTimeInterval{
+					{
+						Name:          "test-1",
+						TimeIntervals: defaultInterval(t),
+					},
+				},
+				map[string]models.Provenance{
+					"test-1": models.ProvenanceNone,
+				}),
+			newConfig: postableMuteIntervals(t, []amConfig.MuteTimeInterval{}),
+		},
+		{
+			name:      "removing a provisioned object should fail",
+			shouldErr: true,
+			currentConfig: gettableMuteIntervals(t,
+				[]amConfig.MuteTimeInterval{
+					{
+						Name:          "test-1",
+						TimeIntervals: defaultInterval(t),
+					},
+					{
+						Name:          "test-2",
+						TimeIntervals: defaultInterval(t),
+					},
+				},
+				map[string]models.Provenance{
+					"test-1": models.ProvenanceAPI,
+				}),
+			newConfig: postableMuteIntervals(t, []amConfig.MuteTimeInterval{
+				{
+					Name:          "test-2",
+					TimeIntervals: defaultInterval(t),
+				},
+			}),
+		},
+		{
+			name:      "adding a non provisioned object should not fail",
+			shouldErr: false,
+			currentConfig: gettableMuteIntervals(t,
+				[]amConfig.MuteTimeInterval{
+					{
+						Name:          "test-1",
+						TimeIntervals: defaultInterval(t),
+					},
+				},
+				map[string]models.Provenance{
+					"test-1": models.ProvenanceNone,
+				}),
+			newConfig: postableMuteIntervals(t,
+				[]amConfig.MuteTimeInterval{
+					{
+						Name:          "test-1",
+						TimeIntervals: defaultInterval(t),
+					},
+					{
+						Name:          "test-2",
+						TimeIntervals: defaultInterval(t),
+					},
+				}),
+		},
+		{
+			name:      "editing a non provisioned object should not fail",
+			shouldErr: false,
+			currentConfig: gettableMuteIntervals(t,
+				[]amConfig.MuteTimeInterval{
+					{
+						Name:          "test-1",
+						TimeIntervals: defaultInterval(t),
+					},
+				},
+				map[string]models.Provenance{
+					"test-1": models.ProvenanceNone,
+				}),
+			newConfig: postableMuteIntervals(t,
+				[]amConfig.MuteTimeInterval{
+					{
+						Name: "test-1",
+						TimeIntervals: func() []timeinterval.TimeInterval {
+							intervals := defaultInterval(t)
+							intervals[0].Times = []timeinterval.TimeRange{
+								{
+									StartMinute: 10,
+									EndMinute:   50,
+								},
+							}
+							return intervals
+						}(),
+					},
+				}),
+		},
+		{
+			name:      "editing a provisioned object should fail",
+			shouldErr: true,
+			currentConfig: gettableMuteIntervals(t,
+				[]amConfig.MuteTimeInterval{
+					{
+						Name:          "test-1",
+						TimeIntervals: defaultInterval(t),
+					},
+				},
+				map[string]models.Provenance{
+					"test-1": models.ProvenanceAPI,
+				}),
+			newConfig: postableMuteIntervals(t,
+				[]amConfig.MuteTimeInterval{
+					{
+						Name: "test-1",
+						TimeIntervals: func() []timeinterval.TimeInterval {
+							intervals := defaultInterval(t)
+							intervals[0].Times = []timeinterval.TimeRange{
+								{
+									StartMinute: 10,
+									EndMinute:   50,
+								},
+							}
+							return intervals
+						}(),
+					},
+				}),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := checkMuteTimes(test.currentConfig, test.newConfig)
+			if test.shouldErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func gettableMuteIntervals(t *testing.T, muteTimeIntervals []amConfig.MuteTimeInterval, provenances map[string]models.Provenance) definitions.GettableUserConfig {
+	return definitions.GettableUserConfig{
+		AlertmanagerConfig: definitions.GettableApiAlertingConfig{
+			MuteTimeProvenances: provenances,
+			Config: definitions.Config{
+				MuteTimeIntervals: muteTimeIntervals,
+			},
+		},
+	}
+}
+
+func postableMuteIntervals(t *testing.T, muteTimeIntervals []amConfig.MuteTimeInterval) definitions.PostableUserConfig {
+	t.Helper()
+	return definitions.PostableUserConfig{
+		AlertmanagerConfig: definitions.PostableApiAlertingConfig{
+			Config: definitions.Config{
+				MuteTimeIntervals: muteTimeIntervals,
+			},
+		},
+	}
+}
+
+func defaultInterval(t *testing.T) []timeinterval.TimeInterval {
+	t.Helper()
+	return []timeinterval.TimeInterval{
+		{
+			Years: []timeinterval.YearRange{
+				{
+					InclusiveRange: timeinterval.InclusiveRange{
+						Begin: 2002,
+						End:   2008,
+					},
+				},
+			},
+			Times: []timeinterval.TimeRange{
+				{
+					StartMinute: 10,
+					EndMinute:   40,
+				},
+			},
+			Weekdays: []timeinterval.WeekdayRange{
+				{
+					InclusiveRange: timeinterval.InclusiveRange{
+						Begin: 1,
+						End:   5,
+					},
+				},
+			},
+			DaysOfMonth: []timeinterval.DayOfMonthRange{
+				{
+					InclusiveRange: timeinterval.InclusiveRange{
+						Begin: 1,
+						End:   20,
+					},
+				},
+			},
+			Months: []timeinterval.MonthRange{
+				{
+					InclusiveRange: timeinterval.InclusiveRange{
+						Begin: 1,
+						End:   6,
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
This PR adds a guard to the alertmanager config route that does:

- Detect any changes in the posted config by comparing it to the latest one
- Check if those changes affected things that have another provenance then the default on `ProvenanceNone`
- Block the request if the caller tries to change something that has not `ProvenanceNone`

builds on top of #50149 