### PR TITLE
Annotations: Use point marker for short time range annotations

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin.tsx
@@ -131,7 +131,14 @@ export const AnnotationsPlugin: React.FC<AnnotationsPluginProps> = ({ annotation
           x1 = plotInstance.current.bbox.width / window.devicePixelRatio;
         }
         markerStyle = { width: `${x1 - x0}px` };
+
+        if (x1 - x0 < 8) {
+          markerStyle = undefined;
+        }
       }
+
+      console.log(annotation);
+      console.log(markerStyle);
 
       return <AnnotationMarker annotation={annotation} timeZone={timeZone} style={markerStyle} />;
     },

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin.tsx
@@ -113,7 +113,7 @@ export const AnnotationsPlugin: React.FC<AnnotationsPluginProps> = ({ annotation
 
   const renderMarker = useCallback(
     (frame: DataFrame, dataFrameFieldIndex: DataFrameFieldIndex) => {
-      let markerStyle;
+      let width = 0;
       const view = new DataFrameView<AnnotationsDataFrameViewDTO>(frame);
       const annotation = view.get(dataFrameFieldIndex.fieldIndex);
       const isRegionAnnotation = Boolean(annotation.isRegion);
@@ -130,17 +130,10 @@ export const AnnotationsPlugin: React.FC<AnnotationsPluginProps> = ({ annotation
         if (x1 > plotInstance.current.bbox.width / window.devicePixelRatio) {
           x1 = plotInstance.current.bbox.width / window.devicePixelRatio;
         }
-        markerStyle = { width: `${x1 - x0}px` };
-
-        if (x1 - x0 < 8) {
-          markerStyle = undefined;
-        }
+        width = x1 - x0;
       }
 
-      console.log(annotation);
-      console.log(markerStyle);
-
-      return <AnnotationMarker annotation={annotation} timeZone={timeZone} style={markerStyle} />;
+      return <AnnotationMarker annotation={annotation} timeZone={timeZone} width={width} />;
     },
     [timeZone]
   );

--- a/public/app/plugins/panel/timeseries/plugins/annotations/AnnotationMarker.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations/AnnotationMarker.tsx
@@ -98,7 +98,7 @@ export function AnnotationMarker({ annotation, timeZone, style }: Props) {
     );
   }, [canEditAnnotations, canDeleteAnnotations, onAnnotationDelete, onAnnotationEdit, timeFormatter, annotation]);
 
-  const isRegionAnnotation = Boolean(annotation.isRegion);
+  const isRegionAnnotation = Boolean(annotation.isRegion) && style !== undefined;
 
   let marker = (
     <div className={commonStyles(annotation).markerTriangle} style={{ transform: 'translate3d(-100%,-50%, 0)' }} />

--- a/public/app/plugins/panel/timeseries/plugins/annotations/AnnotationMarker.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations/AnnotationMarker.tsx
@@ -14,7 +14,10 @@ import { AnnotationTooltip } from './AnnotationTooltip';
 interface Props extends HTMLAttributes<HTMLDivElement> {
   timeZone: TimeZone;
   annotation: AnnotationsDataFrameViewDTO;
+  width: number;
 }
+
+const MIN_REGION_ANNOTATION_WIDTH = 6;
 
 const POPPER_CONFIG = {
   modifiers: [
@@ -29,7 +32,7 @@ const POPPER_CONFIG = {
   ],
 };
 
-export function AnnotationMarker({ annotation, timeZone, style }: Props) {
+export function AnnotationMarker({ annotation, timeZone, width }: Props) {
   const { canAddAnnotations, canEditAnnotations, canDeleteAnnotations, ...panelCtx } = usePanelContext();
   const commonStyles = useStyles2(getCommonAnnotationStyles);
   const styles = useStyles2(getStyles);
@@ -98,15 +101,22 @@ export function AnnotationMarker({ annotation, timeZone, style }: Props) {
     );
   }, [canEditAnnotations, canDeleteAnnotations, onAnnotationDelete, onAnnotationEdit, timeFormatter, annotation]);
 
-  const isRegionAnnotation = Boolean(annotation.isRegion) && style !== undefined;
+  const isRegionAnnotation = Boolean(annotation.isRegion) && width > MIN_REGION_ANNOTATION_WIDTH;
 
+  let left = `${width / 2}px`;
   let marker = (
-    <div className={commonStyles(annotation).markerTriangle} style={{ transform: 'translate3d(-100%,-50%, 0)' }} />
+    <div
+      className={commonStyles(annotation).markerTriangle}
+      style={{ left, position: 'relative', transform: 'translate3d(-100%,-50%, 0)' }}
+    />
   );
 
   if (isRegionAnnotation) {
     marker = (
-      <div className={commonStyles(annotation).markerBar} style={{ ...style, transform: 'translate3d(0,-50%, 0)' }} />
+      <div
+        className={commonStyles(annotation).markerBar}
+        style={{ width: `${width}px`, transform: 'translate3d(0,-50%, 0)' }}
+      />
     );
   }
   return (


### PR DESCRIPTION
Currently, if range annotations are made with a short time frame the width of the rendered bar will be either zero or near zero making annotations impossible to view. This PR addresses that by using the same annotation marker as point annotations when the range of the annotation becomes small.

Video of this in action:

https://user-images.githubusercontent.com/199847/176243270-ba1277cd-01e8-4c1b-b569-ad8f3057f1fd.mov

Fixes #48087



