### PR TITLE
Datasource: Prevent panic when proxying for non-existing data source

### DIFF
--- a/pkg/services/datasourceproxy/datasourceproxy.go
+++ b/pkg/services/datasourceproxy/datasourceproxy.go
@@ -86,6 +86,7 @@ func (p *DataSourceProxyService) ProxyDatasourceRequestWithID(c *models.ReqConte
 	ds, err := p.DataSourceCache.GetDatasource(c.Req.Context(), dsID, c.SignedInUser, c.SkipCache)
 	if err != nil {
 		toAPIError(c, err)
+		return
 	}
 	p.proxyDatasourceRequest(c, ds)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When proxying for a data source which does not exist, this results in a panic

<details>
  <summary>Error log</summary>
msg="Request error" error="runtime error: invalid memory address or nil pointer dereference" stack="/usr/local/go/src/runtime/panic.go:221 (0x4572c6)\n/usr/local/go/src/runtime/signal_unix.go:735 (0x457296)\n/drone/src/pkg/services/datasourceproxy/datasourceproxy.go:106 (0x2004f90)\n/drone/src/pkg/services/datasourceproxy/datasourceproxy.go:90 (0x2004dea)\n/drone/src/pkg/services/datasourceproxy/datasourceproxy.go:60 (0x2004b28)\n/drone/src/pkg/api/dataproxy.go:6 (0x21606b2)\n/drone/src/pkg/api/response/web_hack.go:39 (0x1106692)\n/usr/local/go/src/reflect/value.go:556 (0x4eba44)\n/usr/local/go/src/reflect/value.go:339 (0x4eafc4)\n/drone/src/pkg/web/inject.go:159 (0xf74266)\n/drone/src/pkg/web/inject.go:119 (0xf73eb4)\n/drone/src/pkg/web/context.go:71 (0xf7314b)\n/drone/src/pkg/web/context.go:66 (0x2a63b7a)\n/drone/src/pkg/extensions/ratelimiting/ratelimiting.go:54 (0x2a63b6e)\n/drone/src/pkg/api/response/web_hack.go:31 (0x1106854)\n/usr/local/go/src/reflect/value.go:556 (0x4eba44)\n/usr/local/go/src/reflect/value.go:339 (0x4eafc4)\n/drone/src/pkg/web/inject.go:159 (0xf74266)\n/drone/src/pkg/web/inject.go:119 (0xf73eb4)\n/drone/src/pkg/web/context.go:71 (0xf7314b)\n/drone/src/pkg/web/context.go:66 (0x23ea23b)\n/drone/src/pkg/extensions/caching/middleware/query_middleware.go:327 (0x23ea22a)\n/drone/src/pkg/api/response/web_hack.go:51 (0x11064f3)\n/usr/local/go/src/reflect/value.go:556 (0x4eba44)\n/usr/local/go/src/reflect/value.go:339 (0x4eafc4)\n/drone/src/pkg/web/inject.go:159 (0xf74266)\n/drone/src/pkg/web/inject.go:119 (0xf73eb4)\n/drone/src/pkg/web/context.go:71 (0xf7314b)\n/drone/src/pkg/web/context.go:66 (0xf7af9a)\n/drone/src/pkg/web/macaron.go:141 (0xf7af8c)\n/usr/local/go/src/net/http/server.go:2047 (0x6e19ae)\n/drone/src/pkg/middleware/csp.go:22 (0x188fe52)\n/usr/local/go/src/reflect/value.go:556 (0x4eba44)\n/usr/local/go/src/reflect/value.go:339 (0x4eafc4)\n/drone/src/pkg/web/inject.go:159 (0xf74266)\n/drone/src/pkg/web/inject.go:119 (0xf73eb4)\n/drone/src/pkg/web/context.go:71 (0xf7314b)\n/drone/src/pkg/web/context.go:66 (0xf7af9a)\n/drone/src/pkg/web/macaron.go:141 (0xf7af8c)\n/usr/local/go/src/net/http/server.go:2047 (0x6e19ae)\n/drone/src/pkg/web/render.go:44 (0xf75d46)\n/usr/local/go/src/reflect/value.go:556 (0x4eba44)\n/usr/local/go/src/reflect/value.go:339 (0x4eafc4)\n/drone/src/pkg/web/inject.go:159 (0xf74266)\n/drone/src/pkg/web/inject.go:119 (0xf73eb4)\n/drone/src/pkg/web/context.go:71 (0xf7314b)\n/drone/src/pkg/web/context.go:66 (0xf7af9a)\n/drone/src/pkg/web/macaron.go:141 (0xf7af8c)\n/usr/local/go/src/net/http/server.go:2047 (0x6e19ae)\n/drone/src/pkg/middleware/csrf.go:21 (0x189026f)\n/usr/local/go/src/reflect/value.go:556 (0x4eba44)\n/usr/local/go/src/reflect/value.go:339 (0x4eafc4)\n/drone/src/pkg/web/inject.go:159 (0xf74266)\n/drone/src/pkg/web/inject.go:119 (0xf73eb4)\n/drone/src/pkg/web/context.go:71 (0xf7314b)\n/drone/src/pkg/web/context.go:66 (0x18933aa)\n/drone/src/pkg/middleware/recovery.go:168 (0x18933a1)\n/drone/src/pkg/api/response/web_hack.go:51 (0x11064f3)\n/usr/local/go/src/reflect/value.go:556 (0x4eba44)\n/usr/local/go/src/reflect/value.go:339 (0x4eafc4)\n/drone/src/pkg/web/inject.go:159 (0xf74266)\n/drone/src/pkg/web/inject.go:119 (0xf73eb4)\n/drone/src/pkg/web/context.go:71 (0xf7314b)\n/drone/src/pkg/web/context.go:66 (0x1890f24)\n/drone/src/pkg/middleware/logger.go:35 (0x1890f10)\n/drone/src/pkg/api/response/web_hack.go:31 (0x1106854)\n/usr/local/go/src/reflect/value.go:556 (0x4eba44)\n/usr/local/go/src/reflect/value.go:339 (0x4eafc4)\n/drone/src/pkg/web/inject.go:159 (0xf74266)\n/drone/src/pkg/web/inject.go:119 (0xf73eb4)\n/drone/src/pkg/web/context.go:71 (0xf7314b)\n/drone/src/pkg/web/context.go:66 (0x1896028)\n/drone/src/pkg/middleware/request_metrics.go:60 (0x1896017)\n/drone/src/pkg/api/response/web_hack.go:31 (0x1106854)\n/usr/local/go/src/reflect/value.go:556 (0x4eba44)\n/usr/local/go/src/reflect/value.go:339 (0x4eafc4)\n/drone/src/pkg/web/inject.go:159 (0xf74266)\n/drone/src/pkg/web/inject.go:119 (0xf73eb4)\n/drone/src/pkg/web/context.go:71 (0xf7314b)\n/drone/src/pkg/web/context.go:66 (0x1894e79)\n/drone/src/pkg/middleware/request_tracing.go:60 (0x1894e68)\n/drone/src/pkg/api/response/web_hack.go:31 (0x1106854)\n/usr/local/go/src/reflect/value.go:556 (0x4eba44)\n/usr/local/go/src/reflect/value.go:339 (0x4eafc4)\n/drone/src/pkg/web/inject.go:159 (0xf74266)\n/drone/src/pkg/web/inject.go:119 (0xf73eb4)\n/drone/src/pkg/web/context.go:71 (0xf7314b)\n/drone/src/pkg/web/router.go:156 (0xf775bd)\n/drone/src/pkg/web/router.go:223 (0xf78251)\n/drone/src/pkg/web/macaron.go:176 (0xf75690)\n/usr/local/go/src/net/http/server.go:2879 (0x6e4f1a)\n/usr/local/go/src/net/http/server.go:1930 (0x6e0a87)\n/usr/local/go/src/runtime/asm_amd64.s:1581 (0x475380)\n"
</details>
  

