### PR TITLE
CI: Include `public/app/plugins/**/plugin.json` in the BE test paths

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -166,6 +166,7 @@ trigger:
     - conf/**
     - go.sum
     - go.mod
+    - public/app/plugins/**/plugin.json
 type: docker
 volumes:
 - host:
@@ -4682,6 +4683,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 5f90961f151491580770a354e6f60ceddf35557f1094ec0ee94369fe52285697
+hmac: 1327a42ff9a4cd493e256b2d795783077e344ae2f2374e7fb5b5543e534e8401
 
 ...

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -103,7 +103,7 @@ def pr_test_backend():
         test_backend_integration_step(edition="oss"),
     ]
     return pipeline(
-        name='pr-test-backend', edition="oss", trigger=get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod']), services=[], steps=init_steps + test_steps,
+        name='pr-test-backend', edition="oss", trigger=get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json']), services=[], steps=init_steps + test_steps,
     )
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR https://github.com/grafana/grafana/pull/50733, passed the PR pipelines but failed on main. This happened because in the PR pipeline only frontend tests ran, while backend tests should run as well, since the `plugin.json` file changed.
The current PR includes all `plugin.json` files under the `public/app/plugins/` directory.