### PR TITLE
Chore: Add scripts/go/bin/** to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ pkg/cmd/grafana-server/__debug_bin
 /packages/**/.rpt2_cache
 /packages/**/tsdoc-metadata.json
 
+# Ignore go local build dependencies
+/scripts/go/bin/**
+
 # Ignore compilation stats from `yarn stats`
 compilation-stats.json
 


### PR DESCRIPTION
Add back scripts/go/bin/** to .gitignore so we can keep ignoring it!