### PR TITLE
RBAC: Add access control metadata to folder dtos

### DIFF
--- a/pkg/api/dtos/folder.go
+++ b/pkg/api/dtos/folder.go
@@ -1,22 +1,27 @@
 package dtos
 
-import "time"
+import (
+	"time"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+)
 
 type Folder struct {
-	Id        int64     `json:"id"`
-	Uid       string    `json:"uid"`
-	Title     string    `json:"title"`
-	Url       string    `json:"url"`
-	HasAcl    bool      `json:"hasAcl"`
-	CanSave   bool      `json:"canSave"`
-	CanEdit   bool      `json:"canEdit"`
-	CanAdmin  bool      `json:"canAdmin"`
-	CanDelete bool      `json:"canDelete"`
-	CreatedBy string    `json:"createdBy"`
-	Created   time.Time `json:"created"`
-	UpdatedBy string    `json:"updatedBy"`
-	Updated   time.Time `json:"updated"`
-	Version   int       `json:"version"`
+	Id            int64                  `json:"id"`
+	Uid           string                 `json:"uid"`
+	Title         string                 `json:"title"`
+	Url           string                 `json:"url"`
+	HasAcl        bool                   `json:"hasAcl"`
+	CanSave       bool                   `json:"canSave"`
+	CanEdit       bool                   `json:"canEdit"`
+	CanAdmin      bool                   `json:"canAdmin"`
+	CanDelete     bool                   `json:"canDelete"`
+	CreatedBy     string                 `json:"createdBy"`
+	Created       time.Time              `json:"created"`
+	UpdatedBy     string                 `json:"updatedBy"`
+	Updated       time.Time              `json:"updated"`
+	Version       int                    `json:"version"`
+	AccessControl accesscontrol.Metadata `json:"accessControl,omitempty"`
 }
 
 type FolderSearchHit struct {

--- a/pkg/api/dtos/folder.go
+++ b/pkg/api/dtos/folder.go
@@ -25,7 +25,8 @@ type Folder struct {
 }
 
 type FolderSearchHit struct {
-	Id    int64  `json:"id"`
-	Uid   string `json:"uid"`
-	Title string `json:"title"`
+	Id            int64                  `json:"id"`
+	Uid           string                 `json:"uid"`
+	Title         string                 `json:"title"`
+	AccessControl accesscontrol.Metadata `json:"accessControl,omitempty"`
 }

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -11,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/libraryelements"
 	"github.com/grafana/grafana/pkg/services/store"
@@ -45,7 +45,7 @@ func (hs *HTTPServer) GetFolderByUID(c *models.ReqContext) response.Response {
 	}
 
 	g := guardian.New(c.Req.Context(), folder.Id, c.OrgId, c.SignedInUser)
-	return response.JSON(http.StatusOK, hs.toFolderDto(c.Req.Context(), g, folder))
+	return response.JSON(http.StatusOK, hs.toFolderDto(c, g, folder))
 }
 
 func (hs *HTTPServer) GetFolderByID(c *models.ReqContext) response.Response {
@@ -59,7 +59,7 @@ func (hs *HTTPServer) GetFolderByID(c *models.ReqContext) response.Response {
 	}
 
 	g := guardian.New(c.Req.Context(), folder.Id, c.OrgId, c.SignedInUser)
-	return response.JSON(http.StatusOK, hs.toFolderDto(c.Req.Context(), g, folder))
+	return response.JSON(http.StatusOK, hs.toFolderDto(c, g, folder))
 }
 
 func (hs *HTTPServer) CreateFolder(c *models.ReqContext) response.Response {
@@ -81,7 +81,7 @@ func (hs *HTTPServer) CreateFolder(c *models.ReqContext) response.Response {
 	}
 
 	g := guardian.New(c.Req.Context(), folder.Id, c.OrgId, c.SignedInUser)
-	return response.JSON(http.StatusOK, hs.toFolderDto(c.Req.Context(), g, folder))
+	return response.JSON(http.StatusOK, hs.toFolderDto(c, g, folder))
 }
 
 func (hs *HTTPServer) UpdateFolder(c *models.ReqContext) response.Response {
@@ -103,7 +103,7 @@ func (hs *HTTPServer) UpdateFolder(c *models.ReqContext) response.Response {
 	}
 
 	g := guardian.New(c.Req.Context(), cmd.Result.Id, c.OrgId, c.SignedInUser)
-	return response.JSON(http.StatusOK, hs.toFolderDto(c.Req.Context(), g, cmd.Result))
+	return response.JSON(http.StatusOK, hs.toFolderDto(c, g, cmd.Result))
 }
 
 func (hs *HTTPServer) DeleteFolder(c *models.ReqContext) response.Response { // temporarily adding this function to HTTPServer, will be removed from HTTPServer when librarypanels featuretoggle is removed
@@ -136,7 +136,7 @@ func (hs *HTTPServer) DeleteFolder(c *models.ReqContext) response.Response { // 
 	})
 }
 
-func (hs *HTTPServer) toFolderDto(ctx context.Context, g guardian.DashboardGuardian, folder *models.Folder) dtos.Folder {
+func (hs *HTTPServer) toFolderDto(c *models.ReqContext, g guardian.DashboardGuardian, folder *models.Folder) dtos.Folder {
 	canEdit, _ := g.CanEdit()
 	canSave, _ := g.CanSave()
 	canAdmin, _ := g.CanAdmin()
@@ -145,26 +145,27 @@ func (hs *HTTPServer) toFolderDto(ctx context.Context, g guardian.DashboardGuard
 	// Finding creator and last updater of the folder
 	updater, creator := anonString, anonString
 	if folder.CreatedBy > 0 {
-		creator = hs.getUserLogin(ctx, folder.CreatedBy)
+		creator = hs.getUserLogin(c.Req.Context(), folder.CreatedBy)
 	}
 	if folder.UpdatedBy > 0 {
-		updater = hs.getUserLogin(ctx, folder.UpdatedBy)
+		updater = hs.getUserLogin(c.Req.Context(), folder.UpdatedBy)
 	}
 
 	return dtos.Folder{
-		Id:        folder.Id,
-		Uid:       folder.Uid,
-		Title:     folder.Title,
-		Url:       folder.Url,
-		HasAcl:    folder.HasAcl,
-		CanSave:   canSave,
-		CanEdit:   canEdit,
-		CanAdmin:  canAdmin,
-		CanDelete: canDelete,
-		CreatedBy: creator,
-		Created:   folder.Created,
-		UpdatedBy: updater,
-		Updated:   folder.Updated,
-		Version:   folder.Version,
+		Id:            folder.Id,
+		Uid:           folder.Uid,
+		Title:         folder.Title,
+		Url:           folder.Url,
+		HasAcl:        folder.HasAcl,
+		CanSave:       canSave,
+		CanEdit:       canEdit,
+		CanAdmin:      canAdmin,
+		CanDelete:     canDelete,
+		CreatedBy:     creator,
+		Created:       folder.Created,
+		UpdatedBy:     updater,
+		Updated:       folder.Updated,
+		Version:       folder.Version,
+		AccessControl: hs.getAccessControlMetadata(c, c.OrgId, dashboards.ScopeFoldersPrefix, folder.Uid),
 	}
 }

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -159,6 +159,7 @@ func TestHTTPServer_FolderMetadata(t *testing.T) {
 
 		res, err := server.Send(req)
 		require.NoError(t, err)
+		defer func() { require.NoError(t, res.Body.Close()) }()
 		assert.Equal(t, http.StatusOK, res.StatusCode)
 
 		body := []dtos.FolderSearchHit{}
@@ -172,7 +173,6 @@ func TestHTTPServer_FolderMetadata(t *testing.T) {
 				assert.False(t, f.AccessControl[dashboards.ActionFoldersWrite])
 			}
 		}
-
 	})
 
 	t.Run("Should attach access control metadata to folder response", func(t *testing.T) {
@@ -189,6 +189,7 @@ func TestHTTPServer_FolderMetadata(t *testing.T) {
 		res, err := server.Send(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
+		defer func() { require.NoError(t, res.Body.Close()) }()
 
 		body := dtos.Folder{}
 		require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
@@ -211,6 +212,7 @@ func TestHTTPServer_FolderMetadata(t *testing.T) {
 		res, err := server.Send(req)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, res.StatusCode)
+		defer func() { require.NoError(t, res.Body.Close()) }()
 
 		body := dtos.Folder{}
 		require.NoError(t, json.NewDecoder(res.Body).Decode(&body))

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/web/webtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -130,16 +134,68 @@ func TestFoldersAPIEndpoint(t *testing.T) {
 	})
 }
 
+func TestHTTPServer_FolderMetadata(t *testing.T) {
+	setUpRBACGuardian(t)
+	server := SetupAPITestServer(t, func(hs *HTTPServer) {
+		folderService := dashboards.NewFakeFolderService(t)
+		folderService.On("GetFolderByUID", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&models.Folder{Uid: "folderUid"}, nil)
+		hs.folderService = folderService
+		hs.AccessControl = acmock.New()
+	})
+
+	t.Run("Should attach access control metadata to folder response", func(t *testing.T) {
+		req := server.NewGetRequest("/api/folders/folderUid?accesscontrol=true")
+		webtest.RequestWithSignedInUser(req, &models.SignedInUser{UserId: 1, OrgId: 1, Permissions: map[int64]map[string][]string{
+			1: accesscontrol.GroupScopesByAction([]accesscontrol.Permission{
+				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersAll},
+				{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("folderUid")},
+			}),
+		}})
+
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+
+		body := dtos.Folder{}
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+
+		assert.True(t, body.AccessControl[dashboards.ActionFoldersRead])
+		assert.True(t, body.AccessControl[dashboards.ActionFoldersWrite])
+	})
+
+	t.Run("Should attach access control metadata to folder response", func(t *testing.T) {
+		req := server.NewGetRequest("/api/folders/folderUid")
+		webtest.RequestWithSignedInUser(req, &models.SignedInUser{UserId: 1, OrgId: 1, Permissions: map[int64]map[string][]string{
+			1: accesscontrol.GroupScopesByAction([]accesscontrol.Permission{
+				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersAll},
+				{Action: dashboards.ActionFoldersWrite, Scope: dashboards.ScopeFoldersProvider.GetResourceScopeUID("folderUid")},
+			}),
+		}})
+
+		res, err := server.Send(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+
+		body := dtos.Folder{}
+		require.NoError(t, json.NewDecoder(res.Body).Decode(&body))
+
+		assert.False(t, body.AccessControl[dashboards.ActionFoldersRead])
+		assert.False(t, body.AccessControl[dashboards.ActionFoldersWrite])
+	})
+}
+
 func callCreateFolder(sc *scenarioContext) {
 	sc.fakeReqWithParams("POST", sc.url, map[string]string{}).exec()
 }
 
 func createFolderScenario(t *testing.T, desc string, url string, routePattern string, folderService dashboards.FolderService,
 	cmd models.CreateFolderCommand, fn scenarioFunc) {
+	setUpRBACGuardian(t)
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
 		hs := HTTPServer{
-			Cfg:           setting.NewCfg(),
+			AccessControl: acmock.New(),
 			folderService: folderService,
+			Cfg:           setting.NewCfg(),
 			Features:      featuremgmt.WithFeatures(),
 		}
 
@@ -165,9 +221,11 @@ func callUpdateFolder(sc *scenarioContext) {
 
 func updateFolderScenario(t *testing.T, desc string, url string, routePattern string, folderService dashboards.FolderService,
 	cmd models.UpdateFolderCommand, fn scenarioFunc) {
+	setUpRBACGuardian(t)
 	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
 		hs := HTTPServer{
 			Cfg:           setting.NewCfg(),
+			AccessControl: acmock.New(),
 			folderService: folderService,
 		}
 

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -93,20 +93,14 @@ func (m *Mock) Evaluate(ctx context.Context, user *models.SignedInUser, evaluato
 		user.Permissions = map[int64]map[string][]string{}
 	}
 
-	if _, ok := user.Permissions[user.OrgId]; !ok {
-		permissions, err := m.GetUserPermissions(ctx, user, accesscontrol.Options{ReloadCache: true})
-		if err != nil {
-			return false, err
-		}
-		user.Permissions[user.OrgId] = accesscontrol.GroupScopesByAction(permissions)
-	}
+	permissions, err := m.GetUserPermissions(ctx, user, accesscontrol.Options{ReloadCache: true})
 
 	attributeMutator := m.scopeResolvers.GetScopeAttributeMutator(user.OrgId)
 	resolvedEvaluator, err := evaluator.MutateScopes(ctx, attributeMutator)
 	if err != nil {
 		return false, err
 	}
-	return resolvedEvaluator.Evaluate(user.Permissions[user.OrgId]), nil
+	return resolvedEvaluator.Evaluate(accesscontrol.GroupScopesByAction(permissions)), nil
 }
 
 // GetUserPermissions returns user permissions.

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -713,21 +713,18 @@ func TestRouteGetRulesGroupConfig(t *testing.T) {
 			expectedRules := models.GenerateAlertRules(rand.Intn(4)+2, models.AlertRuleGen(withGroupKey(groupKey)))
 			ruleStore.PutRule(context.Background(), expectedRules...)
 
+			request := createRequestContext(orgID, "", map[string]string{
+				":Namespace": folder.Title,
+				":Groupname": groupKey.RuleGroup,
+			})
+
 			t.Run("and return 401 if user does not have access one of rules", func(t *testing.T) {
-				request := createRequestContext(orgID, "", map[string]string{
-					":Namespace": folder.Title,
-					":Groupname": groupKey.RuleGroup,
-				})
 				ac := acMock.New().WithPermissions(createPermissionsForRules(expectedRules[1:]))
 				response := createService(ac, ruleStore, nil).RouteGetRulesGroupConfig(request)
 				require.Equal(t, http.StatusUnauthorized, response.Status())
 			})
 
 			t.Run("and return rules if user has access to all of them", func(t *testing.T) {
-				request := createRequestContext(orgID, "", map[string]string{
-					":Namespace": folder.Title,
-					":Groupname": groupKey.RuleGroup,
-				})
 				ac := acMock.New().WithPermissions(createPermissionsForRules(expectedRules))
 				response := createService(ac, ruleStore, nil).RouteGetRulesGroupConfig(request)
 

--- a/pkg/services/ngalert/api/api_ruler_test.go
+++ b/pkg/services/ngalert/api/api_ruler_test.go
@@ -713,18 +713,21 @@ func TestRouteGetRulesGroupConfig(t *testing.T) {
 			expectedRules := models.GenerateAlertRules(rand.Intn(4)+2, models.AlertRuleGen(withGroupKey(groupKey)))
 			ruleStore.PutRule(context.Background(), expectedRules...)
 
-			request := createRequestContext(orgID, "", map[string]string{
-				":Namespace": folder.Title,
-				":Groupname": groupKey.RuleGroup,
-			})
-
 			t.Run("and return 401 if user does not have access one of rules", func(t *testing.T) {
+				request := createRequestContext(orgID, "", map[string]string{
+					":Namespace": folder.Title,
+					":Groupname": groupKey.RuleGroup,
+				})
 				ac := acMock.New().WithPermissions(createPermissionsForRules(expectedRules[1:]))
 				response := createService(ac, ruleStore, nil).RouteGetRulesGroupConfig(request)
 				require.Equal(t, http.StatusUnauthorized, response.Status())
 			})
 
 			t.Run("and return rules if user has access to all of them", func(t *testing.T) {
+				request := createRequestContext(orgID, "", map[string]string{
+					":Namespace": folder.Title,
+					":Groupname": groupKey.RuleGroup,
+				})
 				ac := acMock.New().WithPermissions(createPermissionsForRules(expectedRules))
 				response := createService(ac, ruleStore, nil).RouteGetRulesGroupConfig(request)
 

--- a/public/app/types/folders.ts
+++ b/public/app/types/folders.ts
@@ -1,6 +1,8 @@
+import { WithAccessControlMetadata } from '@grafana/data';
+
 import { DashboardAcl } from './acl';
 
-export interface FolderDTO {
+export interface FolderDTO extends WithAccessControlMetadata {
   id: number;
   uid: string;
   title: string;


### PR DESCRIPTION
**What this PR does / why we need it**:
Access Control metadata i required for folder to perform more fine-grained checks than we currently can using canSave, canEdit, canAdmin and canDelete properties.

For example check if a a user can read, write and delete alert rules in a certain folder. For those kind of lookups the old properties is not enough.


**Which issue(s) this PR fixes**:
Partially Fixes https://github.com/grafana/grafana-enterprise/issues/3401

**Special notes for your reviewer**:

