### PR TITLE
Graphite plugin: fix duplicate query issue

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -8828,11 +8828,11 @@ exports[`better eslint`] = {
     "public/app/plugins/datasource/graphite/state/helpers.ts:3983357936": [
       [163, 73, 22, "Do not use any type assertions.", "3063692579"]
     ],
-    "public/app/plugins/datasource/graphite/state/store.ts:3772633353": [
-      [101, 16, 34, "Do not use any type assertions.", "2382199947"],
-      [141, 47, 26, "Do not use any type assertions.", "3915892908"],
-      [199, 14, 30, "Do not use any type assertions.", "2823515321"],
-      [206, 9, 31, "Do not use any type assertions.", "3670756765"]
+    "public/app/plugins/datasource/graphite/state/store.ts:1840705671": [
+      [100, 16, 34, "Do not use any type assertions.", "2382199947"],
+      [140, 47, 26, "Do not use any type assertions.", "3915892908"],
+      [198, 14, 30, "Do not use any type assertions.", "2823515321"],
+      [205, 9, 31, "Do not use any type assertions.", "3670756765"]
     ],
     "public/app/plugins/datasource/graphite/types.ts:1719498934": [
       [23, 17, 3, "Unexpected any. Specify a different type.", "193409811"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -8821,18 +8821,18 @@ exports[`better eslint`] = {
       [37, 14, 555, "Do not use any type assertions.", "2834937127"],
       [48, 7, 3, "Unexpected any. Specify a different type.", "193409811"]
     ],
-    "public/app/plugins/datasource/graphite/state/context.tsx:1303848651": [
+    "public/app/plugins/datasource/graphite/state/context.tsx:4190000323": [
       [13, 59, 25, "Do not use any type assertions.", "695205067"],
       [14, 69, 30, "Do not use any type assertions.", "2823515321"]
     ],
     "public/app/plugins/datasource/graphite/state/helpers.ts:3983357936": [
       [163, 73, 22, "Do not use any type assertions.", "3063692579"]
     ],
-    "public/app/plugins/datasource/graphite/state/store.ts:2705871887": [
-      [93, 16, 34, "Do not use any type assertions.", "2382199947"],
-      [133, 47, 26, "Do not use any type assertions.", "3915892908"],
-      [191, 14, 30, "Do not use any type assertions.", "2823515321"],
-      [198, 9, 31, "Do not use any type assertions.", "3670756765"]
+    "public/app/plugins/datasource/graphite/state/store.ts:3772633353": [
+      [101, 16, 34, "Do not use any type assertions.", "2382199947"],
+      [141, 47, 26, "Do not use any type assertions.", "3915892908"],
+      [199, 14, 30, "Do not use any type assertions.", "2823515321"],
+      [206, 9, 31, "Do not use any type assertions.", "3670756765"]
     ],
     "public/app/plugins/datasource/graphite/types.ts:1719498934": [
       [23, 17, 3, "Unexpected any. Specify a different type.", "193409811"],

--- a/public/app/plugins/datasource/graphite/state/context.tsx
+++ b/public/app/plugins/datasource/graphite/state/context.tsx
@@ -74,7 +74,7 @@ export const GraphiteQueryEditorContext = ({
 
   useEffect(
     () => {
-      if (needsRefresh && state) {
+      if (needsRefresh && state && state.target?.target) {
         setNeedsRefresh(false);
         onChange({ ...query, target: state.target.target });
         onRunQuery();

--- a/public/app/plugins/datasource/graphite/state/store.ts
+++ b/public/app/plugins/datasource/graphite/state/store.ts
@@ -68,12 +68,11 @@ const reducer = async (action: Action, state: GraphiteQueryEditorState): Promise
     await buildSegments(state, false);
 
     // fix for Explore: graph is not rendered until refresh when the query is duplicated #48145
-    // when copying and pasting a query,
-    // refresh to store the query
-    // set the timeout to handle race conditions with updating the time range
+    // when copying and pasting a query,refresh to store the query
+    // use setTimeout to handle race conditions with updating the time range
     // because on duplicating the query a second time
     // the time range overwrites the state and disrupts the refresh
-    setTimeout(() => state.refresh(), 100);
+    setTimeout(state.refresh);
   }
   if (actions.timeRangeChanged.match(action)) {
     state.range = action.payload;

--- a/public/app/plugins/datasource/graphite/state/store.ts
+++ b/public/app/plugins/datasource/graphite/state/store.ts
@@ -66,6 +66,14 @@ const reducer = async (action: Action, state: GraphiteQueryEditorState): Promise
     };
 
     await buildSegments(state, false);
+
+    // fix for Explore: graph is not rendered until refresh when the query is duplicated #48145
+    // when copying and pasting a query,
+    // refresh to store the query
+    // set the timeout to handle race conditions with updating the time range
+    // because on duplicating the query a second time
+    // the time range overwrites the state and disrupts the refresh
+    setTimeout(() => state.refresh(), 100);
   }
   if (actions.timeRangeChanged.match(action)) {
     state.range = action.payload;


### PR DESCRIPTION
#### Fixes [#48145](https://github.com/grafana/grafana/issues/48145)

### What is the Problem?

Duplicating the query in Graphite does not run and store the query. In other datasources, duplicating a query will run the query and store it. For example, duplicating a query in Datadog runs and stores the query. 

In Graphite, the query is not run after initializing the state of a new query editor. To run the query we need to call ```state.refresh()``` after initializing a new query editor with a target, i.e., duplicating a query. To handle race conditions with updating the time range, we run the query 100ms after initializing the state. If this is not done, there is another issue where the state of the time range will overwrite the query editor state and the query will not be run. 
