### PR TITLE
RBAC: Inheritance permission migration should handle empty managed roles

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
@@ -134,6 +134,10 @@ func (sp *managedPermissionMigrator) Exec(sess *xorm.Session, mg *migrator.Migra
 
 			// assign permissions if they don't exist to the role
 			roleID := foundRole.ID
+			if roleID == 0 {
+				logger.Warn("Unable to create managed permission, got role ID 0", "orgID", orgID, "managedRole", managedRole)
+				continue
+			}
 			for p, toInsert := range permissions {
 				if toInsert {
 					perm := accesscontrol.Permission{RoleID: roleID, Action: p.Action, Scope: p.Scope, Created: now, Updated: now}

--- a/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
@@ -106,12 +106,15 @@ func (sp *managedPermissionMigrator) Exec(sess *xorm.Session, mg *migrator.Migra
 	for orgID, orgMap := range permissionMap {
 		for managedRole, permissions := range orgMap {
 			// ensure managed role exists, create and add to map if it doesn't
-			ok, err := sess.Get(&accesscontrol.Role{Name: managedRole, OrgID: orgID})
+			foundRole := &accesscontrol.Role{Name: managedRole, OrgID: orgID}
+			ok, err := sess.Get(foundRole)
 			if err != nil {
 				return err
 			}
 
-			if !ok {
+			if ok {
+				roleMap[orgID][managedRole] = foundRole.ID
+			} else {
 				uid, err := generateNewRoleUID(sess, orgID)
 				if err != nil {
 					return err

--- a/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/managed_permission_migrator.go
@@ -57,17 +57,10 @@ func (sp *managedPermissionMigrator) Exec(sess *xorm.Session, mg *migrator.Migra
 		return errFindPermissions
 	}
 
-	roleMap := make(map[int64]map[string]int64)                     // map[org_id][role_name] = role_id
 	permissionMap := make(map[int64]map[string]map[Permission]bool) // map[org_id][role_name][Permission] = toInsert
 
 	// for each managed permission make a map of which permissions need to be added to inheritors
 	for _, p := range managedPermissions {
-		if _, ok := roleMap[p.OrgID]; !ok {
-			roleMap[p.OrgID] = map[string]int64{p.RoleName: p.RoleID}
-		} else {
-			roleMap[p.OrgID][p.RoleName] = p.RoleID
-		}
-
 		// this ensures we can use p as a key in the map between different permissions
 		// ensuring we're only comparing on the action and scope
 		roleName := p.RoleName
@@ -112,9 +105,7 @@ func (sp *managedPermissionMigrator) Exec(sess *xorm.Session, mg *migrator.Migra
 				return err
 			}
 
-			if ok {
-				roleMap[orgID][managedRole] = foundRole.ID
-			} else {
+			if !ok {
 				uid, err := generateNewRoleUID(sess, orgID)
 				if err != nil {
 					return err
@@ -138,11 +129,11 @@ func (sp *managedPermissionMigrator) Exec(sess *xorm.Session, mg *migrator.Migra
 					return err
 				}
 
-				roleMap[orgID][managedRole] = createdRole.ID
+				foundRole = &createdRole
 			}
 
 			// assign permissions if they don't exist to the role
-			roleID := roleMap[orgID][managedRole]
+			roleID := foundRole.ID
 			for p, toInsert := range permissions {
 				if toInsert {
 					perm := accesscontrol.Permission{RoleID: roleID, Action: p.Action, Scope: p.Scope, Created: now, Updated: now}

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/managed_permission_migrator_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/managed_permission_migrator_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -14,36 +15,21 @@ import (
 	"xorm.io/xorm"
 )
 
-func TestManagedPermissionsMigration(t *testing.T) {
-	// Run initial migration to have a working DB
-	x := setupTestDB(t)
+type inheritanceTestCase struct {
+	desc          string
+	putRolePerms  map[int64]map[string][]rawPermission
+	wantRolePerms map[int64]map[string][]rawPermission
+}
 
+func inheritanceTestCases() []inheritanceTestCase {
 	team1Scope := accesscontrol.Scope("teams", "id", "1")
 	team2Scope := accesscontrol.Scope("teams", "id", "2")
 
-	type teamMigrationTestCase struct {
-		desc          string
-		putRolePerms  map[int64]map[string][]rawPermission
-		wantRolePerms map[int64]map[string][]rawPermission
-	}
-	testCases := []teamMigrationTestCase{
+	return []inheritanceTestCase{
 		{
 			desc:          "empty perms",
 			putRolePerms:  map[int64]map[string][]rawPermission{},
 			wantRolePerms: map[int64]map[string][]rawPermission{},
-		},
-		{
-			desc: "only unrelated perms",
-			putRolePerms: map[int64]map[string][]rawPermission{
-				1: {
-					"managed:users:1:permissions": {{Action: "teams:read", Scope: team1Scope}},
-				},
-			},
-			wantRolePerms: map[int64]map[string][]rawPermission{
-				1: {
-					"managed:users:1:permissions": {{Action: "teams:read", Scope: team1Scope}},
-				},
-			},
 		},
 		{
 			desc: "inherit permissions from managed role",
@@ -79,7 +65,7 @@ func TestManagedPermissionsMigration(t *testing.T) {
 						{Action: "teams.permissions:read", Scope: team1Scope},
 						{Action: "teams.permissions:write", Scope: team2Scope},
 					},
-					"managed:builtins:admin:permissions": {},
+					"managed:builtins:admin:permissions": {}, //Role existed with no permission
 				},
 			},
 			wantRolePerms: map[int64]map[string][]rawPermission{
@@ -131,13 +117,21 @@ func TestManagedPermissionsMigration(t *testing.T) {
 			},
 		},
 	}
+}
 
-	for _, tc := range testCases {
+func TestManagedPermissionsMigration(t *testing.T) {
+	// Run initial migration to have a working DB
+	x := setupTestDB(t)
+
+	for _, tc := range inheritanceTestCases() {
 		t.Run(tc.desc, func(t *testing.T) {
 			// Remove migration
-			_, errDeleteMig := x.Exec(`DELETE FROM migration_log WHERE migration_id = ?;
-DELETE FROM permission; DELETE FROM role`, acmig.ManagedPermissionsMigrationID)
+			_, errDeleteMig := x.Exec(`DELETE FROM migration_log WHERE migration_id LIKE ?`, acmig.ManagedPermissionsMigrationID+"%")
 			require.NoError(t, errDeleteMig)
+			_, errDeletePerm := x.Exec(`DELETE FROM permission`)
+			require.NoError(t, errDeletePerm)
+			_, errDeleteRole := x.Exec(`DELETE FROM role`)
+			require.NoError(t, errDeleteRole)
 
 			// put permissions
 			putTestPermissions(t, x, tc.putRolePerms)
@@ -174,6 +168,65 @@ DELETE FROM permission; DELETE FROM role`, acmig.ManagedPermissionsMigrationID)
 					has, errAssignmentSearch := x.Table("builtin_role").Where("role_id = ? AND role = ? AND org_id = ?", role.ID, acmig.ParseRoleFromName(roleName), orgID).Get(&br)
 					require.NoError(t, errAssignmentSearch)
 					require.True(t, has, "expected assignment of role to builtin role", "orgID", orgID, "role", roleName)
+				}
+			}
+		})
+	}
+}
+
+func TestManagedPermissionsMigrationRunTwice(t *testing.T) {
+	// Run initial migration to have a working DB
+	x := setupTestDB(t)
+
+	for _, tc := range inheritanceTestCases() {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Remove migration
+			_, errDeleteMig := x.Exec(`DELETE FROM migration_log WHERE migration_id LIKE ?`, acmig.ManagedPermissionsMigrationID+"%")
+			require.NoError(t, errDeleteMig)
+			_, errDeletePerm := x.Exec(`DELETE FROM permission`)
+			require.NoError(t, errDeletePerm)
+			_, errDeleteRole := x.Exec(`DELETE FROM role`)
+			require.NoError(t, errDeleteRole)
+
+			for i := 0; i < 2; i++ {
+				if i == 0 {
+					// put permissions
+					putTestPermissions(t, x, tc.putRolePerms)
+				}
+
+				// Run accesscontrol migration (permissions insertion should not have conflicted)
+				acmigrator := migrator.NewMigrator(x, &setting.Cfg{Logger: log.New("acmigration.test")})
+				acmig.AddManagedPermissionsMigration(acmigrator, acmig.ManagedPermissionsMigrationID+fmt.Sprint(i))
+
+				errRunningMig := acmigrator.Start(false, 0)
+				require.NoError(t, errRunningMig)
+
+				// verify got == want
+				for orgID, roles := range tc.wantRolePerms {
+					for roleName := range roles {
+						// Check managed roles exist
+						role := accesscontrol.Role{}
+						hasRole, errManagedRoleSearch := x.Table("role").Where("org_id = ? AND name = ?", orgID, roleName).Get(&role)
+
+						require.NoError(t, errManagedRoleSearch)
+						require.True(t, hasRole, "expected role to exist", "orgID", orgID, "role", roleName)
+
+						// Check permissions associated with each role
+						perms := []accesscontrol.Permission{}
+						count, errManagedPermsSearch := x.Table("permission").Where("role_id = ?", role.ID).FindAndCount(&perms)
+
+						require.NoError(t, errManagedPermsSearch)
+						require.Equal(t, int64(len(tc.wantRolePerms[orgID][roleName])), count, "expected role to be tied to permissions", "orgID", orgID, "role", roleName)
+
+						gotRawPerms := convertToRawPermissions(perms)
+						require.ElementsMatch(t, gotRawPerms, tc.wantRolePerms[orgID][roleName], "expected role to have permissions", "orgID", orgID, "role", roleName)
+
+						// Check assignment of the roles
+						br := accesscontrol.BuiltinRole{}
+						has, errAssignmentSearch := x.Table("builtin_role").Where("role_id = ? AND role = ? AND org_id = ?", role.ID, acmig.ParseRoleFromName(roleName), orgID).Get(&br)
+						require.NoError(t, errAssignmentSearch)
+						require.True(t, has, "expected assignment of role to builtin role", "orgID", orgID, "role", roleName)
+					}
 				}
 			}
 		})

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/managed_permission_migrator_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/managed_permission_migrator_test.go
@@ -80,6 +80,9 @@ func inheritanceTestCases() []inheritanceTestCase {
 					},
 					"managed:builtins:admin:permissions": {}, //Role existed with no permission
 				},
+				4: {
+					"managed:builtins:admin:permissions": {}, //Role existed with no permission
+				},
 			},
 			wantRolePerms: map[int64]map[string][]rawPermission{
 				1: {
@@ -127,6 +130,9 @@ func inheritanceTestCases() []inheritanceTestCase {
 						{Action: "teams.permissions:write", Scope: team2Scope},
 					},
 				},
+				4: {
+					"managed:builtins:admin:permissions": {}, //Role existed with no permission
+				},
 			},
 		},
 	}
@@ -139,7 +145,7 @@ func TestManagedPermissionsMigration(t *testing.T) {
 	for _, tc := range inheritanceTestCases() {
 		t.Run(tc.desc, func(t *testing.T) {
 			// Remove migration
-			_, errDeleteMig := x.Exec(`DELETE FROM migration_log WHERE migration_id LIKE ?`, acmig.ManagedPermissionsMigrationID+"%")
+			_, errDeleteMig := x.Exec(`DELETE FROM migration_log WHERE migration_id = ?`, acmig.ManagedPermissionsMigrationID)
 			require.NoError(t, errDeleteMig)
 			_, errDeletePerm := x.Exec(`DELETE FROM permission`)
 			require.NoError(t, errDeletePerm)

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/managed_permission_migrator_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/managed_permission_migrator_test.go
@@ -32,6 +32,19 @@ func inheritanceTestCases() []inheritanceTestCase {
 			wantRolePerms: map[int64]map[string][]rawPermission{},
 		},
 		{
+			desc: "only unrelated perms",
+			putRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"managed:users:1:permissions": {{Action: "teams:read", Scope: team1Scope}},
+				},
+			},
+			wantRolePerms: map[int64]map[string][]rawPermission{
+				1: {
+					"managed:users:1:permissions": {{Action: "teams:read", Scope: team1Scope}},
+				},
+			},
+		},
+		{
 			desc: "inherit permissions from managed role",
 			putRolePerms: map[int64]map[string][]rawPermission{
 				1: {

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/managed_permission_migrator_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/managed_permission_migrator_test.go
@@ -74,6 +74,13 @@ func TestManagedPermissionsMigration(t *testing.T) {
 						{Action: "teams:write", Scope: team1Scope},
 					},
 				},
+				3: {
+					"managed:builtins:editor:permissions": {
+						{Action: "teams.permissions:read", Scope: team1Scope},
+						{Action: "teams.permissions:write", Scope: team2Scope},
+					},
+					"managed:builtins:admin:permissions": {},
+				},
 			},
 			wantRolePerms: map[int64]map[string][]rawPermission{
 				1: {
@@ -109,6 +116,16 @@ func TestManagedPermissionsMigration(t *testing.T) {
 						{Action: "teams.permissions:read", Scope: team1Scope},
 						{Action: "teams.permissions:write", Scope: team2Scope},
 						{Action: "teams:write", Scope: team1Scope},
+					},
+				},
+				3: {
+					"managed:builtins:editor:permissions": {
+						{Action: "teams.permissions:read", Scope: team1Scope},
+						{Action: "teams.permissions:write", Scope: team2Scope},
+					},
+					"managed:builtins:admin:permissions": {
+						{Action: "teams.permissions:read", Scope: team1Scope},
+						{Action: "teams.permissions:write", Scope: team2Scope},
 					},
 				},
 			},
@@ -190,13 +207,15 @@ func putTestPermissions(t *testing.T, x *xorm.Engine, rolePerms map[int64]map[st
 			require.NoError(t, err)
 			require.Equal(t, int64(1), brCount)
 
-			permissions := []accesscontrol.Permission{}
-			for _, p := range perms {
-				permissions = append(permissions, p.toPermission(role.ID, now))
+			if len(perms) > 0 {
+				permissions := []accesscontrol.Permission{}
+				for _, p := range perms {
+					permissions = append(permissions, p.toPermission(role.ID, now))
+				}
+				permissionsCount, err := x.Insert(permissions)
+				require.NoError(t, err)
+				require.Equal(t, int64(len(perms)), permissionsCount)
 			}
-			permissionsCount, err := x.Insert(permissions)
-			require.NoError(t, err)
-			require.Equal(t, int64(len(perms)), permissionsCount)
 		}
 	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Noticed that if a managed role has no permissions then we don't have its role ID in the roleMap since it's not bound to any permission. However the role does exist. Resulting in permissions being inserted with `role_id` `0`. On second run (in enterprise) then the same permissions are inserted and the migration fails.

This is an edge case so the chance of it happening is rather low but if it happens then grafana doesn't start so it's critical.

This is why I'd like to merge this for 9.0 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
Nicer alternative to https://github.com/grafana/grafana/pull/50601
