### PR TITLE
Timepicker: disable restoring focus to the timepicker button after closing the timepicker

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -118,7 +118,7 @@ export function UnthemedTimeRangePicker(props: TimeRangePickerProps): ReactEleme
         </ToolbarButton>
       </Tooltip>
       {isOpen && (
-        <FocusScope contain autoFocus restoreFocus>
+        <FocusScope contain autoFocus>
           <section ref={ref} {...overlayProps} {...dialogProps}>
             <TimePickerContent
               timeZone={timeZone}


### PR DESCRIPTION

**What this PR does / why we need it**:
When the timepicker is closed the FocusScope element restores the focus to the previously focused element. This in turn opens the tooltip for the focused element. This disables restoring the focus so that the tooltip doesn't remain open.

This is a trade-off for accessibility using the keyboard, as the wrong element will be focused when the timepicker closes.

I suggest we make this trade off and handle the accessibility in a second issue, as this issue is likely impacting more users than the slightly degraded keyboard navigation would.

This also doesn't handle the issue where the tooltip for the settings is visible after closing the settings.

**Which issue(s) this PR fixes**:
Fixes #51037
