### PR TITLE
Owensmallwood/pubdash get public dashboard definition

### DIFF
--- a/pkg/api/dashboard_public.go
+++ b/pkg/api/dashboard_public.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"github.com/grafana/grafana/pkg/api/dtos"
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
@@ -16,7 +17,26 @@ func (hs *HTTPServer) GetPublicDashboard(c *models.ReqContext) response.Response
 	if err != nil {
 		return handleDashboardErr(http.StatusInternalServerError, "Failed to get public dashboard", err)
 	}
-	return response.JSON(http.StatusOK, dash)
+
+	meta := dtos.DashboardMeta{
+		Slug:      dash.Slug,
+		Type:      models.DashTypeDB,
+		CanStar:   false,
+		CanSave:   false,
+		CanEdit:   false,
+		CanAdmin:  false,
+		CanDelete: false,
+		Created:   dash.Created,
+		Updated:   dash.Updated,
+		Version:   dash.Version,
+		IsFolder:  false,
+		FolderId:  dash.FolderId,
+		IsPublic:  dash.IsPublic,
+	}
+
+	dto := dtos.DashboardFullWithMeta{Meta: meta, Dashboard: dash.Data}
+
+	return response.JSON(http.StatusOK, dto)
 }
 
 // gets public dashboard configuration for dashboard

--- a/pkg/api/dashboard_public.go
+++ b/pkg/api/dashboard_public.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"errors"
-	"github.com/grafana/grafana/pkg/api/dtos"
 	"net/http"
 
+	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"

--- a/pkg/api/dashboard_public_test.go
+++ b/pkg/api/dashboard_public_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"net/http"
 	"strings"
 	"testing"
@@ -44,6 +46,9 @@ func TestAPIGetPublicDashboard(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, response.Code)
 	})
 
+	dashboardUid := "dashboard-abcd1234"
+	pubdashUid := "pubdash-abcd1234"
+
 	testCases := []struct {
 		name                  string
 		uid                   string
@@ -53,16 +58,19 @@ func TestAPIGetPublicDashboard(t *testing.T) {
 	}{
 		{
 			name:                 "It gets a public dashboard",
-			uid:                  "pubdash-abcd1234",
+			uid:                  pubdashUid,
 			expectedHttpResponse: http.StatusOK,
 			publicDashboardResult: &models.Dashboard{
-				Uid: "dashboard-abcd1234",
+				Data: simplejson.NewFromAny(map[string]interface{}{
+					"Uid": dashboardUid,
+				}),
+				IsPublic: true,
 			},
 			publicDashboardErr: nil,
 		},
 		{
 			name:                  "It should return 404 if isPublicDashboard is false",
-			uid:                   "pubdash-abcd1234",
+			uid:                   pubdashUid,
 			expectedHttpResponse:  http.StatusNotFound,
 			publicDashboardResult: nil,
 			publicDashboardErr:    models.ErrPublicDashboardNotFound,
@@ -89,10 +97,15 @@ func TestAPIGetPublicDashboard(t *testing.T) {
 			assert.Equal(t, test.expectedHttpResponse, response.Code)
 
 			if test.publicDashboardErr == nil {
-				var dashResp models.Dashboard
+				var dashResp dtos.DashboardFullWithMeta
 				err := json.Unmarshal(response.Body.Bytes(), &dashResp)
 				require.NoError(t, err)
-				assert.Equal(t, test.publicDashboardResult.Uid, dashResp.Uid)
+
+				assert.Equal(t, dashboardUid, dashResp.Dashboard.Get("Uid").MustString())
+				assert.Equal(t, true, dashResp.Meta.IsPublic)
+				assert.Equal(t, false, dashResp.Meta.CanEdit)
+				assert.Equal(t, false, dashResp.Meta.CanDelete)
+				assert.Equal(t, false, dashResp.Meta.CanSave)
 			} else {
 				var errResp struct {
 					Error string `json:"error"`

--- a/pkg/api/dashboard_public_test.go
+++ b/pkg/api/dashboard_public_test.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/grafana/grafana/pkg/api/dtos"
-	"github.com/grafana/grafana/pkg/components/simplejson"
 	"net/http"
 	"strings"
 	"testing"
@@ -14,6 +12,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -429,6 +429,10 @@ export class BackendSrv implements BackendService {
     return this.get<DashboardDTO>(`/api/dashboards/uid/${uid}`);
   }
 
+  getPublicDashboardByUid(uid: string) {
+    return this.get<DashboardDTO>(`/api/public/dashboards/${uid}`);
+  }
+
   getFolderByUid(uid: string) {
     return this.get<FolderDTO>(`/api/folders/${uid}`);
   }

--- a/public/app/features/dashboard/containers/DashboardPage.test.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.test.tsx
@@ -302,4 +302,20 @@ describe('DashboardPage', () => {
       expect(screen.queryAllByLabelText(selectors.pages.Dashboard.SubMenu.submenu)).toHaveLength(0);
     });
   });
+
+  dashboardPageScenario('When dashboard is public', (ctx) => {
+    ctx.setup(() => {
+      locationService.partial({ kiosk: false });
+      ctx.mount({
+        queryParams: {},
+        dashboard: getTestDashboard(),
+      });
+      ctx.rerender({ dashboard: ctx.dashboard, isPublic: true });
+    });
+
+    it('should not render page toolbar and submenu', () => {
+      expect(screen.queryAllByTestId(selectors.pages.Dashboard.DashNav.navV2)).toHaveLength(0);
+      expect(screen.queryAllByLabelText(selectors.pages.Dashboard.SubMenu.submenu)).toHaveLength(0);
+    });
+  });
 });

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -41,6 +41,15 @@ export class DashboardLoaderSrv {
       });
     } else if (type === 'ds') {
       promise = this._loadFromDatasource(slug); // explore dashboards as code
+    } else if (type === 'public') {
+      promise = backendSrv
+        .getPublicDashboardByUid(uid)
+        .then((result: any) => {
+          return result;
+        })
+        .catch(() => {
+          return this._dashboardLoadFailed('Public Dashboard Not found', true);
+        });
     } else {
       promise = backendSrv
         .getDashboardByUid(uid)

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -61,13 +61,7 @@ async function fetchDashboard(
         return dashDTO;
       }
       case DashboardRoutes.Public: {
-        const dashDTO: DashboardDTO = await dashboardLoaderSrv.loadDashboard(args.urlType, args.urlSlug, args.urlUid);
-        // Make sure new endpoint to fetch dashboard DTO sets these as false
-        dashDTO.meta.canEdit = false;
-        dashDTO.meta.canMakeEditable = false;
-        dashDTO.meta.isPublic = true;
-
-        return dashDTO;
+        return await dashboardLoaderSrv.loadDashboard('public', args.urlSlug, args.urlUid);
       }
       case DashboardRoutes.Normal: {
         const dashDTO: DashboardDTO = await dashboardLoaderSrv.loadDashboard(args.urlType, args.urlSlug, args.urlUid);


### PR DESCRIPTION
**What this does**
You can use a public dashboard url to load a public dashboard. If you have a pubdash uid of `-ycskU9nz` you should be able to go to `/public-dashboards/-ycskU9nz` and it will load the source dashboard in the public dashboard view.

**Whats missing**
All panels still fetch their data from the original endpoint. This will be changed in another card so that panels will fetch their data from a query endpoint specifically for public dashboard queries.

**How to test**

1. Save your dashboard as public
2. Get your public dashboard uid from the database
3. On your local instance, go to `/public-dashboards/<YourPubDashUID`
4. Your dashboard should be loaded in a public view

<img width="1650" alt="Screen Shot 2022-06-06 at 12 22 11 PM" src="https://user-images.githubusercontent.com/20195316/172223171-83fa0340-a191-4bb4-8c8d-b2a0b9320a89.png">

