### PR TITLE
Scene: Small refactorings and name changes

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5729,11 +5729,9 @@ exports[`better eslint`] = {
     "public/app/features/scenes/components/SceneFlexLayout.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/features/scenes/core/SceneComponentEditWrapper.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+    "public/app/features/scenes/core/SceneComponentWrapper.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/features/scenes/core/SceneObjectBase.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/public/app/features/scenes/components/Scene.tsx
+++ b/public/app/features/scenes/components/Scene.tsx
@@ -17,21 +17,19 @@ export class Scene extends SceneObjectBase<SceneState> {
   static Component = SceneRenderer;
   urlSyncManager?: UrlSyncManager;
 
-  onMount() {
-    super.onMount();
+  activate() {
+    super.activate();
     this.urlSyncManager = new UrlSyncManager(this);
   }
 
-  onUnmount() {
-    super.onUnmount();
+  deactivate() {
+    super.deactivate();
     this.urlSyncManager!.cleanUp();
   }
 }
 
 function SceneRenderer({ model }: SceneComponentProps<Scene>) {
   const { title, layout, actions = [], isEditing, $editor } = model.useState();
-
-  console.log('render scene');
 
   return (
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column', flex: '1 1 0', minHeight: 0 }}>

--- a/public/app/features/scenes/components/ScenePanelRepeater.tsx
+++ b/public/app/features/scenes/components/ScenePanelRepeater.tsx
@@ -11,8 +11,8 @@ interface RepeatOptions extends SceneObjectState {
 }
 
 export class ScenePanelRepeater extends SceneObjectBase<RepeatOptions> {
-  onMount() {
-    super.onMount();
+  activate(): void {
+    super.activate();
 
     this.subs.add(
       this.getData().subscribe({

--- a/public/app/features/scenes/core/SceneComponentWrapper.tsx
+++ b/public/app/features/scenes/core/SceneComponentWrapper.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect } from 'react';
+
+import { SceneComponentEditingWrapper } from '../editor/SceneComponentEditWrapper';
+
+import { SceneObjectBase } from './SceneObjectBase';
+import { SceneComponentProps } from './types';
+
+export function SceneComponentWrapper<T extends SceneObjectBase>({ model, isEditing }: SceneComponentProps<T>) {
+  const Component = (model as any).constructor['Component'] ?? EmptyRenderer;
+  const inner = <Component model={model} isEditing={isEditing} />;
+
+  // Handle component activation state state
+  useEffect(() => {
+    if (!model.isActive) {
+      model.activate();
+    }
+    return () => {
+      if (model.isActive) {
+        model.deactivate();
+      }
+    };
+  }, [model]);
+
+  if (!isEditing) {
+    return inner;
+  }
+
+  return <SceneComponentEditingWrapper model={model}>{inner}</SceneComponentEditingWrapper>;
+}
+
+function EmptyRenderer<T>(_: SceneComponentProps<T>): React.ReactElement | null {
+  return null;
+}

--- a/public/app/features/scenes/core/SceneComponentWrapper.tsx
+++ b/public/app/features/scenes/core/SceneComponentWrapper.tsx
@@ -2,10 +2,9 @@ import React, { useEffect } from 'react';
 
 import { SceneComponentEditingWrapper } from '../editor/SceneComponentEditWrapper';
 
-import { SceneObjectBase } from './SceneObjectBase';
-import { SceneComponentProps } from './types';
+import { SceneComponentProps, SceneObject } from './types';
 
-export function SceneComponentWrapper<T extends SceneObjectBase>({ model, isEditing }: SceneComponentProps<T>) {
+export function SceneComponentWrapper<T extends SceneObject>({ model, isEditing }: SceneComponentProps<T>) {
   const Component = (model as any).constructor['Component'] ?? EmptyRenderer;
   const inner = <Component model={model} isEditing={isEditing} />;
 

--- a/public/app/features/scenes/core/SceneObjectBase.test.ts
+++ b/public/app/features/scenes/core/SceneObjectBase.test.ts
@@ -23,12 +23,12 @@ describe('SceneObject', () => {
       ],
     });
 
-    scene.state.nested?.onMount();
+    scene.state.nested?.activate();
 
     const clone = scene.clone();
     expect(clone).not.toBe(scene);
     expect(clone.state.nested).not.toBe(scene.state.nested);
-    expect(clone.state.nested?.isMounted).toBe(undefined);
+    expect(clone.state.nested?.isActive).toBe(undefined);
     expect(clone.state.children![0]).not.toBe(scene.state.children![0]);
   });
 

--- a/public/app/features/scenes/core/types.ts
+++ b/public/app/features/scenes/core/types.ts
@@ -41,7 +41,7 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   state: TState;
 
   /** True when there is a React component mounted for this Object */
-  isMounted?: boolean;
+  isActive?: boolean;
 
   /** SceneObject parent */
   parent?: SceneObject;
@@ -55,14 +55,11 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   /** How to modify state */
   setState(state: Partial<TState>): void;
 
-  /** Utility hook for main component so that object knows when it's mounted */
-  useMount(): this;
-
-  /** Called when component mounts. A place to register event listeners add subscribe to state changes */
-  onMount(): void;
+  /** Called when the Component is mounted. A place to register event listeners add subscribe to state changes */
+  activate(): void;
 
   /** Called when component unmounts. Unsubscribe to events */
-  onUnmount(): void;
+  deactivate(): void;
 
   /** Get the scene editor */
   getSceneEditor(): SceneEditor;

--- a/public/app/features/scenes/editor/SceneComponentEditWrapper.tsx
+++ b/public/app/features/scenes/editor/SceneComponentEditWrapper.tsx
@@ -4,26 +4,9 @@ import React, { CSSProperties } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
-import { SceneObjectBase } from './SceneObjectBase';
-import { SceneComponentProps } from './types';
+import { SceneObjectBase } from '../core/SceneObjectBase';
 
-export function SceneComponentEditWrapper<T extends SceneObjectBase<any>>({
-  model,
-  isEditing,
-}: SceneComponentProps<T>) {
-  const Component = (model as any).constructor['Component'] ?? EmptyRenderer;
-  const inner = <Component model={model} isEditing={isEditing} />;
-
-  model.useMount();
-
-  if (!isEditing) {
-    return inner;
-  }
-
-  return <SceneComponentEditingWrapper model={model}>{inner}</SceneComponentEditingWrapper>;
-}
-
-export function SceneComponentEditingWrapper<T extends SceneObjectBase<any>>({
+export function SceneComponentEditingWrapper<T extends SceneObjectBase>({
   model,
   children,
 }: {
@@ -76,7 +59,3 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
   };
 };
-
-function EmptyRenderer<T>(_: SceneComponentProps<T>): React.ReactElement | null {
-  return null;
-}

--- a/public/app/features/scenes/editor/SceneComponentEditWrapper.tsx
+++ b/public/app/features/scenes/editor/SceneComponentEditWrapper.tsx
@@ -4,9 +4,9 @@ import React, { CSSProperties } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
-import { SceneObjectBase } from '../core/SceneObjectBase';
+import { SceneObject } from '../core/types';
 
-export function SceneComponentEditingWrapper<T extends SceneObjectBase>({
+export function SceneComponentEditingWrapper<T extends SceneObject>({
   model,
   children,
 }: {

--- a/public/app/features/scenes/querying/SceneQueryRunner.ts
+++ b/public/app/features/scenes/querying/SceneQueryRunner.ts
@@ -31,8 +31,8 @@ export interface DataQueryExtended extends DataQuery {
 export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
   private querySub?: Unsubscribable;
 
-  onMount() {
-    super.onMount();
+  activate() {
+    super.activate();
 
     const timeRange = this.getTimeRange();
 
@@ -49,12 +49,9 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
     }
   }
 
-  onUnmount() {
-    super.onUnmount();
-    this.cleanUp();
-  }
+  deactivate(): void {
+    super.deactivate();
 
-  cleanUp() {
     if (this.querySub) {
       this.querySub.unsubscribe();
       this.querySub = undefined;
@@ -107,8 +104,6 @@ export class SceneQueryRunner extends SceneObjectBase<QueryRunnerState> {
 
       request.interval = norm.interval;
       request.intervalMs = norm.intervalMs;
-
-      console.log('Query runner run');
 
       this.querySub = runRequest(ds, request).subscribe({
         next: (data) => {


### PR DESCRIPTION

* Rename of the onMount and onUnmount functions
* Now that useMount was only called from the component wrapper it is no longer needed as as part of the base class or interface
* Moved the useMount logic tot the component wrapper
* Moved component wrapper to it's own file and the edit wrapper to editor/ComponentEditWrapper
* Removed some console.logs

