### PR TITLE
Secret migration from Sql KV Store to Secret Plugin

### DIFF
--- a/pkg/infra/kvstore/kvstore_test.go
+++ b/pkg/infra/kvstore/kvstore_test.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func createTestableKVStore(t *testing.T) KVStore {

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -295,6 +295,7 @@ var wireBasicSet = wire.NewSet(
 	userimpl.ProvideService,
 	orgimpl.ProvideService,
 	datasourceservice.ProvideDataSourceMigrationService,
+	secretsStore.ProvidePluginSecretMigrationService,
 	secretsMigrations.ProvideSecretMigrationService,
 	wire.Bind(new(secretsMigrations.SecretMigrationService), new(*secretsMigrations.SecretMigrationServiceImpl)),
 )

--- a/pkg/services/secrets/kvstore/helpers.go
+++ b/pkg/services/secrets/kvstore/helpers.go
@@ -56,7 +56,7 @@ func (f FakeSecretsKVStore) Del(ctx context.Context, orgId int64, namespace stri
 
 func (f FakeSecretsKVStore) Keys(ctx context.Context, orgId int64, namespace string, typ string) ([]Key, error) {
 	res := make([]Key, 0)
-	for k, _ := range f.store {
+	for k := range f.store {
 		if k.OrgId == orgId && k.Namespace == namespace && k.Type == typ {
 			res = append(res, k)
 		}

--- a/pkg/services/secrets/kvstore/helpers.go
+++ b/pkg/services/secrets/kvstore/helpers.go
@@ -1,6 +1,7 @@
 package kvstore
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -27,3 +28,54 @@ func SetupTestService(t *testing.T) SecretsKVStore {
 
 	return kv
 }
+
+// In memory kv store used for testing
+type FakeSecretsKVStore struct {
+	store map[Key]string
+}
+
+func NewFakeSecretsKVStore() FakeSecretsKVStore {
+	return FakeSecretsKVStore{store: make(map[Key]string)}
+}
+
+func (f FakeSecretsKVStore) Get(ctx context.Context, orgId int64, namespace string, typ string) (string, bool, error) {
+	value := f.store[buildKey(orgId, namespace, typ)]
+	found := value != ""
+	return value, found, nil
+}
+
+func (f FakeSecretsKVStore) Set(ctx context.Context, orgId int64, namespace string, typ string, value string) error {
+	f.store[buildKey(orgId, namespace, typ)] = value
+	return nil
+}
+
+func (f FakeSecretsKVStore) Del(ctx context.Context, orgId int64, namespace string, typ string) error {
+	delete(f.store, buildKey(orgId, namespace, typ))
+	return nil
+}
+
+func (f FakeSecretsKVStore) Keys(ctx context.Context, orgId int64, namespace string, typ string) ([]Key, error) {
+	res := make([]Key, 0)
+	for k, _ := range f.store {
+		if k.OrgId == orgId && k.Namespace == namespace && k.Type == typ {
+			res = append(res, k)
+		}
+	}
+	return res, nil
+}
+
+func (f FakeSecretsKVStore) Rename(ctx context.Context, orgId int64, namespace string, typ string, newNamespace string) error {
+	f.store[buildKey(orgId, newNamespace, typ)] = f.store[buildKey(orgId, namespace, typ)]
+	delete(f.store, buildKey(orgId, namespace, typ))
+	return nil
+}
+
+func buildKey(orgId int64, namespace string, typ string) Key {
+	return Key{
+		OrgId:     orgId,
+		Namespace: namespace,
+		Type:      typ,
+	}
+}
+
+var _ SecretsKVStore = FakeSecretsKVStore{}

--- a/pkg/services/secrets/kvstore/kvstore.go
+++ b/pkg/services/secrets/kvstore/kvstore.go
@@ -37,8 +37,9 @@ func ProvideService(sqlStore sqlstore.Store, secretsService secrets.Service, rem
 				log:            logger,
 			}
 		}
+	} else {
+		logger.Debug("secrets kvstore is using the default (SQL) implementation for secrets management")
 	}
-	logger.Debug("secrets kvstore is using the default (SQL) implementation for secrets management")
 	return NewCachedKVStore(store, 5*time.Second, 5*time.Minute)
 }
 

--- a/pkg/services/secrets/kvstore/migrations/migrator.go
+++ b/pkg/services/secrets/kvstore/migrations/migrator.go
@@ -2,13 +2,13 @@ package migrations
 
 import (
 	"context"
-	"github.com/grafana/grafana/pkg/services/secrets/kvstore"
 	"reflect"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/serverlock"
 	datasources "github.com/grafana/grafana/pkg/services/datasources/service"
+	"github.com/grafana/grafana/pkg/services/secrets/kvstore"
 )
 
 var logger = log.New("secret.migration")

--- a/pkg/services/secrets/kvstore/migrations/migrator.go
+++ b/pkg/services/secrets/kvstore/migrations/migrator.go
@@ -28,7 +28,6 @@ func ProvideSecretMigrationService(
 	dataSourceSecretMigrationService *datasources.DataSourceSecretMigrationService,
 	pluginSecretMigrationService *kvstore.PluginSecretMigrationService,
 ) *SecretMigrationServiceImpl {
-
 	services := make([]SecretMigrationService, 0)
 	services = append(services, dataSourceSecretMigrationService)
 	// pluginMigrationService should always be the last one

--- a/pkg/services/secrets/kvstore/migrations/migrator.go
+++ b/pkg/services/secrets/kvstore/migrations/migrator.go
@@ -28,14 +28,15 @@ func ProvideSecretMigrationService(
 	dataSourceSecretMigrationService *datasources.DataSourceSecretMigrationService,
 	pluginSecretMigrationService *kvstore.PluginSecretMigrationService,
 ) *SecretMigrationServiceImpl {
+
+	services := make([]SecretMigrationService, 0)
+	services = append(services, dataSourceSecretMigrationService)
+	// pluginMigrationService should always be the last one
+	services = append(services, pluginSecretMigrationService)
+
 	return &SecretMigrationServiceImpl{
 		ServerLockService: serverLockService,
-		Services: []SecretMigrationService{
-			dataSourceSecretMigrationService,
-			// migration from unified secrets to plugin secrets, if enabled.
-			// pluginMigrationService should always be the last one
-			pluginSecretMigrationService,
-		},
+		Services:          services,
 	}
 }
 

--- a/pkg/services/secrets/kvstore/plugin_mig.go
+++ b/pkg/services/secrets/kvstore/plugin_mig.go
@@ -2,8 +2,6 @@ package kvstore
 
 import (
 	"context"
-	"strconv"
-
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/secrets"
@@ -44,14 +42,8 @@ func ProvidePluginSecretMigrationService(
 }
 
 func (s *PluginSecretMigrationService) Migrate(ctx context.Context) error {
-	// TODO LND DONE 1- check if the configuration is set to true.
-	// TODO LND DONE 2- Retrieve all the secrets from the secretsKVStoreSQL (we may need to add a new service there).
-	// TODO LND DONE 3- Store one by one to the plugin
-	// TODO LND DONE 4- Delete all the secrets once all are migrated
-	// TODO LND DONE We need to take into account HA, see gui conversation to check how to lock on that - This is done, as with Gui implementation this runs within a lock.
-
 	// TODO LND Check the config key if need rename it
-	// TODO LND check other parameters with gui, if legacy mode or other config is enabled what whould we do
+	// TODO LND check other parameters with gui, if legacy mode or other config is enabled what would we do
 	// Check if we should migrate to plugin - default false
 	if s.cfg.SectionWithEnvOverrides("secrets").Key("migrate_to_plugin").MustBool(false) &&
 		s.remoteCheck.ShouldUseRemoteSecretsPlugin() {
@@ -66,13 +58,10 @@ func (s *PluginSecretMigrationService) Migrate(ctx context.Context) error {
 			},
 		}
 
-		// TODO LND this needs to change to return all the rows
 		allSec, err := secretsSql.GetAll(ctx)
 		if err != nil {
 			return nil
 		}
-		// TODO LND Remove this log
-		s.logger.Debug("item count" + strconv.Itoa(len(allSec)))
 		// We just set it again as the current secret store should be the plugin secret
 		for _, sec := range allSec {
 			err = s.secretsStore.Set(ctx, *sec.OrgId, *sec.Namespace, *sec.Type, sec.Value)
@@ -81,7 +70,6 @@ func (s *PluginSecretMigrationService) Migrate(ctx context.Context) error {
 			}
 		}
 		// as no err was returned, when we delete all the secrets from the sql store
-		// TODO LND Should we do this as we save into the plugin?? Or we still need that for
 		for _, sec := range allSec {
 			err = secretsSql.Del(ctx, *sec.OrgId, *sec.Namespace, *sec.Type)
 			if err != nil {

--- a/pkg/services/secrets/kvstore/plugin_mig.go
+++ b/pkg/services/secrets/kvstore/plugin_mig.go
@@ -2,12 +2,13 @@ package kvstore
 
 import (
 	"context"
+	"strconv"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
-	"strconv"
 )
 
 // PluginSecretMigrationService This migrator will handle migration of datasource secrets (aka Unified secrets)

--- a/pkg/services/secrets/kvstore/plugin_mig.go
+++ b/pkg/services/secrets/kvstore/plugin_mig.go
@@ -47,7 +47,7 @@ func (s *PluginSecretMigrationService) Migrate(ctx context.Context) error {
 	// TODO LND DONE 1- check if the configuration is set to true.
 	// TODO LND DONE 2- Retrieve all the secrets from the secretsKVStoreSQL (we may need to add a new service there).
 	// TODO LND DONE 3- Store one by one to the plugin
-	// TODO LND 4- Delete all the secrets once all are migrated
+	// TODO LND DONE 4- Delete all the secrets once all are migrated
 	// TODO LND DONE We need to take into account HA, see gui conversation to check how to lock on that - This is done, as with Gui implementation this runs within a lock.
 
 	// TODO LND Check the config key if need rename it
@@ -81,7 +81,7 @@ func (s *PluginSecretMigrationService) Migrate(ctx context.Context) error {
 			}
 		}
 		// as no err was returned, when we delete all the secrets from the sql store
-		// TODO LND Should we do this as we save into the plugin??
+		// TODO LND Should we do this as we save into the plugin?? Or we still need that for
 		for _, sec := range allSec {
 			err = secretsSql.Del(ctx, *sec.OrgId, *sec.Namespace, *sec.Type)
 			if err != nil {

--- a/pkg/services/secrets/kvstore/plugin_mig.go
+++ b/pkg/services/secrets/kvstore/plugin_mig.go
@@ -24,7 +24,6 @@ type PluginSecretMigrationService struct {
 
 func ProvidePluginSecretMigrationService(
 	features featuremgmt.FeatureToggles,
-	// TODO LND We need to check if this is actually a plugin store
 	secretsStore SecretsKVStore,
 	cfg *setting.Cfg,
 	sqlStore sqlstore.Store,
@@ -43,8 +42,6 @@ func ProvidePluginSecretMigrationService(
 }
 
 func (s *PluginSecretMigrationService) Migrate(ctx context.Context) error {
-	// TODO LND Check the config key if need rename it
-	// TODO LND check other parameters with gui, if legacy mode or other config is enabled what would we do
 	// Check if we should migrate to plugin - default false
 	if s.cfg.SectionWithEnvOverrides("secrets").Key("migrate_to_plugin").MustBool(false) &&
 		s.remoteCheck.ShouldUseRemoteSecretsPlugin() {

--- a/pkg/services/secrets/kvstore/plugin_mig.go
+++ b/pkg/services/secrets/kvstore/plugin_mig.go
@@ -2,6 +2,7 @@ package kvstore
 
 import (
 	"context"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/secrets"
@@ -23,7 +24,7 @@ type PluginSecretMigrationService struct {
 
 func ProvidePluginSecretMigrationService(
 	features featuremgmt.FeatureToggles,
-	// TODO LND We need to check if this is actually a plugin store
+// TODO LND We need to check if this is actually a plugin store
 	secretsStore SecretsKVStore,
 	cfg *setting.Cfg,
 	sqlStore sqlstore.Store,

--- a/pkg/services/secrets/kvstore/plugin_mig.go
+++ b/pkg/services/secrets/kvstore/plugin_mig.go
@@ -24,7 +24,7 @@ type PluginSecretMigrationService struct {
 
 func ProvidePluginSecretMigrationService(
 	features featuremgmt.FeatureToggles,
-// TODO LND We need to check if this is actually a plugin store
+	// TODO LND We need to check if this is actually a plugin store
 	secretsStore SecretsKVStore,
 	cfg *setting.Cfg,
 	sqlStore sqlstore.Store,

--- a/pkg/services/secrets/kvstore/plugin_mig.go
+++ b/pkg/services/secrets/kvstore/plugin_mig.go
@@ -1,0 +1,92 @@
+package kvstore
+
+import (
+	"context"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/secrets"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
+	"strconv"
+)
+
+// PluginSecretMigrationService This migrator will handle migration of datasource secrets (aka Unified secrets)
+// into the plugin secrets configured
+type PluginSecretMigrationService struct {
+	features       featuremgmt.FeatureToggles
+	secretsStore   SecretsKVStore
+	cfg            *setting.Cfg
+	logger         log.Logger
+	sqlStore       sqlstore.Store
+	secretsService secrets.Service
+	remoteCheck    UseRemoteSecretsPluginCheck
+}
+
+func ProvidePluginSecretMigrationService(
+	features featuremgmt.FeatureToggles,
+	// TODO LND We need to check if this is actually a plugin store
+	secretsStore SecretsKVStore,
+	cfg *setting.Cfg,
+	sqlStore sqlstore.Store,
+	secretsService secrets.Service,
+	remoteCheck UseRemoteSecretsPluginCheck,
+) *PluginSecretMigrationService {
+	return &PluginSecretMigrationService{
+		features:       features,
+		secretsStore:   secretsStore,
+		cfg:            cfg,
+		logger:         log.New("sec-plugin-mig"),
+		sqlStore:       sqlStore,
+		secretsService: secretsService,
+		remoteCheck:    remoteCheck,
+	}
+}
+
+func (s *PluginSecretMigrationService) Migrate(ctx context.Context) error {
+	// TODO LND DONE 1- check if the configuration is set to true.
+	// TODO LND DONE 2- Retrieve all the secrets from the secretsKVStoreSQL (we may need to add a new service there).
+	// TODO LND DONE 3- Store one by one to the plugin
+	// TODO LND 4- Delete all the secrets once all are migrated
+	// TODO LND DONE We need to take into account HA, see gui conversation to check how to lock on that - This is done, as with Gui implementation this runs within a lock.
+
+	// TODO LND Check the config key if need rename it
+	// TODO LND check other parameters with gui, if legacy mode or other config is enabled what whould we do
+	// Check if we should migrate to plugin - default false
+	if s.cfg.SectionWithEnvOverrides("secrets").Key("migrate_to_plugin").MustBool(false) &&
+		s.remoteCheck.ShouldUseRemoteSecretsPlugin() {
+		// we need to instantiate the secretsKVStore as this is not on wire, and in this scenario,
+		// the secrets store would be the plugin.
+		secretsSql := &secretsKVStoreSQL{
+			sqlStore:       s.sqlStore,
+			secretsService: s.secretsService,
+			log:            s.logger,
+			decryptionCache: decryptionCache{
+				cache: make(map[int64]cachedDecrypted),
+			},
+		}
+
+		// TODO LND this needs to change to return all the rows
+		allSec, err := secretsSql.GetAll(ctx)
+		if err != nil {
+			return nil
+		}
+		// TODO LND Remove this log
+		s.logger.Debug("item count" + strconv.Itoa(len(allSec)))
+		// We just set it again as the current secret store should be the plugin secret
+		for _, sec := range allSec {
+			err = s.secretsStore.Set(ctx, *sec.OrgId, *sec.Namespace, *sec.Type, sec.Value)
+			if err != nil {
+				return err
+			}
+		}
+		// as no err was returned, when we delete all the secrets from the sql store
+		// TODO LND Should we do this as we save into the plugin??
+		for _, sec := range allSec {
+			err = secretsSql.Del(ctx, *sec.OrgId, *sec.Namespace, *sec.Type)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/services/secrets/kvstore/plugin_mig.go
+++ b/pkg/services/secrets/kvstore/plugin_mig.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/secrets"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
@@ -13,7 +12,6 @@ import (
 // PluginSecretMigrationService This migrator will handle migration of datasource secrets (aka Unified secrets)
 // into the plugin secrets configured
 type PluginSecretMigrationService struct {
-	features       featuremgmt.FeatureToggles
 	secretsStore   SecretsKVStore
 	cfg            *setting.Cfg
 	logger         log.Logger
@@ -23,7 +21,6 @@ type PluginSecretMigrationService struct {
 }
 
 func ProvidePluginSecretMigrationService(
-	features featuremgmt.FeatureToggles,
 	secretsStore SecretsKVStore,
 	cfg *setting.Cfg,
 	sqlStore sqlstore.Store,
@@ -31,7 +28,6 @@ func ProvidePluginSecretMigrationService(
 	remoteCheck UseRemoteSecretsPluginCheck,
 ) *PluginSecretMigrationService {
 	return &PluginSecretMigrationService{
-		features:       features,
 		secretsStore:   secretsStore,
 		cfg:            cfg,
 		logger:         log.New("sec-plugin-mig"),

--- a/pkg/services/secrets/kvstore/plugin_mig_test.go
+++ b/pkg/services/secrets/kvstore/plugin_mig_test.go
@@ -1,0 +1,121 @@
+package kvstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/plugins/backendplugin/secretsmanagerplugin"
+	"github.com/grafana/grafana/pkg/services/secrets/fakes"
+	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
+)
+
+// This tests will create a mock sql database and an inmemory
+// implementation of the secret manager to simulate the plugin.
+func TestPluginSecretMigrationService_Migrate(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("migration run ok - 2 secrets migrated", func(t *testing.T) {
+		// --- SETUP
+		migratorService, secretsStore, sqlSecretStore := setupTestMigratorService(t)
+		var orgId int64 = 1
+		namespace1, namespace2 := "namespace-test", "namespace-test2"
+		typ := "type-test"
+		value := "SUPER_SECRET"
+
+		addSecretToSqlStore(t, sqlSecretStore, ctx, orgId, namespace1, typ, value)
+		addSecretToSqlStore(t, sqlSecretStore, ctx, orgId, namespace2, typ, value)
+
+		// --- EXECUTION
+		err := migratorService.Migrate(ctx)
+		require.NoError(t, err)
+
+		// --- VALIDATIONS
+		validateSecretWasDeleted(t, sqlSecretStore, ctx, orgId, namespace1, typ)
+		validateSecretWasDeleted(t, sqlSecretStore, ctx, orgId, namespace2, typ)
+
+		validateSecretWasStoreInPlugin(t, secretsStore, ctx, orgId, namespace1, typ)
+		validateSecretWasStoreInPlugin(t, secretsStore, ctx, orgId, namespace1, typ)
+	})
+}
+
+func addSecretToSqlStore(t *testing.T, sqlSecretStore *secretsKVStoreSQL, ctx context.Context, orgId int64, namespace1 string, typ string, value string) {
+	err := sqlSecretStore.Set(ctx, orgId, namespace1, typ, value)
+	require.NoError(t, err)
+}
+
+// validates that secrets on the sql store were deleted.
+func validateSecretWasDeleted(t *testing.T, sqlSecretStore *secretsKVStoreSQL, ctx context.Context, orgId int64, namespace1 string, typ string) {
+	res, err := sqlSecretStore.Keys(ctx, orgId, namespace1, typ)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(res))
+}
+
+// validates that secrets should be on the plugin
+func validateSecretWasStoreInPlugin(t *testing.T, secretsStore SecretsKVStore, ctx context.Context, orgId int64, namespace1 string, typ string) {
+	resPlugin, err := secretsStore.Keys(ctx, orgId, namespace1, typ)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(resPlugin))
+}
+
+//
+func setupTestMigratorService(t *testing.T) (*PluginSecretMigrationService, SecretsKVStore, *secretsKVStoreSQL) {
+	t.Helper()
+
+	rawCfg := `
+		[secrets]
+		use_plugin = true
+		migrate_to_plugin = true
+		`
+	raw, err := ini.Load([]byte(rawCfg))
+	require.NoError(t, err)
+	cfg := &setting.Cfg{Raw: raw}
+	// this would be the plugin - mocked at the moment
+	secretsStoreForPlugin := NewFakeSecretsKVStore()
+	// Mocked remote plugin check, always return true
+	remoteCheck := provideMockRemotePluginCheck()
+
+	// this is to init the sql secret store inside the migration
+	sqlStore := sqlstore.InitTestDB(t)
+	secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
+
+	migratorService := ProvidePluginSecretMigrationService(
+		secretsStoreForPlugin,
+		cfg,
+		sqlStore,
+		secretsService,
+		remoteCheck,
+	)
+
+	secretsSql := &secretsKVStoreSQL{
+		sqlStore:       sqlStore,
+		secretsService: secretsService,
+		log:            log.New("test.logger"),
+		decryptionCache: decryptionCache{
+			cache: make(map[int64]cachedDecrypted),
+		},
+	}
+
+	return migratorService, secretsStoreForPlugin, secretsSql
+}
+
+//
+type mockRemoteSecretsPluginCheck struct {
+	UseRemoteSecretsPluginCheck
+}
+
+func provideMockRemotePluginCheck() *mockRemoteSecretsPluginCheck {
+	return &mockRemoteSecretsPluginCheck{}
+}
+
+func (c *mockRemoteSecretsPluginCheck) ShouldUseRemoteSecretsPlugin() bool {
+	return true
+}
+
+func (c *mockRemoteSecretsPluginCheck) GetPlugin() (secretsmanagerplugin.SecretsManagerPlugin, error) {
+	return nil, nil
+}

--- a/pkg/services/secrets/kvstore/plugin_mig_test.go
+++ b/pkg/services/secrets/kvstore/plugin_mig_test.go
@@ -4,14 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/plugins/backendplugin/secretsmanagerplugin"
-	"github.com/grafana/grafana/pkg/services/secrets/fakes"
-	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
-	"github.com/grafana/grafana/pkg/services/sqlstore"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/ini.v1"
 )
 
 // This tests will create a mock sql database and an inmemory
@@ -21,7 +14,7 @@ func TestPluginSecretMigrationService_Migrate(t *testing.T) {
 
 	t.Run("migration run ok - 2 secrets migrated", func(t *testing.T) {
 		// --- SETUP
-		migratorService, secretsStore, sqlSecretStore := setupTestMigratorService(t)
+		migratorService, secretsStore, sqlSecretStore := SetupTestMigratorService(t)
 		var orgId int64 = 1
 		namespace1, namespace2 := "namespace-test", "namespace-test2"
 		typ := "type-test"
@@ -60,62 +53,4 @@ func validateSecretWasStoreInPlugin(t *testing.T, secretsStore SecretsKVStore, c
 	resPlugin, err := secretsStore.Keys(ctx, orgId, namespace1, typ)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(resPlugin))
-}
-
-//
-func setupTestMigratorService(t *testing.T) (*PluginSecretMigrationService, SecretsKVStore, *secretsKVStoreSQL) {
-	t.Helper()
-
-	rawCfg := `
-		[secrets]
-		use_plugin = true
-		migrate_to_plugin = true
-		`
-	raw, err := ini.Load([]byte(rawCfg))
-	require.NoError(t, err)
-	cfg := &setting.Cfg{Raw: raw}
-	// this would be the plugin - mocked at the moment
-	secretsStoreForPlugin := NewFakeSecretsKVStore()
-	// Mocked remote plugin check, always return true
-	remoteCheck := provideMockRemotePluginCheck()
-
-	// this is to init the sql secret store inside the migration
-	sqlStore := sqlstore.InitTestDB(t)
-	secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
-
-	migratorService := ProvidePluginSecretMigrationService(
-		secretsStoreForPlugin,
-		cfg,
-		sqlStore,
-		secretsService,
-		remoteCheck,
-	)
-
-	secretsSql := &secretsKVStoreSQL{
-		sqlStore:       sqlStore,
-		secretsService: secretsService,
-		log:            log.New("test.logger"),
-		decryptionCache: decryptionCache{
-			cache: make(map[int64]cachedDecrypted),
-		},
-	}
-
-	return migratorService, secretsStoreForPlugin, secretsSql
-}
-
-//
-type mockRemoteSecretsPluginCheck struct {
-	UseRemoteSecretsPluginCheck
-}
-
-func provideMockRemotePluginCheck() *mockRemoteSecretsPluginCheck {
-	return &mockRemoteSecretsPluginCheck{}
-}
-
-func (c *mockRemoteSecretsPluginCheck) ShouldUseRemoteSecretsPlugin() bool {
-	return true
-}
-
-func (c *mockRemoteSecretsPluginCheck) GetPlugin() (secretsmanagerplugin.SecretsManagerPlugin, error) {
-	return nil, nil
 }

--- a/pkg/services/secrets/kvstore/plugin_mig_test.go
+++ b/pkg/services/secrets/kvstore/plugin_mig_test.go
@@ -4,7 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/plugins/backendplugin/secretsmanagerplugin"
+	"github.com/grafana/grafana/pkg/services/secrets/fakes"
+	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/ini.v1"
 )
 
 // This tests will create a mock sql database and an inmemory
@@ -14,7 +21,7 @@ func TestPluginSecretMigrationService_Migrate(t *testing.T) {
 
 	t.Run("migration run ok - 2 secrets migrated", func(t *testing.T) {
 		// --- SETUP
-		migratorService, secretsStore, sqlSecretStore := SetupTestMigratorService(t)
+		migratorService, secretsStore, sqlSecretStore := setupTestMigratorService(t)
 		var orgId int64 = 1
 		namespace1, namespace2 := "namespace-test", "namespace-test2"
 		typ := "type-test"
@@ -53,4 +60,62 @@ func validateSecretWasStoreInPlugin(t *testing.T, secretsStore SecretsKVStore, c
 	resPlugin, err := secretsStore.Keys(ctx, orgId, namespace1, typ)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(resPlugin))
+}
+
+//
+func setupTestMigratorService(t *testing.T) (*PluginSecretMigrationService, SecretsKVStore, *secretsKVStoreSQL) {
+	t.Helper()
+
+	rawCfg := `
+		[secrets]
+		use_plugin = true
+		migrate_to_plugin = true
+		`
+	raw, err := ini.Load([]byte(rawCfg))
+	require.NoError(t, err)
+	cfg := &setting.Cfg{Raw: raw}
+	// this would be the plugin - mocked at the moment
+	secretsStoreForPlugin := NewFakeSecretsKVStore()
+	// Mocked remote plugin check, always return true
+	remoteCheck := provideMockRemotePluginCheck()
+
+	// this is to init the sql secret store inside the migration
+	sqlStore := sqlstore.InitTestDB(t)
+	secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
+
+	migratorService := ProvidePluginSecretMigrationService(
+		secretsStoreForPlugin,
+		cfg,
+		sqlStore,
+		secretsService,
+		remoteCheck,
+	)
+
+	secretsSql := &secretsKVStoreSQL{
+		sqlStore:       sqlStore,
+		secretsService: secretsService,
+		log:            log.New("test.logger"),
+		decryptionCache: decryptionCache{
+			cache: make(map[int64]cachedDecrypted),
+		},
+	}
+
+	return migratorService, secretsStoreForPlugin, secretsSql
+}
+
+//
+type mockRemoteSecretsPluginCheck struct {
+	UseRemoteSecretsPluginCheck
+}
+
+func provideMockRemotePluginCheck() *mockRemoteSecretsPluginCheck {
+	return &mockRemoteSecretsPluginCheck{}
+}
+
+func (c *mockRemoteSecretsPluginCheck) ShouldUseRemoteSecretsPlugin() bool {
+	return true
+}
+
+func (c *mockRemoteSecretsPluginCheck) GetPlugin() (secretsmanagerplugin.SecretsManagerPlugin, error) {
+	return nil, nil
 }

--- a/pkg/services/secrets/kvstore/sql.go
+++ b/pkg/services/secrets/kvstore/sql.go
@@ -31,6 +31,8 @@ type cachedDecrypted struct {
 
 var b64 = base64.RawStdEncoding
 
+// TODO LND Write a test for this implementation
+
 // Get an item from the store
 func (kv *secretsKVStoreSQL) Get(ctx context.Context, orgId int64, namespace string, typ string) (string, bool, error) {
 	item := Item{
@@ -222,4 +224,18 @@ func (kv *secretsKVStoreSQL) Rename(ctx context.Context, orgId int64, namespace 
 
 		return err
 	})
+}
+
+// GetAll this returns all the secrets stored in the database. This is not part of the kvstore interface as we
+// only need it for migration from sql to plugin at this moment
+func (kv *secretsKVStoreSQL) GetAll(ctx context.Context) ([]Item, error) {
+	// TODO LND should we do this for a certain orgId?
+	var items []Item
+	err := kv.sqlStore.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
+		return dbSession.Find(&items)
+	})
+	if err != nil {
+		kv.log.Debug("error getting all the items", "err", err)
+	}
+	return items, err
 }

--- a/pkg/services/secrets/kvstore/sql.go
+++ b/pkg/services/secrets/kvstore/sql.go
@@ -31,8 +31,6 @@ type cachedDecrypted struct {
 
 var b64 = base64.RawStdEncoding
 
-// TODO LND Write a test for this implementation
-
 // Get an item from the store
 func (kv *secretsKVStoreSQL) Get(ctx context.Context, orgId int64, namespace string, typ string) (string, bool, error) {
 	item := Item{

--- a/pkg/services/secrets/kvstore/sql.go
+++ b/pkg/services/secrets/kvstore/sql.go
@@ -250,14 +250,14 @@ func (kv *secretsKVStoreSQL) GetAll(ctx context.Context) ([]Item, error) {
 		decodedValue, err := b64.DecodeString(items[i].Value)
 		if err != nil {
 			kv.log.Debug("error decoding secret value", "orgId", items[i].OrgId, "type", items[i].Type, "namespace", items[i].Namespace, "err", err)
-			items[i].Value = ""
+			items[i].Value = string(decryptedValue)
 			continue
 		}
 
 		decryptedValue, err = kv.secretsService.Decrypt(ctx, decodedValue)
 		if err != nil {
 			kv.log.Debug("error decrypting secret value", "orgId", items[i].OrgId, "type", items[i].Type, "namespace", items[i].Namespace, "err", err)
-			items[i].Value = ""
+			items[i].Value = string(decryptedValue)
 			continue
 		}
 

--- a/pkg/services/secrets/kvstore/sql.go
+++ b/pkg/services/secrets/kvstore/sql.go
@@ -44,11 +44,11 @@ func (kv *secretsKVStoreSQL) Get(ctx context.Context, orgId int64, namespace str
 	err := kv.sqlStore.WithDbSession(ctx, func(dbSession *sqlstore.DBSession) error {
 		has, err := dbSession.Get(&item)
 		if err != nil {
-			kv.log.Debug("error getting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+			kv.log.Error("error getting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			return err
 		}
 		if !has {
-			kv.log.Debug("secret value not found", "orgId", orgId, "type", typ, "namespace", namespace)
+			kv.log.Error("secret value not found", "orgId", orgId, "type", typ, "namespace", namespace)
 			return nil
 		}
 		isFound = true
@@ -66,13 +66,13 @@ func (kv *secretsKVStoreSQL) Get(ctx context.Context, orgId int64, namespace str
 
 		decodedValue, err := b64.DecodeString(item.Value)
 		if err != nil {
-			kv.log.Debug("error decoding secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+			kv.log.Error("error decoding secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			return string(decryptedValue), isFound, err
 		}
 
 		decryptedValue, err = kv.secretsService.Decrypt(ctx, decodedValue)
 		if err != nil {
-			kv.log.Debug("error decrypting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+			kv.log.Error("error decrypting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			return string(decryptedValue), isFound, err
 		}
 
@@ -90,7 +90,7 @@ func (kv *secretsKVStoreSQL) Get(ctx context.Context, orgId int64, namespace str
 func (kv *secretsKVStoreSQL) Set(ctx context.Context, orgId int64, namespace string, typ string, value string) error {
 	encryptedValue, err := kv.secretsService.Encrypt(ctx, []byte(value), secrets.WithoutScope())
 	if err != nil {
-		kv.log.Debug("error encrypting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+		kv.log.Error("error encrypting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 		return err
 	}
 	encodedValue := b64.EncodeToString(encryptedValue)
@@ -103,7 +103,7 @@ func (kv *secretsKVStoreSQL) Set(ctx context.Context, orgId int64, namespace str
 
 		has, err := dbSession.Get(&item)
 		if err != nil {
-			kv.log.Debug("error checking secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+			kv.log.Error("error checking secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			return err
 		}
 
@@ -119,7 +119,7 @@ func (kv *secretsKVStoreSQL) Set(ctx context.Context, orgId int64, namespace str
 			// if item already exists we update it
 			_, err = dbSession.ID(item.Id).Update(&item)
 			if err != nil {
-				kv.log.Debug("error updating secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+				kv.log.Error("error updating secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			} else {
 				kv.decryptionCache.Lock()
 				defer kv.decryptionCache.Unlock()
@@ -136,7 +136,7 @@ func (kv *secretsKVStoreSQL) Set(ctx context.Context, orgId int64, namespace str
 		item.Created = item.Updated
 		_, err = dbSession.Insert(&item)
 		if err != nil {
-			kv.log.Debug("error inserting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+			kv.log.Error("error inserting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 		} else {
 			kv.log.Debug("secret value inserted", "orgId", orgId, "type", typ, "namespace", namespace)
 		}
@@ -155,7 +155,7 @@ func (kv *secretsKVStoreSQL) Del(ctx context.Context, orgId int64, namespace str
 
 		has, err := dbSession.Get(&item)
 		if err != nil {
-			kv.log.Debug("error checking secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+			kv.log.Error("error checking secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			return err
 		}
 
@@ -163,7 +163,7 @@ func (kv *secretsKVStoreSQL) Del(ctx context.Context, orgId int64, namespace str
 			// if item exists we delete it
 			_, err = dbSession.ID(item.Id).Delete(&item)
 			if err != nil {
-				kv.log.Debug("error deleting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+				kv.log.Error("error deleting secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			} else {
 				kv.decryptionCache.Lock()
 				defer kv.decryptionCache.Unlock()
@@ -202,7 +202,7 @@ func (kv *secretsKVStoreSQL) Rename(ctx context.Context, orgId int64, namespace 
 
 		has, err := dbSession.Get(&item)
 		if err != nil {
-			kv.log.Debug("error checking secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+			kv.log.Error("error checking secret value", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			return err
 		}
 
@@ -213,7 +213,7 @@ func (kv *secretsKVStoreSQL) Rename(ctx context.Context, orgId int64, namespace 
 			// if item already exists we update it
 			_, err = dbSession.ID(item.Id).Update(&item)
 			if err != nil {
-				kv.log.Debug("error updating secret namespace", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
+				kv.log.Error("error updating secret namespace", "orgId", orgId, "type", typ, "namespace", namespace, "err", err)
 			} else {
 				kv.log.Debug("secret namespace updated", "orgId", orgId, "type", typ, "namespace", namespace)
 			}
@@ -232,7 +232,7 @@ func (kv *secretsKVStoreSQL) GetAll(ctx context.Context) ([]Item, error) {
 		return dbSession.Find(&items)
 	})
 	if err != nil {
-		kv.log.Debug("error getting all the items", "err", err)
+		kv.log.Error("error getting all the items", "err", err)
 		return nil, err
 	}
 
@@ -249,14 +249,14 @@ func (kv *secretsKVStoreSQL) GetAll(ctx context.Context) ([]Item, error) {
 
 		decodedValue, err := b64.DecodeString(items[i].Value)
 		if err != nil {
-			kv.log.Debug("error decoding secret value", "orgId", items[i].OrgId, "type", items[i].Type, "namespace", items[i].Namespace, "err", err)
+			kv.log.Error("error decoding secret value", "orgId", items[i].OrgId, "type", items[i].Type, "namespace", items[i].Namespace, "err", err)
 			items[i].Value = string(decryptedValue)
 			continue
 		}
 
 		decryptedValue, err = kv.secretsService.Decrypt(ctx, decodedValue)
 		if err != nil {
-			kv.log.Debug("error decrypting secret value", "orgId", items[i].OrgId, "type", items[i].Type, "namespace", items[i].Namespace, "err", err)
+			kv.log.Error("error decrypting secret value", "orgId", items[i].OrgId, "type", items[i].Type, "namespace", items[i].Namespace, "err", err)
 			items[i].Value = string(decryptedValue)
 			continue
 		}

--- a/pkg/services/secrets/kvstore/sql_test.go
+++ b/pkg/services/secrets/kvstore/sql_test.go
@@ -303,8 +303,8 @@ func TestSecretsKVStoreSQL(t *testing.T) {
 			for _, tc := range testCases {
 				if *s.OrgId == tc.OrgId &&
 					*s.Namespace == tc.Namespace &&
-					*s.Type == tc.Type &&
-					s.Value == tc.Value() {
+					*s.Type == tc.Type {
+					require.Equal(t, tc.Value(), s.Value, "secret found but value is not equals")
 					found++
 					break
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds functionality to migrate from the SQL KV Store (aka Unified Secrets) to the secrets plugin installed.
This new migrator is based on SecretMigratorService. It will retrieve all the secrets stored at the SQL KV Store and use the plugin to store them again. Then it will erase from the KV Store
In this stage, the migration tries to save all the secrets using the plugin and then proceeds to delete the secret from the database. However, for this to happen, the secret plugin is already loaded as the default secret manager. The problem with this is that if the migration fails, the startup of grafana continues, but the secrets will not be available, so the datasources will not be able to be queried. We will improve this process in the future and it is also clarified in the documentation. 


**Which issue(s) this PR fixes**:
Fixes [#51595](https://github.com/grafana/grafana/issues/51595)

**Special notes for your reviewer**:
* Added `secretsKVStoreSQL.GetAll()` to be able to get in one single query all the secrets in the database. This was only added to the SQL Store as would only be needed for this migration. I was not added to the KVStore interface on purpose
* `/pkg/services/secrets/kvstore/plug_mig.go` was located in that folder as is related to the secrets store, but also it should have access to the `secretsKVStoreSQL` which is private. Another option would be to just use the SqlStore, but we would need to reimplement the decryption of secrets again. If the plugin is installed, when the migration is run, the secrets store is the Plugin store, so we need a way to access the database. 
* The migration process is run within Migrator.go#Migrate() which first assures that the first migration (Legacy to KV Store) is completed and then runs the complete process within a lock, to avoid race conditions or concurrency problems when running Grafana in HA. 
* `pkg/services/secrets/kvstore/plugin_mig_test.go` All the helper func and structs needed for the test were included in this file, as this would be used on this test only (also marked as private). This can be extracted in the future to use in other tests. 
* `pkg/services/secrets/kvstore/sql.go` can be refactored to avoid some code duplication, this will be solved in a future PR to avoid getting more changes into this one. Created https://github.com/grafana/grafana-partnerships-team/issues/274
