### PR TITLE
PasswordReset: Enforce password length check on password reset request

### DIFF
--- a/pkg/api/password.go
+++ b/pkg/api/password.go
@@ -64,6 +64,11 @@ func (hs *HTTPServer) ResetPassword(c *models.ReqContext) response.Response {
 		return response.Error(400, "Passwords do not match", nil)
 	}
 
+	password := models.Password(form.NewPassword)
+	if password.IsWeak() {
+		return response.Error(400, "New password is too short", nil)
+	}
+
 	cmd := models.ChangeUserPasswordCommand{}
 	cmd.UserId = query.Result.Id
 	var err error


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Currently, the password length is not validated on the backend when user is resetting password and allows user to set a weak password at reset time. This PR adds the same validation that is used on update password endpoint to make the behavior consistent.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #50968 

