### PR TITLE
Emphasize American English as source language

### DIFF
--- a/contribute/localization.md
+++ b/contribute/localization.md
@@ -191,4 +191,4 @@ import { Plural } from "@lingui/macro"
 
 ## Documentation
 
-[Grafana's documentation](https://grafana.com/docs/grafana/latest/) is not yet open for translation and should be authored in English only.
+[Grafana's documentation](https://grafana.com/docs/grafana/latest/) is not yet open for translation and should be authored in American English only.


### PR DESCRIPTION
Signal that the source language is American English, so that contributions contain less rework.