### PR TITLE
ColorScale: prevent vertical scrollbar in container during hover

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3179,7 +3179,7 @@ exports[`better eslint`] = {
       [73, 37, 3, "Unexpected any. Specify a different type.", "193409811"],
       [89, 39, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "public/app/core/components/ColorScale/ColorScale.tsx:661627953": [
+    "public/app/core/components/ColorScale/ColorScale.tsx:12349772": [
       [38, 24, 43, "Do not use any type assertions.", "1727107527"],
       [38, 25, 19, "Do not use any type assertions.", "1979047218"],
       [38, 41, 3, "Unexpected any. Specify a different type.", "193409811"]

--- a/public/app/core/components/ColorScale/ColorScale.tsx
+++ b/public/app/core/components/ColorScale/ColorScale.tsx
@@ -154,7 +154,6 @@ const getStyles = (theme: GrafanaTheme2, colors: string[]) => ({
     position: relative;
     pointer-events: none;
     white-space: nowrap;
-    height: 10px;
   `,
   follower: css`
     position: absolute;


### PR DESCRIPTION
not reproducible on all systems, but causes a perf hotspot due to frequent dom layout changes.

scrollbar in lower right:

![Peek 2022-06-29 13-13](https://user-images.githubusercontent.com/43234/176507144-d3cd5b8b-ae25-4fd6-bc0b-f7ef147787eb.gif)