### PR TITLE
Auth: Lockdown non-editables in frontend when external auth is configured

### DIFF
--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -60,7 +60,8 @@ export class UserOrgs extends PureComponent<Props, State> {
     const addToOrgContainerClass = css`
       margin-top: 0.8rem;
     `;
-    const canAddToOrg = contextSrv.hasPermission(AccessControlAction.OrgUsersAdd);
+
+    const canAddToOrg = contextSrv.hasPermission(AccessControlAction.OrgUsersAdd) && !isExternalUser;
     return (
       <>
         <h3 className="page-heading">Organizations</h3>

--- a/public/app/features/profile/UserProfileEditForm.tsx
+++ b/public/app/features/profile/UserProfileEditForm.tsx
@@ -21,16 +21,22 @@ export const UserProfileEditForm: FC<Props> = ({ user, isSavingUser, updateProfi
     updateProfile(data);
   };
 
+  // check if authLabels is longer than 0 otherwise false
+  const isExternalUser: boolean = (user && user.authLabels && user.authLabels.length > 0) ?? false;
+  const authSource = isExternalUser && user && user.authLabels ? user.authLabels[0] : '';
+  const lockMessage = authSource ? ` (Synced via ${authSource})` : '';
+  const disabledEdit = disableLoginForm || isExternalUser;
+
   return (
     <Form onSubmit={onSubmitProfileUpdate} validateOn="onBlur">
       {({ register, errors }) => {
         return (
           <FieldSet label={<Trans id="user-profile.title">Edit profile</Trans>}>
             <Field
-              label={t({ id: 'user-profile.fields.name-label', message: 'Name' })}
+              label={t({ id: 'user-profile.fields.name-label', message: 'Name' }) + lockMessage}
               invalid={!!errors.name}
               error={<Trans id="user-profile.fields.name-error">Name is required</Trans>}
-              disabled={disableLoginForm}
+              disabled={disabledEdit}
             >
               <Input
                 {...register('name', { required: true })}
@@ -42,10 +48,10 @@ export const UserProfileEditForm: FC<Props> = ({ user, isSavingUser, updateProfi
             </Field>
 
             <Field
-              label={t({ id: 'user-profile.fields.email-label', message: 'Email' })}
+              label={t({ id: 'user-profile.fields.email-label', message: 'Email' }) + lockMessage}
               invalid={!!errors.email}
               error={<Trans id="user-profile.fields.email-error">Email is required</Trans>}
-              disabled={disableLoginForm}
+              disabled={disabledEdit}
             >
               <Input
                 {...register('email', { required: true })}
@@ -57,14 +63,14 @@ export const UserProfileEditForm: FC<Props> = ({ user, isSavingUser, updateProfi
             </Field>
 
             <Field
-              label={t({ id: 'user-profile.fields.username-label', message: 'Username' })}
-              disabled={disableLoginForm}
+              label={t({ id: 'user-profile.fields.username-label', message: 'Username' }) + lockMessage}
+              disabled={disabledEdit}
             >
               <Input
                 {...register('login')}
                 id="edit-user-profile-username"
                 defaultValue={user?.login ?? ''}
-                placeholder={t({ id: 'user-profile.fields.username-label', message: 'Username' })}
+                placeholder={t({ id: 'user-profile.fields.username-label', message: 'Username' }) + lockMessage}
                 suffix={<InputSuffix />}
               />
             </Field>
@@ -72,7 +78,7 @@ export const UserProfileEditForm: FC<Props> = ({ user, isSavingUser, updateProfi
             <div className="gf-form-button-row">
               <Button
                 variant="primary"
-                disabled={isSavingUser}
+                disabled={isSavingUser || disabledEdit}
                 data-testid={selectors.components.UserProfile.profileSaveButton}
                 type="submit"
               >

--- a/public/app/features/profile/UserProfileEditForm.tsx
+++ b/public/app/features/profile/UserProfileEditForm.tsx
@@ -22,7 +22,7 @@ export const UserProfileEditForm: FC<Props> = ({ user, isSavingUser, updateProfi
   };
 
   // check if authLabels is longer than 0 otherwise false
-  const isExternalUser: boolean = (user && user.authLabels && user.authLabels.length > 0) ?? false;
+  const isExternalUser: boolean = (user && user.isExternal) ?? false;
   const authSource = isExternalUser && user && user.authLabels ? user.authLabels[0] : '';
   const lockMessage = authSource ? ` (Synced via ${authSource})` : '';
   const disabledEdit = disableLoginForm || isExternalUser;


### PR DESCRIPTION
**What this PR does / why we need it**:

Block frontend editing of attributes that will just be reset by the user logging back in.

- Profile info from signed in profile page
- Adding users to new orgs when they'll just be removed after

Before:
![swappy-20220713_143847](https://user-images.githubusercontent.com/8071073/178758897-3c8f5792-1b5d-42fa-8156-7a6699c7a98e.png)

![swappy-20220713_143941](https://user-images.githubusercontent.com/8071073/178758950-47aa2dc0-125f-4d3b-ad51-ab05ca11ef2c.png)


-------

After:

![swappy-20220713_151758](https://user-images.githubusercontent.com/8071073/178759315-6f12967c-d37b-49de-a610-a23dc6701a6a.png)


![swappy-20220713_153954](https://user-images.githubusercontent.com/8071073/178759319-3743c54b-727d-4800-9abb-ac49202502d6.png)

![swappy-20220713_151612](https://user-images.githubusercontent.com/8071073/178759308-630f661e-8254-4f24-9523-076b6ad6e16e.png)

(Save button was greyed out after this screenshot)

In future PRs:

- we'll block on the backend side as well
- we'll stop org users from being removed from org member view if they'll just be added right back by Auth