### PR TITLE
Service account: Ensure that you can revert only service accounts which you can access

### DIFF
--- a/docs/sources/developers/http_api/serviceaccount.md
+++ b/docs/sources/developers/http_api/serviceaccount.md
@@ -138,9 +138,9 @@ Content-Type: application/json
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action               | Scope                |
-| -------------------- | -------------------- |
-| serviceaccounts:read | serviceaccounts:id:1 |
+| Action               | Scope                 |
+| -------------------- | --------------------- |
+| serviceaccounts:read | serviceaccounts:id:\* |
 
 **Example Request**:
 
@@ -179,9 +179,9 @@ Content-Type: application/json
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action                | Scope                |
-| --------------------- | -------------------- |
-| serviceaccounts:write | serviceaccounts:id:1 |
+| Action                | Scope                 |
+| --------------------- | --------------------- |
+| serviceaccounts:write | serviceaccounts:id:\* |
 
 **Example Request**:
 
@@ -227,9 +227,9 @@ Content-Type: application/json
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action               | Scope                |
-| -------------------- | -------------------- |
-| serviceaccounts:read | serviceaccounts:id:1 |
+| Action               | Scope                 |
+| -------------------- | --------------------- |
+| serviceaccounts:read | serviceaccounts:id:\* |
 
 **Example Request**:
 
@@ -267,9 +267,9 @@ Content-Type: application/json
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action                | Scope                |
-| --------------------- | -------------------- |
-| serviceaccounts:write | serviceaccounts:id:1 |
+| Action                | Scope                 |
+| --------------------- | --------------------- |
+| serviceaccounts:write | serviceaccounts:id:\* |
 
 **Example Request**:
 
@@ -306,9 +306,9 @@ Content-Type: application/json
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action                | Scope                |
-| --------------------- | -------------------- |
-| serviceaccounts:write | serviceaccounts:id:1 |
+| Action                | Scope                 |
+| --------------------- | --------------------- |
+| serviceaccounts:write | serviceaccounts:id:\* |
 
 **Example Request**:
 
@@ -332,7 +332,7 @@ Content-Type: application/json
 
 ## Revert service account token to API key
 
-`DELETE /api/serviceaccounts/revert/:keyId`
+`DELETE /api/serviceaccounts/:serviceAccountId/revert/:keyId`
 
 This operation will delete the service account and create a legacy API Key for the given `keyId`.
 
@@ -340,14 +340,14 @@ This operation will delete the service account and create a legacy API Key for t
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action                 | Scope |
-| ---------------------- | ----- |
-| serviceaccounts:delete | n/a   |
+| Action                 | Scope                 |
+| ---------------------- | --------------------- |
+| serviceaccounts:delete | serviceaccounts:id:\* |
 
 **Example Request**:
 
 ```http
-DELETE /api/serviceaccounts/revert/glsa_VVQjot0nijQ59lun6pMZRtsdBXxnFQ9M_77c34a79 HTTP/1.1
+DELETE /api/serviceaccounts/1/revert/glsa_VVQjot0nijQ59lun6pMZRtsdBXxnFQ9M_77c34a79 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
 Authorization: Basic YWRtaW46YWRtaW4=

--- a/docs/sources/developers/http_api/serviceaccount.md
+++ b/docs/sources/developers/http_api/serviceaccount.md
@@ -140,7 +140,7 @@ See note in the [introduction]({{< ref "#service-account-api" >}}) for an explan
 
 | Action               | Scope                 |
 | -------------------- | --------------------- |
-| serviceaccounts:read | serviceaccounts:id:\* |
+| serviceaccounts:read | serviceaccounts:id:* |
 
 **Example Request**:
 
@@ -181,7 +181,7 @@ See note in the [introduction]({{< ref "#service-account-api" >}}) for an explan
 
 | Action                | Scope                 |
 | --------------------- | --------------------- |
-| serviceaccounts:write | serviceaccounts:id:\* |
+| serviceaccounts:write | serviceaccounts:id:* |
 
 **Example Request**:
 
@@ -229,7 +229,7 @@ See note in the [introduction]({{< ref "#service-account-api" >}}) for an explan
 
 | Action               | Scope                 |
 | -------------------- | --------------------- |
-| serviceaccounts:read | serviceaccounts:id:\* |
+| serviceaccounts:read | serviceaccounts:id:* |
 
 **Example Request**:
 
@@ -269,7 +269,7 @@ See note in the [introduction]({{< ref "#service-account-api" >}}) for an explan
 
 | Action                | Scope                 |
 | --------------------- | --------------------- |
-| serviceaccounts:write | serviceaccounts:id:\* |
+| serviceaccounts:write | serviceaccounts:id:* |
 
 **Example Request**:
 
@@ -308,7 +308,7 @@ See note in the [introduction]({{< ref "#service-account-api" >}}) for an explan
 
 | Action                | Scope                 |
 | --------------------- | --------------------- |
-| serviceaccounts:write | serviceaccounts:id:\* |
+| serviceaccounts:write | serviceaccounts:id:* |
 
 **Example Request**:
 
@@ -340,9 +340,9 @@ This operation will delete the service account and create a legacy API Key for t
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action                 | Scope                 |
-| ---------------------- | --------------------- |
-| serviceaccounts:delete | serviceaccounts:id:\* |
+| Action                 | Scope                  |
+| ---------------------- |------------------------|
+| serviceaccounts:delete | serviceaccounts:id:*   |
 
 **Example Request**:
 

--- a/docs/sources/developers/http_api/serviceaccount.md
+++ b/docs/sources/developers/http_api/serviceaccount.md
@@ -138,8 +138,8 @@ Content-Type: application/json
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action               | Scope                 |
-| -------------------- | --------------------- |
+| Action               | Scope                |
+| -------------------- |----------------------|
 | serviceaccounts:read | serviceaccounts:id:* |
 
 **Example Request**:
@@ -179,8 +179,8 @@ Content-Type: application/json
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action                | Scope                 |
-| --------------------- | --------------------- |
+| Action                | Scope                |
+| --------------------- |----------------------|
 | serviceaccounts:write | serviceaccounts:id:* |
 
 **Example Request**:
@@ -227,8 +227,8 @@ Content-Type: application/json
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action               | Scope                 |
-| -------------------- | --------------------- |
+| Action               | Scope                |
+| -------------------- |----------------------|
 | serviceaccounts:read | serviceaccounts:id:* |
 
 **Example Request**:
@@ -267,8 +267,8 @@ Content-Type: application/json
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action                | Scope                 |
-| --------------------- | --------------------- |
+| Action                | Scope                |
+| --------------------- |----------------------|
 | serviceaccounts:write | serviceaccounts:id:* |
 
 **Example Request**:
@@ -307,8 +307,8 @@ Content-Type: application/json
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
 | Action                | Scope                 |
-| --------------------- | --------------------- |
-| serviceaccounts:write | serviceaccounts:id:* |
+| --------------------- |-----------------------|
+| serviceaccounts:write | serviceaccounts:id:*  |
 
 **Example Request**:
 
@@ -340,9 +340,9 @@ This operation will delete the service account and create a legacy API Key for t
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action                 | Scope                  |
-| ---------------------- |------------------------|
-| serviceaccounts:delete | serviceaccounts:id:*   |
+| Action                 | Scope                 |
+| ---------------------- |-----------------------|
+| serviceaccounts:delete | serviceaccounts:id:*  |
 
 **Example Request**:
 

--- a/docs/sources/developers/http_api/serviceaccount.md
+++ b/docs/sources/developers/http_api/serviceaccount.md
@@ -138,9 +138,9 @@ Content-Type: application/json
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action               | Scope                |
-| -------------------- |----------------------|
-| serviceaccounts:read | serviceaccounts:id:* |
+| Action               | Scope                 |
+| -------------------- | --------------------- |
+| serviceaccounts:read | serviceaccounts:id:\* |
 
 **Example Request**:
 
@@ -179,9 +179,9 @@ Content-Type: application/json
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action                | Scope                |
-| --------------------- |----------------------|
-| serviceaccounts:write | serviceaccounts:id:* |
+| Action                | Scope                 |
+| --------------------- | --------------------- |
+| serviceaccounts:write | serviceaccounts:id:\* |
 
 **Example Request**:
 
@@ -227,9 +227,9 @@ Content-Type: application/json
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action               | Scope                |
-| -------------------- |----------------------|
-| serviceaccounts:read | serviceaccounts:id:* |
+| Action               | Scope                 |
+| -------------------- | --------------------- |
+| serviceaccounts:read | serviceaccounts:id:\* |
 
 **Example Request**:
 
@@ -267,9 +267,9 @@ Content-Type: application/json
 
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
-| Action                | Scope                |
-| --------------------- |----------------------|
-| serviceaccounts:write | serviceaccounts:id:* |
+| Action                | Scope                 |
+| --------------------- | --------------------- |
+| serviceaccounts:write | serviceaccounts:id:\* |
 
 **Example Request**:
 
@@ -307,8 +307,8 @@ Content-Type: application/json
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
 | Action                | Scope                 |
-| --------------------- |-----------------------|
-| serviceaccounts:write | serviceaccounts:id:*  |
+| --------------------- | --------------------- |
+| serviceaccounts:write | serviceaccounts:id:\* |
 
 **Example Request**:
 
@@ -341,8 +341,8 @@ This operation will delete the service account and create a legacy API Key for t
 See note in the [introduction]({{< ref "#service-account-api" >}}) for an explanation.
 
 | Action                 | Scope                 |
-| ---------------------- |-----------------------|
-| serviceaccounts:delete | serviceaccounts:id:*  |
+| ---------------------- | --------------------- |
+| serviceaccounts:delete | serviceaccounts:id:\* |
 
 **Example Request**:
 

--- a/pkg/services/serviceaccounts/database/database.go
+++ b/pkg/services/serviceaccounts/database/database.go
@@ -463,7 +463,7 @@ func (s *ServiceAccountsStoreImpl) CreateServiceAccountFromApikey(ctx context.Co
 }
 
 // RevertApiKey converts service account token to old API key
-func (s *ServiceAccountsStoreImpl) RevertApiKey(ctx context.Context, keyId int64) error {
+func (s *ServiceAccountsStoreImpl) RevertApiKey(ctx context.Context, saId int64, keyId int64) error {
 	query := models.GetApiKeyByIdQuery{ApiKeyId: keyId}
 	if err := s.sqlStore.GetApiKeyById(ctx, &query); err != nil {
 		return err
@@ -472,6 +472,10 @@ func (s *ServiceAccountsStoreImpl) RevertApiKey(ctx context.Context, keyId int64
 
 	if key.ServiceAccountId == nil {
 		return fmt.Errorf("API key is not service account token")
+	}
+
+	if *key.ServiceAccountId != saId {
+		return ErrServiceAccountAndTokenMismatch
 	}
 
 	tokens, err := s.ListTokens(ctx, key.OrgId, *key.ServiceAccountId)

--- a/pkg/services/serviceaccounts/database/errors.go
+++ b/pkg/services/serviceaccounts/database/errors.go
@@ -5,8 +5,9 @@ import (
 )
 
 var (
-	ErrServiceAccountAlreadyExists = errors.New("service account already exists")
-	ErrServiceAccountTokenNotFound = errors.New("service account token not found")
-	ErrInvalidTokenExpiration      = errors.New("invalid SecondsToLive value")
-	ErrDuplicateToken              = errors.New("service account token with given name already exists in the organization")
+	ErrServiceAccountAlreadyExists    = errors.New("service account already exists")
+	ErrServiceAccountTokenNotFound    = errors.New("service account token not found")
+	ErrInvalidTokenExpiration         = errors.New("invalid SecondsToLive value")
+	ErrDuplicateToken                 = errors.New("service account token with given name already exists in the organization")
+	ErrServiceAccountAndTokenMismatch = errors.New("API token does not belong to the given service account")
 )

--- a/pkg/services/serviceaccounts/serviceaccounts.go
+++ b/pkg/services/serviceaccounts/serviceaccounts.go
@@ -26,7 +26,7 @@ type Store interface {
 	HideApiKeysTab(ctx context.Context, orgID int64) error
 	MigrateApiKeysToServiceAccounts(ctx context.Context, orgID int64) error
 	MigrateApiKey(ctx context.Context, orgID int64, keyId int64) error
-	RevertApiKey(ctx context.Context, keyId int64) error
+	RevertApiKey(ctx context.Context, saId int64, keyId int64) error
 	ListTokens(ctx context.Context, orgID int64, serviceAccount int64) ([]*models.ApiKey, error)
 	DeleteServiceAccountToken(ctx context.Context, orgID, serviceAccountID, tokenID int64) error
 	AddServiceAccountToken(ctx context.Context, serviceAccountID int64, cmd *AddServiceAccountTokenCommand) error

--- a/pkg/services/serviceaccounts/tests/common.go
+++ b/pkg/services/serviceaccounts/tests/common.go
@@ -174,7 +174,7 @@ func (s *ServiceAccountsStoreMock) MigrateApiKey(ctx context.Context, orgID int6
 	return nil
 }
 
-func (s *ServiceAccountsStoreMock) RevertApiKey(ctx context.Context, keyId int64) error {
+func (s *ServiceAccountsStoreMock) RevertApiKey(ctx context.Context, saId int64, keyId int64) error {
 	s.Calls.RevertApiKey = append(s.Calls.RevertApiKey, []interface{}{ctx})
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When reverting a service account token to an API key, we just required to have the `serviceaccount:delete` action, without scope this would mean that you could essentially revert an API key and delete service account without having an access to.

This PR adds serviceAccountId to the route params and double checks that the API key you are trying to delete is indeed attached to the service account you have an access to.