### PR TITLE
Instrumentation: Convert some metrics to histograms

### DIFF
--- a/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
+++ b/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
@@ -7,51 +7,47 @@ import (
 	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-var datasourceRequestCounter = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Namespace: "grafana",
-		Name:      "datasource_request_total",
-		Help:      "A counter for outgoing requests for a datasource",
-	},
-	[]string{"datasource", "code", "method"},
-)
+var (
+	datasourceRequestCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "grafana",
+			Name:      "datasource_request_total",
+			Help:      "A counter for outgoing requests for a data source",
+		},
+		[]string{"datasource", "code", "method"},
+	)
 
-var datasourceRequestSummary = prometheus.NewSummaryVec(
-	prometheus.SummaryOpts{
-		Namespace:  "grafana",
-		Name:       "datasource_request_duration_seconds",
-		Help:       "summary of outgoing datasource requests sent from Grafana",
-		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
-	}, []string{"datasource", "code", "method"},
-)
+	datasourceRequestHistogram = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "grafana",
+			Name:      "datasource_request_duration_seconds",
+			Help:      "summary of outgoing data source requests sent from Grafana",
+			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50, 100},
+		}, []string{"datasource", "code", "method"},
+	)
 
-var datasourceResponseSummary = prometheus.NewSummaryVec(
-	prometheus.SummaryOpts{
-		Namespace:  "grafana",
-		Name:       "datasource_response_size_bytes",
-		Help:       "summary of datasource response sizes returned to Grafana",
-		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
-	}, []string{"datasource"},
-)
+	datasourceResponseHistogram = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "grafana",
+			Name:      "datasource_response_size_bytes",
+			Help:      "summary of data source response sizes returned to Grafana",
+			Buckets:   []float64{128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576},
+		}, []string{"datasource"},
+	)
 
-var datasourceRequestsInFlight = prometheus.NewGaugeVec(
-	prometheus.GaugeOpts{
-		Namespace: "grafana",
-		Name:      "datasource_request_in_flight",
-		Help:      "A gauge of outgoing datasource requests currently being sent by Grafana",
-	},
-	[]string{"datasource"},
+	datasourceRequestsInFlight = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "grafana",
+			Name:      "datasource_request_in_flight",
+			Help:      "A gauge of outgoing data source requests currently being sent by Grafana",
+		},
+		[]string{"datasource"},
+	)
 )
-
-func init() {
-	prometheus.MustRegister(datasourceRequestSummary,
-		datasourceRequestCounter,
-		datasourceRequestsInFlight,
-		datasourceResponseSummary)
-}
 
 const DataSourceMetricsMiddlewareName = "metrics"
 
@@ -84,11 +80,11 @@ func DataSourceMetricsMiddleware() sdkhttpclient.Middleware {
 func executeMiddleware(next http.RoundTripper, datasourceLabel prometheus.Labels) http.RoundTripper {
 	return sdkhttpclient.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 		requestCounter := datasourceRequestCounter.MustCurryWith(datasourceLabel)
-		requestSummary := datasourceRequestSummary.MustCurryWith(datasourceLabel)
+		requestHistogram := datasourceRequestHistogram.MustCurryWith(datasourceLabel)
 		requestInFlight := datasourceRequestsInFlight.With(datasourceLabel)
-		responseSizeSummary := datasourceResponseSummary.With(datasourceLabel)
+		responseSizeHistogram := datasourceResponseHistogram.With(datasourceLabel)
 
-		res, err := promhttp.InstrumentRoundTripperDuration(requestSummary,
+		res, err := promhttp.InstrumentRoundTripperDuration(requestHistogram,
 			promhttp.InstrumentRoundTripperCounter(requestCounter,
 				promhttp.InstrumentRoundTripperInFlight(requestInFlight, next))).
 			RoundTrip(r)
@@ -98,7 +94,7 @@ func executeMiddleware(next http.RoundTripper, datasourceLabel prometheus.Labels
 
 		if res != nil && res.StatusCode != http.StatusSwitchingProtocols {
 			res.Body = httpclient.CountBytesReader(res.Body, func(bytesRead int64) {
-				responseSizeSummary.Observe(float64(bytesRead))
+				responseSizeHistogram.Observe(float64(bytesRead))
 			})
 		}
 

--- a/pkg/plugins/backendplugin/instrumentation/instrumentation.go
+++ b/pkg/plugins/backendplugin/instrumentation/instrumentation.go
@@ -5,29 +5,23 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 var (
-	pluginRequestCounter  *prometheus.CounterVec
-	pluginRequestDuration *prometheus.SummaryVec
-)
-
-func init() {
-	pluginRequestCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	pluginRequestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "grafana",
 		Name:      "plugin_request_total",
 		Help:      "The total amount of plugin requests",
 	}, []string{"plugin_id", "endpoint", "status"})
 
-	pluginRequestDuration = prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Namespace:  "grafana",
-		Name:       "plugin_request_duration_milliseconds",
-		Help:       "Plugin request duration",
-		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	pluginRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "grafana",
+		Name:      "plugin_request_duration_milliseconds",
+		Help:      "Plugin request duration",
+		Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50, 100},
 	}, []string{"plugin_id", "endpoint"})
-
-	prometheus.MustRegister(pluginRequestCounter, pluginRequestDuration)
-}
+)
 
 // instrumentPluginRequest instruments success rate and latency of `fn`
 func instrumentPluginRequest(pluginID string, endpoint string, fn func() error) error {

--- a/pkg/services/ngalert/metrics/ngalert.go
+++ b/pkg/services/ngalert/metrics/ngalert.go
@@ -50,7 +50,7 @@ type Scheduler struct {
 	BehindSeconds                       prometheus.Gauge
 	EvalTotal                           *prometheus.CounterVec
 	EvalFailures                        *prometheus.CounterVec
-	EvalDuration                        *prometheus.SummaryVec
+	EvalDuration                        *prometheus.HistogramVec
 	SchedulePeriodicDuration            prometheus.Histogram
 	SchedulableAlertRules               prometheus.Gauge
 	SchedulableAlertRulesHash           prometheus.Gauge
@@ -156,13 +156,13 @@ func newSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 			},
 			[]string{"org"},
 		),
-		EvalDuration: promauto.With(r).NewSummaryVec(
-			prometheus.SummaryOpts{
-				Namespace:  Namespace,
-				Subsystem:  Subsystem,
-				Name:       "rule_evaluation_duration_seconds",
-				Help:       "The duration for a rule to execute.",
-				Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		EvalDuration: promauto.With(r).NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "rule_evaluation_duration_seconds",
+				Help:      "The duration for a rule to execute.",
+				Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50, 100},
 			},
 			[]string{"org"},
 		),

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -441,10 +441,22 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 				// duration metric has 0 values because of mocked clock that do not advance
 				expectedMetric := fmt.Sprintf(
 					`# HELP grafana_alerting_rule_evaluation_duration_seconds The duration for a rule to execute.
-        	            	# TYPE grafana_alerting_rule_evaluation_duration_seconds summary
-        	            	grafana_alerting_rule_evaluation_duration_seconds{org="%[1]d",quantile="0.5"} 0
-        	            	grafana_alerting_rule_evaluation_duration_seconds{org="%[1]d",quantile="0.9"} 0
-        	            	grafana_alerting_rule_evaluation_duration_seconds{org="%[1]d",quantile="0.99"} 0
+        	            	# TYPE grafana_alerting_rule_evaluation_duration_seconds histogram
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.005"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.01"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.025"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.05"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.1"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.25"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="0.5"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="1"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="2.5"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="5"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="10"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="25"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="50"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="100"} 1
+        	            	grafana_alerting_rule_evaluation_duration_seconds_bucket{org="%[1]d",le="+Inf"} 1
         	            	grafana_alerting_rule_evaluation_duration_seconds_sum{org="%[1]d"} 0
         	            	grafana_alerting_rule_evaluation_duration_seconds_count{org="%[1]d"} 1
 							# HELP grafana_alerting_rule_evaluation_failures_total The total number of rule evaluation failures.


### PR DESCRIPTION
Because summary metrics cannot be aggregated, convert them to histograms
so that users with HA deployments can use these metrics.

Signed-off-by: SuperQ <superq@gmail.com>

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

[Edit: Ursula checked if "can not" was accurate. It was not. Changed to "cannot".]

# Release notice breaking change

The following metrics have been converted to histograms:
- grafana_datasource_request_total
- grafana_datasource_request_duration_seconds
- grafana_datasource_response_size_bytes
- grafana_datasource_request_in_flight
- grafana_plugin_request_duration_milliseconds
- grafana_alerting_rule_evaluation_duration_seconds