### PR TITLE
Alerting: Add custom templated title to Wecom notifier

### DIFF
--- a/pkg/services/ngalert/notifier/available_channels.go
+++ b/pkg/services/ngalert/notifier/available_channels.go
@@ -696,7 +696,7 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 					Placeholder:  `{{ template "default.message" . }}`,
 					PropertyName: "message",
 				},
-				{ // New in 9.0.
+				{ // New in 9.1.
 					Label:        "Title",
 					Element:      alerting.ElementTypeInput,
 					InputType:    alerting.InputTypeText,

--- a/pkg/services/ngalert/notifier/available_channels.go
+++ b/pkg/services/ngalert/notifier/available_channels.go
@@ -700,7 +700,7 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 					Label:        "Title",
 					Element:      alerting.ElementTypeInput,
 					InputType:    alerting.InputTypeText,
-					Description:  "Templated title of the email",
+					Description:  "Templated title of the message",
 					PropertyName: "title",
 					Placeholder:  `{{ template "default.title" . }}`,
 				},

--- a/pkg/services/ngalert/notifier/available_channels.go
+++ b/pkg/services/ngalert/notifier/available_channels.go
@@ -696,6 +696,14 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 					Placeholder:  `{{ template "default.message" . }}`,
 					PropertyName: "message",
 				},
+				{ // New in 9.0.
+					Label:        "Title",
+					Element:      alerting.ElementTypeInput,
+					InputType:    alerting.InputTypeText,
+					Description:  "Templated title of the email",
+					PropertyName: "title",
+					Placeholder:  `{{ template "default.title" . }}`,
+				},
 			},
 		},
 		{

--- a/pkg/services/ngalert/notifier/channels/wecom.go
+++ b/pkg/services/ngalert/notifier/channels/wecom.go
@@ -18,6 +18,7 @@ type WeComConfig struct {
 	*NotificationChannelConfig
 	URL     string
 	Message string
+	Title   string
 }
 
 func WeComFactory(fc FactoryConfig) (NotificationChannel, error) {
@@ -40,6 +41,7 @@ func NewWeComConfig(config *NotificationChannelConfig, decryptFunc GetDecryptedV
 		NotificationChannelConfig: config,
 		URL:                       url,
 		Message:                   config.Settings.Get("message").MustString(`{{ template "default.message" .}}`),
+		Title:                     config.Settings.Get("title").MustString(DefaultMessageTitleEmbed),
 	}, nil
 }
 
@@ -55,6 +57,7 @@ func NewWeComNotifier(config *WeComConfig, ns notifications.WebhookSender, t *te
 		}),
 		URL:     config.URL,
 		Message: config.Message,
+		Title:   config.Title,
 		log:     log.New("alerting.notifier.wecom"),
 		ns:      ns,
 		tmpl:    t,
@@ -66,6 +69,7 @@ type WeComNotifier struct {
 	*Base
 	URL     string
 	Message string
+	Title   string
 	tmpl    *template.Template
 	log     log.Logger
 	ns      notifications.WebhookSender
@@ -82,7 +86,7 @@ func (w *WeComNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, e
 		"msgtype": "markdown",
 	}
 	content := fmt.Sprintf("# %s\n%s\n",
-		tmpl(DefaultMessageTitleEmbed),
+		tmpl(w.Title),
 		tmpl(w.Message),
 	)
 

--- a/pkg/services/ngalert/notifier/channels/wecom_test.go
+++ b/pkg/services/ngalert/notifier/channels/wecom_test.go
@@ -79,7 +79,7 @@ func TestWeComNotifier(t *testing.T) {
 		}, {
 			name: "Custom title and message with multiple alerts",
 			settings: `{
-				"url": "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=db0e4533-aa2a-4385-8a24-2a7b6be72d20",
+				"url": "http://localhost",
 				"message": "{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved",
 				"title":"This notification is {{ .Status }}!"
 			}`,

--- a/pkg/services/ngalert/notifier/channels/wecom_test.go
+++ b/pkg/services/ngalert/notifier/channels/wecom_test.go
@@ -77,6 +77,33 @@ func TestWeComNotifier(t *testing.T) {
 			},
 			expMsgError: nil,
 		}, {
+			name: "Custom title and message with multiple alerts",
+			settings: `{
+				"url": "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=db0e4533-aa2a-4385-8a24-2a7b6be72d20",
+				"message": "{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved",
+				"title":"This notification is {{ .Status }}!"
+			}`,
+			alerts: []*types.Alert{
+				{
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val1"},
+						Annotations: model.LabelSet{"ann1": "annv1"},
+					},
+				}, {
+					Alert: model.Alert{
+						Labels:      model.LabelSet{"alertname": "alert1", "lbl1": "val2"},
+						Annotations: model.LabelSet{"ann1": "annv2"},
+					},
+				},
+			},
+			expMsg: map[string]interface{}{
+				"markdown": map[string]interface{}{
+					"content": "# This notification is firing!\n2 alerts are firing, 0 are resolved\n",
+				},
+				"msgtype": "markdown",
+			},
+			expMsgError: nil,
+		}, {
 			name:         "Error in initing",
 			settings:     `{}`,
 			expInitError: `could not find webhook URL in settings`,

--- a/pkg/services/ngalert/notifier/channels/wecom_test.go
+++ b/pkg/services/ngalert/notifier/channels/wecom_test.go
@@ -81,7 +81,7 @@ func TestWeComNotifier(t *testing.T) {
 			settings: `{
 				"url": "http://localhost",
 				"message": "{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved",
-				"title":"This notification is {{ .Status }}!"
+				"title": "This notification is {{ .Status }}!"
 			}`,
 			alerts: []*types.Alert{
 				{


### PR DESCRIPTION
**What this PR does / why we need it**:
When someone need to change  title in wecom  alert message , and this pr  support this case.

**Which issue(s) this PR fixes**:
#51528 #48159

**Special notes for your reviewer**:
I follow the code pattern about custom email subject .
