### PR TITLE
Dashboard: Support specifying percentage as max data points

### DIFF
--- a/public/app/angular/panel/metrics_panel_ctrl.ts
+++ b/public/app/angular/panel/metrics_panel_ctrl.ts
@@ -190,6 +190,17 @@ class MetricsPanelCtrl extends PanelCtrl {
     const panel = this.panel as PanelModel;
     const queryRunner = panel.getQueryRunner();
 
+    let evaluatedMaxDataPoints = Math.floor(this.width);
+    if (typeof panel.maxDataPoints === 'number') {
+      evaluatedMaxDataPoints = panel.maxDataPoints;
+    } else if (typeof panel.maxDataPoints === 'string' && panel.maxDataPoints.endsWith('%')) {
+      const percent = panel.maxDataPoints.substring(0, panel.maxDataPoints.length - 1);
+      evaluatedMaxDataPoints = Math.floor((parseFloat(percent) / 100) * this.width);
+    }
+    if (Number.isNaN(evaluatedMaxDataPoints)) {
+      evaluatedMaxDataPoints = Math.floor(this.width);
+    }
+
     return queryRunner.run({
       datasource: panel.datasource,
       queries: panel.targets,
@@ -198,7 +209,7 @@ class MetricsPanelCtrl extends PanelCtrl {
       timezone: this.dashboard.getTimezone(),
       timeInfo: this.timeInfo,
       timeRange: this.range,
-      maxDataPoints: panel.maxDataPoints || this.width,
+      maxDataPoints: evaluatedMaxDataPoints,
       minInterval: panel.interval,
       scopedVars: panel.scopedVars,
       cacheTimeout: panel.cacheTimeout,

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -303,7 +303,7 @@ export const panelToRuleFormValues = async (
     relativeTimeRange,
     panel.scopedVars || {},
     panel.datasource ?? undefined,
-    panel.maxDataPoints ?? undefined,
+    typeof panel.maxDataPoints === 'number' ? panel.maxDataPoints : undefined,
     panel.interval ?? undefined
   );
   // if no alerting capable queries are found, can't create a rule

--- a/public/app/features/dashboard/utils/panel.ts
+++ b/public/app/features/dashboard/utils/panel.ts
@@ -171,13 +171,6 @@ export function applyPanelTimeOverrides(panel: PanelModel, timeRange: TimeRange)
   return newTimeData;
 }
 
-export function getResolution(panel: PanelModel): number {
-  const htmlEl = document.getElementsByTagName('html')[0];
-  const width = htmlEl.getBoundingClientRect().width; // https://stackoverflow.com/a/21454625
-
-  return panel.maxDataPoints ? panel.maxDataPoints : Math.ceil(width * (panel.gridPos.w / 24));
-}
-
 export function calculateInnerPanelHeight(panel: PanelModel, containerHeight: number): number {
   const chromePadding = panel.plugin && panel.plugin.noPadding ? 0 : config.theme.panelPadding * 2;
   const headerHeight = panel.hasTitle() ? config.theme.panelHeaderHeight : 0;

--- a/public/app/features/query/components/QueryGroupOptions.tsx
+++ b/public/app/features/query/components/QueryGroupOptions.tsx
@@ -276,9 +276,11 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
       return undefined;
     }
 
-    let mdDesc = options.maxDataPoints ?? '';
+    let mdDesc = String(options.maxDataPoints ?? '');
     if (mdDesc === '' && data.request) {
       mdDesc = `auto = ${data.request.maxDataPoints}`;
+    } else if (mdDesc.endsWith('%') && data.request) {
+      mdDesc = `${mdDesc} = ${data.request.maxDataPoints}`;
     }
 
     let intervalDesc = options.minInterval;

--- a/public/app/features/query/components/QueryGroupOptions.tsx
+++ b/public/app/features/query/components/QueryGroupOptions.tsx
@@ -113,13 +113,7 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
 
   onMaxDataPointsBlur = (event: ChangeEvent<HTMLInputElement>) => {
     const { options, onChange } = this.props;
-
-    let maxDataPoints: number | null = parseInt(event.target.value as string, 10);
-
-    if (isNaN(maxDataPoints) || maxDataPoints === 0) {
-      maxDataPoints = null;
-    }
-
+    const maxDataPoints = parseMaxDataPointsInput(event.target.value as string);
     if (maxDataPoints !== options.maxDataPoints) {
       onChange({
         ...options,
@@ -171,8 +165,9 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
   renderMaxDataPointsOption() {
     const { data, options } = this.props;
     const realMd = data.request?.maxDataPoints;
-    const value = options.maxDataPoints ?? '';
+    const value = String(options.maxDataPoints ?? '');
     const isAuto = value === '';
+    const isPercentage = value.endsWith('%');
 
     return (
       <div className="gf-form-inline">
@@ -189,7 +184,6 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
             Max data points
           </InlineFormLabel>
           <Input
-            type="number"
             className="width-6"
             placeholder={`${realMd}`}
             spellCheck={false}
@@ -199,6 +193,12 @@ export class QueryGroupOptionsEditor extends PureComponent<Props, State> {
           {isAuto && (
             <>
               <div className="gf-form-label query-segment-operator">=</div>
+              <div className="gf-form-label">Width of panel</div>
+            </>
+          )}
+          {isPercentage && (
+            <>
+              <div className="gf-form-label query-segment-operator">*</div>
               <div className="gf-form-label">Width of panel</div>
             </>
           )}
@@ -373,5 +373,27 @@ const getStyles = stylesFactory(() => {
     `,
   };
 });
+
+const parseMaxDataPointsInput = (inputValue: string) => {
+  if (inputValue === '') {
+    return null;
+  }
+
+  if (inputValue.endsWith('%')) {
+    const percentValue = parseFloat(inputValue.substring(0, inputValue.length - 1));
+    if (isNaN(percentValue) || percentValue <= 0) {
+      return null;
+    } else {
+      return `${percentValue}%`;
+    }
+  }
+
+  const intValue = parseInt(inputValue, 10);
+  if (isNaN(intValue) || intValue <= 0) {
+    return null;
+  }
+
+  return intValue;
+};
 
 type StylesType = ReturnType<typeof getStyles>;

--- a/public/app/features/sandbox/TestStuffPage.tsx
+++ b/public/app/features/sandbox/TestStuffPage.tsx
@@ -1,3 +1,4 @@
+import { isNumber } from 'lodash';
 import React, { FC, useMemo, useState } from 'react';
 import { useObservable } from 'react-use';
 import AutoSizer from 'react-virtualized-auto-sizer';
@@ -38,7 +39,7 @@ export const TestStuffPage: FC = () => {
       datasource: queryOptions.dataSource,
       timezone: 'browser',
       timeRange: { from: dateMath.parse(timeRange.from)!, to: dateMath.parse(timeRange.to)!, raw: timeRange },
-      maxDataPoints: queryOptions.maxDataPoints ?? 100,
+      maxDataPoints: isNumber(queryOptions.maxDataPoints) ? queryOptions.maxDataPoints : 100,
       minInterval: queryOptions.minInterval,
     });
   };

--- a/public/app/types/query.ts
+++ b/public/app/types/query.ts
@@ -3,7 +3,7 @@ import { DataQuery, DataSourceRef } from '@grafana/data';
 export interface QueryGroupOptions {
   queries: DataQuery[];
   dataSource: QueryGroupDataSource;
-  maxDataPoints?: number | null;
+  maxDataPoints?: number | string /* must be 'x%' */ | null /* auto */;
   minInterval?: string | null;
   cacheTimeout?: string | null;
   timeRange?: {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Allows user to specify a percentage (like `10%`) in the "max data points" option. When using a percentage-based MD with an appropriate expression, users can get smoothed charts for large time range, while keep enough details for small time range. Everything is done automatically when user changes the time range.

Note: Setting MD to `100%` is equal to `auto`.

Here is a demo comparing different resolutions, using the same expression `rate(process_cpu_seconds_total[$__rate_interval])`.

**Large Time Range**, series are smoothed (compare with 1/1 resolution):

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/1916485/172034729-522585a5-73bf-4f82-a1bc-3dfef9131b95.png">

**Small Time Range**, details are retained (compare with 1/10 resolution):

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/1916485/172034735-82cf0bba-4231-4928-a0e6-608bcfe759a3.png">

<img width="1428" alt="image" src="https://user-images.githubusercontent.com/1916485/172037622-877c3948-6b34-43ba-8bad-783ce8052112.png">


As you can see, the percentage-based MD brings great visualizations **in both cases**.

Additionally, it **adjusts the precision automatically when panel size is changed**: for small panels series are smoothed, for large panels that have enough space to display, details are retained:

<img width="1434" alt="image" src="https://user-images.githubusercontent.com/1916485/172034781-4670f576-f2e3-441d-929a-4afb88b921e7.png">

<img width="1432" alt="image" src="https://user-images.githubusercontent.com/1916485/172037704-d8eff288-df5c-4e53-a1d9-43ff6d76cfa4.png">

(Note: In real world user will more likely to change the browser size or different screen resolutions, resulting in a panel width change)

When using a static MD instead of a percentage-based MD, the chart will not work great in both cases, for example, either the details are collapsed, or the series is not smoothed:

<img width="1428" alt="image" src="https://user-images.githubusercontent.com/1916485/172037924-846385a5-8232-4927-961b-fb57dd39069a.png">

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/1916485/172037968-fc3d51fa-092c-4b99-b8c4-a55b27f25ac2.png">

This proposal is first raised in https://github.com/grafana/grafana/discussions/50134. It should also be a great replacement for the deprecated "resolution" option discussed in https://github.com/grafana/grafana/issues/48081.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

There is currently no tests for the new percentage-based MD, as the proposal is still under discussion. Feel free to try by yourself. If the idea is great, I will add tests for it!