### PR TITLE
Timeseries: Improve cursor Y sync behavior

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/__snapshots__/utils.test.ts.snap
+++ b/packages/grafana-ui/src/components/GraphNG/__snapshots__/utils.test.ts.snap
@@ -77,13 +77,9 @@ Object {
         "pub": [Function],
       },
       "key": "__global_",
-      "match": Array [
-        [Function],
-        [Function],
-      ],
       "scales": Array [
         "x",
-        null,
+        "__fixed/na-na/na-na/auto/linear/na",
       ],
     },
   },

--- a/packages/grafana-ui/src/components/TimeSeries/utils.ts
+++ b/packages/grafana-ui/src/components/TimeSeries/utils.ts
@@ -465,10 +465,8 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<{
           return true;
         },
       },
-      // ??? setSeries: syncMode === DashboardCursorSync.Tooltip,
-      //TODO: remove any once https://github.com/leeoniya/uPlot/pull/611 got merged or the typing is fixed
-      scales: [xScaleKey, null as any],
-      match: [() => true, () => true],
+      scales: [xScaleKey, yScaleKey],
+      // match: [() => true, (a, b) => a === b],
     };
   }
 


### PR DESCRIPTION
The current cursor sync behavior has the Y axis always sync based on relative position -- this is pretty much nonsense.

This PR changes things so that it will sync when they have the same scale key -- this works OK when simple, but has odd behavior when syncing left vs right scales.  Regardless the behavior is much better than the current one, so I think we should do it :)

Test with: http://localhost:3000/d/ICiqZ1rGk/panel-tests-shared-tooltips-cursor-positioning?orgId=1

![2022-06-13_21-12-22 (1)](https://user-images.githubusercontent.com/705951/173491891-2ba6a663-82f5-4c80-8e97-c6c8fc93477e.gif)

Before:
![2022-06-13_21-13-54 (1)](https://user-images.githubusercontent.com/705951/173492028-573b734a-30b3-4a66-83ed-6e1c3a20aaf9.gif)
