### PR TITLE
Instrumentation: Add more buckets to the HTTP request histogram

### DIFF
--- a/pkg/middleware/request_metrics.go
+++ b/pkg/middleware/request_metrics.go
@@ -20,7 +20,7 @@ var (
 
 	// DefBuckets are histogram buckets for the response time (in seconds)
 	// of a network service, including one that is responding very slowly.
-	defBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5}
+	defBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25}
 )
 
 func init() {


### PR DESCRIPTION
5s is fairly low when looking at p99 and p999. Adding 10 and 25 seconds should make it easier to identify strong outliers. 

Signed-off-by: bergquist <carl.bergquist@gmail.com>
