### PR TITLE
FeatureFlags: omit metric when grafana cant run the feature

### DIFF
--- a/pkg/services/featuremgmt/manager.go
+++ b/pkg/services/featuremgmt/manager.go
@@ -73,7 +73,8 @@ func (fm *FeatureManager) registerFlags(flags ...FeatureFlag) {
 	fm.update()
 }
 
-func (fm *FeatureManager) evaluate(ff *FeatureFlag) bool {
+// meetsRequirements checks if grafana is able to run the given feature due to dev mode or licensing requirements
+func (fm *FeatureManager) meetsRequirements(ff *FeatureFlag) bool {
 	if ff.RequiresDevMode && !fm.isDevMod {
 		return false
 	}
@@ -82,19 +83,22 @@ func (fm *FeatureManager) evaluate(ff *FeatureFlag) bool {
 		return false
 	}
 
-	// TODO: CEL - expression
-	return ff.Expression == "true"
+	return true
 }
 
 // Update
 func (fm *FeatureManager) update() {
 	enabled := make(map[string]bool)
 	for _, flag := range fm.flags {
-		val := fm.evaluate(flag)
+		// if grafana cannot run the feature, omit metrics around it
+		if !fm.meetsRequirements(flag) {
+			continue
+		}
 
 		// Update the registry
 		track := 0.0
-		if val {
+		// TODO: CEL - expression
+		if flag.Expression == "true" {
 			track = 1
 			enabled[flag.Name] = true
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, if a feature flag is in dev mode or requires licensing, a metric for that feature flag is still emitted, regardless of if grafana is in dev mode or has the licensing required. This is misleading, because the metric seems to signal that the feature flag is disabled (not unavailable), and can cause confusion when the feature is enabled in the feature toggles config section.

This PR changes the logic to omit the metrics for feature toggles that grafana cannot run, to make it clear that it is unavailable for this grafana instance. This follows the pattern where if a grafana instance is running 8.x with a feature flag from 9.x, the metric is not emitted.

**Which issue(s) this PR fixes**:

Internal - related to Grafana Cloud.

**Special notes for your reviewer**:

