### PR TITLE
Alerting: Change __alertScreenshotToken__ to __alertImageToken__

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -87,7 +87,7 @@ const (
 
 	// This isn't a hard-coded secret token, hence the nolint.
 	//nolint:gosec
-	ScreenshotTokenAnnotation = "__alertScreenshotToken__"
+	ImageTokenAnnotation = "__alertImageToken__"
 
 	// GrafanaReservedLabelPrefix contains the prefix for Grafana reserved labels. These differ from "__<label>__" labels
 	// in that they are not meant for internal-use only and will be passed-through to AMs and available to users in the same
@@ -105,9 +105,9 @@ var (
 		NamespaceUIDLabel: {},
 	}
 	InternalAnnotationNameSet = map[string]struct{}{
-		DashboardUIDAnnotation:    {},
-		PanelIDAnnotation:         {},
-		ScreenshotTokenAnnotation: {},
+		DashboardUIDAnnotation: {},
+		PanelIDAnnotation:      {},
+		ImageTokenAnnotation:   {},
 	}
 )
 

--- a/pkg/services/ngalert/notifier/channels/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/channels/alertmanager_test.go
@@ -108,7 +108,7 @@ func TestAlertmanagerNotifier_Notify(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"__alert_rule_uid__": "rule uid", "alertname": "alert1"},
-						Annotations: model.LabelSet{"__alertScreenshotToken__": "test-image-1"},
+						Annotations: model.LabelSet{"__alertImageToken__": "test-image-1"},
 					},
 				},
 			},

--- a/pkg/services/ngalert/notifier/channels/kafka_test.go
+++ b/pkg/services/ngalert/notifier/channels/kafka_test.go
@@ -40,7 +40,7 @@ func TestKafkaNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertScreenshotToken__": "test-image-1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertImageToken__": "test-image-1"},
 					},
 				},
 			},
@@ -71,12 +71,12 @@ func TestKafkaNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__alertScreenshotToken__": "test-image-1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__alertImageToken__": "test-image-1"},
 					},
 				}, {
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
-						Annotations: model.LabelSet{"ann1": "annv2", "__alertScreenshotToken__": "test-image-2"},
+						Annotations: model.LabelSet{"ann1": "annv2", "__alertImageToken__": "test-image-2"},
 					},
 				},
 			},

--- a/pkg/services/ngalert/notifier/channels/pushover_test.go
+++ b/pkg/services/ngalert/notifier/channels/pushover_test.go
@@ -49,7 +49,7 @@ func TestPushoverNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"__alert_rule_uid__": "rule uid", "alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertScreenshotToken__": "test-image-1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertImageToken__": "test-image-1"},
 					},
 				},
 			},
@@ -85,12 +85,12 @@ func TestPushoverNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"__alert_rule_uid__": "rule uid", "alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__alertScreenshotToken__": "test-image-1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__alertImageToken__": "test-image-1"},
 					},
 				}, {
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
-						Annotations: model.LabelSet{"ann1": "annv2", "__alertScreenshotToken__": "test-image-2"},
+						Annotations: model.LabelSet{"ann1": "annv2", "__alertImageToken__": "test-image-2"},
 					},
 				},
 			},

--- a/pkg/services/ngalert/notifier/channels/sensugo_test.go
+++ b/pkg/services/ngalert/notifier/channels/sensugo_test.go
@@ -44,7 +44,7 @@ func TestSensuGoNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"__alert_rule_uid__": "rule uid", "alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertScreenshotToken__": "test-image-1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertImageToken__": "test-image-1"},
 					},
 				},
 			},
@@ -87,12 +87,12 @@ func TestSensuGoNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"__alert_rule_uid__": "rule uid", "alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__alertScreenshotToken__": "test-image-1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__alertImageToken__": "test-image-1"},
 					},
 				}, {
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
-						Annotations: model.LabelSet{"ann1": "annv2", "__alertScreenshotToken__": "test-image-2"},
+						Annotations: model.LabelSet{"ann1": "annv2", "__alertImageToken__": "test-image-2"},
 					},
 				},
 			},

--- a/pkg/services/ngalert/notifier/channels/slack_test.go
+++ b/pkg/services/ngalert/notifier/channels/slack_test.go
@@ -128,7 +128,7 @@ func TestSlackNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertScreenshotToken__": "test-with-url"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertImageToken__": "test-with-url"},
 					},
 				},
 			},

--- a/pkg/services/ngalert/notifier/channels/telegram_test.go
+++ b/pkg/services/ngalert/notifier/channels/telegram_test.go
@@ -40,7 +40,7 @@ func TestTelegramNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations:  model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertScreenshotToken__": "test-image-1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertImageToken__": "test-image-1"},
 						GeneratorURL: "a URL",
 					},
 				},
@@ -61,13 +61,13 @@ func TestTelegramNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:       model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations:  model.LabelSet{"ann1": "annv1", "__alertScreenshotToken__": "test-image-1"},
+						Annotations:  model.LabelSet{"ann1": "annv1", "__alertImageToken__": "test-image-1"},
 						GeneratorURL: "a URL",
 					},
 				}, {
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
-						Annotations: model.LabelSet{"ann1": "annv2", "__alertScreenshotToken__": "test-image-2"},
+						Annotations: model.LabelSet{"ann1": "annv2", "__alertImageToken__": "test-image-2"},
 					},
 				},
 			},

--- a/pkg/services/ngalert/notifier/channels/threema_test.go
+++ b/pkg/services/ngalert/notifier/channels/threema_test.go
@@ -43,7 +43,7 @@ func TestThreemaNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertScreenshotToken__": "test-image-1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertImageToken__": "test-image-1"},
 					},
 				},
 			},
@@ -60,12 +60,12 @@ func TestThreemaNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__alertScreenshotToken__": "test-image-1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__alertImageToken__": "test-image-1"},
 					},
 				}, {
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
-						Annotations: model.LabelSet{"ann1": "annv2", "__alertScreenshotToken__": "test-image-2"},
+						Annotations: model.LabelSet{"ann1": "annv2", "__alertImageToken__": "test-image-2"},
 					},
 				},
 			},

--- a/pkg/services/ngalert/notifier/channels/util.go
+++ b/pkg/services/ngalert/notifier/channels/util.go
@@ -113,7 +113,7 @@ func openImage(path string) (io.ReadCloser, error) {
 }
 
 func getTokenFromAnnotations(annotations model.LabelSet) string {
-	if value, ok := annotations[models.ScreenshotTokenAnnotation]; ok {
+	if value, ok := annotations[models.ImageTokenAnnotation]; ok {
 		return string(value)
 	}
 	return ""

--- a/pkg/services/ngalert/notifier/channels/util_test.go
+++ b/pkg/services/ngalert/notifier/channels/util_test.go
@@ -19,13 +19,13 @@ func TestWithStoredImages(t *testing.T) {
 	alerts := []*types.Alert{{
 		Alert: model.Alert{
 			Annotations: model.LabelSet{
-				models.ScreenshotTokenAnnotation: "test-image-1",
+				models.ImageTokenAnnotation: "test-image-1",
 			},
 		},
 	}, {
 		Alert: model.Alert{
 			Annotations: model.LabelSet{
-				models.ScreenshotTokenAnnotation: "test-image-2",
+				models.ImageTokenAnnotation: "test-image-2",
 			},
 		},
 	}}

--- a/pkg/services/ngalert/notifier/channels/victorops_test.go
+++ b/pkg/services/ngalert/notifier/channels/victorops_test.go
@@ -39,7 +39,7 @@ func TestVictoropsNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertScreenshotToken__": "test-image-1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__dashboardUid__": "abcd", "__panelId__": "efgh", "__alertImageToken__": "test-image-1"},
 					},
 				},
 			},
@@ -60,12 +60,12 @@ func TestVictoropsNotifier(t *testing.T) {
 				{
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
-						Annotations: model.LabelSet{"ann1": "annv1", "__alertScreenshotToken__": "test-image-1"},
+						Annotations: model.LabelSet{"ann1": "annv1", "__alertImageToken__": "test-image-1"},
 					},
 				}, {
 					Alert: model.Alert{
 						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
-						Annotations: model.LabelSet{"ann1": "annv2", "__alertScreenshotToken__": "test-image-2"},
+						Annotations: model.LabelSet{"ann1": "annv2", "__alertImageToken__": "test-image-2"},
 					},
 				},
 			},

--- a/pkg/services/ngalert/schedule/compat.go
+++ b/pkg/services/ngalert/schedule/compat.go
@@ -40,7 +40,7 @@ func stateToPostableAlert(alertState *state.State, appURL *url.URL) *models.Post
 	}
 
 	if alertState.Image != nil {
-		nA[ngModels.ScreenshotTokenAnnotation] = alertState.Image.Token
+		nA[ngModels.ImageTokenAnnotation] = alertState.Image.Token
 	}
 
 	var urlStr string

--- a/pkg/services/ngalert/schedule/compat_test.go
+++ b/pkg/services/ngalert/schedule/compat_test.go
@@ -118,7 +118,7 @@ func Test_stateToPostableAlert(t *testing.T) {
 					require.Equal(t, expected, result.Annotations)
 				})
 
-				t.Run("add __alertScreenshotToken__ if there is an image token", func(t *testing.T) {
+				t.Run("add __alertImageToken__ if there is an image token", func(t *testing.T) {
 					alertState := randomState(tc.state)
 					alertState.Annotations = randomMapOfStrings()
 					alertState.Image = &ngModels.Image{Token: "test_token"}
@@ -129,7 +129,7 @@ func Test_stateToPostableAlert(t *testing.T) {
 					for k, v := range alertState.Annotations {
 						expected[k] = v
 					}
-					expected["__alertScreenshotToken__"] = alertState.Image.Token
+					expected["__alertImageToken__"] = alertState.Image.Token
 
 					require.Equal(t, expected, result.Annotations)
 				})


### PR DESCRIPTION
**What this PR does / why we need it**:

This is something we shouldn't change until at least the next minor version release (9.1) but I thought we should consider fixing this as images in alert notifications won't be limited to just screenshots in the future.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

