### PR TITLE
Traces: Align APM table names

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -8479,8 +8479,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "14"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "15"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "16"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "17"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "18"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "17"]
     ],
     "public/app/plugins/datasource/tempo/language_provider.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -511,21 +511,18 @@ describe('Tempo apm table', () => {
     ];
     const objToAlign = {
       'HTTP GET - root': {
-        name: 'HTTP GET - root',
-        value: 0.2724936652307618,
+        value: 0.1234,
       },
       'HTTP GET': {
-        name: 'HTTP GET',
-        value: 0.2724936652307618,
+        value: 0.6789,
       },
       'HTTP POST - post': {
-        name: 'HTTP POST - post',
-        value: 0.03697421858453128,
+        value: 0.4321,
       },
     };
 
     let value = getRateAlignedValues(resp, objToAlign as any);
-    expect(value.toString()).toBe('0,0.2724936652307618,0.2724936652307618,0,0.03697421858453128');
+    expect(value.toString()).toBe('0,0.6789,0.1234,0,0.4321');
   });
 
   it('should make apm request correctly', () => {

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -692,10 +692,10 @@ function getApmTable(
     const errorRateValues = errorRate[0].fields[2]?.values.toArray() ?? [];
     let errorRateObj: any = {};
     errorRateNames.map((name: string, index: number) => {
-      errorRateObj[name] = { name: name, value: errorRateValues[index] };
+      errorRateObj[name] = { value: errorRateValues[index] };
     });
 
-    const values = getRateAlignedValues(rate, errorRateObj);
+    const values = getRateAlignedValues({ ...rate }, errorRateObj);
 
     df.fields.push({
       ...errorRate[0].fields[2],
@@ -736,13 +736,13 @@ function getApmTable(
     duration.map((d) => {
       const delimiter = d.refId?.includes('span_name=~"') ? 'span_name=~"' : 'span_name="';
       const name = d.refId?.split(delimiter)[1].split('"}')[0];
-      durationObj[name] = { name: name, value: d.fields[1].values.toArray()[0] };
+      durationObj[name] = { value: d.fields[1].values.toArray()[0] };
     });
 
     df.fields.push({
       ...duration[0].fields[1],
       name: 'Duration (p90)',
-      values: getRateAlignedValues(rate, durationObj),
+      values: getRateAlignedValues({ ...rate }, durationObj),
       config: {
         links: [
           makePromLink(
@@ -802,26 +802,14 @@ export function getRateAlignedValues(
   rateResp: DataQueryResponseData[],
   objToAlign: { [x: string]: { value: string } }
 ) {
-  const rateNames = rateResp[0]?.fields[1]?.values.toArray().sort() ?? [];
-  let tempRateNames = rateNames;
+  const rateNames = rateResp[0]?.fields[1]?.values.toArray() ?? [];
   let values: string[] = [];
 
-  objToAlign = Object.keys(objToAlign)
-    .sort()
-    .reduce((obj: any, key) => {
-      obj[key] = objToAlign[key];
-      return obj;
-    }, {});
-
   for (let i = 0; i < rateNames.length; i++) {
-    if (tempRateNames[i]) {
-      if (tempRateNames[i] === Object.keys(objToAlign)[i]) {
-        values.push(objToAlign[Object.keys(objToAlign)[i]].value);
-      } else {
-        i--;
-        tempRateNames = tempRateNames.slice(1);
-        values.push('0');
-      }
+    if (Object.keys(objToAlign).includes(rateNames[i])) {
+      values.push(objToAlign[rateNames[i]].value);
+    } else {
+      values.push('0');
     }
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that all col values are ordered according to rate names order. We first query for the rate and order the first three columns based on that order. The remaining columns (errorRate and duration) must be ordered according to the first 3 columns. When querying for the errorRate and duration there is no guarantee that the results will come back in the same order as they did for the rate query.