### PR TITLE
Prometheus: Fix resource call panic

### DIFF
--- a/pkg/tsdb/prometheus/resource/resource.go
+++ b/pkg/tsdb/prometheus/resource/resource.go
@@ -58,7 +58,11 @@ func (r *Resource) fetch(ctx context.Context, client *client.Client, req *backen
 
 	resp, err := client.QueryResource(ctx, req.Method, u.Path, u.Query())
 	if err != nil {
-		return resp.StatusCode, nil, err
+		statusCode := 500
+		if resp != nil {
+			statusCode = resp.StatusCode
+		}
+		return statusCode, nil, err
 	}
 
 	defer resp.Body.Close() //nolint (we don't care about the error being returned by resp.Body.Close())


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

my local prometheus instance was down, and when I loaded Grafana I got this in explore:
<img width="674" alt="image" src="https://user-images.githubusercontent.com/360020/172063835-35e319bf-80b1-4191-be8a-6f865a3b1d5b.png">

logs:
```
logger=context traceID=00000000000000000000000000000000 userId=1 orgId=1 uname=admin error="runtime error: invalid memory address or nil pointer dereference" stack="/usr/local/go/src/runtime/panic.go:220 (0x457715)\n\tpanicmem: panic(memoryError)\n/usr/local/go/src/runtime/signal_unix.go:818 (0x4576e5)\n\tsigpanic: panicmem()\n/home/todd/grafana/pkg/tsdb/prometheus/resource/resource.go:61 (0x270a4ec)\n\t(*Resource).fetch: return resp.StatusCode, nil, err
```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

