### PR TITLE
OAuth: Redirect to login if no oauth module is found or if module is not configured

### DIFF
--- a/pkg/api/login_oauth.go
+++ b/pkg/api/login_oauth.go
@@ -75,19 +75,13 @@ func (hs *HTTPServer) OAuthLogin(ctx *models.ReqContext) {
 	loginInfo.AuthModule = name
 	provider := hs.SocialService.GetOAuthInfoProvider(name)
 	if provider == nil {
-		hs.handleOAuthLoginError(ctx, loginInfo, LoginError{
-			HttpStatus:    http.StatusNotFound,
-			PublicMessage: "OAuth not enabled",
-		})
+		hs.handleOAuthLoginErrorWithRedirect(ctx, loginInfo, errors.New("OAuth not enabled"))
 		return
 	}
 
 	connect, err := hs.SocialService.GetConnector(name)
 	if err != nil {
-		hs.handleOAuthLoginError(ctx, loginInfo, LoginError{
-			HttpStatus:    http.StatusNotFound,
-			PublicMessage: fmt.Sprintf("No OAuth with name %s configured", name),
-		})
+		hs.handleOAuthLoginErrorWithRedirect(ctx, loginInfo, fmt.Errorf("no OAuth with name %s configured", name))
 		return
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of returning a 500 error when requesting login to  missing oauth provider or a provider that is not configured we should log the error and redirect user to /login

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana-com/issues/4336

**Special notes for your reviewer**:

