### PR TITLE
Revert "Explore: Convert SASS styles of explore-active-button to emotion"

### DIFF
--- a/public/app/features/explore/SecondaryActions.tsx
+++ b/public/app/features/explore/SecondaryActions.tsx
@@ -21,11 +21,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     containerMargin: css`
       margin-top: ${theme.spacing(2)};
     `,
-    exploreActiveButton: css`
-      box-shadow: ${theme.shadows.z1};
-      border: 1px solid ${theme.colors.warning.border};
-      color: ${theme.colors.warning.text};
-    `,
   };
 };
 export function SecondaryActions(props: Props) {
@@ -49,7 +44,7 @@ export function SecondaryActions(props: Props) {
           <Button
             variant="secondary"
             aria-label="Rich history button"
-            className={cx({ [styles.exploreActiveButton]: props.richHistoryButtonActive })}
+            className={cx({ ['explore-active-button']: props.richHistoryButtonActive })}
             onClick={props.onClickRichHistoryButton}
             icon="history"
           >
@@ -59,7 +54,7 @@ export function SecondaryActions(props: Props) {
         <Button
           variant="secondary"
           aria-label="Query inspector button"
-          className={cx({ [styles.exploreActiveButton]: props.queryInspectorButtonActive })}
+          className={cx({ ['explore-active-button']: props.queryInspectorButtonActive })}
           onClick={props.onClickQueryInspectorButton}
           icon="info-circle"
         >

--- a/public/sass/pages/_explore.scss
+++ b/public/sass/pages/_explore.scss
@@ -1,3 +1,9 @@
+.explore-active-button {
+  box-shadow: $btn-active-box-shadow;
+  border: 1px solid $orange-dark !important;
+  color: $orange-dark !important;
+}
+
 // TODO: check if this is used
 .explore {
   display: flex;


### PR DESCRIPTION
Reverts grafana/grafana#50061
As the new colour doesn't really fit the rest of the Explore page the OX team and Pauric decided to remove it and restore the old orange.