### PR TITLE
Alerting: use static channel configuration to determinate secure fields

### DIFF
--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/guardian"
-	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels_config"
 	"github.com/grafana/grafana/pkg/services/search"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
@@ -198,7 +198,7 @@ func (hs *HTTPServer) GetAlert(c *models.ReqContext) response.Response {
 func (hs *HTTPServer) GetAlertNotifiers(ngalertEnabled bool) func(*models.ReqContext) response.Response {
 	return func(_ *models.ReqContext) response.Response {
 		if ngalertEnabled {
-			return response.JSON(http.StatusOK, notifier.GetAvailableNotifiers())
+			return response.JSON(http.StatusOK, channels_config.GetAvailableNotifiers())
 		}
 		// TODO(codesome): This wont be required in 8.0 since ngalert
 		// will be enabled by default with no disabling. This is to be removed later.

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels_config"
 )
 
 // swagger:route GET /api/v1/provisioning/contact-points provisioning stable RouteGetContactpoints
@@ -119,7 +119,7 @@ func (e *EmbeddedContactPoint) Valid(decryptFunc channels.GetDecryptedValueFn) e
 }
 
 func (e *EmbeddedContactPoint) SecretKeys() ([]string, error) {
-	notifiers := notifier.GetAvailableNotifiers()
+	notifiers := channels_config.GetAvailableNotifiers()
 	for _, n := range notifiers {
 		if n.Name == e.Type {
 			secureFields := []string{}

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels"
 )
 
@@ -118,43 +119,17 @@ func (e *EmbeddedContactPoint) Valid(decryptFunc channels.GetDecryptedValueFn) e
 }
 
 func (e *EmbeddedContactPoint) SecretKeys() ([]string, error) {
-	switch e.Type {
-	case "alertmanager":
-		return []string{"basicAuthPassword"}, nil
-	case "dingding":
-		return []string{}, nil
-	case "discord":
-		return []string{}, nil
-	case "email":
-		return []string{}, nil
-	case "googlechat":
-		return []string{}, nil
-	case "kafka":
-		return []string{}, nil
-	case "line":
-		return []string{"token"}, nil
-	case "opsgenie":
-		return []string{"apiKey"}, nil
-	case "pagerduty":
-		return []string{"integrationKey"}, nil
-	case "pushover":
-		return []string{"userKey", "apiToken"}, nil
-	case "sensugo":
-		return []string{"apiKey"}, nil
-	case "slack":
-		return []string{"url", "token"}, nil
-	case "teams":
-		return []string{}, nil
-	case "telegram":
-		return []string{"bottoken"}, nil
-	case "threema":
-		return []string{"api_secret"}, nil
-	case "victorops":
-		return []string{}, nil
-	case "webhook":
-		return []string{}, nil
-	case "wecom":
-		return []string{"url"}, nil
+	notifiers := notifier.GetAvailableNotifiers()
+	for _, n := range notifiers {
+		if n.Name == e.Type {
+			secureFields := []string{}
+			for _, field := range n.Options {
+				if field.Secure {
+					secureFields = append(secureFields, field.PropertyName)
+				}
+			}
+			return secureFields, nil
+		}
 	}
 	return nil, fmt.Errorf("no secrets configured for type '%s'", e.Type)
 }

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
@@ -121,7 +121,7 @@ func (e *EmbeddedContactPoint) Valid(decryptFunc channels.GetDecryptedValueFn) e
 func (e *EmbeddedContactPoint) SecretKeys() ([]string, error) {
 	notifiers := channels_config.GetAvailableNotifiers()
 	for _, n := range notifiers {
-		if n.Name == e.Type {
+		if n.Type == e.Type {
 			secureFields := []string{}
 			for _, field := range n.Options {
 				if field.Secure {

--- a/pkg/services/ngalert/notifier/channels/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels/available_channels.go
@@ -1,8 +1,7 @@
-package notifier
+package channels
 
 import (
 	"github.com/grafana/grafana/pkg/services/alerting"
-	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels"
 )
 
 // GetAvailableNotifiers returns the metadata of all the notification channels that can be configured.
@@ -901,15 +900,15 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 					Element: alerting.ElementTypeSelect,
 					SelectOptions: []alerting.SelectOption{
 						{
-							Value: channels.OpsgenieSendTags,
+							Value: OpsgenieSendTags,
 							Label: "Tags",
 						},
 						{
-							Value: channels.OpsgenieSendDetails,
+							Value: OpsgenieSendDetails,
 							Label: "Extra Properties",
 						},
 						{
-							Value: channels.OpsgenieSendBoth,
+							Value: OpsgenieSendBoth,
 							Label: "Tags & Extra Properties",
 						},
 					},

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -1,7 +1,8 @@
-package channels
+package channels_config
 
 import (
 	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels"
 )
 
 // GetAvailableNotifiers returns the metadata of all the notification channels that can be configured.
@@ -900,15 +901,15 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 					Element: alerting.ElementTypeSelect,
 					SelectOptions: []alerting.SelectOption{
 						{
-							Value: OpsgenieSendTags,
+							Value: channels.OpsgenieSendTags,
 							Label: "Tags",
 						},
 						{
-							Value: OpsgenieSendDetails,
+							Value: channels.OpsgenieSendDetails,
 							Label: "Extra Properties",
 						},
 						{
-							Value: OpsgenieSendBoth,
+							Value: channels.OpsgenieSendBoth,
 							Label: "Tags & Extra Properties",
 						},
 					},

--- a/pkg/tests/api/alerting/api_available_channel_test.go
+++ b/pkg/tests/api/alerting/api_available_channel_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels_config"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 )
@@ -44,7 +44,7 @@ func TestAvailableChannels(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode)
 
-	expNotifiers := notifier.GetAvailableNotifiers()
+	expNotifiers := channels_config.GetAvailableNotifiers()
 	expJson, err := json.Marshal(expNotifiers)
 	require.NoError(t, err)
 	require.Equal(t, string(expJson), string(b))


### PR DESCRIPTION
Currently, we use a static map that needs to be extended every time we add a new secure field to the channel definition. This is very hard to maintain. Instead of this static map, we now leverage the static channel configuration that we have and extract the secure fields from there.