### PR TITLE
Alerting: Backport fix database unavailable removes rules from scheduler

### DIFF
--- a/pkg/services/ngalert/CHANGELOG.md
+++ b/pkg/services/ngalert/CHANGELOG.md
@@ -72,6 +72,10 @@ Scopes must have an order to ensure consistency and ease of search, this helps u
 - [ENHANCEMENT] Scheduler: ticker to support stopping #48142
 - [ENHANCEMENT] Migration: Don't stop the migration when failing to parse alert rule tags #51253
 
+## 8.5.9
+
+- [ENHANCEMENT] Scheduler: Adds new metrics to track rules that might be scheduled.
+
 ## 8.5.5
 
 - [BUGFIX] Alerting: Remove double quotes from double quoted matchers #50038

--- a/pkg/services/ngalert/metrics/ngalert.go
+++ b/pkg/services/ngalert/metrics/ngalert.go
@@ -50,8 +50,10 @@ type Scheduler struct {
 	EvalTotal                *prometheus.CounterVec
 	EvalFailures             *prometheus.CounterVec
 	EvalDuration             *prometheus.SummaryVec
-	GetAlertRulesDuration    prometheus.Histogram
 	SchedulePeriodicDuration prometheus.Histogram
+	AlertRules               prometheus.Gauge
+	AlertRulesHash           prometheus.Gauge
+	UpdateAlertRulesDuration prometheus.Histogram
 }
 
 type MultiOrgAlertmanager struct {
@@ -161,21 +163,36 @@ func newSchedulerMetrics(r prometheus.Registerer) *Scheduler {
 			},
 			[]string{"org"},
 		),
-		GetAlertRulesDuration: promauto.With(r).NewHistogram(
-			prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Subsystem: Subsystem,
-				Name:      "get_alert_rules_duration_seconds",
-				Help:      "The time taken to get all alert rules.",
-				Buckets:   []float64{0.1, 0.25, 0.5, 1, 2, 5, 10},
-			},
-		),
 		SchedulePeriodicDuration: promauto.With(r).NewHistogram(
 			prometheus.HistogramOpts{
 				Namespace: Namespace,
 				Subsystem: Subsystem,
 				Name:      "schedule_periodic_duration_seconds",
 				Help:      "The time taken to run the scheduler.",
+				Buckets:   []float64{0.1, 0.25, 0.5, 1, 2, 5, 10},
+			},
+		),
+		AlertRules: promauto.With(r).NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "schedule_alert_rules",
+				Help:      "The number of alert rules being considered for evaluation each tick.",
+			},
+		),
+		AlertRulesHash: promauto.With(r).NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "schedule_alert_rules_hash",
+				Help:      "A hash of the alert rules over time.",
+			}),
+		UpdateAlertRulesDuration: promauto.With(r).NewHistogram(
+			prometheus.HistogramOpts{
+				Namespace: Namespace,
+				Subsystem: Subsystem,
+				Name:      "schedule_query_alert_rules_duration_seconds",
+				Help:      "The time taken to fetch alert rules from the database.",
 				Buckets:   []float64{0.1, 0.25, 0.5, 1, 2, 5, 10},
 			},
 		),

--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -2,24 +2,54 @@ package schedule
 
 import (
 	"context"
+	"fmt"
+	"hash/fnv"
+	"sort"
 	"time"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-func (sch *schedule) getAlertRules(ctx context.Context, disabledOrgs []int64) []*models.AlertRule {
+// hashUIDs returns a fnv64 hash of the UIDs for all alert rules.
+// The order of the alert rules does not matter as hashUIDs sorts
+// the UIDs in increasing order.
+func hashUIDs(alertRules []*models.AlertRule) uint64 {
+	h := fnv.New64()
+	for _, uid := range sortedUIDs(alertRules) {
+		// We can ignore err as fnv64 does not return an error
+		// nolint:errcheck,gosec
+		h.Write([]byte(uid))
+	}
+	return h.Sum64()
+}
+
+// sortedUIDs returns a slice of sorted UIDs.
+func sortedUIDs(alertRules []*models.AlertRule) []string {
+	uids := make([]string, 0, len(alertRules))
+	for _, alertRule := range alertRules {
+		uids = append(uids, alertRule.UID)
+	}
+	sort.Strings(uids)
+	return uids
+}
+
+// updateAlertRules updates the alert rules for the scheduler. It returns an error
+// if the database is unavailable or the query returned an error.
+func (sch *schedule) updateAlertRules(ctx context.Context, disabledOrgs []int64) error {
 	start := time.Now()
 	defer func() {
-		sch.metrics.GetAlertRulesDuration.Observe(time.Since(start).Seconds())
+		sch.metrics.UpdateAlertRulesDuration.Observe(
+			time.Since(start).Seconds())
 	}()
 
 	q := models.ListAlertRulesQuery{
 		ExcludeOrgs: disabledOrgs,
 	}
-	err := sch.ruleStore.GetAlertRulesForScheduling(ctx, &q)
-	if err != nil {
-		sch.log.Error("failed to fetch alert definitions", "err", err)
-		return nil
+	if err := sch.ruleStore.GetAlertRulesForScheduling(ctx, &q); err != nil {
+		return fmt.Errorf("failed to get alert rules: %w", err)
 	}
-	return q.Result
+	sch.alertRules.set(q.Result)
+	sch.metrics.AlertRules.Set(float64(len(q.Result)))
+	sch.metrics.AlertRulesHash.Set(float64(hashUIDs(q.Result)))
+	return nil
 }

--- a/pkg/services/ngalert/schedule/fetcher_test.go
+++ b/pkg/services/ngalert/schedule/fetcher_test.go
@@ -1,0 +1,26 @@
+package schedule
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+func TestHashUIDs(t *testing.T) {
+	r := []*models.AlertRule{{UID: "foo"}, {UID: "bar"}}
+	assert.Equal(t, uint64(0xade76f55c76a1c48), hashUIDs(r))
+	// expect the same hash irrespective of order
+	r = []*models.AlertRule{{UID: "bar"}, {UID: "foo"}}
+	assert.Equal(t, uint64(0xade76f55c76a1c48), hashUIDs(r))
+	// expect a different hash
+	r = []*models.AlertRule{{UID: "bar"}}
+	assert.Equal(t, uint64(0xd8d9a5186bad3880), hashUIDs(r))
+	// slice with no items
+	r = []*models.AlertRule{}
+	assert.Equal(t, uint64(0xcbf29ce484222325), hashUIDs(r))
+	// a different slice with no items should have the same hash
+	r = []*models.AlertRule{}
+	assert.Equal(t, uint64(0xcbf29ce484222325), hashUIDs(r))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request backports https://github.com/grafana/grafana/pull/49874 to `v8.5.x`. It was not possible to automatically backport this PR as `v8.5.x` and `main` have forked.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

