### PR TITLE
ServiceAccounts: Updates the service accounts list page to look good in new top nav design

### DIFF
--- a/public/app/core/components/Page/types.ts
+++ b/public/app/core/components/Page/types.ts
@@ -11,6 +11,7 @@ export interface PageProps extends HTMLAttributes<HTMLDivElement> {
   navId?: string;
   navModel?: NavModel;
   pageNav?: NavModelItem;
+  subTitle?: React.ReactNode;
   layout?: PageLayoutType;
   /** Something we can remove when we remove the old nav. */
   toolbar?: React.ReactNode;

--- a/public/app/core/components/PageNew/Page.tsx
+++ b/public/app/core/components/PageNew/Page.tsx
@@ -21,6 +21,7 @@ export const Page: PageType = ({
   navId,
   navModel: oldNavProp,
   pageNav,
+  subTitle,
   children,
   className,
   layout = PageLayoutType.Default,
@@ -52,7 +53,7 @@ export const Page: PageType = ({
           <div className={styles.pageContent}>
             <CustomScrollbar autoHeightMin={'100%'} scrollTop={scrollTop} scrollRefCallback={scrollRef}>
               <div className={styles.pageInner}>
-                {pageHeaderNav && <PageHeader navItem={pageHeaderNav} />}
+                {pageHeaderNav && <PageHeader navItem={pageHeaderNav} subTitle={subTitle} />}
                 {pageNav && pageNav.children && <PageTabs navItem={pageNav} />}
                 {children}
               </div>

--- a/public/app/core/components/PageNew/PageHeader.tsx
+++ b/public/app/core/components/PageNew/PageHeader.tsx
@@ -6,10 +6,12 @@ import { useStyles2 } from '@grafana/ui';
 
 export interface Props {
   navItem: NavModelItem;
+  subTitle?: React.ReactNode;
 }
 
-export function PageHeader({ navItem }: Props) {
+export function PageHeader({ navItem, subTitle }: Props) {
   const styles = useStyles2(getStyles);
+  const sub = subTitle ?? navItem.subTitle;
 
   return (
     <>
@@ -17,7 +19,7 @@ export function PageHeader({ navItem }: Props) {
         {navItem.img && <img className={styles.pageImg} src={navItem.img} alt={`logo for ${navItem.text}`} />}
         {navItem.text}
       </h1>
-      {navItem.subTitle && <div className={styles.pageSubTitle}>{navItem.subTitle}</div>}
+      {sub && <div className={styles.pageSubTitle}>{sub}</div>}
     </>
   );
 }

--- a/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { GrafanaTheme2, OrgRole } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { Alert, ConfirmModal, FilterInput, Icon, LinkButton, RadioButtonGroup, Tooltip, useStyles2 } from '@grafana/ui';
 import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
 import { Page } from 'app/core/components/Page/Page';
@@ -165,8 +166,24 @@ export const ServiceAccountsListPageUnconnected = ({
     closeApiKeysMigrationInfo();
   };
 
+  const docsLink = (
+    <a
+      className="external-link"
+      href="https://grafana.com/docs/grafana/latest/administration/service-accounts/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      here.
+    </a>
+  );
+  const subTitle = (
+    <span>
+      Service accounts and their tokens can be used to authenticate against the Grafana API. Find out more {docsLink}
+    </span>
+  );
+
   return (
-    <Page navId="serviceaccounts">
+    <Page navId="serviceaccounts" subTitle={subTitle}>
       <Page.Contents>
         {apiKeysMigrated && showApiKeysMigrationInfo && (
           <Alert
@@ -176,32 +193,30 @@ export const ServiceAccountsListPageUnconnected = ({
             onRemove={onMigrationInfoClose}
           ></Alert>
         )}
-        <div className={styles.pageHeader}>
-          <h2>Service accounts</h2>
-          <div className={styles.apiKeyInfoLabel}>
-            <Tooltip
-              placement="bottom"
-              interactive
-              content={
-                <>
-                  API keys are now service accounts with tokens. Find out more{' '}
-                  <a href="https://grafana.com/docs/grafana/latest/administration/service-accounts/">here.</a>
-                </>
-              }
-            >
-              <Icon name="question-circle" />
-            </Tooltip>
-            <span>Looking for API keys?</span>
+        {!config.featureToggles.topnav && (
+          <div className={styles.pageHeader}>
+            <h2>Service accounts</h2>
+            <div className={styles.apiKeyInfoLabel}>
+              <Tooltip
+                placement="bottom"
+                interactive
+                content={<>API keys are now service accounts with tokens. Find out more {docsLink}</>}
+              >
+                <Icon name="question-circle" />
+              </Tooltip>
+              <span>Looking for API keys?</span>
+            </div>
           </div>
-          {!noServiceAccountsCreated && contextSrv.hasPermission(AccessControlAction.ServiceAccountsCreate) && (
-            <LinkButton href="org/serviceaccounts/create" variant="primary">
-              Add service account
-            </LinkButton>
-          )}
-        </div>
-        <div className={styles.filterRow}>
-          <FilterInput placeholder="Search service account by name" value={query} onChange={onQueryChange} width={50} />
-          <div className={styles.filterDelimiter}></div>
+        )}
+        <div className="page-action-bar">
+          <div className="gf-form gf-form--grow">
+            <FilterInput
+              placeholder="Search service account by name"
+              value={query}
+              onChange={onQueryChange}
+              width={50}
+            />
+          </div>
           <RadioButtonGroup
             options={[
               { label: 'All', value: ServiceAccountStateFilter.All },
@@ -212,6 +227,11 @@ export const ServiceAccountsListPageUnconnected = ({
             value={serviceAccountStateFilter}
             className={styles.filter}
           />
+          {!noServiceAccountsCreated && contextSrv.hasPermission(AccessControlAction.ServiceAccountsCreate) && (
+            <LinkButton href="org/serviceaccounts/create" variant="primary">
+              Add service account
+            </LinkButton>
+          )}
         </div>
         {isLoading && <PageLoader />}
         {!isLoading && noServiceAccountsCreated && (
@@ -350,13 +370,6 @@ export const getStyles = (theme: GrafanaTheme2) => {
         padding: ${theme.spacing(0.5)};
       }
     `,
-    filterRow: cx(
-      'page-action-bar',
-      css`
-        display: flex;
-        justifycontent: flex-end;
-      `
-    ),
     filterDelimiter: css`
       flex-grow: 1;
     `,


### PR DESCRIPTION
Part of #50791

The service accounts page had a tooltip with link to docs. To support sub titles with react elements (like links and icons) I added new prop subTitle to Page component which get's passed to new PageHeader. If we want the subTitle set on the nav model (from backend) to also support links we would have to make this string field support markdown (but then we would not be able to add icons still) so opted to use react node. 

* Moves the new service account button down into the page-action-bar (like all other pages)
* Hides the page header when topnav is enabled as this is handled by Page component 
* Adds new page subTitle with link to docs 
* Feedback on the subtitle text appreciated 

topnav (to test add `?__feature.topnav=true`)  http://localhost:3000/org/serviceaccounts?__feature.topnav=true
<img width="1511" alt="Screenshot 2022-07-18 at 15 10 01" src="https://user-images.githubusercontent.com/10999/179626645-dbfd5111-8b93-4fbf-98d9-039d24b66356.png">

oldnav:
<img width="1443" alt="Screenshot 2022-07-18 at 15 17 47" src="https://user-images.githubusercontent.com/10999/179626722-b0833bf8-d19e-44f0-b137-b469a82ee272.png">

