### PR TITLE
Service accounts: don't update RBAC roles in OSS when creating servic…

### DIFF
--- a/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
@@ -85,7 +85,9 @@ export const ServiceAccountCreatePageUnconnected = ({ navModel }: Props): JSX.El
           tokens: response.tokens,
         };
         await updateServiceAccount(response.id, data);
-        await updateUserRoles(pendingRoles, newAccount.id, newAccount.orgId);
+        if (contextSrv.licensedAccessControlEnabled()) {
+          await updateUserRoles(pendingRoles, newAccount.id, newAccount.orgId);
+        }
       } catch (e) {
         console.error(e);
       }


### PR DESCRIPTION
When enterprise access control is not enabled (in OSS), RBAC roles should not be updated since API is not exposed (causes 404 error).