### PR TITLE
devenv: removes old ab benchmark script

### DIFF
--- a/devenv/benchmarks/ab/ab_test.sh
+++ b/devenv/benchmarks/ab/ab_test.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-ab -n 20000 -c 100 -H "Authorization: Bearer vEustw23NSOZ27y3zlj28ZL3B7BpBk5kqR85DOfT5AwiS3nCi33dnsk6nhvXhZdn" \
-  http://localhost:3000/api/dashboards/db/dash1


### PR DESCRIPTION
Deleting old files :) We should be using k6 now!

Signed-off-by: bergquist <carl.bergquist@gmail.com>
