### PR TITLE
Remove indentation from docs/list shortcode usage

### DIFF
--- a/docs/sources/administration/organization-preferences/_index.md
+++ b/docs/sources/administration/organization-preferences/_index.md
@@ -45,7 +45,8 @@ Follow these instructions if you are a Grafana Server Admin.
 1. In the organization list, click the name of the organization that you want to change.
 1. In **Name**, enter the new organization name.
 1. Click **Update**.
-   {{< /docs/list >}}
+
+{{< /docs/list >}}
 
 #### Organization Admin change organization name
 
@@ -56,7 +57,8 @@ If you are an Organization Admin, follow these steps:
 
 1. In **Organization name**, enter the new name.
 1. Click **Update organization name**.
-   {{< /docs/list >}}
+
+{{< /docs/list >}}
 
 ### Change team name or email
 
@@ -125,8 +127,9 @@ Organization and team administrators can change the UI theme for all users in a 
 {{< docs/shared "manage-users/view-team-list.md" >}}
 
 1. Click on the team that you want to change the UI theme for and then navigate to the **Settings** tab.
-   {{< docs/shared "preferences/select-ui-theme-list.md" >}}
-   {{< /docs/list >}}
+
+{{< docs/shared "preferences/select-ui-theme-list.md" >}}
+{{< /docs/list >}}
 
 ### Change your personal UI theme
 
@@ -164,8 +167,9 @@ Organization administrators and team administrators can choose a default timezon
 {{< docs/shared "manage-users/view-team-list.md" >}}
 
 1. Click on the team you that you want to change the timezone for and then navigate to the **Settings** tab.
-   {{< docs/shared "preferences/select-timezone-list.md" >}}
-   {{< /docs/list >}}
+
+{{< docs/shared "preferences/select-timezone-list.md" >}}
+{{< /docs/list >}}
 
 ### Set your personal timezone
 
@@ -231,8 +235,9 @@ Organization administrators and Team Admins can choose a home dashboard for a te
 {{< docs/shared "manage-users/view-team-list.md" >}}
 
 1. Click on the team that you want to change the home dashboard for and then navigate to the **Settings** tab.
-   {{< docs/shared "preferences/select-home-dashboard-list.md" >}}
-   {{< /docs/list >}}
+
+{{< docs/shared "preferences/select-home-dashboard-list.md" >}}
+{{< /docs/list >}}
 
 ### Set your personal home dashboard
 

--- a/docs/sources/shared/manage-users/view-server-org-list-and-edit.md
+++ b/docs/sources/shared/manage-users/view-server-org-list-and-edit.md
@@ -8,4 +8,5 @@ title: View org list as server admin
 {{< docs/shared "manage-users/view-server-org-list.md" >}}
 
 1. Click the name of the organization that you want to edit.
-   {{< /docs/list >}}
+
+{{< /docs/list >}}

--- a/docs/sources/shared/manage-users/view-server-user-list-search.md
+++ b/docs/sources/shared/manage-users/view-server-user-list-search.md
@@ -8,4 +8,5 @@ title: View user list and search - list format
 {{< docs/shared "manage-users/view-server-user-list.md" >}}
 
 1. Click the user account that you want to edit. If necessary, use the search field to find the account.
-   {{< /docs/list >}}
+
+{{< /docs/list >}}


### PR DESCRIPTION
Signed-off-by: Jack Baldry <jack.baldry@grafana.com>

I'm hoping this removes the stay `ol` tags in https://grafana.com/docs/grafana/next/administration/organization-preferences/ and other places.

