### PR TITLE
do not update react-redux

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,6 +23,7 @@
     "node-fetch", // we should bump this once we move to esm modules
     "react-hook-form", // due to us exposing these hooks via @grafana/ui form components bumping can break plugins
     "react-icons", // jaeger-ui-components is being refactored to use @grafana/ui icons instead
+    "react-redux", // react-beautiful-dnd depends on react-redux 7.x, we need to update that one first
     "react-router-dom", // we should bump this together with history
     "slate",
     "slate-plain-serializer",


### PR DESCRIPTION
renovate wants to update `react-redux` from `7.x` to `8.x`, but we use the package `react-beautiful-dnd`, and that one depends on `react-redux 7.x`.

even the newest version of `react-beautiful-dnd` depends on `react-redux 7.x`, so we cannot do the upgrade yet.