### PR TITLE
Histogram: filter nulls, bucket-adaptive xAxis decimals

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -254,10 +254,13 @@ export function buildHistogram(frames: DataFrame[], options?: HistogramTransform
     values: new ArrayVector(joinedHists[0]),
     type: FieldType.number,
     state: undefined,
-    config: {
-      ...config,
-      decimals: Math.max(config?.decimals ?? 0, bucketDecimals),
-    },
+    config:
+      bucketDecimals === 0
+        ? config ?? {}
+        : {
+            ...config,
+            decimals: bucketDecimals,
+          },
   };
   const bucketMax = {
     ...bucketMin,

--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -160,12 +160,12 @@ export function buildHistogram(frames: DataFrame[], options?: HistogramTransform
     for (const frame of frames) {
       for (const field of frame.fields) {
         if (field.type === FieldType.number) {
-          allValues = allValues.concat(
-            field.values.toArray().map((val: number) => Number(val.toFixed(field.config.decimals ?? 0)))
-          );
+          allValues = allValues.concat(field.values.toArray());
         }
       }
     }
+
+    allValues = allValues.filter((v) => v != null);
 
     allValues.sort((a, b) => a - b);
 
@@ -204,6 +204,9 @@ export function buildHistogram(frames: DataFrame[], options?: HistogramTransform
 
   const getBucket = (v: number) => incrRoundDn(v - bucketOffset, bucketSize!) + bucketOffset;
 
+  // guess number of decimals
+  let bucketDecimals = (('' + bucketSize).match(/\.\d+$/) ?? ['.'])[0].length - 1;
+
   let histograms: AlignedData[] = [];
   let counts: Field[] = [];
   let config: FieldConfig | undefined = undefined;
@@ -220,7 +223,7 @@ export function buildHistogram(frames: DataFrame[], options?: HistogramTransform
             unit: undefined,
           },
         });
-        if (!config && Object.keys(field.config).length) {
+        if (!config && field.config.unit) {
           config = field.config;
         }
       }
@@ -251,7 +254,10 @@ export function buildHistogram(frames: DataFrame[], options?: HistogramTransform
     values: new ArrayVector(joinedHists[0]),
     type: FieldType.number,
     state: undefined,
-    config: config ?? {},
+    config: {
+      ...config,
+      decimals: Math.max(config?.decimals ?? 0, bucketDecimals),
+    },
   };
   const bucketMax = {
     ...bucketMin,


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/51612

additionally, this alters the approach introduced in https://github.com/grafana/grafana/pull/47330 to deal with "repeated" x axis ticks by using the number of decimals in the bucket size for x tick formatting rather than reducing the bucket resolution to try to conform to the fieldConfig decimals setting. since we already have dedicated bucket size controls, i think this keeps things more predictable and closer to the original design.

for this set of CSV Metric Values:

`
145.3,145.4,147.7,145.7,145.7,146.4,146.4,146.6,146.1,145.5,146,145.6,146.1,145.2,146.6,146.5,145.3,146.1,145.6,145,147,145.7,146.8,145.3,144.8,146.2,145.4,145.9,147,146.2,146.7,145.6,145.2,146.7,146,145.8,146.5,146.2,146.8,145.8,146.1,145.9,147,145,145.8,145.8,146.2,145.1,146,146.1,146.3,146.1,145.9,145.4,146.5,146.5,145.9,146.1,146.1,146.7,146.3,145.8,146.5,145.6,145.6,146.2,146.7,145.4,145.4,146.7,147.4,145.4,146.8,145.8,145.5,145.3,145.3,146.8,145.8,146.6,146,145.8,144.7,145.4,146.2,146.3,146.4,144.7,146.5,145.1,145.9,145.5,145,146.6,146.8,146,146.1,143.6,146.2,145.5,145.8,147.2,146.7,145.9,145.2,146.5,146.4,145.3,146.1,145.4,146.3,146.2,145.9,146.9,145.4,145,145.9,147.3,146.6,146.9,146.4,145.8,146.6,146,145.7,146.1,144.8,146.5,145.1,146.8,145.7,146.1,146.4,145.6,145.2,146.5,146.7,147.8,145.5,145.9,145.3,145.6,145.1,145.9,,,
`

before (after removing the trailing `null`s to avoid panel error):
![image](https://user-images.githubusercontent.com/43234/177466417-87c4a233-eeea-4c28-b34b-b02c4a60dd50.png)

after (with trailing `null`s):
![image](https://user-images.githubusercontent.com/43234/177466485-b8b6fcf4-e8ca-48ab-9398-a3b784159911.png)
