### PR TITLE
Draft Dashboard: Propagate timezone URL query parameter

### DIFF
--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -144,6 +144,11 @@ export function initDashboard(args: InitDashboardArgs): ThunkResult<void> {
       locationService.partial({ orgId: storeState.user.orgId }, true);
     }
 
+    // Make a timezone supplied through a URL parameter take preference.
+    if (queryParams.tz) {
+      dashboard.timezone = queryParams.tz;
+    }
+
     // init services
     const timeSrv: TimeSrv = getTimeSrv();
     const dashboardSrv: DashboardSrv = getDashboardSrv();


### PR DESCRIPTION
Specifying the tz=<timezone> parameter on the URL will propagate
will change the dashboard to display in this timezone.

Fixes: #51407

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

