### PR TITLE
TopNav: Keyboard shortcut to toggle topnav on or off

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -3,7 +3,7 @@ import Mousetrap from 'mousetrap';
 import 'mousetrap-global-bind';
 import 'mousetrap/plugins/global-bind/mousetrap-global-bind';
 import { LegacyGraphHoverClearEvent, locationUtil } from '@grafana/data';
-import { locationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import appEvents from 'app/core/app_events';
 import { getExploreUrl } from 'app/core/utils/explore';
 import { SaveDashboardDrawer } from 'app/features/dashboard/components/SaveDashboard/SaveDashboardDrawer';
@@ -47,6 +47,7 @@ export class KeybindingSrv {
 
     this.bind('t t', () => toggleTheme(false));
     this.bind('t r', () => toggleTheme(true));
+    this.bind('t n', () => this.toggleNav());
   }
 
   globalEsc() {
@@ -73,6 +74,12 @@ export class KeybindingSrv {
 
     // ok no focused input or editor that should block this, let exist!
     this.exit();
+  }
+
+  toggleNav() {
+    window.location.href = locationUtil.getUrlForPartial(locationService.getLocation(), {
+      '__feature.topnav': (!config.featureToggles.topnav).toString(),
+    });
   }
 
   private openSearch() {

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -47,7 +47,10 @@ export class KeybindingSrv {
 
     this.bind('t t', () => toggleTheme(false));
     this.bind('t r', () => toggleTheme(true));
-    this.bind('t n', () => this.toggleNav());
+
+    if (process.env.NODE_ENV === 'development') {
+      this.bind('t n', () => this.toggleNav());
+    }
   }
 
   globalEsc() {


### PR DESCRIPTION
Find myself adding `?__feature.topnav=false` or `&__feature.topnav=false` to
the URL to test in old nav, and then switch back.


This adds a keyboard shortcut `t n` that toggles topnav on or off
to help speed up development of the topnav change.
