### PR TITLE
HeatmapNG: pre-allocate arrays during calc

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -7070,10 +7070,10 @@ exports[`better eslint`] = {
     "public/app/features/transformers/calculateHeatmap/editor/helper.ts:2898656130": [
       [10, 37, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "public/app/features/transformers/calculateHeatmap/heatmap.ts:2895010613": [
+    "public/app/features/transformers/calculateHeatmap/heatmap.ts:992367420": [
       [65, 9, 52, "Do not use any type assertions.", "3480700880"],
-      [306, 63, 29, "Do not use any type assertions.", "255738422"],
-      [306, 89, 3, "Unexpected any. Specify a different type.", "193409811"]
+      [321, 63, 29, "Do not use any type assertions.", "255738422"],
+      [321, 89, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "public/app/features/transformers/configFromQuery/ConfigFromQueryTransformerEditor.test.tsx:1060905279": [
       [44, 29, 21, "Do not use any type assertions.", "1548027068"]


### PR DESCRIPTION
this avoids a pretty bad spot in V8 when calculating a heatmap from data, to the tune of 15x. those mem profiles are just...idk :exploding_head: 

this is for a non-artificial dataset from `ops` with 861 frames and ~461k cumulative datapoints.

before:

![image](https://user-images.githubusercontent.com/43234/176033513-5349c3ba-d7ee-4c16-8285-7d7c4782b77e.png)

after:

![image](https://user-images.githubusercontent.com/43234/176033387-e89cda80-9f00-4838-ae98-90d1a4b69819.png)

this was somehow even worse perf than the old svg-based heatmap panel:

![image](https://user-images.githubusercontent.com/43234/176034555-bf59ebec-33e6-4c4f-9f33-fb782c1db24a.png)