### PR TITLE
Chore: Remove volumes from `build-e2e` pipeline on `main`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1305,12 +1305,6 @@ volumes:
 - host:
     path: /var/run/docker.sock
   name: docker
-- name: postgres
-  temp:
-    medium: memory
-- name: mysql
-  temp:
-    medium: memory
 ---
 depends_on: []
 kind: pipeline
@@ -4880,6 +4874,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 55383abbbc205824d35aa689a0e00f374e74520d77dc387e354b063e4ade0869
+hmac: 6ca96adcc90cb32d6ded5bcd804548f5c2a5dfdfa1791761f150e1447852357a
 
 ...

--- a/scripts/drone/pipelines/main.star
+++ b/scripts/drone/pipelines/main.star
@@ -219,7 +219,6 @@ def main_pipelines(edition):
     pipelines = [docs_pipelines(edition, ver_mode, trigger), main_test_frontend(), main_test_backend(), pipeline(
         name='main-build-e2e-publish', edition=edition, trigger=trigger, services=[],
         steps=init_steps + build_steps,
-        volumes=volumes,
     ), pipeline(
         name='main-integration-tests', edition=edition, trigger=trigger, services=services,
         steps=[download_grabpl_step(), identify_runner_step(), verify_gen_cue_step(edition="oss"), wire_install_step(), ] + integration_test_steps,


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes volumes from the build pipeline, as they are only needed to speed up the integration tests pipelines.