### PR TITLE
Loki: Fix showing of duplicated label values in dropdown in query builder

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
@@ -43,7 +43,7 @@ export function LabelFilterItem({ item, defaultOp, onChange, onDelete, onGetLabe
     const selectedOptions = getSelectOptionsFromString(item?.value).map(toOption);
 
     // Remove possible duplicated values
-    return uniqBy([...labelValues, ...selectedOptions], 'value');
+    return uniqBy([...selectedOptions, ...labelValues], 'value');
   };
 
   return (

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
@@ -38,7 +38,19 @@ export function LabelFilterItem({ item, defaultOp, onChange, onDelete, onGetLabe
   };
 
   const getOptions = (): SelectableValue[] => {
-    return [...getSelectOptionsFromString(item?.value).map(toOption), ...(state.labelValues ?? [])];
+    const allOptions = state.labelValues ? [...state.labelValues] : [];
+    const selectedOptions = getSelectOptionsFromString(item?.value).map(toOption);
+
+    // Add selectedOptions to allOptions only if they are created
+    selectedOptions.forEach((option) => {
+      if (state.labelValues?.find((value) => value.label === option.label)) {
+        return;
+      } else {
+        allOptions.unshift(option);
+      }
+    });
+
+    return allOptions;
   };
 
   return (

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/LabelFilterItem.tsx
@@ -1,3 +1,4 @@
+import { uniqBy } from 'lodash';
 import React, { useState } from 'react';
 
 import { SelectableValue, toOption } from '@grafana/data';
@@ -38,19 +39,11 @@ export function LabelFilterItem({ item, defaultOp, onChange, onDelete, onGetLabe
   };
 
   const getOptions = (): SelectableValue[] => {
-    const allOptions = state.labelValues ? [...state.labelValues] : [];
+    const labelValues = state.labelValues ? [...state.labelValues] : [];
     const selectedOptions = getSelectOptionsFromString(item?.value).map(toOption);
 
-    // Add selectedOptions to allOptions only if they are created
-    selectedOptions.forEach((option) => {
-      if (state.labelValues?.find((value) => value.label === option.label)) {
-        return;
-      } else {
-        allOptions.unshift(option);
-      }
-    });
-
-    return allOptions;
+    // Remove possible duplicated values
+    return uniqBy([...labelValues, ...selectedOptions], 'value');
   };
 
   return (


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the issue where value dropdown in loki /prometheus query builder that had duplicated values - the selected values were always duplicated. This PR fixes this by ensuring that all values are deduplicated/unique.

See videos on how to reproduce and test the issue. 

Issue (current main branch):

https://user-images.githubusercontent.com/30407135/173351541-c9e74fb5-4268-4285-9c94-91afb9b772c8.mov

Fix (this branch):

https://user-images.githubusercontent.com/30407135/173353061-6c5a4407-ba20-44bb-a3b6-07c8cabfdb45.mov


**Which issue(s) this PR fixes**:

Fixes #50617 

