### PR TITLE
Expressions: Fixes dashboard schema migration issue that casued Expression datasource to be set on panel level

### DIFF
--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.test.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.test.ts
@@ -345,6 +345,7 @@ describe('given dashboard with repeated panels', () => {
     expect(element.model).toEqual({
       id: 17,
       datasource: { type: 'other2', uid: '$ds' },
+      targets: [{ refId: 'A', datasource: { type: 'other2', uid: '$ds' } }],
       type: 'graph',
     });
   });

--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -2012,7 +2012,7 @@ describe('DashboardModel', () => {
             ],
           },
         ],
-        schemaVersion: 35,
+        schemaVersion: 30,
       });
     });
 

--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -1992,6 +1992,38 @@ describe('DashboardModel', () => {
       expect(model.panels[0].targets[0].datasource).toEqual({ type: 'prometheus', uid: 'prom2-uid' });
     });
   });
+
+  describe('when migrating default (null) datasource with panel with expressions queries', () => {
+    let model: DashboardModel;
+
+    beforeEach(() => {
+      model = new DashboardModel({
+        panels: [
+          {
+            id: 2,
+            targets: [
+              {
+                refId: 'A',
+              },
+              {
+                refId: 'B',
+                datasource: '__expr__',
+              },
+            ],
+          },
+        ],
+        schemaVersion: 35,
+      });
+    });
+
+    it('should update panel datasource props to default datasource', () => {
+      expect(model.panels[0].datasource).toEqual({ type: 'prometheus', uid: 'prom2-uid' });
+    });
+
+    it('should update target datasource props to default data source', () => {
+      expect(model.panels[0].targets[0].datasource).toEqual({ type: 'prometheus', uid: 'prom2-uid' });
+    });
+  });
 });
 
 function createRow(options: any, panelDescriptions: any[]) {

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -761,14 +761,14 @@ export class DashboardMigrator {
             }
 
             for (const target of panel.targets) {
-              if (target.datasource && panelDataSourceWasDefault) {
+              if (target.datasource && panelDataSourceWasDefault && target.datasource.type !== '__expr__') {
                 // We can have situations when default ds changed and the panel level data source is different from the queries
                 // In this case we use the query level data source as source for truth
                 panel.datasource = target.datasource as DataSourceRef;
               }
 
-              if (target.datasource === null) {
-                target.datasource = getDataSourceRef(defaultDs);
+              if (target.datasource == null) {
+                target.datasource = { ...panel.datasource };
               }
             }
           }

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -761,14 +761,14 @@ export class DashboardMigrator {
             }
 
             for (const target of panel.targets) {
-              if (target.datasource && panelDataSourceWasDefault && target.datasource.type !== '__expr__') {
+              if (target.datasource == null || target.datasource.uid == null) {
+                target.datasource = { ...panel.datasource };
+              }
+
+              if (panelDataSourceWasDefault && target.datasource.uid !== '__expr__') {
                 // We can have situations when default ds changed and the panel level data source is different from the queries
                 // In this case we use the query level data source as source for truth
                 panel.datasource = target.datasource as DataSourceRef;
-              }
-
-              if (target.datasource == null) {
-                target.datasource = { ...panel.datasource };
               }
             }
           }


### PR DESCRIPTION
Fixes #50895

There was mistake in the migration from default (null) data source props to current default that
lead to __expr__ data source being set on panel (and on query) level.

This PR fixes the migration issue.

