### PR TITLE
Live: Sync routing tree with latest changes in Gin

### DIFF
--- a/pkg/services/live/pipeline/tree/tree_test.go
+++ b/pkg/services/live/pipeline/tree/tree_test.go
@@ -588,6 +588,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/blog/:p",
 		"/posts/:b/:c",
 		"/posts/b/:c/d/",
+		"/vendor/:x/*y",
 	}
 	for _, route := range routes {
 		recv := catchPanic(func() {
@@ -624,6 +625,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/api/world/abc/",
 		"/blog/pp/",
 		"/posts/b/c/d",
+		"/vendor/x",
 	}
 	for _, route := range tsrRoutes {
 		value := tree.GetValue(route, false)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adopts latest changes to routing tree from Gin to our copy: i.e. those from https://github.com/gin-gonic/gin/commits/master/tree.go. So we are up-to-date with upstream.