### PR TITLE
Plugins: InfluxDB datasource - set epoch query param value as "ms"

### DIFF
--- a/pkg/tsdb/influxdb/influxdb.go
+++ b/pkg/tsdb/influxdb/influxdb.go
@@ -173,7 +173,7 @@ func (s *Service) createRequest(ctx context.Context, dsInfo *models.DatasourceIn
 
 	params := req.URL.Query()
 	params.Set("db", dsInfo.Database)
-	params.Set("epoch", "s")
+	params.Set("epoch", "ms")
 
 	if httpMode == "GET" {
 		params.Set("q", query)

--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -207,14 +207,14 @@ func parseTimestamp(value interface{}) (time.Time, error) {
 	if !ok {
 		return time.Time{}, fmt.Errorf("timestamp-value has invalid type: %#v", value)
 	}
-	timestampFloat, err := timestampNumber.Int64()
+	timestampInMilliseconds, err := timestampNumber.Int64()
 	if err != nil {
 		return time.Time{}, err
 	}
 
 	// currently in the code the influxdb-timestamps are requested with
 	// milliseconds-precision, meaning these values are milliseconds
-	t := time.UnixMilli(timestampFloat).UTC()
+	t := time.UnixMilli(timestampInMilliseconds).UTC()
 
 	return t, nil
 }

--- a/pkg/tsdb/influxdb/response_parser.go
+++ b/pkg/tsdb/influxdb/response_parser.go
@@ -207,14 +207,14 @@ func parseTimestamp(value interface{}) (time.Time, error) {
 	if !ok {
 		return time.Time{}, fmt.Errorf("timestamp-value has invalid type: %#v", value)
 	}
-	timestampFloat, err := timestampNumber.Float64()
+	timestampFloat, err := timestampNumber.Int64()
 	if err != nil {
 		return time.Time{}, err
 	}
 
 	// currently in the code the influxdb-timestamps are requested with
-	// seconds-precision, meaning these values are seconds
-	t := time.Unix(int64(timestampFloat), 0).UTC()
+	// milliseconds-precision, meaning these values are milliseconds
+	t := time.UnixMilli(timestampFloat).UTC()
 
 	return t, nil
 }

--- a/pkg/tsdb/influxdb/response_parser_test.go
+++ b/pkg/tsdb/influxdb/response_parser_test.go
@@ -77,9 +77,9 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		floatFrame := data.NewFrame("cpu.mean { datacenter: America }",
 			data.NewField("time", nil,
 				[]time.Time{
-					time.Date(1970, 1, 1, 0, 1, 51, 0, time.UTC),
-					time.Date(1970, 1, 1, 0, 1, 51, 0, time.UTC),
-					time.Date(1970, 1, 1, 0, 1, 51, 0, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 111000000, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 111000000, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 111000000, time.UTC),
 				}),
 			floatField,
 		)
@@ -92,9 +92,9 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		stringFrame := data.NewFrame("cpu.path { datacenter: America }",
 			data.NewField("time", nil,
 				[]time.Time{
-					time.Date(1970, 1, 1, 0, 1, 51, 0, time.UTC),
-					time.Date(1970, 1, 1, 0, 1, 51, 0, time.UTC),
-					time.Date(1970, 1, 1, 0, 1, 51, 0, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 111000000, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 111000000, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 111000000, time.UTC),
 				}),
 			stringField,
 		)
@@ -107,9 +107,9 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		boolFrame := data.NewFrame("cpu.isActive { datacenter: America }",
 			data.NewField("time", nil,
 				[]time.Time{
-					time.Date(1970, 1, 1, 0, 1, 51, 0, time.UTC),
-					time.Date(1970, 1, 1, 0, 1, 51, 0, time.UTC),
-					time.Date(1970, 1, 1, 0, 1, 51, 0, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 111000000, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 111000000, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 111000000, time.UTC),
 				}),
 			boolField,
 		)
@@ -300,9 +300,9 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		testFrame := data.NewFrame("cpu.mean",
 			data.NewField("time", nil,
 				[]time.Time{
-					time.Date(1970, 1, 1, 0, 1, 40, 0, time.UTC),
-					time.Date(1970, 1, 1, 0, 1, 41, 0, time.UTC),
-					time.Date(1970, 1, 1, 0, 1, 42, 0, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 101000000, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 102000000, time.UTC),
 				}),
 			newField,
 		)
@@ -349,8 +349,8 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		testFrame := data.NewFrame("cpu.mean",
 			data.NewField("time", nil,
 				[]time.Time{
-					time.Date(1970, 1, 1, 0, 1, 40, 0, time.UTC),
-					time.Date(1970, 1, 1, 0, 1, 42, 0, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 102000000, time.UTC),
 				}),
 			newField,
 		)
@@ -402,7 +402,7 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		testFrame := data.NewFrame("series alias",
 			data.NewField("time", nil,
 				[]time.Time{
-					time.Date(1970, 1, 1, 0, 1, 51, 0, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 111000000, time.UTC),
 				}),
 			newField,
 		)
@@ -667,9 +667,9 @@ func TestInfluxdbResponseParser(t *testing.T) {
 		testFrame := data.NewFrame("cpu.mean { datacenter: America }",
 			data.NewField("time", nil,
 				[]time.Time{
-					time.Date(1970, 1, 1, 0, 1, 51, 0, time.UTC),
-					time.Date(1970, 1, 1, 0, 1, 51, 0, time.UTC),
-					time.Date(1970, 1, 1, 0, 1, 51, 0, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 111000000, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 111000000, time.UTC),
+					time.Date(1970, 1, 1, 0, 0, 0, 111000000, time.UTC),
 				}),
 			newField,
 		)
@@ -718,9 +718,9 @@ func TestInfluxdbResponseParser(t *testing.T) {
 	})
 
 	t.Run("Influxdb response parser parseTimestamp valid JSON.number", func(t *testing.T) {
-		// currently we use seconds-precision with influxdb, so the test works with that.
-		// if we change this to for example milliseconds-precision, the tests will have to change.
-		timestamp, err := parseTimestamp(json.Number("1609556645"))
+		// currently we use milliseconds-precision with influxdb, so the test works with that.
+		// if we change this to for example nanoseconds-precision, the tests will have to change.
+		timestamp, err := parseTimestamp(json.Number("1609556645000"))
 		require.NoError(t, err)
 		require.Equal(t, timestamp.Format(time.RFC3339), "2021-01-02T03:04:05Z")
 	})
@@ -754,9 +754,9 @@ func TestResponseParser_Parse(t *testing.T) {
 				testFrame := data.NewFrame("cpu.mean",
 					data.NewField("time", nil,
 						[]time.Time{
-							time.Date(1970, 1, 1, 0, 1, 40, 0, time.UTC),
-							time.Date(1970, 1, 1, 0, 1, 41, 0, time.UTC),
-							time.Date(1970, 1, 1, 0, 1, 42, 0, time.UTC),
+							time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
+							time.Date(1970, 1, 1, 0, 0, 0, 101000000, time.UTC),
+							time.Date(1970, 1, 1, 0, 0, 0, 102000000, time.UTC),
 						}),
 					newField,
 				)
@@ -781,9 +781,9 @@ func TestResponseParser_Parse(t *testing.T) {
 				testFrame := data.NewFrame("cpu.mean",
 					data.NewField("time", nil,
 						[]time.Time{
-							time.Date(1970, 1, 1, 0, 1, 40, 0, time.UTC),
-							time.Date(1970, 1, 1, 0, 1, 41, 0, time.UTC),
-							time.Date(1970, 1, 1, 0, 1, 42, 0, time.UTC),
+							time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
+							time.Date(1970, 1, 1, 0, 0, 0, 101000000, time.UTC),
+							time.Date(1970, 1, 1, 0, 0, 0, 102000000, time.UTC),
 						}),
 					newField,
 				)


### PR DESCRIPTION
**What this PR does / why we need it**:
Before influxdbd backend migration, all requests were done with the `epoch=ms` query param. After the migration, it was set as `epoch=s` by default. So we need to set it back to what it was. 

**Which issue(s) this PR fixes**:
 This PR changes the result precision to what it was before migration. 
About `epoch` parameter: https://docs.influxdata.com/influxdb/v2.3/reference/api/influxdb-1x/query/#epoch

Fixes https://github.com/grafana/grafana/issues/51547 (the first item in the checklist)
