### PR TITLE
CI: Add `gen-version` step to release pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3324,6 +3324,12 @@ steps:
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
 - commands:
+  - ./bin/grabpl gen-version ${DRONE_TAG}
+  depends_on:
+  - grabpl
+  image: grafana/build-container:1.5.7
+  name: gen-version
+- commands:
   - ./bin/grabpl store-packages --edition oss --packages-bucket grafana-downloads
     --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
   depends_on:
@@ -3371,6 +3377,12 @@ steps:
   - chmod +x bin/grabpl
   image: byrnedo/alpine-curl:0.1.8
   name: grabpl
+- commands:
+  - ./bin/grabpl gen-version ${DRONE_TAG}
+  depends_on:
+  - grabpl
+  image: grafana/build-container:1.5.7
+  name: gen-version
 - commands:
   - ./bin/grabpl store-packages --edition enterprise --packages-bucket grafana-downloads
     --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
@@ -4799,6 +4811,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: b885bb4e5374691a66b4fa8c6f53cdcebeef573895ea629d4e8b0af715573cea
+hmac: 02df03be213abe0242b1c47e0e57cecd1ec3b2572d1f214afb55ef3a94c99750
 
 ...

--- a/scripts/drone/pipelines/release.star
+++ b/scripts/drone/pipelines/release.star
@@ -394,11 +394,13 @@ def publish_packages_pipeline():
     }
     oss_steps = [
         download_grabpl_step(),
+        gen_version_step(ver_mode='release'),
         store_packages_step(edition='oss', ver_mode='release'),
     ]
 
     enterprise_steps = [
         download_grabpl_step(),
+        gen_version_step(ver_mode='release'),
         store_packages_step(edition='enterprise', ver_mode='release'),
     ]
     deps = [


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up to #51890. Adds `gen-version` to release pipelines.

**Which issue(s) this PR fixes**:

Fixes #47702
