### PR TITLE
Grafana UI: Put back production build in rollup config

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -170,7 +170,6 @@
     "rollup-plugin-sourcemaps": "0.6.3",
     "rollup-plugin-svg-import": "^1.6.0",
     "rollup-plugin-terser": "7.0.2",
-    "rollup-plugin-visualizer": "^5.6.0",
     "sass-loader": "13.0.0",
     "storybook-dark-mode": "1.1.0",
     "style-loader": "3.3.1",

--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -53,4 +53,4 @@ const buildCjsPackage = ({ env }) => {
     ],
   };
 };
-export default [buildCjsPackage({ env: 'development' })];
+export default [buildCjsPackage({ env: 'development' }), buildCjsPackage({ env: 'production' })];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4797,7 +4797,6 @@ __metadata:
     rollup-plugin-sourcemaps: 0.6.3
     rollup-plugin-svg-import: ^1.6.0
     rollup-plugin-terser: 7.0.2
-    rollup-plugin-visualizer: ^5.6.0
     rxjs: 7.5.5
     sass-loader: 13.0.0
     slate: 0.47.8
@@ -26425,7 +26424,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.1.32, nanoid@npm:^3.3.3, nanoid@npm:^3.3.4":
+"nanoid@npm:^3.3.3, nanoid@npm:^3.3.4":
   version: 3.3.4
   resolution: "nanoid@npm:3.3.4"
   bin:
@@ -32215,22 +32214,6 @@ __metadata:
   peerDependencies:
     rollup: ^2.0.0
   checksum: af84bb7a7a894cd00852b6486528dfb8653cf94df4c126f95f389a346f401d054b08c46bee519a2ab6a22b33804d1d6ac6d8c90b1b2bf8fffb097eed73fc3c72
-  languageName: node
-  linkType: hard
-
-"rollup-plugin-visualizer@npm:^5.6.0":
-  version: 5.6.0
-  resolution: "rollup-plugin-visualizer@npm:5.6.0"
-  dependencies:
-    nanoid: ^3.1.32
-    open: ^8.4.0
-    source-map: ^0.7.3
-    yargs: ^17.3.1
-  peerDependencies:
-    rollup: ^2.0.0
-  bin:
-    rollup-plugin-visualizer: dist/bin/cli.js
-  checksum: 1036a3873f3b6a0c46d692538aaac5dc9f7a7b2a5aec9e7ab816aaf8a31576ae750f415e1019e401707d18490b634a982fbe8c22d9761cafbd9b12c756e7fd99
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
PR #50529 accidentally introduced a change to grafana-ui rollup bundle which means rollup won't generate the `index.production.js` file when compiling. (This was debug and never intended to make it to production. 🤦‍♂️ ) 

This PR addresses that issue and  removes a stray rollup-visualiser plugin used for debugging.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #50363

**Special notes for your reviewer**:

