### PR TITLE
Loki: Handle data source configs with path in the url

### DIFF
--- a/pkg/tsdb/loki/api.go
+++ b/pkg/tsdb/loki/api.go
@@ -169,13 +169,13 @@ func (api *LokiAPI) DataQuery(ctx context.Context, query lokiQuery) (data.Frames
 	return res.Frames, nil
 }
 
-func makeRawRequest(ctx context.Context, lokiDsUrl string, resourceURL string, headers map[string]string) (*http.Request, error) {
+func makeRawRequest(ctx context.Context, lokiDsUrl string, resourcePath string, headers map[string]string) (*http.Request, error) {
 	lokiUrl, err := url.Parse(lokiDsUrl)
 	if err != nil {
 		return nil, err
 	}
 
-	url, err := lokiUrl.Parse(resourceURL)
+	url, err := lokiUrl.Parse(resourcePath)
 	if err != nil {
 		return nil, err
 	}
@@ -191,8 +191,8 @@ func makeRawRequest(ctx context.Context, lokiDsUrl string, resourceURL string, h
 	return req, nil
 }
 
-func (api *LokiAPI) RawQuery(ctx context.Context, resourceURL string) ([]byte, error) {
-	req, err := makeRawRequest(ctx, api.url, resourceURL, api.headers)
+func (api *LokiAPI) RawQuery(ctx context.Context, resourcePath string) ([]byte, error) {
+	req, err := makeRawRequest(ctx, api.url, resourcePath, api.headers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/loki/api_mock.go
+++ b/pkg/tsdb/loki/api_mock.go
@@ -33,9 +33,13 @@ func (mockedRT *mockedRoundTripper) RoundTrip(req *http.Request) (*http.Response
 }
 
 func makeMockedAPI(statusCode int, contentType string, responseBytes []byte, requestCallback mockRequestCallback) *LokiAPI {
+	return makeMockedAPIWithUrl("http://localhost:9999", statusCode, contentType, responseBytes, requestCallback)
+}
+
+func makeMockedAPIWithUrl(url string, statusCode int, contentType string, responseBytes []byte, requestCallback mockRequestCallback) *LokiAPI {
 	client := http.Client{
 		Transport: &mockedRoundTripper{statusCode: statusCode, contentType: contentType, responseBytes: responseBytes, requestCallback: requestCallback},
 	}
 
-	return newLokiAPI(&client, "http://localhost:9999", log.New("test"), nil)
+	return newLokiAPI(&client, url, log.New("test"), nil)
 }

--- a/pkg/tsdb/loki/api_test.go
+++ b/pkg/tsdb/loki/api_test.go
@@ -1,0 +1,127 @@
+package loki
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApiLogVolume(t *testing.T) {
+	response := []byte(`
+	{
+		"status": "success",
+		"data": {
+			"resultType" : "matrix",
+			"result": []
+		}
+	}
+	`)
+
+	t.Run("log-volume queries should set log-volume http header", func(t *testing.T) {
+		called := false
+		api := makeMockedAPI(200, "application/json", response, func(req *http.Request) {
+			called = true
+			require.Equal(t, "Source=logvolhist", req.Header.Get("X-Query-Tags"))
+		})
+
+		_, err := api.DataQuery(context.Background(), lokiQuery{Expr: "", VolumeQuery: true, QueryType: QueryTypeRange})
+		require.NoError(t, err)
+		require.True(t, called)
+	})
+
+	t.Run("non-log-volume queries should not set log-volume http header", func(t *testing.T) {
+		called := false
+		api := makeMockedAPI(200, "application/json", response, func(req *http.Request) {
+			called = true
+			require.Equal(t, "", req.Header.Get("X-Query-Tags"))
+		})
+
+		_, err := api.DataQuery(context.Background(), lokiQuery{Expr: "", VolumeQuery: false, QueryType: QueryTypeRange})
+		require.NoError(t, err)
+		require.True(t, called)
+	})
+}
+
+func TestApiUrlHandling(t *testing.T) {
+	response := []byte(`
+	{
+		"status": "success",
+		"data": {
+			"resultType" : "matrix",
+			"result": []
+		}
+	}
+	`)
+
+	queryTestData := []struct {
+		name        string
+		dsUrl       string
+		queryPrefix string
+		metaUrl     string
+	}{
+		{
+			name:        "no path in datasource-config",
+			dsUrl:       "http://localhost:3100",
+			queryPrefix: "http://localhost:3100/loki/api/v1/query_range?",
+			metaUrl:     "http://localhost:3100/loki/api/v1/labels?start=1&end=2",
+		},
+		{
+			name:        "just a slash path in datasource-config",
+			dsUrl:       "http://localhost:3100/",
+			queryPrefix: "http://localhost:3100/loki/api/v1/query_range?",
+			metaUrl:     "http://localhost:3100/loki/api/v1/labels?start=1&end=2",
+		},
+		{
+			name:        "when path-without-end-slash in datasource-config",
+			dsUrl:       "http://localhost:3100/a/b/c",
+			queryPrefix: "http://localhost:3100/a/b/c/loki/api/v1/query_range?",
+			metaUrl:     "http://localhost:3100/a/b/c/loki/api/v1/labels?start=1&end=2",
+		},
+		{
+			name:        "path-with-end-slash in datasource-config",
+			dsUrl:       "http://localhost:3100/a/b/c/",
+			queryPrefix: "http://localhost:3100/a/b/c/loki/api/v1/query_range?",
+			metaUrl:     "http://localhost:3100/a/b/c/loki/api/v1/labels?start=1&end=2",
+		},
+	}
+
+	for _, test := range queryTestData {
+		t.Run("Loki should build the query URL correctly when "+test.name, func(t *testing.T) {
+			called := false
+			api := makeMockedAPIWithUrl(test.dsUrl, 200, "application/json", response, func(req *http.Request) {
+				called = true
+				urlString := req.URL.String()
+				wantedPrefix := test.queryPrefix
+				failMessage := fmt.Sprintf(`wanted prefix: [%s], got string [%s]`, wantedPrefix, urlString)
+				require.True(t, strings.HasPrefix(urlString, wantedPrefix), failMessage)
+			})
+
+			query := lokiQuery{
+				QueryType: QueryTypeRange,
+			}
+
+			_, err := api.DataQuery(context.Background(), query)
+			require.NoError(t, err)
+			require.True(t, called)
+		})
+	}
+
+	for _, test := range queryTestData {
+		t.Run("Loki should build the metadata query URL correctly when "+test.name, func(t *testing.T) {
+			called := false
+			api := makeMockedAPIWithUrl(test.dsUrl, 200, "application/json", response, func(req *http.Request) {
+				called = true
+				require.Equal(t, test.metaUrl, req.URL.String())
+			})
+
+			_, err := api.RawQuery(context.Background(), "/loki/api/v1/labels?start=1&end=2")
+			require.NoError(t, err)
+			require.True(t, called)
+
+		})
+	}
+}

--- a/pkg/tsdb/loki/api_test.go
+++ b/pkg/tsdb/loki/api_test.go
@@ -121,7 +121,6 @@ func TestApiUrlHandling(t *testing.T) {
 			_, err := api.RawQuery(context.Background(), "/loki/api/v1/labels?start=1&end=2")
 			require.NoError(t, err)
 			require.True(t, called)
-
 		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/50939

if a Loki datasource is configured so that the URL contains a path component, for example: `http://localhost:3100/a/b/c` , then the loki datasource ignores the path (`/a/b/c` ) part.

this pull request fixes the problem.

how to test:
1. we need a loki that is running on an URL with a path:
    - modify `https://github.com/grafana/grafana/blob/main/devenv/docker/blocks/loki/docker-compose.yaml` , add a new line below the second line, with this content: `command: -config.file=/etc/loki/local-config.yaml -server.path-prefix=/a/b/c` . 
    - our loki fake data generator is not able to handle urls with paths, so as a quick hack, modify this line: https://github.com/grafana/grafana/blob/main/devenv/docker/blocks/loki/data/data.js#L64 , change it to `url.pathname = '/a/b/c/loki/api/v1/push';`
    - now run `make devenv sources=loki`
2. create a loki datasource where the `URL` is set to `http://localhost:3100/a/b/c`
3. go to explore:
    - running loki queries should work
    - the log-browser should work
    - the autocomplete-system should autocomplete label-names and label-values