### PR TITLE
datasource metrics: Correct help text for histograms

### DIFF
--- a/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
+++ b/pkg/infra/httpclient/httpclientprovider/datasource_metrics_middleware.go
@@ -25,7 +25,7 @@ var (
 		prometheus.HistogramOpts{
 			Namespace: "grafana",
 			Name:      "datasource_request_duration_seconds",
-			Help:      "summary of outgoing data source requests sent from Grafana",
+			Help:      "histogram of durations of outgoing data source requests sent from Grafana",
 			Buckets:   []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50, 100},
 		}, []string{"datasource", "code", "method"},
 	)
@@ -34,7 +34,7 @@ var (
 		prometheus.HistogramOpts{
 			Namespace: "grafana",
 			Name:      "datasource_response_size_bytes",
-			Help:      "summary of data source response sizes returned to Grafana",
+			Help:      "histogram of data source response sizes returned to Grafana",
 			Buckets:   []float64{128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576},
 		}, []string{"datasource"},
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:

In #50420 a few summary metrics were converted to histograms,
but the Help text in a couple of them still referred to summaries.
This fixes that help text.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:


Signed-off-by: Dave Henderson <dave.henderson@grafana.com>