### PR TITLE
Alerting: change optimistic lock to use proper insert select

### DIFF
--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -121,6 +121,11 @@ func (st *DBstore) UpdateAlertmanagerConfiguration(ctx context.Context, cmd *mod
 	})
 }
 
+// getInsertQuery is used to determinate the insert query for the alertmanager config
+// based on the provided sql driver. This is necesarry as such an advanced query
+// is not supported by our ORM and we need to generate it manually for each SQL dialect.
+// We introduced this as part of a bug fix as the old approach wasn't working.
+// Rel: https://github.com/grafana/grafana/issues/51356
 func getInsertQuery(driver string) string {
 	switch driver {
 	case "mysql":

--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -119,7 +119,6 @@ func (st *DBstore) UpdateAlertmanagerConfiguration(ctx context.Context, cmd *mod
 		}
 		return err
 	})
-
 }
 
 func getInsertQuery(driver string) string {

--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -121,8 +121,6 @@ func (st *DBstore) UpdateAlertmanagerConfiguration(ctx context.Context, cmd *mod
 			cmd.OrgID,
 			cmd.FetchedConfigurationHash,
 		)
-		query, args := sess.LastSQL()
-		st.Logger.Info("last SQL", "query", query, "args", args)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR introduces a fix for #51356 by creating three different queries for each of the supported databases. **The semantics does not change, we don't drop the concept of the append style table**. The query has to be in its raw form as it's some more advanced SQL that is different in each supported database.

I tested the PR manually with all three databases (Postgres,MySQL, SQLite) and the affected part also runs as integration test on all three databases.