### PR TITLE
Service accounts: Migrate expired API keys

### DIFF
--- a/pkg/services/serviceaccounts/database/database_test.go
+++ b/pkg/services/serviceaccounts/database/database_test.go
@@ -185,6 +185,16 @@ func TestStore_MigrateAllApiKeys(t *testing.T) {
 			expectedServiceAccouts: 0,
 			expectedErr:            nil,
 		},
+		{
+			desc: "expired api keys should be migrated",
+			keys: []tests.TestApiKey{
+				{Name: "test1", Role: models.ROLE_EDITOR, Key: "secret1", OrgId: 1},
+				{Name: "test2", Role: models.ROLE_EDITOR, Key: "secret2", OrgId: 1, IsExpired: true},
+			},
+			orgId:                  1,
+			expectedServiceAccouts: 2,
+			expectedErr:            nil,
+		},
 	}
 
 	for _, c := range cases {

--- a/pkg/services/serviceaccounts/tests/common.go
+++ b/pkg/services/serviceaccounts/tests/common.go
@@ -20,10 +20,11 @@ type TestUser struct {
 }
 
 type TestApiKey struct {
-	Name  string
-	Role  models.RoleType
-	OrgId int64
-	Key   string
+	Name      string
+	Role      models.RoleType
+	OrgId     int64
+	Key       string
+	IsExpired bool
 }
 
 func SetupUserServiceAccount(t *testing.T, sqlStore *sqlstore.SQLStore, testUser TestUser) *models.User {
@@ -61,6 +62,19 @@ func SetupApiKey(t *testing.T, sqlStore *sqlstore.SQLStore, testKey TestApiKey) 
 	}
 	err := sqlStore.AddAPIKey(context.Background(), addKeyCmd)
 	require.NoError(t, err)
+
+	if testKey.IsExpired {
+		err := sqlStore.WithTransactionalDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+			// Force setting expires to time before now to make key expired
+			var expires int64 = 1
+			key := models.ApiKey{Expires: &expires}
+			rowsAffected, err := sess.ID(addKeyCmd.Result.Id).Update(&key)
+			require.Equal(t, int64(1), rowsAffected)
+			return err
+		})
+		require.NoError(t, err)
+	}
+
 	return addKeyCmd.Result
 }
 

--- a/pkg/services/sqlstore/apikey.go
+++ b/pkg/services/sqlstore/apikey.go
@@ -46,8 +46,7 @@ func (ss *SQLStore) GetAPIKeys(ctx context.Context, query *models.GetApiKeysQuer
 func (ss *SQLStore) GetAllAPIKeys(ctx context.Context, orgID int64) []*models.ApiKey {
 	result := make([]*models.ApiKey, 0)
 	err := ss.WithDbSession(ctx, func(dbSession *DBSession) error {
-		sess := dbSession.
-			Where("(expires IS NULL OR expires >= ?) AND service_account_id IS NULL", timeNow().Unix()).Asc("name")
+		sess := dbSession.Where("service_account_id IS NULL").Asc("name")
 		if orgID != -1 {
 			sess = sess.Where("org_id=?", orgID)
 		}


### PR DESCRIPTION
Migrate expired API keys to service accounts tokens. Ref #49821