### PR TITLE
Dashboard: Add guidance about reload required after updating shared cursor/tooltip setting.

### DIFF
--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
@@ -146,7 +146,7 @@ export function GeneralSettingsUnconnected({ dashboard, updateTimeZone, updateWe
       <CollapsableSection label="Panel options" isOpen={true}>
         <Field
           label="Graph tooltip"
-          description="Controls tooltip and hover highlight behavior across different panels"
+          description="Controls tooltip and hover highlight behavior across different panels. Reload the dashboard for changes to take effect"
         >
           <RadioButtonGroup onChange={onTooltipChange} options={GRAPH_TOOLTIP_OPTIONS} value={dashboard.graphTooltip} />
         </Field>

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
@@ -142,7 +142,8 @@ export function GeneralSettingsUnconnected({ dashboard, updateTimeZone, updateWe
         weekStart={dashboard.weekStart}
         liveNow={dashboard.liveNow}
       />
-
+      
+      { /* @todo: Update "Graph tooltip" description to remove prompt about reloading when resolving #46581 */}
       <CollapsableSection label="Panel options" isOpen={true}>
         <Field
           label="Graph tooltip"

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
@@ -142,8 +142,8 @@ export function GeneralSettingsUnconnected({ dashboard, updateTimeZone, updateWe
         weekStart={dashboard.weekStart}
         liveNow={dashboard.liveNow}
       />
-      
-      { /* @todo: Update "Graph tooltip" description to remove prompt about reloading when resolving #46581 */}
+
+      {/* @todo: Update "Graph tooltip" description to remove prompt about reloading when resolving #46581 */}
       <CollapsableSection label="Panel options" isOpen={true}>
         <Field
           label="Graph tooltip"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

This PR adds the user guidance from @zoltanbedi on #46581. This is a work around to address the updating shared cursor/tooltip setting issue by asking users to reload the page. Language of user prompt used is copied from the existing "Read-only" control for consistency. 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates to #46581

**Special notes for your reviewer**:
I'm not sure if there is snapshot test coverage for the text here. I can't see any but happy to update it if needed.

