### PR TITLE
AzureMonitor: Add support for Subscriptions template variable

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -64,5 +64,4 @@ export interface FeatureToggles {
   internationalization?: boolean;
   topnav?: boolean;
   customBranding?: boolean;
-  azTemplateVars?: boolean;
 }

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -64,4 +64,5 @@ export interface FeatureToggles {
   internationalization?: boolean;
   topnav?: boolean;
   customBranding?: boolean;
+  azTemplateVars?: boolean;
 }

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/VariableEditor/GrafanaTemplateVariableFn.tsx
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/VariableEditor/GrafanaTemplateVariableFn.tsx
@@ -1,0 +1,59 @@
+import React, { ChangeEvent, useCallback, useEffect, useState } from 'react';
+
+import { InlineField, Input } from '@grafana/ui';
+
+import DataSource from '../../datasource';
+import { migrateStringQueriesToObjectQueries } from '../../grafanaTemplateVariableFns';
+import { AzureMonitorQuery, AzureQueryType } from '../../types';
+
+const GrafanaTemplateVariableFnInput = ({
+  query,
+  updateQuery,
+  datasource,
+}: {
+  query: AzureMonitorQuery;
+  updateQuery: (val: AzureMonitorQuery) => void;
+  datasource: DataSource;
+}) => {
+  const [inputVal, setInputVal] = useState('');
+
+  useEffect(() => {
+    setInputVal(query.grafanaTemplateVariableFn?.rawQuery || '');
+  }, [query.grafanaTemplateVariableFn?.rawQuery]);
+
+  const onRunQuery = useCallback(
+    (newQuery: string) => {
+      migrateStringQueriesToObjectQueries(newQuery, { datasource }).then((updatedQuery) => {
+        if (updatedQuery.queryType === AzureQueryType.GrafanaTemplateVariableFn) {
+          updateQuery(updatedQuery);
+        } else {
+          updateQuery({
+            ...query,
+            grafanaTemplateVariableFn: {
+              kind: 'UnknownQuery',
+              rawQuery: newQuery,
+            },
+          });
+        }
+      });
+    },
+    [datasource, query, updateQuery]
+  );
+
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setInputVal(event.target.value);
+  };
+
+  return (
+    <InlineField label="Grafana template variable function">
+      <Input
+        placeholder={'type a grafana template variable function, ex: Subscriptions()'}
+        value={inputVal}
+        onChange={onChange}
+        onBlur={() => onRunQuery(inputVal)}
+      />
+    </InlineField>
+  );
+};
+
+export default GrafanaTemplateVariableFnInput;

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/types/query.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/types/query.ts
@@ -6,6 +6,8 @@ export enum AzureQueryType {
   AzureMonitor = 'Azure Monitor',
   LogAnalytics = 'Azure Log Analytics',
   AzureResourceGraph = 'Azure Resource Graph',
+  SubscriptionsQuery = 'Azure Subscriptions',
+  /** Deprecated */
   GrafanaTemplateVariableFn = 'Grafana Template Variable Function',
 }
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.test.ts
@@ -513,4 +513,28 @@ describe('VariableSupport', () => {
       done();
     });
   });
+
+  describe('querying for subscriptions', () => {
+    it('can fetch subscriptions', (done) => {
+      const fakeSubscriptions = ['subscriptionId'];
+      const variableSupport = new VariableSupport(
+        createMockDatasource({
+          getSubscriptions: jest.fn().mockResolvedValueOnce(fakeSubscriptions),
+        })
+      );
+      const mockRequest = {
+        targets: [
+          {
+            refId: 'A',
+            queryType: AzureQueryType.SubscriptionsQuery,
+          } as AzureMonitorQuery,
+        ],
+      } as DataQueryRequest<AzureMonitorQuery>;
+      const observables = variableSupport.query(mockRequest);
+      observables.subscribe((result: DataQueryResponseData) => {
+        expect(result.data[0].source).toEqual(fakeSubscriptions);
+        done();
+      });
+    });
+  });
 });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.ts
@@ -29,28 +29,28 @@ export class VariableSupport extends CustomVariableSupport<DataSource, AzureMoni
     const promisedResults = async () => {
       const queryObj = await migrateStringQueriesToObjectQueries(request.targets[0], { datasource: this.datasource });
 
-      switch (queryObj.queryType) {
-        case AzureQueryType.SubscriptionsQuery:
-          const res = await this.datasource.getSubscriptions();
-          return {
-            data: res?.length ? [toDataFrame(res)] : [],
-          };
-        case AzureQueryType.GrafanaTemplateVariableFn:
-          if (queryObj.grafanaTemplateVariableFn) {
-            try {
+      try {
+        switch (queryObj.queryType) {
+          case AzureQueryType.SubscriptionsQuery:
+            const res = await this.datasource.getSubscriptions();
+            return {
+              data: res?.length ? [toDataFrame(res)] : [],
+            };
+          case AzureQueryType.GrafanaTemplateVariableFn:
+            if (queryObj.grafanaTemplateVariableFn) {
               const templateVariablesResults = await this.callGrafanaTemplateVariableFn(
                 queryObj.grafanaTemplateVariableFn
               );
               return {
                 data: templateVariablesResults?.length ? [toDataFrame(templateVariablesResults)] : [],
               };
-            } catch (err) {
-              return { data: [], error: { message: messageFromError(err) } };
             }
-          }
-        default:
-          request.targets[0] = queryObj;
-          return lastValueFrom(this.datasource.query(request));
+          default:
+            request.targets[0] = queryObj;
+            return lastValueFrom(this.datasource.query(request));
+        }
+      } catch (err) {
+        return { data: [], error: { message: messageFromError(err) } };
       }
     };
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

First step towards https://github.com/grafana/grafana/issues/50231.

Added a new query type "Subscriptions" that can be used in the variable editor:

![Screenshot from 2022-07-12 13-09-59](https://user-images.githubusercontent.com/4025665/178479100-0cf8f308-bd56-4aa5-8c37-860daa546244.png)

Summary of the changes:
 - (housekeeping) Moved GrafanaTemplateVariableFn.tsx to its own file.
 - Added a feature flag so users won't be able to see any change until all the resource types are supported.
 - Added an input for getting subscriptions (which has no inputs).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Ref #50231

**Special notes for your reviewer**:

