### PR TITLE
Timezone: Consistency in how we write time zone

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerFooter.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerFooter.tsx
@@ -78,7 +78,7 @@ export const TimePickerFooter: FC<Props> = (props) => {
             <RadioButtonGroup
               value={editMode}
               options={[
-                { label: 'Time Zone', value: 'tz' },
+                { label: 'Time zone', value: 'tz' },
                 { label: 'Fiscal year', value: 'fy' },
               ]}
               onChange={setEditMode}

--- a/public/app/core/components/OptionsUI/registry.tsx
+++ b/public/app/core/components/OptionsUI/registry.tsx
@@ -147,8 +147,8 @@ export const getAllOptionEditors = () => {
 
   const timeZone: StandardEditorsRegistryItem<TimeZone> = {
     id: 'timezone',
-    name: 'Time Zone',
-    description: 'Time zone selection',
+    name: 'Time zone',
+    description: 'Timezone selection',
     editor: TimeZonePicker as any,
   };
 

--- a/public/app/core/components/OptionsUI/registry.tsx
+++ b/public/app/core/components/OptionsUI/registry.tsx
@@ -148,7 +148,7 @@ export const getAllOptionEditors = () => {
   const timeZone: StandardEditorsRegistryItem<TimeZone> = {
     id: 'timezone',
     name: 'Time zone',
-    description: 'Timezone selection',
+    description: 'Time zone selection',
     editor: TimeZonePicker as any,
   };
 

--- a/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/TimePickerSettings.tsx
@@ -67,7 +67,7 @@ export class TimePickerSettings extends PureComponent<Props, State> {
   render() {
     return (
       <CollapsableSection label="Time options" isOpen={true}>
-        <Field label="Timezone" data-testid={selectors.components.TimeZonePicker.containerV2}>
+        <Field label="Time zone" data-testid={selectors.components.TimeZonePicker.containerV2}>
           <TimeZonePicker
             inputId="time-options-input"
             includeInternal={true}

--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -18,7 +18,7 @@ export const plugin = new PanelPlugin<TimeSeriesOptions, GraphFieldConfig>(TimeS
 
     builder.addCustomEditor({
       id: 'timezones',
-      name: 'Timezone',
+      name: 'Time zone',
       path: 'timezones',
       category: ['Axis'],
       editor: TimezonesEditor,


### PR DESCRIPTION
Was some inconsistency in how we write time zone / Timezone / TimeZone in the application.

Seems like there is no real right or wrong, some preference in british english to write "time zone" and in american english to write it "timezone".

Google calendar uses "Time zone", and looks like it's the most common. :shrug:


