### PR TITLE
Instrumentation: Add feature toggle for logging requests instrumented as unknown

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -58,4 +58,5 @@ export interface FeatureToggles {
   prometheusWideSeries?: boolean;
   canvasPanelNesting?: boolean;
   cloudMonitoringExperimentalUI?: boolean;
+  logRequestsInstrumentedAsUnknown?: boolean;
 }

--- a/pkg/middleware/request_metrics.go
+++ b/pkg/middleware/request_metrics.go
@@ -62,11 +62,11 @@ func RequestMetrics(features featuremgmt.FeatureToggles) web.Handler {
 		handler := "unknown"
 		if routeOperation, exists := RouteOperationNameFromContext(c.Req.Context()); exists {
 			handler = routeOperation
-		}
-
-		if features.IsEnabled(featuremgmt.FlagLogRequestsInstrumentedAsUnknown) {
-			ctx := contexthandler.FromContext(c.Req.Context())
-			ctx.Logger.Warn("request instrumented as unknown", "path", c.Req.URL.Path)
+		} else {
+			if features.IsEnabled(featuremgmt.FlagLogRequestsInstrumentedAsUnknown) {
+				ctx := contexthandler.FromContext(c.Req.Context())
+				ctx.Logger.Warn("request instrumented as unknown", "path", c.Req.URL.Path)
+			}
 		}
 
 		status := rw.Status()

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -237,5 +237,10 @@ var (
 			State:        FeatureStateAlpha,
 			FrontendOnly: true,
 		},
+		{
+			Name:        "logRequestsInstrumentedAsUnknown",
+			Description: "Logs the path for requests that are instrumented as unknown",
+			State:       FeatureStateAlpha,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -174,4 +174,8 @@ const (
 	// FlagCloudMonitoringExperimentalUI
 	// Use grafana-experimental UI in Cloud Monitoring
 	FlagCloudMonitoringExperimentalUI = "cloudMonitoringExperimentalUI"
+
+	// FlagLogRequestsInstrumentedAsUnknown
+	// Logs the path for requests that are instrumented as unknown
+	FlagLogRequestsInstrumentedAsUnknown = "logRequestsInstrumentedAsUnknown"
 )


### PR DESCRIPTION
We are instrumenting some requests as unknown. 

This PR adds a feature toggle for logging the requests that are considered `unknown`.

Signed-off-by: bergquist <carl.bergquist@gmail.com>
