### PR TITLE
codegen: Correctly gen TS without defaults

### DIFF
--- a/pkg/codegen/coremodel.go
+++ b/pkg/codegen/coremodel.go
@@ -227,8 +227,10 @@ func (ls *ExtractedLineage) GenerateTypescriptCoremodel(path string) (WriteDiffe
 	}
 
 	// TODO until cuetsy can toposort its outputs, put the top/parent type at the bottom of the file.
-	parts.Nodes = append(parts.Nodes, top.T, top.D)
-	// parts.Nodes = append([]ts.Decl{top.T, top.D}, parts.Nodes...)
+	parts.Nodes = append(parts.Nodes, top.T)
+	if top.D != nil {
+		parts.Nodes = append(parts.Nodes, top.D)
+	}
 
 	var strb strings.Builder
 	var str string


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This fixes a bug in generating Typescript output for coremodels that have no defaults. Without this fix, that extra `top.D` ends up causing string printing to panic, resulting in generated typescript output like this:

```ts
// This file is autogenerated. DO NOT EDIT.
//
// Run "make gen-cue" from repository root to regenerate.
//
// Derived from the Thema lineage at pkg/coremodel/foo


// This model is a WIP and not yet canonical. Consequently, its members are
// not exported to exclude it from grafana-schema's public API surface.

%!v(PANIC=String method: runtime error: invalid memory address or nil pointer dereference)
```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

