### PR TITLE
StateTimeline: make sure we use result of applyNullInsertThreshold()

### DIFF
--- a/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.test.ts
+++ b/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.test.ts
@@ -164,7 +164,7 @@ describe('nullInsertThreshold Transformer', () => {
 
     const result = applyNullInsertThreshold({ frame: df, refFieldName: null, refFieldPseudoMax: 13 });
 
-    expect(result.fields[0].values.toArray()).toStrictEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+    expect(result.fields[0].values.toArray()).toStrictEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
     expect(result.fields[1].values.toArray()).toStrictEqual([
       4,
       null,
@@ -176,7 +176,6 @@ describe('nullInsertThreshold Transformer', () => {
       null,
       null,
       8,
-      null,
       null,
       null,
     ]);
@@ -193,7 +192,6 @@ describe('nullInsertThreshold Transformer', () => {
       'c',
       null,
       null,
-      null,
     ]);
 
     // should work for frames with 1 datapoint
@@ -208,7 +206,7 @@ describe('nullInsertThreshold Transformer', () => {
 
     // Max is 2 as opposed to the above 13 otherwise
     // we get 12 nulls instead of the additional 1
-    const result2 = applyNullInsertThreshold({ frame: df2, refFieldName: null, refFieldPseudoMax: 2 });
+    const result2 = applyNullInsertThreshold({ frame: df2, refFieldName: null, refFieldPseudoMax: 2.5 });
 
     expect(result2.fields[0].values.toArray()).toStrictEqual([1, 2]);
     expect(result2.fields[1].values.toArray()).toStrictEqual([1, null]);

--- a/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.test.ts
+++ b/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.test.ts
@@ -111,12 +111,14 @@ describe('nullInsertThreshold Transformer', () => {
     const result = applyNullInsertThreshold({
       frame: df,
       refFieldName: null,
-      refFieldPseudoMin: 1,
+      refFieldPseudoMin: -0.5,
       refFieldPseudoMax: 13,
     });
 
-    expect(result.fields[0].values.toArray()).toStrictEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
+    expect(result.fields[0].values.toArray()).toStrictEqual([-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
     expect(result.fields[1].values.toArray()).toStrictEqual([
+      null,
+      null,
       null,
       null,
       null,
@@ -132,6 +134,8 @@ describe('nullInsertThreshold Transformer', () => {
       8,
     ]);
     expect(result.fields[2].values.toArray()).toStrictEqual([
+      null,
+      null,
       null,
       null,
       null,

--- a/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.test.ts
+++ b/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.test.ts
@@ -204,13 +204,30 @@ describe('nullInsertThreshold Transformer', () => {
       ],
     });
 
-    // Max is 2 as opposed to the above 13 otherwise
+    // Max is 2.5 as opposed to the above 13 otherwise
     // we get 12 nulls instead of the additional 1
     const result2 = applyNullInsertThreshold({ frame: df2, refFieldName: null, refFieldPseudoMax: 2.5 });
 
     expect(result2.fields[0].values.toArray()).toStrictEqual([1, 2]);
     expect(result2.fields[1].values.toArray()).toStrictEqual([1, null]);
     expect(result2.fields[2].values.toArray()).toStrictEqual(['a', null]);
+  });
+
+  test('should not insert trailing null at end +interval when timeRange.to.valueOf() equals threshold', () => {
+    const df = new MutableDataFrame({
+      refId: 'A',
+      fields: [
+        { name: 'Time', type: FieldType.time, config: { interval: 1 }, values: [1] },
+        { name: 'One', type: FieldType.number, values: [1] },
+        { name: 'Two', type: FieldType.string, values: ['a'] },
+      ],
+    });
+
+    const result = applyNullInsertThreshold({ frame: df, refFieldName: null, refFieldPseudoMax: 2 });
+
+    expect(result.fields[0].values.toArray()).toStrictEqual([1]);
+    expect(result.fields[1].values.toArray()).toStrictEqual([1]);
+    expect(result.fields[2].values.toArray()).toStrictEqual(['a']);
   });
 
   // TODO: make this work

--- a/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.ts
+++ b/packages/grafana-ui/src/components/GraphNG/nullInsertThreshold.ts
@@ -114,9 +114,8 @@ function nullInsertThreshold(
   const len = refValues.length;
   const refValuesNew: number[] = [];
 
-  // Continiuously add the threshold to the minimum value
-  // While this is less than "prevValue" which is the lowest
-  // time value in the sequence add in time frames
+  // Continiuously subtract the threshold from the first data
+  // point filling in insert values accordingly
   if (refFieldPseudoMin != null && refFieldPseudoMin < refValues[0]) {
     // this will be 0 or 1 threshold increment left of visible range
     let prevSlot = incrRoundDn(refFieldPseudoMin, threshold);

--- a/public/app/plugins/panel/state-timeline/utils.ts
+++ b/public/app/plugins/panel/state-timeline/utils.ts
@@ -401,11 +401,9 @@ export function prepareTimelineFields(
       refFieldPseudoMax: timeRange.to.valueOf(),
     });
 
-    // Mark the field state as having a null threhold applied
-    frame.fields[0].state = {
-      ...frame.fields[0].state,
-      nullThresholdApplied: true,
-    };
+    if (nulledFrame !== frame) {
+      changed = true;
+    }
 
     const fields: Field[] = [];
     for (let field of nullToValue(nulledFrame).fields) {


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/2866

the actual fix was to set the `changed` flag, so we actually use null-inserted fields. i also moved the `nullThresholdApplied` flag into `applyNullInsertThreshold()`. related: https://github.com/grafana/grafana/pull/50054#pullrequestreview-994196141

another drive-by fix here is to make sure the time intervals we prepend work backwards from the first real datapoint rather than forwards from the left view bound, which can have an arbitrary timestamp that does not align with the interval.