### PR TITLE
Alerting: Adds Mimir to Alertmanager data source implementation

### DIFF
--- a/pkg/services/ngalert/api/lotex_am.go
+++ b/pkg/services/ngalert/api/lotex_am.go
@@ -25,6 +25,14 @@ var endpoints = map[string]map[string]string{
 		"alerts":   "/alertmanager/api/v2/alerts",
 		"config":   "/api/v1/alerts",
 	},
+	"mimir": {
+		"silences": "/alertmanager/api/v2/silences",
+		"silence":  "/alertmanager/api/v2/silence/%s",
+		"status":   "/alertmanager/api/v2/status",
+		"groups":   "/alertmanager/api/v2/alerts/groups",
+		"alerts":   "/alertmanager/api/v2/alerts",
+		"config":   "/api/v1/alerts",
+	},
 	"prometheus": {
 		"silences": "/api/v2/silences",
 		"silence":  "/api/v2/silence/%s",

--- a/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/alertmanager/ConfigEditor.tsx
@@ -11,6 +11,12 @@ export type Props = DataSourcePluginOptionsEditorProps<AlertManagerDataSourceJso
 
 const IMPL_OPTIONS: SelectableValue[] = [
   {
+    value: AlertManagerImplementation.mimir,
+    icon: 'public/img/alerting/mimir_logo.svg',
+    label: 'Mimir',
+    description: `https://grafana.com/oss/mimir/. An open source, horizontally scalable, highly available, multi-tenant, long-term storage for Prometheus.`,
+  },
+  {
     value: AlertManagerImplementation.cortex,
     label: 'Cortex',
     description: `https://cortexmetrics.io/`,
@@ -36,7 +42,7 @@ export const ConfigEditor = (props: Props) => {
             <Select
               width={40}
               options={IMPL_OPTIONS}
-              value={options.jsonData.implementation || AlertManagerImplementation.cortex}
+              value={options.jsonData.implementation || AlertManagerImplementation.mimir}
               onChange={(value) =>
                 onOptionsChange({
                   ...options,

--- a/public/app/plugins/datasource/alertmanager/DataSource.ts
+++ b/public/app/plugins/datasource/alertmanager/DataSource.ts
@@ -51,7 +51,7 @@ export class AlertManagerDatasource extends DataSourceApi<AlertManagerQuery, Ale
           return {
             status: 'error',
             message:
-              'It looks like you have chosen Prometheus implementation, but detected a Cortex endpoint. Please update implementation selection and try again.',
+              'It looks like you have chosen Prometheus implementation, but detected a Cortex or Mimir endpoint. Please update implementation selection and try again.',
           };
         }
       } catch (e) {}
@@ -65,7 +65,7 @@ export class AlertManagerDatasource extends DataSourceApi<AlertManagerQuery, Ale
           return {
             status: 'error',
             message:
-              'It looks like you have chosen Cortex implementation, but detected a Prometheus endpoint. Please update implementation selection and try again.',
+              'It looks like you have chosen a Cortex or Mimir implementation, but detected a Prometheus endpoint. Please update implementation selection and try again.',
           };
         }
       } catch (e) {}

--- a/public/app/plugins/datasource/alertmanager/DataSource.ts
+++ b/public/app/plugins/datasource/alertmanager/DataSource.ts
@@ -51,7 +51,7 @@ export class AlertManagerDatasource extends DataSourceApi<AlertManagerQuery, Ale
           return {
             status: 'error',
             message:
-              'It looks like you have chosen Prometheus implementation, but detected a Cortex or Mimir endpoint. Please update implementation selection and try again.',
+              'It looks like you have chosen Prometheus implementation, but detected a Mimir or Cortex endpoint. Please update implementation selection and try again.',
           };
         }
       } catch (e) {}
@@ -65,7 +65,7 @@ export class AlertManagerDatasource extends DataSourceApi<AlertManagerQuery, Ale
           return {
             status: 'error',
             message:
-              'It looks like you have chosen a Cortex or Mimir implementation, but detected a Prometheus endpoint. Please update implementation selection and try again.',
+              'It looks like you have chosen a Mimir or Cortex implementation, but detected a Prometheus endpoint. Please update implementation selection and try again.',
           };
         }
       } catch (e) {}

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -280,6 +280,7 @@ export interface ExternalAlertmanagerConfig {
 
 export enum AlertManagerImplementation {
   cortex = 'cortex',
+  mimir = 'mimir',
   prometheus = 'prometheus',
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Mimir as a configurable Alertmanager data source implementation.

**Which issue(s) this PR fixes**:

Fixes #50930

**Special notes for your reviewer**:

I've tested this with a locally running Mimir instance and it continued to work as expected.

These routes should continue to work with Mimir going forward and there are currently no plans to deprecate them.