### PR TITLE
Prometheus datasource: query builder freezes when metrics metadata is undefined

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -133,9 +133,7 @@ async function getMetrics(
     await datasource.languageProvider.loadMetricsMetadata();
   }
 
-  // Error handling for https://github.com/grafana/support-escalations/issues/2985
-  // Metrics metadata returns undefined on cloud grafana and breaks
-  // when mapping metrics to metadata
+  // Error handling for when metrics metadata returns as undefined
   if (!datasource.languageProvider.metricsMetadata) {
     datasource.languageProvider.metricsMetadata = {};
   }

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -133,6 +133,13 @@ async function getMetrics(
     await datasource.languageProvider.loadMetricsMetadata();
   }
 
+  // Error handling for https://github.com/grafana/support-escalations/issues/2985
+  // Metrics metadata returns undefined on cloud grafana and breaks
+  // when mapping metrics to metadata
+  if (!datasource.languageProvider.metricsMetadata) {
+    datasource.languageProvider.metricsMetadata = {};
+  }
+
   let metrics;
   if (query.labels.length > 0) {
     const expr = promQueryModeller.renderLabels(query.labels);


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/2985

On cloud grafana, the prometheus query builder returns undefined metrics metadata and breaks the metrics select. This PR adds error handling for this so that the select does not freeze on loading when this occurs.

I am still looking into why this is breaking in cloud grafana. I will update the PR if I come to any conclusions.