### PR TITLE
Scene: Fixing state issue with useState when SceneObject instance changes

### DIFF
--- a/public/app/features/scenes/components/ScenePanelRepeater.tsx
+++ b/public/app/features/scenes/components/ScenePanelRepeater.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { v4 as uuidv4 } from 'uuid';
 
 import { LoadingState, PanelData } from '@grafana/data';
 
@@ -33,9 +32,7 @@ export class ScenePanelRepeater extends SceneObjectBase<RepeatOptions> {
 
     for (const series of data.series) {
       const clone = firstChild.clone({
-        // Setting key to guid here will cause unmount / remount on every refresh
-        // To preserve children between refreshes we need to figure out how to instead update objects
-        key: uuidv4(),
+        key: `${newChildren.length}`,
         $data: new SceneDataNode({
           data: {
             ...data,

--- a/public/app/features/scenes/components/ScenePanelRepeater.tsx
+++ b/public/app/features/scenes/components/ScenePanelRepeater.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { v4 as uuidv4 } from 'uuid';
 
 import { LoadingState, PanelData } from '@grafana/data';
 
@@ -32,7 +33,9 @@ export class ScenePanelRepeater extends SceneObjectBase<RepeatOptions> {
 
     for (const series of data.series) {
       const clone = firstChild.clone({
-        key: `${newChildren.length}`,
+        // Setting key to guid here will cause unmount / remount on every refresh
+        // To preserve children between refreshes we need to figure out how to instead update objects
+        key: uuidv4(),
         $data: new SceneDataNode({
           data: {
             ...data,

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -1,8 +1,9 @@
-import { useObservable } from 'react-use';
+import { useEffect } from 'react';
 import { Observer, Subject, Subscription } from 'rxjs';
 import { v4 as uuidv4 } from 'uuid';
 
 import { EventBusSrv } from '@grafana/data';
+import { useForceUpdate } from '@grafana/ui';
 
 import { SceneComponentWrapper } from './SceneComponentWrapper';
 import { SceneObjectStateChangedEvent } from './events';
@@ -118,7 +119,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
 
   useState() {
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useObservable(this.subject, this.state);
+    return useSceneObjectState(this);
   }
 
   /**
@@ -197,4 +198,19 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
 
     return new (this.constructor as any)(clonedState);
   }
+}
+
+/**
+ * This hook is always returning model.state instead of a useState that remembers the last state emitted on the subject
+ * The reason for this is so that if the model instance change this function will always return the latest state.
+ */
+function useSceneObjectState<TState>(model: SceneObjectBase<TState>): TState {
+  const forceUpdate = useForceUpdate();
+
+  useEffect(() => {
+    const s = model.subject.subscribe(forceUpdate);
+    return () => s.unsubscribe();
+  }, [model, forceUpdate]);
+
+  return model.state;
 }

--- a/public/app/features/scenes/scenes/demo.tsx
+++ b/public/app/features/scenes/scenes/demo.tsx
@@ -78,7 +78,7 @@ export function getScenePanelRepeaterTest(): Scene {
           uid: 'gdev-testdata',
           type: 'testdata',
         },
-        seriesCount: 5,
+        seriesCount: 2,
         alias: '__server_names',
         scenarioId: 'random_walk',
       },
@@ -119,7 +119,7 @@ export function getScenePanelRepeaterTest(): Scene {
     $data: queryRunner,
     actions: [
       new SceneToolbarInput({
-        value: '5',
+        value: '2',
         onChange: (newValue) => {
           queryRunner.setState({
             queries: [


### PR DESCRIPTION
Noticed an issue with the PanelRepeater, updates where not working. New data where not being shown after changing time range.

The issue was that there where new SceneObject instances created but the FlexLayout rendering was rendering with old state. Tracked it down to an issue with
using useState inside useObservable, when the SceneObject instance changes, useObservable will still return the old state (until a new state update is made on that SceneObject). In this case it whole layout is new with new children (but the same react keys as I don't want unmounts).

To solve the issue I stopped using useObservable and instead useForceUpdate and make useState always return the model.state. This makes it so that the subject is only used to trigger react re-renders and not for transmitting state (this is only for the React useState usage). The other solution would require switching to BehaviorSubject and double renderings as the only way to return the new state in the case of a new SceneObject instance would be inside the useEffect (of a custom useObservable).


To help explain this issue look at:

```ts
function useObservable<T>(observable$: Observable<T>, initialValue?: T): T | undefined {
  const [value, update] = useState<T | undefined>(initialValue);

  useIsomorphicLayoutEffect(() => {
    const s = observable$.subscribe(update);
    return () => s.unsubscribe();
  }, [observable$]);

  return value;
}
```

When the observable (SceneObject) is a new instance, this function will always return the old state (for the old instance). The effect needs to re-trigger and a new subscription needs to happen for a new state to be set. This means that the above solution will always cause a Component that re-renders with a new SceneObject to get old state before getting new updated state of the new SceneObject instance.


I solved this by creating this hook:

```ts
function useSceneObjectState<TState>(model: SceneObjectBase<TState>): TState {
  const forceUpdate = useForceUpdate();

  useEffect(() => {
    const s = model.subject.subscribe(forceUpdate);
    return () => s.unsubscribe();
  }, [model, forceUpdate]);

  return model.state;
}
```

This will always return the latest model.state without any extra re-renders (or with it returning state from the previous SceneObject).


