### PR TITLE
CloudMonitoring: Migrate query editor to use new UI

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/Aggregation.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Aggregation.tsx
@@ -1,12 +1,11 @@
 import React, { FC, useMemo } from 'react';
 
 import { SelectableValue } from '@grafana/data';
+import { EditorField } from '@grafana/experimental';
 import { Select } from '@grafana/ui';
 
 import { getAggregationOptionsByMetric } from '../functions';
 import { MetricDescriptor, MetricKind, ValueTypes } from '../types';
-
-import { QueryEditorField } from '.';
 
 export interface Props {
   refId: string;
@@ -22,12 +21,7 @@ export const Aggregation: FC<Props> = (props) => {
   const selected = useSelectedFromOptions(aggOptions, props);
 
   return (
-    <QueryEditorField
-      labelWidth={18}
-      label="Group by function"
-      data-testid="cloud-monitoring-aggregation"
-      htmlFor={`${props.refId}-group-by-function`}
-    >
+    <EditorField width={18} label="Group by function" data-testid="cloud-monitoring-aggregation">
       <Select
         width={16}
         onChange={({ value }) => props.onChange(value!)}
@@ -46,7 +40,7 @@ export const Aggregation: FC<Props> = (props) => {
         placeholder="Select Reducer"
         inputId={`${props.refId}-group-by-function`}
       />
-    </QueryEditorField>
+    </EditorField>
   );
 };
 

--- a/public/app/plugins/datasource/cloud-monitoring/components/Aggregation.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Aggregation.tsx
@@ -4,6 +4,7 @@ import { SelectableValue } from '@grafana/data';
 import { EditorField } from '@grafana/experimental';
 import { Select } from '@grafana/ui';
 
+import { LABEL_WIDTH, SELECT_WIDTH } from '../constants';
 import { getAggregationOptionsByMetric } from '../functions';
 import { MetricDescriptor, MetricKind, ValueTypes } from '../types';
 
@@ -21,9 +22,9 @@ export const Aggregation: FC<Props> = (props) => {
   const selected = useSelectedFromOptions(aggOptions, props);
 
   return (
-    <EditorField width={18} label="Group by function" data-testid="cloud-monitoring-aggregation">
+    <EditorField width={LABEL_WIDTH} label="Group by function" data-testid="cloud-monitoring-aggregation">
       <Select
-        width={16}
+        width={SELECT_WIDTH}
         onChange={({ value }) => props.onChange(value!)}
         value={selected}
         options={[

--- a/public/app/plugins/datasource/cloud-monitoring/components/AliasBy.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/AliasBy.tsx
@@ -1,11 +1,10 @@
 import { debounce } from 'lodash';
 import React, { FunctionComponent, useState } from 'react';
 
+import { EditorRow, EditorField } from '@grafana/experimental';
 import { Input } from '@grafana/ui';
 
 import { INPUT_WIDTH } from '../constants';
-
-import { QueryEditorRow } from '.';
 
 export interface Props {
   refId: string;
@@ -24,8 +23,10 @@ export const AliasBy: FunctionComponent<Props> = ({ refId, value = '', onChange 
   };
 
   return (
-    <QueryEditorRow label="Alias by" htmlFor={`${refId}-alias-by`}>
-      <Input id={`${refId}-alias-by`} width={INPUT_WIDTH} value={alias} onChange={onChange} />
-    </QueryEditorRow>
+    <EditorRow>
+      <EditorField label="Alias by">
+        <Input id={`${refId}-alias-by`} width={INPUT_WIDTH} value={alias} onChange={onChange} />
+      </EditorField>
+    </EditorRow>
   );
 };

--- a/public/app/plugins/datasource/cloud-monitoring/components/Alignment.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Alignment.tsx
@@ -1,12 +1,13 @@
 import React, { FC } from 'react';
 
 import { SelectableValue } from '@grafana/data';
+import { EditorRow, EditorField, EditorFieldGroup, Stack } from '@grafana/experimental';
 
 import { ALIGNMENT_PERIODS, SELECT_WIDTH } from '../constants';
 import CloudMonitoringDatasource from '../datasource';
 import { CustomMetaData, MetricQuery, SLOQuery } from '../types';
 
-import { AlignmentFunction, PeriodSelect, AlignmentPeriodLabel, QueryEditorField, QueryEditorRow } from '.';
+import { AlignmentFunction, PeriodSelect, AlignmentPeriodLabel } from '.';
 
 export interface Props {
   refId: string;
@@ -26,28 +27,33 @@ export const Alignment: FC<Props> = ({
   datasource,
 }) => {
   return (
-    <QueryEditorRow
-      label="Alignment function"
-      tooltip="The process of alignment consists of collecting all data points received in a fixed length of time, applying a function to combine those data points, and assigning a timestamp to the result."
-      fillComponent={<AlignmentPeriodLabel datasource={datasource} customMetaData={customMetaData} />}
-      htmlFor={`${refId}-alignment-function`}
-    >
-      <AlignmentFunction
-        inputId={`${refId}-alignment-function`}
-        templateVariableOptions={templateVariableOptions}
-        query={query}
-        onChange={onChange}
-      />
-      <QueryEditorField label="Alignment period" htmlFor={`${refId}-alignment-period`}>
-        <PeriodSelect
-          inputId={`${refId}-alignment-period`}
-          selectWidth={SELECT_WIDTH}
-          templateVariableOptions={templateVariableOptions}
-          current={query.alignmentPeriod}
-          onChange={(period) => onChange({ ...query, alignmentPeriod: period })}
-          aligmentPeriods={ALIGNMENT_PERIODS}
-        />
-      </QueryEditorField>
-    </QueryEditorRow>
+    <EditorRow>
+      <EditorFieldGroup>
+        <EditorField
+          label="Alignment function"
+          tooltip="The process of alignment consists of collecting all data points received in a fixed length of time, applying a function to combine those data points, and assigning a timestamp to the result."
+        >
+          <AlignmentFunction
+            inputId={`${refId}-alignment-function`}
+            templateVariableOptions={templateVariableOptions}
+            query={query}
+            onChange={onChange}
+          />
+        </EditorField>
+        <EditorField label="Alignment period">
+          <PeriodSelect
+            inputId={`${refId}-alignment-period`}
+            selectWidth={SELECT_WIDTH}
+            templateVariableOptions={templateVariableOptions}
+            current={query.alignmentPeriod}
+            onChange={(period) => onChange({ ...query, alignmentPeriod: period })}
+            aligmentPeriods={ALIGNMENT_PERIODS}
+          />
+        </EditorField>
+        <Stack alignItems="flex-end">
+          <AlignmentPeriodLabel datasource={datasource} customMetaData={customMetaData} />
+        </Stack>
+      </EditorFieldGroup>
+    </EditorRow>
   );
 };

--- a/public/app/plugins/datasource/cloud-monitoring/components/AlignmentPeriodLabel.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/AlignmentPeriodLabel.tsx
@@ -1,6 +1,8 @@
+import { css } from '@emotion/css';
 import React, { FC, useMemo } from 'react';
 
-import { rangeUtil } from '@grafana/data';
+import { rangeUtil, GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
 
 import { ALIGNMENTS } from '../constants';
 import CloudMonitoringDatasource from '../datasource';
@@ -13,6 +15,7 @@ export interface Props {
 
 export const AlignmentPeriodLabel: FC<Props> = ({ customMetaData, datasource }) => {
   const { perSeriesAligner, alignmentPeriod } = customMetaData;
+  const styles = useStyles2(getStyles);
   const formatAlignmentText = useMemo(() => {
     if (!alignmentPeriod || !perSeriesAligner) {
       return '';
@@ -24,5 +27,12 @@ export const AlignmentPeriodLabel: FC<Props> = ({ customMetaData, datasource }) 
     return `${hms} interval (${alignment?.text ?? ''})`;
   }, [datasource, perSeriesAligner, alignmentPeriod]);
 
-  return <label>{formatAlignmentText}</label>;
+  return <label className={styles.label}>{formatAlignmentText}</label>;
 };
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  label: css({
+    fontSize: 12,
+    fontWeight: theme.typography.fontWeightMedium,
+  }),
+});

--- a/public/app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useDebounce } from 'react-use';
 
 import { QueryEditorProps, toOption } from '@grafana/data';
+import { EditorRow, EditorField } from '@grafana/experimental';
 import { Input } from '@grafana/ui';
 
 import { INPUT_WIDTH } from '../constants';
@@ -17,7 +18,7 @@ import {
 
 import { MetricQueryEditor } from './MetricQueryEditor';
 
-import { AnnotationsHelp, QueryEditorRow } from './';
+import { AnnotationsHelp } from './';
 
 export type Props = QueryEditorProps<CloudMonitoringDatasource, CloudMonitoringQuery, CloudMonitoringOptions>;
 
@@ -88,13 +89,16 @@ export const AnnotationQueryEditor = (props: Props) => {
         query={metricQuery}
       />
 
-      <QueryEditorRow label="Title" htmlFor="annotation-query-title">
-        <Input id="annotation-query-title" value={title} width={INPUT_WIDTH} onChange={handleTitleChange} />
-      </QueryEditorRow>
-
-      <QueryEditorRow label="Text" htmlFor="annotation-query-text">
-        <Input id="annotation-query-text" value={text} width={INPUT_WIDTH} onChange={handleTextChange} />
-      </QueryEditorRow>
+      <EditorRow>
+        <EditorField label="Title">
+          <Input id="annotation-query-title" value={title} width={INPUT_WIDTH} onChange={handleTitleChange} />
+        </EditorField>
+      </EditorRow>
+      <EditorRow>
+        <EditorField label="Text">
+          <Input id="annotation-query-text" value={text} width={INPUT_WIDTH} onChange={handleTextChange} />
+        </EditorField>
+      </EditorRow>
 
       <AnnotationsHelp />
     </>

--- a/public/app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useDebounce } from 'react-use';
 
 import { QueryEditorProps, toOption } from '@grafana/data';
-import { EditorRow, EditorField } from '@grafana/experimental';
+import { EditorRow, EditorField, EditorRows } from '@grafana/experimental';
 import { Input } from '@grafana/ui';
 
 import { INPUT_WIDTH } from '../constants';
@@ -78,7 +78,7 @@ export const AnnotationQueryEditor = (props: Props) => {
   );
 
   return (
-    <>
+    <EditorRows>
       <MetricQueryEditor
         refId={query.refId}
         variableOptionGroup={variableOptionGroup}
@@ -101,6 +101,6 @@ export const AnnotationQueryEditor = (props: Props) => {
       </EditorRow>
 
       <AnnotationsHelp />
-    </>
+    </EditorRows>
   );
 };

--- a/public/app/plugins/datasource/cloud-monitoring/components/Fields.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Fields.tsx
@@ -1,8 +1,7 @@
 import React, { FC } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { EditorRow, EditorField } from '@grafana/experimental';
-import { Select } from '@grafana/ui';
+import { Select, InlineField } from '@grafana/ui';
 
 interface VariableQueryFieldProps {
   onChange: (value: string) => void;
@@ -20,16 +19,14 @@ export const VariableQueryField: FC<VariableQueryFieldProps> = ({
   allowCustomValue = false,
 }) => {
   return (
-    <EditorRow>
-      <EditorField label={label} width={20}>
-        <Select
-          width={25}
-          allowCustomValue={allowCustomValue}
-          value={value}
-          onChange={({ value }) => onChange(value!)}
-          options={options}
-        />
-      </EditorField>
-    </EditorRow>
+    <InlineField label={label} labelWidth={20}>
+      <Select
+        width={25}
+        allowCustomValue={allowCustomValue}
+        value={value}
+        onChange={({ value }) => onChange(value!)}
+        options={options}
+      />
+    </InlineField>
   );
 };

--- a/public/app/plugins/datasource/cloud-monitoring/components/Fields.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Fields.tsx
@@ -1,10 +1,8 @@
-import { css } from '@emotion/css';
 import React, { FC } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { HorizontalGroup, InlineField, InlineLabel, PopoverContent, Select } from '@grafana/ui';
-
-import { INNER_LABEL_WIDTH, LABEL_WIDTH } from '../constants';
+import { EditorRow, EditorField } from '@grafana/experimental';
+import { Select } from '@grafana/ui';
 
 interface VariableQueryFieldProps {
   onChange: (value: string) => void;
@@ -22,71 +20,16 @@ export const VariableQueryField: FC<VariableQueryFieldProps> = ({
   allowCustomValue = false,
 }) => {
   return (
-    <InlineField label={label} labelWidth={20}>
-      <Select
-        width={25}
-        allowCustomValue={allowCustomValue}
-        value={value}
-        onChange={({ value }) => onChange(value!)}
-        options={options}
-      />
-    </InlineField>
-  );
-};
-
-export interface Props {
-  children: React.ReactNode;
-  tooltip?: PopoverContent;
-  label?: React.ReactNode;
-  className?: string;
-  noFillEnd?: boolean;
-  labelWidth?: number;
-  fillComponent?: React.ReactNode;
-  htmlFor?: string;
-}
-
-export const QueryEditorRow: FC<Props> = ({
-  children,
-  label,
-  tooltip,
-  fillComponent,
-  noFillEnd = false,
-  labelWidth = LABEL_WIDTH,
-  htmlFor,
-  ...rest
-}) => {
-  return (
-    <div className="gf-form" {...rest}>
-      {label && (
-        <InlineLabel width={labelWidth} tooltip={tooltip} htmlFor={htmlFor}>
-          {label}
-        </InlineLabel>
-      )}
-      <div
-        className={css`
-          margin-right: 4px;
-        `}
-      >
-        <HorizontalGroup spacing="xs" width="auto">
-          {children}
-        </HorizontalGroup>
-      </div>
-      <div className={'gf-form--grow'}>
-        {noFillEnd || <div className={'gf-form-label gf-form-label--grow'}>{fillComponent}</div>}
-      </div>
-    </div>
-  );
-};
-
-export const QueryEditorField: FC<Props> = ({ children, label, tooltip, labelWidth = INNER_LABEL_WIDTH, ...rest }) => {
-  return (
-    <>
-      {label && (
-        <InlineLabel width={labelWidth} tooltip={tooltip} {...rest}>
-          {label}
-        </InlineLabel>
-      )}
-      {children}
-    </>
+    <EditorRow>
+      <EditorField label={label} width={20}>
+        <Select
+          width={25}
+          allowCustomValue={allowCustomValue}
+          value={value}
+          onChange={({ value }) => onChange(value!)}
+          options={options}
+        />
+      </EditorField>
+    </EditorRow>
   );
 };

--- a/public/app/plugins/datasource/cloud-monitoring/components/GraphPeriod.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/GraphPeriod.tsx
@@ -1,11 +1,12 @@
 import React, { FunctionComponent } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { Switch } from '@grafana/ui';
+import { EditorField, EditorRow } from '@grafana/experimental';
+import { HorizontalGroup, Switch } from '@grafana/ui';
 
 import { GRAPH_PERIODS, SELECT_WIDTH } from '../constants';
 
-import { PeriodSelect, QueryEditorRow } from '.';
+import { PeriodSelect } from '.';
 
 export interface Props {
   refId: string;
@@ -16,8 +17,8 @@ export interface Props {
 
 export const GraphPeriod: FunctionComponent<Props> = ({ refId, onChange, graphPeriod, variableOptionGroup }) => {
   return (
-    <>
-      <QueryEditorRow
+    <EditorRow>
+      <EditorField
         label="Graph period"
         htmlFor={`${refId}-graph-period`}
         tooltip={
@@ -27,21 +28,23 @@ export const GraphPeriod: FunctionComponent<Props> = ({ refId, onChange, graphPe
           </>
         }
       >
-        <Switch
-          data-testid={`${refId}-switch-graph-period`}
-          value={graphPeriod !== 'disabled'}
-          onChange={(e) => onChange(e.currentTarget.checked ? '' : 'disabled')}
-        />
-        <PeriodSelect
-          inputId={`${refId}-graph-period`}
-          templateVariableOptions={variableOptionGroup.options}
-          current={graphPeriod}
-          onChange={onChange}
-          selectWidth={SELECT_WIDTH}
-          disabled={graphPeriod === 'disabled'}
-          aligmentPeriods={GRAPH_PERIODS}
-        />
-      </QueryEditorRow>
-    </>
+        <HorizontalGroup>
+          <Switch
+            data-testid={`${refId}-switch-graph-period`}
+            value={graphPeriod !== 'disabled'}
+            onChange={(e) => onChange(e.currentTarget.checked ? '' : 'disabled')}
+          />
+          <PeriodSelect
+            inputId={`${refId}-graph-period`}
+            templateVariableOptions={variableOptionGroup.options}
+            current={graphPeriod}
+            onChange={onChange}
+            selectWidth={SELECT_WIDTH}
+            disabled={graphPeriod === 'disabled'}
+            aligmentPeriods={GRAPH_PERIODS}
+          />
+        </HorizontalGroup>
+      </EditorField>
+    </EditorRow>
   );
 };

--- a/public/app/plugins/datasource/cloud-monitoring/components/GroupBy.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/GroupBy.tsx
@@ -1,13 +1,14 @@
 import React, { FunctionComponent, useMemo } from 'react';
 
 import { SelectableValue } from '@grafana/data';
+import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
 import { MultiSelect } from '@grafana/ui';
 
 import { INPUT_WIDTH, SYSTEM_LABELS } from '../constants';
 import { labelsToGroupedOptions } from '../functions';
 import { MetricDescriptor, MetricQuery } from '../types';
 
-import { Aggregation, QueryEditorRow } from '.';
+import { Aggregation } from '.';
 
 export interface Props {
   refId: string;
@@ -32,29 +33,33 @@ export const GroupBy: FunctionComponent<Props> = ({
   );
 
   return (
-    <QueryEditorRow
-      label="Group by"
-      tooltip="You can reduce the amount of data returned for a metric by combining different time series. To combine multiple time series, you can specify a grouping and a function. Grouping is done on the basis of labels. The grouping function is used to combine the time series in the group into a single time series."
-      htmlFor={`${refId}-group-by`}
-    >
-      <MultiSelect
-        inputId={`${refId}-group-by`}
-        width={INPUT_WIDTH}
-        placeholder="Choose label"
-        options={options}
-        value={query.groupBys ?? []}
-        onChange={(options) => {
-          onChange({ ...query, groupBys: options.map((o) => o.value!) });
-        }}
-      ></MultiSelect>
-      <Aggregation
-        metricDescriptor={metricDescriptor}
-        templateVariableOptions={variableOptionGroup.options}
-        crossSeriesReducer={query.crossSeriesReducer}
-        groupBys={query.groupBys ?? []}
-        onChange={(crossSeriesReducer) => onChange({ ...query, crossSeriesReducer })}
-        refId={refId}
-      ></Aggregation>
-    </QueryEditorRow>
+    <EditorRow>
+      <EditorFieldGroup>
+        <EditorField
+          label="Group by"
+          tooltip="You can reduce the amount of data returned for a metric by combining different time series. To combine multiple time series, you can specify a grouping and a function. Grouping is done on the basis of labels. The grouping function is used to combine the time series in the group into a single time series."
+          htmlFor={`${refId}-group-by`}
+        >
+          <MultiSelect
+            inputId={`${refId}-group-by`}
+            width={INPUT_WIDTH}
+            placeholder="Choose label"
+            options={options}
+            value={query.groupBys ?? []}
+            onChange={(options) => {
+              onChange({ ...query, groupBys: options.map((o) => o.value!) });
+            }}
+          />
+        </EditorField>
+        <Aggregation
+          metricDescriptor={metricDescriptor}
+          templateVariableOptions={variableOptionGroup.options}
+          crossSeriesReducer={query.crossSeriesReducer}
+          groupBys={query.groupBys ?? []}
+          onChange={(crossSeriesReducer) => onChange({ ...query, crossSeriesReducer })}
+          refId={refId}
+        />
+      </EditorFieldGroup>
+    </EditorRow>
   );
 };

--- a/public/app/plugins/datasource/cloud-monitoring/components/LabelFilter.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/LabelFilter.tsx
@@ -64,6 +64,7 @@ export const LabelFilter: FunctionComponent<Props> = ({
         }
         menuPlacement="bottom"
         renderControl={FilterButton}
+        width="auto"
       />
     );
   };

--- a/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.tsx
@@ -134,7 +134,7 @@ function Editor({
             onChange={(q: string) => onQueryChange({ ...query, query: q })}
             onRunQuery={onRunQuery}
             query={query.query}
-          ></MQLQueryEditor>
+          />
           <GraphPeriod
             onChange={(graphPeriod: string) => onQueryChange({ ...query, graphPeriod })}
             graphPeriod={query.graphPeriod}

--- a/public/app/plugins/datasource/cloud-monitoring/components/Metrics.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Metrics.tsx
@@ -3,14 +3,13 @@ import { startCase, uniqBy } from 'lodash';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/experimental';
 import { TemplateSrv } from '@grafana/runtime';
 import { getSelectStyles, Select, useStyles2, useTheme2 } from '@grafana/ui';
 
 import { INNER_LABEL_WIDTH, LABEL_WIDTH, SELECT_WIDTH } from '../constants';
 import CloudMonitoringDatasource from '../datasource';
 import { MetricDescriptor } from '../types';
-
-import { QueryEditorField, QueryEditorRow } from '.';
 
 export interface Props {
   refId: string;
@@ -137,40 +136,42 @@ export function Metrics(props: Props) {
 
   return (
     <>
-      <QueryEditorRow>
-        <QueryEditorField labelWidth={LABEL_WIDTH} label="Service" htmlFor={`${props.refId}-service`}>
-          <Select
-            width={SELECT_WIDTH}
-            onChange={onServiceChange}
-            value={[...services, ...templateVariableOptions].find((s) => s.value === service)}
-            options={[
-              {
-                label: 'Template Variables',
-                options: templateVariableOptions,
-              },
-              ...services,
-            ]}
-            placeholder="Select Services"
-            inputId={`${props.refId}-service`}
-          ></Select>
-        </QueryEditorField>
-        <QueryEditorField label="Metric name" labelWidth={INNER_LABEL_WIDTH} htmlFor={`${props.refId}-select-metric`}>
-          <Select
-            width={SELECT_WIDTH}
-            onChange={onMetricTypeChange}
-            value={[...metrics, ...templateVariableOptions].find((s) => s.value === metricType)}
-            options={[
-              {
-                label: 'Template Variables',
-                options: templateVariableOptions,
-              },
-              ...metrics,
-            ]}
-            placeholder="Select Metric"
-            inputId={`${props.refId}-select-metric`}
-          ></Select>
-        </QueryEditorField>
-      </QueryEditorRow>
+      <EditorRow>
+        <EditorFieldGroup>
+          <EditorField width={LABEL_WIDTH} label="Service">
+            <Select
+              width={SELECT_WIDTH}
+              onChange={onServiceChange}
+              value={[...services, ...templateVariableOptions].find((s) => s.value === service)}
+              options={[
+                {
+                  label: 'Template Variables',
+                  options: templateVariableOptions,
+                },
+                ...services,
+              ]}
+              placeholder="Select Services"
+              inputId={`${props.refId}-service`}
+            />
+          </EditorField>
+          <EditorField label="Metric name" width={INNER_LABEL_WIDTH}>
+            <Select
+              width={SELECT_WIDTH}
+              onChange={onMetricTypeChange}
+              value={[...metrics, ...templateVariableOptions].find((s) => s.value === metricType)}
+              options={[
+                {
+                  label: 'Template Variables',
+                  options: templateVariableOptions,
+                },
+                ...metrics,
+              ]}
+              placeholder="Select Metric"
+              inputId={`${props.refId}-select-metric`}
+            />
+          </EditorField>
+        </EditorFieldGroup>
+      </EditorRow>
 
       {children(state.metricDescriptor)}
     </>

--- a/public/app/plugins/datasource/cloud-monitoring/components/PeriodSelect.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/PeriodSelect.tsx
@@ -55,6 +55,6 @@ export function PeriodSelect({
       inputId={inputId}
       disabled={disabled}
       allowCustomValue
-    ></Select>
+    />
   );
 }

--- a/public/app/plugins/datasource/cloud-monitoring/components/Preprocessor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Preprocessor.tsx
@@ -1,12 +1,11 @@
 import React, { FunctionComponent, useMemo } from 'react';
 
 import { SelectableValue } from '@grafana/data';
+import { EditorField, EditorRow } from '@grafana/experimental';
 import { RadioButtonGroup } from '@grafana/ui';
 
 import { getAlignmentPickerData } from '../functions';
 import { MetricDescriptor, MetricKind, MetricQuery, PreprocessorType, ValueTypes } from '../types';
-
-import { QueryEditorRow } from '.';
 
 const NONE_OPTION = { label: 'None', value: PreprocessorType.None };
 
@@ -19,20 +18,22 @@ export interface Props {
 export const Preprocessor: FunctionComponent<Props> = ({ query, metricDescriptor, onChange }) => {
   const options = useOptions(metricDescriptor);
   return (
-    <QueryEditorRow
-      label="Pre-processing"
-      tooltip="Preprocessing options are displayed when the selected metric has a metric kind of delta or cumulative. The specific options available are determined by the metic's value type. If you select 'Rate', data points are aligned and converted to a rate per time series. If you select 'Delta', data points are aligned by their delta (difference) per time series"
-    >
-      <RadioButtonGroup
-        onChange={(value: PreprocessorType) => {
-          const { valueType, metricKind, perSeriesAligner: psa } = query;
-          const { perSeriesAligner } = getAlignmentPickerData(valueType, metricKind, psa, value);
-          onChange({ ...query, preprocessor: value, perSeriesAligner });
-        }}
-        value={query.preprocessor ?? PreprocessorType.None}
-        options={options}
-      ></RadioButtonGroup>
-    </QueryEditorRow>
+    <EditorRow>
+      <EditorField
+        label="Pre-processing"
+        tooltip="Preprocessing options are displayed when the selected metric has a metric kind of delta or cumulative. The specific options available are determined by the metic's value type. If you select 'Rate', data points are aligned and converted to a rate per time series. If you select 'Delta', data points are aligned by their delta (difference) per time series"
+      >
+        <RadioButtonGroup
+          onChange={(value: PreprocessorType) => {
+            const { valueType, metricKind, perSeriesAligner: psa } = query;
+            const { perSeriesAligner } = getAlignmentPickerData(valueType, metricKind, psa, value);
+            onChange({ ...query, preprocessor: value, perSeriesAligner });
+          }}
+          value={query.preprocessor ?? PreprocessorType.None}
+          options={options}
+        />
+      </EditorField>
+    </EditorRow>
   );
 };
 

--- a/public/app/plugins/datasource/cloud-monitoring/components/Project.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Project.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useMemo, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
+import { EditorField, EditorRow } from '@grafana/experimental';
 import { Select } from '@grafana/ui';
 
 import { SELECT_WIDTH } from '../constants';
 import CloudMonitoringDatasource from '../datasource';
-
-import { QueryEditorRow } from '.';
 
 export interface Props {
   refId: string;
@@ -35,17 +34,19 @@ export function Project({ refId, projectName, datasource, onChange, templateVari
   );
 
   return (
-    <QueryEditorRow label="Project" htmlFor={`${refId}-project`}>
-      <Select
-        width={SELECT_WIDTH}
-        allowCustomValue
-        formatCreateLabel={(v) => `Use project: ${v}`}
-        onChange={({ value }) => onChange(value!)}
-        options={projectsWithTemplateVariables}
-        value={{ value: projectName, label: projectName }}
-        placeholder="Select Project"
-        inputId={`${refId}-project`}
-      />
-    </QueryEditorRow>
+    <EditorRow>
+      <EditorField label="Project">
+        <Select
+          width={SELECT_WIDTH}
+          allowCustomValue
+          formatCreateLabel={(v) => `Use project: ${v}`}
+          onChange={({ value }) => onChange(value!)}
+          options={projectsWithTemplateVariables}
+          value={{ value: projectName, label: projectName }}
+          placeholder="Select Project"
+          inputId={`${refId}-project`}
+        />
+      </EditorField>
+    </EditorRow>
   );
 }

--- a/public/app/plugins/datasource/cloud-monitoring/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/QueryEditor.tsx
@@ -1,8 +1,8 @@
-import { css } from '@emotion/css';
 import React, { PureComponent } from 'react';
 
 import { QueryEditorProps, toOption } from '@grafana/data';
-import { Button, Select } from '@grafana/ui';
+import { EditorField, EditorRows, EditorRow, Stack, AccessoryButton } from '@grafana/experimental';
+import { HorizontalGroup, Select } from '@grafana/ui';
 
 import { QUERY_TYPES, SELECT_WIDTH } from '../constants';
 import CloudMonitoringDatasource from '../datasource';
@@ -11,7 +11,7 @@ import { CloudMonitoringQuery, EditorMode, MetricQuery, QueryType, SLOQuery, Clo
 import { defaultQuery } from './MetricQueryEditor';
 import { defaultQuery as defaultSLOQuery } from './SLO/SLOQueryEditor';
 
-import { MetricQueryEditor, QueryEditorRow, SLOQueryEditor } from './';
+import { MetricQueryEditor, SLOQueryEditor } from './';
 
 export type Props = QueryEditorProps<CloudMonitoringDatasource, CloudMonitoringQuery, CloudMonitoringOptions>;
 
@@ -55,41 +55,39 @@ export class QueryEditor extends PureComponent<Props> {
     };
 
     return (
-      <>
-        <QueryEditorRow
-          label="Query type"
-          fillComponent={
-            query.queryType !== QueryType.SLO && (
-              <Button
-                variant="secondary"
-                className={css`
-                  margin-left: auto;
-                `}
-                icon="edit"
-                onClick={() =>
-                  this.onQueryChange('metricQuery', {
-                    ...metricQuery,
-                    editorMode: metricQuery.editorMode === EditorMode.MQL ? EditorMode.Visual : EditorMode.MQL,
-                  })
-                }
-              >
-                {metricQuery.editorMode === EditorMode.MQL ? 'Switch to builder' : 'Edit MQL'}
-              </Button>
-            )
-          }
-          htmlFor={`${query.refId}-query-type`}
-        >
-          <Select
-            width={SELECT_WIDTH}
-            value={queryType}
-            options={QUERY_TYPES}
-            onChange={({ value }) => {
-              onChange({ ...query, sloQuery, queryType: value! });
-              onRunQuery();
-            }}
-            inputId={`${query.refId}-query-type`}
-          />
-        </QueryEditorRow>
+      <EditorRows>
+        <EditorRow>
+          <EditorField label="Query type" htmlFor={`${query.refId}-query-type`}>
+            <HorizontalGroup>
+              <Select
+                width={SELECT_WIDTH}
+                value={queryType}
+                options={QUERY_TYPES}
+                onChange={({ value }) => {
+                  onChange({ ...query, sloQuery, queryType: value! });
+                  onRunQuery();
+                }}
+                inputId={`${query.refId}-query-type`}
+              />
+              <Stack alignItems="flex-end">
+                {query.queryType !== QueryType.SLO && (
+                  <AccessoryButton
+                    variant="secondary"
+                    icon="edit"
+                    onClick={() =>
+                      this.onQueryChange('metricQuery', {
+                        ...metricQuery,
+                        editorMode: metricQuery.editorMode === EditorMode.MQL ? EditorMode.Visual : EditorMode.MQL,
+                      })
+                    }
+                  >
+                    {metricQuery.editorMode === EditorMode.MQL ? 'Switch to builder' : 'Edit MQL'}
+                  </AccessoryButton>
+                )}
+              </Stack>
+            </HorizontalGroup>
+          </EditorField>
+        </EditorRow>
 
         {queryType === QueryType.METRICS && (
           <MetricQueryEditor
@@ -102,7 +100,7 @@ export class QueryEditor extends PureComponent<Props> {
             onRunQuery={onRunQuery}
             datasource={datasource}
             query={metricQuery}
-          ></MetricQueryEditor>
+          />
         )}
 
         {queryType === QueryType.SLO && (
@@ -114,9 +112,9 @@ export class QueryEditor extends PureComponent<Props> {
             onRunQuery={onRunQuery}
             datasource={datasource}
             query={sloQuery}
-          ></SLOQueryEditor>
+          />
         )}
-      </>
+      </EditorRows>
     );
   }
 }

--- a/public/app/plugins/datasource/cloud-monitoring/components/SLO/SLO.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/SLO/SLO.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
+import { EditorField, EditorRow } from '@grafana/experimental';
 import { Select } from '@grafana/ui';
 
-import { QueryEditorRow } from '..';
 import { SELECT_WIDTH } from '../../constants';
 import CloudMonitoringDatasource from '../../datasource';
 import { SLOQuery } from '../../types';
@@ -37,20 +37,22 @@ export const SLO: React.FC<Props> = ({ refId, query, templateVariableOptions, on
   }, [datasource, projectName, serviceId, templateVariableOptions]);
 
   return (
-    <QueryEditorRow label="SLO" htmlFor={`${refId}-slo`}>
-      <Select
-        inputId={`${refId}-slo`}
-        width={SELECT_WIDTH}
-        allowCustomValue
-        value={query?.sloId && { value: query?.sloId, label: query?.sloName || query?.sloId }}
-        placeholder="Select SLO"
-        options={slos}
-        onChange={async ({ value: sloId = '', label: sloName = '' }) => {
-          const slos = await datasource.getServiceLevelObjectives(projectName, serviceId);
-          const slo = slos.find(({ value }) => value === datasource.templateSrv.replace(sloId));
-          onChange({ ...query, sloId, sloName, goal: slo?.goal });
-        }}
-      />
-    </QueryEditorRow>
+    <EditorRow>
+      <EditorField label="SLO">
+        <Select
+          inputId={`${refId}-slo`}
+          width={SELECT_WIDTH}
+          allowCustomValue
+          value={query?.sloId && { value: query?.sloId, label: query?.sloName || query?.sloId }}
+          placeholder="Select SLO"
+          options={slos}
+          onChange={async ({ value: sloId = '', label: sloName = '' }) => {
+            const slos = await datasource.getServiceLevelObjectives(projectName, serviceId);
+            const slo = slos.find(({ value }) => value === datasource.templateSrv.replace(sloId));
+            onChange({ ...query, sloId, sloName, goal: slo?.goal });
+          }}
+        />
+      </EditorField>
+    </EditorRow>
   );
 };

--- a/public/app/plugins/datasource/cloud-monitoring/components/SLO/SLOQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/SLO/SLOQueryEditor.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import { SelectableValue } from '@grafana/data';
+import { EditorRow, EditorField, Stack } from '@grafana/experimental';
 
-import { AliasBy, PeriodSelect, AlignmentPeriodLabel, Project, QueryEditorRow } from '..';
+import { AliasBy, PeriodSelect, AlignmentPeriodLabel, Project } from '..';
 import { ALIGNMENT_PERIODS, SELECT_WIDTH } from '../../constants';
 import CloudMonitoringDatasource from '../../datasource';
 import { AlignmentTypes, CustomMetaData, SLOQuery } from '../../types';
@@ -54,33 +55,37 @@ export function SLOQueryEditor({
         templateVariableOptions={variableOptionGroup.options}
         query={query}
         onChange={onChange}
-      ></Service>
+      />
       <SLO
         refId={refId}
         datasource={datasource}
         templateVariableOptions={variableOptionGroup.options}
         query={query}
         onChange={onChange}
-      ></SLO>
+      />
       <Selector
         refId={refId}
         datasource={datasource}
         templateVariableOptions={variableOptionGroup.options}
         query={query}
         onChange={onChange}
-      ></Selector>
+      />
 
-      <QueryEditorRow label="Alignment period" htmlFor={`${refId}-alignment-period`}>
-        <PeriodSelect
-          inputId={`${refId}-alignment-period`}
-          templateVariableOptions={variableOptionGroup.options}
-          selectWidth={SELECT_WIDTH}
-          current={query.alignmentPeriod}
-          onChange={(period) => onChange({ ...query, alignmentPeriod: period })}
-          aligmentPeriods={ALIGNMENT_PERIODS}
-        />
-        <AlignmentPeriodLabel datasource={datasource} customMetaData={customMetaData} />
-      </QueryEditorRow>
+      <EditorRow>
+        <EditorField label="Alignment period" htmlFor={`${refId}-alignment-period`}>
+          <PeriodSelect
+            inputId={`${refId}-alignment-period`}
+            templateVariableOptions={variableOptionGroup.options}
+            selectWidth={SELECT_WIDTH}
+            current={query.alignmentPeriod}
+            onChange={(period) => onChange({ ...query, alignmentPeriod: period })}
+            aligmentPeriods={ALIGNMENT_PERIODS}
+          />
+        </EditorField>
+        <Stack alignItems="flex-end">
+          <AlignmentPeriodLabel datasource={datasource} customMetaData={customMetaData} />
+        </Stack>
+      </EditorRow>
 
       <AliasBy refId={refId} value={query.aliasBy} onChange={(aliasBy) => onChange({ ...query, aliasBy })} />
     </>

--- a/public/app/plugins/datasource/cloud-monitoring/components/SLO/Selector.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/SLO/Selector.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import { SelectableValue } from '@grafana/data';
+import { EditorField, EditorRow } from '@grafana/experimental';
 import { Select } from '@grafana/ui';
 
-import { QueryEditorRow } from '..';
 import { SELECT_WIDTH, SELECTORS } from '../../constants';
 import CloudMonitoringDatasource from '../../datasource';
 import { SLOQuery } from '../../types';
@@ -18,21 +18,23 @@ export interface Props {
 
 export const Selector: React.FC<Props> = ({ refId, query, templateVariableOptions, onChange, datasource }) => {
   return (
-    <QueryEditorRow label="Selector" htmlFor={`${refId}-slo-selector`}>
-      <Select
-        inputId={`${refId}-slo-selector`}
-        width={SELECT_WIDTH}
-        allowCustomValue
-        value={[...SELECTORS, ...templateVariableOptions].find((s) => s.value === query?.selectorName ?? '')}
-        options={[
-          {
-            label: 'Template Variables',
-            options: templateVariableOptions,
-          },
-          ...SELECTORS,
-        ]}
-        onChange={({ value: selectorName }) => onChange({ ...query, selectorName: selectorName ?? '' })}
-      />
-    </QueryEditorRow>
+    <EditorRow>
+      <EditorField label="Selector">
+        <Select
+          inputId={`${refId}-slo-selector`}
+          width={SELECT_WIDTH}
+          allowCustomValue
+          value={[...SELECTORS, ...templateVariableOptions].find((s) => s.value === query?.selectorName ?? '')}
+          options={[
+            {
+              label: 'Template Variables',
+              options: templateVariableOptions,
+            },
+            ...SELECTORS,
+          ]}
+          onChange={({ value: selectorName }) => onChange({ ...query, selectorName: selectorName ?? '' })}
+        />
+      </EditorField>
+    </EditorRow>
   );
 };

--- a/public/app/plugins/datasource/cloud-monitoring/components/SLO/Service.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/SLO/Service.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
+import { EditorField, EditorRow } from '@grafana/experimental';
 import { Select } from '@grafana/ui';
 
-import { QueryEditorRow } from '..';
 import { SELECT_WIDTH } from '../../constants';
 import CloudMonitoringDatasource from '../../datasource';
 import { SLOQuery } from '../../types';
@@ -37,18 +37,20 @@ export const Service: React.FC<Props> = ({ refId, query, templateVariableOptions
   }, [datasource, projectName, templateVariableOptions]);
 
   return (
-    <QueryEditorRow label="Service" htmlFor={`${refId}-slo-service`}>
-      <Select
-        inputId={`${refId}-slo-service`}
-        width={SELECT_WIDTH}
-        allowCustomValue
-        value={query?.serviceId && { value: query?.serviceId, label: query?.serviceName || query?.serviceId }}
-        placeholder="Select service"
-        options={services}
-        onChange={({ value: serviceId = '', label: serviceName = '' }) =>
-          onChange({ ...query, serviceId, serviceName, sloId: '' })
-        }
-      />
-    </QueryEditorRow>
+    <EditorRow>
+      <EditorField label="Service">
+        <Select
+          inputId={`${refId}-slo-service`}
+          width={SELECT_WIDTH}
+          allowCustomValue
+          value={query?.serviceId && { value: query?.serviceId, label: query?.serviceName || query?.serviceId }}
+          placeholder="Select service"
+          options={services}
+          onChange={({ value: serviceId = '', label: serviceName = '' }) =>
+            onChange({ ...query, serviceId, serviceName, sloId: '' })
+          }
+        />
+      </EditorField>
+    </EditorRow>
   );
 };

--- a/public/app/plugins/datasource/cloud-monitoring/components/index.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/components/index.ts
@@ -11,7 +11,7 @@ export { Aggregation } from './Aggregation';
 export { MetricQueryEditor } from './MetricQueryEditor';
 export { SLOQueryEditor } from './SLO/SLOQueryEditor';
 export { MQLQueryEditor } from './MQLQueryEditor';
-export { VariableQueryField, QueryEditorRow, QueryEditorField } from './Fields';
+export { VariableQueryField } from './Fields';
 export { VisualMetricQueryEditor } from './VisualMetricQueryEditor';
 export { PeriodSelect } from './PeriodSelect';
 export { Preprocessor } from './Preprocessor';


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #44431

**Special notes for your reviewer**:
## Query editor builder mode

Current
<img width="1667" alt="Current Cloud Monitoring Query Editor in builder mode" src="https://user-images.githubusercontent.com/19530599/172500310-db036c6b-8334-4c44-a9ad-a16b72656a04.png">

Updated
- The `Edit MQL` toggle is next to the query type selector
<img width="1669" alt="Updated Cloud Monitoring Query Editor in builder mode" src="https://user-images.githubusercontent.com/19530599/172501421-b6e5bc38-0828-4573-a88e-97801b0ad02a.png">

## Query editor MQL mode
Current
<img width="1667" alt="Current Cloud Monitoring Query Editor in MQL mode" src="https://user-images.githubusercontent.com/19530599/172500369-e427470a-4e55-48f5-81c8-269e50405b52.png">

Updated
<img width="1669" alt="Updated Cloud Monitoring Query Editor in MQL mode" src="https://user-images.githubusercontent.com/19530599/172501494-cae60529-7944-4a54-8b0e-1e1f3901e546.png">

## Differences between the period alignment label in the Query editor
Current period alignment label
<img width="754" alt="Current Cloud Monitoring Query Editor period alignment label" src="https://user-images.githubusercontent.com/19530599/172501940-cee8d063-5484-4628-bb6a-b464914bec52.png">

Updated period alignment label
<img width="321" alt="Updated Cloud Monitoring Query Editor period alignment label" src="https://user-images.githubusercontent.com/19530599/172501977-1f201b1d-aa35-414e-9518-4f9634585d39.png">

## Annotation query editor
The annotation query editor uses the `MetricQueryEditor` component so its UI is updated as well.

Current
<img width="1457" alt="Current Cloud Monitoring annotation query editor" src="https://user-images.githubusercontent.com/19530599/172634663-3360c5db-ddca-4d42-89d0-2defb8f27dae.png">

Updated 
<img width="1457" alt="Updated Cloud Monitoring annotation query editor" src="https://user-images.githubusercontent.com/19530599/172634757-20fb21dd-33ab-46fb-83d4-e06b600c63e2.png">