### PR TITLE
Alerting: Use ErrImagesDone in Discord and SensuGo

### DIFF
--- a/pkg/services/ngalert/notifier/channels/discord.go
+++ b/pkg/services/ngalert/notifier/channels/discord.go
@@ -201,8 +201,7 @@ func (d DiscordNotifier) constructAttachments(ctx context.Context, as []*types.A
 	_ = withStoredImages(ctx, d.log, d.images,
 		func(index int, image *ngmodels.Image) error {
 			if embedQuota < 1 {
-				// TODO: Could be a sentinel error to stop execution.
-				return nil
+				return ErrImagesDone
 			}
 
 			if image == nil {

--- a/pkg/services/ngalert/notifier/channels/sensugo.go
+++ b/pkg/services/ngalert/notifier/channels/sensugo.go
@@ -147,6 +147,7 @@ func (sn *SensuGoNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool
 			// one image per request.
 			if image != nil && image.URL != "" && imageURL == "" {
 				imageURL = image.URL
+				return ErrImagesDone
 			}
 			return nil
 		}, as...)


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request uses the new `ErrImagesDone` error to stop iteration of images for Discord and SensuGo.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

