### PR TITLE
DashboardRow: Collapse shortcut prevent to move the collapsed rows

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4682,12 +4682,11 @@ exports[`better eslint`] = {
       [207, 40, 20, "Do not use any type assertions.", "2225958749"],
       [207, 57, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "public/app/features/dashboard/components/DashboardRow/DashboardRow.test.tsx:3204880669": [
+    "public/app/features/dashboard/components/DashboardRow/DashboardRow.test.tsx:3328105205": [
       [9, 40, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx:2916737379": [
-      [19, 69, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [46, 30, 3, "Unexpected any. Specify a different type.", "193409811"]
+    "public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx:3890988818": [
+      [19, 69, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "public/app/features/dashboard/components/DashboardSettings/AnnotationsSettings.test.tsx:1365286122": [
       [12, 17, 3, "Unexpected any. Specify a different type.", "193409811"]

--- a/public/app/features/dashboard/components/DashboardRow/DashboardRow.test.tsx
+++ b/public/app/features/dashboard/components/DashboardRow/DashboardRow.test.tsx
@@ -29,12 +29,16 @@ describe('DashboardRow', () => {
     expect(row).not.toHaveClass('dashboard-row--collapsed');
   });
 
+  it('Should collapse when the panel is collapsed', async () => {
+    const panel = new PanelModel({ collapsed: true });
+    render(<DashboardRow panel={panel} dashboard={dashboardMock} />);
+    const row = screen.getByTestId('dashboard-row-container');
+    expect(row).toHaveClass('dashboard-row--collapsed');
+  });
+
   it('Should collapse after clicking title', async () => {
     render(<DashboardRow panel={panel} dashboard={dashboardMock} />);
     await userEvent.click(screen.getByTestId('data-testid dashboard-row-title-'));
-
-    const row = screen.getByTestId('dashboard-row-container');
-    expect(row).toHaveClass('dashboard-row--collapsed');
     expect(dashboardMock.toggleRow.mock.calls).toHaveLength(1);
   });
 

--- a/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
+++ b/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
@@ -19,13 +19,6 @@ export interface DashboardRowProps {
 
 export class DashboardRow extends React.Component<DashboardRowProps, any> {
   sub?: Unsubscribable;
-  constructor(props: DashboardRowProps) {
-    super(props);
-
-    this.state = {
-      collapsed: this.props.panel.collapsed,
-    };
-  }
 
   componentDidMount() {
     this.sub = this.props.dashboard.events.subscribe(RefreshEvent, this.onVariableUpdated);
@@ -43,10 +36,6 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
 
   onToggle = () => {
     this.props.dashboard.toggleRow(this.props.panel);
-
-    this.setState((prevState: any) => {
-      return { collapsed: !prevState.collapsed };
-    });
   };
 
   onUpdate = (title: string, repeat?: string | null) => {
@@ -77,7 +66,7 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
   render() {
     const classes = classNames({
       'dashboard-row': true,
-      'dashboard-row--collapsed': this.state.collapsed,
+      'dashboard-row--collapsed': this.props.panel.collapsed,
     });
 
     const title = getTemplateSrv().replace(this.props.panel.title, this.props.panel.scopedVars, 'text');
@@ -92,7 +81,7 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
           data-testid={selectors.components.DashboardRow.title(title)}
           onClick={this.onToggle}
         >
-          <Icon name={this.state.collapsed ? 'angle-right' : 'angle-down'} />
+          <Icon name={this.props.panel.collapsed ? 'angle-right' : 'angle-down'} />
           {title}
           <span className="dashboard-row__panel_count">
             ({count} {panels})
@@ -110,7 +99,7 @@ export class DashboardRow extends React.Component<DashboardRowProps, any> {
             </a>
           </div>
         )}
-        {this.state.collapsed === true && (
+        {this.props.panel.collapsed === true && (
           <div className="dashboard-row__toggle-target" onClick={this.onToggle}>
             &nbsp;
           </div>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
It removes the dashboard row component state. The state was initialized with the panel prop when but it was never updated when the prop changes. The shortcut uses the DashboardMode to toggle the rows. The component receives the new value from props, but it doesn't update the state keeping the panel open.

The solution is to remove the state from the component and only the callback and the props to collapse/expand. This will keep the DashboardModal as the single source of truth for the panel state.

**Which issue(s) this PR fixes**:
The collapse/Expand shortcut affects the component status, so they can be moved when collapsed  

|Before|After|
|-|-|
|![2022-06-29 19 38 15](https://user-images.githubusercontent.com/5699976/176500789-d7aed4f6-2989-4c81-8602-0cd38f5ce237.gif)|![2022-06-29 19 37 00](https://user-images.githubusercontent.com/5699976/176500774-59a7e4e0-5eb3-4a27-9c6c-4764a9ee3b53.gif)|

Fixes #51369

**Special notes for your reviewer**:
I updated the tests to reflect the change. Since we rely on DashboardModal, we just need to make sure the component is properly set up depending on the `panel` prop and it calls the `toggleRow` when clicked. 
