### PR TITLE
Table panel: Show ellipsis in Default cell when data link is wider than the column

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinksContextMenu.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinksContextMenu.tsx
@@ -62,7 +62,7 @@ export const DataLinksContextMenu: React.FC<DataLinksContextMenuProps> = ({ chil
         onClick={linkModel.onClick}
         target={linkModel.target}
         title={linkModel.title}
-        style={style}
+        style={{ ...style, overflow: 'hidden' }}
         aria-label={selectors.components.DataLinksContextMenu.singleLink}
       >
         {children({})}


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/51969

Followup to https://github.com/grafana/grafana/pull/51162
