### PR TITLE
Logs: Improve getLogRowContext API

### DIFF
--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -149,13 +149,14 @@ export enum LogsDedupDescription {
  * Data sources that allow showing context rows around the provided LowRowModel should implement this method.
  * This will enable "context" button in Logs Panel.
  */
-export interface DataSourceWithLogsContextSupport {
+export interface DataSourceWithLogsContextSupport<TQuery extends DataQuery = DataQuery> {
   /**
    * Retrieve context for a given log row
    */
   getLogRowContext: <TContextQueryOptions extends {}>(
     row: LogRowModel,
-    options?: TContextQueryOptions
+    options?: TContextQueryOptions,
+    query?: TQuery
   ) => Promise<DataQueryResponse>;
 
   /**

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -44,10 +44,15 @@ class LogsContainer extends PureComponent<LogsContainerProps> {
   };
 
   getLogRowContext = async (row: LogRowModel, options?: any): Promise<any> => {
-    const { datasourceInstance } = this.props;
+    const { datasourceInstance, logsQueries } = this.props;
 
     if (hasLogsContextSupport(datasourceInstance)) {
-      return datasourceInstance.getLogRowContext(row, options);
+      // we need to find the query, and we need to be very sure that
+      // it's a query from this datasource
+      const query = (logsQueries ?? []).find(
+        (q) => q.refId === row.dataFrame.refId && q.datasource != null && q.datasource.type === datasourceInstance.type
+      );
+      return datasourceInstance.getLogRowContext(row, options, query);
     }
 
     return [];


### PR DESCRIPTION
give access to the original `query` in `getLogRowContext` . should help with https://github.com/grafana/grafana/pull/52118