### PR TITLE
Chore: add support for controls in `DataSourceHttpSettings` story

### DIFF
--- a/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.story.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/DataSourceHttpSettings.story.tsx
@@ -1,11 +1,13 @@
+import { action } from '@storybook/addon-actions';
+import { useArgs } from '@storybook/client-api';
+import { Meta, Story } from '@storybook/react';
 import React from 'react';
 
 import { DataSourceSettings } from '@grafana/data';
 
-import { UseState } from '../../utils/storybook/UseState';
-
 import { DataSourceHttpSettings } from './DataSourceHttpSettings';
 import mdx from './DataSourceHttpSettings.mdx';
+import { HttpSettingsProps } from './types';
 
 const settingsMock: DataSourceSettings<any, any> = {
   id: 4,
@@ -36,29 +38,34 @@ const settingsMock: DataSourceSettings<any, any> = {
   readOnly: true,
 };
 
-export default {
+const meta: Meta = {
   title: 'Data Source/DataSourceHttpSettings',
   component: DataSourceHttpSettings,
   parameters: {
+    controls: {
+      exclude: ['onChange'],
+    },
     docs: {
       page: mdx,
     },
   },
+  args: {
+    dataSourceConfig: settingsMock,
+    defaultUrl: 'http://localhost:9999',
+  },
 };
 
-export const basic = () => {
+export const Basic: Story<HttpSettingsProps> = (args) => {
+  const [, updateArgs] = useArgs();
   return (
-    <UseState initialState={settingsMock} logState>
-      {(dataSourceSettings, updateDataSourceSettings) => {
-        return (
-          <DataSourceHttpSettings
-            defaultUrl="http://localhost:9999"
-            dataSourceConfig={dataSourceSettings}
-            onChange={updateDataSourceSettings}
-            showAccessOptions={true}
-          />
-        );
+    <DataSourceHttpSettings
+      {...args}
+      onChange={(change: typeof settingsMock) => {
+        action('onChange')(change);
+        updateArgs({ dataSourceConfig: change });
       }}
-    </UseState>
+    />
   );
 };
+
+export default meta;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- adds controls support
- removes `UseState` in favour of using storybook's client-api
- this hooks up the state to the control allowing changes to happen in both places
- see https://github.com/storybookjs/storybook/issues/3855#issuecomment-660158622

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/52617

**Special notes for your reviewer**:

