### PR TITLE
Alerting: Update alert rule diff to not see difference between nil and empty map

### DIFF
--- a/pkg/services/ngalert/CHANGELOG.md
+++ b/pkg/services/ngalert/CHANGELOG.md
@@ -51,6 +51,7 @@ Scopes must have an order to ensure consistency and ease of search, this helps u
   - `grafana_alerting_ticker_interval_seconds`
 - [ENHANCEMENT] Create folder 'General Alerting' when Grafana starts from the scratch #48866
 - [ENHANCEMENT] Rule changes authorization logic to use UID folder scope instead of ID scope #48970
+- [ENHANCEMENT] Scheduler: ticker to support stopping #48142
 - [FEATURE] Indicate whether routes are provisioned when GETting Alertmanager configuration #47857
 - [FEATURE] Indicate whether contact point is provisioned when GETting Alertmanager configuration #48323
 - [FEATURE] Indicate whether alert rule is provisioned when GETting the rule #48458
@@ -60,7 +61,7 @@ Scopes must have an order to ensure consistency and ease of search, this helps u
 - [BUGFIX] RBAC: replace create\update\delete actions for notification policies by alert.notifications:write #49185
 - [BUGFIX] Fix access to alerts for Viewer role with editor permissions in folder #49270
 - [BUGFIX] Alerting: Remove double quotes from double quoted matchers #xxxx
-- [ENHANCEMENT] Scheduler: ticker to support stopping #48142
+- [BUGFIX] Alerting: rules API to not detect difference between nil and empty map (Annotations, Labels) #50192
 
 ## 8.5.3
 

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -157,13 +157,13 @@ func (alertRule *AlertRule) GetLabels(opts ...LabelOption) map[string]string {
 // Diff calculates diff between two alert rules. Returns nil if two rules are equal. Otherwise, returns cmputil.DiffReport
 func (alertRule *AlertRule) Diff(rule *AlertRule, ignore ...string) cmputil.DiffReport {
 	var reporter cmputil.DiffReporter
-	ops := make([]cmp.Option, 0, 4)
+	ops := make([]cmp.Option, 0, 5)
 
 	// json.RawMessage is a slice of bytes and therefore cmp's default behavior is to compare it by byte, which is not really useful
 	var jsonCmp = cmp.Transformer("", func(in json.RawMessage) string {
 		return string(in)
 	})
-	ops = append(ops, cmp.Reporter(&reporter), cmpopts.IgnoreFields(AlertQuery{}, "modelProps"), jsonCmp)
+	ops = append(ops, cmp.Reporter(&reporter), cmpopts.IgnoreFields(AlertQuery{}, "modelProps"), jsonCmp, cmpopts.EquateEmpty())
 
 	if len(ignore) > 0 {
 		ops = append(ops, cmpopts.IgnoreFields(AlertRule{}, ignore...))

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -362,6 +362,16 @@ func TestDiff(t *testing.T) {
 		}
 	})
 
+	t.Run("should not see difference between nil and empty Annotations", func(t *testing.T) {
+		rule1 := AlertRuleGen()()
+		rule1.Annotations = make(map[string]string)
+		rule2 := CopyRule(rule1)
+		rule2.Annotations = nil
+
+		diff := rule1.Diff(rule2)
+		require.Empty(t, diff)
+	})
+
 	t.Run("should detect changes in Annotations", func(t *testing.T) {
 		rule1 := AlertRuleGen()()
 		rule2 := CopyRule(rule1)
@@ -397,6 +407,16 @@ func TestDiff(t *testing.T) {
 		if t.Failed() {
 			t.Logf("rule1: %#v, rule2: %#v\ndiff: %v", rule1, rule2, diff)
 		}
+	})
+
+	t.Run("should not see difference between nil and empty Labels", func(t *testing.T) {
+		rule1 := AlertRuleGen()()
+		rule1.Annotations = make(map[string]string)
+		rule2 := CopyRule(rule1)
+		rule2.Annotations = nil
+
+		diff := rule1.Diff(rule2)
+		require.Empty(t, diff)
 	})
 
 	t.Run("should detect changes in Labels", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Currently, when user omits annotations and labels and submits rules via API, those fields are assigned empty map on read from database, and therefore, the subsequent noop submission will cause diff 
```
logger=ngalert.api namespace_uid=TYKOLl_nk group=1123 org_id=1 user_id=1 t=2022-05-10T17:33:05.7355927-04:00 level=debug msg="updating rule" rule_uid=0Aj2Ell7z 
diff="Annotations:\n\t-: map[]\n\t+: map[]\n\nLabels:\n\t-: map[]\n\t+: map[]\n\n"
```
This PR updates cmp.Diff to ignore such difference.

