### PR TITLE
Loki: Handle invalid query type values

### DIFF
--- a/public/app/plugins/datasource/loki/query_utils.test.ts
+++ b/public/app/plugins/datasource/loki/query_utils.test.ts
@@ -97,4 +97,16 @@ describe('getNormalizedLokiQuery', () => {
   it('handles new<>old conflict (new wins), instant', () => {
     expectNormalized({ instant: true, range: false, queryType: LokiQueryType.Instant }, LokiQueryType.Instant);
   });
+
+  it('handles invalid new, range', () => {
+    expectNormalized({ queryType: 'invalid' }, LokiQueryType.Range);
+  });
+
+  it('handles invalid new, when old-range exists, use old', () => {
+    expectNormalized({ instant: false, range: true, queryType: 'invalid' }, LokiQueryType.Range);
+  });
+
+  it('handles invalid new, when old-instant exists, use old', () => {
+    expectNormalized({ instant: true, range: false, queryType: 'invalid' }, LokiQueryType.Instant);
+  });
 });

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -80,9 +80,7 @@ export function addParsedLabelToQuery(expr: string, key: string, value: string |
 // - does not have `.instant`
 // - does not have `.range`
 export function getNormalizedLokiQuery(query: LokiQuery): LokiQuery {
-  // for historical reasons, the queryType field might
-  // contain some invalid data. in that case we behave
-  // as if the queryType is empty
+  //  if queryType field contains invalid data we behave as if the queryType is empty
   const { queryType } = query;
   const hasValidQueryType =
     queryType === LokiQueryType.Range || queryType === LokiQueryType.Instant || queryType === LokiQueryType.Stream;

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -80,8 +80,15 @@ export function addParsedLabelToQuery(expr: string, key: string, value: string |
 // - does not have `.instant`
 // - does not have `.range`
 export function getNormalizedLokiQuery(query: LokiQuery): LokiQuery {
+  // for historical reasons, the queryType field might
+  // contain some invalid data. in that case we behave
+  // as if the queryType is empty
+  const { queryType } = query;
+  const hasValidQueryType =
+    queryType === LokiQueryType.Range || queryType === LokiQueryType.Instant || queryType === LokiQueryType.Stream;
+
   // if queryType exists, it is respected
-  if (query.queryType !== undefined) {
+  if (hasValidQueryType) {
     const { instant, range, ...rest } = query;
     return rest;
   }


### PR DESCRIPTION
the Loki `queryType` field may contain invalid values (for any reason), and this is a problem, because previous Grafana versions ignored `queryType`, so such dashboards worked OK, but now we use `queryType`, so those dashboards break.

this pull request updates the query-type handling code to be more robust. the approach is this: if the stored `queryType` is not valid, we behave as if it did not exist (so we fallback to the older `.instant` and `.range` booleans, or fallback to `QueryTypeRange` at the end).

how to test:
1. create a dashboard with a loki data source and a working loki query
2. edit the panel-json ([query inspector], [json]), find the query's queryType field:
    - if it exists: change it's value to `"invalid"`. 
    - if it does not exist: add it, with `"queryType": "invalid",`
3. [apply]
4. save the dashhboard, reload the page
5. verify that the query still works ok
6. verify in the browser dev-tools that the outgoing ajax-request has `queryType=range`


(NOTE: when the queryType has an invalid value, the visual representation of the query-type-radio-buttons shows all of them unselected. this is probably not optimal. we can fix this problem in a separate pull request.)