### PR TITLE
Alerting: take datasources as external alertmanagers into consideration

### DIFF
--- a/pkg/services/datasources/fakes/fake_datasource_service.go
+++ b/pkg/services/datasources/fakes/fake_datasource_service.go
@@ -49,6 +49,9 @@ func (s *FakeDataSourceService) GetAllDataSources(ctx context.Context, query *da
 
 func (s *FakeDataSourceService) GetDataSourcesByType(ctx context.Context, query *datasources.GetDataSourcesByTypeQuery) error {
 	for _, datasource := range s.DataSources {
+		if query.OrgId > 0 && datasource.OrgId != query.OrgId {
+			continue
+		}
 		typeMatch := query.Type != "" && query.Type == datasource.Type
 		if typeMatch {
 			query.Result = append(query.Result, datasource)

--- a/pkg/services/datasources/models.go
+++ b/pkg/services/datasources/models.go
@@ -165,6 +165,7 @@ type GetAllDataSourcesQuery struct {
 }
 
 type GetDataSourcesByTypeQuery struct {
+	OrgId  int64 // optional: filter by org_id
 	Type   string
 	Result []*DataSource
 }

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -62,6 +62,7 @@ type AlertingStore interface {
 type API struct {
 	Cfg                  *setting.Cfg
 	DatasourceCache      datasources.CacheService
+	DatasourceService    datasources.DataSourceService
 	RouteRegister        routing.RouteRegister
 	ExpressionService    *expr.Service
 	QuotaService         quota.Service
@@ -130,6 +131,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 		}), m)
 	api.RegisterConfigurationApiEndpoints(NewConfiguration(
 		&ConfigSrv{
+			datasourceService:    api.DatasourceService,
 			store:                api.AdminConfigStore,
 			log:                  logger,
 			alertmanagerProvider: api.AlertsRouter,

--- a/pkg/services/ngalert/api/api_configuration.go
+++ b/pkg/services/ngalert/api/api_configuration.go
@@ -1,12 +1,16 @@
 package api
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
@@ -16,6 +20,7 @@ import (
 )
 
 type ConfigSrv struct {
+	datasourceService    datasources.DataSourceService
 	alertmanagerProvider ExternalAlertmanagerProvider
 	store                store.AdminConfigurationStore
 	log                  log.Logger
@@ -68,11 +73,17 @@ func (srv ConfigSrv) RoutePostNGalertConfig(c *models.ReqContext, body apimodels
 
 	sendAlertsTo, err := ngmodels.StringToAlertmanagersChoice(string(body.AlertmanagersChoice))
 	if err != nil {
-		return response.Error(400, "Invalid alertmanager choice specified", nil)
+		return response.Error(400, "Invalid alertmanager choice specified", err)
 	}
 
-	if sendAlertsTo == ngmodels.ExternalAlertmanagers && len(body.Alertmanagers) == 0 {
-		return response.Error(400, "At least one Alertmanager must be provided to choose this option", nil)
+	externalAlertmanagers, err := srv.externalAlertmanagers(c.Req.Context(), c.OrgId)
+	if err != nil {
+		return response.Error(500, "Couldn't fetch the external Alertmanagers from datasources", err)
+	}
+
+	if sendAlertsTo == ngmodels.ExternalAlertmanagers &&
+		len(body.Alertmanagers)+len(externalAlertmanagers) < 1 {
+		return response.Error(400, "At least one Alertmanager must be provided or configured as a datasource that handles alerts to choose this option", nil)
 	}
 
 	cfg := &ngmodels.AdminConfiguration{
@@ -109,4 +120,26 @@ func (srv ConfigSrv) RouteDeleteNGalertConfig(c *models.ReqContext) response.Res
 	}
 
 	return response.JSON(http.StatusOK, util.DynMap{"message": "admin configuration deleted"})
+}
+
+// externalAlertmanagers returns the URL of any external alertmanager that is
+// configured as datasource. The URL does not contain any auth.
+func (srv ConfigSrv) externalAlertmanagers(ctx context.Context, orgID int64) ([]string, error) {
+	var alertmanagers []string
+	query := &datasources.GetDataSourcesByTypeQuery{
+		OrgId: orgID,
+		Type:  datasources.DS_ALERTMANAGER,
+	}
+	err := srv.datasourceService.GetDataSourcesByType(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch datasources for org: %w", err)
+	}
+	for _, ds := range query.Result {
+		if ds.JsonData.Get(definitions.HandleGrafanaManagedAlerts).MustBool(false) {
+			// we don't need to build the exact URL as we only need
+			// to know if any is set
+			alertmanagers = append(alertmanagers, ds.Uid)
+		}
+	}
+	return alertmanagers, nil
 }

--- a/pkg/services/ngalert/api/api_configuration.go
+++ b/pkg/services/ngalert/api/api_configuration.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/datasources"
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
@@ -135,7 +134,7 @@ func (srv ConfigSrv) externalAlertmanagers(ctx context.Context, orgID int64) ([]
 		return nil, fmt.Errorf("failed to fetch datasources for org: %w", err)
 	}
 	for _, ds := range query.Result {
-		if ds.JsonData.Get(definitions.HandleGrafanaManagedAlerts).MustBool(false) {
+		if ds.JsonData.Get(apimodels.HandleGrafanaManagedAlerts).MustBool(false) {
 			// we don't need to build the exact URL as we only need
 			// to know if any is set
 			alertmanagers = append(alertmanagers, ds.Uid)

--- a/pkg/services/ngalert/api/api_configuration_test.go
+++ b/pkg/services/ngalert/api/api_configuration_test.go
@@ -1,0 +1,117 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	fakeDatasources "github.com/grafana/grafana/pkg/services/datasources/fakes"
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalAlertmanagerChoice(t *testing.T) {
+	tests := []struct {
+		name               string
+		alertmanagerChoice definitions.AlertmanagersChoice
+		alertmanagers      []string
+		datasources        []*datasources.DataSource
+		statusCode         int
+		message            string
+	}{
+		{
+			name:               "setting the choice to external by passing a plain url should succeed",
+			alertmanagerChoice: definitions.ExternalAlertmanagers,
+			alertmanagers:      []string{"http://localhost:9000"},
+			datasources:        []*datasources.DataSource{},
+			statusCode:         http.StatusCreated,
+			message:            "admin configuration updated",
+		},
+		{
+			name:               "setting the choice to external by having a enabled external am datasource should succeed",
+			alertmanagerChoice: definitions.ExternalAlertmanagers,
+			alertmanagers:      []string{},
+			datasources: []*datasources.DataSource{
+				{
+					OrgId: 1,
+					Type:  datasources.DS_ALERTMANAGER,
+					Url:   "http://localhost:9000",
+					JsonData: simplejson.NewFromAny(map[string]interface{}{
+						definitions.HandleGrafanaManagedAlerts: true,
+					}),
+				},
+			},
+			statusCode: http.StatusCreated,
+			message:    "admin configuration updated",
+		},
+		{
+			name:               "setting the choice to external by having a disabled external am datasource should fail",
+			alertmanagerChoice: definitions.ExternalAlertmanagers,
+			alertmanagers:      []string{},
+			datasources: []*datasources.DataSource{
+				{
+					OrgId:    1,
+					Type:     datasources.DS_ALERTMANAGER,
+					Url:      "http://localhost:9000",
+					JsonData: simplejson.NewFromAny(map[string]interface{}{}),
+				},
+			},
+			statusCode: http.StatusBadRequest,
+			message:    "At least one Alertmanager must be provided or configured as a datasource that handles alerts to choose this option",
+		},
+		{
+			name:               "setting the choice to external and having no am configured should fail",
+			alertmanagerChoice: definitions.ExternalAlertmanagers,
+			alertmanagers:      []string{},
+			datasources:        []*datasources.DataSource{},
+			statusCode:         http.StatusBadRequest,
+			message:            "At least one Alertmanager must be provided or configured as a datasource that handles alerts to choose this option",
+		},
+		{
+			name:               "setting the choice to all and having no external am configured should succeed",
+			alertmanagerChoice: definitions.AllAlertmanagers,
+			alertmanagers:      []string{},
+			datasources:        []*datasources.DataSource{},
+			statusCode:         http.StatusCreated,
+			message:            "admin configuration updated",
+		},
+		{
+			name:               "setting the choice to internal should always succeed",
+			alertmanagerChoice: definitions.InternalAlertmanager,
+			alertmanagers:      []string{},
+			datasources:        []*datasources.DataSource{},
+			statusCode:         http.StatusCreated,
+			message:            "admin configuration updated",
+		},
+	}
+	ctx := createRequestCtxInOrg(1)
+	ctx.OrgRole = models.ROLE_ADMIN
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sut := createAPIAdminSut(t, test.datasources)
+			resp := sut.RoutePostNGalertConfig(ctx, definitions.PostableNGalertConfig{
+				Alertmanagers:       test.alertmanagers,
+				AlertmanagersChoice: test.alertmanagerChoice,
+			})
+			var res map[string]interface{}
+			err := json.Unmarshal(resp.Body(), &res)
+			require.NoError(t, err)
+			require.Equal(t, test.message, res["message"])
+			require.Equal(t, test.statusCode, resp.Status())
+		})
+	}
+}
+
+func createAPIAdminSut(t *testing.T,
+	datasources []*datasources.DataSource) ConfigSrv {
+	return ConfigSrv{
+		datasourceService: &fakeDatasources.FakeDataSourceService{
+			DataSources: datasources,
+		},
+		store: store.NewFakeAdminConfigStore(t),
+	}
+}

--- a/pkg/services/ngalert/api/tooling/definitions/admin.go
+++ b/pkg/services/ngalert/api/tooling/definitions/admin.go
@@ -58,9 +58,10 @@ type NGalertConfig struct {
 type AlertmanagersChoice string
 
 const (
-	AllAlertmanagers      AlertmanagersChoice = "all"
-	InternalAlertmanager  AlertmanagersChoice = "internal"
-	ExternalAlertmanagers AlertmanagersChoice = "external"
+	AllAlertmanagers           AlertmanagersChoice = "all"
+	InternalAlertmanager       AlertmanagersChoice = "internal"
+	ExternalAlertmanagers      AlertmanagersChoice = "external"
+	HandleGrafanaManagedAlerts                     = "handleGrafanaManagedAlerts"
 )
 
 // swagger:model

--- a/pkg/services/ngalert/sender/router_test.go
+++ b/pkg/services/ngalert/sender/router_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
-	"github.com/grafana/grafana/pkg/services/secrets/fakes"
 	fake_secrets "github.com/grafana/grafana/pkg/services/secrets/fakes"
 	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
 	"github.com/grafana/grafana/pkg/setting"
@@ -350,7 +349,7 @@ func createMultiOrgAlertmanager(t *testing.T, orgs []int64) *notifier.MultiOrgAl
 	kvStore := notifier.NewFakeKVStore(t)
 	registry := prometheus.NewPedanticRegistry()
 	m := metrics.NewNGAlert(registry)
-	secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
+	secretsService := secretsManager.SetupTestService(t, fake_secrets.NewFakeSecretsStore())
 	decryptFn := secretsService.GetDecryptedValue
 	moa, err := notifier.NewMultiOrgAlertmanager(cfg, &cfgStore, &orgStore, kvStore, provisioning.NewFakeProvisioningStore(), decryptFn, m.GetMultiOrgAlertmanagerMetrics(), nil, log.New("testlogger"), secretsService)
 	require.NoError(t, err)
@@ -369,7 +368,7 @@ func createMultiOrgAlertmanager(t *testing.T, orgs []int64) *notifier.MultiOrgAl
 
 func TestBuildExternalURL(t *testing.T) {
 	sch := AlertsRouter{
-		secretService: fakes.NewFakeSecretsService(),
+		secretService: fake_secrets.NewFakeSecretsService(),
 	}
 	tests := []struct {
 		name        string

--- a/pkg/services/ngalert/tests/util.go
+++ b/pkg/services/ngalert/tests/util.go
@@ -63,7 +63,7 @@ func SetupTestEnv(t *testing.T, baseInterval time.Duration) (*ngalert.AlertNG, *
 	)
 
 	ng, err := ngalert.ProvideService(
-		cfg, nil, routing.NewRouteRegister(), sqlStore, nil, nil, nil, nil,
+		cfg, nil, nil, routing.NewRouteRegister(), sqlStore, nil, nil, nil, nil,
 		secretsService, nil, m, folderService, ac, &dashboards.FakeDashboardService{}, nil, bus,
 	)
 	require.NoError(t, err)

--- a/pkg/services/sqlstore/datasource.go
+++ b/pkg/services/sqlstore/datasource.go
@@ -76,6 +76,9 @@ func (ss *SQLStore) GetDataSourcesByType(ctx context.Context, query *datasources
 
 	query.Result = make([]*datasources.DataSource, 0)
 	return ss.WithDbSession(ctx, func(sess *DBSession) error {
+		if query.OrgId > 0 {
+			return sess.Where("type=? AND org_id=?", query.Type, query.OrgId).Asc("id").Find(&query.Result)
+		}
 		return sess.Where("type=?", query.Type).Asc("id").Find(&query.Result)
 	})
 }

--- a/pkg/tests/api/alerting/api_admin_configuration_test.go
+++ b/pkg/tests/api/alerting/api_admin_configuration_test.go
@@ -108,7 +108,7 @@ func TestAdminConfiguration_SendingToExternalAlertmanagers(t *testing.T) {
 		var res map[string]interface{}
 		err = json.Unmarshal(b, &res)
 		require.NoError(t, err)
-		require.Equal(t, "At least one Alertmanager must be provided to choose this option", res["message"])
+		require.Equal(t, "At least one Alertmanager must be provided or configured as a datasource that handles alerts to choose this option", res["message"])
 	}
 
 	// Now, lets re-set external Alertmanagers for main organisation

--- a/pkg/tests/api/alerting/api_admin_configuration_test.go
+++ b/pkg/tests/api/alerting/api_admin_configuration_test.go
@@ -84,7 +84,10 @@ func TestAdminConfiguration_SendingToExternalAlertmanagers(t *testing.T) {
 		resp := postRequest(t, alertsURL, buf.String(), http.StatusBadRequest) // nolint
 		b, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
-		require.JSONEq(t, `{"message": "Invalid alertmanager choice specified"}`, string(b))
+		var res map[string]interface{}
+		err = json.Unmarshal(b, &res)
+		require.NoError(t, err)
+		require.Equal(t, "Invalid alertmanager choice specified", res["message"])
 	}
 
 	// Let's try to send all the alerts to an external Alertmanager
@@ -102,7 +105,10 @@ func TestAdminConfiguration_SendingToExternalAlertmanagers(t *testing.T) {
 		resp := postRequest(t, alertsURL, buf.String(), http.StatusBadRequest) // nolint
 		b, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
-		require.JSONEq(t, `{"message": "At least one Alertmanager must be provided to choose this option"}`, string(b))
+		var res map[string]interface{}
+		err = json.Unmarshal(b, &res)
+		require.NoError(t, err)
+		require.Equal(t, "At least one Alertmanager must be provided to choose this option", res["message"])
 	}
 
 	// Now, lets re-set external Alertmanagers for main organisation
@@ -121,7 +127,10 @@ func TestAdminConfiguration_SendingToExternalAlertmanagers(t *testing.T) {
 		resp := postRequest(t, alertsURL, buf.String(), http.StatusCreated) // nolint
 		b, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
-		require.JSONEq(t, `{"message": "admin configuration updated"}`, string(b))
+		var res map[string]interface{}
+		err = json.Unmarshal(b, &res)
+		require.NoError(t, err)
+		require.Equal(t, "admin configuration updated", res["message"])
 	}
 
 	// If we get the configuration again, it shows us what we've set.
@@ -220,7 +229,10 @@ func TestAdminConfiguration_SendingToExternalAlertmanagers(t *testing.T) {
 		resp := postRequest(t, alertsURL, buf.String(), http.StatusCreated) // nolint
 		b, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
-		require.JSONEq(t, "{\"message\": \"admin configuration updated\"}", string(b))
+		var res map[string]interface{}
+		err = json.Unmarshal(b, &res)
+		require.NoError(t, err)
+		require.Equal(t, "admin configuration updated", res["message"])
 	}
 
 	// If we get the configuration again, it shows us what we've set.


### PR DESCRIPTION
Same PR as #52404, just adapted to the new alert router that was created in the meantime. Rebasing was too much of an effort so I created a new PR.