### PR TITLE
Previews: use ETag header

### DIFF
--- a/pkg/services/thumbs/service.go
+++ b/pkg/services/thumbs/service.go
@@ -233,7 +233,7 @@ func (hs *thumbService) GetImage(c *models.ReqContext) {
 		return
 	}
 
-	currentEtag := res.Updated.String()
+	currentEtag := fmt.Sprintf("%d", res.Updated.Unix())
 	c.Resp.Header().Set("ETag", currentEtag)
 
 	previousEtag := c.Req.Header.Get("If-None-Match")

--- a/pkg/services/thumbs/service.go
+++ b/pkg/services/thumbs/service.go
@@ -227,9 +227,18 @@ func (hs *thumbService) GetImage(c *models.ReqContext) {
 		return
 	}
 
-	if err != nil {
+	if err != nil || res == nil {
 		hs.log.Error("Error when retrieving thumbnail", "dashboardUid", req.UID, "err", err.Error())
 		c.JSON(500, map[string]string{"dashboardUID": req.UID, "error": "unknown"})
+		return
+	}
+
+	currentEtag := res.Updated.String()
+	c.Resp.Header().Set("ETag", currentEtag)
+
+	previousEtag := c.Req.Header.Get("If-None-Match")
+	if previousEtag == currentEtag {
+		c.Resp.WriteHeader(http.StatusNotModified)
 		return
 	}
 


### PR DESCRIPTION
Simple optimization to avoid sending unchanged previews over the network over and over again.

We could also move that comparison to the DB level, but that's for another PR :)