### PR TITLE
Encryption: Re-order error check

### DIFF
--- a/pkg/services/secrets/database/database.go
+++ b/pkg/services/secrets/database/database.go
@@ -38,12 +38,12 @@ func (ss *SecretsStoreImpl) GetDataKey(ctx context.Context, id string) (*secrets
 		return err
 	})
 
-	if !exists {
-		return nil, secrets.ErrDataKeyNotFound
-	}
-
 	if err != nil {
 		return nil, fmt.Errorf("failed getting data key: %w", err)
+	}
+
+	if !exists {
+		return nil, secrets.ErrDataKeyNotFound
 	}
 
 	return dataKey, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

It re-orders the error check to prevent `secrets.ErrDataKeyNotFound` being returned in case of error.

**Special notes for your reviewer**:

Note that `exists` is always `false` in case of error.
