### PR TITLE
UnsavedChanges: Should not be triggered when only going into panel edit without changing anything

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.test.ts
@@ -134,6 +134,35 @@ describe('panelEditor actions', () => {
       expect(dispatchedActions.length).toBe(2);
       expect(sourcePanel.getOptions()).toEqual({});
     });
+
+    it('should not increment configRev when no changes made and leaving panel edit', async () => {
+      const sourcePanel = new PanelModel({ id: 12, type: 'graph' });
+      sourcePanel.plugin = getPanelPlugin({});
+
+      const dashboard = new DashboardModel({
+        panels: [{ id: 12, type: 'graph' }],
+      });
+
+      const panel = dashboard.initEditPanel(sourcePanel);
+
+      const state: PanelEditorState = {
+        ...initialState(),
+        getPanel: () => panel,
+        getSourcePanel: () => sourcePanel,
+      };
+
+      await thunkTester({
+        panelEditor: state,
+        panels: {},
+        dashboard: {
+          getModel: () => dashboard,
+        },
+      })
+        .givenThunk(exitPanelEditor)
+        .whenThunkIsDispatched();
+
+      expect(sourcePanel.configRev).toEqual(0);
+    });
   });
 
   describe('skipPanelUpdate', () => {

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -116,7 +116,7 @@ export function exitPanelEditor(): ThunkResult<void> {
       dashboard.exitPanelEditor();
     }
 
-    if (!shouldDiscardChanges) {
+    if (panel.hasChanged && !shouldDiscardChanges) {
       const modifiedSaveModel = panel.getSaveModel();
       const sourcePanel = getSourcePanel();
       const panelTypeChanged = sourcePanel.type !== panel.type;


### PR DESCRIPTION
Fixes an issue where unsaved changes warning would show after into panel edit and then trying to leave dashboard or go back to dashboard and then leave (without changing any panel option)
