### PR TITLE
Drone: remove param from main downstream step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -912,7 +912,6 @@ steps:
     params:
     - SOURCE_BUILD_NUMBER=${DRONE_COMMIT}
     - SOURCE_COMMIT=${DRONE_COMMIT}
-    - OSS_PULL_REQUEST=${DRONE_PULL_REQUEST}
     repositories:
     - grafana/grafana-enterprise@main
     server: https://drone.grafana.net
@@ -4683,6 +4682,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: df6f9fbc1fe40e3ecad762194eeb466ded8aa92cc0ee13a77ea5142d9a3a4749
+hmac: 5f90961f151491580770a354e6f60ceddf35557f1094ec0ee94369fe52285697
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -206,13 +206,13 @@ def enterprise_downstream_step(edition, ver_mode):
             'params': [
                 'SOURCE_BUILD_NUMBER=${DRONE_COMMIT}',
                 'SOURCE_COMMIT=${DRONE_COMMIT}',
-                'OSS_PULL_REQUEST=${DRONE_PULL_REQUEST}',
             ],
         },
     }
 
     if ver_mode == 'pr':
         step.update({ 'failure': 'ignore' })
+        step['settings']['params'].append('OSS_PULL_REQUEST=${DRONE_PULL_REQUEST}')
 
     return step
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the `OSS_PULL_REQUEST` params for downstream builds triggered by the main branch as it shouldn't be used. It should be empty anyway but it's cleaner this way. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

