### PR TITLE
PasswordReset: Fix double change password calls

### DIFF
--- a/public/app/core/components/Login/LoginCtrl.tsx
+++ b/public/app/core/components/Login/LoginCtrl.tsx
@@ -61,7 +61,19 @@ export class LoginCtrl extends PureComponent<Props, State> {
       oldPassword: 'admin',
     };
 
-    if (!this.props.resetCode) {
+    if (this.props.resetCode) {
+      const resetModel = {
+        code: this.props.resetCode,
+        newPassword: password,
+        confirmPassword: password,
+      };
+
+      getBackendSrv()
+        .post('/api/user/password/reset', resetModel)
+        .then(() => {
+          this.toGrafana();
+        });
+    } else {
       getBackendSrv()
         .put('/api/user/password', pw)
         .then(() => {
@@ -69,18 +81,6 @@ export class LoginCtrl extends PureComponent<Props, State> {
         })
         .catch((err: any) => console.error(err));
     }
-
-    const resetModel = {
-      code: this.props.resetCode,
-      newPassword: password,
-      confirmPassword: password,
-    };
-
-    getBackendSrv()
-      .post('/api/user/password/reset', resetModel)
-      .then(() => {
-        this.toGrafana();
-      });
   };
 
   login = (formModel: FormModel) => {


### PR DESCRIPTION
**What this PR does / why we need it**:

- Only call PUT endpoint for password change when logged in
- Only call POST endpoint for password reset when code is present

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/50938

**Special notes for your reviewer**:

- Tested locally both scenarios to check they're working

- Found a weird issue where I can't change my password to "test" if using the PUT route, but can change if using the POST reset route. Creating another issue for it

![swappy-20220616_144029](https://user-images.githubusercontent.com/8071073/174072331-5ecf2666-e3c7-4c3c-bc39-e30ebbf9966c.png)

