### PR TITLE
ToolbarButton: Add back useful storybook story

### DIFF
--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.story.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.story.tsx
@@ -126,22 +126,6 @@ export const Examples: ComponentStory<typeof ToolbarButton> = (args) => {
           ))}
         </ToolbarButtonRow>
         <br />
-        disabled
-        <ToolbarButtonRow>
-          <ToolbarButton icon="sync" disabled>
-            Disabled
-          </ToolbarButton>
-        </ToolbarButtonRow>
-        <br />
-        Variants
-        <ToolbarButtonRow>
-          {variants.map((variant) => (
-            <ToolbarButton icon="sync" tooltip="Sync" variant={variant} key={variant}>
-              {variant}
-            </ToolbarButton>
-          ))}
-        </ToolbarButtonRow>
-        <br />
         Wrapped in noSpacing ButtonGroup
         <ButtonGroup>
           <ToolbarButton icon="clock-nine" tooltip="Time picker">
@@ -155,7 +139,7 @@ export const Examples: ComponentStory<typeof ToolbarButton> = (args) => {
           <ToolbarButton isOpen={false} narrow />
         </ButtonGroup>
         <br />
-        As primary and destructive variant
+        Inside button group
         <HorizontalGroup>
           <ButtonGroup>
             <ToolbarButton variant="primary" icon="sync">

--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.story.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.story.tsx
@@ -1,10 +1,12 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import React from 'react';
 
+import { DashboardStoryCanvas } from '../../utils/storybook/DashboardStoryCanvas';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 import { ButtonGroup } from '../Button';
+import { HorizontalGroup, VerticalGroup } from '../Layout/Layout';
 
-import { ToolbarButton } from './ToolbarButton';
+import { ToolbarButton, ToolbarButtonVariant } from './ToolbarButton';
 import mdx from './ToolbarButton.mdx';
 import { ToolbarButtonRow } from './ToolbarButtonRow';
 
@@ -89,18 +91,87 @@ BasicWithIcon.args = {
   iconOnly: true,
 };
 
-export const List: ComponentStory<typeof ToolbarButton> = (args) => {
+export const Examples: ComponentStory<typeof ToolbarButton> = (args) => {
+  const variants: ToolbarButtonVariant[] = ['default', 'active', 'primary', 'destructive'];
+
   return (
-    <ToolbarButtonRow>
-      <ToolbarButton variant={args.variant} iconOnly={false} isOpen={false}>
-        Last 6 hours
-      </ToolbarButton>
-      <ButtonGroup>
-        <ToolbarButton icon="search-minus" variant={args.variant} />
-        <ToolbarButton icon="search-plus" variant={args.variant} />
-      </ButtonGroup>
-      <ToolbarButton icon="sync" isOpen={false} variant={args.variant} />
-    </ToolbarButtonRow>
+    <DashboardStoryCanvas>
+      <VerticalGroup>
+        Button states
+        <ToolbarButtonRow>
+          <ToolbarButton>Just text</ToolbarButton>
+          <ToolbarButton icon="sync" tooltip="Sync" />
+          <ToolbarButton imgSrc="./grafana_icon.svg">With imgSrc</ToolbarButton>
+          <ToolbarButton icon="cloud" isOpen={true}>
+            isOpen
+          </ToolbarButton>
+          <ToolbarButton icon="cloud" isOpen={false}>
+            isOpen = false
+          </ToolbarButton>
+        </ToolbarButtonRow>
+        <br />
+        disabled
+        <ToolbarButtonRow>
+          <ToolbarButton icon="sync" disabled>
+            Disabled
+          </ToolbarButton>
+        </ToolbarButtonRow>
+        <br />
+        Variants
+        <ToolbarButtonRow>
+          {variants.map((variant) => (
+            <ToolbarButton icon="sync" tooltip="Sync" variant={variant} key={variant}>
+              {variant}
+            </ToolbarButton>
+          ))}
+        </ToolbarButtonRow>
+        <br />
+        disabled
+        <ToolbarButtonRow>
+          <ToolbarButton icon="sync" disabled>
+            Disabled
+          </ToolbarButton>
+        </ToolbarButtonRow>
+        <br />
+        Variants
+        <ToolbarButtonRow>
+          {variants.map((variant) => (
+            <ToolbarButton icon="sync" tooltip="Sync" variant={variant} key={variant}>
+              {variant}
+            </ToolbarButton>
+          ))}
+        </ToolbarButtonRow>
+        <br />
+        Wrapped in noSpacing ButtonGroup
+        <ButtonGroup>
+          <ToolbarButton icon="clock-nine" tooltip="Time picker">
+            2020-10-02
+          </ToolbarButton>
+          <ToolbarButton icon="search-minus" />
+        </ButtonGroup>
+        <br />
+        <ButtonGroup>
+          <ToolbarButton icon="sync" />
+          <ToolbarButton isOpen={false} narrow />
+        </ButtonGroup>
+        <br />
+        As primary and destructive variant
+        <HorizontalGroup>
+          <ButtonGroup>
+            <ToolbarButton variant="primary" icon="sync">
+              Run query
+            </ToolbarButton>
+            <ToolbarButton isOpen={false} narrow variant="primary" />
+          </ButtonGroup>
+          <ButtonGroup>
+            <ToolbarButton variant="destructive" icon="sync">
+              Run query
+            </ToolbarButton>
+            <ToolbarButton isOpen={false} narrow variant="destructive" />
+          </ButtonGroup>
+        </HorizontalGroup>
+      </VerticalGroup>
+    </DashboardStoryCanvas>
   );
 };
 


### PR DESCRIPTION
Was using storybook today (for new Dropdown component), and wanted to checkout the ToolbarButton story and could not find the story that showed it in all its states (the actually useful story for development and regression testing) but could not find it.

I could only find this :( 
![Screenshot from 2022-07-23 19-44-14](https://user-images.githubusercontent.com/10999/180616779-c76b957d-654f-433c-adfb-a9b061ffde3f.png)

The story that I remembered creating was removed in this PR: https://github.com/grafana/grafana/pull/51255

This PR restores this story: 

![Screenshot from 2022-07-23 19-54-23](https://user-images.githubusercontent.com/10999/180617165-e002fcea-bf74-43e5-b530-890df4fdb964.png)

