### PR TITLE
Splunk: Add Splunk to annotations legacy runner

### DIFF
--- a/public/app/features/annotations/standardAnnotationSupport.ts
+++ b/public/app/features/annotations/standardAnnotationSupport.ts
@@ -236,6 +236,7 @@ const legacyRunner = [
   'loki',
   'elasticsearch',
   'grafana-opensearch-datasource', // external
+  'grafana-splunk-datasource', // external
 ];
 
 /**


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds Splunk to the annotations legacy runner. This allows us to use the existing Splunk annotations editor and logic without fully migrating to the new annotations API (Same approach taken for Prometheus, Loki, ElasticSearch, OpenSearch).