### PR TITLE
Storage: Remove storageLocalUpload flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -43,7 +43,6 @@ export interface FeatureToggles {
   storage?: boolean;
   dashboardsFromStorage?: boolean;
   export?: boolean;
-  storageLocalUpload?: boolean;
   azureMonitorResourcePickerForMetrics?: boolean;
   explore2Dashboard?: boolean;
   tracing?: boolean;

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -227,17 +227,16 @@ func (hs *HTTPServer) registerRoutes() {
 		})
 
 		if hs.Features.IsEnabled(featuremgmt.FlagStorage) {
-			apiRoute.Group("/storage", func(orgRoute routing.RouteRegister) {
-				orgRoute.Get("/list/", routing.Wrap(hs.StorageService.List))
-				orgRoute.Get("/list/*", routing.Wrap(hs.StorageService.List))
-				orgRoute.Get("/read/*", routing.Wrap(hs.StorageService.Read))
+			apiRoute.Group("/storage", func(storageRoute routing.RouteRegister) {
+				storageRoute.Get("/list/", routing.Wrap(hs.StorageService.List))
+				storageRoute.Get("/list/*", routing.Wrap(hs.StorageService.List))
+				storageRoute.Get("/read/*", routing.Wrap(hs.StorageService.Read))
 
-				if hs.Features.IsEnabled(featuremgmt.FlagStorageLocalUpload) {
-					orgRoute.Post("/delete/*", reqGrafanaAdmin, routing.Wrap(hs.StorageService.Delete))
-					orgRoute.Post("/upload", reqGrafanaAdmin, routing.Wrap(hs.StorageService.Upload))
-					orgRoute.Post("/createFolder", reqGrafanaAdmin, routing.Wrap(hs.StorageService.CreateFolder))
-					orgRoute.Post("/deleteFolder", reqGrafanaAdmin, routing.Wrap(hs.StorageService.DeleteFolder))
-				}
+				// Write paths
+				storageRoute.Post("/delete/*", reqGrafanaAdmin, routing.Wrap(hs.StorageService.Delete))
+				storageRoute.Post("/upload", reqGrafanaAdmin, routing.Wrap(hs.StorageService.Upload))
+				storageRoute.Post("/createFolder", reqGrafanaAdmin, routing.Wrap(hs.StorageService.CreateFolder))
+				storageRoute.Post("/deleteFolder", reqGrafanaAdmin, routing.Wrap(hs.StorageService.DeleteFolder))
 			})
 		}
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -153,12 +153,6 @@ var (
 			RequiresDevMode: true,
 		},
 		{
-			Name:            "storageLocalUpload",
-			Description:     "allow uploads to local storage",
-			State:           FeatureStateAlpha,
-			RequiresDevMode: true,
-		},
-		{
 			Name:            "azureMonitorResourcePickerForMetrics",
 			Description:     "New UI for Azure Monitor Metrics Query",
 			State:           FeatureStateAlpha,

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -115,10 +115,6 @@ const (
 	// Export grafana instance (to git, etc)
 	FlagExport = "export"
 
-	// FlagStorageLocalUpload
-	// allow uploads to local storage
-	FlagStorageLocalUpload = "storageLocalUpload"
-
 	// FlagAzureMonitorResourcePickerForMetrics
 	// New UI for Azure Monitor Metrics Query
 	FlagAzureMonitorResourcePickerForMetrics = "azureMonitorResourcePickerForMetrics"

--- a/pkg/services/store/service.go
+++ b/pkg/services/store/service.go
@@ -108,15 +108,16 @@ func ProvideService(sql *sqlstore.SQLStore, features featuremgmt.FeatureToggles,
 
 	initializeOrgStorages := func(orgId int64) []storageRuntime {
 		storages := make([]storageRuntime, 0)
-		if features.IsEnabled(featuremgmt.FlagStorageLocalUpload) {
-			storages = append(storages,
-				newSQLStorage(RootResources,
-					"Resources",
-					&StorageSQLConfig{orgId: orgId}, sql).
-					setBuiltin(true).
-					setDescription("Upload custom resource files"))
-		}
 
+		// Custom upload files
+		storages = append(storages,
+			newSQLStorage(RootResources,
+				"Resources",
+				&StorageSQLConfig{orgId: orgId}, sql).
+				setBuiltin(true).
+				setDescription("Upload custom resource files"))
+
+		// System settings
 		storages = append(storages,
 			newSQLStorage(RootSystem,
 				"System",

--- a/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
+++ b/public/app/features/dimensions/editors/ResourcePickerPopover.tsx
@@ -94,16 +94,6 @@ export const ResourcePickerPopover = (props: Props) => {
             <button className={getTabClassName(PickerTabType.URL)} onClick={() => setActivePicker(PickerTabType.URL)}>
               URL
             </button>
-            {config.featureToggles['storageLocalUpload'] ? (
-              <button
-                className={getTabClassName(PickerTabType.Upload)}
-                onClick={() => setActivePicker(PickerTabType.Upload)}
-              >
-                Upload
-              </button>
-            ) : (
-              ''
-            )}
           </div>
           <div className={styles.resourcePickerPopoverContent}>
             {renderPicker()}


### PR DESCRIPTION
This removes the `storageLocalUpload` flag -- the feature still requires the `storage` flag, but now we can always upload.

This is now "safe" because we:
1. are saving to SQL, not a real local file system (like the first pass of this feature)
2. this requires grafana admin permissions -- only the most elevated super users can upload
3. we have basic upload verification enabled