### PR TITLE
Chore: remove `UseState` from `ColorPicker` story

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1368,8 +1368,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "packages/grafana-ui/src/components/ColorPicker/ColorPicker.story.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "packages/grafana-ui/src/components/ColorPicker/ColorPicker.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -1367,9 +1367,6 @@ exports[`better eslint`] = {
     "packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.story.internal.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "packages/grafana-ui/src/components/ColorPicker/ColorPicker.story.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "packages/grafana-ui/src/components/ColorPicker/ColorPicker.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/packages/grafana-ui/src/components/ColorPicker/ColorPicker.story.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/ColorPicker.story.tsx
@@ -1,10 +1,10 @@
 import { action } from '@storybook/addon-actions';
+import { useArgs } from '@storybook/client-api';
 import { Meta, Story } from '@storybook/react';
 import React from 'react';
 
 import { SeriesColorPicker, ColorPicker } from '@grafana/ui';
 
-import { UseState } from '../../utils/storybook/UseState';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 import { renderComponentWithTheme } from '../../utils/storybook/withTheme';
 
@@ -22,66 +22,58 @@ export default {
       page: mdx,
     },
     controls: {
-      exclude: ['color', 'onChange', 'onColorChange'],
+      exclude: ['onChange', 'onColorChange'],
     },
   },
   args: {
     enableNamedColors: false,
+    color: '#00ff00',
   },
 } as Meta;
 
-export const Basic: Story<ColorPickerProps> = ({ enableNamedColors }) => {
+export const Basic: Story<ColorPickerProps> = ({ color, enableNamedColors }) => {
+  const [, updateArgs] = useArgs();
+  return renderComponentWithTheme(ColorPicker, {
+    enableNamedColors,
+    color,
+    onChange: (color: string) => {
+      action('Color changed')(color);
+      updateArgs({ color });
+    },
+  });
+};
+
+export const SeriesPicker: Story<ColorPickerProps> = ({ color, enableNamedColors }) => {
+  const [, updateArgs] = useArgs();
   return (
-    <UseState initialState="#00ff00">
-      {(selectedColor, updateSelectedColor) => {
-        return renderComponentWithTheme(ColorPicker, {
-          enableNamedColors,
-          color: selectedColor,
-          onChange: (color: any) => {
-            action('Color changed')(color);
-            updateSelectedColor(color);
-          },
-        });
+    <SeriesColorPicker
+      enableNamedColors={enableNamedColors}
+      yaxis={1}
+      onToggleAxis={() => {}}
+      color={color}
+      onChange={(color) => {
+        action('Color changed')(color);
+        updateArgs({ color });
       }}
-    </UseState>
+    >
+      {({ ref, showColorPicker, hideColorPicker }) => (
+        <div ref={ref} onMouseLeave={hideColorPicker} onClick={showColorPicker} style={{ color, cursor: 'pointer' }}>
+          Open color picker
+        </div>
+      )}
+    </SeriesColorPicker>
   );
 };
 
-export const SeriesPicker: Story<ColorPickerProps> = ({ enableNamedColors }) => {
+export const Input: Story<ColorPickerInputProps> = ({ color }) => {
+  const [, updateArgs] = useArgs();
   return (
-    <UseState initialState="#00ff00">
-      {(selectedColor, updateSelectedColor) => {
-        return (
-          <SeriesColorPicker
-            enableNamedColors={enableNamedColors}
-            yaxis={1}
-            onToggleAxis={() => {}}
-            color={selectedColor}
-            onChange={(color) => updateSelectedColor(color)}
-          >
-            {({ ref, showColorPicker, hideColorPicker }) => (
-              <div
-                ref={ref}
-                onMouseLeave={hideColorPicker}
-                onClick={showColorPicker}
-                style={{ color: selectedColor, cursor: 'pointer' }}
-              >
-                Open color picker
-              </div>
-            )}
-          </SeriesColorPicker>
-        );
+    <ColorPickerInput
+      value={color}
+      onChange={(color) => {
+        action('Color changed')(color);
+        updateArgs({ color });
       }}
-    </UseState>
-  );
-};
-
-export const Input: Story<ColorPickerInputProps> = () => {
-  return (
-    <UseState initialState="#ffffff">
-      {(value, onChange) => {
-        return <ColorPickerInput value={value} onChange={onChange} />;
-      }}
-    </UseState>
+    />
   );
 };

--- a/packages/grafana-ui/src/components/ColorPicker/ColorPicker.story.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/ColorPicker.story.tsx
@@ -12,7 +12,7 @@ import mdx from './ColorPicker.mdx';
 import { ColorPickerInput, ColorPickerInputProps } from './ColorPickerInput';
 import { ColorPickerProps } from './ColorPickerPopover';
 
-export default {
+const meta: Meta = {
   title: 'Pickers and Editors/ColorPicker',
   component: ColorPicker,
   subcomponents: { SeriesColorPicker, ColorPickerInput },
@@ -29,7 +29,7 @@ export default {
     enableNamedColors: false,
     color: '#00ff00',
   },
-} as Meta;
+};
 
 export const Basic: Story<ColorPickerProps> = ({ color, enableNamedColors }) => {
   const [, updateArgs] = useArgs();
@@ -77,3 +77,5 @@ export const Input: Story<ColorPickerInputProps> = ({ color }) => {
     />
   );
 };
+
+export default meta;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- removes `UseState` in favour of using storybook's client-api
- this hooks up the state to the control allowing changes to happen in both places
- see https://github.com/storybookjs/storybook/issues/3855#issuecomment-660158622

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

