### PR TITLE
Log: Fix text logging for unsupported types

### DIFF
--- a/pkg/infra/log/log.go
+++ b/pkg/infra/log/log.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-stack/stack"
 	"github.com/grafana/grafana/pkg/infra/log/level"
 	"github.com/grafana/grafana/pkg/infra/log/term"
+	"github.com/grafana/grafana/pkg/infra/log/text"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/mattn/go-isatty"
 	"gopkg.in/ini.v1"
@@ -325,11 +326,11 @@ func getLogFormat(format string) Formatedlogger {
 			}
 		}
 		return func(w io.Writer) gokitlog.Logger {
-			return gokitlog.NewLogfmtLogger(w)
+			return text.NewTextLogger(w)
 		}
 	case "text":
 		return func(w io.Writer) gokitlog.Logger {
-			return gokitlog.NewLogfmtLogger(w)
+			return text.NewTextLogger(w)
 		}
 	case "json":
 		return func(w io.Writer) gokitlog.Logger {
@@ -337,7 +338,7 @@ func getLogFormat(format string) Formatedlogger {
 		}
 	default:
 		return func(w io.Writer) gokitlog.Logger {
-			return gokitlog.NewLogfmtLogger(w)
+			return text.NewTextLogger(w)
 		}
 	}
 }

--- a/pkg/infra/log/text/text_logger.go
+++ b/pkg/infra/log/text/text_logger.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"reflect"
 
-	gokitlog "github.com/go-kit/log"
+	gokitlog "github.com/go-kit/kit/log"
 )
 
 type textLogger struct {
@@ -22,10 +22,9 @@ func NewTextLogger(w io.Writer) gokitlog.Logger {
 func (l textLogger) Log(keyvals ...interface{}) error {
 	for i, val := range keyvals {
 		switch val.(type) {
-		case nil, string, []byte, encoding.TextMarshaler, error, fmt.Stringer:
+		case nil, string, []byte, encoding.TextMarshaler, error, fmt.Stringer: // supported natively by gokit.
 		default:
-			rvalue := reflect.ValueOf(val)
-			switch rvalue.Kind() {
+			switch reflect.TypeOf(val).Kind() {
 			case reflect.Array, reflect.Chan, reflect.Func, reflect.Map, reflect.Slice, reflect.Struct:
 				keyvals[i] = fmt.Sprintf("%+v", val)
 			default:

--- a/pkg/infra/log/text/text_logger.go
+++ b/pkg/infra/log/text/text_logger.go
@@ -1,0 +1,40 @@
+package text
+
+import (
+	"encoding"
+	"fmt"
+	"io"
+	"reflect"
+
+	gokitlog "github.com/go-kit/log"
+)
+
+type textLogger struct {
+	w io.Writer
+}
+
+// NewTextLogger similar to gokitlog.NewLogfmtLogger
+// but converts unsupported types to string
+func NewTextLogger(w io.Writer) gokitlog.Logger {
+	return &textLogger{w}
+}
+
+func (l textLogger) Log(keyvals ...interface{}) error {
+	for i, val := range keyvals {
+		switch val.(type) {
+		case nil, string, []byte, encoding.TextMarshaler, error, fmt.Stringer:
+		default:
+			rvalue := reflect.ValueOf(val)
+			switch rvalue.Kind() {
+			case reflect.Array, reflect.Chan, reflect.Func, reflect.Map, reflect.Slice, reflect.Struct:
+				keyvals[i] = fmt.Sprintf("%+v", val)
+			default:
+			}
+		}
+	}
+	ll := gokitlog.NewLogfmtLogger(l.w)
+	if err := ll.Log(keyvals...); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The logger that `go-kit/log` uses  (in logfmt format) [does not support logging compound types](https://github.com/go-logfmt/logfmt/issues/1); [`ErrUnsupportedKeyType` is returned for those cases](https://github.com/go-logfmt/logfmt/blob/99455b83edb21b32a1f1c0a32f5001b77487b721/encode.go#L157)
As a result, there are a lot of occurrences of `unsupported value type` in the logs since migrating to `go-kit/log`. This fix defines a new logger (used when `text` log format is set) which converts those values to string before calling the actual logger.

<details>
<summary>Before the fix:</summary>

```
# GF_LOG_CONSOLE_FORMAT=text GF_LOG_LEVEL=debug make run
logger=ngalert uid=32x8Fo_7z org=1 version=1 attempt=0 now=2022-06-23T12:30:10+03:00 t=2022-06-23T12:30:10.014449+03:00 level=debug msg="sending alerts to local notifier" count=1 alerts="unsupported value type"
```
</details>

<details>
<summary>After applying the fix:</summary>

```
# GF_LOG_CONSOLE_FORMAT=text GF_LOG_LEVEL=debug make run
logger=ngalert uid=32x8Fo_7z org=1 version=1 attempt=0 now=2022-06-23T12:43:00+03:00 t=2022-06-23T12:43:07.939706+03:00 level=debug msg="sending alerts to local notifier" count=1 alerts="[{Annotations:map[__alertId__:6 __dashboardUid__:ffKlLpuMz __panelId__:2 message:] EndsAt:2022-06-23T12:46:00.000+03:00 StartsAt:2022-06-23T12:23:00.000+03:00 Alert:{GeneratorURL:http://localhost:3000/alerting/grafana/32x8Fo_7z/view Labels:map[__alert_rule_namespace_uid__:fhx8Fol7k __alert_rule_uid__:32x8Fo_7z alertname:Alert in dashboard with permissions under folder with permissions rule_uid:32x8Fo_7z]}}]"
```
</details>

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
`console` and `json` log format should not be affected by this fix