### PR TITLE
Loki: Do not show histogram for instant queries

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -24,7 +24,7 @@ import { CustomVariableModel } from '../../../features/variables/types';
 
 import { isMetricsQuery, LokiDatasource } from './datasource';
 import { makeMockLokiDatasource } from './mocks';
-import { LokiQuery } from './types';
+import { LokiQuery, LokiQueryType } from './types';
 
 const rawRange = {
   from: toUtc('2018-04-25 10:00'),
@@ -757,6 +757,15 @@ describe('LokiDatasource', () => {
       });
 
       expect(ds.getLogsVolumeDataProvider(options)).toBeDefined();
+    });
+
+    it('does not create provider if there is only an instant logs query', () => {
+      const ds = createLokiDSForTests();
+      const options = getQueryOptions<LokiQuery>({
+        targets: [{ expr: '{label=value', refId: 'A', queryType: LokiQueryType.Instant }],
+      });
+
+      expect(ds.getLogsVolumeDataProvider(options)).not.toBeDefined();
     });
   });
 


### PR DESCRIPTION
(NOTE: this is the same code-change as was done in https://github.com/grafana/grafana/pull/50019, but we had to revert that one, because it uncovered an other problem. now we fixed the other problem in https://github.com/grafana/grafana/pull/50676, so we can apply this one again 😁  )

Fixes https://github.com/grafana/grafana/issues/49749

in the Loki datasource, when you use an instant-query, that is only really useful for metric (numbers-producing) queries. for logs-producing queries, range-queries are the way to go. still, logs-producing instant-queries can happen, and it causes problems for the log-volume-histogram.
this pull-request modifes the log-volume-histogram so that it ignores instant-queries.

how to test:
1. use a loki datasource
2. go to explore
3. run a logs-producing range query. 
4. verify that you see a histogram
5. run a logs-producing instant query. IMPORTANT: make sure that it produces log-lines.
6.  verify that you do not see a histogram