### PR TITLE
Docs: updates auth alias to fix redirect 404

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - /docs/grafana/latest/auth/overview/
-  - /docs/grafana/latest/auth
+  - /docs/grafana/latest/auth/
   - /docs/grafana/latest/setup-grafana/configure-security/configure-authentication/
 description: Learn about all the ways in which you can configure Grafana to authenticate
   users.

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/_index.md
@@ -1,6 +1,7 @@
 ---
 aliases:
   - /docs/grafana/latest/auth/overview/
+  - /docs/grafana/latest/auth
   - /docs/grafana/latest/setup-grafana/configure-security/configure-authentication/
 description: Learn about all the ways in which you can configure Grafana to authenticate
   users.


### PR DESCRIPTION
This PR adds an alias to the authentication landing page to correct a 404.