### PR TITLE
Explore: Update service graph stats and links

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -728,7 +728,7 @@ const serviceGraphLinks = [
     title: 'Request rate',
     internal: {
       query: {
-        expr: 'rate(traces_service_graph_request_total{server="${__data.fields.id}"}[$__rate_interval])',
+        expr: 'sum by (client, server)(rate(traces_service_graph_request_total{server="${__data.fields.id}"}[$__rate_interval]))',
         instant: false,
         range: true,
         exemplar: true,
@@ -756,7 +756,7 @@ const serviceGraphLinks = [
     title: 'Failed request rate',
     internal: {
       query: {
-        expr: 'rate(traces_service_graph_request_failed_total{server="${__data.fields.id}"}[$__rate_interval])',
+        expr: 'sum by (client, server)(rate(traces_service_graph_request_failed_total{server="${__data.fields.id}"}[$__rate_interval]))',
         instant: false,
         range: true,
         exemplar: true,

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -438,7 +438,7 @@ function serviceMapQuery(request: DataQueryRequest<TempoQuery>, datasourceUid: s
         links: [
           makePromLink(
             'Request rate',
-            `rate(${totalsMetric}{server="\${__data.fields.id}"}[$__rate_interval])`,
+            `sum by (client, server)(rate(${totalsMetric}{server="\${__data.fields.id}"}[$__rate_interval]))`,
             datasourceUid,
             false
           ),
@@ -450,7 +450,7 @@ function serviceMapQuery(request: DataQueryRequest<TempoQuery>, datasourceUid: s
           ),
           makePromLink(
             'Failed request rate',
-            `rate(${failedMetric}{server="\${__data.fields.id}"}[$__rate_interval])`,
+            `sum by (client, server)(rate(${failedMetric}{server="\${__data.fields.id}"}[$__rate_interval]))`,
             datasourceUid,
             false
           ),

--- a/public/app/plugins/datasource/tempo/graphTransform.test.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.test.ts
@@ -85,8 +85,8 @@ describe('mapPromMetricsToServiceMap', () => {
       { name: 'id', values: new ArrayVector(['app_db', 'lb_app']) },
       { name: 'source', values: new ArrayVector(['app', 'lb']) },
       { name: 'target', values: new ArrayVector(['db', 'app']) },
-      { name: 'mainstat', values: new ArrayVector([10, 20]) },
-      { name: 'secondarystat', values: new ArrayVector([1000, 2000]) },
+      { name: 'mainstat', values: new ArrayVector([1000, 2000]) },
+      { name: 'secondarystat', values: new ArrayVector([0.17, 0.33]) },
     ]);
   });
 

--- a/public/app/plugins/datasource/tempo/graphTransform.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.ts
@@ -207,8 +207,8 @@ function createServiceMapDataFrames() {
     { name: Fields.id },
     { name: Fields.source },
     { name: Fields.target },
-    { name: Fields.mainStat, config: { unit: 'r', displayName: 'Requests' } },
-    { name: Fields.secondaryStat, config: { unit: 'ms/r', displayName: 'Average response time' } },
+    { name: Fields.mainStat, config: { unit: 'ms/r', displayName: 'Average response time' } },
+    { name: Fields.secondaryStat, config: { unit: 'r/sec', displayName: 'Requests per second' } },
   ]);
 
   return [nodes, edges];
@@ -327,8 +327,8 @@ function convertToDataFrames(
       [Fields.id]: edgeId,
       [Fields.source]: edge.source,
       [Fields.target]: edge.target,
-      [Fields.mainStat]: edge.total, // Requests
-      [Fields.secondaryStat]: edge.total ? (edge.seconds! / edge.total) * 1000 : Number.NaN, // Average response time
+      [Fields.mainStat]: edge.total ? (edge.seconds! / edge.total) * 1000 : Number.NaN, // Average response time
+      [Fields.secondaryStat]: edge.total ? Math.round((edge.total / (rangeMs / 1000)) * 100) / 100 : Number.NaN, // Request per second (to 2 decimals)
     });
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the service graph stats for consistency by keeping the same order and units (ms/r, r/sec)

Updates service graph links to sum by client and server

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates to #48351

**Special notes for your reviewer**:
![Screen Shot 2022-06-15 at 9 53 54 AM](https://user-images.githubusercontent.com/12838032/173878195-92818a22-0217-4dd2-bc88-f9bf2e7ae6fe.png)

