### PR TITLE
Alerting: add YAML support for relative time range

### DIFF
--- a/pkg/services/ngalert/models/alert_query.go
+++ b/pkg/services/ngalert/models/alert_query.go
@@ -40,11 +40,29 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 	}
 }
 
+func (d Duration) MarshalYAML() (interface{}, error) {
+	return time.Duration(d).Seconds(), nil
+}
+
+func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var v interface{}
+	if err := unmarshal(&v); err != nil {
+		return err
+	}
+	switch value := v.(type) {
+	case int:
+		*d = Duration(time.Duration(value) * time.Second)
+		return nil
+	default:
+		return fmt.Errorf("invalid duration %v", v)
+	}
+}
+
 // RelativeTimeRange is the per query start and end time
 // for requests.
 type RelativeTimeRange struct {
-	From Duration `json:"from"`
-	To   Duration `json:"to"`
+	From Duration `json:"from" yaml:"from"`
+	To   Duration `json:"to" yaml:"to"`
 }
 
 // isValid checks that From duration is greater than To duration.

--- a/pkg/services/ngalert/models/alert_rule_test.go
+++ b/pkg/services/ngalert/models/alert_rule_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -581,4 +582,18 @@ func TestSortByGroupIndex(t *testing.T) {
 			return rules[i].ID < rules[j].ID
 		}))
 	})
+}
+
+func TestTimeRangeYAML(t *testing.T) {
+	yamlRaw := "from: 600\nto: 0\n"
+	var rtr RelativeTimeRange
+	err := yaml.Unmarshal([]byte(yamlRaw), &rtr)
+	require.NoError(t, err)
+	// nanoseconds
+	require.Equal(t, Duration(600000000000), rtr.From)
+	require.Equal(t, Duration(0), rtr.To)
+
+	serialized, err := yaml.Marshal(rtr)
+	require.NoError(t, err)
+	require.Equal(t, yamlRaw, string(serialized))
 }


### PR DESCRIPTION
This PR adds support for YAML on the relative time range struct and adds Marshal/Unmarshal on our duration type. This is needed for file provisioning as we will support JSON and YAML.