### PR TITLE
Owensmallwood/pubdash panel blank when target has no datasource

### DIFF
--- a/pkg/models/dashboard_queries.go
+++ b/pkg/models/dashboard_queries.go
@@ -45,7 +45,12 @@ func GroupQueriesByPanelId(dashboard *simplejson.Json) map[int64][]*simplejson.J
 			query := simplejson.NewFromAny(queryObj)
 
 			if _, ok := query.CheckGet("datasource"); !ok {
-				query.Set("datasource", panel.Get("datasource"))
+				datasource, err := panel.Get("datasource").Map()
+				if err != nil {
+					continue
+				}
+
+				query.Set("datasource", datasource)
 			}
 
 			panelQueries = append(panelQueries, query)

--- a/pkg/models/dashboard_queries.go
+++ b/pkg/models/dashboard_queries.go
@@ -44,13 +44,22 @@ func GroupQueriesByPanelId(dashboard *simplejson.Json) map[int64][]*simplejson.J
 		for _, queryObj := range panel.Get("targets").MustArray() {
 			query := simplejson.NewFromAny(queryObj)
 
+			// if query target has no datasource, set it to have the datasource on the panel
 			if _, ok := query.CheckGet("datasource"); !ok {
-				datasource, err := panel.Get("datasource").Map()
-				if err != nil {
-					continue
-				}
+				_, err := panel.Get("datasource").String()
 
-				query.Set("datasource", datasource)
+				if err != nil {
+					// panel datasource is a json object
+					datasource, err := panel.Get("datasource").Map()
+					if err != nil {
+						continue
+					}
+					query.Set("datasource", datasource)
+				} else {
+					// panel datasource is a string
+					datasource := panel.Get("datasource").MustString()
+					query.Set("datasource", datasource)
+				}
 			}
 
 			panelQueries = append(panelQueries, query)

--- a/pkg/models/dashboard_queries_test.go
+++ b/pkg/models/dashboard_queries_test.go
@@ -20,6 +20,37 @@ const (
   "schemaVersion": 35
 }`
 
+	dashboardWithTargetsWithNoDatasources = `
+{
+  "panels": [
+    {
+      "id": 2,
+      "datasource": {
+          "type": "postgres",
+          "uid": "abc123"
+      },
+      "targets": [
+        {
+          "expr": "go_goroutines{job=\"$job\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "query2",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "title": "Panel Title",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 35
+}`
+
 	dashboardWithQueries = `
 {
   "panels": [
@@ -256,6 +287,15 @@ func TestGetUniqueDashboardDatasourceUids(t *testing.T) {
 }
 
 func TestGroupQueriesByPanelId(t *testing.T) {
+	t.Run("can extract queries from dashboard that has no datasource on panel targets", func(t *testing.T) {
+		json, err := simplejson.NewJson([]byte(dashboardWithTargetsWithNoDatasources))
+		require.NoError(t, err)
+		queries := GroupQueriesByPanelId(json)
+
+		panelId := int64(2)
+		queriesByDatasource := GroupQueriesByDataSource(queries[panelId])
+		require.Len(t, queriesByDatasource[0], 2)
+	})
 	t.Run("can extract no queries from empty dashboard", func(t *testing.T) {
 		json, err := simplejson.NewJson([]byte(`{"panels": {}}`))
 		require.NoError(t, err)

--- a/pkg/models/dashboard_queries_test.go
+++ b/pkg/models/dashboard_queries_test.go
@@ -287,7 +287,16 @@ func TestGetUniqueDashboardDatasourceUids(t *testing.T) {
 }
 
 func TestGroupQueriesByPanelId(t *testing.T) {
-	t.Run("can extract queries from dashboard that has no datasource on panel targets", func(t *testing.T) {
+	t.Run("can extract queries from dashboard with panel datasource string that has no datasource on panel targets", func(t *testing.T) {
+		json, err := simplejson.NewJson([]byte(oldStyleDashboard))
+		require.NoError(t, err)
+		queries := GroupQueriesByPanelId(json)
+
+		panelId := int64(2)
+		queriesByDatasource := GroupQueriesByDataSource(queries[panelId])
+		require.Len(t, queriesByDatasource[0], 1)
+	})
+	t.Run("can extract queries from dashboard with panel json datasource that has no datasource on panel targets", func(t *testing.T) {
 		json, err := simplejson.NewJson([]byte(dashboardWithTargetsWithNoDatasources))
 		require.NoError(t, err)
 		queries := GroupQueriesByPanelId(json)
@@ -361,7 +370,10 @@ func TestGroupQueriesByPanelId(t *testing.T) {
 		query, err := queries[2][0].MarshalJSON()
 		require.NoError(t, err)
 		require.JSONEq(t, `{
-            "datasource": "_yxMP8Ynk",
+            "datasource": {
+				"uid": "_yxMP8Ynk",
+				"type": "public-ds"
+			},
             "exemplar": true,
             "expr": "go_goroutines{job=\"$job\"}",
             "interval": "",


### PR DESCRIPTION
**Problem**
Dashboards whose targets had no datasources and panel had a json datasource were not working. Currently, if the targets had no datasource, we assumed the panel datasource value was string.

**Solution**
If the targets have no datasource, we handle the case where the panel datasource is a json object with a uid property.

fixes https://github.com/grafana/grafana-enterprise-partnerships-team/issues/268