### PR TITLE
CloudWatch: Allow hidden queries to be executed in case an ID is provided

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/__mocks__/queries.ts
+++ b/public/app/plugins/datasource/cloudwatch/__mocks__/queries.ts
@@ -1,0 +1,28 @@
+import { CloudWatchMetricsQuery, MetricQueryType, MetricEditorMode, CloudWatchLogsQuery } from '../types';
+
+export const validMetricsQuery: CloudWatchMetricsQuery = {
+  id: '',
+  queryMode: 'Metrics',
+  region: 'us-east-2',
+  namespace: 'AWS/EC2',
+  period: '3000',
+  alias: '',
+  metricName: 'CPUUtilization',
+  dimensions: { InstanceId: 'i-123' },
+  matchExact: true,
+  statistic: 'Average',
+  expression: '',
+  refId: 'A',
+  metricQueryType: MetricQueryType.Search,
+  metricEditorMode: MetricEditorMode.Code,
+  hide: false,
+};
+
+export const validLogsQuery: CloudWatchLogsQuery = {
+  queryMode: 'Logs',
+  logGroupNames: ['group-A', 'group-B'],
+  hide: false,
+  id: '',
+  region: 'us-east-2',
+  refId: 'A',
+};

--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -54,11 +54,9 @@ describe('datasource', () => {
       { query: { ...validMetricsQuery, hide: false }, valid: true },
     ];
 
-    describe.each(testTable)('should use the right time zone offset', ({ query, valid }) => {
-      it('should filter out hidden queries unless id is provided', async () => {
-        const { datasource } = setupMockedDataSource();
-        expect(datasource.filterQuery(query)).toEqual(valid);
-      });
+    test.each(testTable)('should filter out hidden queries unless id is provided', ({ query, valid }) => {
+      const { datasource } = setupMockedDataSource();
+      expect(datasource.filterQuery(query)).toEqual(valid);
     });
 
     it('should interpolate variables in the query', async () => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow hidden queries to be executed in case an ID is provided

**Which issue(s) this PR fixes**:

Fixes #50947
First reported in https://github.com/grafana/support-escalations/issues/2880

