### PR TITLE
BarChart: fix yAxis min

### DIFF
--- a/public/app/plugins/panel/barchart/models.gen.ts
+++ b/public/app/plugins/panel/barchart/models.gen.ts
@@ -45,5 +45,4 @@ export const defaultBarChartFieldConfig: BarChartFieldConfig = {
   lineWidth: 1,
   fillOpacity: 80,
   gradientMode: GraphGradientMode.None,
-  axisSoftMin: 0,
 };

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -173,6 +173,18 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptionsEX> = ({
     const scaleColor = getFieldSeriesColor(field, theme);
     const seriesColor = scaleColor.color;
 
+    // make barcharts start at 0 unless explicitly overridden
+    let softMin = customConfig.axisSoftMin;
+    let softMax = customConfig.axisSoftMax;
+
+    if (softMin == null && field.config.min == null) {
+      softMin = 0;
+    }
+
+    if (softMax == null && field.config.max == null) {
+      softMax = 0;
+    }
+
     builder.addSeries({
       scaleKey,
       pxAlign: true,
@@ -187,8 +199,8 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptionsEX> = ({
       thresholds: field.config.thresholds,
       hardMin: field.config.min,
       hardMax: field.config.max,
-      softMin: customConfig.axisSoftMin,
-      softMax: customConfig.axisSoftMax,
+      softMin,
+      softMax,
 
       // The following properties are not used in the uPlot config, but are utilized as transport for legend config
       // PlotLegend currently gets unfiltered DataFrame[], so index must be into that field array, not the prepped frame's which we're iterating here
@@ -207,8 +219,8 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<BarChartOptionsEX> = ({
       scaleKey,
       min: field.config.min,
       max: field.config.max,
-      softMin: customConfig.axisSoftMin,
-      softMax: customConfig.axisSoftMax,
+      softMin,
+      softMax,
       orientation: vizOrientation.yOri,
       direction: vizOrientation.yDir,
       distribution: customConfig.scaleDistribution?.type,


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/51675

this internalizes `axisSoftMin` and `axisSoftMax` and sets them to 0 when they are not explicitly set via JSON in `fieldConfig` _and_ in the absence of [hard]`min` and [hard]`max` settings.