### PR TITLE
Docs: Fix relrefs to refactored documentation

### DIFF
--- a/docs/sources/administration/api-keys/_index.md
+++ b/docs/sources/administration/api-keys/_index.md
@@ -14,23 +14,17 @@ weight: 700
 
 # API keys
 
-API keys can be used to interact with Grafana HTTP APIs.
-
-We recommend using service accounts instead of API keys if you are on Grafana 8.5+, for more information refer to [About service accounts]({{< relref "../service-accounts/about-service-accounts/#" >}}).
-
-{{< section >}}
-
-## About API keys
-
 An API key is a randomly generated string that external systems use to interact with Grafana HTTP APIs.
 
-When you create an API key, you specify a **Role** that determines the permissions associated with the API key. Role permissions control that actions the API key can perform on Grafana resources. For more information about creating API keys, refer to [Create an API key]({{< relref "create-api-key/#" >}}).
+When you create an API key, you specify a **Role** that determines the permissions associated with the API key. Role permissions control that actions the API key can perform on Grafana resources.
+
+> **Note:** If you use Grafana v8.5 or newer, use service accounts instead of API keys. For more information, refer to [Service accounts]({{< relref "../service-accounts/" >}}).
+
+{{< section >}}
 
 ## Create an API key
 
 Create an API key when you want to manage your computed workload with a user.
-
-For more information about API keys, refer to [About API keys in Grafana]({{< relref "about-api-keys/" >}}).
 
 This topic shows you how to create an API key using the Grafana UI. You can also create an API key using the Grafana HTTP API. For more information about creating API keys via the API, refer to [Create API key via API]({{< relref "../../developers/http_api/create-api-tokens-for-org/#how-to-create-a-new-organization-and-an-api-token" >}}).
 

--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -8,7 +8,7 @@ weight: 60
 
 # Data sources
 
-Grafana supports many different storage backends for your time series data (data source). Refer to [Add a data source]({{< relref "../../administration/datasources/add-a-data-source/" >}}) for instructions on how to add a data source to Grafana. Only users with the organization admin role can add data sources.
+Grafana supports many different storage backends for your time series data (data source). Refer to [Add a data source]({{< relref "../administration/data-source-management/#add-a-data-source/" >}}) for instructions on how to add a data source to Grafana. Only users with the organization admin role can add data sources.
 
 ## Querying
 
@@ -18,23 +18,23 @@ Each data source has a specific Query Editor that is customized for the features
 
 The following data sources are officially supported:
 
-- [Alertmanager]({{< relref "../../datasources/alertmanager/" >}})
-- [AWS CloudWatch]({{< relref "aws-cloudwatch/" >}})
-- [Azure Monitor]({{< relref "azuremonitor/" >}})
-- [Elasticsearch]({{< relref "../../datasources/elasticsearch/" >}})
-- [Google Cloud Monitoring]({{< relref "google-cloud-monitoring/" >}})
-- [Graphite]({{< relref "../../datasources/graphite/" >}})
-- [InfluxDB]({{< relref "influxdb/" >}})
-- [Loki]({{< relref "../../datasources/loki/" >}})
-- [Microsoft SQL Server (MSSQL)]({{< relref "../../datasources/mssql/" >}})
-- [MySQL]({{< relref "../../datasources/mysql/" >}})
-- [OpenTSDB]({{< relref "../../datasources/opentsdb/" >}})
-- [PostgreSQL]({{< relref "../../datasources/postgres/" >}})
-- [Prometheus]({{< relref "../../datasources/prometheus/" >}})
-- [Jaeger]({{< relref "../../datasources/jaeger/" >}})
-- [Zipkin]({{< relref "../../datasources/zipkin/" >}})
-- [Tempo]({{< relref "../../datasources/tempo/" >}})
-- [Testdata]({{< relref "../../datasources/testdata/" >}})
+- [Alertmanager]({{< relref "./alertmanager/" >}})
+- [AWS CloudWatch]({{< relref "./aws-cloudwatch/" >}})
+- [Azure Monitor]({{< relref "./azuremonitor/" >}})
+- [Elasticsearch]({{< relref "./elasticsearch/" >}})
+- [Google Cloud Monitoring]({{< relref "./google-cloud-monitoring/" >}})
+- [Graphite]({{< relref "./graphite/" >}})
+- [InfluxDB]({{< relref "./influxdb/" >}})
+- [Loki]({{< relref "./loki/" >}})
+- [Microsoft SQL Server (MSSQL)]({{< relref "./mssql/" >}})
+- [MySQL]({{< relref "./mysql/" >}})
+- [OpenTSDB]({{< relref "./opentsdb/" >}})
+- [PostgreSQL]({{< relref "./postgres/" >}})
+- [Prometheus]({{< relref "./prometheus/" >}})
+- [Jaeger]({{< relref "./jaeger/" >}})
+- [Zipkin]({{< relref "./zipkin/" >}})
+- [Tempo]({{< relref "./tempo/" >}})
+- [Testdata]({{< relref "./testdata/" >}})
 
 In addition to the data sources that you have configured in your Grafana, there are three special data sources available:
 

--- a/docs/sources/developers/http_api/access_control.md
+++ b/docs/sources/developers/http_api/access_control.md
@@ -21,7 +21,7 @@ title: RBAC HTTP API
 
 The API can be used to create, update, delete, get, and list roles.
 
-To check which basic or fixed roles have the required permissions, refer to [RBAC role definitions]({{< ref "../../enterprise/access-control/rbac-fixed-basic-role-definitions.md" >}}).
+To check which basic or fixed roles have the required permissions, refer to [RBAC role definitions]({{< ref "../../administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/" >}}).
 
 ## Get status
 
@@ -222,7 +222,7 @@ Content-Type: application/json; charset=UTF-8
 
 `POST /api/access-control/roles`
 
-Creates a new custom role and maps given permissions to that role. Note that roles with the same prefix as [Fixed roles]({{< relref "../../enterprise/access-control/about-rbac/#fixed-roles" >}}) can't be created.
+Creates a new custom role and maps given permissions to that role. Note that roles with the same prefix as [Fixed roles]({{< relref "../../administration/roles-and-permissions/access-control/#fixed-roles" >}}) can't be created.
 
 #### Required permissions
 
@@ -262,9 +262,9 @@ Content-Type: application/json
 
 | Field Name  | Date Type  | Required | Description                                                                                                                                                                                                                            |
 | ----------- | ---------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| uid         | string     | No       | UID of the role. If not present, the UID will be automatically created for you and returned in response. Refer to the [Custom roles]({{< relref "../../enterprise/access-control/about-rbac/#custom-roles" >}}) for more information.  |
+| uid         | string     | No       | UID of the role. If not present, the UID will be automatically created for you and returned in response. Refer to the [Custom roles]({{< relref "../../administration/roles-and-permissions/access-control/#custom-roles" >}}) for more information.  |
 | global      | boolean    | No       | A flag indicating if the role is global or not. If set to `false`, the default org ID of the authenticated user will be used from the request.                                                                                         |
-| version     | number     | No       | Version of the role. If not present, version 0 will be assigned to the role and returned in the response. Refer to the [Custom roles]({{< relref "../../enterprise/access-control/about-rbac/#custom-roles" >}}) for more information. |
+| version     | number     | No       | Version of the role. If not present, version 0 will be assigned to the role and returned in the response. Refer to the [Custom roles]({{< relref "../../administration/roles-and-permissions/access-control/#custom-roles" >}}) for more information. |
 | name        | string     | Yes      | Name of the role. Refer to [Custom roles]({{< relref "../../enterprise/access-control/about-rbac/#custom-roles" >}}) for more information.                                                                                             |
 | description | string     | No       | Description of the role.                                                                                                                                                                                                               |
 | displayName | string     | No       | Display name of the role, visible in the UI.                                                                                                                                                                                           |
@@ -276,8 +276,8 @@ Content-Type: application/json
 
 | Field Name | Data Type | Required | Description                                                                                                                                                                                                            |
 | ---------- | --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| action     | string    | Yes      | Refer to [Custom role actions and scopes]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for full list of available actions.                                                            |
-| scope      | string    | No       | If not present, no scope will be mapped to the permission. Refer to [[Custom role actions and scopes]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for full list of available scopes. |
+| action     | string    | Yes      | Refer to [Custom role actions and scopes]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for full list of available actions.                                                            |
+| scope      | string    | No       | If not present, no scope will be mapped to the permission. Refer to [Custom role actions and scopes]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for full list of available scopes. |
 
 #### Example response
 
@@ -377,8 +377,8 @@ Content-Type: application/json
 
 | Field Name | Data Type | Required | Description                                                                                                                                                                                                           |
 | ---------- | --------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| action     | string    | Yes      | Refer to [Custom role actions and scopes]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for full list of available actions.                                                           |
-| scope      | string    | No       | If not present, no scope will be mapped to the permission. Refer to [Custom role actions and scopes]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for full list of available scopes. |
+| action     | string    | Yes      | Refer to [Custom role actions and scopes]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for full list of available actions.                                                           |
+| scope      | string    | No       | If not present, no scope will be mapped to the permission. Refer to [Custom role actions and scopes]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for full list of available scopes. |
 
 #### Example response
 
@@ -451,7 +451,7 @@ Accept: application/json
 | Param  | Type    | Required | Description                                                                                                                                                                                                                                                |
 | ------ | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | force  | boolean | No       | When set to `true`, the role will be deleted with all it's assignments.                                                                                                                                                                                    |
-| global | boolean | No       | A flag indicating if the role is global or not. If set to false, the default org ID of the authenticated user will be used from the request. Refer to the [About RBAC]({{< relref "../../enterprise/access-control/about-rbac/" >}}) for more information. |
+| global | boolean | No       | A flag indicating if the role is global or not. If set to false, the default org ID of the authenticated user will be used from the request. Refer to the [About RBAC]({{< relref "../../administration/roles-and-permissions/access-control/" >}}) for more information. |
 
 #### Example response
 

--- a/docs/sources/developers/http_api/admin.md
+++ b/docs/sources/developers/http_api/admin.md
@@ -18,13 +18,13 @@ The Admin HTTP API does not currently work with an API Token. API Tokens are cur
 the permission of server admin, only users can be given that permission. So in order to use these API calls you will have to use Basic Auth and the Grafana user
 must have the Grafana Admin permission. (The default admin user is called `admin` and has permission to use this API.)
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 ## Fetch settings
 
 `GET /api/admin/settings`
 
-Only works with Basic Authentication (username and password). See [introduction](http://docs.grafana.org/http_api/admin/#admin-api) for an explanation.
+Only works with Basic Authentication (username and password). See [introduction]({{< ref "#admin-api" >}}) for an explanation.
 
 **Required permissions**
 

--- a/docs/sources/developers/http_api/annotations.md
+++ b/docs/sources/developers/http_api/annotations.md
@@ -11,14 +11,14 @@ keywords:
   - annotation
   - annotations
   - comment
-title: 'Annotations HTTP API '
+title: 'Annotations HTTP API'
 ---
 
 # Annotations API
 
 This is the API documentation for the new Grafana Annotations feature released in Grafana 4.6. Annotations are saved in the Grafana database (sqlite, mysql or postgres). Annotations can be organization annotations that can be shown on any dashboard by configuring an annotation data source - they are filtered by tags. Or they can be tied to a panel on a dashboard and are then only shown on that panel.
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 ## Find Annotations
 

--- a/docs/sources/developers/http_api/auth.md
+++ b/docs/sources/developers/http_api/auth.md
@@ -15,7 +15,7 @@ title: 'Authentication HTTP API '
 
 # Authentication API
 
-> If you are running Grafana Enterprise, for some endpoints you would need to have relevant permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you would need to have relevant permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 ## Tokens
 

--- a/docs/sources/developers/http_api/dashboard.md
+++ b/docs/sources/developers/http_api/dashboard.md
@@ -9,12 +9,12 @@ keywords:
   - documentation
   - api
   - dashboard
-title: 'Dashboard HTTP API '
+title: 'Dashboard HTTP API'
 ---
 
 # Dashboard API
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 ## Identifier (id) vs unique identifier (uid)
 

--- a/docs/sources/developers/http_api/dashboard_permissions.md
+++ b/docs/sources/developers/http_api/dashboard_permissions.md
@@ -13,7 +13,7 @@ keywords:
   - permission
   - permissions
   - acl
-title: 'Dashboard Permissions HTTP API '
+title: 'Dashboard Permissions HTTP API'
 ---
 
 # Dashboard Permissions API
@@ -28,7 +28,7 @@ The permission levels for the permission field:
 - 2 = Edit
 - 4 = Admin
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 ## Get permissions for a dashboard
 

--- a/docs/sources/developers/http_api/data_source.md
+++ b/docs/sources/developers/http_api/data_source.md
@@ -10,12 +10,12 @@ keywords:
   - documentation
   - api
   - data source
-title: 'Data source HTTP API '
+title: 'Data source HTTP API'
 ---
 
 # Data source API
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 ## Get all data sources
 

--- a/docs/sources/developers/http_api/datasource_permissions.md
+++ b/docs/sources/developers/http_api/datasource_permissions.md
@@ -14,14 +14,14 @@ keywords:
   - permissions
   - acl
   - enterprise
-title: 'Datasource Permissions HTTP API '
+title: 'Datasource Permissions HTTP API'
 ---
 
 # Data Source Permissions API
 
 > The Data Source Permissions is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 This API can be used to enable, disable, list, add and remove permissions for a data source.
 

--- a/docs/sources/developers/http_api/external_group_sync.md
+++ b/docs/sources/developers/http_api/external_group_sync.md
@@ -13,14 +13,14 @@ keywords:
   - group
   - member
   - enterprise
-title: 'External Group Sync HTTP API '
+title: 'External Group Sync HTTP API'
 ---
 
 # External Group Synchronization API
 
 > External Group Synchronization is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 ## Get External Groups
 

--- a/docs/sources/developers/http_api/folder.md
+++ b/docs/sources/developers/http_api/folder.md
@@ -9,12 +9,12 @@ keywords:
   - documentation
   - api
   - folder
-title: 'Folder HTTP API '
+title: 'Folder HTTP API'
 ---
 
 # Folder API
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 ## Identifier (id) vs unique identifier (uid)
 

--- a/docs/sources/developers/http_api/folder_dashboard_search.md
+++ b/docs/sources/developers/http_api/folder_dashboard_search.md
@@ -11,7 +11,7 @@ keywords:
   - search
   - folder
   - dashboard
-title: 'Folder/Dashboard Search HTTP API '
+title: 'Folder/Dashboard Search HTTP API'
 ---
 
 # Folder/Dashboard Search API
@@ -20,7 +20,7 @@ title: 'Folder/Dashboard Search HTTP API '
 
 `GET /api/search/`
 
-> Note: When using [Role-based access control]({{< relref "../../enterprise/access-control/" >}}), search results will contain only dashboards and folders which you have access to.
+> Note: When using [Role-based access control]({{< relref "../../administration/roles-and-permissions/access-control/" >}}), search results will contain only dashboards and folders which you have access to.
 
 Query parameters:
 

--- a/docs/sources/developers/http_api/folder_permissions.md
+++ b/docs/sources/developers/http_api/folder_permissions.md
@@ -13,7 +13,7 @@ keywords:
   - permission
   - permissions
   - acl
-title: 'Folder Permissions HTTP API '
+title: 'Folder Permissions HTTP API'
 ---
 
 # Folder Permissions API
@@ -28,7 +28,7 @@ The permission levels for the permission field:
 - 2 = Edit
 - 4 = Admin
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 ## Get permissions for a folder
 

--- a/docs/sources/developers/http_api/licensing.md
+++ b/docs/sources/developers/http_api/licensing.md
@@ -10,14 +10,14 @@ keywords:
   - api
   - licensing
   - enterprise
-title: 'Licensing HTTP API '
+title: 'Licensing HTTP API'
 ---
 
 # Enterprise License API
 
 Licensing is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 ## Check license availability
 

--- a/docs/sources/developers/http_api/org.md
+++ b/docs/sources/developers/http_api/org.md
@@ -10,7 +10,7 @@ keywords:
   - documentation
   - api
   - organization
-title: 'Organization HTTP API '
+title: 'Organization HTTP API'
 ---
 
 # Organization API
@@ -19,7 +19,7 @@ The Organization HTTP API is divided in two resources, `/api/org` (current organ
 and `/api/orgs` (admin organizations). One big difference between these are that
 the admin of all organizations API only works with basic authentication, see [Admin Organizations API](#admin-organizations-api) for more information.
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 ## Current Organization API
 

--- a/docs/sources/developers/http_api/reporting.md
+++ b/docs/sources/developers/http_api/reporting.md
@@ -17,7 +17,7 @@ This API allows you to interact programmatically with the [Reporting]({{< relref
 
 > Reporting is only available in Grafana Enterprise. Read more about [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 ## Send a report
 

--- a/docs/sources/developers/http_api/serviceaccount.md
+++ b/docs/sources/developers/http_api/serviceaccount.md
@@ -9,12 +9,12 @@ keywords:
   - documentation
   - api
   - serviceaccount
-title: 'Service account HTTP API '
+title: 'Service account HTTP API'
 ---
 
 # Service account API
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 ## Search service accounts with Paging
 

--- a/docs/sources/developers/http_api/team.md
+++ b/docs/sources/developers/http_api/team.md
@@ -11,7 +11,7 @@ keywords:
   - team
   - teams
   - group
-title: 'Team HTTP API '
+title: 'Team HTTP API'
 ---
 
 # Team API
@@ -25,7 +25,7 @@ Access to these API endpoints is restricted as follows:
 - If you enable `editors_can_admin` configuration flag, then Organization Editors can create teams and manage teams where they are Admin.
   - If you enable `editors_can_admin` configuration flag, Editors can find out whether a team that they are not members of exists by trying to create a team with the same name.
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 ## Team Search With Paging
 

--- a/docs/sources/developers/http_api/user.md
+++ b/docs/sources/developers/http_api/user.md
@@ -9,12 +9,12 @@ keywords:
   - documentation
   - api
   - user
-title: 'User HTTP API '
+title: 'User HTTP API'
 ---
 
 # User API
 
-> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../enterprise/access-control/custom-role-actions-scopes/" >}}) for more information.
+> If you are running Grafana Enterprise, for some endpoints you'll need to have specific permissions. Refer to [Role-based access control permissions]({{< relref "../../administration/roles-and-permissions/access-control/custom-role-actions-scopes/" >}}) for more information.
 
 ## Search Users
 

--- a/docs/sources/developers/plugins/_index.md
+++ b/docs/sources/developers/plugins/_index.md
@@ -3,6 +3,7 @@ aliases:
   - /docs/grafana/latest/developers/plugins/
   - /docs/grafana/latest/plugins/developing/
 title: Build a plugin
+description: Resources for creating Grafana plugins
 weight: 200
 ---
 

--- a/docs/sources/developers/plugins/add-support-for-annotations.md
+++ b/docs/sources/developers/plugins/add-support-for-annotations.md
@@ -10,7 +10,7 @@ This guide explains how to add support for [annotations]({{< relref "../../dashb
 
 This guide assumes that you're already familiar with how to [Build a data source plugin]({{< ref "/tutorials/build-a-data-source-plugin/" >}}).
 
-> **Note:** Annotation support for React plugins was released in Grafana 7.2. To support earlier versions, refer to the [Add support for annotation for Grafana 7.1](https://grafana.com/docs/grafana/v7.1/developers/plugins/add-support-for-annotations/).
+> **Note:** Annotation support for React plugins was released in Grafana 7.2. To support earlier versions, refer to [Add support for annotation for Grafana 7.1](https://grafana.com/docs/grafana/v7.1/developers/plugins/add-support-for-annotations/).
 
 ## Add annotations support to your data source
 

--- a/docs/sources/enterprise/_index.md
+++ b/docs/sources/enterprise/_index.md
@@ -26,7 +26,7 @@ To learn more about Grafana Enterprise, refer to [our product page](https://graf
 
 ## Enterprise features in Grafana Cloud
 
-Many Grafana Enterprise features are also available in [Grafana Cloud]({{< ref "/grafana-cloud" >}}) Pro and Advanced accounts. For details, refer to [the Grafana Cloud features table](https://grafana.com/pricing/#featuresTable) and [Enterprise features available to Grafana Cloud Pro and Advanced accounts]({{< ref "/grafana-cloud/reference/enterprise-features" >}}).
+Many Grafana Enterprise features are also available in [Grafana Cloud]({{< ref "/docs/grafana-cloud" >}}) Pro and Advanced accounts. For details, refer to [the Grafana Cloud features table](https://grafana.com/pricing/#featuresTable) and [Enterprise features available to Grafana Cloud Pro and Advanced accounts]({{< ref "/docs/grafana-cloud/reference/enterprise-features" >}}).
 
 ## Authentication
 

--- a/docs/sources/introduction/_index.md
+++ b/docs/sources/introduction/_index.md
@@ -11,19 +11,19 @@ weight: 5
 
 [Grafana open source software](https://grafana.com/oss/) enables you to query, visualize, alert on, and explore your metrics, logs, and traces wherever they are stored. Grafana OSS provides you with tools to turn your time-series database (TSDB) data into insightful graphs and visualizations.
 
-After you have [installed Grafana]({{< relref "../setup-grafana/installation/" >}}) and set up your first dashboard using instructions in [Getting started with Grafana]({{< relref "../getting-started/build-first-dashboard.md" >}}), you will have many options to choose from depending on your requirements. For example, if you want to view weather data and statistics about your smart home, then you can create a [playlist]({{< relref "../dashboards/playlist.md" >}}). If you are the administrator for an enterprise and are managing Grafana for multiple teams, then you can set up [provisioning]({{< relref "../administration/server-administration/provisioning.md" >}}) and [authentication]({{< relref "../setup-grafana/configure-security/configure-authentication/" >}}).
+After you have [installed Grafana]({{< relref "../setup-grafana/installation/" >}}) and set up your first dashboard using instructions in [Getting started with Grafana]({{< relref "../getting-started/build-first-dashboard.md" >}}), you will have many options to choose from depending on your requirements. For example, if you want to view weather data and statistics about your smart home, then you can create a [playlist]({{< relref "../dashboards/playlist.md" >}}). If you are the administrator for an enterprise and are managing Grafana for multiple teams, then you can set up [provisioning]({{< relref "../administration/provisioning/" >}}) and [authentication]({{< relref "../setup-grafana/configure-security/configure-authentication/" >}}).
 
 The following sections provide an overview of Grafana features and links to product documentation to help you learn more. For more guidance and ideas, check out our [Grafana Community forums](https://community.grafana.com/).
 
 ## Explore metrics, logs, and traces
 
-Explore your data through ad-hoc queries and dynamic drilldown. Split view and compare different time ranges, queries and data sources side by side. Refer to [Explore]({{< relref "../explore/_index.md" >}}) for more information.
+Explore your data through ad-hoc queries and dynamic drilldown. Split view and compare different time ranges, queries and data sources side by side. Refer to [Explore]({{< relref "../explore/" >}}) for more information.
 
 ## Alerts
 
 If you're using Grafana Alerting, then you can have alerts sent through a number of different [alert notifiers]({{< relref "../alerting/contact-points/_index.md#list-of-notifiers-supported-by-grafana" >}}), including PagerDuty, SMS, email, VictorOps, OpsGenie, or Slack.
 
-Alert hooks allow you to create different notifiers with a bit of code if you prefer some other channels of communication. Visually define [alert rules]({{< relref "../alerting/alerting-rules/_index.md" >}}) for your most important metrics.
+Alert hooks allow you to create different notifiers with a bit of code if you prefer some other channels of communication. Visually define [alert rules]({{< relref "../alerting/alerting-rules/" >}}) for your most important metrics.
 
 ## Annotations
 
@@ -33,7 +33,7 @@ This feature, which shows up as a graph marker in Grafana, is useful for correla
 
 ## Dashboard variables
 
-[Template variables]({{< relref "../variables/_index.md" >}}) allow you to create dashboards that can be reused for lots of different use cases. Values aren't hard-coded with these templates, so for instance, if you have a production server and a test server, you can use the same dashboard for both.
+[Template variables]({{< relref "../variables/" >}}) allow you to create dashboards that can be reused for lots of different use cases. Values aren't hard-coded with these templates, so for instance, if you have a production server and a test server, you can use the same dashboard for both.
 
 Templating allows you to drill down into your data, say, from all data to North America data, down to Texas data, and beyond. You can also share these dashboards across teams within your organization—or if you create a great dashboard template for a popular data source, you can contribute it to the whole community to customize and use.
 
@@ -57,11 +57,11 @@ In Grafana Enterprise, you can also map users to teams: If your company has its 
 
 While it's easy to click, drag, and drop to create a single dashboard, power users in need of many dashboards will want to automate the setup with a script. You can script anything in Grafana.
 
-For example, if you're spinning up a new Kubernetes cluster, you can also spin up a Grafana automatically with a script that would have the right server, IP address, and data sources preset and locked in so users cannot change them. It's also a way of getting control over a lot of dashboards. Refer to [Provisioning]({{< relref "../administration/server-administration/provisioning.md" >}}) for more information.
+For example, if you're spinning up a new Kubernetes cluster, you can also spin up a Grafana automatically with a script that would have the right server, IP address, and data sources preset and locked in so users cannot change them. It's also a way of getting control over a lot of dashboards. Refer to [Provisioning]({{< relref "../administration/provisioning/" >}}) for more information.
 
 ## Permissions
 
-When organizations have one Grafana and multiple teams, they often want the ability to both keep things separate and share dashboards. You can create a team of users and then set permissions on [folders and dashboards]({{< relref "../administration/user-management/manage-dashboard-permissions/_index.md" >}}), and down to the [data source level]({{< relref "../administration/data-source-management/datasource-permissions.md" >}}) if you're using [Grafana Enterprise]({{< relref "../enterprise/_index.md" >}}).
+When organizations have one Grafana and multiple teams, they often want the ability to both keep things separate and share dashboards. You can create a team of users and then set permissions on [folders and dashboards]({{< relref "../administration/user-management/manage-dashboard-permissions/" >}}), and down to the [data source level]({{< relref "../administration/data-source-management#data-source-permissions" >}}) if you're using [Grafana Enterprise]({{< relref "../enterprise/" >}}).
 
 ## Other Grafana Labs OSS Projects
 

--- a/docs/sources/introduction/grafana-enterprise.md
+++ b/docs/sources/introduction/grafana-enterprise.md
@@ -49,8 +49,8 @@ With [enhanced LDAP integration]({{< relref "../setup-grafana/configure-security
 
 Grafana Enterprise adds the following features:
 
-- [Role-based access control]({{< relref "../enterprise/access-control/" >}}) to control access with role-based permissions.
-- [Data source permissions]({{< relref "../administration/data-source-management/datasource-permissions.md" >}}) to restrict query access to specific teams and users.
+- [Role-based access control]({{< relref "../administration/roles-and-permissions/access-control/" >}}) to control access with role-based permissions.
+- [Data source permissions]({{< relref "../administration/data-source-management#data-source-permissions" >}}) to restrict query access to specific teams and users.
 - [Data source query caching]({{< relref "../enterprise/query-caching.md" >}}) to temporarily store query results in Grafana to reduce data source load and rate limiting.
 - [Reporting]({{< relref "../enterprise/reporting.md" >}}) to generate a PDF report from any dashboard and set up a schedule to have it emailed to whoever you choose.
 - [Export dashboard as PDF]({{< relref "../enterprise/export-pdf.md" >}})

--- a/docs/sources/whatsnew/whats-new-in-v7-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-4.md
@@ -193,13 +193,13 @@ These features are included in the Grafana Enterprise edition.
 
 ### Licensing changes
 
-When determining a user’s role for billing purposes, a user who has the ability to edit and save dashboards is considered an Editor. This includes any user who is an Editor or Admin at the Org level, and who has granted Admin or Edit permissions via [Dashboard permissions]({{< relref "../administration/manage-users-and-permissions/about-users-and-permissions/#dashboard-permissions" >}}).
+When determining a user’s role for billing purposes, a user who has the ability to edit and save dashboards is considered an Editor. This includes any user who is an Editor or Admin at the Org level, and who has granted Admin or Edit permissions via [Dashboard permissions]({{< relref "../administration/user-management/manage-dashboard-permissions/" >}}).
 
 After the number of Viewers or Editors has reached its license limit, only Admins will see a banner in Grafana indicating that the license limit has been reached. Previously, all users saw the banner.
 
 Grafana Enterprise license tokens update automatically on a daily basis, which means you no longer need to manually update your license, and the process for adding additional users to a license is smoother than it was before.
 
-Refer to [Licensing restrictions]({{< relref "../enterprise/license/license-restrictions/" >}}) for more information.
+Refer to [Licensing restrictions]({{< relref "../administration/enterprise-licensing#license-restrictions" >}}) for more information.
 
 ### Export usage insights to Loki
 

--- a/docs/sources/whatsnew/whats-new-in-v7-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-5.md
@@ -153,7 +153,7 @@ Each Grafana Enterprise user will be limited to three concurrent user sessions. 
 
 A new session is created when you sign in to Grafana from a different device or a different browser. Multiple windows and tabs in the same browser are all part of the same session, so having many Grafana tabs open will not cause any issues.
 
-For more information on Grafana Enterprise licensing and restrictions, refer to [License restrictions]({{< relref "../enterprise/license/license-restrictions/" >}}).
+For more information on Grafana Enterprise licensing and restrictions, refer to [License restrictions]({{< relref "../administration/enterprise-licensing#license-restrictions" >}}).
 
 ## Breaking changes
 

--- a/docs/sources/whatsnew/whats-new-in-v8-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-0.md
@@ -156,7 +156,7 @@ Log navigation in Explore has been significantly improved. We added pagination t
 
 You can now use the Plugin catalog app to easily manage your plugins from within Grafana. Install, update, and uninstall plugins without requiring a server restart.
 
-[Plugin catalog]({{< relref "../plugins/catalog/" >}}) was added as a result of this feature.
+[Plugin catalog]({{< relref "../administration/plugin-management#plugin-catalog/" >}}) was added as a result of this feature.
 
 ### Performance improvements
 
@@ -294,7 +294,7 @@ These features are included in the Grafana Enterprise edition.
 
 You can now add or remove detailed permissions from Viewer, Editor, and Admin org roles, to grant users just the right amount of access within Grafana. Available permissions include the ability to view and manage Users, Reports, and the Access Control API itself. Grafana will support more and more permissions over the coming months.
 
-[Role-based access control docs]({{< relref "../enterprise/access-control/" >}}) were added as a result of this feature.
+[Role-based access control docs]({{< relref "../administration/roles-and-permissions/access-control/" >}}) were added as a result of this feature.
 
 ### Data source query caching
 
@@ -318,7 +318,7 @@ For more information, refer to [Reporting docs]({{< relref "../enterprise/report
 
 The Grafana Enterprise documentation has been updated to describe more specifically how licensed roles are counted, how they can be updated, and where you can see details about dashboard and folder permissions that affect users' licensed roles.
 
-For more information, refer to [License restrictions docs]({{< relref "../enterprise/license/license-restrictions/" >}}).
+For more information, refer to [License restrictions docs]({{< relref "../administration/enterprise-licensing#license-restrictions" >}}).
 
 ## Breaking changes
 

--- a/docs/sources/whatsnew/whats-new-in-v8-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-1.md
@@ -146,7 +146,7 @@ These features are included in the Grafana Enterprise edition.
 
 Role-based access control remains in beta. You can now grant or revoke permissions for Viewers, Editors, or Admins to use Explore mode, configure LDAP or SAML settings, or view the admin/stats page. These new permissions enhance the existing permissions that can be customized, namely permissions to access Users, Orgs, LDAP settings, and Reports in Grafana.
 
-Fine grained access control allows you to customize roles and permissions in Grafana beyond the built-in Viewer, Editor, and Admin roles. As of 8.1, you can modify some of the permissions for any of these built-in roles. This is helpful if you’d like users to have more or fewer access permissions than a given role allows for by default. For an overview of role-based access control and a complete list of available permissions, refer to the [Fine grained access control]({{< relref "../enterprise/access-control/" >}}) documentation.
+Fine grained access control allows you to customize roles and permissions in Grafana beyond the built-in Viewer, Editor, and Admin roles. As of 8.1, you can modify some of the permissions for any of these built-in roles. This is helpful if you’d like users to have more or fewer access permissions than a given role allows for by default. For an overview of role-based access control and a complete list of available permissions, refer to the [Fine grained access control]({{< relref "../administration/roles-and-permissions/access-control/" >}}) documentation.
 
 ### New and improved reporting scheduler
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix several `relref`s (links) to recently refactored setup and administration docs.

**Which issue(s) this PR fixes**:

None; this is continuing work.

**Special notes for your reviewer**:

Links were manually tested in a local docs build.