### PR TITLE
Chore: Resolve unnecessary complexity in `lib.star` for `upload-packages` step 

### DIFF
--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -975,14 +975,6 @@ def upload_packages_step(edition, ver_mode, trigger=None):
     if ver_mode == 'main' and edition in ('enterprise', 'enterprise2'):
         return None
 
-    if ver_mode == 'release':
-        cmd = './bin/grabpl upload-packages --edition {}'.format(edition)
-    elif edition == 'enterprise2':
-        cmd = './bin/grabpl upload-packages --edition {}'.format(
-            edition)
-    else:
-        cmd = './bin/grabpl upload-packages --edition {}'.format(edition)
-
     deps = []
     if edition in 'enterprise2' or not end_to_end_tests_deps(edition):
         deps.extend([
@@ -999,7 +991,7 @@ def upload_packages_step(edition, ver_mode, trigger=None):
             'GCP_KEY': from_secret('gcp_key'),
             'PRERELEASE_BUCKET': from_secret('prerelease_bucket'),
         },
-        'commands': [cmd, ],
+        'commands': ['./bin/grabpl upload-packages --edition {}'.format(edition),],
     }
     if trigger and ver_mode in ("release-branch", "main"):
         step.update(trigger)


### PR DESCRIPTION
**What this PR does / why we need it**:

No-op.

There is a condition which handles three different cases, but the commands for all three of those are the same. Can be removed for simplicity.
