### PR TITLE
Storage: improve path validation, add tests

### DIFF
--- a/pkg/infra/filestorage/api_test.go
+++ b/pkg/infra/filestorage/api_test.go
@@ -1,6 +1,7 @@
 package filestorage
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -32,5 +33,79 @@ func TestFilestorageApi_Join(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.expected, Join(tt.parts...))
 		})
+	}
+}
+
+func pathPart(length int) string {
+	sb := strings.Builder{}
+	for i := 0; i < length; i++ {
+		sb.WriteString("a")
+	}
+	return sb.String()
+}
+
+func TestFilestorageApi_ValidatePath(t *testing.T) {
+	var tests = []struct {
+		path          string
+		expectedError error
+	}{
+		{
+			path:          "abc/file.jpg",
+			expectedError: ErrRelativePath,
+		},
+		{
+			path:          "../abc/file.jpg",
+			expectedError: ErrRelativePath,
+		},
+		{
+			path:          "/abc/./file.jpg",
+			expectedError: ErrNonCanonicalPath,
+		},
+		{
+			path:          "/abc/../abc/file.jpg",
+			expectedError: ErrNonCanonicalPath,
+		},
+		{
+			path:          "/abc//folder/file.jpg",
+			expectedError: ErrNonCanonicalPath,
+		},
+		{
+			path:          "/abc/file.jpg/",
+			expectedError: ErrPathEndsWithDelimiter,
+		},
+		{
+			path:          "/abc/folder/ ",
+			expectedError: ErrEmptyPathPart,
+		},
+		{
+			path:          "/abc/ /file.jpg",
+			expectedError: ErrEmptyPathPart,
+		},
+		{
+			path:          "/abc/" + pathPart(260) + "/file.jpg",
+			expectedError: ErrPathPartTooLong,
+		},
+		{
+			path:          "/abc/" + pathPart(1050) + "/file.jpg",
+			expectedError: ErrPathTooLong,
+		},
+		{
+			path:          "/abc/folder🚀/file.jpg",
+			expectedError: ErrInvalidCharacters,
+		},
+		{
+			path: "/myFile/file.jpg",
+		},
+	}
+	for _, tt := range tests {
+		if tt.expectedError == nil {
+			t.Run("path "+tt.path+" should be valid", func(t *testing.T) {
+				require.Nil(t, ValidatePath(tt.path))
+			})
+		} else {
+			t.Run("path "+tt.path+" should be invalid: "+tt.expectedError.Error(), func(t *testing.T) {
+				require.Equal(t, tt.expectedError, ValidatePath(tt.path))
+			})
+		}
 	}
 }

--- a/pkg/infra/filestorage/api_test.go
+++ b/pkg/infra/filestorage/api_test.go
@@ -94,6 +94,10 @@ func TestFilestorageApi_ValidatePath(t *testing.T) {
 			expectedError: ErrInvalidCharacters,
 		},
 		{
+			path:          "/path/with/utf/char/at/the/end.jpg�",
+			expectedError: ErrInvalidCharacters,
+		},
+		{
 			path: "/myFile/file.jpg",
 		},
 	}

--- a/pkg/infra/filestorage/wrapper.go
+++ b/pkg/infra/filestorage/wrapper.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"mime"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -14,7 +13,6 @@ import (
 
 var (
 	directoryMarker = ".___gf_dir_marker___"
-	pathRegex       = regexp.MustCompile(`(^/$)|(^(/[A-Za-z0-9!\-_.*'() ]+)+$)`)
 )
 
 type wrapper struct {
@@ -100,37 +98,8 @@ func getName(path string) string {
 	return split[len(split)-1]
 }
 
-func validatePath(path string) error {
-	if !filepath.IsAbs(path) {
-		return ErrRelativePath
-	}
-
-	if path == Delimiter {
-		return nil
-	}
-
-	if filepath.Clean(path) != path {
-		return ErrNonCanonicalPath
-	}
-
-	if strings.HasSuffix(path, Delimiter) {
-		return ErrPathEndsWithDelimiter
-	}
-
-	if len(path) > 1000 {
-		return ErrPathTooLong
-	}
-
-	matches := pathRegex.MatchString(path)
-	if !matches {
-		return ErrPathInvalid
-	}
-
-	return nil
-}
-
 func (b wrapper) validatePath(path string) error {
-	if err := validatePath(path); err != nil {
+	if err := ValidatePath(path); err != nil {
 		b.log.Error("Path failed validation", "path", path, "error", err)
 		return err
 	}


### PR DESCRIPTION
This PR adds limitation on the length of any individual path part (folder/file name), exports the function so that it can be used by the storage service, and adds some unit test coverage