### PR TITLE
Canvas: Stop selecto box from triggering when programmatically selecting elements

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4581,7 +4581,7 @@ exports[`better eslint`] = {
     "public/app/features/canvas/runtime/root.tsx:2845174121": [
       [24, 19, 36, "Do not use any type assertions.", "1413431594"]
     ],
-    "public/app/features/canvas/runtime/scene.tsx:2490140997": [
+    "public/app/features/canvas/runtime/scene.tsx:4285479205": [
       [155, 61, 25, "Do not use any type assertions.", "588553285"],
       [160, 42, 25, "Do not use any type assertions.", "588553285"]
     ],
@@ -10980,10 +10980,9 @@ exports[`better eslint`] = {
       [41, 64, 3, "Unexpected any. Specify a different type.", "193409811"],
       [41, 69, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "public/app/plugins/panel/canvas/editor/LayerElementListEditor.tsx:2866351070": [
+    "public/app/plugins/panel/canvas/editor/LayerElementListEditor.tsx:374041207": [
       [21, 33, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [40, 30, 44, "Do not use any type assertions.", "712744497"],
-      [50, 20, 3, "Unexpected any. Specify a different type.", "193409811"]
+      [40, 30, 44, "Do not use any type assertions.", "712744497"]
     ],
     "public/app/plugins/panel/canvas/editor/PlacementEditor.tsx:1494111960": [
       [33, 53, 3, "Unexpected any. Specify a different type.", "193409811"]

--- a/public/app/features/canvas/runtime/scene.tsx
+++ b/public/app/features/canvas/runtime/scene.tsx
@@ -394,8 +394,12 @@ export class Scene {
         this.moveable!.isMoveableElement(selectedTarget) ||
         targets.some((target) => target === selectedTarget || target.contains(selectedTarget));
 
-      if (isTargetMoveableElement) {
-        // Prevent drawing selection box when selected target is a moveable element
+      const isTargetAlreadySelected = this.selecto
+        ?.getSelectedTargets()
+        .includes(selectedTarget.parentElement.parentElement);
+
+      if (isTargetMoveableElement || isTargetAlreadySelected) {
+        // Prevent drawing selection box when selected target is a moveable element or already selected
         event.stop();
       }
     }).on('selectEnd', (event) => {

--- a/public/app/plugins/panel/canvas/editor/LayerElementListEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/LayerElementListEditor.tsx
@@ -48,7 +48,7 @@ export class LayerElementListEditor extends PureComponent<Props> {
     layer.reinitializeMoveable();
   };
 
-  onSelect = (item: FrameState | ElementState) => {
+  onSelect = (item: ElementState) => {
     const { settings } = this.props.item;
 
     if (settings?.scene) {

--- a/public/app/plugins/panel/canvas/editor/LayerElementListEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/LayerElementListEditor.tsx
@@ -48,7 +48,7 @@ export class LayerElementListEditor extends PureComponent<Props> {
     layer.reinitializeMoveable();
   };
 
-  onSelect = (item: any) => {
+  onSelect = (item: FrameState | ElementState) => {
     const { settings } = this.props.item;
 
     if (settings?.scene) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Selection box would trigger when trying to move an element that was selected programmatically via the layer list editor. This would result in an annoying UX where user would lose their selection context.

Before

https://user-images.githubusercontent.com/22381771/176485847-47a6bd5d-a2f5-4369-89fe-79952365a1b8.mov



After

https://user-images.githubusercontent.com/22381771/176485949-2612e985-cf9a-44ad-aa48-7479247315e9.mov




**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #51565
