### PR TITLE
Slider: Fixes styling of marker dots

### DIFF
--- a/packages/grafana-ui/src/components/Slider/styles.ts
+++ b/packages/grafana-ui/src/components/Slider/styles.ts
@@ -48,10 +48,16 @@ export const getStyles = stylesFactory((theme: GrafanaTheme2, isHorizontal: bool
       .rc-slider-handle:hover,
       .rc-slider-handle:active,
       .rc-slider-handle:focus,
-      .rc-slider-handle-click-focused:focus,
-      .rc-slider-dot-active {
+      .rc-slider-handle-click-focused:focus {
         ${hoverSyle};
       }
+
+      .rc-slider-dot,
+      .rc-slider-dot-active {
+        background-color: ${theme.colors.text.primary};
+        border-color: ${theme.colors.text.primary};
+      }
+
       .rc-slider-track {
         background-color: ${trackColor};
       }


### PR DESCRIPTION
Noticed styling of Slider looked of as if the first dot was focused/selected, also the light theme did not look right with white color for marker dots.

Before:
![Screenshot from 2022-07-23 11-51-08](https://user-images.githubusercontent.com/10999/180600437-855782ec-c57e-4c80-9dae-80a10db6b0fd.png)
![Screenshot from 2022-07-23 11-51-21](https://user-images.githubusercontent.com/10999/180600455-16004b8b-1dd1-45c9-b84a-dc0634947952.png)


After:
![Screenshot from 2022-07-23 11-55-28](https://user-images.githubusercontent.com/10999/180600444-22f74abb-f146-4e4f-805d-af8b2bbf9d42.png)
![Screenshot from 2022-07-23 11-55-21](https://user-images.githubusercontent.com/10999/180600446-820152c3-35fe-4aec-a0ea-6135a85cddcb.png)
![Screenshot from 2022-07-23 11-55-49](https://user-images.githubusercontent.com/10999/180600452-219e1d8f-10d9-4836-b872-8a31e307ff8f.png)

