### PR TITLE
Access control: Fix org user removal for OSS users

### DIFF
--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -284,7 +284,7 @@ func ProvideServiceAccountPermissions(
 		},
 		Assignments: resourcepermissions.Assignments{
 			Users:           true,
-			Teams:           false,
+			Teams:           true,
 			BuiltInRoles:    false,
 			ServiceAccounts: false,
 		},

--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -284,7 +284,7 @@ func ProvideServiceAccountPermissions(
 		},
 		Assignments: resourcepermissions.Assignments{
 			Users:           true,
-			Teams:           true,
+			Teams:           false,
 			BuiltInRoles:    false,
 			ServiceAccounts: false,
 		},

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -164,8 +164,13 @@ class UnThemedOrgRow extends PureComponent<OrgRowProps> {
 
   onOrgRemove = async () => {
     const { org, user } = this.props;
-    user && (await updateUserRoles([], user.id, org.orgId));
     this.props.onOrgRemove(org.orgId);
+    // add the stored userRoles also
+    if (contextSrv.licensedAccessControlEnabled()) {
+      if (contextSrv.hasPermission(AccessControlAction.OrgUsersRemove)) {
+        user && (await updateUserRoles([], user.id, org.orgId));
+      }
+    }
   };
 
   onChangeRoleClick = () => {

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -165,7 +165,6 @@ class UnThemedOrgRow extends PureComponent<OrgRowProps> {
   onOrgRemove = async () => {
     const { org, user } = this.props;
     this.props.onOrgRemove(org.orgId);
-    // add the stored userRoles also
     if (contextSrv.licensedAccessControlEnabled()) {
       if (contextSrv.hasPermission(AccessControlAction.OrgUsersRemove)) {
         user && (await updateUserRoles([], user.id, org.orgId));


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix org user removal for OSS - only call the enterprise access control endpoint for licensed users.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/52434
