### PR TITLE
AzureMonitor: Improve handling of unsupported template variable cases in URIs

### DIFF
--- a/docs/sources/datasources/azuremonitor/template-variables.md
+++ b/docs/sources/datasources/azuremonitor/template-variables.md
@@ -67,8 +67,7 @@ Perf
 
 As of Grafana 9.0, a resource URI is constructed to identify resources using the resource picker. If a dashboard had been created prior to Grafana 9.0 then any queries utilising the prior resource picking mechanism will be migrated to resource URIs.
 
-This presents an issue as some resource types make use of nested namespaces and resource names e.g:
-`Microsoft.Storage/tableServices` and `storageAccount/default` or `Microsoft.Sql/servers/databases` and `serverName/databaseName`. There are possible cases where template variables cannot be used as a malformed resource URI may be constructed.
+Some resource types use nested namespaces and resource names, such as `Microsoft.Storage/tableServices` and `storageAccount/default`, or `Microsoft.Sql/servers/databases` and `serverName/databaseName`. Such template variables cannot be used because the result could be a malformed resource URI.
 
 ### Supported cases
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/QueryEditor.tsx
@@ -47,7 +47,7 @@ const QueryEditor: React.FC<AzureMonitorQueryEditorProps> = ({
     [onChange, onRunQuery]
   );
 
-  const query = usePreparedQuery(baseQuery, onQueryChange);
+  const query = usePreparedQuery(baseQuery, onQueryChange, setError);
 
   const subscriptionId = query.subscription || datasource.azureMonitorDatasource.defaultSubscriptionId;
   const variableOptionGroup = {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/usePreparedQuery.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/usePreparedQuery.ts
@@ -1,6 +1,6 @@
 import deepEqual from 'fast-deep-equal';
 import { defaults } from 'lodash';
-import React, { useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { getTemplateSrv } from '@grafana/runtime';
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/usePreparedQuery.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/QueryEditor/usePreparedQuery.ts
@@ -1,20 +1,23 @@
 import deepEqual from 'fast-deep-equal';
 import { defaults } from 'lodash';
-import { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import { getTemplateSrv } from '@grafana/runtime';
 
-import { AzureMonitorQuery, AzureQueryType } from '../../types';
+import { AzureMonitorErrorish, AzureMonitorQuery, AzureQueryType } from '../../types';
 import migrateQuery from '../../utils/migrateQuery';
 
 const DEFAULT_QUERY = {
   queryType: AzureQueryType.AzureMonitor,
 };
 
-const prepareQuery = (query: AzureMonitorQuery) => {
+const prepareQuery = (
+  query: AzureMonitorQuery,
+  setError: (errorSource: string, error: AzureMonitorErrorish) => void
+) => {
   // Note: _.defaults does not apply default values deeply.
   const withDefaults = defaults({}, query, DEFAULT_QUERY);
-  const migratedQuery = migrateQuery(withDefaults, getTemplateSrv());
+  const migratedQuery = migrateQuery(withDefaults, getTemplateSrv(), setError);
 
   // If we didn't make any changes to the object, then return the original object to keep the
   // identity the same, and not trigger any other useEffects or anything.
@@ -24,8 +27,12 @@ const prepareQuery = (query: AzureMonitorQuery) => {
 /**
  * Returns queries with some defaults + migrations, and calls onChange function to notify if it changes
  */
-const usePreparedQuery = (query: AzureMonitorQuery, onChangeQuery: (newQuery: AzureMonitorQuery) => void) => {
-  const preparedQuery = useMemo(() => prepareQuery(query), [query]);
+const usePreparedQuery = (
+  query: AzureMonitorQuery,
+  onChangeQuery: (newQuery: AzureMonitorQuery) => void,
+  setError: (errorSource: string, error: AzureMonitorErrorish) => void
+) => {
+  const preparedQuery = useMemo(() => prepareQuery(query, setError), [query, setError]);
 
   useEffect(() => {
     if (preparedQuery !== query) {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/types/types.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/types/types.ts
@@ -85,7 +85,7 @@ export interface AzureDataSourceSecureJsonData {
 
 // Represents an errors that come back from frontend requests.
 // Not totally sure how accurate this type is.
-export type AzureMonitorErrorish = Error;
+export type AzureMonitorErrorish = Error | string | React.ReactElement;
 
 // Azure Monitor API Types
 export interface AzureMonitorMetricsMetadataResponse {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/utils/messageFromError.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/utils/messageFromError.ts
@@ -1,4 +1,8 @@
-export default function messageFromError(error: any): string | undefined {
+import { isValidElement } from 'react';
+
+import { AzureMonitorErrorish } from '../types';
+
+export default function messageFromError(error: any): AzureMonitorErrorish | undefined {
   if (!error || typeof error !== 'object') {
     return undefined;
   }
@@ -9,6 +13,10 @@ export default function messageFromError(error: any): string | undefined {
 
   if (typeof error.data?.error?.message === 'string') {
     return error.data.error.message;
+  }
+
+  if (isValidElement(error)) {
+    return error;
   }
 
   // Copied from the old Angular code - this might be checking for errors in places

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/utils/messageFromError.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/utils/messageFromError.ts
@@ -2,7 +2,15 @@ import { isValidElement } from 'react';
 
 import { AzureMonitorErrorish } from '../types';
 
-export default function messageFromError(error: any): AzureMonitorErrorish | undefined {
+export function messageFromElement(error: AzureMonitorErrorish): AzureMonitorErrorish | undefined {
+  if (isValidElement(error)) {
+    return error;
+  } else {
+    return messageFromError(error);
+  }
+}
+
+export default function messageFromError(error: any): string | undefined {
   if (!error || typeof error !== 'object') {
     return undefined;
   }
@@ -13,10 +21,6 @@ export default function messageFromError(error: any): AzureMonitorErrorish | und
 
   if (typeof error.data?.error?.message === 'string') {
     return error.data.error.message;
-  }
-
-  if (isValidElement(error)) {
-    return error;
   }
 
   // Copied from the old Angular code - this might be checking for errors in places

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/utils/migrateQuery.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/utils/migrateQuery.test.ts
@@ -1,6 +1,8 @@
+import React from 'react';
+
 import { getTemplateSrv } from '@grafana/runtime';
 
-import { AzureMetricDimension, AzureMonitorQuery, AzureQueryType } from '../types';
+import { AzureMetricDimension, AzureMonitorErrorish, AzureMonitorQuery, AzureQueryType } from '../types';
 
 import migrateQuery from './migrateQuery';
 
@@ -16,6 +18,8 @@ jest.mock('@grafana/runtime', () => {
 });
 
 let templateSrv = getTemplateSrv();
+
+let setErrorMock = jest.fn();
 
 const azureMonitorQueryV7 = {
   appInsights: { dimension: [], metricName: 'select', timeGrain: 'auto' },
@@ -97,7 +101,7 @@ const modernMetricsQuery: AzureMonitorQuery = {
 
 describe('AzureMonitor: migrateQuery', () => {
   it('modern queries should not change', () => {
-    const result = migrateQuery(modernMetricsQuery, templateSrv);
+    const result = migrateQuery(modernMetricsQuery, templateSrv, setErrorMock);
 
     // MUST use .toBe because we want to assert that the identity of unmigrated queries remains the same
     expect(modernMetricsQuery).toBe(result);
@@ -105,7 +109,7 @@ describe('AzureMonitor: migrateQuery', () => {
 
   describe('migrating from a v7 query to the latest query version', () => {
     it('should build a resource uri', () => {
-      const result = migrateQuery(azureMonitorQueryV7, templateSrv);
+      const result = migrateQuery(azureMonitorQueryV7, templateSrv, setErrorMock);
       expect(result).toMatchObject(
         expect.objectContaining({
           azureMonitor: expect.objectContaining({
@@ -119,7 +123,7 @@ describe('AzureMonitor: migrateQuery', () => {
 
   describe('migrating from a v8 query to the latest query version', () => {
     it('should build a resource uri', () => {
-      const result = migrateQuery(azureMonitorQueryV8, templateSrv);
+      const result = migrateQuery(azureMonitorQueryV8, templateSrv, setErrorMock);
       expect(result).toMatchObject(
         expect.objectContaining({
           azureMonitor: expect.objectContaining({
@@ -130,18 +134,66 @@ describe('AzureMonitor: migrateQuery', () => {
       );
     });
 
-    it('should not build a resource uri with an unsupported template variable', () => {
-      replaceMock = jest.fn().mockImplementation((s: string) => s.replace('$ns', 'Microsoft.Storage/storageAccounts'));
+    it('should not build a resource uri with an unsupported namespace template variable', () => {
+      replaceMock = jest
+        .fn()
+        .mockImplementation((s: string) => s.replace('$ns', 'Microsoft.Storage/storageAccounts/tableServices'));
+      setErrorMock = jest
+        .fn()
+        .mockImplementation((errorSource: string, error: AzureMonitorErrorish) => 'Template Var error');
+      const errorElement = React.createElement(
+        'div',
+        null,
+        `Failed to create resource URI. Validate the metric definition template variable against supported cases `,
+        React.createElement(
+          'a',
+          {
+            href: 'https://grafana.com/docs/grafana/latest/datasources/azuremonitor/template-variables/',
+          },
+          'here.'
+        )
+      );
       templateSrv = getTemplateSrv();
       const query = {
         ...azureMonitorQueryV8,
         azureMonitor: {
-          ...azureMonitorQueryV8,
+          ...azureMonitorQueryV8.azureMonitor,
           metricDefinition: '$ns',
         },
       };
-      const result = migrateQuery(query, templateSrv);
+      const result = migrateQuery(query, templateSrv, setErrorMock);
       expect(result.azureMonitor?.resourceUri).toBeUndefined();
+      expect(setErrorMock).toHaveBeenCalledWith('Resource URI migration', errorElement);
+    });
+
+    it('should not build a resource uri with unsupported resource name template variable', () => {
+      replaceMock = jest.fn().mockImplementation((s: string) => s.replace('$resource', 'resource/default'));
+      setErrorMock = jest
+        .fn()
+        .mockImplementation((errorSource: string, error: AzureMonitorErrorish) => 'Template Var error');
+      const errorElement = React.createElement(
+        'div',
+        null,
+        `Failed to create resource URI. Validate the resource name template variable against supported cases `,
+        React.createElement(
+          'a',
+          {
+            href: 'https://grafana.com/docs/grafana/latest/datasources/azuremonitor/template-variables/',
+          },
+          'here.'
+        )
+      );
+      templateSrv = getTemplateSrv();
+      const query = {
+        ...azureMonitorQueryV8,
+        azureMonitor: {
+          ...azureMonitorQueryV8.azureMonitor,
+          resourceName: '$resource',
+        },
+      };
+      const result = migrateQuery(query, templateSrv, setErrorMock);
+      expect(result.azureMonitor?.resourceUri).toBeUndefined();
+      expect(setErrorMock).toHaveBeenCalledWith('Resource URI migration', errorElement);
     });
   });
 
@@ -150,7 +202,11 @@ describe('AzureMonitor: migrateQuery', () => {
       const dimensionFilters: AzureMetricDimension[] = [
         { dimension: 'TestDimension', operator: 'eq', filters: ['testFilter'] },
       ];
-      const result = migrateQuery({ ...azureMonitorQueryV8, azureMonitor: { dimensionFilters } }, templateSrv);
+      const result = migrateQuery(
+        { ...azureMonitorQueryV8, azureMonitor: { dimensionFilters } },
+        templateSrv,
+        setErrorMock
+      );
       expect(result).toMatchObject(
         expect.objectContaining({
           azureMonitor: expect.objectContaining({
@@ -161,7 +217,11 @@ describe('AzureMonitor: migrateQuery', () => {
     });
     it('correctly updates old filter containing wildcard', () => {
       const dimensionFilters: AzureMetricDimension[] = [{ dimension: 'TestDimension', operator: 'eq', filter: '*' }];
-      const result = migrateQuery({ ...azureMonitorQueryV8, azureMonitor: { dimensionFilters } }, templateSrv);
+      const result = migrateQuery(
+        { ...azureMonitorQueryV8, azureMonitor: { dimensionFilters } },
+        templateSrv,
+        setErrorMock
+      );
       expect(result).toMatchObject(
         expect.objectContaining({
           azureMonitor: expect.objectContaining({
@@ -174,7 +234,11 @@ describe('AzureMonitor: migrateQuery', () => {
     });
     it('correctly updates old filter containing value', () => {
       const dimensionFilters: AzureMetricDimension[] = [{ dimension: 'TestDimension', operator: 'eq', filter: 'test' }];
-      const result = migrateQuery({ ...azureMonitorQueryV8, azureMonitor: { dimensionFilters } }, templateSrv);
+      const result = migrateQuery(
+        { ...azureMonitorQueryV8, azureMonitor: { dimensionFilters } },
+        templateSrv,
+        setErrorMock
+      );
       expect(result).toMatchObject(
         expect.objectContaining({
           azureMonitor: expect.objectContaining({
@@ -189,7 +253,11 @@ describe('AzureMonitor: migrateQuery', () => {
       const dimensionFilters: AzureMetricDimension[] = [
         { dimension: 'TestDimension', operator: 'eq', filter: '*', filters: ['testFilter'] },
       ];
-      const result = migrateQuery({ ...azureMonitorQueryV8, azureMonitor: { dimensionFilters } }, templateSrv);
+      const result = migrateQuery(
+        { ...azureMonitorQueryV8, azureMonitor: { dimensionFilters } },
+        templateSrv,
+        setErrorMock
+      );
       expect(result).toMatchObject(
         expect.objectContaining({
           azureMonitor: expect.objectContaining({
@@ -208,7 +276,11 @@ describe('AzureMonitor: migrateQuery', () => {
       const dimensionFilters: AzureMetricDimension[] = [
         { dimension: 'TestDimension', operator: 'eq', filter: 'testFilter', filters: ['testFilter'] },
       ];
-      const result = migrateQuery({ ...azureMonitorQueryV8, azureMonitor: { dimensionFilters } }, templateSrv);
+      const result = migrateQuery(
+        { ...azureMonitorQueryV8, azureMonitor: { dimensionFilters } },
+        templateSrv,
+        setErrorMock
+      );
       expect(result).toMatchObject(
         expect.objectContaining({
           azureMonitor: expect.objectContaining({

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/utils/useLastError.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/utils/useLastError.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useMemo } from 'react';
 
 import { AzureMonitorErrorish } from '../types';
 
-import messageFromError from './messageFromError';
+import { messageFromElement } from './messageFromError';
 
 type SourcedError = [string, AzureMonitorErrorish];
 
@@ -33,7 +33,7 @@ export default function useLastError() {
 
   const errorMessage = useMemo(() => {
     const recentError = errors[0];
-    return recentError && messageFromError(recentError[1]);
+    return recentError && messageFromElement(recentError[1]);
   }, [errors]);
 
   return [errorMessage, addError] as const;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Updates docs with detailed information describing what template variable combinations are supported in resource URI construction. 

In addition, a warning is also issued in the UI if a migration is attempted on a query with an invalid template variable combination. In this case the resource URI will remain unset as the backend is appropriately set up to handle this case. See case 2 [here](https://github.com/grafana/grafana/pull/51331#pullrequestreview-1027433910).

**Which issue(s) this PR fixes**:

Fixes #50530

**Special notes for your reviewer**:

