### PR TITLE
Docs: update query caching InfluxDB support

### DIFF
--- a/docs/sources/enterprise/query-caching.md
+++ b/docs/sources/enterprise/query-caching.md
@@ -37,11 +37,11 @@ Query caching works for all [Enterprise data sources](https://grafana.com/grafan
 
 - CloudWatch Metrics
 - Google Cloud Monitoring
-- InfluxDB
 - Microsoft SQL Server
 - MySQL
 - Postgres
 - Tempo
+- InfluxDB (using Flux query language)
 
 Some data sources, such as Elasticsearch, Prometheus, and Loki, cache queries themselves, so Grafana query caching does not improve performance.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the query caching doc for InfluxDB datasources to add that it's only supported when using the Flux query language. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
This PR targets 8.5.x as it won't be true from Grafana 9.0+. 
