### PR TITLE
Alerting: Fix normalization of alert states for panel annotations

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4134,11 +4134,11 @@ exports[`better eslint`] = {
       [37, 48, 3, "Unexpected any. Specify a different type.", "193409811"],
       [50, 46, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "public/app/features/alerting/state/alertDef.ts:2887521080": [
+    "public/app/features/alerting/state/alertDef.ts:3662811918": [
       [78, 34, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [159, 34, 3, "Unexpected any. Specify a different type.", "193409811"],
-      [174, 4, 14, "Do not use any type assertions.", "3854427458"],
-      [178, 36, 3, "Unexpected any. Specify a different type.", "193409811"]
+      [165, 34, 3, "Unexpected any. Specify a different type.", "193409811"],
+      [180, 4, 14, "Do not use any type assertions.", "3854427458"],
+      [184, 36, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
     "public/app/features/alerting/state/query_part.ts:2255335987": [
       [4, 10, 3, "Unexpected any. Specify a different type.", "193409811"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -4134,7 +4134,7 @@ exports[`better eslint`] = {
       [37, 48, 3, "Unexpected any. Specify a different type.", "193409811"],
       [50, 46, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "public/app/features/alerting/state/alertDef.ts:3662811918": [
+    "public/app/features/alerting/state/alertDef.ts:4055067364": [
       [78, 34, 3, "Unexpected any. Specify a different type.", "193409811"],
       [165, 34, 3, "Unexpected any. Specify a different type.", "193409811"],
       [180, 4, 14, "Do not use any type assertions.", "3854427458"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -4134,7 +4134,7 @@ exports[`better eslint`] = {
       [37, 48, 3, "Unexpected any. Specify a different type.", "193409811"],
       [50, 46, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "public/app/features/alerting/state/alertDef.ts:4055067364": [
+    "public/app/features/alerting/state/alertDef.ts:1683373860": [
       [78, 34, 3, "Unexpected any. Specify a different type.", "193409811"],
       [165, 34, 3, "Unexpected any. Specify a different type.", "193409811"],
       [180, 4, 14, "Do not use any type assertions.", "3854427458"],

--- a/public/app/features/alerting/state/alertDef.ts
+++ b/public/app/features/alerting/state/alertDef.ts
@@ -81,8 +81,8 @@ function createReducerPart(model: any) {
   return new QueryPart(model, def);
 }
 
-// state can also contain the state it was mapped from, ie. "Alerting (NoData)" which means the alert rule is "Alerting" but
-// because the alert rule was configured to use this state instead of "NoData"
+// state can also contain a "Reason", ie. "Alerting (NoData)" which indicates that the actual state is "Alerting" but
+// the reason it is set to "Alerting" is "NoData"; a lack of data points to evaluate.
 function normalizeAlertState(state: string) {
   return state.toLowerCase().replace(/_/g, '').split(' ')[0];
 }
@@ -127,13 +127,6 @@ function getStateDisplayModel(state: string) {
         stateClass: 'alert-state-warning',
       };
     }
-    case 'unknown': {
-      return {
-        text: 'UNKNOWN',
-        iconClass: 'question-circle',
-        stateClass: '.alert-state-paused',
-      };
-    }
 
     case 'firing': {
       return {
@@ -158,9 +151,16 @@ function getStateDisplayModel(state: string) {
         stateClass: 'alert-state-critical',
       };
     }
-  }
 
-  throw { message: 'Unknown alert state' };
+    default:
+    case 'unknown': {
+      return {
+        text: 'UNKNOWN',
+        iconClass: 'question-circle',
+        stateClass: '.alert-state-paused',
+      };
+    }
+  }
 }
 
 function joinEvalMatches(matches: any, separator: string) {

--- a/public/app/features/alerting/state/alertDef.ts
+++ b/public/app/features/alerting/state/alertDef.ts
@@ -81,8 +81,14 @@ function createReducerPart(model: any) {
   return new QueryPart(model, def);
 }
 
+// state can also contain the state it was mapped from, ie. "Alerting (NoData)" which means the alert rule is "Alerting" but
+// because the alert rule was configured to use this state instead of "NoData"
+function normalizeAlertState(state: string) {
+  return state.toLowerCase().replace(/_/g, '').split(' ')[0];
+}
+
 function getStateDisplayModel(state: string) {
-  const normalizedState = state.toLowerCase().replace(/_/g, '');
+  const normalizedState = normalizeAlertState(state);
 
   switch (normalizedState) {
     case 'normal':

--- a/public/app/features/alerting/state/alertDef.ts
+++ b/public/app/features/alerting/state/alertDef.ts
@@ -152,8 +152,8 @@ function getStateDisplayModel(state: string) {
       };
     }
 
-    default:
-    case 'unknown': {
+    case 'unknown':
+    default: {
       return {
         text: 'UNKNOWN',
         iconClass: 'question-circle',


### PR DESCRIPTION
**What this PR does / why we need it**:

A bug introduced by #49259 would crash the annotations view of a panel with a linked alert rule.

We would call a function to determine the correct base state but it would throw an exception and crash the panel visualization.

https://github.com/grafana/grafana/blob/a1fb73c503455f6906fb70ba4e1022d4010f016a/public/app/features/alerting/state/alertDef.ts#L84

This PR normalizes the state so crashes won't occur and the mapped state is used instead.

**Special notes for your reviewer**:

