### PR TITLE
TimeSrv: Don't modify refresh interval when editing panel

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4535,8 +4535,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
     ],
     "public/app/features/dashboard/state/DashboardMigrator.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/public/app/features/dashboard/services/TimeSrv.test.ts
+++ b/public/app/features/dashboard/services/TimeSrv.test.ts
@@ -253,24 +253,18 @@ describe('timeSrv', () => {
   });
 
   describe('pauseAutoRefresh', () => {
-    it('should set refresh to empty value', () => {
+    it('should set refreshActive to false', () => {
       _dashboard.refresh = '10s';
       timeSrv.pauseAutoRefresh();
-      expect(_dashboard.refresh).toBe('');
-    });
-
-    it('should set previousAutoRefresh value', () => {
-      _dashboard.refresh = '10s';
-      timeSrv.pauseAutoRefresh();
-      expect(timeSrv.previousAutoRefresh).toBe('10s');
+      expect(timeSrv.refreshActive).toBe(false);
     });
   });
 
   describe('resumeAutoRefresh', () => {
     it('should set refresh to empty value', () => {
-      timeSrv.previousAutoRefresh = '10s';
+      timeSrv.refreshActive = false;
       timeSrv.resumeAutoRefresh();
-      expect(_dashboard.refresh).toBe('10s');
+      expect(timeSrv.refreshActive).toBe(true);
     });
   });
 

--- a/public/app/features/dashboard/services/TimeSrv.test.ts
+++ b/public/app/features/dashboard/services/TimeSrv.test.ts
@@ -253,18 +253,18 @@ describe('timeSrv', () => {
   });
 
   describe('pauseAutoRefresh', () => {
-    it('should set refreshActive to false', () => {
+    it('should set autoRefreshPaused to true', () => {
       _dashboard.refresh = '10s';
       timeSrv.pauseAutoRefresh();
-      expect(timeSrv.refreshActive).toBe(false);
+      expect(timeSrv.autoRefreshPaused).toBe(true);
     });
   });
 
   describe('resumeAutoRefresh', () => {
     it('should set refresh to empty value', () => {
-      timeSrv.refreshActive = false;
+      timeSrv.autoRefreshPaused = true;
       timeSrv.resumeAutoRefresh();
-      expect(timeSrv.refreshActive).toBe(true);
+      expect(timeSrv.autoRefreshPaused).toBe(false);
     });
   });
 

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -24,7 +24,7 @@ export class TimeSrv {
   time: any;
   refreshTimer: any;
   refresh: any;
-  previousAutoRefresh: any;
+  refreshActive = true;
   oldRefresh: string | null | undefined;
   timeModel?: TimeModel;
   timeAtLoad: any;
@@ -232,7 +232,7 @@ export class TimeSrv {
 
     this.refreshTimer = setTimeout(() => {
       this.startNextRefreshTimer(intervalMs);
-      this.refreshTimeModel();
+      this.refreshActive && this.refreshTimeModel();
     }, intervalMs);
 
     const refresh = this.contextSrv.getValidInterval(interval);
@@ -250,7 +250,7 @@ export class TimeSrv {
     this.refreshTimer = setTimeout(() => {
       this.startNextRefreshTimer(afterMs);
       if (this.contextSrv.isGrafanaVisible()) {
-        this.refreshTimeModel();
+        this.refreshActive && this.refreshTimeModel();
       } else {
         this.autoRefreshBlocked = true;
       }
@@ -264,13 +264,13 @@ export class TimeSrv {
   // store timeModel refresh value and pause auto-refresh in some places
   // i.e panel edit
   pauseAutoRefresh() {
-    this.previousAutoRefresh = this.timeModel?.refresh;
-    this.setAutoRefresh('');
+    this.refreshActive = false;
   }
 
   // resume auto-refresh based on old dashboard refresh property
   resumeAutoRefresh() {
-    this.setAutoRefresh(this.previousAutoRefresh);
+    this.refreshActive = true;
+    this.refreshTimeModel();
   }
 
   setTime(time: RawTimeRange, updateUrl = true) {

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -24,7 +24,7 @@ export class TimeSrv {
   time: any;
   refreshTimer: any;
   refresh: any;
-  refreshActive = true;
+  autoRefreshPaused = false;
   oldRefresh: string | null | undefined;
   timeModel?: TimeModel;
   timeAtLoad: any;
@@ -232,7 +232,7 @@ export class TimeSrv {
 
     this.refreshTimer = setTimeout(() => {
       this.startNextRefreshTimer(intervalMs);
-      this.refreshActive && this.refreshTimeModel();
+      !this.autoRefreshPaused && this.refreshTimeModel();
     }, intervalMs);
 
     const refresh = this.contextSrv.getValidInterval(interval);
@@ -250,7 +250,7 @@ export class TimeSrv {
     this.refreshTimer = setTimeout(() => {
       this.startNextRefreshTimer(afterMs);
       if (this.contextSrv.isGrafanaVisible()) {
-        this.refreshActive && this.refreshTimeModel();
+        !this.autoRefreshPaused && this.refreshTimeModel();
       } else {
         this.autoRefreshBlocked = true;
       }
@@ -264,12 +264,12 @@ export class TimeSrv {
   // store timeModel refresh value and pause auto-refresh in some places
   // i.e panel edit
   pauseAutoRefresh() {
-    this.refreshActive = false;
+    this.autoRefreshPaused = true;
   }
 
   // resume auto-refresh based on old dashboard refresh property
   resumeAutoRefresh() {
-    this.refreshActive = true;
+    this.autoRefreshPaused = false;
     this.refreshTimeModel();
   }
 

--- a/public/app/features/dashboard/state/DashboardModel.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.test.ts
@@ -976,7 +976,7 @@ describe('exitViewPanel', () => {
 });
 
 describe('exitPanelEditor', () => {
-  function getTestContext(setPreviousAutoRefresh = false) {
+  function getTestContext(pauseAutoRefresh = false) {
     const panel: any = { destroy: jest.fn() };
     const dashboard = new DashboardModel({});
     const timeSrvMock = {
@@ -986,8 +986,8 @@ describe('exitPanelEditor', () => {
     } as unknown as TimeSrv;
     dashboard.startRefresh = jest.fn();
     dashboard.panelInEdit = panel;
-    if (setPreviousAutoRefresh) {
-      timeSrvMock.previousAutoRefresh = '5s';
+    if (pauseAutoRefresh) {
+      timeSrvMock.refreshActive = false;
     }
     setTimeSrv(timeSrvMock);
     return { dashboard, panel, timeSrvMock };

--- a/public/app/features/dashboard/state/DashboardModel.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.test.ts
@@ -987,7 +987,7 @@ describe('exitPanelEditor', () => {
     dashboard.startRefresh = jest.fn();
     dashboard.panelInEdit = panel;
     if (pauseAutoRefresh) {
-      timeSrvMock.refreshActive = false;
+      timeSrvMock.autoRefreshPaused = true;
     }
     setTimeSrv(timeSrvMock);
     return { dashboard, panel, timeSrvMock };


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes some of the logic in `TimeSrv.ts` to flag the dashboard refresh as being "active" or not, rather than directly changing the refresh interval. This prevents the cleared refresh interval from being committed to the dashboard json when saving from the panel edit view.

**Which issue(s) this PR fixes**:
Fixes #51542


