### PR TITLE
Storage: refactor readonly support

### DIFF
--- a/pkg/services/store/entity_events.go
+++ b/pkg/services/store/entity_events.go
@@ -26,6 +26,7 @@ const (
 	EntityTypeDashboard EntityType = "dashboard"
 	EntityTypeFolder    EntityType = "folder"
 	EntityTypeImage     EntityType = "image"
+	EntityTypeJSON      EntityType = "json"
 )
 
 // CreateDatabaseEntityId creates entityId for entities stored in the existing SQL tables

--- a/pkg/services/store/http.go
+++ b/pkg/services/store/http.go
@@ -15,8 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
-var errFileTooBig = response.Error(400, "Please limit file uploaded under 1MB", errors.New("file is too big"))
-
 // HTTPStorageService passes raw HTTP requests to a well typed storage service
 type HTTPStorageService interface {
 	List(c *models.ReqContext) response.Response
@@ -57,87 +55,91 @@ func UploadErrorToStatusCode(err error) int {
 }
 
 func (s *httpStorage) Upload(c *models.ReqContext) response.Response {
-	// 32 MB is the default used by FormFile()
-	if err := c.Req.ParseMultipartForm(32 << 20); err != nil {
-		return response.Error(400, "error in parsing form", err)
+	type rspInfo struct {
+		Message string `json:"message,omitempty"`
+		Path    string `json:"path,omitempty"`
+		Count   int    `json:"count,omitempty"`
+		Bytes   int    `json:"bytes,omitempty"`
+		Error   bool   `json:"err,omitempty"`
 	}
+	rsp := &rspInfo{Message: "uploaded"}
+
 	c.Req.Body = http.MaxBytesReader(c.Resp, c.Req.Body, MAX_UPLOAD_SIZE)
 	if err := c.Req.ParseMultipartForm(MAX_UPLOAD_SIZE); err != nil {
-		msg := fmt.Sprintf("Please limit file uploaded under %s", util.ByteCountSI(MAX_UPLOAD_SIZE))
-		return response.Error(400, msg, err)
+		rsp.Message = fmt.Sprintf("Please limit file uploaded under %s", util.ByteCountSI(MAX_UPLOAD_SIZE))
+		rsp.Error = true
+		return response.JSON(400, rsp)
+	}
+	message := getMultipartFormValue(c.Req, "message")
+	overwriteExistingFile := getMultipartFormValue(c.Req, "overwriteExistingFile") != "false" // must explicitly overwrite
+	folder := getMultipartFormValue(c.Req, "folder")
+
+	for k, fileHeaders := range c.Req.MultipartForm.File {
+		path := getMultipartFormValue(c.Req, k+".path") // match the path with a file
+		if len(fileHeaders) > 1 {
+			path = ""
+		}
+		if path == "" && folder == "" {
+			rsp.Message = "please specify the upload folder or full path"
+			rsp.Error = true
+			return response.JSON(400, rsp)
+		}
+
+		for _, fileHeader := range fileHeaders {
+			// restrict file size based on file size
+			// open each file to copy contents
+			file, err := fileHeader.Open()
+			if err != nil {
+				return response.Error(500, "Internal Server Error", err)
+			}
+			err = file.Close()
+			if err != nil {
+				return response.Error(500, "Internal Server Error", err)
+			}
+			data, err := ioutil.ReadAll(file)
+			if err != nil {
+				return response.Error(500, "Internal Server Error", err)
+			}
+
+			if path == "" {
+				path = folder + "/" + fileHeader.Filename
+			}
+
+			entityType := EntityTypeJSON
+			mimeType := http.DetectContentType(data)
+			if strings.HasPrefix(mimeType, "image") {
+				entityType = EntityTypeImage
+			}
+
+			err = s.store.Upload(c.Req.Context(), c.SignedInUser, &UploadRequest{
+				Contents:              data,
+				MimeType:              mimeType,
+				EntityType:            entityType,
+				Path:                  path,
+				OverwriteExistingFile: overwriteExistingFile,
+				Properties: map[string]string{
+					"message": message, // the commit/changelog entry
+				},
+			})
+
+			if err != nil {
+				return response.Error(UploadErrorToStatusCode(err), err.Error(), err)
+			}
+			rsp.Count++
+			rsp.Bytes += len(data)
+			rsp.Path = path
+		}
 	}
 
-	files := c.Req.MultipartForm.File["file"]
-	if len(files) != 1 {
-		return response.JSON(400, map[string]interface{}{
-			"message": "please upload files one at a time",
-			"err":     true,
-		})
-	}
-
-	folder, ok := getMultipartFormValue(c.Req, "folder")
-	if !ok || folder == "" {
-		return response.JSON(400, map[string]interface{}{
-			"message": "please specify the upload folder",
-			"err":     true,
-		})
-	}
-	overwriteExistingFile, _ := getMultipartFormValue(c.Req, "overwriteExistingFile")
-
-	fileHeader := files[0]
-	if fileHeader.Size > MAX_UPLOAD_SIZE {
-		return errFileTooBig
-	}
-
-	// restrict file size based on file size
-	// open each file to copy contents
-	file, err := fileHeader.Open()
-	if err != nil {
-		return response.Error(500, "Internal Server Error", err)
-	}
-	err = file.Close()
-	if err != nil {
-		return response.Error(500, "Internal Server Error", err)
-	}
-	data, err := ioutil.ReadAll(file)
-	if err != nil {
-		return response.Error(500, "Internal Server Error", err)
-	}
-
-	if (len(data)) > MAX_UPLOAD_SIZE {
-		return errFileTooBig
-	}
-
-	path := folder + "/" + fileHeader.Filename
-
-	mimeType := http.DetectContentType(data)
-
-	err = s.store.Upload(c.Req.Context(), c.SignedInUser, &UploadRequest{
-		Contents:              data,
-		MimeType:              mimeType,
-		EntityType:            EntityTypeImage,
-		Path:                  path,
-		OverwriteExistingFile: overwriteExistingFile == "true",
-	})
-
-	if err != nil {
-		return response.Error(UploadErrorToStatusCode(err), err.Error(), err)
-	}
-
-	return response.JSON(200, map[string]interface{}{
-		"message": "Uploaded successfully",
-		"path":    path,
-		"file":    fileHeader.Filename,
-		"err":     true,
-	})
+	return response.JSON(200, rsp)
 }
 
-func getMultipartFormValue(req *http.Request, key string) (string, bool) {
+func getMultipartFormValue(req *http.Request, key string) string {
 	v, ok := req.MultipartForm.Value[key]
 	if !ok || len(v) != 1 {
-		return "", false
+		return ""
 	}
-	return v[0], ok
+	return v[0]
 }
 
 func (s *httpStorage) Read(c *models.ReqContext) response.Response {

--- a/pkg/services/store/tree.go
+++ b/pkg/services/store/tree.go
@@ -11,7 +11,7 @@ import (
 
 type nestedTree struct {
 	rootsByOrgId map[int64][]storageRuntime
-	lookup       map[int64]map[string]filestorage.FileStorage
+	lookup       map[int64]map[string]storageRuntime
 
 	orgInitMutex          sync.Mutex
 	initializeOrgStorages func(orgId int64) []storageRuntime
@@ -21,10 +21,10 @@ var (
 	_ storageTree = (*nestedTree)(nil)
 )
 
-func asNameToFileStorageMap(storages []storageRuntime) map[string]filestorage.FileStorage {
-	lookup := make(map[string]filestorage.FileStorage)
+func asNameToFileStorageMap(storages []storageRuntime) map[string]storageRuntime {
+	lookup := make(map[string]storageRuntime)
 	for _, storage := range storages {
-		lookup[storage.Meta().Config.Prefix] = storage.Store()
+		lookup[storage.Meta().Config.Prefix] = storage
 	}
 	return lookup
 }
@@ -33,7 +33,7 @@ func (t *nestedTree) init() {
 	t.orgInitMutex.Lock()
 	defer t.orgInitMutex.Unlock()
 
-	t.lookup = make(map[int64]map[string]filestorage.FileStorage, len(t.rootsByOrgId))
+	t.lookup = make(map[int64]map[string]storageRuntime, len(t.rootsByOrgId))
 
 	for orgId, storages := range t.rootsByOrgId {
 		t.lookup[orgId] = asNameToFileStorageMap(storages)
@@ -50,7 +50,7 @@ func (t *nestedTree) assureOrgIsInitialized(orgId int64) {
 	}
 }
 
-func (t *nestedTree) getRoot(orgId int64, path string) (filestorage.FileStorage, string) {
+func (t *nestedTree) getRoot(orgId int64, path string) (storageRuntime, string) {
 	t.assureOrgIsInitialized(orgId)
 
 	if path == "" {
@@ -82,7 +82,7 @@ func (t *nestedTree) GetFile(ctx context.Context, orgId int64, path string) (*fi
 	if root == nil {
 		return nil, nil // not found (or not ready)
 	}
-	return root.Get(ctx, path)
+	return root.Store().Get(ctx, path)
 }
 
 func (t *nestedTree) ListFolder(ctx context.Context, orgId int64, path string) (*StorageListFrame, error) {
@@ -146,7 +146,7 @@ func (t *nestedTree) ListFolder(ctx context.Context, orgId int64, path string) (
 		return nil, nil // not found (or not ready)
 	}
 
-	listResponse, err := root.List(ctx, path, nil, &filestorage.ListOptions{
+	listResponse, err := root.Store().List(ctx, path, nil, &filestorage.ListOptions{
 		Recursive:   false,
 		WithFolders: true,
 		WithFiles:   true,

--- a/pkg/services/store/validate.go
+++ b/pkg/services/store/validate.go
@@ -74,15 +74,15 @@ func (s *standardStorageService) validateUploadRequest(ctx context.Context, user
 	}
 
 	switch req.EntityType {
+	case EntityTypeJSON:
+		fallthrough
 	case EntityTypeFolder:
 		fallthrough
 	case EntityTypeDashboard:
 		// TODO: add proper validation
-		var something interface{}
-		if err := json.Unmarshal(req.Contents, &something); err != nil {
-			return fail(err.Error())
+		if !json.Valid(req.Contents) {
+			return fail("invalid json")
 		}
-
 		return success()
 	case EntityTypeImage:
 		return s.validateImage(ctx, user, req)


### PR DESCRIPTION
The current implementation is hardcoded to only let you upload to "/resources" this structures things so the "read-only" flag controls if you can write to it or not.  We should also add control for RBAC... but not today :)

This should also fix an error that sometimes allowed you to upload files larger than the max size