### PR TITLE
Scenes: Fixes layout when the editor is active

### DIFF
--- a/public/app/features/scenes/components/Scene.tsx
+++ b/public/app/features/scenes/components/Scene.tsx
@@ -55,8 +55,10 @@ function SceneRenderer({ model }: SceneComponentProps<Scene>) {
 
   return (
     <Page navId="scenes" layout={PageLayoutType.Dashboard} toolbar={pageToolbar}>
-      <layout.Component model={layout} isEditing={isEditing} />
-      {$editor && <$editor.Component model={$editor} isEditing={isEditing} />}
+      <div style={{ flexGrow: 1, display: 'flex', gap: '8px', overflow: 'auto' }}>
+        <layout.Component model={layout} isEditing={isEditing} />
+        {$editor && <$editor.Component model={$editor} isEditing={isEditing} />}
+      </div>
     </Page>
   );
 }

--- a/public/app/features/scenes/components/SceneToolbarButton.tsx
+++ b/public/app/features/scenes/components/SceneToolbarButton.tsx
@@ -30,6 +30,7 @@ export class SceneToolbarInput extends SceneObjectBase<SceneToolbarInputState> {
     return (
       <Input
         defaultValue={state.value}
+        width={8}
         onBlur={(evt) => {
           model.state.onChange(parseInt(evt.currentTarget.value, 10));
         }}


### PR DESCRIPTION
The changes to the Page component in recent PR https://github.com/grafana/grafana/pull/52039

Defaults the page content container to flex direction column, and Scene needs a special container there to support the editor (as it is placed for now)
