### PR TITLE
Altering: validate that the mute time intervals exist when updating routing tree

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_validation.go
@@ -114,6 +114,21 @@ func (r *Route) ValidateReceivers(receivers map[string]struct{}) error {
 	return nil
 }
 
+func (r *Route) ValidateMuteTimes(muteTimes map[string]struct{}) error {
+	for _, name := range r.MuteTimeIntervals {
+		if _, exists := muteTimes[name]; !exists {
+			return fmt.Errorf("mute time interval '%s' does not exist", name)
+		}
+	}
+	for _, child := range r.Routes {
+		err := child.ValidateMuteTimes(muteTimes)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (mt *MuteTimeInterval) Validate() error {
 	s, err := yaml.Marshal(mt.MuteTimeInterval)
 	if err != nil {

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -76,6 +76,15 @@ func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgI
 		return fmt.Errorf("%w: %s", ErrValidation, err.Error())
 	}
 
+	muteTimes := map[string]struct{}{}
+	for _, mt := range revision.cfg.AlertmanagerConfig.MuteTimeIntervals {
+		muteTimes[mt.Name] = struct{}{}
+	}
+	err = tree.ValidateMuteTimes(muteTimes)
+	if err != nil {
+		return fmt.Errorf("%w: %s", ErrValidation, err.Error())
+	}
+	
 	revision.cfg.AlertmanagerConfig.Config.Route = &tree
 
 	serialized, err := serializeAlertmanagerConfig(*revision.cfg)

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -84,7 +84,7 @@ func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgI
 	if err != nil {
 		return fmt.Errorf("%w: %s", ErrValidation, err.Error())
 	}
-	
+
 	revision.cfg.AlertmanagerConfig.Config.Route = &tree
 
 	serialized, err := serializeAlertmanagerConfig(*revision.cfg)

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -8,8 +8,9 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/common/model"
-	mock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,6 +22,68 @@ func TestNotificationPolicyService(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, "grafana-default-email", tree.Receiver)
+	})
+
+	t.Run("error if referenced mute time interval is not existing", func(t *testing.T) {
+		sut := createNotificationPolicyServiceSut()
+		sut.amStore = &MockAMConfigStore{}
+		sut.amStore.(*MockAMConfigStore).On("GetLatestAlertmanagerConfiguration", mock.Anything, mock.Anything).
+			Return(
+				func(ctx context.Context, query *models.GetLatestAlertmanagerConfigurationQuery) error {
+					cfg, _ := deserializeAlertmanagerConfig([]byte(defaultConfig))
+					mti := config.MuteTimeInterval{
+						Name:          "not-the-one-we-need",
+						TimeIntervals: []timeinterval.TimeInterval{},
+					}
+					cfg.AlertmanagerConfig.MuteTimeIntervals = append(cfg.AlertmanagerConfig.MuteTimeIntervals, mti)
+					data, _ := serializeAlertmanagerConfig(*cfg)
+					query.Result = &models.AlertConfiguration{
+						AlertmanagerConfiguration: string(data),
+					}
+					return nil
+				})
+		sut.amStore.(*MockAMConfigStore).EXPECT().
+			UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).
+			Return(nil)
+		newRoute := createTestRoutingTree()
+		newRoute.Routes = append(newRoute.Routes, &definitions.Route{
+			Receiver:          "test-receiver",
+			MuteTimeIntervals: []string{"not-existing"},
+		})
+
+		err := sut.UpdatePolicyTree(context.Background(), 1, newRoute, models.ProvenanceNone)
+		require.Error(t, err)
+	})
+
+	t.Run("pass if referenced mute time interval is existing", func(t *testing.T) {
+		sut := createNotificationPolicyServiceSut()
+		sut.amStore = &MockAMConfigStore{}
+		sut.amStore.(*MockAMConfigStore).On("GetLatestAlertmanagerConfiguration", mock.Anything, mock.Anything).
+			Return(
+				func(ctx context.Context, query *models.GetLatestAlertmanagerConfigurationQuery) error {
+					cfg, _ := deserializeAlertmanagerConfig([]byte(defaultConfig))
+					mti := config.MuteTimeInterval{
+						Name:          "existing",
+						TimeIntervals: []timeinterval.TimeInterval{},
+					}
+					cfg.AlertmanagerConfig.MuteTimeIntervals = append(cfg.AlertmanagerConfig.MuteTimeIntervals, mti)
+					data, _ := serializeAlertmanagerConfig(*cfg)
+					query.Result = &models.AlertConfiguration{
+						AlertmanagerConfiguration: string(data),
+					}
+					return nil
+				})
+		sut.amStore.(*MockAMConfigStore).EXPECT().
+			UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).
+			Return(nil)
+		newRoute := createTestRoutingTree()
+		newRoute.Routes = append(newRoute.Routes, &definitions.Route{
+			Receiver:          "test-receiver",
+			MuteTimeIntervals: []string{"existing"},
+		})
+
+		err := sut.UpdatePolicyTree(context.Background(), 1, newRoute, models.ProvenanceNone)
+		require.NoError(t, err)
 	})
 
 	t.Run("service stitches policy tree into org's AM config", func(t *testing.T) {

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -36,6 +36,13 @@ func TestNotificationPolicyService(t *testing.T) {
 						TimeIntervals: []timeinterval.TimeInterval{},
 					}
 					cfg.AlertmanagerConfig.MuteTimeIntervals = append(cfg.AlertmanagerConfig.MuteTimeIntervals, mti)
+					cfg.AlertmanagerConfig.Receivers = append(cfg.AlertmanagerConfig.Receivers,
+						&definitions.PostableApiReceiver{
+							Receiver: config.Receiver{
+								// default one from createTestRoutingTree()
+								Name: "a new receiver",
+							},
+						})
 					data, _ := serializeAlertmanagerConfig(*cfg)
 					query.Result = &models.AlertConfiguration{
 						AlertmanagerConfiguration: string(data),
@@ -47,7 +54,7 @@ func TestNotificationPolicyService(t *testing.T) {
 			Return(nil)
 		newRoute := createTestRoutingTree()
 		newRoute.Routes = append(newRoute.Routes, &definitions.Route{
-			Receiver:          "test-receiver",
+			Receiver:          "a new receiver",
 			MuteTimeIntervals: []string{"not-existing"},
 		})
 
@@ -67,6 +74,13 @@ func TestNotificationPolicyService(t *testing.T) {
 						TimeIntervals: []timeinterval.TimeInterval{},
 					}
 					cfg.AlertmanagerConfig.MuteTimeIntervals = append(cfg.AlertmanagerConfig.MuteTimeIntervals, mti)
+					cfg.AlertmanagerConfig.Receivers = append(cfg.AlertmanagerConfig.Receivers,
+						&definitions.PostableApiReceiver{
+							Receiver: config.Receiver{
+								// default one from createTestRoutingTree()
+								Name: "a new receiver",
+							},
+						})
 					data, _ := serializeAlertmanagerConfig(*cfg)
 					query.Result = &models.AlertConfiguration{
 						AlertmanagerConfiguration: string(data),
@@ -78,7 +92,7 @@ func TestNotificationPolicyService(t *testing.T) {
 			Return(nil)
 		newRoute := createTestRoutingTree()
 		newRoute.Routes = append(newRoute.Routes, &definitions.Route{
-			Receiver:          "test-receiver",
+			Receiver:          "a new receiver",
 			MuteTimeIntervals: []string{"existing"},
 		})
 


### PR DESCRIPTION
This PR will check that if we create a new route, the referenced mute time interval is existing in the configuration.