### PR TITLE
Provision dashboards on server init

### DIFF
--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -113,29 +113,28 @@ type ProvisioningServiceImpl struct {
 func (ps *ProvisioningServiceImpl) RunInitProvisioners(ctx context.Context) error {
 	err := ps.ProvisionDatasources(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to provision datasources: %w", err)
 	}
 
 	err = ps.ProvisionPlugins(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to provision plugins: %w", err)
 	}
 
 	err = ps.ProvisionNotifications(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to provision notifications: %w", err)
+	}
+
+	err = ps.ProvisionDashboards(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to provision dashboards: %w", err)
 	}
 
 	return nil
 }
 
 func (ps *ProvisioningServiceImpl) Run(ctx context.Context) error {
-	err := ps.ProvisionDashboards(ctx)
-	if err != nil {
-		ps.log.Error("Failed to provision dashboard", "error", err)
-		return err
-	}
-
 	for {
 		// Wait for unlock. This is tied to new dashboardProvisioner to be instantiated before we start polling.
 		ps.mutex.Lock()


### PR DESCRIPTION
**What this PR does / why we need it**:

We have a new search which indexes dashboards on Grafana start. This seems the simplest approach to have provisioned dashboards in database before indexing. Other approaches - like additional synchronization between provisioning service and searchv2 service or sending entity events during dashboard provisioning are more complicated. Wondering whether we can afford doing dashboard provisioning synchronously on server start (especially since we already provision notifications, plugins, datasources on start)  


