### PR TITLE
Add plugins to the list of resources that have fixed roles

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/_index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/_index.md
@@ -84,6 +84,7 @@ Assign fixed roles when the basic roles do not meet your permission requirements
 - [LDAP]({{< relref "../../../setup-grafana/configure-security/configure-authentication/ldap/" >}})
 - [Licenses]({{< relref "../../stats-and-license/" >}})
 - [Organizations]({{< relref "../../organization-management/" >}})
+- [Plugins]({{< relref "../../plugin-management/" >}})
 - [Provisioning]({{< relref "../../provisioning/" >}})
 - [Reports]({{< relref "../../../enterprise/reporting/" >}})
 - [Roles]({{< relref "../../" >}})


### PR DESCRIPTION
Add plugins to the list of resources that have fixed roles, including a link. This is a quick followup to https://github.com/grafana/grafana/pull/52542.