### PR TITLE
Update the hint text in service accounts to point to docs

### DIFF
--- a/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
@@ -187,7 +187,8 @@ export const ServiceAccountsListPageUnconnected = ({
               interactive
               content={
                 <>
-                  API keys are now service Accounts with tokens. <a href="">Read more</a>
+                  API keys are now Service Accounts with tokens. Find out more{' '}
+                  <a href="https://grafana.com/docs/grafana/latest/administration/service-accounts/">here.</a>
                 </>
               }
             >

--- a/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
@@ -187,7 +187,7 @@ export const ServiceAccountsListPageUnconnected = ({
               interactive
               content={
                 <>
-                  API keys are now Service Accounts with tokens. Find out more{' '}
+                  API keys are now service accounts with tokens. Find out more{' '}
                   <a href="https://grafana.com/docs/grafana/latest/administration/service-accounts/">here.</a>
                 </>
               }


### PR DESCRIPTION
**What this PR does / why we need it**:

The hint text in info icon was semi-broken and there was no link.

<img width="434" alt="Screenshot 2022-06-24 at 21 14 14" src="https://user-images.githubusercontent.com/1861190/175650310-9e329d3c-eb50-4d42-9607-273366a36585.png">

I am actually not entirely sure where the link should redirect, but thought the best would be to send to the main docs page.

