### PR TITLE
Alerting: Add method to provisioning API for obtaining a group and its rules

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -284,7 +284,7 @@ func (srv *ProvisioningSrv) RouteDeleteAlertRule(c *models.ReqContext, UID strin
 	return response.JSON(http.StatusNoContent, "")
 }
 
-func (srv *ProvisioningSrv) RouteGetAlertRuleGroup(c *models.ReqContext) response.Response {
+func (srv *ProvisioningSrv) RouteGetAlertRuleGroup(c *models.ReqContext, folder string, group string) response.Response {
 	return nil
 }
 

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -54,7 +54,7 @@ type AlertRuleService interface {
 	CreateAlertRule(ctx context.Context, rule alerting_models.AlertRule, provenance alerting_models.Provenance) (alerting_models.AlertRule, error)
 	UpdateAlertRule(ctx context.Context, rule alerting_models.AlertRule, provenance alerting_models.Provenance) (alerting_models.AlertRule, error)
 	DeleteAlertRule(ctx context.Context, orgID int64, ruleUID string, provenance alerting_models.Provenance) error
-	GetRuleGroup(ctx context.Context, orgID int64, folder, group string) (*definitions.AlertRuleGroup, error)
+	GetRuleGroup(ctx context.Context, orgID int64, folder, group string) (definitions.AlertRuleGroup, error)
 	UpdateRuleGroup(ctx context.Context, orgID int64, folderUID, rulegroup string, interval int64) error
 }
 
@@ -288,10 +288,10 @@ func (srv *ProvisioningSrv) RouteDeleteAlertRule(c *models.ReqContext, UID strin
 func (srv *ProvisioningSrv) RouteGetAlertRuleGroup(c *models.ReqContext, folder string, group string) response.Response {
 	g, err := srv.alertRules.GetRuleGroup(c.Req.Context(), c.OrgId, folder, group)
 	if err != nil {
+		if errors.Is(err, store.ErrAlertRuleGroupNotFound) {
+			return ErrResp(http.StatusNotFound, err, "")
+		}
 		return ErrResp(http.StatusInternalServerError, err, "")
-	}
-	if g == nil {
-		return response.Empty(http.StatusNotFound)
 	}
 	return response.JSON(http.StatusOK, g)
 }

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -284,7 +284,11 @@ func (srv *ProvisioningSrv) RouteDeleteAlertRule(c *models.ReqContext, UID strin
 	return response.JSON(http.StatusNoContent, "")
 }
 
-func (srv *ProvisioningSrv) RoutePutAlertRuleGroup(c *models.ReqContext, ag definitions.AlertRuleGroup, folderUID string, group string) response.Response {
+func (srv *ProvisioningSrv) RouteGetAlertRuleGroup(c *models.ReqContext) response.Response {
+	return nil
+}
+
+func (srv *ProvisioningSrv) RoutePutAlertRuleGroup(c *models.ReqContext, ag definitions.AlertRuleGroupMetadata, folderUID string, group string) response.Response {
 	err := srv.alertRules.UpdateRuleGroup(c.Req.Context(), c.OrgId, folderUID, group, ag.Interval)
 	if err != nil {
 		if errors.Is(err, store.ErrOptimisticLock) {

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -54,6 +54,7 @@ type AlertRuleService interface {
 	CreateAlertRule(ctx context.Context, rule alerting_models.AlertRule, provenance alerting_models.Provenance) (alerting_models.AlertRule, error)
 	UpdateAlertRule(ctx context.Context, rule alerting_models.AlertRule, provenance alerting_models.Provenance) (alerting_models.AlertRule, error)
 	DeleteAlertRule(ctx context.Context, orgID int64, ruleUID string, provenance alerting_models.Provenance) error
+	GetRuleGroup(ctx context.Context, orgID int64, folder, group string) (*definitions.AlertRuleGroup, error)
 	UpdateRuleGroup(ctx context.Context, orgID int64, folderUID, rulegroup string, interval int64) error
 }
 
@@ -285,7 +286,14 @@ func (srv *ProvisioningSrv) RouteDeleteAlertRule(c *models.ReqContext, UID strin
 }
 
 func (srv *ProvisioningSrv) RouteGetAlertRuleGroup(c *models.ReqContext, folder string, group string) response.Response {
-	return nil
+	g, err := srv.alertRules.GetRuleGroup(c.Req.Context(), c.OrgId, folder, group)
+	if err != nil {
+		return ErrResp(http.StatusInternalServerError, err, "")
+	}
+	if g == nil {
+		return response.Empty(http.StatusNotFound)
+	}
+	return response.JSON(http.StatusOK, g)
 }
 
 func (srv *ProvisioningSrv) RoutePutAlertRuleGroup(c *models.ReqContext, ag definitions.AlertRuleGroupMetadata, folderUID string, group string) response.Response {

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -239,6 +239,28 @@ func TestProvisioningApi(t *testing.T) {
 			require.Equal(t, 404, response.Status())
 		})
 	})
+
+	t.Run("alert rule groups", func(t *testing.T) {
+		t.Run("are present, GET returns 200", func(t *testing.T) {
+			sut := createProvisioningSrvSut(t)
+			rc := createTestRequestCtx()
+			insertRule(t, sut, createTestAlertRule("rule", 1))
+
+			response := sut.RouteGetAlertRuleGroup(&rc, "folder-uid", "my-cool-group")
+
+			require.Equal(t, 200, response.Status())
+		})
+
+		t.Run("are missing, GET returns 404", func(t *testing.T) {
+			sut := createProvisioningSrvSut(t)
+			rc := createTestRequestCtx()
+			insertRule(t, sut, createTestAlertRule("rule", 1))
+
+			response := sut.RouteGetAlertRuleGroup(&rc, "folder-uid", "does not exist")
+
+			require.Equal(t, 404, response.Status())
+		})
+	})
 }
 
 func createProvisioningSrvSut(t *testing.T) ProvisioningSrv {
@@ -382,6 +404,7 @@ func createTestAlertRule(title string, orgID int64) definitions.AlertRule {
 			},
 		},
 		RuleGroup:    "my-cool-group",
+		FolderUID:    "folder-uid",
 		For:          time.Second * 60,
 		NoDataState:  models.OK,
 		ExecErrState: models.OkErrState,

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -185,7 +185,8 @@ func (api *API) authorize(method, path string) web.Handler {
 		http.MethodGet + "/api/v1/provisioning/templates/{name}",
 		http.MethodGet + "/api/v1/provisioning/mute-timings",
 		http.MethodGet + "/api/v1/provisioning/mute-timings/{name}",
-		http.MethodGet + "/api/v1/provisioning/alert-rules/{UID}":
+		http.MethodGet + "/api/v1/provisioning/alert-rules/{UID}",
+		http.MethodGet + "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}":
 		fallback = middleware.ReqOrgAdmin
 		eval = ac.EvalPermission(ac.ActionAlertingProvisioningRead) // organization scope
 

--- a/pkg/services/ngalert/api/forked_provisioning.go
+++ b/pkg/services/ngalert/api/forked_provisioning.go
@@ -95,6 +95,10 @@ func (f *ForkedProvisioningApi) forkRouteDeleteAlertRule(ctx *models.ReqContext,
 	return f.svc.RouteDeleteAlertRule(ctx, UID)
 }
 
-func (f *ForkedProvisioningApi) forkRoutePutAlertRuleGroup(ctx *models.ReqContext, ag apimodels.AlertRuleGroup, folder, group string) response.Response {
+func (f *ForkedProvisioningApi) forkRouteGetAlertRuleGroup(ctx *models.ReqContext) response.Response {
+	return f.svc.RouteGetAlertRuleGroup(ctx)
+}
+
+func (f *ForkedProvisioningApi) forkRoutePutAlertRuleGroup(ctx *models.ReqContext, ag apimodels.AlertRuleGroupMetadata, folder, group string) response.Response {
 	return f.svc.RoutePutAlertRuleGroup(ctx, ag, folder, group)
 }

--- a/pkg/services/ngalert/api/forked_provisioning.go
+++ b/pkg/services/ngalert/api/forked_provisioning.go
@@ -95,8 +95,8 @@ func (f *ForkedProvisioningApi) forkRouteDeleteAlertRule(ctx *models.ReqContext,
 	return f.svc.RouteDeleteAlertRule(ctx, UID)
 }
 
-func (f *ForkedProvisioningApi) forkRouteGetAlertRuleGroup(ctx *models.ReqContext) response.Response {
-	return f.svc.RouteGetAlertRuleGroup(ctx)
+func (f *ForkedProvisioningApi) forkRouteGetAlertRuleGroup(ctx *models.ReqContext, folder, group string) response.Response {
+	return f.svc.RouteGetAlertRuleGroup(ctx, folder, group)
 }
 
 func (f *ForkedProvisioningApi) forkRoutePutAlertRuleGroup(ctx *models.ReqContext, ag apimodels.AlertRuleGroupMetadata, folder, group string) response.Response {

--- a/pkg/services/ngalert/api/generated_base_api_provisioning.go
+++ b/pkg/services/ngalert/api/generated_base_api_provisioning.go
@@ -24,6 +24,7 @@ type ProvisioningApiForkingService interface {
 	RouteDeleteMuteTiming(*models.ReqContext) response.Response
 	RouteDeleteTemplate(*models.ReqContext) response.Response
 	RouteGetAlertRule(*models.ReqContext) response.Response
+	RouteGetAlertRuleGroup(*models.ReqContext) response.Response
 	RouteGetContactpoints(*models.ReqContext) response.Response
 	RouteGetMuteTiming(*models.ReqContext) response.Response
 	RouteGetMuteTimings(*models.ReqContext) response.Response
@@ -60,6 +61,9 @@ func (f *ForkedProvisioningApi) RouteDeleteTemplate(ctx *models.ReqContext) resp
 func (f *ForkedProvisioningApi) RouteGetAlertRule(ctx *models.ReqContext) response.Response {
 	uIDParam := web.Params(ctx.Req)[":UID"]
 	return f.forkRouteGetAlertRule(ctx, uIDParam)
+}
+func (f *ForkedProvisioningApi) RouteGetAlertRuleGroup(ctx *models.ReqContext) response.Response {
+	return f.forkRouteGetAlertRuleGroup(ctx)
 }
 func (f *ForkedProvisioningApi) RouteGetContactpoints(ctx *models.ReqContext) response.Response {
 	return f.forkRouteGetContactpoints(ctx)
@@ -113,7 +117,7 @@ func (f *ForkedProvisioningApi) RoutePutAlertRule(ctx *models.ReqContext) respon
 func (f *ForkedProvisioningApi) RoutePutAlertRuleGroup(ctx *models.ReqContext) response.Response {
 	folderUIDParam := web.Params(ctx.Req)[":FolderUID"]
 	groupParam := web.Params(ctx.Req)[":Group"]
-	conf := apimodels.AlertRuleGroup{}
+	conf := apimodels.AlertRuleGroupMetadata{}
 	if err := web.Bind(ctx.Req, &conf); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
@@ -200,6 +204,16 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingServi
 				http.MethodGet,
 				"/api/v1/provisioning/alert-rules/{UID}",
 				srv.RouteGetAlertRule,
+				m,
+			),
+		)
+		group.Get(
+			toMacaronPath("/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}"),
+			api.authorize(http.MethodGet, "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}"),
+			metrics.Instrument(
+				http.MethodGet,
+				"/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}",
+				srv.RouteGetAlertRuleGroup,
 				m,
 			),
 		)

--- a/pkg/services/ngalert/api/generated_base_api_provisioning.go
+++ b/pkg/services/ngalert/api/generated_base_api_provisioning.go
@@ -63,7 +63,9 @@ func (f *ForkedProvisioningApi) RouteGetAlertRule(ctx *models.ReqContext) respon
 	return f.forkRouteGetAlertRule(ctx, uIDParam)
 }
 func (f *ForkedProvisioningApi) RouteGetAlertRuleGroup(ctx *models.ReqContext) response.Response {
-	return f.forkRouteGetAlertRuleGroup(ctx)
+	folderUIDParam := web.Params(ctx.Req)[":FolderUID"]
+	groupParam := web.Params(ctx.Req)[":Group"]
+	return f.forkRouteGetAlertRuleGroup(ctx, folderUIDParam, groupParam)
 }
 func (f *ForkedProvisioningApi) RouteGetContactpoints(ctx *models.ReqContext) response.Response {
 	return f.forkRouteGetContactpoints(ctx)

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -3188,13 +3188,15 @@
    "type": "object"
   },
   "gettableAlerts": {
-   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
-   "type": "array"
+   "type": "array",
+   "x-go-name": "GettableAlerts",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "gettableSilence": {
+   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3240,9 +3242,7 @@
     "status",
     "updatedAt"
    ],
-   "type": "object",
-   "x-go-name": "GettableSilence",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "object"
   },
   "gettableSilences": {
    "description": "GettableSilences gettable silences",
@@ -3744,6 +3744,20 @@
   "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
    "get": {
     "operationId": "RouteGetAlertRuleGroup",
+    "parameters": [
+     {
+      "in": "path",
+      "name": "FolderUID",
+      "required": true,
+      "type": "string"
+     },
+     {
+      "in": "path",
+      "name": "Group",
+      "required": true,
+      "type": "string"
+     }
+    ],
     "responses": {
      "200": {
       "$ref": "#/responses/AlertRuleGroup"

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -308,7 +308,7 @@
    ],
    "type": "object"
   },
-  "AlertRuleGroup": {
+  "AlertRuleGroupMetadata": {
    "properties": {
     "interval": {
      "format": "int64",
@@ -470,6 +470,7 @@
    },
    "type": "array"
   },
+<<<<<<< HEAD
   "DashboardAclUpdateItem": {
    "properties": {
     "permission": {
@@ -494,6 +495,8 @@
    },
    "type": "object"
   },
+=======
+>>>>>>> 01a9b04d19 (Generate shell for new route)
   "DateTime": {
    "description": "DateTime is a time but it serializes to ISO8601 format with millis\nIt knows how to read 3 different variations of a RFC3339 date time.\nMost APIs we encounter want either millisecond or second precision times.\nThis just tries to make it worry-free.",
    "format": "date-time",
@@ -2738,6 +2741,7 @@
    "type": "object"
   },
   "URL": {
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -2770,6 +2774,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
+<<<<<<< HEAD
    "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object"
   },
@@ -2823,6 +2828,11 @@
     }
    },
    "type": "object"
+=======
+   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "type": "object",
+   "x-go-package": "net/url"
+>>>>>>> 01a9b04d19 (Generate shell for new route)
   },
   "Userinfo": {
    "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -3178,13 +3188,13 @@
    "type": "object"
   },
   "gettableAlerts": {
+   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
    "type": "array"
   },
   "gettableSilence": {
-   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3230,7 +3240,9 @@
     "status",
     "updatedAt"
    ],
-   "type": "object"
+   "type": "object",
+   "x-go-name": "GettableSilence",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "gettableSilences": {
    "description": "GettableSilences gettable silences",
@@ -3730,6 +3742,21 @@
    }
   },
   "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
+   "get": {
+    "operationId": "RouteGetAlertRuleGroup",
+    "responses": {
+     "200": {
+      "$ref": "#/responses/AlertRuleGroup"
+     },
+     "404": {
+      "description": " Not found."
+     }
+    },
+    "summary": "Get a rule group.",
+    "tags": [
+     "provisioning"
+    ]
+   },
    "put": {
     "consumes": [
      "application/json"
@@ -3752,16 +3779,13 @@
       "in": "body",
       "name": "Body",
       "schema": {
-       "$ref": "#/definitions/AlertRuleGroup"
+       "$ref": "#/definitions/AlertRuleGroupMetadata"
       }
      }
     ],
     "responses": {
      "200": {
-      "description": "AlertRuleGroup",
-      "schema": {
-       "$ref": "#/definitions/AlertRuleGroup"
-      }
+      "$ref": "#/responses/AlertRuleGroup"
      },
      "400": {
       "description": "ValidationError",

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -470,33 +470,6 @@
    },
    "type": "array"
   },
-<<<<<<< HEAD
-  "DashboardAclUpdateItem": {
-   "properties": {
-    "permission": {
-     "$ref": "#/definitions/PermissionType"
-    },
-    "role": {
-     "enum": [
-      "Viewer",
-      "Editor",
-      "Admin"
-     ],
-     "type": "string"
-    },
-    "teamId": {
-     "format": "int64",
-     "type": "integer"
-    },
-    "userId": {
-     "format": "int64",
-     "type": "integer"
-    }
-   },
-   "type": "object"
-  },
-=======
->>>>>>> 01a9b04d19 (Generate shell for new route)
   "DateTime": {
    "description": "DateTime is a time but it serializes to ISO8601 format with millis\nIt knows how to read 3 different variations of a RFC3339 date time.\nMost APIs we encounter want either millisecond or second precision times.\nThis just tries to make it worry-free.",
    "format": "date-time",
@@ -1339,48 +1312,6 @@
    },
    "type": "array"
   },
-  "MetricRequest": {
-   "properties": {
-    "debug": {
-     "type": "boolean"
-    },
-    "from": {
-     "description": "From Start time in epoch timestamps in milliseconds or relative using Grafana time units.",
-     "example": "now-1h",
-     "type": "string"
-    },
-    "queries": {
-     "description": "queries.refId – Specifies an identifier of the query. Is optional and default to “A”.\nqueries.datasourceId – Specifies the data source to be queried. Each query in the request must have an unique datasourceId.\nqueries.maxDataPoints - Species maximum amount of data points that dashboard panel can render. Is optional and default to 100.\nqueries.intervalMs - Specifies the time interval in milliseconds of time series. Is optional and defaults to 1000.",
-     "example": [
-      {
-       "datasource": {
-        "uid": "PD8C576611E62080A"
-       },
-       "format": "table",
-       "intervalMs": 86400000,
-       "maxDataPoints": 1092,
-       "rawSql": "SELECT 1 as valueOne, 2 as valueTwo",
-       "refId": "A"
-      }
-     ],
-     "items": {
-      "$ref": "#/definitions/Json"
-     },
-     "type": "array"
-    },
-    "to": {
-     "description": "To End time in epoch timestamps in milliseconds or relative using Grafana time units.",
-     "example": "now",
-     "type": "string"
-    }
-   },
-   "required": [
-    "from",
-    "to",
-    "queries"
-   ],
-   "type": "object"
-  },
   "MonthRange": {
    "properties": {
     "Begin": {
@@ -1425,34 +1356,6 @@
      "$ref": "#/definitions/GettableRuleGroupConfig"
     },
     "type": "array"
-   },
-   "type": "object"
-  },
-  "NavLink": {
-   "properties": {
-    "id": {
-     "type": "string"
-    },
-    "target": {
-     "type": "string"
-    },
-    "text": {
-     "type": "string"
-    },
-    "url": {
-     "type": "string"
-    }
-   },
-   "type": "object"
-  },
-  "NavbarPreference": {
-   "properties": {
-    "savedItems": {
-     "items": {
-      "$ref": "#/definitions/NavLink"
-     },
-     "type": "array"
-    }
    },
    "type": "object"
   },
@@ -1671,52 +1574,8 @@
    },
    "type": "object"
   },
-  "PatchPrefsCmd": {
-   "properties": {
-    "homeDashboardId": {
-     "default": 0,
-     "description": "The numerical :id of a favorited dashboard",
-     "format": "int64",
-     "type": "integer"
-    },
-    "homeDashboardUID": {
-     "type": "string"
-    },
-    "locale": {
-     "type": "string"
-    },
-    "navbar": {
-     "$ref": "#/definitions/NavbarPreference"
-    },
-    "queryHistory": {
-     "$ref": "#/definitions/QueryHistoryPreference"
-    },
-    "theme": {
-     "enum": [
-      "light",
-      "dark"
-     ],
-     "type": "string"
-    },
-    "timezone": {
-     "enum": [
-      "utc",
-      "browser"
-     ],
-     "type": "string"
-    },
-    "weekStart": {
-     "type": "string"
-    }
-   },
-   "type": "object"
-  },
   "PermissionDenied": {
    "type": "object"
-  },
-  "PermissionType": {
-   "format": "int64",
-   "type": "integer"
   },
   "Point": {
    "properties": {
@@ -2035,14 +1894,6 @@
     },
     "user_key": {
      "$ref": "#/definitions/Secret"
-    }
-   },
-   "type": "object"
-  },
-  "QueryHistoryPreference": {
-   "properties": {
-    "homeTab": {
-     "type": "string"
     }
    },
    "type": "object"
@@ -2774,65 +2625,8 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-<<<<<<< HEAD
-   "title": "URL is a custom URL type that allows validation at configuration load time.",
-   "type": "object"
-  },
-  "UpdateDashboardAclCommand": {
-   "properties": {
-    "items": {
-     "items": {
-      "$ref": "#/definitions/DashboardAclUpdateItem"
-     },
-     "type": "array"
-    }
-   },
-   "type": "object"
-  },
-  "UpdatePrefsCmd": {
-   "properties": {
-    "homeDashboardId": {
-     "default": 0,
-     "description": "The numerical :id of a favorited dashboard",
-     "format": "int64",
-     "type": "integer"
-    },
-    "homeDashboardUID": {
-     "type": "string"
-    },
-    "locale": {
-     "type": "string"
-    },
-    "navbar": {
-     "$ref": "#/definitions/NavbarPreference"
-    },
-    "queryHistory": {
-     "$ref": "#/definitions/QueryHistoryPreference"
-    },
-    "theme": {
-     "enum": [
-      "light",
-      "dark"
-     ],
-     "type": "string"
-    },
-    "timezone": {
-     "enum": [
-      "utc",
-      "browser"
-     ],
-     "type": "string"
-    },
-    "weekStart": {
-     "type": "string"
-    }
-   },
-   "type": "object"
-=======
    "title": "A URL represents a parsed URL (technically, a URI reference).",
-   "type": "object",
-   "x-go-package": "net/url"
->>>>>>> 01a9b04d19 (Generate shell for new route)
+   "type": "object"
   },
   "Userinfo": {
    "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -3001,7 +2795,6 @@
    "type": "object"
   },
   "alertGroup": {
-   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -3025,7 +2818,6 @@
    "type": "object"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -3133,6 +2925,7 @@
    "$ref": "#/definitions/Duration"
   },
   "gettableAlert": {
+   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -3191,12 +2984,9 @@
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
-   "type": "array",
-   "x-go-name": "GettableAlerts",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "array"
   },
   "gettableSilence": {
-   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3356,7 +3146,6 @@
    "type": "array"
   },
   "postableSilence": {
-   "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3394,6 +3183,7 @@
    "type": "object"
   },
   "receiver": {
+   "description": "Receiver receiver",
    "properties": {
     "name": {
      "description": "name",
@@ -3799,7 +3589,10 @@
     ],
     "responses": {
      "200": {
-      "$ref": "#/responses/AlertRuleGroup"
+      "description": "AlertRuleGroupMetadata",
+      "schema": {
+       "$ref": "#/definitions/AlertRuleGroupMetadata"
+      }
      },
      "400": {
       "description": "ValidationError",

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -135,6 +135,14 @@ func NewAlertRule(rule models.AlertRule, provenance models.Provenance) AlertRule
 	}
 }
 
+// swagger:route GET /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group} provisioning stable RouteGetAlertRuleGroup
+//
+// Get a rule group.
+//
+//     Responses:
+//       200: AlertRuleGroup
+//       404: description: Not found.
+
 // swagger:route PUT /api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group} provisioning stable RoutePutAlertRuleGroup
 //
 // Update the interval of a rule group.
@@ -161,9 +169,9 @@ type RuleGroupPathParam struct {
 // swagger:parameters RoutePutAlertRuleGroup
 type AlertRuleGroupPayload struct {
 	// in:body
-	Body AlertRuleGroup
+	Body AlertRuleGroupMetadata
 }
 
-type AlertRuleGroup struct {
+type AlertRuleGroupMetadata struct {
 	Interval int64 `json:"interval"`
 }

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -151,7 +151,7 @@ func NewAlertRule(rule models.AlertRule, provenance models.Provenance) AlertRule
 //     - application/json
 //
 //     Responses:
-//       200: AlertRuleGroup
+//       200: AlertRuleGroupMetadata
 //       400: ValidationError
 
 // swagger:parameters RouteGetAlertRuleGroup RoutePutAlertRuleGroup
@@ -174,4 +174,11 @@ type AlertRuleGroupPayload struct {
 
 type AlertRuleGroupMetadata struct {
 	Interval int64 `json:"interval"`
+}
+
+type AlertRuleGroup struct {
+	Title     string             `json:"title"`
+	FolderUID string             `json:"folderUid"`
+	Interval  int64              `json:"interval"`
+	Rules     []models.AlertRule `json:"rules"`
 }

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -154,13 +154,13 @@ func NewAlertRule(rule models.AlertRule, provenance models.Provenance) AlertRule
 //       200: AlertRuleGroup
 //       400: ValidationError
 
-// swagger:parameters RoutePutAlertRuleGroup
+// swagger:parameters RouteGetAlertRuleGroup RoutePutAlertRuleGroup
 type FolderUIDPathParam struct {
 	// in:path
 	FolderUID string `json:"FolderUID"`
 }
 
-// swagger:parameters RoutePutAlertRuleGroup
+// swagger:parameters RouteGetAlertRuleGroup RoutePutAlertRuleGroup
 type RuleGroupPathParam struct {
 	// in:path
 	Group string `json:"Group"`

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -308,7 +308,7 @@
    ],
    "type": "object"
   },
-  "AlertRuleGroup": {
+  "AlertRuleGroupMetadata": {
    "properties": {
     "interval": {
      "format": "int64",
@@ -468,7 +468,12 @@
    "items": {
     "$ref": "#/definitions/EmbeddedContactPoint"
    },
+<<<<<<< HEAD
    "type": "array"
+=======
+   "type": "array",
+   "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+>>>>>>> 01a9b04d19 (Generate shell for new route)
   },
   "DateTime": {
    "description": "DateTime is a time but it serializes to ISO8601 format with millis\nIt knows how to read 3 different variations of a RFC3339 date time.\nMost APIs we encounter want either millisecond or second precision times.\nThis just tries to make it worry-free.",
@@ -2625,7 +2630,12 @@
     }
    },
    "title": "URL is a custom URL type that allows validation at configuration load time.",
+<<<<<<< HEAD
    "type": "object"
+=======
+   "type": "object",
+   "x-go-package": "github.com/prometheus/common/config"
+>>>>>>> 01a9b04d19 (Generate shell for new route)
   },
   "Userinfo": {
    "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -2817,11 +2827,12 @@
    "type": "object"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
-   "type": "array"
+   "type": "array",
+   "x-go-name": "AlertGroups",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "alertStatus": {
    "description": "AlertStatus alert status",
@@ -3192,7 +3203,9 @@
    "required": [
     "name"
    ],
-   "type": "object"
+   "type": "object",
+   "x-go-name": "Receiver",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "silence": {
    "description": "Silence silence",
@@ -5157,6 +5170,21 @@
    }
   },
   "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
+   "get": {
+    "operationId": "RouteGetAlertRuleGroup",
+    "responses": {
+     "200": {
+      "$ref": "#/responses/AlertRuleGroup"
+     },
+     "404": {
+      "description": " Not found."
+     }
+    },
+    "summary": "Get a rule group.",
+    "tags": [
+     "provisioning"
+    ]
+   },
    "put": {
     "consumes": [
      "application/json"
@@ -5179,16 +5207,13 @@
       "in": "body",
       "name": "Body",
       "schema": {
-       "$ref": "#/definitions/AlertRuleGroup"
+       "$ref": "#/definitions/AlertRuleGroupMetadata"
       }
      }
     ],
     "responses": {
      "200": {
-      "description": "AlertRuleGroup",
-      "schema": {
-       "$ref": "#/definitions/AlertRuleGroup"
-      }
+      "$ref": "#/responses/AlertRuleGroup"
      },
      "400": {
       "description": "ValidationError",

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -468,12 +468,7 @@
    "items": {
     "$ref": "#/definitions/EmbeddedContactPoint"
    },
-<<<<<<< HEAD
    "type": "array"
-=======
-   "type": "array",
-   "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
->>>>>>> 01a9b04d19 (Generate shell for new route)
   },
   "DateTime": {
    "description": "DateTime is a time but it serializes to ISO8601 format with millis\nIt knows how to read 3 different variations of a RFC3339 date time.\nMost APIs we encounter want either millisecond or second precision times.\nThis just tries to make it worry-free.",
@@ -2630,19 +2625,8 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-<<<<<<< HEAD
-   "title": "URL is a custom URL type that allows validation at configuration load time.",
-<<<<<<< HEAD
-   "type": "object"
-=======
-   "type": "object",
-   "x-go-package": "github.com/prometheus/common/config"
->>>>>>> 01a9b04d19 (Generate shell for new route)
-=======
    "title": "A URL represents a parsed URL (technically, a URI reference).",
-   "type": "object",
-   "x-go-package": "net/url"
->>>>>>> 96e1b2239a (Propagate path parameters)
+   "type": "object"
   },
   "Userinfo": {
    "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -3006,6 +2990,7 @@
    "type": "array"
   },
   "gettableSilence": {
+   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3054,7 +3039,6 @@
    "type": "object"
   },
   "gettableSilences": {
-   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
@@ -3165,6 +3149,7 @@
    "type": "array"
   },
   "postableSilence": {
+   "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3199,12 +3184,9 @@
     "matchers",
     "startsAt"
    ],
-   "type": "object",
-   "x-go-name": "PostableSilence",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "object"
   },
   "receiver": {
-   "description": "Receiver receiver",
    "properties": {
     "name": {
      "description": "name",
@@ -5236,7 +5218,10 @@
     ],
     "responses": {
      "200": {
-      "$ref": "#/responses/AlertRuleGroup"
+      "description": "AlertRuleGroupMetadata",
+      "schema": {
+       "$ref": "#/definitions/AlertRuleGroupMetadata"
+      }
      },
      "400": {
       "description": "ValidationError",

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -2597,6 +2597,7 @@
    "type": "object"
   },
   "URL": {
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -2629,6 +2630,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
+<<<<<<< HEAD
    "title": "URL is a custom URL type that allows validation at configuration load time.",
 <<<<<<< HEAD
    "type": "object"
@@ -2636,6 +2638,11 @@
    "type": "object",
    "x-go-package": "github.com/prometheus/common/config"
 >>>>>>> 01a9b04d19 (Generate shell for new route)
+=======
+   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "type": "object",
+   "x-go-package": "net/url"
+>>>>>>> 96e1b2239a (Propagate path parameters)
   },
   "Userinfo": {
    "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -2804,6 +2811,7 @@
    "type": "object"
   },
   "alertGroup": {
+   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -2827,12 +2835,11 @@
    "type": "object"
   },
   "alertGroups": {
+   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
-   "type": "array",
-   "x-go-name": "AlertGroups",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "array"
   },
   "alertStatus": {
    "description": "AlertStatus alert status",
@@ -3047,6 +3054,7 @@
    "type": "object"
   },
   "gettableSilences": {
+   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
@@ -3191,9 +3199,12 @@
     "matchers",
     "startsAt"
    ],
-   "type": "object"
+   "type": "object",
+   "x-go-name": "PostableSilence",
+   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
   },
   "receiver": {
+   "description": "Receiver receiver",
    "properties": {
     "name": {
      "description": "name",
@@ -3203,9 +3214,7 @@
    "required": [
     "name"
    ],
-   "type": "object",
-   "x-go-name": "Receiver",
-   "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"
+   "type": "object"
   },
   "silence": {
    "description": "Silence silence",
@@ -5172,6 +5181,20 @@
   "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
    "get": {
     "operationId": "RouteGetAlertRuleGroup",
+    "parameters": [
+     {
+      "in": "path",
+      "name": "FolderUID",
+      "required": true,
+      "type": "string"
+     },
+     {
+      "in": "path",
+      "name": "Group",
+      "required": true,
+      "type": "string"
+     }
+    ],
     "responses": {
      "200": {
       "$ref": "#/responses/AlertRuleGroup"

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1900,6 +1900,20 @@
         ],
         "summary": "Get a rule group.",
         "operationId": "RouteGetAlertRuleGroup",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "FolderUID",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
+            "name": "Group",
+            "in": "path",
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "$ref": "#/responses/AlertRuleGroup"
@@ -4935,8 +4949,9 @@
       }
     },
     "URL": {
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "URL is a custom URL type that allows validation at configuration load time.",
+      "title": "A URL represents a parsed URL (technically, a URI reference).",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -4972,8 +4987,12 @@
       }
 =======
       },
+<<<<<<< HEAD
       "x-go-package": "github.com/prometheus/common/config"
 >>>>>>> 01a9b04d19 (Generate shell for new route)
+=======
+      "x-go-package": "net/url"
+>>>>>>> 96e1b2239a (Propagate path parameters)
     },
     "Userinfo": {
       "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -5142,6 +5161,7 @@
       }
     },
     "alertGroup": {
+      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -5166,12 +5186,11 @@
       "$ref": "#/definitions/alertGroup"
     },
     "alertGroups": {
+      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "$ref": "#/definitions/alertGroup"
       },
-      "x-go-name": "AlertGroups",
-      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/alertGroups"
     },
     "alertStatus": {
@@ -5390,6 +5409,7 @@
       "$ref": "#/definitions/gettableSilence"
     },
     "gettableSilences": {
+      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
@@ -5536,9 +5556,12 @@
           "format": "date-time"
         }
       },
+      "x-go-name": "PostableSilence",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/postableSilence"
     },
     "receiver": {
+      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "name"
@@ -5549,8 +5572,6 @@
           "type": "string"
         }
       },
-      "x-go-name": "Receiver",
-      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/receiver"
     },
     "silence": {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1893,6 +1893,22 @@
       }
     },
     "/api/v1/provisioning/folder/{FolderUID}/rule-groups/{Group}": {
+      "get": {
+        "tags": [
+          "provisioning",
+          "stable"
+        ],
+        "summary": "Get a rule group.",
+        "operationId": "RouteGetAlertRuleGroup",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/AlertRuleGroup"
+          },
+          "404": {
+            "description": " Not found."
+          }
+        }
+      },
       "put": {
         "consumes": [
           "application/json"
@@ -1920,16 +1936,13 @@
             "name": "Body",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/AlertRuleGroup"
+              "$ref": "#/definitions/AlertRuleGroupMetadata"
             }
           }
         ],
         "responses": {
           "200": {
-            "description": "AlertRuleGroup",
-            "schema": {
-              "$ref": "#/definitions/AlertRuleGroup"
-            }
+            "$ref": "#/responses/AlertRuleGroup"
           },
           "400": {
             "description": "ValidationError",
@@ -2629,7 +2642,7 @@
         }
       }
     },
-    "AlertRuleGroup": {
+    "AlertRuleGroupMetadata": {
       "type": "object",
       "properties": {
         "interval": {
@@ -2789,7 +2802,12 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/EmbeddedContactPoint"
+<<<<<<< HEAD
       }
+=======
+      },
+      "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+>>>>>>> 01a9b04d19 (Generate shell for new route)
     },
     "DateTime": {
       "description": "DateTime is a time but it serializes to ISO8601 format with millis\nIt knows how to read 3 different variations of a RFC3339 date time.\nMost APIs we encounter want either millisecond or second precision times.\nThis just tries to make it worry-free.",
@@ -4950,7 +4968,12 @@
         "User": {
           "$ref": "#/definitions/Userinfo"
         }
+<<<<<<< HEAD
       }
+=======
+      },
+      "x-go-package": "github.com/prometheus/common/config"
+>>>>>>> 01a9b04d19 (Generate shell for new route)
     },
     "Userinfo": {
       "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -5143,11 +5166,12 @@
       "$ref": "#/definitions/alertGroup"
     },
     "alertGroups": {
-      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "$ref": "#/definitions/alertGroup"
       },
+      "x-go-name": "AlertGroups",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/alertGroups"
     },
     "alertStatus": {
@@ -5525,6 +5549,8 @@
           "type": "string"
         }
       },
+      "x-go-name": "Receiver",
+      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/receiver"
     },
     "silence": {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1956,7 +1956,10 @@
         ],
         "responses": {
           "200": {
-            "$ref": "#/responses/AlertRuleGroup"
+            "description": "AlertRuleGroupMetadata",
+            "schema": {
+              "$ref": "#/definitions/AlertRuleGroupMetadata"
+            }
           },
           "400": {
             "description": "ValidationError",
@@ -2816,12 +2819,7 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/EmbeddedContactPoint"
-<<<<<<< HEAD
       }
-=======
-      },
-      "x-go-package": "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
->>>>>>> 01a9b04d19 (Generate shell for new route)
     },
     "DateTime": {
       "description": "DateTime is a time but it serializes to ISO8601 format with millis\nIt knows how to read 3 different variations of a RFC3339 date time.\nMost APIs we encounter want either millisecond or second precision times.\nThis just tries to make it worry-free.",
@@ -4983,16 +4981,7 @@
         "User": {
           "$ref": "#/definitions/Userinfo"
         }
-<<<<<<< HEAD
       }
-=======
-      },
-<<<<<<< HEAD
-      "x-go-package": "github.com/prometheus/common/config"
->>>>>>> 01a9b04d19 (Generate shell for new route)
-=======
-      "x-go-package": "net/url"
->>>>>>> 96e1b2239a (Propagate path parameters)
     },
     "Userinfo": {
       "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -5186,7 +5175,6 @@
       "$ref": "#/definitions/alertGroup"
     },
     "alertGroups": {
-      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "$ref": "#/definitions/alertGroup"
@@ -5295,7 +5283,6 @@
       "$ref": "#/definitions/Duration"
     },
     "gettableAlert": {
-      "description": "GettableAlert gettable alert",
       "type": "object",
       "required": [
         "labels",
@@ -5352,7 +5339,6 @@
       "$ref": "#/definitions/gettableAlert"
     },
     "gettableAlerts": {
-      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableAlert"
@@ -5409,7 +5395,6 @@
       "$ref": "#/definitions/gettableSilence"
     },
     "gettableSilences": {
-      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
@@ -5556,8 +5541,6 @@
           "format": "date-time"
         }
       },
-      "x-go-name": "PostableSilence",
-      "x-go-package": "github.com/prometheus/alertmanager/api/v2/models",
       "$ref": "#/definitions/postableSilence"
     },
     "receiver": {

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -90,17 +90,17 @@ func (service *AlertRuleService) CreateAlertRule(ctx context.Context, rule model
 	return rule, nil
 }
 
-func (service *AlertRuleService) GetRuleGroup(ctx context.Context, orgID int64, folder, group string) (*definitions.AlertRuleGroup, error) {
+func (service *AlertRuleService) GetRuleGroup(ctx context.Context, orgID int64, folder, group string) (definitions.AlertRuleGroup, error) {
 	q := models.ListAlertRulesQuery{
 		OrgID:         orgID,
 		NamespaceUIDs: []string{folder},
 		RuleGroup:     group,
 	}
 	if err := service.ruleStore.ListAlertRules(ctx, &q); err != nil {
-		return nil, err
+		return definitions.AlertRuleGroup{}, err
 	}
 	if len(q.Result) == 0 {
-		return nil, nil
+		return definitions.AlertRuleGroup{}, store.ErrAlertRuleGroupNotFound
 	}
 	res := definitions.AlertRuleGroup{
 		Title:     q.Result[0].RuleGroup,
@@ -113,7 +113,7 @@ func (service *AlertRuleService) GetRuleGroup(ctx context.Context, orgID int64, 
 			res.Rules = append(res.Rules, *r)
 		}
 	}
-	return &res, nil
+	return res, nil
 }
 
 // UpdateRuleGroup will update the interval for all rules in the group.

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/util"
@@ -87,6 +88,32 @@ func (service *AlertRuleService) CreateAlertRule(ctx context.Context, rule model
 		return models.AlertRule{}, err
 	}
 	return rule, nil
+}
+
+func (service *AlertRuleService) GetRuleGroup(ctx context.Context, orgID int64, folder, group string) (*definitions.AlertRuleGroup, error) {
+	q := models.ListAlertRulesQuery{
+		OrgID:         orgID,
+		NamespaceUIDs: []string{folder},
+		RuleGroup:     group,
+	}
+	if err := service.ruleStore.ListAlertRules(ctx, &q); err != nil {
+		return nil, err
+	}
+	if len(q.Result) == 0 {
+		return nil, nil
+	}
+	res := definitions.AlertRuleGroup{
+		Title:     q.Result[0].RuleGroup,
+		FolderUID: q.Result[0].NamespaceUID,
+		Interval:  q.Result[0].IntervalSeconds,
+		Rules:     []models.AlertRule{},
+	}
+	for _, r := range q.Result {
+		if r != nil {
+			res.Rules = append(res.Rules, *r)
+		}
+	}
+	return &res, nil
 }
 
 // UpdateRuleGroup will update the interval for all rules in the group.


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds `GET /api/v1/provisioning/folder/<uid>/rule-groups/<group>` which gets a group and all its rules. This supplements the existing PUT method on the same endpoint.

This is needed for Terraform to work properly at the group level.

**Which issue(s) this PR fixes**:

Rel https://github.com/grafana/grafana/issues/36153

**Special notes for your reviewer**:

