### PR TITLE
Documentation: Show that admin/pause-all-alerts is only for legacy.

### DIFF
--- a/docs/sources/developers/http_api/admin.md
+++ b/docs/sources/developers/http_api/admin.md
@@ -471,6 +471,8 @@ Content-Type: application/json
 
 `POST /api/admin/pause-all-alerts`
 
+> **Note:** This API is relevant for the [legacy dashboard alerts]({{< relref "../../old-alerting/" >}}) only. For default alerting, use [silences]({{< relref "../../alerting/silences/" >}}) to stop alerts from being delivered.
+
 Only works with Basic Authentication (username and password). See [introduction](http://docs.grafana.org/http_api/admin/#admin-api) for an explanation.
 
 **Example Request**:

--- a/docs/sources/developers/http_api/alerting.md
+++ b/docs/sources/developers/http_api/alerting.md
@@ -15,7 +15,7 @@ title: 'Alerting HTTP API '
 
 # Alerting API
 
-> **Note:** This topic is relevant for the [legacy dashboard alerts]({{< ref "/docs/grafana/v8.5/alerting/old-alerting/" >}}) only.
+> **Note:** This topic is relevant for the [legacy dashboard alerts]({{< relref "../../old-alerting/" >}}) only.
 
 You can find Grafana Alerting API specification details [here](https://editor.swagger.io/?url=https://raw.githubusercontent.com/grafana/grafana/main/pkg/services/ngalert/api/tooling/post.json). Also, refer to [Grafana Alerting alerts documentation]({{< relref "../../alerting/" >}}) for details on how to create and manage new alerts.
 


### PR DESCRIPTION
Fixes #51728