### PR TITLE
Alerting: Add receivers error feedback in contact point list

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5517,11 +5517,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "20"],
       [0, 0, 0, "Do not use any type assertions.", "21"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "22"],
-      [0, 0, 0, "Do not use any type assertions.", "23"],
-      [0, 0, 0, "Do not use any type assertions.", "24"],
-      [0, 0, 0, "Do not use any type assertions.", "25"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "26"],
-      [0, 0, 0, "Do not use any type assertions.", "27"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "23"],
+      [0, 0, 0, "Do not use any type assertions.", "24"]
     ],
     "public/app/features/plugins/hooks/tests/useImportAppPlugin.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/public/app/features/alerting/unified/api/grafana.test.ts
+++ b/public/app/features/alerting/unified/api/grafana.test.ts
@@ -1,4 +1,6 @@
-import { getIntegrationType, isValidIntegrationType } from './grafana';
+import { ReceiversStateDTO } from 'app/types';
+
+import { contactPointsStateDtoToModel, getIntegrationType, isValidIntegrationType } from './grafana';
 
 describe('getIntegrationType method', () => {
   it('should return the integration name when it is a valid type name with [{number}] ', () => {
@@ -33,5 +35,115 @@ describe('isValidIntegrationType method', () => {
   it('should return false when it is a name followed with [{index} ', () => {
     const name = isValidIntegrationType('coolIntegration[11');
     expect(name).toBe(false);
+  });
+});
+
+describe('contactPointsStateDtoToModel method', () => {
+  it('should return the expected object', () => {
+    const response = [
+      {
+        active: true,
+        integrations: [
+          {
+            lastError: 'establish connection to server: dial tcp: lookup smtp.example.org on 8.8.8.8:53: no such host',
+            lastNotify: '2022-07-08 17:42:44.998893 +0000 UTC',
+            lastNotifyDuration: '117.2455ms',
+            name: 'email[0]',
+          },
+          {
+            lastError: 'establish connection to server: dial tcp: lookup smtp.example.org on 8.8.8.8:53: no such host',
+            lastNotify: '2022-07-08 17:42:44.998893 +0000 UTC',
+            lastNotifyDuration: '117.2455ms',
+            name: 'email[1]',
+          },
+          {
+            lastNotify: '2022-07-08 17:42:44.998893 +0000 UTC',
+            lastNotifyDuration: '117.2455ms',
+            name: 'email[2]',
+          },
+          {
+            lastError: 'establish connection to server: dial tcp: lookup smtp.example.org on 8.8.8.8:53: no such host',
+            lastNotify: '2022-07-08 17:42:44.998893 +0000 UTC',
+            lastNotifyDuration: '117.2455ms',
+            name: 'webhook[0]',
+          },
+        ],
+        name: 'contact point 1',
+      },
+      {
+        active: true,
+        integrations: [
+          {
+            lastNotify: '2022-07-08 17:42:44.998893 +0000 UTC',
+            lastNotifyDuration: '117.2455ms',
+            name: 'email[0]',
+          },
+        ],
+        name: 'contact point 2',
+      },
+    ];
+    expect(contactPointsStateDtoToModel(response)).toStrictEqual({
+      errorCount: 3,
+      receivers: {
+        'contact point 1': {
+          active: true,
+          errorCount: 3,
+          integrations: {
+            email: [
+              {
+                lastError:
+                  'establish connection to server: dial tcp: lookup smtp.example.org on 8.8.8.8:53: no such host',
+                lastNotify: '2022-07-08 17:42:44.998893 +0000 UTC',
+                lastNotifyDuration: '117.2455ms',
+                name: 'email[0]',
+              },
+              {
+                lastError:
+                  'establish connection to server: dial tcp: lookup smtp.example.org on 8.8.8.8:53: no such host',
+                lastNotify: '2022-07-08 17:42:44.998893 +0000 UTC',
+                lastNotifyDuration: '117.2455ms',
+                name: 'email[1]',
+              },
+              {
+                lastNotify: '2022-07-08 17:42:44.998893 +0000 UTC',
+                lastNotifyDuration: '117.2455ms',
+                name: 'email[2]',
+              },
+            ],
+            webhook: [
+              {
+                lastError:
+                  'establish connection to server: dial tcp: lookup smtp.example.org on 8.8.8.8:53: no such host',
+                lastNotify: '2022-07-08 17:42:44.998893 +0000 UTC',
+                lastNotifyDuration: '117.2455ms',
+                name: 'webhook[0]',
+              },
+            ],
+          },
+        },
+        'contact point 2': {
+          active: true,
+          errorCount: 0,
+          integrations: {
+            email: [
+              {
+                lastNotify: '2022-07-08 17:42:44.998893 +0000 UTC',
+                lastNotifyDuration: '117.2455ms',
+                name: 'email[0]',
+              },
+            ],
+          },
+        },
+      },
+    });
+  });
+
+  //this test will be updated depending on how BE response is implemented when there is no state available for this AM
+  it('should return the expected object if response is an empty array (no state available for this AM)', () => {
+    const response: ReceiversStateDTO[] = [];
+    expect(contactPointsStateDtoToModel(response)).toStrictEqual({
+      errorCount: 0,
+      receivers: {},
+    });
   });
 });

--- a/public/app/features/alerting/unified/api/grafana.test.ts
+++ b/public/app/features/alerting/unified/api/grafana.test.ts
@@ -1,0 +1,37 @@
+import { getIntegrationType, isValidIntegrationType } from './grafana';
+
+describe('getIntegrationType method', () => {
+  it('should return the integration name when it is a valid type name with [{number}] ', () => {
+    const name = getIntegrationType('coolIntegration[1]');
+    expect(name).toBe('coolIntegration');
+
+    const name2 = getIntegrationType('coolIntegration[6767]');
+    expect(name2).toBe('coolIntegration');
+  });
+  it('should return the integration name when it is a valid type name without [{number}] ', () => {
+    const name = getIntegrationType('coolIntegration');
+    expect(name).toBe('coolIntegration');
+  });
+  it('should return undefined when it is a invalid type name ', () => {
+    const name = getIntegrationType('coolIntegration[345vadkfjgh');
+    expect(name).toBe(undefined);
+  });
+});
+describe('isValidIntegrationType method', () => {
+  it('should return true when it is a name followed with [{number}] ', () => {
+    const name = isValidIntegrationType('coolIntegration[1]');
+    expect(name).toBe(true);
+  });
+  it('should return true when it is a name without [{number}] ', () => {
+    const name = isValidIntegrationType('coolIntegration');
+    expect(name).toBe(true);
+  });
+  it('should return false when it is a name followed with [{wrong index}] ', () => {
+    const name = isValidIntegrationType('coolIntegration[1123sfsf]');
+    expect(name).toBe(false);
+  });
+  it('should return false when it is a name followed with [{index} ', () => {
+    const name = isValidIntegrationType('coolIntegration[11');
+    expect(name).toBe(false);
+  });
+});

--- a/public/app/features/alerting/unified/api/grafana.test.ts
+++ b/public/app/features/alerting/unified/api/grafana.test.ts
@@ -1,6 +1,24 @@
 import { ReceiversStateDTO } from 'app/types';
 
-import { contactPointsStateDtoToModel, getIntegrationType, isValidIntegrationType } from './grafana';
+import { contactPointsStateDtoToModel, getIntegrationType, parseIntegrationName } from './grafana';
+
+describe('parseIntegrationName method', () => {
+  it('should return the integration name and index string when it is a valid type name with [{number}] ', () => {
+    const { type, index } = parseIntegrationName('coolIntegration[1]');
+    expect(type).toBe('coolIntegration');
+    expect(index).toBe('[1]');
+  });
+  it('should return the integration name when it is a valid type name without [{number}] ', () => {
+    const { type, index } = parseIntegrationName('coolIntegration');
+    expect(type).toBe('coolIntegration');
+    expect(index).toBe(undefined);
+  });
+  it('should return name as it is and index as undefined when it is a invalid index format ', () => {
+    const { type, index } = parseIntegrationName('coolIntegration[345vadkfjgh');
+    expect(type).toBe('coolIntegration[345vadkfjgh');
+    expect(index).toBe(undefined);
+  });
+});
 
 describe('getIntegrationType method', () => {
   it('should return the integration name when it is a valid type name with [{number}] ', () => {
@@ -14,27 +32,9 @@ describe('getIntegrationType method', () => {
     const name = getIntegrationType('coolIntegration');
     expect(name).toBe('coolIntegration');
   });
-  it('should return undefined when it is a invalid type name ', () => {
+  it('should return name as it is when it is a invalid index format ', () => {
     const name = getIntegrationType('coolIntegration[345vadkfjgh');
-    expect(name).toBe(undefined);
-  });
-});
-describe('isValidIntegrationType method', () => {
-  it('should return true when it is a name followed with [{number}] ', () => {
-    const name = isValidIntegrationType('coolIntegration[1]');
-    expect(name).toBe(true);
-  });
-  it('should return true when it is a name without [{number}] ', () => {
-    const name = isValidIntegrationType('coolIntegration');
-    expect(name).toBe(true);
-  });
-  it('should return false when it is a name followed with [{wrong index}] ', () => {
-    const name = isValidIntegrationType('coolIntegration[1123sfsf]');
-    expect(name).toBe(false);
-  });
-  it('should return false when it is a name followed with [{index} ', () => {
-    const name = isValidIntegrationType('coolIntegration[11');
-    expect(name).toBe(false);
+    expect(name).toBe('coolIntegration[345vadkfjgh');
   });
 });
 

--- a/public/app/features/alerting/unified/api/grafana.ts
+++ b/public/app/features/alerting/unified/api/grafana.ts
@@ -5,10 +5,21 @@ export function fetchNotifiers(): Promise<NotifierDTO[]> {
   return getBackendSrv().get(`/api/alert-notifiers`);
 }
 
-const hasArrayIndex = (name: string) => name.indexOf('[') !== -1;
+interface IntegrationNameObject {
+  type: string;
+  index?: string;
+}
+export const parseIntegrationName = (integrationName: string): IntegrationNameObject => {
+  const matches = integrationName.match(/^(\w+)(\[\d+\])?$/);
+  if (!matches) {
+    return { type: integrationName, index: undefined };
+  }
 
-export const isValidIntegrationType = (integrationName: string): boolean =>
-  hasArrayIndex(integrationName) ? /\w(\[((\d*))])$/.test(integrationName) : true;
+  return {
+    type: matches[1],
+    index: matches[2],
+  };
+};
 
 export const contactPointsStateDtoToModel = (receiversStateDto: ReceiversStateDTO[]): ContactPointsState => {
   // init object to return
@@ -43,11 +54,7 @@ export const contactPointsStateDtoToModel = (receiversStateDto: ReceiversStateDT
 };
 
 export const getIntegrationType = (integrationName: string): string | undefined =>
-  isValidIntegrationType(integrationName)
-    ? hasArrayIndex(integrationName)
-      ? integrationName.substring(0, integrationName.indexOf('['))
-      : integrationName
-    : undefined;
+  parseIntegrationName(integrationName)?.type;
 
 export function fetchContactPointsState(alertManagerSourceName: String): Promise<ContactPointsState> {
   return new Promise<ContactPointsState>((resolve) => {

--- a/public/app/features/alerting/unified/api/grafana.ts
+++ b/public/app/features/alerting/unified/api/grafana.ts
@@ -10,7 +10,7 @@ export function fetchContactPointsState(alertManagerSourceName: String): Promise
     integrationName.indexOf('[') !== -1 ? integrationName.substring(0, integrationName.indexOf('[')) : integrationName;
 
   const contactPointsStateDtoToModel = (receiversSateDto: ReceiversStateDTO[]): ContactPointsState => {
-    //init object to return
+    // init object to return
     const contactPointpState: ContactPointsState = { receivers: {}, errorCount: 0 };
 
     // for each receiver from response

--- a/public/app/features/alerting/unified/api/grafana.ts
+++ b/public/app/features/alerting/unified/api/grafana.ts
@@ -7,7 +7,31 @@ export function fetchNotifiers(): Promise<NotifierDTO[]> {
 
 export function fetchContactPointsState(alertManagerSourceName: String): Promise<ContactPointsState> {
   return new Promise<ContactPointsState>((resolve) => {
-    const fakeState: ContactPointsState = { receivers: [], errorCount: 0 };
+    //WIP: Example of possible response:
+    // const emailInt: IntegrationState = {
+    //   ['Email']: [{
+    //     lastError: 'Error',
+    //     lastNotify:'',
+    //     lastNotifyDuration: '117.2455ms'
+    //   }]
+    // }
+    // const grafanaDefaultEmailState: ReceiverState = {
+    //   active: true,
+    //   integrations: [emailInt],
+    //   errorCount: 1
+    // }
+    // const multipleState: ReceiverState = {
+    //   active: true,
+    //   integrations: [emailInt, emailInt],
+    //   errorCount: 2
+    // }
+    // const fakeReceivers: ReceiversState = {
+    //   ['grafana-default-email']: grafanaDefaultEmailState,
+    //   ['multiple3']: multipleState
+    // }
+    // const fakeState: ContactPointsState = { receivers: fakeReceivers, errorCount: 3};
+
+    const fakeState: ContactPointsState = { receivers: {}, errorCount: 0 };
     setTimeout(() => {
       resolve(fakeState);
     }, 1000);

--- a/public/app/features/alerting/unified/api/grafana.ts
+++ b/public/app/features/alerting/unified/api/grafana.ts
@@ -7,7 +7,7 @@ export function fetchNotifiers(): Promise<NotifierDTO[]> {
 
 export function fetchContactPointsState(alertManagerSourceName: String): Promise<ContactPointsState> {
   const getIntegrationType = (integrationName: string): string =>
-    integrationName.indexOf('[') !== -1 ? integrationName.substring(0, integrationName.indexOf('[]')) : integrationName;
+    integrationName.indexOf('[') !== -1 ? integrationName.substring(0, integrationName.indexOf('[')) : integrationName;
 
   const contactPointsStateDtoToModel = (receiversSateDto: ReceiversStateDTO[]): ContactPointsState => {
     //init object to return

--- a/public/app/features/alerting/unified/api/grafana.ts
+++ b/public/app/features/alerting/unified/api/grafana.ts
@@ -1,37 +1,78 @@
 import { getBackendSrv } from '@grafana/runtime';
-import { ContactPointsState, NotifierDTO } from 'app/types';
+import { ContactPointsState, NotifierDTO, ReceiversStateDTO } from 'app/types';
 
 export function fetchNotifiers(): Promise<NotifierDTO[]> {
   return getBackendSrv().get(`/api/alert-notifiers`);
 }
 
 export function fetchContactPointsState(alertManagerSourceName: String): Promise<ContactPointsState> {
-  return new Promise<ContactPointsState>((resolve) => {
-    //WIP: Example of possible response:
-    // const emailInt: IntegrationState = {
-    //   ['Email']: [{
-    //     lastError: 'Error',
-    //     lastNotify:'',
-    //     lastNotifyDuration: '117.2455ms'
-    //   }]
-    // }
-    // const grafanaDefaultEmailState: ReceiverState = {
-    //   active: true,
-    //   integrations: [emailInt],
-    //   errorCount: 1
-    // }
-    // const multipleState: ReceiverState = {
-    //   active: true,
-    //   integrations: [emailInt, emailInt],
-    //   errorCount: 2
-    // }
-    // const fakeReceivers: ReceiversState = {
-    //   ['grafana-default-email']: grafanaDefaultEmailState,
-    //   ['multiple3']: multipleState
-    // }
-    // const fakeState: ContactPointsState = { receivers: fakeReceivers, errorCount: 3};
+  const getIntegrationType = (integrationName: string): string =>
+    integrationName.indexOf('[') !== -1 ? integrationName.substring(0, integrationName.indexOf('[]')) : integrationName;
 
-    const fakeState: ContactPointsState = { receivers: {}, errorCount: 0 };
+  const contactPointsStateDtoToModel = (receiversSateDto: ReceiversStateDTO[]): ContactPointsState => {
+    //init object to return
+    const contactPointpState: ContactPointsState = { receivers: {}, errorCount: 0 };
+
+    // for each receiver from response
+    receiversSateDto.forEach((cpState) => {
+      //init receiver state
+      contactPointpState.receivers[cpState.name] = { active: cpState.active, integrations: {}, errorCount: 0 };
+      const receiverState = contactPointpState.receivers[cpState.name];
+      //update integrations in response
+      cpState.integrations.forEach((integrationStatusDTO) => {
+        //update errorcount
+        const hasError = Boolean(integrationStatusDTO?.lastError);
+        if (hasError) {
+          receiverState.errorCount += 1;
+          contactPointpState.errorCount += 1;
+        }
+        //add integration for this type
+        const type = getIntegrationType(integrationStatusDTO.name);
+        //if type still does not exist in IntegrationsTypeState we initialize it with an empty array
+        if (!receiverState.integrations[type]) {
+          receiverState.integrations[type] = [];
+        }
+        // add error status for this type
+        receiverState.integrations[type].push(integrationStatusDTO);
+      });
+    });
+    return contactPointpState;
+  };
+  return new Promise<ContactPointsState>((resolve) => {
+    // Response EXAMPLE
+    //    const fakeResponse = [
+    //   {
+    //     "active": true, // Whether the contact point is used or not.
+    //     "integrations": [ // Can be multiple of the same type. Are identified by the index.
+    //       {
+    //         "lastError": "establish connection to server: dial tcp: lookup smtp.example.org on 8.8.8.8:53: no such host",
+    //         "lastNotify": "2022-07-08 17:42:44.998893 +0000 UTC",
+    //         "lastNotifyDuration": "117.2455ms",
+    //         "name": "email[0]"
+    //       },
+    //       {
+    //         "lastError": "establish connection to server: dial tcp: lookup smtp.example.org on 8.8.8.8:53: no such host",
+    //         "lastNotify": "2022-07-08 17:42:44.998893 +0000 UTC",
+    //         "lastNotifyDuration": "117.2455ms",
+    //         "name": "email[1]"
+    //       }
+    //     ],
+    //     "name": "multiple3"
+    //   },
+    //   {
+    //     "active": true, // Whether the contact point is used or not.
+    //     "integrations": [ // Can be multiple of the same type. Are identified by the index.
+    //       {
+    //         "lastNotify": "2022-07-08 17:42:44.998893 +0000 UTC",
+    //         "lastNotifyDuration": "117.2455ms",
+    //         "name": "email[0]"
+    //       }
+    //     ],
+    //     "name": "grafana-default-email"
+    //   },
+    // ]
+
+    const fakeState: ContactPointsState = contactPointsStateDtoToModel([]);
     setTimeout(() => {
       resolve(fakeState);
     }, 1000);

--- a/public/app/features/alerting/unified/api/grafana.ts
+++ b/public/app/features/alerting/unified/api/grafana.ts
@@ -9,22 +9,22 @@ export function fetchContactPointsState(alertManagerSourceName: String): Promise
   const getIntegrationType = (integrationName: string): string =>
     integrationName.indexOf('[') !== -1 ? integrationName.substring(0, integrationName.indexOf('[')) : integrationName;
 
-  const contactPointsStateDtoToModel = (receiversSateDto: ReceiversStateDTO[]): ContactPointsState => {
+  const contactPointsStateDtoToModel = (receiversStateDto: ReceiversStateDTO[]): ContactPointsState => {
     // init object to return
-    const contactPointpState: ContactPointsState = { receivers: {}, errorCount: 0 };
+    const contactPointsState: ContactPointsState = { receivers: {}, errorCount: 0 };
 
     // for each receiver from response
-    receiversSateDto.forEach((cpState) => {
+    receiversStateDto.forEach((cpState) => {
       //init receiver state
-      contactPointpState.receivers[cpState.name] = { active: cpState.active, integrations: {}, errorCount: 0 };
-      const receiverState = contactPointpState.receivers[cpState.name];
+      contactPointsState.receivers[cpState.name] = { active: cpState.active, integrations: {}, errorCount: 0 };
+      const receiverState = contactPointsState.receivers[cpState.name];
       //update integrations in response
       cpState.integrations.forEach((integrationStatusDTO) => {
         //update errorcount
         const hasError = Boolean(integrationStatusDTO?.lastError);
         if (hasError) {
           receiverState.errorCount += 1;
-          contactPointpState.errorCount += 1;
+          contactPointsState.errorCount += 1;
         }
         //add integration for this type
         const integrationType = getIntegrationType(integrationStatusDTO.name);
@@ -36,7 +36,7 @@ export function fetchContactPointsState(alertManagerSourceName: String): Promise
         receiverState.integrations[integrationType].push(integrationStatusDTO);
       });
     });
-    return contactPointpState;
+    return contactPointsState;
   };
   return new Promise<ContactPointsState>((resolve) => {
     // Response EXAMPLE

--- a/public/app/features/alerting/unified/api/grafana.ts
+++ b/public/app/features/alerting/unified/api/grafana.ts
@@ -27,13 +27,13 @@ export function fetchContactPointsState(alertManagerSourceName: String): Promise
           contactPointpState.errorCount += 1;
         }
         //add integration for this type
-        const type = getIntegrationType(integrationStatusDTO.name);
+        const integrationType = getIntegrationType(integrationStatusDTO.name);
         //if type still does not exist in IntegrationsTypeState we initialize it with an empty array
-        if (!receiverState.integrations[type]) {
-          receiverState.integrations[type] = [];
+        if (!receiverState.integrations[integrationType]) {
+          receiverState.integrations[integrationType] = [];
         }
         // add error status for this type
-        receiverState.integrations[type].push(integrationStatusDTO);
+        receiverState.integrations[integrationType].push(integrationStatusDTO);
       });
     });
     return contactPointpState;

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -52,6 +52,14 @@ interface Props {
   alertManagerName: string;
 }
 
+const useContactPointsState = (alertManagerName: string) => {
+  const contactPointsStateRequest = useUnifiedAlertingSelector((state) => state.contactPointsState);
+  const { result: contactPointsState } = (alertManagerName && contactPointsStateRequest) || initialAsyncRequestState;
+  const receivers = contactPointsState?.receivers ?? {};
+  const errorStateAvailable = Object.keys(receivers).length > 0; // this logic can change depending on how we implement this in the BE
+  return { contactPointsState, errorStateAvailable };
+};
+
 export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
   const dispatch = useDispatch();
   const tableStyles = useStyles2(getAlertTableStyles);
@@ -60,10 +68,7 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
   const permissions = getNotificationsPermissions(alertManagerName);
   const grafanaNotifiers = useUnifiedAlertingSelector((state) => state.grafanaNotifiers);
 
-  const contactPointsStateRequest = useUnifiedAlertingSelector((state) => state.contactPointsState);
-  const { result: contactPointsState } = (alertManagerName && contactPointsStateRequest) || initialAsyncRequestState;
-  const receivers = contactPointsState?.receivers ?? {};
-  const errorStateAvailable = Object.keys(receivers).length > 0; // this logic can change depending on how we implement this in the BE
+  const { contactPointsState, errorStateAvailable } = useContactPointsState(alertManagerName);
 
   // receiver name slated for deletion. If this is set, a confirmation modal is shown. If user approves, this receiver is deleted
   const [receiverToDelete, setReceiverToDelete] = useState<string>();

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -28,7 +28,7 @@ import { ReceiversSection } from './ReceiversSection';
 interface ReceiverErrorProps {
   errorCount: number;
 }
-const ReceiverError: FC<ReceiverErrorProps> = ({ errorCount }: ReceiverErrorProps) => {
+function ReceiverError({ errorCount }: ReceiverErrorProps) {
   const styles = useStyles2(getStyles);
   return (
     <div className={styles.warning}>
@@ -38,12 +38,12 @@ const ReceiverError: FC<ReceiverErrorProps> = ({ errorCount }: ReceiverErrorProp
       </Stack>
     </div>
   );
-};
+}
 interface ReceiverHealthProps {
   receiverName: string;
 }
 
-const ReceiverHealth: FC<ReceiverHealthProps> = ({ receiverName }) => {
+function ReceiverHealth({ receiverName }: ReceiverHealthProps) {
   const contactPointsStateRequest = useUnifiedAlertingSelector((state) => state.contactPointsState);
   const { result: contactPointsState } = contactPointsStateRequest ?? initialAsyncRequestState;
   const receiverState: ReceiverState | undefined = contactPointsState?.receivers[receiverName];
@@ -53,7 +53,7 @@ const ReceiverHealth: FC<ReceiverHealthProps> = ({ receiverName }) => {
   } else {
     return <div>OK</div>;
   }
-};
+}
 
 interface Props {
   config: AlertManagerCortexConfig;

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -107,7 +107,7 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
   );
 
   const errorsByReceiver = (contactPointsState: ContactPointsState, receiverName: string) =>
-    contactPointsState?.receivers[receiverName]?.errorCount ?? 0;
+    contactPointsState.receivers[receiverName]?.errorCount ?? 0;
 
   return (
     <ReceiversSection

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -4,8 +4,7 @@ import React, { FC, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Stack } from '@grafana/experimental';
-import { Button, ConfirmModal, Modal, useStyles2, Icon } from '@grafana/ui';
+import { Button, ConfirmModal, Modal, useStyles2, Badge } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 import { ContactPointsState } from 'app/types';
@@ -29,14 +28,13 @@ interface ReceiverErrorProps {
   errorCount: number;
 }
 function ReceiverError({ errorCount }: ReceiverErrorProps) {
-  const styles = useStyles2(getStyles);
   return (
-    <div className={styles.warning}>
-      <Stack alignItems="center">
-        <Icon name="exclamation-triangle" />
-        <div className={styles.countMessage}>{`${errorCount} ${pluralize('error', errorCount)}`}</div>
-      </Stack>
-    </div>
+    <Badge
+      color="orange"
+      icon="exclamation-triangle"
+      text={`${errorCount} ${pluralize('error', errorCount)}`}
+      tooltip={`${errorCount} ${pluralize('error', errorCount)} detected in this contact point`}
+    />
   );
 }
 interface ReceiverHealthProps {
@@ -44,7 +42,11 @@ interface ReceiverHealthProps {
 }
 
 function ReceiverHealth({ errorsByReceiver }: ReceiverHealthProps) {
-  return errorsByReceiver > 0 ? <ReceiverError errorCount={errorsByReceiver} /> : <div>OK</div>;
+  return errorsByReceiver > 0 ? (
+    <ReceiverError errorCount={errorsByReceiver} />
+  ) : (
+    <Badge color="green" text="OK" tooltip="No errors detected" />
+  );
 }
 
 interface Props {

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -46,9 +46,9 @@ interface ReceiverHealthProps {
 const ReceiverHealth: FC<ReceiverHealthProps> = ({ receiverName }) => {
   const contactPointsStateRequest = useUnifiedAlertingSelector((state) => state.contactPointsState);
   const { result: contactPointsState } = contactPointsStateRequest ?? initialAsyncRequestState;
-  if (contactPointsState?.errorCount ?? 0 > 0) {
-    const receiverState: ReceiverState | undefined = contactPointsState?.receivers[receiverName];
-    const errorsByReceiver = receiverState?.errorCount ?? 0;
+  const receiverState: ReceiverState | undefined = contactPointsState?.receivers[receiverName];
+  const errorsByReceiver = receiverState?.errorCount ?? 0;
+  if (errorsByReceiver > 0) {
     return <ReceiverError errorCount={errorsByReceiver} />;
   } else {
     return <div>OK</div>;

--- a/public/app/types/alerting.ts
+++ b/public/app/types/alerting.ts
@@ -143,19 +143,19 @@ export interface NotificationChannelState {
 }
 
 export interface IntegrationError {
-  lastError: string;
+  lastError: null | string;
   lastNotify: string;
-  lastNotifyDuration: number;
-  name: string;
+  lastNotifyDuration: string;
 }
 
 export interface IntegrationState {
-  [key: string]: IntegrationError;
+  [key: string]: IntegrationError[]; // key is the integration name
 }
 
 export interface ReceiverState {
   active: boolean;
   integrations: IntegrationState[];
+  errorCount: number; // errors by receiver
 }
 
 export interface ReceiversState {
@@ -163,7 +163,7 @@ export interface ReceiversState {
 }
 
 export interface ContactPointsState {
-  receivers: ReceiversState[];
+  receivers: ReceiversState;
   errorCount: number;
 }
 

--- a/public/app/types/alerting.ts
+++ b/public/app/types/alerting.ts
@@ -142,15 +142,15 @@ export interface NotificationChannelState {
   notificationChannel: any;
 }
 
-export interface IntegrationError {
-  lastError: null | string;
+export interface IntegrationStatus {
+  lastError?: null | string;
   lastNotify: string;
   lastNotifyDuration: string;
   name: string;
 }
 
 export interface IntegrationTypesState {
-  [key: string]: IntegrationError[]; // key is the integration type
+  [key: string]: IntegrationStatus[]; // key is the integration type
 }
 
 export interface ReceiverState {
@@ -170,7 +170,7 @@ export interface ContactPointsState {
 
 export interface ReceiversStateDTO {
   active: boolean;
-  integrations: IntegrationError[];
+  integrations: IntegrationStatus[];
   name: string;
 }
 export interface AlertRulesState {

--- a/public/app/types/alerting.ts
+++ b/public/app/types/alerting.ts
@@ -146,15 +146,16 @@ export interface IntegrationError {
   lastError: null | string;
   lastNotify: string;
   lastNotifyDuration: string;
+  name: string;
 }
 
-export interface IntegrationState {
-  [key: string]: IntegrationError[]; // key is the integration name
+export interface IntegrationTypesState {
+  [key: string]: IntegrationError[]; // key is the integration type
 }
 
 export interface ReceiverState {
   active: boolean;
-  integrations: IntegrationState[];
+  integrations: IntegrationTypesState;
   errorCount: number; // errors by receiver
 }
 
@@ -167,11 +168,11 @@ export interface ContactPointsState {
   errorCount: number;
 }
 
-export interface ContactPointStateDTO {
+export interface ReceiversStateDTO {
   active: boolean;
   integrations: IntegrationError[];
+  name: string;
 }
-
 export interface AlertRulesState {
   items: AlertRule[];
   searchQuery: string;


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a health column in contact point list in case selected alert manager has error state api available.

If there is no errors in this contact point integrations, value for this column is OK
If there is any error in this contact point integrations, value for this column will be an error message with the number of errors for this type of contact point.

<img width="1119" alt="Screenshot 2022-07-20 at 13 36 07" src="https://user-images.githubusercontent.com/33540275/179973379-0cf238dd-ebd4-451d-b5ef-d180f960e568.png">


**Special notes for your reviewer**:
This PR still relies on a 'fake' enpoint response until we have the actual one available.
Info about the response we are going to get: https://gist.github.com/gotjosh/641362540acb8c01efca398a22ed395a
This PR also adds a method to convert dto response to the type we need for the Redux store.