### PR TITLE
Fix metric names for screenshots

### DIFF
--- a/pkg/services/screenshot/screenshot.go
+++ b/pkg/services/screenshot/screenshot.go
@@ -322,12 +322,12 @@ func NewUploadingScreenshotService(r prometheus.Registerer, service ScreenshotSe
 		service:  service,
 		uploader: uploader,
 		uploadFailures: promauto.With(r).NewCounter(prometheus.CounterOpts{
-			Name:      "upload_failures",
+			Name:      "upload_failures_total",
 			Namespace: namespace,
 			Subsystem: subsystem,
 		}),
 		uploadSuccesses: promauto.With(r).NewCounter(prometheus.CounterOpts{
-			Name:      "upload_successes",
+			Name:      "upload_successes_total",
 			Namespace: namespace,
 			Subsystem: subsystem,
 		}),


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes missing `_total` in two screenshot metrics:

- `grafana_screenshot_upload_failures_total`
- `grafana_screenshot_upload_successes_total`

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

