### PR TITLE
logs: better hasLogsVolumeSupport check

### DIFF
--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -356,7 +356,6 @@ export const runQueries = (
       refreshInterval,
       absoluteRange,
       cache,
-      logsVolumeDataProvider,
     } = exploreItemState;
     let newQuerySub;
 
@@ -378,7 +377,14 @@ export const runQueries = (
       newQuerySub = of(cachedValue)
         .pipe(
           mergeMap((data: PanelData) =>
-            decorateData(data, queryResponse, absoluteRange, refreshInterval, queries, !!logsVolumeDataProvider)
+            decorateData(
+              data,
+              queryResponse,
+              absoluteRange,
+              refreshInterval,
+              queries,
+              datasourceInstance != null && hasLogsVolumeSupport(datasourceInstance)
+            )
           )
         )
         .subscribe((data) => {
@@ -436,7 +442,7 @@ export const runQueries = (
               absoluteRange,
               refreshInterval,
               queries,
-              !!getState().explore[exploreId]!.logsVolumeDataProvider
+              datasourceInstance != null && hasLogsVolumeSupport(datasourceInstance)
             )
           )
         )


### PR DESCRIPTION
there is a problem with the  full-range histogram, when this happens:
- the datasource has a `getLogsVolumeDataProvider` method
- and it returns `undefined`


what should happen: no histogram is shown
what happens: the from-logs-lines histogram is shown

this pull request fixes this corner-case, we only generate from-logs-lines histogram if there is no `datassource.getLogsVolumeDataProvider` method at all.

this is needed to fix some other bugs, but i wanted to keep this pull request small.

how to test:

1. `make devenv sources=loki`
2. go to explore, choose Loki, run this query `{place="moon"}`
3. you should get the full-range histogram
4. now modify the source code here: https://github.com/grafana/grafana/blob/gabor/logs-better-histogram-check/public/app/plugins/datasource/loki/datasource.ts#L106
    - make this the first line `return undefined;`
5. run the loki query again. you should see no histogram.
6. go back to the source code and:
    - revert the change
    - also, rename the `getLogsVolumeDataProvider` method do something else, for example `getLogsVolumeDataProvider2`
7. run the loki query again, you should see the from-logs-lines histogram