### PR TITLE
UX: angularPanelStyles to align correctly with OptionsPaneCategory

### DIFF
--- a/packages/grafana-ui/src/themes/GlobalStyles/angularPanelStyles.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/angularPanelStyles.ts
@@ -25,6 +25,7 @@ export function getAgularPanelStyles(theme: GrafanaTheme2) {
     .panel-options-group__icon {
       color: ${theme.colors.text.secondary};
       margin-right: ${theme.spacing(1)};
+      padding: ${theme.spacing(0, 0.9, 0, 0.6)};
     }
 
     .panel-options-group__title {


### PR DESCRIPTION
Adjust padding for panel-options-group__icon in angularPanelStyles to line-up when used alongside OptionsPaneCategory

The only way to make this 'pixel perfect' was to use decimal values for the theme spacing props -- hope this is ok!


Fixes #50644

<img width="202" alt="Screenshot 2022-06-15 at 02 25 52" src="https://user-images.githubusercontent.com/67058118/173716723-2b16d85c-4290-4421-9912-07ec26d47d60.png">
