### PR TITLE
CloudMonitoring: Update Selector to use experimental UI components

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/Experimental/Selector.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Experimental/Selector.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import { SelectableValue } from '@grafana/data';
+import { EditorField, EditorRow } from '@grafana/experimental';
 import { Select } from '@grafana/ui';
 
-import { QueryEditorRow } from '..';
-import { SELECT_WIDTH, SELECTORS } from '../../constants';
+import { SELECTORS } from '../../constants';
 import CloudMonitoringDatasource from '../../datasource';
 import { SLOQuery } from '../../types';
 
@@ -18,21 +18,23 @@ export interface Props {
 
 export const Selector: React.FC<Props> = ({ refId, query, templateVariableOptions, onChange, datasource }) => {
   return (
-    <QueryEditorRow label="Selector" htmlFor={`${refId}-slo-selector`}>
-      <Select
-        inputId={`${refId}-slo-selector`}
-        width={SELECT_WIDTH}
-        allowCustomValue
-        value={[...SELECTORS, ...templateVariableOptions].find((s) => s.value === query?.selectorName ?? '')}
-        options={[
-          {
-            label: 'Template Variables',
-            options: templateVariableOptions,
-          },
-          ...SELECTORS,
-        ]}
-        onChange={({ value: selectorName }) => onChange({ ...query, selectorName: selectorName ?? '' })}
-      />
-    </QueryEditorRow>
+    <EditorRow>
+      <EditorField label="Selector" htmlFor={`${refId}-slo-selector`}>
+        <Select
+          inputId={`${refId}-slo-selector`}
+          width="auto"
+          allowCustomValue
+          value={[...SELECTORS, ...templateVariableOptions].find((s) => s.value === query?.selectorName ?? '')}
+          options={[
+            {
+              label: 'Template Variables',
+              options: templateVariableOptions,
+            },
+            ...SELECTORS,
+          ]}
+          onChange={({ value: selectorName }) => onChange({ ...query, selectorName: selectorName ?? '' })}
+        />
+      </EditorField>
+    </EditorRow>
   );
 };


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Relates to #44431

**Special notes for your reviewer**:
Current `Selector` Component
<img width="402" alt="selector-current" src="https://user-images.githubusercontent.com/19530599/177609273-af8f368c-7e7d-4ef3-b3d2-6305e7c36b16.png">

Updated `Selector` Component
<img width="402" alt="selector-updated" src="https://user-images.githubusercontent.com/19530599/177609314-ba632d5a-70db-48e7-a47b-061a6710b0cf.png">