### PR TITLE
Alerting: Add method to reset notification policy tree back to the default

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -85,6 +85,10 @@ func (srv *ProvisioningSrv) RoutePutPolicyTree(c *models.ReqContext, tree defini
 	return response.JSON(http.StatusAccepted, util.DynMap{"message": "policies updated"})
 }
 
+func (srv *ProvisioningSrv) RouteResetPolicyTree(c *models.ReqContext) response.Response {
+	return response.Error(http.StatusInternalServerError, "not implemented", nil)
+}
+
 func (srv *ProvisioningSrv) RouteGetContactPoints(c *models.ReqContext) response.Response {
 	cps, err := srv.contactPointService.GetContactPoints(c.Req.Context(), c.OrgId)
 	if err != nil {

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -40,6 +40,7 @@ type TemplateService interface {
 type NotificationPolicyService interface {
 	GetPolicyTree(ctx context.Context, orgID int64) (definitions.Route, error)
 	UpdatePolicyTree(ctx context.Context, orgID int64, tree definitions.Route, p alerting_models.Provenance) error
+	ResetPolicyTree(ctx context.Context, orgID int64) (definitions.Route, error)
 }
 
 type MuteTimingService interface {
@@ -86,7 +87,11 @@ func (srv *ProvisioningSrv) RoutePutPolicyTree(c *models.ReqContext, tree defini
 }
 
 func (srv *ProvisioningSrv) RouteResetPolicyTree(c *models.ReqContext) response.Response {
-	return response.Error(http.StatusInternalServerError, "not implemented", nil)
+	tree, err := srv.policies.ResetPolicyTree(c.Req.Context(), c.OrgId)
+	if err != nil {
+		return ErrResp(http.StatusInternalServerError, err, "")
+	}
+	return response.JSON(http.StatusAccepted, tree)
 }
 
 func (srv *ProvisioningSrv) RouteGetContactPoints(c *models.ReqContext) response.Response {

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -335,6 +335,11 @@ func (f *fakeNotificationPolicyService) UpdatePolicyTree(ctx context.Context, or
 	return nil
 }
 
+func (f *fakeNotificationPolicyService) ResetPolicyTree(ctx context.Context, orgID int64) (definitions.Route, error) {
+	f.tree = definitions.Route{} // TODO
+	return f.tree, nil
+}
+
 type fakeFailingNotificationPolicyService struct{}
 
 func (f *fakeFailingNotificationPolicyService) GetPolicyTree(ctx context.Context, orgID int64) (definitions.Route, error) {
@@ -345,6 +350,10 @@ func (f *fakeFailingNotificationPolicyService) UpdatePolicyTree(ctx context.Cont
 	return fmt.Errorf("something went wrong")
 }
 
+func (f *fakeFailingNotificationPolicyService) ResetPolicyTree(ctx context.Context, orgID int64) (definitions.Route, error) {
+	return definitions.Route{}, fmt.Errorf("something went wrong")
+}
+
 type fakeRejectingNotificationPolicyService struct{}
 
 func (f *fakeRejectingNotificationPolicyService) GetPolicyTree(ctx context.Context, orgID int64) (definitions.Route, error) {
@@ -353,6 +362,10 @@ func (f *fakeRejectingNotificationPolicyService) GetPolicyTree(ctx context.Conte
 
 func (f *fakeRejectingNotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgID int64, tree definitions.Route, p models.Provenance) error {
 	return fmt.Errorf("%w: invalid policy tree", provisioning.ErrValidation)
+}
+
+func (f *fakeRejectingNotificationPolicyService) ResetPolicyTree(ctx context.Context, orgID int64) (definitions.Route, error) {
+	return definitions.Route{}, nil
 }
 
 func createInvalidContactPoint() definitions.EmbeddedContactPoint {

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -44,6 +44,15 @@ func TestProvisioningApi(t *testing.T) {
 			require.Equal(t, 202, response.Status())
 		})
 
+		t.Run("successful DELETE returns 202", func(t *testing.T) {
+			sut := createProvisioningSrvSut(t)
+			rc := createTestRequestCtx()
+
+			response := sut.RouteResetPolicyTree(&rc)
+
+			require.Equal(t, 202, response.Status())
+		})
+
 		t.Run("when new policy tree is invalid", func(t *testing.T) {
 			t.Run("PUT returns 400", func(t *testing.T) {
 				sut := createProvisioningSrvSut(t)
@@ -101,6 +110,18 @@ func TestProvisioningApi(t *testing.T) {
 				tree := definitions.Route{}
 
 				response := sut.RoutePutPolicyTree(&rc, tree)
+
+				require.Equal(t, 500, response.Status())
+				require.NotEmpty(t, response.Body())
+				require.Contains(t, string(response.Body()), "something went wrong")
+			})
+
+			t.Run("DELETE returns 500", func(t *testing.T) {
+				sut := createProvisioningSrvSut(t)
+				sut.policies = &fakeFailingNotificationPolicyService{}
+				rc := createTestRequestCtx()
+
+				response := sut.RouteResetPolicyTree(&rc)
 
 				require.Equal(t, 500, response.Status())
 				require.NotEmpty(t, response.Body())

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -191,6 +191,7 @@ func (api *API) authorize(method, path string) web.Handler {
 		eval = ac.EvalPermission(ac.ActionAlertingProvisioningRead) // organization scope
 
 	case http.MethodPut + "/api/v1/provisioning/policies",
+		http.MethodDelete + "/api/v1/provisioning/policies",
 		http.MethodPost + "/api/v1/provisioning/contact-points",
 		http.MethodPut + "/api/v1/provisioning/contact-points/{UID}",
 		http.MethodDelete + "/api/v1/provisioning/contact-points/{UID}",

--- a/pkg/services/ngalert/api/forked_provisioning.go
+++ b/pkg/services/ngalert/api/forked_provisioning.go
@@ -27,6 +27,10 @@ func (f *ForkedProvisioningApi) forkRoutePutPolicyTree(ctx *models.ReqContext, r
 	return f.svc.RoutePutPolicyTree(ctx, route)
 }
 
+func (f *ForkedProvisioningApi) forkRouteResetPolicyTree(ctx *models.ReqContext) response.Response {
+	return f.svc.RouteResetPolicyTree(ctx)
+}
+
 func (f *ForkedProvisioningApi) forkRouteGetContactpoints(ctx *models.ReqContext) response.Response {
 	return f.svc.RouteGetContactPoints(ctx)
 }

--- a/pkg/services/ngalert/api/generated_base_api_provisioning.go
+++ b/pkg/services/ngalert/api/generated_base_api_provisioning.go
@@ -40,6 +40,7 @@ type ProvisioningApiForkingService interface {
 	RoutePutMuteTiming(*models.ReqContext) response.Response
 	RoutePutPolicyTree(*models.ReqContext) response.Response
 	RoutePutTemplate(*models.ReqContext) response.Response
+	RouteResetPolicyTree(*models.ReqContext) response.Response
 }
 
 func (f *ForkedProvisioningApi) RouteDeleteAlertRule(ctx *models.ReqContext) response.Response {
@@ -155,6 +156,9 @@ func (f *ForkedProvisioningApi) RoutePutTemplate(ctx *models.ReqContext) respons
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 	return f.forkRoutePutTemplate(ctx, conf, nameParam)
+}
+func (f *ForkedProvisioningApi) RouteResetPolicyTree(ctx *models.ReqContext) response.Response {
+	return f.forkRouteResetPolicyTree(ctx)
 }
 
 func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingService, m *metrics.API) {
@@ -366,6 +370,16 @@ func (api *API) RegisterProvisioningApiEndpoints(srv ProvisioningApiForkingServi
 				http.MethodPut,
 				"/api/v1/provisioning/templates/{name}",
 				srv.RoutePutTemplate,
+				m,
+			),
+		)
+		group.Delete(
+			toMacaronPath("/api/v1/provisioning/policies"),
+			api.authorize(http.MethodDelete, "/api/v1/provisioning/policies"),
+			metrics.Instrument(
+				http.MethodDelete,
+				"/api/v1/provisioning/policies",
+				srv.RouteResetPolicyTree,
 				m,
 			),
 		)

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -2592,7 +2592,6 @@
    "type": "object"
   },
   "URL": {
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -2625,7 +2624,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object"
   },
   "Userinfo": {
@@ -2818,6 +2817,7 @@
    "type": "object"
   },
   "alertGroups": {
+   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -2925,7 +2925,6 @@
    "$ref": "#/definitions/Duration"
   },
   "gettableAlert": {
-   "description": "GettableAlert gettable alert",
    "properties": {
     "annotations": {
      "$ref": "#/definitions/labelSet"
@@ -3035,7 +3034,6 @@
    "type": "object"
   },
   "gettableSilences": {
-   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
@@ -3146,6 +3144,7 @@
    "type": "array"
   },
   "postableSilence": {
+   "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3183,7 +3182,6 @@
    "type": "object"
   },
   "receiver": {
-   "description": "Receiver receiver",
    "properties": {
     "name": {
      "description": "name",
@@ -3748,6 +3746,24 @@
    }
   },
   "/api/v1/provisioning/policies": {
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "operationId": "RouteResetPolicyTree",
+    "responses": {
+     "202": {
+      "description": "Ack",
+      "schema": {
+       "$ref": "#/definitions/Ack"
+      }
+     }
+    },
+    "summary": "Clears the notification policy tree.",
+    "tags": [
+     "provisioning"
+    ]
+   },
    "get": {
     "operationId": "RouteGetPolicyTree",
     "responses": {

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_policies.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_policies.go
@@ -19,6 +19,16 @@ package definitions
 //       202: Ack
 //       400: ValidationError
 
+// swagger:route DELETE /api/v1/provisioning/policies provisioning stable RouteResetPolicyTree
+//
+// Clears the notification policy tree.
+//
+//     Consumes:
+//     - application/json
+//
+//     Responses:
+//       202: Ack
+
 // swagger:parameters RoutePutPolicyTree
 type Policytree struct {
 	// The new notification routing tree to use

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -2592,7 +2592,6 @@
    "type": "object"
   },
   "URL": {
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -2625,7 +2624,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object"
   },
   "Userinfo": {
@@ -2819,7 +2818,6 @@
    "type": "object"
   },
   "alertGroups": {
-   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -2983,7 +2981,6 @@
    "type": "object"
   },
   "gettableAlerts": {
-   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
@@ -3039,6 +3036,7 @@
    "type": "object"
   },
   "gettableSilences": {
+   "description": "GettableSilences gettable silences",
    "items": {
     "$ref": "#/definitions/gettableSilence"
    },
@@ -3187,6 +3185,7 @@
    "type": "object"
   },
   "receiver": {
+   "description": "Receiver receiver",
    "properties": {
     "name": {
      "description": "name",
@@ -5377,6 +5376,24 @@
    }
   },
   "/api/v1/provisioning/policies": {
+   "delete": {
+    "consumes": [
+     "application/json"
+    ],
+    "operationId": "RouteResetPolicyTree",
+    "responses": {
+     "202": {
+      "description": "Ack",
+      "schema": {
+       "$ref": "#/definitions/Ack"
+      }
+     }
+    },
+    "summary": "Clears the notification policy tree.",
+    "tags": [
+     "provisioning"
+    ]
+   },
    "get": {
     "operationId": "RouteGetPolicyTree",
     "responses": {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -2166,6 +2166,25 @@
             }
           }
         }
+      },
+      "delete": {
+        "consumes": [
+          "application/json"
+        ],
+        "tags": [
+          "provisioning",
+          "stable"
+        ],
+        "summary": "Clears the notification policy tree.",
+        "operationId": "RouteResetPolicyTree",
+        "responses": {
+          "202": {
+            "description": "Ack",
+            "schema": {
+              "$ref": "#/definitions/Ack"
+            }
+          }
+        }
       }
     },
     "/api/v1/provisioning/templates": {
@@ -4947,9 +4966,8 @@
       }
     },
     "URL": {
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "title": "URL is a custom URL type that allows validation at configuration load time.",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -5283,6 +5301,7 @@
       "$ref": "#/definitions/Duration"
     },
     "gettableAlert": {
+      "description": "GettableAlert gettable alert",
       "type": "object",
       "required": [
         "labels",
@@ -5346,6 +5365,7 @@
       "$ref": "#/definitions/gettableAlerts"
     },
     "gettableSilence": {
+      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -5395,6 +5415,7 @@
       "$ref": "#/definitions/gettableSilence"
     },
     "gettableSilences": {
+      "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableSilence"
@@ -5506,6 +5527,7 @@
       }
     },
     "postableSilence": {
+      "description": "PostableSilence postable silence",
       "type": "object",
       "required": [
         "comment",

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -158,7 +158,7 @@ func (ng *AlertNG) init() error {
 	ng.schedule = scheduler
 
 	// Provisioning
-	policyService := provisioning.NewNotificationPolicyService(store, store, store, ng.Cfg, ng.Log)
+	policyService := provisioning.NewNotificationPolicyService(store, store, store, ng.Cfg.UnifiedAlerting, ng.Log)
 	contactPointService := provisioning.NewContactPointService(store, ng.SecretsService, store, store, ng.Log)
 	templateService := provisioning.NewTemplateService(store, store, store, ng.Log)
 	muteTimingService := provisioning.NewMuteTimingService(store, store, store, ng.Log)

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -158,7 +158,7 @@ func (ng *AlertNG) init() error {
 	ng.schedule = scheduler
 
 	// Provisioning
-	policyService := provisioning.NewNotificationPolicyService(store, store, store, ng.Log)
+	policyService := provisioning.NewNotificationPolicyService(store, store, store, ng.Cfg, ng.Log)
 	contactPointService := provisioning.NewContactPointService(store, ng.SecretsService, store, store, ng.Log)
 	templateService := provisioning.NewTemplateService(store, store, store, ng.Log)
 	muteTimingService := provisioning.NewMuteTimingService(store, store, store, ng.Log)

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 type NotificationPolicyService struct {
@@ -14,15 +15,17 @@ type NotificationPolicyService struct {
 	provenanceStore ProvisioningStore
 	xact            TransactionManager
 	log             log.Logger
+	settings        *setting.Cfg
 }
 
 func NewNotificationPolicyService(am AMConfigStore, prov ProvisioningStore,
-	xact TransactionManager, log log.Logger) *NotificationPolicyService {
+	xact TransactionManager, settings *setting.Cfg, log log.Logger) *NotificationPolicyService {
 	return &NotificationPolicyService{
 		amStore:         am,
 		provenanceStore: prov,
 		xact:            xact,
 		log:             log,
+		settings:        settings,
 	}
 }
 
@@ -117,7 +120,46 @@ func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgI
 }
 
 func (nps *NotificationPolicyService) ResetPolicyTree(ctx context.Context, orgID int64) (definitions.Route, error) {
-	return definitions.Route{}, nil
+	defaultCfg, err := deserializeAlertmanagerConfig([]byte(nps.settings.UnifiedAlerting.DefaultConfiguration))
+	if err != nil {
+		nps.log.Error("failed to parse default alertmanager config: %w", err)
+		return definitions.Route{}, fmt.Errorf("failed to parse default alertmanager config: %w", err)
+	}
+	route := defaultCfg.AlertmanagerConfig.Route
+
+	revision, err := getLastConfiguration(ctx, orgID, nps.amStore)
+	if err != nil {
+		return definitions.Route{}, err
+	}
+	revision.cfg.AlertmanagerConfig.Config.Route = route
+
+	serialized, err := serializeAlertmanagerConfig(*revision.cfg)
+	if err != nil {
+		return definitions.Route{}, err
+	}
+	cmd := models.SaveAlertmanagerConfigurationCmd{
+		AlertmanagerConfiguration: string(serialized),
+		ConfigurationVersion:      revision.version,
+		FetchedConfigurationHash:  revision.concurrencyToken,
+		Default:                   false,
+		OrgID:                     orgID,
+	}
+	err = nps.xact.InTransaction(ctx, func(ctx context.Context) error {
+		err := nps.amStore.UpdateAlertmanagerConfiguration(ctx, &cmd)
+		if err != nil {
+			return err
+		}
+		err = nps.provenanceStore.DeleteProvenance(ctx, route, orgID)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return definitions.Route{}, nil
+	}
+
+	return *route, nil
 }
 
 func (nps *NotificationPolicyService) receiversToMap(records []*definitions.PostableApiReceiver) (map[string]struct{}, error) {

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -116,6 +116,10 @@ func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgI
 	return nil
 }
 
+func (nps *NotificationPolicyService) ResetPolicyTree(ctx context.Context, orgID int64) (definitions.Route, error) {
+	return definitions.Route{}, nil
+}
+
 func (nps *NotificationPolicyService) receiversToMap(records []*definitions.PostableApiReceiver) (map[string]struct{}, error) {
 	receivers := map[string]struct{}{}
 	for _, receiver := range records {

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -15,11 +15,11 @@ type NotificationPolicyService struct {
 	provenanceStore ProvisioningStore
 	xact            TransactionManager
 	log             log.Logger
-	settings        *setting.Cfg
+	settings        setting.UnifiedAlertingSettings
 }
 
 func NewNotificationPolicyService(am AMConfigStore, prov ProvisioningStore,
-	xact TransactionManager, settings *setting.Cfg, log log.Logger) *NotificationPolicyService {
+	xact TransactionManager, settings setting.UnifiedAlertingSettings, log log.Logger) *NotificationPolicyService {
 	return &NotificationPolicyService{
 		amStore:         am,
 		provenanceStore: prov,
@@ -120,7 +120,7 @@ func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgI
 }
 
 func (nps *NotificationPolicyService) ResetPolicyTree(ctx context.Context, orgID int64) (definitions.Route, error) {
-	defaultCfg, err := deserializeAlertmanagerConfig([]byte(nps.settings.UnifiedAlerting.DefaultConfiguration))
+	defaultCfg, err := deserializeAlertmanagerConfig([]byte(nps.settings.DefaultConfiguration))
 	if err != nil {
 		nps.log.Error("failed to parse default alertmanager config: %w", err)
 		return definitions.Route{}, fmt.Errorf("failed to parse default alertmanager config: %w", err)

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -233,10 +233,8 @@ func createNotificationPolicyServiceSut() *NotificationPolicyService {
 		provenanceStore: NewFakeProvisioningStore(),
 		xact:            newNopTransactionManager(),
 		log:             log.NewNopLogger(),
-		settings: &setting.Cfg{
-			UnifiedAlerting: setting.UnifiedAlertingSettings{
-				DefaultConfiguration: setting.GetAlertmanagerDefaultConfiguration(),
-			},
+		settings: setting.UnifiedAlertingSettings{
+			DefaultConfiguration: setting.GetAlertmanagerDefaultConfiguration(),
 		},
 	}
 }

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/prometheus/common/model"
@@ -213,6 +214,17 @@ func TestNotificationPolicyService(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrValidation)
 	})
+
+	t.Run("deleting route replaces with default", func(t *testing.T) {
+		sut := createNotificationPolicyServiceSut()
+
+		tree, err := sut.ResetPolicyTree(context.Background(), 1)
+
+		require.NoError(t, err)
+		require.Equal(t, "grafana-default-email", tree.Receiver)
+		require.Nil(t, tree.Routes)
+		require.Nil(t, tree.GroupBy)
+	})
 }
 
 func createNotificationPolicyServiceSut() *NotificationPolicyService {
@@ -221,6 +233,11 @@ func createNotificationPolicyServiceSut() *NotificationPolicyService {
 		provenanceStore: NewFakeProvisioningStore(),
 		xact:            newNopTransactionManager(),
 		log:             log.NewNopLogger(),
+		settings: &setting.Cfg{
+			UnifiedAlerting: setting.UnifiedAlertingSettings{
+				DefaultConfiguration: setting.GetAlertmanagerDefaultConfiguration(),
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now, we only allow provisioning the policy tree as a single large unit. So, the only supported operations currently are `GET /policies` and `PUT /policies`.

This led to a problem where the policy tree could never be un-provisioned once it was provisioned. Hitting the PUT route would automatically elevate the resource to API-level provenance with no way to change it back, effectively locking down the resource forever, even if it gets deleted from terraform or the provisioning file.

This PR adds a `DELETE` method to `/policies`. It deletes any modification to the policy tree and returns it back to the default, also lowering its provenance to None. The policy tree will revert to whatever is in the currently configured `DefaultConfiguration`.

**Which issue(s) this PR fixes**:

Supports https://github.com/grafana/grafana/issues/36153

**Special notes for your reviewer**:
n/a