### PR TITLE
CI: Add `gen-version` step for `main-publish` pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1490,6 +1490,12 @@ steps:
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
 - commands:
+  - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
+  depends_on:
+  - grabpl
+  image: grafana/build-container:1.5.7
+  name: gen-version
+- commands:
   - echo $DRONE_RUNNER_NAME
   image: alpine:3.15
   name: identify-runner
@@ -4793,6 +4799,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: ec563f30c3aa398768ee9399bc2f6f50533da9b53c19d1c8b10a96277a42070c
+hmac: b885bb4e5374691a66b4fa8c6f53cdcebeef573895ea629d4e8b0af715573cea
 
 ...

--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -233,7 +233,7 @@ def main_pipelines(edition):
         template=drone_change_template, secret='drone-changes-webhook',
     ), pipeline(
         name='main-publish', edition=edition, trigger=dict(trigger, repo=['grafana/grafana']),
-        steps=[download_grabpl_step(), identify_runner_step(),] + store_steps,
+        steps=[download_grabpl_step(), gen_version_step(ver_mode), identify_runner_step(),] + store_steps,
         depends_on=['main-test-frontend', 'main-test-backend', 'main-build-e2e-publish', 'main-integration-tests', 'main-windows', ],
     ), notify_pipeline(
         name='main-notify', slack_channel='grafana-ci-notifications', trigger=dict(trigger, status=['failure']),


### PR DESCRIPTION
**What this PR does / why we need it**:

`main-publish` pipeline needs the Grafana version available to know where to pull artifacts from.

**Which issue(s) this PR fixes**:

Fixes #47702
