### PR TITLE
CloudMonitoring: Update Service to use experimental UI components

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/Experimental/Service.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Experimental/Service.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
+import { EditorField, EditorRow } from '@grafana/experimental';
 import { Select } from '@grafana/ui';
 
-import { QueryEditorRow } from '..';
-import { SELECT_WIDTH } from '../../constants';
 import CloudMonitoringDatasource from '../../datasource';
 import { SLOQuery } from '../../types';
 
@@ -37,18 +36,20 @@ export const Service: React.FC<Props> = ({ refId, query, templateVariableOptions
   }, [datasource, projectName, templateVariableOptions]);
 
   return (
-    <QueryEditorRow label="Service" htmlFor={`${refId}-slo-service`}>
-      <Select
-        inputId={`${refId}-slo-service`}
-        width={SELECT_WIDTH}
-        allowCustomValue
-        value={query?.serviceId && { value: query?.serviceId, label: query?.serviceName || query?.serviceId }}
-        placeholder="Select service"
-        options={services}
-        onChange={({ value: serviceId = '', label: serviceName = '' }) =>
-          onChange({ ...query, serviceId, serviceName, sloId: '' })
-        }
-      />
-    </QueryEditorRow>
+    <EditorRow>
+      <EditorField label="Service">
+        <Select
+          inputId={`${refId}-slo-service`}
+          width="auto"
+          allowCustomValue
+          value={query?.serviceId && { value: query?.serviceId, label: query?.serviceName || query?.serviceId }}
+          placeholder="Select service"
+          options={services}
+          onChange={({ value: serviceId = '', label: serviceName = '' }) =>
+            onChange({ ...query, serviceId, serviceName, sloId: '' })
+          }
+        />
+      </EditorField>
+    </EditorRow>
   );
 };


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Relates to #44431

**Special notes for your reviewer**:
Current `Service` Component
<img width="402" alt="service-current" src="https://user-images.githubusercontent.com/19530599/177609109-2e298530-6b85-4754-80d7-bd742df6b673.png">

Updated `Service` Component
<img width="402" alt="service-updated" src="https://user-images.githubusercontent.com/19530599/177609129-556871b3-afbd-47da-81f2-9d384075b08f.png">