### PR TITLE
Fix Reporter GetDiffsForField

### DIFF
--- a/pkg/util/cmputil/reporter.go
+++ b/pkg/util/cmputil/reporter.go
@@ -14,7 +14,13 @@ type DiffReport []Diff
 func (r DiffReport) GetDiffsForField(path string) DiffReport {
 	var result []Diff
 	for _, diff := range r {
-		if strings.HasPrefix(path, diff.Path) {
+		if strings.HasPrefix(diff.Path, path) {
+			if diff.Path != path {
+				char := []rune(diff.Path)[len(path)]
+				if char != '.' && char != '[' { // if the following symbol is not a delimiter or bracket then that's not our path
+					continue
+				}
+			}
 			result = append(result, diff)
 		}
 	}

--- a/pkg/util/cmputil/reporter_test.go
+++ b/pkg/util/cmputil/reporter_test.go
@@ -130,3 +130,68 @@ func TestIsAddedDeleted_Collections(t *testing.T) {
 		}
 	})
 }
+
+func TestGetDiffsForField(t *testing.T) {
+	t.Run("should not include fields that starts has prefix", func(t *testing.T) {
+		diff := DiffReport{
+			Diff{
+				Path: "Property",
+			},
+			Diff{
+				Path: "PropertyData",
+			},
+		}
+
+		result := diff.GetDiffsForField("Property")
+		require.Len(t, result, 1)
+		require.Equal(t, "Property", result[0].Path)
+	})
+
+	t.Run("should return all changes by parent path", func(t *testing.T) {
+		diff := DiffReport{
+			Diff{
+				Path: "Property.Data.Value",
+			},
+			Diff{
+				Path: "Property.Array[0].Value",
+			},
+		}
+
+		result := diff.GetDiffsForField("Property")
+		require.Len(t, result, 2)
+	})
+
+	t.Run("should return all elements of array", func(t *testing.T) {
+		diff := DiffReport{
+			Diff{
+				Path: "Property[0].Data.Test",
+			},
+			Diff{
+				Path: "Property",
+			},
+			Diff{
+				Path: "Property[1]",
+			},
+		}
+
+		result := diff.GetDiffsForField("Property")
+		require.Len(t, result, 3)
+	})
+
+	t.Run("should find nothing if parent path does not exist", func(t *testing.T) {
+		diff := DiffReport{
+			Diff{
+				Path: "Property[0].Data.Test",
+			},
+			Diff{
+				Path: "Property",
+			},
+			Diff{
+				Path: "Property[1]",
+			},
+		}
+
+		result := diff.GetDiffsForField("Proper")
+		require.Empty(t, result)
+	})
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR fixes the method DiffReport.GetDiffsForField to distinguish between a diff which path contains a prefix of the parent path (incorrect) and a diff that contains the parent path. 
For example, the current implementation produces incorrect results when the report contains the paths: "Property" and "PropertyIndex", and the method GetDiffsForField is called with the argument "Property"

**Special notes for your reviewer**:
This bug does not need to be backported or mentioned in the changelog because this method is not used anywhere in the production code.
