### PR TITLE
Prometheus: Don't show undefined for step in collapsed options in query editor when value is "auto"

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.tsx
@@ -126,7 +126,7 @@ function getCollapsedInfo(query: PromQuery, formatOption: string, queryType: str
 
   items.push(`Legend: ${getLegendModeLabel(query.legendFormat)}`);
   items.push(`Format: ${formatOption}`);
-  items.push(`Step ${query.interval}`);
+  items.push(`Step: ${query.interval ?? 'auto'}`);
   items.push(`Type: ${queryType}`);
 
   if (query.exemplar) {


### PR DESCRIPTION
Before
![Screenshot from 2022-06-09 14-05-03](https://user-images.githubusercontent.com/1014802/172842863-49fe9177-466a-4433-8da7-8799dea9a881.png)

After
![Screenshot from 2022-06-09 14-04-46](https://user-images.githubusercontent.com/1014802/172842876-d69562c6-684a-4660-83bb-c6726735fb09.png)
