### PR TITLE
AzureMonitor: changes to azureMonitorExperimentalUI after feedback

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -198,11 +198,10 @@ var (
 			State:       FeatureStateAlpha,
 		},
 		{
-			Name:            "azureMonitorExperimentalUI",
-			Description:     "Use grafana-experimental UI in Azure Monitor",
-			State:           FeatureStateAlpha,
-			RequiresDevMode: true,
-			FrontendOnly:    true,
+			Name:         "azureMonitorExperimentalUI",
+			Description:  "Use grafana-experimental UI in Azure Monitor",
+			State:        FeatureStateAlpha,
+			FrontendOnly: true,
 		},
 		{
 			Name:         "traceToMetrics",

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/Field.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/Field.tsx
@@ -7,13 +7,21 @@ import { Props as InlineFieldProps } from '@grafana/ui/src/components/Forms/Inli
 
 interface Props extends InlineFieldProps {
   label: string;
+  inlineField?: boolean;
+  labelWidth?: number;
 }
 
 const DEFAULT_LABEL_WIDTH = 18;
 
 export const Field = (props: Props) => {
+  const { labelWidth, inlineField, ...remainingProps } = props;
+
   if (config.featureToggles.azureMonitorExperimentalUI) {
-    return <EditorField width={DEFAULT_LABEL_WIDTH} {...props} />;
+    if (inlineField) {
+      return <InlineField labelWidth={labelWidth || DEFAULT_LABEL_WIDTH} {...remainingProps} />;
+    } else {
+      return <EditorField width={labelWidth || DEFAULT_LABEL_WIDTH} {...remainingProps} />;
+    }
   }
-  return <InlineField labelWidth={DEFAULT_LABEL_WIDTH} {...props} />;
+  return <InlineField labelWidth={labelWidth || DEFAULT_LABEL_WIDTH} {...remainingProps} />;
 };

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/Field.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/Field.tsx
@@ -16,12 +16,9 @@ const DEFAULT_LABEL_WIDTH = 18;
 export const Field = (props: Props) => {
   const { labelWidth, inlineField, ...remainingProps } = props;
 
-  if (config.featureToggles.azureMonitorExperimentalUI) {
-    if (inlineField) {
-      return <InlineField labelWidth={labelWidth || DEFAULT_LABEL_WIDTH} {...remainingProps} />;
-    } else {
-      return <EditorField width={labelWidth || DEFAULT_LABEL_WIDTH} {...remainingProps} />;
-    }
+  if (config.featureToggles.azureMonitorExperimentalUI && !inlineField) {
+    return <EditorField width={labelWidth || DEFAULT_LABEL_WIDTH} {...remainingProps} />;
+  } else {
+    return <InlineField labelWidth={labelWidth || DEFAULT_LABEL_WIDTH} {...remainingProps} />;
   }
-  return <InlineField labelWidth={labelWidth || DEFAULT_LABEL_WIDTH} {...remainingProps} />;
 };

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -44,6 +44,8 @@ const LogsQueryEditor: React.FC<LogsQueryEditorProps> = ({
               <ResourceField
                 query={query}
                 datasource={datasource}
+                inlineField={true}
+                labelWidth={10}
                 subscriptionId={subscriptionId}
                 variableOptionGroup={variableOptionGroup}
                 onQueryChange={onChange}

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.tsx
@@ -60,11 +60,6 @@ const MetricsQueryEditor: React.FC<MetricsQueryEditorProps> = ({
                 setResource={setResource}
                 resourceUri={query.azureMonitor?.resourceUri}
               />
-            </EditorFieldGroup>
-          </EditorRow>
-
-          <EditorRow>
-            <EditorFieldGroup>
               <MetricNamespaceField
                 metricNamespaces={metricNamespaces}
                 query={query}

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourceField/ResourceField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourceField/ResourceField.tsx
@@ -29,6 +29,8 @@ interface ResourceFieldProps extends AzureQueryEditorFieldProps {
   setResource: (query: AzureMonitorQuery, resourceURI?: string) => AzureMonitorQuery;
   selectableEntryTypes: ResourceRowType[];
   resourceUri?: string;
+  inlineField?: boolean;
+  labelWidth?: number;
 }
 
 const ResourceField: React.FC<ResourceFieldProps> = ({
@@ -38,6 +40,8 @@ const ResourceField: React.FC<ResourceFieldProps> = ({
   setResource,
   selectableEntryTypes,
   resourceUri,
+  inlineField,
+  labelWidth,
 }) => {
   const styles = useStyles2(getStyles);
   const [pickerIsOpen, setPickerIsOpen] = useState(false);
@@ -77,8 +81,7 @@ const ResourceField: React.FC<ResourceFieldProps> = ({
           selectableEntryTypes={selectableEntryTypes}
         />
       </Modal>
-
-      <Field label="Resource">
+      <Field label="Resource" inlineField={inlineField} labelWidth={labelWidth}>
         <Button className={styles.resourceFieldButton} variant="secondary" onClick={handleOpenPicker} type="button">
           <ResourceLabel resource={resourceUri} datasource={datasource} />
         </Button>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR addresses feedback from the UX Feedback session about the `azureMonitorExperimentalUI` feature work.

- Moves metrics into the same row as the Resource Picker
![image](https://user-images.githubusercontent.com/1048831/172685407-26d79caf-47c6-4823-b6e0-347864121b63.png)
- Removes the `RequiresDevMode` requirement for the feature flag so we can test it on Grafana Cloud
- Adds new props to the `Field` component for Azure Monitor which allows the field to be inline or not and also control the label width.
![image](https://user-images.githubusercontent.com/1048831/172685460-0d6b2161-5b0a-4c3f-a0aa-d2bc58b444a3.png)

