### PR TITLE
ci: Depend on init-enterprise for gen-cue verify

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -95,8 +95,22 @@ steps:
   image: grafana/build-container:1.5.5
   name: gen-version
 - commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  image: grafana/build-container:1.5.4
+  name: verify-gen-cue
+- commands:
   - make gen-go
+<<<<<<< HEAD
   image: grafana/build-container:1.5.5
+=======
+  depends_on:
+  - verify-gen-cue
+  image: grafana/build-container:1.5.4
+>>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
   name: wire-install
 - commands:
   - ./bin/grabpl verify-drone
@@ -189,8 +203,22 @@ steps:
   image: grafana/build-container:1.5.5
   name: gen-version
 - commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  image: grafana/build-container:1.5.4
+  name: verify-gen-cue
+- commands:
   - make gen-go
+<<<<<<< HEAD
   image: grafana/build-container:1.5.5
+=======
+  depends_on:
+  - verify-gen-cue
+  image: grafana/build-container:1.5.4
+>>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
   name: wire-install
 - commands:
   - yarn install --immutable
@@ -246,6 +274,7 @@ steps:
   image: grafana/build-container:1.5.5
   name: build-plugins
 - commands:
+<<<<<<< HEAD
   - '# It is required that code generated from Thema/CUE be committed and in sync
     with its inputs.'
   - '# The following command will fail if running code generators produces any diff
@@ -253,6 +282,26 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
+=======
+  - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
+  depends_on:
+  - build-backend
+  image: grafana/build-container:1.5.4
+  name: validate-scuemata
+- commands:
+  - '# It is required that the generated Typescript be in sync with the input CUE
+    files.'
+  - '# To enforce this, the following command will attempt to generate Typescript
+    from all'
+  - '# appropriate .cue files, then compare with the corresponding (*.gen.ts) file
+    the generated'
+  - '# code would have been written to. It exits 1 if any diffs are found.'
+  - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
+  depends_on:
+  - validate-scuemata
+  image: grafana/build-container:1.5.4
+  name: ensure-cuetsified
+>>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
 - commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss
     --build-id ${DRONE_BUILD_NUMBER} --variants linux-amd64,linux-amd64-musl,darwin-amd64,windows-amd64,armv6
@@ -754,8 +803,22 @@ steps:
   image: grafana/build-container:1.5.5
   name: gen-version
 - commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  image: grafana/build-container:1.5.4
+  name: verify-gen-cue
+- commands:
   - make gen-go
+<<<<<<< HEAD
   image: grafana/build-container:1.5.5
+=======
+  depends_on:
+  - verify-gen-cue
+  image: grafana/build-container:1.5.4
+>>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
   name: wire-install
 - commands:
   - ./bin/grabpl verify-drone
@@ -838,8 +901,22 @@ steps:
   image: grafana/build-container:1.5.5
   name: gen-version
 - commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  image: grafana/build-container:1.5.4
+  name: verify-gen-cue
+- commands:
   - make gen-go
+<<<<<<< HEAD
   image: grafana/build-container:1.5.5
+=======
+  depends_on:
+  - verify-gen-cue
+  image: grafana/build-container:1.5.4
+>>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
   name: wire-install
 - commands:
   - yarn install --immutable
@@ -922,6 +999,7 @@ steps:
   image: grafana/build-container:1.5.5
   name: build-plugins
 - commands:
+<<<<<<< HEAD
   - '# It is required that code generated from Thema/CUE be committed and in sync
     with its inputs.'
   - '# The following command will fail if running code generators produces any diff
@@ -929,6 +1007,26 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
+=======
+  - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
+  depends_on:
+  - build-backend
+  image: grafana/build-container:1.5.4
+  name: validate-scuemata
+- commands:
+  - '# It is required that the generated Typescript be in sync with the input CUE
+    files.'
+  - '# To enforce this, the following command will attempt to generate Typescript
+    from all'
+  - '# appropriate .cue files, then compare with the corresponding (*.gen.ts) file
+    the generated'
+  - '# code would have been written to. It exits 1 if any diffs are found.'
+  - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
+  depends_on:
+  - validate-scuemata
+  image: grafana/build-container:1.5.4
+  name: ensure-cuetsified
+>>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
   depends_on:
@@ -1506,8 +1604,22 @@ steps:
   image: grafana/build-container:1.5.5
   name: gen-version
 - commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  image: grafana/build-container:1.5.4
+  name: verify-gen-cue
+- commands:
   - make gen-go
+<<<<<<< HEAD
   image: grafana/build-container:1.5.5
+=======
+  depends_on:
+  - verify-gen-cue
+  image: grafana/build-container:1.5.4
+>>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
   name: wire-install
 - commands:
   - yarn install --immutable
@@ -1551,6 +1663,7 @@ steps:
   image: grafana/build-container:1.5.5
   name: build-plugins
 - commands:
+<<<<<<< HEAD
   - '# It is required that code generated from Thema/CUE be committed and in sync
     with its inputs.'
   - '# The following command will fail if running code generators produces any diff
@@ -1558,6 +1671,26 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
+=======
+  - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
+  depends_on:
+  - build-backend
+  image: grafana/build-container:1.5.4
+  name: validate-scuemata
+- commands:
+  - '# It is required that the generated Typescript be in sync with the input CUE
+    files.'
+  - '# To enforce this, the following command will attempt to generate Typescript
+    from all'
+  - '# appropriate .cue files, then compare with the corresponding (*.gen.ts) file
+    the generated'
+  - '# code would have been written to. It exits 1 if any diffs are found.'
+  - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
+  depends_on:
+  - validate-scuemata
+  image: grafana/build-container:1.5.4
+  name: ensure-cuetsified
+>>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss  --sign ${DRONE_TAG}
   depends_on:
@@ -1801,8 +1934,22 @@ steps:
   image: grafana/build-container:1.5.5
   name: gen-version
 - commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  image: grafana/build-container:1.5.4
+  name: verify-gen-cue
+- commands:
   - make gen-go
+<<<<<<< HEAD
   image: grafana/build-container:1.5.5
+=======
+  depends_on:
+  - verify-gen-cue
+  image: grafana/build-container:1.5.4
+>>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
   name: wire-install
 - commands:
   - yarn install --immutable
@@ -2102,6 +2249,16 @@ steps:
   image: grafana/build-container:1.5.5
   name: gen-version
 - commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  depends_on:
+  - init-enterprise
+  image: grafana/build-container:1.5.4
+  name: verify-gen-cue
+- commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise ${DRONE_TAG}
   depends_on:
   - gen-version
@@ -2137,6 +2294,7 @@ steps:
   image: grafana/build-container:1.5.5
   name: build-plugins
 - commands:
+<<<<<<< HEAD
   - '# It is required that code generated from Thema/CUE be committed and in sync
     with its inputs.'
   - '# The following command will fail if running code generators produces any diff
@@ -2144,6 +2302,26 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
+=======
+  - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
+  depends_on:
+  - build-backend
+  image: grafana/build-container:1.5.4
+  name: validate-scuemata
+- commands:
+  - '# It is required that the generated Typescript be in sync with the input CUE
+    files.'
+  - '# To enforce this, the following command will attempt to generate Typescript
+    from all'
+  - '# appropriate .cue files, then compare with the corresponding (*.gen.ts) file
+    the generated'
+  - '# code would have been written to. It exits 1 if any diffs are found.'
+  - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
+  depends_on:
+  - validate-scuemata
+  image: grafana/build-container:1.5.4
+  name: ensure-cuetsified
+>>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 ${DRONE_TAG}
   depends_on:
@@ -2447,6 +2625,16 @@ steps:
   - init-enterprise
   image: grafana/build-container:1.5.5
   name: gen-version
+- commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  depends_on:
+  - init-enterprise
+  image: grafana/build-container:1.5.4
+  name: verify-gen-cue
 - commands:
   - |-
     echo -e "unknwon
@@ -3294,8 +3482,22 @@ steps:
   image: grafana/build-container:1.5.5
   name: gen-version
 - commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  image: grafana/build-container:1.5.4
+  name: verify-gen-cue
+- commands:
   - make gen-go
+<<<<<<< HEAD
   image: grafana/build-container:1.5.5
+=======
+  depends_on:
+  - verify-gen-cue
+  image: grafana/build-container:1.5.4
+>>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
   name: wire-install
 - commands:
   - yarn install --immutable
@@ -3339,6 +3541,7 @@ steps:
   image: grafana/build-container:1.5.5
   name: build-plugins
 - commands:
+<<<<<<< HEAD
   - '# It is required that code generated from Thema/CUE be committed and in sync
     with its inputs.'
   - '# The following command will fail if running code generators produces any diff
@@ -3346,6 +3549,26 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
+=======
+  - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
+  depends_on:
+  - build-backend
+  image: grafana/build-container:1.5.4
+  name: validate-scuemata
+- commands:
+  - '# It is required that the generated Typescript be in sync with the input CUE
+    files.'
+  - '# To enforce this, the following command will attempt to generate Typescript
+    from all'
+  - '# appropriate .cue files, then compare with the corresponding (*.gen.ts) file
+    the generated'
+  - '# code would have been written to. It exits 1 if any diffs are found.'
+  - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
+  depends_on:
+  - validate-scuemata
+  image: grafana/build-container:1.5.4
+  name: ensure-cuetsified
+>>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
   depends_on:
@@ -3559,8 +3782,22 @@ steps:
   image: grafana/build-container:1.5.5
   name: gen-version
 - commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  image: grafana/build-container:1.5.4
+  name: verify-gen-cue
+- commands:
   - make gen-go
+<<<<<<< HEAD
   image: grafana/build-container:1.5.5
+=======
+  depends_on:
+  - verify-gen-cue
+  image: grafana/build-container:1.5.4
+>>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
   name: wire-install
 - commands:
   - yarn install --immutable
@@ -3834,6 +4071,16 @@ steps:
   image: grafana/build-container:1.5.5
   name: gen-version
 - commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  depends_on:
+  - init-enterprise
+  image: grafana/build-container:1.5.4
+  name: verify-gen-cue
+- commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - gen-version
@@ -3870,6 +4117,7 @@ steps:
   image: grafana/build-container:1.5.5
   name: build-plugins
 - commands:
+<<<<<<< HEAD
   - '# It is required that code generated from Thema/CUE be committed and in sync
     with its inputs.'
   - '# The following command will fail if running code generators produces any diff
@@ -3877,6 +4125,26 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
+=======
+  - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
+  depends_on:
+  - build-backend
+  image: grafana/build-container:1.5.4
+  name: validate-scuemata
+- commands:
+  - '# It is required that the generated Typescript be in sync with the input CUE
+    files.'
+  - '# To enforce this, the following command will attempt to generate Typescript
+    from all'
+  - '# appropriate .cue files, then compare with the corresponding (*.gen.ts) file
+    the generated'
+  - '# code would have been written to. It exits 1 if any diffs are found.'
+  - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
+  depends_on:
+  - validate-scuemata
+  image: grafana/build-container:1.5.4
+  name: ensure-cuetsified
+>>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
     --variants linux-amd64
@@ -4177,6 +4445,16 @@ steps:
   - init-enterprise
   image: grafana/build-container:1.5.5
   name: gen-version
+- commands:
+  - '# It is required that code generated from Thema/CUE be committed and in sync
+    with its inputs.'
+  - '# The following command will fail if running code generators produces any diff
+    in output.'
+  - CODEGEN_VERIFY=1 make gen-cue
+  depends_on:
+  - init-enterprise
+  image: grafana/build-container:1.5.4
+  name: verify-gen-cue
 - commands:
   - |-
     echo -e "unknwon
@@ -4611,6 +4889,10 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
+<<<<<<< HEAD
 hmac: d2e97d6683c33ccb2dba773e3c103105227a74448fa732124e4c38d67eb464d8
+=======
+hmac: 6a36a7fac6b3cee60a407a5815711cb12ae92ba8325475a0ee8e5bb6a92108b8
+>>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -100,17 +100,13 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
-  image: grafana/build-container:1.5.4
+  image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
   - make gen-go
-<<<<<<< HEAD
-  image: grafana/build-container:1.5.5
-=======
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.4
->>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
+  image: grafana/build-container:1.5.5
   name: wire-install
 - commands:
   - ./bin/grabpl verify-drone
@@ -208,17 +204,13 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
-  image: grafana/build-container:1.5.4
+  image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
   - make gen-go
-<<<<<<< HEAD
-  image: grafana/build-container:1.5.5
-=======
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.4
->>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
+  image: grafana/build-container:1.5.5
   name: wire-install
 - commands:
   - yarn install --immutable
@@ -273,35 +265,6 @@ steps:
   environment: null
   image: grafana/build-container:1.5.5
   name: build-plugins
-- commands:
-<<<<<<< HEAD
-  - '# It is required that code generated from Thema/CUE be committed and in sync
-    with its inputs.'
-  - '# The following command will fail if running code generators produces any diff
-    in output.'
-  - CODEGEN_VERIFY=1 make gen-cue
-  image: grafana/build-container:1.5.5
-  name: verify-gen-cue
-=======
-  - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
-  depends_on:
-  - build-backend
-  image: grafana/build-container:1.5.4
-  name: validate-scuemata
-- commands:
-  - '# It is required that the generated Typescript be in sync with the input CUE
-    files.'
-  - '# To enforce this, the following command will attempt to generate Typescript
-    from all'
-  - '# appropriate .cue files, then compare with the corresponding (*.gen.ts) file
-    the generated'
-  - '# code would have been written to. It exits 1 if any diffs are found.'
-  - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
-  depends_on:
-  - validate-scuemata
-  image: grafana/build-container:1.5.4
-  name: ensure-cuetsified
->>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
 - commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss
     --build-id ${DRONE_BUILD_NUMBER} --variants linux-amd64,linux-amd64-musl,darwin-amd64,windows-amd64,armv6
@@ -808,17 +771,13 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
-  image: grafana/build-container:1.5.4
+  image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
   - make gen-go
-<<<<<<< HEAD
-  image: grafana/build-container:1.5.5
-=======
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.4
->>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
+  image: grafana/build-container:1.5.5
   name: wire-install
 - commands:
   - ./bin/grabpl verify-drone
@@ -906,17 +865,13 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
-  image: grafana/build-container:1.5.4
+  image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
   - make gen-go
-<<<<<<< HEAD
-  image: grafana/build-container:1.5.5
-=======
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.4
->>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
+  image: grafana/build-container:1.5.5
   name: wire-install
 - commands:
   - yarn install --immutable
@@ -998,35 +953,6 @@ steps:
       from_secret: grafana_api_key
   image: grafana/build-container:1.5.5
   name: build-plugins
-- commands:
-<<<<<<< HEAD
-  - '# It is required that code generated from Thema/CUE be committed and in sync
-    with its inputs.'
-  - '# The following command will fail if running code generators produces any diff
-    in output.'
-  - CODEGEN_VERIFY=1 make gen-cue
-  image: grafana/build-container:1.5.5
-  name: verify-gen-cue
-=======
-  - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
-  depends_on:
-  - build-backend
-  image: grafana/build-container:1.5.4
-  name: validate-scuemata
-- commands:
-  - '# It is required that the generated Typescript be in sync with the input CUE
-    files.'
-  - '# To enforce this, the following command will attempt to generate Typescript
-    from all'
-  - '# appropriate .cue files, then compare with the corresponding (*.gen.ts) file
-    the generated'
-  - '# code would have been written to. It exits 1 if any diffs are found.'
-  - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
-  depends_on:
-  - validate-scuemata
-  image: grafana/build-container:1.5.4
-  name: ensure-cuetsified
->>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
   depends_on:
@@ -1609,17 +1535,13 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
-  image: grafana/build-container:1.5.4
+  image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
   - make gen-go
-<<<<<<< HEAD
-  image: grafana/build-container:1.5.5
-=======
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.4
->>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
+  image: grafana/build-container:1.5.5
   name: wire-install
 - commands:
   - yarn install --immutable
@@ -1662,35 +1584,6 @@ steps:
       from_secret: grafana_api_key
   image: grafana/build-container:1.5.5
   name: build-plugins
-- commands:
-<<<<<<< HEAD
-  - '# It is required that code generated from Thema/CUE be committed and in sync
-    with its inputs.'
-  - '# The following command will fail if running code generators produces any diff
-    in output.'
-  - CODEGEN_VERIFY=1 make gen-cue
-  image: grafana/build-container:1.5.5
-  name: verify-gen-cue
-=======
-  - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
-  depends_on:
-  - build-backend
-  image: grafana/build-container:1.5.4
-  name: validate-scuemata
-- commands:
-  - '# It is required that the generated Typescript be in sync with the input CUE
-    files.'
-  - '# To enforce this, the following command will attempt to generate Typescript
-    from all'
-  - '# appropriate .cue files, then compare with the corresponding (*.gen.ts) file
-    the generated'
-  - '# code would have been written to. It exits 1 if any diffs are found.'
-  - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
-  depends_on:
-  - validate-scuemata
-  image: grafana/build-container:1.5.4
-  name: ensure-cuetsified
->>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss  --sign ${DRONE_TAG}
   depends_on:
@@ -1939,17 +1832,13 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
-  image: grafana/build-container:1.5.4
+  image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
   - make gen-go
-<<<<<<< HEAD
-  image: grafana/build-container:1.5.5
-=======
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.4
->>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
+  image: grafana/build-container:1.5.5
   name: wire-install
 - commands:
   - yarn install --immutable
@@ -2256,7 +2145,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.4
+  image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -2293,35 +2182,6 @@ steps:
       from_secret: grafana_api_key
   image: grafana/build-container:1.5.5
   name: build-plugins
-- commands:
-<<<<<<< HEAD
-  - '# It is required that code generated from Thema/CUE be committed and in sync
-    with its inputs.'
-  - '# The following command will fail if running code generators produces any diff
-    in output.'
-  - CODEGEN_VERIFY=1 make gen-cue
-  image: grafana/build-container:1.5.5
-  name: verify-gen-cue
-=======
-  - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
-  depends_on:
-  - build-backend
-  image: grafana/build-container:1.5.4
-  name: validate-scuemata
-- commands:
-  - '# It is required that the generated Typescript be in sync with the input CUE
-    files.'
-  - '# To enforce this, the following command will attempt to generate Typescript
-    from all'
-  - '# appropriate .cue files, then compare with the corresponding (*.gen.ts) file
-    the generated'
-  - '# code would have been written to. It exits 1 if any diffs are found.'
-  - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
-  depends_on:
-  - validate-scuemata
-  image: grafana/build-container:1.5.4
-  name: ensure-cuetsified
->>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 ${DRONE_TAG}
   depends_on:
@@ -2633,7 +2493,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.4
+  image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
   - |-
@@ -3487,17 +3347,13 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
-  image: grafana/build-container:1.5.4
+  image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
   - make gen-go
-<<<<<<< HEAD
-  image: grafana/build-container:1.5.5
-=======
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.4
->>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
+  image: grafana/build-container:1.5.5
   name: wire-install
 - commands:
   - yarn install --immutable
@@ -3540,35 +3396,6 @@ steps:
       from_secret: grafana_api_key
   image: grafana/build-container:1.5.5
   name: build-plugins
-- commands:
-<<<<<<< HEAD
-  - '# It is required that code generated from Thema/CUE be committed and in sync
-    with its inputs.'
-  - '# The following command will fail if running code generators produces any diff
-    in output.'
-  - CODEGEN_VERIFY=1 make gen-cue
-  image: grafana/build-container:1.5.5
-  name: verify-gen-cue
-=======
-  - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
-  depends_on:
-  - build-backend
-  image: grafana/build-container:1.5.4
-  name: validate-scuemata
-- commands:
-  - '# It is required that the generated Typescript be in sync with the input CUE
-    files.'
-  - '# To enforce this, the following command will attempt to generate Typescript
-    from all'
-  - '# appropriate .cue files, then compare with the corresponding (*.gen.ts) file
-    the generated'
-  - '# code would have been written to. It exits 1 if any diffs are found.'
-  - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
-  depends_on:
-  - validate-scuemata
-  image: grafana/build-container:1.5.4
-  name: ensure-cuetsified
->>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
   depends_on:
@@ -3787,17 +3614,13 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
-  image: grafana/build-container:1.5.4
+  image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
   - make gen-go
-<<<<<<< HEAD
-  image: grafana/build-container:1.5.5
-=======
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.4
->>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
+  image: grafana/build-container:1.5.5
   name: wire-install
 - commands:
   - yarn install --immutable
@@ -4078,7 +3901,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.4
+  image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -4116,35 +3939,6 @@ steps:
       from_secret: grafana_api_key
   image: grafana/build-container:1.5.5
   name: build-plugins
-- commands:
-<<<<<<< HEAD
-  - '# It is required that code generated from Thema/CUE be committed and in sync
-    with its inputs.'
-  - '# The following command will fail if running code generators produces any diff
-    in output.'
-  - CODEGEN_VERIFY=1 make gen-cue
-  image: grafana/build-container:1.5.5
-  name: verify-gen-cue
-=======
-  - ./bin/linux-amd64/grafana-cli cue validate-schema --grafana-root .
-  depends_on:
-  - build-backend
-  image: grafana/build-container:1.5.4
-  name: validate-scuemata
-- commands:
-  - '# It is required that the generated Typescript be in sync with the input CUE
-    files.'
-  - '# To enforce this, the following command will attempt to generate Typescript
-    from all'
-  - '# appropriate .cue files, then compare with the corresponding (*.gen.ts) file
-    the generated'
-  - '# code would have been written to. It exits 1 if any diffs are found.'
-  - ./bin/linux-amd64/grafana-cli cue gen-ts --grafana-root . --diff
-  depends_on:
-  - validate-scuemata
-  image: grafana/build-container:1.5.4
-  name: ensure-cuetsified
->>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
     --variants linux-amd64
@@ -4453,7 +4247,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.4
+  image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
   - |-
@@ -4889,10 +4683,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-<<<<<<< HEAD
-hmac: d2e97d6683c33ccb2dba773e3c103105227a74448fa732124e4c38d67eb464d8
-=======
-hmac: 6a36a7fac6b3cee60a407a5815711cb12ae92ba8325475a0ee8e5bb6a92108b8
->>>>>>> 7f93cb02c1 (Put verify_gen_cue_step() in the right places)
+hmac: 378147a306d077b0566f5353c9e5c236c40dbb8d81392091a1346ed275b86496
 
 ...

--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -93,6 +93,7 @@ def main_test_backend():
         identify_runner_step(),
         download_grabpl_step(),
         gen_version_step(ver_mode),
+        verify_gen_cue_step(),
         wire_install_step(),
     ]
     test_steps = [
@@ -113,6 +114,7 @@ def get_steps(edition):
         identify_runner_step(),
         download_grabpl_step(),
         gen_version_step(ver_mode),
+        verify_gen_cue_step(),
         wire_install_step(),
         yarn_install_step(),
     ]
@@ -133,7 +135,6 @@ def get_steps(edition):
         build_frontend_step(edition=edition, ver_mode=ver_mode),
         build_frontend_package_step(edition=edition, ver_mode=ver_mode),
         build_plugins_step(edition=edition, sign=True),
-        verify_gen_cue_step(),
     ]
     integration_test_steps = [
         postgres_integration_tests_step(edition=edition, ver_mode=ver_mode),

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -91,6 +91,7 @@ def pr_test_backend():
         identify_runner_step(),
         download_grabpl_step(),
         gen_version_step(ver_mode),
+        verify_gen_cue_step(),
         wire_install_step(),
     ]
     test_steps = [
@@ -114,6 +115,7 @@ def pr_pipelines(edition):
         identify_runner_step(),
         download_grabpl_step(),
         gen_version_step(ver_mode),
+        verify_gen_cue_step(),
         wire_install_step(),
         yarn_install_step(),
     ]
@@ -123,7 +125,6 @@ def pr_pipelines(edition):
         build_frontend_step(edition=edition, ver_mode=ver_mode),
         build_frontend_package_step(edition=edition, ver_mode=ver_mode),
         build_plugins_step(edition=edition),
-        verify_gen_cue_step(),
     ]
     integration_test_steps = [
         postgres_integration_tests_step(edition=edition, ver_mode=ver_mode),

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -307,7 +307,7 @@ def get_enterprise_pipelines(trigger, ver_mode):
         clone_enterprise_step(ver_mode),
         init_enterprise_step(ver_mode)
     ]
-    for step in [wire_install_step(), yarn_install_step(), gen_version_step(ver_mode)]:
+    for step in [wire_install_step(), yarn_install_step(), gen_version_step(ver_mode), verify_gen_cue_step()]:
         step.update(deps_on_clone_enterprise_step)
         init_steps.extend([step])
 

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -158,6 +158,7 @@ def get_steps(edition, ver_mode):
         identify_runner_step(),
         download_grabpl_step(),
         gen_version_step(ver_mode),
+        verify_gen_cue_step(),
         wire_install_step(),
         yarn_install_step(),
     ]
@@ -180,7 +181,6 @@ def get_steps(edition, ver_mode):
         build_frontend_step(edition=edition, ver_mode=ver_mode),
         build_frontend_package_step(edition=edition, ver_mode=ver_mode),
         build_plugins_step(edition=edition, sign=True),
-        verify_gen_cue_step(),
     ]
 
     integration_test_steps = [

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -69,6 +69,9 @@ def wire_install_step():
         'commands': [
             'make gen-go',
         ],
+        'depends_on': [
+            'verify-gen-cue',
+        ],
     }
 
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This makes the `verify_gen_cue_step` depend on the cloning enterprise steps in the appropriate pipelines, following the same pattern as `wire_install_step`. It also makes `wire_install_step` formally depend on `verify_gen_cue_step`.

i feel like there was another thing we talked about doing, @dsotirakis? can't recall now :/

**Which issue(s) this PR fixes**:

No issue posted for it, but [build failures like this](https://drone.grafana.net/grafana/grafana-private-mirror/1352/5/14) are what we're aiming to fix. Those will start mattering when we cut the next release after 9.0.0.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

