### PR TITLE
Alerting: Update alertmanager config in place and avoid repeated alertmanager config insertion

### DIFF
--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -94,18 +94,6 @@ func (st *DBstore) UpdateAlertmanagerConfiguration(ctx context.Context, cmd *mod
 			Default:                   cmd.Default,
 			OrgID:                     cmd.OrgID,
 		}
-		/*rows, err := sess.Where(`
-		EXISTS (
-			SELECT 1
-			FROM alert_configuration
-			WHERE
-				org_id = ?
-			AND
-				id = (SELECT MAX(id) FROM alert_configuration WHERE org_id = ?)
-			AND
-				configuration_hash = ?
-		)`,
-		cmd.OrgID, cmd.OrgID, cmd.FetchedConfigurationHash).Insert(config)*/
 
 		rows, err := sess.Where(`org_id = ? AND configuration_hash = ? AND id = (SELECT MAX(id) FROM alert_configuration WHERE org_id = ?)`, cmd.OrgID, cmd.FetchedConfigurationHash, cmd.OrgID).Update(config)
 

--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -95,8 +95,7 @@ func (st *DBstore) UpdateAlertmanagerConfiguration(ctx context.Context, cmd *mod
 			OrgID:                     cmd.OrgID,
 		}
 
-		rows, err := sess.Where(`org_id = ? AND configuration_hash = ? AND id = (SELECT MAX(id) FROM alert_configuration WHERE org_id = ?)`, cmd.OrgID, cmd.FetchedConfigurationHash, cmd.OrgID).Update(config)
-
+		rows, err := sess.Where(`org_id = ? AND configuration_hash = ? AND id = (SELECT MAX(T.id) FROM (SELECT MAX(id) AS id FROM alert_configuration WHERE org_id = ?) AS T)`, cmd.OrgID, cmd.FetchedConfigurationHash, cmd.OrgID).Update(config)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -94,21 +94,27 @@ func (st *DBstore) UpdateAlertmanagerConfiguration(ctx context.Context, cmd *mod
 			Default:                   cmd.Default,
 			OrgID:                     cmd.OrgID,
 		}
-		rows, err := sess.Table("alert_configuration").Where(`
-			EXISTS (
-				SELECT 1 
-				FROM alert_configuration 
-				WHERE 
-					org_id = ? 
-				AND 
-					id = (SELECT MAX(id) FROM alert_configuration WHERE org_id = ?) 
-				AND 
-					configuration_hash = ?
-			)`,
-			cmd.OrgID, cmd.OrgID, cmd.FetchedConfigurationHash).Insert(config)
+		/*rows, err := sess.Where(`
+		EXISTS (
+			SELECT 1
+			FROM alert_configuration
+			WHERE
+				org_id = ?
+			AND
+				id = (SELECT MAX(id) FROM alert_configuration WHERE org_id = ?)
+			AND
+				configuration_hash = ?
+		)`,
+		cmd.OrgID, cmd.OrgID, cmd.FetchedConfigurationHash).Insert(config)*/
+
+		rows, err := sess.Where(`org_id = ? AND configuration_hash = ? AND id = (SELECT MAX(id) FROM alert_configuration WHERE org_id = ?)`, cmd.OrgID, cmd.FetchedConfigurationHash, cmd.OrgID).Update(config)
+
+		if err != nil {
+			return err
+		}
 		if rows == 0 {
 			return ErrVersionLockedObjectNotFound
 		}
-		return err
+		return nil
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Rather than insert new alertmanager configs, provisioning will now update them in place.

Turns out, not only is locking happening, the issue is even worse - XORM is not mapping the contents of the `.Insert()` correctly due to it being confused by the WHERE. This code is confusingly inserting many records, not just one, even though one struct is being passed to xorm `.Insert()`. This seems like a major bug in the ORM.

Still, the proposed fix is the same.

There is some discussion on the approach in the below linked PR. This PR implements option 2 in the comments. There was no responses on which options others preferred. The multiple-write must be urgently fixed, and I am going forward with this because we do not use the current config history whatsoever and this is the fastest option to implement. We can come back and implement option 3 on top of this if that is what people prefer long term.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/51356

**Special notes for your reviewer**:

