### PR TITLE
Search: Loading to memory from backup on start

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,8 @@ replace k8s.io/client-go => k8s.io/client-go v0.22.1
 
 replace github.com/russellhaering/goxmldsig@v1.1.0 => github.com/russellhaering/goxmldsig v1.1.1
 
+replace github.com/blugelabs/bluge => github.com/FZambia/bluge v0.1.10-0.20220705124321-5f2de18ac909
+
 require (
 	cloud.google.com/go/storage v1.21.0
 	cuelang.org/go v0.4.3
@@ -241,6 +243,7 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.9.17
 	github.com/armon/go-radix v1.0.0
 	github.com/blugelabs/bluge v0.1.9
+	github.com/blugelabs/bluge_segment_api v0.2.0
 	github.com/getkin/kin-openapi v0.94.0
 	github.com/golang-migrate/migrate/v4 v4.7.0
 	github.com/grafana/dskit v0.0.0-20211011144203-3a88ec0b675f
@@ -255,7 +258,6 @@ require (
 require (
 	cloud.google.com/go v0.100.2 // indirect
 	github.com/armon/go-metrics v0.3.10 // indirect
-	github.com/blugelabs/bluge_segment_api v0.2.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,8 @@ github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
+github.com/FZambia/bluge v0.1.10-0.20220705124321-5f2de18ac909 h1:8uZBegpvox42QkNQDLKTjY5zaciFXCghUDidRVqz4nE=
+github.com/FZambia/bluge v0.1.10-0.20220705124321-5f2de18ac909/go.mod h1:5d7LktUkQgvbh5Bmi6tPWtvo4+6uRTm6gAwP+5z6FqQ=
 github.com/FZambia/eagle v0.0.1 h1:FN1yTkPihMb5nE8SrlRjoCf7T9H9bTKJFQOm6ach2YU=
 github.com/FZambia/eagle v0.0.1/go.mod h1:xq6u/JeNZ5/8mrAQ76MMhzNTodASh9FavQlCgg4j48w=
 github.com/FZambia/sentinel v1.1.0 h1:qrCBfxc8SvJihYNjBWgwUI93ZCvFe/PJIPTHKmlp8a8=
@@ -435,8 +437,6 @@ github.com/blevesearch/snowballstem v0.9.0/go.mod h1:PivSj3JMc8WuaFkTSRDW2SlrulN
 github.com/blevesearch/vellum v1.0.5/go.mod h1:atE0EH3fvk43zzS7t1YNdNC7DbmcC3uz+eMD5xZ2OyQ=
 github.com/blevesearch/vellum v1.0.7 h1:+vn8rfyCRHxKVRgDLeR0FAXej2+6mEb5Q15aQE/XESQ=
 github.com/blevesearch/vellum v1.0.7/go.mod h1:doBZpmRhwTsASB4QdUZANlJvqVAUdUyX0ZK7QJCTeBE=
-github.com/blugelabs/bluge v0.1.9 h1:bPgXlcsWugrXNjzeoLdOnvfJpHsyODKpYaAndayl/SM=
-github.com/blugelabs/bluge v0.1.9/go.mod h1:5d7LktUkQgvbh5Bmi6tPWtvo4+6uRTm6gAwP+5z6FqQ=
 github.com/blugelabs/bluge_segment_api v0.2.0 h1:cCX1Y2y8v0LZ7+EEJ6gH7dW6TtVTW4RhG0vp3R+N2Lo=
 github.com/blugelabs/bluge_segment_api v0.2.0/go.mod h1:95XA+ZXfRj/IXADm7gZ+iTcWOJPg5jQTY1EReIzl3LA=
 github.com/blugelabs/ice v0.2.0/go.mod h1:7foiDf4V83FIYYnGh2LOoRWsbNoCqAAMNgKn879Iyu0=

--- a/pkg/services/searchV2/readme.md
+++ b/pkg/services/searchV2/readme.md
@@ -1,0 +1,32 @@
+Search service has:
+
+* `searchIndex` - manages all organization indexes
+* `orgIndex` - organization index, every organization has its own `orgIndex`
+* every `orgIndex` has different index types (separate `*bluge.Writer`)
+
+Index backup is global as we don't have org id separation in `entity_event` table. And manage indexes for all organizations in one goroutine.
+
+On Grafana start we check whether search index backup exists.
+
+* if yes - load all in-memory `orgIndex` from backup, load last event ID applied to the index in backup, apply missing updates
+* if not - build orgIndex from scratch, at the end of building create backup.
+
+Backup directory is configurable, inside backup directory structure looks like this:
+
+```
+gf_index
+├── event_id.txt
+├── org_1
+│   └── dashboard
+│       ├── 0000000004a7.seg
+│       ├── 0000000004a8.seg
+│       ├── 0000000004a9.seg
+│       └── 000000000893.snp
+└── org_2
+```
+
+`event_id.txt` contains the last event ID applied to the index version in the backup. Since we make backups periodically we may need to apply some missing updates from `entity_event` table to catch up the state. 
+
+At this moment we still need to re-index periodically since not all changes come to `entity_event` table. Though we may try to apply some checks to avoid full-reindexing if we know that database state match state in index (i.e. no updates were missed).
+
+We can also save/load backup to remote storage, but need to preserve the structure.

--- a/pkg/services/searchV2/readme.md
+++ b/pkg/services/searchV2/readme.md
@@ -14,8 +14,8 @@ On Grafana start we check whether search index backup exists.
 Backup directory is configurable, inside backup directory structure looks like this:
 
 ```
-gf_index
-├── event_id.txt
+gf_index_backup
+├── meta.json
 ├── org_1
 │   └── dashboard
 │       ├── 0000000004a7.seg
@@ -25,8 +25,28 @@ gf_index
 └── org_2
 ```
 
-`event_id.txt` contains the last event ID applied to the index version in the backup. Since we make backups periodically we may need to apply some missing updates from `entity_event` table to catch up the state. 
+or
+
+```
+gf_index_backup
+├── dashboard
+|   ├-- meta.json
+│   ├── org1
+│   │   ├── 0000000004a7.seg
+│   │   ├── 0000000004a8.seg
+│   │   ├── 0000000004a9.seg
+│   │   └── 000000000893.snp
+│   └── org2
+```
+
+Think that second option is better since it allows making isolated indexes, each consuming entity events separately.
+
+`meta.json` contains:
+
+* the last event ID applied to the index version in the backup. Since we make backups periodically we may need to apply some missing updates from `entity_event` table to catch up the state. 
 
 At this moment we still need to re-index periodically since not all changes come to `entity_event` table. Though we may try to apply some checks to avoid full-reindexing if we know that database state match state in index (i.e. no updates were missed).
 
 We can also save/load backup to remote storage, but need to preserve the structure.
+
+Also, in HA scenario we can theoretically only have one node that does re-indexing, then share backup to all nodes.


### PR DESCRIPTION
**What this PR does / why we need it**:

Some steps to achieve:

* extend Bluge with possibility to load disk backup to in-memory index on start - https://github.com/FZambia/bluge/commit/6c276d229277989452b3dd6045409451c04df4aa
* load all indexes from backup on start, apply missed events
* periodically do backups
* do backups to remote storage, load from remote storage on start