### PR TITLE
Elasticsearch: Added `modifyQuery` method to add filters in Explore

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1021,6 +1021,54 @@ describe('enhanceDataFrame', () => {
   });
 });
 
+describe('modifyQuery', () => {
+  let ds: ElasticDatasource;
+  beforeEach(() => {
+    ds = getTestContext().ds;
+  });
+  describe('with empty query', () => {
+    let query: ElasticsearchQuery;
+    beforeEach(() => {
+      query = { query: '', refId: 'A' };
+    });
+
+    it('should add the filter', () => {
+      expect(ds.modifyQuery(query, { type: 'ADD_FILTER', key: 'foo', value: 'bar' }).query).toBe('foo:"bar"');
+    });
+
+    it('should add the negative filter', () => {
+      expect(ds.modifyQuery(query, { type: 'ADD_FILTER_OUT', key: 'foo', value: 'bar' }).query).toBe('-foo:"bar"');
+    });
+
+    it('should do nothing on unknown type', () => {
+      expect(ds.modifyQuery(query, { type: 'unknown', key: 'foo', value: 'bar' }).query).toBe(query.query);
+    });
+  });
+
+  describe('with non-empty query', () => {
+    let query: ElasticsearchQuery;
+    beforeEach(() => {
+      query = { query: 'test:"value"', refId: 'A' };
+    });
+
+    it('should add the filter', () => {
+      expect(ds.modifyQuery(query, { type: 'ADD_FILTER', key: 'foo', value: 'bar' }).query).toBe(
+        'test:"value" AND foo:"bar"'
+      );
+    });
+
+    it('should add the negative filter', () => {
+      expect(ds.modifyQuery(query, { type: 'ADD_FILTER_OUT', key: 'foo', value: 'bar' }).query).toBe(
+        'test:"value" AND -foo:"bar"'
+      );
+    });
+
+    it('should do nothing on unknown type', () => {
+      expect(ds.modifyQuery(query, { type: 'unknown', key: 'foo', value: 'bar' }).query).toBe(query.query);
+    });
+  });
+});
+
 const createElasticQuery = (): DataQueryRequest<ElasticsearchQuery> => {
   return {
     requestId: '',

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -952,6 +952,27 @@ export class ElasticDatasource
 
     return false;
   }
+
+  modifyQuery(query: ElasticsearchQuery, action: { type: string; key: string; value: string }): ElasticsearchQuery {
+    let expression = query.query ?? '';
+    switch (action.type) {
+      case 'ADD_FILTER': {
+        if (expression.length > 0) {
+          expression += ' AND ';
+        }
+        expression += `${action.key}:"${action.value}"`;
+        break;
+      }
+      case 'ADD_FILTER_OUT': {
+        if (expression.length > 0) {
+          expression += ' AND ';
+        }
+        expression += `-${action.key}:"${action.value}"`;
+        break;
+      }
+    }
+    return { ...query, query: expression };
+  }
 }
 
 /**


### PR DESCRIPTION
**What this PR does / why we need it**:
Ad-hoc filters with Elasticsearch in Explore were not working. This PR adds the missing `modifyQuery` method, which will add filters like `foo:"bar"` or negative filters like `-foo:"bar"`.

**Which issue(s) this PR fixes**:
Fixes #28076

**Special notes for your reviewer**:

https://user-images.githubusercontent.com/8092184/179196171-c3a3d234-0580-4322-bbb3-c402c1d63665.mov


