### PR TITLE
Elasticsearch: Always use fixed_interval

### DIFF
--- a/pkg/tsdb/elasticsearch/client/client_test.go
+++ b/pkg/tsdb/elasticsearch/client/client_test.go
@@ -145,7 +145,7 @@ func TestClient_ExecuteMultisearch(t *testing.T) {
 
 		assert.Equal(t, "15000*@hostname", jBody.GetPath("aggs", "2", "aggs", "1", "avg", "script").MustString())
 
-		assert.Equal(t, "15s", jBody.GetPath("aggs", "2", "date_histogram", "interval").MustString())
+		assert.Equal(t, "15s", jBody.GetPath("aggs", "2", "date_histogram", "fixed_interval").MustString())
 
 		assert.Equal(t, 200, res.Status)
 		require.Len(t, res.Responses, 1)
@@ -197,7 +197,7 @@ func TestClient_ExecuteMultisearch(t *testing.T) {
 
 		assert.Equal(t, "15000*@hostname", jBody.GetPath("aggs", "2", "aggs", "1", "avg", "script").MustString())
 
-		assert.Equal(t, "15s", jBody.GetPath("aggs", "2", "date_histogram", "interval").MustString())
+		assert.Equal(t, "15s", jBody.GetPath("aggs", "2", "date_histogram", "fixed_interval").MustString())
 
 		assert.Equal(t, 200, res.Status)
 		require.Len(t, res.Responses, 1)
@@ -252,7 +252,7 @@ func TestClient_ExecuteMultisearch(t *testing.T) {
 
 		assert.Equal(t, "15000*@hostname", jBody.GetPath("aggs", "2", "aggs", "1", "avg", "script").MustString())
 
-		assert.Equal(t, "15s", jBody.GetPath("aggs", "2", "date_histogram", "interval").MustString())
+		assert.Equal(t, "15s", jBody.GetPath("aggs", "2", "date_histogram", "fixed_interval").MustString())
 
 		assert.Equal(t, 200, res.Status)
 		require.Len(t, res.Responses, 1)
@@ -308,7 +308,7 @@ func TestClient_ExecuteMultisearch(t *testing.T) {
 
 		assert.Equal(t, "15000*@hostname", jBody.GetPath("aggs", "2", "aggs", "1", "avg", "script").MustString())
 
-		assert.Equal(t, "15s", jBody.GetPath("aggs", "2", "date_histogram", "interval").MustString())
+		assert.Equal(t, "15s", jBody.GetPath("aggs", "2", "date_histogram", "fixed_interval").MustString())
 
 		assert.Equal(t, 200, res.Status)
 		require.Len(t, res.Responses, 1)
@@ -321,7 +321,7 @@ func createMultisearchForTest(t *testing.T, c Client) (*MultiSearchRequest, erro
 	msb := c.MultiSearch()
 	s := msb.Search(intervalv2.Interval{Value: 15 * time.Second, Text: "15s"})
 	s.Agg().DateHistogram("2", "@timestamp", func(a *DateHistogramAgg, ab AggBuilder) {
-		a.Interval = "$__interval"
+		a.FixedInterval = "$__interval"
 
 		ab.Metric("1", "avg", "@hostname", func(a *MetricAggregation) {
 			a.Settings["script"] = "$__interval_ms*@hostname"

--- a/pkg/tsdb/elasticsearch/client/models.go
+++ b/pkg/tsdb/elasticsearch/client/models.go
@@ -238,7 +238,6 @@ type HistogramAgg struct {
 // DateHistogramAgg represents a date histogram aggregation
 type DateHistogramAgg struct {
 	Field          string          `json:"field"`
-	Interval       string          `json:"interval,omitempty"`
 	FixedInterval  string          `json:"fixed_interval,omitempty"`
 	MinDocCount    int             `json:"min_doc_count"`
 	Missing        *string         `json:"missing,omitempty"`

--- a/pkg/tsdb/elasticsearch/client/search_request.go
+++ b/pkg/tsdb/elasticsearch/client/search_request.go
@@ -342,11 +342,6 @@ func (b *aggBuilderImpl) DateHistogram(key, field string, fn func(a *DateHistogr
 		fn(innerAgg, builder)
 	}
 
-	if b.version.Major() >= 8 {
-		innerAgg.FixedInterval = innerAgg.Interval
-		innerAgg.Interval = ""
-	}
-
 	b.aggDefs = append(b.aggDefs, aggDef)
 
 	return b

--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -245,13 +245,13 @@ func (bucketAgg BucketAgg) generateSettingsForDSL() map[string]interface{} {
 
 func addDateHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, timeFrom, timeTo int64) es.AggBuilder {
 	aggBuilder.DateHistogram(bucketAgg.ID, bucketAgg.Field, func(a *es.DateHistogramAgg, b es.AggBuilder) {
-		a.Interval = bucketAgg.Settings.Get("interval").MustString("auto")
+		a.FixedInterval = bucketAgg.Settings.Get("interval").MustString("auto")
 		a.MinDocCount = bucketAgg.Settings.Get("min_doc_count").MustInt(0)
 		a.ExtendedBounds = &es.ExtendedBounds{Min: timeFrom, Max: timeTo}
 		a.Format = bucketAgg.Settings.Get("format").MustString(es.DateFormatEpochMS)
 
-		if a.Interval == "auto" {
-			a.Interval = "$__interval"
+		if a.FixedInterval == "auto" {
+			a.FixedInterval = "$__interval"
 		}
 
 		if offset, err := bucketAgg.Settings.Get("offset").String(); err == nil {

--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -112,13 +112,7 @@ export class ElasticQueryBuilder {
 
     const interval = settings.interval === 'auto' ? '$__interval' : settings.interval;
 
-    if (gte(this.esVersion, '8.0.0')) {
-      // The deprecation was actually introduced in 7.0.0, we might want to use that instead of the removal date,
-      // but it woudl be a breaking change on our side.
-      esAgg.fixed_interval = interval;
-    } else {
-      esAgg.interval = interval;
-    }
+    esAgg.fixed_interval = interval;
 
     return esAgg;
   }

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
@@ -763,16 +763,12 @@ describe('ElasticQueryBuilder', () => {
                 extended_bounds: { max: '$timeTo', min: '$timeFrom' },
                 field: '@timestamp',
                 format: 'epoch_millis',
-                interval: '$__interval',
+                fixed_interval: '$__interval',
                 min_doc_count: 0,
               },
             },
           };
 
-          if (gte(builder.esVersion, '8.0.0')) {
-            expectedAggs['1'].date_histogram.fixed_interval = expectedAggs['1'].date_histogram.interval;
-            delete expectedAggs['1'].date_histogram.interval;
-          }
           expect(query.aggs).toMatchObject(expectedAggs);
         });
 
@@ -959,7 +955,7 @@ describe('ElasticQueryBuilder', () => {
         });
 
         describe('interval parameter', () => {
-          it('should use interval if Elasticsearch version <8.0.0', () => {
+          it('should use fixed_interval', () => {
             const query = builder77.build({
               refId: 'A',
               metrics: [{ type: 'count', id: '1' }],
@@ -974,8 +970,7 @@ describe('ElasticQueryBuilder', () => {
               ],
             });
 
-            expect(query.aggs['2'].date_histogram.interval).toBe('1d');
-            expect(query.aggs['2'].date_histogram.fixed_interval).toBeUndefined();
+            expect(query.aggs['2'].date_histogram.fixed_interval).toBe('1d');
           });
         });
 


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/19911

in previous grafana versions, for Elasticsearch7.x we used the `interval` attribute to specify the interval-value. the problem is, this can become `fixed_interval` or `calendar_interval` based on the interval-value, so for example, when the user resized the dashboard-window, this might trigger a different interval-handling. this is not good, so we are switching to always use `fixed_interval` to provide consistent results. this is technically a breaking change, but it is a change to a better situation.

(NOTE: in elastic8, we already always use `fixed_interval`.)

how to test:
- `make devenv sources=elastic elastic_verison=7.10.0`
- make an elastic datasource that connect to this one where the elastic-version specified is `7.10`. (simply copy the values from the `gdev-elastic` datasource, and change the elastic-version select-box). let's name it `elastictest`
- you need a way to see the http-requests going from grafana to the elasticsearch-database
- test frontend-part:
    - go to Explore, choose the `elastictest` datasource
    - a query will happen at this point, check the http-request that was sent to the elasticsearch-database, the request-params are in JSON, you should see the word `"fixed_interval"` there, and you should not see `"interval"` there
- test backend-part:
    - create a dashboard, choose the `elastictest` datasource
    - add an alert, test the alert, check the http-request sent to the elasticsearch-database, the request-params are in JSON, you should see the word `"fixed_interval"` there, and you should not see `"interval"` there

# Release notice breaking change

In Elasticsearch versions 7.x, to specify the interval-value we used the `interval` property. In Grafana 9.1.0 we switched to use the `fixed_interval` property. This makes it to be the same as in Elasticsearch versions 8.x, also this provides a more consistent experience,  `fixed_interval` is a better match to Grafana's time invervals. For most situations this will not cause any visible change to query results.