### PR TITLE
Canvas: Address center constraint on drag glitch

### DIFF
--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -381,13 +381,12 @@ export class ElementState implements LayerElement {
     const hasHorizontalCenterConstraint = this.options.constraint?.horizontal === HorizontalConstraint.Center;
     const hasVerticalCenterConstraint = this.options.constraint?.vertical === VerticalConstraint.Center;
     if (hasHorizontalCenterConstraint || hasVerticalCenterConstraint) {
-      const elementContainer = this.div?.getBoundingClientRect();
-      const height = elementContainer?.height ?? 100;
-      const yOffset = hasVerticalCenterConstraint ? height / 4 : 0;
-
       const numberOfTargets = this.getScene()?.selecto?.getSelectedTargets().length ?? 0;
       const isMultiSelection = numberOfTargets > 1;
       if (!isMultiSelection) {
+        const elementContainer = this.div?.getBoundingClientRect();
+        const height = elementContainer?.height ?? 100;
+        const yOffset = hasVerticalCenterConstraint ? height / 4 : 0;
         event.target.style.transform = `translate(${event.translate[0]}px, ${event.translate[1] - yOffset}px)`;
         return;
       }

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -378,6 +378,21 @@ export class ElementState implements LayerElement {
   };
 
   applyDrag = (event: OnDrag) => {
+    const hasHorizontalCenterConstraint = this.options.constraint?.horizontal === HorizontalConstraint.Center;
+    const hasVerticalCenterConstraint = this.options.constraint?.vertical === VerticalConstraint.Center;
+    if (hasHorizontalCenterConstraint || hasVerticalCenterConstraint) {
+      const elementContainer = this.div?.getBoundingClientRect();
+      const height = elementContainer?.height ?? 100;
+      const yOffset = hasVerticalCenterConstraint ? height / 4 : 0;
+
+      const numberOfTargets = this.getScene()?.selecto?.getSelectedTargets().length ?? 0;
+      const isMultiSelection = numberOfTargets > 1;
+      if (!isMultiSelection) {
+        event.target.style.transform = `translate(${event.translate[0]}px, ${event.translate[1] - yOffset}px)`;
+        return;
+      }
+    }
+
     event.target.style.transform = event.transform;
   };
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Address UX glitch where element with center constraint would "jump" on drag.

NOTE: This issue still occurs when element is being dragged as part of a group selection, but as we implement support for group / nested frames we can address this.

BEFORE

https://user-images.githubusercontent.com/22381771/165188411-c6d66d31-d88c-44c9-b4c8-711289d009cf.mov

AFTER


https://user-images.githubusercontent.com/22381771/175092207-d9b5e78b-7f82-4d60-ac0e-ec32e8317f49.mov



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #48230


