### PR TITLE
Loki: Fix incorrect TopK value type in query builder

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/operationUtils.test.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/operationUtils.test.ts
@@ -124,4 +124,43 @@ describe('createAggregationOperationWithParams', () => {
       },
     ]);
   });
+  it('returns correct query string using aggregation definitions with overrides and number type param', () => {
+    const def = createAggregationOperationWithParam(
+      'test_aggregation',
+      {
+        params: [{ name: 'K-value', type: 'number' }],
+        defaultParams: [5],
+      },
+      { category: 'test_category' }
+    );
+
+    const topKByDefinition = def[1];
+    expect(
+      topKByDefinition.renderer(
+        { id: '__topk_by', params: ['5', 'source', 'place'] },
+        def[1],
+        'rate({place="luna"} |= `` [5m])'
+      )
+    ).toBe('test_aggregation by(source, place) (5, rate({place="luna"} |= `` [5m]))');
+  });
+
+  it('returns correct query string using aggregation definitions with overrides and string type param', () => {
+    const def = createAggregationOperationWithParam(
+      'test_aggregation',
+      {
+        params: [{ name: 'Identifier', type: 'string' }],
+        defaultParams: ['count'],
+      },
+      { category: 'test_category' }
+    );
+
+    const countValueDefinition = def[1];
+    expect(
+      countValueDefinition.renderer(
+        { id: 'count_values', params: ['5', 'source', 'place'] },
+        def[1],
+        'rate({place="luna"} |= `` [5m])'
+      )
+    ).toBe('test_aggregation by(source, place) ("5", rate({place="luna"} |= `` [5m]))');
+  });
 });

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/operationUtils.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/operationUtils.ts
@@ -279,15 +279,20 @@ function getAggregationExplainer(aggregationName: string, mode: 'by' | 'without'
 
 function getAggregationByRendererWithParameter(aggregation: string) {
   return function aggregationRenderer(model: QueryBuilderOperation, def: QueryBuilderOperationDef, innerExpr: string) {
-    function mapType(p: QueryBuilderOperationParamValue) {
-      if (typeof p === 'string') {
+    const restParamIndex = def.params.findIndex((param) => param.restParam);
+    const params = model.params.slice(0, restParamIndex);
+    const restParams = model.params.slice(restParamIndex);
+
+    function mapType(p: QueryBuilderOperationParamValue, type: string) {
+      if (type === 'string') {
         return `\"${p}\"`;
       }
       return p;
     }
-    const params = model.params.slice(0, -1);
-    const restParams = model.params.slice(1);
-    return `${aggregation} by(${restParams.join(', ')}) (${params.map(mapType).join(', ')}, ${innerExpr})`;
+
+    return `${aggregation} by(${restParams.join(', ')}) (${params
+      .map((param, idx) => mapType(param, def.params[idx].type))
+      .join(', ')}, ${innerExpr})`;
   };
 }
 

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/operationUtils.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/operationUtils.ts
@@ -284,7 +284,7 @@ function getAggregationByRendererWithParameter(aggregation: string) {
     const restParams = model.params.slice(restParamIndex);
 
     return `${aggregation} by(${restParams.join(', ')}) (${params
-      .map((param, idx) => (def.params[idx].type === 'string' ? `\"${param}\"` : param))
+      .map((param, idx) => def.params[idx].type === 'string' ? `\"${param}\"` : param)
       .join(', ')}, ${innerExpr})`;
   };
 }

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/operationUtils.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/operationUtils.ts
@@ -284,7 +284,7 @@ function getAggregationByRendererWithParameter(aggregation: string) {
     const restParams = model.params.slice(restParamIndex);
 
     return `${aggregation} by(${restParams.join(', ')}) (${params
-      .map((param, idx) => def.params[idx].type === 'string' ? `\"${param}\"` : param)
+      .map((param, idx) => (def.params[idx].type === 'string' ? `\"${param}\"` : param))
       .join(', ')}, ${innerExpr})`;
   };
 }

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/operationUtils.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/operationUtils.ts
@@ -283,15 +283,8 @@ function getAggregationByRendererWithParameter(aggregation: string) {
     const params = model.params.slice(0, restParamIndex);
     const restParams = model.params.slice(restParamIndex);
 
-    function mapType(p: QueryBuilderOperationParamValue, type: string) {
-      if (type === 'string') {
-        return `\"${p}\"`;
-      }
-      return p;
-    }
-
     return `${aggregation} by(${restParams.join(', ')}) (${params
-      .map((param, idx) => mapType(param, def.params[idx].type))
+      .map((param, idx) => (def.params[idx].type === 'string' ? `\"${param}\"` : param))
       .join(', ')}, ${innerExpr})`;
   };
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the issue where in `TopK` queries, if we add `labels` and then change `K-value`, it becomes quoted string. This is happening because `renderer`  function which is responsible for creating query string was considering paremeter type and not type in the definition.

This PR fixes it and adds tests.

**Special notes for your reviewer**:

Here is how to reproduce issue and test solution with loki data source:

https://user-images.githubusercontent.com/30407135/178974654-3f0138e0-177f-4600-a990-10e81d165332.mov
