### PR TITLE
Dependencies: Update to Go version 1.18.4

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -66,13 +66,13 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: yarn-install
 - commands:
   - yarn run prettier:check
@@ -83,14 +83,14 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-frontend
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
   failure: ignore
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -98,7 +98,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-frontend
 trigger:
   event:
@@ -142,7 +142,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -151,13 +151,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - |-
@@ -169,13 +169,13 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: shellcheck
 - commands:
   - make lint-go
@@ -183,19 +183,19 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-backend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-backend-integration
 trigger:
   event:
@@ -242,7 +242,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -251,19 +251,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: yarn-install
 - failure: ignore
   image: grafana/drone-downstream
@@ -283,7 +283,7 @@ steps:
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -292,7 +292,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -301,7 +301,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss
@@ -309,7 +309,7 @@ steps:
   - gen-version
   - yarn-install
   environment: null
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-plugins
 - commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss
@@ -320,7 +320,7 @@ steps:
   - build-frontend
   - build-frontend-packages
   environment: null
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -333,7 +333,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -411,7 +411,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-storybook
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -431,7 +431,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition oss -archs amd64
@@ -506,13 +506,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - apt-get update
@@ -528,7 +528,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -544,7 +544,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: mysql-integration-tests
 trigger:
   event:
@@ -590,13 +590,13 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: yarn-install
 - commands:
   - |-
@@ -608,7 +608,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -616,7 +616,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-docs
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -625,13 +625,13 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend-packages
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend-packages
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana
@@ -680,13 +680,13 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: yarn-install
 - commands:
   - |-
@@ -698,7 +698,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -706,7 +706,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-docs
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -715,13 +715,13 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend-packages
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend-packages
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana
@@ -765,13 +765,13 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: yarn-install
 - commands:
   - yarn run prettier:check
@@ -782,14 +782,14 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-frontend
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
   failure: ignore
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -797,7 +797,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-frontend
 trigger:
   branch: main
@@ -833,7 +833,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -842,13 +842,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - ./bin/grabpl verify-drone
@@ -866,13 +866,13 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: shellcheck
 - commands:
   - make lint-go
@@ -880,19 +880,19 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-backend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-backend-integration
 trigger:
   branch: main
@@ -928,7 +928,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -937,19 +937,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: yarn-install
 - commands:
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
@@ -970,7 +970,7 @@ steps:
       from_secret: github_token
     TEST_TAG: v0.0.0-test
   failure: ignore
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: trigger-test-release
   when:
     paths:
@@ -994,7 +994,7 @@ steps:
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -1003,7 +1003,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -1012,7 +1012,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss
@@ -1022,7 +1022,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-plugins
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -1040,7 +1040,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -1053,7 +1053,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -1131,7 +1131,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-storybook
 - commands:
   - ./bin/grabpl store-storybook --deployment canary --src-bucket grafana-storybook
@@ -1172,7 +1172,7 @@ steps:
     GRAFANA_MISC_STATS_API_KEY:
       from_secret: grafana_misc_stats_api_key
   failure: ignore
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: publish-frontend-metrics
   when:
     repo:
@@ -1182,7 +1182,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition oss
@@ -1260,7 +1260,7 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: release-canary-npm-packages
   when:
     repo:
@@ -1359,13 +1359,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - apt-get update
@@ -1381,7 +1381,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -1397,7 +1397,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: mysql-integration-tests
 trigger:
   branch: main
@@ -1530,7 +1530,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -1621,7 +1621,7 @@ steps:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1630,26 +1630,26 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: yarn-install
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss ${DRONE_TAG}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss ${DRONE_TAG}
@@ -1658,7 +1658,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss ${DRONE_TAG}
@@ -1667,7 +1667,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss
@@ -1677,7 +1677,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-plugins
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss  --sign ${DRONE_TAG}
@@ -1695,14 +1695,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition oss --shouldSave
@@ -1739,7 +1739,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -1817,7 +1817,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition oss
@@ -1918,7 +1918,7 @@ steps:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1927,25 +1927,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: yarn-install
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: shellcheck
 - commands:
   - |-
@@ -1957,7 +1957,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: codespell
 - commands:
   - make lint-go
@@ -1965,7 +1965,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -1976,19 +1976,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -1996,7 +1996,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-frontend
 trigger:
   event:
@@ -2060,13 +2060,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - apt-get update
@@ -2082,7 +2082,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -2098,7 +2098,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: mysql-integration-tests
 trigger:
   event:
@@ -2213,7 +2213,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2229,25 +2229,25 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2257,14 +2257,14 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise ${DRONE_TAG}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -2273,7 +2273,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -2282,7 +2282,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise
@@ -2292,14 +2292,14 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-plugins
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 ${DRONE_TAG}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise  --sign ${DRONE_TAG}
@@ -2318,14 +2318,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition enterprise --shouldSave
@@ -2363,7 +2363,7 @@ steps:
     ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -2483,7 +2483,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: package-enterprise2
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise2
@@ -2559,7 +2559,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2575,25 +2575,25 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2603,7 +2603,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - |-
@@ -2615,7 +2615,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: codespell
 - commands:
   - make lint-go
@@ -2623,7 +2623,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -2634,19 +2634,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -2654,7 +2654,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-frontend
 - commands:
   - make lint-go
@@ -2662,13 +2662,13 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-backend-enterprise2
 - commands:
   - go test -tags=pro -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-backend-enterprise2
 trigger:
   event:
@@ -2742,7 +2742,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2758,7 +2758,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: init-enterprise
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2768,13 +2768,13 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - apt-get update
@@ -2790,7 +2790,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -2806,7 +2806,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -2815,7 +2815,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -2824,7 +2824,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: memcached-integration-tests
 trigger:
   event:
@@ -3308,7 +3308,7 @@ steps:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: yarn-install
 - commands:
   - ./bin/grabpl artifacts npm retrieve --tag v${TAG}
@@ -3328,7 +3328,7 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: release-npm-packages
 trigger:
   event:
@@ -3364,7 +3364,7 @@ steps:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - ./bin/grabpl store-packages --edition oss --packages-bucket grafana-downloads
@@ -3418,7 +3418,7 @@ steps:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - ./bin/grabpl store-packages --edition enterprise --packages-bucket grafana-downloads
@@ -3469,7 +3469,7 @@ steps:
   - ./bin/grabpl artifacts-page
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: artifacts-page
 trigger:
   event:
@@ -3505,7 +3505,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3514,26 +3514,26 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: yarn-install
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -3542,7 +3542,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -3551,7 +3551,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss
@@ -3561,7 +3561,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-plugins
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -3579,14 +3579,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition oss --shouldSave
@@ -3623,7 +3623,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -3701,7 +3701,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition oss
@@ -3773,7 +3773,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3782,25 +3782,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: yarn-install
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: shellcheck
 - commands:
   - |-
@@ -3812,7 +3812,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: codespell
 - commands:
   - make lint-go
@@ -3820,7 +3820,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -3831,19 +3831,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -3851,7 +3851,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-frontend
 trigger:
   ref:
@@ -3909,13 +3909,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - apt-get update
@@ -3931,7 +3931,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -3947,7 +3947,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: mysql-integration-tests
 trigger:
   ref:
@@ -4045,7 +4045,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -4058,25 +4058,25 @@ steps:
   depends_on:
   - clone-enterprise
   environment: {}
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4086,14 +4086,14 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -4102,7 +4102,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition enterprise --build-id
@@ -4112,7 +4112,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise
@@ -4122,7 +4122,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-plugins
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
@@ -4130,7 +4130,7 @@ steps:
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -4150,14 +4150,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition enterprise --shouldSave
@@ -4195,7 +4195,7 @@ steps:
     ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -4273,7 +4273,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise
@@ -4321,7 +4321,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: package-enterprise2
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise2
@@ -4391,7 +4391,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -4404,25 +4404,25 @@ steps:
   depends_on:
   - clone-enterprise
   environment: {}
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4432,7 +4432,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - |-
@@ -4444,7 +4444,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: codespell
 - commands:
   - make lint-go
@@ -4452,7 +4452,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -4463,19 +4463,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -4483,7 +4483,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-frontend
 - commands:
   - make lint-go
@@ -4491,13 +4491,13 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: lint-backend-enterprise2
 - commands:
   - go test -tags=pro -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: test-backend-enterprise2
 trigger:
   ref:
@@ -4565,7 +4565,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -4578,7 +4578,7 @@ steps:
   depends_on:
   - clone-enterprise
   environment: {}
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: init-enterprise
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4588,13 +4588,13 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: wire-install
 - commands:
   - apt-get update
@@ -4610,7 +4610,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -4626,7 +4626,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -4635,7 +4635,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -4644,7 +4644,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.5.7
+  image: grafana/build-container:1.5.8
   name: memcached-integration-tests
 trigger:
   ref:
@@ -4880,6 +4880,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 55383abbbc205824d35aa689a0e00f374e74520d77dc387e354b063e4ade0869
+hmac: 4e16b0f029b0302baa5b9c2e3edea0a25337ffe2c0b805d7f189814e6c9c278e
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -66,13 +66,13 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: yarn-install
 - commands:
   - yarn run prettier:check
@@ -83,14 +83,14 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-frontend
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
   failure: ignore
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -98,7 +98,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-frontend
 trigger:
   event:
@@ -142,7 +142,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -151,13 +151,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - |-
@@ -169,13 +169,13 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: shellcheck
 - commands:
   - make lint-go
@@ -183,19 +183,19 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-backend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-backend-integration
 trigger:
   event:
@@ -242,7 +242,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -251,19 +251,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: yarn-install
 - failure: ignore
   image: grafana/drone-downstream
@@ -283,7 +283,7 @@ steps:
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -292,7 +292,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -301,7 +301,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss
@@ -309,7 +309,7 @@ steps:
   - gen-version
   - yarn-install
   environment: null
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-plugins
 - commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss
@@ -320,7 +320,7 @@ steps:
   - build-frontend
   - build-frontend-packages
   environment: null
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -333,7 +333,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -411,7 +411,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-storybook
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -431,7 +431,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition oss -archs amd64
@@ -506,13 +506,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - apt-get update
@@ -528,7 +528,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -544,7 +544,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: mysql-integration-tests
 trigger:
   event:
@@ -590,13 +590,13 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: yarn-install
 - commands:
   - |-
@@ -608,7 +608,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -616,7 +616,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-docs
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -625,13 +625,13 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend-packages
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend-packages
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana
@@ -680,13 +680,13 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: yarn-install
 - commands:
   - |-
@@ -698,7 +698,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -706,7 +706,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-docs
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -715,13 +715,13 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend-packages
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend-packages
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana
@@ -765,13 +765,13 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: yarn-install
 - commands:
   - yarn run prettier:check
@@ -782,14 +782,14 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-frontend
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
   failure: ignore
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -797,7 +797,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-frontend
 trigger:
   branch: main
@@ -833,7 +833,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -842,13 +842,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - ./bin/grabpl verify-drone
@@ -866,13 +866,13 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: shellcheck
 - commands:
   - make lint-go
@@ -880,19 +880,19 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-backend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-backend-integration
 trigger:
   branch: main
@@ -928,7 +928,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -937,19 +937,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: yarn-install
 - commands:
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
@@ -970,7 +970,7 @@ steps:
       from_secret: github_token
     TEST_TAG: v0.0.0-test
   failure: ignore
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: trigger-test-release
   when:
     paths:
@@ -994,7 +994,7 @@ steps:
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -1003,7 +1003,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -1012,7 +1012,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss
@@ -1022,7 +1022,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-plugins
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -1040,7 +1040,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -1053,7 +1053,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -1131,7 +1131,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-storybook
 - commands:
   - ./bin/grabpl store-storybook --deployment canary --src-bucket grafana-storybook
@@ -1172,7 +1172,7 @@ steps:
     GRAFANA_MISC_STATS_API_KEY:
       from_secret: grafana_misc_stats_api_key
   failure: ignore
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: publish-frontend-metrics
   when:
     repo:
@@ -1182,7 +1182,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition oss
@@ -1260,7 +1260,7 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: release-canary-npm-packages
   when:
     repo:
@@ -1359,13 +1359,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - apt-get update
@@ -1381,7 +1381,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -1397,7 +1397,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: mysql-integration-tests
 trigger:
   branch: main
@@ -1530,7 +1530,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -1621,7 +1621,7 @@ steps:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1630,26 +1630,26 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: yarn-install
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss ${DRONE_TAG}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss ${DRONE_TAG}
@@ -1658,7 +1658,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss ${DRONE_TAG}
@@ -1667,7 +1667,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss
@@ -1677,7 +1677,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-plugins
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss  --sign ${DRONE_TAG}
@@ -1695,14 +1695,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition oss --shouldSave
@@ -1739,7 +1739,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -1817,7 +1817,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition oss
@@ -1918,7 +1918,7 @@ steps:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1927,25 +1927,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: yarn-install
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: shellcheck
 - commands:
   - |-
@@ -1957,7 +1957,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: codespell
 - commands:
   - make lint-go
@@ -1965,7 +1965,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -1976,19 +1976,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -1996,7 +1996,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-frontend
 trigger:
   event:
@@ -2060,13 +2060,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - apt-get update
@@ -2082,7 +2082,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -2098,7 +2098,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: mysql-integration-tests
 trigger:
   event:
@@ -2213,7 +2213,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2229,25 +2229,25 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2257,14 +2257,14 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise ${DRONE_TAG}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -2273,7 +2273,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -2282,7 +2282,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise
@@ -2292,14 +2292,14 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-plugins
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 ${DRONE_TAG}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise  --sign ${DRONE_TAG}
@@ -2318,14 +2318,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition enterprise --shouldSave
@@ -2363,7 +2363,7 @@ steps:
     ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -2483,7 +2483,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: package-enterprise2
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise2
@@ -2559,7 +2559,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2575,25 +2575,25 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2603,7 +2603,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - |-
@@ -2615,7 +2615,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: codespell
 - commands:
   - make lint-go
@@ -2623,7 +2623,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -2634,19 +2634,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -2654,7 +2654,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-frontend
 - commands:
   - make lint-go
@@ -2662,13 +2662,13 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-backend-enterprise2
 - commands:
   - go test -tags=pro -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-backend-enterprise2
 trigger:
   event:
@@ -2742,7 +2742,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2758,7 +2758,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: init-enterprise
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2768,13 +2768,13 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - apt-get update
@@ -2790,7 +2790,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -2806,7 +2806,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -2815,7 +2815,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -2824,7 +2824,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: memcached-integration-tests
 trigger:
   event:
@@ -3308,7 +3308,7 @@ steps:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: yarn-install
 - commands:
   - ./bin/grabpl artifacts npm retrieve --tag v${TAG}
@@ -3328,7 +3328,7 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: release-npm-packages
 trigger:
   event:
@@ -3364,7 +3364,7 @@ steps:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - ./bin/grabpl store-packages --edition oss --packages-bucket grafana-downloads
@@ -3418,7 +3418,7 @@ steps:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - ./bin/grabpl store-packages --edition enterprise --packages-bucket grafana-downloads
@@ -3469,7 +3469,7 @@ steps:
   - ./bin/grabpl artifacts-page
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: artifacts-page
 trigger:
   event:
@@ -3505,7 +3505,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3514,26 +3514,26 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: yarn-install
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -3542,7 +3542,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -3551,7 +3551,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss
@@ -3561,7 +3561,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-plugins
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -3579,14 +3579,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition oss --shouldSave
@@ -3623,7 +3623,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -3701,7 +3701,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition oss
@@ -3773,7 +3773,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3782,25 +3782,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: yarn-install
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: shellcheck
 - commands:
   - |-
@@ -3812,7 +3812,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: codespell
 - commands:
   - make lint-go
@@ -3820,7 +3820,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -3831,19 +3831,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -3851,7 +3851,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-frontend
 trigger:
   ref:
@@ -3909,13 +3909,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - apt-get update
@@ -3931,7 +3931,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -3947,7 +3947,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: mysql-integration-tests
 trigger:
   ref:
@@ -4045,7 +4045,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -4058,25 +4058,25 @@ steps:
   depends_on:
   - clone-enterprise
   environment: {}
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4086,14 +4086,14 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -4102,7 +4102,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition enterprise --build-id
@@ -4112,7 +4112,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise
@@ -4122,7 +4122,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-plugins
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
@@ -4130,7 +4130,7 @@ steps:
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -4150,14 +4150,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition enterprise --shouldSave
@@ -4195,7 +4195,7 @@ steps:
     ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -4273,7 +4273,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise
@@ -4321,7 +4321,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: package-enterprise2
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise2
@@ -4391,7 +4391,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -4404,25 +4404,25 @@ steps:
   depends_on:
   - clone-enterprise
   environment: {}
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4432,7 +4432,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - |-
@@ -4444,7 +4444,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: codespell
 - commands:
   - make lint-go
@@ -4452,7 +4452,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -4463,19 +4463,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -4483,7 +4483,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-frontend
 - commands:
   - make lint-go
@@ -4491,13 +4491,13 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: lint-backend-enterprise2
 - commands:
   - go test -tags=pro -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: test-backend-enterprise2
 trigger:
   ref:
@@ -4565,7 +4565,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -4578,7 +4578,7 @@ steps:
   depends_on:
   - clone-enterprise
   environment: {}
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: init-enterprise
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4588,13 +4588,13 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: wire-install
 - commands:
   - apt-get update
@@ -4610,7 +4610,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -4626,7 +4626,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -4635,7 +4635,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -4644,7 +4644,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.6.0
   name: memcached-integration-tests
 trigger:
   ref:
@@ -4880,6 +4880,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 4e16b0f029b0302baa5b9c2e3edea0a25337ffe2c0b805d7f189814e6c9c278e
+hmac: c48c3b155ee0b82d714d17ab17e7ca6ddea108b624882f939072cd1b6cf7c3cc
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN yarn build
 
-FROM golang:1.17.11-alpine3.15 as go-builder
+FROM golang:1.17.12-alpine3.15 as go-builder
 
 RUN apk add --no-cache gcc g++ make
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN yarn build
 
-FROM golang:1.17.12-alpine3.15 as go-builder
+FROM golang:1.18.4-alpine3.15 as go-builder
 
 RUN apk add --no-cache gcc g++ make
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -21,7 +21,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN yarn build
 
-FROM golang:1.17.11 AS go-builder
+FROM golang:1.17.12 AS go-builder
 
 WORKDIR /src/grafana
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -21,7 +21,7 @@ COPY emails emails
 ENV NODE_ENV production
 RUN yarn build
 
-FROM golang:1.17.12 AS go-builder
+FROM golang:1.18.4 AS go-builder
 
 WORKDIR /src/grafana
 

--- a/build.go
+++ b/build.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana
 
-go 1.17
+go 1.18
 
 // Override xorm's outdated go-mssqldb dependency, since we can't upgrade to current xorm (due to breaking changes).
 // We need a more current go-mssqldb so we get rid of a version of apache/thrift with vulnerabilities.

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -102,7 +102,7 @@ RUN rm dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz
 # Use old Debian (this has support into 2022) in order to ensure binary compatibility with older glibc's.
 FROM debian:stretch-20210208
 
-ENV GOVERSION=1.17.11 \
+ENV GOVERSION=1.17.12 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
     NODEVERSION=16.14.0-1nodesource1 \

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -106,7 +106,7 @@ ENV GOVERSION=1.17.12 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
     NODEVERSION=16.14.0-1nodesource1 \
-    YARNVERSION=1.22.15-1
+    YARNVERSION=1.22.19-1
 
 # Use ARG so as not to persist environment variable in image
 ARG DEBIAN_FRONTEND=noninteractive
@@ -117,7 +117,8 @@ COPY --from=toolchain /tmp/cue /usr/local/bin/
 COPY --from=toolchain /tmp/dockerize /usr/local/bin/
 
 RUN apt-get update && \
-    apt-get install -yq  \
+    apt-get install -yq \
+        apt-transport-https \
         build-essential netcat-traditional clang gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf gcc-mingw-w64-x86-64 \
         python-pip      \
         ca-certificates \

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -102,7 +102,7 @@ RUN rm dockerize-linux-amd64-v${DOCKERIZE_VERSION}.tar.gz
 # Use old Debian (this has support into 2022) in order to ensure binary compatibility with older glibc's.
 FROM debian:stretch-20210208
 
-ENV GOVERSION=1.17.12 \
+ENV GOVERSION=1.18.4 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
     NODEVERSION=16.14.0-1nodesource1 \

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -174,7 +174,7 @@ RUN cd /tmp && \
     tar xf x86_64-linux-musl-cross.tgz && \
     rm x86_64-linux-musl-cross.tgz
 
-RUN go install github.com/mgechev/revive@v1.0.2 && \
+RUN go install github.com/mgechev/revive@v1.2.1 && \
   mv ${GOPATH}/bin/revive /usr/local/bin/ && \
   go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest && \
   mv ${GOPATH}/bin/jsonnetfmt /usr/local/bin/ && \

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1,7 +1,7 @@
 load('scripts/drone/vault.star', 'from_secret', 'github_token', 'pull_secret', 'drone_token', 'prerelease_bucket')
 
 grabpl_version = 'v2.9.52'
-build_image = 'grafana/build-container:1.5.7'
+build_image = 'grafana/build-container:1.5.8'
 publish_image = 'grafana/grafana-ci-deploy:1.3.1'
 deploy_docker_image = 'us.gcr.io/kubernetes-dev/drone/plugins/deploy-image'
 alpine_image = 'alpine:3.15'

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1,7 +1,7 @@
 load('scripts/drone/vault.star', 'from_secret', 'github_token', 'pull_secret', 'drone_token', 'prerelease_bucket')
 
 grabpl_version = 'v2.9.52'
-build_image = 'grafana/build-container:1.5.8'
+build_image = 'grafana/build-container:1.6.0'
 publish_image = 'grafana/grafana-ci-deploy:1.3.1'
 deploy_docker_image = 'us.gcr.io/kubernetes-dev/drone/plugins/deploy-image'
 alpine_image = 'alpine:3.15'


### PR DESCRIPTION
**What this PR does / why we need it**:

1.17 is reaching EOL ~soon, we should upgrade to 1.18 in the next minor.

**missing grabpl update**