### PR TITLE
Alerting: only delete mute time if not used by route

### DIFF
--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/prometheus/alertmanager/config"
 )
@@ -159,6 +160,9 @@ func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, name string,
 	if revision.cfg.AlertmanagerConfig.MuteTimeIntervals == nil {
 		return nil
 	}
+	if isMuteTimeInUse(name, []*apimodels.Route{revision.cfg.AlertmanagerConfig.Route}) {
+		return fmt.Errorf("mute time '%s' is currently used by a notification policy", name)
+	}
 	for i, existing := range revision.cfg.AlertmanagerConfig.MuteTimeIntervals {
 		if name == existing.Name {
 			intervals := revision.cfg.AlertmanagerConfig.MuteTimeIntervals
@@ -189,4 +193,21 @@ func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, name string,
 		}
 		return nil
 	})
+}
+
+func isMuteTimeInUse(name string, routes []*apimodels.Route) bool {
+	if len(routes) == 0 {
+		return false
+	}
+	for _, route := range routes {
+		for _, mtName := range route.MuteTimeIntervals {
+			if mtName == name {
+				return true
+			}
+		}
+		if isMuteTimeInUse(name, route.Routes) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
-	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/prometheus/alertmanager/config"
 )
@@ -195,7 +194,7 @@ func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, name string,
 	})
 }
 
-func isMuteTimeInUse(name string, routes []*apimodels.Route) bool {
+func isMuteTimeInUse(name string, routes []*definitions.Route) bool {
 	if len(routes) == 0 {
 		return false
 	}

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -159,7 +159,7 @@ func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, name string,
 	if revision.cfg.AlertmanagerConfig.MuteTimeIntervals == nil {
 		return nil
 	}
-	if isMuteTimeInUse(name, []*apimodels.Route{revision.cfg.AlertmanagerConfig.Route}) {
+	if isMuteTimeInUse(name, []*definitions.Route{revision.cfg.AlertmanagerConfig.Route}) {
 		return fmt.Errorf("mute time '%s' is currently used by a notification policy", name)
 	}
 	for i, existing := range revision.cfg.AlertmanagerConfig.MuteTimeIntervals {

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -356,6 +356,18 @@ func TestMuteTimingService(t *testing.T) {
 
 				require.ErrorContains(t, err, "failed to save config")
 			})
+
+			t.Run("when mute timing is used in route", func(t *testing.T) {
+				sut := createMuteTimingSvcSut()
+				sut.config.(*MockAMConfigStore).EXPECT().
+					getsConfig(models.AlertConfiguration{
+						AlertmanagerConfiguration: configWithMuteTimingsInRoute,
+					})
+
+				err := sut.DeleteMuteTiming(context.Background(), "asdf", 1)
+
+				require.Error(t, err)
+			})
 		})
 	})
 }
@@ -385,6 +397,44 @@ var configWithMuteTimings = `
 	"alertmanager_config": {
 		"route": {
 			"receiver": "grafana-default-email"
+		},
+		"mute_time_intervals": [{
+			"name": "asdf",
+			"time_intervals": [{
+				"times": [],
+				"weekdays": ["monday"]
+			}]
+		}],
+		"receivers": [{
+			"name": "grafana-default-email",
+			"grafana_managed_receiver_configs": [{
+				"uid": "",
+				"name": "email receiver",
+				"type": "email",
+				"isDefault": true,
+				"settings": {
+					"addresses": "<example@email.com>"
+				}
+			}]
+		}]
+	}
+}
+`
+
+var configWithMuteTimingsInRoute = `
+{
+	"template_files": {
+		"a": "template"
+	},
+	"alertmanager_config": {
+		"route": {
+			"receiver": "grafana-default-email",
+			"routes": [
+				{
+					"receiver": "grafana-default-email",
+					"mute_time_intervals": ["asdf"]
+				}
+			]
 		},
 		"mute_time_intervals": [{
 			"name": "asdf",


### PR DESCRIPTION
This PR prevents the deletion of mute times when they are currently used by a route. It follows the same approach as we did for contact points.