### PR TITLE
Chore: Add new go test commands for unit, integration, and pro tests to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,11 +139,13 @@ test-go-integration: ## Run integration tests for backend with flags.
 .PHONY: test-go-integration-postgres
 test-go-integration-postgres: devenv-postgres ## Run integration tests for postgres backend with flags.
 	@echo "test backend integration postgres tests"
+	$(GO) clean -testcache
 	$(GO) list './pkg/...' | xargs -I {} sh -c 'GRAFANA_TEST_DB=postgres go test -run Integration -covermode=atomic -timeout=30m {}'
 
 .PHONY: test-go-integration-mysql
 test-go-integration-mysql: devenv-mysql ## Run integration tests for mysql backend with flags.
 	@echo "test backend integration mysql tests"
+	$(GO) clean -testcache
 	$(GO) list './pkg/...' | xargs -I {} sh -c 'GRAFANA_TEST_DB=mysql go test -run Integration -covermode=atomic -timeout=30m {}'
 
 test-js: ## Run tests for frontend.

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ test-go-integration-postgres: devenv-postgres ## Run integration tests for postg
 .PHONY: test-go-integration-mysql
 test-go-integration-mysql: devenv-mysql ## Run integration tests for mysql backend with flags.
 	@echo "test backend integration mysql tests"
-	GRAFANA_TEST_DB=mysql $(GO) list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'
+	$(GO) list './pkg/...' | xargs -I {} sh -c 'GRAFANA_TEST_DB=mysql go test -run Integration -covermode=atomic -timeout=30m {}'
 
 test-js: ## Run tests for frontend.
 	@echo "test frontend"

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ test-go-integration: ## Run integration tests for backend with flags.
 .PHONY: test-go-integration-postgres
 test-go-integration-postgres: devenv-postgres ## Run integration tests for postgres backend with flags.
 	@echo "test backend integration postgres tests"
-	GRAFANA_TEST_DB=postgres $(GO) list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'
+	$(GO) list './pkg/...' | xargs -I {} sh -c 'GRAFANA_TEST_DB=postgres go test -run Integration -covermode=atomic -timeout=30m {}'
 
 .PHONY: test-go-integration-mysql
 test-go-integration-mysql: devenv-mysql ## Run integration tests for mysql backend with flags.

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ devenv-postgres:
 
 devenv-mysql:
 	@cd devenv; \
-	sources=mysql
+	sources=mysql_tests
 
 ##@ Helpers
 

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ devenv-down: ## Stop optional services.
 
 devenv-postgres:
 	@cd devenv; \
-	sources=postgres
+	sources=postgres_tests
 
 devenv-mysql:
 	@cd devenv; \

--- a/Makefile
+++ b/Makefile
@@ -127,14 +127,28 @@ run-frontend: deps-js ## Fetch js dependencies and watch frontend for rebuild
 test-go: test-go-unit test-go-integration
 
 .PHONY: test-go-unit
-test-go-unit: ## Run unit tests for backend.
+test-go-unit: ## Run unit tests for backend with flags.
 	@echo "test backend unit tests"
 	$(GO) test -short -covermode=atomic -timeout=30m ./pkg/...
 
 .PHONY: test-go-integration
-test-go-integration: ## Run integration tests for backend.
+test-go-integration: ## Run integration tests for backend with flags.
 	@echo "test backend integration tests"
 	$(GO) test -run Integration -covermode=atomic -timeout=30m ./pkg/...
+
+.PHONY: test-go-integration-postgres
+test-go-integration-postgres: ## Run integration tests for postgres backend with flags.
+	@echo "test backend integration postgres tests"
+	make devenv sources=postgres_tests
+	GRAFANA_TEST_DB=postgres
+	$(GO) list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'
+
+.PHONY: test-go-integration-mysql
+test-go-integration-mysql: ## Run integration tests for mysql backend with flags.
+	@echo "test backend integration mysql tests"
+	make devenv sources=mysql_tests
+	GRAFANA_TEST_DB=mysql
+	$(GO) list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'
 
 test-js: ## Run tests for frontend.
 	@echo "test frontend"

--- a/Makefile
+++ b/Makefile
@@ -135,10 +135,6 @@ test-go-integration: ## Run integration tests for backend.
 	@echo "test backend integration tests"
 	$(GO) test -run Integration -covermode=atomic -timeout=30m ./pkg/...
 
-test-go-pro: ## Run enterprise2 pro tests for backend.
-	@echo "test backend enterprise2 pro tests"
-	$(GO) test -tags=pro -covermode=atomic -timeout=30m ./pkg/...
-
 test-js: ## Run tests for frontend.
 	@echo "test frontend"
 	yarn test

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,18 @@ test-go: ## Run tests for backend.
 	@echo "test backend"
 	$(GO) test -v ./pkg/...
 
+test-go-unit: ## Run unit tests for backend.
+	@echo "test backend unit tests"
+	$(GO) test -short -covermode=atomic -timeout=30m ./pkg/...
+
+test-go-integration: ## Run integration tests for backend.
+	@echo "test backend integration tests"
+	$(GO) test -run Integration -covermode=atomic -timeout=30m ./pkg/...
+
+test-go-pro: ## Run enterprise2 pro tests for backend.
+	@echo "test backend enterprise2 pro tests"
+	$(GO) test -tags=pro -covermode=atomic -timeout=30m ./pkg/...
+
 test-js: ## Run tests for frontend.
 	@echo "test frontend"
 	yarn test

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ WIRE_TAGS = "oss"
 -include local/Makefile
 include .bingo/Variables.mk
 
-.PHONY: all deps-go deps-js deps build-go build-server build-cli build-js build build-docker-full build-docker-full-ubuntu lint-go golangci-lint test-go test-js gen-ts test run run-frontend clean devenv devenv-down protobuf drone help gen-go gen-cue test-go-unit test-go-integration
+.PHONY: all deps-go deps-js deps build-go build-server build-cli build-js build build-docker-full build-docker-full-ubuntu lint-go golangci-lint test-go test-js gen-ts test run run-frontend clean devenv devenv-down protobuf drone help gen-go gen-cue
 
 GO = go
 GO_FILES ?= ./pkg/...
@@ -124,8 +124,7 @@ run-frontend: deps-js ## Fetch js dependencies and watch frontend for rebuild
 ##@ Testing
 
 .PHONY: test-go
-test-go: ## Run tests for backend.
-	test-go-unit test-go-integration
+test-go: test-go-unit test-go-integration
 
 .PHONY: test-go-unit
 test-go-unit: ## Run unit tests for backend.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ WIRE_TAGS = "oss"
 -include local/Makefile
 include .bingo/Variables.mk
 
-.PHONY: all deps-go deps-js deps build-go build-server build-cli build-js build build-docker-full build-docker-full-ubuntu lint-go golangci-lint test-go test-js gen-ts test run run-frontend clean devenv devenv-down protobuf drone help gen-go gen-cue
+.PHONY: all deps-go deps-js deps build-go build-server build-cli build-js build build-docker-full build-docker-full-ubuntu lint-go golangci-lint test-go test-js gen-ts test run run-frontend clean devenv devenv-down protobuf drone help gen-go gen-cue test-go-unit test-go-integration
 
 GO = go
 GO_FILES ?= ./pkg/...
@@ -123,14 +123,16 @@ run-frontend: deps-js ## Fetch js dependencies and watch frontend for rebuild
 
 ##@ Testing
 
+.PHONY: test-go
 test-go: ## Run tests for backend.
-	@echo "test backend"
-	$(GO) test -v ./pkg/...
+	test-go-unit test-go-integration
 
+.PHONY: test-go-unit
 test-go-unit: ## Run unit tests for backend.
 	@echo "test backend unit tests"
 	$(GO) test -short -covermode=atomic -timeout=30m ./pkg/...
 
+.PHONY: test-go-integration
 test-go-integration: ## Run integration tests for backend.
 	@echo "test backend integration tests"
 	$(GO) test -run Integration -covermode=atomic -timeout=30m ./pkg/...

--- a/Makefile
+++ b/Makefile
@@ -137,18 +137,14 @@ test-go-integration: ## Run integration tests for backend with flags.
 	$(GO) test -run Integration -covermode=atomic -timeout=30m ./pkg/...
 
 .PHONY: test-go-integration-postgres
-test-go-integration-postgres: ## Run integration tests for postgres backend with flags.
+test-go-integration-postgres: devenv-postgres ## Run integration tests for postgres backend with flags.
 	@echo "test backend integration postgres tests"
-	make devenv sources=postgres_tests
-	GRAFANA_TEST_DB=postgres
-	$(GO) list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'
+	GRAFANA_TEST_DB=postgres $(GO) list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'
 
 .PHONY: test-go-integration-mysql
-test-go-integration-mysql: ## Run integration tests for mysql backend with flags.
+test-go-integration-mysql: devenv-mysql ## Run integration tests for mysql backend with flags.
 	@echo "test backend integration mysql tests"
-	make devenv sources=mysql_tests
-	GRAFANA_TEST_DB=mysql
-	$(GO) list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'
+	GRAFANA_TEST_DB=mysql $(GO) list './pkg/...' | xargs -I {} sh -c 'go test -run Integration -covermode=atomic -timeout=30m {}'
 
 test-js: ## Run tests for frontend.
 	@echo "test frontend"
@@ -204,6 +200,14 @@ devenv-down: ## Stop optional services.
 	@cd devenv; \
 	test -f docker-compose.yaml && \
 	docker-compose down || exit 0;
+
+devenv-postgres:
+	@cd devenv; \
+	sources=postgres
+
+devenv-mysql:
+	@cd devenv; \
+	sources=mysql
 
 ##@ Helpers
 


### PR DESCRIPTION
Now, you can run unit and integration tests locally via the following makefile commands:
`make test-go-unit`: runs unit tests for backend
`make test-go-integration`: runs integration tests for backend
`make test-go-integration-postgres`: runs integration tests with postgres backend
`make test-go-integration-mysql`: runs integration tests with mysql backend
