### PR TITLE
LogRow: Fixed background-height when hovering and label-alignment

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogLabels.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogLabels.tsx
@@ -23,7 +23,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       padding: 0 2px;
       background-color: ${theme.colors.bg2};
       border-radius: ${theme.border.radius};
-      margin: 1.75px 4px 0 0;
+      margin: 1px 4px 0 0;
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;

--- a/packages/grafana-ui/src/components/Logs/LogLabels.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogLabels.tsx
@@ -23,7 +23,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme) => {
       padding: 0 2px;
       background-color: ${theme.colors.bg2};
       border-radius: ${theme.border.radius};
-      margin: 1px 4px 0 0;
+      margin: 1.75px 4px 0 0;
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -124,6 +124,11 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme2, logLevel?: L
       label: logs-row__labels;
       white-space: nowrap;
       max-width: 22em;
+
+      /* This is to make the labels vertical align */
+      > span {
+        margin-top: 0.75px;
+      }
     `,
     logsRowMessage: css`
       label: logs-row__message;

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -75,6 +75,7 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme2, logLevel?: L
       }
 
       > td {
+        position: relative;
         padding-right: ${theme.spacing(1)};
         border-top: ${theme.v1.border.width.sm} solid transparent;
         border-bottom: ${theme.v1.border.width.sm} solid transparent;
@@ -93,7 +94,6 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme2, logLevel?: L
     `,
     logsRowLevel: css`
       label: logs-row__level;
-      position: relative;
       max-width: 10px;
       cursor: default;
       &::after {
@@ -112,7 +112,6 @@ export const getLogRowStyles = stylesFactory((theme: GrafanaTheme2, logLevel?: L
     `,
     logsRowToggleDetails: css`
       label: logs-row-toggle-details__level;
-      position: relative;
       font-size: 9px;
       padding-top: 5px;
       max-width: 15px;


### PR DESCRIPTION
**What this PR does / why we need it**:

While reviewing #51010 I noticed a small difference in heights in the LogRow. This PR fixes the height differences by adding a `position: relative` to every table-cell.

Additionally I noticed that log-lables are not vertically aligned inside a row. Fixed that by adjusting it to the right `margin-top`.

**Special notes for your reviewer**:

Before the fix:
![image](https://user-images.githubusercontent.com/8092184/174280608-7ae7e694-0f87-4bbc-bf52-8c2b9e914b93.png)
Especially the height difference is hard to spot. I tried highlighting that by adding some blue lines.

After the fix:
![Screenshot 2022-06-17 at 12 07 24](https://user-images.githubusercontent.com/8092184/174279945-83921403-73fe-4807-aac5-fd81e3bf0c13.png)

By the way, the reason for this difference is kinda weird. The `computed` tab for table-cells before the fix on cells already having the `position: relative` looks like this:
![image](https://user-images.githubusercontent.com/8092184/174281064-369113e8-7059-429a-aa61-174c60f358b5.png)

And for cells not having `position: relative` looks like this:
![image](https://user-images.githubusercontent.com/8092184/174281124-35b0d3b2-f80d-4703-b6e0-01b9ef1ef035.png)

I went with the approach to add `position: relative` to every cell because it was just easier. At least the first cell indicating the log-level **needs** `position: relative`, so there wasn't really a way to remove it.