### PR TITLE
Loki: Fix issues with using query patterns

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.test.ts
@@ -73,7 +73,7 @@ describe('LokiQueryModeller', () => {
         labels: [{ label: 'app', op: '=', value: 'grafana' }],
         operations: [{ id: LokiOperationId.LineContains, params: [''] }],
       })
-    ).toBe('{app="grafana"}');
+    ).toBe('{app="grafana"} |= ``');
   });
 
   it('Can query with line filter contains not operation', () => {

--- a/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
@@ -40,11 +40,6 @@ export class LokiQueryModeller extends LokiAndPromQueryModellerBase {
         name: 'Log query with filtering and parsing',
         // {} |= `` | logfmt | __error__=``
         operations: [
-          // Line contains is an issue, because if it is empty, we don't add
-          // it to expr and then it doesn't appear in model.
-          // Should we add there something?
-          // Should we always render it (only not if it is the only thing in query)
-          // Should we always render it?
           { id: LokiOperationId.LineContains, params: [''] },
           { id: LokiOperationId.Logfmt, params: [] },
           { id: LokiOperationId.LabelFilterNoErrors, params: [] },
@@ -99,11 +94,9 @@ export class LokiQueryModeller extends LokiAndPromQueryModellerBase {
           { id: LokiOperationId.LineContains, params: [''] },
           { id: LokiOperationId.Logfmt, params: [] },
           { id: LokiOperationId.LabelFilterNoErrors, params: [] },
-          { id: LokiOperationId.Unwrap, params: [] },
+          { id: LokiOperationId.Unwrap, params: [''] },
           { id: LokiOperationId.LabelFilterNoErrors, params: [] },
           { id: LokiOperationId.SumOverTime, params: ['$__interval'] },
-          // Should we add here any example label
-          // then we need to rename it to __sum_by
           { id: LokiOperationId.Sum, params: [] },
         ],
       },
@@ -113,7 +106,7 @@ export class LokiQueryModeller extends LokiAndPromQueryModellerBase {
         operations: [
           { id: LokiOperationId.LineContains, params: [''] },
           { id: LokiOperationId.CountOverTime, params: ['$__interval'] },
-          { id: LokiOperationId.Sum, params: ['label'] },
+          { id: LokiOperationId.Sum, params: [] },
         ],
       },
       {

--- a/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.ts
@@ -40,6 +40,11 @@ export class LokiQueryModeller extends LokiAndPromQueryModellerBase {
         name: 'Log query with filtering and parsing',
         // {} |= `` | logfmt | __error__=``
         operations: [
+          // Line contains is an issue, because if it is empty, we don't add
+          // it to expr and then it doesn't appear in model.
+          // Should we add there something?
+          // Should we always render it (only not if it is the only thing in query)
+          // Should we always render it?
           { id: LokiOperationId.LineContains, params: [''] },
           { id: LokiOperationId.Logfmt, params: [] },
           { id: LokiOperationId.LabelFilterNoErrors, params: [] },
@@ -97,6 +102,8 @@ export class LokiQueryModeller extends LokiAndPromQueryModellerBase {
           { id: LokiOperationId.Unwrap, params: [] },
           { id: LokiOperationId.LabelFilterNoErrors, params: [] },
           { id: LokiOperationId.SumOverTime, params: ['$__interval'] },
+          // Should we add here any example label
+          // then we need to rename it to __sum_by
           { id: LokiOperationId.Sum, params: [] },
         ],
       },
@@ -149,7 +156,7 @@ export class LokiQueryModeller extends LokiAndPromQueryModellerBase {
       },
       {
         name: 'Metrics query for extracted quantile',
-        // quantile_over_time(0.99,{} | logfmt | unwrap latency[$__interval]) by ()
+        // quantile_over_time(0.5,{} | logfmt | unwrap latency[$__interval]) by ()
         operations: [
           { id: LokiOperationId.Logfmt, params: [] },
           { id: LokiOperationId.LabelFilterNoErrors, params: [] },

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -400,9 +400,6 @@ function operationWithRangeVectorRendererAndParam(
 
 function getLineFilterRenderer(operation: string) {
   return function lineFilterRenderer(model: QueryBuilderOperation, def: QueryBuilderOperationDef, innerExpr: string) {
-    if (model.params[0] === '') {
-      return innerExpr;
-    }
     return `${innerExpr} ${operation} \`${model.params[0]}\``;
   };
 }

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -374,6 +374,29 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
+  it('parses metrics query with vector aggregation with number', () => {
+    expect(
+      buildVisualQueryFromString('topk(10, sum(count_over_time({app="frontend"} | logfmt | __error__=`` [5m])))')
+    ).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [
+          { id: 'logfmt', params: [] },
+          { id: '__label_filter_no_errors', params: [] },
+          { id: 'count_over_time', params: ['5m'] },
+          { id: 'sum', params: [] },
+          { id: 'topk', params: [10] },
+        ],
+      })
+    );
+  });
+
   it('parses template variables in strings', () => {
     expect(buildVisualQueryFromString('{instance="$label_variable"}')).toEqual(
       noErrors({

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -360,7 +360,15 @@ function handleVectorAggregation(expr: string, node: SyntaxNode, context: Contex
   let funcName = getString(expr, nameNode);
 
   const grouping = node.getChild('Grouping');
-  const labels: string[] = [];
+  const params = [];
+
+  const numberNode = node.getChild('Number');
+
+  if (numberNode) {
+    params.push(getString(expr, numberNode));
+  }
+
+  console.log(grouping);
 
   if (grouping) {
     const byModifier = grouping.getChild(`By`);
@@ -373,11 +381,11 @@ function handleVectorAggregation(expr: string, node: SyntaxNode, context: Contex
       funcName = `__${funcName}_without`;
     }
 
-    labels.push(...getAllByType(expr, grouping, 'Identifier'));
+    params.push(...getAllByType(expr, grouping, 'Identifier'));
   }
 
   const metricExpr = node.getChild('MetricExpr');
-  const op: QueryBuilderOperation = { id: funcName, params: labels };
+  const op: QueryBuilderOperation = { id: funcName, params };
 
   if (metricExpr) {
     handleExpression(expr, metricExpr, context);

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -365,7 +365,7 @@ function handleVectorAggregation(expr: string, node: SyntaxNode, context: Contex
   const numberNode = node.getChild('Number');
 
   if (numberNode) {
-    params.push(getString(expr, numberNode));
+    params.push(Number(getString(expr, numberNode)));
   }
 
   if (grouping) {

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -368,8 +368,6 @@ function handleVectorAggregation(expr: string, node: SyntaxNode, context: Contex
     params.push(getString(expr, numberNode));
   }
 
-  console.log(grouping);
-
   if (grouping) {
     const byModifier = grouping.getChild(`By`);
     if (byModifier && funcName) {


### PR DESCRIPTION
**What this PR does / why we need it**:
There were couple issues related to query patterns:
1. `topk` aggregation didn't have parsing for its number parameter
2. `line contains` wasn't shown because it has empty string
This PR fixes both cases
