### PR TITLE
bra: Ignore wildcard generated go files

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -13,7 +13,7 @@ watch_dirs = [
   "$WORKDIR/conf",
 ]
 watch_exts = [".go", ".ini", ".toml", ".template.html"]
-ignore_files = ["wire_gen.go", "coremodel_gen.go", "registry_gen.go"]
+ignore_files = [".*_gen.go"]
 build_delay = 1500
 cmds = [
   ["make", "gen-go"],


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

#51349 changed the name of generated Go output files, which caused bra to start missing them.

Last time i went through this, i mistakenly thought that you couldn't use wildcards in bra. Not true! It just wants regex, not globbing.

This makes everything all nice and better.

cc @vtorosyan 