### PR TITLE
Logs: Handle backend-mode errors in histogram

### DIFF
--- a/public/app/core/logs_model.ts
+++ b/public/app/core/logs_model.ts
@@ -702,7 +702,17 @@ export function queryLogsVolume<T extends DataQuery>(
         observer.complete();
       },
       next: (dataQueryResponse: DataQueryResponse) => {
-        rawLogsVolume = rawLogsVolume.concat(dataQueryResponse.data.map(toDataFrame));
+        const { error } = dataQueryResponse;
+        if (error !== undefined) {
+          observer.next({
+            state: LoadingState.Error,
+            error,
+            data: [],
+          });
+          observer.error(error);
+        } else {
+          rawLogsVolume = rawLogsVolume.concat(dataQueryResponse.data.map(toDataFrame));
+        }
       },
       error: (error) => {
         observer.next({


### PR DESCRIPTION
the current full-range-logs-volume-histogram codebase was written when the datasources that used it were all frontend-mode datasources.

now Loki switched to backend-mode, and we found out that the histogram-code does not handle errors well in that case.
whenever an error happens, the histogram just shows "No volume data."

after some investigation i found that when in backend-mode, the error-information arrives at a different place, compared to frontend-mode.

so i added a check to the "backend-mode place" too.

how to test:
1. `make devenv sources=loki`
2. go to explore, run `{place="moon"}`
3. we need a failing logs-volume-query, the easiest way is to modify the source-code to make an invalid query:
    - modify this line: https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/loki/datasource.ts#L120 to make it an invalid query, for example, replace `sum` with `xsum` or something else
4. run the query from [2] again
5. you should see an error-message for the log-volume-query