### PR TITLE
[9.0.x] Alerting: Update alert rule diff to not see difference between nil and empty map

### DIFF
--- a/pkg/services/ngalert/CHANGELOG.md
+++ b/pkg/services/ngalert/CHANGELOG.md
@@ -51,6 +51,7 @@ Scopes must have an order to ensure consistency and ease of search, this helps u
   - `grafana_alerting_ticker_interval_seconds`
 - [ENHANCEMENT] Create folder 'General Alerting' when Grafana starts from the scratch #48866
 - [ENHANCEMENT] Rule changes authorization logic to use UID folder scope instead of ID scope #48970
+- [ENHANCEMENT] Scheduler: ticker to support stopping #48142
 - [FEATURE] Indicate whether routes are provisioned when GETting Alertmanager configuration #47857
 - [FEATURE] Indicate whether contact point is provisioned when GETting Alertmanager configuration #48323
 - [FEATURE] Indicate whether alert rule is provisioned when GETting the rule #48458
@@ -59,9 +60,8 @@ Scopes must have an order to ensure consistency and ease of search, this helps u
 - [BUGFIX] Allow anonymous access to alerts #49203 
 - [BUGFIX] RBAC: replace create\update\delete actions for notification policies by alert.notifications:write #49185
 - [BUGFIX] Fix access to alerts for Viewer role with editor permissions in folder #49270
-- [FEATURE] Alert rules with associated panels will take screenshots. #49293 #49338 #49374 #49377 #49378 #49379 #49381 #49385 #49439 #49445
 - [BUGFIX] Alerting: Remove double quotes from double quoted matchers #50038
-- [ENHANCEMENT] Scheduler: ticker to support stopping #48142
+- [BUGFIX] Alerting: rules API to not detect difference between nil and empty map (Annotations, Labels) #5019
 
 ## 8.5.3
 

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -157,13 +157,13 @@ func (alertRule *AlertRule) GetLabels(opts ...LabelOption) map[string]string {
 // Diff calculates diff between two alert rules. Returns nil if two rules are equal. Otherwise, returns cmputil.DiffReport
 func (alertRule *AlertRule) Diff(rule *AlertRule, ignore ...string) cmputil.DiffReport {
 	var reporter cmputil.DiffReporter
-	ops := make([]cmp.Option, 0, 4)
+	ops := make([]cmp.Option, 0, 5)
 
 	// json.RawMessage is a slice of bytes and therefore cmp's default behavior is to compare it by byte, which is not really useful
 	var jsonCmp = cmp.Transformer("", func(in json.RawMessage) string {
 		return string(in)
 	})
-	ops = append(ops, cmp.Reporter(&reporter), cmpopts.IgnoreFields(AlertQuery{}, "modelProps"), jsonCmp)
+	ops = append(ops, cmp.Reporter(&reporter), cmpopts.IgnoreFields(AlertQuery{}, "modelProps"), jsonCmp, cmpopts.EquateEmpty())
 
 	if len(ignore) > 0 {
 		ops = append(ops, cmpopts.IgnoreFields(AlertRule{}, ignore...))

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -362,6 +362,16 @@ func TestDiff(t *testing.T) {
 		}
 	})
 
+	t.Run("should not see difference between nil and empty Annotations", func(t *testing.T) {
+		rule1 := AlertRuleGen()()
+		rule1.Annotations = make(map[string]string)
+		rule2 := CopyRule(rule1)
+		rule2.Annotations = nil
+
+		diff := rule1.Diff(rule2)
+		require.Empty(t, diff)
+	})
+
 	t.Run("should detect changes in Annotations", func(t *testing.T) {
 		rule1 := AlertRuleGen()()
 		rule2 := CopyRule(rule1)
@@ -397,6 +407,16 @@ func TestDiff(t *testing.T) {
 		if t.Failed() {
 			t.Logf("rule1: %#v, rule2: %#v\ndiff: %v", rule1, rule2, diff)
 		}
+	})
+
+	t.Run("should not see difference between nil and empty Labels", func(t *testing.T) {
+		rule1 := AlertRuleGen()()
+		rule1.Annotations = make(map[string]string)
+		rule2 := CopyRule(rule1)
+		rule2.Annotations = nil
+
+		diff := rule1.Diff(rule2)
+		require.Empty(t, diff)
 	})
 
 	t.Run("should detect changes in Labels", func(t *testing.T) {


### PR DESCRIPTION
Backport https://github.com/grafana/grafana/commit/49d93fb67ee9259fba667dbe11665fcea368fbc7 from  https://github.com/grafana/grafana/pull/50192