### PR TITLE
Docs: moves custom branding to configuration

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/configure-custom-branding.md
+++ b/docs/sources/setup-grafana/configure-grafana/configure-custom-branding.md
@@ -2,16 +2,17 @@
 aliases:
   - /docs/grafana/latest/enterprise/white-labeling/
   - /docs/grafana/latest/setup-grafana/enable-custom-branding/
+  - /docs/grafana/latest/setup-grafana/configure-grafana/configure-custom-branding/
 description: Change the look of Grafana to match your corporate brand.
 title: Enable custom branding
-weight: 1300
+weight: 300
 ---
 
-# Enable custom branding
+# Configure custom branding
 
 Custom branding allows you to replace the Grafana brand and logo with your own corporate brand and logo.
 
-> **Note:** Available in [Grafana Enterprise]({{< relref "../enterprise/" >}}) and [Grafana Cloud Advanced]({{< ref "/docs/grafana-cloud" >}}).
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}) and [Grafana Cloud Advanced]({{< ref "/docs/grafana-cloud" >}}).
 
 Grafana Enterprise has custom branding options in the `grafana.ini` file. As with all configuration options, you can also set them with environment variables.
 
@@ -32,7 +33,7 @@ You can change the following elements:
 
 {{< figure src="/static/img/docs/v66/whitelabeling_1.png" max-width="800px" caption="Custom branding example" >}}
 
-The configuration file in Grafana Enterprise contains the following options. Each option is defined in the file. For more information about configuring Grafana, refer to [Configuration]({{< relref "configure-grafana/" >}}).
+The configuration file in Grafana Enterprise contains the following options. Each option is defined in the file. For more information about configuring Grafana, refer to [Configuration]({{< relref "../configure-grafana/" >}}).
 
 ```ini
 # Enterprise only


### PR DESCRIPTION
This PR moves the custom branding from Setup to Setup > Configuration.