### PR TITLE
Alerting: Bump provisioning to admin-only in lieu of dedicated RBAC permissions

### DIFF
--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -186,7 +186,7 @@ func (api *API) authorize(method, path string) web.Handler {
 		http.MethodGet + "/api/v1/provisioning/mute-timings",
 		http.MethodGet + "/api/v1/provisioning/mute-timings/{name}",
 		http.MethodGet + "/api/v1/provisioning/alert-rules/{UID}":
-		return middleware.ReqSignedIn
+		return middleware.ReqOrgAdmin
 
 	case http.MethodPut + "/api/v1/provisioning/policies",
 		http.MethodPost + "/api/v1/provisioning/contact-points",
@@ -201,7 +201,7 @@ func (api *API) authorize(method, path string) web.Handler {
 		http.MethodPut + "/api/v1/provisioning/alert-rules/{UID}",
 		http.MethodDelete + "/api/v1/provisioning/alert-rules/{UID}",
 		http.MethodPut + "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}":
-		return middleware.ReqEditorRole
+		return middleware.ReqOrgAdmin
 	}
 
 	if eval != nil {

--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -64,24 +64,24 @@ func TestProvisioning(t *testing.T) {
 			require.Equal(t, 401, resp.StatusCode)
 		})
 
-		t.Run("viewer GET should succeed", func(t *testing.T) {
+		t.Run("viewer GET should 403", func(t *testing.T) {
 			req := createTestRequest("GET", url, "viewer", "")
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
 			require.NoError(t, resp.Body.Close())
 
-			require.Equal(t, 200, resp.StatusCode)
+			require.Equal(t, 403, resp.StatusCode)
 		})
 
-		t.Run("editor GET should succeed", func(t *testing.T) {
+		t.Run("editor GET should 403", func(t *testing.T) {
 			req := createTestRequest("GET", url, "editor", "")
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
 			require.NoError(t, resp.Body.Close())
 
-			require.Equal(t, 200, resp.StatusCode)
+			require.Equal(t, 403, resp.StatusCode)
 		})
 
 		t.Run("admin GET should succeed", func(t *testing.T) {
@@ -114,14 +114,14 @@ func TestProvisioning(t *testing.T) {
 			require.Equal(t, 403, resp.StatusCode)
 		})
 
-		t.Run("editor PUT should succeed", func(t *testing.T) {
+		t.Run("editor PUT should 403", func(t *testing.T) {
 			req := createTestRequest("PUT", url, "editor", body)
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
 			require.NoError(t, resp.Body.Close())
 
-			require.Equal(t, 202, resp.StatusCode)
+			require.Equal(t, 403, resp.StatusCode)
 		})
 
 		t.Run("admin PUT should succeed", func(t *testing.T) {
@@ -157,24 +157,24 @@ func TestProvisioning(t *testing.T) {
 			require.Equal(t, 401, resp.StatusCode)
 		})
 
-		t.Run("viewer GET should succeed", func(t *testing.T) {
+		t.Run("viewer GET should 403", func(t *testing.T) {
 			req := createTestRequest("GET", url, "viewer", "")
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
 			require.NoError(t, resp.Body.Close())
 
-			require.Equal(t, 200, resp.StatusCode)
+			require.Equal(t, 403, resp.StatusCode)
 		})
 
-		t.Run("editor GET should succeed", func(t *testing.T) {
+		t.Run("editor GET should 403", func(t *testing.T) {
 			req := createTestRequest("GET", url, "editor", "")
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
 			require.NoError(t, resp.Body.Close())
 
-			require.Equal(t, 200, resp.StatusCode)
+			require.Equal(t, 403, resp.StatusCode)
 		})
 
 		t.Run("admin GET should succeed", func(t *testing.T) {
@@ -207,14 +207,14 @@ func TestProvisioning(t *testing.T) {
 			require.Equal(t, 403, resp.StatusCode)
 		})
 
-		t.Run("editor POST should succeed", func(t *testing.T) {
+		t.Run("editor POST should 403", func(t *testing.T) {
 			req := createTestRequest("POST", url, "editor", body)
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
 			require.NoError(t, resp.Body.Close())
 
-			require.Equal(t, 202, resp.StatusCode)
+			require.Equal(t, 403, resp.StatusCode)
 		})
 
 		t.Run("admin POST should succeed", func(t *testing.T) {
@@ -241,24 +241,24 @@ func TestProvisioning(t *testing.T) {
 			require.Equal(t, 401, resp.StatusCode)
 		})
 
-		t.Run("viewer GET should succeed", func(t *testing.T) {
+		t.Run("viewer GET should 403", func(t *testing.T) {
 			req := createTestRequest("GET", url, "viewer", "")
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
 			require.NoError(t, resp.Body.Close())
 
-			require.Equal(t, 200, resp.StatusCode)
+			require.Equal(t, 403, resp.StatusCode)
 		})
 
-		t.Run("editor GET should succeed", func(t *testing.T) {
+		t.Run("editor GET should 403", func(t *testing.T) {
 			req := createTestRequest("GET", url, "editor", "")
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
 			require.NoError(t, resp.Body.Close())
 
-			require.Equal(t, 200, resp.StatusCode)
+			require.Equal(t, 403, resp.StatusCode)
 		})
 
 		t.Run("admin GET should succeed", func(t *testing.T) {
@@ -285,24 +285,24 @@ func TestProvisioning(t *testing.T) {
 			require.Equal(t, 401, resp.StatusCode)
 		})
 
-		t.Run("viewer GET should succeed", func(t *testing.T) {
+		t.Run("viewer GET should 403", func(t *testing.T) {
 			req := createTestRequest("GET", url, "viewer", "")
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
 			require.NoError(t, resp.Body.Close())
 
-			require.Equal(t, 200, resp.StatusCode)
+			require.Equal(t, 403, resp.StatusCode)
 		})
 
-		t.Run("editor GET should succeed", func(t *testing.T) {
+		t.Run("editor GET should 403", func(t *testing.T) {
 			req := createTestRequest("GET", url, "editor", "")
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
 			require.NoError(t, resp.Body.Close())
 
-			require.Equal(t, 200, resp.StatusCode)
+			require.Equal(t, 403, resp.StatusCode)
 		})
 
 		t.Run("admin GET should succeed", func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Alert rule creation has a separate mechanism of auth checks underneath the scoped RBAC auth on the alert resource - that is to say, it is also manually reaches out and performs RBAC checks underneath this against several other resources.

Provisioning routes use legacy Editor permissions, which doesn't match this more complex check in the event of certain custom configurations on folders.

The ideal for provisioning is to have a dedicated set of RBAC roles, but we'd like to introduce that in the future. For now, change them to admin-only. This is consistent with how the routes are intended to be used, anyway.

