### PR TITLE
[v9.0.x] GraphNG: uPlot 1.6.22 (#51945)

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -9918,11 +9918,10 @@ exports[`better eslint`] = {
     "public/app/plugins/panel/histogram/Histogram.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Do not use any type assertions.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
+      [0, 0, 0, "Do not use any type assertions.", "2"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
+      [0, 0, 0, "Do not use any type assertions.", "4"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
     ],
     "public/app/plugins/panel/icon/IconPanel.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/package.json
+++ b/package.json
@@ -389,7 +389,7 @@
     "tether-drop": "https://github.com/torkelo/drop",
     "tinycolor2": "1.4.2",
     "tslib": "2.4.0",
-    "uplot": "1.6.21",
+    "uplot": "1.6.22",
     "uuid": "8.3.2",
     "vendor": "link:./public/vendor",
     "visjs-network": "4.25.0",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -38,7 +38,7 @@
     "regenerator-runtime": "0.13.9",
     "rxjs": "7.5.5",
     "tslib": "2.4.0",
-    "uplot": "1.6.21",
+    "uplot": "1.6.22",
     "xss": "1.0.11"
   },
   "devDependencies": {

--- a/packages/grafana-data/src/transformations/transformers/joinDataFrames.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinDataFrames.ts
@@ -241,10 +241,9 @@ export type TypedArray =
   | Float32Array
   | Float64Array;
 
-export type AlignedData = [
-  xValues: number[] | TypedArray,
-  ...yValues: Array<Array<number | null | undefined> | TypedArray>
-];
+export type AlignedData =
+  | TypedArray[]
+  | [xValues: number[] | TypedArray, ...yValues: Array<Array<number | null | undefined> | TypedArray>];
 
 // nullModes
 const NULL_REMOVE = 0; // nulls are converted to undefined (e.g. for spanGaps: true)

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -90,7 +90,7 @@
     "slate-plain-serializer": "0.7.10",
     "tinycolor2": "1.4.2",
     "tslib": "2.4.0",
-    "uplot": "1.6.21",
+    "uplot": "1.6.22",
     "uuid": "8.3.2"
   },
   "devDependencies": {

--- a/packages/grafana-ui/src/components/uPlot/Plot.tsx
+++ b/packages/grafana-ui/src/components/uPlot/Plot.tsx
@@ -102,14 +102,6 @@ export class UPlotChart extends React.Component<PlotProps, UPlotChartState> {
       this.reinitPlot();
     } else if (!sameData(prevProps, this.props)) {
       plot?.setData(this.props.data as AlignedData);
-
-      // this is a uPlot cache-busting hack for bar charts in case x axis labels changed
-      // since the x scale's "range" doesnt change, the axis size doesnt get recomputed, which is where the tick labels are regenerated & cached
-      // the more expensive, more proper/thorough way to do this is to force all axes to recalc: plot?.redraw(false, true);
-      if (plot && typeof this.props.data[0]?.[0] === 'string') {
-        //@ts-ignore
-        plot.axes[0]._values = this.props.data[0];
-      }
     } else if (!sameTimeRange(prevProps, this.props)) {
       plot?.setScale('x', {
         min: this.props.timeRange.from.valueOf(),

--- a/public/app/plugins/panel/histogram/Histogram.tsx
+++ b/public/app/plugins/panel/histogram/Histogram.tsx
@@ -221,7 +221,7 @@ const prepConfig = (frame: DataFrame, theme: GrafanaTheme2) => {
 };
 
 const preparePlotData = (frame: DataFrame) => {
-  let data: AlignedData = [] as any;
+  let data = [];
 
   for (const field of frame.fields) {
     if (field.name !== histogramFrameBucketMaxFieldName) {
@@ -240,7 +240,7 @@ const preparePlotData = (frame: DataFrame) => {
     }
   }
 
-  return data;
+  return data as AlignedData;
 };
 
 interface State {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3884,7 +3884,7 @@ __metadata:
     tinycolor2: 1.4.2
     tslib: 2.4.0
     typescript: 4.6.4
-    uplot: 1.6.21
+    uplot: 1.6.22
     xss: 1.0.11
   languageName: unknown
   linkType: soft
@@ -4330,7 +4330,7 @@ __metadata:
     ts-loader: 8.0.11
     tslib: 2.4.0
     typescript: 4.6.4
-    uplot: 1.6.21
+    uplot: 1.6.22
     uuid: 8.3.2
     webpack: 5.72.1
     webpack-filter-warnings-plugin: 1.2.1
@@ -19714,7 +19714,7 @@ __metadata:
     ts-node: 10.7.0
     tslib: 2.4.0
     typescript: 4.6.4
-    uplot: 1.6.21
+    uplot: 1.6.22
     uuid: 8.3.2
     vendor: "link:./public/vendor"
     visjs-network: 4.25.0
@@ -34023,10 +34023,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uplot@npm:1.6.21":
-  version: 1.6.21
-  resolution: "uplot@npm:1.6.21"
-  checksum: 38aa8c899f5010ce6a340db2717ef14e50e49a227a64be225ecba5a5d64bbda4d84a29a6a93ce77aa19a68f0631beaab8ba9ed6a456f11ce65160a6757b5b384
+"uplot@npm:1.6.22":
+  version: 1.6.22
+  resolution: "uplot@npm:1.6.22"
+  checksum: 4a73835b93fcbd0f62d99c062aac75d0d9d2e3f383fcc77b022abbecd936cd989188ed60da756e45d4306353c6d0e38baaac73b372a674d9e2f47bff7f7d11a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
manual backport PR of https://github.com/grafana/grafana/pull/51945

(cherry picked from commit fda7f064adcdc97ffce4c4913f4ea12ba222b815)