### PR TITLE
ServiceAccounts: Add Service Account Token last used at date

### DIFF
--- a/pkg/models/apikey.go
+++ b/pkg/models/apikey.go
@@ -20,6 +20,7 @@ type ApiKey struct {
 	Role             RoleType
 	Created          time.Time
 	Updated          time.Time
+	LastUsedAt       *time.Time `xorm:"last_used_at"`
 	Expires          *int64
 	ServiceAccountId *int64
 }

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -272,6 +272,12 @@ func (h *ContextHandler) initContextWithAPIKey(reqContext *models.ReqContext) bo
 		return true
 	}
 
+	// update api_key last used date
+	if err := h.SQLStore.UpdateAPIKeyLastUsedDate(reqContext.Req.Context(), apikey.Id); err != nil {
+		reqContext.JsonApiErr(http.StatusInternalServerError, InvalidAPIKey, errKey)
+		return true
+	}
+
 	if apikey.ServiceAccountId == nil || *apikey.ServiceAccountId < 1 { //There is no service account attached to the apikey
 		//Use the old APIkey method.  This provides backwards compatibility.
 		reqContext.SignedInUser = &models.SignedInUser{}
@@ -305,6 +311,7 @@ func (h *ContextHandler) initContextWithAPIKey(reqContext *models.ReqContext) bo
 
 	reqContext.IsSignedIn = true
 	reqContext.SignedInUser = querySignedInUser.Result
+
 	return true
 }
 

--- a/pkg/services/serviceaccounts/api/token.go
+++ b/pkg/services/serviceaccounts/api/token.go
@@ -24,6 +24,7 @@ type TokenDTO struct {
 	Id                     int64      `json:"id"`
 	Name                   string     `json:"name"`
 	Created                *time.Time `json:"created"`
+	LastUsedAt             *time.Time `json:"lastUsedAt"`
 	Expiration             *time.Time `json:"expiration"`
 	SecondsUntilExpiration *float64   `json:"secondsUntilExpiration"`
 	HasExpired             bool       `json:"hasExpired"`
@@ -72,6 +73,7 @@ func (api *ServiceAccountsAPI) ListTokens(ctx *models.ReqContext) response.Respo
 			Expiration:             expiration,
 			SecondsUntilExpiration: &secondsUntilExpiration,
 			HasExpired:             isExpired,
+			LastUsedAt:             t.LastUsedAt,
 		}
 	}
 

--- a/pkg/services/serviceaccounts/database/token_store.go
+++ b/pkg/services/serviceaccounts/database/token_store.go
@@ -55,6 +55,7 @@ func (s *ServiceAccountsStoreImpl) AddServiceAccountToken(ctx context.Context, s
 			Created:          updated,
 			Updated:          updated,
 			Expires:          expires,
+			LastUsedAt:       nil,
 			ServiceAccountId: &serviceAccountId,
 		}
 

--- a/pkg/services/sqlstore/apikey.go
+++ b/pkg/services/sqlstore/apikey.go
@@ -166,7 +166,7 @@ func (ss *SQLStore) GetAPIKeyByHash(ctx context.Context, hash string) (*models.A
 
 // UpdateAPIKeyLastUsedDate updates the last used date of the API key to current time.
 func (ss *SQLStore) UpdateAPIKeyLastUsedDate(ctx context.Context, tokenID int64) error {
-	now := time.Now()
+	now := timeNow()
 	return ss.WithDbSession(ctx, func(sess *DBSession) error {
 		if _, err := sess.Table("api_key").ID(tokenID).Cols("last_used_at").Update(&models.ApiKey{LastUsedAt: &now}); err != nil {
 			return err

--- a/pkg/services/sqlstore/apikey.go
+++ b/pkg/services/sqlstore/apikey.go
@@ -163,3 +163,15 @@ func (ss *SQLStore) GetAPIKeyByHash(ctx context.Context, hash string) (*models.A
 
 	return &apikey, err
 }
+
+// UpdateAPIKeyLastUsedDate updates the last used date of the API key to current time.
+func (ss *SQLStore) UpdateAPIKeyLastUsedDate(ctx context.Context, tokenID int64) error {
+	now := time.Now()
+	return ss.WithDbSession(ctx, func(sess *DBSession) error {
+		if _, err := sess.Table("api_key").ID(tokenID).Cols("last_used_at").Update(&models.ApiKey{LastUsedAt: &now}); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}

--- a/pkg/services/sqlstore/apikey_test.go
+++ b/pkg/services/sqlstore/apikey_test.go
@@ -76,6 +76,24 @@ func TestIntegrationApiKeyDataAccess(t *testing.T) {
 			assert.Equal(t, *query.Result.Expires, expected)
 		})
 
+		t.Run("Last Used At datetime update", func(t *testing.T) {
+			// expires in one hour
+			cmd := models.AddApiKeyCommand{OrgId: 1, Name: "last-update-at", Key: "asd3", SecondsToLive: 3600}
+			err := ss.AddAPIKey(context.Background(), &cmd)
+			require.NoError(t, err)
+
+			assert.Nil(t, cmd.Result.LastUsedAt)
+
+			err = ss.UpdateAPIKeyLastUsedDate(context.Background(), cmd.Result.Id)
+			require.NoError(t, err)
+
+			query := models.GetApiKeyByNameQuery{KeyName: "last-update-at", OrgId: 1}
+			err = ss.GetApiKeyByName(context.Background(), &query)
+			assert.Nil(t, err)
+
+			assert.NotNil(t, query.Result.LastUsedAt)
+		})
+
 		t.Run("Add a key with negative lifespan", func(t *testing.T) {
 			// expires in one day
 			cmd := models.AddApiKeyCommand{OrgId: 1, Name: "key-with-negative-lifespan", Key: "asd3", SecondsToLive: -3600}

--- a/pkg/services/sqlstore/migrations/apikey_mig.go
+++ b/pkg/services/sqlstore/migrations/apikey_mig.go
@@ -91,4 +91,8 @@ func addApiKeyMigrations(mg *Migrator) {
 
 	mg.AddMigration("set service account foreign key to nil if 0", NewRawSQLMigration(
 		"UPDATE api_key SET service_account_id = NULL WHERE service_account_id = 0;"))
+
+	mg.AddMigration("Add last_used_at to api_key table", NewAddColumnMigration(apiKeyV2, &Column{
+		Name: "last_used_at", Type: DB_DateTime, Nullable: true,
+	}))
 }

--- a/pkg/services/sqlstore/mockstore/mockstore.go
+++ b/pkg/services/sqlstore/mockstore/mockstore.go
@@ -541,6 +541,10 @@ func (m *SQLStoreMock) GetApiKeyByName(ctx context.Context, query *models.GetApi
 	return m.ExpectedError
 }
 
+func (m *SQLStoreMock) UpdateAPIKeyLastUsedDate(ctx context.Context, tokenID int64) error {
+	return nil
+}
+
 func (m *SQLStoreMock) UpdateTempUserStatus(ctx context.Context, cmd *models.UpdateTempUserStatusCommand) error {
 	return m.ExpectedError
 }

--- a/pkg/services/sqlstore/store.go
+++ b/pkg/services/sqlstore/store.go
@@ -119,6 +119,7 @@ type Store interface {
 	GetApiKeyById(ctx context.Context, query *models.GetApiKeyByIdQuery) error
 	GetApiKeyByName(ctx context.Context, query *models.GetApiKeyByNameQuery) error
 	GetAPIKeyByHash(ctx context.Context, hash string) (*models.ApiKey, error)
+	UpdateAPIKeyLastUsedDate(ctx context.Context, tokenID int64) error
 	UpdateTempUserStatus(ctx context.Context, cmd *models.UpdateTempUserStatusCommand) error
 	CreateTempUser(ctx context.Context, cmd *models.CreateTempUserCommand) error
 	UpdateTempUserWithEmailSent(ctx context.Context, cmd *models.UpdateTempUserWithEmailSentCommand) error

--- a/public/app/features/serviceaccounts/components/ServiceAccountTokensTable.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountTokensTable.tsx
@@ -23,6 +23,7 @@ export const ServiceAccountTokensTable = ({ tokens, timeZone, tokenActionsDisabl
           <th>Name</th>
           <th>Expires</th>
           <th>Created</th>
+          <th>Last used at</th>
           <th />
         </tr>
       </thead>
@@ -35,6 +36,7 @@ export const ServiceAccountTokensTable = ({ tokens, timeZone, tokenActionsDisabl
                 <TokenExpiration timeZone={timeZone} token={key} />
               </td>
               <td>{formatDate(timeZone, key.created)}</td>
+              <td>{formatLastUsedAtDate(timeZone, key.lastUsedAt)}</td>
               <td>
                 <DeleteButton
                   aria-label={`Delete service account token ${key.name}`}
@@ -50,6 +52,13 @@ export const ServiceAccountTokensTable = ({ tokens, timeZone, tokenActionsDisabl
     </table>
   );
 };
+
+function formatLastUsedAtDate(timeZone: TimeZone, lastUsedAt?: string): string {
+  if (!lastUsedAt) {
+    return 'Never';
+  }
+  return dateTimeFormat(lastUsedAt, { timeZone });
+}
 
 function formatDate(timeZone: TimeZone, expiration?: string): string {
   if (!expiration) {

--- a/public/app/types/apiKeys.ts
+++ b/public/app/types/apiKeys.ts
@@ -11,6 +11,7 @@ export interface ApiKey extends WithAccessControlMetadata {
   secondsUntilExpiration?: number;
   hasExpired?: boolean;
   created?: string;
+  lastUsedAt?: string;
 }
 
 export interface NewApiKey {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- Add Service Account Token last used at  

![swappy-20220627_161945](https://user-images.githubusercontent.com/8071073/175967186-796a6e01-749d-455b-8761-1d7b7c9c19a5.png)

Query implemented example:

```
 UPDATE `api_key` SET `last_used_at` = ? WHERE `id`=? []interface {}{"2022-06-27 14:40:12", 3}
 ```

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/4961

