### PR TITLE
Adds documentation for public dashboards under the dashboards section.

### DIFF
--- a/docs/sources/dashboards/_index.md
+++ b/docs/sources/dashboards/_index.md
@@ -18,6 +18,7 @@ Before you begin, ensure that you have configured a data source. See also:
 - [Dashboard folders]({{< relref "dashboard-folders/" >}})
 - [Create dashboard]({{< relref "dashboard-create/" >}})
 - [Manage dashboards]({{< relref "dashboard-manage/" >}})
+- [Public dashboards]({{< relref "dashboard-public/" >}})
 - [Annotations]({{< relref "annotations/" >}})
 - [Playlist]({{< relref "playlist/" >}})
 - [Reporting]({{< relref "reporting/" >}})

--- a/docs/sources/dashboards/dashboard-public.md
+++ b/docs/sources/dashboards/dashboard-public.md
@@ -11,9 +11,16 @@ weight: 8
 > **Note:** This page describes a feature for Grafana 9.1 and is available as an opt-in alpha feature.
 
 > **Caution:** Making your dashboard public could result in a large number of queries to the datasources used by your dashboard.
+> This can be mitigated by utilizing the enterprise [caching](https://grafana.com/docs/grafana/latest/enterprise/query-caching/) and/or rate limiting features.
 
 Public dashboards allow you to share your Grafana dashboard with anyone. This is useful when you want to expose your
 dashboard to the world.
+
+#### Enable the feature
+
+Add the `publicDashboards` feature toggle to your `custom.ini` file.
+
+> **Note:** For Grafana Cloud, you will need to contact support to have the feature enabled.
 
 #### Make a dashboard public
 
@@ -21,18 +28,21 @@ dashboard to the world.
 - Click on the Public Dashboard tab.
 - Acknowledge the implications of making the dashboard public by checking all the checkboxes.
 - Turn on the Enabled toggle.
+- Click `Save Sharing Configuration` to make the dashboard public and make your link live.
 - Copy the public dashboard link if you'd like to share it. You can always come back later for it.
-- Click Save Sharing Configuration to make the dashboard public and make your link live.
 
 #### Revoke access
 
 - Click on the sharing icon to the right of the dashboard title.
 - Click on the Public Dashboard tab.
 - Turn off the Enabled toggle.
+- Click `Save Sharing Configuration` to save your changes.
 - Anyone with the link will not be able to access the dashboard publicly anymore.
 
 #### Limitations
 
 - Panels that use frontend datasources will fail to fetch data.
-- Template variables are currently not supported, but are planned for our beta release.
-- The time range is permanently set to the default time range on the dashboard.
+- Template variables are currently not supported, but are planned to be in the future.
+- The time range is permanently set to the default time range on the dashboard. If you update the default time range for a dashboard, it will be reflected in the public dashboard.
+
+We are excited to share this enhancement with you and we’d love your feedback! Please check out the [Github](https://github.com/grafana/grafana/discussions/49253) discussion and join the conversation.

--- a/docs/sources/dashboards/dashboard-public.md
+++ b/docs/sources/dashboards/dashboard-public.md
@@ -1,0 +1,38 @@
+---
+aliases:
+  - /docs/grafana/latest/dashboards/dashboard-manage/
+  - /docs/grafana/latest/features/dashboard/dashboards/
+title: Public dashboards
+weight: 8
+---
+
+## Public dashboards
+
+> **Note:** This page describes a feature for Grafana 9.1 and is available as an opt-in alpha feature.
+
+> **Caution:** Making your dashboard public could result in a large number of queries to the datasources used by your dashboard.
+
+Public dashboards allow you to share your Grafana dashboard with anyone. This is useful when you want to expose your
+dashboard to the world.
+
+#### Make a dashboard public
+
+- Click on the sharing icon to the right of the dashboard title.
+- Click on the Public Dashboard tab.
+- Acknowledge the implications of making the dashboard public by checking all the checkboxes.
+- Turn on the Enabled toggle.
+- Copy the public dashboard link if you'd like to share it. You can always come back later for it.
+- Click Save Sharing Configuration to make the dashboard public and make your link live.
+
+#### Revoke access
+
+- Click on the sharing icon to the right of the dashboard title.
+- Click on the Public Dashboard tab.
+- Turn off the Enabled toggle.
+- Anyone with the link will not be able to access the dashboard publicly anymore.
+
+#### Limitations
+
+- Panels that use frontend datasources will fail to fetch data.
+- Template variables are currently not supported, but are planned for our beta release.
+- The time range is permanently set to the default time range on the dashboard.

--- a/docs/sources/dashboards/dashboard-public.md
+++ b/docs/sources/dashboards/dashboard-public.md
@@ -8,7 +8,7 @@ weight: 8
 
 ## Public dashboards
 
-> **Note:** This alpha-based feature is opt-in.
+> **Note:** This is an opt-in alpha feature.
 
 > **Caution:** Making your dashboard public could result in a large number of queries to the datasources used by your dashboard.
 > This can be mitigated by utilizing the enterprise [caching](https://grafana.com/docs/grafana/latest/enterprise/query-caching/) and/or rate limiting features.

--- a/docs/sources/dashboards/dashboard-public.md
+++ b/docs/sources/dashboards/dashboard-public.md
@@ -16,6 +16,13 @@ weight: 8
 Public dashboards allow you to share your Grafana dashboard with anyone. This is useful when you want to expose your
 dashboard to the world.
 
+#### Security implications of making your dashboard public
+
+- Anyone with the URL can access the dashboard.
+- Public dashboards are read-only.
+- Arbitrary queries **cannot** be run against your datasources through public dashboards. Public dashboards can only execute the
+  queries stored on the original dashboard.
+
 #### Enable the feature
 
 Add the `publicDashboards` feature toggle to your `custom.ini` file.

--- a/docs/sources/dashboards/dashboard-public.md
+++ b/docs/sources/dashboards/dashboard-public.md
@@ -8,7 +8,7 @@ weight: 8
 
 ## Public dashboards
 
-> **Note:** This page describes a feature for Grafana 9.1 and is available as an opt-in alpha feature.
+> **Note:** This alpha-based feature is opt-in.
 
 > **Caution:** Making your dashboard public could result in a large number of queries to the datasources used by your dashboard.
 > This can be mitigated by utilizing the enterprise [caching](https://grafana.com/docs/grafana/latest/enterprise/query-caching/) and/or rate limiting features.


### PR DESCRIPTION
Adds docs for public dashboards
<img width="1666" alt="Screen Shot 2022-07-13 at 11 23 04 AM" src="https://user-images.githubusercontent.com/20195316/178793578-ab82912b-603e-4c8d-8a1f-292fb8a855b2.png">



Fixes https://github.com/grafana/grafana-enterprise-partnerships-team/issues/249