### PR TITLE
Docs: fixes redirect from unified alerting

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
@@ -3,6 +3,7 @@ aliases:
   - /docs/grafana/latest/alerting/alerting-rules/create-mimir-loki-managed-rule/
   - /docs/grafana/latest/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule/
   - /docs/grafana/latest/alerting/unified-alerting/alerting-rules/create-mimir-loki-managed-recording-rule/
+  - /docs/grafana/latest/alerting/unified-alerting/alerting-rules/create-mimir-loki-managed-rule
 description: Create Grafana Mimir or Loki managed alerting rule
 keywords:
   - grafana

--- a/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
+++ b/docs/sources/alerting/alerting-rules/create-mimir-loki-managed-rule.md
@@ -3,7 +3,7 @@ aliases:
   - /docs/grafana/latest/alerting/alerting-rules/create-mimir-loki-managed-rule/
   - /docs/grafana/latest/alerting/unified-alerting/alerting-rules/create-cortex-loki-managed-recording-rule/
   - /docs/grafana/latest/alerting/unified-alerting/alerting-rules/create-mimir-loki-managed-recording-rule/
-  - /docs/grafana/latest/alerting/unified-alerting/alerting-rules/create-mimir-loki-managed-rule
+  - /docs/grafana/latest/alerting/unified-alerting/alerting-rules/create-mimir-loki-managed-rule/
 description: Create Grafana Mimir or Loki managed alerting rule
 keywords:
   - grafana

--- a/docs/sources/alerting/migrating-alerts/_index.md
+++ b/docs/sources/alerting/migrating-alerts/_index.md
@@ -2,6 +2,7 @@
 aliases:
   - /docs/grafana/latest/alerting/migrating-alerts/
   - /docs/grafana/latest/alerting/unified-alerting/
+  - /docs/grafana/latest/alerting/unified-alerting/difference-old-new/
 description: Upgrade Grafana alerts
 title: Upgrade to Grafana Alerting
 weight: 101


### PR DESCRIPTION
https://grafana.com/docs/grafana/latest/alerting/unified-alerting/difference-old-new/ was throwing a 404 because it didn't redirect to the new upgrade alerts topic. This PR adds the alias to fix the error and display the new topic. 