### PR TITLE
CI: Make `store-packages` step depend on `gen-version`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1503,7 +1503,7 @@ steps:
   - ./bin/grabpl store-packages --edition oss --gcp-key /tmp/gcpkey.json --build-id
     ${DRONE_BUILD_NUMBER}
   depends_on:
-  - grabpl
+  - gen-version
   environment:
     GCP_KEY:
       from_secret: gcp_key
@@ -3333,7 +3333,7 @@ steps:
   - ./bin/grabpl store-packages --edition oss --packages-bucket grafana-downloads
     --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
   depends_on:
-  - grabpl
+  - gen-version
   environment:
     GCP_KEY:
       from_secret: gcp_key
@@ -3387,7 +3387,7 @@ steps:
   - ./bin/grabpl store-packages --edition enterprise --packages-bucket grafana-downloads
     --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
   depends_on:
-  - grabpl
+  - gen-version
   environment:
     GCP_KEY:
       from_secret: gcp_key
@@ -4843,6 +4843,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 0135b400f98ec7b242dd29aebe848db0055edfe64af2f2dd589d0d8384bb2f17
+hmac: 74b8d8bd1c224fb4b1eb263d989588095bd9001519bebbe9a4fc5a9aa924aa41
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1023,7 +1023,7 @@ def store_packages_step(edition, ver_mode):
         'name': 'store-packages-{}'.format(edition),
         'image': publish_image,
         'depends_on': [
-            'grabpl',
+            'gen-version',
         ],
         'environment': {
             'GRAFANA_COM_API_KEY': from_secret('grafana_api_key'),


### PR DESCRIPTION
**What this PR does / why we need it**:

In case `gen-version` is slow, `version.json` isn't generated so there isn't a version to be picked up from `store-packages`. We change the `store-packages` dependency to be `gen-version` rather than `grabpl`.

**Which issue(s) this PR fixes**:

Fixes #47702

