### PR TITLE
Docs: fixes warning for enterprise customers

### DIFF
--- a/docs/sources/alerting/fundamentals/data-source-alerting.md
+++ b/docs/sources/alerting/fundamentals/data-source-alerting.md
@@ -19,7 +19,7 @@ These are the data sources that are compatible with and supported by Grafana Ale
 - [AWS CloudWatch]({{< relref "../../datasources/aws-cloudwatch/" >}})
 - [Azure Monitor]({{< relref "../../datasources/azuremonitor/" >}})
 - [Elasticsearch]({{< relref "../../datasources/elasticsearch/" >}})
-- [Google Cloud Monitoring]({{< relref "../../google-cloud-monitoring/" >}})
+- [Google Cloud Monitoring]({{< relref "../../datasources/google-cloud-monitoring/" >}})
 - [Graphite]({{< relref "../../datasources/graphite/" >}})
 - [InfluxDB]({{< relref "influxdb/" >}})
 - [Loki]({{< relref "../../datasources/loki/" >}})

--- a/docs/sources/alerting/migrating-alerts/_index.md
+++ b/docs/sources/alerting/migrating-alerts/_index.md
@@ -13,7 +13,7 @@ weight: 101
 
 Grafana Alerting is enabled by default for new installations or existing installations whether or not legacy alerting is configured.
 
-> **Note**: We recommend that Grafana Enterprise customers with more than a dozen Grafana dashboard alert rules do not upgrade and remain on legacy alerting for now by [opting out]({{< relref "opt-out/" >}}). If you do want to upgrade to Grafana Alerting, contact customer support.
+> **Note**: When upgrading, your dashboard alerts are migrated to a new format. This migration can be rolled back easily by [opting out]({{< relref "opt-out/" >}}). If you have any questions regarding this migration, please contact us.
 
 Existing installations that do not use legacy alerting will have Grafana Alerting enabled by default unless alerting is disabled in the configuration.
 

--- a/docs/sources/alerting/migrating-alerts/_index.md
+++ b/docs/sources/alerting/migrating-alerts/_index.md
@@ -3,6 +3,7 @@ aliases:
   - /docs/grafana/latest/alerting/migrating-alerts/
   - /docs/grafana/latest/alerting/unified-alerting/
   - /docs/grafana/latest/alerting/unified-alerting/difference-old-new/
+  - /docs/grafana/latest/alerting/difference-old-new/
 description: Upgrade Grafana alerts
 title: Upgrade to Grafana Alerting
 weight: 101


### PR DESCRIPTION
Makes enterprise customer warning less severe as per Farhan/Armand discussion on slack: "I believe that we could rephrase this with Grafana 9.1, the customer issues with Grafana 9.0 have been less than expected and we have been overly cautious on this."