### PR TITLE
Loki: Fix error when changing operations with different parameters

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationHeader.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationHeader.tsx
@@ -83,7 +83,9 @@ export const OperationHeader = React.memo<Props>(
                   // copy default params, and override with all current params
                   const newParams = [...newDef.defaultParams];
                   for (let i = 0; i < Math.min(operation.params.length, newParams.length); i++) {
-                    newParams[i] = operation.params[i];
+                    if (newDef.params[i].type === def.params[i].type && newDef.params[i].name === def.params[i].name) {
+                      newParams[i] = operation.params[i];
+                    }
                   }
 
                   const changedOp = { ...operation, params: newParams, id: value.value.id };

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationHeader.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationHeader.tsx
@@ -83,7 +83,7 @@ export const OperationHeader = React.memo<Props>(
                   // copy default params, and override with all current params
                   const newParams = [...newDef.defaultParams];
                   for (let i = 0; i < Math.min(operation.params.length, newParams.length); i++) {
-                    if (newDef.params[i].type === def.params[i].type && newDef.params[i].name === def.params[i].name) {
+                    if (newDef.params[i].type === def.params[i].type) {
                       newParams[i] = operation.params[i];
                     }
                   }

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationHeader.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationHeader.tsx
@@ -79,7 +79,14 @@ export const OperationHeader = React.memo<Props>(
                 if (value.value) {
                   // Operation should exist if it is selectable
                   const newDef = queryModeller.getOperationDef(value.value.id)!;
-                  let changedOp = { ...operation, id: value.value.id };
+
+                  // copy default params, and override with all current params
+                  const newParams = [...newDef.defaultParams];
+                  for (let i = 0; i < Math.min(operation.params.length, newParams.length); i++) {
+                    newParams[i] = operation.params[i];
+                  }
+
+                  const changedOp = { ...operation, params: newParams, id: value.value.id };
                   onChange(index, def.changeTypeHandler ? def.changeTypeHandler(changedOp, newDef) : changedOp);
                 }
               }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the Loki/Prometheus Query Builder crashes when changing from an operation with a parameter to an operation without parameters. The change in this PR copies the operation's `defaultParams` and overwrites any set parameters.

**Which issue(s) this PR fixes**:

Fixes #51657

**Special notes for your reviewer**:

https://user-images.githubusercontent.com/8092184/177498492-78f910a4-f191-479f-83c9-68629e0185a3.mov


