### PR TITLE
Query Caching POC: enterprise query caching for public dashboards

### DIFF
--- a/pkg/api/dashboard_public.go
+++ b/pkg/api/dashboard_public.go
@@ -90,7 +90,8 @@ func (hs *HTTPServer) QueryPublicDashboard(c *models.ReqContext) response.Respon
 		return handleDashboardErr(http.StatusInternalServerError, "Failed to get queries for public dashboard", err)
 	}
 
-	resp, err := hs.queryDataService.QueryDataMultipleSources(c.Req.Context(), nil, c.SkipCache, reqDTO, true)
+	user := models.SignedInUser{IsAnonymous: true, OrgId: c.OrgId}
+	resp, err := hs.queryDataService.QueryDataMultipleSources(c.Req.Context(), &user, c.SkipCache, reqDTO, true)
 
 	if err != nil {
 		return hs.handleQueryMetricsError(err)

--- a/public/app/features/dashboard/services/PublicDashboardDataSource.ts
+++ b/public/app/features/dashboard/services/PublicDashboardDataSource.ts
@@ -4,13 +4,13 @@ import { DataQuery, DataQueryRequest, DataQueryResponse, DataSourceApi, PluginMe
 import { BackendDataSourceResponse, getBackendSrv, toDataQueryResponse } from '@grafana/runtime';
 
 export class PublicDashboardDataSource extends DataSourceApi<any> {
-  constructor() {
+  constructor(id: number, uid: string) {
     super({
       name: 'public-ds',
-      id: 1,
+      id,
       type: 'public-ds',
       meta: {} as PluginMeta,
-      uid: '1',
+      uid,
       jsonData: {},
       access: 'proxy',
     });

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -362,7 +362,8 @@ async function getDataSource(
   publicDashboardUid?: string
 ): Promise<DataSourceApi> {
   if (publicDashboardUid) {
-    return new PublicDashboardDataSource();
+    const ds = datasource as DataSourceApi;
+    return new PublicDashboardDataSource(ds.id, ds.uid);
   }
 
   if (datasource && (datasource as any).query) {


### PR DESCRIPTION
**This is a POC and WILL NOT be merged**

**What this does**
This makes enterprise query caching functional for public dashboards. Any panel requests to `/api/public/dashboards/:uid/panels/:panelId/query` will be cached by the query caching middleware.

<img width="1497" alt="Screen Shot 2022-06-14 at 4 43 19 PM" src="https://user-images.githubusercontent.com/20195316/173701470-92c7661c-e8f1-418d-ab6e-ad82491efcff.png">

**Problems**
There are issues with the current signed in user not existing. The datasource guardian for enterprise will deny access because the user doesn't exist. For now, I just passed it through when the user is anonymous, but thats just for the sake of showing this is functional for the POC. Some discussion around how to deal with no signed in user would be helpful.

See the [Enterprise PR](https://github.com/grafana/grafana-enterprise/pull/3473) as well
