### PR TITLE
Alerting: Use relative path for flow chart image

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
@@ -27,7 +27,7 @@ export const NotificationsStep: FC = () => {
         {!hideFlowChart && (
           <img
             className={styles.flowChart}
-            src={`/public/img/alerting/notification_policy_${theme.name.toLowerCase()}.svg`}
+            src={`public/img/alerting/notification_policy_${theme.name.toLowerCase()}.svg`}
             alt="notification policy flow chart"
           />
         )}


### PR DESCRIPTION
I fixed and incorrect file path in the alert manager page. There was a leading slash, which resulted in a missing flowchart image.