### PR TITLE
Scenes: Improve typing of scene state to avoid type guards and casting

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5729,8 +5729,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/features/scenes/core/types.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/scenes/editor/SceneObjectTree.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -5728,11 +5728,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
-    "public/app/features/scenes/core/events.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
-    ],
     "public/app/features/scenes/core/types.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -5720,12 +5720,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Do not use any type assertions.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Do not use any type assertions.", "6"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
-      [0, 0, 0, "Do not use any type assertions.", "8"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "9"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
+      [0, 0, 0, "Do not use any type assertions.", "5"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
     ],
     "public/app/features/scenes/core/SceneTimeRange.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -5742,8 +5739,7 @@ exports[`better eslint`] = {
     ],
     "public/app/features/scenes/editor/SceneObjectTree.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/features/scenes/querying/SceneQueryRunner.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/public/app/features/scenes/components/NestedScene.tsx
+++ b/public/app/features/scenes/components/NestedScene.tsx
@@ -39,7 +39,7 @@ export class NestedScene extends SceneObjectBase<NestedSceneState> {
   /** Removes itself from it's parent's children array */
   onRemove = () => {
     const parent = this.parent!;
-    if (isSceneLayoutObject(parent)) {
+    if ('children' in parent.state) {
       parent.setState({
         children: parent.state.children.filter((x) => x !== this),
       });

--- a/public/app/features/scenes/components/NestedScene.tsx
+++ b/public/app/features/scenes/components/NestedScene.tsx
@@ -6,20 +6,14 @@ import { Stack } from '@grafana/experimental';
 import { Button, ToolbarButton, useStyles2 } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import {
-  SceneObject,
-  SceneObjectState,
-  SceneLayoutState,
-  SceneComponentProps,
-  isSceneLayoutObject,
-} from '../core/types';
+import { SceneObject, SceneLayoutChildState, SceneComponentProps, SceneLayout } from '../core/types';
 
-interface NestedSceneState extends SceneObjectState {
+interface NestedSceneState extends SceneLayoutChildState {
   title: string;
   isCollapsed?: boolean;
   canCollapse?: boolean;
   canRemove?: boolean;
-  layout: SceneObject<SceneLayoutState>;
+  layout: SceneLayout;
   actions?: SceneObject[];
 }
 

--- a/public/app/features/scenes/components/Scene.tsx
+++ b/public/app/features/scenes/components/Scene.tsx
@@ -7,10 +7,10 @@ import { Page } from 'app/core/components/Page/Page';
 import { PageLayoutType } from 'app/core/components/Page/types';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneComponentProps, SceneObjectState, SceneObject } from '../core/types';
+import { SceneComponentProps, SceneObjectStatePlain, SceneObject } from '../core/types';
 import { UrlSyncManager } from '../services/UrlSyncManager';
 
-interface SceneState extends SceneObjectState {
+interface SceneState extends SceneObjectStatePlain {
   title: string;
   layout: SceneObject;
   actions?: SceneObject[];

--- a/public/app/features/scenes/components/SceneCanvasText.tsx
+++ b/public/app/features/scenes/components/SceneCanvasText.tsx
@@ -3,9 +3,9 @@ import React, { CSSProperties } from 'react';
 import { Field, Input } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneComponentProps, SceneObjectState } from '../core/types';
+import { SceneComponentProps, SceneLayoutChildState } from '../core/types';
 
-export interface SceneCanvasTextState extends SceneObjectState {
+export interface SceneCanvasTextState extends SceneLayoutChildState {
   text: string;
   fontSize?: number;
   align?: 'left' | 'center' | 'right';

--- a/public/app/features/scenes/components/SceneFlexLayout.tsx
+++ b/public/app/features/scenes/components/SceneFlexLayout.tsx
@@ -3,11 +3,11 @@ import React, { CSSProperties } from 'react';
 import { Field, RadioButtonGroup } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneObject, SceneObjectSize, SceneObjectState, SceneLayoutState, SceneComponentProps } from '../core/types';
+import { SceneObjectSize, SceneLayoutState, SceneComponentProps, SceneLayoutChild } from '../core/types';
 
 export type FlexLayoutDirection = 'column' | 'row';
 
-interface SceneFlexLayoutState extends SceneObjectState, SceneLayoutState {
+interface SceneFlexLayoutState extends SceneLayoutState {
   direction?: FlexLayoutDirection;
 }
 
@@ -39,7 +39,7 @@ function FlexLayoutChildComponent({
   direction,
   isEditing,
 }: {
-  item: SceneObject<SceneObjectState>;
+  item: SceneLayoutChild;
   direction: FlexLayoutDirection;
   isEditing?: boolean;
 }) {

--- a/public/app/features/scenes/components/ScenePanelRepeater.tsx
+++ b/public/app/features/scenes/components/ScenePanelRepeater.tsx
@@ -4,9 +4,15 @@ import { LoadingState, PanelData } from '@grafana/data';
 
 import { SceneDataNode } from '../core/SceneDataNode';
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneComponentProps, SceneObject, SceneObjectList, SceneObjectState, SceneLayoutState } from '../core/types';
+import {
+  SceneComponentProps,
+  SceneObject,
+  SceneObjectStatePlain,
+  SceneLayoutState,
+  SceneLayoutChild,
+} from '../core/types';
 
-interface RepeatOptions extends SceneObjectState {
+interface RepeatOptions extends SceneObjectStatePlain {
   layout: SceneObject<SceneLayoutState>;
 }
 
@@ -28,7 +34,7 @@ export class ScenePanelRepeater extends SceneObjectBase<RepeatOptions> {
   performRepeat(data: PanelData) {
     // assume parent is a layout
     const firstChild = this.state.layout.state.children[0]!;
-    const newChildren: SceneObjectList = [];
+    const newChildren: SceneLayoutChild[] = [];
 
     for (const series of data.series) {
       const clone = firstChild.clone({

--- a/public/app/features/scenes/components/SceneTimePicker.tsx
+++ b/public/app/features/scenes/components/SceneTimePicker.tsx
@@ -4,9 +4,9 @@ import { RefreshPicker, ToolbarButtonRow } from '@grafana/ui';
 import { TimePickerWithHistory } from 'app/core/components/TimePicker/TimePickerWithHistory';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneComponentProps, SceneObjectState } from '../core/types';
+import { SceneComponentProps, SceneObjectStatePlain } from '../core/types';
 
-export interface SceneTimePickerState extends SceneObjectState {
+export interface SceneTimePickerState extends SceneObjectStatePlain {
   hidePicker?: boolean;
 }
 

--- a/public/app/features/scenes/components/SceneToolbarButton.tsx
+++ b/public/app/features/scenes/components/SceneToolbarButton.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 import { IconName, Input, ToolbarButton } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneComponentProps, SceneObjectState } from '../core/types';
+import { SceneComponentProps, SceneObjectStatePlain } from '../core/types';
 
-export interface ToolbarButtonState extends SceneObjectState {
+export interface ToolbarButtonState extends SceneObjectStatePlain {
   icon: IconName;
   onClick: () => void;
 }
@@ -18,7 +18,7 @@ export class SceneToolbarButton extends SceneObjectBase<ToolbarButtonState> {
   };
 }
 
-export interface SceneToolbarInputState extends SceneObjectState {
+export interface SceneToolbarInputState extends SceneObjectStatePlain {
   value?: string;
   onChange: (value: number) => void;
 }

--- a/public/app/features/scenes/components/VizPanel.tsx
+++ b/public/app/features/scenes/components/VizPanel.tsx
@@ -6,9 +6,9 @@ import { PanelRenderer } from '@grafana/runtime';
 import { Field, PanelChrome, Input } from '@grafana/ui';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneComponentProps, SceneObjectState } from '../core/types';
+import { SceneComponentProps, SceneLayoutChildState } from '../core/types';
 
-export interface VizPanelState extends SceneObjectState {
+export interface VizPanelState extends SceneLayoutChildState {
   title?: string;
   pluginId: string;
   options?: object;

--- a/public/app/features/scenes/core/SceneDataNode.ts
+++ b/public/app/features/scenes/core/SceneDataNode.ts
@@ -1,9 +1,9 @@
 import { PanelData } from '@grafana/data';
 
 import { SceneObjectBase } from './SceneObjectBase';
-import { SceneObjectState } from './types';
+import { SceneObjectStatePlain } from './types';
 
-export interface SceneDataNodeState extends SceneObjectState {
+export interface SceneDataNodeState extends SceneObjectStatePlain {
   data?: PanelData;
 }
 

--- a/public/app/features/scenes/core/SceneObjectBase.test.ts
+++ b/public/app/features/scenes/core/SceneObjectBase.test.ts
@@ -1,11 +1,11 @@
 import { SceneObjectBase } from './SceneObjectBase';
-import { SceneObject, SceneObjectList, SceneObjectState } from './types';
+import { SceneLayoutChild, SceneObject, SceneObjectStatePlain } from './types';
 
-interface TestSceneState extends SceneObjectState {
+interface TestSceneState extends SceneObjectStatePlain {
   name?: string;
   nested?: SceneObject<TestSceneState>;
-  children?: SceneObjectList;
-  actions?: SceneObjectList;
+  children?: SceneLayoutChild[];
+  actions?: SceneObject[];
 }
 
 class TestScene extends SceneObjectBase<TestSceneState> {}

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -5,7 +5,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { EventBusSrv } from '@grafana/data';
 
 import { SceneComponentWrapper } from './SceneComponentWrapper';
-import { SceneObjectStatePlainChangedEvent } from './events';
+import { SceneObjectStateChangedEvent } from './events';
 import {
   SceneDataState,
   SceneObject,
@@ -82,7 +82,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
 
     // broadcast state change. This is event is subscribed to by UrlSyncManager and UndoManager
     this.getRoot().events.publish(
-      new SceneObjectStatePlainChangedEvent({
+      new SceneObjectStateChangedEvent({
         prevState,
         newState: this.state,
         partialUpdate: update,

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -21,7 +21,7 @@ import {
 export abstract class SceneObjectBase<TState extends SceneObjectState = {}> implements SceneObject<TState> {
   subject = new Subject<TState>();
   state: TState;
-  parent?: SceneObjectBase<SceneObjectState>;
+  parent?: SceneObjectBase<SceneObjectState | SceneLayoutState>;
   subs = new Subscription();
   isActive?: boolean;
   events = new EventBusSrv();

--- a/public/app/features/scenes/core/SceneObjectBase.tsx
+++ b/public/app/features/scenes/core/SceneObjectBase.tsx
@@ -5,23 +5,22 @@ import { v4 as uuidv4 } from 'uuid';
 import { EventBusSrv } from '@grafana/data';
 
 import { SceneComponentWrapper } from './SceneComponentWrapper';
-import { SceneObjectStateChangedEvent } from './events';
+import { SceneObjectStatePlainChangedEvent } from './events';
 import {
   SceneDataState,
   SceneObject,
-  SceneLayoutState,
-  SceneObjectState,
   SceneComponent,
   SceneEditor,
-  SceneObjectList,
   SceneTimeRange,
   isSceneObject,
+  SceneObjectState,
+  SceneLayoutChild,
 } from './types';
 
 export abstract class SceneObjectBase<TState extends SceneObjectState = {}> implements SceneObject<TState> {
   subject = new Subject<TState>();
   state: TState;
-  parent?: SceneObjectBase<SceneObjectState | SceneLayoutState>;
+  parent?: SceneObjectBase<SceneObjectState>;
   subs = new Subscription();
   isActive?: boolean;
   events = new EventBusSrv();
@@ -83,7 +82,7 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
 
     // broadcast state change. This is event is subscribed to by UrlSyncManager and UndoManager
     this.getRoot().events.publish(
-      new SceneObjectStateChangedEvent({
+      new SceneObjectStatePlainChangedEvent({
         prevState,
         newState: this.state,
         partialUpdate: update,
@@ -185,10 +184,9 @@ export abstract class SceneObjectBase<TState extends SceneObjectState = {}> impl
     }
 
     // Clone layout children
-    const layout = this.state as any as SceneLayoutState;
-    if (layout.children) {
-      const newChildren: SceneObjectList = [];
-      for (const child of layout.children) {
+    if ('children' in this.state) {
+      const newChildren: SceneLayoutChild[] = [];
+      for (const child of this.state.children) {
         newChildren.push(child.clone());
       }
       (clonedState as any).children = newChildren;

--- a/public/app/features/scenes/core/events.ts
+++ b/public/app/features/scenes/core/events.ts
@@ -2,13 +2,13 @@ import { BusEventWithPayload } from '@grafana/data';
 
 import { SceneObject } from './types';
 
-export interface SceneObjectStateChangedPayload {
+export interface SceneObjectStatePlainChangedPayload {
   prevState: any;
   newState: any;
   partialUpdate: any;
   changedObject: SceneObject;
 }
 
-export class SceneObjectStateChangedEvent extends BusEventWithPayload<SceneObjectStateChangedPayload> {
+export class SceneObjectStatePlainChangedEvent extends BusEventWithPayload<SceneObjectStatePlainChangedPayload> {
   static type = 'scene-object-state-change';
 }

--- a/public/app/features/scenes/core/events.ts
+++ b/public/app/features/scenes/core/events.ts
@@ -1,12 +1,12 @@
 import { BusEventWithPayload } from '@grafana/data';
 
-import { SceneObject, SceneObjectState } from './types';
+import { SceneObject, SceneObjectState, SceneObjectWithUrlSync } from './types';
 
 export interface SceneObjectStateChangedPayload {
   prevState: SceneObjectState;
   newState: SceneObjectState;
   partialUpdate: Partial<SceneObjectState>;
-  changedObject: SceneObject;
+  changedObject: SceneObject | SceneObjectWithUrlSync;
 }
 
 export class SceneObjectStateChangedEvent extends BusEventWithPayload<SceneObjectStateChangedPayload> {

--- a/public/app/features/scenes/core/events.ts
+++ b/public/app/features/scenes/core/events.ts
@@ -1,14 +1,14 @@
 import { BusEventWithPayload } from '@grafana/data';
 
-import { SceneObject } from './types';
+import { SceneObject, SceneObjectState } from './types';
 
-export interface SceneObjectStatePlainChangedPayload {
-  prevState: any;
-  newState: any;
-  partialUpdate: any;
+export interface SceneObjectStateChangedPayload {
+  prevState: SceneObjectState;
+  newState: SceneObjectState;
+  partialUpdate: Partial<SceneObjectState>;
   changedObject: SceneObject;
 }
 
-export class SceneObjectStatePlainChangedEvent extends BusEventWithPayload<SceneObjectStatePlainChangedPayload> {
+export class SceneObjectStateChangedEvent extends BusEventWithPayload<SceneObjectStateChangedPayload> {
   static type = 'scene-object-state-change';
 }

--- a/public/app/features/scenes/core/types.ts
+++ b/public/app/features/scenes/core/types.ts
@@ -5,14 +5,19 @@ import { EventBus, PanelData, TimeRange, UrlQueryMap } from '@grafana/data';
 
 import { SceneVariableSet } from '../variables/types';
 
-export interface SceneObjectState {
+export interface SceneObjectStatePlain {
   key?: string;
-  size?: SceneObjectSize;
   $timeRange?: SceneTimeRange;
   $data?: SceneObject<SceneDataState>;
   $editor?: SceneEditor;
   $variables?: SceneVariableSet;
 }
+
+export interface SceneLayoutChildState extends SceneObjectStatePlain {
+  size?: SceneObjectSize;
+}
+
+export type SceneObjectState = SceneObjectStatePlain | SceneLayoutState | SceneLayoutChildState;
 
 export interface SceneObjectSize {
   width?: number | string;
@@ -32,7 +37,7 @@ export interface SceneComponentProps<T> {
 
 export type SceneComponent<TModel> = React.FunctionComponent<SceneComponentProps<TModel>>;
 
-export interface SceneDataState extends SceneObjectState {
+export interface SceneDataState extends SceneObjectStatePlain {
   data?: PanelData;
 }
 
@@ -74,15 +79,15 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   Editor(props: SceneComponentProps<SceneObject<TState>>): React.ReactElement | null;
 }
 
-export type SceneObjectList = Array<SceneObject<SceneObjectState | SceneLayoutState>>;
+export type SceneLayoutChild = SceneObject<SceneLayoutChildState | SceneLayoutState>;
 
-export interface SceneLayoutState extends SceneObjectState {
-  children: SceneObjectList;
+export interface SceneLayoutState extends SceneLayoutChildState {
+  children: SceneLayoutChild[];
 }
 
 export type SceneLayout<T extends SceneLayoutState = SceneLayoutState> = SceneObject<T>;
 
-export interface SceneEditorState extends SceneObjectState {
+export interface SceneEditorState extends SceneObjectStatePlain {
   hoverObject?: SceneObjectRef;
   selectedObject?: SceneObjectRef;
 }
@@ -93,7 +98,7 @@ export interface SceneEditor extends SceneObject<SceneEditorState> {
   onSelectObject(model: SceneObject): void;
 }
 
-export interface SceneTimeRangeState extends SceneObjectState, TimeRange {}
+export interface SceneTimeRangeState extends SceneObjectStatePlain, TimeRange {}
 export interface SceneTimeRange extends SceneObject<SceneTimeRangeState> {
   onTimeRangeChange(timeRange: TimeRange): void;
   onIntervalChanged(interval: string): void;
@@ -119,7 +124,7 @@ export function isSceneObjectWithUrlSync(obj: any): obj is SceneObjectWithUrlSyn
 }
 
 export function isSceneLayoutObject(
-  obj: SceneObject<SceneObjectState | SceneLayoutState>
+  obj: SceneObject<SceneObjectStatePlain | SceneLayoutState>
 ): obj is SceneObject<SceneLayoutState> {
   return 'children' in obj.state && obj.state.children !== undefined;
 }

--- a/public/app/features/scenes/core/types.ts
+++ b/public/app/features/scenes/core/types.ts
@@ -118,13 +118,3 @@ export interface SceneObjectWithUrlSync extends SceneObject {
   getUrlState(): UrlQueryMap;
   updateFromUrl(values: UrlQueryMap): void;
 }
-
-export function isSceneObjectWithUrlSync(obj: any): obj is SceneObjectWithUrlSync {
-  return obj.getUrlState !== undefined;
-}
-
-export function isSceneLayoutObject(
-  obj: SceneObject<SceneObjectStatePlain | SceneLayoutState>
-): obj is SceneObject<SceneLayoutState> {
-  return 'children' in obj.state && obj.state.children !== undefined;
-}

--- a/public/app/features/scenes/core/types.ts
+++ b/public/app/features/scenes/core/types.ts
@@ -74,7 +74,7 @@ export interface SceneObject<TState extends SceneObjectState = SceneObjectState>
   Editor(props: SceneComponentProps<SceneObject<TState>>): React.ReactElement | null;
 }
 
-export type SceneObjectList<T extends SceneObjectState | SceneLayoutState = SceneObjectState> = Array<SceneObject<T>>;
+export type SceneObjectList = Array<SceneObject<SceneObjectState | SceneLayoutState>>;
 
 export interface SceneLayoutState extends SceneObjectState {
   children: SceneObjectList;

--- a/public/app/features/scenes/editor/SceneObjectTree.tsx
+++ b/public/app/features/scenes/editor/SceneObjectTree.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Icon, useStyles2 } from '@grafana/ui';
 
-import { SceneObject, SceneLayoutState, SceneObjectList, isSceneObject } from '../core/types';
+import { SceneObject, isSceneObject, SceneLayoutChild } from '../core/types';
 
 export interface Props {
   node: SceneObject;
@@ -14,7 +14,7 @@ export interface Props {
 export function SceneObjectTree({ node, selectedObject }: Props) {
   const styles = useStyles2(getStyles);
   const state = node.useState();
-  let children: SceneObjectList = [];
+  let children: SceneLayoutChild[] = [];
 
   for (const propKey of Object.keys(state)) {
     const propValue = (state as any)[propKey];
@@ -23,9 +23,8 @@ export function SceneObjectTree({ node, selectedObject }: Props) {
     }
   }
 
-  let layoutChildren = (state as SceneLayoutState).children;
-  if (layoutChildren) {
-    for (const child of layoutChildren) {
+  if ('children' in state) {
+    for (const child of state.children) {
       children.push(child);
     }
   }

--- a/public/app/features/scenes/querying/SceneQueryRunner.ts
+++ b/public/app/features/scenes/querying/SceneQueryRunner.ts
@@ -17,9 +17,9 @@ import { getNextRequestId } from 'app/features/query/state/PanelQueryRunner';
 import { runRequest } from 'app/features/query/state/runRequest';
 
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneObjectState } from '../core/types';
+import { SceneObjectStatePlain } from '../core/types';
 
-export interface QueryRunnerState extends SceneObjectState {
+export interface QueryRunnerState extends SceneObjectStatePlain {
   data?: PanelData;
   queries: DataQueryExtended[];
 }

--- a/public/app/features/scenes/services/UrlSyncManager.ts
+++ b/public/app/features/scenes/services/UrlSyncManager.ts
@@ -4,7 +4,7 @@ import { Unsubscribable } from 'rxjs';
 import { locationService } from '@grafana/runtime';
 
 import { SceneObjectStateChangedEvent } from '../core/events';
-import { isSceneObjectWithUrlSync, SceneObject } from '../core/types';
+import { SceneObject } from '../core/types';
 
 export class UrlSyncManager {
   private locationListenerUnsub: () => void;
@@ -21,12 +21,11 @@ export class UrlSyncManager {
 
   onStateChanged = ({ payload }: SceneObjectStateChangedEvent) => {
     const changedObject = payload.changedObject;
-    if (!isSceneObjectWithUrlSync(changedObject)) {
-      return;
-    }
 
-    const urlUpdate = changedObject.getUrlState();
-    locationService.partial(urlUpdate, true);
+    if ('getUrlState' in changedObject) {
+      const urlUpdate = changedObject.getUrlState();
+      locationService.partial(urlUpdate, true);
+    }
   };
 
   cleanUp() {

--- a/public/app/features/scenes/services/UrlSyncManager.ts
+++ b/public/app/features/scenes/services/UrlSyncManager.ts
@@ -3,7 +3,7 @@ import { Unsubscribable } from 'rxjs';
 
 import { locationService } from '@grafana/runtime';
 
-import { SceneObjectStateChangedEvent } from '../core/events';
+import { SceneObjectStatePlainChangedEvent } from '../core/events';
 import { isSceneObjectWithUrlSync, SceneObject } from '../core/types';
 
 export class UrlSyncManager {
@@ -11,7 +11,7 @@ export class UrlSyncManager {
   private stateChangeSub: Unsubscribable;
 
   constructor(sceneRoot: SceneObject) {
-    this.stateChangeSub = sceneRoot.events.subscribe(SceneObjectStateChangedEvent, this.onStateChanged);
+    this.stateChangeSub = sceneRoot.events.subscribe(SceneObjectStatePlainChangedEvent, this.onStateChanged);
     this.locationListenerUnsub = locationService.getHistory().listen(this.onLocationUpdate);
   }
 
@@ -19,7 +19,7 @@ export class UrlSyncManager {
     // TODO: find any scene object whose state we need to update
   };
 
-  onStateChanged = ({ payload }: SceneObjectStateChangedEvent) => {
+  onStateChanged = ({ payload }: SceneObjectStatePlainChangedEvent) => {
     const changedObject = payload.changedObject;
     if (!isSceneObjectWithUrlSync(changedObject)) {
       return;

--- a/public/app/features/scenes/services/UrlSyncManager.ts
+++ b/public/app/features/scenes/services/UrlSyncManager.ts
@@ -3,7 +3,7 @@ import { Unsubscribable } from 'rxjs';
 
 import { locationService } from '@grafana/runtime';
 
-import { SceneObjectStatePlainChangedEvent } from '../core/events';
+import { SceneObjectStateChangedEvent } from '../core/events';
 import { isSceneObjectWithUrlSync, SceneObject } from '../core/types';
 
 export class UrlSyncManager {
@@ -11,7 +11,7 @@ export class UrlSyncManager {
   private stateChangeSub: Unsubscribable;
 
   constructor(sceneRoot: SceneObject) {
-    this.stateChangeSub = sceneRoot.events.subscribe(SceneObjectStatePlainChangedEvent, this.onStateChanged);
+    this.stateChangeSub = sceneRoot.events.subscribe(SceneObjectStateChangedEvent, this.onStateChanged);
     this.locationListenerUnsub = locationService.getHistory().listen(this.onLocationUpdate);
   }
 
@@ -19,7 +19,7 @@ export class UrlSyncManager {
     // TODO: find any scene object whose state we need to update
   };
 
-  onStateChanged = ({ payload }: SceneObjectStatePlainChangedEvent) => {
+  onStateChanged = ({ payload }: SceneObjectStateChangedEvent) => {
     const changedObject = payload.changedObject;
     if (!isSceneObjectWithUrlSync(changedObject)) {
       return;

--- a/public/app/features/scenes/variables/SceneVariableSet.test.ts
+++ b/public/app/features/scenes/variables/SceneVariableSet.test.ts
@@ -1,9 +1,9 @@
 import { SceneObjectBase } from '../core/SceneObjectBase';
-import { SceneObjectState } from '../core/types';
+import { SceneObjectStatePlain } from '../core/types';
 
 import { sceneTemplateInterpolator, SceneVariableManager, TextBoxSceneVariable } from './SceneVariableSet';
 
-interface TestSceneState extends SceneObjectState {
+interface TestSceneState extends SceneObjectStatePlain {
   nested?: TestScene;
 }
 

--- a/public/app/features/scenes/variables/types.ts
+++ b/public/app/features/scenes/variables/types.ts
@@ -1,9 +1,9 @@
 import { LoadingState } from '@grafana/data';
 import { VariableHide } from 'app/features/variables/types';
 
-import { SceneObject, SceneObjectState } from '../core/types';
+import { SceneObject, SceneObjectStatePlain } from '../core/types';
 
-export interface SceneVariableState extends SceneObjectState {
+export interface SceneVariableState extends SceneObjectStatePlain {
   name: string;
   hide?: VariableHide;
   skipUrlSync?: boolean;
@@ -15,7 +15,7 @@ export interface SceneVariableState extends SceneObjectState {
 
 export interface SceneVariable extends SceneObject<SceneVariableState> {}
 
-export interface SceneVariableSetState extends SceneObjectState {
+export interface SceneVariableSetState extends SceneObjectStatePlain {
   variables: SceneVariable[];
 }
 


### PR DESCRIPTION
By switching to typed unions and in operator I could get rid of the type guards and one type cast. (Thanks @joshhunt ! ) 

This also made it possible to move the size property from the base state type to a new layout child type. 



