### PR TITLE
CI: Tidy up `release-enterprise-*` pipeline dependencies

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2735,7 +2735,8 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - ./bin/grabpl integration-tests --database postgres
+  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
+    -timeout=30m {}'
   depends_on:
   - wire-install
   environment:
@@ -2751,7 +2752,8 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - ./bin/grabpl integration-tests --database mysql
+  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
+    -timeout=30m {}'
   depends_on:
   - wire-install
   environment:
@@ -4515,7 +4517,8 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - ./bin/grabpl integration-tests --database postgres
+  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
+    -timeout=30m {}'
   depends_on:
   - wire-install
   environment:
@@ -4531,7 +4534,8 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - ./bin/grabpl integration-tests --database mysql
+  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
+    -timeout=30m {}'
   depends_on:
   - wire-install
   environment:
@@ -4791,6 +4795,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: c22383a21a14c2da68967cb483aa8c7c70ed47c4832c2d45403a80aad57f0e0a
+hmac: 2593b9d6157c1173e25bd68c86b320cb84a17d90ce803676f2e8a22b03fafa9f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -100,6 +100,7 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
@@ -205,6 +206,7 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
@@ -460,6 +462,7 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
@@ -788,6 +791,7 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
@@ -882,6 +886,7 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
@@ -1303,6 +1308,7 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
@@ -1567,6 +1573,7 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
@@ -1864,6 +1871,7 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
@@ -1996,6 +2004,7 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
@@ -2710,6 +2719,8 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
+  depends_on:
+  - init-enterprise
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
@@ -2724,10 +2735,9 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+  - ./bin/grabpl integration-tests --database postgres
   depends_on:
-  - init-enterprise
+  - wire-install
   environment:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
@@ -2741,10 +2751,9 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+  - ./bin/grabpl integration-tests --database mysql
   depends_on:
-  - init-enterprise
+  - wire-install
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
@@ -2754,7 +2763,7 @@ steps:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - init-enterprise
+  - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
   image: grafana/build-container:1.5.5
@@ -2763,7 +2772,7 @@ steps:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - init-enterprise
+  - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
   image: grafana/build-container:1.5.5
@@ -3411,6 +3420,7 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
@@ -3678,6 +3688,7 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
@@ -3804,6 +3815,7 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
+  depends_on: []
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
@@ -4487,6 +4499,8 @@ steps:
   - '# The following command will fail if running code generators produces any diff
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
+  depends_on:
+  - init-enterprise
   image: grafana/build-container:1.5.5
   name: verify-gen-cue
 - commands:
@@ -4501,10 +4515,9 @@ steps:
   - dockerize -wait tcp://postgres:5432 -timeout 120s
   - psql -p 5432 -h postgres -U grafanatest -d grafanatest -f devenv/docker/blocks/postgres_tests/setup.sql
   - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+  - ./bin/grabpl integration-tests --database postgres
   depends_on:
-  - init-enterprise
+  - wire-install
   environment:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
@@ -4518,10 +4531,9 @@ steps:
   - cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root
     -prootpass
   - go clean -testcache
-  - go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic
-    -timeout=30m {}'
+  - ./bin/grabpl integration-tests --database mysql
   depends_on:
-  - init-enterprise
+  - wire-install
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
@@ -4531,7 +4543,7 @@ steps:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - init-enterprise
+  - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
   image: grafana/build-container:1.5.5
@@ -4540,7 +4552,7 @@ steps:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
   - ./bin/grabpl integration-tests
   depends_on:
-  - init-enterprise
+  - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
   image: grafana/build-container:1.5.5
@@ -4779,6 +4791,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 6fda0984bf108d3b9ba3ea2ec16a68ed5e81a0c66b4910605759714817808eeb
+hmac: c22383a21a14c2da68967cb483aa8c7c70ed47c4832c2d45403a80aad57f0e0a
 
 ...

--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -93,7 +93,7 @@ def main_test_backend():
         identify_runner_step(),
         download_grabpl_step(),
         gen_version_step(ver_mode),
-        verify_gen_cue_step(),
+        verify_gen_cue_step(edition="oss"),
         wire_install_step(),
     ]
     test_steps = [
@@ -114,7 +114,7 @@ def get_steps(edition):
         identify_runner_step(),
         download_grabpl_step(),
         gen_version_step(ver_mode),
-        verify_gen_cue_step(),
+        verify_gen_cue_step(edition="oss"),
         wire_install_step(),
         yarn_install_step(),
     ]
@@ -220,7 +220,7 @@ def main_pipelines(edition):
         volumes=volumes,
     ), pipeline(
         name='main-integration-tests', edition=edition, trigger=trigger, services=services,
-        steps=[download_grabpl_step(), identify_runner_step(), verify_gen_cue_step(), wire_install_step(), ] + integration_test_steps,
+        steps=[download_grabpl_step(), identify_runner_step(), verify_gen_cue_step(edition="oss"), wire_install_step(), ] + integration_test_steps,
         volumes=volumes,
     ), pipeline(
         name='main-windows', edition=edition, trigger=dict(trigger, repo=['grafana/grafana']),

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -91,7 +91,7 @@ def pr_test_backend():
         identify_runner_step(),
         download_grabpl_step(),
         gen_version_step(ver_mode),
-        verify_gen_cue_step(),
+        verify_gen_cue_step(edition="oss"),
         wire_install_step(),
     ]
     test_steps = [
@@ -115,7 +115,7 @@ def pr_pipelines(edition):
         identify_runner_step(),
         download_grabpl_step(),
         gen_version_step(ver_mode),
-        verify_gen_cue_step(),
+        verify_gen_cue_step(edition="oss"),
         wire_install_step(),
         yarn_install_step(),
     ]
@@ -153,7 +153,7 @@ def pr_pipelines(edition):
             name='pr-build-e2e', edition=edition, trigger=trigger, services=[], steps=init_steps + build_steps,
         ), pipeline(
             name='pr-integration-tests', edition=edition, trigger=trigger, services=services,
-            steps=[download_grabpl_step(), identify_runner_step(), verify_gen_cue_step(), wire_install_step(), ] + integration_test_steps,
+            steps=[download_grabpl_step(), identify_runner_step(), verify_gen_cue_step(edition="oss"), wire_install_step(), ] + integration_test_steps,
             volumes=volumes,
         ), docs_pipelines(edition, ver_mode, trigger_docs())
     ]

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -158,7 +158,7 @@ def get_steps(edition, ver_mode):
         identify_runner_step(),
         download_grabpl_step(),
         gen_version_step(ver_mode),
-        verify_gen_cue_step(),
+        verify_gen_cue_step(edition),
         wire_install_step(),
         yarn_install_step(),
     ]
@@ -275,7 +275,7 @@ def get_oss_pipelines(trigger, ver_mode):
             ),
             pipeline(
                 name='{}-oss-integration-tests'.format(ver_mode), edition=edition, trigger=trigger, services=services,
-                steps=[download_grabpl_step(), identify_runner_step(), verify_gen_cue_step(), wire_install_step(), ] + integration_test_steps,
+                steps=[download_grabpl_step(), identify_runner_step(), verify_gen_cue_step(edition), wire_install_step(), ] + integration_test_steps,
                 volumes=volumes,
             )
         ])
@@ -307,12 +307,9 @@ def get_enterprise_pipelines(trigger, ver_mode):
         clone_enterprise_step(ver_mode),
         init_enterprise_step(ver_mode)
     ]
-    for step in [wire_install_step(), yarn_install_step(), gen_version_step(ver_mode), verify_gen_cue_step()]:
+    for step in [wire_install_step(), yarn_install_step(), gen_version_step(ver_mode), verify_gen_cue_step(edition)]:
         step.update(deps_on_clone_enterprise_step)
         init_steps.extend([step])
-
-    for step in integration_test_steps:
-        step.update(deps_on_clone_enterprise_step)
 
     windows_pipeline = pipeline(
         name='{}-enterprise-windows'.format(ver_mode), edition=edition, trigger=trigger,
@@ -337,7 +334,7 @@ def get_enterprise_pipelines(trigger, ver_mode):
             ),
             pipeline(
                 name='{}-enterprise-integration-tests'.format(ver_mode), edition=edition, trigger=trigger, services=services,
-                steps=[download_grabpl_step(), identify_runner_step(), clone_enterprise_step(ver_mode), init_enterprise_step(ver_mode), verify_gen_cue_step(), wire_install_step(),] + integration_test_steps,
+                steps=[download_grabpl_step(), identify_runner_step(), clone_enterprise_step(ver_mode), init_enterprise_step(ver_mode), verify_gen_cue_step(edition), wire_install_step()] + integration_test_steps,
                 volumes=volumes,
             ),
         ])

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -879,11 +879,8 @@ def postgres_integration_tests_step(edition, ver_mode):
             'devenv/docker/blocks/postgres_tests/setup.sql',
             # Make sure that we don't use cached results for another database
             'go clean -testcache',
+            "go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'",
         ]
-    if edition == 'oss':
-        cmds.extend(["go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'"])
-    else:
-        cmds.extend(['./bin/grabpl integration-tests --database postgres'])
     return {
         'name': 'postgres-integration-tests',
         'image': build_image,
@@ -898,7 +895,6 @@ def postgres_integration_tests_step(edition, ver_mode):
 
 
 def mysql_integration_tests_step(edition, ver_mode):
-    deps = []
     cmds = [
             'apt-get update',
             'apt-get install -yq default-mysql-client',
@@ -906,11 +902,8 @@ def mysql_integration_tests_step(edition, ver_mode):
             'cat devenv/docker/blocks/mysql_tests/setup.sql | mysql -h mysql -P 3306 -u root -prootpass',
             # Make sure that we don't use cached results for another database
             'go clean -testcache',
+            "go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'",
         ]
-    if edition == 'oss':
-        cmds.extend(["go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'"])
-    else:
-        cmds.extend(['./bin/grabpl integration-tests --database mysql'])
     return {
         'name': 'mysql-integration-tests',
         'image': build_image,

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -871,7 +871,6 @@ def publish_images_step(edition, ver_mode, mode, docker_repo, trigger=None):
 
 
 def postgres_integration_tests_step(edition, ver_mode):
-    deps = []
     cmds = [
             'apt-get update',
             'apt-get install -yq postgresql-client',
@@ -881,12 +880,14 @@ def postgres_integration_tests_step(edition, ver_mode):
             # Make sure that we don't use cached results for another database
             'go clean -testcache',
         ]
-    deps.extend(['wire-install'])
-    cmds.extend(["go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'"])
+    if edition == 'oss':
+        cmds.extend(["go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'"])
+    else:
+        cmds.extend(['./bin/grabpl integration-tests --database postgres'])
     return {
         'name': 'postgres-integration-tests',
         'image': build_image,
-        'depends_on': deps,
+        'depends_on': ['wire-install'],
         'environment': {
             'PGPASSWORD': 'grafanatest',
             'GRAFANA_TEST_DB': 'postgres',
@@ -906,12 +907,14 @@ def mysql_integration_tests_step(edition, ver_mode):
             # Make sure that we don't use cached results for another database
             'go clean -testcache',
         ]
-    deps.extend(['wire-install'])
-    cmds.extend(["go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'"])
+    if edition == 'oss':
+        cmds.extend(["go list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'"])
+    else:
+        cmds.extend(['./bin/grabpl integration-tests --database mysql'])
     return {
         'name': 'mysql-integration-tests',
         'image': build_image,
-        'depends_on': deps,
+        'depends_on': ['wire-install'],
         'environment': {
             'GRAFANA_TEST_DB': 'mysql',
             'MYSQL_HOST': 'mysql',
@@ -921,12 +924,10 @@ def mysql_integration_tests_step(edition, ver_mode):
 
 
 def redis_integration_tests_step():
-    deps = []
-    deps.extend(['grabpl'])
     return {
         'name': 'redis-integration-tests',
         'image': build_image,
-        'depends_on': deps,
+        'depends_on': ['wire-install'],
         'environment': {
             'REDIS_URL': 'redis://redis:6379/0',
         },
@@ -938,12 +939,10 @@ def redis_integration_tests_step():
 
 
 def memcached_integration_tests_step():
-    deps = []
-    deps.extend(['grabpl'])
     return {
         'name': 'memcached-integration-tests',
         'image': build_image,
-        'depends_on': deps,
+        'depends_on': ['wire-install'],
         'environment': {
             'MEMCACHED_HOSTS': 'memcached:11211',
         },
@@ -1168,10 +1167,14 @@ def get_windows_steps(edition, ver_mode):
 
     return steps
 
-def verify_gen_cue_step():
+def verify_gen_cue_step(edition):
+    deps = []
+    if edition == "enterprise":
+        deps.extend(['init-enterprise'])
     return {
         'name': 'verify-gen-cue',
         'image': build_image,
+        'depends_on': deps,
         'commands': [
             '# It is required that code generated from Thema/CUE be committed and in sync with its inputs.',
             '# The following command will fail if running code generators produces any diff in output.',


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR aims to tidy up things in the current pipeline dependency structure, so the PR to remove build tags can be digested easier.

**Special notes for your reviewer**:

auxiliary PR for https://github.com/grafana/grafana/pull/50974 
