### PR TITLE
Search: fix nil pointer dereference

### DIFF
--- a/pkg/services/searchV2/extract/dashboard.go
+++ b/pkg/services/searchV2/extract/dashboard.go
@@ -35,7 +35,11 @@ func (d *datasourceVariableLookup) getDsRefsByTemplateVariableValue(value string
 			// get the actual default DS
 			candidateDs = d.dsLookup.ByRef(nil)
 		}
-		return []DataSourceRef{*candidateDs}
+
+		if candidateDs != nil {
+			return []DataSourceRef{*candidateDs}
+		}
+		return []DataSourceRef{}
 	case "$__all":
 		// TODO: filter datasources by template variable's regex
 		return d.dsLookup.ByType(datasourceType)


### PR DESCRIPTION
log:

```

2022-07-08 14:30:33 | github.com/grafana/grafana/pkg/services/searchV2/extract.(*datasourceVariableLookup).getDsRefsByTemplateVariableValue(0xc001233480, {0xc0016adc65, 0x7}, {0xc0016adca0, 0x0})
-- | --

```

not yet 100% sure if this is the root cause, but this fix is necessary anyway