### PR TITLE
Alerting: Fix RegExp matchers in frontend for Silences and other previews.

### DIFF
--- a/public/app/features/alerting/unified/utils/matchers.test.ts
+++ b/public/app/features/alerting/unified/utils/matchers.test.ts
@@ -59,6 +59,7 @@ describe('Unified Alerting matchers', () => {
       const matchers = [{ name: 'foo', value: 'b{1}a.*', operator: MatcherOperator.regex }];
       const alerts = [
         mockPromAlert({ labels: { foo: 'bbr' } }),
+        mockPromAlert({ labels: { foo: 'aba' } }), // This does not match because the regex is implicitly anchored.
         mockPromAlert({ labels: { foo: 'ba' } }),
         mockPromAlert({ labels: { foo: 'bar' } }),
         mockPromAlert({ labels: { foo: 'baz' } }),

--- a/public/app/features/alerting/unified/utils/matchers.test.ts
+++ b/public/app/features/alerting/unified/utils/matchers.test.ts
@@ -56,27 +56,37 @@ describe('Unified Alerting matchers', () => {
     });
 
     it('should match for regex', () => {
-      const matchers = [{ name: 'foo', value: 'bar', operator: MatcherOperator.regex }];
+      const matchers = [{ name: 'foo', value: 'b{1}a.*', operator: MatcherOperator.regex }];
       const alerts = [
+        mockPromAlert({ labels: { foo: 'bbr' } }),
+        mockPromAlert({ labels: { foo: 'ba' } }),
         mockPromAlert({ labels: { foo: 'bar' } }),
         mockPromAlert({ labels: { foo: 'baz' } }),
         mockPromAlert({ labels: { foo: 'bas' } }),
       ];
 
       const matchedAlerts = findAlertInstancesWithMatchers(alerts, matchers);
-      expect(matchedAlerts).toHaveLength(1);
+      expect(matchedAlerts).toHaveLength(4);
+      expect(matchedAlerts.map((instance) => instance.data.matchedInstance.labels.foo)).toEqual([
+        'ba',
+        'bar',
+        'baz',
+        'bas',
+      ]);
     });
 
     it('should not match regex', () => {
-      const matchers = [{ name: 'foo', value: 'bar', operator: MatcherOperator.notRegex }];
+      const matchers = [{ name: 'foo', value: 'ba{3}', operator: MatcherOperator.notRegex }];
       const alerts = [
         mockPromAlert({ labels: { foo: 'bar' } }),
         mockPromAlert({ labels: { foo: 'baz' } }),
+        mockPromAlert({ labels: { foo: 'baaa' } }),
         mockPromAlert({ labels: { foo: 'bas' } }),
       ];
 
       const matchedAlerts = findAlertInstancesWithMatchers(alerts, matchers);
-      expect(matchedAlerts).toHaveLength(2);
+      expect(matchedAlerts).toHaveLength(3);
+      expect(matchedAlerts.map((instance) => instance.data.matchedInstance.labels.foo)).toEqual(['bar', 'baz', 'bas']);
     });
   });
 });

--- a/public/app/features/alerting/unified/utils/matchers.ts
+++ b/public/app/features/alerting/unified/utils/matchers.ts
@@ -41,6 +41,17 @@ export const findAlertInstancesWithMatchers = (
   instances: Alert[],
   matchers: MatcherFieldValue[]
 ): MatchedInstance[] => {
+  const anchorRegex = (regexpString: string): RegExp => {
+    // Silence matchers are always fully anchored in the Alertmanager: https://github.com/prometheus/alertmanager/pull/748
+    if (!regexpString.startsWith('^')) {
+      regexpString = '^' + regexpString;
+    }
+    if (!regexpString.endsWith('$')) {
+      regexpString = regexpString + '$';
+    }
+    return new RegExp(regexpString);
+  };
+
   const matchesInstance = (instance: Alert, matcher: MatcherFieldValue) => {
     return Object.entries(instance.labels).some(([key, value]) => {
       if (!matcher.name || !matcher.value) {
@@ -55,10 +66,10 @@ export const findAlertInstancesWithMatchers = (
         case MatcherOperator.notEqual:
           return matcher.value !== value;
         case MatcherOperator.regex:
-          const regex = new RegExp(matcher.value);
+          const regex = anchorRegex(matcher.value);
           return regex.test(value);
         case MatcherOperator.notRegex:
-          const negregex = new RegExp(matcher.value);
+          const negregex = anchorRegex(matcher.value);
           return !negregex.test(value);
         default:
           return false;


### PR DESCRIPTION
The `regex` and `notRegex` matcher operators were not properly matching
against supplied values. If using an unknown string instead of a known
RegExp array like `/[a-b]*/`, then a new RegExp must be created before
calling `match()`