### PR TITLE
Chore: remove `UseState` from `SpectrumPalette` story

### DIFF
--- a/packages/grafana-ui/src/components/ColorPicker/SpectrumPalette.story.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/SpectrumPalette.story.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
+import { action } from '@storybook/addon-actions';
+import { useArgs } from '@storybook/client-api';
+import { Meta, Story } from '@storybook/react';
 
-import { UseState } from '../../utils/storybook/UseState';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 import { renderComponentWithTheme } from '../../utils/storybook/withTheme';
 
 import mdx from './ColorPicker.mdx';
-import SpectrumPalette from './SpectrumPalette';
+import SpectrumPalette, { SpectrumPaletteProps } from './SpectrumPalette';
 
-export default {
+const meta: Meta = {
   title: 'Pickers and Editors/ColorPicker/Palettes/SpectrumPalette',
   component: SpectrumPalette,
   decorators: [withCenteredStory],
@@ -15,15 +16,24 @@ export default {
     docs: {
       page: mdx,
     },
+    controls: {
+      exclude: ['onChange'],
+    },
+  },
+  args: {
+    color: 'red',
   },
 };
 
-export const simple = () => {
-  return (
-    <UseState initialState="red">
-      {(selectedColor, updateSelectedColor) => {
-        return renderComponentWithTheme(SpectrumPalette, { color: selectedColor, onChange: updateSelectedColor });
-      }}
-    </UseState>
-  );
+export const Simple: Story<SpectrumPaletteProps> = ({ color }) => {
+  const [, updateArgs] = useArgs();
+  return renderComponentWithTheme(SpectrumPalette, {
+    color,
+    onChange: (color: string) => {
+      action('Color changed')(color);
+      updateArgs({ color });
+    },
+  });
 };
+
+export default meta;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- removes `UseState` in favour of using storybook's client-api
- this hooks up the state to the control allowing changes to happen in both places
- see https://github.com/storybookjs/storybook/issues/3855#issuecomment-660158622

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

