### PR TITLE
Fix broken links for template functions docs

### DIFF
--- a/docs/sources/alerting/fundamentals/annotation-label/example-template-functions.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/example-template-functions.md
@@ -1,7 +1,7 @@
 ---
 aliases:
+  - /docs/grafana/latest/alerting/contact-points/message-templating/example-template-functions/
   - /docs/grafana/latest/alerting/fundamentals/annotation-label/example-template-functions/
-  - /docs/grafana/latest/alerting/unified-alerting/fundamentals/annotation-label/template-functions/
 keywords:
   - grafana
   - alerting

--- a/docs/sources/alerting/fundamentals/annotation-label/template-functions.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/template-functions.md
@@ -1,5 +1,8 @@
 ---
 aliases:
+  - /docs/grafana/latest/alerting/contact-points/message-templating/template-functions/
+  - /docs/grafana/latest/alerting/message-templating/template-functions/
+  - /docs/grafana/latest/alerting/unified-alerting/message-templating/template-functions/
   - /docs/grafana/latest/alerting/fundamentals/annotation-label/template-functions/
   - /docs/grafana/latest/alerting/unified-alerting/fundamentals/annotation-label/template-functions/
 keywords:


### PR DESCRIPTION
**What this PR does / why we need it**:

The docs for template functions and template function examples were misplaced. After that was fixed, some links from Google searches resulted in `404`s. This was caused by aliases being deleted.

![Screen Shot 2022-07-06 at 11 21 48](https://user-images.githubusercontent.com/41638679/177579271-395b7aae-994b-4027-8031-a6a4ba3a4271.png)

![Screen Shot 2022-07-06 at 11 21 55](https://user-images.githubusercontent.com/41638679/177579284-9f04f11f-0386-4263-aebb-3a6608ff3d41.png)

This PR brings back the old aliases and de-duplicates them (if needed).

**Which issue(s) this PR fixes**:

No related issue.
