### PR TITLE
AzureMonitor: Filter resources by the right type

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azureMetadata/logsResourceTypes.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azureMetadata/logsResourceTypes.ts
@@ -193,5 +193,3 @@ export const logsResourceTypes = [
   'microsoft.web/sites',
   'microsoft.web/sites/slots',
 ];
-
-export const logsSupportedResourceTypesKusto = logsResourceTypes.map((v) => `"${v}"`).join(',');

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azureMetadata/metricNamespaces.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azureMetadata/metricNamespaces.ts
@@ -173,7 +173,3 @@ export const supportedMetricNamespaces = [
   'Microsoft.Web/staticSites',
   'Wandisco.Fusion/migrators',
 ];
-
-export const supportedMetricNamespacesKusto = supportedMetricNamespaces
-  .map((v) => `"${v.toLocaleLowerCase()}"`)
-  .join(',');

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -58,6 +58,7 @@ const LogsQueryEditor: React.FC<LogsQueryEditorProps> = ({
                 ]}
                 setResource={setResource}
                 resourceUri={query.azureLogAnalytics?.resource}
+                queryType="logs"
               />
             </EditorFieldGroup>
           </EditorRow>
@@ -106,6 +107,7 @@ const LogsQueryEditor: React.FC<LogsQueryEditorProps> = ({
           ]}
           setResource={setResource}
           resourceUri={query.azureLogAnalytics?.resource}
+          queryType="logs"
         />
 
         <QueryField

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/MetricsQueryEditor.tsx
@@ -59,6 +59,7 @@ const MetricsQueryEditor: React.FC<MetricsQueryEditorProps> = ({
                 selectableEntryTypes={[ResourceRowType.Resource]}
                 setResource={setResource}
                 resourceUri={query.azureMonitor?.resourceUri}
+                queryType={'metrics'}
               />
               <MetricNamespaceField
                 metricNamespaces={metricNamespaces}
@@ -146,6 +147,7 @@ const MetricsQueryEditor: React.FC<MetricsQueryEditorProps> = ({
             selectableEntryTypes={[ResourceRowType.Resource]}
             setResource={setResource}
             resourceUri={query.azureMonitor?.resourceUri}
+            queryType="metrics"
           />
         </InlineFieldRow>
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourceField/ResourceField.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourceField/ResourceField.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Button, Icon, Modal, useStyles2 } from '@grafana/ui';
 
 import Datasource from '../../datasource';
+import { ResourcePickerQueryType } from '../../resourcePicker/resourcePickerData';
 import { AzureQueryEditorFieldProps, AzureMonitorQuery, AzureResourceSummaryItem } from '../../types';
 import { Field } from '../Field';
 import ResourcePicker from '../ResourcePicker';
@@ -28,6 +29,7 @@ function parseResourceDetails(resourceURI: string) {
 interface ResourceFieldProps extends AzureQueryEditorFieldProps {
   setResource: (query: AzureMonitorQuery, resourceURI?: string) => AzureMonitorQuery;
   selectableEntryTypes: ResourceRowType[];
+  queryType: ResourcePickerQueryType;
   resourceUri?: string;
   inlineField?: boolean;
   labelWidth?: number;
@@ -39,6 +41,7 @@ const ResourceField: React.FC<ResourceFieldProps> = ({
   onQueryChange,
   setResource,
   selectableEntryTypes,
+  queryType,
   resourceUri,
   inlineField,
   labelWidth,
@@ -79,6 +82,7 @@ const ResourceField: React.FC<ResourceFieldProps> = ({
           onApply={handleApply}
           onCancel={closePicker}
           selectableEntryTypes={selectableEntryTypes}
+          queryType={queryType}
         />
       </Modal>
       <Field label="Resource" inlineField={inlineField} labelWidth={labelWidth}>

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/ResourcePicker.test.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/ResourcePicker/ResourcePicker.test.tsx
@@ -9,7 +9,7 @@ import {
   mockResourcesByResourceGroup,
   mockSearchResults,
 } from '../../__mocks__/resourcePickerRows';
-import ResourcePickerData from '../../resourcePicker/resourcePickerData';
+import ResourcePickerData, { ResourcePickerQueryType } from '../../resourcePicker/resourcePickerData';
 
 import { ResourceRowType } from './types';
 
@@ -37,6 +37,8 @@ function createMockResourcePickerData() {
   return mockResourcePicker;
 }
 
+const queryType: ResourcePickerQueryType = 'logs';
+
 const defaultProps = {
   templateVariables: [],
   resourceURI: noResourceURI,
@@ -49,6 +51,7 @@ const defaultProps = {
     ResourceRowType.Resource,
     ResourceRowType.Variable,
   ],
+  queryType,
 };
 
 describe('AzureMonitor ResourcePicker', () => {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
@@ -24,6 +24,9 @@ import { routeNames } from '../utils/common';
 
 const RESOURCE_GRAPH_URL = '/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01';
 
+const logsSupportedResourceTypesKusto = logsResourceTypes.map((v) => `"${v}"`).join(',');
+const supportedMetricNamespacesKusto = supportedMetricNamespaces.map((v) => `"${v.toLocaleLowerCase()}"`).join(',');
+
 export type ResourcePickerQueryType = 'logs' | 'metrics';
 
 export default class ResourcePickerData extends DataSourceWithBackend<AzureMonitorQuery, AzureDataSourceJsonData> {
@@ -321,8 +324,6 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
   }
 
   private filterByType = (t: ResourcePickerQueryType) => {
-    const logsSupportedResourceTypesKusto = logsResourceTypes.map((v) => `"${v}"`).join(',');
-    const supportedMetricNamespacesKusto = supportedMetricNamespaces.map((v) => `"${v.toLocaleLowerCase()}"`).join(',');
     return t === 'logs'
       ? `| where type in (${logsSupportedResourceTypesKusto})`
       : `| where type in (${supportedMetricNamespacesKusto})`;

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/resourcePicker/resourcePickerData.ts
@@ -4,9 +4,9 @@ import { DataSourceInstanceSettings } from '../../../../../../packages/grafana-d
 import {
   locationDisplayNames,
   logsSupportedLocationsKusto,
-  logsSupportedResourceTypesKusto,
+  logsResourceTypes,
   resourceTypeDisplayNames,
-  supportedMetricNamespacesKusto,
+  supportedMetricNamespaces,
 } from '../azureMetadata';
 import { ResourceRow, ResourceRowGroup, ResourceRowType } from '../components/ResourcePicker/types';
 import { addResources, parseResourceURI } from '../components/ResourcePicker/utils';
@@ -23,6 +23,9 @@ import {
 import { routeNames } from '../utils/common';
 
 const RESOURCE_GRAPH_URL = '/providers/Microsoft.ResourceGraph/resources?api-version=2021-03-01';
+
+export type ResourcePickerQueryType = 'logs' | 'metrics';
+
 export default class ResourcePickerData extends DataSourceWithBackend<AzureMonitorQuery, AzureDataSourceJsonData> {
   private resourcePath: string;
   resultLimit = 200;
@@ -32,7 +35,7 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
     this.resourcePath = `${routeNames.resourceGraph}`;
   }
 
-  async fetchInitialRows(currentSelection?: string): Promise<ResourceRowGroup> {
+  async fetchInitialRows(type: ResourcePickerQueryType, currentSelection?: string): Promise<ResourceRowGroup> {
     const subscriptions = await this.getSubscriptions();
     if (!currentSelection) {
       return subscriptions;
@@ -44,46 +47,44 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
       const resourceGroupURI = `/subscriptions/${parsedURI.subscriptionID}/resourceGroups/${parsedURI.resourceGroup}`;
 
       if (parsedURI.resourceGroup) {
-        const resourceGroups = await this.getResourceGroupsBySubscriptionId(parsedURI.subscriptionID);
+        const resourceGroups = await this.getResourceGroupsBySubscriptionId(parsedURI.subscriptionID, type);
         resources = addResources(resources, `/subscriptions/${parsedURI.subscriptionID}`, resourceGroups);
       }
 
       if (parsedURI.resource) {
-        const resourcesForResourceGroup = await this.getResourcesForResourceGroup(resourceGroupURI);
+        const resourcesForResourceGroup = await this.getResourcesForResourceGroup(resourceGroupURI, type);
         resources = addResources(resources, resourceGroupURI, resourcesForResourceGroup);
       }
     }
     return resources;
   }
 
-  async fetchAndAppendNestedRow(rows: ResourceRowGroup, parentRow: ResourceRow): Promise<ResourceRowGroup> {
+  async fetchAndAppendNestedRow(
+    rows: ResourceRowGroup,
+    parentRow: ResourceRow,
+    type: ResourcePickerQueryType
+  ): Promise<ResourceRowGroup> {
     const nestedRows =
       parentRow.type === ResourceRowType.Subscription
-        ? await this.getResourceGroupsBySubscriptionId(parentRow.id)
-        : await this.getResourcesForResourceGroup(parentRow.id);
+        ? await this.getResourceGroupsBySubscriptionId(parentRow.id, type)
+        : await this.getResourcesForResourceGroup(parentRow.id, type);
 
     return addResources(rows, parentRow.uri, nestedRows);
   }
 
-  search = async (searchPhrase: string, searchType: 'logs' | 'metrics'): Promise<ResourceRowGroup> => {
-    const searchQuery = {
-      metrics: `
-        resources
+  search = async (searchPhrase: string, searchType: ResourcePickerQueryType): Promise<ResourceRowGroup> => {
+    let searchQuery = 'resources';
+    if (searchType === 'logs') {
+      searchQuery += `
+      | union resourcecontainers`;
+    }
+    searchQuery += `
         | where id contains "${searchPhrase}"
-        | where type in (${supportedMetricNamespacesKusto})
+        ${this.filterByType(searchType)}
         | order by tolower(name) asc
         | limit ${this.resultLimit}
-      `,
-      logs: `
-        resources
-        | union resourcecontainers 
-        | where id contains "${searchPhrase}"
-        | where type in (${logsSupportedResourceTypesKusto})
-        | order by tolower(name) asc
-        | limit ${this.resultLimit}
-      `,
-    };
-    const { data: response } = await this.makeResourceGraphRequest<RawAzureResourceItem[]>(searchQuery[searchType]);
+      `;
+    const { data: response } = await this.makeResourceGraphRequest<RawAzureResourceItem[]>(searchQuery);
     return response.map((item) => {
       const parsedUri = parseResourceURI(item.id);
       if (!parsedUri || !(parsedUri.resource || parsedUri.resourceGroup || parsedUri.subscriptionID)) {
@@ -154,7 +155,10 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
     }));
   }
 
-  async getResourceGroupsBySubscriptionId(subscriptionId: string): Promise<ResourceRowGroup> {
+  async getResourceGroupsBySubscriptionId(
+    subscriptionId: string,
+    type: ResourcePickerQueryType
+  ): Promise<ResourceRowGroup> {
     const query = `
     resources
      | join kind=inner (
@@ -163,7 +167,7 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
        | project resourceGroupURI=id, resourceGroupName=name, resourceGroup, subscriptionId
      ) on resourceGroup, subscriptionId
 
-     | where type in (${logsSupportedResourceTypesKusto})
+     ${this.filterByType(type)}
      | where subscriptionId == '${subscriptionId}'
      | summarize count() by resourceGroupName, resourceGroupURI
      | order by resourceGroupURI asc`;
@@ -201,11 +205,14 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
     });
   }
 
-  async getResourcesForResourceGroup(resourceGroupId: string): Promise<ResourceRowGroup> {
+  async getResourcesForResourceGroup(
+    resourceGroupId: string,
+    type: ResourcePickerQueryType
+  ): Promise<ResourceRowGroup> {
     const { data: response } = await this.makeResourceGraphRequest<RawAzureResourceItem[]>(`
       resources
       | where id hasprefix "${resourceGroupId}"
-      | where type in (${logsSupportedResourceTypesKusto}) and location in (${logsSupportedLocationsKusto})
+      ${this.filterByType(type)} and location in (${logsSupportedLocationsKusto})
     `);
 
     return response.map((item) => {
@@ -312,4 +319,12 @@ export default class ResourcePickerData extends DataSourceWithBackend<AzureMonit
       throw error;
     }
   }
+
+  private filterByType = (t: ResourcePickerQueryType) => {
+    const logsSupportedResourceTypesKusto = logsResourceTypes.map((v) => `"${v}"`).join(',');
+    const supportedMetricNamespacesKusto = supportedMetricNamespaces.map((v) => `"${v.toLocaleLowerCase()}"`).join(',');
+    return t === 'logs'
+      ? `| where type in (${logsSupportedResourceTypesKusto})`
+      : `| where type in (${supportedMetricNamespacesKusto})`;
+  };
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

In the `resourcePickerData`, there are 3 methods that we filter the resources returned by the supported types (which is different for Metrics and Logs):

 - When searching for resources matching a term
 - When listing resource groups within a subscription
 - When listing resources within a resource group

But only in the first method we were actualy changing the query depending if we wanted to retrieve resources compatible with Azure Monitor Metrics or Logs (so for the rest, we were just using Logs resources for both). This PR fixes that.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Ref https://github.com/grafana/grafana/issues/50239#issuecomment-1156336413

**Special notes for your reviewer**:

Based on #50788

