### PR TITLE
Node Graph: Emphasize hovered or connected nodes

### DIFF
--- a/public/app/plugins/panel/nodeGraph/EdgeArrowMarker.tsx
+++ b/public/app/plugins/panel/nodeGraph/EdgeArrowMarker.tsx
@@ -12,7 +12,7 @@ export function EdgeArrowMarker() {
         viewBox="0 0 10 10"
         refX="8"
         refY="5"
-        markerUnits="strokeWidth"
+        markerUnits="userSpaceOnUse"
         markerWidth="10"
         markerHeight="10"
         orient="auto"

--- a/public/app/plugins/panel/nodeGraph/Node.tsx
+++ b/public/app/plugins/panel/nodeGraph/Node.tsx
@@ -17,7 +17,7 @@ const getStyles = (theme: GrafanaTheme2, hovering: HoverState) => ({
     cursor: pointer;
     font-size: 10px;
     transition: opacity 300ms;
-    opacity: ${hovering === 'inactive' ? 0.6 : 1};
+    opacity: ${hovering === 'inactive' ? 0.5 : 1};
   `,
 
   mainCircle: css`
@@ -69,6 +69,7 @@ export const Node = memo(function Node(props: {
   const { node, onMouseEnter, onMouseLeave, onClick, hovering } = props;
   const theme = useTheme2();
   const styles = getStyles(theme, hovering);
+  const isHovered = hovering === 'active';
 
   if (!(node.x !== undefined && node.y !== undefined)) {
     return null;
@@ -90,30 +91,23 @@ export const Node = memo(function Node(props: {
       aria-label={`Node: ${node.title}`}
     >
       <circle className={styles.mainCircle} r={nodeR} cx={node.x} cy={node.y} />
-      {hovering === 'active' && (
-        <circle className={styles.hoverCircle} r={nodeR - 3} cx={node.x} cy={node.y} strokeWidth={2} />
-      )}
+      {isHovered && <circle className={styles.hoverCircle} r={nodeR - 3} cx={node.x} cy={node.y} strokeWidth={2} />}
       <ColorCircle node={node} />
       <g className={styles.text}>
-        <foreignObject
-          x={node.x - (hovering === 'active' ? 100 : 35)}
-          y={node.y - 15}
-          width={hovering === 'active' ? '200' : '70'}
-          height="40"
-        >
-          <div className={cx(styles.statsText, hovering === 'active' && styles.textHovering)}>
+        <foreignObject x={node.x - (isHovered ? 100 : 35)} y={node.y - 15} width={isHovered ? '200' : '70'} height="40">
+          <div className={cx(styles.statsText, isHovered && styles.textHovering)}>
             <span>{node.mainStat && statToString(node.mainStat, node.dataFrameRowIndex)}</span>
             <br />
             <span>{node.secondaryStat && statToString(node.secondaryStat, node.dataFrameRowIndex)}</span>
           </div>
         </foreignObject>
         <foreignObject
-          x={node.x - (hovering === 'active' ? 100 : 50)}
+          x={node.x - (isHovered ? 100 : 50)}
           y={node.y + nodeR + 5}
-          width={hovering === 'active' ? '200' : '100'}
+          width={isHovered ? '200' : '100'}
           height="40"
         >
-          <div className={cx(styles.titleText, hovering === 'active' && styles.textHovering)}>
+          <div className={cx(styles.titleText, isHovered && styles.textHovering)}>
             <span>{node.title}</span>
             <br />
             <span>{node.subTitle}</span>

--- a/public/app/plugins/panel/nodeGraph/Node.tsx
+++ b/public/app/plugins/panel/nodeGraph/Node.tsx
@@ -4,17 +4,20 @@ import React, { MouseEvent, memo } from 'react';
 import tinycolor from 'tinycolor2';
 
 import { Field, getFieldColorModeForField, GrafanaTheme2 } from '@grafana/data';
-import { useStyles2, useTheme2 } from '@grafana/ui';
+import { useTheme2 } from '@grafana/ui';
 
+import { HoverState } from './NodeGraph';
 import { NodeDatum } from './types';
 import { statToString } from './utils';
 
 const nodeR = 40;
 
-const getStyles = (theme: GrafanaTheme2) => ({
+const getStyles = (theme: GrafanaTheme2, hovering: HoverState) => ({
   mainGroup: css`
     cursor: pointer;
     font-size: 10px;
+    transition: opacity 300ms;
+    opacity: ${hovering === 'inactive' ? 0.6 : 1};
   `,
 
   mainCircle: css`
@@ -61,10 +64,11 @@ export const Node = memo(function Node(props: {
   onMouseEnter: (id: string) => void;
   onMouseLeave: (id: string) => void;
   onClick: (event: MouseEvent<SVGElement>, node: NodeDatum) => void;
-  hovering: boolean;
+  hovering: HoverState;
 }) {
   const { node, onMouseEnter, onMouseLeave, onClick, hovering } = props;
-  const styles = useStyles2(getStyles);
+  const theme = useTheme2();
+  const styles = getStyles(theme, hovering);
 
   if (!(node.x !== undefined && node.y !== undefined)) {
     return null;
@@ -86,23 +90,30 @@ export const Node = memo(function Node(props: {
       aria-label={`Node: ${node.title}`}
     >
       <circle className={styles.mainCircle} r={nodeR} cx={node.x} cy={node.y} />
-      {hovering && <circle className={styles.hoverCircle} r={nodeR - 3} cx={node.x} cy={node.y} strokeWidth={2} />}
+      {hovering === 'active' && (
+        <circle className={styles.hoverCircle} r={nodeR - 3} cx={node.x} cy={node.y} strokeWidth={2} />
+      )}
       <ColorCircle node={node} />
       <g className={styles.text}>
-        <foreignObject x={node.x - (hovering ? 100 : 35)} y={node.y - 15} width={hovering ? '200' : '70'} height="40">
-          <div className={cx(styles.statsText, hovering && styles.textHovering)}>
+        <foreignObject
+          x={node.x - (hovering === 'active' ? 100 : 35)}
+          y={node.y - 15}
+          width={hovering === 'active' ? '200' : '70'}
+          height="40"
+        >
+          <div className={cx(styles.statsText, hovering === 'active' && styles.textHovering)}>
             <span>{node.mainStat && statToString(node.mainStat, node.dataFrameRowIndex)}</span>
             <br />
             <span>{node.secondaryStat && statToString(node.secondaryStat, node.dataFrameRowIndex)}</span>
           </div>
         </foreignObject>
         <foreignObject
-          x={node.x - (hovering ? 100 : 50)}
+          x={node.x - (hovering === 'active' ? 100 : 50)}
           y={node.y + nodeR + 5}
-          width={hovering ? '200' : '100'}
+          width={hovering === 'active' ? '200' : '100'}
           height="40"
         >
-          <div className={cx(styles.titleText, hovering && styles.textHovering)}>
+          <div className={cx(styles.titleText, hovering === 'active' && styles.textHovering)}>
             <span>{node.title}</span>
             <br />
             <span>{node.subTitle}</span>

--- a/public/app/plugins/panel/nodeGraph/utils.test.ts
+++ b/public/app/plugins/panel/nodeGraph/utils.test.ts
@@ -2,6 +2,8 @@ import { ArrayVector, createTheme, DataFrame, FieldType, MutableDataFrame } from
 
 import { NodeGraphOptions } from './types';
 import {
+  findConnectedNodesForEdge,
+  findConnectedNodesForNode,
   getEdgeFields,
   getNodeFields,
   getNodeGraphDataFrames,
@@ -357,5 +359,39 @@ describe('processNodes', () => {
     expect(edgesFrame).toBeDefined();
     expect(edgesFrame?.fields.find((f) => f.name === 'mainStat')?.config).toEqual({ unit: 'r/sec' });
     expect(edgesFrame?.fields.find((f) => f.name === 'secondaryStat')?.config).toEqual({ unit: 'ft^2' });
+  });
+});
+
+describe('finds connections', () => {
+  const theme = createTheme();
+
+  it('finds connected nodes given an edge id', () => {
+    const { nodes, edges } = processNodes(
+      makeNodesDataFrame(3),
+      makeEdgesDataFrame([
+        [0, 1],
+        [0, 2],
+        [1, 2],
+      ]),
+      theme
+    );
+
+    const linked = findConnectedNodesForEdge(nodes, edges, edges[0].id);
+    expect(linked).toEqual(['0', '1']);
+  });
+
+  it('finds connected nodes given a node id', () => {
+    const { nodes, edges } = processNodes(
+      makeNodesDataFrame(4),
+      makeEdgesDataFrame([
+        [0, 1],
+        [0, 2],
+        [1, 2],
+      ]),
+      theme
+    );
+
+    const linked = findConnectedNodesForNode(nodes, edges, nodes[0].id);
+    expect(linked).toEqual(['0', '1', '2']);
   });
 });

--- a/public/app/plugins/panel/nodeGraph/utils.ts
+++ b/public/app/plugins/panel/nodeGraph/utils.ts
@@ -404,3 +404,30 @@ export const applyOptionsToFrames = (frames: DataFrame[], options: NodeGraphOpti
     return frame;
   });
 };
+
+// Returns an array of node ids which are connected to a given edge
+export const findConnectedNodesForEdge = (nodes: NodeDatum[], edges: EdgeDatum[], edgeId: string): string[] => {
+  const edge = edges.find((edge) => edge.id === edgeId);
+  if (edge) {
+    return [
+      ...new Set(nodes.filter((node) => edge.source === node.id || edge.target === node.id).map((node) => node.id)),
+    ];
+  }
+  return [];
+};
+
+// Returns an array of node ids which are connected to a given node
+export const findConnectedNodesForNode = (nodes: NodeDatum[], edges: EdgeDatum[], nodeId: string): string[] => {
+  const node = nodes.find((node) => node.id === nodeId);
+  if (node) {
+    const linkedEdges = edges.filter((edge) => edge.source === node.id || edge.target === node.id);
+    return [
+      ...new Set(
+        linkedEdges.flatMap((edge) =>
+          nodes.filter((n) => edge.source === n.id || edge.target === n.id).map((n) => n.id)
+        )
+      ),
+    ];
+  }
+  return [];
+};


### PR DESCRIPTION
**What this PR does / why we need it**:
Emphasizes 1 level of the node graph on hover (the hovered node + connected edges and nodes or the hovered edge + connecting nodes)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates #48351

**Special notes for your reviewer**:
If we like the styles/new behavior, I'll clean this PR up a bit and update tests

https://user-images.githubusercontent.com/12838032/177827699-15666a21-22ff-483b-b4ad-e851f9144d32.mov


