### PR TITLE
SQL: Add timezone offset parameter to timeGroup macros

### DIFF
--- a/pkg/tsdb/mssql/macros.go
+++ b/pkg/tsdb/mssql/macros.go
@@ -89,7 +89,7 @@ func (m *msSQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *bac
 		result := fmt.Sprintf("FLOOR(DATEDIFF(second, '1970-01-01', %s)/%.0f)*%.0f", args[0], interval.Seconds(), interval.Seconds())
 
 		if len(args) == 4 {
-			timezoneOffset, err := util.CalculateMacroTimezoneOffset(args)
+			timezoneOffset, err := util.CalculateMacroTimezoneOffset(args[3])
 			if err != nil {
 				return "", err
 			}

--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -95,7 +95,7 @@ func (m *mySQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *bac
 		result := fmt.Sprintf("UNIX_TIMESTAMP(%s) DIV %.0f * %.0f", args[0], interval.Seconds(), interval.Seconds())
 
 		if len(args) == 4 {
-			timezoneOffset, err := util.CalculateMacroTimezoneOffset(args)
+			timezoneOffset, err := util.CalculateMacroTimezoneOffset(args[3])
 			if err != nil {
 				return "", err
 			}

--- a/pkg/tsdb/postgres/macros.go
+++ b/pkg/tsdb/postgres/macros.go
@@ -106,7 +106,7 @@ func (m *postgresMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *
 
 		var timezoneOffset string
 		if len(args) == 4 {
-			timezoneOffset, err = util.CalculateMacroTimezoneOffset(args)
+			timezoneOffset, err = util.CalculateMacroTimezoneOffset(args[3])
 			if err != nil {
 				return "", err
 			}

--- a/pkg/util/macros.go
+++ b/pkg/util/macros.go
@@ -6,14 +6,19 @@ import (
 	"time"
 )
 
-func CalculateMacroTimezoneOffset(args []string) (string, error) {
-	trimmedArg := strings.Trim(args[3], "\"")
+func CalculateMacroTimezoneOffset(rawTimezoneOffset string) (string, error) {
+	trimmedArg := strings.Trim(rawTimezoneOffset, "\"")
 	sign := trimmedArg[:1]
 	timeStr := strings.Split(trimmedArg[1:], ":")
+
+	if len(timeStr) != 2 {
+		return "", fmt.Errorf("timezone argument error %v", rawTimezoneOffset)
+	}
+
 	timeParsed, err := time.ParseDuration(timeStr[0] + "h" + timeStr[1] + "m")
 
 	if err != nil {
-		return "", fmt.Errorf("timezone argument error %v", args[3])
+		return "", fmt.Errorf("timezone argument error %v", rawTimezoneOffset)
 	}
 
 	var offset string

--- a/pkg/util/macros.go
+++ b/pkg/util/macros.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+func CalculateMacroTimezoneOffset(args []string) (string, error) {
+	trimmedArg := strings.Trim(args[3], "\"")
+	sign := trimmedArg[:1]
+	timeStr := strings.Split(trimmedArg[1:], ":")
+	timeParsed, err := time.ParseDuration(timeStr[0] + "h" + timeStr[1] + "m")
+
+	if err != nil {
+		return "", fmt.Errorf("timezone argument error %v", args[3])
+	}
+
+	var offset string
+	if sign == "-" {
+		offset = "+"
+	} else {
+		offset = "-"
+	}
+
+	return fmt.Sprintf(" %v %d", offset, int(timeParsed.Seconds())), nil
+}

--- a/pkg/util/macros.go
+++ b/pkg/util/macros.go
@@ -23,5 +23,5 @@ func CalculateMacroTimezoneOffset(args []string) (string, error) {
 		offset = "-"
 	}
 
-	return fmt.Sprintf(" %v %d", offset, int(timeParsed.Seconds())), nil
+	return fmt.Sprintf("%v %d", offset, int(timeParsed.Seconds())), nil
 }

--- a/pkg/util/macros_test.go
+++ b/pkg/util/macros_test.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestCalculateMacroTimezoneOffset(t *testing.T) {
+	// tests := []struct {
+	// 	input       string
+	// 	defaultHost string
+	// 	defaultPort string
+
+	// 	host string
+	// 	port string
+	// }{
+	// 	{input: "192.168.0.140:456", defaultHost: "", defaultPort: "", host: "192.168.0.140", port: "456"},
+	// 	{input: "192.168.0.140", defaultHost: "", defaultPort: "123", host: "192.168.0.140", port: "123"},
+	// 	{input: "[::1]:456", defaultHost: "", defaultPort: "", host: "::1", port: "456"},
+	// 	{input: "[::1]", defaultHost: "", defaultPort: "123", host: "::1", port: "123"},
+	// 	{input: ":456", defaultHost: "1.2.3.4", defaultPort: "", host: "1.2.3.4", port: "456"},
+	// 	{input: "xyz.rds.amazonaws.com", defaultHost: "", defaultPort: "123", host: "xyz.rds.amazonaws.com", port: "123"},
+	// 	{input: "xyz.rds.amazonaws.com:123", defaultHost: "", defaultPort: "", host: "xyz.rds.amazonaws.com", port: "123"},
+	// 	{input: "", defaultHost: "localhost", defaultPort: "1433", host: "localhost", port: "1433"},
+	// }
+
+	// for _, testcase := range tests {
+	// 	addr, err := SplitHostPortDefault(testcase.input, testcase.defaultHost, testcase.defaultPort)
+	// 	assert.NoError(t, err)
+	// 	assert.Equal(t, testcase.host, addr.Host)
+	// 	assert.Equal(t, testcase.port, addr.Port)
+	// }
+}

--- a/pkg/util/macros_test.go
+++ b/pkg/util/macros_test.go
@@ -1,32 +1,48 @@
 package util
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestCalculateMacroTimezoneOffset(t *testing.T) {
-	// tests := []struct {
-	// 	input       string
-	// 	defaultHost string
-	// 	defaultPort string
+func TestCalculateMacroTimezoneOffset_Valid(t *testing.T) {
+	tests := []struct {
+		rawTimezoneOffset string
+		expected          string
+	}{
+		{rawTimezoneOffset: "-05:00", expected: "+ 18000"},
+		{rawTimezoneOffset: "-04:00", expected: "+ 14400"},
+		{rawTimezoneOffset: "+02:00", expected: "- 7200"},
+		{rawTimezoneOffset: "+05:20", expected: "- 19200"},
+		{rawTimezoneOffset: "-02:30", expected: "+ 9000"},
+		{rawTimezoneOffset: "-12:00", expected: "+ 43200"},
+		{rawTimezoneOffset: "-00:33", expected: "+ 1980"},
+		{rawTimezoneOffset: "-00:00", expected: "+ 0"},
+		{rawTimezoneOffset: "+00:00", expected: "- 0"},
+	}
 
-	// 	host string
-	// 	port string
-	// }{
-	// 	{input: "192.168.0.140:456", defaultHost: "", defaultPort: "", host: "192.168.0.140", port: "456"},
-	// 	{input: "192.168.0.140", defaultHost: "", defaultPort: "123", host: "192.168.0.140", port: "123"},
-	// 	{input: "[::1]:456", defaultHost: "", defaultPort: "", host: "::1", port: "456"},
-	// 	{input: "[::1]", defaultHost: "", defaultPort: "123", host: "::1", port: "123"},
-	// 	{input: ":456", defaultHost: "1.2.3.4", defaultPort: "", host: "1.2.3.4", port: "456"},
-	// 	{input: "xyz.rds.amazonaws.com", defaultHost: "", defaultPort: "123", host: "xyz.rds.amazonaws.com", port: "123"},
-	// 	{input: "xyz.rds.amazonaws.com:123", defaultHost: "", defaultPort: "", host: "xyz.rds.amazonaws.com", port: "123"},
-	// 	{input: "", defaultHost: "localhost", defaultPort: "1433", host: "localhost", port: "1433"},
-	// }
+	for _, testcase := range tests {
+		timezoneOffset, err := CalculateMacroTimezoneOffset(testcase.rawTimezoneOffset)
+		assert.NoError(t, err)
+		assert.Equal(t, testcase.expected, timezoneOffset)
+	}
+}
 
-	// for _, testcase := range tests {
-	// 	addr, err := SplitHostPortDefault(testcase.input, testcase.defaultHost, testcase.defaultPort)
-	// 	assert.NoError(t, err)
-	// 	assert.Equal(t, testcase.host, addr.Host)
-	// 	assert.Equal(t, testcase.port, addr.Port)
-	// }
+func TestCalculateMacroTimezoneOffset_Error(t *testing.T) {
+	tests := []struct {
+		rawTimezoneOffset string
+	}{
+		{rawTimezoneOffset: "UTC"},
+		{rawTimezoneOffset: "UTC-04:00"},
+		{rawTimezoneOffset: "Europe/London"},
+	}
+
+	for _, testcase := range tests {
+		_, err := CalculateMacroTimezoneOffset(testcase.rawTimezoneOffset)
+		if assert.Error(t, err) {
+			assert.Equal(t, fmt.Sprintf("timezone argument error %v", testcase.rawTimezoneOffset), err.Error())
+		}
+	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The SQL `$__timeGroup` macros do not show data correctly when an interval of `12h` is set if the Grafana timezone is different than `UTC`. This is because the macros return time as UNIX timestamps always in `UTC`. If the interval is set to `12h` then the user expects to see increments of dates starting from `00:00`. E.g: `01-01-2022 00:00`, `01-01-2022 12:00`, `02-01-2022 00:00`, `02-01-2022 12:00`. If the Grafana instance timezone is different than `UTC`, then the macro will return the correct time at `00:00` but convert it on the client-side to whatever the timezone is. 

The back-end does not have access to the client timezone and I am not sure if making it visible there would be the best course of action. A solution is to give control to the user to add the timezone in the query by adding a new parameter to the existing timeGroup macros which specifies the desired offset.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes grafana/grafana-postgresql-datasource#131

**Special notes for your reviewer**:

