### PR TITLE
Chore: Remove any generics from configureMockStore in tests

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
@@ -24,7 +24,7 @@ import { dataOverrideTooltipDescription, overrideRuleTooltipDescription } from '
 standardEditorsRegistry.setInit(getAllOptionEditors);
 standardFieldConfigEditorRegistry.setInit(getAllStandardFieldConfigs);
 
-const mockStore = configureMockStore<any, any>();
+const mockStore = configureMockStore();
 const OptionsPaneSelector = selectors.components.PanelEditor.OptionsPane;
 jest.mock('react-router-dom', () => ({
   ...(jest.requireActual('react-router-dom') as any),

--- a/public/app/features/dashboard/dashgrid/PanelChrome.test.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.test.tsx
@@ -19,7 +19,7 @@ jest.mock('app/core/profiler', () => ({
 }));
 
 function setupTestContext(options: Partial<Props>) {
-  const mockStore = configureMockStore<any, any>();
+  const mockStore = configureMockStore();
   const store = mockStore({ dashboard: { panels: [] } });
   const subject: ReplaySubject<PanelData> = new ReplaySubject<PanelData>();
   const panelQueryRunner = {

--- a/public/app/features/playlist/PlaylistSrv.test.ts
+++ b/public/app/features/playlist/PlaylistSrv.test.ts
@@ -18,7 +18,7 @@ jest.mock('@grafana/runtime', () => {
   };
 });
 
-const mockStore = configureMockStore<any, any>();
+const mockStore = configureMockStore();
 
 setStore(
   mockStore({

--- a/public/app/features/search/page/components/ManageActions.test.tsx
+++ b/public/app/features/search/page/components/ManageActions.test.tsx
@@ -33,7 +33,7 @@ describe('ManageActions', () => {
     mockItemsSelected.set('dashboard', mockDashboardsUIDsSelected);
 
     //Mock store redux for old MoveDashboards state action
-    const mockStore = configureMockStore<any, any>();
+    const mockStore = configureMockStore();
     const store = mockStore({ dashboard: { panels: [] } });
 
     const onChange = jest.fn();
@@ -77,7 +77,7 @@ describe('ManageActions', () => {
       mockItemsSelected.set('dashboard', mockDashboardsUIDsSelected);
 
       //Mock store
-      const mockStore = configureMockStore<any, any>();
+      const mockStore = configureMockStore();
       const store = mockStore({ dashboard: { panels: [] } });
 
       const onChange = jest.fn();
@@ -102,7 +102,7 @@ describe('ManageActions', () => {
     mockItemsSelected.set('folder', mockFolderUIDSelected);
 
     //Mock store
-    const mockStore = configureMockStore<any, any>();
+    const mockStore = configureMockStore();
     const store = mockStore({ dashboard: { panels: [] } });
 
     const onChange = jest.fn();

--- a/public/app/features/search/page/components/MoveToFolderModal.test.tsx
+++ b/public/app/features/search/page/components/MoveToFolderModal.test.tsx
@@ -19,7 +19,7 @@ describe('MoveToFolderModal', () => {
     dashboardsUIDs.add('uid2');
     items.set('dashboard', dashboardsUIDs);
     const isMoveModalOpen = true;
-    const mockStore = configureMockStore<any, any>();
+    const mockStore = configureMockStore();
     const store = mockStore({ dashboard: { panels: [] } });
     const onMoveItems = jest.fn();
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`any` is yucky. doesn't look like it was needed in these

