### PR TITLE
Panels: Prevent panel content from escaping its bounds

### DIFF
--- a/public/sass/pages/_dashboard.scss
+++ b/public/sass/pages/_dashboard.scss
@@ -46,6 +46,7 @@
   padding: $panel-padding;
   width: 100%;
   flex-grow: 1;
+  contain: strict;
   height: calc(100% - #{$panel-header-height});
 
   &--no-padding {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `contain: strict;` to `.panel-content` to prevent panel content escaping its bounds, which could previously be used in conjunction with the text panel and `position: fixed;`, for example, to arbitrarily place content on the screen.

**Special notes for your reviewer**:
As a bonus side-effect, `contain:strict;` could have minor performance benefits by allowing browsers to do less work