### PR TITLE
AzureMonitor: Clean namespace when changing the resource

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/setQueryValue.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/setQueryValue.test.ts
@@ -1,0 +1,31 @@
+import createMockQuery from '../../__mocks__/query';
+
+import { setResource } from './setQueryValue';
+
+describe('setResource', () => {
+  it('should set a resource URI', () => {
+    const q = setResource(createMockQuery(), '/new-uri');
+    expect(q.azureMonitor?.resourceUri).toEqual('/new-uri');
+  });
+
+  it('should remove clean up dependent fields', () => {
+    const q = createMockQuery();
+    expect(q.azureMonitor?.metricNamespace).not.toEqual(undefined);
+    expect(q.azureMonitor?.metricName).not.toEqual(undefined);
+    expect(q.azureMonitor?.metricDefinition).not.toEqual(undefined);
+    expect(q.azureMonitor?.aggregation).not.toEqual(undefined);
+    expect(q.azureMonitor?.metricDefinition).not.toEqual(undefined);
+    expect(q.azureMonitor?.metricDefinition).not.toEqual(undefined);
+    expect(q.azureMonitor?.timeGrain).not.toEqual('');
+    expect(q.azureMonitor?.timeGrain).not.toEqual([]);
+    const newQ = setResource(createMockQuery(), '/new-uri');
+    expect(newQ.azureMonitor).toMatchObject({
+      metricNamespace: undefined,
+      metricName: undefined,
+      aggregation: undefined,
+      metricDefinition: undefined,
+      timeGrain: '',
+      dimensionFilters: [],
+    });
+  });
+});

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/setQueryValue.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/setQueryValue.ts
@@ -9,6 +9,7 @@ export function setResource(query: AzureMonitorQuery, resourceURI: string | unde
       metricNamespace: undefined,
       metricName: undefined,
       aggregation: undefined,
+      metricDefinition: undefined,
       timeGrain: '',
       dimensionFilters: [],
     },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Closes #44394

When changing the resource URI in Azure Monitor Metrics, we were correctly removing the `metricNamespace` but there is some migration code that sets the namespace to the value of `metricDefinition` and we were not cleaning that one.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #44394

**Special notes for your reviewer**:

