### PR TITLE
Logs: Fixed wrapping log lines from detected fields

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRowMessageDetectedFields.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessageDetectedFields.tsx
@@ -19,12 +19,11 @@ class UnThemedLogRowMessageDetectedFields extends PureComponent<Props> {
   render() {
     const { row, showDetectedFields, getFieldLinks, wrapLogMessage } = this.props;
     const fields = getAllFields(row, getFieldLinks);
-    const wrapClassName = cx(
-      wrapLogMessage &&
-        css`
-          white-space: pre-wrap;
-        `
-    );
+    const wrapClassName = wrapLogMessage
+      ? ''
+      : cx(css`
+          white-space: nowrap;
+        `);
 
     const line = showDetectedFields
       .map((parsedKey) => {

--- a/packages/grafana-ui/src/components/Logs/LogRowMessageDetectedFields.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessageDetectedFields.tsx
@@ -1,4 +1,4 @@
-import { cx, css } from '@emotion/css';
+import { css } from '@emotion/css';
 import React, { PureComponent } from 'react';
 
 import { LogRowModel, Field, LinkModel } from '@grafana/data';
@@ -21,9 +21,9 @@ class UnThemedLogRowMessageDetectedFields extends PureComponent<Props> {
     const fields = getAllFields(row, getFieldLinks);
     const wrapClassName = wrapLogMessage
       ? ''
-      : cx(css`
+      : css`
           white-space: nowrap;
-        `);
+        `;
 
     const line = showDetectedFields
       .map((parsedKey) => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Log lines with detected fields are not wrapped if enabled.

**Which issue(s) this PR fixes**:

Fixes #48398

**Special notes for your reviewer**:

https://user-images.githubusercontent.com/8092184/178507519-67546161-0b9b-4186-a8aa-d18273254a51.mov


