### PR TITLE
Alerting: Fix force_migration when alerting is disabled

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -75,7 +75,7 @@ func AddDashAlertMigration(mg *migrator.Migrator) {
 		})
 	// If unified alerting is disabled and upgrade migration has been run
 	case !mg.Cfg.UnifiedAlerting.IsEnabled() && migrationRun:
-		// If legacy alertung is also disabled, there is nothing to do
+		// If legacy alerting is also disabled, there is nothing to do
 		if setting.AlertingEnabled != nil && !*setting.AlertingEnabled {
 			return
 		}

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -59,6 +59,7 @@ func AddDashAlertMigration(mg *migrator.Migrator) {
 	_, migrationRun := logs[migTitle]
 
 	switch {
+	// If unified alerting is enabled and the upgrade migration has not been run
 	case mg.Cfg.UnifiedAlerting.IsEnabled() && !migrationRun:
 		// Remove the migration entry that removes all unified alerting data. This is so when the feature
 		// flag is removed in future the "remove unified alerting data" migration will be run again.
@@ -72,7 +73,13 @@ func AddDashAlertMigration(mg *migrator.Migrator) {
 			seenChannelUIDs: make(map[string]struct{}),
 			silences:        make(map[int64][]*pb.MeshSilence),
 		})
+	// If unified alerting is disabled and upgrade migration has been run
 	case !mg.Cfg.UnifiedAlerting.IsEnabled() && migrationRun:
+		// If LA is also disabled then there is nothing to do
+		if setting.AlertingEnabled != nil && !*setting.AlertingEnabled {
+			return
+		}
+
 		// Safeguard to prevent data loss when migrating from UA to LA
 		if !mg.Cfg.ForceMigration {
 			panic("New alert rules created while using unified alerting will be deleted, set force_migration=true in your grafana.ini and try again if this is okay.")

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -75,7 +75,7 @@ func AddDashAlertMigration(mg *migrator.Migrator) {
 		})
 	// If unified alerting is disabled and upgrade migration has been run
 	case !mg.Cfg.UnifiedAlerting.IsEnabled() && migrationRun:
-		// If LA is also disabled then there is nothing to do
+		// If legacy alertung is also disabled, there is nothing to do
 		if setting.AlertingEnabled != nil && !*setting.AlertingEnabled {
 			return
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes a bug where force_migration must be set to `true` when both unified and legacy alerting is disabled.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

