### PR TITLE
Service Accounts: allow setting team managed permissions for service accounts

### DIFF
--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -284,7 +284,7 @@ func ProvideServiceAccountPermissions(
 		},
 		Assignments: resourcepermissions.Assignments{
 			Users:           true,
-			Teams:           false,
+			Teams:           true,
 			BuiltInRoles:    false,
 			ServiceAccounts: false,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows granting managed permissions on a service account to teams through the UI:

<img width="1393" alt="Screenshot 2022-07-19 at 15 51 07" src="https://user-images.githubusercontent.com/9482349/179780742-75e05b0d-1bcf-4dca-a746-c575ed8a00ed.png">

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-enterprise/issues/3594