### PR TITLE
Prometheus: Don't show errors from unsuccessful API checks like rules or exemplar checks

### DIFF
--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -11,6 +11,7 @@ import {
   HistoryItem,
   LanguageProvider,
 } from '@grafana/data';
+import { BackendSrvRequest } from '@grafana/runtime';
 import { CompletionItem, CompletionItemGroup, SearchFunctionType, TypeaheadInput, TypeaheadOutput } from '@grafana/ui';
 
 import { PrometheusDatasource } from './datasource';
@@ -120,9 +121,9 @@ export default class PromQlLanguageProvider extends LanguageProvider {
     return PromqlSyntax;
   }
 
-  request = async (url: string, defaultValue: any, params = {}): Promise<any> => {
+  request = async (url: string, defaultValue: any, params = {}, options?: Partial<BackendSrvRequest>): Promise<any> => {
     try {
-      const res = await this.datasource.metadataRequest(url, params);
+      const res = await this.datasource.metadataRequest(url, params, options);
       return res.data.data;
     } catch (error) {
       console.error(error);
@@ -145,7 +146,9 @@ export default class PromQlLanguageProvider extends LanguageProvider {
   };
 
   async loadMetricsMetadata() {
-    this.metricsMetadata = fixSummariesMetadata(await this.request('/api/v1/metadata', {}));
+    this.metricsMetadata = fixSummariesMetadata(
+      await this.request('/api/v1/metadata', {}, {}, { showErrorAlert: false })
+    );
   }
 
   getLabelKeys(): string[] {


### PR DESCRIPTION
**What this PR does / why we need it**:

The query inspector was experiencing some error pop-ups due to errors encountered on metrics datasources configured with multiple tenants.

e.g., team-a|team-b

Some of the backend implementations of these metadata endpoints aren't yet well-defined for multi-tenant queries, so they often result in error messages.

This fix suppresses those errors..

In the event of a multi-tenant datasource, these endpoints were contributing to the pop-up errors. 

`/api/v1/query_exemplars` - in a check to see if query examplars can be accessed.

`/api/v1/rules` as a metadata request
`/api/v1/metadata` as a metadata request (see: https://github.com/grafana/mimir/issues/2410)

These error messages newly became visible in version 9. Some of the underlying request errors were still present in 8.5, but they were not visible.

![image](https://user-images.githubusercontent.com/38694490/178888710-0cd49adf-777e-4481-9ba9-1c8ea40ad6f2.png)


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->



<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


