### PR TITLE
Geomap: Fix tooltip offset bug

### DIFF
--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -369,8 +369,8 @@ export class GeomapPanel extends Component<Props, State> {
     const hover = toLonLat(this.map.getCoordinateFromPixel(pixel));
 
     const { hoverPayload } = this;
-    hoverPayload.pageX = mouse.pageX;
-    hoverPayload.pageY = mouse.pageY;
+    hoverPayload.pageX = mouse.offsetX;
+    hoverPayload.pageY = mouse.offsetY;
     hoverPayload.point = {
       lat: hover[1],
       lon: hover[0],


### PR DESCRIPTION
What this PR does / why we need it:
Tooltip offset is incorrect.

Before
![before](https://user-images.githubusercontent.com/22381771/180304193-c2d9ea46-62cb-4113-87e8-13b4bc19e1f1.png)

After 
![after](https://user-images.githubusercontent.com/22381771/180304217-aa097e7b-a0e5-4f63-82dc-a00d4ee9f5c9.png)

