### PR TITLE
[v9.0.x] Prometheus datasource: query builder freezes when metrics metadata is undefined #51988

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilder.tsx
@@ -134,6 +134,11 @@ async function getMetrics(
     await datasource.languageProvider.loadMetricsMetadata();
   }
 
+  // Error handling for when metrics metadata returns as undefined
+  if (!datasource.languageProvider.metricsMetadata) {
+    datasource.languageProvider.metricsMetadata = {};
+  }
+
   let metrics;
   if (query.labels.length > 0) {
     const expr = promQueryModeller.renderLabels(query.labels);


### PR DESCRIPTION
Backport e51187a47420c91cde38f1aa3fed445776f82fae from #51929

* add error handling for prom query builder returning undefined metrics metadata

* remove reference to escalation

(cherry picked from commit e51187a47420c91cde38f1aa3fed445776f82fae)

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


