### PR TITLE
Cloudwatch: Upgrade grafana-aws-sdk to fix auth issue with secret keys. 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/gosimple/slug v1.12.0
 	github.com/grafana/cuetsy v0.0.3
-	github.com/grafana/grafana-aws-sdk v0.10.7
+	github.com/grafana/grafana-aws-sdk v0.10.8
 	github.com/grafana/grafana-azure-sdk-go v1.3.0
 	github.com/grafana/grafana-plugin-sdk-go v0.138.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1336,6 +1336,8 @@ github.com/grafana/go-mssqldb v0.0.0-20210326084033-d0ce3c521036 h1:GplhUk6Xes5J
 github.com/grafana/go-mssqldb v0.0.0-20210326084033-d0ce3c521036/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/grafana/grafana-aws-sdk v0.10.7 h1:kXOuWCI+fV561/9sOU0DnzlFwqblfW36XptJLv78l8s=
 github.com/grafana/grafana-aws-sdk v0.10.7/go.mod h1:5Iw3xY7iXJfNaYHrRHMXa/kaB2lWoyntg71PPLGvSs8=
+github.com/grafana/grafana-aws-sdk v0.10.8 h1:6MGlWlQD4E0aI+Vp4Cfgzsj9V3U7kSQ1wCye9D1NMoU=
+github.com/grafana/grafana-aws-sdk v0.10.8/go.mod h1:5Iw3xY7iXJfNaYHrRHMXa/kaB2lWoyntg71PPLGvSs8=
 github.com/grafana/grafana-azure-sdk-go v1.2.0 h1:f/7BjCHGIU0JYOsLIt4oJztDy0fOPBRHB5R0Xe9++ew=
 github.com/grafana/grafana-azure-sdk-go v1.2.0/go.mod h1:rgrnK9m6CgKlgx4rH3FFP/6dTdyRO6LYC2mVZov35yo=
 github.com/grafana/grafana-azure-sdk-go v1.3.0 h1:zboQpq/ljBjqHo/6UQNZAUwqGTtnEGRYSEnqIQvLuAo=

--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
     "@emotion/react": "11.9.0",
     "@grafana/agent-core": "^0.3.0",
     "@grafana/agent-web": "^0.3.0",
-    "@grafana/aws-sdk": "0.0.36",
+    "@grafana/aws-sdk": "0.0.37",
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/experimental": "^0.0.2-canary.32",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@emotion/css": "11.9.0",
     "@emotion/react": "11.9.0",
-    "@grafana/aws-sdk": "0.0.36",
     "@grafana/data": "9.1.0-pre",
     "@grafana/e2e-selectors": "9.1.0-pre",
     "@grafana/schema": "9.1.0-pre",

--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -29,7 +29,6 @@ const buildCjsPackage = ({ env }) => {
     external: [
       'react',
       'react-dom',
-      '@grafana/aws-sdk',
       '@grafana/data',
       '@grafana/schema',
       '@grafana/e2e-selectors',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4657,10 +4657,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/aws-sdk@npm:0.0.36":
-  version: 0.0.36
-  resolution: "@grafana/aws-sdk@npm:0.0.36"
-  checksum: c243f7c900551e98fd23ef805e983d7db3180992e652ef9ad656acc74ac1c1e779e9b500db08a39d5cd0bc02fdb584e4c7dd89be8546e115ae12c085773cd212
+"@grafana/aws-sdk@npm:0.0.37":
+  version: 0.0.37
+  resolution: "@grafana/aws-sdk@npm:0.0.37"
+  checksum: 3994e78182dc181c9ba1b0595551480eb699c34531f582c52badec8da1d930a3198530145ef58a9543f77e424026c6a70a213097e0b56534f44894165db9c4d2
   languageName: node
   linkType: hard
 
@@ -5024,7 +5024,6 @@ __metadata:
     "@babel/core": 7.18.2
     "@emotion/css": 11.9.0
     "@emotion/react": 11.9.0
-    "@grafana/aws-sdk": 0.0.36
     "@grafana/data": 9.1.0-pre
     "@grafana/e2e-selectors": 9.1.0-pre
     "@grafana/schema": 9.1.0-pre
@@ -20976,7 +20975,7 @@ __metadata:
     "@grafana/agent-core": ^0.3.0
     "@grafana/agent-web": ^0.3.0
     "@grafana/api-documenter": 7.11.2
-    "@grafana/aws-sdk": 0.0.36
+    "@grafana/aws-sdk": 0.0.37
     "@grafana/data": "workspace:*"
     "@grafana/e2e": "workspace:*"
     "@grafana/e2e-selectors": "workspace:*"


### PR DESCRIPTION
**What this PR does / why we need it**:
- fixes a bug with auth and secret keys first seen in athena, in which a user mistypes their auth keys once, fixes the issue, but then old incorrect credentials are used in future requests. I believe the issue also exists in cloudwatch and potentially any aws plugin: https://github.com/grafana/athena-datasource/issues/144 + https://github.com/grafana/grafana-aws-sdk/pull/59
- removes grafana-aws-sdk from grafana/ui as I believe it is not actually used anymore

**Which issue(s) this PR fixes**:

(no associated ticket at this point)

**Special notes for your reviewer**:

