### PR TITLE
Alerting: replace a duplicated configuration key

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -844,7 +844,7 @@ min_interval = 10s
 [unified_alerting.screenshots]
 # Enable screenshots in notifications. This option requires a remote HTTP image rendering service. Please
 # see [rendering] for further configuration options.
-enabled =
+capture =
 
 # The maximum number of screenshots that can be taken at the same time. This option is different from
 # concurrent_render_request_limit as max_concurrent_screenshots sets the number of concurrent screenshots

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -844,7 +844,7 @@ min_interval = 10s
 [unified_alerting.screenshots]
 # Enable screenshots in notifications. This option requires a remote HTTP image rendering service. Please
 # see [rendering] for further configuration options.
-capture =
+capture = false
 
 # The maximum number of screenshots that can be taken at the same time. This option is different from
 # concurrent_render_request_limit as max_concurrent_screenshots sets the number of concurrent screenshots

--- a/pkg/services/ngalert/image/service.go
+++ b/pkg/services/ngalert/image/service.go
@@ -55,7 +55,7 @@ func NewScreenshotImageService(screenshots screenshot.ScreenshotService, store s
 // from the configuration.
 func NewScreenshotImageServiceFromCfg(cfg *setting.Cfg, metrics prometheus.Registerer,
 	db *store.DBstore, ds dashboards.DashboardService, rs rendering.Service) (ImageService, error) {
-	if !cfg.UnifiedAlerting.Screenshots.Enabled {
+	if !cfg.UnifiedAlerting.Screenshots.Capture {
 		return &ScreenshotImageService{
 			screenshots: &screenshot.ScreenshotUnavailableService{},
 		}, nil

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -48,7 +48,7 @@ const (
 	schedulereDefaultExecuteAlerts          = true
 	schedulerDefaultMaxAttempts             = 3
 	schedulerDefaultLegacyMinInterval       = 1
-	screenshotsDefaultEnabled               = false
+	screenshotsDefaultCapture               = false
 	screenshotsDefaultMaxConcurrent         = 5
 	screenshotsDefaultUploadImageStorage    = false
 	// SchedulerBaseInterval base interval of the scheduler. Controls how often the scheduler fetches database for new changes as well as schedules evaluation of a rule
@@ -84,7 +84,7 @@ type UnifiedAlertingSettings struct {
 }
 
 type UnifiedAlertingScreenshotSettings struct {
-	Enabled                    bool
+	Capture                    bool
 	MaxConcurrentScreenshots   int64
 	UploadExternalImageStorage bool
 }
@@ -260,7 +260,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	screenshots := iniFile.Section("unified_alerting.screenshots")
 	uaCfgScreenshots := uaCfg.Screenshots
 
-	uaCfgScreenshots.Enabled = screenshots.Key("enabled").MustBool(screenshotsDefaultEnabled)
+	uaCfgScreenshots.Capture = screenshots.Key("capture").MustBool(screenshotsDefaultCapture)
 	uaCfgScreenshots.MaxConcurrentScreenshots = screenshots.Key("max_concurrent_screenshots").MustInt64(screenshotsDefaultMaxConcurrent)
 	uaCfgScreenshots.UploadExternalImageStorage = screenshots.Key("upload_external_image_storage").MustBool(screenshotsDefaultUploadImageStorage)
 	uaCfg.Screenshots = uaCfgScreenshots


### PR DESCRIPTION
This PR renames the configuration key `enabled` to `capture`. This is needed as we already have a configuration key with the name `enabled`.

Fixes #50328 