### PR TITLE
CI: Remove `build-storybook` from `release-branch` mode for enterprise

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4260,16 +4260,6 @@ steps:
     - success
     - failure
 - commands:
-  - yarn storybook:build
-  - ./bin/grabpl verify-storybook
-  depends_on:
-  - build-frontend
-  - build-frontend-packages
-  environment:
-    NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.8
-  name: build-storybook
-- commands:
   - ./bin/grabpl upload-cdn --edition enterprise
   depends_on:
   - package
@@ -4874,6 +4864,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: fdbc2724cf738ea9a2cd2be46f70d13928c96cc29179a79b7108650af40740ff
+hmac: 2d5af91789aad1299f5e8525b4c8fdeca5e7154ab2cd509547133ae9ff7295a6
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -250,7 +250,7 @@ def benchmark_ldap_step():
 
 
 def build_storybook_step(edition, ver_mode):
-    if edition in ('enterprise', 'enterprise2') and ver_mode == 'release':
+    if edition in ('enterprise', 'enterprise2'):
         return None
 
     return {


### PR DESCRIPTION
**What this PR does / why we need it**:

Storybook is only built and deployed for OSS. Currently we also build it in enterprise pipelines, but that's not needed since we rebuild the same thing many times.
