### PR TITLE
Query history: Fix default value when no config

### DIFF
--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -48,7 +48,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   angularSupportEnabled = false;
   authProxyEnabled = false;
   exploreEnabled = false;
-  queryHistoryEnabled = false;
+  queryHistoryEnabled = true;
   helpEnabled = false;
   profileEnabled = false;
   ldapEnabled = false;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -48,7 +48,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   angularSupportEnabled = false;
   authProxyEnabled = false;
   exploreEnabled = false;
-  queryHistoryEnabled = true;
+  queryHistoryEnabled = false;
   helpEnabled = false;
   profileEnabled = false;
   ldapEnabled = false;

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -972,7 +972,7 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 	ProfileEnabled = profile.Key("enabled").MustBool(true)
 
 	queryHistory := iniFile.Section("query_history")
-	cfg.QueryHistoryEnabled = queryHistory.Key("enabled").MustBool(false)
+	cfg.QueryHistoryEnabled = queryHistory.Key("enabled").MustBool(true)
 
 	panelsSection := iniFile.Section("panels")
 	cfg.DisableSanitizeHtml = panelsSection.Key("disable_sanitize_html").MustBool(false)


### PR DESCRIPTION
**What this PR does / why we need it**:
When switching `queryHistoryEnabled` default value from `false` to `true`, we forgot to update this default value. It means, that if  `defaults.ini` or `custom.ini` file wouldn't have `query_history` `enabled` section/value (which probably almost never happens, it would default to `false`. And we want it to default to `true`

This PR fixes it.

**Special notes for your reviewer**:

To test, you can delete `query_history` section from defaults.ini and custom.ini. When you then start grafana and go to explore, it should do request to backend to retrieve query history
<img width="1499" alt="image" src="https://user-images.githubusercontent.com/30407135/174632588-0dcb304b-3046-4ed8-922f-ecc76c7f50e8.png">


If you test this on main, it shouldn't do request to backend to retrieve query history - which is incorrect.
<img width="758" alt="image" src="https://user-images.githubusercontent.com/30407135/174632267-f9486bc5-5257-44ce-9609-ae4850b78eac.png">


