### PR TITLE
Cloud Monitoring: add feature toggle for experimental UI

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -56,4 +56,5 @@ export interface FeatureToggles {
   validateDashboardsOnSave?: boolean;
   prometheusWideSeries?: boolean;
   canvasPanelNesting?: boolean;
+  cloudMonitoringExperimentalUI?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -227,11 +227,10 @@ var (
 			FrontendOnly: true,
 		},
 		{
-			Name:            "cloudMonitoringExperimentalUI",
-			Description:     "Use grafana-experimental UI in Cloud Monitoring",
-			State:           FeatureStateAlpha,
-			RequiresDevMode: true,
-			FrontendOnly:    true,
+			Name:         "cloudMonitoringExperimentalUI",
+			Description:  "Use grafana-experimental UI in Cloud Monitoring",
+			State:        FeatureStateAlpha,
+			FrontendOnly: true,
 		},
 	}
 )

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -226,5 +226,12 @@ var (
 			State:        FeatureStateAlpha,
 			FrontendOnly: true,
 		},
+		{
+			Name:            "cloudMonitoringExperimentalUI",
+			Description:     "Use grafana-experimental UI in Cloud Monitoring",
+			State:           FeatureStateAlpha,
+			RequiresDevMode: true,
+			FrontendOnly:    true,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -166,4 +166,8 @@ const (
 	// FlagCanvasPanelNesting
 	// Allow elements nesting
 	FlagCanvasPanelNesting = "canvasPanelNesting"
+
+	// FlagCloudMonitoringExperimentalUI
+	// Use grafana-experimental UI in Cloud Monitoring
+	FlagCloudMonitoringExperimentalUI = "cloudMonitoringExperimentalUI"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a feature toggle while the experimental UI is being developed.

**Which issue(s) this PR fixes**:

Relates to #44431

**Special notes for your reviewer**:
Smaller upcoming PRs will add parts of the experimental UI for Cloud Monitoring behind the `cloudMonitoringExperimentalUI` feature toggle.
