### PR TITLE
Alerting: Reload user permissions after create folder in integration tests

### DIFF
--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -479,7 +479,6 @@ func TestAlertAndGroupsQuery(t *testing.T) {
 	{
 		// Create the namespace we'll save our alerts to.
 		apiClient.CreateFolder(t, "default", "default")
-		reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
 	}
 
 	// Create an alert that will fire as quickly as possible
@@ -580,7 +579,6 @@ func TestRulerAccess(t *testing.T) {
 
 	// Create the namespace we'll save our alerts to.
 	client.CreateFolder(t, "default", "default")
-	reloadCachedPermissions(t, grafanaListedAddr, "editor", "editor")
 
 	// Now, let's test the access policies.
 	testCases := []struct {
@@ -691,7 +689,6 @@ func TestDeleteFolderWithRules(t *testing.T) {
 	// Create the namespace we'll save our alerts to.
 	namespaceUID := "default"
 	apiClient.CreateFolder(t, namespaceUID, namespaceUID)
-	reloadCachedPermissions(t, grafanaListedAddr, "editor", "editor")
 
 	createRule(t, apiClient, "default")
 
@@ -846,7 +843,6 @@ func TestAlertRuleCRUD(t *testing.T) {
 
 	// Create the namespace we'll save our alerts to.
 	apiClient.CreateFolder(t, "default", "default")
-	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
 
 	interval, err := model.ParseDuration("1m")
 	require.NoError(t, err)
@@ -1886,7 +1882,6 @@ func TestQuota(t *testing.T) {
 	apiClient := newAlertingApiClient(grafanaListedAddr, "grafana", "password")
 	// Create the namespace we'll save our alerts to.
 	apiClient.CreateFolder(t, "default", "default")
-	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
 
 	interval, err := model.ParseDuration("1m")
 	require.NoError(t, err)

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -758,7 +758,6 @@ func TestNotificationChannels(t *testing.T) {
 	{
 		// Create the namespace we'll save our alerts to.
 		apiClient.CreateFolder(t, "default", "default")
-		reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
 
 		// Post the alertmanager config.
 		u := fmt.Sprintf("http://grafana:password@%s/api/alertmanager/grafana/config/api/v1/alerts", grafanaListedAddr)

--- a/pkg/tests/api/alerting/api_prometheus_test.go
+++ b/pkg/tests/api/alerting/api_prometheus_test.go
@@ -45,7 +45,6 @@ func TestPrometheusRules(t *testing.T) {
 
 	// Create the namespace we'll save our alerts to.
 	apiClient.CreateFolder(t, "default", "default")
-	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
 
 	interval, err := model.ParseDuration("10s")
 	require.NoError(t, err)
@@ -340,7 +339,6 @@ func TestPrometheusRulesFilterByDashboard(t *testing.T) {
 	// Create the namespace we'll save our alerts to.
 	dashboardUID := "default"
 	apiClient.CreateFolder(t, dashboardUID, dashboardUID)
-	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
 
 	interval, err := model.ParseDuration("10s")
 	require.NoError(t, err)
@@ -642,8 +640,6 @@ func TestPrometheusRulesPermissions(t *testing.T) {
 	// Create the namespace we'll save our alerts to.
 	apiClient.CreateFolder(t, "folder2", "folder2")
 
-	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
-
 	// Create rule under folder1
 	createRule(t, apiClient, "folder1")
 
@@ -678,7 +674,7 @@ func TestPrometheusRulesPermissions(t *testing.T) {
 
 	// remove permissions from folder2
 	removeFolderPermission(t, permissionsStore, 1, userID, models.ROLE_EDITOR, "folder2")
-	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
+	apiClient.ReloadCachedPermissions(t)
 
 	// make sure that folder2 is not included in the response
 	{
@@ -703,7 +699,7 @@ func TestPrometheusRulesPermissions(t *testing.T) {
 
 	// remove permissions from folder1
 	removeFolderPermission(t, permissionsStore, 1, userID, models.ROLE_EDITOR, "folder1")
-	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
+	apiClient.ReloadCachedPermissions(t)
 
 	// make sure that no folders are included in the response
 	{
@@ -727,19 +723,6 @@ func TestPrometheusRulesPermissions(t *testing.T) {
 	}
 }`, string(b))
 	}
-}
-
-func reloadCachedPermissions(t *testing.T, addr, login, password string) {
-	t.Helper()
-
-	u := fmt.Sprintf("http://%s:%s@%s/api/access-control/user/permissions?reloadcache=true", login, password, addr)
-	// nolint:gosec
-	resp, err := http.Get(u)
-	t.Cleanup(func() {
-		require.NoError(t, resp.Body.Close())
-	})
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func removeFolderPermission(t *testing.T, store *acdb.AccessControlStore, orgID, userID int64, role models.RoleType, uid string) {

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -47,8 +47,6 @@ func TestAlertRulePermissions(t *testing.T) {
 	// Create the namespace we'll save our alerts to.
 	apiClient.CreateFolder(t, "folder2", "folder2")
 
-	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
-
 	// Create rule under folder1
 	createRule(t, apiClient, "folder1")
 
@@ -178,7 +176,7 @@ func TestAlertRulePermissions(t *testing.T) {
 
 		// remove permissions from folder2
 		removeFolderPermission(t, permissionsStore, 1, userID, models.ROLE_EDITOR, "folder2")
-		reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
+		apiClient.ReloadCachedPermissions(t)
 
 		// make sure that folder2 is not included in the response
 		// nolint:gosec
@@ -252,7 +250,7 @@ func TestAlertRulePermissions(t *testing.T) {
 
 	// Remove permissions from folder1.
 	removeFolderPermission(t, permissionsStore, 1, userID, models.ROLE_EDITOR, "folder1")
-	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
+	apiClient.ReloadCachedPermissions(t)
 	{
 		u := fmt.Sprintf("http://grafana:password@%s/api/ruler/grafana/api/v1/rules", grafanaListedAddr)
 		// nolint:gosec
@@ -404,8 +402,6 @@ func TestRulerRulesFilterByDashboard(t *testing.T) {
 	dashboardUID := "default"
 	// Create the namespace under default organisation (orgID = 1) where we'll save our alerts to.
 	apiClient.CreateFolder(t, "default", "default")
-
-	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
 
 	interval, err := model.ParseDuration("10s")
 	require.NoError(t, err)
@@ -741,8 +737,6 @@ func TestRuleGroupSequence(t *testing.T) {
 	client := newAlertingApiClient(grafanaListedAddr, "grafana", "password")
 	folder1Title := "folder1"
 	client.CreateFolder(t, util.GenerateShortUID(), folder1Title)
-
-	reloadCachedPermissions(t, grafanaListedAddr, "grafana", "password")
 
 	group1 := generateAlertRuleGroup(5, alertRuleGen())
 	group2 := generateAlertRuleGroup(5, alertRuleGen())

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -171,7 +171,21 @@ func newAlertingApiClient(host, user, pass string) apiClient {
 	return apiClient{url: fmt.Sprintf("http://%s:%s@%s", user, pass, host)}
 }
 
-// CreateFolder creates a folder for storing our alerts under.
+// ReloadCachedPermissions sends a request to access control API to refresh cached user permissions
+func (a apiClient) ReloadCachedPermissions(t *testing.T) {
+	t.Helper()
+
+	u := fmt.Sprintf("%s/api/access-control/user/permissions?reloadcache=true", a.url)
+	// nolint:gosec
+	resp, err := http.Get(u)
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	require.NoErrorf(t, err, "failed to reload permissions cache")
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "failed to reload permissions cache")
+}
+
+// CreateFolder creates a folder for storing our alerts, and then refreshes the permission cache to make sure that following requests will be accepted
 func (a apiClient) CreateFolder(t *testing.T, uID string, title string) {
 	t.Helper()
 	payload := fmt.Sprintf(`{"uid": "%s","title": "%s"}`, uID, title)
@@ -184,6 +198,7 @@ func (a apiClient) CreateFolder(t *testing.T, uID string, title string) {
 	}()
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	a.ReloadCachedPermissions(t)
 }
 
 func (a apiClient) PostRulesGroup(t *testing.T, folder string, group *apimodels.PostableRuleGroupConfig) (int, string) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This is a follow-up for https://github.com/grafana/grafana/pull/51284.  This PR makes CreateFolder method automatically refresh the user permissions. This reduces the boilerplate code needs to create a folder.
