### PR TITLE
renovate: add more default-labels

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,7 +42,7 @@
     "react-test-renderer"
   ],
   "ignorePaths": ["packages/grafana-toolkit/package.json", "emails/**", "plugins-bundled/**", "**/mocks/**"],
-  "labels": ["area/frontend", "dependencies"],
+  "labels": ["area/frontend", "dependencies", "no-backport", "no-changelog"],
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
`no-backport` and `no-changelog` seems to be useful to be set by default