### PR TITLE
Explore: Fix log context scroll to bottom

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
@@ -82,6 +82,7 @@ export class UnThemedLogMessageAnsi extends PureComponent<Props, State> {
     return chunks.map((chunk, index) => {
       const chunkText = this.props.highlight?.searchWords ? (
         <Highlighter
+          key={index}
           textToHighlight={chunk.text}
           searchWords={this.props.highlight.searchWords}
           findChunks={findHighlightChunksInText}

--- a/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
@@ -140,7 +140,7 @@ export const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps
     if (shouldScrollToBottom && listContainerRef.current) {
       setScrollTop(listContainerRef.current.offsetHeight);
     }
-  }, [shouldScrollToBottom]);
+  }, [shouldScrollToBottom, rows]);
 
   const headerProps = {
     row,

--- a/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
@@ -137,7 +137,9 @@ export const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps
   const listContainerRef = useRef<HTMLDivElement>() as React.RefObject<HTMLDivElement>;
 
   useLayoutEffect(() => {
-    if (shouldScrollToBottom && listContainerRef.current) {
+    // We want to scroll to bottom only when we receive first 10 log lines
+    const shouldScrollRows = rows.length > 0 && rows.length <= 10;
+    if (shouldScrollToBottom && shouldScrollRows && listContainerRef.current) {
       setScrollTop(listContainerRef.current.offsetHeight);
     }
   }, [shouldScrollToBottom, rows]);


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the issue with log context, where top log context window wasn't scrolled downed. You can find more information in why it is wanted in https://github.com/grafana/grafana/issues/50268. 

The main issue was that we didn't add rows into the `useLayoutEffect`  dependency array which meant, that we didn't run when rows changed. And because fetching of rows is async, we firstly passed to context empty array https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/Logs/LogRowContextProvider.tsx#L199-L202,  which meant that the `offsetHeight` of that element was 0 as it was empty, and then when actual rows arrived, we didn't re-calculate this. 

Moreover, we want to do this scrolling only when first batch of rows arrive.


https://user-images.githubusercontent.com/30407135/173063423-bba6f9af-699b-4b14-91cc-9bf7a9c881d8.mov


**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/50268

**How to test**:
1. run `make devenv sources=loki` in terminal
2. In Explore, open `gdev-loki` data source and run `{place="luna"} |= "error"` query
3. Click on `Show context` in one of the log lines
4. Check if top log context container is scrolled down to the bottom

