### PR TITLE
Dashboards: Fix folder picker not showing correct results when typing too fast

### DIFF
--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -88,7 +88,7 @@ export interface SelectAsyncProps<T> {
   /** When specified as boolean the loadOptions will execute when component is mounted */
   defaultOptions?: boolean | Array<SelectableValue<T>>;
   /** Asynchronously load select options */
-  loadOptions?: (query: string) => Promise<Array<SelectableValue<T>>>;
+  loadOptions?: (query: string, cb: (options: Array<SelectableValue<T>>) => void) => Promise<Array<SelectableValue<T>>>;
   /** If cacheOptions is true, then the loaded data will be cached. The cache will remain until cacheOptions changes value. */
   cacheOptions?: boolean;
   /** Message to display when options are loading */

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -8,6 +8,7 @@ export type ActionMeta = SelectActionMeta<{}>;
 export type InputActionMeta = {
   action: 'set-value' | 'input-change' | 'input-blur' | 'menu-close';
 };
+export type LoadOptionsCallback<T> = (options: Array<SelectableValue<T>>) => void;
 
 export interface SelectCommonProps<T> {
   /** Aria label applied to the input field */
@@ -87,8 +88,10 @@ export interface SelectCommonProps<T> {
 export interface SelectAsyncProps<T> {
   /** When specified as boolean the loadOptions will execute when component is mounted */
   defaultOptions?: boolean | Array<SelectableValue<T>>;
+
   /** Asynchronously load select options */
-  loadOptions?: (query: string, cb: (options: Array<SelectableValue<T>>) => void) => Promise<Array<SelectableValue<T>>>;
+  loadOptions?: (query: string, cb?: LoadOptionsCallback<T>) => Promise<Array<SelectableValue<T>>> | void;
+
   /** If cacheOptions is true, then the loaded data will be cached. The cache will remain until cacheOptions changes value. */
   cacheOptions?: boolean;
   /** Message to display when options are loading */

--- a/public/app/core/components/Select/FolderPicker.tsx
+++ b/public/app/core/components/Select/FolderPicker.tsx
@@ -83,7 +83,7 @@ export class FolderPicker extends PureComponent<Props, State> {
   };
 
   // when debouncing, we must use the callback form of react-select's loadOptions so we don't
-  // drop results for user input
+  // drop results for user input. This must not return a promise/use await.
   loadOptions = (query: string, callback: LoadOptionsCallback<number>): void => {
     this.searchFolders(query).then(callback);
   };

--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.test.tsx
@@ -19,7 +19,7 @@ jest.mock('@grafana/runtime', () => ({
 }));
 
 setBackendSrv({
-  get: jest.fn().mockResolvedValue({}),
+  get: jest.fn().mockResolvedValue([]),
 } as any);
 
 describe('DashboardSettings', () => {

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.test.tsx
@@ -5,10 +5,15 @@ import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
 import { byRole } from 'testing-library-selector';
 
 import { selectors } from '@grafana/e2e-selectors';
+import { setBackendSrv } from '@grafana/runtime';
 
 import { DashboardModel } from '../../state';
 
 import { GeneralSettingsUnconnected as GeneralSettings, Props } from './GeneralSettings';
+
+setBackendSrv({
+  get: jest.fn().mockResolvedValue([]),
+} as any);
 
 const setupTestContext = (options: Partial<Props>) => {
   const defaults: Props = {


### PR DESCRIPTION
**What this PR does / why we need it**:

**tl;dr** don't use debounce with async functions if you care about the return result.

The Folder Picker component in the Dashboard Save component will not show the results for the current input if you type your search in quickly. You can reproduce this on [play.grafana.com](https://play.grafana.org/) by saving a new dashboard and in the folder picker _quickly_ type `iss`. The top result _should_ be "Replicating Issues", but its not. If you slowly type `iss`, then "Replicating Issues" will be the top issue as expected. The user's last input will essentially be discarded.

This issue is caused by debouncing `loadOptions` while trying to use its async return value. While the inner function will be called at the trailing end (for the user's last input), it will happen after the debounced function resolves, and because a function cannot return multiple times, the value is essentially discarded and never available for react-select. 

Here's a simplified timeline for the user searching for `Fo`(der)

 - User types `F`, search query is `F`
   - `debouncedFn(F)` is called by react-select. This triggers the 'leading' call
       - `fn(F)` is called and returns `searchResults<F>`
       - `debouncedFn(F)` returns `searchResults<F>`
   - react-select is showing results for `F`
 - User types `o` within the debounce period, search query is `Fo`
    - `debouncedFn(Fo)` is called by react-select
       - `fn` is _not_ called because we're within the debounce period
       - `debouncedFn(Fo)` returns `searchResults<F>`, from the previous call
   - react-select is showing results for `F`
 - User pauses input and causes the debounce period to expire
    - `fn(Fo)` is called by _lodash.debounce_. This is the 'trailing' call
       - `fn(Fo)` returns the results `searchResults<Fo>`
       - because all calls to `debouncedFn()` have already resolved, the return value from `fn(Fo)` cannot be returned from anywhere.
   - react-select is showing results for `F`

The solution is to not rely on the return value on the debounced function and instead pass a callback to `fn` so it can pass its value to react-select directly.