### PR TITLE
[WIP] Alerting: Rule evaluaton API endpoint

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -116,6 +116,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 			log:             logger,
 			cfg:             &api.Cfg.UnifiedAlerting,
 			ac:              api.AccessControl,
+			evaluator:       eval.NewEvaluator(api.Cfg, log.New("ngalert.eval"), api.DatasourceCache, api.SecretsService, api.ExpressionService),
 		},
 	), m)
 	api.RegisterTestingApiEndpoints(NewForkedTestingApi(

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -62,6 +62,10 @@ func (api *API) authorize(method, path string) web.Handler {
 	case http.MethodGet + "/api/prometheus/grafana/api/v1/rules":
 		eval = ac.EvalPermission(ac.ActionAlertingRuleRead)
 
+	// Only access to data sources is required. Additional datasource authorization happens in the request handler
+	case http.MethodPost + "/v1/api/alerting/rules/eval":
+		eval = ac.EvalPermission(datasources.ActionQuery)
+
 	// Grafana Rules Testing Paths
 	case http.MethodPost + "/api/v1/rule/test/grafana":
 		fallback = middleware.ReqSignedIn

--- a/pkg/services/ngalert/api/authorization_test.go
+++ b/pkg/services/ngalert/api/authorization_test.go
@@ -48,7 +48,7 @@ func TestAuthorize(t *testing.T) {
 		}
 		paths[p] = methods
 	}
-	require.Len(t, paths, 39)
+	require.Len(t, paths, 40)
 
 	ac := acmock.New()
 	api := &API{AccessControl: ac}

--- a/pkg/services/ngalert/api/fork_ruler.go
+++ b/pkg/services/ngalert/api/fork_ruler.go
@@ -136,3 +136,7 @@ func (f *ForkedRulerApi) forkRoutePostNameGrafanaRulesConfig(ctx *models.ReqCont
 	}
 	return f.GrafanaRuler.RoutePostNameRulesConfig(ctx, conf, namespace)
 }
+
+func (f *ForkedRulerApi) forkRouteEvaluateGrafanaRule(ctx *models.ReqContext, conf apimodels.EvaluateRuleRequestBody) response.Response {
+	return f.GrafanaRuler.EvaluateRule(ctx, conf)
+}

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -470,30 +470,6 @@
    },
    "type": "array"
   },
-  "DashboardAclUpdateItem": {
-   "properties": {
-    "permission": {
-     "$ref": "#/definitions/PermissionType"
-    },
-    "role": {
-     "enum": [
-      "Viewer",
-      "Editor",
-      "Admin"
-     ],
-     "type": "string"
-    },
-    "teamId": {
-     "format": "int64",
-     "type": "integer"
-    },
-    "userId": {
-     "format": "int64",
-     "type": "integer"
-    }
-   },
-   "type": "object"
-  },
   "DateTime": {
    "description": "DateTime is a time but it serializes to ISO8601 format with millis\nIt knows how to read 3 different variations of a RFC3339 date time.\nMost APIs we encounter want either millisecond or second precision times.\nThis just tries to make it worry-free.",
    "format": "date-time",
@@ -686,6 +662,80 @@
    "type": "object"
   },
   "EvalQueriesResponse": {},
+  "EvaluateRuleError": {
+   "properties": {
+    "errors": {
+     "items": {
+      "type": "string"
+     },
+     "type": "array"
+    },
+    "evaluatedAt": {
+     "format": "date-time",
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
+  "EvaluateRuleRequestBody": {
+   "properties": {
+    "condition": {
+     "$ref": "#/definitions/RefID"
+    },
+    "data": {
+     "items": {
+      "$ref": "#/definitions/AlertQuery"
+     },
+     "type": "array"
+    },
+    "now": {
+     "format": "date-time",
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
+  "EvaluateRuleResponse": {
+   "properties": {
+    "condition": {
+     "$ref": "#/definitions/RefID"
+    },
+    "duration": {
+     "$ref": "#/definitions/Duration"
+    },
+    "evaluatedAt": {
+     "format": "date-time",
+     "type": "string"
+    },
+    "result": {
+     "items": {
+      "$ref": "#/definitions/EvaluationResult"
+     },
+     "type": "array"
+    }
+   },
+   "type": "object"
+  },
+  "EvaluationResult": {
+   "description": "EvaluationResult contains the evaluated State of an alert instance\nidentified by its labels.",
+   "properties": {
+    "state": {
+     "$ref": "#/definitions/EvaluationState"
+    },
+    "values": {
+     "additionalProperties": {
+      "$ref": "#/definitions/NumberValueCapture"
+     },
+     "description": "Values contains the RefID and value of reduce and math expressions.\nIt does not contain values for classic conditions as the values\nin classic conditions do not have a RefID.",
+     "type": "object"
+    }
+   },
+   "type": "object"
+  },
+  "EvaluationState": {
+   "title": "EvaluationState is an enum of the evaluation State for an alert instance.",
+   "type": "string"
+  },
   "ExtendedReceiver": {
    "properties": {
     "email_configs": {
@@ -1336,48 +1386,6 @@
    },
    "type": "array"
   },
-  "MetricRequest": {
-   "properties": {
-    "debug": {
-     "type": "boolean"
-    },
-    "from": {
-     "description": "From Start time in epoch timestamps in milliseconds or relative using Grafana time units.",
-     "example": "now-1h",
-     "type": "string"
-    },
-    "queries": {
-     "description": "queries.refId – Specifies an identifier of the query. Is optional and default to “A”.\nqueries.datasourceId – Specifies the data source to be queried. Each query in the request must have an unique datasourceId.\nqueries.maxDataPoints - Species maximum amount of data points that dashboard panel can render. Is optional and default to 100.\nqueries.intervalMs - Specifies the time interval in milliseconds of time series. Is optional and defaults to 1000.",
-     "example": [
-      {
-       "datasource": {
-        "uid": "PD8C576611E62080A"
-       },
-       "format": "table",
-       "intervalMs": 86400000,
-       "maxDataPoints": 1092,
-       "rawSql": "SELECT 1 as valueOne, 2 as valueTwo",
-       "refId": "A"
-      }
-     ],
-     "items": {
-      "$ref": "#/definitions/Json"
-     },
-     "type": "array"
-    },
-    "to": {
-     "description": "To End time in epoch timestamps in milliseconds or relative using Grafana time units.",
-     "example": "now",
-     "type": "string"
-    }
-   },
-   "required": [
-    "from",
-    "to",
-    "queries"
-   ],
-   "type": "object"
-  },
   "MonthRange": {
    "properties": {
     "Begin": {
@@ -1425,32 +1433,7 @@
    },
    "type": "object"
   },
-  "NavLink": {
-   "properties": {
-    "id": {
-     "type": "string"
-    },
-    "target": {
-     "type": "string"
-    },
-    "text": {
-     "type": "string"
-    },
-    "url": {
-     "type": "string"
-    }
-   },
-   "type": "object"
-  },
-  "NavbarPreference": {
-   "properties": {
-    "savedItems": {
-     "items": {
-      "$ref": "#/definitions/NavLink"
-     },
-     "type": "array"
-    }
-   },
+  "NoDataResponse": {
    "type": "object"
   },
   "NotFound": {
@@ -1463,6 +1446,21 @@
     }
    },
    "title": "NotifierConfig contains base options common across all notifier configurations.",
+   "type": "object"
+  },
+  "NumberValueCapture": {
+   "properties": {
+    "labels": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object"
+    },
+    "value": {
+     "format": "double",
+     "type": "number"
+    }
+   },
    "type": "object"
   },
   "OAuth2": {
@@ -1668,52 +1666,8 @@
    },
    "type": "object"
   },
-  "PatchPrefsCmd": {
-   "properties": {
-    "homeDashboardId": {
-     "default": 0,
-     "description": "The numerical :id of a favorited dashboard",
-     "format": "int64",
-     "type": "integer"
-    },
-    "homeDashboardUID": {
-     "type": "string"
-    },
-    "locale": {
-     "type": "string"
-    },
-    "navbar": {
-     "$ref": "#/definitions/NavbarPreference"
-    },
-    "queryHistory": {
-     "$ref": "#/definitions/QueryHistoryPreference"
-    },
-    "theme": {
-     "enum": [
-      "light",
-      "dark"
-     ],
-     "type": "string"
-    },
-    "timezone": {
-     "enum": [
-      "utc",
-      "browser"
-     ],
-     "type": "string"
-    },
-    "weekStart": {
-     "type": "string"
-    }
-   },
-   "type": "object"
-  },
   "PermissionDenied": {
    "type": "object"
-  },
-  "PermissionType": {
-   "format": "int64",
-   "type": "integer"
   },
   "Point": {
    "properties": {
@@ -2036,14 +1990,6 @@
    },
    "type": "object"
   },
-  "QueryHistoryPreference": {
-   "properties": {
-    "homeTab": {
-     "type": "string"
-    }
-   },
-   "type": "object"
-  },
   "Receiver": {
    "properties": {
     "email_configs": {
@@ -2107,6 +2053,9 @@
    },
    "title": "Receiver configuration provides configuration on how to contact a receiver.",
    "type": "object"
+  },
+  "RefID": {
+   "type": "string"
   },
   "Regexp": {
    "description": "A Regexp is safe for concurrent use by multiple goroutines,\nexcept for configuration methods, such as Longest.",
@@ -2738,6 +2687,7 @@
    "type": "object"
   },
   "URL": {
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -2770,58 +2720,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "URL is a custom URL type that allows validation at configuration load time.",
-   "type": "object"
-  },
-  "UpdateDashboardAclCommand": {
-   "properties": {
-    "items": {
-     "items": {
-      "$ref": "#/definitions/DashboardAclUpdateItem"
-     },
-     "type": "array"
-    }
-   },
-   "type": "object"
-  },
-  "UpdatePrefsCmd": {
-   "properties": {
-    "homeDashboardId": {
-     "default": 0,
-     "description": "The numerical :id of a favorited dashboard",
-     "format": "int64",
-     "type": "integer"
-    },
-    "homeDashboardUID": {
-     "type": "string"
-    },
-    "locale": {
-     "type": "string"
-    },
-    "navbar": {
-     "$ref": "#/definitions/NavbarPreference"
-    },
-    "queryHistory": {
-     "$ref": "#/definitions/QueryHistoryPreference"
-    },
-    "theme": {
-     "enum": [
-      "light",
-      "dark"
-     ],
-     "type": "string"
-    },
-    "timezone": {
-     "enum": [
-      "utc",
-      "browser"
-     ],
-     "type": "string"
-    },
-    "weekStart": {
-     "type": "string"
-    }
-   },
+   "title": "A URL represents a parsed URL (technically, a URI reference).",
    "type": "object"
   },
   "Userinfo": {
@@ -2991,7 +2890,6 @@
    "type": "object"
   },
   "alertGroup": {
-   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -3015,7 +2913,6 @@
    "type": "object"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -3123,6 +3020,7 @@
    "$ref": "#/definitions/Duration"
   },
   "gettableAlert": {
+   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -3178,13 +3076,13 @@
    "type": "object"
   },
   "gettableAlerts": {
+   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
    "type": "array"
   },
   "gettableSilence": {
-   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3344,7 +3242,6 @@
    "type": "array"
   },
   "postableSilence": {
-   "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
      "description": "comment",

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -662,6 +662,80 @@
    "type": "object"
   },
   "EvalQueriesResponse": {},
+  "EvaluateRuleError": {
+   "properties": {
+    "Error": {
+     "type": "string"
+    },
+    "EvaluatedAt": {
+     "format": "date-time",
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
+  "EvaluateRuleRequestBody": {
+   "properties": {
+    "condition": {
+     "$ref": "#/definitions/RefID"
+    },
+    "data": {
+     "items": {
+      "$ref": "#/definitions/AlertQuery"
+     },
+     "type": "array"
+    },
+    "now": {
+     "format": "date-time",
+     "type": "string"
+    }
+   },
+   "type": "object"
+  },
+  "EvaluateRuleResponse": {
+   "properties": {
+    "EvaluatedAt": {
+     "format": "date-time",
+     "type": "string"
+    },
+    "EvaluationDuration": {
+     "$ref": "#/definitions/Duration"
+    },
+    "result": {
+     "items": {
+      "$ref": "#/definitions/EvaluationResult"
+     },
+     "type": "array"
+    }
+   },
+   "type": "object"
+  },
+  "EvaluationResult": {
+   "description": "EvaluationResult contains the evaluated State of an alert instance\nidentified by its labels.",
+   "properties": {
+    "Labels": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object"
+    },
+    "State": {
+     "$ref": "#/definitions/EvaluationState"
+    },
+    "Values": {
+     "additionalProperties": {
+      "$ref": "#/definitions/NumberValueCapture"
+     },
+     "description": "Values contains the RefID and value of reduce and math expressions.\nIt does not contain values for classic conditions as the values\nin classic conditions do not have a RefID.",
+     "type": "object"
+    }
+   },
+   "type": "object"
+  },
+  "EvaluationState": {
+   "title": "EvaluationState is an enum of the evaluation State for an alert instance.",
+   "type": "string"
+  },
   "ExtendedReceiver": {
    "properties": {
     "email_configs": {
@@ -1359,6 +1433,9 @@
    },
    "type": "object"
   },
+  "NoDataResponse": {
+   "type": "object"
+  },
   "NotFound": {
    "type": "object"
   },
@@ -1369,6 +1446,21 @@
     }
    },
    "title": "NotifierConfig contains base options common across all notifier configurations.",
+   "type": "object"
+  },
+  "NumberValueCapture": {
+   "properties": {
+    "Labels": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object"
+    },
+    "Value": {
+     "format": "double",
+     "type": "number"
+    }
+   },
    "type": "object"
   },
   "OAuth2": {
@@ -1961,6 +2053,9 @@
    },
    "title": "Receiver configuration provides configuration on how to contact a receiver.",
    "type": "object"
+  },
+  "RefID": {
+   "type": "string"
   },
   "Regexp": {
    "description": "A Regexp is safe for concurrent use by multiple goroutines,\nexcept for configuration methods, such as Longest.",
@@ -2592,6 +2687,7 @@
    "type": "object"
   },
   "URL": {
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -2624,7 +2720,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "URL is a custom URL type that allows validation at configuration load time.",
+   "title": "A URL represents a parsed URL (technically, a URI reference).",
    "type": "object"
   },
   "Userinfo": {
@@ -2925,7 +3021,6 @@
    "$ref": "#/definitions/Duration"
   },
   "gettableAlert": {
-   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -2981,13 +3076,13 @@
    "type": "object"
   },
   "gettableAlerts": {
-   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
    "type": "array"
   },
   "gettableSilence": {
+   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -5572,6 +5667,50 @@
     },
     "tags": [
      "testing"
+    ]
+   }
+  },
+  "/v1/api/alerting/rules/eval": {
+   "post": {
+    "consumes": [
+     "application/json"
+    ],
+    "description": "Evaluate a Grafana alert rule expression",
+    "operationId": "RouteEvaluateGrafanaRule",
+    "parameters": [
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/EvaluateRuleRequestBody"
+      }
+     }
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "responses": {
+     "200": {
+      "description": "EvaluateRuleResponse",
+      "schema": {
+       "$ref": "#/definitions/EvaluateRuleResponse"
+      }
+     },
+     "204": {
+      "description": "NoDataResponse",
+      "schema": {
+       "$ref": "#/definitions/NoDataResponse"
+      }
+     },
+     "500": {
+      "description": "EvaluateRuleError",
+      "schema": {
+       "$ref": "#/definitions/EvaluateRuleError"
+      }
+     }
+    },
+    "tags": [
+     "ruler"
     ]
    }
   }

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -2322,6 +2322,50 @@
           }
         }
       }
+    },
+    "/v1/api/alerting/rules/eval": {
+      "post": {
+        "description": "Evaluate a Grafana alert rule expression",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "ruler"
+        ],
+        "operationId": "RouteEvaluateGrafanaRule",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/EvaluateRuleRequestBody"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "EvaluateRuleResponse",
+            "schema": {
+              "$ref": "#/definitions/EvaluateRuleResponse"
+            }
+          },
+          "204": {
+            "description": "NoDataResponse",
+            "schema": {
+              "$ref": "#/definitions/NoDataResponse"
+            }
+          },
+          "500": {
+            "description": "EvaluateRuleError",
+            "schema": {
+              "$ref": "#/definitions/EvaluateRuleError"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -2985,6 +3029,80 @@
     },
     "EvalQueriesResponse": {
       "$ref": "#/definitions/EvalQueriesResponse"
+    },
+    "EvaluateRuleError": {
+      "type": "object",
+      "properties": {
+        "errors": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "evaluatedAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "EvaluateRuleRequestBody": {
+      "type": "object",
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/RefID"
+        },
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/AlertQuery"
+          }
+        },
+        "now": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "EvaluateRuleResponse": {
+      "type": "object",
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/RefID"
+        },
+        "duration": {
+          "$ref": "#/definitions/Duration"
+        },
+        "evaluatedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "result": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/EvaluationResult"
+          }
+        }
+      }
+    },
+    "EvaluationResult": {
+      "description": "EvaluationResult contains the evaluated State of an alert instance\nidentified by its labels.",
+      "type": "object",
+      "properties": {
+        "state": {
+          "$ref": "#/definitions/EvaluationState"
+        },
+        "values": {
+          "description": "Values contains the RefID and value of reduce and math expressions.\nIt does not contain values for classic conditions as the values\nin classic conditions do not have a RefID.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/NumberValueCapture"
+          }
+        }
+      }
+    },
+    "EvaluationState": {
+      "type": "string",
+      "title": "EvaluationState is an enum of the evaluation State for an alert instance."
     },
     "ExtendedReceiver": {
       "type": "object",
@@ -3684,6 +3802,9 @@
         }
       }
     },
+    "NoDataResponse": {
+      "type": "object"
+    },
     "NotFound": {
       "type": "object"
     },
@@ -3693,6 +3814,21 @@
       "properties": {
         "send_resolved": {
           "type": "boolean"
+        }
+      }
+    },
+    "NumberValueCapture": {
+      "type": "object",
+      "properties": {
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "value": {
+          "type": "number",
+          "format": "double"
         }
       }
     },
@@ -4286,6 +4422,9 @@
           }
         }
       }
+    },
+    "RefID": {
+      "type": "string"
     },
     "Regexp": {
       "description": "A Regexp is safe for concurrent use by multiple goroutines,\nexcept for configuration methods, such as Longest.",
@@ -5119,6 +5258,7 @@
       }
     },
     "alertGroup": {
+      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -5309,7 +5449,6 @@
       "$ref": "#/definitions/gettableAlert"
     },
     "gettableAlerts": {
-      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableAlert"
@@ -5366,6 +5505,7 @@
       "$ref": "#/definitions/gettableSilence"
     },
     "gettableSilences": {
+      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
@@ -5515,6 +5655,7 @@
       "$ref": "#/definitions/postableSilence"
     },
     "receiver": {
+      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "name"

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/datasourceproxy"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -237,6 +238,16 @@ func validateQueriesAndExpressions(ctx context.Context, data []ngmodels.AlertQue
 		refIDs[query.RefID] = struct{}{}
 	}
 	return refIDs, nil
+}
+
+func checkDatasource(c *models.ReqContext, cache datasources.CacheService) func(uid string) error {
+	return func(uid string) error {
+		if expr.IsDataSource(uid) {
+			return nil
+		}
+		_, err := cache.GetDatasourceByUID(c.Req.Context(), uid, c.SignedInUser, c.SkipCache)
+		return err
+	}
 }
 
 // ErrorResp creates a response with a visible error


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR introduces a new API endpoint `/v1/api/alerting/rules/eval` that accepts the request like 
<details><summary> Request (Prometheus + Reduce) </summary> 

```json
{
    "condition": "C",
    "data": [
        {
            "refId": "A",
            "datasourceUid": "{{DATASOURCE_UID}}",
            "queryType": "",
            "relativeTimeRange": {
                "from": 600,
                "to": 0
            },
            "model": {
                "refId": "A",
                "hide": false,
                "expr": "up{}"
            }
        },
        {
            "refId": "B",
            "datasourceUid": "-100",
            "queryType": "",
            "model": {
                "refId": "B",
                "hide": false,
                "type": "reduce",
                "datasource": {
                    "uid": "-100",
                    "type": "__expr__"
                },
                "conditions": [
                    {
                        "type": "query",
                        "evaluator": {
                            "params": [
                                3
                            ],
                            "type": "gt"
                        },
                        "operator": {
                            "type": "and"
                        },
                        "query": {
                            "params": [
                                "A"
                            ]
                        },
                        "reducer": {
                            "params": [],
                            "type": "last"
                        }
                    }
                ],
                "reducer": "mean",
                "expression": "A"
            }
        },
        {
            "datasourceUid": "-100",
            "model": {
                "refId": "C",
                "type": "math",
                "datasource": {
                    "type": "__expr__",
                    "uid": "__expr__",
                    "name": "Expression"
                },
                "conditions": [
                    {
                        "type": "query",
                        "reducer": {
                            "params": [],
                            "type": "avg"
                        },
                        "operator": {
                            "type": "and"
                        },
                        "query": {
                            "params": []
                        },
                        "evaluator": {
                            "params": [
                                0,
                                0
                            ],
                            "type": "gt"
                        }
                    }
                ],
                "hide": false,
                "expression": "$B > 0"
            },
            "refId": "C",
            "queryType": ""
        }
    ],
    "now": "{{$isoTimestamp}}"
}
```

</details>

and, in the case of successful execution, returns the following response 

<details> <summary> Response (Prometheus + Reduce) </summary>

```json
{
    "condition": "C",
    "evaluatedAt": "2022-07-01T15:11:07.797Z",
    "duration": "31ms",
    "result": [
        {
            "state": "Alerting",
            "values": {
                "B": {
                    "labels": {
                        "__name__": "up",
                        "instance": "fake-prometheus-data:9091",
                        "job": "fake-data-gen"
                    },
                    "value": 1
                },
                "C": {
                    "labels": {
                        "__name__": "up",
                        "instance": "fake-prometheus-data:9091",
                        "job": "fake-data-gen"
                    },
                    "value": 1
                }
            }
        },
        {
            "state": "Alerting",
            "values": {
                "B": {
                    "labels": {
                        "__name__": "up",
                        "instance": "host.docker.internal:3000",
                        "job": "grafana"
                    },
                    "value": 0.8186356073211315
                },
                "C": {
                    "labels": {
                        "__name__": "up",
                        "instance": "host.docker.internal:3000",
                        "job": "grafana"
                    },
                    "value": 1
                }
            }
        },
        {
            "state": "Alerting",
            "values": {
                "B": {
                    "labels": {
                        "__name__": "up",
                        "instance": "localhost:9090",
                        "job": "prometheus"
                    },
                    "value": 1
                },
                "C": {
                    "labels": {
                        "__name__": "up",
                        "instance": "localhost:9090",
                        "job": "prometheus"
                    },
                    "value": 1
                }
            }
        },
        {
            "state": "Alerting",
            "values": {
                "B": {
                    "labels": {
                        "__name__": "up",
                        "instance": "node_exporter:9100",
                        "job": "node_exporter"
                    },
                    "value": 1
                },
                "C": {
                    "labels": {
                        "__name__": "up",
                        "instance": "node_exporter:9100",
                        "job": "node_exporter"
                    },
                    "value": 1
                }
            }
        },
        {
            "state": "Alerting",
            "values": {
                "B": {
                    "labels": {
                        "__name__": "up",
                        "instance": "prometheus-random-data:8080",
                        "job": "prometheus-random-data"
                    },
                    "value": 1
                },
                "C": {
                    "labels": {
                        "__name__": "up",
                        "instance": "prometheus-random-data:8080",
                        "job": "prometheus-random-data"
                    },
                    "value": 1
                }
            }
        }
    ]
}
```
</details>

In the case of request with the classic condition (legacy mode)

<details><summary> Request (Prometheus + Classic Condition) </summary>

```json
{
    "condition": "B",
    "data": [
        {
            "refId": "A",
            "datasourceUid": "{{DATASOURCE_UID}}",
            "queryType": "",
            "relativeTimeRange": {
                "from": 600,
                "to": 0
            },
            "model": {
                "refId": "A",
                "hide": false,
                "expr": "up{}"
            }
        },
        {
            "refId": "B",
            "datasourceUid": "-100",
            "queryType": "",
            "model": {
                "refId": "B",
                "hide": false,
                "type": "classic_conditions",
                "datasource": {
                    "uid": "-100",
                    "type": "__expr__"
                },
                "conditions": [
                    {
                        "type": "query",
                        "evaluator": {
                            "params": [
                                0.698
                            ],
                            "type": "gt"
                        },
                        "operator": {
                            "type": "and"
                        },
                        "query": {
                            "params": [
                                "A"
                            ]
                        },
                        "reducer": {
                            "type": "avg",
                            "params": []
                        }
                    }
                ]
            }
        }
    ],
    "now": "{{$isoTimestamp}}"
}
```
</details>

<details> <summary> Response (Prometheus + Classic Condition) </summary> 

```json
{
    "result": [
        {
            "state": "Alerting",
            "values": {
                "B0": {
                    "labels": {
                        "__name__": "up",
                        "instance": "fake-prometheus-data:9091",
                        "job": "fake-data-gen"
                    },
                    "value": 1
                },
                "B1": {
                    "labels": {
                        "__name__": "up",
                        "instance": "host.docker.internal:3000",
                        "job": "grafana"
                    },
                    "value": 0.9334442595673876
                },
                "B2": {
                    "labels": {
                        "__name__": "up",
                        "instance": "localhost:9090",
                        "job": "prometheus"
                    },
                    "value": 1
                },
                "B3": {
                    "labels": {
                        "__name__": "up",
                        "instance": "node_exporter:9100",
                        "job": "node_exporter"
                    },
                    "value": 1
                },
                "B4": {
                    "labels": {
                        "__name__": "up",
                        "instance": "prometheus-random-data:8080",
                        "job": "prometheus-random-data"
                    },
                    "value": 1
                }
            }
        }
    ],
    "condition": "B",
    "evaluatedAt": "2022-07-06T15:19:16.328Z",
    "duration": "3s125ms"
}
```

</details>

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

