### PR TITLE
Canvas: Set element cursor to grab

### DIFF
--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -82,6 +82,7 @@ export class ElementState implements LayerElement {
     const placement = this.options.placement ?? ({} as Placement);
 
     const style: React.CSSProperties = {
+      cursor: 'grab',
       position: 'absolute',
       // Minimum element size is 10x10
       minWidth: '10px',

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -81,8 +81,10 @@ export class ElementState implements LayerElement {
     const { vertical, horizontal } = constraint ?? {};
     const placement = this.options.placement ?? ({} as Placement);
 
+    const editingEnabled = this.getScene()?.isEditingEnabled;
+
     const style: React.CSSProperties = {
-      cursor: 'grab',
+      cursor: editingEnabled ? 'grab' : 'auto',
       position: 'absolute',
       // Minimum element size is 10x10
       minWidth: '10px',

--- a/public/app/features/canvas/runtime/scene.tsx
+++ b/public/app/features/canvas/runtime/scene.tsx
@@ -414,6 +414,11 @@ export class Scene {
         ?.getSelectedTargets()
         .includes(selectedTarget.parentElement.parentElement);
 
+      // Apply grabbing cursor while dragging, applyLayoutStylesToDiv() resets it to grab when done
+      if (this.isEditingEnabled && isTargetMoveableElement && this.selecto?.getSelectedTargets().length) {
+        this.selecto.getSelectedTargets()[0].style.cursor = 'grabbing';
+      }
+
       if (isTargetMoveableElement || isTargetAlreadySelected) {
         // Prevent drawing selection box when selected target is a moveable element or already selected
         event.stop();


### PR DESCRIPTION
What this PR does / why we need it:
Since we only support dragging elements at this point, make cursor consistent to keep the UX intuitive.

Element drag cursor:
![Jul-19-2022 21-59-24](https://user-images.githubusercontent.com/60050885/179900545-86c96d7b-a86c-4b16-8bed-7c283022ed76.gif)


Closes #52469 

