### PR TITLE
Log Panel: Improve log row hover contrast and visibility

### DIFF
--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -6,7 +6,7 @@ import { styleMixins, stylesFactory } from '../../themes';
 
 export const getLogRowStyles = stylesFactory((theme: GrafanaTheme2, logLevel?: LogLevel) => {
   let logColor = theme.isLight ? theme.v1.palette.gray5 : theme.v1.palette.gray2;
-  const hoverBgColor = styleMixins.hoverColor(theme.colors.background.primary, theme);
+  const hoverBgColor = styleMixins.hoverColor(theme.colors.background.secondary, theme);
 
   switch (logLevel) {
     case LogLevel.crit:


### PR DESCRIPTION



<img width="984" alt="Screenshot 2022-06-15 at 22 30 58" src="https://user-images.githubusercontent.com/67058118/173934924-2fe0b2a4-ce0f-4006-9fa4-cf532db7fe81.png">

Fixes #50861

As requested in the above issue the contrast has been changed to provide higher visibility. 

:) 
