### PR TITLE
Remove debug log when publishing live message

### DIFF
--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -940,7 +940,6 @@ func (g *GrafanaLive) handleDatasourceScope(ctx context.Context, user *models.Si
 
 // Publish sends the data to the channel without checking permissions etc.
 func (g *GrafanaLive) Publish(orgID int64, channel string, data []byte) error {
-	logger.Debug("publish into channel", "channel", channel, "orgId", orgID, "data", string(data))
 	_, err := g.node.Publish(orgchannel.PrependOrgID(orgID, channel), data)
 	return err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This log line can result in logging huge JSON data - for example when saving dashboards. Seems that we don't actually need it these days.