### PR TITLE
Data Connections: set a base-path for the embedded Cloud Onboarding plugin

### DIFF
--- a/public/app/features/data-connections/tabs/CloudIntegrations/CloudIntegrations.tsx
+++ b/public/app/features/data-connections/tabs/CloudIntegrations/CloudIntegrations.tsx
@@ -5,14 +5,14 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 import { AppPluginLoader } from 'app/features/plugins/components/AppPluginLoader';
 
-import { CLOUD_ONBOARDING_APP_ID } from '../../constants';
+import { CLOUD_ONBOARDING_APP_ID, ROUTES } from '../../constants';
 
 export function CloudIntegrations(): ReactElement | null {
   const s = useStyles2(getStyles);
 
   return (
     <div className={s.container}>
-      <AppPluginLoader id={CLOUD_ONBOARDING_APP_ID} />
+      <AppPluginLoader id={CLOUD_ONBOARDING_APP_ID} basePath={ROUTES.CloudIntegrations} />
     </div>
   );
 }


### PR DESCRIPTION
### What changed?
In case we didn't set a `basePath` directly, then `<AppPluginLoader>` would always use the current path as a `basePath`.
This can get problematic in case the Cloud Onboarding app tries to handle it's own sub-routes, as the sub-route would be part of the `basePath` as well. This PR fixes this issue.