### PR TITLE
Alerting: Fixes slack push notifications

### DIFF
--- a/pkg/services/ngalert/notifier/channels/slack.go
+++ b/pkg/services/ngalert/notifier/channels/slack.go
@@ -166,6 +166,7 @@ func NewSlackNotifier(config *SlackConfig,
 // slackMessage is the slackMessage for sending a slack notification.
 type slackMessage struct {
 	Channel     string                   `json:"channel,omitempty"`
+	Text        string                   `json:"text,omitempty"`
 	Username    string                   `json:"username,omitempty"`
 	IconEmoji   string                   `json:"icon_emoji,omitempty"`
 	IconURL     string                   `json:"icon_url,omitempty"`
@@ -353,6 +354,8 @@ func (sn *SlackNotifier) buildSlackMessage(ctx context.Context, alrts []*types.A
 		for _, u := range sn.MentionUsers {
 			mentionsBuilder.WriteString(fmt.Sprintf("<@%s>", tmpl(u)))
 		}
+		// When mentioning a user, we need to provide text for notifications
+		req.Text = tmpl(sn.Title)
 	}
 
 	if mentionsBuilder.Len() > 0 {

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -2118,7 +2118,7 @@ var expNonEmailNotifications = map[string][]string{
 	"slack_recv1/slack_test_without_token": {
 		`{
 		  "channel": "#test-channel",
-			"text": "Integration Test [FIRING:1] SlackAlert1 ",
+		  "text": "Integration Test [FIRING:1] SlackAlert1 ",
 		  "username": "Integration Test",
 		  "icon_emoji": "🚀",
 		  "icon_url": "https://awesomeemoji.com/rocket",
@@ -2148,7 +2148,7 @@ var expNonEmailNotifications = map[string][]string{
 	"slack_recvX/slack_testX": {
 		`{
 		  "channel": "#test-channel",
-			"text": "[FIRING:1] SlackAlert2 ",
+		  "text": "[FIRING:1] SlackAlert2 ",
 		  "username": "Integration Test",
 		  "attachments": [
 			{

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -2118,6 +2118,7 @@ var expNonEmailNotifications = map[string][]string{
 	"slack_recv1/slack_test_without_token": {
 		`{
 		  "channel": "#test-channel",
+			"text": "Integration Test [FIRING:1] SlackAlert1 ",
 		  "username": "Integration Test",
 		  "icon_emoji": "🚀",
 		  "icon_url": "https://awesomeemoji.com/rocket",
@@ -2147,6 +2148,7 @@ var expNonEmailNotifications = map[string][]string{
 	"slack_recvX/slack_testX": {
 		`{
 		  "channel": "#test-channel",
+			"text": "[FIRING:1] SlackAlert2 ",
 		  "username": "Integration Test",
 		  "attachments": [
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:
When a user is mentioned in a slack alert, the push notifications are broken and simply say "This content can't be displayed". There is a pretty easy workaround for this [limitation of slack](https://api.slack.com/messaging/composing/layouts#limitations). Simply adding a top-level "text" element, as a fallback, will allow the push notification to come through as expected.

**Which issue(s) this PR fixes**:
Fixes #42768
