### PR TITLE
SearchV2: add back the column styles for the SearchResultsTable component

### DIFF
--- a/public/app/features/search/page/components/SearchResultsTable.tsx
+++ b/public/app/features/search/page/components/SearchResultsTable.tsx
@@ -48,6 +48,7 @@ export const SearchResultsTable = React.memo(
     keyboardEvents,
   }: SearchResultsProps) => {
     const styles = useStyles2(getStyles);
+    const columnStyles = useStyles2(getColumnStyles);
     const tableStyles = useStyles2(getTableStyles);
     const infiniteLoaderRef = useRef<InfiniteLoader>(null);
     const [listEl, setListEl] = useState<FixedSizeList | null>(null);
@@ -82,12 +83,12 @@ export const SearchResultsTable = React.memo(
         selection,
         selectionToggle,
         clearSelection,
-        styles,
+        columnStyles,
         onTagSelected,
         onDatasourceChange,
         response.view?.length >= response.totalRows
       );
-    }, [response, width, styles, selection, selectionToggle, clearSelection, onTagSelected, onDatasourceChange]);
+    }, [response, width, columnStyles, selection, selectionToggle, clearSelection, onTagSelected, onDatasourceChange]);
 
     const options: TableOptions<{}> = useMemo(
       () => ({
@@ -220,6 +221,83 @@ const getStyles = (theme: GrafanaTheme2) => {
         overflow: hidden;
         text-overflow: ellipsis;
       }
+    `,
+  };
+};
+
+// CSS for columns from react table
+const getColumnStyles = (theme: GrafanaTheme2) => {
+  return {
+    nameCellStyle: css`
+      border-right: none;
+      padding: ${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(2)};
+      overflow: hidden;
+      text-overflow: ellipsis;
+      user-select: text;
+      white-space: nowrap;
+      &:hover {
+        box-shadow: none;
+      }
+    `,
+    headerNameStyle: css`
+      padding-left: ${theme.spacing(1)};
+    `,
+
+    typeIcon: css`
+      margin-left: 5px;
+      margin-right: 9.5px;
+      vertical-align: middle;
+      display: inline-block;
+      margin-bottom: ${theme.v1.spacing.xxs};
+      fill: ${theme.colors.text.secondary};
+    `,
+    datasourceItem: css`
+      span {
+        &:hover {
+          color: ${theme.colors.text.link};
+        }
+      }
+    `,
+    missingTitleText: css`
+      color: ${theme.colors.text.disabled};
+      font-style: italic;
+    `,
+    invalidDatasourceItem: css`
+      color: ${theme.colors.error.main};
+      text-decoration: line-through;
+    `,
+    typeText: css`
+      color: ${theme.colors.text.secondary};
+      padding-top: ${theme.spacing(1)};
+    `,
+    locationItem: css`
+      color: ${theme.colors.text.secondary};
+      margin-right: 12px;
+    `,
+    sortedHeader: css`
+      text-align: right;
+      padding-right: ${theme.spacing(2)};
+    `,
+    sortedItems: css`
+      text-align: right;
+      padding: ${theme.spacing(1)} ${theme.spacing(3)} ${theme.spacing(1)} ${theme.spacing(1)};
+    `,
+    locationCellStyle: css`
+      padding-top: ${theme.spacing(1)};
+      padding-right: ${theme.spacing(1)};
+    `,
+    checkboxHeader: css`
+      margin-left: 2px;
+    `,
+    checkbox: css`
+      margin-left: 10px;
+      margin-right: 10px;
+      margin-top: 5px;
+    `,
+    tagList: css`
+      padding-top: ${theme.spacing(0.5)};
+      justify-content: flex-start;
+      flex-wrap: nowrap;
     `,
   };
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

We removed by mistake the column styles from `SearchResultsTable` in https://github.com/grafana/grafana/pull/51269 , this PR add the styles back.


Before

![BeforeBrokenStyles](https://user-images.githubusercontent.com/239999/176441536-e8d1e276-47ee-45e1-975d-ea026efc28ff.png)


After

![AfterFixedStyles](https://user-images.githubusercontent.com/239999/176441562-12d7d550-bc31-4dc9-a1c7-071058842744.png)

