### PR TITLE
Chore: avoid implicit any by using inline functions

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3197,18 +3197,14 @@ exports[`no type assertions`] = {
       [26, 25, 60, "Do not use any type assertions.", "1006626118"],
       [61, 21, 28, "Do not use any type assertions.", "1547636696"]
     ],
-    "public/app/features/search/page/components/FolderSection.tsx:2694034564": [
-      [139, 27, 22, "Do not use any type assertions.", "3217586069"]
-    ],
     "public/app/features/search/page/components/ManageActions.tsx:2913473343": [
       [47, 28, 26, "Do not use any type assertions.", "1971436753"]
     ],
     "public/app/features/search/page/components/MoveToFolderModal.tsx:739519709": [
       [66, 51, 15, "Do not use any type assertions.", "3135191849"]
     ],
-    "public/app/features/search/page/components/SearchResultsCards.tsx:4110686088": [
-      [54, 21, 56, "Do not use any type assertions.", "1375039711"],
-      [94, 31, 22, "Do not use any type assertions.", "3217586069"]
+    "public/app/features/search/page/components/SearchResultsCards.tsx:590892204": [
+      [45, 21, 56, "Do not use any type assertions.", "1375039711"]
     ],
     "public/app/features/search/page/components/SearchResultsGrid.tsx:994645204": [
       [30, 16, 28, "Do not use any type assertions.", "1941050010"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -10058,14 +10058,8 @@ exports[`no explicit any`] = {
     "public/app/features/search/components/SearchResults.tsx:4264592788": [
       [19, 35, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "public/app/features/search/page/components/FolderSection.tsx:2694034564": [
-      [139, 46, 3, "Unexpected any. Specify a different type.", "193409811"]
-    ],
     "public/app/features/search/page/components/MoveToFolderModal.tsx:739519709": [
       [31, 63, 3, "Unexpected any. Specify a different type.", "193409811"]
-    ],
-    "public/app/features/search/page/components/SearchResultsCards.tsx:4110686088": [
-      [94, 50, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "public/app/features/search/page/components/SearchResultsGrid.test.tsx:2090205358": [
       [40, 35, 3, "Unexpected any. Specify a different type.", "193409811"]

--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -99,12 +99,6 @@ export const FolderSection: FC<SectionHeaderProps> = ({
     }
   };
 
-  const onToggleChecked = (item: DashboardSectionItem) => {
-    if (selectionToggle) {
-      selectionToggle('dashboard', item.uid!);
-    }
-  };
-
   const id = useUniqueId();
   const labelId = `section-header-label-${id}`;
 
@@ -137,7 +131,11 @@ export const FolderSection: FC<SectionHeaderProps> = ({
           key={v.uid}
           item={v}
           onTagSelected={onTagSelected}
-          onToggleChecked={onToggleChecked as any}
+          onToggleChecked={(item) => {
+            if (selectionToggle) {
+              selectionToggle('dashboard', item.uid!);
+            }
+          }}
           editable={Boolean(selection != null)}
         />
       );

--- a/public/app/features/search/page/components/SearchResultsCards.tsx
+++ b/public/app/features/search/page/components/SearchResultsCards.tsx
@@ -41,15 +41,6 @@ export const SearchResultsCards = React.memo(
       }
     }, [response, listEl]);
 
-    const onToggleChecked = useCallback(
-      (item: DashboardSectionItem) => {
-        if (selectionToggle) {
-          selectionToggle('dashboard', item.uid!);
-        }
-      },
-      [selectionToggle]
-    );
-
     const RenderRow = useCallback(
       ({ index: rowIndex, style }) => {
         const meta = response.view.dataFrame.meta?.custom as SearchResultMeta;
@@ -92,13 +83,17 @@ export const SearchResultsCards = React.memo(
             <SearchItem
               item={v}
               onTagSelected={onTagSelected}
-              onToggleChecked={onToggleChecked as any}
+              onToggleChecked={(item) => {
+                if (selectionToggle) {
+                  selectionToggle('dashboard', item.uid!);
+                }
+              }}
               editable={Boolean(selection != null)}
             />
           </div>
         );
       },
-      [response.view, highlightIndex, styles, onTagSelected, selection, selectionToggle, onToggleChecked]
+      [response.view, highlightIndex, styles, onTagSelected, selection, selectionToggle]
     );
 
     if (!response.totalRows) {


### PR DESCRIPTION
I'm not sure it is better... but it does cause fewer lint issues 🤷 

These are both in temporary migration interfaces where we should replace them with "real" objects after https://github.com/grafana/grafana/pull/50125

