### PR TITLE
Service accounts: Grafana service accounts are enabled by default

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -18,7 +18,6 @@ export interface FeatureToggles {
 
   trimDefaults?: boolean;
   disableEnvelopeEncryption?: boolean;
-  serviceAccounts?: boolean;
   database_metrics?: boolean;
   dashboardPreviews?: boolean;
   dashboardPreviewsAdmin?: boolean;

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -151,9 +151,6 @@ func (hs *HTTPServer) getAppLinks(c *models.ReqContext) ([]*dtos.NavLink, error)
 }
 
 func enableServiceAccount(hs *HTTPServer, c *models.ReqContext) bool {
-	if !hs.Features.IsEnabled(featuremgmt.FlagServiceAccounts) {
-		return false
-	}
 	hasAccess := ac.HasAccess(hs.AccessControl, c)
 	return hasAccess(ac.ReqOrgAdmin, serviceAccountAccessEvaluator)
 }
@@ -298,7 +295,6 @@ func (hs *HTTPServer) getNavTree(c *models.ReqContext, hasEditPerm bool, prefs *
 			Url:         hs.Cfg.AppSubURL + "/org/apikeys",
 		})
 	}
-	// needs both feature flag and migration to be able to show service accounts
 	if enableServiceAccount(hs, c) {
 		configNodes = append(configNodes, &dtos.NavLink{
 			Text:        "Service accounts",

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -20,11 +20,6 @@ var (
 			State:       FeatureStateStable,
 		},
 		{
-			Name:        "serviceAccounts",
-			Description: "support service accounts",
-			State:       FeatureStateBeta,
-		},
-		{
 			Name:        "database_metrics",
 			Description: "Add prometheus metrics for database tables",
 			State:       FeatureStateStable,

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -15,10 +15,6 @@ const (
 	// Disable envelope encryption (emergency only)
 	FlagDisableEnvelopeEncryption = "disableEnvelopeEncryption"
 
-	// FlagServiceAccounts
-	// support service accounts
-	FlagServiceAccounts = "serviceAccounts"
-
 	// FlagDatabaseMetrics
 	// Add prometheus metrics for database tables
 	FlagDatabaseMetrics = "database_metrics"

--- a/pkg/services/featuremgmt/usage_stats_test.go
+++ b/pkg/services/featuremgmt/usage_stats_test.go
@@ -11,7 +11,6 @@ func TestFeatureUsageStats(t *testing.T) {
 	featureManagerWithAllFeatures := WithFeatures(
 		"trimDefaults",
 		"httpclientprovider_azure_auth",
-		"serviceAccounts",
 		"database_metrics",
 		"dashboardPreviews",
 		"live-config",

--- a/pkg/services/featuremgmt/usage_stats_test.go
+++ b/pkg/services/featuremgmt/usage_stats_test.go
@@ -22,7 +22,6 @@ func TestFeatureUsageStats(t *testing.T) {
 	require.Equal(t, map[string]interface{}{
 		"stats.features.trim_defaults.count":                 1,
 		"stats.features.httpclientprovider_azure_auth.count": 1,
-		"stats.features.service_accounts.count":              1,
 		"stats.features.database_metrics.count":              1,
 		"stats.features.dashboard_previews.count":            1,
 		"stats.features.live_config.count":                   1,

--- a/pkg/services/serviceaccounts/api/api.go
+++ b/pkg/services/serviceaccounts/api/api.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts/database"
 	"github.com/grafana/grafana/pkg/setting"
@@ -46,13 +45,7 @@ func NewServiceAccountsAPI(
 	}
 }
 
-func (api *ServiceAccountsAPI) RegisterAPIEndpoints(
-	features featuremgmt.FeatureToggles,
-) {
-	if !features.IsEnabled(featuremgmt.FlagServiceAccounts) {
-		return
-	}
-
+func (api *ServiceAccountsAPI) RegisterAPIEndpoints() {
 	auth := accesscontrol.Middleware(api.accesscontrol)
 	api.RouterRegister.Group("/api/serviceaccounts", func(serviceAccountsRoute routing.RouteRegister) {
 		serviceAccountsRoute.Get("/search", auth(middleware.ReqOrgAdmin,

--- a/pkg/services/serviceaccounts/api/api_test.go
+++ b/pkg/services/serviceaccounts/api/api_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts/database"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts/tests"
@@ -226,7 +225,7 @@ func setupTestServer(t *testing.T, svc *tests.ServiceAccountMock,
 	acmock *accesscontrolmock.Mock,
 	sqlStore *sqlstore.SQLStore, saStore serviceaccounts.Store) (*web.Mux, *ServiceAccountsAPI) {
 	a := NewServiceAccountsAPI(setting.NewCfg(), svc, acmock, routerRegister, saStore)
-	a.RegisterAPIEndpoints(featuremgmt.WithFeatures(featuremgmt.FlagServiceAccounts))
+	a.RegisterAPIEndpoints()
 
 	a.cfg.ApiKeyMaxSecondsToLive = -1 // disable api key expiration
 

--- a/pkg/services/serviceaccounts/manager/service_test.go
+++ b/pkg/services/serviceaccounts/manager/service_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,8 +14,7 @@ func TestProvideServiceAccount_DeleteServiceAccount(t *testing.T) {
 	t.Run("feature toggle present, should call store function", func(t *testing.T) {
 		storeMock := &tests.ServiceAccountsStoreMock{Calls: tests.Calls{}}
 		svc := ServiceAccountsService{
-			features: featuremgmt.WithFeatures("serviceAccounts", true),
-			store:    storeMock}
+			store: storeMock}
 		err := svc.DeleteServiceAccount(context.Background(), 1, 1)
 		require.NoError(t, err)
 		assert.Len(t, storeMock.Calls.DeleteServiceAccount, 1)
@@ -25,9 +23,8 @@ func TestProvideServiceAccount_DeleteServiceAccount(t *testing.T) {
 	t.Run("no feature toggle present, should not call store function", func(t *testing.T) {
 		svcMock := &tests.ServiceAccountsStoreMock{Calls: tests.Calls{}}
 		svc := ServiceAccountsService{
-			features: featuremgmt.WithFeatures("serviceAccounts", false),
-			store:    svcMock,
-			log:      log.New("serviceaccounts-manager-test"),
+			store: svcMock,
+			log:   log.New("serviceaccounts-manager-test"),
 		}
 		err := svc.DeleteServiceAccount(context.Background(), 1, 1)
 		require.NoError(t, err)

--- a/pkg/services/serviceaccounts/manager/service_test.go
+++ b/pkg/services/serviceaccounts/manager/service_test.go
@@ -4,30 +4,17 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestProvideServiceAccount_DeleteServiceAccount(t *testing.T) {
-	t.Run("feature toggle present, should call store function", func(t *testing.T) {
+	t.Run("should call store function", func(t *testing.T) {
 		storeMock := &tests.ServiceAccountsStoreMock{Calls: tests.Calls{}}
-		svc := ServiceAccountsService{
-			store: storeMock}
+		svc := ServiceAccountsService{store: storeMock}
 		err := svc.DeleteServiceAccount(context.Background(), 1, 1)
 		require.NoError(t, err)
 		assert.Len(t, storeMock.Calls.DeleteServiceAccount, 1)
-	})
-
-	t.Run("no feature toggle present, should not call store function", func(t *testing.T) {
-		svcMock := &tests.ServiceAccountsStoreMock{Calls: tests.Calls{}}
-		svc := ServiceAccountsService{
-			store: svcMock,
-			log:   log.New("serviceaccounts-manager-test"),
-		}
-		err := svc.DeleteServiceAccount(context.Background(), 1, 1)
-		require.NoError(t, err)
-		assert.Len(t, svcMock.Calls.DeleteServiceAccount, 0)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Grafana Service Accounts is planned to be released as GA with 9.1. This PR remove the feature toggle which was controlling the access to the feature.

**Which issue(s) this PR fixes**:

Fixes # https://github.com/grafana/grafana/issues/51206

**Special notes for your reviewer**:

Am I missing the feature toggle in any other place?
