### PR TITLE
Alerting: Use google/uuid instead of gofrs/uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/go-stack/stack v1.8.0
 	github.com/gobwas/glob v0.2.3
-	github.com/gofrs/uuid v4.0.0+incompatible
+	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
 	github.com/golang/snappy v0.0.4

--- a/pkg/services/ngalert/store/image.go
+++ b/pkg/services/ngalert/store/image.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
@@ -59,7 +59,7 @@ func (st DBstore) SaveImage(ctx context.Context, img *models.Image) error {
 		// rows? See issue https://github.com/grafana/grafana/issues/49366
 		img.ExpiresAt = TimeNow().Add(1 * time.Minute).UTC()
 		if img.ID == 0 { // xorm will fill this field on Insert.
-			token, err := uuid.NewV4()
+			token, err := uuid.NewRandom()
 			if err != nil {
 				return fmt.Errorf("failed to create token: %w", err)
 			}

--- a/pkg/services/ngalert/store/image_test.go
+++ b/pkg/services/ngalert/store/image_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -29,7 +29,7 @@ func addID(img *models.Image, id int64) *models.Image {
 }
 
 func addToken(img *models.Image) *models.Image {
-	token, err := uuid.NewV4()
+	token, err := uuid.NewRandom()
 	if err != nil {
 		panic("wat")
 	}

--- a/pkg/services/sqlstore/migrations/ualert/silences.go
+++ b/pkg/services/sqlstore/migrations/ualert/silences.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/matttproud/golang_protobuf_extensions/pbutil"
 	pb "github.com/prometheus/alertmanager/silence/silencepb"
 	"github.com/prometheus/common/model"
@@ -31,7 +31,7 @@ func (m *migration) addSilence(da dashAlert, rule *alertRule) error {
 		return nil
 	}
 
-	uid, err := uuid.NewV4()
+	uid, err := uuid.NewRandom()
 	if err != nil {
 		return errors.New("failed to create uuid for silence")
 	}
@@ -68,7 +68,7 @@ func (m *migration) addErrorSilence(da dashAlert, rule *alertRule) error {
 		return nil
 	}
 
-	uid, err := uuid.NewV4()
+	uid, err := uuid.NewRandom()
 	if err != nil {
 		return errors.New("failed to create uuid for silence")
 	}
@@ -107,7 +107,7 @@ func (m *migration) addNoDataSilence(da dashAlert, rule *alertRule) error {
 		return nil
 	}
 
-	uid, err := uuid.NewV4()
+	uid, err := uuid.NewRandom()
 	if err != nil {
 		return errors.New("failed to create uuid for silence")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

We don't _need_ it. I noticed that we're using `github.com/gofrs/uuid` only in alerting and I wonder if we have a reason (if so, should we change the other UUID constructions to the Gofrs lib) or if it'd be possible for us to converge on the `github.com/google/uuid` library used elsewhere to reduce the dependency sprawl a tiny bit?

Figured opening a PR is as good a way to ask that question as any 😇
