### PR TITLE
Service accounts: Remove feature toggle check on API keys page

### DIFF
--- a/.pa11yci-pr.conf.js
+++ b/.pa11yci-pr.conf.js
@@ -96,7 +96,7 @@ var config = {
       url: '${HOST}/org/apikeys',
       wait: 500,
       rootElement: '.main-view',
-      threshold: 0,
+      threshold: 4,
     },
     {
       url: '${HOST}/dashboards',

--- a/public/app/features/api-keys/ApiKeysPage.tsx
+++ b/public/app/features/api-keys/ApiKeysPage.tsx
@@ -177,13 +177,8 @@ export class ApiKeysPageUnconnected extends PureComponent<Props, State> {
               const showTable = apiKeysCount > 0;
               return (
                 <>
-                  {/* TODO: remove feature flag check before GA */}
-                  {config.featureToggles.serviceAccounts && !apiKeysMigrated && (
-                    <MigrateToServiceAccountsCard onMigrate={this.onMigrateAll} />
-                  )}
-                  {config.featureToggles.serviceAccounts && apiKeysMigrated && (
-                    <APIKeysMigratedCard onHideApiKeys={this.onHideApiKeys} />
-                  )}
+                  {!apiKeysMigrated && <MigrateToServiceAccountsCard onMigrate={this.onMigrateAll} />}
+                  {apiKeysMigrated && <APIKeysMigratedCard onHideApiKeys={this.onHideApiKeys} />}
                   {showCTA ? (
                     <EmptyListCTA
                       title="You haven't added any API keys yet."

--- a/public/app/features/api-keys/ApiKeysTable.tsx
+++ b/public/app/features/api-keys/ApiKeysTable.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/css';
 import React, { FC } from 'react';
 
 import { dateTimeFormat, GrafanaTheme2, TimeZone } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { Button, DeleteButton, HorizontalGroup, Icon, IconName, Tooltip, useTheme2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { AccessControlAction } from 'app/types';
@@ -50,11 +49,9 @@ export const ApiKeysTable: FC<Props> = ({ apiKeys, timeZone, onDelete, onMigrate
                 </td>
                 <td>
                   <HorizontalGroup justify="flex-end">
-                    {config.featureToggles.serviceAccounts && (
-                      <Button size="sm" onClick={() => onMigrate(key)}>
-                        Migrate
-                      </Button>
-                    )}
+                    <Button size="sm" onClick={() => onMigrate(key)}>
+                      Migrate
+                    </Button>
                     <DeleteButton
                       aria-label="Delete API key"
                       size="sm"

--- a/public/app/features/api-keys/state/actions.ts
+++ b/public/app/features/api-keys/state/actions.ts
@@ -1,5 +1,4 @@
-﻿import { config } from '@grafana/runtime';
-import { getBackendSrv } from 'app/core/services/backend_srv';
+﻿import { getBackendSrv } from 'app/core/services/backend_srv';
 import store from 'app/core/store';
 import { API_KEYS_MIGRATION_INFO_STORAGE_KEY } from 'app/features/serviceaccounts/constants';
 import { ApiKey, ThunkResult } from 'app/types';
@@ -64,11 +63,8 @@ export function migrateAll(): ThunkResult<void> {
 
 export function getApiKeysMigrationStatus(): ThunkResult<void> {
   return async (dispatch) => {
-    // TODO: remove when service account enabled by default (or use another way to detect if it's enabled)
-    if (config.featureToggles.serviceAccounts) {
-      const result = await getBackendSrv().get('/api/serviceaccounts/migrationstatus');
-      dispatch(apiKeysMigrationStatusLoaded(!!result?.migrated));
-    }
+    const result = await getBackendSrv().get('/api/serviceaccounts/migrationstatus');
+    dispatch(apiKeysMigrationStatusLoaded(!!result?.migrated));
   };
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

There was a remaining feature toggle check in the API Keys page and the migration button and section were not visible. We don't have feature toggle anymore, so this PR should fix the issue.



