### PR TITLE
Alerting: Add config disabled_labels to disable reserved labels

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -576,7 +576,7 @@ tls_client_cert =
 tls_client_key =
 tls_client_ca =
 use_pkce = false
-auth_style = 
+auth_style =
 
 #################################### Basic Auth ##########################
 [auth.basic]
@@ -762,7 +762,7 @@ instrumentations_console_enabled = false
 instrumentations_webvitals_enabled = false
 
 # Api Key, only applies to Grafana Javascript Agent provider
-api_key = 
+api_key =
 
 #################################### Usage Quotas ########################
 [quota]
@@ -875,6 +875,11 @@ max_concurrent_screenshots = 5
 # see [external_image_storage] for further configuration options. If this option is false then
 # screenshots will be persisted to disk for up to temp_data_lifetime.
 upload_external_image_storage = false
+
+[unified_alerting.reserved_labels]
+# Comma-separated list of reserved labels added by the Grafana Alerting engine that should be disabled.
+# For example: `disabled_labels=grafana_folder`
+disabled_labels =
 
 #################################### Alerting ############################
 [alerting]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -847,6 +847,11 @@
 # The interval string is a possibly signed sequence of decimal numbers, followed by a unit suffix (ms, s, m, h, d), e.g. 30s or 1m.
 ;min_interval = 10s
 
+[unified_alerting.reserved_labels]
+# Comma-separated list of reserved labels added by the Grafana Alerting engine that should be disabled.
+# For example: `disabled_labels=grafana_folder`
+;disabled_labels =
+
 #################################### Alerting ############################
 [alerting]
 # Disable legacy alerting engine & UI features

--- a/docs/sources/alerting/fundamentals/annotation-label/how-to-use-labels.md
+++ b/docs/sources/alerting/fundamentals/annotation-label/how-to-use-labels.md
@@ -26,6 +26,7 @@ This topic explains why labels are a fundamental component of alerting.
 # Grafana reserved labels
 
 > **Note:** Labels prefixed with `grafana_` are reserved by Grafana for special use. If a manually configured label is added beginning with `grafana_` it may be overwritten in case of collision.
+> To stop the Grafana Alerting engine from adding a reserved label, you can disable it via the `disabled_labels` option in [unified_alerting.reserved_labels]({{< relref "../../../setup-grafana/configure-grafana/#unified_alertingreserved_labels" >}}) configuration.
 
 Grafana reserved labels can be used in the same way as manually configured labels. The current list of available reserved labels are:
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1305,6 +1305,18 @@ Uploads screenshots to the local Grafana server or remote storage such as Azure,
 
 <hr>
 
+## [unified_alerting.reserved_labels]
+
+For more information about Grafana Reserved Labels, refer to [Labels in Grafana Alerting]({{< relref "../../alerting/fundamentals/annotation-label/how-to-use-labels/#grafana-reserved-labels" >}}).
+
+### disabled_labels
+
+Comma-separated list of reserved labels added by the Grafana Alerting engine that should be disabled.
+
+For example: `disabled_labels=grafana_folder`
+
+<hr>
+
 ## [alerting]
 
 For more information about the legacy dashboard alerting feature in Grafana, refer to [Alerts overview]({{< relref "../../alerting/" >}}).

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -20,7 +20,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/image"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
-	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/schedule"
@@ -130,21 +129,16 @@ func (ng *AlertNG) init() error {
 	}
 
 	schedCfg := schedule.SchedulerCfg{
-		C:                       clock.New(),
-		BaseInterval:            ng.Cfg.UnifiedAlerting.BaseInterval,
-		Logger:                  ng.Log,
-		MaxAttempts:             ng.Cfg.UnifiedAlerting.MaxAttempts,
-		Evaluator:               eval.NewEvaluator(ng.Cfg, ng.Log, ng.DataSourceCache, ng.SecretsService, ng.ExpressionService),
-		InstanceStore:           store,
-		RuleStore:               store,
-		AdminConfigStore:        store,
-		OrgStore:                store,
-		MultiOrgNotifier:        ng.MultiOrgAlertmanager,
-		Metrics:                 ng.Metrics.GetSchedulerMetrics(),
-		AdminConfigPollInterval: ng.Cfg.UnifiedAlerting.AdminConfigPollInterval,
-		DisabledOrgs:            ng.Cfg.UnifiedAlerting.DisabledOrgs,
-		MinRuleInterval:         ng.Cfg.UnifiedAlerting.MinInterval,
-		DisableGrafanaFolder:    ng.Cfg.UnifiedAlerting.ReservedLabels.IsReservedLabelDisabled(models.FolderTitleLabel),
+		Cfg:              ng.Cfg.UnifiedAlerting,
+		C:                clock.New(),
+		Logger:           ng.Log,
+		Evaluator:        eval.NewEvaluator(ng.Cfg, ng.Log, ng.DataSourceCache, ng.SecretsService, ng.ExpressionService),
+		InstanceStore:    store,
+		RuleStore:        store,
+		AdminConfigStore: store,
+		OrgStore:         store,
+		MultiOrgNotifier: ng.MultiOrgAlertmanager,
+		Metrics:          ng.Metrics.GetSchedulerMetrics(),
 	}
 
 	appUrl, err := url.Parse(ng.Cfg.AppURL)

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/image"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/schedule"
@@ -143,7 +144,7 @@ func (ng *AlertNG) init() error {
 		AdminConfigPollInterval: ng.Cfg.UnifiedAlerting.AdminConfigPollInterval,
 		DisabledOrgs:            ng.Cfg.UnifiedAlerting.DisabledOrgs,
 		MinRuleInterval:         ng.Cfg.UnifiedAlerting.MinInterval,
-		DisableGrafanaFolder:    ng.Cfg.UnifiedAlerting.ReservedLabels.IsGrafanaFolderDisabled(),
+		DisableGrafanaFolder:    ng.Cfg.UnifiedAlerting.ReservedLabels.IsReservedLabelDisabled(models.FolderTitleLabel),
 	}
 
 	appUrl, err := url.Parse(ng.Cfg.AppURL)

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -143,6 +143,7 @@ func (ng *AlertNG) init() error {
 		AdminConfigPollInterval: ng.Cfg.UnifiedAlerting.AdminConfigPollInterval,
 		DisabledOrgs:            ng.Cfg.UnifiedAlerting.DisabledOrgs,
 		MinRuleInterval:         ng.Cfg.UnifiedAlerting.MinInterval,
+		DisableGrafanaFolder:    ng.Cfg.UnifiedAlerting.ReservedLabels.IsGrafanaFolderDisabled(),
 	}
 
 	appUrl, err := url.Parse(ng.Cfg.AppURL)

--- a/pkg/services/ngalert/schedule/schedule_test.go
+++ b/pkg/services/ngalert/schedule/schedule_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/schedule"
 	"github.com/grafana/grafana/pkg/services/ngalert/state"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 var testMetrics = metrics.NewNGAlert(prometheus.NewPedanticRegistry())
@@ -98,15 +99,18 @@ func TestWarmStateCache(t *testing.T) {
 	}
 	_ = dbstore.SaveAlertInstance(ctx, saveCmd2)
 
-	schedCfg := schedule.SchedulerCfg{
-		C:            clock.NewMock(),
-		BaseInterval: time.Second,
-		Logger:       log.New("ngalert cache warming test"),
-
-		RuleStore:               dbstore,
-		InstanceStore:           dbstore,
-		Metrics:                 testMetrics.GetSchedulerMetrics(),
+	cfg := setting.UnifiedAlertingSettings{
+		BaseInterval:            time.Second,
 		AdminConfigPollInterval: 10 * time.Minute, // do not poll in unit tests.
+	}
+
+	schedCfg := schedule.SchedulerCfg{
+		Cfg:           cfg,
+		C:             clock.NewMock(),
+		Logger:        log.New("ngalert cache warming test"),
+		RuleStore:     dbstore,
+		InstanceStore: dbstore,
+		Metrics:       testMetrics.GetSchedulerMetrics(),
 	}
 	st := state.NewManager(schedCfg.Logger, testMetrics.GetStateMetrics(), nil, dbstore, dbstore, &dashboards.FakeDashboardService{}, &image.NoopImageService{}, clock.NewMock())
 	st.Warm(ctx)
@@ -140,25 +144,28 @@ func TestAlertingTicker(t *testing.T) {
 	stopAppliedCh := make(chan models.AlertRuleKey, len(alerts))
 
 	mockedClock := clock.NewMock()
-	baseInterval := time.Second
+
+	cfg := setting.UnifiedAlertingSettings{
+		BaseInterval:            time.Second,
+		AdminConfigPollInterval: 10 * time.Minute, // do not poll in unit tests.
+		DisabledOrgs: map[int64]struct{}{
+			disabledOrgID: {},
+		},
+	}
 
 	schedCfg := schedule.SchedulerCfg{
-		C:            mockedClock,
-		BaseInterval: baseInterval,
+		Cfg: cfg,
+		C:   mockedClock,
 		EvalAppliedFunc: func(alertDefKey models.AlertRuleKey, now time.Time) {
 			evalAppliedCh <- evalAppliedInfo{alertDefKey: alertDefKey, now: now}
 		},
 		StopAppliedFunc: func(alertDefKey models.AlertRuleKey) {
 			stopAppliedCh <- alertDefKey
 		},
-		RuleStore:               dbstore,
-		InstanceStore:           dbstore,
-		Logger:                  log.New("ngalert schedule test"),
-		Metrics:                 testMetrics.GetSchedulerMetrics(),
-		AdminConfigPollInterval: 10 * time.Minute, // do not poll in unit tests.
-		DisabledOrgs: map[int64]struct{}{
-			disabledOrgID: {},
-		},
+		RuleStore:     dbstore,
+		InstanceStore: dbstore,
+		Logger:        log.New("ngalert schedule test"),
+		Metrics:       testMetrics.GetSchedulerMetrics(),
 	}
 	st := state.NewManager(schedCfg.Logger, testMetrics.GetStateMetrics(), nil, dbstore, dbstore, &dashboards.FakeDashboardService{}, &image.NoopImageService{}, clock.NewMock())
 	appUrl := &url.URL{

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -945,18 +945,22 @@ func setupScheduler(t *testing.T, rs store.RuleStore, is store.InstanceStore, ac
 	moa, err := notifier.NewMultiOrgAlertmanager(&setting.Cfg{}, &notifier.FakeConfigStore{}, &notifier.FakeOrgStore{}, &notifier.FakeKVStore{}, provisioning.NewFakeProvisioningStore(), decryptFn, m.GetMultiOrgAlertmanagerMetrics(), nil, log.New("testlogger"), secretsService)
 	require.NoError(t, err)
 
-	schedCfg := SchedulerCfg{
-		C:                       mockedClock,
+	cfg := setting.UnifiedAlertingSettings{
 		BaseInterval:            time.Second,
 		MaxAttempts:             1,
-		Evaluator:               eval.NewEvaluator(&setting.Cfg{ExpressionsEnabled: true}, logger, nil, secretsService, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil)),
-		RuleStore:               rs,
-		InstanceStore:           is,
-		AdminConfigStore:        acs,
-		MultiOrgNotifier:        moa,
-		Logger:                  logger,
-		Metrics:                 m.GetSchedulerMetrics(),
 		AdminConfigPollInterval: 10 * time.Minute, // do not poll in unit tests.
+	}
+
+	schedCfg := SchedulerCfg{
+		Cfg:              cfg,
+		C:                mockedClock,
+		Evaluator:        eval.NewEvaluator(&setting.Cfg{ExpressionsEnabled: true}, logger, nil, secretsService, expr.ProvideService(&setting.Cfg{ExpressionsEnabled: true}, nil, nil)),
+		RuleStore:        rs,
+		InstanceStore:    is,
+		AdminConfigStore: acs,
+		MultiOrgNotifier: moa,
+		Logger:           logger,
+		Metrics:          m.GetSchedulerMetrics(),
 	}
 	st := state.NewManager(schedCfg.Logger, m.GetStateMetrics(), nil, rs, is, &dashboards.FakeDashboardService{}, &image.NoopImageService{}, clock.NewMock())
 	appUrl := &url.URL{

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 
-	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/util"
 
 	"github.com/prometheus/alertmanager/cluster"
@@ -101,9 +100,9 @@ func (u *UnifiedAlertingSettings) IsEnabled() bool {
 	return u.Enabled == nil || *u.Enabled
 }
 
-// IsGrafanaFolderDisabled returns true if UnifiedAlertingReservedLabelSettings.DisabledLabels contains the grafana_folder reserved label.
-func (u *UnifiedAlertingReservedLabelSettings) IsGrafanaFolderDisabled() bool {
-	_, ok := u.DisabledLabels[models.FolderTitleLabel]
+// IsReservedLabelDisabled returns true if UnifiedAlertingReservedLabelSettings.DisabledLabels contains the given reserved label.
+func (u *UnifiedAlertingReservedLabelSettings) IsReservedLabelDisabled(label string) bool {
+	_, ok := u.DisabledLabels[label]
 	return ok
 }
 


### PR DESCRIPTION


**What this PR does / why we need it**:
Adds config toggle for Grafana Reserved Labels (https://github.com/grafana/grafana/pull/50262)

```
[unified_alerting.reserved_labels]
# Comma-separated list of reserved labels added by the Grafana Alerting engine that should be disabled.
# For example: `disabled_labels=grafana_folder`
disabled_labels =

```

This gives users recourse in case new Grafana reserved labels conflict with their existing labels.

Partial #48781

**Special notes for your reviewer**:

![Screenshot from 2022-07-01 01-09-25](https://user-images.githubusercontent.com/8484471/177599671-f744f899-272b-4605-8db3-9489d25e56b9.png)

![Screenshot from 2022-07-01 01-09-34](https://user-images.githubusercontent.com/8484471/177599686-939a1867-05a4-4603-b64d-295db91954e4.png)
