### PR TITLE
Access control: role checks before updates

### DIFF
--- a/pkg/api/org_invite.go
+++ b/pkg/api/org_invite.go
@@ -38,6 +38,9 @@ func (hs *HTTPServer) AddOrgInvite(c *models.ReqContext) response.Response {
 	if !inviteDto.Role.IsValid() {
 		return response.Error(400, "Invalid role specified", nil)
 	}
+	if !c.OrgRole.Includes(inviteDto.Role) && !c.IsGrafanaAdmin {
+		return response.Error(http.StatusForbidden, "Cannot assign a role higher than user's role", nil)
+	}
 
 	// first try get existing user
 	userQuery := models.GetUserByLoginQuery{LoginOrEmail: inviteDto.LoginOrEmail}

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -577,7 +577,7 @@ func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
 		url          string
 		method       string
 		permissions  []accesscontrol.Permission
-		input string
+		input        string
 	}
 	tests := []accessControlTestCase2{
 		{
@@ -586,7 +586,7 @@ func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
 			url:          "/api/org/users",
 			method:       http.MethodPost,
 			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersAdd, Scope: accesscontrol.ScopeUsersAll}},
-			input: `{"loginOrEmail": "` + testAdminOrg2.Login + `", "role": "` + string(models.ROLE_VIEWER) + `"}`,
+			input:        `{"loginOrEmail": "` + testAdminOrg2.Login + `", "role": "` + string(models.ROLE_VIEWER) + `"}`,
 		},
 		{
 			expectedCode: http.StatusForbidden,
@@ -594,7 +594,7 @@ func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
 			url:          "/api/org/users",
 			method:       http.MethodPost,
 			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersAdd, Scope: accesscontrol.ScopeUsersAll}},
-			input: `{"loginOrEmail": "` + testAdminOrg2.Login + `", "role": "` + string(models.ROLE_EDITOR) + `"}`,
+			input:        `{"loginOrEmail": "` + testAdminOrg2.Login + `", "role": "` + string(models.ROLE_EDITOR) + `"}`,
 		},
 		{
 			expectedCode: http.StatusOK,
@@ -602,7 +602,7 @@ func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
 			url:          "/api/orgs/1/users",
 			method:       http.MethodPost,
 			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersAdd, Scope: accesscontrol.ScopeUsersAll}},
-			input: `{"loginOrEmail": "` + testAdminOrg2.Login + `", "role": "` + string(models.ROLE_VIEWER) + `"}`,
+			input:        `{"loginOrEmail": "` + testAdminOrg2.Login + `", "role": "` + string(models.ROLE_VIEWER) + `"}`,
 		},
 		{
 			expectedCode: http.StatusForbidden,
@@ -610,7 +610,7 @@ func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
 			url:          "/api/orgs/1/users",
 			method:       http.MethodPost,
 			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersAdd, Scope: accesscontrol.ScopeUsersAll}},
-			input: `{"loginOrEmail": "` + testAdminOrg2.Login + `", "role": "` + string(models.ROLE_EDITOR) + `"}`,
+			input:        `{"loginOrEmail": "` + testAdminOrg2.Login + `", "role": "` + string(models.ROLE_EDITOR) + `"}`,
 		},
 		{
 			expectedCode: http.StatusOK,
@@ -618,7 +618,7 @@ func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
 			url:          fmt.Sprintf("/api/org/users/%d", testEditorOrg1.UserId),
 			method:       http.MethodPatch,
 			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersWrite, Scope: accesscontrol.ScopeUsersAll}},
-			input: `{"role": "` + string(models.ROLE_VIEWER) + `"}`,
+			input:        `{"role": "` + string(models.ROLE_VIEWER) + `"}`,
 		},
 		{
 			expectedCode: http.StatusForbidden,
@@ -626,7 +626,7 @@ func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
 			url:          fmt.Sprintf("/api/org/users/%d", testEditorOrg1.UserId),
 			method:       http.MethodPatch,
 			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersWrite, Scope: accesscontrol.ScopeUsersAll}},
-			input: `{"role": "` + string(models.ROLE_EDITOR) + `"}`,
+			input:        `{"role": "` + string(models.ROLE_EDITOR) + `"}`,
 		},
 		{
 			expectedCode: http.StatusOK,
@@ -634,7 +634,7 @@ func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
 			url:          fmt.Sprintf("/api/orgs/1/users/%d", testEditorOrg1.UserId),
 			method:       http.MethodPatch,
 			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersWrite, Scope: accesscontrol.ScopeUsersAll}},
-			input: `{"role": "` + string(models.ROLE_VIEWER) + `"}`,
+			input:        `{"role": "` + string(models.ROLE_VIEWER) + `"}`,
 		},
 		{
 			expectedCode: http.StatusForbidden,
@@ -642,7 +642,7 @@ func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
 			url:          fmt.Sprintf("/api/orgs/1/users/%d", testEditorOrg1.UserId),
 			method:       http.MethodPatch,
 			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersWrite, Scope: accesscontrol.ScopeUsersAll}},
-			input: `{"role": "` + string(models.ROLE_EDITOR) + `"}`,
+			input:        `{"role": "` + string(models.ROLE_EDITOR) + `"}`,
 		},
 		{
 			expectedCode: http.StatusOK,
@@ -650,7 +650,7 @@ func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
 			url:          "/api/org/invites",
 			method:       http.MethodPost,
 			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionUsersCreate}},
-			input: `{"loginOrEmail": "newUserEmail@test.com", "sendEmail": false, "role": "` + string(models.ROLE_VIEWER) + `"}`,
+			input:        `{"loginOrEmail": "newUserEmail@test.com", "sendEmail": false, "role": "` + string(models.ROLE_VIEWER) + `"}`,
 		},
 		{
 			expectedCode: http.StatusForbidden,
@@ -658,7 +658,7 @@ func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
 			url:          "/api/org/invites",
 			method:       http.MethodPost,
 			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionUsersCreate}},
-			input: `{"loginOrEmail": "newUserEmail@test.com", "sendEmail": false, "role": "` + string(models.ROLE_EDITOR) + `"}`,
+			input:        `{"loginOrEmail": "newUserEmail@test.com", "sendEmail": false, "role": "` + string(models.ROLE_EDITOR) + `"}`,
 		},
 	}
 

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -570,6 +570,112 @@ func TestPostOrgUsersAPIEndpoint_AccessControl(t *testing.T) {
 	}
 }
 
+func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
+	type accessControlTestCase2 struct {
+		expectedCode int
+		desc         string
+		url          string
+		method       string
+		permissions  []accesscontrol.Permission
+		input string
+	}
+	tests := []accessControlTestCase2{
+		{
+			expectedCode: http.StatusOK,
+			desc:         "org viewer with the correct permissions can add a user as a viewer to his org",
+			url:          "/api/org/users",
+			method:       http.MethodPost,
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersAdd, Scope: accesscontrol.ScopeUsersAll}},
+			input: `{"loginOrEmail": "` + testAdminOrg2.Login + `", "role": "` + string(models.ROLE_VIEWER) + `"}`,
+		},
+		{
+			expectedCode: http.StatusForbidden,
+			desc:         "org viewer with the correct permissions cannot add a user as an editor to his org",
+			url:          "/api/org/users",
+			method:       http.MethodPost,
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersAdd, Scope: accesscontrol.ScopeUsersAll}},
+			input: `{"loginOrEmail": "` + testAdminOrg2.Login + `", "role": "` + string(models.ROLE_EDITOR) + `"}`,
+		},
+		{
+			expectedCode: http.StatusOK,
+			desc:         "org viewer with the correct permissions can add a user as a viewer to his org",
+			url:          "/api/orgs/1/users",
+			method:       http.MethodPost,
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersAdd, Scope: accesscontrol.ScopeUsersAll}},
+			input: `{"loginOrEmail": "` + testAdminOrg2.Login + `", "role": "` + string(models.ROLE_VIEWER) + `"}`,
+		},
+		{
+			expectedCode: http.StatusForbidden,
+			desc:         "org viewer with the correct permissions cannot add a user as an editor to his org",
+			url:          "/api/orgs/1/users",
+			method:       http.MethodPost,
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersAdd, Scope: accesscontrol.ScopeUsersAll}},
+			input: `{"loginOrEmail": "` + testAdminOrg2.Login + `", "role": "` + string(models.ROLE_EDITOR) + `"}`,
+		},
+		{
+			expectedCode: http.StatusOK,
+			desc:         "org viewer with the correct permissions can update a user's role to a viewer in his org",
+			url:          fmt.Sprintf("/api/org/users/%d", testEditorOrg1.UserId),
+			method:       http.MethodPatch,
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersWrite, Scope: accesscontrol.ScopeUsersAll}},
+			input: `{"role": "` + string(models.ROLE_VIEWER) + `"}`,
+		},
+		{
+			expectedCode: http.StatusForbidden,
+			desc:         "org viewer with the correct permissions cannot update a user's role to a viewer in his org",
+			url:          fmt.Sprintf("/api/org/users/%d", testEditorOrg1.UserId),
+			method:       http.MethodPatch,
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersWrite, Scope: accesscontrol.ScopeUsersAll}},
+			input: `{"role": "` + string(models.ROLE_EDITOR) + `"}`,
+		},
+		{
+			expectedCode: http.StatusOK,
+			desc:         "org viewer with the correct permissions can update a user's role to a viewer in his org",
+			url:          fmt.Sprintf("/api/orgs/1/users/%d", testEditorOrg1.UserId),
+			method:       http.MethodPatch,
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersWrite, Scope: accesscontrol.ScopeUsersAll}},
+			input: `{"role": "` + string(models.ROLE_VIEWER) + `"}`,
+		},
+		{
+			expectedCode: http.StatusForbidden,
+			desc:         "org viewer with the correct permissions cannot update a user's role to a viewer in his org",
+			url:          fmt.Sprintf("/api/orgs/1/users/%d", testEditorOrg1.UserId),
+			method:       http.MethodPatch,
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersWrite, Scope: accesscontrol.ScopeUsersAll}},
+			input: `{"role": "` + string(models.ROLE_EDITOR) + `"}`,
+		},
+		{
+			expectedCode: http.StatusOK,
+			desc:         "org viewer with the correct permissions can invite a user as a viewer in his org",
+			url:          "/api/org/invites",
+			method:       http.MethodPost,
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionUsersCreate}},
+			input: `{"loginOrEmail": "newUserEmail@test.com", "sendEmail": false, "role": "` + string(models.ROLE_VIEWER) + `"}`,
+		},
+		{
+			expectedCode: http.StatusForbidden,
+			desc:         "org viewer with the correct permissions cannot invite a user as an editor in his org",
+			url:          "/api/org/invites",
+			method:       http.MethodPost,
+			permissions:  []accesscontrol.Permission{{Action: accesscontrol.ActionUsersCreate}},
+			input: `{"loginOrEmail": "newUserEmail@test.com", "sendEmail": false, "role": "` + string(models.ROLE_EDITOR) + `"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			sc := setupHTTPServer(t, true, true)
+			setInitCtxSignedInViewer(sc.initCtx)
+			setupOrgUsersDBForAccessControlTests(t, sc.db)
+			setAccessControlPermissions(sc.acmock, test.permissions, sc.initCtx.OrgId)
+
+			input := strings.NewReader(test.input)
+			response := callAPI(sc.server, test.method, test.url, input, t)
+			assert.Equal(t, test.expectedCode, response.Code)
+		})
+	}
+}
+
 func TestPatchOrgUsersAPIEndpoint_AccessControl(t *testing.T) {
 	url := "/api/orgs/%v/users/%v"
 	type testCase struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

Check user's role before allowing them to update roles.

**Which issue(s) this PR fixes**:

Related to #https://github.com/grafana/grafana-enterprise/discussions/2374 and https://github.com/grafana/grafana-enterprise/issues/3510

