### PR TITLE
CI: Move `memcached` and `redis` integration tests to enterprise release pipelines only

### DIFF
--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -220,9 +220,6 @@ def get_steps(edition, ver_mode):
     if build_storybook:
         build_steps.append(build_storybook)
 
-    if include_enterprise2:
-      integration_test_steps.extend([redis_integration_tests_step(), memcached_integration_tests_step()])
-
     if should_upload:
         publish_steps.append(upload_cdn_step(edition=edition, ver_mode=ver_mode, trigger=trigger_oss))
         publish_steps.append(upload_packages_step(edition=edition, ver_mode=ver_mode, trigger=trigger_oss))
@@ -337,7 +334,7 @@ def get_enterprise_pipelines(trigger, ver_mode):
             ),
             pipeline(
                 name='{}-enterprise-integration-tests'.format(ver_mode), edition=edition, trigger=trigger, services=services,
-                steps=[download_grabpl_step(), identify_runner_step(), clone_enterprise_step(ver_mode), init_enterprise_step(ver_mode),] + integration_test_steps,
+                steps=[download_grabpl_step(), identify_runner_step(), clone_enterprise_step(ver_mode), init_enterprise_step(ver_mode),] + integration_test_steps + [redis_integration_tests_step(), memcached_integration_tests_step()],
                 volumes=volumes,
             ),
         ])

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -927,12 +927,10 @@ def mysql_integration_tests_step(edition, ver_mode):
 
 
 def redis_integration_tests_step():
-    deps = []
-    deps.extend(['grabpl'])
     return {
         'name': 'redis-integration-tests',
         'image': build_image,
-        'depends_on': deps,
+        'depends_on': ['init-enterprise'],
         'environment': {
             'REDIS_URL': 'redis://redis:6379/0',
         },
@@ -944,12 +942,10 @@ def redis_integration_tests_step():
 
 
 def memcached_integration_tests_step():
-    deps = []
-    deps.extend(['grabpl'])
     return {
         'name': 'memcached-integration-tests',
         'image': build_image,
-        'depends_on': deps,
+        'depends_on': ['init-enterprise'],
         'environment': {
             'MEMCACHED_HOSTS': 'memcached:11211',
         },


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the unnecessary and complicated logic which checks if the edition is enterprise2 in order to place `memcached` and `redis` tests accordingly.

No-op change.