### PR TITLE
Panels: Fixes issue with showing 'Cannot visualize data' when query returned 0 rows

### DIFF
--- a/public/app/features/panel/components/PanelDataErrorView.tsx
+++ b/public/app/features/panel/components/PanelDataErrorView.tsx
@@ -67,7 +67,7 @@ function getMessageFor(
   }
 
   // In some cases there is a data frame but with no fields
-  if (!data.series || data.series.length === 0 || (data.series.length === 1 && data.series[0].fields.length === 0)) {
+  if (!data.series || data.series.length === 0 || (data.series.length === 1 && data.series[0].length === 0)) {
     return fieldConfig?.defaults.noValue ?? 'No data';
   }
 


### PR DESCRIPTION
Noticed that the LogsPanel showed "Cannot visualize data" when the query returns zero rows.

Tracked it down to a bad condition inside PanelDataErrorView where it checks fields length instead
of checking if there are any rows.
