### PR TITLE
Explore: Add Mixed Datasource

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1208,8 +1208,11 @@ lokiQueryBuilder = true
 # Experimental Explore to Dashboard workflow
 explore2Dashboard = true
 
-# Experimental Command Palette
+# Command Palette
 commandPalette = true
+
+# Experimental Explore Mixed Datasource
+exploreMixedDatasource = false
 
 # Use dynamic labels in CloudWatch datasource
 cloudWatchDynamicLabels = true

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1211,9 +1211,6 @@ explore2Dashboard = true
 # Command Palette
 commandPalette = true
 
-# Experimental Explore Mixed Datasource
-exploreMixedDatasource = false
-
 # Use dynamic labels in CloudWatch datasource
 cloudWatchDynamicLabels = true
 

--- a/docs/sources/explore/_index.md
+++ b/docs/sources/explore/_index.md
@@ -73,3 +73,7 @@ The Share shortened link capability allows you to create smaller and simpler URL
 > **Note:** Available in Grafana 8.5.0 and later versions.
 
 Enabled by default, allows users to create panels in dashboards from within Explore.
+
+### exploreMixedDatasource
+
+Disabled by default, allows users in Explore to have different datasources for different queries. If compatible, results will be combined.

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -44,6 +44,7 @@ export interface FeatureToggles {
   export?: boolean;
   azureMonitorResourcePickerForMetrics?: boolean;
   explore2Dashboard?: boolean;
+  exploreMixedDatasource?: boolean;
   tracing?: boolean;
   commandPalette?: boolean;
   cloudWatchDynamicLabels?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -160,6 +160,12 @@ var (
 			FrontendOnly: true,
 		},
 		{
+			Name:         "exploreMixedDatasource",
+			Description:  "Enable mixed datasource in Explore",
+			State:        FeatureStateAlpha,
+			FrontendOnly: true,
+		},
+		{
 			Name:         "tracing",
 			Description:  "Adds trace ID to error notifications",
 			State:        FeatureStateAlpha,

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -119,6 +119,10 @@ const (
 	// Experimental Explore to Dashboard workflow
 	FlagExplore2Dashboard = "explore2Dashboard"
 
+	// FlagExploreMixedDatasource
+	// Enable mixed datasource in Explore
+	FlagExploreMixedDatasource = "exploreMixedDatasource"
+
 	// FlagTracing
 	// Adds trace ID to error notifications
 	FlagTracing = "tracing"

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -259,13 +259,16 @@ export async function generateEmptyQuery(
   index = 0,
   dataSourceOverride?: DataSourceRef
 ): Promise<DataQuery> {
-  // if queries is empty, datasource is default
   let datasource;
+
+  // datasource override is if we have switched datasources with no carry-over - we want to create a new query with a datasource we define
   if (dataSourceOverride) {
     datasource = dataSourceOverride;
   } else if (queries.length > 0 && queries[queries.length - 1].datasource) {
+    // otherwise use last queries' datasource
     datasource = queries[queries.length - 1].datasource;
   } else {
+    // if neither exists, use the default datasource
     const datasourceFull = await getDataSourceSrv().get();
     datasource = datasourceFull.getRef();
   }

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -6,7 +6,6 @@ import {
   CoreApp,
   DataQuery,
   DataQueryRequest,
-  DataSourceApi,
   dateMath,
   DateTime,
   DefaultTimeZone,

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -6,6 +6,7 @@ import {
   CoreApp,
   DataQuery,
   DataQueryRequest,
+  DataSourceRef,
   dateMath,
   DateTime,
   DefaultTimeZone,
@@ -253,11 +254,16 @@ export function generateKey(index = 0): string {
   return `Q-${uuidv4()}-${index}`;
 }
 
-// TODO have logic include top level DS for URL reasons
-export async function generateEmptyQuery(queries: DataQuery[], index = 0): Promise<DataQuery> {
+export async function generateEmptyQuery(
+  queries: DataQuery[],
+  index = 0,
+  dataSourceOverride?: DataSourceRef
+): Promise<DataQuery> {
   // if queries is empty, datasource is default
   let datasource;
-  if (queries.length > 0 && queries[queries.length - 1].datasource) {
+  if (dataSourceOverride) {
+    datasource = dataSourceOverride;
+  } else if (queries.length > 0 && queries[queries.length - 1].datasource) {
     datasource = queries[queries.length - 1].datasource;
   } else {
     const datasourceFull = await getDataSourceSrv().get();
@@ -276,7 +282,10 @@ export const generateNewKeyAndAddRefIdIfMissing = (target: DataQuery, queries: D
 /**
  * Ensure at least one target exists and that targets have the necessary keys
  */
-export async function ensureQueries(queries?: DataQuery[]): Promise<DataQuery[]> {
+export async function ensureQueries(
+  queries?: DataQuery[],
+  newQueryDataSourceOverride?: DataSourceRef
+): Promise<DataQuery[]> {
   if (queries && typeof queries === 'object' && queries.length > 0) {
     const allQueries = [];
     for (let index = 0; index < queries.length; index++) {
@@ -295,7 +304,7 @@ export async function ensureQueries(queries?: DataQuery[]): Promise<DataQuery[]>
     }
     return allQueries;
   }
-  const emptyQuery = await generateEmptyQuery(queries ?? []);
+  const emptyQuery = await generateEmptyQuery(queries ?? [], undefined, newQueryDataSourceOverride);
   return [{ ...emptyQuery }];
 }
 

--- a/public/app/core/utils/explore.ts
+++ b/public/app/core/utils/explore.ts
@@ -70,19 +70,6 @@ export async function getExploreUrl(args: GetExploreUrlArguments): Promise<strin
   let exploreTargets: DataQuery[] = panel.targets.map((t) => omit(t, 'legendFormat'));
   let url: string | undefined;
 
-  // Mixed datasources need to choose only one datasource
-  if (exploreDatasource.meta?.id === 'mixed' && exploreTargets) {
-    // Find first explore datasource among targets
-    for (const t of exploreTargets) {
-      const datasource = await datasourceSrv.get(t.datasource || undefined);
-      if (datasource) {
-        exploreDatasource = datasource;
-        exploreTargets = panel.targets.filter((t) => t.datasource === datasource.name);
-        break;
-      }
-    }
-  }
-
   if (exploreDatasource) {
     const range = timeSrv.timeRangeForUrl();
     let state: Partial<ExploreUrlState> = { range };
@@ -99,7 +86,7 @@ export async function getExploreUrl(args: GetExploreUrlArguments): Promise<strin
         ...state,
         datasource: exploreDatasource.name,
         context: 'explore',
-        queries: exploreTargets.map((t) => ({ ...t, datasource: exploreDatasource.getRef() })),
+        queries: exploreTargets,
       };
     }
 

--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -219,8 +219,7 @@ export function getQueryDisplayText(query: DataQuery, isMixed = false): string {
    * stringifying query that was stripped of key, refId and datasource for nicer
    * formatting and improved readability
    */
-  let keysToStrip = ['key', 'refId', 'datasource'];
-  const strippedQuery = omit(query, keysToStrip);
+  const strippedQuery = omit(query, ['key', 'refId', 'datasource']);
   const strippedQueryJSON = JSON.stringify(strippedQuery);
   const prefix = isMixed ? query.datasource?.type : undefined;
   return `${prefix ? prefix + ': ' : ''}${strippedQueryJSON}`;

--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -214,13 +214,16 @@ export function createDateStringFromTs(ts: number) {
   });
 }
 
-export function getQueryDisplayText(query: DataQuery): string {
+export function getQueryDisplayText(query: DataQuery, isMixed = false): string {
   /* If datasource doesn't have getQueryDisplayText, create query display text by
    * stringifying query that was stripped of key, refId and datasource for nicer
    * formatting and improved readability
    */
-  const strippedQuery = omit(query, ['key', 'refId', 'datasource']);
-  return JSON.stringify(strippedQuery);
+  let keysToStrip = ['key', 'refId', 'datasource'];
+  const strippedQuery = omit(query, keysToStrip);
+  const strippedQueryJSON = JSON.stringify(strippedQuery);
+  const prefix = isMixed ? query.datasource?.type : undefined;
+  return `${prefix ? prefix + ': ' : ''}${strippedQueryJSON}`;
 }
 
 export function createQueryHeading(query: RichHistoryQuery, sortOrder: SortOrder) {
@@ -241,7 +244,7 @@ export function createQueryText(query: DataQuery, queryDsInstance: DataSourceApi
     return queryDsInstance.getQueryDisplayText(query);
   }
 
-  return getQueryDisplayText(query);
+  return getQueryDisplayText(query, queryDsInstance?.meta.mixed);
 }
 
 export function mapQueriesToHeadings(query: RichHistoryQuery[], sortOrder: SortOrder) {
@@ -264,7 +267,7 @@ export function mapQueriesToHeadings(query: RichHistoryQuery[], sortOrder: SortO
  */
 export function createDatasourcesList() {
   return getDataSourceSrv()
-    .getList()
+    .getList({ mixed: true })
     .map((dsSettings) => {
       return {
         name: dsSettings.name,

--- a/public/app/core/utils/richHistory.ts
+++ b/public/app/core/utils/richHistory.ts
@@ -214,15 +214,13 @@ export function createDateStringFromTs(ts: number) {
   });
 }
 
-export function getQueryDisplayText(query: DataQuery, isMixed = false): string {
+export function getQueryDisplayText(query: DataQuery): string {
   /* If datasource doesn't have getQueryDisplayText, create query display text by
    * stringifying query that was stripped of key, refId and datasource for nicer
    * formatting and improved readability
    */
   const strippedQuery = omit(query, ['key', 'refId', 'datasource']);
-  const strippedQueryJSON = JSON.stringify(strippedQuery);
-  const prefix = isMixed ? query.datasource?.type : undefined;
-  return `${prefix ? prefix + ': ' : ''}${strippedQueryJSON}`;
+  return JSON.stringify(strippedQuery);
 }
 
 export function createQueryHeading(query: RichHistoryQuery, sortOrder: SortOrder) {
@@ -243,7 +241,7 @@ export function createQueryText(query: DataQuery, queryDsInstance: DataSourceApi
     return queryDsInstance.getQueryDisplayText(query);
   }
 
-  return getQueryDisplayText(query, queryDsInstance?.meta.mixed);
+  return getQueryDisplayText(query);
 }
 
 export function mapQueriesToHeadings(query: RichHistoryQuery[], sortOrder: SortOrder) {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -157,9 +157,9 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
     this.onModifyQueries({ type: 'ADD_FILTER_OUT', options: { key, value } });
   };
 
-  onClickAddQueryRowButton = async () => {
+  onClickAddQueryRowButton = () => {
     const { exploreId, queryKeys } = this.props;
-    await this.props.addQueryRow(exploreId, queryKeys.length);
+    this.props.addQueryRow(exploreId, queryKeys.length);
   };
 
   onMakeAbsoluteTime = () => {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -157,9 +157,9 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
     this.onModifyQueries({ type: 'ADD_FILTER_OUT', options: { key, value } });
   };
 
-  onClickAddQueryRowButton = () => {
-    const { exploreId, queryKeys, datasourceInstance } = this.props;
-    this.props.addQueryRow(exploreId, queryKeys.length, datasourceInstance);
+  onClickAddQueryRowButton = async () => {
+    const { exploreId, queryKeys } = this.props;
+    await this.props.addQueryRow(exploreId, queryKeys.length);
   };
 
   onMakeAbsoluteTime = () => {

--- a/public/app/features/explore/ExplorePaneContainer.tsx
+++ b/public/app/features/explore/ExplorePaneContainer.tsx
@@ -70,7 +70,7 @@ class ExplorePaneContainerUnconnected extends React.PureComponent<Props> {
 
     // initialize the whole explore first time we mount and if browser history contains a change in datasource
     if (!initialized) {
-      const queries = await ensureQueries(initialQueries);
+      const queries = await ensureQueries(initialQueries); // this will return an empty array if there are no datasources
       this.props.initializeExplore(
         exploreId,
         initialDatasource,

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -145,7 +145,7 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
             !datasourceMissing && (
               <DataSourcePicker
                 key={`${exploreId}-ds-picker`}
-                mixed={true}
+                mixed={config.featureToggles.exploreMixedDatasource === true}
                 onChange={this.onChangeDatasource}
                 current={this.props.datasourceRef}
                 hideTextValue={showSmallDataSourcePicker}

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -145,6 +145,7 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
             !datasourceMissing && (
               <DataSourcePicker
                 key={`${exploreId}-ds-picker`}
+                mixed={true}
                 onChange={this.onChangeDatasource}
                 current={this.props.datasourceRef}
                 hideTextValue={showSmallDataSourcePicker}

--- a/public/app/features/explore/Wrapper.test.tsx
+++ b/public/app/features/explore/Wrapper.test.tsx
@@ -39,8 +39,7 @@ describe('Wrapper', () => {
 
   it('shows warning if there are no data sources', async () => {
     setupExplore({ datasources: [] });
-    // Will throw if isn't found
-    screen.getByText(/Explore requires at least one data source/i);
+    await waitFor(() => screen.getByText(/Explore requires at least one data source/i));
   });
 
   it('inits url and renders editor but does not call query on empty url', async () => {
@@ -52,7 +51,7 @@ describe('Wrapper', () => {
       orgId: '1',
       left: serializeStateToUrlParam({
         datasource: 'loki',
-        queries: [{ refId: 'A' }],
+        queries: [{ refId: 'A', datasource: { type: 'logs', uid: 'loki' } }],
         range: { from: 'now-1h', to: 'now' },
       }),
     });
@@ -144,7 +143,7 @@ describe('Wrapper', () => {
       orgId: '1',
       left: serializeStateToUrlParam({
         datasource: 'elastic',
-        queries: [{ refId: 'A' }],
+        queries: [{ refId: 'A', datasource: { type: 'logs', uid: 'elastic' } }],
         range: { from: 'now-1h', to: 'now' },
       }),
     });

--- a/public/app/features/explore/spec/helper/setup.tsx
+++ b/public/app/features/explore/spec/helper/setup.tsx
@@ -32,7 +32,7 @@ type SetupOptions = {
 };
 
 export function setupExplore(options?: SetupOptions): {
-  datasources: { [name: string]: DataSourceApi };
+  datasources: { [uid: string]: DataSourceApi };
   store: ReturnType<typeof configureStore>;
   unmount: () => void;
   container: HTMLElement;
@@ -58,15 +58,19 @@ export function setupExplore(options?: SetupOptions): {
     getInstanceSettings(ref: DataSourceRef) {
       return dsSettings.map((d) => d.settings).find((x) => x.name === ref || x.uid === ref || x.uid === ref.uid);
     },
-    get(datasource?: string | DataSourceRef | null, scopedVars?: ScopedVars): Promise<DataSourceApi> {
-      const datasourceStr = typeof datasource === 'string';
-      return Promise.resolve(
-        (datasource
-          ? dsSettings.find((d) =>
-              datasourceStr ? d.api.name === datasource || d.api.uid === datasource : d.api.uid === datasource?.uid
-            )
-          : dsSettings[0])!.api
-      );
+    get(datasource?: string | DataSourceRef | null, scopedVars?: ScopedVars): Promise<DataSourceApi | undefined> {
+      if (dsSettings.length === 0) {
+        return Promise.resolve(undefined);
+      } else {
+        const datasourceStr = typeof datasource === 'string';
+        return Promise.resolve(
+          (datasource
+            ? dsSettings.find((d) =>
+                datasourceStr ? d.api.name === datasource || d.api.uid === datasource : d.api.uid === datasource?.uid
+              )
+            : dsSettings[0])!.api
+        );
+      }
     },
   } as any);
 
@@ -149,7 +153,7 @@ function makeDatasourceSetup({ name = 'loki', id = 1 }: { name?: string; id?: nu
       name: name,
       uid: name,
       query: jest.fn(),
-      getRef: jest.fn().mockReturnValue(name),
+      getRef: jest.fn().mockReturnValue({ type: 'logs', uid: name }),
       meta,
     } as any,
   };

--- a/public/app/features/explore/state/datasource.ts
+++ b/public/app/features/explore/state/datasource.ts
@@ -53,7 +53,7 @@ export function changeDatasource(
     );
 
     if (options?.importQueries) {
-      const queries = getState().explore[exploreId]!.queries;
+      const queries = getState().explore[exploreId]!.queries.filter((q) => q.datasource?.type === instance.type);
       await dispatch(importQueries(exploreId, queries, currentDataSourceInstance, instance));
     }
 

--- a/public/app/features/explore/state/datasource.ts
+++ b/public/app/features/explore/state/datasource.ts
@@ -53,7 +53,8 @@ export function changeDatasource(
     );
 
     if (options?.importQueries) {
-      const queries = getState().explore[exploreId]!.queries.filter((q) => q.datasource?.type === instance.type);
+      //TODO: WHY
+      const queries = getState().explore[exploreId]!.queries; //.filter(q => q.datasource?.type === instance.type);
       await dispatch(importQueries(exploreId, queries, currentDataSourceInstance, instance));
     }
 

--- a/public/app/features/explore/state/datasource.ts
+++ b/public/app/features/explore/state/datasource.ts
@@ -53,8 +53,7 @@ export function changeDatasource(
     );
 
     if (options?.importQueries) {
-      //TODO: WHY
-      const queries = getState().explore[exploreId]!.queries; //.filter(q => q.datasource?.type === instance.type);
+      const queries = getState().explore[exploreId]!.queries;
       await dispatch(importQueries(exploreId, queries, currentDataSourceInstance, instance));
     }
 

--- a/public/app/features/explore/state/datasource.ts
+++ b/public/app/features/explore/state/datasource.ts
@@ -2,6 +2,7 @@
 import { AnyAction, createAction } from '@reduxjs/toolkit';
 
 import { DataSourceApi, HistoryItem } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 import { RefreshPicker } from '@grafana/ui';
 import { stopQueryState } from 'app/core/utils/explore';
 import { ExploreItemState, ThunkResult } from 'app/types';
@@ -43,6 +44,12 @@ export function changeDatasource(
     const orgId = getState().user.orgId;
     const { history, instance } = await loadAndInitDatasource(orgId, { uid: datasourceUid });
     const currentDataSourceInstance = getState().explore[exploreId]!.datasourceInstance;
+
+    if (instance.meta.mixed) {
+      reportInteraction('explore_change_ds_to_mixed');
+    } else if (currentDataSourceInstance?.meta.mixed) {
+      reportInteraction('explore_change_ds_from_mixed');
+    }
 
     dispatch(
       updateDatasourceInstanceAction({

--- a/public/app/features/explore/state/datasource.ts
+++ b/public/app/features/explore/state/datasource.ts
@@ -45,12 +45,11 @@ export function changeDatasource(
     const { history, instance } = await loadAndInitDatasource(orgId, { uid: datasourceUid });
     const currentDataSourceInstance = getState().explore[exploreId]!.datasourceInstance;
 
-    if (instance.meta.mixed) {
-      reportInteraction('explore_change_ds_to_mixed');
-    } else if (currentDataSourceInstance?.meta.mixed) {
-      reportInteraction('explore_change_ds_from_mixed');
-    }
-
+    reportInteraction('explore_change_ds', {
+      from: (currentDataSourceInstance?.meta?.mixed ? 'mixed' : currentDataSourceInstance?.type) || 'unknown',
+      to: instance.meta.mixed ? 'mixed' : instance.type,
+      exploreId,
+    });
     dispatch(
       updateDatasourceInstanceAction({
         exploreId,

--- a/public/app/features/explore/state/explorePane.test.ts
+++ b/public/app/features/explore/state/explorePane.test.ts
@@ -72,6 +72,9 @@ function setup(state?: any) {
               testDatasource: jest.fn(),
               init: jest.fn(),
               name: 'default',
+              getRef() {
+                return { type: 'default', uid: 'default' };
+              },
             }
       );
     },

--- a/public/app/features/explore/state/explorePane.ts
+++ b/public/app/features/explore/state/explorePane.ts
@@ -222,7 +222,7 @@ export function refreshExplore(exploreId: ExploreId, newUrlQuery: string): Thunk
     // commit changes based on the diff of new url vs old url
 
     if (update.datasource) {
-      const initialQueries = ensureQueries(queries);
+      const initialQueries = await ensureQueries(queries);
       await dispatch(
         initializeExplore(exploreId, datasource, initialQueries, range, containerWidth, eventBridge, panelsState)
       );
@@ -304,7 +304,7 @@ export const paneReducer = (state: ExploreItemState = makeExplorePaneState(), ac
       range,
       queries,
       initialized: true,
-      queryKeys: getQueryKeys(queries, datasourceInstance),
+      queryKeys: getQueryKeys(queries),
       datasourceInstance,
       history,
       datasourceMissing: !datasourceInstance,

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -154,12 +154,32 @@ describe('running queries', () => {
 describe('importing queries', () => {
   describe('when importing queries between the same type of data source', () => {
     it('remove datasource property from all of the queries', async () => {
+      const datasources = [
+        {
+          name: 'testDs',
+          type: 'postgres',
+          uid: 'ds1',
+          getRef: () => {
+            return { type: 'postgres', uid: 'ds1' };
+          },
+        },
+
+        {
+          name: 'testDs2',
+          type: 'postgres',
+          uid: 'ds2',
+          getRef: () => {
+            return { type: 'postgres', uid: 'ds2' };
+          },
+        },
+      ];
+
       const { dispatch, getState }: { dispatch: ThunkDispatch; getState: () => StoreState } = configureStore({
         ...(defaultInitialState as any),
         explore: {
           [ExploreId.left]: {
             ...defaultInitialState.explore[ExploreId.left],
-            datasourceInstance: { name: 'testDs', type: 'postgres' },
+            datasourceInstance: datasources[0],
           },
         },
       });
@@ -168,18 +188,18 @@ describe('importing queries', () => {
         importQueries(
           ExploreId.left,
           [
-            { datasource: { type: 'postgresql' }, refId: 'refId_A' },
-            { datasource: { type: 'postgresql' }, refId: 'refId_B' },
+            { datasource: { type: 'postgresql', uid: 'ds1' }, refId: 'refId_A' },
+            { datasource: { type: 'postgresql', uid: 'ds1' }, refId: 'refId_B' },
           ],
-          { name: 'Postgres1', type: 'postgres' } as DataSourceApi<DataQuery, DataSourceJsonData, {}>,
-          { name: 'Postgres2', type: 'postgres' } as DataSourceApi<DataQuery, DataSourceJsonData, {}>
+          datasources[0],
+          datasources[1]
         )
       );
 
       expect(getState().explore[ExploreId.left].queries[0]).toHaveProperty('refId', 'refId_A');
       expect(getState().explore[ExploreId.left].queries[1]).toHaveProperty('refId', 'refId_B');
-      expect(getState().explore[ExploreId.left].queries[0]).not.toHaveProperty('datasource');
-      expect(getState().explore[ExploreId.left].queries[1]).not.toHaveProperty('datasource');
+      expect(getState().explore[ExploreId.left].queries[0]).toHaveProperty('datasource.uid', 'ds2');
+      expect(getState().explore[ExploreId.left].queries[1]).toHaveProperty('datasource.uid', 'ds2');
     });
   });
 });

--- a/public/app/features/explore/state/query.test.ts
+++ b/public/app/features/explore/state/query.test.ts
@@ -154,7 +154,7 @@ describe('running queries', () => {
 describe('importing queries', () => {
   describe('when importing queries between the same type of data source', () => {
     it('remove datasource property from all of the queries', async () => {
-      const datasources = [
+      const datasources: DataSourceApi[] = [
         {
           name: 'testDs',
           type: 'postgres',
@@ -162,8 +162,7 @@ describe('importing queries', () => {
           getRef: () => {
             return { type: 'postgres', uid: 'ds1' };
           },
-        },
-
+        } as DataSourceApi<DataQuery, DataSourceJsonData, {}>,
         {
           name: 'testDs2',
           type: 'postgres',
@@ -171,7 +170,7 @@ describe('importing queries', () => {
           getRef: () => {
             return { type: 'postgres', uid: 'ds2' };
           },
-        },
+        } as DataSourceApi<DataQuery, DataSourceJsonData, {}>,
       ];
 
       const { dispatch, getState }: { dispatch: ThunkDispatch; getState: () => StoreState } = configureStore({

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -33,7 +33,7 @@ import {
 } from 'app/core/utils/explore';
 import { getShiftedTimeRange } from 'app/core/utils/timePicker';
 import { getTimeZone } from 'app/features/profile/state/selectors';
-import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDatasource';
+import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 import { ExploreItemState, ExplorePanelData, ThunkDispatch, ThunkResult } from 'app/types';
 import { ExploreId, ExploreState, QueryOptions } from 'app/types/explore';
 
@@ -215,17 +215,11 @@ export const clearCacheAction = createAction<ClearCachePayload>('explore/clearCa
 /**
  * Adds a query row after the row with the given index.
  */
-export function addQueryRow(
-  exploreId: ExploreId,
-  index: number,
-  datasource: DataSourceApi | undefined | null
-): ThunkResult<void> {
-  return (dispatch, getState) => {
+export function addQueryRow(exploreId: ExploreId, index: number): ThunkResult<void> {
+  return async (dispatch, getState) => {
     const queries = getState().explore[exploreId]!.queries;
-    const query = {
-      ...datasource?.getDefaultQuery?.(CoreApp.Explore),
-      ...generateEmptyQuery(queries, index),
-    };
+    const emptyQuery = await generateEmptyQuery(queries, index);
+    const query = { ...emptyQuery };
 
     dispatch(addQueryRowAction({ exploreId, index, query }));
   };
@@ -290,10 +284,10 @@ export const importQueries = (
       importedQueries = await targetDataSource.importQueries(queries, sourceDataSource);
     } else {
       // Default is blank queries
-      importedQueries = ensureQueries();
+      importedQueries = await ensureQueries();
     }
 
-    const nextQueries = ensureQueries(importedQueries);
+    const nextQueries = await ensureQueries(importedQueries);
 
     dispatch(queriesImportedAction({ exploreId, queries: nextQueries }));
   };
@@ -644,7 +638,7 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
     return {
       ...state,
       queries: nextQueries,
-      queryKeys: getQueryKeys(nextQueries, state.datasourceInstance),
+      queryKeys: getQueryKeys(nextQueries),
     };
   }
 
@@ -690,7 +684,7 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
     return {
       ...state,
       queries: nextQueries,
-      queryKeys: getQueryKeys(nextQueries, state.datasourceInstance),
+      queryKeys: getQueryKeys(nextQueries),
     };
   }
 
@@ -699,7 +693,7 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
     return {
       ...state,
       queries: queries.slice(),
-      queryKeys: getQueryKeys(queries, state.datasourceInstance),
+      queryKeys: getQueryKeys(queries),
     };
   }
 
@@ -708,7 +702,7 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
     return {
       ...state,
       queries,
-      queryKeys: getQueryKeys(queries, state.datasourceInstance),
+      queryKeys: getQueryKeys(queries),
     };
   }
 
@@ -765,7 +759,7 @@ export const queryReducer = (state: ExploreItemState, action: AnyAction): Explor
     return {
       ...state,
       queries,
-      queryKeys: getQueryKeys(queries, state.datasourceInstance),
+      queryKeys: getQueryKeys(queries),
     };
   }
 

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -33,6 +33,7 @@ import {
 } from 'app/core/utils/explore';
 import { getShiftedTimeRange } from 'app/core/utils/timePicker';
 import { getTimeZone } from 'app/features/profile/state/selectors';
+import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDatasource';
 import { ExploreItemState, ExplorePanelData, ThunkDispatch, ThunkResult } from 'app/types';
 import { ExploreId, ExploreState, QueryOptions } from 'app/types/explore';
 
@@ -274,7 +275,11 @@ export const importQueries = (
 
     let importedQueries = queries;
     // Check if queries can be imported from previously selected datasource
-    if (sourceDataSource.meta?.id === targetDataSource.meta?.id) {
+    if (targetDataSource.name === MIXED_DATASOURCE_NAME) {
+      importedQueries = queries.map((query) => {
+        return { ...query, datasource: sourceDataSource.getRef() };
+      });
+    } else if (sourceDataSource.meta?.id === targetDataSource.meta?.id) {
       // Keep same queries if same type of datasource, but delete datasource query property to prevent mismatch of new and old data source instance
       importedQueries = queries.map(({ datasource, ...query }) => query);
     } else if (hasQueryExportSupport(sourceDataSource) && hasQueryImportSupport(targetDataSource)) {

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -320,7 +320,7 @@ export const importQueries = (
       importedQueries = await getImportableQueries(targetDataSource, sourceDataSource, queries);
     }
 
-    const nextQueries = await ensureQueries(importedQueries);
+    const nextQueries = await ensureQueries(importedQueries, targetDataSource.getRef());
     dispatch(queriesImportedAction({ exploreId, queries: nextQueries }));
   };
 };

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -258,18 +258,14 @@ const getImportableQueries = async (
   sourceDataSource: DataSourceApi,
   queries: DataQuery[]
 ): Promise<DataQuery[]> => {
-  console.log('importing queries from', targetDataSource.name, sourceDataSource.name);
   let queriesOut: DataQuery[] = [];
   if (sourceDataSource.meta?.id === targetDataSource.meta?.id) {
-    console.log('meta ids are the same, copying');
     queriesOut = queries;
   } else if (hasQueryExportSupport(sourceDataSource) && hasQueryImportSupport(targetDataSource)) {
-    console.log('export/import is compatible, converting');
     const abstractQueries = await sourceDataSource.exportToAbstractQueries(queries);
     queriesOut = await targetDataSource.importFromAbstractQueries(abstractQueries);
   } else if (targetDataSource.importQueries) {
     // Datasource-specific importers
-    console.log('legacy importQueries exists, converting');
     queriesOut = await targetDataSource.importQueries(queries, sourceDataSource);
   }
   // add new datasource to queries before returning
@@ -306,7 +302,6 @@ export const importQueries = (
     }
     // If going from mixed, see what queries you keep by their individual datasources
     else if (sourceDataSource.name === MIXED_DATASOURCE_NAME) {
-      console.log('starting move from mixed');
       const groupedQueries = groupBy(queries, (query) => query.datasource?.uid);
       const groupedImportableQueries = await Promise.all(
         Object.keys(groupedQueries).map(async (key: string) => {
@@ -314,7 +309,6 @@ export const importQueries = (
           return await getImportableQueries(targetDataSource, queryDatasource, groupedQueries[key]);
         })
       );
-      console.log('move from mixed complete', groupedImportableQueries);
       importedQueries = flatten(groupedImportableQueries.filter((arr) => arr.length > 0));
     } else {
       importedQueries = await getImportableQueries(targetDataSource, sourceDataSource, queries);

--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -218,8 +218,7 @@ export const clearCacheAction = createAction<ClearCachePayload>('explore/clearCa
 export function addQueryRow(exploreId: ExploreId, index: number): ThunkResult<void> {
   return async (dispatch, getState) => {
     const queries = getState().explore[exploreId]!.queries;
-    const emptyQuery = await generateEmptyQuery(queries, index);
-    const query = { ...emptyQuery };
+    const query = await generateEmptyQuery(queries, index);
 
     dispatch(addQueryRowAction({ exploreId, index, query }));
   };

--- a/public/app/plugins/datasource/mixed/MixedDataSource.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.ts
@@ -101,8 +101,8 @@ export class MixedDatasource extends DataSourceApi<DataQuery> {
   getQueryDisplayText(query: DataQuery) {
     const strippedQuery = omit(query, ['key', 'refId', 'datasource']);
     const strippedQueryJSON = JSON.stringify(strippedQuery);
-    const prefix = query.datasource?.type ? query.datasource?.type : undefined;
-    return `${prefix ? prefix + ': ' : ''}${strippedQueryJSON}`;
+    const prefix = query.datasource?.type ? `${query.datasource?.type}: ` : '';
+    return `${prefix}${strippedQueryJSON}`;
   }
 
   private isQueryable(query: BatchedQueries): boolean {

--- a/public/app/plugins/datasource/mixed/MixedDataSource.ts
+++ b/public/app/plugins/datasource/mixed/MixedDataSource.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, groupBy } from 'lodash';
+import { cloneDeep, groupBy, omit } from 'lodash';
 import { forkJoin, from, Observable, of, OperatorFunction } from 'rxjs';
 import { catchError, map, mergeAll, mergeMap, reduce, toArray } from 'rxjs/operators';
 
@@ -96,6 +96,13 @@ export class MixedDatasource extends DataSourceApi<DataQuery> {
 
   testDatasource() {
     return Promise.resolve({});
+  }
+
+  getQueryDisplayText(query: DataQuery) {
+    const strippedQuery = omit(query, ['key', 'refId', 'datasource']);
+    const strippedQueryJSON = JSON.stringify(strippedQuery);
+    const prefix = query.datasource?.type ? query.datasource?.type : undefined;
+    return `${prefix ? prefix + ': ' : ''}${strippedQueryJSON}`;
   }
 
   private isQueryable(query: BatchedQueries): boolean {


### PR DESCRIPTION
This adds the ability to use a mixed datasource in Explore. It is behind a feature flag with the default set to off so other teams can see how this feature behaves with their datasources. To view, add the following to `custom.ini`

```
[explore_mixed_datasource]
enabled = true
```

**Expected UX to work like the following**
- Changing to Mixed DS
  - Change queries' DS to previous DS
  - If something was not defined (page load), use default DS
- Changing from mixed DS
   - Any queries matching new DS will be imported
   - All others will follow current logic in explore when switching datasources
   - If none match, create empty query
 
In mixed mode, adding a new query uses previous queries' DS

**Other aspects**
-  Ensure Query History functions as expected
- ~Ensure URL functions as expected~ The url seems to work right now, lets tackle this in a separate ticket because it removes a lot of expected defaults.
- Added feature tracking for switching to and from mixed datasource

**Open Questions**
- How would we want to display query history? See below for low-impact change
<img width="704" alt="Screen Shot 2022-06-29 at 4 25 01 PM" src="https://user-images.githubusercontent.com/1533128/176548455-92eb5558-d45c-4e11-91d6-85746c4983c7.png">

Fixes #44438 

Ticket to remove the feature flag in the future #52417 