### PR TITLE
SSE: Add noData type

### DIFF
--- a/pkg/expr/mathexp/parse/node.go
+++ b/pkg/expr/mathexp/parse/node.go
@@ -401,6 +401,8 @@ const (
 	TypeSeriesSet
 	// TypeVariantSet is a collection of the same type Number, Series, or Scalar.
 	TypeVariantSet
+	// TypeNoData is a no data response without a known data type.
+	TypeNoData
 )
 
 // String returns a string representation of the ReturnType.
@@ -416,6 +418,8 @@ func (f ReturnType) String() string {
 		return "scalar"
 	case TypeVariantSet:
 		return "variant"
+	case TypeNoData:
+		return "noData"
 	default:
 		return "unknown"
 	}

--- a/pkg/expr/mathexp/types.go
+++ b/pkg/expr/mathexp/types.go
@@ -43,7 +43,7 @@ type Value interface {
 type Scalar struct{ Frame *data.Frame }
 
 // Type returns the Value type and allows it to fulfill the Value interface.
-func (s Scalar) Type() parse.ReturnType { return parse.TypeScalar }
+func (s Scalar) Type() parse.ReturnType { return parse.TypeNoData }
 
 // Value returns the actual value allows it to fulfill the Value interface.
 func (s Scalar) Value() interface{} { return s }
@@ -172,4 +172,45 @@ func (ff *Float64Field) GetValue(idx int) *float64 {
 func (ff *Float64Field) Len() int {
 	df := data.Field(*ff)
 	return df.Len()
+}
+
+// NoData is an untyped no data response.
+type NoData struct{ Frame *data.Frame }
+
+// Type returns the Value type and allows it to fulfill the Value interface.
+func (s NoData) Type() parse.ReturnType { return parse.TypeNoData }
+
+// Value returns the actual value allows it to fulfill the Value interface.
+func (s NoData) Value() interface{} { return s }
+
+func (s NoData) GetLabels() data.Labels { return nil }
+
+func (s NoData) SetLabels(ls data.Labels) {}
+
+func (s NoData) GetMeta() interface{} {
+	return s.Frame.Meta.Custom
+}
+
+func (s NoData) SetMeta(v interface{}) {
+	m := s.Frame.Meta
+	if m == nil {
+		m = &data.FrameMeta{}
+		s.Frame.SetMeta(m)
+	}
+	m.Custom = v
+}
+
+func (s NoData) AddNotice(notice data.Notice) {
+	m := s.Frame.Meta
+	if m == nil {
+		m = &data.FrameMeta{}
+		s.Frame.SetMeta(m)
+	}
+	m.Notices = append(m.Notices, notice)
+}
+
+func (s NoData) AsDataFrame() *data.Frame { return s.Frame }
+
+func (s NoData) New() NoData {
+	return NoData{data.NewFrame("no data")}
 }

--- a/pkg/expr/mathexp/types.go
+++ b/pkg/expr/mathexp/types.go
@@ -43,7 +43,7 @@ type Value interface {
 type Scalar struct{ Frame *data.Frame }
 
 // Type returns the Value type and allows it to fulfill the Value interface.
-func (s Scalar) Type() parse.ReturnType { return parse.TypeNoData }
+func (s Scalar) Type() parse.ReturnType { return parse.TypeScalar }
 
 // Value returns the actual value allows it to fulfill the Value interface.
 func (s Scalar) Value() interface{} { return s }

--- a/pkg/expr/mathexp/union_test.go
+++ b/pkg/expr/mathexp/union_test.go
@@ -80,6 +80,32 @@ func Test_union(t *testing.T) {
 			unions:    []*Union{},
 		},
 		{
+			name: "empty result and data result will result in no unions",
+			aResults: Results{
+				Values: Values{
+					makeSeries("a", data.Labels{"id": "1"}),
+				},
+			},
+			bResults:  Results{},
+			unionsAre: assert.EqualValues,
+			unions:    []*Union{},
+		},
+		{
+			name: "no data result and data result will result in no unions",
+			aResults: Results{
+				Values: Values{
+					makeSeries("a", data.Labels{"id": "1"}),
+				},
+			},
+			bResults: Results{
+				Values: Values{
+					NoData{}.New(),
+				},
+			},
+			unionsAre: assert.EqualValues,
+			unions:    []*Union{},
+		},
+		{
 			name: "incompatible tags of different length with will result in no unions when len(A) != 1 && len(B) != 1",
 			aResults: Results{
 				Values: Values{

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -249,7 +249,7 @@ func (dn *DSNode) Execute(ctx context.Context, vars mathexp.Vars, s *Service) (m
 			frame := qr.Frames[0]
 			// Handle Untyped NoData
 			if len(frame.Fields) == 0 {
-				return mathexp.Results{Values: mathexp.Values{mathexp.NoData{frame}}}, nil
+				return mathexp.Results{Values: mathexp.Values{mathexp.NoData{Frame: frame}}}, nil
 			}
 
 			// Handle Numeric Table

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -237,7 +237,7 @@ func (dn *DSNode) Execute(ctx context.Context, vars mathexp.Vars, s *Service) (m
 		}
 
 		dataSource := dn.datasource.Type
-		if isAllFrameVectors(dataSource, qr.Frames) {
+		if isAllFrameVectors(dataSource, qr.Frames) { // Prometheus Specific Handling
 			vals, err = framesToNumbers(qr.Frames)
 			if err != nil {
 				return mathexp.Results{}, fmt.Errorf("failed to read frames as numbers: %w", err)
@@ -247,6 +247,12 @@ func (dn *DSNode) Execute(ctx context.Context, vars mathexp.Vars, s *Service) (m
 
 		if len(qr.Frames) == 1 {
 			frame := qr.Frames[0]
+			// Handle Untyped NoData
+			if len(frame.Fields) == 0 {
+				return mathexp.Results{Values: mathexp.Values{mathexp.NoData{frame}}}, nil
+			}
+
+			// Handle Numeric Table
 			if frame.TimeSeriesSchema().Type == data.TimeSeriesTypeNot && isNumberTable(frame) {
 				logger.Debug("expression datasource query (numberSet)", "query", refID)
 				numberSet, err := extractNumberSet(frame)


### PR DESCRIPTION
**What this PR does / why we need it**:
When there is a single frame with no fields (e.g. splunk datasource) SSE errors when trying to figure out the data type. This frame needs to exist since this is where the executedQueryString metadata exists.

This adds a new return type to SSE to represent no data, so the original frame with its metadata can still be maintained.

A operations within SSE's math operation results in no data if the input is no data. `e.g $A + 1`, if $a is no data, the result of this math expression will also be no data.

All other SSE operations (e.g. Reduce) will error if the input is "No Data". This perhaps should be changed, in particular with Reduce that includes a "Replace With", but would need to get with Alerting to see how this plays out. Right now by returning an error, the behavior should be the same (it least in single frame / no fields) since that would have already returned an error earlier in the execution pipeline before this PR.

This meant for "untyped" nodata. Ideally we get to a point where the metadata assigns a type, and it can be an empty type. Howerver, there are datasources where the type is not known at query time, so this will need to exist anyways.



