### PR TITLE
Configure Grafana AuthNZ labels to add to the AuthNZ project

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -217,5 +217,93 @@
     "addToProject": {
       "url": "https://github.com/orgs/grafana/projects/87"
     }
+  },
+  {
+    "type": "label",
+    "name": "team/grafana-authnz",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/86"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/86"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth/rbac",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/86"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth/serviceaccount",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/86"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth/authproxy",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/86"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth/oauth",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/86"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth/ldap",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/86"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth/saml",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/86"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth/apikeys",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/86"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth/dspermissions",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/86"
+    }
+  },
+  {
+    "type": "label",
+    "name": "area/auth/teamsync",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/86"
+    }
   }
 ]


### PR DESCRIPTION
We would like to add AuthNZ related issues directly to the Grafana AuthNZ team project, this PR adds the automation for the following labels:

```
team/grafana-authnz
area/auth
area/auth/rbac
area/auth/serviceaccount
area/auth/authproxy
area/auth/oauth
area/auth/ldap
area/auth/saml
area/auth/apikeys
area/auth/dspermissions
area/auth/teamsync
```
