### PR TITLE
Prometheus: Fix integer overflow in rate interval calculation

### DIFF
--- a/pkg/tsdb/prometheus/models/query.go
+++ b/pkg/tsdb/prometheus/models/query.go
@@ -181,7 +181,7 @@ func calculateRateInterval(interval time.Duration, scrapeInterval string, interv
 		return time.Duration(0)
 	}
 
-	rateInterval := time.Duration(int(math.Max(float64(interval+scrapeIntervalDuration), float64(4)*float64(scrapeIntervalDuration))))
+	rateInterval := time.Duration(int64(math.Max(float64(interval+scrapeIntervalDuration), float64(4)*float64(scrapeIntervalDuration))))
 	return rateInterval
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the following integer overflow in time series query rate interval calculation on 32-bit architectures:
```
$ CGO_ENABLED=1 GOARCH=386 go test github.com/grafana/grafana/pkg/tsdb/prometheus/models
--- FAIL: TestPrometheus_timeSeriesQuery_parseTimeSeriesQuery (0.00s)
    --- FAIL: TestPrometheus_timeSeriesQuery_parseTimeSeriesQuery/parsing_query_model_with_$__rate_interval_variable (0.00s)
        query_test.go:363: 
            	Error Trace:	query_test.go:363
            	Error:      	Not equal: 
            	            	expected: "rate(ALERTS{job=\"test\" [5m15s]})"
            	            	actual  : "rate(ALERTS{job=\"test\" [-2.147483648s]})"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1 +1 @@
            	            	-rate(ALERTS{job="test" [5m15s]})
            	            	+rate(ALERTS{job="test" [-2.147483648s]})
            	Test:       	TestPrometheus_timeSeriesQuery_parseTimeSeriesQuery/parsing_query_model_with_$__rate_interval_variable
    --- FAIL: TestPrometheus_timeSeriesQuery_parseTimeSeriesQuery/parsing_query_model_with_$__rate_interval_variable_in_expr_and_interval (0.00s)
        query_test.go:382: 
            	Error Trace:	query_test.go:382
            	Error:      	Not equal: 
            	            	expected: "rate(ALERTS{job=\"test\" [1m0s]})"
            	            	actual  : "rate(ALERTS{job=\"test\" [-2.147483648s]})"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1 +1 @@
            	            	-rate(ALERTS{job="test" [1m0s]})
            	            	+rate(ALERTS{job="test" [-2.147483648s]})
            	Test:       	TestPrometheus_timeSeriesQuery_parseTimeSeriesQuery/parsing_query_model_with_$__rate_interval_variable_in_expr_and_interval
FAIL
FAIL	github.com/grafana/grafana/pkg/tsdb/prometheus/models	0.008s
FAIL
```

**Special notes for your reviewer**:
This change can be tested using cross-compilation on a 64-bit machine: `CGO_ENABLED=1 GOARCH=386 go test github.com/grafana/grafana/pkg/tsdb/prometheus/models`

It fixes the same issue as in #51508 (parts of `pkg/tsdb/prometheus/buffered/time_series_query.go` got copied to `pkg/tsdb/prometheus/models/query.go` in PR #48477).