### PR TITLE
Dashboard: Prevent unnecessary scrollbar when viewing single panel

### DIFF
--- a/public/sass/components/_dashboard_grid.scss
+++ b/public/sass/components/_dashboard_grid.scss
@@ -18,6 +18,9 @@
 }
 
 .panel-in-fullscreen {
+  .react-grid-layout {
+    height: auto !important;
+  }
   .react-grid-item {
     display: none !important;
     transition-property: none !important;


### PR DESCRIPTION
**What this PR does / why we need it**:
This will override the calculated inline style added by RGL in the wrapper `div`. It will `ONLY` override the wrapper when a panel is in viewing mode. This will remove the gaps and scrollbar when the wrapper height is too long and panel is in viewing mode.


**Which issue(s) this PR fixes**:
Fixes #42691 
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer**:
- Since RGL is using inline style, the only way to  i think so far to override the style is by using `!important`. Let me know if there are other ways to address it.


