### PR TITLE
Slider: Enforce numeric constraints and styling within the text input

### DIFF
--- a/packages/grafana-ui/src/components/Slider/styles.ts
+++ b/packages/grafana-ui/src/components/Slider/styles.ts
@@ -90,7 +90,7 @@ export const getStyles = stylesFactory((theme: GrafanaTheme2, isHorizontal: bool
     sliderInput: css`
       display: flex;
       flex-direction: row;
-      align-items: start;
+      align-items: center;
       width: 100%;
     `,
     sliderInputVertical: css`

--- a/packages/grafana-ui/src/components/Slider/styles.ts
+++ b/packages/grafana-ui/src/components/Slider/styles.ts
@@ -90,7 +90,7 @@ export const getStyles = stylesFactory((theme: GrafanaTheme2, isHorizontal: bool
     sliderInput: css`
       display: flex;
       flex-direction: row;
-      align-items: center;
+      align-items: start;
       width: 100%;
     `,
     sliderInputVertical: css`

--- a/public/app/core/components/OptionsUI/NumberInput.tsx
+++ b/public/app/core/components/OptionsUI/NumberInput.tsx
@@ -126,7 +126,12 @@ export class NumberInput extends PureComponent<Props, State> {
         range = `> ${max}`;
       }
       return (
-        <Field invalid={inputCorrected} error={`Value out of range ${range} `}>
+        <Field
+          invalid={inputCorrected}
+          error={`Out of range ${range}`}
+          validationMessageHorizontalOverflow={true}
+          style={{ direction: 'rtl' }}
+        >
           {this.renderInput()}
         </Field>
       );

--- a/public/app/core/components/OptionsUI/slider.tsx
+++ b/public/app/core/components/OptionsUI/slider.tsx
@@ -1,7 +1,7 @@
 import { cx } from '@emotion/css';
 import { Global } from '@emotion/react';
 import SliderComponent from 'rc-slider';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { FieldConfigEditorProps, SliderFieldConfigSettings } from '@grafana/data';
 import { useTheme2 } from '@grafana/ui';
@@ -28,6 +28,13 @@ export const SliderValueEditor: React.FC<FieldConfigEditorProps<number, SliderFi
   const styles = getStyles(theme, isHorizontal, Boolean(marks));
   const SliderWithTooltip = SliderComponent;
   const [sliderValue, setSliderValue] = useState<number>(value ?? min);
+
+  // Check for a difference between prop value and internal state
+  useEffect(() => {
+    if (value != null && value !== sliderValue) {
+      setSliderValue(value);
+    }
+  }, [value, sliderValue]);
 
   const onSliderChange = useCallback(
     (v: number) => {
@@ -62,7 +69,7 @@ export const SliderValueEditor: React.FC<FieldConfigEditorProps<number, SliderFi
   return (
     <div className={cx(styles.container, styles.slider)}>
       {/** Slider tooltip's parent component is body and therefore we need Global component to do css overrides for it. */}
-      <Global styles={styles.tooltip} />
+      <Global styles={styles.slider} />
       <label className={cx(styles.sliderInput, ...sliderInputClassNames)}>
         <SliderWithTooltip
           min={min}

--- a/public/app/core/components/OptionsUI/slider.tsx
+++ b/public/app/core/components/OptionsUI/slider.tsx
@@ -5,8 +5,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { FieldConfigEditorProps, GrafanaTheme2, SliderFieldConfigSettings } from '@grafana/data';
 import { useTheme2 } from '@grafana/ui';
-
-import { getStyles } from '../../../../../packages/grafana-ui/src/components/Slider/styles';
+import { getStyles } from '@grafana/ui/src/components/Slider/styles';
 
 import { NumberInput } from './NumberInput';
 

--- a/public/app/core/components/OptionsUI/slider.tsx
+++ b/public/app/core/components/OptionsUI/slider.tsx
@@ -15,7 +15,10 @@ export const SliderValueEditor: React.FC<FieldConfigEditorProps<number, SliderFi
   onChange,
   item,
 }) => {
+  // Input reference
   const inputRef = useRef<HTMLSpanElement>(null);
+
+  // Settings
   const { settings } = item;
   const min = settings?.min || 0;
   const max = settings?.max || 100;
@@ -23,15 +26,14 @@ export const SliderValueEditor: React.FC<FieldConfigEditorProps<number, SliderFi
   const marks = settings?.marks;
   const included = settings?.included;
   const ariaLabelForHandle = settings?.ariaLabelForHandle;
-  const inputWidthDefault = 75;
 
+  // Core slider specific parameters and state
+  const inputWidthDefault = 75;
   const isHorizontal = true;
   const theme = useTheme2();
-  const styles = getStyles(theme, isHorizontal, Boolean(marks));
   const SliderWithTooltip = SliderComponent;
   const [sliderValue, setSliderValue] = useState<number>(value ?? min);
   const [inputWidth, setInputWidth] = useState<number>(inputWidthDefault);
-  const stylesSlider = getStylesSlider(theme, inputWidth);
 
   // Check for a difference between prop value and internal state
   useEffect(() => {
@@ -46,11 +48,12 @@ export const SliderValueEditor: React.FC<FieldConfigEditorProps<number, SliderFi
     const fontWeight = inputElement.getPropertyValue('font-weight') || 'normal';
     const fontSize = inputElement.getPropertyValue('font-size') || '16px';
     const fontFamily = inputElement.getPropertyValue('font-family') || 'Arial';
+    const wideNumericalCharacter = '0';
     const marginDigits = 4; // extra digits to account for things like negative, exponential, and controls
     const inputPadding = 8; // TODO: base this on input styling
     const maxDigits =
       Math.max((max + (step || 0)).toString().length, (max - (step || 0)).toString().length) + marginDigits;
-    const refString = '0'.repeat(maxDigits); // use "0" as widest numerical character
+    const refString = wideNumericalCharacter.repeat(maxDigits);
     const calculatedTextWidth = getTextWidth(refString, `${fontWeight} ${fontSize} ${fontFamily}`);
     if (calculatedTextWidth) {
       setInputWidth(calculatedTextWidth + inputPadding * 2);
@@ -85,6 +88,9 @@ export const SliderValueEditor: React.FC<FieldConfigEditorProps<number, SliderFi
     [onChange]
   );
 
+  // Styles
+  const styles = getStyles(theme, isHorizontal, Boolean(marks));
+  const stylesSlider = getStylesSlider(theme, inputWidth);
   const sliderInputClassNames = !isHorizontal ? [styles.sliderInputVertical] : [];
 
   return (
@@ -105,7 +111,6 @@ export const SliderValueEditor: React.FC<FieldConfigEditorProps<number, SliderFi
           marks={marks}
           included={included}
         />
-        {/* Uses text input so that the number spinners are not shown */}
         <span className={stylesSlider.numberInputWrapper} ref={inputRef}>
           <NumberInput value={sliderValue} onChange={onSliderInputChange} max={max} min={min} step={step} />
         </span>
@@ -133,9 +138,6 @@ const getStylesSlider = (theme: GrafanaTheme2, width: number) => {
       max-width: ${width}px;
       min-width: ${width}px;
       width: 100%;
-    `,
-    numberInputHidden: css`
-      display: none;
     `,
   };
 };

--- a/public/app/core/components/OptionsUI/slider.tsx
+++ b/public/app/core/components/OptionsUI/slider.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { Global } from '@emotion/react';
 import SliderComponent from 'rc-slider';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { FieldConfigEditorProps, GrafanaTheme2, SliderFieldConfigSettings } from '@grafana/data';
 import { useTheme2 } from '@grafana/ui';
@@ -15,7 +15,7 @@ export const SliderValueEditor: React.FC<FieldConfigEditorProps<number, SliderFi
   onChange,
   item,
 }) => {
-  const inputRef = React.useRef<HTMLSpanElement>(null);
+  const inputRef = useRef<HTMLSpanElement>(null);
   const { settings } = item;
   const min = settings?.min || 0;
   const max = settings?.max || 100;

--- a/public/app/core/components/OptionsUI/slider.tsx
+++ b/public/app/core/components/OptionsUI/slider.tsx
@@ -1,7 +1,14 @@
-import React from 'react';
+import { cx } from '@emotion/css';
+import { Global } from '@emotion/react';
+import SliderComponent from 'rc-slider';
+import React, { useCallback, useState } from 'react';
 
 import { FieldConfigEditorProps, SliderFieldConfigSettings } from '@grafana/data';
-import { Slider } from '@grafana/ui';
+import { useTheme2 } from '@grafana/ui';
+
+import { getStyles } from '../../../../../packages/grafana-ui/src/components/Slider/styles';
+
+import { NumberInput } from './NumberInput';
 
 export const SliderValueEditor: React.FC<FieldConfigEditorProps<number, SliderFieldConfigSettings>> = ({
   value,
@@ -9,18 +16,70 @@ export const SliderValueEditor: React.FC<FieldConfigEditorProps<number, SliderFi
   item,
 }) => {
   const { settings } = item;
-  const initialValue = typeof value === 'number' ? value : typeof value === 'string' ? +value : 0;
+  const min = settings?.min || 0;
+  const max = settings?.max || 100;
+  const step = settings?.step;
+  const marks = settings?.marks;
+  const included = settings?.included;
+  const ariaLabelForHandle = settings?.ariaLabelForHandle;
+
+  const isHorizontal = true;
+  const theme = useTheme2();
+  const styles = getStyles(theme, isHorizontal, Boolean(marks));
+  const SliderWithTooltip = SliderComponent;
+  const [sliderValue, setSliderValue] = useState<number>(value ?? min);
+
+  const onSliderChange = useCallback(
+    (v: number) => {
+      setSliderValue(v);
+
+      if (onChange) {
+        onChange(v);
+      }
+    },
+    [setSliderValue, onChange]
+  );
+
+  const onSliderInputChange = useCallback(
+    (value?: number) => {
+      let v = value;
+
+      if (Number.isNaN(v) || !v) {
+        v = 0;
+      }
+
+      setSliderValue(v);
+
+      if (onChange) {
+        onChange(v);
+      }
+    },
+    [onChange]
+  );
+
+  const sliderInputClassNames = !isHorizontal ? [styles.sliderInputVertical] : [];
 
   return (
-    <Slider
-      value={initialValue}
-      min={settings?.min || 0}
-      max={settings?.max || 100}
-      step={settings?.step}
-      marks={settings?.marks}
-      included={settings?.included}
-      onChange={onChange}
-      ariaLabelForHandle={settings?.ariaLabelForHandle}
-    />
+    <div className={cx(styles.container, styles.slider)}>
+      {/** Slider tooltip's parent component is body and therefore we need Global component to do css overrides for it. */}
+      <Global styles={styles.tooltip} />
+      <label className={cx(styles.sliderInput, ...sliderInputClassNames)}>
+        <SliderWithTooltip
+          min={min}
+          max={max}
+          step={step}
+          defaultValue={value}
+          value={sliderValue}
+          onChange={onSliderChange}
+          vertical={!isHorizontal}
+          reverse={false}
+          ariaLabelForHandle={ariaLabelForHandle}
+          marks={marks}
+          included={included}
+        />
+        {/* Uses text input so that the number spinners are not shown */}
+        <NumberInput value={sliderValue} onChange={onSliderInputChange} max={settings?.max} min={settings?.min} />
+      </label>
+    </div>
   );
 };

--- a/public/app/core/components/OptionsUI/slider.tsx
+++ b/public/app/core/components/OptionsUI/slider.tsx
@@ -85,7 +85,7 @@ export const SliderValueEditor: React.FC<FieldConfigEditorProps<number, SliderFi
           included={included}
         />
         {/* Uses text input so that the number spinners are not shown */}
-        <NumberInput value={sliderValue} onChange={onSliderInputChange} max={settings?.max} min={settings?.min} />
+        <NumberInput value={sliderValue} onChange={onSliderInputChange} max={max} min={min} step={step} />
       </label>
     </div>
   );

--- a/public/app/core/components/OptionsUI/slider.tsx
+++ b/public/app/core/components/OptionsUI/slider.tsx
@@ -22,7 +22,7 @@ export const SliderValueEditor: React.FC<FieldConfigEditorProps<number, SliderFi
   const min = settings?.min || 0;
   const max = settings?.max || 100;
   const step = settings?.step;
-  const marks = settings?.marks;
+  const marks = settings?.marks || { [min]: min, [max]: max };
   const included = settings?.included;
   const ariaLabelForHandle = settings?.ariaLabelForHandle;
 
@@ -134,8 +134,10 @@ const getStylesSlider = (theme: GrafanaTheme2, width: number) => {
   return {
     numberInputWrapper: css`
       margin-left: 10px;
+      max-height: 32px;
       max-width: ${width}px;
       min-width: ${width}px;
+      overflow: visible;
       width: 100%;
     `,
   };

--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -504,7 +504,7 @@ export class GeomapPanel extends Component<Props, State> {
     const handler = await item.create(map, options, config.theme2);
     const layer = handler.init();
     if (options.opacity != null) {
-      layer.setOpacity(1 - options.opacity);
+      layer.setOpacity(options.opacity);
     }
 
     if (!options.name) {


### PR DESCRIPTION
What this PR does / why we need it:
Improved state management is needed when using one instance of slider across multiple layers, for example in geomap.

- [x] Add NumberInput to core slider
- [x] Improve state management
- [x] Improve styling for NumberInput adjacent to slider
- [x] Simplify

