### PR TITLE
RBAC: Only select roles that is delegatable when selecting a group

### DIFF
--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -118,14 +118,15 @@ export const RolePickerMenu = ({
     const group = optionGroups.find((g) => {
       return g.value === value;
     });
-    if (groupSelected(value)) {
+    if (groupSelected(value) || groupPartiallySelected(value)) {
       if (group) {
         setSelectedOptions(selectedOptions.filter((role) => !group.options.find((option) => role.uid === option.uid)));
       }
     } else {
       if (group) {
+        const groupOptions = group.options.filter((role) => role.delegatable);
         const restOptions = selectedOptions.filter((role) => !group.options.find((option) => role.uid === option.uid));
-        setSelectedOptions([...restOptions, ...group.options]);
+        setSelectedOptions([...restOptions, ...groupOptions]);
       }
     }
   };


### PR DESCRIPTION
**What this PR does / why we need it**:
Using the group selector will mark roles that the user cannot delegate.
![before-select-group](https://user-images.githubusercontent.com/23356117/175039185-956f4c2f-dbc1-4477-9b70-5f5aa0d59b26.gif)
 
This will result in a permission denied request when trying to update roles.
This pr will only select roles that the user can delegate when using the group selector
![partially-select-group](https://user-images.githubusercontent.com/23356117/175039375-e1938551-18a8-4b18-8e6b-3ba14b511bcd.gif)


**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana-enterprise/issues/3328

**Special notes for your reviewer**:

