### PR TITLE
 Prometheus: Enforce table format when in explore

### DIFF
--- a/public/app/plugins/datasource/prometheus/result_transformer.ts
+++ b/public/app/plugins/datasource/prometheus/result_transformer.ts
@@ -20,6 +20,7 @@ import {
   DataQueryRequest,
   PreferredVisualisationType,
   DataFrameType,
+  CoreApp,
 } from '@grafana/data';
 import { FetchResponse, getDataSourceSrv, getTemplateSrv } from '@grafana/runtime';
 
@@ -47,7 +48,10 @@ interface TimeAndValue {
 
 const isTableResult = (dataFrame: DataFrame, options: DataQueryRequest<PromQuery>): boolean => {
   // We want to process vector and scalar results in Explore as table
-  if (dataFrame.meta?.custom?.resultType === 'vector' || dataFrame.meta?.custom?.resultType === 'scalar') {
+  if (
+    options.app === CoreApp.Explore &&
+    (dataFrame.meta?.custom?.resultType === 'vector' || dataFrame.meta?.custom?.resultType === 'scalar')
+  ) {
     return true;
   }
 


### PR DESCRIPTION
Reverts a change from https://github.com/grafana/grafana/pull/48654
Fixes: #50606 

Only send tabular data when in explore mode.