### PR TITLE
fix dockerfile for oracle alpine image

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN apk add --no-cache openssl --repository=http://dl-cdn.alpinelinux.org/alpine
 # Oracle Support for x86_64 only
 RUN if [ `arch` = "x86_64" ]; then \
       wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk \
-        -O /tmp/glibc-2.35-r0.apk && \
+        -O /tmp/glibc-2.34-r0.apk && \
       wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-bin-2.34-r0.apk \
         -O /tmp/glibc-bin-2.35-r0.apk && \
       apk add --no-cache --allow-untrusted /tmp/glibc-2.34-r0.apk /tmp/glibc-bin-2.34-r0.apk && \

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -33,15 +33,13 @@ RUN apk add --no-cache openssl --repository=http://dl-cdn.alpinelinux.org/alpine
 
 # Oracle Support for x86_64 only
 RUN if [ `arch` = "x86_64" ]; then \
-      apk add --no-cache libaio libnsl && \
-      ln -s /usr/lib/libnsl.so.2 /usr/lib/libnsl.so.1 && \
-      wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk \
+      wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk \
         -O /tmp/glibc-2.35-r0.apk && \
-      wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-bin-2.35-r0.apk \
+      wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-bin-2.34-r0.apk \
         -O /tmp/glibc-bin-2.35-r0.apk && \
-      apk add --no-cache --allow-untrusted /tmp/glibc-2.35-r0.apk /tmp/glibc-bin-2.35-r0.apk && \
-      rm -f /tmp/glibc-2.35-r0.apk && \
-      rm -f /tmp/glibc-bin-2.35-r0.apk && \
+      apk add --no-cache --allow-untrusted /tmp/glibc-2.34-r0.apk /tmp/glibc-bin-2.34-r0.apk && \
+      rm -f /tmp/glibc-2.34-r0.apk && \
+      rm -f /tmp/glibc-bin-2.34-r0.apk && \
       rm -f /lib/ld-linux-x86-64.so.2 && \
       rm -f /etc/ld.so.cache; \
     fi

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -33,13 +33,15 @@ RUN apk add --no-cache openssl --repository=http://dl-cdn.alpinelinux.org/alpine
 
 # Oracle Support for x86_64 only
 RUN if [ `arch` = "x86_64" ]; then \
-      wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk \
+      wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk \
         -O /tmp/glibc-2.35-r0.apk && \
-      wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-bin-2.34-r0.apk \
+      wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-bin-2.35-r0.apk \
         -O /tmp/glibc-bin-2.35-r0.apk && \
-      apk add --no-cache --allow-untrusted /tmp/glibc-2.34-r0.apk /tmp/glibc-bin-2.34-r0.apk && \
-      rm -f /tmp/glibc-2.34-r0.apk && \
-      rm -f /tmp/glibc-bin-2.34-r0.apk && \
+      apk add --no-cache --allow-untrusted /tmp/glibc-2.35-r0.apk /tmp/glibc-bin-2.35-r0.apk && \
+      rm -f /lib64/ld-linux-x86-64.so.2 && \
+      ln -s /usr/glibc-compat/lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2 && \
+      rm -f /tmp/glibc-2.35-r0.apk && \
+      rm -f /tmp/glibc-bin-2.35-r0.apk && \
       rm -f /lib/ld-linux-x86-64.so.2 && \
       rm -f /etc/ld.so.cache; \
     fi

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -36,7 +36,7 @@ RUN if [ `arch` = "x86_64" ]; then \
       wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-2.34-r0.apk \
         -O /tmp/glibc-2.34-r0.apk && \
       wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.34-r0/glibc-bin-2.34-r0.apk \
-        -O /tmp/glibc-bin-2.35-r0.apk && \
+        -O /tmp/glibc-bin-2.34-r0.apk && \
       apk add --no-cache --allow-untrusted /tmp/glibc-2.34-r0.apk /tmp/glibc-bin-2.34-r0.apk && \
       rm -f /tmp/glibc-2.34-r0.apk && \
       rm -f /tmp/glibc-bin-2.34-r0.apk && \


### PR DESCRIPTION
**What this PR does / why we need it**:
The oracle plugin doesn't currently work on our default docker image which is alpine based.

**Which issue(s) this PR fixes**:
https://github.com/grafana/support-escalations/issues/3313

Restore link with 2.35 based on [this issue](https://github.com/sgerrand/alpine-pkg-glibc/issues/181) and remove libs no longer needed since the oracle client was updated to 21.6.

