### PR TITLE
Infra: Pass custom headers in resource request

### DIFF
--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tsdb/grafanads"
 	"github.com/grafana/grafana/pkg/tsdb/legacydata"
+	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/proxyutil"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -184,7 +185,7 @@ func (s *Service) handleQueryData(ctx context.Context, user *models.SignedInUser
 		}
 	}
 
-	for k, v := range customHeaders(ds.JsonData, instanceSettings.DecryptedSecureJSONData) {
+	for k, v := range util.CustomHeaders(ds.JsonData, instanceSettings.DecryptedSecureJSONData) {
 		req.Headers[k] = v
 	}
 

--- a/pkg/util/req_headers.go
+++ b/pkg/util/req_headers.go
@@ -11,6 +11,8 @@ const (
 	headerValue = "httpHeaderValue"
 )
 
+// CustomHeaders return all the custom headers defined on the json data objects of the datasource. We store the
+// name unencrypted and value encrypted.
 func CustomHeaders(jsonData *simplejson.Json, decryptedJsonData map[string]string) map[string]string {
 	if jsonData == nil {
 		return nil

--- a/pkg/util/req_headers.go
+++ b/pkg/util/req_headers.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"strings"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+)
+
+const (
+	headerName  = "httpHeaderName"
+	headerValue = "httpHeaderValue"
+)
+
+func CustomHeaders(jsonData *simplejson.Json, decryptedJsonData map[string]string) map[string]string {
+	if jsonData == nil {
+		return nil
+	}
+
+	data := jsonData.MustMap()
+
+	headers := map[string]string{}
+	for k := range data {
+		if strings.HasPrefix(k, headerName) {
+			if header, ok := data[k].(string); ok {
+				valueKey := strings.ReplaceAll(k, headerName, headerValue)
+				headers[header] = decryptedJsonData[valueKey]
+			}
+		}
+	}
+
+	return headers
+}


### PR DESCRIPTION
This adds custom headers from the datasource to the resource request. This aligns the resource calls with query calls as for queries this is done in https://github.com/grafana/grafana/blob/69d22d0ab6e3c22217c12b8adb57d908a37f5b8f/pkg/services/query/query.go#L188.