### PR TITLE
RBAC: Inheritance permission migration should handle empty managed roles

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
@@ -106,12 +106,15 @@ func (sp *managedPermissionMigrator) Exec(sess *xorm.Session, mg *migrator.Migra
 	for orgID, orgMap := range permissionMap {
 		for managedRole, permissions := range orgMap {
 			// ensure managed role exists, create and add to map if it doesn't
-			ok, err := sess.Get(&accesscontrol.Role{Name: managedRole, OrgID: orgID})
+			foundRole := &accesscontrol.Role{Name: managedRole, OrgID: orgID}
+			ok, err := sess.Get(foundRole)
 			if err != nil {
 				return err
 			}
 
-			if !ok {
+			if ok {
+				roleMap[orgID][managedRole] = foundRole.ID
+			} else {
 				uid, err := generateNewRoleUID(sess, orgID)
 				if err != nil {
 					return err

--- a/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
@@ -143,6 +143,10 @@ func (sp *managedPermissionMigrator) Exec(sess *xorm.Session, mg *migrator.Migra
 
 			// assign permissions if they don't exist to the role
 			roleID := roleMap[orgID][managedRole]
+			if roleID == 0 {
+				logger.Warn("Unable to create managed permission, got role ID 0", "orgID", orgID, "managedRole", managedRole)
+				continue
+			}
 			for p, toInsert := range permissions {
 				if toInsert {
 					perm := accesscontrol.Permission{RoleID: roleID, Action: p.Action, Scope: p.Scope, Created: now, Updated: now}

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/managed_permission_migrator_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/managed_permission_migrator_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -14,19 +15,17 @@ import (
 	"xorm.io/xorm"
 )
 
-func TestManagedPermissionsMigration(t *testing.T) {
-	// Run initial migration to have a working DB
-	x := setupTestDB(t)
+type inheritanceTestCase struct {
+	desc          string
+	putRolePerms  map[int64]map[string][]rawPermission
+	wantRolePerms map[int64]map[string][]rawPermission
+}
 
+func inheritanceTestCases() []inheritanceTestCase {
 	team1Scope := accesscontrol.Scope("teams", "id", "1")
 	team2Scope := accesscontrol.Scope("teams", "id", "2")
 
-	type teamMigrationTestCase struct {
-		desc          string
-		putRolePerms  map[int64]map[string][]rawPermission
-		wantRolePerms map[int64]map[string][]rawPermission
-	}
-	testCases := []teamMigrationTestCase{
+	return []inheritanceTestCase{
 		{
 			desc:          "empty perms",
 			putRolePerms:  map[int64]map[string][]rawPermission{},
@@ -74,6 +73,16 @@ func TestManagedPermissionsMigration(t *testing.T) {
 						{Action: "teams:write", Scope: team1Scope},
 					},
 				},
+				3: {
+					"managed:builtins:editor:permissions": {
+						{Action: "teams.permissions:read", Scope: team1Scope},
+						{Action: "teams.permissions:write", Scope: team2Scope},
+					},
+					"managed:builtins:admin:permissions": {}, //Role existed with no permission
+				},
+				4: {
+					"managed:builtins:admin:permissions": {}, //Role existed with no permission
+				},
 			},
 			wantRolePerms: map[int64]map[string][]rawPermission{
 				1: {
@@ -111,16 +120,37 @@ func TestManagedPermissionsMigration(t *testing.T) {
 						{Action: "teams:write", Scope: team1Scope},
 					},
 				},
+				3: {
+					"managed:builtins:editor:permissions": {
+						{Action: "teams.permissions:read", Scope: team1Scope},
+						{Action: "teams.permissions:write", Scope: team2Scope},
+					},
+					"managed:builtins:admin:permissions": {
+						{Action: "teams.permissions:read", Scope: team1Scope},
+						{Action: "teams.permissions:write", Scope: team2Scope},
+					},
+				},
+				4: {
+					"managed:builtins:admin:permissions": {}, //Role existed with no permission
+				},
 			},
 		},
 	}
+}
 
-	for _, tc := range testCases {
+func TestManagedPermissionsMigration(t *testing.T) {
+	// Run initial migration to have a working DB
+	x := setupTestDB(t)
+
+	for _, tc := range inheritanceTestCases() {
 		t.Run(tc.desc, func(t *testing.T) {
 			// Remove migration
-			_, errDeleteMig := x.Exec(`DELETE FROM migration_log WHERE migration_id = ?;
-DELETE FROM permission; DELETE FROM role`, acmig.ManagedPermissionsMigrationID)
+			_, errDeleteMig := x.Exec(`DELETE FROM migration_log WHERE migration_id = ?`, acmig.ManagedPermissionsMigrationID)
 			require.NoError(t, errDeleteMig)
+			_, errDeletePerm := x.Exec(`DELETE FROM permission`)
+			require.NoError(t, errDeletePerm)
+			_, errDeleteRole := x.Exec(`DELETE FROM role`)
+			require.NoError(t, errDeleteRole)
 
 			// put permissions
 			putTestPermissions(t, x, tc.putRolePerms)
@@ -163,6 +193,65 @@ DELETE FROM permission; DELETE FROM role`, acmig.ManagedPermissionsMigrationID)
 	}
 }
 
+func TestManagedPermissionsMigrationRunTwice(t *testing.T) {
+	// Run initial migration to have a working DB
+	x := setupTestDB(t)
+
+	for _, tc := range inheritanceTestCases() {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Remove migration
+			_, errDeleteMig := x.Exec(`DELETE FROM migration_log WHERE migration_id LIKE ?`, acmig.ManagedPermissionsMigrationID+"%")
+			require.NoError(t, errDeleteMig)
+			_, errDeletePerm := x.Exec(`DELETE FROM permission`)
+			require.NoError(t, errDeletePerm)
+			_, errDeleteRole := x.Exec(`DELETE FROM role`)
+			require.NoError(t, errDeleteRole)
+
+			for i := 0; i < 2; i++ {
+				if i == 0 {
+					// put permissions
+					putTestPermissions(t, x, tc.putRolePerms)
+				}
+
+				// Run accesscontrol migration (permissions insertion should not have conflicted)
+				acmigrator := migrator.NewMigrator(x, &setting.Cfg{Logger: log.New("acmigration.test")})
+				acmig.AddManagedPermissionsMigration(acmigrator, acmig.ManagedPermissionsMigrationID+fmt.Sprint(i))
+
+				errRunningMig := acmigrator.Start(false, 0)
+				require.NoError(t, errRunningMig)
+
+				// verify got == want
+				for orgID, roles := range tc.wantRolePerms {
+					for roleName := range roles {
+						// Check managed roles exist
+						role := accesscontrol.Role{}
+						hasRole, errManagedRoleSearch := x.Table("role").Where("org_id = ? AND name = ?", orgID, roleName).Get(&role)
+
+						require.NoError(t, errManagedRoleSearch)
+						require.True(t, hasRole, "expected role to exist", "orgID", orgID, "role", roleName)
+
+						// Check permissions associated with each role
+						perms := []accesscontrol.Permission{}
+						count, errManagedPermsSearch := x.Table("permission").Where("role_id = ?", role.ID).FindAndCount(&perms)
+
+						require.NoError(t, errManagedPermsSearch)
+						require.Equal(t, int64(len(tc.wantRolePerms[orgID][roleName])), count, "expected role to be tied to permissions", "orgID", orgID, "role", roleName)
+
+						gotRawPerms := convertToRawPermissions(perms)
+						require.ElementsMatch(t, gotRawPerms, tc.wantRolePerms[orgID][roleName], "expected role to have permissions", "orgID", orgID, "role", roleName)
+
+						// Check assignment of the roles
+						br := accesscontrol.BuiltinRole{}
+						has, errAssignmentSearch := x.Table("builtin_role").Where("role_id = ? AND role = ? AND org_id = ?", role.ID, acmig.ParseRoleFromName(roleName), orgID).Get(&br)
+						require.NoError(t, errAssignmentSearch)
+						require.True(t, has, "expected assignment of role to builtin role", "orgID", orgID, "role", roleName)
+					}
+				}
+			}
+		})
+	}
+}
+
 func putTestPermissions(t *testing.T, x *xorm.Engine, rolePerms map[int64]map[string][]rawPermission) {
 	for orgID, roles := range rolePerms {
 		for roleName, perms := range roles {
@@ -190,13 +279,15 @@ func putTestPermissions(t *testing.T, x *xorm.Engine, rolePerms map[int64]map[st
 			require.NoError(t, err)
 			require.Equal(t, int64(1), brCount)
 
-			permissions := []accesscontrol.Permission{}
-			for _, p := range perms {
-				permissions = append(permissions, p.toPermission(role.ID, now))
+			if len(perms) > 0 {
+				permissions := []accesscontrol.Permission{}
+				for _, p := range perms {
+					permissions = append(permissions, p.toPermission(role.ID, now))
+				}
+				permissionsCount, err := x.Insert(permissions)
+				require.NoError(t, err)
+				require.Equal(t, int64(len(perms)), permissionsCount)
 			}
-			permissionsCount, err := x.Insert(permissions)
-			require.NoError(t, err)
-			require.Equal(t, int64(len(perms)), permissionsCount)
 		}
 	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Noticed that if a managed role has no permissions then we don't have its role ID in the roleMap since it's not bound to any permission. However the role does exist. Resulting in permissions being inserted with `role_id` `0`. On second run (in enterprise) then the same permissions are inserted and the migration fails.

This is an edge case so the chances of it happening is rather low but if it happens then grafana doesn't start so it's critical.

This is why I'd like to merge this for 9.0 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

