### PR TITLE
Loki: Add hints for level-like labels

### DIFF
--- a/public/app/plugins/datasource/loki/addtoQuery.test.ts
+++ b/public/app/plugins/datasource/loki/addtoQuery.test.ts
@@ -212,4 +212,24 @@ describe('addLabelFormatToQuery', () => {
       addLabelFormatToQuery('{job="grafana"} | logfmt | label_format a=b', { originalLabel: 'lvl', renameTo: 'level' })
     ).toBe('{job="grafana"} | logfmt | label_format a=b | label_format level=lvl');
   });
+
+  it('should add label format at the end of log query part of metrics query', () => {
+    expect(
+      addLabelFormatToQuery('rate({job="grafana"} | logfmt | label_format a=b [5m])', {
+        originalLabel: 'lvl',
+        renameTo: 'level',
+      })
+    ).toBe('rate({job="grafana"} | logfmt | label_format a=b | label_format level=lvl [5m])');
+  });
+
+  it('should add label format at the end of multiple log query part of metrics query', () => {
+    expect(
+      addLabelFormatToQuery(
+        'rate({job="grafana"} | logfmt | label_format a=b [5m]) + rate({job="grafana"} | logfmt | label_format a=b [5m])',
+        { originalLabel: 'lvl', renameTo: 'level' }
+      )
+    ).toBe(
+      'rate({job="grafana"} | logfmt | label_format a=b | label_format level=lvl [5m]) + rate({job="grafana"} | logfmt | label_format a=b | label_format level=lvl [5m])'
+    );
+  });
 });

--- a/public/app/plugins/datasource/loki/addtoQuery.test.ts
+++ b/public/app/plugins/datasource/loki/addtoQuery.test.ts
@@ -1,4 +1,4 @@
-import { addLabelToQuery, addNoPipelineErrorToQuery, addParserToQuery } from './addToQuery';
+import { addLabelFormatToQuery, addLabelToQuery, addNoPipelineErrorToQuery, addParserToQuery } from './addToQuery';
 
 describe('addLabelToQuery()', () => {
   it('should add label to simple query', () => {
@@ -191,5 +191,25 @@ describe('addNoPipelineErrorToQuery', () => {
 
   it('should not add error filtering if no parser', () => {
     expect(addNoPipelineErrorToQuery('{job="grafana"} |="no parser"')).toBe('{job="grafana"} |="no parser"');
+  });
+});
+
+describe('addLabelFormatToQuery', () => {
+  it('should add label format at the end of log query when parser', () => {
+    expect(addLabelFormatToQuery('{job="grafana"} | logfmt', { originalLabel: 'lvl', renameTo: 'level' })).toBe(
+      '{job="grafana"} | logfmt | label_format level=lvl'
+    );
+  });
+
+  it('should add label format at the end of log query when no parser', () => {
+    expect(addLabelFormatToQuery('{job="grafana"}', { originalLabel: 'lvl', renameTo: 'level' })).toBe(
+      '{job="grafana"} | label_format level=lvl'
+    );
+  });
+
+  it('should add label format at the end of log query when more label parser', () => {
+    expect(
+      addLabelFormatToQuery('{job="grafana"} | logfmt | label_format a=b', { originalLabel: 'lvl', renameTo: 'level' })
+    ).toBe('{job="grafana"} | logfmt | label_format a=b | label_format level=lvl');
   });
 });

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -423,8 +423,8 @@ export class LokiDatasource
             renameTo: action.options.renameTo,
             originalLabel: action.options.originalLabel,
           });
-          break;
         }
+        break;
       }
       default:
         break;

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -44,7 +44,7 @@ import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_sr
 import { serializeParams } from '../../../core/utils/fetch';
 import { renderLegendFormat } from '../prometheus/legend';
 
-import { addLabelToQuery, addNoPipelineErrorToQuery, addParserToQuery } from './addToQuery';
+import { addLabelFormatToQuery, addLabelToQuery, addNoPipelineErrorToQuery, addParserToQuery } from './addToQuery';
 import { transformBackendResult } from './backendResultTransformer';
 import { LokiAnnotationsQueryEditor } from './components/AnnotationsQueryEditor';
 import LanguageProvider from './language_provider';
@@ -358,7 +358,7 @@ export class LokiDatasource
       expr: query.expr,
       queryType: LokiQueryType.Range,
       refId: 'log-samples',
-      maxLines: 50,
+      maxLines: 10,
     };
 
     // For samples, we use defaultTimeRange (now-6h/now) and limit od 10 lines so queries are small and fast
@@ -416,6 +416,15 @@ export class LokiDatasource
       case 'ADD_NO_PIPELINE_ERROR': {
         expression = addNoPipelineErrorToQuery(expression);
         break;
+      }
+      case 'ADD_LEVEL_LABEL_FORMAT': {
+        if (action.options?.originalLabel && action.options?.renameTo) {
+          expression = addLabelFormatToQuery(expression, {
+            renameTo: action.options.renameTo,
+            originalLabel: action.options.originalLabel,
+          });
+          break;
+        }
       }
       default:
         break;

--- a/public/app/plugins/datasource/loki/queryHints.ts
+++ b/public/app/plugins/datasource/loki/queryHints.ts
@@ -77,9 +77,9 @@ export function getQueryHints(query: string, series: DataFrame[]): QueryHint[] {
     if (!hasLevel && levelLikeLabel) {
       hints.push({
         type: 'ADD_LEVEL_LABEL_FORMAT',
-        label: 'Selected log stream selector has level-like label',
+        label: `Some logs in your selected log stream have "${levelLikeLabel}" label.`,
         fix: {
-          label: 'Consider using label format to rename it to level.',
+          label: `If ${levelLikeLabel} label has level values, consider using label_format to rename it to "level". Level label can be then visualized in log volumes.`,
           action: {
             type: 'ADD_LEVEL_LABEL_FORMAT',
             query,

--- a/public/app/plugins/datasource/loki/queryHints.ts
+++ b/public/app/plugins/datasource/loki/queryHints.ts
@@ -1,7 +1,12 @@
 import { DataFrame, QueryHint } from '@grafana/data';
 
-import { isQueryPipelineErrorFiltering, isQueryWithParser } from './query_utils';
-import { extractHasErrorLabelFromDataFrame, extractLogParserFromDataFrame } from './responseUtils';
+import { isQueryPipelineErrorFiltering, isQueryWithLabelFormat, isQueryWithParser } from './query_utils';
+import {
+  dataFrameHasLevelLabel,
+  extractHasErrorLabelFromDataFrame,
+  extractLevelLikeLabelFromDataFrame,
+  extractLogParserFromDataFrame,
+} from './responseUtils';
 
 export function getQueryHints(query: string, series: DataFrame[]): QueryHint[] {
   if (series.length === 0) {
@@ -60,6 +65,31 @@ export function getQueryHints(query: string, series: DataFrame[]): QueryHint[] {
           },
         });
       }
+    }
+  }
+
+  const queryWithLabelFormat = isQueryWithLabelFormat(query);
+  if (!queryWithLabelFormat) {
+    const hasLevel = dataFrameHasLevelLabel(series[0]);
+    const levelLikeLabel = extractLevelLikeLabelFromDataFrame(series[0]);
+
+    // Add hint only if we don't have "level" label and have level-like label
+    if (!hasLevel && levelLikeLabel) {
+      hints.push({
+        type: 'ADD_LEVEL_LABEL_FORMAT',
+        label: 'Selected log stream selector has level-like label',
+        fix: {
+          label: 'Consider using label format to rename it to level.',
+          action: {
+            type: 'ADD_LEVEL_LABEL_FORMAT',
+            query,
+            options: {
+              renameTo: 'level',
+              originalLabel: levelLikeLabel,
+            },
+          },
+        },
+      });
     }
   }
 

--- a/public/app/plugins/datasource/loki/query_utils.test.ts
+++ b/public/app/plugins/datasource/loki/query_utils.test.ts
@@ -2,6 +2,7 @@ import {
   getHighlighterExpressionsFromQuery,
   getNormalizedLokiQuery,
   isLogsQuery,
+  isQueryWithLabelFormat,
   isQueryWithParser,
   isValidQuery,
 } from './query_utils';
@@ -185,5 +186,23 @@ describe('isQueryWithParser', () => {
       parserCount: 1,
       queryWithParser: true,
     });
+  });
+});
+
+describe('isQueryWithLabelFormat', () => {
+  it('returns true if log query with label format', () => {
+    expect(isQueryWithLabelFormat('{job="grafana"} | label_format level=lvl')).toBe(true);
+  });
+
+  it('returns true if metrics query with label format', () => {
+    expect(isQueryWithLabelFormat('rate({job="grafana"} | label_format level=lvl [5m])')).toBe(true);
+  });
+
+  it('returns false if log query without label format', () => {
+    expect(isQueryWithLabelFormat('{job="grafana"} | json')).toBe(false);
+  });
+
+  it('returns false if metrics query without label format', () => {
+    expect(isQueryWithLabelFormat('rate({job="grafana"} [5m])')).toBe(false);
   });
 });

--- a/public/app/plugins/datasource/loki/query_utils.ts
+++ b/public/app/plugins/datasource/loki/query_utils.ts
@@ -159,3 +159,16 @@ export function isQueryPipelineErrorFiltering(query: string): boolean {
 
   return isQueryPipelineErrorFiltering;
 }
+
+export function isQueryWithLabelFormat(query: string): boolean {
+  let queryWithLabelFormat = false;
+  const tree = parser.parse(query);
+  tree.iterate({
+    enter: (type): false | void => {
+      if (type.name === 'LabelFormatExpr') {
+        queryWithLabelFormat = true;
+      }
+    },
+  });
+  return queryWithLabelFormat;
+}

--- a/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/LokiQueryModeller.test.ts
@@ -170,9 +170,9 @@ describe('LokiQueryModeller', () => {
     expect(
       modeller.renderQuery({
         labels: [{ label: 'app', op: '=', value: 'grafana' }],
-        operations: [{ id: LokiOperationId.LabelFormat, params: ['new', 'old'] }],
+        operations: [{ id: LokiOperationId.LabelFormat, params: ['original', 'renameTo'] }],
       })
-    ).toBe('{app="grafana"} | label_format old=`new`');
+    ).toBe('{app="grafana"} | label_format renameTo=original');
   });
 
   it('Can render simply binary operation with scalar', () => {

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -187,13 +187,13 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       name: 'Label format',
       params: [
         { name: 'Label', type: 'string' },
-        { name: 'Rename', type: 'string' },
+        { name: 'Rename to', type: 'string' },
       ],
       defaultParams: ['', ''],
       alternativesKey: 'format',
       category: LokiVisualQueryOperationCategory.Formats,
       orderRank: LokiOperationOrder.LineFormats,
-      renderer: (model, def, innerExpr) => `${innerExpr} | label_format ${model.params[1]}=\`${model.params[0]}\``,
+      renderer: (model, def, innerExpr) => `${innerExpr} | label_format ${model.params[1]}=${model.params[0]}`,
       addOperationHandler: addLokiOperation,
       explainHandler: () =>
         `This will change name of label to desired new label. In the example below, label "error_level" will be renamed to "level".

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -456,7 +456,7 @@ describe('buildVisualQueryFromString', () => {
   });
 
   it('parses query with label format', () => {
-    expect(buildVisualQueryFromString('{app="frontend"} | label_format newLabel=oldLabel')).toEqual(
+    expect(buildVisualQueryFromString('{app="frontend"} | label_format renameTo=original')).toEqual(
       noErrors({
         labels: [
           {
@@ -465,13 +465,13 @@ describe('buildVisualQueryFromString', () => {
             label: 'app',
           },
         ],
-        operations: [{ id: 'label_format', params: ['newLabel', 'oldLabel'] }],
+        operations: [{ id: 'label_format', params: ['original', 'renameTo'] }],
       })
     );
   });
 
   it('parses query with multiple label format', () => {
-    expect(buildVisualQueryFromString('{app="frontend"} | label_format newLabel=oldLabel, bar="baz"')).toEqual(
+    expect(buildVisualQueryFromString('{app="frontend"} | label_format renameTo=original, bar=baz')).toEqual(
       noErrors({
         labels: [
           {
@@ -481,8 +481,8 @@ describe('buildVisualQueryFromString', () => {
           },
         ],
         operations: [
-          { id: 'label_format', params: ['newLabel', 'oldLabel'] },
-          { id: 'label_format', params: ['bar', 'baz'] },
+          { id: 'label_format', params: ['original', 'renameTo'] },
+          { id: 'label_format', params: ['baz', 'bar'] },
         ],
       })
     );

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -295,15 +295,13 @@ function getLineFormat(expr: string, node: SyntaxNode): QueryBuilderOperation {
 
 function getLabelFormat(expr: string, node: SyntaxNode): QueryBuilderOperation {
   const id = 'label_format';
-  const identifier = node.getChild('Identifier');
-  const op = identifier!.nextSibling;
-  const value = op!.nextSibling;
-
-  let valueString = handleQuotes(getString(expr, value));
+  const renameTo = node.getChild('Identifier');
+  const op = renameTo!.nextSibling;
+  const originalLabel = op!.nextSibling;
 
   return {
     id,
-    params: [getString(expr, identifier), valueString],
+    params: [getString(expr, originalLabel), handleQuotes(getString(expr, renameTo))],
   };
 }
 

--- a/public/app/plugins/datasource/loki/responseUtils.test.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.test.ts
@@ -2,7 +2,7 @@ import { cloneDeep } from 'lodash';
 
 import { ArrayVector, DataFrame, FieldType } from '@grafana/data';
 
-import { dataFrameHasLokiError } from './responseUtils';
+import { dataFrameHasLevelLabel, dataFrameHasLokiError, extractLevelLikeLabelFromDataFrame } from './responseUtils';
 
 const frame: DataFrame = {
   length: 1,
@@ -28,7 +28,7 @@ const frame: DataFrame = {
   ],
 };
 
-describe('dataframeHasParsingError', () => {
+describe('dataFrameHasParsingError', () => {
   it('handles frame with parsing error', () => {
     const input = cloneDeep(frame);
     input.fields[1].values = new ArrayVector([{ level: 'info', __error__: 'error' }]);
@@ -37,5 +37,36 @@ describe('dataframeHasParsingError', () => {
   it('handles frame without parsing error', () => {
     const input = cloneDeep(frame);
     expect(dataFrameHasLokiError(input)).toBe(false);
+  });
+});
+
+describe('dataFrameHasLevelLabel', () => {
+  it('returns true if level label is present', () => {
+    const input = cloneDeep(frame);
+    input.fields[1].values = new ArrayVector([{ level: 'info' }]);
+    expect(dataFrameHasLevelLabel(input)).toBe(true);
+  });
+  it('returns false if level label is present', () => {
+    const input = cloneDeep(frame);
+    input.fields[1].values = new ArrayVector([{ foo: 'bar' }]);
+    expect(dataFrameHasLevelLabel(input)).toBe(false);
+  });
+});
+
+describe('extractLevelLikeLabelFromDataFrame', () => {
+  it('returns label if lvl label is present', () => {
+    const input = cloneDeep(frame);
+    input.fields[1].values = new ArrayVector([{ lvl: 'info' }]);
+    expect(extractLevelLikeLabelFromDataFrame(input)).toBe('lvl');
+  });
+  it('returns label if level-like label is present', () => {
+    const input = cloneDeep(frame);
+    input.fields[1].values = new ArrayVector([{ error_level: 'info' }]);
+    expect(extractLevelLikeLabelFromDataFrame(input)).toBe('error_level');
+  });
+  it('returns undefined if no level-like label is present', () => {
+    const input = cloneDeep(frame);
+    input.fields[1].values = new ArrayVector([{ foo: 'info' }]);
+    expect(extractLevelLikeLabelFromDataFrame(input)).toBe(undefined);
   });
 });

--- a/public/app/plugins/datasource/loki/responseUtils.test.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.test.ts
@@ -67,6 +67,6 @@ describe('extractLevelLikeLabelFromDataFrame', () => {
   it('returns undefined if no level-like label is present', () => {
     const input = cloneDeep(frame);
     input.fields[1].values = new ArrayVector([{ foo: 'info' }]);
-    expect(extractLevelLikeLabelFromDataFrame(input)).toBe(undefined);
+    expect(extractLevelLikeLabelFromDataFrame(input)).toBe(null);
   });
 });

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -44,16 +44,16 @@ export function extractHasErrorLabelFromDataFrame(frame: DataFrame): boolean {
   return labels.some((label) => label['__error__']);
 }
 
-export function extractLevelLikeLabelFromDataFrame(frame: DataFrame): string | undefined {
+export function extractLevelLikeLabelFromDataFrame(frame: DataFrame): string | null {
   const labelField = frame.fields.find((field) => field.name === 'labels' && field.type === FieldType.other);
   if (labelField == null) {
-    return undefined;
+    return null;
   }
 
   // Depending on number of labels, this can be pretty heavy operation.
   // Let's just look at first 2 lines If needed, we can introduce more later.
   const labelsArray: Array<{ [key: string]: string }> = labelField.values.toArray().slice(0, 2);
-  let levelLikeLabel: string | undefined = undefined;
+  let levelLikeLabel: string | null = null;
 
   // Find first level-like label
   for (let labels of labelsArray) {

--- a/public/app/plugins/datasource/loki/responseUtils.ts
+++ b/public/app/plugins/datasource/loki/responseUtils.ts
@@ -4,6 +4,12 @@ export function dataFrameHasLokiError(frame: DataFrame): boolean {
   const labelSets: Labels[] = frame.fields.find((f) => f.name === 'labels')?.values.toArray() ?? [];
   return labelSets.some((labels) => labels.__error__ !== undefined);
 }
+
+export function dataFrameHasLevelLabel(frame: DataFrame): boolean {
+  const labelSets: Labels[] = frame.fields.find((f) => f.name === 'labels')?.values.toArray() ?? [];
+  return labelSets.some((labels) => labels.level !== undefined);
+}
+
 export function extractLogParserFromDataFrame(frame: DataFrame): { hasLogfmt: boolean; hasJSON: boolean } {
   const lineField = frame.fields.find((field) => field.type === FieldType.string);
   if (lineField == null) {
@@ -36,4 +42,26 @@ export function extractHasErrorLabelFromDataFrame(frame: DataFrame): boolean {
 
   const labels: Array<{ [key: string]: string }> = labelField.values.toArray();
   return labels.some((label) => label['__error__']);
+}
+
+export function extractLevelLikeLabelFromDataFrame(frame: DataFrame): string | undefined {
+  const labelField = frame.fields.find((field) => field.name === 'labels' && field.type === FieldType.other);
+  if (labelField == null) {
+    return undefined;
+  }
+
+  // Depending on number of labels, this can be pretty heavy operation.
+  // Let's just look at first 2 lines If needed, we can introduce more later.
+  const labelsArray: Array<{ [key: string]: string }> = labelField.values.toArray().slice(0, 2);
+  let levelLikeLabel: string | undefined = undefined;
+
+  // Find first level-like label
+  for (let labels of labelsArray) {
+    const label = Object.keys(labels).find((label) => label === 'lvl' || label.includes('level'));
+    if (label) {
+      levelLikeLabel = label;
+      break;
+    }
+  }
+  return levelLikeLabel;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the last hint - hinting to use `label_format` to rename level-like label (`lvl/error_level/levelInfo`) to `level`. This is beneficial because log histogram works only with `level` label and in that case displays colourful graph with differentiated log levels. 

https://user-images.githubusercontent.com/30407135/179794139-76faf75a-7120-4a84-9053-d2cb7897024f.mov

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/51980

**Special notes for your reviewer**:

To test this out, I suggest to:
1.  go to `devenv/docker/blocks/loki/data/data.js` and change line 77 to `lvl: chooseRandomElement(['debug','info', 'info', 'info', 'info', 'warning', 'error', 'error']),`. 
2. Re-run the `make devenv sources=loki`
3. Go to explore, choose `gdev-loki` data sources and switch to query builder
4. Run `{place="moon"} | json` query and see if the level hint pops up.
5. You can then play with different scenarios - instead of replacing `level` with `lvl` in `data.js`, add both and see if (correctly) hint doesn't pop up. 
