### PR TITLE
Docs: Correct references to 'lockingMigration'

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -125,7 +125,7 @@ path = grafana.db
 # For "sqlite3" only. cache mode setting used for connecting to the database
 cache_mode = private
 
-# For "mysql" only if lockingMigration feature toggle is set. How many seconds to wait before failing to lock the database for the migrations, default is 0.
+# For "mysql" only if migrationLocking feature toggle is set. How many seconds to wait before failing to lock the database for the migrations, default is 0.
 locking_attempt_timeout_sec = 0
 
 #################################### Cache server #############################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -126,7 +126,7 @@
 # For "sqlite3" only. cache mode setting used for connecting to the database. (private, shared)
 ;cache_mode = private
 
-# For "mysql" only if lockingMigration feature toggle is set. How many seconds to wait before failing to lock the database for the migrations, default is 0.
+# For "mysql" only if migrationLocking feature toggle is set. How many seconds to wait before failing to lock the database for the migrations, default is 0.
 ;locking_attempt_timeout_sec = 0
 
 ################################### Data sources #########################

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -324,7 +324,7 @@ Sets the maximum amount of time a connection may be reused. The default is 14400
 
 ### locking_attempt_timeout_sec
 
-For "mysql", if `lockingMigration` feature toggle is set, specify the time (in seconds) to wait before failing to lock the database for the migrations. Default is 0.
+For "mysql", if the `migrationLocking` feature toggle is set, specify the time (in seconds) to wait before failing to lock the database for the migrations. Default is 0.
 
 ### log_queries
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The docs [refer](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#locking_attempt_timeout_sec) to a feature toggle named `lockingMigration`, but the actual name of the toggle is `migrationLocking`. This PR fixes the docs to refer instead to the correct name, `migrationLocking`.

It was introduced in https://github.com/grafana/grafana/pull/44101, and the reference in code can be seen here:

https://github.com/grafana/grafana/blob/ee3f4f1709cd1b04b0b9c175c3d9a11d892a6cfa/pkg/services/featuremgmt/toggles_gen.go#L104

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

I've set this to backport to v9.0.x so that the docs will be updated appropriately for the "latest" version.

Signed-off-by: Dave Henderson <dave.henderson@grafana.com>
