### PR TITLE
Profile: Fix nav tree link to notifications

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -41,7 +41,7 @@ func (hs *HTTPServer) getProfileNode(c *models.ReqContext) *dtos.NavLink {
 	}
 
 	children = append(children, &dtos.NavLink{
-		Text: "Notification history", Id: "profile/notifications", Url: hs.Cfg.AppSubURL + "profile/notifications", Icon: "bell",
+		Text: "Notification history", Id: "profile/notifications", Url: hs.Cfg.AppSubURL + "/profile/notifications", Icon: "bell",
 	})
 
 	if setting.AddChangePasswordLink() {


### PR DESCRIPTION
Fixes issue introduced in recent TopNav PR where I updated the URL to notifications but missed a leading / slash which is needed when Grafana is under a subpath
