### PR TITLE
StyleGuide: Update frontend style guide to not explicitly type return type for functional components 

### DIFF
--- a/contribute/style-guides/frontend.md
+++ b/contribute/style-guides/frontend.md
@@ -351,7 +351,7 @@ static defaultProps: Partial<Props> = { ... }
 We recommend using named regular functions when creating a new react functional component.
 
 ```typescript
-export function Component(props: Props): ReactElement { ... }
+export function Component(props: Props) { ... }
 ```
 
 ## State management


### PR DESCRIPTION
We should not explicitly type the return type for React functional components.

I think this is what we decided ~1 a year ago when we decided to stop using React.FC type 
