### PR TITLE
Updating migration docs to include most relevant breaking changes

### DIFF
--- a/docs/sources/release-notes/release-notes-9-0-0-beta2.md
+++ b/docs/sources/release-notes/release-notes-9-0-0-beta2.md
@@ -83,6 +83,28 @@ module.exports.getWebpackConfig = (config, options) => ({
 
 Please refer to the webpack build error messages or the [official migration guide](https://webpack.js.org/migrate/5/) for assistance with fallbacks.
 
+**Which issue(s) this PR fixes**:
+
+<!--
+
+- Automatically closes linked issue when the Pull Request is merged.
+
+Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"
+
+-->
+
+Fixes #
+
+**Special notes for your reviewer**:
+
+It does not bump the following dependencies to the very latest due to the latest versions being ES modules:
+
+- ora
+- globby
+- execa
+- chalk
+  Issue [#47826](https://github.com/grafana/grafana/issues/47826)
+
 We have changed the internals of `backendSrv.fetch()` to throw an error when the response is an incorrect JSON.
 
 ```javascript

--- a/docs/sources/release-notes/release-notes-9-0-0-beta2.md
+++ b/docs/sources/release-notes/release-notes-9-0-0-beta2.md
@@ -83,28 +83,6 @@ module.exports.getWebpackConfig = (config, options) => ({
 
 Please refer to the webpack build error messages or the [official migration guide](https://webpack.js.org/migrate/5/) for assistance with fallbacks.
 
-**Which issue(s) this PR fixes**:
-
-<!--
-
-- Automatically closes linked issue when the Pull Request is merged.
-
-Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"
-
--->
-
-Fixes #
-
-**Special notes for your reviewer**:
-
-It does not bump the following dependencies to the very latest due to the latest versions being ES modules:
-
-- ora
-- globby
-- execa
-- chalk
-  Issue [#47826](https://github.com/grafana/grafana/issues/47826)
-
 We have changed the internals of `backendSrv.fetch()` to throw an error when the response is an incorrect JSON.
 
 ```javascript

--- a/docs/sources/whatsnew/whats-new-in-v9-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-0.md
@@ -215,6 +215,25 @@ In the InfluxDB data source, browser access mode was deprecated in grafana 8.0.0
 
 The rename by regex transformation has been improved to allow global patterns of the form `/<stringToReplace>/g`. Depending on the regex match used, this may cause some transformations to behave slightly differently. You can guarantee the same behavior as before by wrapping the match string in forward slashes (/), for example, (._) would become /(._)/. ([Github Issue #48179](https://github.com/grafana/grafana/pull/48179))
 
+### Clock Panel
+
+We have updated [clock panel](https://grafana.com/grafana/plugins/grafana-clock-panel/) to version `2.0.0` and encourage everyone to update as soon as possible. It will cause the Grafana to [crash](https://github.com/grafana/clock-panel/issues/106) when being used in a dashboard.
+
+### Plugins: Most relevant breaking changes
+
+- `getColorForTheme` was removed, use `theme.visualization.getColorByName` instead [PR #49519](https://github.com/grafana/grafana/pull/49519)
+- `TextDisplayOptions` was removed, use `VizTextDisplayOptions` instead [PR #49705](https://github.com/grafana/grafana/pull/49705)
+- We have changed the internals of `backendSrv.fetch()` to throw an error when the response is an incorrect JSON. Make sure to handle possible errors on the callsite where using `backendSrv.fetch()` (or any other `backendSrv` methods) [PR #47493](https://github.com/grafana/grafana/pull/47493)
+- We have removed the deprecated `getFormStyles` function from [grafana-ui](https://www.npmjs.com/package/@grafana/ui). Use `GrafanaTheme2` and the `useStyles2` hook instead [PR #49945](https://github.com/grafana/grafana/pull/49945)
+- We have removed the deprecated `/api/tsdb/query` metrics endpoint. Use `/api/ds/query` instead [PR #49916](https://github.com/grafana/grafana/pull/49916)
+
+You can find the complete list of breaking changes in the links below. Please check them out for more details and see if there is anything affecting your plugin
+
+- https://grafana.com/docs/grafana/next/release-notes/release-notes-9-0-0-beta1/
+- https://grafana.com/docs/grafana/next/release-notes/release-notes-9-0-0-beta2/
+- https://grafana.com/docs/grafana/next/release-notes/release-notes-9-0-0-beta3/
+- https://grafana.com/docs/grafana/next/release-notes/release-notes-9-0-0
+
 ## A note on Grafana Enterprise licensing
 
 When we release Grafana 9.0 on June 14th, Grafana will no longer enforce viewers and editor-admins differently. That means that regardless of whether your Grafana Enterprise license is tiered or combined, instead of seeing this on the Stats & Licensing page:

--- a/docs/sources/whatsnew/whats-new-in-v9-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-0.md
@@ -217,7 +217,7 @@ The rename by regex transformation has been improved to allow global patterns of
 
 ### Clock Panel
 
-We have updated [clock panel](https://grafana.com/grafana/plugins/grafana-clock-panel/) to version `2.0.0` and encourage everyone to update as soon as possible. It will cause the Grafana to [crash](https://github.com/grafana/clock-panel/issues/106) when being used in a dashboard.
+We have updated [clock panel](https://grafana.com/grafana/plugins/grafana-clock-panel/) to version `2.0.0` to make it Compatible with Grafana 9. The previous version `1.3.1` will cause the Grafana 9 to [crash](https://github.com/grafana/clock-panel/issues/106) when being used in a dashboard, we encourage you to update the panel before migrating to Grafana 9.
 
 ### Plugins: Most relevant breaking changes
 

--- a/docs/sources/whatsnew/whats-new-in-v9-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-0.md
@@ -226,6 +226,7 @@ We have updated [clock panel](https://grafana.com/grafana/plugins/grafana-clock-
 - We have changed the internals of `backendSrv.fetch()` to throw an error when the response is an incorrect JSON. Make sure to handle possible errors on the callsite where using `backendSrv.fetch()` (or any other `backendSrv` methods) [PR #47493](https://github.com/grafana/grafana/pull/47493)
 - We have removed the deprecated `getFormStyles` function from [grafana-ui](https://www.npmjs.com/package/@grafana/ui). Use `GrafanaTheme2` and the `useStyles2` hook instead [PR #49945](https://github.com/grafana/grafana/pull/49945)
 - We have removed the deprecated `/api/tsdb/query` metrics endpoint. Use `/api/ds/query` instead [PR #49916](https://github.com/grafana/grafana/pull/49916)
+- We have removed the deprecated `update` method from `LocationSrv`. Use `partial`, `push`, or `replace` instead [PR #50294](https://github.com/grafana/grafana/pull/50294)
 
 You can find the complete list of breaking changes in the links below. Please check them out for more details and see if there is anything affecting your plugin
 

--- a/docs/sources/whatsnew/whats-new-in-v9-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-0.md
@@ -226,7 +226,6 @@ We have updated [clock panel](https://grafana.com/grafana/plugins/grafana-clock-
 - We have changed the internals of `backendSrv.fetch()` to throw an error when the response is an incorrect JSON. Make sure to handle possible errors on the callsite where using `backendSrv.fetch()` (or any other `backendSrv` methods) [PR #47493](https://github.com/grafana/grafana/pull/47493)
 - We have removed the deprecated `getFormStyles` function from [grafana-ui](https://www.npmjs.com/package/@grafana/ui). Use `GrafanaTheme2` and the `useStyles2` hook instead [PR #49945](https://github.com/grafana/grafana/pull/49945)
 - We have removed the deprecated `/api/tsdb/query` metrics endpoint. Use `/api/ds/query` instead [PR #49916](https://github.com/grafana/grafana/pull/49916)
-- We have removed the deprecated `update` method from `LocationSrv`. Use `partial`, `push`, or `replace` instead [PR #50294](https://github.com/grafana/grafana/pull/50294)
 
 You can find the complete list of breaking changes in the links below. Please check them out for more details and see if there is anything affecting your plugin
 


### PR DESCRIPTION
Adding documentation about most relevant breaking changes for plugin authors.

**Additional changes**
- Update the beta2 change log as the auto-generated parts of it does not seem to read well.