### PR TITLE
BackendSrv: Make it possible to pass `options` to `.get|post|patch...` methods

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1075,12 +1075,10 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "10"],
-      [0, 0, 0, "Do not use any type assertions.", "11"],
-      [0, 0, 0, "Do not use any type assertions.", "12"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "13"],
-      [0, 0, 0, "Do not use any type assertions.", "14"]
+      [0, 0, 0, "Do not use any type assertions.", "9"],
+      [0, 0, 0, "Do not use any type assertions.", "10"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "11"],
+      [0, 0, 0, "Do not use any type assertions.", "12"]
     ],
     "packages/grafana-runtime/src/utils/analytics.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -2878,8 +2876,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "14"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "15"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "16"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "17"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "18"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "17"]
     ],
     "public/app/core/services/context_srv.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/packages/grafana-runtime/src/services/backendSrv.ts
+++ b/packages/grafana-runtime/src/services/backendSrv.ts
@@ -150,8 +150,9 @@ export interface BackendSrv {
   put<T = any>(url: string, data?: any, options?: Partial<BackendSrvRequest>): Promise<T>;
 
   /**
-   * @deprecated Use the fetch function instead. If you prefer to work with a promise
-   * wrap the Observable returned by fetch with the lastValueFrom function.
+   * @deprecated Use the `.fetch()` function instead. If you prefer to work with a promise
+   * wrap the Observable returned by fetch with the lastValueFrom function, or use the get|delete|post|patch|put methods.
+   * This method is going to be private from Grafana 10.
    */
   request<T = any>(options: BackendSrvRequest): Promise<T>;
 

--- a/packages/grafana-runtime/src/services/backendSrv.ts
+++ b/packages/grafana-runtime/src/services/backendSrv.ts
@@ -143,11 +143,11 @@ export function isFetchError(e: unknown): e is FetchError {
  * @public
  */
 export interface BackendSrv {
-  get<T = any>(url: string, params?: any, requestId?: string, options?: BackendSrvRequest): Promise<T>;
-  delete<T = any>(url: string, data?: any, options?: BackendSrvRequest): Promise<T>;
-  post<T = any>(url: string, data?: any, options?: BackendSrvRequest): Promise<T>;
-  patch<T = any>(url: string, data?: any, options?: BackendSrvRequest): Promise<T>;
-  put<T = any>(url: string, data?: any, options?: BackendSrvRequest): Promise<T>;
+  get<T = any>(url: string, params?: any, requestId?: string, options?: Partial<BackendSrvRequest>): Promise<T>;
+  delete<T = any>(url: string, data?: any, options?: Partial<BackendSrvRequest>): Promise<T>;
+  post<T = any>(url: string, data?: any, options?: Partial<BackendSrvRequest>): Promise<T>;
+  patch<T = any>(url: string, data?: any, options?: Partial<BackendSrvRequest>): Promise<T>;
+  put<T = any>(url: string, data?: any, options?: Partial<BackendSrvRequest>): Promise<T>;
 
   /**
    * @deprecated Use the fetch function instead. If you prefer to work with a promise

--- a/packages/grafana-runtime/src/services/backendSrv.ts
+++ b/packages/grafana-runtime/src/services/backendSrv.ts
@@ -143,11 +143,11 @@ export function isFetchError(e: unknown): e is FetchError {
  * @public
  */
 export interface BackendSrv {
-  get<T = any>(url: string, params?: any, requestId?: string): Promise<T>;
-  delete<T = any>(url: string, data?: any): Promise<T>;
-  post<T = any>(url: string, data?: any): Promise<T>;
-  patch<T = any>(url: string, data?: any): Promise<T>;
-  put<T = any>(url: string, data?: any): Promise<T>;
+  get<T = any>(url: string, params?: any, requestId?: string, options?: BackendSrvRequest): Promise<T>;
+  delete<T = any>(url: string, data?: any, options?: BackendSrvRequest): Promise<T>;
+  post<T = any>(url: string, data?: any, options?: BackendSrvRequest): Promise<T>;
+  patch<T = any>(url: string, data?: any, options?: BackendSrvRequest): Promise<T>;
+  put<T = any>(url: string, data?: any, options?: BackendSrvRequest): Promise<T>;
 
   /**
    * @deprecated Use the fetch function instead. If you prefer to work with a promise

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -25,6 +25,7 @@ import {
   StreamingFrameOptions,
   StreamingFrameAction,
   BackendSrvRequest,
+  FetchResponse,
 } from '../services';
 
 import { BackendDataSourceResponse, toDataQueryResponse } from './queryResponse';
@@ -225,14 +226,7 @@ class DataSourceWithBackend<
     params?: BackendSrvRequest['params'],
     options?: Partial<BackendSrvRequest>
   ): Promise<any> {
-    return lastValueFrom(
-      getBackendSrv().fetch<HealthCheckResult>({
-        ...options,
-        method: 'GET',
-        url: `/api/datasources/${this.id}/resources/${path}`,
-        params,
-      })
-    );
+    return getBackendSrv().get(`/api/datasources/${this.id}/resources/${path}`, params, options?.requestId, options);
   }
 
   /**
@@ -243,14 +237,7 @@ class DataSourceWithBackend<
     data?: BackendSrvRequest['data'],
     options?: Partial<BackendSrvRequest>
   ): Promise<any> {
-    return lastValueFrom(
-      getBackendSrv().fetch<HealthCheckResult>({
-        ...options,
-        method: 'POST',
-        url: `/api/datasources/${this.id}/resources/${path}`,
-        data: { ...data },
-      })
-    );
+    return getBackendSrv().post(`/api/datasources/${this.id}/resources/${path}`, { ...data }, options);
   }
 
   /**
@@ -264,7 +251,7 @@ class DataSourceWithBackend<
         showErrorAlert: false,
       })
     )
-      .then((v: unknown) => v as HealthCheckResult)
+      .then((v: FetchResponse) => v.data as HealthCheckResult)
       .catch((err) => err.data as HealthCheckResult);
   }
 

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -24,6 +24,7 @@ import {
   getGrafanaLiveSrv,
   StreamingFrameOptions,
   StreamingFrameAction,
+  BackendSrvRequest,
 } from '../services';
 
 import { BackendDataSourceResponse, toDataQueryResponse } from './queryResponse';
@@ -219,15 +220,18 @@ class DataSourceWithBackend<
   /**
    * Make a GET request to the datasource resource path
    */
-  async getResource(path: string, params?: any): Promise<any> {
-    return getBackendSrv().get(`/api/datasources/${this.id}/resources/${path}`, params);
+  async getResource(path: string, params?: any, options?: BackendSrvRequest): Promise<any> {
+    // Unfortunately we need to keep passing this in due using positional arguments in the get() method below.
+    const requestId = undefined;
+
+    return getBackendSrv().get(`/api/datasources/${this.id}/resources/${path}`, params, requestId, options);
   }
 
   /**
    * Send a POST request to the datasource resource path
    */
-  async postResource(path: string, body?: any): Promise<any> {
-    return getBackendSrv().post(`/api/datasources/${this.id}/resources/${path}`, { ...body });
+  async postResource(path: string, body?: any, options?: BackendSrvRequest): Promise<any> {
+    return getBackendSrv().post(`/api/datasources/${this.id}/resources/${path}`, { ...body }, options);
   }
 
   /**

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -220,7 +220,11 @@ class DataSourceWithBackend<
   /**
    * Make a GET request to the datasource resource path
    */
-  async getResource(path: string, params?: any, options?: Partial<BackendSrvRequest>): Promise<any> {
+  async getResource(
+    path: string,
+    params?: BackendSrvRequest['params'],
+    options?: Partial<BackendSrvRequest>
+  ): Promise<any> {
     return lastValueFrom(
       getBackendSrv().fetch<HealthCheckResult>({
         ...options,
@@ -234,7 +238,11 @@ class DataSourceWithBackend<
   /**
    * Send a POST request to the datasource resource path
    */
-  async postResource(path: string, data?: any, options?: Partial<BackendSrvRequest>): Promise<any> {
+  async postResource(
+    path: string,
+    data?: BackendSrvRequest['data'],
+    options?: Partial<BackendSrvRequest>
+  ): Promise<any> {
     return lastValueFrom(
       getBackendSrv().fetch<HealthCheckResult>({
         ...options,

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -407,24 +407,24 @@ export class BackendSrv implements BackendService {
     return this.inspectorStream;
   }
 
-  async get<T = any>(url: string, params?: any, requestId?: string): Promise<T> {
-    return await this.request({ method: 'GET', url, params, requestId });
+  async get<T = any>(url: string, params?: any, requestId?: string, options?: BackendSrvRequest): Promise<T> {
+    return await this.request({ ...options, method: 'GET', url, params, requestId });
   }
 
-  async delete<T = any>(url: string, data?: any): Promise<T> {
-    return await this.request({ method: 'DELETE', url, data });
+  async delete<T = any>(url: string, data?: any, options?: BackendSrvRequest): Promise<T> {
+    return await this.request({ ...options, method: 'DELETE', url, data });
   }
 
-  async post<T = any>(url: string, data?: any): Promise<T> {
-    return await this.request({ method: 'POST', url, data });
+  async post<T = any>(url: string, data?: any, options?: BackendSrvRequest): Promise<T> {
+    return await this.request({ ...options, method: 'POST', url, data });
   }
 
-  async patch<T = any>(url: string, data: any): Promise<T> {
-    return await this.request({ method: 'PATCH', url, data });
+  async patch<T = any>(url: string, data: any, options?: BackendSrvRequest): Promise<T> {
+    return await this.request({ ...options, method: 'PATCH', url, data });
   }
 
-  async put<T = any>(url: string, data: any): Promise<T> {
-    return await this.request({ method: 'PUT', url, data });
+  async put<T = any>(url: string, data: any, options?: BackendSrvRequest): Promise<T> {
+    return await this.request({ ...options, method: 'PUT', url, data });
   }
 
   withNoBackendCache(callback: any) {

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -407,7 +407,12 @@ export class BackendSrv implements BackendService {
     return this.inspectorStream;
   }
 
-  async get<T = any>(url: string, params?: any, requestId?: string, options?: Partial<BackendSrvRequest>) {
+  async get<T = any>(
+    url: string,
+    params?: BackendSrvRequest['params'],
+    requestId?: BackendSrvRequest['requestId'],
+    options?: Partial<BackendSrvRequest>
+  ) {
     return await lastValueFrom(
       this.fetch<T>({ ...options, method: 'GET', url, params, requestId }).pipe(
         map((response: FetchResponse<T>) => response.data)

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -407,24 +407,36 @@ export class BackendSrv implements BackendService {
     return this.inspectorStream;
   }
 
-  async get<T = any>(url: string, params?: any, requestId?: string, options?: Partial<BackendSrvRequest>): Promise<T> {
-    return await this.request({ ...options, method: 'GET', url, params, requestId });
+  async get<T = any>(url: string, params?: any, requestId?: string, options?: Partial<BackendSrvRequest>) {
+    return await lastValueFrom(
+      this.fetch<T>({ ...options, method: 'GET', url, params, requestId }).pipe(
+        map((response: FetchResponse<T>) => response.data)
+      )
+    );
   }
 
-  async delete<T = any>(url: string, data?: any, options?: BackendSrvRequest): Promise<T> {
-    return await this.request({ ...options, method: 'DELETE', url, data });
+  async delete<T = any>(url: string, data?: any, options?: BackendSrvRequest) {
+    return await lastValueFrom(
+      this.fetch<T>({ ...options, method: 'DELETE', url, data }).pipe(map((response: FetchResponse) => response.data))
+    );
   }
 
-  async post<T = any>(url: string, data?: any, options?: BackendSrvRequest): Promise<T> {
-    return await this.request({ ...options, method: 'POST', url, data });
+  async post<T = any>(url: string, data?: any, options?: BackendSrvRequest) {
+    return await lastValueFrom(
+      this.fetch<T>({ ...options, method: 'POST', url, data }).pipe(map((response: FetchResponse) => response.data))
+    );
   }
 
-  async patch<T = any>(url: string, data: any, options?: BackendSrvRequest): Promise<T> {
-    return await this.request({ ...options, method: 'PATCH', url, data });
+  async patch<T = any>(url: string, data: any, options?: BackendSrvRequest) {
+    return await lastValueFrom(
+      this.fetch<T>({ ...options, method: 'PATCH', url, data }).pipe(map((response: FetchResponse) => response.data))
+    );
   }
 
   async put<T = any>(url: string, data: any, options?: BackendSrvRequest): Promise<T> {
-    return await this.request({ ...options, method: 'PUT', url, data });
+    return await lastValueFrom(
+      this.fetch({ ...options, method: 'PUT', url, data }).pipe(map((response: FetchResponse) => response.data))
+    );
   }
 
   withNoBackendCache(callback: any) {
@@ -435,7 +447,11 @@ export class BackendSrv implements BackendService {
   }
 
   loginPing() {
-    return this.request({ url: '/api/login/ping', method: 'GET', retry: 1 });
+    return lastValueFrom(
+      this.fetch({ method: 'GET', url: '/api/login/ping', retry: 1 }).pipe(
+        map((response: FetchResponse) => response.data)
+      )
+    );
   }
 
   /** @deprecated */

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -440,7 +440,7 @@ export class BackendSrv implements BackendService {
   }
 
   loginPing() {
-    return this.request({ method: 'GET', url: '/api/login/ping', retry: 1 });
+    return this.request({ url: '/api/login/ping', method: 'GET', retry: 1 });
   }
 
   /** @deprecated */

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -407,7 +407,7 @@ export class BackendSrv implements BackendService {
     return this.inspectorStream;
   }
 
-  async get<T = any>(url: string, params?: any, requestId?: string, options?: BackendSrvRequest): Promise<T> {
+  async get<T = any>(url: string, params?: any, requestId?: string, options?: Partial<BackendSrvRequest>): Promise<T> {
     return await this.request({ ...options, method: 'GET', url, params, requestId });
   }
 

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -413,35 +413,23 @@ export class BackendSrv implements BackendService {
     requestId?: BackendSrvRequest['requestId'],
     options?: Partial<BackendSrvRequest>
   ) {
-    return await lastValueFrom(
-      this.fetch<T>({ ...options, method: 'GET', url, params, requestId }).pipe(
-        map((response: FetchResponse<T>) => response.data)
-      )
-    );
+    return this.request<T>({ ...options, method: 'GET', url, params, requestId });
   }
 
-  async delete<T = any>(url: string, data?: any, options?: BackendSrvRequest) {
-    return await lastValueFrom(
-      this.fetch<T>({ ...options, method: 'DELETE', url, data }).pipe(map((response: FetchResponse) => response.data))
-    );
+  async delete<T = any>(url: string, data?: any, options?: Partial<BackendSrvRequest>) {
+    return this.request<T>({ ...options, method: 'DELETE', url, data });
   }
 
-  async post<T = any>(url: string, data?: any, options?: BackendSrvRequest) {
-    return await lastValueFrom(
-      this.fetch<T>({ ...options, method: 'POST', url, data }).pipe(map((response: FetchResponse) => response.data))
-    );
+  async post<T = any>(url: string, data?: any, options?: Partial<BackendSrvRequest>) {
+    return this.request<T>({ ...options, method: 'POST', url, data });
   }
 
-  async patch<T = any>(url: string, data: any, options?: BackendSrvRequest) {
-    return await lastValueFrom(
-      this.fetch<T>({ ...options, method: 'PATCH', url, data }).pipe(map((response: FetchResponse) => response.data))
-    );
+  async patch<T = any>(url: string, data: any, options?: Partial<BackendSrvRequest>) {
+    return this.request<T>({ ...options, method: 'PATCH', url, data });
   }
 
-  async put<T = any>(url: string, data: any, options?: BackendSrvRequest): Promise<T> {
-    return await lastValueFrom(
-      this.fetch({ ...options, method: 'PUT', url, data }).pipe(map((response: FetchResponse) => response.data))
-    );
+  async put<T = any>(url: string, data: any, options?: Partial<BackendSrvRequest>): Promise<T> {
+    return this.request<T>({ ...options, method: 'PUT', url, data });
   }
 
   withNoBackendCache(callback: any) {
@@ -452,11 +440,7 @@ export class BackendSrv implements BackendService {
   }
 
   loginPing() {
-    return lastValueFrom(
-      this.fetch({ method: 'GET', url: '/api/login/ping', retry: 1 }).pipe(
-        map((response: FetchResponse) => response.data)
-      )
-    );
+    return this.request({ method: 'GET', url: '/api/login/ping', retry: 1 });
   }
 
   /** @deprecated */

--- a/public/app/features/dashboard/components/DeleteDashboard/useDashboardDelete.tsx
+++ b/public/app/features/dashboard/components/DeleteDashboard/useDashboardDelete.tsx
@@ -13,7 +13,7 @@ export const useDashboardDelete = (uid: string, cleanUpDashboardAndVariables: ()
     if (state.value) {
       cleanUpDashboardAndVariables();
       locationService.replace('/');
-      notifyApp.success('Dashboard Deleted', `${state.value.title} has been deleted`);
+      notifyApp.success('Dashboard Deleted', `${state.value.data.title} has been deleted`);
     }
   }, [state, notifyApp, cleanUpDashboardAndVariables]);
 

--- a/public/app/features/dashboard/components/DeleteDashboard/useDashboardDelete.tsx
+++ b/public/app/features/dashboard/components/DeleteDashboard/useDashboardDelete.tsx
@@ -13,7 +13,7 @@ export const useDashboardDelete = (uid: string, cleanUpDashboardAndVariables: ()
     if (state.value) {
       cleanUpDashboardAndVariables();
       locationService.replace('/');
-      notifyApp.success('Dashboard Deleted', `${state.value.data.title} has been deleted`);
+      notifyApp.success('Dashboard Deleted', `${state.value.title} has been deleted`);
     }
   }, [state, notifyApp, cleanUpDashboardAndVariables]);
 

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -1,3 +1,5 @@
+import { lastValueFrom } from 'rxjs';
+
 import { DataSourceInstanceSettings, locationUtil } from '@grafana/data';
 import { getDataSourceSrv, locationService, getBackendSrv, isFetchError } from '@grafana/runtime';
 import { notifyApp } from 'app/core/actions';
@@ -275,11 +277,13 @@ export function saveDashboard(options: SaveDashboardCommand) {
 }
 
 function deleteFolder(uid: string, showSuccessAlert: boolean) {
-  return getBackendSrv().request({
-    method: 'DELETE',
-    url: `/api/folders/${uid}?forceDeleteRules=false`,
-    showSuccessAlert: showSuccessAlert,
-  });
+  return lastValueFrom(
+    getBackendSrv().fetch({
+      method: 'DELETE',
+      url: `/api/folders/${uid}?forceDeleteRules=false`,
+      showSuccessAlert: showSuccessAlert,
+    })
+  );
 }
 
 export function createFolder(payload: any) {
@@ -304,11 +308,13 @@ export function getFolderById(id: number): Promise<{ id: number; title: string }
 }
 
 export function deleteDashboard(uid: string, showSuccessAlert: boolean) {
-  return getBackendSrv().request({
-    method: 'DELETE',
-    url: `/api/dashboards/uid/${uid}`,
-    showSuccessAlert: showSuccessAlert,
-  });
+  return lastValueFrom(
+    getBackendSrv().fetch({
+      method: 'DELETE',
+      url: `/api/dashboards/uid/${uid}`,
+      showSuccessAlert: showSuccessAlert,
+    })
+  );
 }
 
 function executeInOrder(tasks: any[]) {

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -12,6 +12,7 @@ import { LibraryElementExport } from '../../dashboard/components/DashExportModal
 import { getLibraryPanel } from '../../library-panels/state/api';
 import { LibraryElementDTO, LibraryElementKind } from '../../library-panels/types';
 import { DashboardSearchHit } from '../../search/types';
+import { DeleteDashboardResponse } from '../types';
 
 import {
   clearDashboard,
@@ -309,7 +310,7 @@ export function getFolderById(id: number): Promise<{ id: number; title: string }
 
 export function deleteDashboard(uid: string, showSuccessAlert: boolean) {
   return lastValueFrom(
-    getBackendSrv().fetch({
+    getBackendSrv().fetch<DeleteDashboardResponse>({
       method: 'DELETE',
       url: `/api/dashboards/uid/${uid}`,
       showSuccessAlert: showSuccessAlert,

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -1,5 +1,3 @@
-import { lastValueFrom } from 'rxjs';
-
 import { DataSourceInstanceSettings, locationUtil } from '@grafana/data';
 import { getDataSourceSrv, locationService, getBackendSrv, isFetchError } from '@grafana/runtime';
 import { notifyApp } from 'app/core/actions';
@@ -278,13 +276,7 @@ export function saveDashboard(options: SaveDashboardCommand) {
 }
 
 function deleteFolder(uid: string, showSuccessAlert: boolean) {
-  return lastValueFrom(
-    getBackendSrv().fetch({
-      method: 'DELETE',
-      url: `/api/folders/${uid}?forceDeleteRules=false`,
-      showSuccessAlert: showSuccessAlert,
-    })
-  );
+  return getBackendSrv().delete(`/api/folders/${uid}?forceDeleteRules=false`, undefined, { showSuccessAlert });
 }
 
 export function createFolder(payload: any) {
@@ -309,13 +301,7 @@ export function getFolderById(id: number): Promise<{ id: number; title: string }
 }
 
 export function deleteDashboard(uid: string, showSuccessAlert: boolean) {
-  return lastValueFrom(
-    getBackendSrv().fetch<DeleteDashboardResponse>({
-      method: 'DELETE',
-      url: `/api/dashboards/uid/${uid}`,
-      showSuccessAlert: showSuccessAlert,
-    })
-  );
+  return getBackendSrv().delete<DeleteDashboardResponse>(`/api/dashboards/uid/${uid}`, { showSuccessAlert });
 }
 
 function executeInOrder(tasks: any[]) {

--- a/public/app/features/manage-dashboards/types.ts
+++ b/public/app/features/manage-dashboards/types.ts
@@ -11,3 +11,9 @@ export interface Snapshot {
   url?: string;
   userId: number;
 }
+
+export type DeleteDashboardResponse = {
+  id: number;
+  message: string;
+  title: string;
+};

--- a/public/app/plugins/panel/gettingstarted/GettingStarted.tsx
+++ b/public/app/plugins/panel/gettingstarted/GettingStarted.tsx
@@ -1,9 +1,10 @@
 // Libraries
 import { css, cx } from '@emotion/css';
 import React, { PureComponent } from 'react';
+import { lastValueFrom } from 'rxjs';
 
 import { PanelProps } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, HealthCheckResult } from '@grafana/runtime';
 import { Button, Spinner, stylesFactory } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { backendSrv } from 'app/core/services/backend_srv';
@@ -71,15 +72,15 @@ export class GettingStarted extends PureComponent<PanelProps, State> {
 
     dashboard?.removePanel(panel!);
 
-    backendSrv
-      .request({
+    lastValueFrom(
+      backendSrv.fetch({
         method: 'PUT',
         url: '/api/user/helpflags/1',
         showSuccessAlert: false,
       })
-      .then((res: any) => {
-        contextSrv.user.helpFlags1 = res.helpFlags1;
-      });
+    ).then((res: any) => {
+      contextSrv.user.helpFlags1 = res.helpFlags1;
+    });
   };
 
   render() {

--- a/public/app/plugins/panel/gettingstarted/GettingStarted.tsx
+++ b/public/app/plugins/panel/gettingstarted/GettingStarted.tsx
@@ -4,7 +4,7 @@ import React, { PureComponent } from 'react';
 import { lastValueFrom } from 'rxjs';
 
 import { PanelProps } from '@grafana/data';
-import { config, HealthCheckResult } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import { Button, Spinner, stylesFactory } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { backendSrv } from 'app/core/services/backend_srv';

--- a/public/app/plugins/panel/gettingstarted/GettingStarted.tsx
+++ b/public/app/plugins/panel/gettingstarted/GettingStarted.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import { css, cx } from '@emotion/css';
 import React, { PureComponent } from 'react';
-import { lastValueFrom } from 'rxjs';
 
 import { PanelProps } from '@grafana/data';
 import { config } from '@grafana/runtime';
@@ -72,13 +71,7 @@ export class GettingStarted extends PureComponent<PanelProps, State> {
 
     dashboard?.removePanel(panel!);
 
-    lastValueFrom(
-      backendSrv.fetch({
-        method: 'PUT',
-        url: '/api/user/helpflags/1',
-        showSuccessAlert: false,
-      })
-    ).then((res: any) => {
+    backendSrv.put('/api/user/helpflags/1', undefined, { showSuccessAlert: false }).then((res: any) => {
       contextSrv.user.helpFlags1 = res.helpFlags1;
     });
   };


### PR DESCRIPTION
**Related Slack conversation:** https://raintank-corp.slack.com/archives/C01C4K8DETW/p1655930051101479 

### What changed?
- **Feature:** made it possible to pass `options` to `getBackendSrv().get|post|patch...` methods
- **Feature:** updated the DatasourceWithBackend's `.postResource()` and `.getResource()` methods to accept an optional `BackendSrvRequest` parameter as well
- **Refactor:** removed internal usage of `.request()` and replaced it with `.fetch()` to follow up on the deprecation

