### PR TITLE
Split up issue boards for cloud datasources

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -79,7 +79,7 @@
     "name":"datasource/Azure",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/97"
+      "url":"https://github.com/orgs/grafana/projects/190"
     }
   },
   {
@@ -103,7 +103,7 @@
     "name":"datasource/GoogleCloudMonitoring",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/97"
+      "url":"https://github.com/orgs/grafana/projects/190"
     }
   },
   {


### PR DESCRIPTION
Cloud datasources is splitting into 2 squads with 2 different project boards:
https://github.com/orgs/grafana/projects/97 and https://github.com/orgs/grafana/projects/190

I believe this should update the Azure and Google Cloud Monitoring labels to now attach the issue to the correct project board
