### PR TITLE
Access control: Show dashboard settings to users who can edit dashboard

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -205,7 +205,7 @@ export class DashboardModel implements TimeModel {
     meta.canEdit = meta.canEdit !== false;
     meta.canDelete = meta.canDelete !== false;
 
-    meta.showSettings = meta.canSave;
+    meta.showSettings = meta.canEdit;
     meta.canMakeEditable = meta.canSave && !this.editable;
     meta.hasUnsavedFolderChange = false;
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When `viewers_can_edit` is set, viewers should be able to access dashboard settings, but we introduced a bug when enabling RBAC for dashboards that changed this.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/50148

