### PR TITLE
Access Control: Add logs to dashboard migration

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
@@ -77,12 +77,12 @@ func (m dashboardPermissionsMigrator) Exec(sess *xorm.Session, migrator *migrato
 
 	var dashboards []dashboard
 	if err := m.sess.SQL("SELECT id, is_folder, folder_id, org_id FROM dashboard").Find(&dashboards); err != nil {
-		return err
+		return fmt.Errorf("failed to list dashboards: %w", err)
 	}
 
 	var acl []models.DashboardACL
 	if err := m.sess.Find(&acl); err != nil {
-		return err
+		return fmt.Errorf("failed to list dashboard ACL: %w", err)
 	}
 
 	aclMap := make(map[int64][]models.DashboardACL, len(acl))
@@ -90,14 +90,14 @@ func (m dashboardPermissionsMigrator) Exec(sess *xorm.Session, migrator *migrato
 		aclMap[p.DashboardID] = append(aclMap[p.DashboardID], p)
 	}
 
-	if err := m.migratePermissions(dashboards, aclMap); err != nil {
-		return err
+	if err := m.migratePermissions(dashboards, aclMap, migrator); err != nil {
+		return fmt.Errorf("failed to migrate permissions: %w", err)
 	}
 
 	return nil
 }
 
-func (m dashboardPermissionsMigrator) migratePermissions(dashboards []dashboard, aclMap map[int64][]models.DashboardACL) error {
+func (m dashboardPermissionsMigrator) migratePermissions(dashboards []dashboard, aclMap map[int64][]models.DashboardACL, migrator *migrator.Migrator) error {
 	permissionMap := map[int64]map[string][]*ac.Permission{}
 	for _, d := range dashboards {
 		if d.ID == -1 {
@@ -133,7 +133,7 @@ func (m dashboardPermissionsMigrator) migratePermissions(dashboards []dashboard,
 		for name := range roles {
 			role, err := m.findRole(orgID, name)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to find role %s: %w", name, err)
 			}
 			if role.ID == 0 {
 				rolesToCreate = append(rolesToCreate, &ac.Role{OrgID: orgID, Name: name})
@@ -145,7 +145,8 @@ func (m dashboardPermissionsMigrator) migratePermissions(dashboards []dashboard,
 
 	createdRoles, err := m.bulkCreateRoles(rolesToCreate)
 	if err != nil {
-		return err
+		migrator.Logger.Debug(fmt.Sprintf("bulk-creating roles %v", rolesToCreate))
+		return fmt.Errorf("failed to bulk-create roles: %w", err)
 	}
 
 	for i := range createdRoles {
@@ -153,17 +154,18 @@ func (m dashboardPermissionsMigrator) migratePermissions(dashboards []dashboard,
 	}
 
 	if err := m.bulkAssignRoles(createdRoles); err != nil {
-		return err
+		return fmt.Errorf("failed to bulk-assign roles: %w", err)
 	}
 
-	return m.setPermissions(allRoles, permissionMap)
+	return m.setPermissions(allRoles, permissionMap, migrator)
 }
 
-func (m dashboardPermissionsMigrator) setPermissions(allRoles []*ac.Role, permissionMap map[int64]map[string][]*ac.Permission) error {
+func (m dashboardPermissionsMigrator) setPermissions(allRoles []*ac.Role, permissionMap map[int64]map[string][]*ac.Permission, migrator *migrator.Migrator) error {
 	now := time.Now()
 	for _, role := range allRoles {
+		migrator.Logger.Debug(fmt.Sprintf("setting permissions for role %s with ID %d in org %d", role.Name, role.ID, role.OrgID))
 		if _, err := m.sess.Exec("DELETE FROM permission WHERE role_id = ? AND (action LIKE ? OR action LIKE ?)", role.ID, "dashboards%", "folders%"); err != nil {
-			return err
+			return fmt.Errorf("failed to clear dashboard and folder permissions for role: %w", err)
 		}
 		var permissions []ac.Permission
 		mappedPermissions := permissionMap[role.OrgID][role.Name]
@@ -178,8 +180,9 @@ func (m dashboardPermissionsMigrator) setPermissions(allRoles []*ac.Role, permis
 		}
 
 		err := batch(len(permissions), batchSize, func(start, end int) error {
+			migrator.Logger.Debug(fmt.Sprintf("inserting permissions %v", permissions[start:end]))
 			if _, err := m.sess.InsertMulti(permissions[start:end]); err != nil {
-				return err
+				return fmt.Errorf("failed to create permissions for role: %w", err)
 			}
 			return nil
 		})

--- a/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/dashboard_permissions.go
@@ -143,9 +143,9 @@ func (m dashboardPermissionsMigrator) migratePermissions(dashboards []dashboard,
 		}
 	}
 
+	migrator.Logger.Debug(fmt.Sprintf("bulk-creating roles %v", rolesToCreate))
 	createdRoles, err := m.bulkCreateRoles(rolesToCreate)
 	if err != nil {
-		migrator.Logger.Debug(fmt.Sprintf("bulk-creating roles %v", rolesToCreate))
 		return fmt.Errorf("failed to bulk-create roles: %w", err)
 	}
 

--- a/pkg/services/sqlstore/migrations/accesscontrol/permission_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/permission_migrator.go
@@ -107,23 +107,25 @@ func (m *permissionMigrator) bulkAssignRoles(allRoles []*accesscontrol.Role) err
 
 	err := batch(len(userRoleAssignments), batchSize, func(start, end int) error {
 		_, err := m.sess.Table("user_role").InsertMulti(userRoleAssignments[start:end])
-		return fmt.Errorf("failed to create user role assignments: %w", err)
+		return err
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create user role assignments: %w", err)
 	}
 
 	err = batch(len(teamRoleAssignments), batchSize, func(start, end int) error {
 		_, err := m.sess.Table("team_role").InsertMulti(teamRoleAssignments[start:end])
-		return fmt.Errorf("failed to create team role assignments: %w", err)
+		return err
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create team role assignments: %w", err)
 	}
 
 	return batch(len(builtInRoleAssignments), batchSize, func(start, end int) error {
-		_, err := m.sess.Table("builtin_role").InsertMulti(builtInRoleAssignments[start:end])
-		return fmt.Errorf("failed to create builtin role assignments: %w", err)
+		if _, err := m.sess.Table("builtin_role").InsertMulti(builtInRoleAssignments[start:end]); err != nil {
+			return fmt.Errorf("failed to create builtin role assignments: %w", err)
+		}
+		return nil
 	})
 }
 

--- a/pkg/services/sqlstore/migrations/accesscontrol/permission_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/permission_migrator.go
@@ -107,7 +107,7 @@ func (m *permissionMigrator) bulkAssignRoles(allRoles []*accesscontrol.Role) err
 
 	err := batch(len(userRoleAssignments), batchSize, func(start, end int) error {
 		_, err := m.sess.Table("user_role").InsertMulti(userRoleAssignments[start:end])
-		return err
+		return fmt.Errorf("failed to create user role assignments: %w", err)
 	})
 	if err != nil {
 		return err
@@ -115,7 +115,7 @@ func (m *permissionMigrator) bulkAssignRoles(allRoles []*accesscontrol.Role) err
 
 	err = batch(len(teamRoleAssignments), batchSize, func(start, end int) error {
 		_, err := m.sess.Table("team_role").InsertMulti(teamRoleAssignments[start:end])
-		return err
+		return fmt.Errorf("failed to create team role assignments: %w", err)
 	})
 	if err != nil {
 		return err
@@ -123,7 +123,7 @@ func (m *permissionMigrator) bulkAssignRoles(allRoles []*accesscontrol.Role) err
 
 	return batch(len(builtInRoleAssignments), batchSize, func(start, end int) error {
 		_, err := m.sess.Table("builtin_role").InsertMulti(builtInRoleAssignments[start:end])
-		return err
+		return fmt.Errorf("failed to create builtin role assignments: %w", err)
 	})
 }
 
@@ -148,7 +148,7 @@ func (m *permissionMigrator) createRoles(roles []*accesscontrol.Role) ([]*access
 	valueString := strings.Join(valueStrings, ",")
 	sql := fmt.Sprintf("INSERT INTO role (org_id, uid, name, version, created, updated) VALUES %s RETURNING id, org_id, name", valueString)
 	if errCreate := m.sess.SQL(sql, args...).Find(&createdRoles); errCreate != nil {
-		return nil, errCreate
+		return nil, fmt.Errorf("failed to create roles: %w", errCreate)
 	}
 
 	return createdRoles, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds debug logs and context for errors to dashboard permission migration. This is to aid debugging when the migration fails.

**Which issue(s) this PR fixes**:

Related to https://github.com/grafana/support-escalations/issues/3087

