### PR TITLE
Revert "[v9.0.x] Loki: Do not produce histogram for instant queries"

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -25,7 +25,7 @@ import { CustomVariableModel } from '../../../features/variables/types';
 
 import { isMetricsQuery, LokiDatasource, RangeQueryOptions } from './datasource';
 import { makeMockLokiDatasource } from './mocks';
-import { LokiQuery, LokiQueryType, LokiResponse, LokiResultType } from './types';
+import { LokiQuery, LokiResponse, LokiResultType } from './types';
 
 jest.mock('@grafana/runtime', () => ({
   // @ts-ignore
@@ -996,15 +996,6 @@ describe('LokiDatasource', () => {
       });
 
       expect(ds.getLogsVolumeDataProvider(options)).toBeDefined();
-    });
-
-    it('does not create provider if there is only an instant logs query', () => {
-      const ds = createLokiDSForTests();
-      const options = getQueryOptions<LokiQuery>({
-        targets: [{ expr: '{label=value', refId: 'A', queryType: LokiQueryType.Instant }],
-      });
-
-      expect(ds.getLogsVolumeDataProvider(options)).not.toBeDefined();
     });
   });
 

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -141,28 +141,22 @@ export class LokiDatasource
   }
 
   getLogsVolumeDataProvider(request: DataQueryRequest<LokiQuery>): Observable<DataQueryResponse> | undefined {
-    const isQuerySuitable = (query: LokiQuery) => {
-      const normalized = getNormalizedLokiQuery(query);
-      const { expr } = normalized;
-      // it has to be a logs-producing range-query
-      return expr && !isMetricsQuery(expr) && normalized.queryType === LokiQueryType.Range;
-    };
-
-    const isLogsVolumeAvailable = request.targets.some(isQuerySuitable);
-
+    const isLogsVolumeAvailable = request.targets.some((target) => target.expr && !isMetricsQuery(target.expr));
     if (!isLogsVolumeAvailable) {
       return undefined;
     }
 
     const logsVolumeRequest = cloneDeep(request);
-    logsVolumeRequest.targets = logsVolumeRequest.targets.filter(isQuerySuitable).map((target) => {
-      return {
-        ...target,
-        instant: false,
-        volumeQuery: true,
-        expr: `sum by (level) (count_over_time(${target.expr}[$__interval]))`,
-      };
-    });
+    logsVolumeRequest.targets = logsVolumeRequest.targets
+      .filter((target) => target.expr && !isMetricsQuery(target.expr))
+      .map((target) => {
+        return {
+          ...target,
+          instant: false,
+          volumeQuery: true,
+          expr: `sum by (level) (count_over_time(${target.expr}[$__interval]))`,
+        };
+      });
 
     return queryLogsVolume(this, logsVolumeRequest, {
       extractLevel,


### PR DESCRIPTION
Reverts grafana/grafana#50065

there is a problem with this pull-request, so i am reverting it.

the problem:
there is the old-volume-histogram and the new-volume-histogram.
when a datasource provides the new histogram, we use that. if not, we use the old one.

this PR (that i am reverting), modified the logic so that when there is only an instant-logs-query in explore, we do not want to show the new histogram. we do not want to show any histogram in that case.
but, what happens instead, is that the old-histogram appears 😄 

we need to re-implement this change in a better way, so i am reverting it.