### PR TITLE
Docs: Remove deprecated inactive state filter

### DIFF
--- a/docs/sources/visualizations/alert-list-panel.md
+++ b/docs/sources/visualizations/alert-list-panel.md
@@ -56,7 +56,6 @@ Choose which alert states to display in this panel.
 
 - Alerting / Firing
 - Pending
-- Inactive
 - No Data
 - Normal
 - Error


### PR DESCRIPTION
**What this PR does / why we need it**:

Following the changes in https://github.com/grafana/grafana/pull/50240 the "Inactive" state no longer exists and has been removed from the documentation.
