### PR TITLE
Data Connections: make sub-routes work

### DIFF
--- a/public/app/features/data-connections/DataConnectionsPage.test.tsx
+++ b/public/app/features/data-connections/DataConnectionsPage.test.tsx
@@ -8,7 +8,7 @@ import { configureStore } from 'app/store/configureStore';
 
 import DataConnectionsPage from './DataConnectionsPage';
 import navIndex from './__mocks__/store.navIndex.mock';
-import { ROUTE_BASE_ID } from './constants';
+import { ROUTE_BASE_ID, ROUTES } from './constants';
 
 const renderPage = (path = `/${ROUTE_BASE_ID}`): RenderResult => {
   // @ts-ignore
@@ -38,5 +38,13 @@ describe('Data Connections Page', () => {
     renderPage();
 
     expect(await screen.findByText('The list of data sources is under development.')).toBeVisible();
+  });
+
+  test('renders the correct tab even if accessing it with a "sub-url"', async () => {
+    renderPage(`${ROUTES.Plugins}/foo`);
+
+    // Check if it still renders the plugins tab
+    expect(await screen.findByText('The list of plugins is under development')).toBeVisible();
+    expect(screen.queryByText('The list of data sources is under development.')).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/data-connections/DataConnectionsPage.tsx
+++ b/public/app/features/data-connections/DataConnectionsPage.tsx
@@ -17,9 +17,9 @@ export default function DataConnectionsPage(): React.ReactElement | null {
     <Page navModel={navModel}>
       <Page.Contents>
         <Switch>
-          <Route exact path={ROUTES.Plugins} component={Plugins} />
-          <Route exact path={ROUTES.CloudIntegrations} component={CloudIntegrations} />
-          <Route exact path={ROUTES.RecordedQueries} component={RecordedQueries} />
+          <Route path={ROUTES.Plugins} component={Plugins} />
+          <Route path={ROUTES.CloudIntegrations} component={CloudIntegrations} />
+          <Route path={ROUTES.RecordedQueries} component={RecordedQueries} />
 
           {/* Default page */}
           <Route component={DataSources} />

--- a/public/app/features/data-connections/hooks/useNavModel.ts
+++ b/public/app/features/data-connections/hooks/useNavModel.ts
@@ -16,7 +16,7 @@ export const useNavModel = () => {
 
   main.children = main.children?.map((item) => ({
     ...item,
-    active: item.url === pathname,
+    active: pathname.startsWith(item.url || ''),
   }));
 
   return {


### PR DESCRIPTION
**Related issue:** [#49910](https://github.com/grafana/grafana/issues/49910)

### What changed?
Until now sub-routes for the different tabs (like `"/data-connections/cloud-integrations/foo"`) didn't work properly, as tab URLs were handled as exact matches. This PR changes that behaviour.

