### PR TITLE
Apps: Fixes navigation between different app plugin pages

### DIFF
--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -80,9 +80,7 @@ class AppRootPage extends Component<Props, State> {
     const { params } = this.props.match;
 
     if (prevProps.match.params.pluginId !== params.pluginId) {
-      this.setState({
-        loading: true,
-      });
+      this.setState({ loading: true, plugin: null });
       this.loadPluginSettings();
     }
   }


### PR DESCRIPTION

App plugins have nested react routers with default routes. When you try to navigate from one app page to another plugin page the
plugin re-renders while the new one is loading triggering the router to redirect to plugin home so you never end up on the page of the new plugin page.


