### PR TITLE
Docker: Install `git` in `grafana/grafana-ci-deploy` image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1146,7 +1146,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: store-storybook
   when:
     repo:
@@ -1277,7 +1277,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: upload-packages
   when:
     repo:
@@ -1291,7 +1291,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: upload-cdn-assets
   when:
     repo:
@@ -1546,7 +1546,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_COM_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: store-packages-oss
 trigger:
   branch: main
@@ -1822,7 +1822,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: upload-cdn-assets
 - commands:
   - ./bin/grabpl upload-packages --edition oss
@@ -1836,7 +1836,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: upload-packages
 - commands:
   - ./bin/grabpl store-storybook --deployment latest --src-bucket grafana-prerelease
@@ -1854,7 +1854,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: store-storybook
 - commands:
   - ./bin/grabpl artifacts npm store --tag ${DRONE_TAG}
@@ -1865,7 +1865,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: store-npm-packages
 trigger:
   event:
@@ -2436,7 +2436,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: upload-cdn-assets
 - commands:
   - ./bin/grabpl upload-packages --edition enterprise
@@ -2447,7 +2447,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: upload-packages
 - commands:
   - ./bin/grabpl artifacts npm store --tag ${DRONE_TAG}
@@ -2458,7 +2458,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: store-npm-packages
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise2  --sign ${DRONE_TAG}
@@ -2488,7 +2488,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: upload-cdn-assets-enterprise2
 - commands:
   - ./bin/grabpl upload-packages --edition enterprise2
@@ -2499,7 +2499,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: upload-packages-enterprise2
 trigger:
   event:
@@ -3231,7 +3231,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: publish-artifacts
 trigger:
   event:
@@ -3269,7 +3269,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: publish-artifacts
 trigger:
   event:
@@ -3313,7 +3313,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: retrieve-npm-packages
 - commands:
   - ./bin/grabpl artifacts npm release --tag v${TAG}
@@ -3376,7 +3376,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_COM_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: store-packages-oss
 trigger:
   event:
@@ -3430,7 +3430,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_COM_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: store-packages-enterprise
 trigger:
   event:
@@ -3706,7 +3706,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: upload-cdn-assets
   when:
     repo:
@@ -3723,7 +3723,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: upload-packages
   when:
     repo:
@@ -4278,7 +4278,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: upload-cdn-assets
   when:
     repo:
@@ -4292,7 +4292,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: upload-packages
   when:
     repo:
@@ -4326,7 +4326,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: upload-cdn-assets-enterprise2
 - commands:
   - ./bin/grabpl upload-packages --edition enterprise2
@@ -4337,7 +4337,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.1
+  image: grafana/grafana-ci-deploy:1.3.2
   name: upload-packages-enterprise2
 trigger:
   ref:
@@ -4874,6 +4874,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 6ca96adcc90cb32d6ded5bcd804548f5c2a5dfdfa1791761f150e1447852357a
+hmac: 21307c19aa1bb40d2da542435c76666ba935db47ddd936ca24cfdf79ffb11443
 
 ...

--- a/scripts/build/ci-deploy/Dockerfile
+++ b/scripts/build/ci-deploy/Dockerfile
@@ -27,7 +27,7 @@ ARG DEBIAN_FRONTEND=noninteractive \
   GOOGLE_SDK_CHECKSUM=374f960c9f384f88b6fc190b268ceac5dcad777301390107af63782bfb5ecbc7
 
 # Need procps for pkill utility, which is used by the build pipeline tool to restart the GPG agent
-RUN apt update && apt install -yq curl python3-pip procps && pip3 install -U awscli crcmod && \
+RUN apt update && apt install -yq git curl python3-pip procps && pip3 install -U awscli crcmod && \
     curl -fLO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz && \
     echo "${GOOGLE_SDK_CHECKSUM} google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz" | sha256sum --check --status && \
     tar xzf google-cloud-sdk-${GOOGLE_SDK_VERSION}-linux-x86_64.tar.gz -C /opt && \

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -2,7 +2,7 @@ load('scripts/drone/vault.star', 'from_secret', 'github_token', 'pull_secret', '
 
 grabpl_version = 'v2.9.52'
 build_image = 'grafana/build-container:1.5.7'
-publish_image = 'grafana/grafana-ci-deploy:1.3.1'
+publish_image = 'grafana/grafana-ci-deploy:1.3.2'
 deploy_docker_image = 'us.gcr.io/kubernetes-dev/drone/plugins/deploy-image'
 alpine_image = 'alpine:3.15'
 curl_image = 'byrnedo/alpine-curl:0.1.8'


### PR DESCRIPTION
**What this PR does / why we need it**:

Installs `git` in `grafana/grafana-ci-deploy` as it's currently missing.
