### PR TITLE
Docs: fixes couple of typos

### DIFF
--- a/docs/sources/alerting/alerting-limitations.md
+++ b/docs/sources/alerting/alerting-limitations.md
@@ -21,7 +21,7 @@ As an example, if the current Prometheus version is `2.31.1`, we support >= `2.2
 
 ## Grafana is not an alert receiver
 
-Grafana is not an alert receiver; is it an alert generator. This means that Grafana cannot receive alerts from anything other than its internal alert generator.
+Grafana is not an alert receiver; it is an alert generator. This means that Grafana cannot receive alerts from anything other than its internal alert generator.
 
 Receiving alerts from Prometheus (or anything else) is not supported at the time.
 

--- a/docs/sources/alerting/fundamentals/data-source-alerting.md
+++ b/docs/sources/alerting/fundamentals/data-source-alerting.md
@@ -23,7 +23,7 @@ These are the data sources that are compatible with and supported by Grafana Ale
 - [Graphite]({{< relref "../../datasources/graphite/" >}})
 - [InfluxDB]({{< relref "influxdb/" >}})
 - [Loki]({{< relref "../../datasources/loki/" >}})
-- ]Microsoft SQL Server (MSSQL)]({{< relref "../../datasources/mssql/" >}})
+- [Microsoft SQL Server (MSSQL)]({{< relref "../../datasources/mssql/" >}})
 - [MySQL]({{< relref "../../datasources/mysql/" >}})
 - [Open TSDB]({{< relref "../../datasources/opentsdb/" >}})
 - [PostgreSQL]({{< relref "../../datasources/postgres/" >}})


### PR DESCRIPTION
Fixes typo in relref in data sources
Fixes typo in alerting limitations