### PR TITLE
Docs: add note on alerting limitation for being an alert receiver

### DIFF
--- a/docs/sources/alerting/alerting-limitations.md
+++ b/docs/sources/alerting/alerting-limitations.md
@@ -11,7 +11,7 @@ weight: 552
 
 Grafana alerting system can retrieve alerting and recording rules **stored** in most available Prometheus, Loki, Mimir and Alertmanager compatible data sources.
 
-It might not be able to fetch alerting rules from all other supported data sources at this time.
+It does not support reading or writing alerting rules from any other data sources but the ones previously mentioned at this time.
 
 ## Prometheus version support
 

--- a/docs/sources/alerting/alerting-limitations.md
+++ b/docs/sources/alerting/alerting-limitations.md
@@ -9,7 +9,7 @@ weight: 552
 
 ## Limited rule sources support
 
-Grafana alerting system can retrieve rules from all available Prometheus, Loki, Mimir and Alertmanager data sources.
+Grafana alerting system can retrieve alerting and recording rules **stored** in most available Prometheus, Loki, Mimir and Alertmanager compatible data sources.
 
 It might not be able to fetch alerting rules from all other supported data sources at this time.
 

--- a/docs/sources/alerting/alerting-limitations.md
+++ b/docs/sources/alerting/alerting-limitations.md
@@ -9,20 +9,20 @@ weight: 552
 
 ## Limited rule sources support
 
-Grafana alerting system can retrieve alerting and recording rules **stored** in most available Prometheus, Loki, Mimir and Alertmanager compatible data sources.
+Grafana Alerting can retrieve alerting and recording rules **stored** in most available Prometheus, Loki, Mimir, and Alertmanager compatible data sources.
 
 It does not support reading or writing alerting rules from any other data sources but the ones previously mentioned at this time.
 
 ## Prometheus version support
 
-We aim to support the latest two minor versions of both Prometheus and Alertmanager. We cannot guarantee that older versions will work.
+We support the latest two minor versions of both Prometheus and Alertmanager. We cannot guarantee that older versions will work.
 
 As an example, if the current Prometheus version is `2.31.1`, we support >= `2.29.0`.
 
 ## Grafana is not an alert receiver
 
-Grafana is not an alert receiver, is it an alert generator. This means that Grafana cannot receive alerts from anything other than its internal alert generator.
+Grafana is not an alert receiver; is it an alert generator. This means that Grafana cannot receive alerts from anything other than its internal alert generator.
 
 Receiving alerts from Prometheus (or anything else) is not supported at the time.
 
-Please see [this GitHub discussion](https://github.com/grafana/grafana/discussions/45773) for additional details.
+For more information, refer to [this GitHub discussion](https://github.com/grafana/grafana/discussions/45773).

--- a/docs/sources/alerting/alerting-limitations.md
+++ b/docs/sources/alerting/alerting-limitations.md
@@ -7,5 +7,22 @@ weight: 552
 
 # Limitations
 
-- Grafana alerting system can retrieve rules from all available Prometheus, Loki, and Alertmanager data sources. It might not be able to fetch alerting rules from all other supported data sources at this time.
-- We aim to support the latest two minor versions of both Prometheus and Alertmanager. We cannot guarantee that older versions will work. As an example, if the current Prometheus version is `2.31.1`, we support >= `2.29.0`.
+## Limited rule sources support
+
+Grafana alerting system can retrieve rules from all available Prometheus, Loki, Mimir and Alertmanager data sources.
+
+It might not be able to fetch alerting rules from all other supported data sources at this time.
+
+## Prometheus version support
+
+We aim to support the latest two minor versions of both Prometheus and Alertmanager. We cannot guarantee that older versions will work.
+
+As an example, if the current Prometheus version is `2.31.1`, we support >= `2.29.0`.
+
+## Grafana is not an alert receiver
+
+Grafana is not an alert receiver, is it an alert generator. This means that Grafana cannot receive alerts from anything other than its internal alert generator.
+
+Receiving alerts from Prometheus (or anything else) is not supported at the time.
+
+Please see [this GitHub discussion](https://github.com/grafana/grafana/discussions/45773) for additional details.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an additional clarification that Grafana is not an alert receiver and refers to [a GitHub discussion](https://github.com/grafana/grafana/discussions/45773) on that topic.

**Special notes for your reviewer**:

I also refactored the limitations somewhat, adding a heading so users can link to specific limitations and added Mimir to the list of supported rule sources.

