### PR TITLE
Loki: Add unwrap with conversion function to builder

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -326,7 +326,7 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       params: [
         { name: 'Identifier', type: 'string', hideName: true, minWidth: 16, placeholder: 'Label key' },
         {
-          name: 'Conversion operator',
+          name: 'Conversion function',
           hideName: true,
           type: 'string',
           options: ['duration', 'duration_seconds', 'bytes'],
@@ -342,7 +342,11 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
       addOperationHandler: addLokiOperation,
       explainHandler: (op) => {
         let label = String(op.params[0]).length > 0 ? op.params[0] : '<label>';
-        return `Use the extracted label \`${label}\` as sample values instead of log lines for the subsequent range aggregation.`;
+        return `Use the extracted label \`${label}\` as sample values instead of log lines for the subsequent range aggregation.${
+          op.params[1]
+            ? ` Conversion function \`${op.params[1]}\` wrapping \`${label}\` will attempt to convert this label from a specific format (e.g. 3k, 500ms).`
+            : ''
+        }`;
       },
     },
     ...binaryScalarOperations,

--- a/public/app/plugins/datasource/loki/querybuilder/operations.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/operations.ts
@@ -323,12 +323,22 @@ export function getOperationDefinitions(): QueryBuilderOperationDef[] {
     {
       id: LokiOperationId.Unwrap,
       name: 'Unwrap',
-      params: [{ name: 'Identifier', type: 'string', hideName: true, minWidth: 16, placeholder: 'Label key' }],
-      defaultParams: [''],
+      params: [
+        { name: 'Identifier', type: 'string', hideName: true, minWidth: 16, placeholder: 'Label key' },
+        {
+          name: 'Conversion operator',
+          hideName: true,
+          type: 'string',
+          options: ['duration', 'duration_seconds', 'bytes'],
+          optional: true,
+        },
+      ],
+      defaultParams: ['', ''],
       alternativesKey: 'format',
       category: LokiVisualQueryOperationCategory.Formats,
       orderRank: LokiOperationOrder.Unwrap,
-      renderer: (op, def, innerExpr) => `${innerExpr} | unwrap ${op.params[0]}`,
+      renderer: (op, def, innerExpr) =>
+        `${innerExpr} | unwrap ${op.params[1] ? `${op.params[1]}(${op.params[0]})` : op.params[0]}`,
       addOperationHandler: addLokiOperation,
       explainHandler: (op) => {
         let label = String(op.params[0]).length > 0 ? op.params[0] : '<label>';

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -268,18 +268,26 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
-  it('returns error for query with unwrap and conversion operation', () => {
+  it('parses query with unwrap and conversion operation', () => {
     const context = buildVisualQueryFromString(
       'sum_over_time({app="frontend"} | logfmt | unwrap duration(label) [5m])'
     );
-    expect(context.errors).toEqual([
-      {
-        text: 'Unwrap with conversion operator not supported in query builder: | unwrap duration(label)',
-        from: 40,
-        to: 64,
-        parentType: 'LogRangeExpr',
-      },
-    ]);
+    expect(context).toEqual(
+      noErrors({
+        labels: [
+          {
+            op: '=',
+            value: 'frontend',
+            label: 'app',
+          },
+        ],
+        operations: [
+          { id: 'logfmt', params: [] },
+          { id: 'unwrap', params: ['label', 'duration'] },
+          { id: 'sum_over_time', params: ['5m'] },
+        ],
+      })
+    );
   });
 
   it('parses metrics query with function', () => {

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -217,7 +217,7 @@ describe('buildVisualQueryFromString', () => {
         ],
         operations: [
           { id: 'logfmt', params: [] },
-          { id: 'unwrap', params: ['bytes_processed'] },
+          { id: 'unwrap', params: ['bytes_processed', ''] },
           { id: 'sum_over_time', params: ['1m'] },
         ],
       })
@@ -238,7 +238,7 @@ describe('buildVisualQueryFromString', () => {
         ],
         operations: [
           { id: 'logfmt', params: [] },
-          { id: 'unwrap', params: ['duration'] },
+          { id: 'unwrap', params: ['duration', ''] },
           { id: '__label_filter_no_errors', params: [] },
           { id: 'sum_over_time', params: ['1m'] },
         ],
@@ -260,7 +260,7 @@ describe('buildVisualQueryFromString', () => {
         ],
         operations: [
           { id: 'logfmt', params: [] },
-          { id: 'unwrap', params: ['duration'] },
+          { id: 'unwrap', params: ['duration', ''] },
           { id: '__label_filter', params: ['label', '=', 'value'] },
           { id: 'sum_over_time', params: ['1m'] },
         ],

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.test.ts
@@ -268,7 +268,7 @@ describe('buildVisualQueryFromString', () => {
     );
   });
 
-  it('parses query with unwrap and conversion operation', () => {
+  it('parses query with unwrap and conversion function', () => {
     const context = buildVisualQueryFromString(
       'sum_over_time({app="frontend"} | logfmt | unwrap duration(label) [5m])'
     );

--- a/public/app/plugins/datasource/loki/querybuilder/parsing.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/parsing.ts
@@ -325,16 +325,21 @@ function handleUnwrapExpr(
   }
 
   if (unwrapChild) {
-    if (unwrapChild?.nextSibling?.type.name === 'ConvOp') {
+    if (unwrapChild.nextSibling?.type.name === 'ConvOp') {
+      const convOp = unwrapChild.nextSibling;
+      const identifier = convOp.nextSibling;
       return {
-        error: 'Unwrap with conversion operator not supported in query builder',
+        operation: {
+          id: 'unwrap',
+          params: [getString(expr, identifier), getString(expr, convOp)],
+        },
       };
     }
 
     return {
       operation: {
         id: 'unwrap',
-        params: [getString(expr, unwrapChild?.nextSibling)],
+        params: [getString(expr, unwrapChild?.nextSibling), ''],
       },
     };
   }

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationParamEditor.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/OperationParamEditor.tsx
@@ -1,7 +1,8 @@
+import { css } from '@emotion/css';
 import React, { ComponentType } from 'react';
 
-import { SelectableValue, toOption } from '@grafana/data';
-import { AutoSizeInput, Checkbox, Select } from '@grafana/ui';
+import { GrafanaTheme2, SelectableValue, toOption } from '@grafana/data';
+import { AutoSizeInput, Button, Checkbox, Select, Stack, useStyles2 } from '@grafana/ui';
 
 import { QueryBuilderOperationParamDef, QueryBuilderOperationParamEditorProps } from '../shared/types';
 
@@ -63,6 +64,7 @@ function SelectInputParamEditor({
   operationIndex,
   onChange,
 }: QueryBuilderOperationParamEditorProps) {
+  const styles = useStyles2(getStyles);
   let selectOptions = paramDef.options as Array<SelectableValue<any>>;
 
   if (!selectOptions[0]?.label) {
@@ -74,14 +76,53 @@ function SelectInputParamEditor({
 
   let valueOption = selectOptions.find((x) => x.value === value) ?? toOption(value as string);
 
+  // If we have optional options param and don't have value, we want to render button with which we add optional options.
+  // This makes it easier to understand what needs to be selected and what is optional.
+  if (!value && paramDef.optional) {
+    return (
+      <div className={styles.optionalParam}>
+        <Button
+          size="sm"
+          variant="secondary"
+          title={`Add ${paramDef.name}`}
+          icon="plus"
+          onClick={() => onChange(index, selectOptions[0].value)}
+        >
+          {paramDef.name}
+        </Button>
+      </div>
+    );
+  }
+
   return (
-    <Select
-      id={getOperationParamId(operationIndex, index)}
-      value={valueOption}
-      options={selectOptions}
-      placeholder={paramDef.placeholder}
-      allowCustomValue={true}
-      onChange={(value) => onChange(index, value.value!)}
-    />
+    <Stack gap={0.5} direction="row" alignItems="center" wrap={false}>
+      <Select
+        id={getOperationParamId(operationIndex, index)}
+        value={valueOption}
+        options={selectOptions}
+        placeholder={paramDef.placeholder}
+        allowCustomValue={true}
+        onChange={(value) => onChange(index, value.value!)}
+      />
+      {paramDef.optional && (
+        <Button
+          data-testid={`operations.${index}.remove-param`}
+          size="sm"
+          fill="text"
+          icon="times"
+          variant="secondary"
+          title={`Remove ${paramDef.name}`}
+          onClick={() => onChange(index, '')}
+        />
+      )}
+    </Stack>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    optionalParam: css({
+      marginTop: theme.spacing(1),
+    }),
+  };
+};


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements unwrap with `conversion function` in query builder. Unwrap usually has 1 argument - `label identifier`. However, it can optionally have second argument - `conversion function`.  If `label identifier` is wrapped by a `conversion function` `| unwrap <function>(label_identifier)`, it will attempt to convert the label value from a specific format. Currently supported `conversion functions`: `duration, duration_seconds, bytes`. 

To support this, we updated:
1. unwrap operation - added optional parameter with options and improve explain section
2. parsing - instead of throwing error on unwrap with `ConvOp`,  we correctly parse it
3. `OperationParamEditor.tsx` here I didn't need to add anything, but current design didn't take into consideration if the param is optional or not. I have decided to update this and follow the same UX as we use with optional labels. This makes it more clear, that `conversion function` is optional.
<img width="567" alt="image" src="https://user-images.githubusercontent.com/30407135/180404081-b6eaf8d5-1ce2-4dda-95e4-2b46429b5a5c.png">

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/grafana/issues/48532

**Special notes for your reviewer**:

To review this:
1. Run loki datasource (`make devenv sources=loki`)
2. In Explore code mode, write query such as:
 - `sum(sum_over_time({place="moon"} |= `` | json | unwrap level [$__interval]))` and switch to builder mode. Query should be parsed without errors (errors from loki server are okay), and in builder you should see button in unwrap operation to add `conversion function`.
 - `sum(sum_over_time({place="moon"} |= `` | json | unwrap duration(level) [$__interval]))` and switch to builder mode. Query should be parsed without errors (errors from loki server are okay), and in builder you should see unwrap with both fields - `level` and `duration`. If you remove `duration` , you should see button again.
 - In query builder mode, choose from Query patterns `Metrics query on value inside log line`, you should see unwrap operation with add `conversion function` button. Write any label and add/don't add `conversion function`. Switch to code mode, check if query was correctly parsed. 
 - Switch to `Explain` mode with unwrap with/without `conversion function`, the documentation section should change. 

https://user-images.githubusercontent.com/30407135/180410657-7a88c0d9-d14e-4348-a454-6268eb147070.mov

