### PR TITLE
GrafanaUI: suppress error from rules api on prom datasource.

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -127,6 +127,12 @@ describe('PrometheusDatasource', () => {
       expect(fetchMock.mock.calls[0][0].url).not.toContain('bar=baz%20baz&foo=foo');
       expect(fetchMock.mock.calls[0][0].data).toEqual({ bar: 'baz baz', foo: 'foo' });
     });
+    it('should perform a GET request and showErrorAlert is false', () => {
+      ds.metadataRequest('/foo', { bar: 'baz baz', foo: 'foo' }, false);
+      expect(fetchMock.mock.calls.length).toBe(1);
+      expect(fetchMock.mock.calls[0][0].method).toBe('GET');
+      expect(fetchMock.mock.calls[0][0].url).toContain('bar=baz%20baz&foo=foo');
+    });
   });
 
   describe('customQueryParams', () => {

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -212,7 +212,7 @@ export class PrometheusDatasource
   }
 
   // Use this for tab completion features, wont publish response to other components
-  async metadataRequest<T = any>(url: string, params = {}) {
+  async metadataRequest<T = any>(url: string, params = {}, showErrorAlert = true) {
     // If URL includes endpoint that supports POST and GET method, try to use configured method. This might fail as POST is supported only in v2.10+.
     if (GET_AND_POST_METADATA_ENDPOINTS.some((endpoint) => url.includes(endpoint))) {
       try {
@@ -237,6 +237,7 @@ export class PrometheusDatasource
       this._request<T>(`/api/datasources/${this.id}/resources${url}`, params, {
         method: 'GET',
         hideFromInspector: true,
+        showErrorAlert: showErrorAlert,
       })
     ); // toPromise until we change getTagValues, getTagKeys to Observable
   }
@@ -1002,7 +1003,7 @@ export class PrometheusDatasource
 
   async loadRules() {
     try {
-      const res = await this.metadataRequest('/api/v1/rules');
+      const res = await this.metadataRequest('/api/v1/rules', {}, false);
       const groups = res.data?.data?.groups;
 
       if (groups) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Suppresses UI error popup for when Rules API is not enabled on Prometheus data source.

**Which issue(s) this PR fixes**:
Fixes #52240 suppresses error from rules api on prom datasource.
