### PR TITLE
TimePicker: TimeRangePicker tooltip visibility fix

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -51,6 +51,7 @@ export interface State {
 
 export function UnthemedTimeRangePicker(props: TimeRangePickerProps): ReactElement {
   const [isOpen, setOpen] = useState(false);
+  const [tooltipVis, setTooltipVis] = useState(false);
 
   const {
     value,
@@ -78,10 +79,18 @@ export function UnthemedTimeRangePicker(props: TimeRangePickerProps): ReactEleme
     event.stopPropagation();
     event.preventDefault();
     setOpen(!isOpen);
+    setTooltipVis(false);
   };
 
   const onClose = () => {
     setOpen(false);
+  };
+
+  const onMouseEnter = () => {
+    setTooltipVis(true);
+  };
+  const onMouseLeave = () => {
+    setTooltipVis(false);
   };
 
   const ref = createRef<HTMLElement>();
@@ -104,19 +113,26 @@ export function UnthemedTimeRangePicker(props: TimeRangePickerProps): ReactEleme
         />
       )}
 
-      <Tooltip content={<TimePickerTooltip timeRange={value} timeZone={timeZone} />} placement="bottom" interactive>
-        <ToolbarButton
-          data-testid={selectors.components.TimePicker.openButton}
-          aria-label={`Time range picker with current time range ${formattedRange(value, timeZone)} selected`}
-          aria-controls="TimePickerContent"
-          onClick={onOpen}
-          icon="clock-nine"
-          isOpen={isOpen}
-          variant={variant}
+      <div onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
+        <Tooltip
+          content={<TimePickerTooltip timeRange={value} timeZone={timeZone} />}
+          show={tooltipVis}
+          placement="bottom"
+          interactive
         >
-          <TimePickerButtonLabel {...props} />
-        </ToolbarButton>
-      </Tooltip>
+          <ToolbarButton
+            data-testid={selectors.components.TimePicker.openButton}
+            aria-label={`Time range picker with current time range ${formattedRange(value, timeZone)} selected`}
+            aria-controls="TimePickerContent"
+            onClick={onOpen}
+            icon="clock-nine"
+            isOpen={isOpen}
+            variant={variant}
+          >
+            <TimePickerButtonLabel {...props} />
+          </ToolbarButton>
+        </Tooltip>
+      </div>
       {isOpen && (
         <FocusScope contain autoFocus restoreFocus>
           <section ref={ref} {...overlayProps} {...dialogProps}>

--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
@@ -95,7 +95,7 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
       </button>
     );
 
-    return tooltip ? (
+    return tooltip && !isOpen ? (
       <Tooltip content={tooltip} placement="bottom">
         {body}
       </Tooltip>

--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
@@ -95,7 +95,7 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
       </button>
     );
 
-    return tooltip && !isOpen ? (
+    return tooltip ? (
       <Tooltip content={tooltip} placement="bottom">
         {body}
       </Tooltip>


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #51037

https://user-images.githubusercontent.com/67058118/176217943-c8ac2870-df30-4610-9d89-5863a9ec9aaa.mov

After some investigation I decided to override the 'show' prop with new state variables in the TimeRangePicker: 
[tooltipVis, setTooltipVis]

It seems like the default 'show' state wasn't resetting properly and when you click out of the range options box it re-renders the ToolbarButton with the previous open state. 

Hope this is ok, happy if anyone has a better solution. 🙂


