### PR TITLE
Add automation when issue labeled area/alerting

### DIFF
--- a/.github/teams.yml
+++ b/.github/teams.yml
@@ -1,0 +1,10 @@
+# The first keys are labels used on issues. All fields are optional.
+# Example
+test:
+  # channel-label is used to send a message to a specific channel
+  # when the label "test" is added to an issue.
+  channel-label: CXXXXXXXXXX
+
+# Alerting team
+area/alerting:
+  channel-label: C02B9MXQE0J

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -1,0 +1,56 @@
+name: Notify Slack channel based on issue label
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: "Determine which team to notify"
+        run: |
+          # Default to null values.
+          CHANNEL="null"
+
+          echo "${{ github.event.label.name }} label added"
+          export CURRENT_LABEL="${{ github.event.label.name }}" # Enable the use of the label in yq evaluations
+          # yq is installed by default in ubuntu-latest
+          if [[ $(yq e 'keys | .[] | select(. == env(CURRENT_LABEL))' .github/teams.yml ) ]]; then
+            # Check if we have a channel set to notify on comments.
+            if [[ $(yq '.[env(CURRENT_LABEL)] | has("channel-label")' .github/teams.yml ) == true ]]; then
+              CHANNEL=$(yq '.[env(CURRENT_LABEL)].channel-label' .github/teams.yml)
+            fi
+          fi
+
+          # set environment for next step
+          echo "CHANNEL=${CHANNEL}" >> $GITHUB_ENV
+
+          # Debug logging
+          echo "Ready to send issue to channel ID ${CHANNEL}"
+
+      - name: "Prepare payload"
+        uses: frabert/replace-string-action@v2.0
+        id: preparePayload
+        with:
+          # replace double quotes with single quotes to avoid breaking the JSON payload sent to Slack
+          string: ${{ github.event.issue.title }}
+          pattern: '"'
+          replace-with: "'"
+          flags: 'g'
+
+      - name: "Send Slack notification"
+        uses: slackapi/slack-github-action@v1.14.0
+        with:
+          payload: >
+            {
+              "icon_emoji": ":grafana:",
+              "username": "Grafana issue labeled",
+              "text": "Issue \"${{ steps.preparePayload.outputs.replaced }}\" labeled \"${{ github.event.label.name }}\": ${{ github.event.issue.html_url }}",
+              "channel": "${{ env.CHANNEL }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This now results in a message being sent to a Slack channel used by the Alerting team at Grafana Labs.
