### PR TITLE
RolePicker: Fix submenu position on horizontal space overflow

### DIFF
--- a/public/app/core/components/RolePicker/RolePicker.tsx
+++ b/public/app/core/components/RolePicker/RolePicker.tsx
@@ -5,7 +5,7 @@ import { Role, OrgRole } from 'app/types';
 
 import { RolePickerInput } from './RolePickerInput';
 import { RolePickerMenu } from './RolePickerMenu';
-import { MENU_MAX_HEIGHT } from './constants';
+import { MENU_MAX_HEIGHT, ROLE_PICKER_WIDTH } from './constants';
 
 export interface Props {
   builtInRole?: OrgRole;
@@ -37,7 +37,7 @@ export const RolePicker = ({
   const [selectedRoles, setSelectedRoles] = useState<Role[]>(appliedRoles);
   const [selectedBuiltInRole, setSelectedBuiltInRole] = useState<OrgRole | undefined>(builtInRole);
   const [query, setQuery] = useState('');
-  const [offset, setOffset] = useState(0);
+  const [offset, setOffset] = useState({ vertical: 0, horizontal: 0 });
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -50,14 +50,22 @@ export const RolePicker = ({
     if (!dimensions || !isOpen) {
       return;
     }
-    const { bottom, top } = dimensions;
+    const { bottom, top, left, right } = dimensions;
     const distance = window.innerHeight - bottom;
-    const offset = bottom - top + 10; // Add extra 10px to offset to account for border and outline
+    const offsetVertical = bottom - top + 10; // Add extra 10px to offset to account for border and outline
+    const offsetHorizontal = right - left;
+    let horizontal = -offsetHorizontal;
+    let vertical = -offsetVertical;
+
     if (distance < MENU_MAX_HEIGHT + 20) {
-      setOffset(offset);
-    } else {
-      setOffset(-offset);
+      vertical = offsetVertical;
     }
+
+    if (window.innerWidth - right < ROLE_PICKER_WIDTH) {
+      horizontal = offsetHorizontal;
+    }
+
+    setOffset({ horizontal, vertical });
   }, [isOpen, selectedRoles]);
 
   const onOpen = useCallback(

--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -42,7 +42,7 @@ interface RolePickerMenuProps {
   onUpdate: (newRoles: Role[], newBuiltInRole?: OrgRole) => void;
   onClear?: () => void;
   updateDisabled?: boolean;
-  offset: number;
+  offset: { vertical: number; horizontal: number };
 }
 
 export const RolePickerMenu = ({
@@ -181,9 +181,10 @@ export const RolePickerMenu = ({
       className={cx(
         styles.menu,
         customStyles.menuWrapper,
+        { [customStyles.menuLeft]: offset.horizontal > 0 },
         css`
-          bottom: ${offset > 0 ? `${offset}px` : 'unset'};
-          top: ${offset < 0 ? `${Math.abs(offset)}px` : 'unset'};
+          bottom: ${offset.vertical > 0 ? `${offset.vertical}px` : 'unset'};
+          top: ${offset.vertical < 0 ? `${Math.abs(offset.vertical)}px` : 'unset'};
         `
       )}
     >
@@ -226,6 +227,7 @@ export const RolePickerMenu = ({
                           selectedOptions={selectedOptions}
                           onSelect={onChange}
                           onClear={onClearSubMenu}
+                          showOnLeft={offset.horizontal > 0}
                         />
                       )}
                     </RoleMenuGroupOption>
@@ -278,7 +280,7 @@ export const RolePickerMenu = ({
           </HorizontalGroup>
         </div>
       </div>
-      <div ref={subMenuNode}></div>
+      <div ref={subMenuNode} />
     </div>
   );
 };
@@ -317,6 +319,7 @@ interface RolePickerSubMenuProps {
   disabledOptions?: Role[];
   onSelect: (option: Role) => void;
   onClear?: () => void;
+  showOnLeft?: boolean;
 }
 
 export const RolePickerSubMenu = ({
@@ -325,6 +328,7 @@ export const RolePickerSubMenu = ({
   disabledOptions,
   onSelect,
   onClear,
+  showOnLeft,
 }: RolePickerSubMenuProps): JSX.Element => {
   const theme = useTheme2();
   const styles = getSelectStyles(theme);
@@ -337,7 +341,10 @@ export const RolePickerSubMenu = ({
   };
 
   return (
-    <div className={customStyles.subMenu} aria-label="Role picker submenu">
+    <div
+      className={cx(customStyles.subMenu, { [customStyles.subMenuLeft]: showOnLeft })}
+      aria-label="Role picker submenu"
+    >
       <CustomScrollbar autoHide={false} autoHeightMax={`${MENU_MAX_HEIGHT}px`} hideHorizontalTrack>
         <div className={styles.optionBody}>
           {options.map((option, i) => (
@@ -506,7 +513,7 @@ export const RoleMenuGroupOption = React.forwardRef<HTMLDivElement, RoleMenuGrou
           />
           <div className={cx(styles.optionBody, customStyles.menuOptionBody)}>
             <span>{data.displayName || data.name}</span>
-            <span className={customStyles.menuOptionExpand}></span>
+            <span className={customStyles.menuOptionExpand} />
           </div>
           {root && children && (
             <Portal className={customStyles.subMenuPortal} root={root}>
@@ -552,18 +559,24 @@ export const getStyles = (theme: GrafanaTheme2) => {
         padding-top: ${theme.spacing(1)};
       }
     `,
+    menuLeft: css`
+      right: 0;
+      flex-direction: row-reverse;
+    `,
     subMenu: css`
       height: 100%;
       min-width: 260px;
       display: flex;
       flex-direction: column;
-      border-left-style: solid;
-      border-left-width: 1px;
-      border-left-color: ${theme.components.input.borderColor};
+      border-left: 1px solid ${theme.components.input.borderColor};
 
       & > div {
         padding-top: ${theme.spacing(1)};
       }
+    `,
+    subMenuLeft: css`
+      border-right: 1px solid ${theme.components.input.borderColor};
+      border-left: unset;
     `,
     groupHeader: css`
       padding: ${theme.spacing(0, 4)};


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Fix role picker's submenu to be shown on the left side of the menu, when there's not enough horizontal space to show it on the right.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/3462

**Special notes for your reviewer**:

Before: 

![Screenshot 2022-06-14 at 13 48 34](https://user-images.githubusercontent.com/8878045/173560481-4feb47fd-9d58-4b22-a841-8e6af7966ac8.png)

After:
![Screenshot 2022-06-14 at 13 36 48](https://user-images.githubusercontent.com/8878045/173560552-76fa934a-0c5b-4a6b-b204-2f280eddc36f.png)
![Screenshot 2022-06-14 at 13 42 17](https://user-images.githubusercontent.com/8878045/173560556-1a7966d4-b3a7-4393-a9ae-07f1f6a6b14e.png)


