### PR TITLE
Alerting: use "find" to wait for expression editor to load

### DIFF
--- a/public/app/features/alerting/unified/RuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditor.test.tsx
@@ -148,18 +148,20 @@ describe('RuleEditor', () => {
 
     await renderRuleEditor();
     await waitFor(() => expect(mocks.searchFolders).toHaveBeenCalled());
-
     await waitFor(() => expect(mocks.api.discoverFeatures).toHaveBeenCalled());
-    await userEvent.type(await ui.inputs.name.find(), 'my great new rule');
-    await userEvent.click(await ui.buttons.lotexAlert.get());
+
+    await userEvent.click(await ui.buttons.lotexAlert.find());
+
     const dataSourceSelect = ui.inputs.dataSource.get();
     await userEvent.click(byRole('combobox').get(dataSourceSelect));
     await clickSelectOption(dataSourceSelect, 'Prom (default)');
     await waitFor(() => expect(mocks.api.fetchRulerRules).toHaveBeenCalled());
+
+    await userEvent.type(await ui.inputs.expr.find(), 'up == 1');
+
+    await userEvent.type(ui.inputs.name.get(), 'my great new rule');
     await clickSelectOption(ui.inputs.namespace.get(), 'namespace2');
     await clickSelectOption(ui.inputs.group.get(), 'group2');
-
-    await userEvent.type(ui.inputs.expr.get(), 'up == 1');
 
     await userEvent.type(ui.inputs.annotationValue(0).get(), 'some summary');
     await userEvent.type(ui.inputs.annotationValue(1).get(), 'some description');
@@ -353,7 +355,7 @@ describe('RuleEditor', () => {
     await clickSelectOption(ui.inputs.namespace.get(), 'namespace2');
     await clickSelectOption(ui.inputs.group.get(), 'group2');
 
-    await userEvent.type(ui.inputs.expr.get(), 'up == 1');
+    await userEvent.type(await ui.inputs.expr.find(), 'up == 1');
 
     // TODO remove skipPointerEventsCheck once https://github.com/jsdom/jsdom/issues/3232 is fixed
     await userEvent.click(ui.buttons.addLabel.get(), { pointerEventsCheck: PointerEventsCheckLevel.Never });


### PR DESCRIPTION
**What this PR does / why we need it**:

This might fix a flakey test and prevent a timeout.

