### PR TITLE
Alerting: Fix alert rule page crashing when datasource contained URL unsafe characters

### DIFF
--- a/public/app/features/alerting/unified/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.tsx
@@ -45,9 +45,10 @@ const pageTitle = 'Alerting / View rule';
 
 export function RuleViewer({ match }: RuleViewerProps) {
   const styles = useStyles2(getStyles);
-  const { id, sourceName } = match.params;
+  const { id } = match.params;
   const identifier = ruleId.tryParse(id, true);
-  const { loading, error, result: rule } = useCombinedRule(identifier, sourceName);
+
+  const { loading, error, result: rule } = useCombinedRule(identifier, identifier?.ruleSourceName);
   const runner = useMemo(() => new AlertingQueryRunner(), []);
   const data = useObservable(runner.get());
   const queries2 = useMemo(() => alertRuleToQueries(rule), [rule]);
@@ -86,7 +87,7 @@ export function RuleViewer({ match }: RuleViewerProps) {
     );
   }, []);
 
-  if (!sourceName) {
+  if (!identifier?.ruleSourceName) {
     return (
       <RuleViewerLayout title={pageTitle}>
         <Alert title={errorTitle}>
@@ -96,7 +97,7 @@ export function RuleViewer({ match }: RuleViewerProps) {
     );
   }
 
-  const rulesSource = getRulesSourceByName(sourceName);
+  const rulesSource = getRulesSourceByName(identifier?.ruleSourceName);
 
   if (loading) {
     return (

--- a/public/app/features/alerting/unified/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.tsx
@@ -97,7 +97,7 @@ export function RuleViewer({ match }: RuleViewerProps) {
     );
   }
 
-  const rulesSource = getRulesSourceByName(identifier?.ruleSourceName);
+  const rulesSource = getRulesSourceByName(identifier.ruleSourceName);
 
   if (loading) {
     return (


### PR DESCRIPTION
**What this PR does / why we need it**:

Any Prometheus datasources that contained URL unsafe characters would crash the application since it fails to find the datasource from the Grafana bootData.

I traced the exception back to https://github.com/grafana/grafana/blob/2dbaf259a71ab43495d894f317087bc808d33882/public/app/features/alerting/unified/hooks/useCombinedRuleNamespaces.ts#L43

In `RuleViewer.tsx` we grab the datasource name from the queryparams, but when it contains URL encoded characters we don't decode it.

We try to find the datasource via the name from `window.grafanaBootData.config.datasources` but there's no match because the name is still URL encoded.

This PR grabs the decoded data source name from the result of the rule ID parser.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/50890

**Special notes for your reviewer**:

Any Prometheus datasources that contained URL unsafe characters would crash the application since it fails to find the datasource from the Grafana bootData