### PR TITLE
Chore: Remove as any from jest.requireActual usage

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -28,7 +28,7 @@ const backendSrv = {
 } as unknown as BackendSrv;
 
 jest.mock('../services', () => ({
-  ...(jest.requireActual('../services') as any),
+  ...jest.requireActual('../services'),
   getBackendSrv: () => backendSrv,
   getDataSourceSrv: () => {
     return {

--- a/packages/grafana-runtime/src/utils/PublicDashboardDataSource.test.ts
+++ b/packages/grafana-runtime/src/utils/PublicDashboardDataSource.test.ts
@@ -14,7 +14,7 @@ const backendSrv = {
 } as unknown as BackendSrv;
 
 jest.mock('../services', () => ({
-  ...(jest.requireActual('../services') as any),
+  ...jest.requireActual('../services'),
   getBackendSrv: () => backendSrv,
   getDataSourceSrv: () => {
     return {

--- a/packages/grafana-ui/src/components/GraphNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/GraphNG/utils.test.ts
@@ -204,7 +204,7 @@ function mockDataFrame() {
 }
 
 jest.mock('@grafana/data', () => ({
-  ...(jest.requireActual('@grafana/data') as any),
+  ...jest.requireActual('@grafana/data'),
   DefaultTimeZone: 'utc',
 }));
 

--- a/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/RedirectToRuleViewer.test.tsx
@@ -17,7 +17,7 @@ import { getRulesSourceByName } from './utils/datasource';
 jest.mock('./hooks/useCombinedRule');
 jest.mock('./utils/datasource');
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   Redirect: jest.fn(({}) => `Redirected`),
 }));
 

--- a/public/app/features/alerting/unified/RuleViewer.test.tsx
+++ b/public/app/features/alerting/unified/RuleViewer.test.tsx
@@ -16,7 +16,7 @@ import { GRAFANA_RULES_SOURCE_NAME } from './utils/datasource';
 
 jest.mock('./hooks/useCombinedRule');
 jest.mock('@grafana/runtime', () => ({
-  ...(jest.requireActual('@grafana/runtime') as any),
+  ...jest.requireActual('@grafana/runtime'),
   getDataSourceSrv: () => {
     return {
       getInstanceSettings: () => ({ name: 'prometheus' }),

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.test.tsx
@@ -27,7 +27,7 @@ standardFieldConfigEditorRegistry.setInit(getAllStandardFieldConfigs);
 const mockStore = configureMockStore<any, any>();
 const OptionsPaneSelector = selectors.components.PanelEditor.OptionsPane;
 jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
+  ...jest.requireActual('react-router-dom'),
   useLocation: () => ({
     pathname: 'localhost:3000/example/path',
   }),

--- a/public/app/features/explore/utils/decorators.test.ts
+++ b/public/app/features/explore/utils/decorators.test.ts
@@ -23,7 +23,7 @@ import {
 } from './decorators';
 
 jest.mock('@grafana/data', () => ({
-  ...(jest.requireActual('@grafana/data') as any),
+  ...jest.requireActual('@grafana/data'),
   dateTimeFormat: () => 'format() jest mocked',
   dateTimeFormatTimeAgo: (ts: any) => 'fromNow() jest mocked',
 }));

--- a/public/app/features/playlist/PlaylistEditPage.test.tsx
+++ b/public/app/features/playlist/PlaylistEditPage.test.tsx
@@ -9,7 +9,7 @@ import { PlaylistEditPage } from './PlaylistEditPage';
 import { Playlist } from './types';
 
 jest.mock('@grafana/runtime', () => ({
-  ...(jest.requireActual('@grafana/runtime') as any),
+  ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: () => backendSrv,
 }));
 

--- a/public/app/features/playlist/PlaylistNewPage.test.tsx
+++ b/public/app/features/playlist/PlaylistNewPage.test.tsx
@@ -17,7 +17,7 @@ jest.mock('./usePlaylist', () => ({
 }));
 
 jest.mock('@grafana/runtime', () => ({
-  ...(jest.requireActual('@grafana/runtime') as any),
+  ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: () => backendSrv,
 }));
 

--- a/public/app/features/query/state/PanelQueryRunner.test.ts
+++ b/public/app/features/query/state/PanelQueryRunner.test.ts
@@ -18,7 +18,7 @@ import { PanelQueryRunner } from './PanelQueryRunner';
 
 jest.mock('@grafana/data', () => ({
   __esModule: true,
-  ...(jest.requireActual('@grafana/data') as any),
+  ...jest.requireActual('@grafana/data'),
   applyFieldOverrides: applyFieldOverridesMock,
 }));
 

--- a/public/app/features/query/state/queryAnalytics.test.ts
+++ b/public/app/features/query/state/queryAnalytics.test.ts
@@ -28,7 +28,7 @@ jest.mock('app/features/dashboard/services/DashboardSrv', () => ({
 }));
 
 jest.mock('@grafana/runtime', () => ({
-  ...(jest.requireActual('@grafana/runtime') as any),
+  ...jest.requireActual('@grafana/runtime'),
   reportMetaAnalytics: jest.fn(),
 }));
 
@@ -36,7 +36,7 @@ const mockGetUrlSearchParams = jest.fn(() => {
   return {};
 });
 jest.mock('@grafana/data', () => ({
-  ...(jest.requireActual('@grafana/data') as any),
+  ...jest.requireActual('@grafana/data'),
   urlUtil: {
     getUrlSearchParams: () => mockGetUrlSearchParams(),
   },

--- a/public/app/plugins/datasource/jaeger/components/SearchForm.test.tsx
+++ b/public/app/plugins/datasource/jaeger/components/SearchForm.test.tsx
@@ -15,7 +15,7 @@ import { JaegerQuery } from '../types';
 import SearchForm from './SearchForm';
 
 jest.mock('@grafana/runtime', () => ({
-  ...(jest.requireActual('@grafana/runtime') as any),
+  ...jest.requireActual('@grafana/runtime'),
   getTemplateSrv: () => ({
     replace: jest.fn(),
     containsTemplate: (val: string): boolean => {

--- a/public/app/plugins/datasource/jaeger/datasource.test.ts
+++ b/public/app/plugins/datasource/jaeger/datasource.test.ts
@@ -23,7 +23,7 @@ import {
 import { JaegerQuery } from './types';
 
 jest.mock('@grafana/runtime', () => ({
-  ...(jest.requireActual('@grafana/runtime') as any),
+  ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: () => backendSrv,
   getTemplateSrv: () => ({
     replace: (val: string, subs: ScopedVars): string => {

--- a/public/app/plugins/datasource/postgres/datasource.test.ts
+++ b/public/app/plugins/datasource/postgres/datasource.test.ts
@@ -6,7 +6,7 @@ import { backendSrv } from 'app/core/services/backend_srv';
 import { PostgresDatasource } from './datasource';
 
 jest.mock('@grafana/runtime', () => ({
-  ...(jest.requireActual('@grafana/runtime') as any),
+  ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: () => backendSrv,
   getTemplateSrv: () => ({
     replace: (val: string): string => {

--- a/public/app/plugins/datasource/prometheus/components/PromLink.test.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromLink.test.tsx
@@ -9,7 +9,7 @@ import { PromQuery } from '../types';
 import PromLink from './PromLink';
 
 jest.mock('@grafana/data', () => ({
-  ...(jest.requireActual('@grafana/data') as any),
+  ...jest.requireActual('@grafana/data'),
   rangeUtil: {
     intervalToSeconds: jest.fn(() => 15),
   },

--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -71,7 +71,7 @@ function mockDataFrame() {
 }
 
 jest.mock('@grafana/data', () => ({
-  ...(jest.requireActual('@grafana/data') as any),
+  ...jest.requireActual('@grafana/data'),
   DefaultTimeZone: 'utc',
 }));
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is mostly a busywork PR. `jest.requireActual` returns `any` anyway, so it doesn't need the explicit `as any` in our code. It's already not very typesafe!

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

