### PR TITLE
Dashboard: Fixes tooltip issue with TimePicker and Setting buttons

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -118,7 +118,7 @@ export function UnthemedTimeRangePicker(props: TimeRangePickerProps): ReactEleme
         </ToolbarButton>
       </Tooltip>
       {isOpen && (
-        <FocusScope contain autoFocus restoreFocus>
+        <FocusScope contain autoFocus>
           <section ref={ref} {...overlayProps} {...dialogProps}>
             <TimePickerContent
               timeZone={timeZone}

--- a/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/DashboardSettings.tsx
@@ -161,7 +161,7 @@ export function DashboardSettings({ dashboard, editview }: Props) {
   const styles = getStyles(config.theme2);
 
   return (
-    <FocusScope contain autoFocus restoreFocus>
+    <FocusScope contain autoFocus>
       <div className="dashboard-settings" ref={ref} {...overlayProps} {...dialogProps}>
         <PageToolbar title={`${dashboard.title} / Settings`} parent={folderTitle} onGoBack={onClose} />
         <CustomScrollbar>


### PR DESCRIPTION
Fixes #51692

The time picker dropdown button opens the time picker popover but after clicking it away (or selecting different time range) the
time range picker tooltip would show.

This was caused by restoreFocus giving the TimePicker button focus which trigger the tooltip. Same issue is there for Dashboard settings,
that tooltip also shows after exiting dashboard settings.

This PR removes the restoreFocus option as it not really needed here anyway.
