### PR TITLE
Storage: remove orgId from sql config object

### DIFF
--- a/pkg/services/store/config.go
+++ b/pkg/services/store/config.go
@@ -34,7 +34,6 @@ type StorageGitConfig struct {
 
 type StorageSQLConfig struct {
 	// SQLStorage will prefix all paths with orgId for isolation between orgs
-	orgId int64
 }
 
 type StorageS3Config struct {

--- a/pkg/services/store/service.go
+++ b/pkg/services/store/service.go
@@ -79,29 +79,37 @@ type standardStorageService struct {
 
 func ProvideService(sql *sqlstore.SQLStore, features featuremgmt.FeatureToggles, cfg *setting.Cfg) StorageService {
 	globalRoots := []storageRuntime{
-		newDiskStorage(RootPublicStatic, "Public static files", &StorageLocalDiskConfig{
-			Path: cfg.StaticRootPath,
-			Roots: []string{
-				"/testdata/",
-				"/img/",
-				"/gazetteer/",
-				"/maps/",
+		newDiskStorage(RootStorageConfig{
+			Prefix:      RootPublicStatic,
+			Name:        "Public static files",
+			Description: "Access files from the static public files",
+			Disk: &StorageLocalDiskConfig{
+				Path: cfg.StaticRootPath,
+				Roots: []string{
+					"/testdata/",
+					"/img/",
+					"/gazetteer/",
+					"/maps/",
+				},
 			},
-		}).setReadOnly(true).setBuiltin(true).
-			setDescription("Access files from the static public files"),
+		}).setReadOnly(true).setBuiltin(true),
 	}
 
 	// Development dashboards
 	if setting.Env != setting.Prod {
 		devenv := filepath.Join(cfg.StaticRootPath, "..", "devenv")
 		if _, err := os.Stat(devenv); !os.IsNotExist(err) {
-			// path/to/whatever exists
-			s := newDiskStorage(RootDevenv, "Development Environment", &StorageLocalDiskConfig{
-				Path: devenv,
-				Roots: []string{
-					"/dev-dashboards/",
-				},
-			}).setReadOnly(false).setDescription("Explore files within the developer environment directly")
+			s := newDiskStorage(RootStorageConfig{
+				Prefix:      RootDevenv,
+				Name:        "Development Environment",
+				Description: "Explore files within the developer environment directly",
+				Disk: &StorageLocalDiskConfig{
+					Path: devenv,
+					Roots: []string{
+						"/dev-dashboards/",
+					},
+				}}).setReadOnly(false)
+
 			globalRoots = append(globalRoots, s)
 		}
 	}
@@ -113,17 +121,17 @@ func ProvideService(sql *sqlstore.SQLStore, features featuremgmt.FeatureToggles,
 		storages = append(storages,
 			newSQLStorage(RootResources,
 				"Resources",
-				&StorageSQLConfig{orgId: orgId}, sql).
-				setBuiltin(true).
-				setDescription("Upload custom resource files"))
+				"Upload custom resource files",
+				&StorageSQLConfig{}, sql, orgId).
+				setBuiltin(true))
 
 		// System settings
 		storages = append(storages,
 			newSQLStorage(RootSystem,
 				"System",
-				&StorageSQLConfig{orgId: orgId},
-				sql,
-			).setBuiltin(true).setDescription("Grafana system storage"))
+				"Grafana system storage",
+				&StorageSQLConfig{}, sql, orgId).
+				setBuiltin(true))
 
 		return storages
 	}

--- a/pkg/services/store/service_test.go
+++ b/pkg/services/store/service_test.go
@@ -32,17 +32,20 @@ var (
 		}
 	})
 	publicRoot, _            = filepath.Abs("../../../public")
-	publicStaticFilesStorage = newDiskStorage("public", "Public static files", &StorageLocalDiskConfig{
-		Path: publicRoot,
-		Roots: []string{
-			"/testdata/",
-			"/img/icons/",
-			"/img/bg/",
-			"/gazetteer/",
-			"/maps/",
-			"/upload/",
-		},
-	}).setReadOnly(true).setBuiltin(true)
+	publicStaticFilesStorage = newDiskStorage(RootStorageConfig{
+		Prefix: "public",
+		Name:   "Public static files",
+		Disk: &StorageLocalDiskConfig{
+			Path: publicRoot,
+			Roots: []string{
+				"/testdata/",
+				"/img/icons/",
+				"/img/bg/",
+				"/gazetteer/",
+				"/maps/",
+				"/upload/",
+			},
+		}}).setReadOnly(true).setBuiltin(true)
 )
 
 func TestListFiles(t *testing.T) {
@@ -82,7 +85,12 @@ func setupUploadStore(t *testing.T, authService storageAuthService) (StorageServ
 	t.Helper()
 	storageName := "resources"
 	mockStorage := &filestorage.MockFileStorage{}
-	sqlStorage := newSQLStorage(storageName, "Testing upload", &StorageSQLConfig{orgId: 1}, sqlstore.InitTestDB(t))
+	sqlStorage := newSQLStorage(
+		storageName, "Testing upload", "dummy descr",
+		&StorageSQLConfig{},
+		sqlstore.InitTestDB(t),
+		1, // orgID (prefix init)
+	)
 	sqlStorage.store = mockStorage
 
 	if authService == nil {

--- a/pkg/services/store/storage_sql.go
+++ b/pkg/services/store/storage_sql.go
@@ -28,17 +28,18 @@ func getDbStoragePathPrefix(orgId int64, storageName string) string {
 	return filestorage.Join(fmt.Sprintf("%d", orgId), storageName+filestorage.Delimiter)
 }
 
-func newSQLStorage(prefix string, name string, cfg *StorageSQLConfig, sql *sqlstore.SQLStore) *rootStorageSQL {
+func newSQLStorage(prefix string, name string, descr string, cfg *StorageSQLConfig, sql *sqlstore.SQLStore, orgId int64) *rootStorageSQL {
 	if cfg == nil {
 		cfg = &StorageSQLConfig{}
 	}
 
 	meta := RootStorageMeta{
 		Config: RootStorageConfig{
-			Type:   rootStorageTypeSQL,
-			Prefix: prefix,
-			Name:   name,
-			SQL:    cfg,
+			Type:        rootStorageTypeSQL,
+			Prefix:      prefix,
+			Name:        name,
+			Description: descr,
+			SQL:         cfg,
 		},
 	}
 
@@ -52,7 +53,7 @@ func newSQLStorage(prefix string, name string, cfg *StorageSQLConfig, sql *sqlst
 	s := &rootStorageSQL{}
 	s.store = filestorage.NewDbStorage(
 		grafanaStorageLogger,
-		sql, nil, getDbStoragePathPrefix(cfg.orgId, prefix))
+		sql, nil, getDbStoragePathPrefix(orgId, prefix))
 
 	meta.Ready = true
 	s.meta = meta

--- a/pkg/services/store/types.go
+++ b/pkg/services/store/types.go
@@ -82,11 +82,6 @@ func (t *baseStorageRuntime) setBuiltin(val bool) *baseStorageRuntime {
 	return t
 }
 
-func (t *baseStorageRuntime) setDescription(v string) *baseStorageRuntime {
-	t.meta.Config.Description = v
-	return t
-}
-
 type RootStorageMeta struct {
 	ReadOnly bool          `json:"editable,omitempty"`
 	Builtin  bool          `json:"builtin,omitempty"`


### PR DESCRIPTION
The PR extracts the simple changes from https://github.com/grafana/grafana/pull/52192 that remove orgId from SQL config and cleans up the initialization paths.

The goal is just to limit complexity in the PR that will add more direct git support and support configuring additional storage options.