### PR TITLE
SQLstore: Fix fetching an inexistent playlist

### DIFF
--- a/pkg/services/sqlstore/playlist.go
+++ b/pkg/services/sqlstore/playlist.go
@@ -103,7 +103,10 @@ func (ss *SQLStore) GetPlaylist(ctx context.Context, query *models.GetPlaylistBy
 
 	return ss.WithDbSession(ctx, func(sess *DBSession) error {
 		playlist := models.Playlist{UID: query.UID, OrgId: query.OrgId}
-		_, err := sess.Get(&playlist)
+		exists, err := sess.Get(&playlist)
+		if !exists {
+			return models.ErrPlaylistNotFound
+		}
 		query.Result = &playlist
 
 		return err
@@ -117,7 +120,10 @@ func (ss *SQLStore) DeletePlaylist(ctx context.Context, cmd *models.DeletePlayli
 
 	return ss.WithTransactionalDbSession(ctx, func(sess *DBSession) error {
 		playlist := models.Playlist{UID: cmd.UID, OrgId: cmd.OrgId}
-		_, err := sess.Get(&playlist)
+		exists, err := sess.Get(&playlist)
+		if !exists {
+			return models.ErrPlaylistNotFound
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/services/sqlstore/playlist.go
+++ b/pkg/services/sqlstore/playlist.go
@@ -54,7 +54,6 @@ func (ss *SQLStore) UpdatePlaylist(ctx context.Context, cmd *models.UpdatePlayli
 
 		existingPlaylist := models.Playlist{UID: cmd.UID, OrgId: cmd.OrgId}
 		_, err := sess.Get(&existingPlaylist)
-
 		if err != nil {
 			return err
 		}

--- a/pkg/services/sqlstore/playlist.go
+++ b/pkg/services/sqlstore/playlist.go
@@ -54,6 +54,7 @@ func (ss *SQLStore) UpdatePlaylist(ctx context.Context, cmd *models.UpdatePlayli
 
 		existingPlaylist := models.Playlist{UID: cmd.UID, OrgId: cmd.OrgId}
 		_, err := sess.Get(&existingPlaylist)
+
 		if err != nil {
 			return err
 		}
@@ -120,10 +121,7 @@ func (ss *SQLStore) DeletePlaylist(ctx context.Context, cmd *models.DeletePlayli
 
 	return ss.WithTransactionalDbSession(ctx, func(sess *DBSession) error {
 		playlist := models.Playlist{UID: cmd.UID, OrgId: cmd.OrgId}
-		exists, err := sess.Get(&playlist)
-		if !exists {
-			return models.ErrPlaylistNotFound
-		}
+		_, err := sess.Get(&playlist)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/sqlstore/playlist_test.go
+++ b/pkg/services/sqlstore/playlist_test.go
@@ -25,6 +25,15 @@ func TestIntegrationPlaylistDataAccess(t *testing.T) {
 		require.NoError(t, err)
 		uid := cmd.Result.UID
 
+		t.Run("Can get playlist", func(t *testing.T) {
+			get := &models.GetPlaylistByUidQuery{UID: uid, OrgId: 1}
+			err = ss.GetPlaylist(context.Background(), get)
+			require.NoError(t, err)
+			require.NotNil(t, get.Result)
+			require.Equal(t, get.Result.Name,  "NYC office")
+			require.Equal(t, get.Result.Interval,  "10m")
+		})
+
 		t.Run("Can get playlist items", func(t *testing.T) {
 			get := &models.GetPlaylistItemsByUidQuery{PlaylistUID: uid, OrgId: 1}
 			err = ss.GetPlaylistItem(context.Background(), get)
@@ -49,15 +58,23 @@ func TestIntegrationPlaylistDataAccess(t *testing.T) {
 
 			getQuery := models.GetPlaylistByUidQuery{UID: uid, OrgId: 1}
 			err = ss.GetPlaylist(context.Background(), &getQuery)
-			require.NoError(t, err)
-			require.Equal(t, uid, getQuery.Result.UID, "playlist should've been removed")
+			require.Error(t, err)
+			require.ErrorIs(t, err, models.ErrPlaylistNotFound)
 		})
+	})
+
+	t.Run("Get playlist that doesn't exist", func(t *testing.T) {
+		get := &models.GetPlaylistByUidQuery{UID: "unknown", OrgId: 1}
+		err := ss.GetPlaylist(context.Background(), get)
+		require.Error(t, err)
+		require.ErrorIs(t, err, models.ErrPlaylistNotFound)
 	})
 
 	t.Run("Delete playlist that doesn't exist", func(t *testing.T) {
 		deleteQuery := models.DeletePlaylistCommand{UID: "654312", OrgId: 1}
 		err := ss.DeletePlaylist(context.Background(), &deleteQuery)
-		require.NoError(t, err)
+		require.Error(t, err)
+		require.ErrorIs(t, err, models.ErrPlaylistNotFound)
 	})
 
 	t.Run("Delete playlist with invalid command yields error", func(t *testing.T) {

--- a/pkg/services/sqlstore/playlist_test.go
+++ b/pkg/services/sqlstore/playlist_test.go
@@ -73,8 +73,7 @@ func TestIntegrationPlaylistDataAccess(t *testing.T) {
 	t.Run("Delete playlist that doesn't exist", func(t *testing.T) {
 		deleteQuery := models.DeletePlaylistCommand{UID: "654312", OrgId: 1}
 		err := ss.DeletePlaylist(context.Background(), &deleteQuery)
-		require.Error(t, err)
-		require.ErrorIs(t, err, models.ErrPlaylistNotFound)
+		require.NoError(t, err)
 	})
 
 	t.Run("Delete playlist with invalid command yields error", func(t *testing.T) {

--- a/pkg/services/sqlstore/playlist_test.go
+++ b/pkg/services/sqlstore/playlist_test.go
@@ -30,8 +30,8 @@ func TestIntegrationPlaylistDataAccess(t *testing.T) {
 			err = ss.GetPlaylist(context.Background(), get)
 			require.NoError(t, err)
 			require.NotNil(t, get.Result)
-			require.Equal(t, get.Result.Name,  "NYC office")
-			require.Equal(t, get.Result.Interval,  "10m")
+			require.Equal(t, get.Result.Name, "NYC office")
+			require.Equal(t, get.Result.Interval, "10m")
 		})
 
 		t.Run("Can get playlist items", func(t *testing.T) {


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
xorm's [session.Get()](https://github.com/go-xorm/xorm/blob/v0.7.9/session_get.go#L19) does not return an error if the raw does not exist. It returns a boolean instead indicating whether the raw was found or not.
The playlist sqlstore.GetPlaylist() function used to check only the error and in case of inexistent UID didn't return an error.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

