### PR TITLE
Alerting: Allow filtering of contact points by name

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -25,7 +25,7 @@ type ProvisioningSrv struct {
 }
 
 type ContactPointService interface {
-	GetContactPoints(ctx context.Context, orgID int64) ([]definitions.EmbeddedContactPoint, error)
+	GetContactPoints(ctx context.Context, q provisioning.ContactPointQuery) ([]definitions.EmbeddedContactPoint, error)
 	CreateContactPoint(ctx context.Context, orgID int64, contactPoint definitions.EmbeddedContactPoint, p alerting_models.Provenance) (definitions.EmbeddedContactPoint, error)
 	UpdateContactPoint(ctx context.Context, orgID int64, contactPoint definitions.EmbeddedContactPoint, p alerting_models.Provenance) error
 	DeleteContactPoint(ctx context.Context, orgID int64, uid string) error
@@ -86,7 +86,11 @@ func (srv *ProvisioningSrv) RoutePutPolicyTree(c *models.ReqContext, tree defini
 }
 
 func (srv *ProvisioningSrv) RouteGetContactPoints(c *models.ReqContext) response.Response {
-	cps, err := srv.contactPointService.GetContactPoints(c.Req.Context(), c.OrgId)
+	q := provisioning.ContactPointQuery{
+		Name:  c.Query("name"),
+		OrgID: c.OrgId,
+	}
+	cps, err := srv.contactPointService.GetContactPoints(c.Req.Context(), q)
 	if err != nil {
 		return ErrResp(http.StatusInternalServerError, err, "")
 	}

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -2795,6 +2795,7 @@
    "type": "object"
   },
   "alertGroup": {
+   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -2818,6 +2819,7 @@
    "type": "object"
   },
   "alertGroups": {
+   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -2925,7 +2927,6 @@
    "$ref": "#/definitions/Duration"
   },
   "gettableAlert": {
-   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -2981,12 +2982,14 @@
    "type": "object"
   },
   "gettableAlerts": {
+   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
    "type": "array"
   },
   "gettableSilence": {
+   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3035,7 +3038,6 @@
    "type": "object"
   },
   "gettableSilences": {
-   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
@@ -3183,7 +3185,6 @@
    "type": "object"
   },
   "receiver": {
-   "description": "Receiver receiver",
    "properties": {
     "name": {
      "description": "name",
@@ -3418,6 +3419,14 @@
   "/api/v1/provisioning/contact-points": {
    "get": {
     "operationId": "RouteGetContactpoints",
+    "parameters": [
+     {
+      "description": "Filter by name",
+      "in": "query",
+      "name": "name",
+      "type": "string"
+     }
+    ],
     "responses": {
      "200": {
       "description": "ContactPoints",

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
@@ -53,6 +53,14 @@ type ContactPointUIDReference struct {
 	UID string
 }
 
+// swagger:parameters RouteGetContactpoints
+type ContactPointParams struct {
+	// Filter by name
+	// in: query
+	// required: false
+	Name string `json:"name"`
+}
+
 // swagger:parameters RoutePostContactpoints RoutePutContactpoint
 type ContactPointPayload struct {
 	// in:body

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -2592,7 +2592,6 @@
    "type": "object"
   },
   "URL": {
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -2625,7 +2624,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object"
   },
   "Userinfo": {
@@ -2795,7 +2794,6 @@
    "type": "object"
   },
   "alertGroup": {
-   "description": "AlertGroup alert group",
    "properties": {
     "alerts": {
      "description": "alerts",
@@ -2990,7 +2988,6 @@
    "type": "array"
   },
   "gettableSilence": {
-   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3039,6 +3036,7 @@
    "type": "object"
   },
   "gettableSilences": {
+   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
@@ -3149,7 +3147,6 @@
    "type": "array"
   },
   "postableSilence": {
-   "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -5047,6 +5044,14 @@
   "/api/v1/provisioning/contact-points": {
    "get": {
     "operationId": "RouteGetContactpoints",
+    "parameters": [
+     {
+      "description": "Filter by name",
+      "in": "query",
+      "name": "name",
+      "type": "string"
+     }
+    ],
     "responses": {
      "200": {
       "description": "ContactPoints",

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1780,6 +1780,14 @@
         ],
         "summary": "Get all the contact points.",
         "operationId": "RouteGetContactpoints",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Filter by name",
+            "name": "name",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "ContactPoints",
@@ -4947,9 +4955,8 @@
       }
     },
     "URL": {
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "title": "URL is a custom URL type that allows validation at configuration load time.",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -5150,7 +5157,6 @@
       }
     },
     "alertGroup": {
-      "description": "AlertGroup alert group",
       "type": "object",
       "required": [
         "alerts",
@@ -5175,6 +5181,7 @@
       "$ref": "#/definitions/alertGroup"
     },
     "alertGroups": {
+      "description": "AlertGroups alert groups",
       "type": "array",
       "items": {
         "$ref": "#/definitions/alertGroup"
@@ -5283,6 +5290,7 @@
       "$ref": "#/definitions/Duration"
     },
     "gettableAlert": {
+      "description": "GettableAlert gettable alert",
       "type": "object",
       "required": [
         "labels",
@@ -5339,6 +5347,7 @@
       "$ref": "#/definitions/gettableAlert"
     },
     "gettableAlerts": {
+      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableAlert"
@@ -5395,6 +5404,7 @@
       "$ref": "#/definitions/gettableSilence"
     },
     "gettableSilences": {
+      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
@@ -5544,7 +5554,6 @@
       "$ref": "#/definitions/postableSilence"
     },
     "receiver": {
-      "description": "Receiver receiver",
       "type": "object",
       "required": [
         "name"

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -34,12 +34,17 @@ func NewContactPointService(store AMConfigStore, encryptionService secrets.Servi
 	}
 }
 
-func (ecp *ContactPointService) GetContactPoints(ctx context.Context, orgID int64) ([]apimodels.EmbeddedContactPoint, error) {
-	revision, err := getLastConfiguration(ctx, orgID, ecp.amStore)
+type ContactPointQuery struct {
+	Name  string
+	OrgID int64
+}
+
+func (ecp *ContactPointService) GetContactPoints(ctx context.Context, q ContactPointQuery) ([]apimodels.EmbeddedContactPoint, error) {
+	revision, err := getLastConfiguration(ctx, q.OrgID, ecp.amStore)
 	if err != nil {
 		return nil, err
 	}
-	provenances, err := ecp.provenanceStore.GetProvenances(ctx, orgID, "contactPoint")
+	provenances, err := ecp.provenanceStore.GetProvenances(ctx, q.OrgID, "contactPoint")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -50,6 +50,10 @@ func (ecp *ContactPointService) GetContactPoints(ctx context.Context, q ContactP
 	}
 	contactPoints := []apimodels.EmbeddedContactPoint{}
 	for _, contactPoint := range revision.cfg.GetGrafanaReceiverMap() {
+		if q.Name != "" && contactPoint.Name != q.Name {
+			continue
+		}
+
 		embeddedContactPoint := apimodels.EmbeddedContactPoint{
 			UID:                   contactPoint.UID,
 			Type:                  contactPoint.Type,
@@ -71,6 +75,7 @@ func (ecp *ContactPointService) GetContactPoints(ctx context.Context, q ContactP
 			}
 			embeddedContactPoint.Settings.Set(k, apimodels.RedactedValue)
 		}
+
 		contactPoints = append(contactPoints, embeddedContactPoint)
 	}
 	sort.SliceStable(contactPoints, func(i, j int) bool {

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -35,6 +35,7 @@ func NewContactPointService(store AMConfigStore, encryptionService secrets.Servi
 }
 
 type ContactPointQuery struct {
+	// Optionally filter by name.
 	Name  string
 	OrgID int64
 }

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -29,6 +29,23 @@ func TestContactPointService(t *testing.T) {
 		require.Equal(t, "email receiver", cps[0].Name)
 	})
 
+	t.Run("service filters contact points by name", func(t *testing.T) {
+		sut := createContactPointServiceSut(secretsService)
+		newCp := createTestContactPoint()
+		_, err := sut.CreateContactPoint(context.Background(), 1, newCp, models.ProvenanceAPI)
+		require.NoError(t, err)
+
+		q := ContactPointQuery{
+			OrgID: 1,
+			Name:  "email receiver",
+		}
+		cps, err := sut.GetContactPoints(context.Background(), q)
+		require.NoError(t, err)
+
+		require.Len(t, cps, 1)
+		require.Equal(t, "email receiver", cps[0].Name)
+	})
+
 	t.Run("service stitches contact point into org's AM config", func(t *testing.T) {
 		sut := createContactPointServiceSut(secretsService)
 		newCp := createTestContactPoint()

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -22,7 +22,7 @@ func TestContactPointService(t *testing.T) {
 	t.Run("service gets contact points from AM config", func(t *testing.T) {
 		sut := createContactPointServiceSut(secretsService)
 
-		cps, err := sut.GetContactPoints(context.Background(), 1)
+		cps, err := sut.GetContactPoints(context.Background(), cpsQuery(1))
 		require.NoError(t, err)
 
 		require.Len(t, cps, 1)
@@ -36,7 +36,7 @@ func TestContactPointService(t *testing.T) {
 		_, err := sut.CreateContactPoint(context.Background(), 1, newCp, models.ProvenanceAPI)
 		require.NoError(t, err)
 
-		cps, err := sut.GetContactPoints(context.Background(), 1)
+		cps, err := sut.GetContactPoints(context.Background(), cpsQuery(1))
 		require.NoError(t, err)
 		require.Len(t, cps, 2)
 		require.Equal(t, "test-contact-point", cps[1].Name)
@@ -52,7 +52,7 @@ func TestContactPointService(t *testing.T) {
 		_, err := sut.CreateContactPoint(context.Background(), 1, newCp, models.ProvenanceAPI)
 		require.NoError(t, err)
 
-		cps, err := sut.GetContactPoints(context.Background(), 1)
+		cps, err := sut.GetContactPoints(context.Background(), cpsQuery(1))
 		require.NoError(t, err)
 		require.Len(t, cps, 2)
 		require.Equal(t, customUID, cps[1].UID)
@@ -120,7 +120,7 @@ func TestContactPointService(t *testing.T) {
 	t.Run("default provenance of contact points is none", func(t *testing.T) {
 		sut := createContactPointServiceSut(secretsService)
 
-		cps, err := sut.GetContactPoints(context.Background(), 1)
+		cps, err := sut.GetContactPoints(context.Background(), cpsQuery(1))
 		require.NoError(t, err)
 
 		require.Equal(t, models.ProvenanceNone, models.Provenance(cps[0].Provenance))
@@ -133,7 +133,7 @@ func TestContactPointService(t *testing.T) {
 		newCp, err := sut.CreateContactPoint(context.Background(), 1, newCp, models.ProvenanceNone)
 		require.NoError(t, err)
 
-		cps, err := sut.GetContactPoints(context.Background(), 1)
+		cps, err := sut.GetContactPoints(context.Background(), cpsQuery(1))
 		require.NoError(t, err)
 		require.Equal(t, newCp.UID, cps[1].UID)
 		require.Equal(t, models.ProvenanceNone, models.Provenance(cps[1].Provenance))
@@ -141,7 +141,7 @@ func TestContactPointService(t *testing.T) {
 		err = sut.UpdateContactPoint(context.Background(), 1, newCp, models.ProvenanceAPI)
 		require.NoError(t, err)
 
-		cps, err = sut.GetContactPoints(context.Background(), 1)
+		cps, err = sut.GetContactPoints(context.Background(), cpsQuery(1))
 		require.NoError(t, err)
 		require.Equal(t, newCp.UID, cps[1].UID)
 		require.Equal(t, models.ProvenanceAPI, models.Provenance(cps[1].Provenance))
@@ -154,7 +154,7 @@ func TestContactPointService(t *testing.T) {
 		newCp, err := sut.CreateContactPoint(context.Background(), 1, newCp, models.ProvenanceNone)
 		require.NoError(t, err)
 
-		cps, err := sut.GetContactPoints(context.Background(), 1)
+		cps, err := sut.GetContactPoints(context.Background(), cpsQuery(1))
 		require.NoError(t, err)
 		require.Equal(t, newCp.UID, cps[1].UID)
 		require.Equal(t, models.ProvenanceNone, models.Provenance(cps[1].Provenance))
@@ -162,7 +162,7 @@ func TestContactPointService(t *testing.T) {
 		err = sut.UpdateContactPoint(context.Background(), 1, newCp, models.ProvenanceFile)
 		require.NoError(t, err)
 
-		cps, err = sut.GetContactPoints(context.Background(), 1)
+		cps, err = sut.GetContactPoints(context.Background(), cpsQuery(1))
 		require.NoError(t, err)
 		require.Equal(t, newCp.UID, cps[1].UID)
 		require.Equal(t, models.ProvenanceFile, models.Provenance(cps[1].Provenance))
@@ -175,7 +175,7 @@ func TestContactPointService(t *testing.T) {
 		newCp, err := sut.CreateContactPoint(context.Background(), 1, newCp, models.ProvenanceFile)
 		require.NoError(t, err)
 
-		cps, err := sut.GetContactPoints(context.Background(), 1)
+		cps, err := sut.GetContactPoints(context.Background(), cpsQuery(1))
 		require.NoError(t, err)
 		require.Equal(t, newCp.UID, cps[1].UID)
 		require.Equal(t, models.ProvenanceFile, models.Provenance(cps[1].Provenance))
@@ -191,7 +191,7 @@ func TestContactPointService(t *testing.T) {
 		newCp, err := sut.CreateContactPoint(context.Background(), 1, newCp, models.ProvenanceAPI)
 		require.NoError(t, err)
 
-		cps, err := sut.GetContactPoints(context.Background(), 1)
+		cps, err := sut.GetContactPoints(context.Background(), cpsQuery(1))
 		require.NoError(t, err)
 		require.Equal(t, newCp.UID, cps[1].UID)
 		require.Equal(t, models.ProvenanceAPI, models.Provenance(cps[1].Provenance))
@@ -266,6 +266,12 @@ func createTestContactPoint() definitions.EmbeddedContactPoint {
 		Name:     "test-contact-point",
 		Type:     "slack",
 		Settings: settings,
+	}
+}
+
+func cpsQuery(orgID int64) ContactPointQuery {
+	return ContactPointQuery{
+		OrgID: orgID,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows filtering of contact points by name through a query parameter, e.g. `GET /api/v1/provisioning/contact-points?name=blah`

**Which issue(s) this PR fixes**:

Supports https://github.com/grafana/grafana/issues/36153

**Special notes for your reviewer**:

