### PR TITLE
Alerting: adds additional command palette actions

### DIFF
--- a/public/app/features/commandPalette/actions/alerting.static.actions.ts
+++ b/public/app/features/commandPalette/actions/alerting.static.actions.ts
@@ -1,0 +1,73 @@
+import { Priority } from 'kbar';
+
+import { locationService } from '@grafana/runtime';
+
+import { NavBarActions } from './global.static.actions';
+
+// Grafana Alerting and alerting sub navigation items
+const alertingCommandPaletteStaticActions: NavBarActions[] = [
+  {
+    url: '/alerting',
+    actions: [
+      {
+        id: 'go/alerting',
+        name: 'Go to alerting',
+        keywords: 'alerting navigate',
+        perform: () => locationService.push('/alerting'),
+        section: 'Navigation',
+        priority: Priority.NORMAL,
+      },
+    ],
+  },
+  {
+    url: '/alerting',
+    actions: [
+      {
+        id: 'go/alerting/rules',
+        name: 'Go to alert rules',
+        keywords: 'alerting navigate rules',
+        perform: () => locationService.push('/alerting/list'),
+        section: 'Navigation',
+        parent: 'go/alerting',
+      },
+    ],
+  },
+  {
+    url: '/alerting',
+    actions: [
+      {
+        id: 'go/alerting/contact-points',
+        name: 'Go to contact points',
+        keywords: 'alerting navigate contact-points',
+        perform: () => locationService.push('/alerting/notifications'),
+        parent: 'go/alerting',
+      },
+    ],
+  },
+  {
+    url: '/alerting',
+    actions: [
+      {
+        id: 'go/alerting/notification-policies',
+        name: 'Go to notification policies',
+        keywords: 'alerting navigate notification-policies',
+        perform: () => locationService.push('/alerting/routes'),
+        parent: 'go/alerting',
+      },
+    ],
+  },
+  {
+    url: '/alerting',
+    actions: [
+      {
+        id: 'go/alerting/silences',
+        name: 'Go to silences',
+        keywords: 'alerting navigate silences',
+        perform: () => locationService.push('/alerting/silences'),
+        parent: 'go/alerting',
+      },
+    ],
+  },
+];
+
+export { alertingCommandPaletteStaticActions };

--- a/public/app/features/commandPalette/actions/alerting.static.actions.ts
+++ b/public/app/features/commandPalette/actions/alerting.static.actions.ts
@@ -7,7 +7,7 @@ import { NavBarActions } from './global.static.actions';
 // Grafana Alerting and alerting sub navigation items
 const alertingCommandPaletteStaticActions: NavBarActions[] = [
   {
-    url: '/alerting',
+    url: '/alerting/list',
     actions: [
       {
         id: 'go/alerting',
@@ -20,7 +20,7 @@ const alertingCommandPaletteStaticActions: NavBarActions[] = [
     ],
   },
   {
-    url: '/alerting',
+    url: '/alerting/list',
     actions: [
       {
         id: 'go/alerting/rules',
@@ -33,7 +33,7 @@ const alertingCommandPaletteStaticActions: NavBarActions[] = [
     ],
   },
   {
-    url: '/alerting',
+    url: '/alerting/notifications',
     actions: [
       {
         id: 'go/alerting/contact-points',
@@ -45,7 +45,7 @@ const alertingCommandPaletteStaticActions: NavBarActions[] = [
     ],
   },
   {
-    url: '/alerting',
+    url: '/alerting/routes',
     actions: [
       {
         id: 'go/alerting/notification-policies',
@@ -57,7 +57,7 @@ const alertingCommandPaletteStaticActions: NavBarActions[] = [
     ],
   },
   {
-    url: '/alerting',
+    url: '/alerting/silences',
     actions: [
       {
         id: 'go/alerting/silences',

--- a/public/app/features/commandPalette/actions/global.static.actions.ts
+++ b/public/app/features/commandPalette/actions/global.static.actions.ts
@@ -3,6 +3,13 @@ import { Action, Priority } from 'kbar';
 import { NavModelItem } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 
+import { alertingCommandPaletteStaticActions } from './alerting.static.actions';
+
+export interface NavBarActions {
+  url: string;
+  actions: Action[];
+}
+
 export default (navBarTree: NavModelItem[]) => {
   const globalActions: Action[] = [
     {
@@ -52,7 +59,7 @@ export default (navBarTree: NavModelItem[]) => {
 
   // this maps actions to navbar by URL items for showing/hiding
   // actions is an array for multiple child actions that would be under one navbar item
-  const navBarActionMap = [
+  const navBarActionMap: NavBarActions[] = [
     {
       url: '/dashboard/new',
       actions: [
@@ -99,19 +106,7 @@ export default (navBarTree: NavModelItem[]) => {
         },
       ],
     },
-    {
-      url: '/alerting',
-      actions: [
-        {
-          id: 'go/alerting',
-          name: 'Go to alerting',
-          keywords: 'navigate notification',
-          perform: () => locationService.push('/alerting'),
-          section: 'Navigation',
-          priority: Priority.NORMAL,
-        },
-      ],
-    },
+    ...alertingCommandPaletteStaticActions,
     {
       url: '/profile',
       actions: [
@@ -143,7 +138,7 @@ export default (navBarTree: NavModelItem[]) => {
   const navBarActions: Action[] = [];
 
   navBarActionMap.forEach((navBarAction) => {
-    const navBarItem = navBarTree.find((navBarItem) => navBarItem.url === navBarAction.url);
+    const navBarItem = navBarTree.find((navBarItem) => navBarItem.url?.startsWith(navBarAction.url));
     if (navBarItem) {
       navBarActions.push(...navBarAction.actions);
     }

--- a/public/app/features/commandPalette/actions/global.static.actions.ts
+++ b/public/app/features/commandPalette/actions/global.static.actions.ts
@@ -1,4 +1,5 @@
 import { Action, Priority } from 'kbar';
+import { flatMapDeep } from 'lodash';
 
 import { NavModelItem } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
@@ -136,9 +137,12 @@ export default (navBarTree: NavModelItem[]) => {
   ];
 
   const navBarActions: Action[] = [];
+  const navBarFlatUrls = flatMapDeep(navBarTree, (nbt) => nbt.children)
+    .map((nbf) => nbf?.url)
+    .filter((url) => url !== undefined);
 
   navBarActionMap.forEach((navBarAction) => {
-    const navBarItem = navBarTree.find((navBarItem) => navBarItem.url?.startsWith(navBarAction.url));
+    const navBarItem = navBarFlatUrls.find((url) => navBarAction.url === url);
     if (navBarItem) {
       navBarActions.push(...navBarAction.actions);
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds additional alerting navigation items to the command palette and fixes a small bug that prevents some navigation actions from showing up.


https://user-images.githubusercontent.com/868844/175574532-85b93176-6f8c-4873-a12e-1da9d9bf1c90.mp4



**Special notes for your reviewer**:

I got confused initially about why the alerting command wouldn't show up and I traced it down to a bug where we assert what navigation commands are available based on the items in the `navBarTree`. 

We'd previously do an URL path comparison (using `===`) but we should be checking instead if the `navBarTree` item's URL starts with the URL we defined on the navigation command since alert's URL is `/alerting/list` instead of `/alerting`.
