### PR TITLE
Playlists: Disable Create Playlist buttons for users with viewer role

### DIFF
--- a/public/app/features/playlist/PlaylistPage.test.tsx
+++ b/public/app/features/playlist/PlaylistPage.test.tsx
@@ -16,6 +16,12 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
+jest.mock('app/core/services/context_srv', () => ({
+  contextSrv: {
+    isEditor: true,
+  },
+}));
+
 function getTestContext(propOverrides?: object) {
   const props: PlaylistPageProps = {
     navModel: {

--- a/public/app/features/playlist/PlaylistPage.test.tsx
+++ b/public/app/features/playlist/PlaylistPage.test.tsx
@@ -1,6 +1,8 @@
 import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 
+import { contextSrv } from 'app/core/services/context_srv';
+
 import { locationService } from '../../../../packages/grafana-runtime/src';
 
 import { PlaylistPage, PlaylistPageProps } from './PlaylistPage';
@@ -12,12 +14,6 @@ jest.mock('@grafana/runtime', () => ({
   getBackendSrv: () => ({
     get: fnMock,
   }),
-}));
-
-jest.mock('app/core/services/context_srv', () => ({
-  contextSrv: {
-    isEditor: true,
-  },
 }));
 
 function getTestContext(propOverrides?: object) {
@@ -56,6 +52,22 @@ describe('PlaylistPage', () => {
       const { getByText } = getTestContext();
       await waitFor(() => getByText('There are no playlists created yet'));
     });
+    describe('and signed in user is not a viewer', () => {
+      it('then create playlist button should not be disabled', async () => {
+        contextSrv.isEditor = true;
+        const { getByRole } = getTestContext();
+        const createPlaylistButton = await waitFor(() => getByRole('link', { name: /create playlist/i }));
+        expect(createPlaylistButton).not.toHaveStyle('pointer-events: none');
+      });
+    });
+    describe('and signed in user is a viewer', () => {
+      it('then create playlist button should be disabled', async () => {
+        contextSrv.isEditor = false;
+        const { getByRole } = getTestContext();
+        const createPlaylistButton = await waitFor(() => getByRole('link', { name: /create playlist/i }));
+        expect(createPlaylistButton).toHaveStyle('pointer-events: none');
+      });
+    });
   });
   describe('when mounted with a playlist', () => {
     it('page should load', () => {
@@ -75,12 +87,27 @@ describe('PlaylistPage', () => {
       const { getByText } = getTestContext();
       expect(getByText(/loading/i)).toBeInTheDocument();
     });
-    it('then playlist title and buttons should appear on the page', async () => {
-      const { getByRole, getByText } = getTestContext();
-      await waitFor(() => getByText('A test playlist'));
-      expect(getByRole('button', { name: /Start playlist/i })).toBeInTheDocument();
-      expect(getByRole('link', { name: /Edit playlist/i })).toBeInTheDocument();
-      expect(getByRole('button', { name: /Delete playlist/i })).toBeInTheDocument();
+    describe('and signed in user is not a viewer', () => {
+      it('then playlist title and all playlist buttons should appear on the page', async () => {
+        contextSrv.isEditor = true;
+        const { getByRole, getByText } = getTestContext();
+        await waitFor(() => getByText('A test playlist'));
+        expect(getByRole('link', { name: /New playlist/i })).toBeInTheDocument();
+        expect(getByRole('button', { name: /Start playlist/i })).toBeInTheDocument();
+        expect(getByRole('link', { name: /Edit playlist/i })).toBeInTheDocument();
+        expect(getByRole('button', { name: /Delete playlist/i })).toBeInTheDocument();
+      });
+    });
+    describe('and signed in user is a viewer', () => {
+      it('then playlist title and only start playlist button should appear on the page', async () => {
+        contextSrv.isEditor = false;
+        const { getByRole, getByText, queryByRole } = getTestContext();
+        await waitFor(() => getByText('A test playlist'));
+        expect(queryByRole('link', { name: /New playlist/i })).not.toBeInTheDocument();
+        expect(getByRole('button', { name: /Start playlist/i })).toBeInTheDocument();
+        expect(queryByRole('link', { name: /Edit playlist/i })).not.toBeInTheDocument();
+        expect(queryByRole('button', { name: /Delete playlist/i })).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/public/app/features/playlist/PlaylistPage.tsx
+++ b/public/app/features/playlist/PlaylistPage.tsx
@@ -7,6 +7,7 @@ import { ConfirmModal } from '@grafana/ui';
 import Page from 'app/core/components/Page/Page';
 import PageActionBar from 'app/core/components/PageActionBar/PageActionBar';
 import { getNavModel } from 'app/core/selectors/navModel';
+import { contextSrv } from 'app/core/services/context_srv';
 import { StoreState } from 'app/types';
 
 import EmptyListCTA from '../../core/components/EmptyListCTA/EmptyListCTA';
@@ -64,6 +65,7 @@ export const PlaylistPage: FC<PlaylistPageProps> = ({ navModel }) => {
       buttonIcon="plus"
       buttonLink="playlists/new"
       buttonTitle="Create Playlist"
+      buttonDisabled={!contextSrv.isEditor}
       proTip="You can use playlists to cycle dashboards on TVs without user control"
       proTipLink="http://docs.grafana.org/reference/playlist/"
       proTipLinkTitle="Learn more"
@@ -79,7 +81,7 @@ export const PlaylistPage: FC<PlaylistPageProps> = ({ navModel }) => {
         {showSearch && (
           <PageActionBar
             searchQuery={searchQuery}
-            linkButton={{ title: 'New playlist', href: '/playlists/new' }}
+            linkButton={contextSrv.isEditor && { title: 'New playlist', href: '/playlists/new' }}
             setSearchQuery={setSearchQuery}
           />
         )}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR hides / disables "Create Playlist" and "New Playlist" buttons for `viewer` users so the `viewer` users don't have access to the New Playlist form.

**Which issue(s) this PR fixes**:
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #50177 


