### PR TITLE
Add doc-validator tool to CI

### DIFF
--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -1,0 +1,15 @@
+name: "doc-validator"
+on:
+  pull_request:
+    paths: ["docs/sources/**"]
+  workflow_dispatch:
+jobs:
+  doc-validator:
+    runs-on: "ubuntu-latest"
+    container:
+      image: "grafana/doc-validator:latest"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v3"
+      - name: "Run doc-validator tool"
+        run: "doc-validator ./docs/sources"

--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -12,4 +12,5 @@ jobs:
       - name: "Checkout code"
         uses: "actions/checkout@v3"
       - name: "Run doc-validator tool"
-        run: "doc-validator ./docs/sources"
+        # Ensure that the CI always passes until all errors are resolved.
+        run: "doc-validator ./docs/sources || true"

--- a/docs/sources/whatsnew/whats-new-in-v7-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v7-5.md
@@ -15,7 +15,7 @@ title: What's new in Grafana v7.5
 weight: -32
 ---
 
-# What’s new in Grafana v7.5
+# What's new in Grafana v7.5
 
 This topic includes the release notes for Grafana v7.5. For all details, read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md).
 

--- a/docs/sources/whatsnew/whats-new-in-v8-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-0.md
@@ -15,7 +15,7 @@ title: What's new in Grafana v8.0
 weight: -33
 ---
 
-# What’s new in Grafana v8.0
+# What's new in Grafana v8.0
 
 This topic includes the release notes for Grafana v8.0. For all details, read the full [CHANGELOG.md](https://github.com/grafana/grafana/blob/master/CHANGELOG.md).
 

--- a/docs/sources/whatsnew/whats-new-in-v8-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-1.md
@@ -15,7 +15,7 @@ title: What's new in Grafana v8.1
 weight: -33
 ---
 
-# What’s new in Grafana v8.1
+# What's new in Grafana v8.1
 
 > **Note:** This topic will be updated frequently between now and the final release.
 

--- a/docs/sources/whatsnew/whats-new-in-v8-2.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-2.md
@@ -15,7 +15,7 @@ title: What's new in Grafana v8.2
 weight: -33
 ---
 
-# What’s new in Grafana v8.2
+# What's new in Grafana v8.2
 
 Grafana 8.2 continues to build on the foundation of Grafana 8.0 & 8.1. Grafana 8.2 also marks the start of our work to bring Grafana closer to all users with a focus on increasing Grafana’s accessibility, part of its continuing mission to democratize metrics _for everyone_.
 

--- a/docs/sources/whatsnew/whats-new-in-v8-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-3.md
@@ -15,7 +15,7 @@ title: What's new in Grafana v8.3
 weight: -33
 ---
 
-# What’s new in Grafana v8.3
+# What's new in Grafana v8.3
 
 Grafana 8.3 is an exciting release for Grafana Labs. This release includes the new Candlestick Panel, a new visualization suggestions engine and, for enterprise users, Recorded Queries.
 

--- a/docs/sources/whatsnew/whats-new-in-v8-4.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-4.md
@@ -15,7 +15,7 @@ title: What's new in Grafana v8.4
 weight: -33
 ---
 
-# What’s new in Grafana v8.4
+# What's new in Grafana v8.4
 
 We’re excited to announce Grafana v8.4, with a variety of improvements that focus on Grafana’s usability, performance, and security. Read on to learn about Alerting enhancements like a WeCom contact point, improved Alert panel and custom mute timings, as well as visualization improvements and details to help you share playlists more easily. In Grafana Enterprise, we’ve made caching more powerful to save you time and money while loading dashboards, boosted database encryption to keep secrets safe in your Grafana database, and made usability improvements to Recorded Queries, which allow you to track any data point over time.
 

--- a/docs/sources/whatsnew/whats-new-in-v8-5.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-5.md
@@ -15,7 +15,7 @@ title: What's new in Grafana v8.5
 weight: -33
 ---
 
-# What’s new in Grafana v8.5
+# What's new in Grafana v8.5
 
 We’re excited to announce Grafana v8.5, with a variety of improvements that focus on Grafana’s usability, performance, and security.
 

--- a/docs/sources/whatsnew/whats-new-in-v9-0.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-0.md
@@ -15,7 +15,7 @@ title: What's new in Grafana v9.0
 weight: -33
 ---
 
-# What’s new in Grafana v9.0
+# What's new in Grafana v9.0
 
 As tradition goes, GrafanaCon — our yearly community event for Grafana open source users — is also where we launch the latest software release of Grafana. Keeping up with tradition, we are excited to be announcing Grafana v9.0: a release that elevates Grafana’s ease of use, discovery of data through new and improved visualizations and a default Grafana Alerting experience.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a CI step for pull requests that validates links in technical documentation and performs linting of technical documentation source files.

Source code:
https://github.com/grafana/technical-documentation/tree/main/tools/doc-validator

**Special notes for your reviewer**:

- There's a lot to fix before we can merge this.
- The tool is still in early development so each error should be scrutinized for validity. 