### PR TITLE
Cloud Monitoring: Update Preprocessing to use experimental UI components

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/__mocks__/cloudMonitoringMetricDescriptor.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/__mocks__/cloudMonitoringMetricDescriptor.ts
@@ -1,0 +1,15 @@
+import { MetricDescriptor, MetricKind, ValueTypes } from '../types';
+
+export const createMockMetricDescriptor = (overrides: Partial<MetricDescriptor>): MetricDescriptor => {
+  return {
+    metricKind: MetricKind.CUMULATIVE,
+    valueType: ValueTypes.DOUBLE,
+    type: 'type',
+    unit: 'unit',
+    service: 'service',
+    serviceShortName: 'srv',
+    displayName: 'displayName',
+    description: 'description',
+    ...overrides,
+  };
+};

--- a/public/app/plugins/datasource/cloud-monitoring/__mocks__/cloudMonitoringMetricDescriptor.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/__mocks__/cloudMonitoringMetricDescriptor.ts
@@ -1,6 +1,6 @@
 import { MetricDescriptor, MetricKind, ValueTypes } from '../types';
 
-export const createMockMetricDescriptor = (overrides: Partial<MetricDescriptor>): MetricDescriptor => {
+export const createMockMetricDescriptor = (overrides?: Partial<MetricDescriptor>): MetricDescriptor => {
   return {
     metricKind: MetricKind.CUMULATIVE,
     valueType: ValueTypes.DOUBLE,

--- a/public/app/plugins/datasource/cloud-monitoring/components/Experimental/GroupBy.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Experimental/GroupBy.tsx
@@ -9,6 +9,7 @@ import { labelsToGroupedOptions } from '../../functions';
 import { MetricDescriptor, MetricQuery } from '../../types';
 
 import { Aggregation } from './Aggregation';
+import { Preprocessor } from './Preprocessor';
 
 export interface Props {
   refId: string;
@@ -35,6 +36,7 @@ export const GroupBy: FunctionComponent<Props> = ({
   return (
     <EditorRow>
       <EditorFieldGroup>
+        <Preprocessor metricDescriptor={metricDescriptor} query={query} onChange={onChange} />
         <EditorField
           label="Group by"
           tooltip="You can reduce the amount of data returned for a metric by combining different time series. To combine multiple time series, you can specify a grouping and a function. Grouping is done on the basis of labels. The grouping function is used to combine the time series in the group into a single time series."

--- a/public/app/plugins/datasource/cloud-monitoring/components/Experimental/GroupBy.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Experimental/GroupBy.tsx
@@ -9,7 +9,6 @@ import { labelsToGroupedOptions } from '../../functions';
 import { MetricDescriptor, MetricQuery } from '../../types';
 
 import { Aggregation } from './Aggregation';
-import { Preprocessor } from './Preprocessor';
 
 export interface Props {
   refId: string;
@@ -36,7 +35,6 @@ export const GroupBy: FunctionComponent<Props> = ({
   return (
     <EditorRow>
       <EditorFieldGroup>
-        <Preprocessor metricDescriptor={metricDescriptor} query={query} onChange={onChange} />
         <EditorField
           label="Group by"
           tooltip="You can reduce the amount of data returned for a metric by combining different time series. To combine multiple time series, you can specify a grouping and a function. Grouping is done on the basis of labels. The grouping function is used to combine the time series in the group into a single time series."

--- a/public/app/plugins/datasource/cloud-monitoring/components/Experimental/Preprocessor.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Experimental/Preprocessor.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { TemplateSrvMock } from 'app/features/templating/template_srv.mock';
+
+import { createMockMetricDescriptor } from '../../__mocks__/cloudMonitoringMetricDescriptor';
+import { createMockMetricQuery } from '../../__mocks__/cloudMonitoringQuery';
+import { MetricKind, ValueTypes } from '../../types';
+
+import { Preprocessor } from './Preprocessor';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getTemplateSrv: () => new TemplateSrvMock({}),
+}));
+
+describe('Preprocessor', () => {
+  it('only provides "None" as an option if no metric descriptor is provided', () => {
+    const query = createMockMetricQuery();
+    const onChange = jest.fn();
+
+    render(<Preprocessor onChange={onChange} query={query} />);
+    expect(screen.getByText('Pre-processing')).toBeInTheDocument();
+    expect(screen.getByText('None')).toBeInTheDocument();
+    expect(screen.queryByText('Rate')).not.toBeInTheDocument();
+    expect(screen.queryByText('Delta')).not.toBeInTheDocument();
+  });
+
+  it('only provides "None" as an option if metric kind is "Gauge"', () => {
+    const query = createMockMetricQuery();
+    const onChange = jest.fn();
+    const metricDescriptor = createMockMetricDescriptor({ metricKind: MetricKind.GAUGE });
+
+    render(<Preprocessor onChange={onChange} query={query} metricDescriptor={metricDescriptor} />);
+    expect(screen.getByText('Pre-processing')).toBeInTheDocument();
+    expect(screen.getByText('None')).toBeInTheDocument();
+    expect(screen.queryByText('Rate')).not.toBeInTheDocument();
+    expect(screen.queryByText('Delta')).not.toBeInTheDocument();
+  });
+
+  it('only provides "None" as an option if value type is "Distribution"', () => {
+    const query = createMockMetricQuery();
+    const onChange = jest.fn();
+    const metricDescriptor = createMockMetricDescriptor({ valueType: ValueTypes.DISTRIBUTION });
+
+    render(<Preprocessor onChange={onChange} query={query} metricDescriptor={metricDescriptor} />);
+    expect(screen.getByText('Pre-processing')).toBeInTheDocument();
+    expect(screen.getByText('None')).toBeInTheDocument();
+    expect(screen.queryByText('Rate')).not.toBeInTheDocument();
+    expect(screen.queryByText('Delta')).not.toBeInTheDocument();
+  });
+
+  it('provides "None" and "Rate" as options if metric kind is not "Delta" or "Cumulative" and value type is not "Distribution"', () => {
+    const query = createMockMetricQuery();
+    const onChange = jest.fn();
+    const metricDescriptor = createMockMetricDescriptor({ metricKind: MetricKind.DELTA });
+
+    render(<Preprocessor onChange={onChange} query={query} metricDescriptor={metricDescriptor} />);
+    expect(screen.getByText('Pre-processing')).toBeInTheDocument();
+    expect(screen.getByText('None')).toBeInTheDocument();
+    expect(screen.queryByText('Rate')).toBeInTheDocument();
+    expect(screen.queryByText('Delta')).not.toBeInTheDocument();
+  });
+
+  it('provides all options if metric kind is "Cumulative" and value type is not "Distribution"', () => {
+    const query = createMockMetricQuery();
+    const onChange = jest.fn();
+    const metricDescriptor = createMockMetricDescriptor({ metricKind: MetricKind.CUMULATIVE });
+
+    render(<Preprocessor onChange={onChange} query={query} metricDescriptor={metricDescriptor} />);
+    expect(screen.getByText('Pre-processing')).toBeInTheDocument();
+    expect(screen.getByText('None')).toBeInTheDocument();
+    expect(screen.queryByText('Rate')).toBeInTheDocument();
+    expect(screen.queryByText('Delta')).toBeInTheDocument();
+  });
+
+  it('provides all options if metric kind is "Cumulative" and value type is not "Distribution"', async () => {
+    const query = createMockMetricQuery();
+    const onChange = jest.fn();
+    const metricDescriptor = createMockMetricDescriptor({ metricKind: MetricKind.CUMULATIVE });
+
+    render(<Preprocessor onChange={onChange} query={query} metricDescriptor={metricDescriptor} />);
+    const none = screen.getByLabelText('None');
+    const rate = screen.getByLabelText('Rate');
+    const delta = screen.getByLabelText('Delta');
+    expect(none).toBeChecked();
+    expect(rate).not.toBeChecked();
+    expect(delta).not.toBeChecked();
+
+    await userEvent.click(rate);
+
+    expect(onChange).toBeCalledWith(expect.objectContaining({ preprocessor: 'rate' }));
+  });
+});

--- a/public/app/plugins/datasource/cloud-monitoring/components/Experimental/Preprocessor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Experimental/Preprocessor.tsx
@@ -1,0 +1,67 @@
+import React, { FunctionComponent, useMemo } from 'react';
+
+import { SelectableValue } from '@grafana/data';
+import { EditorField } from '@grafana/experimental';
+import { RadioButtonGroup } from '@grafana/ui';
+
+import { getAlignmentPickerData } from '../../functions';
+import { MetricDescriptor, MetricKind, MetricQuery, PreprocessorType, ValueTypes } from '../../types';
+
+const NONE_OPTION = { label: 'None', value: PreprocessorType.None };
+
+export interface Props {
+  metricDescriptor?: MetricDescriptor;
+  onChange: (query: MetricQuery) => void;
+  query: MetricQuery;
+}
+
+export const Preprocessor: FunctionComponent<Props> = ({ query, metricDescriptor, onChange }) => {
+  const options = useOptions(metricDescriptor);
+  return (
+    <EditorField
+      label="Pre-processing"
+      tooltip="Preprocessing options are displayed when the selected metric has a metric kind of delta or cumulative. The specific options available are determined by the metic's value type. If you select 'Rate', data points are aligned and converted to a rate per time series. If you select 'Delta', data points are aligned by their delta (difference) per time series"
+    >
+      <RadioButtonGroup
+        onChange={(value: PreprocessorType) => {
+          const { valueType, metricKind, perSeriesAligner: psa } = query;
+          const { perSeriesAligner } = getAlignmentPickerData(valueType, metricKind, psa, value);
+          onChange({ ...query, preprocessor: value, perSeriesAligner });
+        }}
+        value={query.preprocessor ?? PreprocessorType.None}
+        options={options}
+      />
+    </EditorField>
+  );
+};
+
+const useOptions = (metricDescriptor?: MetricDescriptor): Array<SelectableValue<PreprocessorType>> => {
+  const metricKind = metricDescriptor?.metricKind;
+  const valueType = metricDescriptor?.valueType;
+
+  return useMemo(() => {
+    if (!metricKind || metricKind === MetricKind.GAUGE || valueType === ValueTypes.DISTRIBUTION) {
+      return [NONE_OPTION];
+    }
+
+    const options = [
+      NONE_OPTION,
+      {
+        label: 'Rate',
+        value: PreprocessorType.Rate,
+        description: 'Data points are aligned and converted to a rate per time series',
+      },
+    ];
+
+    return metricKind === MetricKind.CUMULATIVE
+      ? [
+          ...options,
+          {
+            label: 'Delta',
+            value: PreprocessorType.Delta,
+            description: 'Data points are aligned by their delta (difference) per time series',
+          },
+        ]
+      : options;
+  }, [metricKind, valueType]);
+};

--- a/public/app/plugins/datasource/cloud-monitoring/components/Experimental/Preprocessor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Experimental/Preprocessor.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useMemo } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { EditorField } from '@grafana/experimental';
+import { EditorField, EditorRow } from '@grafana/experimental';
 import { RadioButtonGroup } from '@grafana/ui';
 
 import { getAlignmentPickerData } from '../../functions';
@@ -18,20 +18,22 @@ export interface Props {
 export const Preprocessor: FunctionComponent<Props> = ({ query, metricDescriptor, onChange }) => {
   const options = useOptions(metricDescriptor);
   return (
-    <EditorField
-      label="Pre-processing"
-      tooltip="Preprocessing options are displayed when the selected metric has a metric kind of delta or cumulative. The specific options available are determined by the metic's value type. If you select 'Rate', data points are aligned and converted to a rate per time series. If you select 'Delta', data points are aligned by their delta (difference) per time series"
-    >
-      <RadioButtonGroup
-        onChange={(value: PreprocessorType) => {
-          const { valueType, metricKind, perSeriesAligner: psa } = query;
-          const { perSeriesAligner } = getAlignmentPickerData(valueType, metricKind, psa, value);
-          onChange({ ...query, preprocessor: value, perSeriesAligner });
-        }}
-        value={query.preprocessor ?? PreprocessorType.None}
-        options={options}
-      />
-    </EditorField>
+    <EditorRow>
+      <EditorField
+        label="Pre-processing"
+        tooltip="Preprocessing options are displayed when the selected metric has a metric kind of delta or cumulative. The specific options available are determined by the metic's value type. If you select 'Rate', data points are aligned and converted to a rate per time series. If you select 'Delta', data points are aligned by their delta (difference) per time series"
+      >
+        <RadioButtonGroup
+          onChange={(value: PreprocessorType) => {
+            const { valueType, metricKind, perSeriesAligner: psa } = query;
+            const { perSeriesAligner } = getAlignmentPickerData(valueType, metricKind, psa, value);
+            onChange({ ...query, preprocessor: value, perSeriesAligner });
+          }}
+          value={query.preprocessor ?? PreprocessorType.None}
+          options={options}
+        />
+      </EditorField>
+    </EditorRow>
   );
 };
 

--- a/public/app/plugins/datasource/cloud-monitoring/components/Experimental/VisualMetricQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Experimental/VisualMetricQueryEditor.tsx
@@ -4,7 +4,7 @@ import { SelectableValue } from '@grafana/data';
 
 import CloudMonitoringDatasource from '../../datasource';
 import { CustomMetaData, MetricDescriptor, MetricQuery, SLOQuery } from '../../types';
-import { LabelFilter, Metrics, Preprocessor } from '../index';
+import { LabelFilter, Metrics } from '../index';
 
 import { Alignment } from './Alignment';
 import { GroupBy } from './GroupBy';
@@ -48,7 +48,6 @@ function Editor({
             onChange={(filters: string[]) => onChange({ ...query, filters })}
             variableOptionGroup={variableOptionGroup}
           />
-          <Preprocessor metricDescriptor={metric} query={query} onChange={onChange} />
           <GroupBy
             refId={refId}
             labels={Object.keys(labels)}

--- a/public/app/plugins/datasource/cloud-monitoring/components/Experimental/VisualMetricQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Experimental/VisualMetricQueryEditor.tsx
@@ -8,6 +8,7 @@ import { LabelFilter, Metrics } from '../index';
 
 import { Alignment } from './Alignment';
 import { GroupBy } from './GroupBy';
+import { Preprocessor } from './Preprocessor';
 
 export interface Props {
   refId: string;
@@ -48,6 +49,7 @@ function Editor({
             onChange={(filters: string[]) => onChange({ ...query, filters })}
             variableOptionGroup={variableOptionGroup}
           />
+          <Preprocessor metricDescriptor={metric} query={query} onChange={onChange} />
           <GroupBy
             refId={refId}
             labels={Object.keys(labels)}


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the pre-processing field to use experimental UI components.

**Which issue(s) this PR fixes**:

Relates to #44431

**Special notes for your reviewer**:
The base branch is currently set to `kevinwcyu/44431-cloudmonitoring-graph-period-experimental-ui`. After that one is merged, I'll update the base branch to `main`

Current pre-proccessing field
<img width="1041" alt="Current Cloud Monitoring pre-proccessing field" src="https://user-images.githubusercontent.com/19530599/172924420-fd3b7dce-cd57-4c00-b390-b8c1b0ac9a04.png">

Updated pre-processing field with multiple options
<img width="1630" alt="Updated Cloud Monitoring pre-processing field with two options" src="https://user-images.githubusercontent.com/19530599/174386249-4ab918ba-3e3c-47c3-8cd6-275f82e4800d.png">



---

The Experimental folder contains all of the components as they are being worked on. Currently the components within the directory are all just copied from the directory one level above. In general the only changes involve adding `<EditorRows>`, `<EditorRow>` (not plural), and `<EditorField>` components.

Eventually, we should be able to just move the components in the Experimental directory up one level and replace the existing files and remove the `cloudMonitoringExperimentalUI` feature toggle.