### PR TITLE
Versions: list, compare and restore using dashboard UID

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/VersionsSettings.tsx
@@ -83,8 +83,8 @@ export class VersionsSettings extends PureComponent<Props, State> {
       isLoading: true,
     });
 
-    const lhs = await historySrv.getDashboardVersion(this.props.dashboard.id, baseInfo.version);
-    const rhs = await historySrv.getDashboardVersion(this.props.dashboard.id, newInfo.version);
+    const lhs = await historySrv.getDashboardVersion(this.props.dashboard.uid, baseInfo.version);
+    const rhs = await historySrv.getDashboardVersion(this.props.dashboard.uid, newInfo.version);
 
     this.setState({
       baseInfo,

--- a/public/app/features/dashboard/components/DashboardSettings/__mocks__/versions.ts
+++ b/public/app/features/dashboard/components/DashboardSettings/__mocks__/versions.ts
@@ -2,6 +2,7 @@ export const versions = [
   {
     id: 249,
     dashboardId: 74,
+    dashboardUID: '_U4zObQMz',
     parentVersion: 10,
     restoredFrom: 0,
     version: 11,
@@ -12,6 +13,7 @@ export const versions = [
   {
     id: 247,
     dashboardId: 74,
+    dashboardUID: '_U4zObQMz',
     parentVersion: 9,
     restoredFrom: 0,
     version: 10,
@@ -22,6 +24,7 @@ export const versions = [
   {
     id: 246,
     dashboardId: 74,
+    dashboardUID: '_U4zObQMz',
     parentVersion: 8,
     restoredFrom: 0,
     version: 9,
@@ -32,6 +35,7 @@ export const versions = [
   {
     id: 245,
     dashboardId: 74,
+    dashboardUID: '_U4zObQMz',
     parentVersion: 7,
     restoredFrom: 0,
     version: 8,
@@ -42,6 +46,7 @@ export const versions = [
   {
     id: 239,
     dashboardId: 74,
+    dashboardUID: '_U4zObQMz',
     parentVersion: 6,
     restoredFrom: 0,
     version: 7,
@@ -52,6 +57,7 @@ export const versions = [
   {
     id: 237,
     dashboardId: 74,
+    dashboardUID: '_U4zObQMz',
     parentVersion: 5,
     restoredFrom: 0,
     version: 6,
@@ -62,6 +68,7 @@ export const versions = [
   {
     id: 236,
     dashboardId: 74,
+    dashboardUID: '_U4zObQMz',
     parentVersion: 4,
     restoredFrom: 0,
     version: 5,
@@ -72,6 +79,7 @@ export const versions = [
   {
     id: 218,
     dashboardId: 74,
+    dashboardUID: '_U4zObQMz',
     parentVersion: 3,
     restoredFrom: 0,
     version: 4,
@@ -82,6 +90,7 @@ export const versions = [
   {
     id: 217,
     dashboardId: 74,
+    dashboardUID: '_U4zObQMz',
     parentVersion: 2,
     restoredFrom: 0,
     version: 3,
@@ -92,6 +101,7 @@ export const versions = [
   {
     id: 216,
     dashboardId: 74,
+    dashboardUID: '_U4zObQMz',
     parentVersion: 1,
     restoredFrom: 0,
     version: 2,
@@ -102,6 +112,7 @@ export const versions = [
   {
     id: 215,
     dashboardId: 74,
+    dashboardUID: '_U4zObQMz',
     parentVersion: 1,
     restoredFrom: 0,
     version: 1,

--- a/public/app/features/dashboard/components/VersionHistory/HistorySrv.test.ts
+++ b/public/app/features/dashboard/components/VersionHistory/HistorySrv.test.ts
@@ -25,7 +25,7 @@ describe('historySrv', () => {
 
   let historySrv = new HistorySrv();
 
-  const dash = new DashboardModel({ id: 1 });
+  const dash = new DashboardModel({ uid: '_U4zObQMz' });
   const emptyDash = new DashboardModel({});
   const historyListOpts = { limit: 10, start: 0 };
 

--- a/public/app/features/dashboard/components/VersionHistory/HistorySrv.ts
+++ b/public/app/features/dashboard/components/VersionHistory/HistorySrv.ts
@@ -12,7 +12,7 @@ export interface HistoryListOpts {
 export interface RevisionsModel {
   id: number;
   checked: boolean;
-  dashboardId: number;
+  dashboardUID: string;
   parentVersion: number;
   version: number;
   created: Date;
@@ -21,26 +21,26 @@ export interface RevisionsModel {
 }
 
 export interface DiffTarget {
-  dashboardId: number;
+  dashboardUID: string;
   version: number;
   unsavedDashboard?: DashboardModel; // when doing diffs against unsaved dashboard version
 }
 
 export class HistorySrv {
   getHistoryList(dashboard: DashboardModel, options: HistoryListOpts) {
-    const id = dashboard && dashboard.id ? dashboard.id : void 0;
-    return id ? getBackendSrv().get(`api/dashboards/id/${id}/versions`, options) : Promise.resolve([]);
+    const uid = dashboard && dashboard.uid ? dashboard.uid : void 0;
+    return uid ? getBackendSrv().get(`api/dashboards/uid/${uid}/versions`, options) : Promise.resolve([]);
   }
 
-  getDashboardVersion(id: number, version: number) {
-    return getBackendSrv().get(`api/dashboards/id/${id}/versions/${version}`);
+  getDashboardVersion(uid: string, version: number) {
+    return getBackendSrv().get(`api/dashboards/uid/${uid}/versions/${version}`);
   }
 
   restoreDashboard(dashboard: DashboardModel, version: number) {
-    const id = dashboard && dashboard.id ? dashboard.id : void 0;
-    const url = `api/dashboards/id/${id}/restore`;
+    const uid = dashboard && dashboard.uid ? dashboard.uid : void 0;
+    const url = `api/dashboards/uid/${uid}/restore`;
 
-    return id && isNumber(version) ? getBackendSrv().post(url, { version }) : Promise.resolve({});
+    return uid && isNumber(version) ? getBackendSrv().post(url, { version }) : Promise.resolve({});
   }
 }
 

--- a/public/app/features/dashboard/components/VersionHistory/__mocks__/dashboardHistoryMocks.ts
+++ b/public/app/features/dashboard/components/VersionHistory/__mocks__/dashboardHistoryMocks.ts
@@ -3,6 +3,7 @@ export function versions() {
     {
       id: 4,
       dashboardId: 1,
+      dashboardUID: '_U4zObQMz',
       parentVersion: 3,
       restoredFrom: 0,
       version: 4,
@@ -13,6 +14,7 @@ export function versions() {
     {
       id: 3,
       dashboardId: 1,
+      dashboardUID: '_U4zObQMz',
       parentVersion: 1,
       restoredFrom: 1,
       version: 3,
@@ -23,6 +25,7 @@ export function versions() {
     {
       id: 2,
       dashboardId: 1,
+      dashboardUID: '_U4zObQMz',
       parentVersion: 0,
       restoredFrom: -1,
       version: 2,
@@ -33,6 +36,7 @@ export function versions() {
     {
       id: 1,
       dashboardId: 1,
+      dashboardUID: '_U4zObQMz',
       parentVersion: 0,
       restoredFrom: -1,
       slug: 'history-dashboard',
@@ -73,6 +77,7 @@ export function restore(version: any, restoredFrom?: any): any {
         gnetId: null,
         graphTooltip: 0,
         id: 1,
+        uid: '_U4zObQMz',
         links: [],
         restoredFrom: restoredFrom,
         rows: [


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder at the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant to the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
To support nested folders in our new Search Engine we need to stop relying on internal IDs for Dashboards and folders.

Because of this, our backend team is migrating the API endpoints to use DashboardUID instead of DashboardID (https://github.com/grafana/grafana/issues/48331). For Grafana v9.0 these changes are still backward compatible, but we need to do the migration in the frontend.

This PR only replaces the usage of ID for managing dashboard versions at dashboard settings.

**Which issue(s) this PR fixes**:
It uses the UID to get the dashboard versions. Also, when comparing, the versions are fetched using UID. 
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #51976

**Special notes for your reviewer**:
I updated the mock with the valid UID, all tests still work.


**How to test it:**
Going to Dashboard settings -> versions, then:
- [x] Ensure the versions are listed for that dashboards. If there are no versions, try to add a panel to that dashboard and go back to the versions view to ensure it appears.
- [x] Restore a version from the list and the version is properly applied
- [x] Compare two different versions and the difference is correct
- [x] Restore a version from the compare view and the version is properly applied 