### PR TITLE
Logs: Fixed LogContext being underneath the table

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -123,7 +123,9 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
     const styles = getStyles(theme);
 
     return (
-      <td className={style.logsRowMessage}>
+      // When context is open, the position has to be NOT relative.
+      // Setting the postion as inline-style to overwrite the more sepecific style definition from `style.logsRowMessage`.
+      <td style={contextIsOpen ? { position: 'unset' } : undefined} className={style.logsRowMessage}>
         <div
           className={cx({ [styles.positionRelative]: wrapLogMessage }, { [styles.horizontalScroll]: !wrapLogMessage })}
         >


### PR DESCRIPTION
**What this PR does / why we need it**:
After #51027 the LogContext in the first few rows would be broken.

![image](https://user-images.githubusercontent.com/8092184/178771632-47def2b5-db65-4136-a149-725af9176d7c.png)

