### PR TITLE
Docs: fix link to `service-accounts` docs

### DIFF
--- a/docs/sources/dashboards/previews.md
+++ b/docs/sources/dashboards/previews.md
@@ -36,7 +36,7 @@ The dashboard previews feature is an opt-in feature that is disabled by default.
 enable = dashboardPreviews
 ```
 
-3. If running Grafana Enterprise with RBAC, enable [service accounts]({{< relref "../administration/service-accounts/enable-service-accounts/" >}}).
+3. If running Grafana Enterprise with RBAC, enable [service accounts]({{< relref "../administration/service-accounts/" >}}).
 
 4. Save your changes. Grafana should reload automatically; we recommend restarting the Grafana server in case of any issues.
 


### PR DESCRIPTION
Fix broken link after https://github.com/grafana/grafana/pull/50592