### PR TITLE
Search: Check whether re-indexing required

### DIFF
--- a/pkg/services/searchV2/index.go
+++ b/pkg/services/searchV2/index.go
@@ -101,7 +101,6 @@ func (i *orgIndex) getCurrentDashboardsForComparison() ([]indexedDashboard, erro
 	var currentDashboards []indexedDashboard
 	match, err := documentMatchIterator.Next()
 	for err == nil && match != nil {
-
 		var uid string
 		var updated time.Time
 

--- a/pkg/services/searchV2/index.go
+++ b/pkg/services/searchV2/index.go
@@ -462,9 +462,10 @@ func dashboardsDiffer(dbDashboards []dashboard, indexedDashboards []indexedDashb
 	})
 
 	for i := 0; i < len(dbDashboards); i++ {
-		if dbDashboards[i].uid != indexedDashboards[i].UID && dbDashboards[i].uid != "" && indexedDashboards[i].UID != "" {
+		if dbDashboards[i].uid != indexedDashboards[i].UID {
 			return true
 		}
+		// For attached general folder (with empty uid) we always have different times. So skipping the check for it.
 		if dbDashboards[i].updated.UTC() != indexedDashboards[i].Updated.UTC() && dbDashboards[i].uid != "" && indexedDashboards[i].UID != "" {
 			return true
 		}

--- a/pkg/services/searchV2/index_test.go
+++ b/pkg/services/searchV2/index_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 
@@ -581,4 +582,56 @@ func TestDashboardIndex_CamelCaseNgram(t *testing.T) {
 			DashboardQuery{Query: "tork"},
 		)
 	})
+}
+
+var reindexCheckInitialDashboards = []dashboard{
+	{
+		id:  1,
+		uid: "1",
+		info: &extract.DashboardInfo{
+			Title: "dash1",
+		},
+		updated: time.Date(2022, 10, 1, 21, 0, 0, 0, time.UTC),
+	},
+}
+
+func TestDashboardIndex_DashboardsDiffer(t *testing.T) {
+	// Same dashboards.
+	require.False(t, dashboardsDiffer(reindexCheckInitialDashboards, []indexedDashboard{
+		{
+			UID:     "1",
+			Updated: time.Date(2022, 10, 1, 21, 0, 0, 0, time.UTC),
+		},
+	}))
+
+	// Updated changed.
+	require.True(t, dashboardsDiffer(reindexCheckInitialDashboards, []indexedDashboard{
+		{
+			UID:     "1",
+			Updated: time.Date(2022, 10, 1, 23, 0, 0, 0, time.UTC),
+		},
+	}))
+
+	// Same size, different uid.
+	require.True(t, dashboardsDiffer(reindexCheckInitialDashboards, []indexedDashboard{
+		{
+			UID:     "2",
+			Updated: time.Date(2022, 10, 1, 21, 0, 0, 0, time.UTC),
+		},
+	}))
+
+	// Dashboard removed.
+	require.True(t, dashboardsDiffer(reindexCheckInitialDashboards, []indexedDashboard{}))
+
+	// Dashboard added.
+	require.True(t, dashboardsDiffer(reindexCheckInitialDashboards, []indexedDashboard{
+		{
+			UID:     "1",
+			Updated: time.Date(2022, 10, 1, 21, 0, 0, 0, time.UTC),
+		},
+		{
+			UID:     "2",
+			Updated: time.Date(2022, 10, 1, 21, 0, 0, 0, time.UTC),
+		},
+	}))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to avoid rather expensive re-indexing, here is an attempt to avoid it by comparing data in database with data in index. For best case scenario this mostly reduces time to loading dashboards from DB, with extra milliseconds to do the comparison.