### PR TITLE
Traces: update metrics

### DIFF
--- a/docs/sources/datasources/tempo.md
+++ b/docs/sources/datasources/tempo.md
@@ -205,7 +205,7 @@ To display the APM table:
 1. Select the **Service Graph** query type and run the query.
 1. (Optional): filter your results.
 
-Note: The metric traces_spanmetrics_calls_total is used to display the name, rate & error rate columns and traces_spanmetrics_duration_seconds_bucket is used to display the duration column (these metrics will need to exist in your Prometheus datasource).
+Note: The metric traces_spanmetrics_calls_total is used to display the name, rate & error rate columns and traces_spanmetrics_latency_bucket is used to display the duration column (these metrics will need to exist in your Prometheus datasource).
 
 Click a row in the rate, error rate, or duration columns to open a query in Prometheus with the span name of that row automatically set in the query. Click a row in the links column to open a query in Tempo with the span name of that row automatically set in the query.
 

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -392,7 +392,7 @@ describe('Tempo apm table', () => {
     expect(response.data[0].fields[3].config.decimals).toBe(2);
     expect(response.data[0].fields[3].config.links[0].title).toBe('Error Rate');
     expect(response.data[0].fields[3].config.links[0].internal.query.expr).toBe(
-      'sum(rate(traces_spanmetrics_calls_total{span_status="STATUS_CODE_ERROR",span_name="${__data.fields[0]}"}[$__rate_interval]))'
+      'sum(rate(traces_spanmetrics_calls_total{status_code="STATUS_CODE_ERROR",span_name="${__data.fields[0]}"}[$__rate_interval]))'
     );
     expect(response.data[0].fields[3].config.links[0].internal.query.range).toBe(true);
     expect(response.data[0].fields[3].config.links[0].internal.query.exemplar).toBe(true);
@@ -412,7 +412,7 @@ describe('Tempo apm table', () => {
     expect(response.data[0].fields[5].config.unit).toBe('s');
     expect(response.data[0].fields[5].config.links[0].title).toBe('Duration');
     expect(response.data[0].fields[5].config.links[0].internal.query.expr).toBe(
-      'histogram_quantile(.9, sum(rate(traces_spanmetrics_duration_seconds_bucket{span_name="${__data.fields[0]}"}[$__rate_interval])) by (le))'
+      'histogram_quantile(.9, sum(rate(traces_spanmetrics_latency_bucket{span_name="${__data.fields[0]}"}[$__rate_interval])) by (le))'
     );
     expect(response.data[0].fields[5].config.links[0].internal.query.range).toBe(true);
     expect(response.data[0].fields[5].config.links[0].internal.query.exemplar).toBe(true);
@@ -445,25 +445,25 @@ describe('Tempo apm table', () => {
     builtQuery = buildExpr(
       {
         expr: 'topk(5, sum(rate(traces_spanmetrics_calls_total{}[$__range])) by (span_name))',
-        params: ['span_status="STATUS_CODE_ERROR"'],
+        params: ['status_code="STATUS_CODE_ERROR"'],
       },
       'span_name=~"HTTP Client|HTTP GET|HTTP GET - root|HTTP POST|HTTP POST - post"',
       targets
     );
     expect(builtQuery).toBe(
-      'topk(5, sum(rate(traces_spanmetrics_calls_total{span_status="STATUS_CODE_ERROR",span_name=~"HTTP Client|HTTP GET|HTTP GET - root|HTTP POST|HTTP POST - post"}[$__range])) by (span_name))'
+      'topk(5, sum(rate(traces_spanmetrics_calls_total{status_code="STATUS_CODE_ERROR",span_name=~"HTTP Client|HTTP GET|HTTP GET - root|HTTP POST|HTTP POST - post"}[$__range])) by (span_name))'
     );
 
     builtQuery = buildExpr(
       {
-        expr: 'histogram_quantile(.9, sum(rate(traces_spanmetrics_duration_seconds_bucket{}[$__range])) by (le))',
-        params: ['span_status="STATUS_CODE_ERROR"'],
+        expr: 'histogram_quantile(.9, sum(rate(traces_spanmetrics_latency_bucket{}[$__range])) by (le))',
+        params: ['status_code="STATUS_CODE_ERROR"'],
       },
       'span_name=~"HTTP Client"',
       targets
     );
     expect(builtQuery).toBe(
-      'histogram_quantile(.9, sum(rate(traces_spanmetrics_duration_seconds_bucket{span_status="STATUS_CODE_ERROR",span_name=~"HTTP Client"}[$__range])) by (le))'
+      'histogram_quantile(.9, sum(rate(traces_spanmetrics_latency_bucket{status_code="STATUS_CODE_ERROR",span_name=~"HTTP Client"}[$__range])) by (le))'
     );
 
     targets = { targets: [{ queryType: 'serviceMap', serviceMapQuery: '{client="app",service="app"}' }] } as any;
@@ -527,7 +527,7 @@ describe('Tempo apm table', () => {
   it('should make apm request correctly', () => {
     const apmRequest = makeApmRequest([
       'topk(5, sum(rate(traces_spanmetrics_calls_total{service="app"}[$__range])) by (span_name))"',
-      'histogram_quantile(.9, sum(rate(traces_spanmetrics_duration_seconds_bucket{span_status="STATUS_CODE_ERROR",service="app",service="app",span_name=~"HTTP Client"}[$__range])) by (le))',
+      'histogram_quantile(.9, sum(rate(traces_spanmetrics_latency_bucket{status_code="STATUS_CODE_ERROR",service="app",service="app",span_name=~"HTTP Client"}[$__range])) by (le))',
     ]);
     expect(apmRequest).toEqual([
       {
@@ -537,8 +537,8 @@ describe('Tempo apm table', () => {
       },
       {
         refId:
-          'histogram_quantile(.9, sum(rate(traces_spanmetrics_duration_seconds_bucket{span_status="STATUS_CODE_ERROR",service="app",service="app",span_name=~"HTTP Client"}[$__range])) by (le))',
-        expr: 'histogram_quantile(.9, sum(rate(traces_spanmetrics_duration_seconds_bucket{span_status="STATUS_CODE_ERROR",service="app",service="app",span_name=~"HTTP Client"}[$__range])) by (le))',
+          'histogram_quantile(.9, sum(rate(traces_spanmetrics_latency_bucket{status_code="STATUS_CODE_ERROR",service="app",service="app",span_name=~"HTTP Client"}[$__range])) by (le))',
+        expr: 'histogram_quantile(.9, sum(rate(traces_spanmetrics_latency_bucket{status_code="STATUS_CODE_ERROR",service="app",service="app",span_name=~"HTTP Client"}[$__range])) by (le))',
         instant: true,
       },
     ]);
@@ -627,12 +627,12 @@ const rateMetric = new MutableDataFrame({
 
 const errorRateMetric = new MutableDataFrame({
   refId:
-    'topk(5, sum(rate(traces_spanmetrics_calls_total{span_status="STATUS_CODE_ERROR",span_name=~"HTTP Client|HTTP GET - root"}[$__range])) by (span_name))',
+    'topk(5, sum(rate(traces_spanmetrics_calls_total{status_code="STATUS_CODE_ERROR",span_name=~"HTTP Client|HTTP GET - root"}[$__range])) by (span_name))',
   fields: [
     { name: 'Time', values: [1653725618609, 1653725618609] },
     { name: 'span_name', values: ['HTTP Client', 'HTTP GET - root'] },
     {
-      name: 'Value #topk(5, sum(rate(traces_spanmetrics_calls_total{span_status="STATUS_CODE_ERROR"}[$__range])) by (span_name))',
+      name: 'Value #topk(5, sum(rate(traces_spanmetrics_calls_total{status_code="STATUS_CODE_ERROR"}[$__range])) by (span_name))',
       values: [3.75164671814457, 3.121331111401608],
     },
   ],
@@ -640,11 +640,11 @@ const errorRateMetric = new MutableDataFrame({
 
 const durationMetric = new MutableDataFrame({
   refId:
-    'histogram_quantile(.9, sum(rate(traces_spanmetrics_duration_seconds_bucket{span_name=~"HTTP GET - root"}[$__range])) by (le))',
+    'histogram_quantile(.9, sum(rate(traces_spanmetrics_latency_bucket{span_name=~"HTTP GET - root"}[$__range])) by (le))',
   fields: [
     { name: 'Time', values: [1653725618609] },
     {
-      name: 'Value #histogram_quantile(.9, sum(rate(traces_spanmetrics_duration_seconds_bucket{span_name=~"HTTP GET - root"}[$__range])) by (le))',
+      name: 'Value #histogram_quantile(.9, sum(rate(traces_spanmetrics_latency_bucket{span_name=~"HTTP GET - root"}[$__range])) by (le))',
       values: [0.12003505696757232],
     },
   ],

--- a/public/app/plugins/datasource/tempo/graphTransform.ts
+++ b/public/app/plugins/datasource/tempo/graphTransform.ts
@@ -142,10 +142,10 @@ export const rateMetric = {
 };
 export const errorRateMetric = {
   expr: 'topk(5, sum(rate(traces_spanmetrics_calls_total{}[$__range])) by (span_name))',
-  params: ['span_status="STATUS_CODE_ERROR"'],
+  params: ['status_code="STATUS_CODE_ERROR"'],
 };
 export const durationMetric = {
-  expr: 'histogram_quantile(.9, sum(rate(traces_spanmetrics_duration_seconds_bucket{}[$__range])) by (le))',
+  expr: 'histogram_quantile(.9, sum(rate(traces_spanmetrics_latency_bucket{}[$__range])) by (le))',
   params: [],
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates some of our spanmetric's metric names and labels based on the [work done here](https://github.com/grafana/tempo/pull/1478#event-6784262255). These changes were made to match OTel's spanmetrics spec.

Fixes #

**Special notes for your reviewer**:

