### PR TITLE
Geomap: Fix layer extent

### DIFF
--- a/public/app/plugins/panel/geomap/utils/getLayersExtent.ts
+++ b/public/app/plugins/panel/geomap/utils/getLayersExtent.ts
@@ -12,7 +12,9 @@ export function getLayersExtent(layers: Collection<BaseLayer>): Extent {
       if (l instanceof LayerGroup) {
         return getLayerGroupExtent(l);
       } else if (l instanceof VectorLayer) {
-        return l.getSource().getExtent() ?? [];
+        return [l.getSource().getExtent()] ?? [];
+      } else {
+        return [];
       }
     })
     .reduce(extend, createEmpty());


### PR DESCRIPTION
This PR fixes bug introduced in #51495
`getLayersExtent()` incorrectly handles extent for `VectorLayer` - `flatMap()` flats extent and causes result to be empty extent.
This causes `Fit data layers view` option not working.