### PR TITLE
PanelEditor: Allow selection of repeated data source variable from datasource picker

### DIFF
--- a/packages/grafana-runtime/src/services/dataSourceSrv.ts
+++ b/packages/grafana-runtime/src/services/dataSourceSrv.ts
@@ -19,7 +19,7 @@ export interface DataSourceSrv {
   /**
    * Get a list of data sources
    */
-  getList(filters?: GetDataSourceListFilters): DataSourceInstanceSettings[];
+  getList(filters?: GetDataSourceListFilters, repeatVariableName?: string): DataSourceInstanceSettings[];
 
   /**
    * Get settings and plugin metadata by name or uid

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -26,7 +26,7 @@ import { PanelModelWithLibraryPanel } from 'app/features/library-panels/types';
 import { getPanelStateForModel } from 'app/features/panel/state/selectors';
 import { updateTimeZoneForSession } from 'app/features/profile/state/reducers';
 import { StoreState } from 'app/types';
-import { PanelOptionsChangedEvent, ShowModalReactEvent } from 'app/types/events';
+import { PanelConfigChangedEvent, PanelOptionsChangedEvent, ShowModalReactEvent } from 'app/types/events';
 
 import { notifyApp } from '../../../../core/actions';
 import { UnlinkModal } from '../../../library-panels/components/UnlinkModal/UnlinkModal';
@@ -108,6 +108,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
     if (initDone && !this.eventSubs) {
       this.eventSubs = new Subscription();
       this.eventSubs.add(panel.events.subscribe(PanelOptionsChangedEvent, this.triggerForceUpdate));
+      this.eventSubs.add(panel.events.subscribe(PanelConfigChangedEvent, this.triggerForceUpdate));
     }
   }
 
@@ -194,9 +195,9 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
   };
 
   onPanelConfigChanged = (configKey: keyof PanelModel, value: any) => {
+    // we do not need to trigger force update here as the function call below
+    // fires PanelConfigChangedEvent which we subscribe to above
     this.props.panel.setProperty(configKey, value);
-    this.props.panel.render();
-    this.forceUpdate();
   };
 
   onDisplayModeChange = (mode?: DisplayMode) => {

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -22,6 +22,7 @@ import config from 'app/core/config';
 import { getNextRefIdChar } from 'app/core/utils/query';
 import { QueryGroupOptions } from 'app/types';
 import {
+  PanelConfigChangedEvent,
   PanelOptionsChangedEvent,
   PanelQueriesChangedEvent,
   PanelTransformationsChangedEvent,
@@ -607,6 +608,9 @@ export class PanelModel implements DataConfigSource, IPanelModel {
         delete this.maxPerRow;
       }
     }
+
+    this.events.publish(new PanelConfigChangedEvent());
+    this.render();
   }
 
   replaceVariables(value: string, extraVars: ScopedVars | undefined, format?: string | Function) {

--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -202,7 +202,7 @@ export class DatasourceSrv implements DataSourceService {
     return Object.values(this.settingsMapByName);
   }
 
-  getList(filters: GetDataSourceListFilters = {}): DataSourceInstanceSettings[] {
+  getList(filters: GetDataSourceListFilters = {}, repeatVariableName?: string): DataSourceInstanceSettings[] {
     const base = Object.values(this.settingsMapByName).filter((x) => {
       if (x.meta.id === 'grafana' || x.meta.id === 'mixed' || x.meta.id === 'dashboard') {
         return false;
@@ -246,10 +246,18 @@ export class DatasourceSrv implements DataSourceService {
 
     if (filters.variables) {
       for (const variable of this.templateSrv.getVariables()) {
-        if (!isDataSource(variable) || variable.multi || variable.includeAll) {
+        if (!isDataSource(variable)) {
           continue;
         }
-        const dsName = variable.current.value === 'default' ? this.defaultName : variable.current.value;
+
+        const isRepeatVar = repeatVariableName === variable.name;
+
+        if (!isRepeatVar && (variable.multi || variable.includeAll)) {
+          continue;
+        }
+
+        const value = isRepeatVar ? variable.options.slice(-1)[0].value : variable.current.value;
+        const dsName = value === 'default' ? this.defaultName : value;
         const dsSettings = !Array.isArray(dsName) && this.settingsMapByName[dsName];
 
         if (dsSettings) {

--- a/public/app/features/query/components/QueryEditorRowHeader.test.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.test.tsx
@@ -1,11 +1,13 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
+import { Provider } from 'react-redux';
 import { openMenu } from 'react-select-event';
 
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
+import { configureStore } from 'app/store/configureStore';
 
 import { Props, QueryEditorRowHeader } from './QueryEditorRowHeader';
 
@@ -106,8 +108,14 @@ function renderScenario(overrides: Partial<Props>) {
 
   Object.assign(props, overrides);
 
+  const store = configureStore({});
+
   return {
     props,
-    renderResult: render(<QueryEditorRowHeader {...props} />),
+    renderResult: render(
+      <Provider store={store}>
+        <QueryEditorRowHeader {...props} />
+      </Provider>
+    ),
   };
 }

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -117,6 +117,10 @@ export class PanelOptionsChangedEvent extends BusEventBase {
   static type = 'panels-options-changed';
 }
 
+export class PanelConfigChangedEvent extends BusEventBase {
+  static type = 'panel-config-changed';
+}
+
 /**
  * Used internally by DashboardModel to commmunicate with DashboardGrid that it needs to re-render
  */


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows the repeated data source variable for a panel to be used from the panel editor's datasource pickers.

**Which issue(s) this PR fixes**:
Closes #52084

**Special notes for your reviewer**:
Not especially keen on the flow of data with this solution, so I might iterate on this in search of a better design

@JoaoSilvaGrafana @lpskdl Ended up re-doing a lot of this to fix some issues with the datasource picker options not being refresh when choosing or disabling a repeat var. :(
