### PR TITLE
Alerting: Provisioning UI

### DIFF
--- a/public/app/features/alerting/unified/AmRoutes.tsx
+++ b/public/app/features/alerting/unified/AmRoutes.tsx
@@ -11,7 +11,7 @@ import { useCleanup } from '../../../core/hooks/useCleanup';
 import { AlertManagerPicker } from './components/AlertManagerPicker';
 import { AlertingPageWrapper } from './components/AlertingPageWrapper';
 import { NoAlertManagerWarning } from './components/NoAlertManagerWarning';
-import { ProvisioningAlert } from './components/Provisioning';
+import { ProvisionedResource, ProvisioningAlert } from './components/Provisioning';
 import { AmRootRoute } from './components/amroutes/AmRootRoute';
 import { AmSpecificRouting } from './components/amroutes/AmSpecificRouting';
 import { MuteTimingsTable } from './components/amroutes/MuteTimingsTable';
@@ -126,7 +126,7 @@ const AmRoutes: FC = () => {
           {resultError.message || 'Unknown error.'}
         </Alert>
       )}
-      {isProvisioned && <ProvisioningAlert type={'root notification policy'} />}
+      {isProvisioned && <ProvisioningAlert resource={ProvisionedResource.RootNotificationPolicy} />}
       {resultLoading && <LoadingPlaceholder text="Loading Alertmanager config..." />}
       {result && !resultLoading && !resultError && (
         <>

--- a/public/app/features/alerting/unified/AmRoutes.tsx
+++ b/public/app/features/alerting/unified/AmRoutes.tsx
@@ -11,6 +11,7 @@ import { useCleanup } from '../../../core/hooks/useCleanup';
 import { AlertManagerPicker } from './components/AlertManagerPicker';
 import { AlertingPageWrapper } from './components/AlertingPageWrapper';
 import { NoAlertManagerWarning } from './components/NoAlertManagerWarning';
+import { ProvisioningAlert } from './components/Provisioning';
 import { AmRootRoute } from './components/amroutes/AmRootRoute';
 import { AmSpecificRouting } from './components/amroutes/AmSpecificRouting';
 import { MuteTimingsTable } from './components/amroutes/MuteTimingsTable';
@@ -125,12 +126,7 @@ const AmRoutes: FC = () => {
           {resultError.message || 'Unknown error.'}
         </Alert>
       )}
-      {isProvisioned && (
-        <Alert severity="info" title="These notification policies have been provisioned">
-          These notification policies were added by config and cannot be modified using the UI. Please contact your
-          server admin to update these notification policies.
-        </Alert>
-      )}
+      {isProvisioned && <ProvisioningAlert type={'root notification policy'} />}
       {resultLoading && <LoadingPlaceholder text="Loading Alertmanager config..." />}
       {result && !resultLoading && !resultError && (
         <>

--- a/public/app/features/alerting/unified/MuteTimings.tsx
+++ b/public/app/features/alerting/unified/MuteTimings.tsx
@@ -38,7 +38,18 @@ const MuteTimings = () => {
 
   const getMuteTimingByName = useCallback(
     (id: string): MuteTimeInterval | undefined => {
-      return config?.mute_time_intervals?.find(({ name }: MuteTimeInterval) => name === id);
+      const timing = config?.mute_time_intervals?.find(({ name }: MuteTimeInterval) => name === id);
+
+      if (timing) {
+        const provenance = (config?.muteTimeProvenances ?? {})[timing.name];
+
+        return {
+          ...timing,
+          provenance,
+        };
+      }
+
+      return timing;
     },
     [config]
   );
@@ -60,7 +71,9 @@ const MuteTimings = () => {
             {() => {
               if (queryParams['muteName']) {
                 const muteTiming = getMuteTimingByName(String(queryParams['muteName']));
-                return <MuteTimingForm muteTiming={muteTiming} showError={!muteTiming} />;
+                const provenance = muteTiming?.provenance;
+
+                return <MuteTimingForm muteTiming={muteTiming} showError={!muteTiming} provenance={provenance} />;
               }
               return <Redirect to="/alerting/routes" />;
             }}

--- a/public/app/features/alerting/unified/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.tsx
@@ -19,7 +19,7 @@ import { AlertQuery } from '../../../types/unified-alerting-dto';
 
 import { AlertLabels } from './components/AlertLabels';
 import { DetailsField } from './components/DetailsField';
-import { ProvisioningAlert } from './components/Provisioning';
+import { ProvisionedResource, ProvisioningAlert } from './components/Provisioning';
 import { RuleViewerLayout, RuleViewerLayoutContent } from './components/rule-viewer/RuleViewerLayout';
 import { RuleViewerVisualization } from './components/rule-viewer/RuleViewerVisualization';
 import { RuleDetailsActionButtons } from './components/rules/RuleDetailsActionButtons';
@@ -147,7 +147,7 @@ export function RuleViewer({ match }: RuleViewerProps) {
           </VerticalGroup>
         </Alert>
       )}
-      {isProvisioned && <ProvisioningAlert type="alert rule" />}
+      {isProvisioned && <ProvisioningAlert resource={ProvisionedResource.AlertRule} />}
       <RuleViewerLayoutContent>
         <div>
           <h4>

--- a/public/app/features/alerting/unified/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.tsx
@@ -19,6 +19,7 @@ import { AlertQuery } from '../../../types/unified-alerting-dto';
 
 import { AlertLabels } from './components/AlertLabels';
 import { DetailsField } from './components/DetailsField';
+import { ProvisioningAlert } from './components/Provisioning';
 import { RuleViewerLayout, RuleViewerLayoutContent } from './components/rule-viewer/RuleViewerLayout';
 import { RuleViewerVisualization } from './components/rule-viewer/RuleViewerVisualization';
 import { RuleDetailsActionButtons } from './components/rules/RuleDetailsActionButtons';
@@ -35,7 +36,7 @@ import { AlertingQueryRunner } from './state/AlertingQueryRunner';
 import { getRulesSourceByName } from './utils/datasource';
 import { alertRuleToQueries } from './utils/query';
 import * as ruleId from './utils/rule-id';
-import { isFederatedRuleGroup } from './utils/rules';
+import { isFederatedRuleGroup, isGrafanaRulerRule } from './utils/rules';
 
 type RuleViewerProps = GrafanaRouteComponentProps<{ id?: string; sourceName?: string }>;
 
@@ -130,6 +131,7 @@ export function RuleViewer({ match }: RuleViewerProps) {
 
   const annotations = Object.entries(rule.annotations).filter(([_, value]) => !!value.trim());
   const isFederatedRule = isFederatedRuleGroup(rule.group);
+  const isProvisioned = isGrafanaRulerRule(rule.rulerRule) && Boolean(rule.rulerRule.grafana_alert.provenance);
 
   return (
     <RuleViewerLayout wrapInContent={false} title={pageTitle}>
@@ -145,6 +147,7 @@ export function RuleViewer({ match }: RuleViewerProps) {
           </VerticalGroup>
         </Alert>
       )}
+      {isProvisioned && <ProvisioningAlert type="alert rule" />}
       <RuleViewerLayoutContent>
         <div>
           <h4>

--- a/public/app/features/alerting/unified/api/alertmanager.ts
+++ b/public/app/features/alerting/unified/api/alertmanager.ts
@@ -33,6 +33,7 @@ export async function fetchAlertManagerConfig(alertManagerSourceName: string): P
     );
     return {
       template_files: result.data.template_files ?? {},
+      template_file_provenances: result.data.template_file_provenances ?? {},
       alertmanager_config: result.data.alertmanager_config ?? {},
     };
   } catch (e) {

--- a/public/app/features/alerting/unified/components/Provisioning.tsx
+++ b/public/app/features/alerting/unified/components/Provisioning.tsx
@@ -2,15 +2,23 @@ import React from 'react';
 
 import { Alert, Badge } from '@grafana/ui';
 
-interface ProvisioningAlertProps {
-  type: string;
+export enum ProvisionedResource {
+  ContactPoint = 'contact point',
+  Template = 'template',
+  MuteTiming = 'mute timing',
+  AlertRule = 'alert rule',
+  RootNotificationPolicy = 'root notification policy',
 }
 
-export const ProvisioningAlert = ({ type }: ProvisioningAlertProps) => {
+interface ProvisioningAlertProps {
+  resource: ProvisionedResource;
+}
+
+export const ProvisioningAlert = ({ resource }: ProvisioningAlertProps) => {
   return (
-    <Alert title={`This ${type} has been provisioned`} severity="info">
-      This {type} was added by config and cannot be modified using the UI. Please contact your server admin to update
-      this {type}.
+    <Alert title={`This ${resource} has been provisioned`} severity="info">
+      This {resource} has been provisioned and cannot be modified using the UI. Please contact your server admin to
+      update this {resource}.
     </Alert>
   );
 };

--- a/public/app/features/alerting/unified/components/Provisioning.tsx
+++ b/public/app/features/alerting/unified/components/Provisioning.tsx
@@ -16,8 +16,8 @@ interface ProvisioningAlertProps {
 
 export const ProvisioningAlert = ({ resource }: ProvisioningAlertProps) => {
   return (
-    <Alert title={`This ${resource} has been provisioned`} severity="info">
-      This {resource} has been provisioned and cannot be modified using the UI. Please contact your server admin to
+    <Alert title={`This ${resource} cannot be edited through the UI`} severity="info">
+      This {resource} has been provisioned, that means it was created by config. Please contact your server admin to
       update this {resource}.
     </Alert>
   );

--- a/public/app/features/alerting/unified/components/Provisioning.tsx
+++ b/public/app/features/alerting/unified/components/Provisioning.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { Alert, Badge } from '@grafana/ui';
+
+interface ProvisioningAlertProps {
+  type: string;
+}
+
+export const ProvisioningAlert = ({ type }: ProvisioningAlertProps) => {
+  return (
+    <Alert title={`This ${type} has been provisioned`} severity="info">
+      This {type} was added by config and cannot be modified using the UI. Please contact your server admin to update
+      this {type}.
+    </Alert>
+  );
+};
+
+export const ProvisioningBadge = () => {
+  return <Badge text={'Provisioned'} color={'purple'} />;
+};

--- a/public/app/features/alerting/unified/components/amroutes/AmRootRoute.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRootRoute.tsx
@@ -7,7 +7,6 @@ import { Button, useStyles2 } from '@grafana/ui';
 import { Authorize } from '../../components/Authorize';
 import { AmRouteReceiver, FormAmRoute } from '../../types/amroutes';
 import { getNotificationsPermissions } from '../../utils/access-control';
-import { isVanillaPrometheusAlertManagerDataSource } from '../../utils/datasource';
 
 import { AmRootRouteForm } from './AmRootRouteForm';
 import { AmRootRouteRead } from './AmRootRouteRead';
@@ -20,6 +19,7 @@ export interface AmRootRouteProps {
   receivers: AmRouteReceiver[];
   routes: FormAmRoute;
   alertManagerSourceName: string;
+  readOnly?: boolean;
 }
 
 export const AmRootRoute: FC<AmRootRouteProps> = ({
@@ -30,11 +30,11 @@ export const AmRootRoute: FC<AmRootRouteProps> = ({
   receivers,
   routes,
   alertManagerSourceName,
+  readOnly = false,
 }) => {
   const styles = useStyles2(getStyles);
 
   const permissions = getNotificationsPermissions(alertManagerSourceName);
-  const isReadOnly = isVanillaPrometheusAlertManagerDataSource(alertManagerSourceName);
 
   return (
     <div className={styles.container} data-testid="am-root-route-container">
@@ -42,7 +42,7 @@ export const AmRootRoute: FC<AmRootRouteProps> = ({
         <h5 className={styles.title}>
           Root policy - <i>default for all alerts</i>
         </h5>
-        {!isEditMode && !isReadOnly && (
+        {!isEditMode && !readOnly && (
           <Authorize actions={[permissions.update]}>
             <Button icon="pen" onClick={onEnterEditMode} size="sm" type="button" variant="secondary">
               Edit

--- a/public/app/features/alerting/unified/components/amroutes/MuteTimingForm.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/MuteTimingForm.tsx
@@ -22,7 +22,7 @@ import { createMuteTiming, defaultTimeInterval } from '../../utils/mute-timings'
 import { initialAsyncRequestState } from '../../utils/redux';
 import { AlertManagerPicker } from '../AlertManagerPicker';
 import { AlertingPageWrapper } from '../AlertingPageWrapper';
-import { ProvisioningAlert } from '../Provisioning';
+import { ProvisionedResource, ProvisioningAlert } from '../Provisioning';
 
 import { MuteTimingTimeInterval } from './MuteTimingTimeInterval';
 
@@ -111,7 +111,7 @@ const MuteTimingForm = ({ muteTiming, showError, provenance }: Props) => {
         disabled
         dataSources={alertManagers}
       />
-      {provenance && <ProvisioningAlert type="mute timing" />}
+      {provenance && <ProvisioningAlert resource={ProvisionedResource.MuteTiming} />}
       {result && !loading && (
         <FormProvider {...formApi}>
           <form onSubmit={formApi.handleSubmit(onSubmit)} data-testid="mute-timing-form">

--- a/public/app/features/alerting/unified/components/amroutes/MuteTimingForm.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/MuteTimingForm.tsx
@@ -22,6 +22,7 @@ import { createMuteTiming, defaultTimeInterval } from '../../utils/mute-timings'
 import { initialAsyncRequestState } from '../../utils/redux';
 import { AlertManagerPicker } from '../AlertManagerPicker';
 import { AlertingPageWrapper } from '../AlertingPageWrapper';
+import { ProvisioningAlert } from '../Provisioning';
 
 import { MuteTimingTimeInterval } from './MuteTimingTimeInterval';
 
@@ -110,12 +111,7 @@ const MuteTimingForm = ({ muteTiming, showError, provenance }: Props) => {
         disabled
         dataSources={alertManagers}
       />
-      {provenance && (
-        <Alert title={'This mute timing has been provisioned'} severity="info">
-          This mute timing was added by config and cannot be modified using the UI. Please contact your server admin to
-          update this mute timing.
-        </Alert>
-      )}
+      {provenance && <ProvisioningAlert type="mute timing" />}
       {result && !loading && (
         <FormProvider {...formApi}>
           <form onSubmit={formApi.handleSubmit(onSubmit)} data-testid="mute-timing-form">

--- a/public/app/features/alerting/unified/components/amroutes/MuteTimingForm.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/MuteTimingForm.tsx
@@ -28,6 +28,7 @@ import { MuteTimingTimeInterval } from './MuteTimingTimeInterval';
 interface Props {
   muteTiming?: MuteTimeInterval;
   showError?: boolean;
+  provenance?: string;
 }
 
 const useDefaultValues = (muteTiming?: MuteTimeInterval): MuteTimingFields => {
@@ -56,7 +57,7 @@ const useDefaultValues = (muteTiming?: MuteTimeInterval): MuteTimingFields => {
   }, [muteTiming]);
 };
 
-const MuteTimingForm = ({ muteTiming, showError }: Props) => {
+const MuteTimingForm = ({ muteTiming, showError, provenance }: Props) => {
   const dispatch = useDispatch();
   const alertManagers = useAlertManagersByPermission('notification');
   const [alertManagerSourceName, setAlertManagerSourceName] = useAlertManagerSourceName(alertManagers);
@@ -109,11 +110,17 @@ const MuteTimingForm = ({ muteTiming, showError }: Props) => {
         disabled
         dataSources={alertManagers}
       />
+      {provenance && (
+        <Alert title={'This mute timing has been provisioned'} severity="info">
+          This mute timing was added by config and cannot be modified using the UI. Please contact your server admin to
+          update this mute timing.
+        </Alert>
+      )}
       {result && !loading && (
         <FormProvider {...formApi}>
           <form onSubmit={formApi.handleSubmit(onSubmit)} data-testid="mute-timing-form">
             {showError && <Alert title="No matching mute timing found" />}
-            <FieldSet label={'Create mute timing'}>
+            <FieldSet label={'Create mute timing'} disabled={Boolean(provenance)}>
               <Field
                 required
                 label="Name"

--- a/public/app/features/alerting/unified/components/amroutes/MuteTimingsTable.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/MuteTimingsTable.tsx
@@ -3,7 +3,7 @@ import React, { FC, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { IconButton, LinkButton, Link, useStyles2, ConfirmModal } from '@grafana/ui';
+import { IconButton, LinkButton, Link, useStyles2, ConfirmModal, Badge } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AlertManagerCortexConfig, MuteTimeInterval, TimeInterval } from 'app/plugins/datasource/alertmanager/types';
 
@@ -40,15 +40,24 @@ export const MuteTimingsTable: FC<Props> = ({ alertManagerSourceName, muteTiming
 
   const items = useMemo((): Array<DynamicTableItemProps<MuteTimeInterval>> => {
     const muteTimings = result?.alertmanager_config?.mute_time_intervals ?? [];
+    const muteTimingsProvenances = result?.alertmanager_config?.muteTimeProvenances ?? {};
+
     return muteTimings
       .filter(({ name }) => (muteTimingNames ? muteTimingNames.includes(name) : true))
       .map((mute) => {
         return {
           id: mute.name,
-          data: mute,
+          data: {
+            ...mute,
+            provenance: muteTimingsProvenances[mute.name],
+          },
         };
       });
-  }, [result?.alertmanager_config?.mute_time_intervals, muteTimingNames]);
+  }, [
+    result?.alertmanager_config?.mute_time_intervals,
+    result?.alertmanager_config?.muteTimeProvenances,
+    muteTimingNames,
+  ]);
 
   const columns = useColumns(alertManagerSourceName, hideActions, setMuteTimingName);
 
@@ -107,13 +116,18 @@ function useColumns(alertManagerSourceName: string, hideActions = false, setMute
   const userHasEditPermissions = contextSrv.hasPermission(permissions.update);
   const userHasDeletePermissions = contextSrv.hasPermission(permissions.delete);
   const showActions = !hideActions && (userHasEditPermissions || userHasDeletePermissions);
+
   return useMemo((): Array<DynamicTableColumnProps<MuteTimeInterval>> => {
     const columns: Array<DynamicTableColumnProps<MuteTimeInterval>> = [
       {
         id: 'name',
         label: 'Name',
         renderCell: function renderName({ data }) {
-          return data.name;
+          return (
+            <>
+              {data.name} {data.provenance && <Badge text={'Provisioned'} color={'purple'} />}
+            </>
+          );
         },
         size: '250px',
       },
@@ -128,6 +142,19 @@ function useColumns(alertManagerSourceName: string, hideActions = false, setMute
         id: 'actions',
         label: 'Actions',
         renderCell: function renderActions({ data }) {
+          if (data.provenance) {
+            return (
+              <div>
+                <Link
+                  href={makeAMLink(`/alerting/routes/mute-timing/edit`, alertManagerSourceName, {
+                    muteName: data.name,
+                  })}
+                >
+                  <IconButton name="file-alt" title="View mute timing" />
+                </Link>
+              </div>
+            );
+          }
           return (
             <div>
               <Authorize actions={[permissions.update]}>

--- a/public/app/features/alerting/unified/components/amroutes/MuteTimingsTable.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/MuteTimingsTable.tsx
@@ -3,7 +3,7 @@ import React, { FC, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { IconButton, LinkButton, Link, useStyles2, ConfirmModal, Badge } from '@grafana/ui';
+import { IconButton, LinkButton, Link, useStyles2, ConfirmModal } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AlertManagerCortexConfig, MuteTimeInterval, TimeInterval } from 'app/plugins/datasource/alertmanager/types';
 
@@ -22,6 +22,7 @@ import { makeAMLink } from '../../utils/misc';
 import { AsyncRequestState, initialAsyncRequestState } from '../../utils/redux';
 import { DynamicTable, DynamicTableItemProps, DynamicTableColumnProps } from '../DynamicTable';
 import { EmptyAreaWithCTA } from '../EmptyAreaWithCTA';
+import { ProvisioningBadge } from '../Provisioning';
 
 interface Props {
   alertManagerSourceName: string;
@@ -125,7 +126,7 @@ function useColumns(alertManagerSourceName: string, hideActions = false, setMute
         renderCell: function renderName({ data }) {
           return (
             <>
-              {data.name} {data.provenance && <Badge text={'Provisioned'} color={'purple'} />}
+              {data.name} {data.provenance && <ProvisioningBadge />}
             </>
           );
         },

--- a/public/app/features/alerting/unified/components/receivers/EditReceiverView.tsx
+++ b/public/app/features/alerting/unified/components/receivers/EditReceiverView.tsx
@@ -19,7 +19,7 @@ export const EditReceiverView: FC<Props> = ({ config, receiverName, alertManager
   if (!receiver) {
     return (
       <Alert severity="error" title="Receiver not found">
-        Sorry, this receiver does not seem to exit.
+        Sorry, this receiver does not seem to exist.
       </Alert>
     );
   }

--- a/public/app/features/alerting/unified/components/receivers/EditReceiverView.tsx
+++ b/public/app/features/alerting/unified/components/receivers/EditReceiverView.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import { InfoBox } from '@grafana/ui';
+import { Alert } from '@grafana/ui';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
@@ -18,9 +18,9 @@ export const EditReceiverView: FC<Props> = ({ config, receiverName, alertManager
   const receiver = config.alertmanager_config.receivers?.find(({ name }) => name === receiverName);
   if (!receiver) {
     return (
-      <InfoBox severity="error" title="Receiver not found">
+      <Alert severity="error" title="Receiver not found">
         Sorry, this receiver does not seem to exit.
-      </InfoBox>
+      </Alert>
     );
   }
 

--- a/public/app/features/alerting/unified/components/receivers/EditTemplateView.tsx
+++ b/public/app/features/alerting/unified/components/receivers/EditTemplateView.tsx
@@ -13,6 +13,8 @@ interface Props {
 
 export const EditTemplateView: FC<Props> = ({ config, templateName, alertManagerSourceName }) => {
   const template = config.template_files?.[templateName];
+  const provenance = config.template_file_provenances?.[templateName];
+
   if (!template) {
     return (
       <InfoBox severity="error" title="Template not found">
@@ -25,6 +27,7 @@ export const EditTemplateView: FC<Props> = ({ config, templateName, alertManager
       alertManagerSourceName={alertManagerSourceName}
       config={config}
       existing={{ name: templateName, content: template }}
+      provenance={provenance}
     />
   );
 };

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -3,7 +3,7 @@ import React, { FC, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Badge, Button, ConfirmModal, Modal, useStyles2 } from '@grafana/ui';
+import { Button, ConfirmModal, Modal, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 
@@ -16,6 +16,7 @@ import { isReceiverUsed } from '../../utils/alertmanager';
 import { isVanillaPrometheusAlertManagerDataSource } from '../../utils/datasource';
 import { makeAMLink } from '../../utils/misc';
 import { extractNotifierTypeCounts } from '../../utils/receivers';
+import { ProvisioningBadge } from '../Provisioning';
 import { ActionIcon } from '../rules/ActionIcon';
 
 import { ReceiversSection } from './ReceiversSection';
@@ -104,7 +105,7 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
           {rows.map((receiver, idx) => (
             <tr key={receiver.name} className={idx % 2 === 0 ? tableStyles.evenRow : undefined}>
               <td>
-                {receiver.name} {receiver.provisioned && <Badge text={'Provisioned'} color={'purple'} />}
+                {receiver.name} {receiver.provisioned && <ProvisioningBadge />}
               </td>
               <td>{receiver.types.join(', ')}</td>
               <Authorize actions={[permissions.update, permissions.delete]}>

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -3,7 +3,7 @@ import React, { FC, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Button, ConfirmModal, Modal, useStyles2 } from '@grafana/ui';
+import { Badge, Button, ConfirmModal, Modal, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 
@@ -64,6 +64,7 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
             return type;
           }
         ),
+        provisioned: receiver.grafana_managed_receiver_configs?.some((receiver) => receiver.provenance),
       })) ?? [],
     [config, grafanaNotifiers.result]
   );
@@ -102,11 +103,13 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
           )}
           {rows.map((receiver, idx) => (
             <tr key={receiver.name} className={idx % 2 === 0 ? tableStyles.evenRow : undefined}>
-              <td>{receiver.name}</td>
+              <td>
+                {receiver.name} {receiver.provisioned && <Badge text={'Provisioned'} color={'purple'} />}
+              </td>
               <td>{receiver.types.join(', ')}</td>
               <Authorize actions={[permissions.update, permissions.delete]}>
                 <td className={tableStyles.actionsCell}>
-                  {!isVanillaAM && (
+                  {!isVanillaAM && !receiver.provisioned && (
                     <>
                       <Authorize actions={[permissions.update]}>
                         <ActionIcon
@@ -129,7 +132,7 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
                       </Authorize>
                     </>
                   )}
-                  {isVanillaAM && (
+                  {(isVanillaAM || receiver.provisioned) && (
                     <Authorize actions={[permissions.update]}>
                       <ActionIcon
                         data-testid="view"

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -12,7 +12,7 @@ import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelect
 import { updateAlertManagerConfigAction } from '../../state/actions';
 import { makeAMLink } from '../../utils/misc';
 import { ensureDefine } from '../../utils/templates';
-import { ProvisioningAlert } from '../Provisioning';
+import { ProvisionedResource, ProvisioningAlert } from '../Provisioning';
 
 interface Values {
   name: string;
@@ -102,7 +102,7 @@ export const TemplateForm: FC<Props> = ({ existing, alertManagerSourceName, conf
           {error.message || (error as any)?.data?.message || String(error)}
         </Alert>
       )}
-      {provenance && <ProvisioningAlert type="template" />}
+      {provenance && <ProvisioningAlert resource={ProvisionedResource.Template} />}
       <FieldSet disabled={Boolean(provenance)}>
         <Field label="Template name" error={errors?.name?.message} invalid={!!errors.name?.message} required>
           <Input

--- a/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateForm.tsx
@@ -4,7 +4,7 @@ import { useForm, Validate } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Alert, Button, Field, Input, LinkButton, TextArea, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Field, FieldSet, Input, LinkButton, TextArea, useStyles2 } from '@grafana/ui';
 import { useCleanup } from 'app/core/hooks/useCleanup';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 
@@ -12,6 +12,7 @@ import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelect
 import { updateAlertManagerConfigAction } from '../../state/actions';
 import { makeAMLink } from '../../utils/misc';
 import { ensureDefine } from '../../utils/templates';
+import { ProvisioningAlert } from '../Provisioning';
 
 interface Values {
   name: string;
@@ -27,9 +28,10 @@ interface Props {
   existing?: Values;
   config: AlertManagerCortexConfig;
   alertManagerSourceName: string;
+  provenance?: string;
 }
 
-export const TemplateForm: FC<Props> = ({ existing, alertManagerSourceName, config }) => {
+export const TemplateForm: FC<Props> = ({ existing, alertManagerSourceName, config, provenance }) => {
   const styles = useStyles2(getStyles);
   const dispatch = useDispatch();
 
@@ -100,73 +102,76 @@ export const TemplateForm: FC<Props> = ({ existing, alertManagerSourceName, conf
           {error.message || (error as any)?.data?.message || String(error)}
         </Alert>
       )}
-      <Field label="Template name" error={errors?.name?.message} invalid={!!errors.name?.message} required>
-        <Input
-          {...register('name', {
-            required: { value: true, message: 'Required.' },
-            validate: { nameIsUnique: validateNameIsUnique },
-          })}
-          placeholder="Give your template a name"
-          width={42}
-          autoFocus={true}
-        />
-      </Field>
-      <Field
-        description={
-          <>
-            You can use the{' '}
-            <a
-              href="https://pkg.go.dev/text/template?utm_source=godoc"
-              target="__blank"
-              rel="noreferrer"
-              className={styles.externalLink}
-            >
-              Go templating language
-            </a>
-            .{' '}
-            <a
-              href="https://prometheus.io/blog/2016/03/03/custom-alertmanager-templates/"
-              target="__blank"
-              rel="noreferrer"
-              className={styles.externalLink}
-            >
-              More info about alertmanager templates
-            </a>
-          </>
-        }
-        label="Content"
-        error={errors?.content?.message}
-        invalid={!!errors.content?.message}
-        required
-      >
-        <TextArea
-          {...register('content', { required: { value: true, message: 'Required.' } })}
-          className={styles.textarea}
-          placeholder="Message"
-          rows={12}
-        />
-      </Field>
-      <div className={styles.buttons}>
-        {loading && (
-          <Button disabled={true} icon="fa fa-spinner" variant="primary">
-            Saving...
-          </Button>
-        )}
-        {!loading && (
-          <Button type="submit" variant="primary">
-            Save template
-          </Button>
-        )}
-        <LinkButton
-          disabled={loading}
-          href={makeAMLink('alerting/notifications', alertManagerSourceName)}
-          variant="secondary"
-          type="button"
-          fill="outline"
+      {provenance && <ProvisioningAlert type="template" />}
+      <FieldSet disabled={Boolean(provenance)}>
+        <Field label="Template name" error={errors?.name?.message} invalid={!!errors.name?.message} required>
+          <Input
+            {...register('name', {
+              required: { value: true, message: 'Required.' },
+              validate: { nameIsUnique: validateNameIsUnique },
+            })}
+            placeholder="Give your template a name"
+            width={42}
+            autoFocus={true}
+          />
+        </Field>
+        <Field
+          description={
+            <>
+              You can use the{' '}
+              <a
+                href="https://pkg.go.dev/text/template?utm_source=godoc"
+                target="__blank"
+                rel="noreferrer"
+                className={styles.externalLink}
+              >
+                Go templating language
+              </a>
+              .{' '}
+              <a
+                href="https://prometheus.io/blog/2016/03/03/custom-alertmanager-templates/"
+                target="__blank"
+                rel="noreferrer"
+                className={styles.externalLink}
+              >
+                More info about alertmanager templates
+              </a>
+            </>
+          }
+          label="Content"
+          error={errors?.content?.message}
+          invalid={!!errors.content?.message}
+          required
         >
-          Cancel
-        </LinkButton>
-      </div>
+          <TextArea
+            {...register('content', { required: { value: true, message: 'Required.' } })}
+            className={styles.textarea}
+            placeholder="Message"
+            rows={12}
+          />
+        </Field>
+        <div className={styles.buttons}>
+          {loading && (
+            <Button disabled={true} icon="fa fa-spinner" variant="primary">
+              Saving...
+            </Button>
+          )}
+          {!loading && (
+            <Button type="submit" variant="primary">
+              Save template
+            </Button>
+          )}
+          <LinkButton
+            disabled={loading}
+            href={makeAMLink('alerting/notifications', alertManagerSourceName)}
+            variant="secondary"
+            type="button"
+            fill="outline"
+          >
+            Cancel
+          </LinkButton>
+        </div>
+      </FieldSet>
     </form>
   );
 };

--- a/public/app/features/alerting/unified/components/receivers/form/CloudReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/CloudReceiverForm.tsx
@@ -62,6 +62,8 @@ export const CloudReceiverForm: FC<Props> = ({ existing, alertManagerSourceName,
     [config, existing]
   );
 
+  const readOnly = isVanillaPrometheusAlertManagerDataSource(alertManagerSourceName);
+
   return (
     <>
       {!isVanillaAM && (
@@ -70,6 +72,7 @@ export const CloudReceiverForm: FC<Props> = ({ existing, alertManagerSourceName,
         </Alert>
       )}
       <ReceiverForm<CloudChannelValues>
+        readOnly={readOnly}
         config={config}
         onSubmit={onSubmit}
         initialValues={existingValue}

--- a/public/app/features/alerting/unified/components/receivers/form/GrafanaCommonChannelSettings.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GrafanaCommonChannelSettings.tsx
@@ -5,7 +5,11 @@ import { Checkbox, Field } from '@grafana/ui';
 
 import { CommonSettingsComponentProps } from '../../../types/receiver-form';
 
-export const GrafanaCommonChannelSettings: FC<CommonSettingsComponentProps> = ({ pathPrefix, className }) => {
+export const GrafanaCommonChannelSettings: FC<CommonSettingsComponentProps> = ({
+  pathPrefix,
+  className,
+  readOnly = false,
+}) => {
   const { register } = useFormContext();
   return (
     <div className={className}>
@@ -14,6 +18,7 @@ export const GrafanaCommonChannelSettings: FC<CommonSettingsComponentProps> = ({
           {...register(`${pathPrefix}disableResolveMessage`)}
           label="Disable resolved message"
           description="Disable the resolve message [OK] that is sent when alerting state returns to false"
+          disabled={readOnly}
         />
       </Field>
     </div>

--- a/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
@@ -23,7 +23,7 @@ import {
   grafanaReceiverToFormValues,
   updateConfigWithReceiver,
 } from '../../../utils/receiver-form';
-import { ProvisioningAlert } from '../../Provisioning';
+import { ProvisionedResource, ProvisioningAlert } from '../../Provisioning';
 
 import { GrafanaCommonChannelSettings } from './GrafanaCommonChannelSettings';
 import { ReceiverForm } from './ReceiverForm';
@@ -119,7 +119,7 @@ export const GrafanaReceiverForm: FC<Props> = ({ existing, alertManagerSourceNam
   if (grafanaNotifiers.result) {
     return (
       <>
-        {hasProvisionedItems && <ProvisioningAlert type={'contact point'} />}
+        {hasProvisionedItems && <ProvisioningAlert resource={ProvisionedResource.ContactPoint} />}
 
         <ReceiverForm<GrafanaChannelValues>
           readOnly={readOnly}

--- a/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { Alert, LoadingPlaceholder } from '@grafana/ui';
+import { LoadingPlaceholder } from '@grafana/ui';
 import {
   AlertManagerCortexConfig,
   GrafanaManagedReceiverConfig,
@@ -23,6 +23,7 @@ import {
   grafanaReceiverToFormValues,
   updateConfigWithReceiver,
 } from '../../../utils/receiver-form';
+import { ProvisioningAlert } from '../../Provisioning';
 
 import { GrafanaCommonChannelSettings } from './GrafanaCommonChannelSettings';
 import { ReceiverForm } from './ReceiverForm';
@@ -118,12 +119,7 @@ export const GrafanaReceiverForm: FC<Props> = ({ existing, alertManagerSourceNam
   if (grafanaNotifiers.result) {
     return (
       <>
-        {hasProvisionedItems && (
-          <Alert title={'This contact point has been provisioned'} severity="info">
-            This contact point was added by config and cannot be modified using the UI. Please contact your server admin
-            to update this contact point.
-          </Alert>
-        )}
+        {hasProvisionedItems && <ProvisioningAlert type={'contact point'} />}
 
         <ReceiverForm<GrafanaChannelValues>
           readOnly={readOnly}

--- a/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
@@ -111,7 +111,7 @@ export const GrafanaReceiverForm: FC<Props> = ({ existing, alertManagerSourceNam
 
   // if any receivers in the contact point have a "provenance", the entire contact point should be readOnly
   const hasProvisionedItems = existing
-    ? existing.grafana_managed_receiver_configs?.some((item) => Boolean(item.provenance))
+    ? (existing.grafana_managed_receiver_configs ?? []).some((item) => Boolean(item.provenance))
     : false;
 
   const readOnly = isVanillaPrometheusAlertManagerDataSource(alertManagerSourceName) || hasProvisionedItems;

--- a/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
@@ -12,7 +12,6 @@ import { NotifierDTO } from 'app/types';
 import { useControlledFieldArray } from '../../../hooks/useControlledFieldArray';
 import { useUnifiedAlertingSelector } from '../../../hooks/useUnifiedAlertingSelector';
 import { ChannelValues, CommonSettingsComponentType, ReceiverFormValues } from '../../../types/receiver-form';
-import { isVanillaPrometheusAlertManagerDataSource } from '../../../utils/datasource';
 import { makeAMLink } from '../../../utils/misc';
 
 import { ChannelSubForm } from './ChannelSubForm';
@@ -28,6 +27,7 @@ interface Props<R extends ChannelValues> {
   takenReceiverNames: string[]; // will validate that user entered receiver name is not one of these
   commonSettingsComponent: CommonSettingsComponentType;
   initialValues?: ReceiverFormValues<R>;
+  readOnly?: boolean;
 }
 
 export function ReceiverForm<R extends ChannelValues>({
@@ -40,10 +40,11 @@ export function ReceiverForm<R extends ChannelValues>({
   onTestChannel,
   takenReceiverNames,
   commonSettingsComponent,
+  readOnly,
 }: Props<R>): JSX.Element {
   const notifyApp = useAppNotification();
   const styles = useStyles2(getStyles);
-  const readOnly = isVanillaPrometheusAlertManagerDataSource(alertManagerSourceName);
+
   const defaultValues = initialValues || {
     name: '',
     items: [

--- a/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
@@ -27,7 +27,7 @@ interface Props<R extends ChannelValues> {
   takenReceiverNames: string[]; // will validate that user entered receiver name is not one of these
   commonSettingsComponent: CommonSettingsComponentType;
   initialValues?: ReceiverFormValues<R>;
-  readOnly?: boolean;
+  readOnly: boolean;
 }
 
 export function ReceiverForm<R extends ChannelValues>({

--- a/public/app/features/alerting/unified/components/rules/RulesTable.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesTable.tsx
@@ -7,8 +7,10 @@ import { CombinedRule } from 'app/types/unified-alerting';
 
 import { useHasRuler } from '../../hooks/useHasRuler';
 import { Annotation } from '../../utils/constants';
+import { isGrafanaRulerRule } from '../../utils/rules';
 import { DynamicTable, DynamicTableColumnProps, DynamicTableItemProps } from '../DynamicTable';
 import { DynamicTableWithGuidelines } from '../DynamicTableWithGuidelines';
+import { ProvisioningBadge } from '../Provisioning';
 import { RuleLocation } from '../RuleLocation';
 
 import { RuleDetails } from './RuleDetails';
@@ -115,6 +117,23 @@ function useColumns(showSummaryColumn: boolean, showGroupColumn: boolean) {
         // eslint-disable-next-line react/display-name
         renderCell: ({ data: rule }) => rule.name,
         size: 5,
+      },
+      {
+        id: 'provisioned',
+        label: '',
+        // eslint-disable-next-line react/display-name
+        renderCell: ({ data: rule }) => {
+          const rulerRule = rule.rulerRule;
+          const isGrafanaManagedRule = isGrafanaRulerRule(rulerRule);
+
+          if (!isGrafanaManagedRule) {
+            return null;
+          }
+
+          const provenance = rulerRule.grafana_alert.provenance;
+          return provenance ? <ProvisioningBadge /> : null;
+        },
+        size: '100px',
       },
       {
         id: 'health',

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -129,6 +129,7 @@ export const fetchAlertManagerConfigAction = createAsyncThunk(
             return fetchStatus(alertManagerSourceName).then((status) => ({
               alertmanager_config: status.config,
               template_files: {},
+              template_file_provenances: result.template_file_provenances,
             }));
           }
           return result;

--- a/public/app/features/alerting/unified/types/receiver-form.ts
+++ b/public/app/features/alerting/unified/types/receiver-form.ts
@@ -25,6 +25,7 @@ export interface CloudChannelValues extends ChannelValues {
 
 export interface GrafanaChannelValues extends ChannelValues {
   type: NotifierType;
+  provenance?: string;
   disableResolveMessage: boolean;
 }
 

--- a/public/app/features/alerting/unified/utils/receiver-form.ts
+++ b/public/app/features/alerting/unified/utils/receiver-form.ts
@@ -192,6 +192,7 @@ function grafanaChannelConfigToFormChannelValues(
   const values: GrafanaChannelValues = {
     __id: id,
     type: channel.type as NotifierType,
+    provenance: channel.provenance,
     secureSettings: {},
     settings: { ...channel.settings },
     secureFields: { ...channel.secureFields },

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -107,6 +107,8 @@ export type Route = {
   repeat_interval?: string;
   routes?: Route[];
   mute_time_intervals?: string[];
+  /** only the root policy might have a provenance field defined */
+  provenance?: string;
 };
 
 export type InhibitRule = {

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -5,6 +5,8 @@ import { DataSourceJsonData } from '@grafana/data';
 export type AlertManagerCortexConfig = {
   template_files: Record<string, string>;
   alertmanager_config: AlertmanagerConfig;
+  /** { [name]: provenance } */
+  template_file_provenances?: Record<string, string>;
 };
 
 export type TLSConfig = {

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -146,6 +146,8 @@ export type AlertmanagerConfig = {
   inhibit_rules?: InhibitRule[];
   receivers?: Receiver[];
   mute_time_intervals?: MuteTimeInterval[];
+  /** { [name]: provenance } */
+  muteTimeProvenances?: Record<string, string>;
 };
 
 export type Matcher = {
@@ -302,6 +304,7 @@ export interface TimeInterval {
 export type MuteTimeInterval = {
   name: string;
   time_intervals: TimeInterval[];
+  provenance?: string;
 };
 
 export type AlertManagerDataSourceJsonData = DataSourceJsonData & { implementation?: AlertManagerImplementation };

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -72,6 +72,7 @@ export type GrafanaManagedReceiverConfig = {
   name: string;
   updated?: string;
   created?: string;
+  provenance?: string;
 };
 
 export type Receiver = {

--- a/public/app/types/unified-alerting-dto.ts
+++ b/public/app/types/unified-alerting-dto.ts
@@ -182,6 +182,7 @@ export interface GrafanaRuleDefinition extends PostableGrafanaRuleDefinition {
   uid: string;
   namespace_uid: string;
   namespace_id: number;
+  provenance?: string;
 }
 
 export interface RulerGrafanaRuleDTO {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds some visual queues and indications for provisioned alert concepts such as:

- [x] Alert rules
- [x] Contact Points
- [x] Templates
- [x] Notification Policies
- [x] Mute Timings

<details>
  <summary><strong>Screenshots</strong>:</summary>

**Alert Rules**

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/868844/173571766-8c64f140-d8e2-4975-817e-299470c0c793.png">
<img width="964" alt="image" src="https://user-images.githubusercontent.com/868844/173571883-e49f1620-0eb9-4db7-af72-8b54ebb4c88f.png">

**Contact Points and Templates**

<img width="1118" alt="image" src="https://user-images.githubusercontent.com/868844/173572088-a64c56bc-6cdb-44e1-83f2-d492a757338f.png">
<img width="1116" alt="image" src="https://user-images.githubusercontent.com/868844/173572200-8cb63a8f-1c4e-49a0-aba6-e241ded5f2ce.png">
<img width="1131" alt="image" src="https://user-images.githubusercontent.com/868844/173572259-145c4889-0825-48f6-85e2-9431781e6fe0.png">

**Notification Policies and Mute Timings**
<img width="1132" alt="image" src="https://user-images.githubusercontent.com/868844/173572362-c8b6f9e8-dbba-49f2-8b96-af0bc0c75e30.png">
<img width="1095" alt="image" src="https://user-images.githubusercontent.com/868844/173572398-cfdf34f5-f40a-4374-aa7e-d88287d00eae.png">
<img width="1131" alt="image" src="https://user-images.githubusercontent.com/868844/173572438-cabb58cb-cba9-4dd7-9fa3-2ecbacdff91e.png">


</details>

**Which issue(s) this PR fixes**:

Related
https://github.com/grafana/grafana/issues/45297

Fixes 
https://github.com/grafana/grafana/issues/48490
https://github.com/grafana/grafana/issues/48493
https://github.com/grafana/grafana/issues/48492
https://github.com/grafana/grafana/issues/48491

**Special notes for your reviewer**:

None

