### PR TITLE
Expression: Execute hidden expressions

### DIFF
--- a/public/app/features/expressions/ExpressionDatasource.ts
+++ b/public/app/features/expressions/ExpressionDatasource.ts
@@ -35,13 +35,6 @@ export class ExpressionDatasourceApi extends DataSourceWithBackend<ExpressionQue
     return `Expression: ${query.type}`;
   }
 
-  filterQuery(query: ExpressionQuery) {
-    if (query.hide) {
-      return false;
-    }
-    return true;
-  }
-
   query(request: DataQueryRequest<ExpressionQuery>): Observable<DataQueryResponse> {
     let targets = request.targets.map(async (query: ExpressionQuery): Promise<ExpressionQuery> => {
       const ds = await getDataSourceSrv().get(query.datasource);


### PR DESCRIPTION
Fixes a bug introduced in grafana-9.0.0-beta3 where the expressions stopped working when hidden. Expressions are expected to be returning the results even when hidden. Hiding should only prevent it from being rendered in the panel.

Fixes https://github.com/grafana/support-escalations/issues/2857