### PR TITLE
CloudMonitoring: Update AnnotationQueryEditor to use experimental UI components

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useDebounce } from 'react-use';
 
 import { QueryEditorProps, toOption } from '@grafana/data';
+import { EditorField, EditorRows, EditorRow } from '@grafana/experimental';
 import { config } from '@grafana/runtime';
 import { Input } from '@grafana/ui';
 
@@ -79,38 +80,52 @@ export const AnnotationQueryEditor = (props: Props) => {
   );
 
   return (
-    <>
+    <EditorRows>
       {config.featureToggles.cloudMonitoringExperimentalUI ? (
-        <ExperimentalMetricQueryEditor
-          refId={query.refId}
-          variableOptionGroup={variableOptionGroup}
-          customMetaData={customMetaData}
-          onChange={handleQueryChange}
-          onRunQuery={onRunQuery}
-          datasource={datasource}
-          query={metricQuery}
-        />
+        <>
+          <ExperimentalMetricQueryEditor
+            refId={query.refId}
+            variableOptionGroup={variableOptionGroup}
+            customMetaData={customMetaData}
+            onChange={handleQueryChange}
+            onRunQuery={onRunQuery}
+            datasource={datasource}
+            query={metricQuery}
+          />
+
+          <EditorRow>
+            <EditorField label="Title" htmlFor="annotation-query-title">
+              <Input id="annotation-query-title" value={title} onChange={handleTitleChange} />
+            </EditorField>
+          </EditorRow>
+
+          <EditorRow>
+            <EditorField label="Text" htmlFor="annotation-query-text">
+              <Input id="annotation-query-text" value={text} onChange={handleTextChange} />
+            </EditorField>
+          </EditorRow>
+        </>
       ) : (
-        <MetricQueryEditor
-          refId={query.refId}
-          variableOptionGroup={variableOptionGroup}
-          customMetaData={customMetaData}
-          onChange={handleQueryChange}
-          onRunQuery={onRunQuery}
-          datasource={datasource}
-          query={metricQuery}
-        />
+        <>
+          <MetricQueryEditor
+            refId={query.refId}
+            variableOptionGroup={variableOptionGroup}
+            customMetaData={customMetaData}
+            onChange={handleQueryChange}
+            onRunQuery={onRunQuery}
+            datasource={datasource}
+            query={metricQuery}
+          />
+          <QueryEditorRow label="Title" htmlFor="annotation-query-title">
+            <Input id="annotation-query-title" value={title} width={INPUT_WIDTH} onChange={handleTitleChange} />
+          </QueryEditorRow>
+
+          <QueryEditorRow label="Text" htmlFor="annotation-query-text">
+            <Input id="annotation-query-text" value={text} width={INPUT_WIDTH} onChange={handleTextChange} />
+          </QueryEditorRow>
+        </>
       )}
-
-      <QueryEditorRow label="Title" htmlFor="annotation-query-title">
-        <Input id="annotation-query-title" value={title} width={INPUT_WIDTH} onChange={handleTitleChange} />
-      </QueryEditorRow>
-
-      <QueryEditorRow label="Text" htmlFor="annotation-query-text">
-        <Input id="annotation-query-text" value={text} width={INPUT_WIDTH} onChange={handleTextChange} />
-      </QueryEditorRow>
-
       <AnnotationsHelp />
-    </>
+    </EditorRows>
   );
 };


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Relates to #44431

**Special notes for your reviewer**:
Current `AnnotationQueryEditor`
<img width="1447" alt="annotation-query-editor-current" src="https://user-images.githubusercontent.com/19530599/177609325-08fb5c2c-e25a-4ec9-9282-968ccfe385aa.png">

Updated `AnnotationQueryEditor`
<img width="1447" alt="annotation-query-editor-updated" src="https://user-images.githubusercontent.com/19530599/177609332-422c3b38-c302-446f-ad9a-2f898f31a34c.png">

Note: the Project component is updated here https://github.com/grafana/grafana/pull/51837