### PR TITLE
Logs: Fixed incorrect highlighting on empty line filter

### DIFF
--- a/public/app/plugins/datasource/loki/query_utils.test.ts
+++ b/public/app/plugins/datasource/loki/query_utils.test.ts
@@ -12,6 +12,14 @@ describe('getHighlighterExpressionsFromQuery', () => {
     expect(getHighlighterExpressionsFromQuery('')).toEqual([]);
   });
 
+  it('returns no expression for query with empty filter ', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= ``')).toEqual(['']);
+  });
+
+  it('returns no expression for query with empty filter and parser', () => {
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= `` | json count="counter" | __error__=``')).toEqual(['']);
+  });
+
   it('returns an expression for query with filter using quotes', () => {
     expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= "x"')).toEqual(['x']);
   });

--- a/public/app/plugins/datasource/loki/query_utils.test.ts
+++ b/public/app/plugins/datasource/loki/query_utils.test.ts
@@ -13,11 +13,33 @@ describe('getHighlighterExpressionsFromQuery', () => {
   });
 
   it('returns no expression for query with empty filter ', () => {
-    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= ``')).toEqual(['']);
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= ``')).toEqual([]);
   });
 
   it('returns no expression for query with empty filter and parser', () => {
-    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= `` | json count="counter" | __error__=``')).toEqual(['']);
+    expect(getHighlighterExpressionsFromQuery('{foo="bar"} |= `` | json count="counter" | __error__=``')).toEqual([]);
+  });
+
+  it('returns no expression for query with empty filter and chained filter', () => {
+    expect(
+      getHighlighterExpressionsFromQuery('{foo="bar"} |= `` |= `highlight` | json count="counter" | __error__=``')
+    ).toEqual(['highlight']);
+  });
+
+  it('returns no expression for query with empty filter, chained and regex filter', () => {
+    expect(
+      getHighlighterExpressionsFromQuery(
+        '{foo="bar"} |= `` |= `highlight` |~ `high.ight` | json count="counter" | __error__=``'
+      )
+    ).toEqual(['highlight', 'high.ight']);
+  });
+
+  it('returns no expression for query with empty filter, chained and regex quotes filter', () => {
+    expect(
+      getHighlighterExpressionsFromQuery(
+        '{foo="bar"} |= `` |= `highlight` |~ "highlight\\\\d" | json count="counter" | __error__=``'
+      )
+    ).toEqual(['highlight', 'highlight\\d']);
   });
 
   it('returns an expression for query with filter using quotes', () => {

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -32,8 +32,8 @@ export function getHighlighterExpressionsFromQuery(input: string): string[] {
     if (skip) {
       continue;
     }
-    // Check if there is more chained
-    const filterEnd = expression.search(/\|=|\|~|!=|!~/);
+    // Check if there is more chained, by just looking for the next pipe-operator
+    const filterEnd = expression.search(/\|/);
     let filterTerm;
     if (filterEnd === -1) {
       filterTerm = expression.trim();

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -50,14 +50,20 @@ export function getHighlighterExpressionsFromQuery(input: string): string[] {
       const unwrappedFilterTerm = term[1];
       const regexOperator = filterOperator === '|~';
 
+      let resultTerm = '';
+
       // Only filter expressions with |~ operator are treated as regular expressions
       if (regexOperator) {
         // When using backticks, Loki doesn't require to escape special characters and we can just push regular expression to highlights array
         // When using quotes, we have extra backslash escaping and we need to replace \\ with \
-        results.push(backtickedTerm ? unwrappedFilterTerm : unwrappedFilterTerm.replace(/\\\\/g, '\\'));
+        resultTerm = backtickedTerm ? unwrappedFilterTerm : unwrappedFilterTerm.replace(/\\\\/g, '\\');
       } else {
         // We need to escape this string so it is not matched as regular expression
-        results.push(escapeRegExp(unwrappedFilterTerm));
+        resultTerm = escapeRegExp(unwrappedFilterTerm);
+      }
+
+      if (resultTerm) {
+        results.push(resultTerm);
       }
     } else {
       return results;


### PR DESCRIPTION
**What this PR does / why we need it**:
When using an empty line-filter and an operation with a parameter, which is in quotes or backticks, this parameter gets incorrectly added as a searchword. This PR fixed this.

**Which issue(s) this PR fixes**:

Fixes #52105

**Special notes for your reviewer**:
To test this, 
1. add an empty line filter and an operation with a parameter, e.g. a JSON parser
2. Before the fix, the parameter from the JSON parser will be highlighted.
3. After the fix, the parameter is not highlighted anymore.
