### PR TITLE
Opensearch: Configure to use plugin's annotations editor

### DIFF
--- a/public/app/features/annotations/standardAnnotationSupport.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.ts
@@ -236,7 +236,9 @@ export function getAnnotationsFromData(
  */
 export function shouldUseMappingUI(datasource: DataSourceApi): boolean {
   const { type } = datasource;
-  return type !== 'prometheus' && type !== 'elasticsearch' && type !== 'loki';
+  return (
+    type !== 'prometheus' && type !== 'elasticsearch' && type !== 'loki' && type !== 'grafana-opensearch-datasource'
+  );
 }
 
 /**
@@ -244,5 +246,7 @@ export function shouldUseMappingUI(datasource: DataSourceApi): boolean {
  */
 export function shouldUseLegacyRunner(datasource: DataSourceApi): boolean {
   const { type } = datasource;
-  return type === 'prometheus' || type === 'elasticsearch' || type === 'loki';
+  return (
+    type === 'prometheus' || type === 'elasticsearch' || type === 'loki' || type === 'grafana-opensearch-datasource'
+  );
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The opensearch datasource's annotation editor was [migrated to React.](https://github.com/grafana/opensearch-datasource/pull/36). This PR opts that datasource out of using the default UI.

Without the PR both annotation editors would be visible:
![Screenshot 2022-06-13 at 10 32 27](https://user-images.githubusercontent.com/8092184/173314525-97ae5403-5043-4cc3-bdad-2428d6974b38.png)

**How to test:**
1. Configure Grafana to use the Opensearch Plugin from this PR: https://github.com/grafana/opensearch-datasource/pull/36
2. Open the annotations editor. 
3. With this PR there should only be the plugin's editor:
![Screenshot 2022-06-13 at 10 33 45](https://user-images.githubusercontent.com/8092184/173314865-4d150f98-8da4-4735-bdff-4a3950e1f6fe.png)

