### PR TITLE
Heatmap: Remove alpha flag from new heatmap panel

### DIFF
--- a/public/app/plugins/panel/heatmap-new/plugin.json
+++ b/public/app/plugins/panel/heatmap-new/plugin.json
@@ -2,10 +2,10 @@
   "type": "panel",
   "name": "Heatmap (preview)",
   "id": "heatmap-new",
-  "state": "alpha",
+  "state": "beta",
 
   "info": {
-    "description": "Like a histogram over time",
+    "description": "This heatmap panel will replace the heatmap panel in 9.1",
     "author": {
       "name": "Grafana Labs",
       "url": "https://grafana.com"

--- a/public/app/plugins/panel/heatmap-new/plugin.json
+++ b/public/app/plugins/panel/heatmap-new/plugin.json
@@ -1,6 +1,6 @@
 {
   "type": "panel",
-  "name": "Heatmap (preview)",
+  "name": "Heatmap (new)",
   "id": "heatmap-new",
   "state": "beta",
 


### PR DESCRIPTION
This PR makes it possible to run the new heatmap panel in 9.x without setting alphaPanels=true.

In 9.1, both `heatmap` and `heatmap-new` will use this same implementation: https://github.com/grafana/grafana/pull/50229 

This means that any panels created with "heatmap-new" will need to be migrated to "heatmap" in 9.0.  50229 will take care of that