### PR TITLE
URL: Encode certain special characters

### DIFF
--- a/packages/grafana-data/src/utils/url.test.ts
+++ b/packages/grafana-data/src/utils/url.test.ts
@@ -13,9 +13,6 @@ describe('toUrlParams', () => {
     });
     expect(url).toBe('server=backend-01&hasSpace=has%20space&many=1&many=2&many=3&true&number=20&isNull=&isUndefined=');
   });
-});
-
-describe('toUrlParams', () => {
   it('should encode the same way as angularjs', () => {
     const url = urlUtil.toUrlParams({
       server: ':@',
@@ -29,6 +26,12 @@ describe('toUrlParams', () => {
       bool2: false,
     });
     expect(url).toBe('bool1&bool2=false');
+  });
+  it("should encode the following special characters [!'()*]", () => {
+    const url = urlUtil.toUrlParams({
+      datasource: "testDs[!'()*]",
+    });
+    expect(url).toBe('datasource=testDs%5B%21%27%28%29%2A%5D');
   });
 });
 

--- a/packages/grafana-data/src/utils/url.ts
+++ b/packages/grafana-data/src/utils/url.ts
@@ -32,7 +32,10 @@ function encodeURIComponentAsAngularJS(val: string, pctEncodeSpaces?: boolean) {
     .replace(/%24/g, '$')
     .replace(/%2C/gi, ',')
     .replace(/%3B/gi, ';')
-    .replace(/%20/g, pctEncodeSpaces ? '%20' : '+');
+    .replace(/%20/g, pctEncodeSpaces ? '%20' : '+')
+    .replace(/[!'()*]/g, function (c) {
+      return '%' + c.charCodeAt(0).toString(16).toUpperCase();
+    });
 }
 
 function toUrlParams(a: any) {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/43190

Certain special characters (e.g. (, ), etc.) need to be encoded as escape sequences in order to prevent issues with URLs from stateless Grafana deployments.
Encoding is done according to [mdn web docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#description):

![image](https://user-images.githubusercontent.com/48948963/177548149-aa05584b-5e05-446f-9a9c-5a1f6e9b7f17.png)