### PR TITLE
Alerting: Move EvalAlertConditionCommand to API models package

### DIFF
--- a/pkg/services/ngalert/api/api_testing_test.go
+++ b/pkg/services/ngalert/api/api_testing_test.go
@@ -43,7 +43,7 @@ func TestRouteTestGrafanaRuleConfig(t *testing.T) {
 
 			response := srv.RouteTestGrafanaRuleConfig(rc, definitions.TestRulePayload{
 				Expr: "",
-				GrafanaManagedCondition: &models.EvalAlertConditionCommand{
+				GrafanaManagedCondition: &definitions.EvalAlertConditionCommand{
 					Condition: data1.RefID,
 					Data:      []models.AlertQuery{data1, data2},
 					Now:       time.Time{},
@@ -75,7 +75,7 @@ func TestRouteTestGrafanaRuleConfig(t *testing.T) {
 
 			response := srv.RouteTestGrafanaRuleConfig(rc, definitions.TestRulePayload{
 				Expr: "",
-				GrafanaManagedCondition: &models.EvalAlertConditionCommand{
+				GrafanaManagedCondition: &definitions.EvalAlertConditionCommand{
 					Condition: data1.RefID,
 					Data:      []models.AlertQuery{data1, data2},
 					Now:       time.Time{},
@@ -115,7 +115,7 @@ func TestRouteTestGrafanaRuleConfig(t *testing.T) {
 
 			response := srv.RouteTestGrafanaRuleConfig(rc, definitions.TestRulePayload{
 				Expr: "",
-				GrafanaManagedCondition: &models.EvalAlertConditionCommand{
+				GrafanaManagedCondition: &definitions.EvalAlertConditionCommand{
 					Condition: data1.RefID,
 					Data:      []models.AlertQuery{data1},
 					Now:       time.Time{},
@@ -129,7 +129,7 @@ func TestRouteTestGrafanaRuleConfig(t *testing.T) {
 
 			response = srv.RouteTestGrafanaRuleConfig(rc, definitions.TestRulePayload{
 				Expr: "",
-				GrafanaManagedCondition: &models.EvalAlertConditionCommand{
+				GrafanaManagedCondition: &definitions.EvalAlertConditionCommand{
 					Condition: data1.RefID,
 					Data:      []models.AlertQuery{data1},
 					Now:       time.Time{},

--- a/pkg/services/ngalert/api/tooling/definitions/eval_condition.go
+++ b/pkg/services/ngalert/api/tooling/definitions/eval_condition.go
@@ -1,16 +1,18 @@
-package models
+package definitions
 
 import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
 // EvalAlertConditionCommand is the command for evaluating a condition
 type EvalAlertConditionCommand struct {
-	Condition string       `json:"condition"`
-	Data      []AlertQuery `json:"data"`
-	Now       time.Time    `json:"now"`
+	Condition string              `json:"condition"`
+	Data      []models.AlertQuery `json:"data"` // TODO yuri. Create API model for AlertQuery
+	Now       time.Time           `json:"now"`
 }
 
 func (cmd *EvalAlertConditionCommand) UnmarshalJSON(b []byte) error {

--- a/pkg/services/ngalert/api/tooling/definitions/testing.go
+++ b/pkg/services/ngalert/api/tooling/definitions/testing.go
@@ -69,7 +69,7 @@ type TestRulePayload struct {
 	// Example: (node_filesystem_avail_bytes{fstype!="",job="integrations/node_exporter"} node_filesystem_size_bytes{fstype!="",job="integrations/node_exporter"} * 100 < 5 and node_filesystem_readonly{fstype!="",job="integrations/node_exporter"} == 0)
 	Expr string `json:"expr,omitempty"`
 	// GrafanaManagedCondition for grafana alerts
-	GrafanaManagedCondition *models.EvalAlertConditionCommand `json:"grafana_condition,omitempty"`
+	GrafanaManagedCondition *EvalAlertConditionCommand `json:"grafana_condition,omitempty"`
 }
 
 // swagger:parameters RouteEvalQueries

--- a/pkg/services/ngalert/api/tooling/definitions/testing_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/testing_test.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
 func TestRulePayloadMarshaling(t *testing.T) {
@@ -30,7 +31,7 @@ func TestRulePayloadMarshaling(t *testing.T) {
 				data.Model = raw
 
 				return TestRulePayload{
-					GrafanaManagedCondition: &models.EvalAlertConditionCommand{
+					GrafanaManagedCondition: &EvalAlertConditionCommand{
 						Condition: "placeholder",
 						Data:      []models.AlertQuery{data},
 					},
@@ -41,7 +42,7 @@ func TestRulePayloadMarshaling(t *testing.T) {
 			desc: "failure mixed",
 			input: TestRulePayload{
 				Expr:                    "rate({cluster=\"us-central1\", job=\"loki-prod/loki-canary\"}[1m]) > 0",
-				GrafanaManagedCondition: &models.EvalAlertConditionCommand{},
+				GrafanaManagedCondition: &EvalAlertConditionCommand{},
 			},
 			err: true,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Model EvalAlertConditionCommand is exclusively used by API (tooling/definition package) models but placed in the `models` package that generally contains domain\data models. This PR moves the struct to package `tooling/definition` as is, without any modifications. 