### PR TITLE
loki: disable histogram for stream-queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -104,6 +104,11 @@ export class LokiDatasource
   }
 
   getLogsVolumeDataProvider(request: DataQueryRequest<LokiQuery>): Observable<DataQueryResponse> | undefined {
+    // if there are any stream-queries, we are not creating a log-volume-histogram
+    if (request.targets.some((query) => query.queryType === LokiQueryType.Stream)) {
+      return undefined;
+    }
+
     const isLogsVolumeAvailable = request.targets.some((target) => target.expr && !isMetricsQuery(target.expr));
     if (!isLogsVolumeAvailable) {
       return undefined;


### PR DESCRIPTION
in the Loki datasource, you can choose the type, `range` or `instant`. if you enable the `lokiLive` feature-flag, there is a third option `stream`.

if you use `type=stream`, we should not run the log-volume-histogram query.

this is still an experimental feature, and to keep it simple, we just check if there are any stream-queries, and if there are, we do not show any histogram.

how to test:
1. `make devenv sources=loki`
2. make sure you have the `lokiLive` feature-flag enabled
3. look at the grafana-logs while doing this.
4. go to explore-mode, enter the query `{place="moon"}`, run it
5. now switch the query-type to stream
6. now we have to verify that there was a websocket-request for the logs-query, but there was no websocket-request for the log-volume-histogram-query:
    - you should see a line like this in the grafana-logs:
        ```
        INFO ... connecting to websocket logger=tsdb.loki url="ws://localhost:3100/loki/api/v1/tail query=%7Bplace%3D%22moon%22%7D"
        ```
    - make sure there is not a log-line like this roughly at the same place:
        ```
        INFO ... connecting to websocket logger=tsdb.loki url="ws://localhost:3100/loki/api/v1/tail?query=sum+by+%28level%29+%28count_over_time%28%7Bplace%3D%2
        ```
         - the important part is at the end, in the query-string, the log-volume query has the `sum+by+...` part