### PR TITLE
Docs: Alertmanager datasource is no longer marked as alpha

### DIFF
--- a/docs/sources/datasources/alertmanager.md
+++ b/docs/sources/datasources/alertmanager.md
@@ -13,7 +13,7 @@ weight: 150
 
 # Alertmanager data source
 
-Grafana includes built-in support for Prometheus Alertmanager. It is presently in alpha and not accessible unless [alpha plugins are enabled in Grafana settings](https://grafana.com/docs/grafana/latest/administration/configuration/#enable_alpha-1). Once you add it as a data source, you can use the [Grafana Alerting UI](https://grafana.com/docs/grafana/latest/alerting/) to manage silences, contact points as well as notification policies. A drop-down option in these pages allows you to switch between Grafana and any configured Alertmanager data sources.
+Grafana includes built-in support for Prometheus Alertmanager. Once you add it as a data source, you can use the [Grafana Alerting UI](https://grafana.com/docs/grafana/latest/alerting/) to manage silences, contact points as well as notification policies. A drop-down option in these pages allows you to switch between Grafana and any configured Alertmanager data sources.
 
 ## Alertmanager implementations
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We recently moved the Alertmanager datasource out of alpha for 9.0: https://github.com/grafana/grafana/pull/49491 

This PR removes the corresponding sentence from the docs. Users no longer need to enable alpha plugins to use it.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

