### PR TITLE
Chore: Remove CI stats that are also reported by betterer

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2384,10 +2384,10 @@ exports[`no type assertions`] = {
       [70, 30, 10, "Do not use any type assertions.", "1501063862"],
       [71, 13, 12, "Do not use any type assertions.", "1619708599"]
     ],
-    "public/app/features/datasources/DataSourceDashboards.test.tsx:1369048021": [
-      [12, 14, 14, "Do not use any type assertions.", "3112983303"],
-      [13, 16, 23, "Do not use any type assertions.", "860279322"],
-      [14, 16, 24, "Do not use any type assertions.", "3405802617"]
+    "public/app/features/datasources/DataSourceDashboards.test.tsx:4128546737": [
+      [14, 16, 23, "Do not use any type assertions.", "860279322"],
+      [15, 16, 24, "Do not use any type assertions.", "3405802617"],
+      [21, 11, 21, "Do not use any type assertions.", "3218407483"]
     ],
     "public/app/features/datasources/DataSourcesListPage.test.tsx:368182366": [
       [19, 17, 26, "Do not use any type assertions.", "3994646623"],

--- a/scripts/ci-frontend-metrics.sh
+++ b/scripts/ci-frontend-metrics.sh
@@ -9,12 +9,6 @@ STORIES_COUNT="$(find ./packages/grafana-ui/src/components -name "*.story.tsx" |
 MDX_COUNT="$(find ./packages/grafana-ui/src/components -name "*.mdx" | wc -l)"
 LEGACY_FORMS="$(grep -r -oP 'LegacyForms;' public/app | wc -l)"
 
-# This is also included in the betterer stats, but we maintain it to keep metric history
-ENZYME_TEST_COUNT="$(grep -l -R --include="*.test.*" "from 'enzyme'" public packages | wc -l)"
-
-STRICT_LINT_RESULTS="$(yarn run eslint --rule '@typescript-eslint/no-explicit-any: ["error"]' --format unix --ext .ts,.tsx ./ || true)"
-STRICT_LINT_EXPLICIT_ANY="$(echo "${STRICT_LINT_RESULTS}" | grep -o "no-explicit-any" | wc -l)"
-
 TOTAL_BUNDLE="$(du -sk ./public/build | cut -f1)"
 OUTDATED_DEPENDENCIES="$(yarn outdated --all | grep -oP '[[:digit:]]+ *(?= dependencies are out of date)')"
 ## Disabled due to yarn PnP update breaking npm audit
@@ -31,14 +25,12 @@ echo -e "Controllers: $CONTROLLERS"
 echo -e "Stories: $STORIES_COUNT"
 echo -e "Documented stories: $MDX_COUNT"
 echo -e "Legacy forms: $LEGACY_FORMS"
-echo -e "TS Explicit any: $STRICT_LINT_EXPLICIT_ANY"
 echo -e "Total bundle folder size: $TOTAL_BUNDLE"
 echo -e "Total outdated dependencies: $OUTDATED_DEPENDENCIES"
 echo -e "Low vulnerabilities: $LOW_VULNERABILITIES"
 echo -e "Med vulnerabilities: $MED_VULNERABILITIES"
 echo -e "High vulnerabilities: $HIGH_VULNERABILITIES"
 echo -e "Critical vulnerabilities: $CRITICAL_VULNERABILITIES"
-echo -e "Number of enzyme tests: $ENZYME_TEST_COUNT"
 
 BETTERER_STATS=""
 while read -r name value
@@ -56,8 +48,6 @@ echo "Metrics: {
   \"grafana.ci-code.grafana-ui.stories\": \"${STORIES_COUNT}\",
   \"grafana.ci-code.grafana-ui.mdx\": \"${MDX_COUNT}\",
   \"grafana.ci-code.legacyForms\": \"${LEGACY_FORMS}\",
-  \"grafana.ci-code.strictLint.noExplicitAny\": \"${STRICT_LINT_EXPLICIT_ANY}\",
   \"grafana.ci-code.bundleFolderSize\": \"${TOTAL_BUNDLE}\",
-  \"grafana.ci-code.dependencies.outdated\": \"${OUTDATED_DEPENDENCIES}\",
-  \"grafana.ci-code.enzymeTests\": \"${ENZYME_TEST_COUNT}\"
+  \"grafana.ci-code.dependencies.outdated\": \"${OUTDATED_DEPENDENCIES}\"
 }"


### PR DESCRIPTION


**What this PR does / why we need it**:

Removes duplicated CI code stats that are now being reported by betterer. Within our dashboard, we'll have to join up the data using Transforms.

