### PR TITLE
[9.0.x] Chore: Update ConcreteLogger to implement gokit Logger interface

### DIFF
--- a/pkg/infra/log/level/level_test.go
+++ b/pkg/infra/log/level/level_test.go
@@ -5,9 +5,10 @@ import (
 
 	gokitlog "github.com/go-kit/log"
 	gokitlevel "github.com/go-kit/log/level"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/log/level"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewFilter(t *testing.T) {
@@ -24,14 +25,14 @@ func TestNewFilter(t *testing.T) {
 		require.Equal(t, "lvl", ctx.loggedArgs[3][2].(string))
 		require.Equal(t, "dbug", ctx.loggedArgs[3][3].(level.Value).String())
 
-		require.Equal(t, "level", ctx.loggedArgs[4][0].(string))
-		require.Equal(t, "info", ctx.loggedArgs[4][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[5][0].(string))
-		require.Equal(t, "warn", ctx.loggedArgs[5][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[6][0].(string))
-		require.Equal(t, "error", ctx.loggedArgs[6][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[7][0].(string))
-		require.Equal(t, "debug", ctx.loggedArgs[7][1].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[4][2].(string))
+		require.Equal(t, "info", ctx.loggedArgs[4][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[5][2].(string))
+		require.Equal(t, "warn", ctx.loggedArgs[5][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[6][2].(string))
+		require.Equal(t, "error", ctx.loggedArgs[6][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[7][2].(string))
+		require.Equal(t, "debug", ctx.loggedArgs[7][3].(gokitlevel.Value).String())
 	})
 
 	newFilteredLoggerScenario(t, "Given error, warnings, info, debug is allowed should log all messages", level.AllowDebug(), func(t *testing.T, ctx *scenarioContext) {
@@ -47,14 +48,14 @@ func TestNewFilter(t *testing.T) {
 		require.Equal(t, "lvl", ctx.loggedArgs[3][2].(string))
 		require.Equal(t, "dbug", ctx.loggedArgs[3][3].(level.Value).String())
 
-		require.Equal(t, "level", ctx.loggedArgs[4][0].(string))
-		require.Equal(t, "info", ctx.loggedArgs[4][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[5][0].(string))
-		require.Equal(t, "warn", ctx.loggedArgs[5][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[6][0].(string))
-		require.Equal(t, "error", ctx.loggedArgs[6][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[7][0].(string))
-		require.Equal(t, "debug", ctx.loggedArgs[7][1].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[4][2].(string))
+		require.Equal(t, "info", ctx.loggedArgs[4][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[5][2].(string))
+		require.Equal(t, "warn", ctx.loggedArgs[5][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[6][2].(string))
+		require.Equal(t, "error", ctx.loggedArgs[6][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[7][2].(string))
+		require.Equal(t, "debug", ctx.loggedArgs[7][3].(gokitlevel.Value).String())
 	})
 
 	newFilteredLoggerScenario(t, "Given error, warnings is allowed should log error and warning messages", level.AllowWarn(), func(t *testing.T, ctx *scenarioContext) {
@@ -66,10 +67,10 @@ func TestNewFilter(t *testing.T) {
 		require.Equal(t, "lvl", ctx.loggedArgs[1][2].(string))
 		require.Equal(t, "eror", ctx.loggedArgs[1][3].(level.Value).String())
 
-		require.Equal(t, "level", ctx.loggedArgs[2][0].(string))
-		require.Equal(t, "warn", ctx.loggedArgs[2][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[3][0].(string))
-		require.Equal(t, "error", ctx.loggedArgs[3][1].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[2][2].(string))
+		require.Equal(t, "warn", ctx.loggedArgs[2][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[3][2].(string))
+		require.Equal(t, "error", ctx.loggedArgs[3][3].(gokitlevel.Value).String())
 	})
 
 	newFilteredLoggerScenario(t, "Given error allowed should log error messages", level.AllowError(), func(t *testing.T, ctx *scenarioContext) {
@@ -79,8 +80,8 @@ func TestNewFilter(t *testing.T) {
 		require.Equal(t, "lvl", ctx.loggedArgs[0][2].(string))
 		require.Equal(t, "eror", ctx.loggedArgs[0][3].(level.Value).String())
 
-		require.Equal(t, "level", ctx.loggedArgs[1][0].(string))
-		require.Equal(t, "error", ctx.loggedArgs[1][1].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[1][2].(string))
+		require.Equal(t, "error", ctx.loggedArgs[1][3].(gokitlevel.Value).String())
 	})
 
 	newFilteredLoggerScenario(t, "Given error, warnings, info is allowed should log error, warning and info messages", level.AllowInfo(), func(t *testing.T, ctx *scenarioContext) {
@@ -94,12 +95,12 @@ func TestNewFilter(t *testing.T) {
 		require.Equal(t, "lvl", ctx.loggedArgs[2][2].(string))
 		require.Equal(t, "eror", ctx.loggedArgs[2][3].(level.Value).String())
 
-		require.Equal(t, "level", ctx.loggedArgs[3][0].(string))
-		require.Equal(t, "info", ctx.loggedArgs[3][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[4][0].(string))
-		require.Equal(t, "warn", ctx.loggedArgs[4][1].(gokitlevel.Value).String())
-		require.Equal(t, "level", ctx.loggedArgs[5][0].(string))
-		require.Equal(t, "error", ctx.loggedArgs[5][1].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[3][2].(string))
+		require.Equal(t, "info", ctx.loggedArgs[3][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[4][2].(string))
+		require.Equal(t, "warn", ctx.loggedArgs[4][3].(gokitlevel.Value).String())
+		require.Equal(t, "level", ctx.loggedArgs[5][2].(string))
+		require.Equal(t, "error", ctx.loggedArgs[5][3].(gokitlevel.Value).String())
 	})
 
 	newFilteredLoggerScenario(t, "Given no levels is allowed should not log any messages", level.AllowNone(), func(t *testing.T, ctx *scenarioContext) {

--- a/pkg/infra/log/log.go
+++ b/pkg/infra/log/log.go
@@ -18,12 +18,13 @@ import (
 
 	gokitlog "github.com/go-kit/log"
 	"github.com/go-stack/stack"
+	"github.com/mattn/go-isatty"
+	"gopkg.in/ini.v1"
+
 	"github.com/grafana/grafana/pkg/infra/log/level"
 	"github.com/grafana/grafana/pkg/infra/log/term"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/errutil"
-	"github.com/mattn/go-isatty"
-	"gopkg.in/ini.v1"
 )
 
 var (
@@ -181,6 +182,11 @@ func (cl *ConcreteLogger) Debug(msg string, args ...interface{}) {
 	_ = cl.log(msg, level.DebugValue(), args...)
 }
 
+func (cl *ConcreteLogger) Log(ctx ...interface{}) error {
+	logger := gokitlog.With(&cl.SwapLogger, "t", gokitlog.TimestampFormat(now, logTimeFormat))
+	return logger.Log(ctx...)
+}
+
 func (cl *ConcreteLogger) Error(msg string, args ...interface{}) {
 	_ = cl.log(msg, level.ErrorValue(), args...)
 }
@@ -190,10 +196,7 @@ func (cl *ConcreteLogger) Info(msg string, args ...interface{}) {
 }
 
 func (cl *ConcreteLogger) log(msg string, logLevel level.Value, args ...interface{}) error {
-	logger := gokitlog.With(&cl.SwapLogger, "t", gokitlog.TimestampFormat(now, logTimeFormat))
-	args = append([]interface{}{level.Key(), logLevel, "msg", msg}, args...)
-
-	return logger.Log(args...)
+	return cl.Log(append([]interface{}{level.Key(), logLevel, "msg", msg}, args...)...)
 }
 
 func (cl *ConcreteLogger) New(ctx ...interface{}) *ConcreteLogger {

--- a/pkg/infra/log/log_test.go
+++ b/pkg/infra/log/log_test.go
@@ -6,9 +6,10 @@ import (
 	"time"
 
 	gokitlog "github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+
 	"github.com/grafana/grafana/pkg/infra/log/level"
 	"github.com/grafana/grafana/pkg/util"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLogger(t *testing.T) {
@@ -33,17 +34,21 @@ func TestLogger(t *testing.T) {
 		log3.Error("hello 3 again")
 
 		require.Len(t, ctx.loggedArgs, 5)
-		require.Len(t, ctx.loggedArgs[0], 4)
+		require.Len(t, ctx.loggedArgs[0], 6)
 		require.Equal(t, "logger", ctx.loggedArgs[0][0].(string))
 		require.Equal(t, "one", ctx.loggedArgs[0][1].(string))
-		require.Equal(t, "msg", ctx.loggedArgs[0][2].(string))
-		require.Equal(t, "hello 1", ctx.loggedArgs[0][3].(string))
+		require.Equal(t, "t", ctx.loggedArgs[0][2].(string))
+		require.Equal(t, ctx.mockedTime.Format("2006-01-02T15:04:05.99-0700"), ctx.loggedArgs[0][3].(fmt.Stringer).String())
+		require.Equal(t, "msg", ctx.loggedArgs[0][4].(string))
+		require.Equal(t, "hello 1", ctx.loggedArgs[0][5].(string))
 
-		require.Len(t, ctx.loggedArgs[1], 4)
+		require.Len(t, ctx.loggedArgs[1], 6)
 		require.Equal(t, "logger", ctx.loggedArgs[1][0].(string))
 		require.Equal(t, "two", ctx.loggedArgs[1][1].(string))
-		require.Equal(t, "msg", ctx.loggedArgs[1][2].(string))
-		require.Equal(t, "hello 2", ctx.loggedArgs[1][3].(string))
+		require.Equal(t, "t", ctx.loggedArgs[0][2].(string))
+		require.Equal(t, ctx.mockedTime.Format("2006-01-02T15:04:05.99-0700"), ctx.loggedArgs[0][3].(fmt.Stringer).String())
+		require.Equal(t, "msg", ctx.loggedArgs[1][4].(string))
+		require.Equal(t, "hello 2", ctx.loggedArgs[1][5].(string))
 
 		require.Len(t, ctx.loggedArgs[2], 8)
 		require.Equal(t, "logger", ctx.loggedArgs[2][0].(string))
@@ -55,13 +60,15 @@ func TestLogger(t *testing.T) {
 		require.Equal(t, "msg", ctx.loggedArgs[2][6].(string))
 		require.Equal(t, "hello 3", ctx.loggedArgs[2][7].(string))
 
-		require.Len(t, ctx.loggedArgs[3], 6)
+		require.Len(t, ctx.loggedArgs[3], 8)
 		require.Equal(t, "logger", ctx.loggedArgs[3][0].(string))
 		require.Equal(t, "three", ctx.loggedArgs[3][1].(string))
 		require.Equal(t, "key", ctx.loggedArgs[3][2].(string))
 		require.Equal(t, "value", ctx.loggedArgs[3][3].(string))
-		require.Equal(t, "msg", ctx.loggedArgs[3][4].(string))
-		require.Equal(t, "hello 4", ctx.loggedArgs[3][5].(string))
+		require.Equal(t, "t", ctx.loggedArgs[3][4].(string))
+		require.Equal(t, ctx.mockedTime.Format("2006-01-02T15:04:05.99-0700"), ctx.loggedArgs[3][5].(fmt.Stringer).String())
+		require.Equal(t, "msg", ctx.loggedArgs[3][6].(string))
+		require.Equal(t, "hello 4", ctx.loggedArgs[3][7].(string))
 
 		require.Len(t, ctx.loggedArgs[4], 8)
 		require.Equal(t, "logger", ctx.loggedArgs[4][0].(string))


### PR DESCRIPTION
Backport 739d3469bc1a341d48c6a5f920939b208db761ff from  #51599

