### PR TITLE
Bug: Fix delete dashboard snapshot for deleted dashboards

### DIFF
--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -269,12 +269,15 @@ func (hs *HTTPServer) DeleteDashboardSnapshot(c *models.ReqContext) response.Res
 
 	guardian := guardian.New(c.Req.Context(), dashboardID, c.OrgId, c.SignedInUser)
 	canEdit, err := guardian.CanEdit()
-	if err != nil {
-		return response.Error(500, "Error while checking permissions for snapshot", err)
-	}
+	// check for permissions only if the dahboard is not deleted
+	if err != models.ErrDashboardNotFound {
+		if err != nil {
+			return response.Error(500, "Error while checking permissions for snapshot", err)
+		}
 
-	if !canEdit && query.Result.UserId != c.SignedInUser.UserId {
-		return response.Error(403, "Access denied to this snapshot", nil)
+		if !canEdit && query.Result.UserId != c.SignedInUser.UserId {
+			return response.Error(403, "Access denied to this snapshot", nil)
+		}
 	}
 
 	if query.Result.External {

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -270,11 +271,11 @@ func (hs *HTTPServer) DeleteDashboardSnapshot(c *models.ReqContext) response.Res
 	guardian := guardian.New(c.Req.Context(), dashboardID, c.OrgId, c.SignedInUser)
 	canEdit, err := guardian.CanEdit()
 	// check for permissions only if the dahboard is found
-	if err != nil && err != models.ErrDashboardNotFound {
+	if err != nil && !errors.Is(err, models.ErrDashboardNotFound) {
 		return response.Error(500, "Error while checking permissions for snapshot", err)
 	}
 
-	if !canEdit && query.Result.UserId != c.SignedInUser.UserId && err != models.ErrDashboardNotFound {
+	if !canEdit && query.Result.UserId != c.SignedInUser.UserId && !errors.Is(err, models.ErrDashboardNotFound) {
 		return response.Error(403, "Access denied to this snapshot", nil)
 	}
 

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -269,15 +269,13 @@ func (hs *HTTPServer) DeleteDashboardSnapshot(c *models.ReqContext) response.Res
 
 	guardian := guardian.New(c.Req.Context(), dashboardID, c.OrgId, c.SignedInUser)
 	canEdit, err := guardian.CanEdit()
-	// check for permissions only if the dahboard is not deleted
-	if err != models.ErrDashboardNotFound {
-		if err != nil {
-			return response.Error(500, "Error while checking permissions for snapshot", err)
-		}
+	// check for permissions only if the dahboard is found
+	if err != nil && err != models.ErrDashboardNotFound {
+		return response.Error(500, "Error while checking permissions for snapshot", err)
+	}
 
-		if !canEdit && query.Result.UserId != c.SignedInUser.UserId {
-			return response.Error(403, "Access denied to this snapshot", nil)
-		}
+	if !canEdit && query.Result.UserId != c.SignedInUser.UserId && err != models.ErrDashboardNotFound {
+		return response.Error(403, "Access denied to this snapshot", nil)
 	}
 
 	if query.Result.External {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
In case the user tries to delete dashboard snapshot for a deleted dashboard it returns a permission error. This PR let a user to delete a snapshot for a deleted dashboard.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/support-escalations/issues/2890

**Special notes for your reviewer**:

