### PR TITLE
Dashboard: Don't show unsaved changes modal for automatic schema changes

### DIFF
--- a/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
+++ b/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.test.tsx
@@ -1,3 +1,5 @@
+import { getPanelPlugin } from 'app/features/plugins/__mocks__/pluginMocks';
+
 import { setContextSrv } from '../../../../core/services/context_srv';
 import { DashboardModel } from '../../state/DashboardModel';
 import { PanelModel } from '../../state/PanelModel';
@@ -136,6 +138,17 @@ describe('DashboardPrompt', () => {
           ignoreChanges({ ...dash, meta: { canSave: true, fromScript: true, fromFile: undefined } }, original)
         ).toBe(true);
       });
+    });
+
+    it('Should ignore panel schema migrations', () => {
+      const { original, dash } = getTestContext();
+      const plugin = getPanelPlugin({}).setMigrationHandler((panel) => {
+        delete (panel as any).legend;
+        return { option1: 'Aasd' };
+      });
+
+      dash.panels[0].pluginLoaded(plugin);
+      expect(hasChanges(dash, original)).toBe(false);
     });
 
     describe('when called with fromFile', () => {

--- a/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.tsx
+++ b/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.tsx
@@ -1,5 +1,5 @@
 import * as H from 'history';
-import { each, filter, find } from 'lodash';
+import { each, find } from 'lodash';
 import React, { useContext, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { Prompt } from 'react-router-dom';
@@ -184,22 +184,7 @@ function cleanDashboardFromIgnoredChanges(dashData: any) {
   // ignore iteration property
   delete dash.iteration;
 
-  dash.panels = filter(dash.panels, (panel) => {
-    if (panel.repeatPanelId) {
-      return false;
-    }
-
-    // remove scopedVars
-    panel.scopedVars = undefined;
-
-    // ignore panel legend sort
-    if (panel.legend) {
-      delete panel.legend.sort;
-      delete panel.legend.sortDesc;
-    }
-
-    return true;
-  });
+  dash.panels = [];
 
   // ignore template variable values
   each(dash.getVariables(), (variable: any) => {
@@ -212,6 +197,10 @@ function cleanDashboardFromIgnoredChanges(dashData: any) {
 }
 
 export function hasChanges(current: DashboardModel, original: any) {
+  if (current.hasUnsavedChanges()) {
+    return true;
+  }
+
   const currentClean = cleanDashboardFromIgnoredChanges(current.getSaveModelClone());
   const originalClean = cleanDashboardFromIgnoredChanges(original);
 

--- a/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
+++ b/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
@@ -50,8 +50,8 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
   };
 
   onUpdate = (title: string, repeat?: string | null) => {
-    this.props.panel['title'] = title;
-    this.props.panel['repeat'] = repeat ?? undefined;
+    this.props.panel.setProperty('title', title);
+    this.props.panel.setProperty('repeat', repeat ?? undefined);
     this.props.panel.render();
     this.props.dashboard.processRepeats();
     this.forceUpdate();

--- a/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardGrid.tsx
@@ -122,7 +122,6 @@ export class DashboardGridUnconnected extends PureComponent<Props, State> {
   onResize: ItemCallback = (layout, oldItem, newItem) => {
     const panel = this.panelMap[newItem.i!];
     panel.updateGridPos(newItem);
-    panel.configRev++; // trigger change handler
   };
 
   onResizeStop: ItemCallback = (layout, oldItem, newItem) => {

--- a/public/app/features/dashboard/state/DashboardModel.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.test.ts
@@ -367,6 +367,15 @@ describe('DashboardModel', () => {
       dashboard.toggleRow(dashboard.panels[1]);
     });
 
+    it('should not impact hasUnsavedChanges', () => {
+      expect(dashboard.hasUnsavedChanges()).toBe(false);
+    });
+
+    it('should impact hasUnsavedChanges if panels have changes when row is collapsed', () => {
+      dashboard.panels[0].setProperty('title', 'new title');
+      expect(dashboard.hasUnsavedChanges()).toBe(true);
+    });
+
     it('should remove panels and put them inside collapsed row', () => {
       expect(dashboard.panels.length).toBe(3);
       expect(dashboard.panels[1].panels?.length).toBe(2);

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -499,10 +499,6 @@ export class DashboardModel implements TimeModel {
 
   hasUnsavedChanges() {
     const changedPanel = this.panels.find((p) => p.hasChanged);
-    if (changedPanel) {
-      console.log('Panel has changed', changedPanel);
-    }
-
     return Boolean(changedPanel);
   }
 
@@ -872,6 +868,10 @@ export class DashboardModel implements TimeModel {
       // save panel models inside row panel
       row.panels = rowPanels.map((panel: PanelModel) => panel.getSaveModel());
       row.collapsed = true;
+
+      if (rowPanels.some((panel) => panel.hasChanged)) {
+        row.configRev++;
+      }
 
       // emit change event
       this.events.publish(new DashboardPanelsChangedEvent());

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -436,8 +436,15 @@ describe('PanelModel', () => {
     });
 
     describe('updateGridPos', () => {
-      it('Should not cause configRev increment', () => {
+      it('Should not cause configRev if no change', () => {
+        model.gridPos = { w: 1, h: 1, x: 1, y: 2 };
         model.updateGridPos({ w: 1, h: 1, x: 1, y: 2 });
+        expect(model.hasChanges()).toBeFalse();
+      });
+
+      it('Should not cause configRev if gridPos is different', () => {
+        model.gridPos = { w: 1, h: 1, x: 1, y: 2 };
+        model.updateGridPos({ w: 10, h: 1, x: 1, y: 2 });
         expect(model.hasChanges()).toBeFalse();
       });
     });

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -435,6 +435,13 @@ describe('PanelModel', () => {
       });
     });
 
+    describe('updateGridPos', () => {
+      it('Should not cause configRev increment', () => {
+        model.updateGridPos({ w: 1, h: 1, x: 1, y: 2 });
+        expect(model.hasChanges()).toBeFalse();
+      });
+    });
+
     describe('destroy', () => {
       it('Should still preserve last query result', () => {
         model.getQueryRunner().useLastResultFrom({

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -439,13 +439,13 @@ describe('PanelModel', () => {
       it('Should not cause configRev if no change', () => {
         model.gridPos = { w: 1, h: 1, x: 1, y: 2 };
         model.updateGridPos({ w: 1, h: 1, x: 1, y: 2 });
-        expect(model.hasChanges()).toBeFalse();
+        expect(model.hasChanged).toBe(false);
       });
 
       it('Should not cause configRev if gridPos is different', () => {
         model.gridPos = { w: 1, h: 1, x: 1, y: 2 };
         model.updateGridPos({ w: 10, h: 1, x: 1, y: 2 });
-        expect(model.hasChanges()).toBeFalse();
+        expect(model.hasChanged).toBe(true);
       });
     });
 

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -297,9 +297,13 @@ export class PanelModel implements DataConfigSource, IPanelModel {
     this.isViewing = isViewing;
   }
 
-  /** Should not increment configRev here as this is called for all panels on grid init */
   updateGridPos(newPos: GridPos) {
-    if (isEqual(this.gridPos, newPos)) {
+    if (
+      newPos.x === this.gridPos.x &&
+      newPos.y === this.gridPos.y &&
+      newPos.h === this.gridPos.h &&
+      newPos.w === this.gridPos.w
+    ) {
       return;
     }
 

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -299,10 +299,15 @@ export class PanelModel implements DataConfigSource, IPanelModel {
 
   /** Should not increment configRev here as this is called for all panels on grid init */
   updateGridPos(newPos: GridPos) {
+    if (isEqual(this.gridPos, newPos)) {
+      return;
+    }
+
     this.gridPos.x = newPos.x;
     this.gridPos.y = newPos.y;
     this.gridPos.w = newPos.w;
     this.gridPos.h = newPos.h;
+    this.configRev++;
   }
 
   runAllPanelQueries(dashboardId: number, dashboardTimezone: string, timeData: TimeOverrideResult, width: number) {

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -297,6 +297,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
     this.isViewing = isViewing;
   }
 
+  /** Should not increment configRev here as this is called for all panels on grid init */
   updateGridPos(newPos: GridPos) {
     this.gridPos.x = newPos.x;
     this.gridPos.y = newPos.y;


### PR DESCRIPTION
Fixes #48304

partial implementation of #24663

This changes the unsaved changes detection to totally ignore the panels array from a json diff perspective.

Instead we only check configRev which is incremented only when user does a real change. Not
when the schema is migrated on load.

Alternative / more complete version of https://github.com/grafana/grafana/pull/50677