### PR TITLE
Loki: Fix bug in labels framing

### DIFF
--- a/pkg/tsdb/loki/framing_test.go
+++ b/pkg/tsdb/loki/framing_test.go
@@ -46,6 +46,8 @@ func TestSuccessResponse(t *testing.T) {
 		{name: "parse a vector response with special values", filepath: "vector_special_values", query: vectorQuery},
 
 		{name: "parse a simple streams response", filepath: "streams_simple", query: streamsQuery},
+
+		{name: "parse a streams response with parse errors", filepath: "streams_parse_errors", query: streamsQuery},
 	}
 
 	for _, test := range tt {

--- a/pkg/tsdb/loki/testdata/streams_parse_errors.golden.jsonc
+++ b/pkg/tsdb/loki/testdata/streams_parse_errors.golden.jsonc
@@ -1,0 +1,120 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "custom": {
+//          "frameType": "LabeledTimeValues"
+//      },
+//      "executedQueryString": "Expr: query1"
+//  }
+//  Name: 
+//  Dimensions: 5 Fields by 4 Rows
+//  +------------------------------------------------+-------------------------------+----------------+---------------------+-------------------------------+
+//  | Name: labels                                   | Name: Time                    | Name: Line     | Name: tsNs          | Name: id                      |
+//  | Labels:                                        | Labels:                       | Labels:        | Labels:             | Labels:                       |
+//  | Type: []json.RawMessage                        | Type: []time.Time             | Type: []string | Type: []string      | Type: []string                |
+//  +------------------------------------------------+-------------------------------+----------------+---------------------+-------------------------------+
+//  | {"__error__":"LogfmtParserErr","place":"moon"} | 2022-06-17 06:49:51 +0000 UTC | "hello1        | 1655448591000000000 | 1655448591000000000_44cbf4ec_ |
+//  | {"__error__":"LogfmtParserErr","place":"moon"} | 2022-06-17 06:49:54 +0000 UTC | "hello4        | 1655448594000000000 | 1655448594000000000_408b3f5b_ |
+//  | {"place":"moon","text":"hello3"}               | 2022-06-17 06:49:52 +0000 UTC | text=hello2    | 1655448592000000000 | 1655448592000000000_d1b2086_  |
+//  | {"place":"moon","text":"hello4"}               | 2022-06-17 06:49:53 +0000 UTC | text=hello3    | 1655448593000000000 | 1655448593000000000_45714922_ |
+//  +------------------------------------------------+-------------------------------+----------------+---------------------+-------------------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "frames": [
+    {
+      "schema": {
+        "meta": {
+          "custom": {
+            "frameType": "LabeledTimeValues"
+          },
+          "executedQueryString": "Expr: query1"
+        },
+        "fields": [
+          {
+            "name": "labels",
+            "type": "other",
+            "typeInfo": {
+              "frame": "json.RawMessage"
+            }
+          },
+          {
+            "name": "Time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "Line",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "tsNs",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "id",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            {
+              "__error__": "LogfmtParserErr",
+              "place": "moon"
+            },
+            {
+              "__error__": "LogfmtParserErr",
+              "place": "moon"
+            },
+            {
+              "place": "moon",
+              "text": "hello3"
+            },
+            {
+              "place": "moon",
+              "text": "hello4"
+            }
+          ],
+          [
+            1655448591000,
+            1655448594000,
+            1655448592000,
+            1655448593000
+          ],
+          [
+            "\"hello1",
+            "\"hello4",
+            "text=hello2",
+            "text=hello3"
+          ],
+          [
+            "1655448591000000000",
+            "1655448594000000000",
+            "1655448592000000000",
+            "1655448593000000000"
+          ],
+          [
+            "1655448591000000000_44cbf4ec_",
+            "1655448594000000000_408b3f5b_",
+            "1655448592000000000_d1b2086_",
+            "1655448593000000000_45714922_"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/loki/testdata/streams_parse_errors.json
+++ b/pkg/tsdb/loki/testdata/streams_parse_errors.json
@@ -1,0 +1,29 @@
+{
+  "status": "success",
+  "data": {
+    "resultType": "streams",
+    "result": [
+      {
+        "stream": { "__error__": "LogfmtParserErr", "place": "moon" },
+        "values": [
+          ["1655448591000000000", "\"hello1"],
+          ["1655448594000000000", "\"hello4"]
+        ]
+      },
+      {
+        "stream": {
+          "place": "moon",
+          "text": "hello3"
+        },
+        "values": [["1655448592000000000", "text=hello2"]]
+      },
+      {
+        "stream": {
+          "place": "moon",
+          "text": "hello4"
+        },
+        "values": [["1655448593000000000", "text=hello3"]]
+      }
+    ]
+  }
+}

--- a/pkg/util/converter/prom.go
+++ b/pkg/util/converter/prom.go
@@ -695,6 +695,9 @@ func readStream(iter *jsoniter.Iterator) *backend.DataResponse {
 		for l1Field := iter.ReadObject(); l1Field != ""; l1Field = iter.ReadObject() {
 			switch l1Field {
 			case "stream":
+				// we need to clear `labels`, because `iter.ReadVal`
+				// only appends to it
+				labels := data.Labels{}
 				iter.ReadVal(&labels)
 				labelJson, err = labelsToRawJson(labels)
 				if err != nil {

--- a/pkg/util/converter/prom_test.go
+++ b/pkg/util/converter/prom_test.go
@@ -32,6 +32,7 @@ func TestReadPromFrames(t *testing.T) {
 		"prom-exemplars",
 		"loki-streams-a",
 		"loki-streams-b",
+		"loki-streams-c",
 	}
 
 	for _, name := range files {

--- a/pkg/util/converter/testdata/loki-streams-c-frame.jsonc
+++ b/pkg/util/converter/testdata/loki-streams-c-frame.jsonc
@@ -1,0 +1,79 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {}
+//  Name: 
+//  Dimensions: 4 Fields by 2 Rows
+//  +-------------------------+-------------------------------+----------------+---------------------+
+//  | Name: __labels          | Name: Time                    | Name: Line     | Name: TS            |
+//  | Labels:                 | Labels:                       | Labels:        | Labels:             |
+//  | Type: []json.RawMessage | Type: []time.Time             | Type: []string | Type: []string      |
+//  +-------------------------+-------------------------------+----------------+---------------------+
+//  | {"label1":"value1"}     | 2022-06-17 06:49:51 +0000 UTC | text1          | 1655448591000000000 |
+//  | {"label2":"value2"}     | 2022-06-17 06:49:52 +0000 UTC | text2          | 1655448592000000000 |
+//  +-------------------------+-------------------------------+----------------+---------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "frames": [
+    {
+      "schema": {
+        "meta": {},
+        "fields": [
+          {
+            "name": "__labels",
+            "type": "other",
+            "typeInfo": {
+              "frame": "json.RawMessage"
+            }
+          },
+          {
+            "name": "Time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "Line",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "TS",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            {
+              "label1": "value1"
+            },
+            {
+              "label2": "value2"
+            }
+          ],
+          [
+            1655448591000,
+            1655448592000
+          ],
+          [
+            "text1",
+            "text2"
+          ],
+          [
+            "1655448591000000000",
+            "1655448592000000000"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/util/converter/testdata/loki-streams-c-wide-frame.jsonc
+++ b/pkg/util/converter/testdata/loki-streams-c-wide-frame.jsonc
@@ -1,0 +1,79 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {}
+//  Name: 
+//  Dimensions: 4 Fields by 2 Rows
+//  +-------------------------+-------------------------------+----------------+---------------------+
+//  | Name: __labels          | Name: Time                    | Name: Line     | Name: TS            |
+//  | Labels:                 | Labels:                       | Labels:        | Labels:             |
+//  | Type: []json.RawMessage | Type: []time.Time             | Type: []string | Type: []string      |
+//  +-------------------------+-------------------------------+----------------+---------------------+
+//  | {"label1":"value1"}     | 2022-06-17 06:49:51 +0000 UTC | text1          | 1655448591000000000 |
+//  | {"label2":"value2"}     | 2022-06-17 06:49:52 +0000 UTC | text2          | 1655448592000000000 |
+//  +-------------------------+-------------------------------+----------------+---------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "frames": [
+    {
+      "schema": {
+        "meta": {},
+        "fields": [
+          {
+            "name": "__labels",
+            "type": "other",
+            "typeInfo": {
+              "frame": "json.RawMessage"
+            }
+          },
+          {
+            "name": "Time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "Line",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          },
+          {
+            "name": "TS",
+            "type": "string",
+            "typeInfo": {
+              "frame": "string"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            {
+              "label1": "value1"
+            },
+            {
+              "label2": "value2"
+            }
+          ],
+          [
+            1655448591000,
+            1655448592000
+          ],
+          [
+            "text1",
+            "text2"
+          ],
+          [
+            "1655448591000000000",
+            "1655448592000000000"
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/util/converter/testdata/loki-streams-c.json
+++ b/pkg/util/converter/testdata/loki-streams-c.json
@@ -1,0 +1,17 @@
+{
+  "status": "success",
+  "data": {
+    "resultType": "streams",
+    "result": [
+      {
+        "stream": {  "label1": "value1" },
+        "values": [["1655448591000000000", "text1"]
+        ]
+      },
+      {
+        "stream": { "label2": "value2"},
+        "values": [["1655448592000000000", "text2"]]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/50901

when we convert a loki json-response to a grafana dataframe, we have a bug where the labels are just appended, never cleared.

in other words, if the first log-line arriving has labels `{label1=value1}`, we report this correctly.
then, if the second log-line has labels `{label2=value2}`, we report it's labels as `{label1=value1, label2=value2}.

the reason is that we use the same variable to store the labels for every row, and we use `iter.ReadVal` ( https://github.com/json-iterator/go/blob/e6b9536d3649bda3e8842bb7e4fab489d79a97ea/reflect.go#L62 ) to read the labels-structure.

note that it's documentation says "ReadVal copy the underlying JSON into go interface, same as json.Unmarshal".

i did a quick test with `json.Unmarshal`, and:
- if i have a `map[string]string`
- and unmarshal into it `{"label1":"value1"}`
- then unmarshal into it `{"label2":"value2"}`
- then the map will contain `{"label1":"value1", "label2":"value2"}`

my fix simply resets the structure to empty before calling `iter.ReadVal`, there may be a better fix, i don't know.

i also added unit-tests to both `converter/prom` and to `loki`.