### PR TITLE
Canvas: Enable multi-select via shift key

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4581,7 +4581,7 @@ exports[`better eslint`] = {
     "public/app/features/canvas/runtime/root.tsx:2845174121": [
       [24, 19, 36, "Do not use any type assertions.", "1413431594"]
     ],
-    "public/app/features/canvas/runtime/scene.tsx:2928385813": [
+    "public/app/features/canvas/runtime/scene.tsx:2490140997": [
       [155, 61, 25, "Do not use any type assertions.", "588553285"],
       [160, 42, 25, "Do not use any type assertions.", "588553285"]
     ],

--- a/public/app/features/canvas/runtime/scene.tsx
+++ b/public/app/features/canvas/runtime/scene.tsx
@@ -307,7 +307,7 @@ export class Scene {
     this.selecto = new Selecto({
       container: this.div,
       selectableTargets: targetElements,
-      selectByClick: true,
+      toggleContinueSelect: 'shift',
     });
 
     this.moveable = new Moveable(this.div!, {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Enable ability to select / deselect multiple elements via holding down the shift key. This functionality is present in Figma and is easily enabled via the selecto library.

Removes redundant selecto config (selectByClick) as it's default value is already `true`


https://user-images.githubusercontent.com/22381771/176490355-db8656a3-8d11-4e3f-97be-c7b097720629.mov



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #51580

