### PR TITLE
loki: better error message when escaping is involved

### DIFF
--- a/public/app/plugins/datasource/loki/backendResultTransformer.ts
+++ b/public/app/plugins/datasource/loki/backendResultTransformer.ts
@@ -1,4 +1,4 @@
-import { DataQueryResponse, DataFrame, isDataFrame, FieldType, QueryResultMeta } from '@grafana/data';
+import { DataQueryResponse, DataFrame, isDataFrame, FieldType, QueryResultMeta, DataQueryError } from '@grafana/data';
 
 import { getDerivedFields } from './getDerivedFields';
 import { makeTableFrames } from './makeTableFrames';
@@ -101,12 +101,39 @@ function groupFrames(
   return { streamsFrames, metricInstantFrames, metricRangeFrames };
 }
 
+function improveError(error: DataQueryError | undefined, queryMap: Map<string, LokiQuery>): DataQueryError | undefined {
+  // many things are optional in an error-object, we need an error-message to exist,
+  // and we need to find the loki-query, based on the refId in the error-object.
+  if (error === undefined) {
+    return error;
+  }
+
+  const { refId, message } = error;
+  if (refId === undefined || message === undefined) {
+    return error;
+  }
+
+  const query = queryMap.get(refId);
+  if (query === undefined) {
+    return error;
+  }
+
+  if (message.includes('escape') && query.expr.includes('\\')) {
+    return {
+      ...error,
+      message: `${message}. Make sure that all special characters are escaped with \\. For more information on escaping of special characters visit LogQL documentation at https://grafana.com/docs/loki/latest/logql/.`,
+    };
+  }
+
+  return error;
+}
+
 export function transformBackendResult(
   response: DataQueryResponse,
   queries: LokiQuery[],
   derivedFieldConfigs: DerivedFieldConfig[]
 ): DataQueryResponse {
-  const { data, ...rest } = response;
+  const { data, error, ...rest } = response;
 
   // in the typescript type, data is an array of basically anything.
   // we do know that they have to be dataframes, so we make a quick check,
@@ -124,6 +151,7 @@ export function transformBackendResult(
 
   return {
     ...rest,
+    error: improveError(error, queryMap),
     data: [
       ...processMetricRangeFrames(metricRangeFrames),
       ...processMetricInstantFrames(metricInstantFrames),


### PR DESCRIPTION
this was done in the frontend-mode, we have to do it in backend-mode too.


how to test:
1. `make devenv sources=loki`
2. go to explore, run a query like `{place="g\arden"`
3. you should get an error-message that contains the phrase "For more information on escaping of special characters visit LogQL documentation"