### PR TITLE
Access Control: Migration order patch

### DIFF
--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -81,6 +81,7 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 			accesscontrol.AddTeamMembershipMigrations(mg)
 			accesscontrol.AddDashboardPermissionsMigrator(mg)
 			accesscontrol.AddAlertingPermissionsMigrator(mg)
+			accesscontrol.AddManagedFolderAlertActionsMigration(mg)
 		}
 	}
 	addQueryHistoryStarMigrations(mg)
@@ -91,7 +92,6 @@ func (*OSSMigrations) AddMigration(mg *Migrator) {
 			addCommentMigrations(mg)
 		}
 	}
-	accesscontrol.AddManagedFolderAlertActionsMigration(mg)
 }
 
 func addMigrationLogMigrations(mg *Migrator) {


### PR DESCRIPTION
**What this PR does / why we need it**:

`AddManagedFolderAlertActionsMigration` (introduced in https://github.com/grafana/grafana/pull/49946, backported in https://github.com/grafana/grafana/pull/50510) has to be run after `AddDashboardPermissionsMigrator`, as it is only effective if dashboard permissions have already been migrated. 

**Why**

If `accesscontrol` feature toggle is not set, `AddManagedFolderAlertActionsMigration` would have been run before `AddDashboardPermissionsMigrator`, so the required alerting actions would not have been added to folder viewers/editors/admins. This has multiple implications, one of which is that folder managed permissions would not correctly appear in the UI.

**Note**

This patch does not fix the issue for users who would have ran v8.5.5, v8.5.6, v8.5.7 or v8.5.8 with RBAC disabled.