### PR TITLE
Rendering: Render csv panel with non-ascii characters

### DIFF
--- a/pkg/services/rendering/http_mode.go
+++ b/pkg/services/rendering/http_mode.go
@@ -95,8 +95,8 @@ func (rs *RenderingService) renderCSVViaHTTP(ctx context.Context, renderKey stri
 	}
 
 	queryParams := rendererURL.Query()
-	url := rs.getURL(opts.Path)
-	queryParams.Add("url", url)
+	pathURL := rs.getURL(opts.Path)
+	queryParams.Add("url", pathURL)
 	queryParams.Add("renderKey", renderKey)
 	queryParams.Add("domain", rs.domain)
 	queryParams.Add("timezone", isoTimeOffsetToPosixTz(opts.Timezone))
@@ -125,9 +125,13 @@ func (rs *RenderingService) renderCSVViaHTTP(ctx context.Context, renderKey stri
 	if err != nil {
 		return nil, err
 	}
-	downloadFileName := params["filename"]
 
-	err = rs.readFileResponse(reqContext, resp, filePath, url)
+	downloadFileName, err := url.PathUnescape(params["filename"])
+	if err != nil {
+		return nil, err
+	}
+
+	err = rs.readFileResponse(reqContext, resp, filePath, pathURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
When we render a panel for CSV, we are setting the file name into the `Content-Disposition` header in image-renderer. 

This header only accepts ASCII characters. When we are setting titles into this field without ASCII characters, image-renderer generates an error and we cannot retrieve the CSV because the temporal file is deleted by the plugin.

To fix it, we escape the fileName in the header and unescape when we receive it.

**Which issue(s) this PR fixes**:
* Issue: https://github.com/grafana/grafana-enterprise/issues/3576
* Escalation: https://github.com/grafana/support-escalations/issues/3221

Image-renderer change: https://github.com/grafana/grafana-image-renderer/pull/357