### PR TITLE
strip null from new heatmap dashboard definition

### DIFF
--- a/devenv/dev-dashboards/panel-heatmap/heatmap-calculate-log.json
+++ b/devenv/dev-dashboards/panel-heatmap/heatmap-calculate-log.json
@@ -71,8 +71,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",


### PR DESCRIPTION
Currently main is broken as we didn't strip nulls from a new dashboard definition, thus the validation is failing. This PR fixes it.