### PR TITLE
Alerting: take external alertmanagers from datasources into consideration

### DIFF
--- a/pkg/services/datasources/fakes/fake_datasource_service.go
+++ b/pkg/services/datasources/fakes/fake_datasource_service.go
@@ -43,6 +43,9 @@ func (s *FakeDataSourceService) GetDataSources(ctx context.Context, query *datas
 
 func (s *FakeDataSourceService) GetDataSourcesByType(ctx context.Context, query *datasources.GetDataSourcesByTypeQuery) error {
 	for _, datasource := range s.DataSources {
+		if query.OrgId > 0 && datasource.OrgId != query.OrgId {
+			continue
+		}
 		typeMatch := query.Type != "" && query.Type == datasource.Type
 		if typeMatch {
 			query.Result = append(query.Result, datasource)

--- a/pkg/services/datasources/models.go
+++ b/pkg/services/datasources/models.go
@@ -161,6 +161,7 @@ type GetDataSourcesQuery struct {
 }
 
 type GetDataSourcesByTypeQuery struct {
+	OrgId  int64 // optional: filter by org_id
 	Type   string
 	Result []*DataSource
 }

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -61,6 +61,7 @@ type AlertingStore interface {
 type API struct {
 	Cfg                  *setting.Cfg
 	DatasourceCache      datasources.CacheService
+	DatasourceService    datasources.DataSourceService
 	RouteRegister        routing.RouteRegister
 	ExpressionService    *expr.Service
 	QuotaService         *quota.QuotaService
@@ -128,9 +129,10 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 		}), m)
 	api.RegisterConfigurationApiEndpoints(NewForkedConfiguration(
 		&AdminSrv{
-			store:     api.AdminConfigStore,
-			log:       logger,
-			scheduler: api.Schedule,
+			datasourceService: api.DatasourceService,
+			store:             api.AdminConfigStore,
+			log:               logger,
+			scheduler:         api.Schedule,
 		},
 	), m)
 

--- a/pkg/services/ngalert/api/api_admin.go
+++ b/pkg/services/ngalert/api/api_admin.go
@@ -82,7 +82,7 @@ func (srv AdminSrv) RoutePostNGalertConfig(c *models.ReqContext, body apimodels.
 
 	if sendAlertsTo == ngmodels.ExternalAlertmanagers &&
 		len(body.Alertmanagers)+len(externalAlertmanagers) < 1 {
-		return response.Error(400, "At least one Alertmanager must be provided to choose this option", nil)
+		return response.Error(400, "At least one Alertmanager must be provided or configured as a datasource that handles alerts to choose this option", nil)
 	}
 
 	cfg := &ngmodels.AdminConfiguration{

--- a/pkg/services/ngalert/api/api_admin.go
+++ b/pkg/services/ngalert/api/api_admin.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
@@ -134,7 +135,7 @@ func (srv AdminSrv) externalAlertmanagers(ctx context.Context, orgID int64) ([]s
 		return nil, fmt.Errorf("failed to fetch datasources for org: %w", err)
 	}
 	for _, ds := range query.Result {
-		if ds.JsonData.Get("handleGrafanaManagedAlerts").MustBool(false) {
+		if ds.JsonData.Get(definitions.HandleGrafanaManagedAlerts).MustBool(false) {
 			// we don't need to build the exact URL as we only need
 			// to know if any is set
 			alertmanagers = append(alertmanagers, ds.Uid)

--- a/pkg/services/ngalert/api/api_admin.go
+++ b/pkg/services/ngalert/api/api_admin.go
@@ -130,7 +130,7 @@ func (srv AdminSrv) hasExternalAlertmanager(ctx context.Context, orgID int64,
 		return false
 	}
 	for _, ds := range query.Result {
-		if !ds.JsonData.Get("handleGrafanaManagedAlerts").MustBool(false) {
+		if ds.JsonData.Get("handleGrafanaManagedAlerts").MustBool(false) {
 			return true
 		}
 	}

--- a/pkg/services/ngalert/api/api_admin.go
+++ b/pkg/services/ngalert/api/api_admin.go
@@ -81,7 +81,7 @@ func (srv AdminSrv) RoutePostNGalertConfig(c *models.ReqContext, body apimodels.
 	}
 
 	if sendAlertsTo == ngmodels.ExternalAlertmanagers &&
-		(len(body.Alertmanagers) < 1 && len(externalAlertmanagers) < 1) {
+		len(body.Alertmanagers)+len(externalAlertmanagers) < 1 {
 		return response.Error(400, "At least one Alertmanager must be provided to choose this option", nil)
 	}
 

--- a/pkg/services/ngalert/api/api_admin.go
+++ b/pkg/services/ngalert/api/api_admin.go
@@ -71,7 +71,7 @@ func (srv AdminSrv) RoutePostNGalertConfig(c *models.ReqContext, body apimodels.
 
 	sendAlertsTo, err := ngmodels.StringToAlertmanagersChoice(string(body.AlertmanagersChoice))
 	if err != nil {
-		return response.Error(400, "Invalid alertmanager choice specified", nil)
+		return response.Error(400, "Invalid alertmanager choice specified", err)
 	}
 
 	if sendAlertsTo == ngmodels.ExternalAlertmanagers && !srv.hasExternalAlertmanager(

--- a/pkg/services/ngalert/api/api_admin.go
+++ b/pkg/services/ngalert/api/api_admin.go
@@ -121,8 +121,8 @@ func (srv AdminSrv) RouteDeleteNGalertConfig(c *models.ReqContext) response.Resp
 	return response.JSON(http.StatusOK, util.DynMap{"message": "admin configuration deleted"})
 }
 
-// externalAlertmanagers returns the URL of any external datasource. The URL
-// does not contain any auth.
+// externalAlertmanagers returns the URL of any external alertmanager that is
+// configured as datasource. The URL does not contain any auth.
 func (srv AdminSrv) externalAlertmanagers(ctx context.Context, orgID int64) ([]string, error) {
 	var alertmanagers []string
 	query := &datasources.GetDataSourcesByTypeQuery{

--- a/pkg/services/ngalert/api/api_admin.go
+++ b/pkg/services/ngalert/api/api_admin.go
@@ -118,8 +118,6 @@ func (srv AdminSrv) hasExternalAlertmanager(orgID int64, alertmanagers []string)
 	if len(alertmanagers) > 0 {
 		return true
 	}
-	// We might have alertmanager datasources that are acting as external
-	// alertmanager, let's fetch them.
 	query := &datasources.GetDataSourcesByTypeQuery{
 		OrgId: orgID,
 		Type:  "alertmanager",

--- a/pkg/services/ngalert/api/api_admin.go
+++ b/pkg/services/ngalert/api/api_admin.go
@@ -122,7 +122,7 @@ func (srv AdminSrv) hasExternalAlertmanager(ctx context.Context, orgID int64,
 	}
 	query := &datasources.GetDataSourcesByTypeQuery{
 		OrgId: orgID,
-		Type:  "alertmanager",
+		Type:  datasources.DS_ALERTMANAGER,
 	}
 	err := srv.datasourceService.GetDataSourcesByType(ctx, query)
 	if err != nil {

--- a/pkg/services/ngalert/api/api_admin.go
+++ b/pkg/services/ngalert/api/api_admin.go
@@ -77,7 +77,7 @@ func (srv AdminSrv) RoutePostNGalertConfig(c *models.ReqContext, body apimodels.
 
 	externalAlertmanagers, err := srv.externalAlertmanagers(c.Req.Context(), c.OrgId)
 	if err != nil {
-		return response.Error(500, "Couldn't fetch the external alertmanagers from datasources", err)
+		return response.Error(500, "Couldn't fetch the external Alertmanagers from datasources", err)
 	}
 
 	if sendAlertsTo == ngmodels.ExternalAlertmanagers &&

--- a/pkg/services/ngalert/api/api_admin.go
+++ b/pkg/services/ngalert/api/api_admin.go
@@ -74,7 +74,8 @@ func (srv AdminSrv) RoutePostNGalertConfig(c *models.ReqContext, body apimodels.
 		return response.Error(400, "Invalid alertmanager choice specified", nil)
 	}
 
-	if sendAlertsTo == ngmodels.ExternalAlertmanagers && !srv.hasExternalAlertmanager(c.OrgId, body.Alertmanagers) {
+	if sendAlertsTo == ngmodels.ExternalAlertmanagers && !srv.hasExternalAlertmanager(
+		c.Req.Context(), c.OrgId, body.Alertmanagers) {
 		return response.Error(400, "At least one Alertmanager must be provided to choose this option", nil)
 	}
 
@@ -114,7 +115,8 @@ func (srv AdminSrv) RouteDeleteNGalertConfig(c *models.ReqContext) response.Resp
 	return response.JSON(http.StatusOK, util.DynMap{"message": "admin configuration deleted"})
 }
 
-func (srv AdminSrv) hasExternalAlertmanager(orgID int64, alertmanagers []string) bool {
+func (srv AdminSrv) hasExternalAlertmanager(ctx context.Context, orgID int64,
+	alertmanagers []string) bool {
 	if len(alertmanagers) > 0 {
 		return true
 	}
@@ -122,7 +124,7 @@ func (srv AdminSrv) hasExternalAlertmanager(orgID int64, alertmanagers []string)
 		OrgId: orgID,
 		Type:  "alertmanager",
 	}
-	err := srv.datasourceService.GetDataSourcesByType(context.Background(), query)
+	err := srv.datasourceService.GetDataSourcesByType(ctx, query)
 	if err != nil {
 		srv.log.Error("failed to fetch datasources for org", "org", orgID)
 		return false

--- a/pkg/services/ngalert/api/api_admin_test.go
+++ b/pkg/services/ngalert/api/api_admin_test.go
@@ -41,7 +41,7 @@ func TestExternalAlertmanagerChoice(t *testing.T) {
 					Type:  datasources.DS_ALERTMANAGER,
 					Url:   "http://localhost:9000",
 					JsonData: simplejson.NewFromAny(map[string]interface{}{
-						"handleGrafanaManagedAlerts": true,
+						definitions.HandleGrafanaManagedAlerts: true,
 					}),
 				},
 			},

--- a/pkg/services/ngalert/api/api_admin_test.go
+++ b/pkg/services/ngalert/api/api_admin_test.go
@@ -1,0 +1,119 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	fakeDatasources "github.com/grafana/grafana/pkg/services/datasources/fakes"
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalAlertmanagerChoice(t *testing.T) {
+	tests := []struct {
+		name               string
+		alertmanagerChoice definitions.AlertmanagersChoice
+		alertmanagers      []string
+		datasources        []*datasources.DataSource
+		statusCode         int
+		message            string
+	}{
+		{
+			name:               "setting the choice to external by passing a plain url should succeed",
+			alertmanagerChoice: definitions.ExternalAlertmanagers,
+			alertmanagers:      []string{"http://localhost:9000"},
+			datasources:        []*datasources.DataSource{},
+			statusCode:         http.StatusCreated,
+			message:            "admin configuration updated",
+		},
+		{
+			name:               "setting the choice to external by having a enabled external am datasource should succeed",
+			alertmanagerChoice: definitions.ExternalAlertmanagers,
+			alertmanagers:      []string{},
+			datasources: []*datasources.DataSource{
+				{
+					OrgId: 1,
+					Type:  datasources.DS_ALERTMANAGER,
+					Url:   "http://localhost:9000",
+					JsonData: simplejson.NewFromAny(map[string]interface{}{
+						"handleGrafanaManagedAlerts": true,
+					}),
+				},
+			},
+			statusCode: http.StatusCreated,
+			message:    "admin configuration updated",
+		},
+		{
+			name:               "setting the choice to external by having a disabled external am datasource should fail",
+			alertmanagerChoice: definitions.ExternalAlertmanagers,
+			alertmanagers:      []string{},
+			datasources: []*datasources.DataSource{
+				{
+					OrgId:    1,
+					Type:     datasources.DS_ALERTMANAGER,
+					Url:      "http://localhost:9000",
+					JsonData: simplejson.NewFromAny(map[string]interface{}{}),
+				},
+			},
+			statusCode: http.StatusBadRequest,
+			message:    "At least one Alertmanager must be provided to choose this option",
+		},
+		{
+			name:               "setting the choice to external and having no am configured should fail",
+			alertmanagerChoice: definitions.ExternalAlertmanagers,
+			alertmanagers:      []string{},
+			datasources:        []*datasources.DataSource{},
+			statusCode:         http.StatusBadRequest,
+			message:            "At least one Alertmanager must be provided to choose this option",
+		},
+		{
+			name:               "setting the choice to all and having no external am configured should succeed",
+			alertmanagerChoice: definitions.AllAlertmanagers,
+			alertmanagers:      []string{},
+			datasources:        []*datasources.DataSource{},
+			statusCode:         http.StatusCreated,
+			message:            "admin configuration updated",
+		},
+		{
+			name:               "setting the choice to internal should always succeed",
+			alertmanagerChoice: definitions.InternalAlertmanager,
+			alertmanagers:      []string{},
+			datasources:        []*datasources.DataSource{},
+			statusCode:         http.StatusCreated,
+			message:            "admin configuration updated",
+		},
+	}
+	ctx := createRequestCtxInOrg(1)
+	ctx.OrgRole = models.ROLE_ADMIN
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sut := createAPIAdminSut(t, test.datasources)
+			resp := sut.RoutePostNGalertConfig(ctx, definitions.PostableNGalertConfig{
+				Alertmanagers:       test.alertmanagers,
+				AlertmanagersChoice: test.alertmanagerChoice,
+			})
+			var res map[string]interface{}
+			err := json.Unmarshal(resp.Body(), &res)
+			require.NoError(t, err)
+			require.Equal(t, test.message, res["message"])
+			require.Equal(t, test.statusCode, resp.Status())
+		})
+
+	}
+
+}
+
+func createAPIAdminSut(t *testing.T,
+	datasources []*datasources.DataSource) AdminSrv {
+	return AdminSrv{
+		datasourceService: &fakeDatasources.FakeDataSourceService{
+			DataSources: datasources,
+		},
+		store: store.NewFakeAdminConfigStore(t),
+	}
+}

--- a/pkg/services/ngalert/api/api_admin_test.go
+++ b/pkg/services/ngalert/api/api_admin_test.go
@@ -103,9 +103,7 @@ func TestExternalAlertmanagerChoice(t *testing.T) {
 			require.Equal(t, test.message, res["message"])
 			require.Equal(t, test.statusCode, resp.Status())
 		})
-
 	}
-
 }
 
 func createAPIAdminSut(t *testing.T,

--- a/pkg/services/ngalert/api/tooling/definitions/admin.go
+++ b/pkg/services/ngalert/api/tooling/definitions/admin.go
@@ -58,9 +58,10 @@ type NGalertConfig struct {
 type AlertmanagersChoice string
 
 const (
-	AllAlertmanagers      AlertmanagersChoice = "all"
-	InternalAlertmanager  AlertmanagersChoice = "internal"
-	ExternalAlertmanagers AlertmanagersChoice = "external"
+	AllAlertmanagers           AlertmanagersChoice = "all"
+	InternalAlertmanager       AlertmanagersChoice = "internal"
+	ExternalAlertmanagers      AlertmanagersChoice = "external"
+	HandleGrafanaManagedAlerts                     = "handleGrafanaManagedAlerts"
 )
 
 // swagger:model

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -33,7 +33,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func ProvideService(cfg *setting.Cfg, dataSourceCache datasources.CacheService, routeRegister routing.RouteRegister,
+func ProvideService(cfg *setting.Cfg, dataSourceCache datasources.CacheService, dataSourceService datasources.DataSourceService, routeRegister routing.RouteRegister,
 	sqlStore *sqlstore.SQLStore, kvStore kvstore.KVStore, expressionService *expr.Service, dataProxy *datasourceproxy.DataSourceProxyService,
 	quotaService *quota.QuotaService, secretsService secrets.Service, notificationService notifications.Service, m *metrics.NGAlert,
 	folderService dashboards.FolderService, ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService, renderService rendering.Service,
@@ -41,6 +41,7 @@ func ProvideService(cfg *setting.Cfg, dataSourceCache datasources.CacheService, 
 	ng := &AlertNG{
 		Cfg:                 cfg,
 		DataSourceCache:     dataSourceCache,
+		DataSourceService:   dataSourceService,
 		RouteRegister:       routeRegister,
 		SQLStore:            sqlStore,
 		KVStore:             kvStore,
@@ -73,6 +74,7 @@ func ProvideService(cfg *setting.Cfg, dataSourceCache datasources.CacheService, 
 type AlertNG struct {
 	Cfg                 *setting.Cfg
 	DataSourceCache     datasources.CacheService
+	DataSourceService   datasources.DataSourceService
 	RouteRegister       routing.RouteRegister
 	SQLStore            *sqlstore.SQLStore
 	KVStore             kvstore.KVStore
@@ -143,6 +145,8 @@ func (ng *AlertNG) init() error {
 		AdminConfigPollInterval: ng.Cfg.UnifiedAlerting.AdminConfigPollInterval,
 		DisabledOrgs:            ng.Cfg.UnifiedAlerting.DisabledOrgs,
 		MinRuleInterval:         ng.Cfg.UnifiedAlerting.MinInterval,
+		DatasourceService:       ng.DataSourceService,
+		SecretService:           ng.SecretsService,
 	}
 
 	appUrl, err := url.Parse(ng.Cfg.AppURL)
@@ -169,6 +173,7 @@ func (ng *AlertNG) init() error {
 	api := api.API{
 		Cfg:                  ng.Cfg,
 		DatasourceCache:      ng.DataSourceCache,
+		DatasourceService:    ng.DataSourceService,
 		RouteRegister:        ng.RouteRegister,
 		ExpressionService:    ng.ExpressionService,
 		Schedule:             ng.schedule,

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -333,7 +333,7 @@ func (sch *schedule) alertmanagersFromDatasources(orgID int64) ([]string, error)
 		return nil, fmt.Errorf("failed to fetch datasources for org: %w", err)
 	}
 	for _, ds := range query.Result {
-		if !ds.JsonData.Get("handleGrafanaManagedAlerts").MustBool(false) {
+		if ds.JsonData.Get("handleGrafanaManagedAlerts").MustBool(false) {
 			continue
 		}
 		amURL, err := sch.buildExternalURL(ds)

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -240,7 +240,7 @@ func (sch *schedule) SyncAndApplyConfigFromDatabase() error {
 		// alertmanager, let's fetch them.
 		query := &datasources.GetDataSourcesByTypeQuery{
 			OrgId: cfg.OrgID,
-			Type:  "alertmanager",
+			Type:  datasources.DS_ALERTMANAGER,
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		defer cancel()

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -333,7 +333,7 @@ func (sch *schedule) alertmanagersFromDatasources(orgID int64) ([]string, error)
 		return nil, fmt.Errorf("failed to fetch datasources for org: %w", err)
 	}
 	for _, ds := range query.Result {
-		if !ds.JsonData.Get("handleGrafanaManagedAlerts").MustBool(false) {
+		if !ds.JsonData.Get(definitions.HandleGrafanaManagedAlerts).MustBool(false) {
 			continue
 		}
 		amURL, err := sch.buildExternalURL(ds)

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -236,14 +236,14 @@ func (sch *schedule) SyncAndApplyConfigFromDatabase() error {
 			continue
 		}
 
-		externalAlertmanager, err := sch.alertmanagersFromDatasources(cfg.OrgID)
+		externalAlertmanagers, err := sch.alertmanagersFromDatasources(cfg.OrgID)
 		if err != nil {
 			sch.log.Error("failed to get alertmanagers from datasources",
 				"org", cfg.OrgID,
 				"err", err)
 			continue
 		}
-		cfg.Alertmanagers = append(cfg.Alertmanagers, externalAlertmanager...)
+		cfg.Alertmanagers = append(cfg.Alertmanagers, externalAlertmanagers...)
 
 		// We have no running sender and no Alertmanager(s) configured, no-op.
 		if !ok && len(cfg.Alertmanagers) == 0 {

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -333,7 +333,7 @@ func (sch *schedule) alertmanagersFromDatasources(orgID int64) ([]string, error)
 		return nil, fmt.Errorf("failed to fetch datasources for org: %w", err)
 	}
 	for _, ds := range query.Result {
-		if ds.JsonData.Get("handleGrafanaManagedAlerts").MustBool(false) {
+		if !ds.JsonData.Get("handleGrafanaManagedAlerts").MustBool(false) {
 			continue
 		}
 		amURL, err := sch.buildExternalURL(ds)

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -242,8 +242,8 @@ func (sch *schedule) SyncAndApplyConfigFromDatabase() error {
 			OrgId: cfg.OrgID,
 			Type:  "alertmanager",
 		}
-		ctx, cancle := context.WithTimeout(context.Background(), time.Second*5)
-		defer cancle()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
 		err = sch.datasourceService.GetDataSourcesByType(ctx, query)
 		if err != nil {
 			sch.log.Error("failed to fetch datasources for org", "org", cfg.OrgID)

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -242,7 +242,9 @@ func (sch *schedule) SyncAndApplyConfigFromDatabase() error {
 			OrgId: cfg.OrgID,
 			Type:  "alertmanager",
 		}
-		err = sch.datasourceService.GetDataSourcesByType(context.Background(), query)
+		ctx, cancle := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancle()
+		err = sch.datasourceService.GetDataSourcesByType(ctx, query)
 		if err != nil {
 			sch.log.Error("failed to fetch datasources for org", "org", cfg.OrgID)
 			continue

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -353,9 +353,9 @@ func (sch *schedule) buildExternalURL(ds *datasources.DataSource) (string, error
 	amURL := ds.Url
 	// if basic auth is enabled we need to build the url with basic auth baked in
 	if !ds.BasicAuth {
-	  return amURL
+		return amURL, nil
 	}
-	
+
 	parsed, err := url.Parse(ds.Url)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse alertmanager datasource url: %w", err)
@@ -365,7 +365,7 @@ func (sch *schedule) buildExternalURL(ds *datasources.DataSource) (string, error
 		return "", fmt.Errorf("basic auth enabled but no password set")
 	}
 	return fmt.Sprintf("%s://%s:%s@%s%s%s", parsed.Scheme, ds.BasicAuthUser,
-			password, parsed.Host, parsed.Path, parsed.RawQuery)
+		password, parsed.Host, parsed.Path, parsed.RawQuery), nil
 }
 
 // AlertmanagersFor returns all the discovered Alertmanager(s) for a particular organization.

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	datasources "github.com/grafana/grafana/pkg/services/datasources/fakes"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/image"
 	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
@@ -957,6 +958,8 @@ func setupScheduler(t *testing.T, rs store.RuleStore, is store.InstanceStore, ac
 		Logger:                  logger,
 		Metrics:                 m.GetSchedulerMetrics(),
 		AdminConfigPollInterval: 10 * time.Minute, // do not poll in unit tests.
+		DatasourceService:       &datasources.FakeDataSourceService{},
+		SecretService:           secretsService,
 	}
 	st := state.NewManager(schedCfg.Logger, m.GetStateMetrics(), nil, rs, is, &dashboards.FakeDashboardService{}, &image.NoopImageService{}, clock.NewMock())
 	appUrl := &url.URL{

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -1058,21 +1058,21 @@ func TestBuildExternalURL(t *testing.T) {
 		expectedURL string
 	}{
 		{
-			name: "datasource wihtout auth",
+			name: "datasource without auth",
 			ds: &ds.DataSource{
 				Url: "https://localhost:9000",
 			},
 			expectedURL: "https://localhost:9000",
 		},
 		{
-			name: "datasource wihtout auth and with path",
+			name: "datasource without auth and with path",
 			ds: &ds.DataSource{
 				Url: "https://localhost:9000/path/to/am",
 			},
 			expectedURL: "https://localhost:9000/path/to/am",
 		},
 		{
-			name: "datasource wiht auth",
+			name: "datasource with auth",
 			ds: &ds.DataSource{
 				Url:           "https://localhost:9000",
 				BasicAuth:     true,
@@ -1084,7 +1084,7 @@ func TestBuildExternalURL(t *testing.T) {
 			expectedURL: "https://johndoe:123@localhost:9000",
 		},
 		{
-			name: "datasource wiht auth and path",
+			name: "datasource with auth and path",
 			ds: &ds.DataSource{
 				Url:           "https://localhost:9000/path/to/am",
 				BasicAuth:     true,

--- a/pkg/services/ngalert/tests/util.go
+++ b/pkg/services/ngalert/tests/util.go
@@ -63,7 +63,7 @@ func SetupTestEnv(t *testing.T, baseInterval time.Duration) (*ngalert.AlertNG, *
 	)
 
 	ng, err := ngalert.ProvideService(
-		cfg, nil, routing.NewRouteRegister(), sqlStore, nil, nil, nil, nil,
+		cfg, nil, nil, routing.NewRouteRegister(), sqlStore, nil, nil, nil, nil,
 		secretsService, nil, m, folderService, ac, &dashboards.FakeDashboardService{}, nil, bus,
 	)
 	require.NoError(t, err)

--- a/pkg/services/sqlstore/datasource.go
+++ b/pkg/services/sqlstore/datasource.go
@@ -69,6 +69,9 @@ func (ss *SQLStore) GetDataSourcesByType(ctx context.Context, query *datasources
 
 	query.Result = make([]*datasources.DataSource, 0)
 	return ss.WithDbSession(ctx, func(sess *DBSession) error {
+		if query.OrgId > 0 {
+			return sess.Where("type=? AND org_id=?", query.Type, query.OrgId).Asc("id").Find(&query.Result)
+		}
 		return sess.Where("type=?", query.Type).Asc("id").Find(&query.Result)
 	})
 }

--- a/pkg/tests/api/alerting/api_admin_configuration_test.go
+++ b/pkg/tests/api/alerting/api_admin_configuration_test.go
@@ -84,7 +84,10 @@ func TestAdminConfiguration_SendingToExternalAlertmanagers(t *testing.T) {
 		resp := postRequest(t, alertsURL, buf.String(), http.StatusBadRequest) // nolint
 		b, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
-		require.JSONEq(t, `{"message": "Invalid alertmanager choice specified"}`, string(b))
+		var res map[string]interface{}
+		err = json.Unmarshal(b, &res)
+		require.NoError(t, err)
+		require.Equal(t, "Invalid alertmanager choice specified", res["message"])
 	}
 
 	// Let's try to send all the alerts to an external Alertmanager
@@ -102,7 +105,10 @@ func TestAdminConfiguration_SendingToExternalAlertmanagers(t *testing.T) {
 		resp := postRequest(t, alertsURL, buf.String(), http.StatusBadRequest) // nolint
 		b, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
-		require.JSONEq(t, `{"message": "At least one Alertmanager must be provided to choose this option"}`, string(b))
+		var res map[string]interface{}
+		err = json.Unmarshal(b, &res)
+		require.NoError(t, err)
+		require.Equal(t, "At least one Alertmanager must be provided to choose this option", res["message"])
 	}
 
 	// Now, lets re-set external Alertmanagers for main organisation
@@ -121,7 +127,10 @@ func TestAdminConfiguration_SendingToExternalAlertmanagers(t *testing.T) {
 		resp := postRequest(t, alertsURL, buf.String(), http.StatusCreated) // nolint
 		b, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
-		require.JSONEq(t, `{"message": "admin configuration updated"}`, string(b))
+		var res map[string]interface{}
+		err = json.Unmarshal(b, &res)
+		require.NoError(t, err)
+		require.Equal(t, "admin configuration updated", res["message"])
 	}
 
 	// If we get the configuration again, it shows us what we've set.
@@ -220,7 +229,10 @@ func TestAdminConfiguration_SendingToExternalAlertmanagers(t *testing.T) {
 		resp := postRequest(t, alertsURL, buf.String(), http.StatusCreated) // nolint
 		b, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
-		require.JSONEq(t, "{\"message\": \"admin configuration updated\"}", string(b))
+		var res map[string]interface{}
+		err = json.Unmarshal(b, &res)
+		require.NoError(t, err)
+		require.Equal(t, "admin configuration updated", res["message"])
 	}
 
 	// If we get the configuration again, it shows us what we've set.


### PR DESCRIPTION
This PR changes how we handle external alertermanger. Additionally to the old behavior, we now check if any datasource of type `alertmangager` is marked as external. If they are, we build the URL and add them to the list of external altermanagers.

The PR also extends the function that provides the datasources by type to accept an `OrgId`.

Rel. https://github.com/grafana/grafana/issues/51424