### PR TITLE
Heatmap: migrate old zero gap to one

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6037,8 +6037,10 @@ exports[`better eslint`] = {
       [9, 6, 59, "Do not use any type assertions.", "3685154675"],
       [9, 6, 49, "Do not use any type assertions.", "1184085652"]
     ],
-    "public/app/features/geo/utils/frameVectorSource.ts:3630880852": [
-      [28, 20, 29, "Do not use any type assertions.", "1337699239"]
+    "public/app/features/geo/utils/frameVectorSource.ts:119928285": [
+      [28, 20, 29, "Do not use any type assertions.", "1337699239"],
+      [47, 21, 81, "Do not use any type assertions.", "1774144811"],
+      [52, 18, 13, "Do not use any type assertions.", "18139833"]
     ],
     "public/app/features/geo/utils/location.test.ts:3751297173": [
       [30, 61, 10, "Do not use any type assertions.", "525921067"],
@@ -11712,14 +11714,15 @@ exports[`better eslint`] = {
     "public/app/plugins/panel/heatmap/fields.test.ts:2095719388": [
       [7, 32, 18, "Do not use any type assertions.", "739464119"]
     ],
-    "public/app/plugins/panel/heatmap/migrations.test.ts:1017455994": [
-      [15, 15, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [18, 18, 16, "Do not use any type assertions.", "388222280"]
+    "public/app/plugins/panel/heatmap/migrations.test.ts:22150861": [
+      [15, 18, 16, "Do not use any type assertions.", "388222280"],
+      [96, 8, 16, "Do not use any type assertions.", "388222280"],
+      [108, 8, 16, "Do not use any type assertions.", "388222280"]
     ],
-    "public/app/plugins/panel/heatmap/migrations.ts:2547355944": [
+    "public/app/plugins/panel/heatmap/migrations.ts:100419160": [
       [43, 47, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [128, 22, 27, "Do not use any type assertions.", "3349635193"],
-      [161, 21, 3, "Unexpected any. Specify a different type.", "193409811"]
+      [129, 22, 27, "Do not use any type assertions.", "3349635193"],
+      [162, 21, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "public/app/plugins/panel/heatmap/module.tsx:3365492927": [
       [27, 16, 30, "Do not use any type assertions.", "3478399522"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -11719,7 +11719,7 @@ exports[`better eslint`] = {
       [96, 8, 16, "Do not use any type assertions.", "388222280"],
       [108, 8, 16, "Do not use any type assertions.", "388222280"]
     ],
-    "public/app/plugins/panel/heatmap/migrations.ts:100419160": [
+    "public/app/plugins/panel/heatmap/migrations.ts:1677424344": [
       [43, 47, 3, "Unexpected any. Specify a different type.", "193409811"],
       [129, 22, 27, "Do not use any type assertions.", "3349635193"],
       [162, 21, 3, "Unexpected any. Specify a different type.", "193409811"]

--- a/public/app/features/geo/utils/frameVectorSource.ts
+++ b/public/app/features/geo/utils/frameVectorSource.ts
@@ -43,6 +43,7 @@ export class FrameVectorSource<T extends Geometry = Geometry> extends VectorSour
       return;
     }
 
+    //eslint-disable-next-line
     const field = info.field as Field<Point>;
     const geometry = new LineString(field.values.toArray().map((p) => p.getCoordinates())) as Geometry;
     this.addFeatureInternal(

--- a/public/app/plugins/panel/heatmap/migrations.test.ts
+++ b/public/app/plugins/panel/heatmap/migrations.test.ts
@@ -13,11 +13,15 @@ describe('Heatmap Migrations', () => {
   });
 
   it('simple heatmap', () => {
-    const old: any = {
-      angular: oldHeatmap,
-    };
     const panel = {} as PanelModel;
-    panel.options = heatmapChangedHandler(panel, 'heatmap', old, prevFieldConfig);
+    panel.options = heatmapChangedHandler(
+      panel,
+      'heatmap',
+      {
+        angular: oldHeatmap,
+      },
+      prevFieldConfig
+    );
     expect(panel).toMatchInlineSnapshot(`
       Object {
         "fieldConfig": Object {
@@ -84,6 +88,32 @@ describe('Heatmap Migrations', () => {
         },
       }
     `);
+  });
+
+  it('Cell padding defaults', () => {
+    // zero becomes 1
+    expect(
+      heatmapChangedHandler(
+        {} as PanelModel,
+        'heatmap',
+        {
+          angular: { cards: { cardPadding: 0 } },
+        },
+        prevFieldConfig
+      ).cellGap
+    ).toEqual(1);
+
+    // missing is 2
+    expect(
+      heatmapChangedHandler(
+        {} as PanelModel,
+        'heatmap',
+        {
+          angular: {},
+        },
+        prevFieldConfig
+      ).cellGap
+    ).toEqual(2);
   });
 });
 

--- a/public/app/plugins/panel/heatmap/migrations.ts
+++ b/public/app/plugins/panel/heatmap/migrations.ts
@@ -79,6 +79,7 @@ export function angularToReactHeatmap(angular: any): { fieldConfig: FieldConfigS
     }
   }
 
+  const cellGap = asNumber(angular.cards?.cardPadding, 2);
   const options: PanelOptions = {
     calculate,
     calculation,
@@ -86,7 +87,7 @@ export function angularToReactHeatmap(angular: any): { fieldConfig: FieldConfigS
       ...defaultPanelOptions.color,
       steps: 128, // best match with existing colors
     },
-    cellGap: asNumber(angular.cards?.cardPadding, 2),
+    cellGap: cellGap ? cellGap : 1, // default to size 1
     cellRadius: asNumber(angular.cards?.cardRound), // just to keep it
     yAxis: {
       axisPlacement: oldYAxis.show === false ? AxisPlacement.Hidden : AxisPlacement.Left,
@@ -104,7 +105,7 @@ export function angularToReactHeatmap(angular: any): { fieldConfig: FieldConfigS
       layout: getHeatmapCellLayout(angular.yBucketBound),
     },
     legend: {
-      show: Boolean(angular.legend.show),
+      show: Boolean(angular.legend?.show),
     },
     showValue: VisibilityMode.Never,
     tooltip: {
@@ -121,7 +122,7 @@ export function angularToReactHeatmap(angular: any): { fieldConfig: FieldConfigS
   }
 
   // Migrate color options
-  const color = angular.color;
+  const color = angular.color ?? {};
   switch (color?.mode) {
     case 'spectrum': {
       options.color.mode = HeatmapColorMode.Scheme;


### PR DESCRIPTION
The old heatmap "0" gap actually showed a 1px border... so we should set it as 1 in the new heatmap