### PR TITLE
Graphite: Introduce new query types in annotation editor

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -7301,9 +7301,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "48"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "49"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "50"],
-      [0, 0, 0, "Do not use any type assertions.", "51"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "51"],
       [0, 0, 0, "Do not use any type assertions.", "52"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "53"],
+      [0, 0, 0, "Do not use any type assertions.", "53"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "54"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "55"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "56"],
@@ -7314,7 +7314,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "61"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "62"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "63"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "64"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "64"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "65"]
     ],
     "public/app/plugins/datasource/graphite/datasource_integration.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -7243,7 +7243,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "27"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "28"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "29"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "30"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "30"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "31"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "32"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "33"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "34"]
     ],
     "public/app/plugins/datasource/graphite/datasource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -94,9 +94,9 @@ export class DataSourcePlugin<
     return this.setQueryEditorHelp(ExploreStartPage);
   }
 
-  /*
+  /**
    * @deprecated -- prefer using {@link StandardVariableSupport} or {@link CustomVariableSupport} or {@link DataSourceVariableSupport} in data source instead
-   * */
+   */
   setVariableQueryEditor(VariableQueryEditor: any) {
     this.components.VariableQueryEditor = VariableQueryEditor;
     return this;

--- a/public/app/plugins/datasource/graphite/components/GraphiteVariableEditor.tsx
+++ b/public/app/plugins/datasource/graphite/components/GraphiteVariableEditor.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+
+import { InlineField, Input, Select } from '@grafana/ui';
+
+import { GraphiteQuery, GraphiteQueryType } from '../types';
+
+import { convertToGraphiteQueryObject } from './helpers';
+
+interface Props {
+  query: GraphiteQuery | string;
+  onChange: (query: GraphiteQuery) => void;
+}
+
+const GRAPHITE_QUERY_VARIABLE_TYPE_OPTIONS = [
+  { label: 'Default Query', value: GraphiteQueryType.Default },
+  { label: 'Value Query', value: GraphiteQueryType.Value },
+  { label: 'Metric Name Query', value: GraphiteQueryType.MetricName },
+];
+
+export const GraphiteVariableEditor: React.FC<Props> = (props) => {
+  const { query, onChange } = props;
+  const [value, setValue] = useState(convertToGraphiteQueryObject(query));
+
+  return (
+    <>
+      <InlineField label="Select query type" labelWidth={20}>
+        <Select
+          aria-label="select query type"
+          options={GRAPHITE_QUERY_VARIABLE_TYPE_OPTIONS}
+          width={25}
+          value={value.queryType ?? GraphiteQueryType.Default}
+          onChange={(selectableValue) => {
+            onChange({
+              ...value,
+              queryType: selectableValue.value,
+            });
+          }}
+        />
+      </InlineField>
+      <InlineField label="Select query type" labelWidth={20} grow>
+        <Input
+          aria-label="Variable editor query input"
+          value={value.target}
+          onBlur={() => onChange(value)}
+          onChange={(e) => {
+            setValue({
+              ...value,
+              target: e.currentTarget.value,
+            });
+          }}
+        />
+      </InlineField>
+    </>
+  );
+};

--- a/public/app/plugins/datasource/graphite/components/helpers.ts
+++ b/public/app/plugins/datasource/graphite/components/helpers.ts
@@ -3,7 +3,7 @@ import { forEach, sortBy } from 'lodash';
 import { SelectableValue } from '@grafana/data';
 
 import { FuncDefs, FuncInstance, ParamDef } from '../gfunc';
-import { GraphiteSegment } from '../types';
+import { GraphiteQuery, GraphiteQueryType, GraphiteSegment } from '../types';
 
 import { EditableParam } from './FunctionParamEditor';
 
@@ -77,4 +77,15 @@ export function mapFuncInstanceToParams(func: FuncInstance): EditableParam[] {
   }
 
   return params;
+}
+
+export function convertToGraphiteQueryObject(query: string | GraphiteQuery): GraphiteQuery {
+  if (typeof query === 'string') {
+    return {
+      refId: 'A',
+      target: query,
+      queryType: GraphiteQueryType.Default.toString(),
+    };
+  }
+  return query;
 }

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -555,7 +555,7 @@ describe('graphiteDatasource', () => {
       expect(data).toBeTruthy();
     });
 
-    it('should fetch from /render endpoint when queryType is not default', async () => {
+    it('should fetch from /render endpoint when queryType is value', async () => {
       fetchMock.mockImplementation((options: any) => {
         requestOptions = options;
         return of(
@@ -616,22 +616,9 @@ describe('graphiteDatasource', () => {
       fetchMock.mockImplementation((options: any) => {
         requestOptions = options;
         return of(
-          createFetchResponse([
-            {
-              target: 'metric.name.A',
-              datapoints: [
-                [10, 1],
-                [12, 1],
-              ],
-            },
-            {
-              target: 'metric.name.B',
-              datapoints: [
-                [20, 2],
-                [22, 2],
-              ],
-            },
-          ])
+          createFetchResponse({
+            results: ['apps.backend.backend_01', 'apps.backend.backend_02', 'apps.country.IE', 'apps.country.SE'],
+          })
         );
       });
 
@@ -642,11 +629,11 @@ describe('graphiteDatasource', () => {
         datasource: ctx.ds,
       };
       const data = await ctx.ds.metricFindQuery(fq);
-      expect(requestOptions.url).toBe('/api/datasources/proxy/1/render');
-      expect(data[0].value).toBe('metric.name.A');
-      expect(data[0].text).toBe('metric.name.A');
-      expect(data[1].value).toBe('metric.name.B');
-      expect(data[1].text).toBe('metric.name.B');
+      expect(requestOptions.url).toBe('/api/datasources/proxy/1/metrics/expand');
+      expect(data[0].text).toBe('apps.backend.backend_01');
+      expect(data[1].text).toBe('apps.backend.backend_02');
+      expect(data[2].text).toBe('apps.country.IE');
+      expect(data[3].text).toBe('apps.country.SE');
     });
   });
 

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -617,7 +617,7 @@ describe('graphiteDatasource', () => {
         requestOptions = options;
         return of(
           createFetchResponse({
-            results: ['apps.backend.backend_01', 'apps.backend.backend_03', 'apps.country.IE', 'apps.country.SE'],
+            results: ['apps.backend.backend_01', 'apps.backend.backend_02', 'apps.country.IE', 'apps.country.SE'],
           })
         );
       });
@@ -631,7 +631,7 @@ describe('graphiteDatasource', () => {
       const data = await ctx.ds.metricFindQuery(fq);
       expect(requestOptions.url).toBe('/api/datasources/proxy/1/metrics/expand');
       expect(data[0].text).toBe('apps.backend.backend_01');
-      expect(data[1].text).toBe('apps.backend.backend_03');
+      expect(data[1].text).toBe('apps.backend.backend_02');
       expect(data[2].text).toBe('apps.country.IE');
       expect(data[3].text).toBe('apps.country.SE');
     });

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -617,7 +617,7 @@ describe('graphiteDatasource', () => {
         requestOptions = options;
         return of(
           createFetchResponse({
-            results: ['apps.backend.backend_01', 'apps.backend.backend_02', 'apps.country.IE', 'apps.country.SE'],
+            results: ['apps.backend.backend_01', 'apps.backend.backend_03', 'apps.country.IE', 'apps.country.SE'],
           })
         );
       });
@@ -631,7 +631,7 @@ describe('graphiteDatasource', () => {
       const data = await ctx.ds.metricFindQuery(fq);
       expect(requestOptions.url).toBe('/api/datasources/proxy/1/metrics/expand');
       expect(data[0].text).toBe('apps.backend.backend_01');
-      expect(data[1].text).toBe('apps.backend.backend_02');
+      expect(data[1].text).toBe('apps.backend.backend_03');
       expect(data[2].text).toBe('apps.country.IE');
       expect(data[3].text).toBe('apps.country.SE');
     });

--- a/public/app/plugins/datasource/graphite/datasource.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource.test.ts
@@ -8,6 +8,7 @@ import { TemplateSrv } from 'app/features/templating/template_srv';
 
 import { fromString } from './configuration/parseLokiLabelMappings';
 import { GraphiteDatasource } from './datasource';
+import { GraphiteQuery, GraphiteQueryType } from './types';
 import { DEFAULT_GRAPHITE_VERSION } from './versions';
 
 jest.mock('@grafana/runtime', () => ({
@@ -533,6 +534,119 @@ describe('graphiteDatasource', () => {
       expect(requestOptions.url).toBe('/api/datasources/proxy/1/metrics/expand');
       expect(requestOptions.params.query).toBe('*.servers.*');
       expect(results).not.toBe(null);
+    });
+
+    it('should fetch from /metrics/find endpoint when queryType is default or query is string', async () => {
+      const stringQuery = 'query';
+      ctx.ds.metricFindQuery(stringQuery).then((data: any) => {
+        results = data;
+      });
+      expect(requestOptions.url).toBe('/api/datasources/proxy/1/metrics/find');
+      expect(results).not.toBe(null);
+
+      const objectQuery = {
+        queryType: GraphiteQueryType.Default,
+        target: 'query',
+        refId: 'A',
+        datasource: ctx.ds,
+      };
+      const data = await ctx.ds.metricFindQuery(objectQuery);
+      expect(requestOptions.url).toBe('/api/datasources/proxy/1/metrics/find');
+      expect(data).toBeTruthy();
+    });
+
+    it('should fetch from /render endpoint when queryType is not default', async () => {
+      fetchMock.mockImplementation((options: any) => {
+        requestOptions = options;
+        return of(
+          createFetchResponse([
+            {
+              target: 'query',
+              datapoints: [
+                [10, 1],
+                [12, 1],
+              ],
+            },
+          ])
+        );
+      });
+
+      const fq: GraphiteQuery = {
+        queryType: GraphiteQueryType.Value,
+        target: 'query',
+        refId: 'A',
+        datasource: ctx.ds,
+      };
+      const data = await ctx.ds.metricFindQuery(fq);
+      expect(requestOptions.url).toBe('/api/datasources/proxy/1/render');
+      expect(data).toBeTruthy();
+    });
+
+    it('should return values of a query when queryType is GraphiteQueryType.Value', async () => {
+      fetchMock.mockImplementation((options: any) => {
+        requestOptions = options;
+        return of(
+          createFetchResponse([
+            {
+              target: 'query',
+              datapoints: [
+                [10, 1],
+                [12, 1],
+              ],
+            },
+          ])
+        );
+      });
+
+      const fq: GraphiteQuery = {
+        queryType: GraphiteQueryType.Value,
+        target: 'query',
+        refId: 'A',
+        datasource: ctx.ds,
+      };
+      const data = await ctx.ds.metricFindQuery(fq);
+      expect(requestOptions.url).toBe('/api/datasources/proxy/1/render');
+      expect(data[0].value).toBe(10);
+      expect(data[0].text).toBe('10');
+      expect(data[1].value).toBe(12);
+      expect(data[1].text).toBe('12');
+    });
+
+    it('should return metric names when queryType is GraphiteQueryType.MetricName', async () => {
+      fetchMock.mockImplementation((options: any) => {
+        requestOptions = options;
+        return of(
+          createFetchResponse([
+            {
+              target: 'metric.name.A',
+              datapoints: [
+                [10, 1],
+                [12, 1],
+              ],
+            },
+            {
+              target: 'metric.name.B',
+              datapoints: [
+                [20, 2],
+                [22, 2],
+              ],
+            },
+          ])
+        );
+      });
+
+      const fq: GraphiteQuery = {
+        queryType: GraphiteQueryType.MetricName,
+        target: 'query',
+        refId: 'A',
+        datasource: ctx.ds,
+      };
+      const data = await ctx.ds.metricFindQuery(fq);
+      expect(requestOptions.url).toBe('/api/datasources/proxy/1/render');
+      expect(data[0].value).toBe('metric.name.A');
+      expect(data[0].text).toBe('metric.name.A');
+      expect(data[1].value).toBe('metric.name.B');
+      expect(data[1].text).toBe('metric.name.B');
     });
   });
 

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -527,8 +527,24 @@ export class GraphiteDatasource
       range,
     };
     const data = await lastValueFrom(this.query(queryReq));
-    console.log(data);
-    return Promise.resolve([]);
+    let result: MetricFindValue[] = [];
+    if (queryObject.queryType === GraphiteQueryType.Value) {
+      result = data.data[0].fields[1].values
+        .filter((f?: number) => !!f)
+        .map((v: number) => ({
+          text: v.toString(),
+          value: v,
+          expandable: false,
+        }));
+    }
+    if (queryObject.queryType === GraphiteQueryType.MetricName) {
+      result = data.data.map((d) => ({
+        value: d.name,
+        text: d.name,
+        expandable: false,
+      }));
+    }
+    return Promise.resolve(result);
   }
 
   /**

--- a/public/app/plugins/datasource/graphite/module.ts
+++ b/public/app/plugins/datasource/graphite/module.ts
@@ -1,6 +1,7 @@
 import { DataSourcePlugin } from '@grafana/data';
 
 import { GraphiteQueryEditor } from './components/GraphiteQueryEditor';
+import { GraphiteVariableEditor } from './components/GraphiteVariableEditor';
 import { MetricTankMetaInspector } from './components/MetricTankMetaInspector';
 import { ConfigEditor } from './configuration/ConfigEditor';
 import { GraphiteDatasource } from './datasource';
@@ -12,5 +13,6 @@ class AnnotationsQueryCtrl {
 export const plugin = new DataSourcePlugin(GraphiteDatasource)
   .setQueryEditor(GraphiteQueryEditor)
   .setConfigEditor(ConfigEditor)
+  .setVariableQueryEditor(GraphiteVariableEditor)
   .setMetadataInspector(MetricTankMetaInspector)
   .setAnnotationQueryCtrl(AnnotationsQueryCtrl);

--- a/public/app/plugins/datasource/graphite/types.ts
+++ b/public/app/plugins/datasource/graphite/types.ts
@@ -4,6 +4,12 @@ import { TemplateSrv } from '../../../features/templating/template_srv';
 
 import { GraphiteDatasource } from './datasource';
 
+export enum GraphiteQueryType {
+  Default = 'Default',
+  Value = 'Value',
+  MetricName = 'Metric Name',
+}
+
 export interface GraphiteQuery extends DataQuery {
   target?: string;
 }


### PR DESCRIPTION
This PR introduces two new variable types to use as a querying option. The existing dashboards will keep working regardless of the variable type. The default variable query type is `Default`. No need to change the dashboard settings. 

1. Value 
It returns the value of the query so it can be used for thresholds, offsets, limits, etc

2. Metric Name
It returns the name of the series.

More info and explanation: https://github.com/grafana/grafana/issues/10242#issuecomment-1098048945

Fixes #
https://github.com/grafana/grafana/issues/10242


