### PR TITLE
Tempo: Remove lowercase transformation in span name dropdown

### DIFF
--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -78,10 +78,6 @@ class TempoQueryFieldComponent extends React.PureComponent<Props> {
       { value: 'serviceMap', label: 'Service Graph' },
     ];
 
-    // span names in Tempo search links (generated on the service graph page) are in camel case (for Prometheus queries)
-    // but the span name dropdown menu in the search tab is lower case
-    query.spanName = query.spanName?.toLowerCase();
-
     if (!datasource?.search?.hide) {
       queryTypeOptions.unshift({ value: 'nativeSearch', label: 'Search' });
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the .toLowerCase() for the span name field. This was previously used as Prometheus and Tempo were using different case preferences for span names. This has since been changed in [Tempo](https://github.com/grafana/tempo/issues/1547), so we no longer need this modification in our Tempo DS.