### PR TITLE
SearchV2: explicit dashboard loading order and cleanups

### DIFF
--- a/pkg/services/searchV2/bluge.go
+++ b/pkg/services/searchV2/bluge.go
@@ -120,14 +120,7 @@ func initIndex(dashboards []dashboard, logger log.Logger, extendDoc ExtendDashbo
 	if err := flushIfRequired(true); err != nil {
 		return nil, nil, err
 	}
-	logger.Info("Finish inserting docs into batch", "elapsed", time.Since(label))
-	label = time.Now()
-
-	err = writer.Batch(batch)
-	if err != nil {
-		return nil, nil, err
-	}
-	logger.Info("Finish writing batch", "elapsed", time.Since(label))
+	logger.Info("Finish inserting docs into index", "elapsed", time.Since(label))
 
 	reader, err := writer.Reader()
 	if err != nil {
@@ -470,9 +463,6 @@ func doSearchQuery(
 		return response
 	}
 
-	dvfieldNames := []string{"type"}
-	sctx := search.NewSearchContext(0, 0)
-
 	fScore := data.NewFieldFromFieldType(data.FieldTypeFloat64, 0)
 	fUID := data.NewFieldFromFieldType(data.FieldTypeString, 0)
 	fKind := data.NewFieldFromFieldType(data.FieldTypeString, 0)
@@ -517,11 +507,6 @@ func doSearchQuery(
 	// iterate through the document matches
 	match, err := documentMatchIterator.Next()
 	for err == nil && match != nil {
-		err = match.LoadDocumentValues(sctx, dvfieldNames)
-		if err != nil {
-			continue
-		}
-
 		uid := ""
 		kind := ""
 		ptype := ""

--- a/pkg/services/searchV2/index.go
+++ b/pkg/services/searchV2/index.go
@@ -567,6 +567,7 @@ func (l sqlDashboardLoader) LoadDashboards(ctx context.Context, orgID int64, das
 
 			sess.Cols("id", "uid", "is_folder", "folder_id", "data", "slug", "created", "updated")
 
+			sess.OrderBy("id ASC")
 			sess.Limit(limit)
 
 			return sess.Find(&rows)
@@ -607,10 +608,6 @@ func newFolderIDLookup(sql *sqlstore.SQLStore) folderUIDLookup {
 	return func(ctx context.Context, folderID int64) (string, error) {
 		uid := ""
 		err := sql.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-			sess.Table("dashboard").
-				Where("id = ?", folderID).
-				Cols("uid")
-
 			res, err := sess.Query("SELECT uid FROM dashboard WHERE id=?", folderID)
 			if err != nil {
 				return err

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -6,6 +6,7 @@ import SVG from 'react-inlinesvg';
 import { Field, getFieldDisplayName } from '@grafana/data';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { Checkbox, Icon, IconButton, IconName, TagList } from '@grafana/ui';
+import { PluginIconName } from 'app/features/plugins/admin/types';
 
 import { QueryResponse, SearchResultMeta } from '../../service';
 import { SelectionChecker, SelectionToggle } from '../selection';
@@ -287,7 +288,7 @@ function makeTypeColumn(
             break;
 
           case 'panel':
-            icon = 'public/img/icons/mono/library-panel.svg';
+            icon = `public/img/icons/unicons/${PluginIconName.panel}.svg`;
             const type = typeField.values.get(i);
             if (type) {
               txt = type;

--- a/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana/components/QueryEditor.tsx
@@ -10,6 +10,7 @@ import {
 } from '@grafana/data';
 import { config, getBackendSrv, getDataSourceSrv } from '@grafana/runtime';
 import { InlineField, Select, Alert, Input, InlineFieldRow, CodeEditor } from '@grafana/ui';
+import { hasAlphaPanels } from 'app/core/config';
 import { SearchQuery } from 'app/features/search/service';
 
 import { GrafanaDatasource } from '../datasource';
@@ -49,7 +50,7 @@ export class QueryEditor extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    if (config.featureToggles.panelTitleSearch) {
+    if (config.featureToggles.panelTitleSearch && hasAlphaPanels) {
       this.queryTypes.push({
         label: 'Search',
         value: GrafanaQueryType.Search,


### PR DESCRIPTION
**What this PR does / why we need it**:

Several cleanups in SearchV2 code, and explicit ordering when loading all dashboards – it seems not guaranteed to be `id ASC` by default.