### PR TITLE
LogRow: Fix placement of icon

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -67,8 +67,7 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     topVerticalAlign: css`
       label: topVerticalAlign;
-      vertical-align: top;
-      margin-top: -${theme.spacing(0.5)};
+      margin-top: -${theme.spacing(0.9)};
       margin-left: -${theme.spacing(0.25)};
     `,
     detailsOpen: css`


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/grafana/grafana/pull/48759 caused issue with placement of icon in log row. This PR fixes it for LogRow. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/50842


Before: 
<img width="1382" alt="image" src="https://user-images.githubusercontent.com/30407135/174244643-912856fe-f104-406c-ba81-c10f346c34e7.png">
<img width="1397" alt="image" src="https://user-images.githubusercontent.com/30407135/174244657-4cebc5e5-7994-4514-8186-789a408f0e96.png">

Now: 
<img width="452" alt="image" src="https://user-images.githubusercontent.com/30407135/174244525-07f7d0ad-444e-4094-a083-cf4c54ec4288.png">
<img width="449" alt="image" src="https://user-images.githubusercontent.com/30407135/174244549-7e560e59-7ad3-4c9d-9979-fb4406122b6f.png">



