### PR TITLE
RBAC: Remove workaround to check permissions on folders for dashboard actions

### DIFF
--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -134,7 +134,6 @@ func ProvideDashboardPermissions(
 
 			return nil
 		},
-		InheritedScopePrefixes: []string{"folders:uid:"},
 		InheritedScopesSolver: func(ctx context.Context, orgID int64, resourceID string) ([]string, error) {
 			dashboard, err := getDashboard(ctx, orgID, resourceID)
 			if err != nil {

--- a/pkg/services/accesscontrol/resourcepermissions/api_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_test.go
@@ -418,66 +418,6 @@ func TestApi_setUserPermission(t *testing.T) {
 	}
 }
 
-type inheritSolverTestCase struct {
-	desc           string
-	resourceID     string
-	expectedStatus int
-}
-
-func TestApi_InheritSolver(t *testing.T) {
-	tests := []inheritSolverTestCase{
-		{
-			desc:           "expect parents permission to apply",
-			resourceID:     "resourceID",
-			expectedStatus: http.StatusOK,
-		},
-		{
-			desc:           "expect direct permissions to apply (no inheritance)",
-			resourceID:     "orphanedID",
-			expectedStatus: http.StatusOK,
-		},
-		{
-			desc:           "expect 404 when resource is not found",
-			resourceID:     "notfound",
-			expectedStatus: http.StatusNotFound,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			userPermissions := []*accesscontrol.Permission{
-				{Action: "dashboards.permissions:read", Scope: "parents:id:parentID"},      // Inherited permission
-				{Action: "dashboards.permissions:read", Scope: "dashboards:id:orphanedID"}, // Direct permission
-				{Action: accesscontrol.ActionTeamsRead, Scope: accesscontrol.ScopeTeamsAll},
-				{Action: accesscontrol.ActionOrgUsersRead, Scope: accesscontrol.ScopeUsersAll},
-			}
-			// Add the inheritance solver "resourceID -> [parentID]" "orphanedID -> []"
-			service, sql := setupTestEnvironment(t, userPermissions,
-				withInheritance(testOptions, testInheritedScopeSolver, testInheritedScopePrefixes),
-			)
-			server := setupTestServer(t, &models.SignedInUser{OrgId: 1, Permissions: map[int64]map[string][]string{
-				1: accesscontrol.GroupScopesByAction(userPermissions),
-			}}, service)
-
-			// Seed permissions for users/teams/built-in roles specific to the test case resourceID
-			seedPermissions(t, tt.resourceID, sql, service)
-
-			permissions, recorder := getPermission(t, server, testOptions.Resource, tt.resourceID)
-			require.Equal(t, tt.expectedStatus, recorder.Code)
-
-			if tt.expectedStatus == http.StatusOK {
-				checkSeededPermissions(t, permissions)
-			}
-		})
-	}
-}
-
-func withInheritance(options Options, solver InheritedScopesSolver, inheritedPrefixes []string) Options {
-	options.InheritedScopesSolver = solver
-	options.InheritedScopePrefixes = inheritedPrefixes
-	return options
-}
-
 func setupTestServer(t *testing.T, user *models.SignedInUser, service *Service) *web.Mux {
 	server := web.New()
 	server.UseMiddleware(web.Renderer(path.Join(setting.StaticRootPath, "views"), "[[", "]]"))

--- a/pkg/services/accesscontrol/resourcepermissions/api_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_test.go
@@ -3,7 +3,6 @@ package resourcepermissions
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -456,17 +455,6 @@ var testOptions = Options{
 		"View": {"dashboards:read"},
 		"Edit": {"dashboards:read", "dashboards:write", "dashboards:delete"},
 	},
-}
-
-var testInheritedScopePrefixes = []string{"parents:id:"}
-var testInheritedScopeSolver = func(ctx context.Context, orgID int64, id string) ([]string, error) {
-	if id == "resourceID" { // Has parent
-		return []string{"parents:id:parentID"}, nil
-	}
-	if id == "orphanedID" { // Exists but with no parent
-		return nil, nil
-	}
-	return nil, errors.New("not found")
 }
 
 func getPermission(t *testing.T, server *web.Mux, resource, resourceID string) ([]resourcePermissionDTO, *httptest.ResponseRecorder) {

--- a/pkg/services/accesscontrol/resourcepermissions/options.go
+++ b/pkg/services/accesscontrol/resourcepermissions/options.go
@@ -39,6 +39,4 @@ type Options struct {
 	OnSetBuiltInRole func(session *sqlstore.DBSession, orgID int64, builtInRole, resourceID, permission string) error
 	// InheritedScopesSolver if configured can generate additional scopes that will be used when fetching permissions for a resource
 	InheritedScopesSolver InheritedScopesSolver
-	// InheritedScopePrefixes if configured are used to create evaluators with the scopes returned by InheritedScopesSolver
-	InheritedScopePrefixes []string
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/grafana/grafana/pull/50110 scope resovlers for dashboard was added.
With this we can remove the workaround we had to check permissions in the resource permissions api for dashboards



**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana-enterprise/issues/3115

**Special notes for your reviewer**:

