### PR TITLE
TeamSync: Remove LDAP specific example from team sync

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4512,7 +4512,7 @@ exports[`no explicit any`] = {
       [45, 20, 3, "Unexpected any. Specify a different type.", "193409811"],
       [47, 17, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "public/app/features/teams/TeamGroupSync.tsx:187124828": [
+    "public/app/features/teams/TeamGroupSync.tsx:2819142271": [
       [59, 32, 3, "Unexpected any. Specify a different type.", "193409811"],
       [63, 23, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],

--- a/public/app/features/teams/TeamGroupSync.tsx
+++ b/public/app/features/teams/TeamGroupSync.tsx
@@ -37,7 +37,7 @@ interface State {
 const connector = connect(mapStateToProps, mapDispatchToProps);
 export type Props = OwnProps & ConnectedProps<typeof connector>;
 
-const headerTooltip = `Sync LDAP or OAuth groups with your Grafana teams.`;
+const headerTooltip = `Sync LDAP, OAuth or SAML groups with your Grafana teams.`;
 
 export class TeamGroupSync extends PureComponent<Props, State> {
   constructor(props: Props) {
@@ -130,17 +130,18 @@ export class TeamGroupSync extends PureComponent<Props, State> {
             <CloseButton onClick={this.onToggleAdding} />
             <form onSubmit={this.onAddGroup}>
               <InlineFieldRow>
-                <InlineField label={'Add External Group'}>
+                <InlineField
+                  label={'Add External Group'}
+                  tooltip={'LDAP Group Example: cn=users,ou=groups,dc=grafana,dc=org.'}
+                >
                   <Input
                     type="text"
                     id={'add-external-group'}
                     value={newGroupId}
                     onChange={this.onNewGroupIdChanged}
-                    placeholder="cn=ops,ou=groups,dc=grafana,dc=org"
                     disabled={isReadOnly}
                   />
                 </InlineField>
-
                 <Button type="submit" disabled={isReadOnly || !this.isNewGroupValid()} style={{ marginLeft: 4 }}>
                   Add group
                 </Button>

--- a/public/app/features/teams/TeamGroupSync.tsx
+++ b/public/app/features/teams/TeamGroupSync.tsx
@@ -132,11 +132,12 @@ export class TeamGroupSync extends PureComponent<Props, State> {
               <InlineFieldRow>
                 <InlineField
                   label={'Add External Group'}
-                  tooltip={'LDAP Group Example: cn=users,ou=groups,dc=grafana,dc=org.'}
+                  tooltip="LDAP Group Example: cn=users,ou=groups,dc=grafana,dc=org."
                 >
                   <Input
                     type="text"
                     id={'add-external-group'}
+                    placeholder=""
                     value={newGroupId}
                     onChange={this.onNewGroupIdChanged}
                     disabled={isReadOnly}


### PR DESCRIPTION
Co-authored-by: Gabriel MABILLE <gamab@users.noreply.github.com>

**Why we need it**:

https://github.com/grafana/support-escalations/issues/2098

User report of unclear prompt making team sync seem LDAP specific.

**What does it do**:

- Clear prompt placeholder
- Add LDAP example as tooltip (mentioning it's specifically for LDAP)