### PR TITLE
Time series panel: Fix an issue with stacks being not complete due to the incorrect data frame length

### DIFF
--- a/public/app/plugins/panel/timeseries/utils.test.ts
+++ b/public/app/plugins/panel/timeseries/utils.test.ts
@@ -100,6 +100,8 @@ describe('prepare timeseries graph', () => {
         3,
       ]
     `);
+
+    expect(frames![0].length).toEqual(6);
   });
 
   it('will insert and convert nulls to a configure "no value" value', () => {
@@ -122,5 +124,6 @@ describe('prepare timeseries graph', () => {
         3,
       ]
     `);
+    expect(frames![0].length).toEqual(6);
   });
 });

--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -104,6 +104,7 @@ export function prepareGraphableFields(
     if (hasTimeField && hasValueField) {
       frames.push({
         ...frame,
+        length: nulledFrame.length,
         fields,
       });
     }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/51893
Fixes https://github.com/grafana/support-escalations/issues/3191

The problem was caused by the fact, that null inserts logic is dependent on the time range and it obviously can change the length of the prepared data frame. Unfortunately, the resulting frame was carrying over the original data frame length - and that length is used to calculate stacks (https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/uPlot/utils.ts#L169). This resulted in the data set being cut.