### PR TITLE
loki: remove unused code

### DIFF
--- a/public/app/plugins/datasource/loki/live_streams.test.ts
+++ b/public/app/plugins/datasource/loki/live_streams.test.ts
@@ -36,12 +36,11 @@ describe('Live Stream Tests', () => {
     const labels: Labels = { job: 'varlogs' };
     const target = makeTarget('fake', labels);
     const stream = new LiveStreams().getStream(target);
-    expect.assertions(4);
+    expect.assertions(3);
 
     const tests = [
       (val: DataFrame[]) => {
         expect(val[0].length).toEqual(7);
-        expect(val[0].fields[2].labels).toEqual(labels);
       },
       (val: DataFrame[]) => {
         expect(val[0].length).toEqual(8);
@@ -49,10 +48,8 @@ describe('Live Stream Tests', () => {
         const last = { ...view.get(view.length - 1) };
         expect(last).toEqual({
           Time: '2019-08-28T20:50:40.118Z',
-          tsNs: '1567025440118944705',
           id: '25d81461-a66f-53ff-98d5-e39515af4735_A',
           Line: 'Kittens',
-          labels: { filename: '/var/log/sntpc.log' },
         });
       },
     ];

--- a/public/app/plugins/datasource/loki/live_streams.ts
+++ b/public/app/plugins/datasource/loki/live_streams.ts
@@ -2,7 +2,7 @@ import { Observable, throwError, timer } from 'rxjs';
 import { finalize, map, retryWhen, mergeMap } from 'rxjs/operators';
 import { webSocket } from 'rxjs/webSocket';
 
-import { DataFrame, FieldType, parseLabels, KeyValue, CircularDataFrame } from '@grafana/data';
+import { DataFrame, FieldType, KeyValue, CircularDataFrame } from '@grafana/data';
 
 import { appendResponseToBufferedData } from './live_streams_result_transformer';
 import { LokiTailResponse } from './types';
@@ -32,11 +32,9 @@ export class LiveStreams {
     }
 
     const data = new CircularDataFrame({ capacity: target.size });
-    data.addField({ name: 'labels', type: FieldType.other }); // The labels for each line
     data.addField({ name: 'Time', type: FieldType.time, config: {} });
-    data.addField({ name: 'Line', type: FieldType.string }).labels = parseLabels(target.query);
+    data.addField({ name: 'Line', type: FieldType.string });
     data.addField({ name: 'id', type: FieldType.string });
-    data.addField({ name: 'tsNs', type: FieldType.time, config: {} });
     data.meta = { ...data.meta, preferredVisualisationType: 'logs' };
     data.refId = target.refId;
 

--- a/public/app/plugins/datasource/loki/live_streams_result_transformer.test.ts
+++ b/public/app/plugins/datasource/loki/live_streams_result_transformer.test.ts
@@ -24,18 +24,14 @@ describe('loki result transformer', () => {
       };
 
       const data = new CircularDataFrame({ capacity: 1 });
-      data.addField({ name: 'labels', type: FieldType.other });
       data.addField({ name: 'ts', type: FieldType.time, config: { displayName: 'Time' } });
       data.addField({ name: 'line', type: FieldType.string }).labels = { job: 'grafana' };
       data.addField({ name: 'id', type: FieldType.string });
-      data.addField({ name: 'tsNs', type: FieldType.time, config: { displayName: 'Time ns' } });
 
       ResultTransformer.appendResponseToBufferedData(tailResponse, data);
       expect(data.get(0)).toEqual({
         ts: '2020-02-12T15:05:14.265Z',
-        tsNs: '1581519914265798400',
         line: 't=2020-02-12T15:04:51+0000 lvl=info msg="Starting Grafana" logger=server version=6.7.0-pre commit=6f09bc9fb4 branch=issue-21929 compiled=2020-02-11T20:43:28+0000',
-        labels: { filename: '/var/log/grafana/grafana.log' },
         id: '07f0607c-04ee-51bd-8a0c-fc0f85d37489',
       });
     });
@@ -61,11 +57,9 @@ describe('loki result transformer', () => {
       };
 
       const data = new CircularDataFrame({ capacity: 6 });
-      data.addField({ name: 'labels', type: FieldType.other });
       data.addField({ name: 'ts', type: FieldType.time, config: { displayName: 'Time' } });
       data.addField({ name: 'line', type: FieldType.string }).labels = { job: 'grafana' };
       data.addField({ name: 'id', type: FieldType.string });
-      data.addField({ name: 'tsNs', type: FieldType.time, config: { displayName: 'Time ns' } });
       data.refId = 'C';
 
       ResultTransformer.appendResponseToBufferedData(tailResponse, data);

--- a/public/app/plugins/datasource/loki/live_streams_result_transformer.ts
+++ b/public/app/plugins/datasource/loki/live_streams_result_transformer.ts
@@ -1,6 +1,6 @@
 import { v5 as uuidv5 } from 'uuid';
 
-import { FieldType, Labels, MutableDataFrame, findUniqueLabels } from '@grafana/data';
+import { MutableDataFrame } from '@grafana/data';
 
 import { LokiStreamResult, LokiTailResponse } from './types';
 
@@ -21,21 +21,9 @@ export function appendResponseToBufferedData(response: LokiTailResponse, data: M
     return;
   }
 
-  let baseLabels: Labels = {};
-  for (const f of data.fields) {
-    if (f.type === FieldType.string) {
-      if (f.labels) {
-        baseLabels = f.labels;
-      }
-      break;
-    }
-  }
-
-  const labelsField = data.fields[0];
-  const tsField = data.fields[1];
-  const lineField = data.fields[2];
-  const idField = data.fields[3];
-  const tsNsField = data.fields[4];
+  const tsField = data.fields[0];
+  const lineField = data.fields[1];
+  const idField = data.fields[2];
 
   // We are comparing used ids only within the received stream. This could be a problem if the same line + labels + nanosecond timestamp came in 2 separate batches.
   // As this is very unlikely, and the result would only affect live-tailing css animation we have decided to not compare all received uids from data param as this would slow down processing.
@@ -43,7 +31,6 @@ export function appendResponseToBufferedData(response: LokiTailResponse, data: M
 
   for (const stream of streams) {
     // Find unique labels
-    const unique = findUniqueLabels(stream.stream, baseLabels);
     const allLabelsString = Object.entries(stream.stream)
       .map(([key, val]) => `${key}="${val}"`)
       .sort()
@@ -52,9 +39,7 @@ export function appendResponseToBufferedData(response: LokiTailResponse, data: M
     // Add each line
     for (const [ts, line] of stream.values) {
       tsField.values.add(new Date(parseInt(ts.slice(0, -6), 10)).toISOString());
-      tsNsField.values.add(ts);
       lineField.values.add(line);
-      labelsField.values.add(unique);
       idField.values.add(createUid(ts, allLabelsString, line, usedUids, data.refId));
     }
   }


### PR DESCRIPTION
the loki live-tailing mode reads the loki-json-response and builds a dataframe, but it also adds fields that are never used (`labels` and `tsNs`). i removed them because why have them if we never use them (also, there might be bugs in the code that parses them)