### PR TITLE
github: add issues to logs-squad based on labels

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -140,18 +140,10 @@
   },
   {
     "type":"label",
-    "name":"datasource/OpenSearch",
-    "action":"addToProject",
-    "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/110"
-    }
-  },
-  {
-    "type":"label",
     "name":"datasource/Loki",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/110"
+      "url":"https://github.com/orgs/grafana/projects/203"
     }
   },
   {
@@ -167,7 +159,7 @@
     "name":"datasource/Elasticsearch",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/110"
+      "url":"https://github.com/orgs/grafana/projects/203"
     }
   },
   {


### PR DESCRIPTION
loki and elasticsearch issues should be auto-assigned to a different squad now.
i also removed the opensearch-rule, because there is no such label in `grafana/grafana` (opensearch lives in a separate repo.