### PR TITLE
Alerting: use static channel configuration to determinate secure fields

### DIFF
--- a/pkg/api/alerting.go
+++ b/pkg/api/alerting.go
@@ -12,7 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
 	"github.com/grafana/grafana/pkg/services/guardian"
-	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels_config"
 	"github.com/grafana/grafana/pkg/services/search"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
@@ -197,7 +197,7 @@ func (hs *HTTPServer) GetAlert(c *models.ReqContext) response.Response {
 func (hs *HTTPServer) GetAlertNotifiers(ngalertEnabled bool) func(*models.ReqContext) response.Response {
 	return func(_ *models.ReqContext) response.Response {
 		if ngalertEnabled {
-			return response.JSON(http.StatusOK, notifier.GetAvailableNotifiers())
+			return response.JSON(http.StatusOK, channels_config.GetAvailableNotifiers())
 		}
 		// TODO(codesome): This wont be required in 8.0 since ngalert
 		// will be enabled by default with no disabling. This is to be removed later.

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_contactpoints.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels_config"
 )
 
 // swagger:route GET /api/v1/provisioning/contact-points provisioning stable RouteGetContactpoints
@@ -118,43 +119,17 @@ func (e *EmbeddedContactPoint) Valid(decryptFunc channels.GetDecryptedValueFn) e
 }
 
 func (e *EmbeddedContactPoint) SecretKeys() ([]string, error) {
-	switch e.Type {
-	case "alertmanager":
-		return []string{"basicAuthPassword"}, nil
-	case "dingding":
-		return []string{}, nil
-	case "discord":
-		return []string{}, nil
-	case "email":
-		return []string{}, nil
-	case "googlechat":
-		return []string{}, nil
-	case "kafka":
-		return []string{}, nil
-	case "line":
-		return []string{"token"}, nil
-	case "opsgenie":
-		return []string{"apiKey"}, nil
-	case "pagerduty":
-		return []string{"integrationKey"}, nil
-	case "pushover":
-		return []string{"userKey", "apiToken"}, nil
-	case "sensugo":
-		return []string{"apiKey"}, nil
-	case "slack":
-		return []string{"url", "token"}, nil
-	case "teams":
-		return []string{}, nil
-	case "telegram":
-		return []string{"bottoken"}, nil
-	case "threema":
-		return []string{"api_secret"}, nil
-	case "victorops":
-		return []string{}, nil
-	case "webhook":
-		return []string{}, nil
-	case "wecom":
-		return []string{"url"}, nil
+	notifiers := channels_config.GetAvailableNotifiers()
+	for _, n := range notifiers {
+		if n.Type == e.Type {
+			secureFields := []string{}
+			for _, field := range n.Options {
+				if field.Secure {
+					secureFields = append(secureFields, field.PropertyName)
+				}
+			}
+			return secureFields, nil
+		}
 	}
 	return nil, fmt.Errorf("no secrets configured for type '%s'", e.Type)
 }

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -1,4 +1,4 @@
-package notifier
+package channels_config
 
 import (
 	"github.com/grafana/grafana/pkg/services/alerting"

--- a/pkg/tests/api/alerting/api_available_channel_test.go
+++ b/pkg/tests/api/alerting/api_available_channel_test.go
@@ -11,7 +11,8 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/channels_config"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 )
 
@@ -47,7 +48,7 @@ func TestAvailableChannels(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode)
 
-	expNotifiers := notifier.GetAvailableNotifiers()
+	expNotifiers := channels_config.GetAvailableNotifiers()
 	expJson, err := json.Marshal(expNotifiers)
 	require.NoError(t, err)
 	require.Equal(t, string(expJson), string(b))


### PR DESCRIPTION
manual backport of (#52527)

* Alerting: use static channel configuration to determinate secure fields

* move to channels package

* introduce channel_config package to fix cyclic import

* add missing changes

* compare type to type

(cherry picked from commit ba9c18d9c37a4f9836daeaf37f5e1d9533decbf2)

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

