### PR TITLE
Loki: Fix query builder header

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryEditorSelector.tsx
@@ -4,6 +4,7 @@ import { CoreApp, LoadingState } from '@grafana/data';
 import { EditorHeader, EditorRows, FlexItem, InlineSelect, Space } from '@grafana/experimental';
 import { reportInteraction } from '@grafana/runtime';
 import { Button, ConfirmModal } from '@grafana/ui';
+import { FeedbackLink } from 'app/plugins/datasource/prometheus/querybuilder/shared/FeedbackLink';
 import { QueryEditorModeToggle } from 'app/plugins/datasource/prometheus/querybuilder/shared/QueryEditorModeToggle';
 import { QueryHeaderSwitch } from 'app/plugins/datasource/prometheus/querybuilder/shared/QueryHeaderSwitch';
 import { QueryEditorMode } from 'app/plugins/datasource/prometheus/querybuilder/shared/types';
@@ -93,7 +94,12 @@ export const LokiQueryEditorSelector = React.memo<LokiQueryEditorProps>((props) 
           }}
           options={lokiQueryModeller.getQueryPatterns().map((x) => ({ label: x.name, value: x }))}
         />
-        <QueryHeaderSwitch label="Raw query" value={rawQuery} onChange={onQueryPreviewChange} />
+        {editorMode === QueryEditorMode.Builder && (
+          <>
+            <QueryHeaderSwitch label="Raw query" value={rawQuery} onChange={onQueryPreviewChange} />
+            <FeedbackLink feedbackUrl="https://github.com/grafana/grafana/discussions/50785" />
+          </>
+        )}
         <FlexItem grow={1} />
         {app !== CoreApp.Explore && (
           <Button

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
@@ -98,9 +98,12 @@ export const PromQueryEditorSelector = React.memo<Props>((props) => {
           }}
           options={promQueryModeller.getQueryPatterns().map((x) => ({ label: x.name, value: x }))}
         />
-        <QueryHeaderSwitch label="Raw query" value={rawQuery} onChange={onQueryPreviewChange} />
+
         {editorMode === QueryEditorMode.Builder && (
-          <FeedbackLink feedbackUrl="https://github.com/grafana/grafana/discussions/47693" />
+          <>
+            <QueryHeaderSwitch label="Raw query" value={rawQuery} onChange={onQueryPreviewChange} />
+            <FeedbackLink feedbackUrl="https://github.com/grafana/grafana/discussions/47693" />
+          </>
         )}
         <FlexItem grow={1} />
         {app !== CoreApp.Explore && (


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
- Fixes showing of `Raw query` toggle to be only in query builder for Prometheus
- Fixes showing of `Raw query` toggle to be only in query builder for Loki
- Adds feedback link to loki that links to https://github.com/grafana/grafana/discussions/50785


https://user-images.githubusercontent.com/30407135/173588176-8a076ad5-5c5f-495b-ab93-7cc7c55f2f0c.mov



