### PR TITLE
Dashboard: Fixes sub menu alignment issue

### DIFF
--- a/public/app/features/dashboard/components/SubMenu/SubMenu.tsx
+++ b/public/app/features/dashboard/components/SubMenu/SubMenu.tsx
@@ -61,7 +61,6 @@ class SubMenuUnConnected extends PureComponent<Props> {
         />
         <div className="gf-form gf-form--grow" />
         {dashboard && <DashboardLinks dashboard={dashboard} links={links} />}
-        <div className="clearfix" />
       </div>
     );
   }


### PR DESCRIPTION
Noticied dashboard links had a strange space on the right side, came from this old div left over from pre flex days 