### PR TITLE
Command Palette: Fix initial load

### DIFF
--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -47,13 +47,11 @@ export const CommandPalette = () => {
   });
 
   useEffect(() => {
-    (async () => {
-      if (isNotLogin) {
-        setStaticActions(getGlobalActions(navBarTree));
-        setActions(staticActions);
-      }
-    })();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    if (isNotLogin) {
+      const staticActionsResp = getGlobalActions(navBarTree);
+      setStaticActions(staticActionsResp);
+      setActions([...staticActionsResp]);
+    }
   }, [isNotLogin, navBarTree]);
 
   useEffect(() => {


### PR DESCRIPTION
Command Palette wasn't receiving the initial static actions in time so it would have them to show the overlay, etc, but not enough to display the command palette. This PR initializes the actions from the response itself, and not the state variable.

