### PR TITLE
Alerting: Add firstImage func

### DIFF
--- a/pkg/services/ngalert/models/image.go
+++ b/pkg/services/ngalert/models/image.go
@@ -1,12 +1,8 @@
 package models
 
 import (
-	"errors"
 	"time"
 )
-
-// ErrImageNotFound is returned when the image does not exist.
-var ErrImageNotFound = errors.New("image not found")
 
 type Image struct {
 	ID        int64     `xorm:"pk autoincr 'id'"`

--- a/pkg/services/ngalert/notifier/channels/discord.go
+++ b/pkg/services/ngalert/notifier/channels/discord.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	store_error "github.com/grafana/grafana/pkg/services/ngalert/store/error"
 	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -224,7 +225,7 @@ func (d DiscordNotifier) constructAttachments(ctx context.Context, as []*types.A
 				base := filepath.Base(image.Path)
 				url := fmt.Sprintf("attachment://%s", base)
 				reader, err := openImage(image.Path)
-				if err != nil && !errors.Is(err, ngmodels.ErrImageNotFound) {
+				if err != nil && !errors.Is(err, store_error.ErrImageNotFound) {
 					d.log.Warn("failed to retrieve image data from store", "err", err)
 					return nil
 				}

--- a/pkg/services/ngalert/notifier/channels/factory.go
+++ b/pkg/services/ngalert/notifier/channels/factory.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	store_error "github.com/grafana/grafana/pkg/services/ngalert/store/error"
 	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/prometheus/alertmanager/template"
 )
@@ -21,6 +22,13 @@ type FactoryConfig struct {
 
 type ImageStore interface {
 	GetImage(ctx context.Context, token string) (*models.Image, error)
+}
+
+type UnavailableImageStore struct{}
+
+// Get returns the image with the corresponding token, or ErrImageNotFound.
+func (u *UnavailableImageStore) GetImage(ctx context.Context, token string) (*models.Image, error) {
+	return nil, store_error.ErrImagesUnavailable
 }
 
 func NewFactoryConfig(config *NotificationChannelConfig, notificationService notifications.Service,

--- a/pkg/services/ngalert/notifier/channels/testing.go
+++ b/pkg/services/ngalert/notifier/channels/testing.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	store_error "github.com/grafana/grafana/pkg/services/ngalert/store/error"
 )
 
 // mockTimeNow replaces function timeNow to return constant time.
@@ -60,5 +61,5 @@ func (f *fakeImageStore) GetImage(ctx context.Context, token string) (*ngmodels.
 			return img, nil
 		}
 	}
-	return nil, ngmodels.ErrImageNotFound
+	return nil, store_error.ErrImageNotFound
 }

--- a/pkg/services/ngalert/notifier/channels/util_test.go
+++ b/pkg/services/ngalert/notifier/channels/util_test.go
@@ -1,0 +1,150 @@
+package channels
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	store_error "github.com/grafana/grafana/pkg/services/ngalert/store/error"
+)
+
+func TestFirstImage(t *testing.T) {
+	ctx := context.Background()
+	images := &fakeImageStore{Images: []*models.Image{{
+		Token: "foo",
+	}, {
+		Token: "bar",
+	}}}
+
+	// should return the image from the alert
+	image, alert, err := firstImage(ctx, images, &types.Alert{
+		Alert: model.Alert{
+			Annotations: model.LabelSet{
+				models.ScreenshotTokenAnnotation: "foo",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// should return the same alert
+	require.NotNil(t, alert)
+	assert.Equal(t, model.LabelValue("foo"), alert.Annotations[models.ScreenshotTokenAnnotation])
+
+	// and the image should have the expected token
+	require.NotNil(t, image)
+	assert.Equal(t, "foo", image.Token)
+
+	// should return the image from the first alert
+	image, alert, err = firstImage(ctx, images, &types.Alert{
+		Alert: model.Alert{
+			Annotations: model.LabelSet{
+				models.ScreenshotTokenAnnotation: "foo",
+			},
+		},
+	}, &types.Alert{
+		Alert: model.Alert{
+			Annotations: model.LabelSet{
+				models.ScreenshotTokenAnnotation: "bar",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// should return the expected alert
+	require.NotNil(t, alert)
+	assert.Equal(t, model.LabelValue("foo"), alert.Annotations[models.ScreenshotTokenAnnotation])
+
+	// and the image should have the expected token
+	require.NotNil(t, image)
+	assert.Equal(t, "foo", image.Token)
+
+	// should return the image for the second alert
+	image, alert, err = firstImage(ctx, images, &types.Alert{
+		Alert: model.Alert{
+			Annotations: model.LabelSet{
+				models.ScreenshotTokenAnnotation: "baz",
+			},
+		},
+	}, &types.Alert{
+		Alert: model.Alert{
+			Annotations: model.LabelSet{
+				models.ScreenshotTokenAnnotation: "bar",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// should return the same alert
+	require.NotNil(t, alert)
+	assert.Equal(t, model.LabelValue("bar"), alert.Annotations[models.ScreenshotTokenAnnotation])
+
+	// and the image should have the expected token
+	require.NotNil(t, image)
+	assert.Equal(t, "bar", image.Token)
+
+	// should return no images for unknown token
+	image, alert, err = firstImage(ctx, images, &types.Alert{
+		Alert: model.Alert{
+			Annotations: model.LabelSet{
+				models.ScreenshotTokenAnnotation: "baz",
+			},
+		},
+	})
+	require.Nil(t, err)
+	require.Nil(t, alert)
+	require.Nil(t, image)
+
+	// should return no images
+	image, alert, err = firstImage(ctx, images, &types.Alert{
+		Alert: model.Alert{
+			Annotations: model.LabelSet{},
+		},
+	})
+	require.NoError(t, err)
+	require.Nil(t, alert)
+	require.Nil(t, image)
+}
+
+func TestGetImage(t *testing.T) {
+	ctx := context.Background()
+	images := &fakeImageStore{Images: []*models.Image{{
+		Token: "foo",
+	}}}
+
+	// should return the image from the alert
+	image, err := getImage(ctx, images, types.Alert{
+		Alert: model.Alert{
+			Annotations: model.LabelSet{
+				models.ScreenshotTokenAnnotation: "foo",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, image)
+	assert.Equal(t, "foo", image.Token)
+
+	// should return ErrImageNotFound
+	image, err = getImage(ctx, images, types.Alert{
+		Alert: model.Alert{
+			Annotations: model.LabelSet{
+				models.ScreenshotTokenAnnotation: "bar",
+			},
+		},
+	})
+	assert.Equal(t, err, store_error.ErrImageNotFound)
+	assert.Nil(t, image)
+
+	// should return nil
+	image, err = getImage(ctx, images, types.Alert{
+		Alert: model.Alert{
+			Annotations: model.LabelSet{},
+		},
+	})
+	assert.Nil(t, err)
+	assert.Nil(t, image)
+}

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
+	store_error "github.com/grafana/grafana/pkg/services/ngalert/store/error"
 )
 
 type FakeConfigStore struct {
@@ -20,15 +21,15 @@ type FakeConfigStore struct {
 
 // Saves the image or returns an error.
 func (f *FakeConfigStore) SaveImage(ctx context.Context, img *models.Image) error {
-	return models.ErrImageNotFound
+	return store_error.ErrImageNotFound
 }
 
 func (f *FakeConfigStore) GetImage(ctx context.Context, token string) (*models.Image, error) {
-	return nil, models.ErrImageNotFound
+	return nil, store_error.ErrImageNotFound
 }
 
 func (f *FakeConfigStore) GetImages(ctx context.Context, tokens []string) ([]models.Image, error) {
-	return nil, models.ErrImageNotFound
+	return nil, store_error.ErrImageNotFound
 }
 
 func NewFakeConfigStore(t *testing.T, configs map[int64]*models.AlertConfiguration) FakeConfigStore {

--- a/pkg/services/ngalert/store/error/image.go
+++ b/pkg/services/ngalert/store/error/image.go
@@ -1,0 +1,11 @@
+package error
+
+import (
+	"errors"
+)
+
+var (
+	// ErrImageNotFound is returned when the image does not exist.
+	ErrImageNotFound     = errors.New("image not found")
+	ErrImagesUnavailable = errors.New("images are unavailable")
+)

--- a/pkg/services/ngalert/store/image.go
+++ b/pkg/services/ngalert/store/image.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	store_error "github.com/grafana/grafana/pkg/services/ngalert/store/error"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 )
 
@@ -31,7 +32,7 @@ func (st DBstore) GetImage(ctx context.Context, token string) (*models.Image, er
 			return fmt.Errorf("failed to get image: %w", err)
 		}
 		if !exists {
-			return models.ErrImageNotFound
+			return store_error.ErrImageNotFound
 		}
 		return nil
 	}); err != nil {
@@ -48,7 +49,7 @@ func (st DBstore) GetImages(ctx context.Context, tokens []string) ([]models.Imag
 		return nil, err
 	}
 	if len(imgs) < len(tokens) {
-		return imgs, models.ErrImageNotFound
+		return imgs, store_error.ErrImageNotFound
 	}
 	return imgs, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit adds a new function called firstImage that returns the first image and the alert for which the image was found for a series of alerts. It means we do not have to use `withStoredImages` which will iterate over all images even after the first image has been found.

This commit also creates a new error package in the store package so we can move the errors back to the store while avoiding import issues between the sqlstore and migrations.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

