### PR TITLE
RBAC: Remove version property from fixed roles

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -38,7 +38,6 @@ var (
 func (hs *HTTPServer) declareFixedRoles() error {
 	provisioningWriterRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     3,
 			Name:        "fixed:provisioning:writer",
 			DisplayName: "Provisioning writer",
 			Description: "Reload provisioning.",
@@ -55,7 +54,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	datasourcesExplorerRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     4,
 			Name:        "fixed:datasources:explorer",
 			DisplayName: "Data source explorer",
 			Description: "Enable the Explore feature. Data source permissions still apply; you can only query data sources for which you have query permissions.",
@@ -75,7 +73,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	datasourcesReaderRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     3,
 			Name:        "fixed:datasources:reader",
 			DisplayName: "Data source reader",
 			Description: "Read and query all data sources.",
@@ -101,7 +98,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	datasourcesWriterRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     3,
 			Name:        "fixed:datasources:writer",
 			DisplayName: "Data source writer",
 			Description: "Create, update, delete, read, or query data sources.",
@@ -125,7 +121,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	datasourcesIdReaderRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     4,
 			Name:        "fixed:datasources.id:reader",
 			DisplayName: "Data source ID reader",
 			Description: "Read the ID of a data source based on its name.",
@@ -142,7 +137,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	apikeyReaderRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     1,
 			Name:        "fixed:apikeys:reader",
 			DisplayName: "APIKeys reader",
 			Description: "Gives access to read api keys.",
@@ -159,7 +153,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	apikeyWriterRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     1,
 			Name:        "fixed:apikeys:writer",
 			DisplayName: "APIKeys writer",
 			Description: "Gives access to add and delete api keys.",
@@ -179,7 +172,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	orgReaderRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     5,
 			Name:        "fixed:organization:reader",
 			DisplayName: "Organization reader",
 			Description: "Read an organization, such as its ID, name, address, or quotas.",
@@ -194,7 +186,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	orgWriterRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     5,
 			Name:        "fixed:organization:writer",
 			DisplayName: "Organization writer",
 			Description: "Read an organization, its quotas, or its preferences. Update organization properties, or its preferences.",
@@ -210,7 +201,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	orgMaintainerRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     5,
 			Name:        "fixed:organization:maintainer",
 			DisplayName: "Organization maintainer",
 			Description: "Create, read, write, or delete an organization. Read or write an organization's quotas. Needs to be assigned globally.",
@@ -235,7 +225,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			DisplayName: "Team creator",
 			Description: "Create teams and read organisation users (required to manage the created teams).",
 			Group:       "Teams",
-			Version:     2,
 			Permissions: []ac.Permission{
 				{Action: ac.ActionTeamsCreate},
 				{Action: ac.ActionOrgUsersRead, Scope: ac.ScopeUsersAll},
@@ -250,7 +239,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			DisplayName: "Team writer",
 			Description: "Create, read, write, or delete a team as well as controlling team memberships.",
 			Group:       "Teams",
-			Version:     2,
 			Permissions: []ac.Permission{
 				{Action: ac.ActionTeamsCreate},
 				{Action: ac.ActionTeamsDelete, Scope: ac.ScopeTeamsAll},
@@ -269,7 +257,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			DisplayName: "Annotation reader",
 			Description: "Read annotations and tags",
 			Group:       "Annotations",
-			Version:     2,
 			Permissions: []ac.Permission{
 				{Action: ac.ActionAnnotationsRead, Scope: ac.ScopeAnnotationsAll},
 			},
@@ -283,7 +270,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			DisplayName: "Dashboard annotation writer",
 			Description: "Update annotations associated with dashboards.",
 			Group:       "Annotations",
-			Version:     3,
 			Permissions: []ac.Permission{
 				{Action: ac.ActionAnnotationsCreate, Scope: ac.ScopeAnnotationsTypeDashboard},
 				{Action: ac.ActionAnnotationsDelete, Scope: ac.ScopeAnnotationsTypeDashboard},
@@ -299,7 +285,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			DisplayName: "Annotation writer",
 			Description: "Update all annotations.",
 			Group:       "Annotations",
-			Version:     2,
 			Permissions: []ac.Permission{
 				{Action: ac.ActionAnnotationsCreate, Scope: ac.ScopeAnnotationsAll},
 				{Action: ac.ActionAnnotationsDelete, Scope: ac.ScopeAnnotationsAll},
@@ -311,7 +296,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	dashboardsCreatorRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     2,
 			Name:        "fixed:dashboards:creator",
 			DisplayName: "Dashboard creator",
 			Description: "Create dashboard in general folder.",
@@ -326,7 +310,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	dashboardsReaderRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     1,
 			Name:        "fixed:dashboards:reader",
 			DisplayName: "Dashboard reader",
 			Description: "Read all dashboards.",
@@ -340,7 +323,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	dashboardsWriterRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     1,
 			Name:        "fixed:dashboards:writer",
 			DisplayName: "Dashboard writer",
 			Group:       "Dashboards",
@@ -358,7 +340,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	foldersCreatorRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     1,
 			Name:        "fixed:folders:creator",
 			DisplayName: "Folder creator",
 			Description: "Create folders.",
@@ -372,7 +353,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	foldersReaderRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     1,
 			Name:        "fixed:folders:reader",
 			DisplayName: "Folder reader",
 			Description: "Read all folders and dashboards.",
@@ -387,7 +367,6 @@ func (hs *HTTPServer) declareFixedRoles() error {
 
 	foldersWriterRole := ac.RoleRegistration{
 		Role: ac.RoleDTO{
-			Version:     1,
 			Name:        "fixed:folders:writer",
 			DisplayName: "Folder writer",
 			Description: "Create, read, write or delete all folders and dashboards and their permissions.",

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
@@ -200,8 +200,7 @@ func TestOSSAccessControlService_DeclareFixedRoles(t *testing.T) {
 			registrations: []accesscontrol.RoleRegistration{
 				{
 					Role: accesscontrol.RoleDTO{
-						Version: 1,
-						Name:    "fixed:test:test",
+						Name: "fixed:test:test",
 					},
 					Grants: []string{"Admin"},
 				},
@@ -213,8 +212,7 @@ func TestOSSAccessControlService_DeclareFixedRoles(t *testing.T) {
 			registrations: []accesscontrol.RoleRegistration{
 				{
 					Role: accesscontrol.RoleDTO{
-						Version: 1,
-						Name:    "custom:test:test",
+						Name: "custom:test:test",
 					},
 					Grants: []string{"Admin"},
 				},
@@ -227,8 +225,7 @@ func TestOSSAccessControlService_DeclareFixedRoles(t *testing.T) {
 			registrations: []accesscontrol.RoleRegistration{
 				{
 					Role: accesscontrol.RoleDTO{
-						Version: 1,
-						Name:    "fixed:test:test",
+						Name: "fixed:test:test",
 					},
 					Grants: []string{"WrongAdmin"},
 				},
@@ -241,15 +238,13 @@ func TestOSSAccessControlService_DeclareFixedRoles(t *testing.T) {
 			registrations: []accesscontrol.RoleRegistration{
 				{
 					Role: accesscontrol.RoleDTO{
-						Version: 1,
-						Name:    "fixed:test:test",
+						Name: "fixed:test:test",
 					},
 					Grants: []string{"Admin"},
 				},
 				{
 					Role: accesscontrol.RoleDTO{
-						Version: 1,
-						Name:    "fixed:test2:test2",
+						Name: "fixed:test2:test2",
 					},
 					Grants: []string{"Admin"},
 				},
@@ -299,7 +294,6 @@ func TestOSSAccessControlService_RegisterFixedRoles(t *testing.T) {
 			registrations: []accesscontrol.RoleRegistration{
 				{
 					Role: accesscontrol.RoleDTO{
-						Version:     1,
 						Name:        "fixed:test:test",
 						Permissions: []accesscontrol.Permission{{Action: "test:test"}},
 					},
@@ -313,7 +307,6 @@ func TestOSSAccessControlService_RegisterFixedRoles(t *testing.T) {
 			registrations: []accesscontrol.RoleRegistration{
 				{
 					Role: accesscontrol.RoleDTO{
-						Version:     1,
 						Name:        "fixed:test:test",
 						Permissions: []accesscontrol.Permission{{Action: "test:test"}},
 					},
@@ -321,8 +314,7 @@ func TestOSSAccessControlService_RegisterFixedRoles(t *testing.T) {
 				},
 				{
 					Role: accesscontrol.RoleDTO{
-						Version: 1,
-						Name:    "fixed:test2:test2",
+						Name: "fixed:test2:test2",
 						Permissions: []accesscontrol.Permission{
 							{Action: "test:test2"},
 							{Action: "test:test3", Scope: "test:*"},
@@ -376,7 +368,6 @@ func TestOSSAccessControlService_GetUserPermissions(t *testing.T) {
 	}
 	registration := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
-			Version:     1,
 			UID:         "fixed:test:test",
 			Name:        "fixed:test:test",
 			Description: "Test role",
@@ -439,7 +430,6 @@ func TestOSSAccessControlService_Evaluate(t *testing.T) {
 	}
 	registration := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
-			Version:     1,
 			UID:         "fixed:test:test",
 			Name:        "fixed:test:test",
 			Description: "Test role",

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -311,7 +311,6 @@ func (s *Service) declareFixedRoles() error {
 	scopeAll := accesscontrol.Scope(s.options.Resource, "*")
 	readerRole := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
-			Version:     6,
 			Name:        fmt.Sprintf("fixed:%s.permissions:reader", s.options.Resource),
 			DisplayName: s.options.ReaderRoleName,
 			Group:       s.options.RoleGroup,
@@ -324,7 +323,6 @@ func (s *Service) declareFixedRoles() error {
 
 	writerRole := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
-			Version:     6,
 			Name:        fmt.Sprintf("fixed:%s.permissions:writer", s.options.Resource),
 			DisplayName: s.options.WriterRoleName,
 			Group:       s.options.RoleGroup,

--- a/pkg/services/accesscontrol/roles.go
+++ b/pkg/services/accesscontrol/roles.go
@@ -15,7 +15,6 @@ var (
 		DisplayName: "LDAP reader",
 		Description: "Read LDAP configuration and status.",
 		Group:       "LDAP",
-		Version:     3,
 		Permissions: []Permission{
 			{
 				Action: ActionLDAPUsersRead,
@@ -31,7 +30,6 @@ var (
 		DisplayName: "LDAP writer",
 		Description: "Read and update LDAP configuration and read LDAP status.",
 		Group:       "LDAP",
-		Version:     4,
 		Permissions: ConcatPermissions(ldapReaderRole.Permissions, []Permission{
 			{
 				Action: ActionLDAPUsersSync,
@@ -47,7 +45,6 @@ var (
 		DisplayName: "Organization user writer",
 		Description: "Within a single organization, add a user, invite a user, read information about a user and their role, remove a user from that organization, or change the role of a user.",
 		Group:       "User administration (organizational)",
-		Version:     4,
 		Permissions: ConcatPermissions(orgUsersReaderRole.Permissions, []Permission{
 			{
 				Action: ActionOrgUsersAdd,
@@ -69,7 +66,6 @@ var (
 		DisplayName: "Organization user reader",
 		Description: "Read users within a single organization.",
 		Group:       "User administration (organizational)",
-		Version:     3,
 		Permissions: []Permission{
 			{
 				Action: ActionOrgUsersRead,
@@ -83,7 +79,6 @@ var (
 		DisplayName: "Setting reader",
 		Description: "Read Grafana instance settings.",
 		Group:       "Settings",
-		Version:     4,
 		Permissions: []Permission{
 			{
 				Action: ActionSettingsRead,
@@ -97,7 +92,6 @@ var (
 		DisplayName: "Statistics reader",
 		Description: "Read Grafana instance statistics.",
 		Group:       "Statistics",
-		Version:     3,
 		Permissions: []Permission{
 			{
 				Action: ActionServerStatsRead,
@@ -110,7 +104,6 @@ var (
 		DisplayName: "User reader",
 		Description: "Read all users and their information, such as team memberships, authentication tokens, and quotas.",
 		Group:       "User administration (global)",
-		Version:     6,
 		Permissions: []Permission{
 			{
 				Action: ActionUsersRead,
@@ -132,7 +125,6 @@ var (
 		DisplayName: "User writer",
 		Description: "Read and update all attributes and settings for all users in Grafana: update user information, read user information, create or enable or disable a user, make a user a Grafana administrator, sign out a user, update a user’s authentication token, or update quotas for all users.",
 		Group:       "User administration (global)",
-		Version:     5,
 		Permissions: ConcatPermissions(usersReaderRole.Permissions, []Permission{
 			{
 				Action: ActionUsersPasswordUpdate,

--- a/pkg/services/ngalert/accesscontrol.go
+++ b/pkg/services/ngalert/accesscontrol.go
@@ -16,7 +16,6 @@ var (
 			DisplayName: "Rules Reader",
 			Description: "Read alert rules in all Grafana folders and external providers",
 			Group:       AlertRolesGroup,
-			Version:     3,
 			Permissions: []accesscontrol.Permission{
 				{
 					Action: accesscontrol.ActionAlertingRuleRead,
@@ -36,7 +35,6 @@ var (
 			DisplayName: "Rules Writer",
 			Description: "Add, update, and delete rules in any Grafana folder and external providers",
 			Group:       AlertRolesGroup,
-			Version:     4,
 			Permissions: accesscontrol.ConcatPermissions(rulesReaderRole.Role.Permissions, []accesscontrol.Permission{
 				{
 					Action: accesscontrol.ActionAlertingRuleCreate,
@@ -64,7 +62,6 @@ var (
 			DisplayName: "Instances and Silences Reader",
 			Description: "Read instances and silences of Grafana and external providers",
 			Group:       AlertRolesGroup,
-			Version:     2,
 			Permissions: []accesscontrol.Permission{
 				{
 					Action: accesscontrol.ActionAlertingInstanceRead,
@@ -84,7 +81,6 @@ var (
 			DisplayName: "Silences Writer",
 			Description: "Add and update silences in Grafana and external providers",
 			Group:       AlertRolesGroup,
-			Version:     3,
 			Permissions: accesscontrol.ConcatPermissions(instancesReaderRole.Role.Permissions, []accesscontrol.Permission{
 				{
 					Action: accesscontrol.ActionAlertingInstanceCreate,
@@ -106,7 +102,6 @@ var (
 			DisplayName: "Notifications Reader",
 			Description: "Read notification policies and contact points in Grafana and external providers",
 			Group:       AlertRolesGroup,
-			Version:     2,
 			Permissions: []accesscontrol.Permission{
 				{
 					Action: accesscontrol.ActionAlertingNotificationsRead,
@@ -125,7 +120,6 @@ var (
 			DisplayName: "Notifications Writer",
 			Description: "Add, update, and delete contact points and notification policies in Grafana and external providers",
 			Group:       AlertRolesGroup,
-			Version:     3,
 			Permissions: accesscontrol.ConcatPermissions(notificationsReaderRole.Role.Permissions, []accesscontrol.Permission{
 				{
 					Action: accesscontrol.ActionAlertingNotificationsWrite,
@@ -144,7 +138,6 @@ var (
 			DisplayName: "Full read-only access",
 			Description: "Read alert rules, instances, silences, contact points, and notification policies in Grafana and all external providers",
 			Group:       AlertRolesGroup,
-			Version:     3,
 			Permissions: accesscontrol.ConcatPermissions(rulesReaderRole.Role.Permissions, instancesReaderRole.Role.Permissions, notificationsReaderRole.Role.Permissions),
 		},
 		Grants: []string{string(models.ROLE_VIEWER)},
@@ -156,7 +149,6 @@ var (
 			DisplayName: "Full access",
 			Description: "Add,update and delete alert rules, instances, silences, contact points, and notification policies in Grafana and all external providers",
 			Group:       AlertRolesGroup,
-			Version:     4,
 			Permissions: accesscontrol.ConcatPermissions(rulesWriterRole.Role.Permissions, instancesWriterRole.Role.Permissions, notificationsWriterRole.Role.Permissions),
 		},
 		Grants: []string{string(models.ROLE_EDITOR), string(models.ROLE_ADMIN)},
@@ -168,7 +160,6 @@ var (
 			DisplayName: "Access to alert rules provisioning API",
 			Description: "Manage all alert rules, contact points, notification policies, silences, etc. in the organization via provisioning API.",
 			Group:       AlertRolesGroup,
-			Version:     2,
 			Permissions: []accesscontrol.Permission{
 				{
 					Action: accesscontrol.ActionAlertingProvisioningRead, // organization scope

--- a/pkg/services/serviceaccounts/manager/roles.go
+++ b/pkg/services/serviceaccounts/manager/roles.go
@@ -9,7 +9,6 @@ import (
 func RegisterRoles(ac accesscontrol.AccessControl) error {
 	saReader := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
-			Version:     1,
 			Name:        "fixed:serviceaccounts:reader",
 			DisplayName: "Service accounts reader",
 			Description: "Read service accounts and service account tokens.",
@@ -26,7 +25,6 @@ func RegisterRoles(ac accesscontrol.AccessControl) error {
 
 	saWriter := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
-			Version:     4,
 			Name:        "fixed:serviceaccounts:writer",
 			DisplayName: "Service accounts writer",
 			Description: "Create, delete, read, or query service accounts.",


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed roles no longer require a version bump to be updated so we can remove the usage of the version field 

**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana-enterprise/issues/3485

**Special notes for your reviewer**:

