### PR TITLE
Storage: branding access

### DIFF
--- a/pkg/services/store/service.go
+++ b/pkg/services/store/service.go
@@ -34,8 +34,8 @@ const brandingStorage = "branding"
 const SystemBrandingStorage = "system/" + brandingStorage
 
 var (
-	SystemBrandingReader = &models.SignedInUser{OrgId: ac.GlobalOrgID}
-	SystemBrandingAdmin  = &models.SignedInUser{OrgId: ac.GlobalOrgID}
+	SystemBrandingReader = &models.SignedInUser{OrgId: 1}
+	SystemBrandingAdmin  = &models.SignedInUser{OrgId: 1}
 )
 
 const MAX_UPLOAD_SIZE = 1 * 1024 * 1024 // 3MB
@@ -132,8 +132,6 @@ func ProvideService(sql *sqlstore.SQLStore, features featuremgmt.FeatureToggles,
 
 		return storages
 	}
-
-	globalRoots = append(globalRoots, initializeOrgStorages(ac.GlobalOrgID)...)
 
 	authService := newStaticStorageAuthService(func(ctx context.Context, user *models.SignedInUser, storageName string) map[string]filestorage.PathFilter {
 		if user == nil {

--- a/pkg/services/store/service.go
+++ b/pkg/services/store/service.go
@@ -34,8 +34,8 @@ const brandingStorage = "branding"
 const SystemBrandingStorage = "system/" + brandingStorage
 
 var (
-	SystemBrandingReader = &models.SignedInUser{}
-	SystemBrandingAdmin  = &models.SignedInUser{}
+	SystemBrandingReader = &models.SignedInUser{OrgId: ac.GlobalOrgID}
+	SystemBrandingAdmin  = &models.SignedInUser{OrgId: ac.GlobalOrgID}
 )
 
 const MAX_UPLOAD_SIZE = 1 * 1024 * 1024 // 3MB

--- a/pkg/services/store/service.go
+++ b/pkg/services/store/service.go
@@ -95,11 +95,6 @@ func ProvideService(sql *sqlstore.SQLStore, features featuremgmt.FeatureToggles,
 			},
 		}).setReadOnly(true).setBuiltin(true).
 			setDescription("Access files from the static public files"),
-		newSQLStorage(RootSystem,
-			"System",
-			&StorageSQLConfig{orgId: ac.GlobalOrgID},
-			sql,
-		).setBuiltin(true).setDescription("Grafana system storage"),
 	}
 
 	// Development dashboards
@@ -137,6 +132,8 @@ func ProvideService(sql *sqlstore.SQLStore, features featuremgmt.FeatureToggles,
 
 		return storages
 	}
+
+	globalRoots = append(globalRoots, initializeOrgStorages(ac.GlobalOrgID)...)
 
 	authService := newStaticStorageAuthService(func(ctx context.Context, user *models.SignedInUser, storageName string) map[string]filestorage.PathFilter {
 		if user == nil {

--- a/pkg/services/store/service.go
+++ b/pkg/services/store/service.go
@@ -143,14 +143,14 @@ func ProvideService(sql *sqlstore.SQLStore, features featuremgmt.FeatureToggles,
 		if storageName == RootSystem {
 			if user == SystemBrandingReader {
 				return map[string]filestorage.PathFilter{
-					ActionFilesRead:   filestorage.NewPathFilter([]string{filestorage.Delimiter + brandingStorage + filestorage.Delimiter}, []string{filestorage.Delimiter + brandingStorage}, nil, nil),
+					ActionFilesRead:   createSystemBrandingPathFilter(),
 					ActionFilesWrite:  denyAllPathFilter,
 					ActionFilesDelete: denyAllPathFilter,
 				}
 			}
 
 			if user == SystemBrandingAdmin {
-				systemBrandingFilter := filestorage.NewPathFilter([]string{filestorage.Delimiter + brandingStorage + filestorage.Delimiter}, []string{filestorage.Delimiter + brandingStorage}, nil, nil)
+				systemBrandingFilter := createSystemBrandingPathFilter()
 				return map[string]filestorage.PathFilter{
 					ActionFilesRead:   systemBrandingFilter,
 					ActionFilesWrite:  systemBrandingFilter,
@@ -188,6 +188,14 @@ func ProvideService(sql *sqlstore.SQLStore, features featuremgmt.FeatureToggles,
 	})
 
 	return newStandardStorageService(sql, globalRoots, initializeOrgStorages, authService)
+}
+
+func createSystemBrandingPathFilter() filestorage.PathFilter {
+	return filestorage.NewPathFilter(
+		[]string{filestorage.Delimiter + brandingStorage + filestorage.Delimiter}, // access to all folders and files inside `/branding/`
+		[]string{filestorage.Delimiter + brandingStorage},                         // access to the `/branding` folder itself, but not to any other sibling folder
+		nil,
+		nil)
 }
 
 func newStandardStorageService(sql *sqlstore.SQLStore, globalRoots []storageRuntime, initializeOrgStorages func(orgId int64) []storageRuntime, authService storageAuthService) *standardStorageService {


### PR DESCRIPTION
follow up after 
- https://github.com/grafana/grafana/pull/51987
- https://github.com/grafana/grafana/pull/52334

This PR adds special users for accessing a specific slice of the storage; a slice that no other user/service has access to. In the future, this would be replaced by a combination of a role + SA in RBAC