### PR TITLE
Chore: Update ConcreteLogger to implement gokit Logger interface

### DIFF
--- a/pkg/infra/log/level/level_test.go
+++ b/pkg/infra/log/level/level_test.go
@@ -5,9 +5,10 @@ import (
 
 	gokitlog "github.com/go-kit/log"
 	gokitlevel "github.com/go-kit/log/level"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/log/level"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewFilter(t *testing.T) {
@@ -24,14 +25,14 @@ func TestNewFilter(t *testing.T) {
 		require.Equal(t, "lvl", ctx.loggedArgs[3][2].(string))
 		require.Equal(t, "dbug", ctx.loggedArgs[3][3].(level.Value).String())
 
-		require.Equal(t, "level", ctx.loggedArgs[4][0].(string))
-		require.Equal(t, "info", ctx.loggedArgs[4][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[5][0].(string))
-		require.Equal(t, "warn", ctx.loggedArgs[5][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[6][0].(string))
-		require.Equal(t, "error", ctx.loggedArgs[6][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[7][0].(string))
-		require.Equal(t, "debug", ctx.loggedArgs[7][1].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[4][2].(string))
+		require.Equal(t, "info", ctx.loggedArgs[4][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[5][2].(string))
+		require.Equal(t, "warn", ctx.loggedArgs[5][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[6][2].(string))
+		require.Equal(t, "error", ctx.loggedArgs[6][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[7][2].(string))
+		require.Equal(t, "debug", ctx.loggedArgs[7][3].(gokitlevel.Value).String())
 	})
 
 	newFilteredLoggerScenario(t, "Given error, warnings, info, debug is allowed should log all messages", level.AllowDebug(), func(t *testing.T, ctx *scenarioContext) {
@@ -47,14 +48,14 @@ func TestNewFilter(t *testing.T) {
 		require.Equal(t, "lvl", ctx.loggedArgs[3][2].(string))
 		require.Equal(t, "dbug", ctx.loggedArgs[3][3].(level.Value).String())
 
-		require.Equal(t, "level", ctx.loggedArgs[4][0].(string))
-		require.Equal(t, "info", ctx.loggedArgs[4][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[5][0].(string))
-		require.Equal(t, "warn", ctx.loggedArgs[5][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[6][0].(string))
-		require.Equal(t, "error", ctx.loggedArgs[6][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[7][0].(string))
-		require.Equal(t, "debug", ctx.loggedArgs[7][1].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[4][2].(string))
+		require.Equal(t, "info", ctx.loggedArgs[4][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[5][2].(string))
+		require.Equal(t, "warn", ctx.loggedArgs[5][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[6][2].(string))
+		require.Equal(t, "error", ctx.loggedArgs[6][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[7][2].(string))
+		require.Equal(t, "debug", ctx.loggedArgs[7][3].(gokitlevel.Value).String())
 	})
 
 	newFilteredLoggerScenario(t, "Given error, warnings is allowed should log error and warning messages", level.AllowWarn(), func(t *testing.T, ctx *scenarioContext) {
@@ -66,10 +67,10 @@ func TestNewFilter(t *testing.T) {
 		require.Equal(t, "lvl", ctx.loggedArgs[1][2].(string))
 		require.Equal(t, "eror", ctx.loggedArgs[1][3].(level.Value).String())
 
-		require.Equal(t, "level", ctx.loggedArgs[2][0].(string))
-		require.Equal(t, "warn", ctx.loggedArgs[2][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[3][0].(string))
-		require.Equal(t, "error", ctx.loggedArgs[3][1].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[2][2].(string))
+		require.Equal(t, "warn", ctx.loggedArgs[2][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[3][2].(string))
+		require.Equal(t, "error", ctx.loggedArgs[3][3].(gokitlevel.Value).String())
 	})
 
 	newFilteredLoggerScenario(t, "Given error allowed should log error messages", level.AllowError(), func(t *testing.T, ctx *scenarioContext) {
@@ -79,8 +80,8 @@ func TestNewFilter(t *testing.T) {
 		require.Equal(t, "lvl", ctx.loggedArgs[0][2].(string))
 		require.Equal(t, "eror", ctx.loggedArgs[0][3].(level.Value).String())
 
-		require.Equal(t, "level", ctx.loggedArgs[1][0].(string))
-		require.Equal(t, "error", ctx.loggedArgs[1][1].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[1][2].(string))
+		require.Equal(t, "error", ctx.loggedArgs[1][3].(gokitlevel.Value).String())
 	})
 
 	newFilteredLoggerScenario(t, "Given error, warnings, info is allowed should log error, warning and info messages", level.AllowInfo(), func(t *testing.T, ctx *scenarioContext) {
@@ -94,12 +95,12 @@ func TestNewFilter(t *testing.T) {
 		require.Equal(t, "lvl", ctx.loggedArgs[2][2].(string))
 		require.Equal(t, "eror", ctx.loggedArgs[2][3].(level.Value).String())
 
-		require.Equal(t, "level", ctx.loggedArgs[3][0].(string))
-		require.Equal(t, "info", ctx.loggedArgs[3][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[4][0].(string))
-		require.Equal(t, "warn", ctx.loggedArgs[4][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[5][0].(string))
-		require.Equal(t, "error", ctx.loggedArgs[5][1].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[3][2].(string))
+		require.Equal(t, "info", ctx.loggedArgs[3][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[4][2].(string))
+		require.Equal(t, "warn", ctx.loggedArgs[4][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[5][2].(string))
+		require.Equal(t, "error", ctx.loggedArgs[5][3].(gokitlevel.Value).String())
 	})
 
 	newFilteredLoggerScenario(t, "Given no levels is allowed should not log any messages", level.AllowNone(), func(t *testing.T, ctx *scenarioContext) {

--- a/pkg/infra/log/log.go
+++ b/pkg/infra/log/log.go
@@ -18,12 +18,13 @@ import (
 
 	gokitlog "github.com/go-kit/log"
 	"github.com/go-stack/stack"
+	"github.com/mattn/go-isatty"
+	"gopkg.in/ini.v1"
+
 	"github.com/grafana/grafana/pkg/infra/log/level"
 	"github.com/grafana/grafana/pkg/infra/log/term"
 	"github.com/grafana/grafana/pkg/infra/log/text"
 	"github.com/grafana/grafana/pkg/util"
-	"github.com/mattn/go-isatty"
-	"gopkg.in/ini.v1"
 )
 
 var (
@@ -181,6 +182,11 @@ func (cl *ConcreteLogger) Debug(msg string, args ...interface{}) {
 	_ = cl.log(msg, level.DebugValue(), args...)
 }
 
+func (cl *ConcreteLogger) Log(ctx ...interface{}) error {
+	logger := gokitlog.With(&cl.SwapLogger, "t", gokitlog.TimestampFormat(now, logTimeFormat))
+	return logger.Log(ctx...)
+}
+
 func (cl *ConcreteLogger) Error(msg string, args ...interface{}) {
 	_ = cl.log(msg, level.ErrorValue(), args...)
 }
@@ -190,10 +196,7 @@ func (cl *ConcreteLogger) Info(msg string, args ...interface{}) {
 }
 
 func (cl *ConcreteLogger) log(msg string, logLevel level.Value, args ...interface{}) error {
-	logger := gokitlog.With(&cl.SwapLogger, "t", gokitlog.TimestampFormat(now, logTimeFormat))
-	args = append([]interface{}{level.Key(), logLevel, "msg", msg}, args...)
-
-	return logger.Log(args...)
+	return cl.Log(append([]interface{}{level.Key(), logLevel, "msg", msg}, args...)...)
 }
 
 func (cl *ConcreteLogger) New(ctx ...interface{}) *ConcreteLogger {

--- a/pkg/infra/log/log_test.go
+++ b/pkg/infra/log/log_test.go
@@ -6,9 +6,10 @@ import (
 	"time"
 
 	gokitlog "github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/log/level"
 	"github.com/grafana/grafana/pkg/util"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLogger(t *testing.T) {
@@ -33,17 +34,21 @@ func TestLogger(t *testing.T) {
 		log3.Error("hello 3 again")
 
 		require.Len(t, ctx.loggedArgs, 5)
-		require.Len(t, ctx.loggedArgs[0], 4)
+		require.Len(t, ctx.loggedArgs[0], 6)
 		require.Equal(t, "logger", ctx.loggedArgs[0][0].(string))
 		require.Equal(t, "one", ctx.loggedArgs[0][1].(string))
-		require.Equal(t, "msg", ctx.loggedArgs[0][2].(string))
-		require.Equal(t, "hello 1", ctx.loggedArgs[0][3].(string))
+		require.Equal(t, "t", ctx.loggedArgs[0][2].(string))
+		require.Equal(t, ctx.mockedTime.Format("2006-01-02T15:04:05.99-0700"), ctx.loggedArgs[0][3].(fmt.Stringer).String())
+		require.Equal(t, "msg", ctx.loggedArgs[0][4].(string))
+		require.Equal(t, "hello 1", ctx.loggedArgs[0][5].(string))
 
-		require.Len(t, ctx.loggedArgs[1], 4)
+		require.Len(t, ctx.loggedArgs[1], 6)
 		require.Equal(t, "logger", ctx.loggedArgs[1][0].(string))
 		require.Equal(t, "two", ctx.loggedArgs[1][1].(string))
-		require.Equal(t, "msg", ctx.loggedArgs[1][2].(string))
-		require.Equal(t, "hello 2", ctx.loggedArgs[1][3].(string))
+		require.Equal(t, "t", ctx.loggedArgs[0][2].(string))
+		require.Equal(t, ctx.mockedTime.Format("2006-01-02T15:04:05.99-0700"), ctx.loggedArgs[0][3].(fmt.Stringer).String())
+		require.Equal(t, "msg", ctx.loggedArgs[1][4].(string))
+		require.Equal(t, "hello 2", ctx.loggedArgs[1][5].(string))
 
 		require.Len(t, ctx.loggedArgs[2], 8)
 		require.Equal(t, "logger", ctx.loggedArgs[2][0].(string))
@@ -55,13 +60,15 @@ func TestLogger(t *testing.T) {
 		require.Equal(t, "msg", ctx.loggedArgs[2][6].(string))
 		require.Equal(t, "hello 3", ctx.loggedArgs[2][7].(string))
 
-		require.Len(t, ctx.loggedArgs[3], 6)
+		require.Len(t, ctx.loggedArgs[3], 8)
 		require.Equal(t, "logger", ctx.loggedArgs[3][0].(string))
 		require.Equal(t, "three", ctx.loggedArgs[3][1].(string))
 		require.Equal(t, "key", ctx.loggedArgs[3][2].(string))
 		require.Equal(t, "value", ctx.loggedArgs[3][3].(string))
-		require.Equal(t, "msg", ctx.loggedArgs[3][4].(string))
-		require.Equal(t, "hello 4", ctx.loggedArgs[3][5].(string))
+		require.Equal(t, "t", ctx.loggedArgs[3][4].(string))
+		require.Equal(t, ctx.mockedTime.Format("2006-01-02T15:04:05.99-0700"), ctx.loggedArgs[3][5].(fmt.Stringer).String())
+		require.Equal(t, "msg", ctx.loggedArgs[3][6].(string))
+		require.Equal(t, "hello 4", ctx.loggedArgs[3][7].(string))
 
 		require.Len(t, ctx.loggedArgs[4], 8)
 		require.Equal(t, "logger", ctx.loggedArgs[4][0].(string))


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Currently, ConcreteLogger "inherits" implementation of gokit.Logger interface from SwapLogger. However, this causes the problem as the ConcreteLogger decorates all methods `Debug, Info etc` with additional context. Therefore, two following calls that are supposed to result in the same log message cause different outcomes:
```
log.New("logger").Debug("test")
log.New("logger").Log(level.Key(), level.DebugValue(), "msg", "test")
```
The difference here is that the first call adds the timestamp to the call, and the second one - does not.
```
DEBUG[06-29|16:08:54] test              logger=test
DEBUG[01-01|00:00:00] test              logger=test
```

Currently, this affects collecting Alertmanager logs (as well as other dependencies that support gokit logger). In Grafana Alertmanager is an external dependency and Grafana provides its logger when it is configuring the service.
https://github.com/grafana/grafana/blob/9e8efaa4599cad3ba272c5a5689b94bb7f6e8b8b/pkg/services/ngalert/notifier/alertmanager.go#L430

This results in a log message without a timestamp like the following:

```
ERROR[01-01|00:00:00] Notify for alerts failed                 logger=alertmanager org=1 component=dispatcher num_alerts=1 err="email/email[0]: notify retry canceled due to unrecoverable error after 1 attempts: failed to send notification to email addresses: mail@mail: dial tcp [::1]:2500: connect: connection refused"
```

This PR fixes ConcreteLogger to implement the method Log and add the current timestamp to the context