### PR TITLE
Alerting: Rename sender.Sender to sender.ExternalAlertmanagerSender

### DIFF
--- a/pkg/services/ngalert/sender/router.go
+++ b/pkg/services/ngalert/sender/router.go
@@ -124,7 +124,7 @@ func (d *AlertsRouter) SyncAndApplyConfigFromDatabase() error {
 
 		// No sender and have Alertmanager(s) to send to - start a new one.
 		d.logger.Info("creating new sender for the external alertmanagers", "org", cfg.OrgID, "alertmanagers", cfg.Alertmanagers)
-		s, err := New()
+		s, err := NewExternalAlertmanagerSender()
 		if err != nil {
 			d.logger.Error("unable to start the sender", "err", err, "org", cfg.OrgID)
 			continue

--- a/pkg/services/ngalert/sender/router.go
+++ b/pkg/services/ngalert/sender/router.go
@@ -30,8 +30,8 @@ type AlertsRouter struct {
 	// externalAlertmanagerSenders help us send alerts to external Alertmanagers.
 	adminConfigMtx                     sync.RWMutex
 	sendAlertsTo                       map[int64]models.AlertmanagersChoice
-	externalAlertmanagerSenders        map[int64]*ExternalAlertmanager
-	externalAlertmanagerSendersCfgHash map[int64]string
+	externalAlertmanagers        map[int64]*ExternalAlertmanager
+	externalAlertmanagersCfgHash map[int64]string
 
 	multiOrgNotifier *notifier.MultiOrgAlertmanager
 
@@ -47,8 +47,8 @@ func NewAlertsRouter(multiOrgNotifier *notifier.MultiOrgAlertmanager, store stor
 		adminConfigStore: store,
 
 		adminConfigMtx:                     sync.RWMutex{},
-		externalAlertmanagerSenders:        map[int64]*ExternalAlertmanager{},
-		externalAlertmanagerSendersCfgHash: map[int64]string{},
+		externalAlertmanagers:        map[int64]*ExternalAlertmanager{},
+		externalAlertmanagersCfgHash: map[int64]string{},
 		sendAlertsTo:                       map[int64]models.AlertmanagersChoice{},
 
 		multiOrgNotifier: multiOrgNotifier,
@@ -83,9 +83,9 @@ func (d *AlertsRouter) SyncAndApplyConfigFromDatabase() error {
 		// Update the Alertmanagers choice for the organization.
 		d.sendAlertsTo[cfg.OrgID] = cfg.SendAlertsTo
 
-		orgsFound[cfg.OrgID] = struct{}{} // keep track of the which externalAlertmanagerSenders we need to keep.
+		orgsFound[cfg.OrgID] = struct{}{} // keep track of the which externalAlertmanagers we need to keep.
 
-		existing, ok := d.externalAlertmanagerSenders[cfg.OrgID]
+		existing, ok := d.externalAlertmanagers[cfg.OrgID]
 
 		// We have no running sender and no Alertmanager(s) configured, no-op.
 		if !ok && len(cfg.Alertmanagers) == 0 {

--- a/pkg/services/ngalert/sender/router.go
+++ b/pkg/services/ngalert/sender/router.go
@@ -30,7 +30,7 @@ type AlertsRouter struct {
 	// externalAlertmanagerSenders help us send alerts to external Alertmanagers.
 	adminConfigMtx                     sync.RWMutex
 	sendAlertsTo                       map[int64]models.AlertmanagersChoice
-	externalAlertmanagerSenders        map[int64]*ExternalAlertmanagerSender
+	externalAlertmanagerSenders        map[int64]*ExternalAlertmanager
 	externalAlertmanagerSendersCfgHash map[int64]string
 
 	multiOrgNotifier *notifier.MultiOrgAlertmanager
@@ -47,7 +47,7 @@ func NewAlertsRouter(multiOrgNotifier *notifier.MultiOrgAlertmanager, store stor
 		adminConfigStore: store,
 
 		adminConfigMtx:                     sync.RWMutex{},
-		externalAlertmanagerSenders:        map[int64]*ExternalAlertmanagerSender{},
+		externalAlertmanagerSenders:        map[int64]*ExternalAlertmanager{},
 		externalAlertmanagerSendersCfgHash: map[int64]string{},
 		sendAlertsTo:                       map[int64]models.AlertmanagersChoice{},
 
@@ -142,7 +142,7 @@ func (d *AlertsRouter) SyncAndApplyConfigFromDatabase() error {
 		d.externalAlertmanagerSendersCfgHash[cfg.OrgID] = cfg.AsSHA256()
 	}
 
-	sendersToStop := map[int64]*ExternalAlertmanagerSender{}
+	sendersToStop := map[int64]*ExternalAlertmanager{}
 
 	for orgID, s := range d.externalAlertmanagerSenders {
 		if _, exists := orgsFound[orgID]; !exists {

--- a/pkg/services/ngalert/sender/router_test.go
+++ b/pkg/services/ngalert/sender/router_test.go
@@ -53,8 +53,8 @@ func TestSendingToExternalAlertmanager(t *testing.T) {
 	// Make sure we sync the configuration at least once before the evaluation happens to guarantee the sender is running
 	// when the first alert triggers.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
-	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSendersCfgHash))
+	require.Equal(t, 1, len(alertsRouter.externalAlertmanagers))
+	require.Equal(t, 1, len(alertsRouter.externalAlertmanagersCfgHash))
 
 	// Then, ensure we've discovered the Alertmanager.
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey.OrgID, 1, 0)
@@ -74,10 +74,10 @@ func TestSendingToExternalAlertmanager(t *testing.T) {
 
 	// Now, let's remove the Alertmanager from the admin configuration.
 	mockedGetAdminConfigurations.Return(nil, nil)
-	// Again, make sure we sync and verify the externalAlertmanagerSenders.
+	// Again, make sure we sync and verify the externalAlertmanagers.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
-	require.Equal(t, 0, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 0, len(alertsRouter.externalAlertmanagerSendersCfgHash))
+	require.Equal(t, 0, len(alertsRouter.externalAlertmanagers))
+	require.Equal(t, 0, len(alertsRouter.externalAlertmanagersCfgHash))
 
 	// Then, ensure we've dropped the Alertmanager.
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey.OrgID, 0, 0)
@@ -111,8 +111,8 @@ func TestSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T) {
 	// Make sure we sync the configuration at least once before the evaluation happens to guarantee the sender is running
 	// when the first alert triggers.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
-	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSendersCfgHash))
+	require.Equal(t, 1, len(alertsRouter.externalAlertmanagers))
+	require.Equal(t, 1, len(alertsRouter.externalAlertmanagersCfgHash))
 
 	// Then, ensure we've discovered the Alertmanager.
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey1.OrgID, 1, 0)
@@ -123,10 +123,10 @@ func TestSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T) {
 		{OrgID: ruleKey2.OrgID, Alertmanagers: []string{fakeAM.Server.URL}},
 	}, nil)
 
-	// If we sync again, new externalAlertmanagerSenders must have spawned.
+	// If we sync again, new externalAlertmanagers must have spawned.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
-	require.Equal(t, 2, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 2, len(alertsRouter.externalAlertmanagerSendersCfgHash))
+	require.Equal(t, 2, len(alertsRouter.externalAlertmanagers))
+	require.Equal(t, 2, len(alertsRouter.externalAlertmanagersCfgHash))
 
 	// Then, ensure we've discovered the Alertmanager for the new organization.
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey1.OrgID, 1, 0)
@@ -160,15 +160,15 @@ func TestSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T) {
 	}, nil)
 
 	// Before we sync, let's grab the existing hash of this particular org.
-	currentHash := alertsRouter.externalAlertmanagerSendersCfgHash[ruleKey2.OrgID]
+	currentHash := alertsRouter.externalAlertmanagersCfgHash[ruleKey2.OrgID]
 
 	// Now, sync again.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
 
-	// The hash for org two should not be the same and we should still have two externalAlertmanagerSenders.
-	require.NotEqual(t, alertsRouter.externalAlertmanagerSendersCfgHash[ruleKey2.OrgID], currentHash)
-	require.Equal(t, 2, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 2, len(alertsRouter.externalAlertmanagerSendersCfgHash))
+	// The hash for org two should not be the same and we should still have two externalAlertmanagers.
+	require.NotEqual(t, alertsRouter.externalAlertmanagersCfgHash[ruleKey2.OrgID], currentHash)
+	require.Equal(t, 2, len(alertsRouter.externalAlertmanagers))
+	require.Equal(t, 2, len(alertsRouter.externalAlertmanagersCfgHash))
 
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey2.OrgID, 2, 0)
 
@@ -179,13 +179,13 @@ func TestSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T) {
 	}, nil)
 
 	// Before we sync, let's get the current config hash.
-	currentHash = alertsRouter.externalAlertmanagerSendersCfgHash[ruleKey1.OrgID]
+	currentHash = alertsRouter.externalAlertmanagersCfgHash[ruleKey1.OrgID]
 
 	// Now, sync again.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
 
 	// The old configuration should still be running.
-	require.Equal(t, alertsRouter.externalAlertmanagerSendersCfgHash[ruleKey1.OrgID], currentHash)
+	require.Equal(t, alertsRouter.externalAlertmanagersCfgHash[ruleKey1.OrgID], currentHash)
 	require.Equal(t, 1, len(alertsRouter.AlertmanagersFor(ruleKey1.OrgID)))
 
 	// If we fix it - it should be applied.
@@ -195,15 +195,15 @@ func TestSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T) {
 	}, nil)
 
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
-	require.NotEqual(t, alertsRouter.externalAlertmanagerSendersCfgHash[ruleKey1.OrgID], currentHash)
+	require.NotEqual(t, alertsRouter.externalAlertmanagersCfgHash[ruleKey1.OrgID], currentHash)
 
 	// Finally, remove everything.
 	mockedGetAdminConfigurations.Return([]*models.AdminConfiguration{}, nil)
 
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
 
-	require.Equal(t, 0, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 0, len(alertsRouter.externalAlertmanagerSendersCfgHash))
+	require.Equal(t, 0, len(alertsRouter.externalAlertmanagers))
+	require.Equal(t, 0, len(alertsRouter.externalAlertmanagersCfgHash))
 
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey1.OrgID, 0, 0)
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey2.OrgID, 0, 0)
@@ -236,8 +236,8 @@ func TestChangingAlertmanagersChoice(t *testing.T) {
 	// Make sure we sync the configuration at least once before the evaluation happens to guarantee the sender is running
 	// when the first alert triggers.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
-	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSendersCfgHash))
+	require.Equal(t, 1, len(alertsRouter.externalAlertmanagers))
+	require.Equal(t, 1, len(alertsRouter.externalAlertmanagersCfgHash))
 	require.Equal(t, models.AllAlertmanagers, alertsRouter.sendAlertsTo[ruleKey.OrgID])
 
 	// Then, ensure we've discovered the Alertmanager.
@@ -259,10 +259,10 @@ func TestChangingAlertmanagersChoice(t *testing.T) {
 	mockedGetAdminConfigurations.Return([]*models.AdminConfiguration{
 		{OrgID: ruleKey.OrgID, Alertmanagers: []string{fakeAM.Server.URL}, SendAlertsTo: models.ExternalAlertmanagers},
 	}, nil)
-	// Again, make sure we sync and verify the externalAlertmanagerSenders.
+	// Again, make sure we sync and verify the externalAlertmanagers.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
-	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSendersCfgHash))
+	require.Equal(t, 1, len(alertsRouter.externalAlertmanagers))
+	require.Equal(t, 1, len(alertsRouter.externalAlertmanagersCfgHash))
 
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey.OrgID, 1, 0)
 	require.Equal(t, models.ExternalAlertmanagers, alertsRouter.sendAlertsTo[ruleKey.OrgID])
@@ -272,11 +272,11 @@ func TestChangingAlertmanagersChoice(t *testing.T) {
 		{OrgID: ruleKey.OrgID, Alertmanagers: []string{fakeAM.Server.URL}, SendAlertsTo: models.InternalAlertmanager},
 	}, nil)
 
-	// Again, make sure we sync and verify the externalAlertmanagerSenders.
-	// externalAlertmanagerSenders should be running even though alerts are being handled externally.
+	// Again, make sure we sync and verify the externalAlertmanagers.
+	// externalAlertmanagers should be running even though alerts are being handled externally.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
-	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSendersCfgHash))
+	require.Equal(t, 1, len(alertsRouter.externalAlertmanagers))
+	require.Equal(t, 1, len(alertsRouter.externalAlertmanagersCfgHash))
 
 	// Then, ensure the Alertmanager is still listed and the Alertmanagers choice has changed.
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey.OrgID, 1, 0)

--- a/pkg/services/ngalert/sender/router_test.go
+++ b/pkg/services/ngalert/sender/router_test.go
@@ -54,7 +54,7 @@ func TestSendingToExternalAlertmanager(t *testing.T) {
 	// when the first alert triggers.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
 	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 1, len(alertsRouter.sendersCfgHash))
+	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSendersCfgHash))
 
 	// Then, ensure we've discovered the Alertmanager.
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey.OrgID, 1, 0)
@@ -77,7 +77,7 @@ func TestSendingToExternalAlertmanager(t *testing.T) {
 	// Again, make sure we sync and verify the externalAlertmanagerSenders.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
 	require.Equal(t, 0, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 0, len(alertsRouter.sendersCfgHash))
+	require.Equal(t, 0, len(alertsRouter.externalAlertmanagerSendersCfgHash))
 
 	// Then, ensure we've dropped the Alertmanager.
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey.OrgID, 0, 0)
@@ -112,7 +112,7 @@ func TestSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T) {
 	// when the first alert triggers.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
 	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 1, len(alertsRouter.sendersCfgHash))
+	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSendersCfgHash))
 
 	// Then, ensure we've discovered the Alertmanager.
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey1.OrgID, 1, 0)
@@ -126,7 +126,7 @@ func TestSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T) {
 	// If we sync again, new externalAlertmanagerSenders must have spawned.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
 	require.Equal(t, 2, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 2, len(alertsRouter.sendersCfgHash))
+	require.Equal(t, 2, len(alertsRouter.externalAlertmanagerSendersCfgHash))
 
 	// Then, ensure we've discovered the Alertmanager for the new organization.
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey1.OrgID, 1, 0)
@@ -160,15 +160,15 @@ func TestSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T) {
 	}, nil)
 
 	// Before we sync, let's grab the existing hash of this particular org.
-	currentHash := alertsRouter.sendersCfgHash[ruleKey2.OrgID]
+	currentHash := alertsRouter.externalAlertmanagerSendersCfgHash[ruleKey2.OrgID]
 
 	// Now, sync again.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
 
 	// The hash for org two should not be the same and we should still have two externalAlertmanagerSenders.
-	require.NotEqual(t, alertsRouter.sendersCfgHash[ruleKey2.OrgID], currentHash)
+	require.NotEqual(t, alertsRouter.externalAlertmanagerSendersCfgHash[ruleKey2.OrgID], currentHash)
 	require.Equal(t, 2, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 2, len(alertsRouter.sendersCfgHash))
+	require.Equal(t, 2, len(alertsRouter.externalAlertmanagerSendersCfgHash))
 
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey2.OrgID, 2, 0)
 
@@ -179,13 +179,13 @@ func TestSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T) {
 	}, nil)
 
 	// Before we sync, let's get the current config hash.
-	currentHash = alertsRouter.sendersCfgHash[ruleKey1.OrgID]
+	currentHash = alertsRouter.externalAlertmanagerSendersCfgHash[ruleKey1.OrgID]
 
 	// Now, sync again.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
 
 	// The old configuration should still be running.
-	require.Equal(t, alertsRouter.sendersCfgHash[ruleKey1.OrgID], currentHash)
+	require.Equal(t, alertsRouter.externalAlertmanagerSendersCfgHash[ruleKey1.OrgID], currentHash)
 	require.Equal(t, 1, len(alertsRouter.AlertmanagersFor(ruleKey1.OrgID)))
 
 	// If we fix it - it should be applied.
@@ -195,7 +195,7 @@ func TestSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T) {
 	}, nil)
 
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
-	require.NotEqual(t, alertsRouter.sendersCfgHash[ruleKey1.OrgID], currentHash)
+	require.NotEqual(t, alertsRouter.externalAlertmanagerSendersCfgHash[ruleKey1.OrgID], currentHash)
 
 	// Finally, remove everything.
 	mockedGetAdminConfigurations.Return([]*models.AdminConfiguration{}, nil)
@@ -203,7 +203,7 @@ func TestSendingToExternalAlertmanager_WithMultipleOrgs(t *testing.T) {
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
 
 	require.Equal(t, 0, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 0, len(alertsRouter.sendersCfgHash))
+	require.Equal(t, 0, len(alertsRouter.externalAlertmanagerSendersCfgHash))
 
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey1.OrgID, 0, 0)
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey2.OrgID, 0, 0)
@@ -237,7 +237,7 @@ func TestChangingAlertmanagersChoice(t *testing.T) {
 	// when the first alert triggers.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
 	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 1, len(alertsRouter.sendersCfgHash))
+	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSendersCfgHash))
 	require.Equal(t, models.AllAlertmanagers, alertsRouter.sendAlertsTo[ruleKey.OrgID])
 
 	// Then, ensure we've discovered the Alertmanager.
@@ -262,7 +262,7 @@ func TestChangingAlertmanagersChoice(t *testing.T) {
 	// Again, make sure we sync and verify the externalAlertmanagerSenders.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
 	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 1, len(alertsRouter.sendersCfgHash))
+	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSendersCfgHash))
 
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey.OrgID, 1, 0)
 	require.Equal(t, models.ExternalAlertmanagers, alertsRouter.sendAlertsTo[ruleKey.OrgID])
@@ -276,7 +276,7 @@ func TestChangingAlertmanagersChoice(t *testing.T) {
 	// externalAlertmanagerSenders should be running even though alerts are being handled externally.
 	require.NoError(t, alertsRouter.SyncAndApplyConfigFromDatabase())
 	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSenders))
-	require.Equal(t, 1, len(alertsRouter.sendersCfgHash))
+	require.Equal(t, 1, len(alertsRouter.externalAlertmanagerSendersCfgHash))
 
 	// Then, ensure the Alertmanager is still listed and the Alertmanagers choice has changed.
 	assertAlertmanagersStatusForOrg(t, alertsRouter, ruleKey.OrgID, 1, 0)

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -26,8 +26,8 @@ const (
 	defaultTimeout          = 10 * time.Second
 )
 
-// ExternalAlertmanagerSender is responsible for dispatching alert notifications to an external Alertmanager service.
-type ExternalAlertmanagerSender struct {
+// ExternalAlertmanager is responsible for dispatching alert notifications to an external Alertmanager service.
+type ExternalAlertmanager struct {
 	logger log.Logger
 	wg     sync.WaitGroup
 
@@ -37,10 +37,10 @@ type ExternalAlertmanagerSender struct {
 	sdManager *discovery.Manager
 }
 
-func NewExternalAlertmanagerSender() (*ExternalAlertmanagerSender, error) {
+func NewExternalAlertmanagerSender() (*ExternalAlertmanager, error) {
 	l := log.New("sender")
 	sdCtx, sdCancel := context.WithCancel(context.Background())
-	s := &ExternalAlertmanagerSender{
+	s := &ExternalAlertmanager{
 		logger:   l,
 		sdCancel: sdCancel,
 	}
@@ -58,7 +58,7 @@ func NewExternalAlertmanagerSender() (*ExternalAlertmanagerSender, error) {
 }
 
 // ApplyConfig syncs a configuration with the sender.
-func (s *ExternalAlertmanagerSender) ApplyConfig(cfg *ngmodels.AdminConfiguration) error {
+func (s *ExternalAlertmanager) ApplyConfig(cfg *ngmodels.AdminConfiguration) error {
 	notifierCfg, err := buildNotifierConfig(cfg)
 	if err != nil {
 		return err
@@ -76,7 +76,7 @@ func (s *ExternalAlertmanagerSender) ApplyConfig(cfg *ngmodels.AdminConfiguratio
 	return s.sdManager.ApplyConfig(sdCfgs)
 }
 
-func (s *ExternalAlertmanagerSender) Run() {
+func (s *ExternalAlertmanager) Run() {
 	s.wg.Add(2)
 
 	go func() {
@@ -93,7 +93,7 @@ func (s *ExternalAlertmanagerSender) Run() {
 }
 
 // SendAlerts sends a set of alerts to the configured Alertmanager(s).
-func (s *ExternalAlertmanagerSender) SendAlerts(alerts apimodels.PostableAlerts) {
+func (s *ExternalAlertmanager) SendAlerts(alerts apimodels.PostableAlerts) {
 	if len(alerts.PostableAlerts) == 0 {
 		s.logger.Debug("no alerts to send to external Alertmanager(s)")
 		return
@@ -109,19 +109,19 @@ func (s *ExternalAlertmanagerSender) SendAlerts(alerts apimodels.PostableAlerts)
 }
 
 // Stop shuts down the sender.
-func (s *ExternalAlertmanagerSender) Stop() {
+func (s *ExternalAlertmanager) Stop() {
 	s.sdCancel()
 	s.manager.Stop()
 	s.wg.Wait()
 }
 
 // Alertmanagers returns a list of the discovered Alertmanager(s).
-func (s *ExternalAlertmanagerSender) Alertmanagers() []*url.URL {
+func (s *ExternalAlertmanager) Alertmanagers() []*url.URL {
 	return s.manager.Alertmanagers()
 }
 
 // DroppedAlertmanagers returns a list of Alertmanager(s) we no longer send alerts to.
-func (s *ExternalAlertmanagerSender) DroppedAlertmanagers() []*url.URL {
+func (s *ExternalAlertmanager) DroppedAlertmanagers() []*url.URL {
 	return s.manager.DroppedAlertmanagers()
 }
 

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -26,8 +26,8 @@ const (
 	defaultTimeout          = 10 * time.Second
 )
 
-// Sender is responsible for dispatching alert notifications to an external Alertmanager service.
-type Sender struct {
+// ExternalAlertmanagerSender is responsible for dispatching alert notifications to an external Alertmanager service.
+type ExternalAlertmanagerSender struct {
 	logger log.Logger
 	wg     sync.WaitGroup
 
@@ -37,10 +37,10 @@ type Sender struct {
 	sdManager *discovery.Manager
 }
 
-func New() (*Sender, error) {
+func New() (*ExternalAlertmanagerSender, error) {
 	l := log.New("sender")
 	sdCtx, sdCancel := context.WithCancel(context.Background())
-	s := &Sender{
+	s := &ExternalAlertmanagerSender{
 		logger:   l,
 		sdCancel: sdCancel,
 	}
@@ -58,7 +58,7 @@ func New() (*Sender, error) {
 }
 
 // ApplyConfig syncs a configuration with the sender.
-func (s *Sender) ApplyConfig(cfg *ngmodels.AdminConfiguration) error {
+func (s *ExternalAlertmanagerSender) ApplyConfig(cfg *ngmodels.AdminConfiguration) error {
 	notifierCfg, err := buildNotifierConfig(cfg)
 	if err != nil {
 		return err
@@ -76,7 +76,7 @@ func (s *Sender) ApplyConfig(cfg *ngmodels.AdminConfiguration) error {
 	return s.sdManager.ApplyConfig(sdCfgs)
 }
 
-func (s *Sender) Run() {
+func (s *ExternalAlertmanagerSender) Run() {
 	s.wg.Add(2)
 
 	go func() {
@@ -93,7 +93,7 @@ func (s *Sender) Run() {
 }
 
 // SendAlerts sends a set of alerts to the configured Alertmanager(s).
-func (s *Sender) SendAlerts(alerts apimodels.PostableAlerts) {
+func (s *ExternalAlertmanagerSender) SendAlerts(alerts apimodels.PostableAlerts) {
 	if len(alerts.PostableAlerts) == 0 {
 		s.logger.Debug("no alerts to send to external Alertmanager(s)")
 		return
@@ -109,19 +109,19 @@ func (s *Sender) SendAlerts(alerts apimodels.PostableAlerts) {
 }
 
 // Stop shuts down the sender.
-func (s *Sender) Stop() {
+func (s *ExternalAlertmanagerSender) Stop() {
 	s.sdCancel()
 	s.manager.Stop()
 	s.wg.Wait()
 }
 
 // Alertmanagers returns a list of the discovered Alertmanager(s).
-func (s *Sender) Alertmanagers() []*url.URL {
+func (s *ExternalAlertmanagerSender) Alertmanagers() []*url.URL {
 	return s.manager.Alertmanagers()
 }
 
 // DroppedAlertmanagers returns a list of Alertmanager(s) we no longer send alerts to.
-func (s *Sender) DroppedAlertmanagers() []*url.URL {
+func (s *ExternalAlertmanagerSender) DroppedAlertmanagers() []*url.URL {
 	return s.manager.DroppedAlertmanagers()
 }
 

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -37,7 +37,7 @@ type ExternalAlertmanagerSender struct {
 	sdManager *discovery.Manager
 }
 
-func New() (*ExternalAlertmanagerSender, error) {
+func NewExternalAlertmanagerSender() (*ExternalAlertmanagerSender, error) {
 	l := log.New("sender")
 	sdCtx, sdCancel := context.WithCancel(context.Background())
 	s := &ExternalAlertmanagerSender{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
In alerting domain there sender is an overloaded term: in the scheduler package, there is an interface AlertsSender and in the sender package, there is a Sender struct. This PR renames the latter occurrence to ExternalAlertmanagerSender which in my opinion better reflects the purpose of the struct.

**Which issue(s) this PR fixes**:
Related to: https://github.com/grafana/grafana/pull/48144#discussion_r919223908
