### PR TITLE
Dashboard: Unsaved changes warning should not trigger when only pluginVersion has changed

### DIFF
--- a/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
+++ b/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
@@ -1,3 +1,5 @@
+import { getPanelPlugin } from 'app/features/plugins/__mocks__/pluginMocks';
+
 import { setContextSrv } from '../../../../core/services/context_srv';
 import { DashboardModel } from '../../state/DashboardModel';
 import { PanelModel } from '../../state/PanelModel';
@@ -13,6 +15,7 @@ function getDefaultDashboardModel(): DashboardModel {
         type: 'graph',
         gridPos: { x: 0, y: 0, w: 24, h: 6 },
         legend: { sortDesc: false },
+        pluginVersion: '8.5.0',
       },
       {
         id: 2,
@@ -80,6 +83,12 @@ describe('DashboardPrompt', () => {
   it('Should ignore panel repeats', () => {
     const { original, dash } = getTestContext();
     dash.panels.push(new PanelModel({ repeatPanelId: 10 }));
+    expect(hasChanges(dash, original)).toBe(false);
+  });
+
+  it('Should ignore panel pluginVersion change', () => {
+    const { original, dash } = getTestContext();
+    dash.panels[0].pluginVersion = '9.0.0';
     expect(hasChanges(dash, original)).toBe(false);
   });
 

--- a/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.tsx
+++ b/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.tsx
@@ -192,6 +192,9 @@ function cleanDashboardFromIgnoredChanges(dashData: any) {
     // remove scopedVars
     panel.scopedVars = undefined;
 
+    // ignore pluginVersion changes
+    delete panel.pluginVersion;
+
     // ignore panel legend sort
     if (panel.legend) {
       delete panel.legend.sort;


### PR DESCRIPTION
Fixes #48304

Sligtly improves the situation with bad unsaved changes warnings by ignoring pluginVersion.



