### PR TITLE
AddDataSourceConfig: Remove deprecated checkHealth prop

### DIFF
--- a/packages/grafana-e2e/src/flows/addDataSource.ts
+++ b/packages/grafana-e2e/src/flows/addDataSource.ts
@@ -8,10 +8,6 @@ export interface AddDataSourceConfig {
   basicAuth: boolean;
   basicAuthPassword: string;
   basicAuthUser: string;
-  /**
-   * @deprecated check health request is no longer supported
-   */
-  checkHealth: boolean;
   expectedAlertMessage: string | RegExp;
   form: () => void;
   name: string;
@@ -26,7 +22,6 @@ export const addDataSource = (config?: Partial<AddDataSourceConfig>) => {
     basicAuth: false,
     basicAuthPassword: '',
     basicAuthUser: '',
-    checkHealth: false,
     expectedAlertMessage: 'Data source is working',
     form: () => {},
     name: `e2e-${uuidv4()}`,


### PR DESCRIPTION
# Release notice breaking change
Removed deprecated `checkHealth` prop from the `@grafana/e2e` `addDataSource` config. Previously this value defaulted to `false`, and has not been used in end-to-end tests since Grafana 8.0.3.