### PR TITLE
Docs: updated configuration description for auto_assign_org

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -675,7 +675,8 @@ Default is `false`.
 
 Set to `true` to automatically add new users to the main organization
 (id 1). When set to `false`, new users automatically cause a new
-organization to be created for that new user. Default is `true`.
+organization to be created for that new user. The organization will be 
+created even if the above setting is set to `false`. Default is `true`.
 
 ### auto_assign_org_id
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -676,7 +676,8 @@ Default is `false`.
 Set to `true` to automatically add new users to the main organization
 (id 1). When set to `false`, new users automatically cause a new
 organization to be created for that new user. The organization will be 
-created even if the above setting is set to `false`. Default is `true`.
+organization to be created for that new user. The organization will be 
+created even if the `allow_org_create` setting is set to `false`. Default is `true`. 
 
 ### auto_assign_org_id
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -675,9 +675,8 @@ Default is `false`.
 
 Set to `true` to automatically add new users to the main organization
 (id 1). When set to `false`, new users automatically cause a new
-organization to be created for that new user. The organization will be 
-organization to be created for that new user. The organization will be 
-created even if the `allow_org_create` setting is set to `false`. Default is `true`. 
+organization to be created for that new user. The organization will be
+created even if the `allow_org_create` setting is set to `false`. Default is `true`.
 
 ### auto_assign_org_id
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -676,7 +676,7 @@ Default is `false`.
 Set to `true` to automatically add new users to the main organization
 (id 1). When set to `false`, new users automatically cause a new
 organization to be created for that new user. The organization will be 
-organization to be created for that new user. The organization will be 
+organization to be created for that new user. The organization will be
 created even if the `allow_org_create` setting is set to `false`. Default is `true`. 
 
 ### auto_assign_org_id


### PR DESCRIPTION
**What this PR does / why we need it**:
Added additional description to clarify what will happen when, in the grafana configuration, both `allow_org_create` and `auto_assign_org` are set to `false`.

**Which issue(s) this PR fixes**: 
none

Fixes #

**Special notes for your reviewer**:

