### PR TITLE
devenv: influxdb: pin version number

### DIFF
--- a/devenv/docker/blocks/influxdb/config.yaml
+++ b/devenv/docker/blocks/influxdb/config.yaml
@@ -1,1 +1,0 @@
-http-bind-address: :8086

--- a/devenv/docker/blocks/influxdb/docker-compose.yaml
+++ b/devenv/docker/blocks/influxdb/docker-compose.yaml
@@ -5,6 +5,7 @@
       - '8086:8086'
     environment:
       INFLUXD_REPORTING_DISABLED: 'true'
+      INFLUXD_HTTP_BIND_ADDRESS: ':8086'
       DOCKER_INFLUXDB_INIT_MODE: 'setup'
       DOCKER_INFLUXDB_INIT_USERNAME: 'grafana'
       DOCKER_INFLUXDB_INIT_PASSWORD: 'grafana12345'
@@ -12,7 +13,6 @@
       DOCKER_INFLUXDB_INIT_BUCKET: 'mybucket'
       DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: 'mytoken'
     volumes:
-      - ./docker/blocks/influxdb/config.yaml:/etc/influxdb2/config.yaml
       - ./docker/blocks/influxdb/setup_influxql.sh:/docker-entrypoint-initdb.d/setup_influxql.sh
 
   telegraf:


### PR DESCRIPTION
[EDIT] 
the port-number is now specified using an env-variable. using the config-file did not work in newer versions of influxdb, and this was the simplest fix.


[OLD VERSION]
the way we configure the influxdb database in this devenv config does not work past `influxdb:2.0.x`. ideally we should fix the configure-script-part, but as a hotfix we can pin the influxdb version number to the last working version.