### PR TITLE
Alerting: Add subpath to the folder edit and permission url

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -4,6 +4,7 @@ import React, { FC, useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { Badge, ConfirmModal, HorizontalGroup, Icon, Spinner, Tooltip, useStyles2 } from '@grafana/ui';
 import kbn from 'app/core/utils/kbn';
 import { CombinedRuleGroup, CombinedRuleNamespace } from 'app/types/unified-alerting';
@@ -70,7 +71,7 @@ export const RulesGroup: FC<Props> = React.memo(({ group, namespace, expandAll }
     );
   } else if (rulesSource === GRAFANA_RULES_SOURCE_NAME) {
     if (folderUID) {
-      const baseUrl = `/dashboards/f/${folderUID}/${kbn.slugifyForUrl(namespace.name)}`;
+      const baseUrl = `${config.appSubUrl}/dashboards/f/${folderUID}/${kbn.slugifyForUrl(namespace.name)}`;
       if (folder?.canSave) {
         actionIcons.push(
           <ActionIcon


### PR DESCRIPTION
**What this PR does / why we need it**:
When Grafana is served under the subpath the Edit Folder and Edit Permission URLs do not take the subpath into consideration, thus users get 404 errors.

**Which issue(s) this PR fixes**:
Fixes #51830

**Special notes for your reviewer**:
The URL will be still an absolute URL as required by https://github.com/grafana/grafana/pull/33782

`config.appSubUrl` starts with `/`

