### PR TITLE
GrafanaUI: improve Prometheus getQueryHints performance

### DIFF
--- a/public/app/plugins/datasource/prometheus/query_hints.ts
+++ b/public/app/plugins/datasource/prometheus/query_hints.ts
@@ -34,23 +34,28 @@ export function getQueryHints(query: string, series?: any[], datasource?: Promet
     // Use metric metadata for exact types
     const nameMatch = query.match(/\b(\w+_(total|sum|count))\b/);
     let counterNameMetric = nameMatch ? nameMatch[1] : '';
-    const metricsMetadata = datasource?.languageProvider?.metricsMetadata ?? {};
-    const metricMetadataKeys = Object.keys(metricsMetadata);
+    const metricsMetadata = datasource?.languageProvider?.metricsMetadata;
     let certain = false;
 
-    if (metricMetadataKeys.length > 0) {
+    if (metricsMetadata) {
+      // Tokenize the query into its identifiers (see https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels)
+      const queryTokens = Array.from(query.matchAll(/\$?[a-zA-Z_:][a-zA-Z0-9_:]*/g))
+        .map(([match]) => match)
+        // Exclude variable identifiers
+        .filter((token) => !token.startsWith('$'))
+        // Split composite keys to match the tokens returned by the language provider
+        .flatMap((token) => token.split(':'));
+      // Determine whether any of the query identifier tokens refers to a counter metric
       counterNameMetric =
-        metricMetadataKeys.find((metricName) => {
+        queryTokens.find((metricName) => {
           // Only considering first type information, could be non-deterministic
           const metadata = metricsMetadata[metricName];
-          if (metadata.type.toLowerCase() === 'counter') {
-            const metricRegex = new RegExp(`\\b${metricName}\\b`);
-            if (query.match(metricRegex)) {
-              certain = true;
-              return true;
-            }
+          if (metadata && metadata.type.toLowerCase() === 'counter') {
+            certain = true;
+            return true;
+          } else {
+            return false;
           }
-          return false;
         }) ?? '';
     }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- Large numbers of metrics (100K+) was causing our Grafana UI to seize up for multiple seconds whenever shifting focus away from the Prometheus query editor field, rendering the UI unusable
- Profiling indicated that >99% of execution time was spent in the `getQueryHint()` function
- `getQueryHint()` attempts to determine whether the query refers to any counter metrics, in order to show the 'Selected metric is a counter...' info message
- It does this by building a massive array containing all the metric names, iterating over each name, constructing a regular expression for each one, and searching for that regex in the query string (bailing out early if a match was found)
- My PR avoids building the large array of names, instead tokenizing the (much-less-unbounded) user query into a short list of promql identifiers and iterating through each one, determining whether the identifier matches one of the precomputed metric metadata names, and if so determining whether that metric is a counter
- For our use case, this brought the function execution time down from multiple seconds to <1ms

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

- I wasn't entirely sure how the `datasource.languageProvider.metricsMetadata` tokenization is meant to work for names containing colons: from my testing with keys containing colons the language provider appears to split the composite key name into sub-tokens; I copied this by splitting any user-provided query identifiers by colons
- The tokenization I implemented will strip out variable identifiers, but will still test any keywords / labels / function names seeing as these are all valid PromQL metric names according to [the Prometheus docs](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels). I don't think this is a concern because each test is an O(1) operation, and a typical query will contain roughly the same number of label identifiers as other identifiers, so the query complexity would have to be absolutely enormous for these unnecessary lookup misses to be a significant concern.
- Collisions / false positives are logically possible but practically fairly unlikely (e.g. if a counter metric name is also used elsewhere as a label) - the existing implementation is also prone to this and it only affects whether a warning is shown so I can't imagine this is a big deal
- The build tools didn't work for me (`yarn test` and `yarn start` both hung forever) so I had to test this manually in the browser by monkey-patching the existing implementation