### PR TITLE
Chore: Make test tracer noop and return no errors

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -193,8 +193,7 @@ func getContextHandler(t *testing.T, cfg *setting.Cfg) *contexthandler.ContextHa
 	userAuthTokenSvc := auth.NewFakeUserAuthTokenService()
 	renderSvc := &fakeRenderService{}
 	authJWTSvc := models.NewFakeJWTService()
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 	authProxy := authproxy.ProvideAuthProxy(cfg, remoteCacheSvc, loginservice.LoginServiceMock{}, sqlStore)
 	loginService := &logintest.LoginServiceFake{}
 	authenticator := &logintest.AuthenticatorFake{}

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -37,8 +37,7 @@ import (
 func TestDataSourceProxy_routeRule(t *testing.T) {
 	cfg := &setting.Cfg{}
 	httpClientProvider := httpclient.NewProvider()
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 
 	t.Run("Plugin with routes", func(t *testing.T) {
 		routes := []*plugins.Route{
@@ -628,8 +627,7 @@ func TestDataSourceProxy_requestHandling(t *testing.T) {
 		}, ds
 	}
 
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 
 	t.Run("When response header Set-Cookie is not set should remove proxied Set-Cookie header", func(t *testing.T) {
 		ctx, ds := setUp(t)
@@ -765,13 +763,12 @@ func TestNewDataSourceProxy_InvalidURL(t *testing.T) {
 		Url:  "://host/root",
 	}
 	cfg := &setting.Cfg{}
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 	var routes []*plugins.Route
 	secretsStore := kvstore.SetupTestService(t)
 	secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
 	dsService := datasourceservice.ProvideService(nil, secretsService, secretsStore, cfg, featuremgmt.WithFeatures(), acmock.New(), acmock.NewMockedPermissionsService())
-	_, err = NewDataSourceProxy(&ds, routes, &ctx, "api/method", cfg, httpclient.NewProvider(), &oauthtoken.Service{}, dsService, tracer)
+	_, err := NewDataSourceProxy(&ds, routes, &ctx, "api/method", cfg, httpclient.NewProvider(), &oauthtoken.Service{}, dsService, tracer)
 	require.Error(t, err)
 	assert.True(t, strings.HasPrefix(err.Error(), `validation of data source URL "://host/root" failed`))
 }
@@ -786,14 +783,13 @@ func TestNewDataSourceProxy_ProtocolLessURL(t *testing.T) {
 		Url:  "127.0.01:5432",
 	}
 	cfg := &setting.Cfg{}
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 
 	var routes []*plugins.Route
 	secretsStore := kvstore.SetupTestService(t)
 	secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
 	dsService := datasourceservice.ProvideService(nil, secretsService, secretsStore, cfg, featuremgmt.WithFeatures(), acmock.New(), acmock.NewMockedPermissionsService())
-	_, err = NewDataSourceProxy(&ds, routes, &ctx, "api/method", cfg, httpclient.NewProvider(), &oauthtoken.Service{}, dsService, tracer)
+	_, err := NewDataSourceProxy(&ds, routes, &ctx, "api/method", cfg, httpclient.NewProvider(), &oauthtoken.Service{}, dsService, tracer)
 
 	require.NoError(t, err)
 }
@@ -804,8 +800,7 @@ func TestNewDataSourceProxy_MSSQL(t *testing.T) {
 		Context:      &web.Context{},
 		SignedInUser: &models.SignedInUser{OrgRole: models.ROLE_EDITOR},
 	}
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 
 	tcs := []struct {
 		description string
@@ -858,8 +853,7 @@ func getDatasourceProxiedRequest(t *testing.T, ctx *models.ReqContext, cfg *sett
 		Type: "custom",
 		Url:  "http://host/root/",
 	}
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 
 	var routes []*plugins.Route
 	secretsStore := kvstore.SetupTestService(t)
@@ -978,8 +972,7 @@ func createAuthTest(t *testing.T, secretsStore kvstore.SecretsKVStore, dsType st
 
 func runDatasourceAuthTest(t *testing.T, secretsService secrets.Service, secretsStore kvstore.SecretsKVStore, cfg *setting.Cfg, test *testCase) {
 	ctx := &models.ReqContext{}
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 
 	var routes []*plugins.Route
 	dsService := datasourceservice.ProvideService(nil, secretsService, secretsStore, cfg, featuremgmt.WithFeatures(), acmock.New(), acmock.NewMockedPermissionsService())
@@ -1011,8 +1004,7 @@ func Test_PathCheck(t *testing.T) {
 			Method:  http.MethodGet,
 		},
 	}
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 
 	setUp := func() (*models.ReqContext, *http.Request) {
 		req, err := http.NewRequest("GET", "http://localhost/asd", nil)

--- a/pkg/bus/bus_test.go
+++ b/pkg/bus/bus_test.go
@@ -14,9 +14,7 @@ type testQuery struct {
 }
 
 func TestEventPublish(t *testing.T) {
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-	bus := ProvideBus(tracer)
+	bus := ProvideBus(tracing.InitializeTracerForTest())
 
 	var invoked bool
 
@@ -25,25 +23,21 @@ func TestEventPublish(t *testing.T) {
 		return nil
 	})
 
-	err = bus.Publish(context.Background(), &testQuery{})
+	err := bus.Publish(context.Background(), &testQuery{})
 	require.NoError(t, err, "unable to publish event")
 
 	require.True(t, invoked)
 }
 
 func TestEventPublish_NoRegisteredListener(t *testing.T) {
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-	bus := ProvideBus(tracer)
+	bus := ProvideBus(tracing.InitializeTracerForTest())
 
-	err = bus.Publish(context.Background(), &testQuery{})
+	err := bus.Publish(context.Background(), &testQuery{})
 	require.NoError(t, err, "unable to publish event")
 }
 
 func TestEventCtxPublishCtx(t *testing.T) {
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-	bus := ProvideBus(tracer)
+	bus := ProvideBus(tracing.InitializeTracerForTest())
 
 	var invoked bool
 
@@ -52,25 +46,21 @@ func TestEventCtxPublishCtx(t *testing.T) {
 		return nil
 	})
 
-	err = bus.Publish(context.Background(), &testQuery{})
+	err := bus.Publish(context.Background(), &testQuery{})
 	require.NoError(t, err, "unable to publish event")
 
 	require.True(t, invoked)
 }
 
 func TestEventPublishCtx_NoRegisteredListener(t *testing.T) {
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-	bus := ProvideBus(tracer)
+	bus := ProvideBus(tracing.InitializeTracerForTest())
 
-	err = bus.Publish(context.Background(), &testQuery{})
+	err := bus.Publish(context.Background(), &testQuery{})
 	require.NoError(t, err, "unable to publish event")
 }
 
 func TestEventPublishCtx(t *testing.T) {
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-	bus := ProvideBus(tracer)
+	bus := ProvideBus(tracing.InitializeTracerForTest())
 
 	var invoked bool
 
@@ -79,16 +69,14 @@ func TestEventPublishCtx(t *testing.T) {
 		return nil
 	})
 
-	err = bus.Publish(context.Background(), &testQuery{})
+	err := bus.Publish(context.Background(), &testQuery{})
 	require.NoError(t, err, "unable to publish event")
 
 	require.True(t, invoked)
 }
 
 func TestEventCtxPublish(t *testing.T) {
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-	bus := ProvideBus(tracer)
+	bus := ProvideBus(tracing.InitializeTracerForTest())
 
 	var invoked bool
 
@@ -97,7 +85,7 @@ func TestEventCtxPublish(t *testing.T) {
 		return nil
 	})
 
-	err = bus.Publish(context.Background(), &testQuery{})
+	err := bus.Publish(context.Background(), &testQuery{})
 	require.NoError(t, err, "unable to publish event")
 
 	require.True(t, invoked)

--- a/pkg/infra/httpclient/httpclientprovider/http_client_provider_test.go
+++ b/pkg/infra/httpclient/httpclientprovider/http_client_provider_test.go
@@ -22,8 +22,7 @@ func TestHTTPClientProvider(t *testing.T) {
 		t.Cleanup(func() {
 			newProviderFunc = origNewProviderFunc
 		})
-		tracer, err := tracing.InitializeTracerForTest()
-		require.NoError(t, err)
+		tracer := tracing.InitializeTracerForTest()
 		_ = New(&setting.Cfg{SigV4AuthEnabled: false}, &validations.OSSPluginRequestValidator{}, tracer)
 		require.Len(t, providerOpts, 1)
 		o := providerOpts[0]
@@ -47,8 +46,7 @@ func TestHTTPClientProvider(t *testing.T) {
 		t.Cleanup(func() {
 			newProviderFunc = origNewProviderFunc
 		})
-		tracer, err := tracing.InitializeTracerForTest()
-		require.NoError(t, err)
+		tracer := tracing.InitializeTracerForTest()
 		_ = New(&setting.Cfg{SigV4AuthEnabled: true}, &validations.OSSPluginRequestValidator{}, tracer)
 		require.Len(t, providerOpts, 1)
 		o := providerOpts[0]

--- a/pkg/infra/httpclient/httpclientprovider/tracing_middleware_test.go
+++ b/pkg/infra/httpclient/httpclientprovider/tracing_middleware_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestTracingMiddleware(t *testing.T) {
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 
 	t.Run("GET request that returns 200 OK should start and capture span", func(t *testing.T) {
 		finalRoundTripper := httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {

--- a/pkg/infra/tracing/test_helper.go
+++ b/pkg/infra/tracing/test_helper.go
@@ -1,20 +1,7 @@
 package tracing
 
-func InitializeTracerForTest() (Tracer, error) {
-	ots := &Opentelemetry{
-		enabled: "jaeger",
-	}
-	err := ots.initOpentelemetryTracer()
-	if err != nil {
-		return ots, err
-	}
-	return ots, err
-}
-
-func InitializeForBus() Tracer {
-	ots := &Opentelemetry{
-		enabled: "jaeger",
-	}
+func InitializeTracerForTest() Tracer {
+	ots := &Opentelemetry{enabled: noopExporter}
 	_ = ots.initOpentelemetryTracer()
 	return ots
 }

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -640,10 +640,9 @@ func getContextHandler(t *testing.T, cfg *setting.Cfg, mockSQLStore *mockstore.S
 	userAuthTokenSvc := auth.NewFakeUserAuthTokenService()
 	renderSvc := &fakeRenderService{}
 	authJWTSvc := models.NewFakeJWTService()
-	tracer, err := tracing.InitializeTracerForTest()
+	tracer := tracing.InitializeTracerForTest()
 	authProxy := authproxy.ProvideAuthProxy(cfg, remoteCacheSvc, loginService, mockSQLStore)
 	authenticator := &logintest.AuthenticatorFake{ExpectedUser: &models.User{}}
-	require.NoError(t, err)
 	return contexthandler.ProvideService(cfg, userAuthTokenSvc, authJWTSvc, remoteCacheSvc, renderSvc, mockSQLStore, tracer, authProxy, loginService, authenticator)
 }
 

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -22,8 +22,7 @@ func TestIntegrationEngineTimeouts(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	usMock := &usagestats.UsageStatsMock{T: t}
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 	engine := ProvideAlertEngine(nil, nil, nil, usMock, ossencryption.ProvideService(), nil, tracer, nil, setting.NewCfg(), nil, nil)
 	setting.AlertingNotificationTimeout = 30 * time.Second
 	setting.AlertingMaxAttempts = 3

--- a/pkg/services/alerting/engine_test.go
+++ b/pkg/services/alerting/engine_test.go
@@ -100,8 +100,7 @@ func (a *AlertStoreMock) SetAlertState(_ context.Context, _ *models.SetAlertStat
 
 func TestEngineProcessJob(t *testing.T) {
 	usMock := &usagestats.UsageStatsMock{T: t}
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 
 	store := &AlertStoreMock{}
 	engine := ProvideAlertEngine(nil, nil, nil, usMock, ossencryption.ProvideService(), nil, tracer, store, setting.NewCfg(), nil, nil)

--- a/pkg/services/contexthandler/auth_proxy_test.go
+++ b/pkg/services/contexthandler/auth_proxy_test.go
@@ -79,8 +79,7 @@ func getContextHandler(t *testing.T) *ContextHandler {
 	userAuthTokenSvc := auth.NewFakeUserAuthTokenService()
 	renderSvc := &fakeRenderService{}
 	authJWTSvc := models.NewFakeJWTService()
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 
 	loginService := loginservice.LoginServiceMock{ExpectedUser: &models.User{Id: userID}}
 	authProxy := authproxy.ProvideAuthProxy(cfg, remoteCacheSvc, loginService, &FakeGetSignUserStore{})

--- a/pkg/services/ngalert/notifier/channels/email_test.go
+++ b/pkg/services/ngalert/notifier/channels/email_test.go
@@ -269,8 +269,7 @@ func TestEmailNotifierIntegration(t *testing.T) {
 func createCoreEmailService(t *testing.T) *notifications.NotificationService {
 	t.Helper()
 
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 	bus := bus.ProvideBus(tracer)
 
 	cfg := setting.NewCfg()

--- a/pkg/services/notifications/notifications_test.go
+++ b/pkg/services/notifications/notifications_test.go
@@ -14,8 +14,7 @@ import (
 
 func newBus(t *testing.T) bus.Bus {
 	t.Helper()
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 	return bus.ProvideBus(tracer)
 }
 

--- a/pkg/services/plugindashboards/service/dashboard_updater_test.go
+++ b/pkg/services/plugindashboards/service/dashboard_updater_test.go
@@ -473,8 +473,7 @@ type scenarioContext struct {
 func scenario(t *testing.T, desc string, input scenarioInput, f func(ctx *scenarioContext)) {
 	t.Helper()
 
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 
 	sCtx := &scenarioContext{
 		t:                              t,

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -542,10 +542,7 @@ func initTestDB(migration registry.DatabaseMigrator, opts ...InitTestDBOpt) (*SQ
 		engine.DatabaseTZ = time.UTC
 		engine.TZLocation = time.UTC
 
-		tracer, err := tracing.InitializeTracerForTest()
-		if err != nil {
-			return nil, err
-		}
+		tracer := tracing.InitializeTracerForTest()
 		bus := bus.ProvideBus(tracer)
 		testSQLStore, err = newSQLStore(cfg, localcache.New(5*time.Minute, 10*time.Minute), engine, migration, bus, tracer, opts...)
 		if err != nil {

--- a/pkg/services/teamguardian/manager/service_test.go
+++ b/pkg/services/teamguardian/manager/service_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/teamguardian/database"
 	"github.com/stretchr/testify/mock"
@@ -33,11 +32,9 @@ func TestUpdateTeam(t *testing.T) {
 
 		t.Run("Given an editor and a team he isn't a member of", func(t *testing.T) {
 			t.Run("Should not be able to update the team", func(t *testing.T) {
-				_, err := tracing.InitializeTracerForTest()
-				require.NoError(t, err)
 				ctx := context.Background()
 				store.On("GetTeamMembers", ctx, mock.Anything).Return([]*models.TeamMemberDTO{}, nil).Once()
-				err = teamGuardianService.CanAdmin(ctx, testTeam.OrgId, testTeam.Id, &editor)
+				err := teamGuardianService.CanAdmin(ctx, testTeam.OrgId, testTeam.Id, &editor)
 				require.Equal(t, models.ErrNotAllowedToUpdateTeam, err)
 			})
 		})

--- a/pkg/tests/api/alerting/api_admin_configuration_test.go
+++ b/pkg/tests/api/alerting/api_admin_configuration_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -22,8 +21,6 @@ import (
 
 func TestAdminConfiguration_SendingToExternalAlertmanagers(t *testing.T) {
 	const disableOrgID int64 = 3
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting:          true,
 		EnableUnifiedAlerting:          true,

--- a/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_configuration_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
@@ -18,9 +17,6 @@ import (
 )
 
 func TestAlertmanagerConfigurationIsTransactional(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting:                 true,
 		EnableUnifiedAlerting:                 true,
@@ -133,9 +129,6 @@ func TestAlertmanagerConfigurationIsTransactional(t *testing.T) {
 }
 
 func TestAlertmanagerConfigurationPersistSecrets(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -32,9 +31,6 @@ type Response struct {
 }
 
 func TestAMConfigAccess(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -320,7 +316,7 @@ func TestAMConfigAccess(t *testing.T) {
 	})
 
 	var silences apimodels.GettableSilences
-	err = json.Unmarshal(blob, &silences)
+	err := json.Unmarshal(blob, &silences)
 	require.NoError(t, err)
 	assert.Len(t, silences, 2)
 	silenceIDs := make([]string, 0, len(silences))
@@ -393,9 +389,6 @@ func TestAMConfigAccess(t *testing.T) {
 }
 
 func TestAlertAndGroupsQuery(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -564,8 +557,6 @@ func TestAlertAndGroupsQuery(t *testing.T) {
 }
 
 func TestRulerAccess(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
 	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
@@ -596,7 +587,7 @@ func TestRulerAccess(t *testing.T) {
 	})
 
 	// Create the namespace we'll save our alerts to.
-	err = createFolder(t, "default", grafanaListedAddr, "editor", "editor")
+	err := createFolder(t, "default", grafanaListedAddr, "editor", "editor")
 	reloadCachedPermissions(t, grafanaListedAddr, "editor", "editor")
 	require.NoError(t, err)
 
@@ -696,8 +687,6 @@ func TestRulerAccess(t *testing.T) {
 }
 
 func TestDeleteFolderWithRules(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
 	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
@@ -723,7 +712,7 @@ func TestDeleteFolderWithRules(t *testing.T) {
 
 	// Create the namespace we'll save our alerts to.
 	namespaceUID := "default"
-	err = createFolder(t, namespaceUID, grafanaListedAddr, "editor", "editor")
+	err := createFolder(t, namespaceUID, grafanaListedAddr, "editor", "editor")
 	reloadCachedPermissions(t, grafanaListedAddr, "editor", "editor")
 	require.NoError(t, err)
 
@@ -859,8 +848,6 @@ func TestDeleteFolderWithRules(t *testing.T) {
 }
 
 func TestAlertRuleCRUD(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
 	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
@@ -879,7 +866,7 @@ func TestAlertRuleCRUD(t *testing.T) {
 	})
 
 	// Create the namespace we'll save our alerts to.
-	err = createFolder(t, "default", grafanaListedAddr, "grafana", "password")
+	err := createFolder(t, "default", grafanaListedAddr, "grafana", "password")
 	require.NoError(t, err)
 	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
 
@@ -2005,8 +1992,6 @@ func TestAlertmanagerStatus(t *testing.T) {
 }
 
 func TestQuota(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
 	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
@@ -2026,7 +2011,7 @@ func TestQuota(t *testing.T) {
 	})
 
 	// Create the namespace we'll save our alerts to.
-	err = createFolder(t, "default", grafanaListedAddr, "grafana", "password")
+	err := createFolder(t, "default", grafanaListedAddr, "grafana", "password")
 	require.NoError(t, err)
 	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
 
@@ -2253,8 +2238,6 @@ func TestQuota(t *testing.T) {
 }
 
 func TestEval(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
 	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
@@ -2273,7 +2256,7 @@ func TestEval(t *testing.T) {
 	})
 
 	// Create the namespace we'll save our alerts to.
-	err = createFolder(t, "default", grafanaListedAddr, "grafana", "password")
+	err := createFolder(t, "default", grafanaListedAddr, "grafana", "password")
 	require.NoError(t, err)
 
 	// test eval conditions

--- a/pkg/tests/api/alerting/api_available_channel_test.go
+++ b/pkg/tests/api/alerting/api_available_channel_test.go
@@ -9,16 +9,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 )
 
 func TestAvailableChannels(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -33,8 +32,6 @@ import (
 
 func TestTestReceivers(t *testing.T) {
 	t.Run("assert no receivers returns 400 Bad Request", func(t *testing.T) {
-		_, err := tracing.InitializeTracerForTest()
-		require.NoError(t, err)
 		// Setup Grafana and its Database
 		dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 			DisableLegacyAlerting: true,
@@ -69,8 +66,6 @@ func TestTestReceivers(t *testing.T) {
 	})
 
 	t.Run("assert working receiver returns OK", func(t *testing.T) {
-		_, err := tracing.InitializeTracerForTest()
-		require.NoError(t, err)
 		// Setup Grafana and its Database
 		dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 			DisableLegacyAlerting: true,
@@ -153,8 +148,6 @@ func TestTestReceivers(t *testing.T) {
 	})
 
 	t.Run("assert invalid receiver returns 400 Bad Request", func(t *testing.T) {
-		_, err := tracing.InitializeTracerForTest()
-		require.NoError(t, err)
 		// Setup Grafana and its Database
 		dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 			DisableLegacyAlerting: true,
@@ -232,8 +225,6 @@ func TestTestReceivers(t *testing.T) {
 	})
 
 	t.Run("assert timed out receiver returns 408 Request Timeout", func(t *testing.T) {
-		_, err := tracing.InitializeTracerForTest()
-		require.NoError(t, err)
 		// Setup Grafana and its Database
 		dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 			DisableLegacyAlerting: true,
@@ -321,8 +312,6 @@ func TestTestReceivers(t *testing.T) {
 	})
 
 	t.Run("assert multiple different errors returns 207 Multi Status", func(t *testing.T) {
-		_, err := tracing.InitializeTracerForTest()
-		require.NoError(t, err)
 		// Setup Grafana and its Database
 		dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 			DisableLegacyAlerting: true,
@@ -436,8 +425,6 @@ func TestTestReceivers(t *testing.T) {
 
 func TestTestReceiversAlertCustomization(t *testing.T) {
 	t.Run("assert custom annotations and labels are sent", func(t *testing.T) {
-		_, err := tracing.InitializeTracerForTest()
-		require.NoError(t, err)
 		// Setup Grafana and its Database
 		dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 			DisableLegacyAlerting: true,
@@ -531,8 +518,6 @@ func TestTestReceiversAlertCustomization(t *testing.T) {
 	})
 
 	t.Run("assert custom annotations can replace default annotations", func(t *testing.T) {
-		_, err := tracing.InitializeTracerForTest()
-		require.NoError(t, err)
 		// Setup Grafana and its Database
 		dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 			DisableLegacyAlerting: true,
@@ -621,8 +606,6 @@ func TestTestReceiversAlertCustomization(t *testing.T) {
 	})
 
 	t.Run("assert custom labels can replace default label", func(t *testing.T) {
-		_, err := tracing.InitializeTracerForTest()
-		require.NoError(t, err)
 		// Setup Grafana and its Database
 		dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 			DisableLegacyAlerting: true,
@@ -711,9 +694,6 @@ func TestTestReceiversAlertCustomization(t *testing.T) {
 }
 
 func TestNotificationChannels(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -775,7 +755,7 @@ func TestNotificationChannels(t *testing.T) {
 
 	{
 		// Create the namespace we'll save our alerts to.
-		err = createFolder(t, "default", grafanaListedAddr, "grafana", "password")
+		err := createFolder(t, "default", grafanaListedAddr, "grafana", "password")
 		require.NoError(t, err)
 		reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
 

--- a/pkg/tests/api/alerting/api_prometheus_test.go
+++ b/pkg/tests/api/alerting/api_prometheus_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	acdb "github.com/grafana/grafana/pkg/services/accesscontrol/database"
@@ -26,9 +25,6 @@ import (
 )
 
 func TestPrometheusRules(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -46,7 +42,7 @@ func TestPrometheusRules(t *testing.T) {
 	})
 
 	// Create the namespace we'll save our alerts to.
-	err = createFolder(t, "default", grafanaListedAddr, "grafana", "password")
+	err := createFolder(t, "default", grafanaListedAddr, "grafana", "password")
 	require.NoError(t, err)
 	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
 
@@ -324,8 +320,6 @@ func TestPrometheusRules(t *testing.T) {
 }
 
 func TestPrometheusRulesFilterByDashboard(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		EnableFeatureToggles: []string{"ngalert"},
 		DisableAnonymous:     true,
@@ -343,7 +337,7 @@ func TestPrometheusRulesFilterByDashboard(t *testing.T) {
 
 	// Create the namespace we'll save our alerts to.
 	dashboardUID := "default"
-	err = createFolder(t, dashboardUID, grafanaListedAddr, "grafana", "password")
+	err := createFolder(t, dashboardUID, grafanaListedAddr, "grafana", "password")
 	require.NoError(t, err)
 	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
 
@@ -620,9 +614,6 @@ func TestPrometheusRulesFilterByDashboard(t *testing.T) {
 }
 
 func TestPrometheusRulesPermissions(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -643,7 +634,7 @@ func TestPrometheusRulesPermissions(t *testing.T) {
 	permissionsStore := acdb.ProvideService(store)
 
 	// Create the namespace we'll save our alerts to.
-	err = createFolder(t, "folder1", grafanaListedAddr, "grafana", "password")
+	err := createFolder(t, "folder1", grafanaListedAddr, "grafana", "password")
 	require.NoError(t, err)
 
 	// Create the namespace we'll save our alerts to.

--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -7,16 +7,12 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/stretchr/testify/require"
 )
 
 func TestProvisioning(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/models"
 	acdb "github.com/grafana/grafana/pkg/services/accesscontrol/database"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -23,9 +22,6 @@ import (
 
 func TestAlertRulePermissions(t *testing.T) {
 	// Setup Grafana and its Database
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -44,7 +40,7 @@ func TestAlertRulePermissions(t *testing.T) {
 	})
 
 	// Create the namespace we'll save our alerts to.
-	err = createFolder(t, "folder1", grafanaListedAddr, "grafana", "password")
+	err := createFolder(t, "folder1", grafanaListedAddr, "grafana", "password")
 	require.NoError(t, err)
 
 	err = createFolder(t, "folder2", grafanaListedAddr, "grafana", "password")
@@ -332,8 +328,6 @@ func createRule(t *testing.T, grafanaListedAddr string, folder string, user, pas
 }
 
 func TestAlertRuleConflictingTitle(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
 	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
@@ -354,7 +348,7 @@ func TestAlertRuleConflictingTitle(t *testing.T) {
 	})
 
 	// Create the namespace we'll save our alerts to.
-	err = createFolder(t, "folder1", grafanaListedAddr, "admin", "admin")
+	err := createFolder(t, "folder1", grafanaListedAddr, "admin", "admin")
 	require.NoError(t, err)
 	// Create the namespace we'll save our alerts to.
 	err = createFolder(t, "folder2", grafanaListedAddr, "admin", "admin")
@@ -472,9 +466,6 @@ func TestAlertRuleConflictingTitle(t *testing.T) {
 }
 
 func TestRulerRulesFilterByDashboard(t *testing.T) {
-	_, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
-
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		EnableFeatureToggles: []string{"ngalert"},
 		DisableAnonymous:     true,
@@ -492,7 +483,7 @@ func TestRulerRulesFilterByDashboard(t *testing.T) {
 
 	dashboardUID := "default"
 	// Create the namespace under default organisation (orgID = 1) where we'll save our alerts to.
-	err = createFolder(t, "default", grafanaListedAddr, "grafana", "password")
+	err := createFolder(t, "default", grafanaListedAddr, "grafana", "password")
 	require.NoError(t, err)
 	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
 

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -230,8 +230,7 @@ func Test_executeQueryErrorWithDifferentLogAnalyticsCreds(t *testing.T) {
 		Params:    url.Values{},
 		TimeRange: backend.TimeRange{},
 	}
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(t, err)
+	tracer := tracing.InitializeTracerForTest()
 	res := ds.executeQuery(ctx, query, dsInfo, &http.Client{}, dsInfo.Services["Azure Log Analytics"].URL, tracer)
 	if res.Error == nil {
 		t.Fatal("expecting an error")

--- a/pkg/tsdb/loki/auth_test.go
+++ b/pkg/tsdb/loki/auth_test.go
@@ -120,8 +120,7 @@ func TestOauthForwardIdentity(t *testing.T) {
 				req.Headers[cookieName] = cookieValue
 			}
 
-			tracer, err := tracing.InitializeTracerForTest()
-			require.NoError(t, err)
+			tracer := tracing.InitializeTracerForTest()
 
 			data, err := queryData(context.Background(), &req, &dsInfo, log.New("testlog"), tracer)
 			// we do a basic check that the result is OK

--- a/pkg/tsdb/prometheus/buffered/framing_test.go
+++ b/pkg/tsdb/prometheus/buffered/framing_test.go
@@ -129,10 +129,7 @@ func runQuery(response []byte, query PrometheusQuery) (*backend.QueryDataRespons
 		return nil, err
 	}
 
-	tracer, err := tracing.InitializeTracerForTest()
-	if err != nil {
-		return nil, err
-	}
+	tracer := tracing.InitializeTracerForTest()
 
 	s := Buffered{
 		intervalCalculator: intervalv2.NewCalculator(),

--- a/pkg/tsdb/prometheus/buffered/prometeus_bench_test.go
+++ b/pkg/tsdb/prometheus/buffered/prometeus_bench_test.go
@@ -21,10 +21,7 @@ func BenchmarkJson(b *testing.B) {
 	api, err := makeMockedApi(resp)
 	require.NoError(b, err)
 
-	tracer, err := tracing.InitializeTracerForTest()
-	require.NoError(b, err)
-
-	s := Buffered{tracer: tracer, log: &fakeLogger{}}
+	s := Buffered{tracer: tracing.InitializeTracerForTest(), log: &fakeLogger{}}
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {

--- a/pkg/tsdb/prometheus/querydata/request_test.go
+++ b/pkg/tsdb/prometheus/querydata/request_test.go
@@ -390,10 +390,7 @@ type testContext struct {
 }
 
 func setup(wideFrames bool) *testContext {
-	tracer, err := tracing.InitializeTracerForTest()
-	if err != nil {
-		panic(err)
-	}
+	tracer := tracing.InitializeTracerForTest()
 	httpProvider := &fakeHttpClientProvider{
 		opts: sdkhttpclient.Options{
 			Timeouts: &sdkhttpclient.DefaultTimeoutOptions,


### PR DESCRIPTION
This PR switches to no-op tracer for tests (instead of a misconfigured Jaeger tracer).
Also, no-op tracer is guaranteed to return no errors on initialisation, thus - some pointless error checks can be removed!