### PR TITLE
Browse/Search: Make browser back work properly when visiting Browse or search

### DIFF
--- a/public/app/features/search/hooks/useSearchQuery.ts
+++ b/public/app/features/search/hooks/useSearchQuery.ts
@@ -19,7 +19,7 @@ import { defaultQuery, defaultQueryParams, queryReducer } from '../reducers/sear
 import { DashboardQuery, SearchLayout } from '../types';
 import { hasFilters, parseRouteParams } from '../utils';
 
-const updateLocation = debounce((query) => locationService.partial(query), 300);
+const updateLocation = debounce((query) => locationService.partial(query, true), 300);
 
 export const useSearchQuery = (defaults: Partial<DashboardQuery>) => {
   const queryParams = parseRouteParams(locationService.getSearchObject());


### PR DESCRIPTION
Noticed that I could not use browser back from browse / folder page. Sometimes it works but sometimes it get stuck between /dashboards redirecting back to /dashboards?query=
