### PR TITLE
I18n: Add default locale server config option

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -376,6 +376,9 @@ password_hint = password
 # Default UI theme ("dark" or "light")
 default_theme = dark
 
+# Default locale (supported IETF language tag, such as en-US)
+default_locale = en-US
+
 # Path to a custom home page. Users are only redirected to this if the default home dashboard is used. It should match a frontend route and contain a leading slash.
 home_page =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -377,10 +377,10 @@
 ;default_theme = dark
 
 # Default locale (supported IETF language tag, such as en-US)
-; default_locale = en-US
+;default_locale = en-US
 
 # Path to a custom home page. Users are only redirected to this if the default home dashboard is used. It should match a frontend route and contain a leading slash.
-; home_page =
+;home_page =
 
 # External user management, these options affect the organization users view
 ;external_manage_link_url =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -376,6 +376,9 @@
 # Default UI theme ("dark" or "light")
 ;default_theme = dark
 
+# Default locale (supported IETF language tag, such as en-US)
+; default_locale = en-US
+
 # Path to a custom home page. Users are only redirected to this if the default home dashboard is used. It should match a frontend route and contain a leading slash.
 ; home_page =
 

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -691,12 +691,16 @@ func (hs *HTTPServer) setIndexViewData(c *models.ReqContext) (*dtos.IndexViewDat
 		return nil, err
 	}
 
-	// Read locale from accept-language
-	acceptLang := c.Req.Header.Get("Accept-Language")
+	// Set locale to the preference, otherwise fall back to the accept language header.
+	// In practice, because the preference has configuration-backed default, the header
+	// shouldn't frequently be used
+	acceptLangHeader := c.Req.Header.Get("Accept-Language")
 	locale := "en-US"
 
-	if len(acceptLang) > 0 {
-		parts := strings.Split(acceptLang, ",")
+	if hs.Features.IsEnabled(featuremgmt.FlagInternationalization) && prefs.JSONData.Locale != "" {
+		locale = prefs.JSONData.Locale
+	} else if len(acceptLangHeader) > 0 {
+		parts := strings.Split(acceptLangHeader, ",")
 		locale = parts[0]
 	}
 

--- a/pkg/services/preference/prefimpl/pref.go
+++ b/pkg/services/preference/prefimpl/pref.go
@@ -51,7 +51,17 @@ func (s *Service) GetWithDefaults(ctx context.Context, query *pref.GetPreference
 			res.HomeDashboardID = p.HomeDashboardID
 		}
 		if p.JSONData != nil {
-			res.JSONData = p.JSONData
+			if p.JSONData.Locale != "" {
+				res.JSONData.Locale = p.JSONData.Locale
+			}
+
+			if len(p.JSONData.Navbar.SavedItems) > 0 {
+				res.JSONData.Navbar = p.JSONData.Navbar
+			}
+
+			if p.JSONData.QueryHistory.HomeTab != "" {
+				res.JSONData.QueryHistory.HomeTab = p.JSONData.QueryHistory.HomeTab
+			}
 		}
 	}
 
@@ -214,7 +224,9 @@ func (s *Service) GetDefaults() *pref.Preference {
 		Timezone:        s.cfg.DateFormats.DefaultTimezone,
 		WeekStart:       s.cfg.DateFormats.DefaultWeekStart,
 		HomeDashboardID: 0,
-		JSONData:        &pref.PreferenceJSONData{},
+		JSONData: &pref.PreferenceJSONData{
+			Locale: s.cfg.DefaultLocale,
+		},
 	}
 
 	return defaults

--- a/pkg/services/preference/prefimpl/pref.go
+++ b/pkg/services/preference/prefimpl/pref.go
@@ -14,7 +14,7 @@ import (
 type Service struct {
 	store    store
 	cfg      *setting.Cfg
-	Features *featuremgmt.FeatureManager
+	features *featuremgmt.FeatureManager
 }
 
 func ProvideService(db db.DB, cfg *setting.Cfg, features *featuremgmt.FeatureManager) pref.Service {
@@ -23,7 +23,7 @@ func ProvideService(db db.DB, cfg *setting.Cfg, features *featuremgmt.FeatureMan
 			db: db,
 		},
 		cfg:      cfg,
-		Features: features,
+		features: features,
 	}
 }
 
@@ -230,7 +230,7 @@ func (s *Service) GetDefaults() *pref.Preference {
 		JSONData:        &pref.PreferenceJSONData{},
 	}
 
-	if s.Features.IsEnabled(featuremgmt.FlagInternationalization) {
+	if s.features.IsEnabled(featuremgmt.FlagInternationalization) {
 		defaults.JSONData.Locale = s.cfg.DefaultLocale
 	}
 

--- a/pkg/services/preference/prefimpl/pref_test.go
+++ b/pkg/services/preference/prefimpl/pref_test.go
@@ -17,7 +17,7 @@ func TestGet_empty(t *testing.T) {
 	prefService := &Service{
 		store:    newFake(),
 		cfg:      setting.NewCfg(),
-		Features: featuremgmt.WithFeatures(),
+		features: featuremgmt.WithFeatures(),
 	}
 	preference, err := prefService.Get(context.Background(), &pref.GetPreferenceQuery{})
 	require.NoError(t, err)
@@ -31,7 +31,7 @@ func TestGetDefaults(t *testing.T) {
 	prefService := &Service{
 		store:    newFake(),
 		cfg:      setting.NewCfg(),
-		Features: featuremgmt.WithFeatures(),
+		features: featuremgmt.WithFeatures(),
 	}
 	prefService.cfg.DefaultLocale = "en-US"
 	prefService.cfg.DefaultTheme = "light"
@@ -70,7 +70,7 @@ func TestGetDefaultsWithI18nFeatureFlag(t *testing.T) {
 	prefService := &Service{
 		store:    newFake(),
 		cfg:      setting.NewCfg(),
-		Features: featuremgmt.WithFeatures(featuremgmt.FlagInternationalization),
+		features: featuremgmt.WithFeatures(featuremgmt.FlagInternationalization),
 	}
 	prefService.cfg.DefaultLocale = "en-US"
 	prefService.cfg.DefaultTheme = "light"
@@ -96,7 +96,7 @@ func TestGetWithDefaults_withUserAndOrgPrefs(t *testing.T) {
 	prefService := &Service{
 		store:    newFake(),
 		cfg:      setting.NewCfg(),
-		Features: featuremgmt.WithFeatures(),
+		features: featuremgmt.WithFeatures(),
 	}
 	prefService.cfg.DefaultLocale = "en-US"
 
@@ -216,7 +216,7 @@ func TestGetDefaults_JSONData(t *testing.T) {
 		prefService := &Service{
 			store:    newFake(),
 			cfg:      setting.NewCfg(),
-			Features: featuremgmt.WithFeatures(),
+			features: featuremgmt.WithFeatures(),
 		}
 
 		insertPrefs(t, prefService.store,
@@ -243,7 +243,7 @@ func TestGetDefaults_JSONData(t *testing.T) {
 		prefService := &Service{
 			store:    newFake(),
 			cfg:      setting.NewCfg(),
-			Features: featuremgmt.WithFeatures(),
+			features: featuremgmt.WithFeatures(),
 		}
 
 		insertPrefs(t, prefService.store,
@@ -274,7 +274,7 @@ func TestGetDefaults_JSONData(t *testing.T) {
 		prefService := &Service{
 			store:    newFake(),
 			cfg:      setting.NewCfg(),
-			Features: featuremgmt.WithFeatures(),
+			features: featuremgmt.WithFeatures(),
 		}
 
 		insertPrefs(t, prefService.store,
@@ -309,7 +309,7 @@ func TestGetWithDefaults_teams(t *testing.T) {
 	prefService := &Service{
 		store:    newFake(),
 		cfg:      setting.NewCfg(),
-		Features: featuremgmt.WithFeatures(),
+		features: featuremgmt.WithFeatures(),
 	}
 	insertPrefs(t, prefService.store,
 		pref.Preference{
@@ -356,7 +356,7 @@ func TestPatch_toCreate(t *testing.T) {
 	prefService := &Service{
 		store:    newFake(),
 		cfg:      setting.NewCfg(),
-		Features: featuremgmt.WithFeatures(),
+		features: featuremgmt.WithFeatures(),
 	}
 
 	themeValue := "light"
@@ -377,7 +377,7 @@ func TestSave(t *testing.T) {
 	prefService := &Service{
 		store:    newFake(),
 		cfg:      setting.NewCfg(),
-		Features: featuremgmt.WithFeatures(),
+		features: featuremgmt.WithFeatures(),
 	}
 
 	t.Run("insert", func(t *testing.T) {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -397,8 +397,9 @@ type Cfg struct {
 
 	Quota QuotaSettings
 
-	DefaultTheme string
-	HomePage     string
+	DefaultTheme  string
+	DefaultLocale string
+	HomePage      string
 
 	AutoAssignOrg              bool
 	AutoAssignOrgId            int
@@ -1356,6 +1357,7 @@ func readUserSettings(iniFile *ini.File, cfg *Cfg) error {
 	LoginHint = valueAsString(users, "login_hint", "")
 	PasswordHint = valueAsString(users, "password_hint", "")
 	cfg.DefaultTheme = valueAsString(users, "default_theme", "")
+	cfg.DefaultLocale = valueAsString(users, "default_locale", "")
 	cfg.HomePage = valueAsString(users, "home_page", "")
 	ExternalUserMngLinkUrl = valueAsString(users, "external_manage_link_url", "")
 	ExternalUserMngLinkName = valueAsString(users, "external_manage_link_name", "")


### PR DESCRIPTION
**What this PR does / why we need it**:

 - introduces new `default_locale` preference for server admins to set a default local for the server
 - updates preferences `GetWithDefaults` to correctly cascade defaults for properties in JSONData
 - returns server config/locale preference in the `grafanaBootData`, instead of the accept-lang header, if the feature flag is on

**Which issue(s) this PR fixes**:

Part of #49280

**Special notes for your reviewer**:

