### PR TITLE
Docs: Add envelope encryption as breaking change

### DIFF
--- a/docs/sources/whatsnew/whats-new-in-v9-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-0.md
@@ -237,7 +237,7 @@ You can find the complete list of breaking changes in the links below. Please ch
 
 ### Envelope encryption enabled by default
 
-Since v8.3, a new kind of encryption called "envelope encryption" was added, for the secrets stored into the Grafana
+Since v8.3, a new kind of encryption called "envelope encryption" was added, for those secrets stored into the Grafana
 database (data source credentials, alerting notification channel credentials, oauth tokens, etc), behind a feature
 toggle named `envelopeEncryption`.
 
@@ -245,10 +245,10 @@ So, now this feature toggle has been replaced in favor of `disableEnvelopeEncryp
 the encryption mechanism used by default.
 
 Therefore, any secret created or updated with Grafana v9.0 won't be decryptable by any previous Grafana version unless the
-feature toggle `envelopeEncryption` is enabled (only since v8.3), which is something that needs to be considered in
-high availability setups, progressive rollouts or in case of need to roll back for any reason.
+feature toggle `envelopeEncryption` is enabled (only available since v8.3). That is something that needs to be particularly
+considered in high availability setups, progressive rollouts or in case of need to roll back for any reason.
 
-The recommendation here is to enable `envelopeEncryption` in that case, or alternatively enable `disableEnvelopeEncryption`
+The recommendation here is to enable `envelopeEncryption` for older versions, or alternatively enable `disableEnvelopeEncryption`
 before upgrading to v9.0. However, the latter is probably going to be removed in one of the next releases, so we hugely
 encourage to move on with envelope encryption.
 

--- a/docs/sources/whatsnew/whats-new-in-v9-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-0.md
@@ -237,16 +237,16 @@ You can find the complete list of breaking changes in the links below. Please ch
 
 ### Envelope encryption enabled by default
 
-Since v8.3, a new kind of encryption called "envelope encryption" was added, for the secrets stored into the Grafana
+Since v8.3 a new kind of encryption called "envelope encryption" was added, for the secrets stored in the Grafana
 database (data source credentials, alerting notification channel credentials, oauth tokens, etc), behind a feature
 toggle named `envelopeEncryption`.
 
-So, now this feature toggle has been replaced in favor of `disableEnvelopeEncryption` and envelope encryption is
+In v9.0, `envelopeEncryption` feature toggle has been replaced in favor of `disableEnvelopeEncryption` and envelope encryption is
 the encryption mechanism used by default.
 
-Therefore, any secret created or updated with Grafana v9.0 won't be decryptable by any previous Grafana version unless the
-feature toggle `envelopeEncryption` is enabled (only since v8.3), which is something that needs to be considered in
-high availability setups, progressive rollouts or in case of need to roll back for any reason.
+Therefore, any secret created or updated in Grafana v9.0 won't be decryptable by any previous Grafana version unless the
+feature toggle `envelopeEncryption` is enabled in the previous version (only since v8.3). 
+This needs to be considered in high availability setups, progressive rollouts or in case of need to roll back to a previous Grafana version for any reason.
 
 The recommendation here is to enable `envelopeEncryption` in that case, or alternatively enable `disableEnvelopeEncryption`
 before upgrading to v9.0. However, the latter is probably going to be removed in one of the next releases, so we hugely

--- a/docs/sources/whatsnew/whats-new-in-v9-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-0.md
@@ -235,6 +235,26 @@ You can find the complete list of breaking changes in the links below. Please ch
 - https://grafana.com/docs/grafana/next/release-notes/release-notes-9-0-0-beta3/
 - https://grafana.com/docs/grafana/next/release-notes/release-notes-9-0-0
 
+### Envelope encryption enabled by default
+
+Since v8.3, a new kind of encryption called "envelope encryption" was added, for the secrets stored into the Grafana
+database (data source credentials, alerting notification channel credentials, oauth tokens, etc), behind a feature
+toggle named `envelopeEncryption`.
+
+So, now this feature toggle has been replaced in favor of `disableEnvelopeEncryption` and envelope encryption is
+the encryption mechanism used by default.
+
+Therefore, any secret created or updated with Grafana v9.0 won't be decryptable by any previous Grafana version unless the
+feature toggle `envelopeEncryption` is enabled (only since v8.3), which is something that needs to be considered in
+high availability setups, progressive rollouts or in case of need to roll back for any reason.
+
+The recommendation here is to enable `envelopeEncryption` in that case, or alternatively enable `disableEnvelopeEncryption`
+before upgrading to v9.0. However, the latter is probably going to be removed in one of the next releases, so we hugely
+encourage to move on with envelope encryption.
+
+Find [here]({{< relref "../setup-grafana/configure-security/configure-database-encryption/" >}}) more details and some
+possible workarounds in case you end up in an undesired situation.
+
 ## A note on Grafana Enterprise licensing
 
 When we release Grafana 9.0 on June 14th, Grafana will no longer enforce viewers and editor-admins differently. That means that regardless of whether your Grafana Enterprise license is tiered or combined, instead of seeing this on the Stats & Licensing page:


### PR DESCRIPTION
**What this PR does / why we need it**:

A new kind of encryption called "envelope encryption", available since Grafana v8.3 behind a feature toggle, has been enabled by default since Grafana v9.0. So, this pull request contains the corresponding notice in the "What's new" entry for Grafana v9.0.

**Special notes for your reviewer**:

As usually, I'm not a native language writer but the opposite, so any kind of feedback will be extremely appreciated  🙌🏻 

