### PR TITLE
Datasource: Propagate datasource secret decryption errors to the frontend

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -626,13 +626,13 @@ func (hs *HTTPServer) checkDatasourceHealth(c *models.ReqContext, ds *datasource
 	return response.JSON(http.StatusOK, payload)
 }
 
-func (hs *HTTPServer) decryptSecureJsonDataFn(ctx context.Context) func(ds *datasources.DataSource) map[string]string {
-	return func(ds *datasources.DataSource) map[string]string {
+func (hs *HTTPServer) decryptSecureJsonDataFn(ctx context.Context) func(ds *datasources.DataSource) (map[string]string, error) {
+	return func(ds *datasources.DataSource) (map[string]string, error) {
 		decryptedJsonData, err := hs.DataSourcesService.DecryptedValues(ctx, ds)
 		if err != nil {
 			hs.log.Error("Failed to decrypt secure json data", "error", err)
 		}
-		return decryptedJsonData
+		return decryptedJsonData, err
 	}
 }
 

--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -628,11 +628,7 @@ func (hs *HTTPServer) checkDatasourceHealth(c *models.ReqContext, ds *datasource
 
 func (hs *HTTPServer) decryptSecureJsonDataFn(ctx context.Context) func(ds *datasources.DataSource) (map[string]string, error) {
 	return func(ds *datasources.DataSource) (map[string]string, error) {
-		decryptedJsonData, err := hs.DataSourcesService.DecryptedValues(ctx, ds)
-		if err != nil {
-			hs.log.Error("Failed to decrypt secure json data", "error", err)
-		}
-		return decryptedJsonData, err
+		return hs.DataSourcesService.DecryptedValues(ctx, ds)
 	}
 }
 

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -24,7 +25,13 @@ func (hs *HTTPServer) handleQueryMetricsError(err error) *response.NormalRespons
 	if errors.Is(err, datasources.ErrDataSourceNotFound) {
 		return response.Error(http.StatusNotFound, "Data source not found", err)
 	}
-	var badQuery *query.ErrBadQuery
+
+	var secretsPlugin datasources.ErrDatasourceSecretsPluginUserFriendly
+	if errors.As(err, &secretsPlugin) {
+		return response.Error(http.StatusInternalServerError, fmt.Sprint("Secrets Plugin error: ", err.Error()), err)
+	}
+
+	var badQuery query.ErrBadQuery
 	if errors.As(err, &badQuery) {
 		return response.Error(http.StatusBadRequest, util.Capitalize(badQuery.Message), err)
 	}

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -142,7 +142,8 @@ func TestAPIEndpoint_Metrics_PluginDecryptionFailure(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 		buf := new(bytes.Buffer)
-		buf.ReadFrom(resp.Body)
+		_, err = buf.ReadFrom(resp.Body)
+		require.NoError(t, err)
 		require.NoError(t, resp.Body.Close())
 		var resObj secretsErrorResponseBody
 		err = json.Unmarshal(buf.Bytes(), &resObj)
@@ -150,5 +151,4 @@ func TestAPIEndpoint_Metrics_PluginDecryptionFailure(t *testing.T) {
 		require.Equal(t, "unknown error", resObj.Error)
 		require.Contains(t, resObj.Message, "Secrets Plugin error:")
 	})
-
 }

--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -38,6 +40,11 @@ var queryDatasourceInput = `{
 
 type fakePluginRequestValidator struct {
 	err error
+}
+
+type secretsErrorResponseBody struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
 }
 
 func (rv *fakePluginRequestValidator) Validate(dsURL string, req *http.Request) error {
@@ -103,4 +110,45 @@ func TestAPIEndpoint_Metrics_QueryMetricsV2(t *testing.T) {
 		require.NoError(t, resp.Body.Close())
 		require.Equal(t, http.StatusMultiStatus, resp.StatusCode)
 	})
+}
+
+func TestAPIEndpoint_Metrics_PluginDecryptionFailure(t *testing.T) {
+	qds := query.ProvideService(
+		nil,
+		nil,
+		nil,
+		&fakePluginRequestValidator{},
+		&fakeDatasources.FakeDataSourceService{SimulatePluginFailure: true},
+		&fakePluginClient{
+			QueryDataHandlerFunc: func(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+				resp := backend.Responses{
+					"A": backend.DataResponse{
+						Error: fmt.Errorf("query failed"),
+					},
+				}
+				return &backend.QueryDataResponse{Responses: resp}, nil
+			},
+		},
+		&fakeOAuthTokenService{},
+	)
+	httpServer := SetupAPITestServer(t, func(hs *HTTPServer) {
+		hs.queryDataService = qds
+	})
+
+	t.Run("Status code is 500 and a secrets plugin error is returned if there is a problem getting secrets from the remote plugin", func(t *testing.T) {
+		req := httpServer.NewPostRequest("/api/ds/query", strings.NewReader(queryDatasourceInput))
+		webtest.RequestWithSignedInUser(req, &models.SignedInUser{UserId: 1, OrgId: 1, OrgRole: models.ROLE_VIEWER})
+		resp, err := httpServer.SendJSON(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(resp.Body)
+		require.NoError(t, resp.Body.Close())
+		var resObj secretsErrorResponseBody
+		err = json.Unmarshal(buf.Bytes(), &resObj)
+		require.NoError(t, err)
+		require.Equal(t, "unknown error", resObj.Error)
+		require.Contains(t, resObj.Message, "Secrets Plugin error:")
+	})
+
 }

--- a/pkg/expr/transform.go
+++ b/pkg/expr/transform.go
@@ -127,12 +127,12 @@ func hiddenRefIDs(queries []Query) (map[string]struct{}, error) {
 	return hidden, nil
 }
 
-func (s *Service) decryptSecureJsonDataFn(ctx context.Context) func(ds *datasources.DataSource) map[string]string {
-	return func(ds *datasources.DataSource) map[string]string {
+func (s *Service) decryptSecureJsonDataFn(ctx context.Context) func(ds *datasources.DataSource) (map[string]string, error) {
+	return func(ds *datasources.DataSource) (map[string]string, error) {
 		decryptedJsonData, err := s.dataSourceService.DecryptedValues(ctx, ds)
 		if err != nil {
 			logger.Error("Failed to decrypt secure json data", "error", err)
 		}
-		return decryptedJsonData
+		return decryptedJsonData, err
 	}
 }

--- a/pkg/expr/transform.go
+++ b/pkg/expr/transform.go
@@ -129,10 +129,6 @@ func hiddenRefIDs(queries []Query) (map[string]struct{}, error) {
 
 func (s *Service) decryptSecureJsonDataFn(ctx context.Context) func(ds *datasources.DataSource) (map[string]string, error) {
 	return func(ds *datasources.DataSource) (map[string]string, error) {
-		decryptedJsonData, err := s.dataSourceService.DecryptedValues(ctx, ds)
-		if err != nil {
-			logger.Error("Failed to decrypt secure json data", "error", err)
-		}
-		return decryptedJsonData, err
+		return s.dataSourceService.DecryptedValues(ctx, ds)
 	}
 }

--- a/pkg/plugins/adapters/adapters.go
+++ b/pkg/plugins/adapters/adapters.go
@@ -3,6 +3,7 @@ package adapters
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 
@@ -11,15 +12,19 @@ import (
 )
 
 // ModelToInstanceSettings converts a datasources.DataSource to a backend.DataSourceInstanceSettings.
-func ModelToInstanceSettings(ds *datasources.DataSource, decryptFn func(ds *datasources.DataSource) map[string]string,
+func ModelToInstanceSettings(ds *datasources.DataSource, decryptFn func(ds *datasources.DataSource) (map[string]string, error),
 ) (*backend.DataSourceInstanceSettings, error) {
 	var jsonDataBytes json.RawMessage
 	if ds.JsonData != nil {
 		var err error
 		jsonDataBytes, err = ds.JsonData.MarshalJSON()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to convert data source to instance settings: %w", err)
 		}
+	}
+	decrypted, err := decryptFn(ds)
+	if err != nil {
+		return nil, err
 	}
 
 	return &backend.DataSourceInstanceSettings{
@@ -32,9 +37,9 @@ func ModelToInstanceSettings(ds *datasources.DataSource, decryptFn func(ds *data
 		BasicAuthEnabled:        ds.BasicAuth,
 		BasicAuthUser:           ds.BasicAuthUser,
 		JSONData:                jsonDataBytes,
-		DecryptedSecureJSONData: decryptFn(ds),
+		DecryptedSecureJSONData: decrypted,
 		Updated:                 ds.Updated,
-	}, nil
+	}, err
 }
 
 // BackendUserFromSignedInUser converts Grafana's SignedInUser model

--- a/pkg/plugins/plugincontext/plugincontext.go
+++ b/pkg/plugins/plugincontext/plugincontext.go
@@ -129,10 +129,6 @@ func (p *Provider) getCachedPluginSettings(ctx context.Context, pluginID string,
 
 func (p *Provider) decryptSecureJsonDataFn(ctx context.Context) func(ds *datasources.DataSource) (map[string]string, error) {
 	return func(ds *datasources.DataSource) (map[string]string, error) {
-		decryptedJsonData, err := p.dataSourceService.DecryptedValues(ctx, ds)
-		if err != nil {
-			p.logger.Error("Failed to decrypt secure json data", "error", err)
-		}
-		return decryptedJsonData, err
+		return p.dataSourceService.DecryptedValues(ctx, ds)
 	}
 }

--- a/pkg/plugins/plugincontext/plugincontext.go
+++ b/pkg/plugins/plugincontext/plugincontext.go
@@ -127,12 +127,12 @@ func (p *Provider) getCachedPluginSettings(ctx context.Context, pluginID string,
 	return ps, nil
 }
 
-func (p *Provider) decryptSecureJsonDataFn(ctx context.Context) func(ds *datasources.DataSource) map[string]string {
-	return func(ds *datasources.DataSource) map[string]string {
+func (p *Provider) decryptSecureJsonDataFn(ctx context.Context) func(ds *datasources.DataSource) (map[string]string, error) {
+	return func(ds *datasources.DataSource) (map[string]string, error) {
 		decryptedJsonData, err := p.dataSourceService.DecryptedValues(ctx, ds)
 		if err != nil {
 			p.logger.Error("Failed to decrypt secure json data", "error", err)
 		}
-		return decryptedJsonData
+		return decryptedJsonData, err
 	}
 }

--- a/pkg/services/datasources/fakes/fake_datasource_service.go
+++ b/pkg/services/datasources/fakes/fake_datasource_service.go
@@ -11,8 +11,9 @@ import (
 )
 
 type FakeDataSourceService struct {
-	lastId      int64
-	DataSources []*datasources.DataSource
+	lastId                int64
+	DataSources           []*datasources.DataSource
+	SimulatePluginFailure bool
 }
 
 var _ datasources.DataSourceService = &FakeDataSourceService{}
@@ -107,6 +108,9 @@ func (s *FakeDataSourceService) GetHTTPTransport(ctx context.Context, ds *dataso
 }
 
 func (s *FakeDataSourceService) DecryptedValues(ctx context.Context, ds *datasources.DataSource) (map[string]string, error) {
+	if s.SimulatePluginFailure {
+		return nil, datasources.ErrDatasourceSecretsPluginUserFriendly{Err: "unknown error"}
+	}
 	values := make(map[string]string)
 	return values, nil
 }

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -151,7 +151,7 @@ func (s *Service) handleQueryData(ctx context.Context, user *models.SignedInUser
 
 	instanceSettings, err := adapters.ModelToInstanceSettings(ds, s.decryptSecureJsonDataFn(ctx))
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert data source to instance settings: %w", err)
+		return nil, err
 	}
 
 	req := &backend.QueryDataRequest{
@@ -343,12 +343,12 @@ func (s *Service) getDataSourceFromQuery(ctx context.Context, user *models.Signe
 	return nil, NewErrBadQuery("missing data source ID/UID")
 }
 
-func (s *Service) decryptSecureJsonDataFn(ctx context.Context) func(ds *datasources.DataSource) map[string]string {
-	return func(ds *datasources.DataSource) map[string]string {
+func (s *Service) decryptSecureJsonDataFn(ctx context.Context) func(ds *datasources.DataSource) (map[string]string, error) {
+	return func(ds *datasources.DataSource) (map[string]string, error) {
 		decryptedJsonData, err := s.dataSourceService.DecryptedValues(ctx, ds)
 		if err != nil {
 			s.log.Error("Failed to decrypt secure json data", "error", err)
 		}
-		return decryptedJsonData
+		return decryptedJsonData, err
 	}
 }

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -345,10 +345,6 @@ func (s *Service) getDataSourceFromQuery(ctx context.Context, user *models.Signe
 
 func (s *Service) decryptSecureJsonDataFn(ctx context.Context) func(ds *datasources.DataSource) (map[string]string, error) {
 	return func(ds *datasources.DataSource) (map[string]string, error) {
-		decryptedJsonData, err := s.dataSourceService.DecryptedValues(ctx, ds)
-		if err != nil {
-			s.log.Error("Failed to decrypt secure json data", "error", err)
-		}
-		return decryptedJsonData, err
+		return s.dataSourceService.DecryptedValues(ctx, ds)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR propagates errors caused by secret decryption to the frontend so that we can show useful error messages when there is a secrets plugin problem.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/51597

**Special notes for your reviewer**:

In the current baseline, when decryption errors occur, we continue to try to query the database anyway, and may be successful because of datasource connection caching. This makes it difficult to deliver useful errors to the frontend, and begs the question of whether we _should_ be able to query a datasource if we don't have up-to-date decrypted passwords.

After chatting with @ryantxu, we determined that updating the /ds/query endpoint to fail if secret decryption fails would make the most sense, unless there is a specific reason why we should continue through the code path anyway. 

Will create a unit test once this code solution is approved. 

Corresponds with enterprise PR https://github.com/grafana/grafana-enterprise/pull/3574