### PR TITLE
CI: Rename release pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1505,7 +1505,7 @@ type: docker
 ---
 depends_on: []
 kind: pipeline
-name: oss-build-e2e-publish-release
+name: release-oss-build-e2e-publish
 node:
   type: no-parallel
 platform:
@@ -1802,7 +1802,7 @@ volumes:
 ---
 depends_on: []
 kind: pipeline
-name: oss-test-release
+name: release-oss-test
 node:
   type: no-parallel
 platform:
@@ -1920,7 +1920,7 @@ volumes:
 ---
 depends_on: []
 kind: pipeline
-name: oss-integration-tests-release
+name: release-oss-integration-tests
 node:
   type: no-parallel
 platform:
@@ -2010,11 +2010,11 @@ volumes:
     medium: memory
 ---
 depends_on:
-- oss-build-e2e-publish-release
-- oss-test-release
-- oss-integration-tests-release
+- release-oss-build-e2e-publish
+- release-oss-test
+- release-oss-integration-tests
 kind: pipeline
-name: oss-windows-release
+name: release-oss-windows
 platform:
   arch: amd64
   os: windows
@@ -2076,7 +2076,7 @@ depends_on: []
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: enterprise-build-e2e-publish-release
+name: release-enterprise-build-e2e-publish
 node:
   type: no-parallel
 platform:
@@ -2424,7 +2424,7 @@ depends_on: []
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: enterprise-test-release
+name: release-enterprise-test
 node:
   type: no-parallel
 platform:
@@ -2587,7 +2587,7 @@ depends_on: []
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: enterprise-integration-tests-release
+name: release-enterprise-integration-tests
 node:
   type: no-parallel
 platform:
@@ -2728,13 +2728,13 @@ volumes:
 clone:
   disable: true
 depends_on:
-- enterprise-build-e2e-publish-release
-- enterprise-test-release
-- enterprise-integration-tests-release
+- release-enterprise-build-e2e-publish
+- release-enterprise-test
+- release-enterprise-integration-tests
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: enterprise-windows-release
+name: release-enterprise-windows
 platform:
   arch: amd64
   os: windows
@@ -3317,7 +3317,7 @@ volumes:
 ---
 depends_on: []
 kind: pipeline
-name: oss-build-e2e-publish-release-branch
+name: release-branch-oss-build-e2e-publish
 node:
   type: no-parallel
 platform:
@@ -3584,7 +3584,7 @@ volumes:
 ---
 depends_on: []
 kind: pipeline
-name: oss-test-release-branch
+name: release-branch-oss-test
 node:
   type: no-parallel
 platform:
@@ -3696,7 +3696,7 @@ volumes:
 ---
 depends_on: []
 kind: pipeline
-name: oss-integration-tests-release-branch
+name: release-branch-oss-integration-tests
 node:
   type: no-parallel
 platform:
@@ -3780,11 +3780,11 @@ volumes:
     medium: memory
 ---
 depends_on:
-- oss-build-e2e-publish-release-branch
-- oss-test-release-branch
-- oss-integration-tests-release-branch
+- release-branch-oss-build-e2e-publish
+- release-branch-oss-test
+- release-branch-oss-integration-tests
 kind: pipeline
-name: oss-windows-release-branch
+name: release-branch-oss-windows
 platform:
   arch: amd64
   os: windows
@@ -3835,7 +3835,7 @@ depends_on: []
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: enterprise-build-e2e-publish-release-branch
+name: release-branch-enterprise-build-e2e-publish
 node:
   type: no-parallel
 platform:
@@ -4181,7 +4181,7 @@ depends_on: []
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: enterprise-test-release-branch
+name: release-branch-enterprise-test
 node:
   type: no-parallel
 platform:
@@ -4335,7 +4335,7 @@ depends_on: []
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: enterprise-integration-tests-release-branch
+name: release-branch-enterprise-integration-tests
 node:
   type: no-parallel
 platform:
@@ -4467,13 +4467,13 @@ volumes:
 clone:
   disable: true
 depends_on:
-- enterprise-build-e2e-publish-release-branch
-- enterprise-test-release-branch
-- enterprise-integration-tests-release-branch
+- release-branch-enterprise-build-e2e-publish
+- release-branch-enterprise-test
+- release-branch-enterprise-integration-tests
 image_pull_secrets:
 - dockerconfigjson
 kind: pipeline
-name: enterprise-windows-release-branch
+name: release-branch-enterprise-windows
 platform:
   arch: amd64
   os: windows
@@ -4683,6 +4683,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 378147a306d077b0566f5353c9e5c236c40dbb8d81392091a1346ed275b86496
+hmac: 0abf901971b403a4cf5887d1051ec4a656335a23d9a92809a71312d115b4862f
 
 ...

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -253,7 +253,7 @@ def get_oss_pipelines(trigger, ver_mode):
     volumes = integration_test_services_volumes()
     init_steps, test_steps, build_steps, integration_test_steps, package_steps, windows_package_steps, publish_steps = get_steps(edition=edition, ver_mode=ver_mode)
     windows_pipeline = pipeline(
-        name='oss-windows-{}'.format(ver_mode), edition=edition, trigger=trigger,
+        name='{}-oss-windows'.format(ver_mode), edition=edition, trigger=trigger,
         steps=[identify_runner_step('windows')] + windows_package_steps,
         platform='windows', depends_on=[
             'oss-build{}-publish-{}'.format(get_e2e_suffix(), ver_mode),
@@ -261,7 +261,7 @@ def get_oss_pipelines(trigger, ver_mode):
     )
     pipelines = [
         pipeline(
-            name='oss-build{}-publish-{}'.format(get_e2e_suffix(), ver_mode), edition=edition, trigger=trigger, services=[],
+            name='{}-oss-build{}-publish'.format(ver_mode, get_e2e_suffix()), edition=edition, trigger=trigger, services=[],
             steps=init_steps + build_steps + package_steps + publish_steps,
             volumes=volumes,
         ),
@@ -269,21 +269,21 @@ def get_oss_pipelines(trigger, ver_mode):
     if not disable_tests:
         pipelines.extend([
             pipeline(
-                name='oss-test-{}'.format(ver_mode), edition=edition, trigger=trigger, services=[],
+                name='{}-oss-test'.format(ver_mode), edition=edition, trigger=trigger, services=[],
                 steps=init_steps + test_steps,
                 volumes=[],
             ),
             pipeline(
-                name='oss-integration-tests-{}'.format(ver_mode), edition=edition, trigger=trigger, services=services,
+                name='{}-oss-integration-tests'.format(ver_mode), edition=edition, trigger=trigger, services=services,
                 steps=[download_grabpl_step(), identify_runner_step(),] + integration_test_steps,
                 volumes=volumes,
             )
         ])
         deps = {
             'depends_on': [
-                'oss-build{}-publish-{}'.format(get_e2e_suffix(), ver_mode),
-                'oss-test-{}'.format(ver_mode),
-                'oss-integration-tests-{}'.format(ver_mode)
+                '{}-oss-build{}-publish'.format(ver_mode, get_e2e_suffix()),
+                '{}-oss-test'.format(ver_mode),
+                '{}-oss-integration-tests'.format(ver_mode)
             ]
         }
         windows_pipeline.update(deps)
@@ -315,7 +315,7 @@ def get_enterprise_pipelines(trigger, ver_mode):
         step.update(deps_on_clone_enterprise_step)
 
     windows_pipeline = pipeline(
-        name='enterprise-windows-{}'.format(ver_mode), edition=edition, trigger=trigger,
+        name='{}-enterprise-windows'.format(ver_mode), edition=edition, trigger=trigger,
         steps=[identify_runner_step('windows')] + windows_package_steps,
         platform='windows', depends_on=[
             'enterprise-build{}-publish-{}'.format(get_e2e_suffix(), ver_mode),
@@ -323,7 +323,7 @@ def get_enterprise_pipelines(trigger, ver_mode):
     )
     pipelines = [
         pipeline(
-            name='enterprise-build{}-publish-{}'.format(get_e2e_suffix(), ver_mode), edition=edition, trigger=trigger, services=[],
+            name='{}-enterprise-build{}-publish'.format(ver_mode, get_e2e_suffix()), edition=edition, trigger=trigger, services=[],
             steps=init_steps + build_steps + package_steps + publish_steps,
             volumes=volumes,
         ),
@@ -331,21 +331,21 @@ def get_enterprise_pipelines(trigger, ver_mode):
     if not disable_tests:
         pipelines.extend([
             pipeline(
-                name='enterprise-test-{}'.format(ver_mode), edition=edition, trigger=trigger, services=[],
+                name='{}-enterprise-test'.format(ver_mode), edition=edition, trigger=trigger, services=[],
                 steps=init_steps + test_steps,
                 volumes=[],
             ),
             pipeline(
-                name='enterprise-integration-tests-{}'.format(ver_mode), edition=edition, trigger=trigger, services=services,
+                name='{}-enterprise-integration-tests'.format(ver_mode), edition=edition, trigger=trigger, services=services,
                 steps=[download_grabpl_step(), identify_runner_step(), clone_enterprise_step(ver_mode), init_enterprise_step(ver_mode),] + integration_test_steps,
                 volumes=volumes,
             ),
         ])
         deps = {
             'depends_on': [
-                'enterprise-build{}-publish-{}'.format(get_e2e_suffix(), ver_mode),
-                'enterprise-test-{}'.format(ver_mode),
-                'enterprise-integration-tests-{}'.format(ver_mode)
+                '{}-enterprise-build{}-publish'.format(ver_mode, get_e2e_suffix()),
+                '{}-enterprise-test'.format(ver_mode),
+                '{}-enterprise-integration-tests'.format(ver_mode)
             ]
         }
         windows_pipeline.update(deps)


### PR DESCRIPTION
**What this PR does / why we need it**:

Rename release pipelines from having the pattern `<oss/enterprise>-buildType-verMode`, to be `verMode-<oss/enterprise>-buildType` to align with what exists for PRs/main pipelines and also make it easier to query them in the Grafana CI dashboard.