### PR TITLE
Loki: Fix `show context` not working in some occasions

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -7674,8 +7674,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "10"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "11"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "12"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "13"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "14"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "13"]
     ],
     "public/app/plugins/datasource/loki/datasource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -431,9 +431,11 @@ export class LokiDatasource
     return Math.ceil(date.valueOf() * 1e6);
   }
 
-  getLogRowContext = (row: LogRowModel, options?: RowContextOptions): Promise<{ data: DataFrame[] }> => {
+  getLogRowContext = async (row: LogRowModel, options?: RowContextOptions): Promise<{ data: DataFrame[] }> => {
     const direction = (options && options.direction) || 'BACKWARD';
     const limit = (options && options.limit) || 10;
+    // need to await the languageProvider to be started to have all labels. This call is not blocking after it has been called once.
+    await this.languageProvider.start();
     const { query, range } = this.prepareLogRowContextQueryTarget(row, limit, direction);
 
     const processDataFrame = (frame: DataFrame): DataFrame => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -434,9 +434,7 @@ export class LokiDatasource
   getLogRowContext = async (row: LogRowModel, options?: RowContextOptions): Promise<{ data: DataFrame[] }> => {
     const direction = (options && options.direction) || 'BACKWARD';
     const limit = (options && options.limit) || 10;
-    // need to await the languageProvider to be started to have all labels. This call is not blocking after it has been called once.
-    await this.languageProvider.start();
-    const { query, range } = this.prepareLogRowContextQueryTarget(row, limit, direction);
+    const { query, range } = await this.prepareLogRowContextQueryTarget(row, limit, direction);
 
     const processDataFrame = (frame: DataFrame): DataFrame => {
       // log-row-context requires specific field-names to work, so we set them here: "ts", "line", "id"
@@ -499,11 +497,13 @@ export class LokiDatasource
     );
   };
 
-  prepareLogRowContextQueryTarget = (
+  prepareLogRowContextQueryTarget = async (
     row: LogRowModel,
     limit: number,
     direction: 'BACKWARD' | 'FORWARD'
-  ): { query: LokiQuery; range: TimeRange } => {
+  ): Promise<{ query: LokiQuery; range: TimeRange }> => {
+    // need to await the languageProvider to be started to have all labels. This call is not blocking after it has been called once.
+    await this.languageProvider.start();
     const labels = this.languageProvider.getLabelKeys();
     const expr = Object.keys(row.labels)
       .map((label: string) => {


### PR DESCRIPTION
**What this PR does / why we need it**:
The LogsContext is depending on the labels being set in those lines: https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/loki/datasource.ts#L505-L516
If the labels are not set, the expression will be empty.

This PR is adding a call to `languageProvider.start()` to ensure labels are fetched before forming the query-expression.

**Which issue(s) this PR fixes**:

Fixes #52018

**Special notes for your reviewer**:

From #52018:

***How to reproduce it (as minimally and precisely as possible):***

1. Goto log browser and filter some logs.
2. Click "Show context" button on a log line, then surrounding logs displayed.
3. Refresh the window.
4. Click "Show context" button on same line, but no other logs displayed except the original one.
5. Click "Run query" then "Show context", still same problem.
6. Goto home or any other page then go back and repeat step 1.
7. Click "Show context" button on a log line, the problem gone.
8. Refresh and the problem back.

