### PR TITLE
Loki: Add missing operators in label filter expression

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -284,7 +284,7 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       name: 'Label filter expression',
       params: [
         { name: 'Label', type: 'string' },
-        { name: 'Operator', type: 'string', options: ['=', '!=', '>', '<', '>=', '<='] },
+        { name: 'Operator', type: 'string', options: ['=', '!=', ' =~', '!~', '>', '<', '>=', '<='] },
         { name: 'Value', type: 'string' },
       ],
       defaultParams: ['', '=', ''],


### PR DESCRIPTION
**What this PR does / why we need it**:

Label filter expression was missing ` =~` and `!~` operators in the dropdown. This PR adds them. 

<img width="878" alt="image" src="https://user-images.githubusercontent.com/30407135/177736025-cb141cce-4ed0-4d84-94c0-733c44e56bee.png">

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/51784


