### PR TITLE
Chore: Type GA and Rudderstack analytics config

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -188,4 +188,9 @@ export interface GrafanaConfig {
   unifiedAlertingEnabled: boolean;
   angularSupportEnabled: boolean;
   feedbackLinksEnabled: boolean;
+  googleAnalyticsId: string | undefined;
+  rudderstackWriteKey: string | undefined;
+  rudderstackDataPlaneUrl: string | undefined;
+  rudderstackSdkUrl: string | undefined;
+  rudderstackConfigUrl: string | undefined;
 }

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -119,6 +119,11 @@ export class GrafanaBootConfig implements GrafanaConfig {
   reporting = {
     enabled: true,
   };
+  googleAnalyticsId: undefined;
+  rudderstackWriteKey: undefined;
+  rudderstackDataPlaneUrl: undefined;
+  rudderstackSdkUrl: undefined;
+  rudderstackConfigUrl: undefined;
 
   constructor(options: GrafanaBootConfig) {
     const mode = options.bootData.user.lightTheme ? 'light' : 'dark';

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -152,7 +152,7 @@ export class GrafanaApp {
         }),
         document.getElementById('reactRoot')
       );
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Failed to start Grafana', error);
       window.__grafana_load_failed();
     }
@@ -204,22 +204,22 @@ function initEchoSrv() {
     );
   }
 
-  if ((config as any).googleAnalyticsId) {
+  if (config.googleAnalyticsId) {
     registerEchoBackend(
       new GAEchoBackend({
-        googleAnalyticsId: (config as any).googleAnalyticsId,
+        googleAnalyticsId: config.googleAnalyticsId,
       })
     );
   }
 
-  if ((config as any).rudderstackWriteKey && (config as any).rudderstackDataPlaneUrl) {
+  if (config.rudderstackWriteKey && config.rudderstackDataPlaneUrl) {
     registerEchoBackend(
       new RudderstackBackend({
-        writeKey: (config as any).rudderstackWriteKey,
-        dataPlaneUrl: (config as any).rudderstackDataPlaneUrl,
+        writeKey: config.rudderstackWriteKey,
+        dataPlaneUrl: config.rudderstackDataPlaneUrl,
         user: config.bootData.user,
-        sdkUrl: (config as any).rudderstackSdkUrl,
-        configUrl: (config as any).rudderstackConfigUrl,
+        sdkUrl: config.rudderstackSdkUrl,
+        configUrl: config.rudderstackConfigUrl,
       })
     );
   }

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -152,7 +152,7 @@ export class GrafanaApp {
         }),
         document.getElementById('reactRoot')
       );
-    } catch (error: unknown) {
+    } catch (error) {
       console.error('Failed to start Grafana', error);
       window.__grafana_load_failed();
     }


### PR DESCRIPTION


**What this PR does / why we need it**:

Types the Google Analytics and Rudderstack config so we don't have to do the doubly whammy of `as any`.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/grafana/issues/51194

**Special notes for your reviewer**:

