### PR TITLE
CI: Add `pr-verify-drone` pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -160,12 +160,6 @@ steps:
   image: grafana/build-container:1.5.7
   name: wire-install
 - commands:
-  - ./bin/grabpl verify-drone
-  depends_on:
-  - grabpl
-  image: byrnedo/alpine-curl:0.1.8
-  name: lint-drone
-- commands:
   - |-
     echo -e "unknwon
     referer
@@ -4886,6 +4880,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: bcd98434441842d70fb295ce77d4dc0db851c1a9ca3416591bb19c5936128a04
+hmac: 55383abbbc205824d35aa689a0e00f374e74520d77dc387e354b063e4ade0869
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,49 @@
 ---
 depends_on: []
 kind: pipeline
+name: pr-verify-drone
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - echo $DRONE_RUNNER_NAME
+  image: alpine:3.15
+  name: identify-runner
+- commands:
+  - mkdir -p bin
+  - curl -fL -o bin/grabpl https://grafana-downloads.storage.googleapis.com/grafana-build-pipeline/v2.9.52/grabpl
+  - chmod +x bin/grabpl
+  image: byrnedo/alpine-curl:0.1.8
+  name: grabpl
+- commands:
+  - ./bin/grabpl verify-drone
+  depends_on:
+  - grabpl
+  image: byrnedo/alpine-curl:0.1.8
+  name: lint-drone
+trigger:
+  event:
+  - pull_request
+  paths:
+    exclude:
+    - docs/**
+    - '*.md'
+    include:
+    - scripts/drone/**
+    - .drone.yml
+    - .drone.star
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+depends_on: []
+kind: pipeline
 name: pr-test-frontend
 node:
   type: no-parallel
@@ -4843,6 +4886,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 74b8d8bd1c224fb4b1eb263d989588095bd9001519bebbe9a4fc5a9aa924aa41
+hmac: bcd98434441842d70fb295ce77d4dc0db851c1a9ca3416591bb19c5936128a04
 
 ...

--- a/package.json
+++ b/package.json
@@ -72,9 +72,6 @@
     ],
     "*pkg/**/*.go": [
       "gofmt -w -s"
-    ],
-    "*.star": [
-      "make drone"
     ]
   },
   "devDependencies": {

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -107,7 +107,6 @@ def pr_test_backend():
         wire_install_step(),
     ]
     test_steps = [
-        lint_drone_step(),
         codespell_step(),
         shellcheck_step(),
         lint_backend_step(edition="oss"),

--- a/scripts/drone/pipelines/pr.star
+++ b/scripts/drone/pipelines/pr.star
@@ -70,6 +70,16 @@ trigger = {
     },
 }
 
+def pr_verify_drone():
+    steps = [
+        identify_runner_step(),
+        download_grabpl_step(),
+        lint_drone_step(),
+    ]
+    return pipeline(
+        name='pr-verify-drone', edition="oss", trigger=get_pr_trigger(include_paths=['scripts/drone/**', '.drone.yml', '.drone.star']), services=[], steps=steps,
+    )
+
 
 def pr_test_frontend():
     init_steps = [
@@ -149,6 +159,7 @@ def pr_pipelines(edition):
     ])
 
     return [
+        pr_verify_drone(),
         pr_test_frontend(),
         pr_test_backend(),
         pipeline(


### PR DESCRIPTION
**What this PR does / why we need it**:

`make drone` pre-commit hook causes problems, since even if someone doesn't touch the `*.star` (and thus `.drone.yml`) files, they cannot proceed further if they don't commit with `--no-verify` flag, which may cause other formatting problems.

Moving this check to CI (as we already have it) but making it a separate pipeline to run only for CI changes.

