### PR TITLE
Geomap: Update with template variable change

### DIFF
--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -134,6 +134,10 @@ export class GeomapPanel extends Component<Props, State> {
     if (this.map && (this.props.height !== prevProps.height || this.props.width !== prevProps.width)) {
       this.map.updateSize();
     }
+    // Check for a difference between previous data and component data
+    if (this.map && this.props.data !== prevProps.data) {
+      this.dataChanged(this.props.data);
+    }
   }
 
   /** This function will actually update the JSON model */
@@ -259,8 +263,11 @@ export class GeomapPanel extends Component<Props, State> {
    * Called when PanelData changes (query results etc)
    */
   dataChanged(data: PanelData) {
-    for (const state of this.layers) {
-      this.applyLayerFilter(state.handler, state.options);
+    // Only update if panel data matches component data
+    if (data === this.props.data) {
+      for (const state of this.layers) {
+        this.applyLayerFilter(state.handler, state.options);
+      }
     }
   }
 


### PR DESCRIPTION
What this PR does / why we need it:
Change in template variable was not updating geomap.

After componentDidUpdate, check for a data change and apply it.

After (placing marks based on longitude template variable):
![Jul-08-2022 15-09-11](https://user-images.githubusercontent.com/60050885/178076533-d3d64e76-b203-4ef3-90ee-378c29e88c43.gif)

Which issue(s) this PR fixes:

Fixes #51983

