### PR TITLE
Traces: Remove serviceMap feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -26,7 +26,6 @@ export interface FeatureToggles {
   ['live-service-web-worker']?: boolean;
   queryOverLive?: boolean;
   panelTitleSearch?: boolean;
-  tempoServiceGraph?: boolean;
   tempoApmTable?: boolean;
   prometheus_azure_auth?: boolean;
   prometheusAzureOverrideAudience?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -63,12 +63,6 @@ var (
 			State:       FeatureStateAlpha,
 		},
 		{
-			Name:         "tempoServiceGraph",
-			Description:  "show service",
-			State:        FeatureStateBeta,
-			FrontendOnly: true,
-		},
-		{
 			Name:         "tempoApmTable",
 			Description:  "Show APM table",
 			State:        FeatureStateAlpha,

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -47,10 +47,6 @@ const (
 	// Search for dashboards using panel title
 	FlagPanelTitleSearch = "panelTitleSearch"
 
-	// FlagTempoServiceGraph
-	// show service
-	FlagTempoServiceGraph = "tempoServiceGraph"
-
 	// FlagTempoApmTable
 	// Show APM table
 	FlagTempoApmTable = "tempoApmTable"

--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -75,9 +75,9 @@ class TempoQueryFieldComponent extends React.PureComponent<Props> {
     const queryTypeOptions: Array<SelectableValue<TempoQueryType>> = [
       { value: 'traceId', label: 'TraceID' },
       { value: 'upload', label: 'JSON file' },
+      { value: 'serviceMap', label: 'Service Graph' },
     ];
 
-    queryTypeOptions.push({ value: 'serviceMap', label: 'Service Graph' });
     // span names in Tempo search links (generated on the service graph page) are in camel case (for Prometheus queries)
     // but the span name dropdown menu in the search tab is lower case
     query.spanName = query.spanName?.toLowerCase();

--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -77,12 +77,10 @@ class TempoQueryFieldComponent extends React.PureComponent<Props> {
       { value: 'upload', label: 'JSON file' },
     ];
 
-    if (config.featureToggles.tempoServiceGraph) {
-      queryTypeOptions.push({ value: 'serviceMap', label: 'Service Graph' });
-      // span names in Tempo search links (generated on the service graph page) are in camel case (for Prometheus queries)
-      // but the span name dropdown menu in the search tab is lower case
-      query.spanName = query.spanName?.toLowerCase();
-    }
+    queryTypeOptions.push({ value: 'serviceMap', label: 'Service Graph' });
+    // span names in Tempo search links (generated on the service graph page) are in camel case (for Prometheus queries)
+    // but the span name dropdown menu in the search tab is lower case
+    query.spanName = query.spanName?.toLowerCase();
 
     if (!datasource?.search?.hide) {
       queryTypeOptions.unshift({ value: 'nativeSearch', label: 'Search' });

--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import useAsync from 'react-use/lib/useAsync';
 
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
-import { config, reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
 import {
   FileDropzone,
   InlineField,

--- a/public/app/plugins/datasource/tempo/configuration/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/tempo/configuration/ConfigEditor.tsx
@@ -34,11 +34,9 @@ export const ConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
         </div>
       ) : null}
 
-      {config.featureToggles.tempoServiceGraph && (
-        <div className="gf-form-group">
-          <ServiceGraphSettings options={options} onOptionsChange={onOptionsChange} />
-        </div>
-      )}
+      <div className="gf-form-group">
+        <ServiceGraphSettings options={options} onOptionsChange={onOptionsChange} />
+      </div>
 
       <div className="gf-form-group">
         <SearchSettings options={options} onOptionsChange={onOptionsChange} />


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the `tempoServiceGraph` feature flag.