### PR TITLE
Alerting: prevent the use of the same uid across all contact points

### DIFF
--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -150,7 +150,7 @@ func (ecp *ContactPointService) CreateContactPoint(ctx context.Context, orgID in
 		for _, rec := range receiver.PostableGrafanaReceivers.GrafanaManagedReceivers {
 			if grafanaReceiver.UID == rec.UID {
 				return apimodels.EmbeddedContactPoint{}, fmt.Errorf(
-					"contact point config with uid '%s' does already exist in contact point '%s'",
+					"receiver configuration with UID '%s' already exist in contact point '%s'. Please use unique identifiers for receivers across all contact points.",
 					rec.UID,
 					rec.Name)
 			}

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -150,7 +150,7 @@ func (ecp *ContactPointService) CreateContactPoint(ctx context.Context, orgID in
 		for _, rec := range receiver.PostableGrafanaReceivers.GrafanaManagedReceivers {
 			if grafanaReceiver.UID == rec.UID {
 				return apimodels.EmbeddedContactPoint{}, fmt.Errorf(
-					"receiver configuration with UID '%s' already exist in contact point '%s'. Please use unique identifiers for receivers across all contact points.",
+					"receiver configuration with UID '%s' already exist in contact point '%s'. Please use unique identifiers for receivers across all contact points",
 					rec.UID,
 					rec.Name)
 			}

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -146,6 +146,15 @@ func (ecp *ContactPointService) CreateContactPoint(ctx context.Context, orgID in
 
 	receiverFound := false
 	for _, receiver := range revision.cfg.AlertmanagerConfig.Receivers {
+		// check if uid is already used in receiver
+		for _, rec := range receiver.PostableGrafanaReceivers.GrafanaManagedReceivers {
+			if grafanaReceiver.UID == rec.UID {
+				return apimodels.EmbeddedContactPoint{}, fmt.Errorf(
+					"contact point config with uid '%s' does already exist in contact point '%s'",
+					rec.UID,
+					rec.Name)
+			}
+		}
 		if receiver.Name == contactPoint.Name {
 			receiver.PostableGrafanaReceivers.GrafanaManagedReceivers = append(receiver.PostableGrafanaReceivers.GrafanaManagedReceivers, grafanaReceiver)
 			receiverFound = true

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -58,6 +58,19 @@ func TestContactPointService(t *testing.T) {
 		require.Equal(t, customUID, cps[1].UID)
 	})
 
+	t.Run("it's not possbile to use the same uid twice", func(t *testing.T) {
+		customUID := "1337"
+		sut := createContactPointServiceSut(secretsService)
+		newCp := createTestContactPoint()
+		newCp.UID = customUID
+
+		_, err := sut.CreateContactPoint(context.Background(), 1, newCp, models.ProvenanceAPI)
+		require.NoError(t, err)
+
+		_, err = sut.CreateContactPoint(context.Background(), 1, newCp, models.ProvenanceAPI)
+		require.Error(t, err)
+	})
+
 	t.Run("create rejects contact points that fail validation", func(t *testing.T) {
 		sut := createContactPointServiceSut(secretsService)
 		newCp := createTestContactPoint()


### PR DESCRIPTION
While debugging some SQLite issues I saw that we could use the same UID multiple times across different contact points. This PR fixes this undesired behavior.