### PR TITLE
GrafanaUI: Reverts changes in styling to tag component

### DIFF
--- a/packages/grafana-ui/src/components/Tags/Tag.tsx
+++ b/packages/grafana-ui/src/components/Tags/Tag.tsx
@@ -64,15 +64,13 @@ const getTagStyles = (theme: GrafanaTheme, name: string, colorIndex?: number) =>
       font-weight: ${theme.typography.weight.semibold};
       font-size: ${theme.typography.size.sm};
       line-height: ${theme.typography.lineHeight.xs};
+      vertical-align: baseline;
       background-color: ${colors.color};
       color: ${theme.palette.gray98};
       white-space: nowrap;
       text-shadow: none;
       padding: 3px 6px;
       border-radius: ${theme.border.radius.md};
-      display: flex;
-      align-items: center;
-      gap: 3px;
     `,
     hover: css`
       &:hover {


### PR DESCRIPTION
**What this PR does / why we need it**:

A [previous PR](https://github.com/grafana/grafana/pull/51677) changed the styling of the `Tag` component which broke it in some cases, this reverts those changes

**Which issue(s) this PR fixes**:

Fixes #51877

