### PR TITLE
CloudWatch: Enable custom session duration in AWS plugin auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/gosimple/slug v1.9.0
 	github.com/grafana/cuetsy v0.0.3
-	github.com/grafana/grafana-aws-sdk v0.10.6
+	github.com/grafana/grafana-aws-sdk v0.10.7
 	github.com/grafana/grafana-azure-sdk-go v1.2.0
 	github.com/grafana/grafana-plugin-sdk-go v0.138.0
 	github.com/grafana/loki v1.6.2-0.20211015002020-7832783b1caa

--- a/go.sum
+++ b/go.sum
@@ -1463,8 +1463,8 @@ github.com/grafana/dskit v0.0.0-20211011144203-3a88ec0b675f h1:FvvSVEbnGeM2bUivG
 github.com/grafana/dskit v0.0.0-20211011144203-3a88ec0b675f/go.mod h1:uPG2nyK4CtgNDmWv7qyzYcdI+S90kHHRWvHnBtEMBXM=
 github.com/grafana/go-mssqldb v0.0.0-20210326084033-d0ce3c521036 h1:GplhUk6Xes5JIhUUrggPcPBhOn+eT8+WsHiebvq7GgA=
 github.com/grafana/go-mssqldb v0.0.0-20210326084033-d0ce3c521036/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
-github.com/grafana/grafana-aws-sdk v0.10.6 h1:IAY/3Oi3XQa/I2GgTU8XVF+a64huwpJqCUq5EomacZw=
-github.com/grafana/grafana-aws-sdk v0.10.6/go.mod h1:5Iw3xY7iXJfNaYHrRHMXa/kaB2lWoyntg71PPLGvSs8=
+github.com/grafana/grafana-aws-sdk v0.10.7 h1:kXOuWCI+fV561/9sOU0DnzlFwqblfW36XptJLv78l8s=
+github.com/grafana/grafana-aws-sdk v0.10.7/go.mod h1:5Iw3xY7iXJfNaYHrRHMXa/kaB2lWoyntg71PPLGvSs8=
 github.com/grafana/grafana-azure-sdk-go v1.2.0 h1:f/7BjCHGIU0JYOsLIt4oJztDy0fOPBRHB5R0Xe9++ew=
 github.com/grafana/grafana-azure-sdk-go v1.2.0/go.mod h1:rgrnK9m6CgKlgx4rH3FFP/6dTdyRO6LYC2mVZov35yo=
 github.com/grafana/grafana-google-sdk-go v0.0.0-20211104130251-b190293eaf58 h1:2ud7NNM7LrGPO4x0NFR8qLq68CqI4SmB7I2yRN2w9oE=


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR upgrades to the most recent version of the grafana-aws-sdk. 

Included in version 0.10.7 of the grafana-aws-sdk is a potential fix for a `SignatureDoesNotMatch` issue in CloudWatch logs. The issue was first reported in [this](https://github.com/grafana/support-escalations/issues/2642) escalation, and more info about the fix can be found in the [PR](https://github.com/grafana/grafana-aws-sdk/pull/58) in the grafana-aws-sdk. 

**Special notes for your reviewer**:
We have not been able to reproduce the issue reported in the escalation, but the theory is that it's caused by mismatching signatures due to too short credentials cache duration in the case logs queries are long running. The customer has confirmed that they're willing to help us test this potential fix. If it solves their problem, we'll make this a part of grafana configuration and document it accordingly. 
