### PR TITLE
Angular: Fixes issue with some old external angular panels (singlestat) not working 

### DIFF
--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -42,6 +42,13 @@ grafanaUI.DataSourcePlugin = grafanaData.DataSourcePlugin;
 grafanaUI.AppPlugin = grafanaData.AppPlugin;
 grafanaUI.DataSourceApi = grafanaData.DataSourceApi;
 
+// Patch in an old function to stop old plugins from crashing
+if (!(grafanaData as any).getColorForTheme) {
+  (grafanaData as any).getColorForTheme = (color: string, theme: grafanaData.GrafanaTheme) => {
+    return theme.visualization.getColorByName(color);
+  };
+}
+
 grafanaRuntime.SystemJS.registry.set('plugin-loader', grafanaRuntime.SystemJS.newModule({ locate: locateWithCache }));
 
 grafanaRuntime.SystemJS.config({


### PR DESCRIPTION
Fixes grafana/singlestat-panel#3

https://github.com/grafana/grafana/pull/49519 correctly removed this deprecated method.

But it is used by some plugins. Not sure what is best, force plugins to update or add this
"shim" to the runtime to make it still work.

