### PR TITLE
Menu: Improvements to menu component

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1588,9 +1588,6 @@ exports[`better eslint`] = {
     "packages/grafana-ui/src/components/MatchersUI/fieldMatchersUI.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "packages/grafana-ui/src/components/Menu/Menu.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "packages/grafana-ui/src/components/Menu/MenuGroup.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -1588,6 +1588,9 @@ exports[`better eslint`] = {
     "packages/grafana-ui/src/components/MatchersUI/fieldMatchersUI.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
+    "packages/grafana-ui/src/components/Menu/Menu.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
     "packages/grafana-ui/src/components/Menu/MenuGroup.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/packages/grafana-ui/src/components/Menu/Menu.mdx
+++ b/packages/grafana-ui/src/components/Menu/Menu.mdx
@@ -1,0 +1,34 @@
+import { Meta, Props } from '@storybook/addon-docs/blocks';
+import { Overlay } from 'ol';
+
+import { Menu } from './Menu';
+
+<Meta title="MDX|Menu" component={Menu} />
+
+# Menu
+
+A simple menu component.
+
+### When to use
+
+When you need to display a list of actions or navigation options in a dropdown.
+
+### Usage
+
+```tsx
+import { Dropdown, Menu, Button } from '@grafana/ui';
+const menu = (
+  <Menu>
+    <Menu.Item label="Google" />
+    <Menu.Divider />
+    <Menu.Item label="Delete" icon="trash-alt" destructive />
+  </Menu>
+);
+return (
+  <Dropdown overlay={menu}>
+    <Button icon="hamburger" />
+  </Dropdown>
+);
+```
+
+<Props of={Menu} />

--- a/packages/grafana-ui/src/components/Menu/Menu.mdx
+++ b/packages/grafana-ui/src/components/Menu/Menu.mdx
@@ -26,7 +26,7 @@ const menu = (
 );
 return (
   <Dropdown overlay={menu}>
-    <Button icon="hamburger" />
+    <Button icon="bars" />
   </Dropdown>
 );
 ```

--- a/packages/grafana-ui/src/components/Menu/Menu.story.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.story.tsx
@@ -1,4 +1,4 @@
-import { Story, ComponentMeta } from '@storybook/react';
+import { ComponentMeta } from '@storybook/react';
 import React from 'react';
 
 import { GraphContextMenuHeader } from '..';
@@ -28,7 +28,7 @@ const meta: ComponentMeta<typeof Menu> = {
   },
 };
 
-export const Examples: Story = (args) => {
+export function Examples() {
   return (
     <VerticalGroup>
       <StoryExample name="Plain">
@@ -99,6 +99,6 @@ export const Examples: Story = (args) => {
       </StoryExample>
     </VerticalGroup>
   );
-};
+}
 
 export default meta;

--- a/packages/grafana-ui/src/components/Menu/Menu.story.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.story.tsx
@@ -37,7 +37,7 @@ export const Examples: Story = (args) => {
           <Menu.Item label="Filter" />
           <Menu.Item label="Active" active />
           <Menu.Item label="I am a link" url="http://google.com" target="_blank" />
-          <Menu.Item label="Delete" destructive />
+          <Menu.Item label="With destructive prop set" destructive />
         </Menu>
       </StoryExample>
       <StoryExample name="With icons and a divider">
@@ -46,7 +46,7 @@ export const Examples: Story = (args) => {
           <Menu.Item label="Filter" icon="filter" />
           <Menu.Item label="History" icon="history" />
           <Menu.Divider />
-          <Menu.Item label="Delete" icon="trash-alt" destructive />
+          <Menu.Item label="With destructive prop set" icon="trash-alt" destructive />
         </Menu>
       </StoryExample>
       <StoryExample name="With header & groups">

--- a/packages/grafana-ui/src/components/Menu/Menu.story.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.story.tsx
@@ -7,8 +7,6 @@ import { VerticalGroup } from '../Layout/Layout';
 
 import { Menu } from './Menu';
 import mdx from './Menu.mdx';
-import { MenuGroup } from './MenuGroup';
-import { MenuItem } from './MenuItem';
 
 const meta: ComponentMeta<typeof Menu> = {
   title: 'General/Menu',
@@ -66,37 +64,37 @@ export const Examples: Story = (args) => {
           }
           ariaLabel="Menu header"
         >
-          <MenuGroup label="Group 1">
-            <MenuItem label="item1" icon="history" />
-            <MenuItem label="item2" icon="filter" />
-          </MenuGroup>
-          <MenuGroup label="Group 2">
-            <MenuItem label="item1" icon="history" />
-          </MenuGroup>
+          <Menu.Group label="Group 1">
+            <Menu.Item label="item1" icon="history" />
+            <Menu.Item label="item2" icon="filter" />
+          </Menu.Group>
+          <Menu.Group label="Group 2">
+            <Menu.Item label="item1" icon="history" />
+          </Menu.Group>
         </Menu>
       </StoryExample>
       <StoryExample name="With submenu">
         <Menu>
-          <MenuItem label="item1" icon="history" />
-          <MenuItem
+          <Menu.Item label="item1" icon="history" />
+          <Menu.Item
             label="item2"
             icon="apps"
             childItems={[
-              <MenuItem key="subitem1" label="subitem1" icon="history" />,
-              <MenuItem key="subitem2" label="subitem2" icon="apps" />,
-              <MenuItem
+              <Menu.Item key="subitem1" label="subitem1" icon="history" />,
+              <Menu.Item key="subitem2" label="subitem2" icon="apps" />,
+              <Menu.Item
                 key="subitem3"
                 label="subitem3"
                 icon="search-plus"
                 childItems={[
-                  <MenuItem key="subitem1" label="subitem1" icon="history" />,
-                  <MenuItem key="subitem2" label="subitem2" icon="apps" />,
-                  <MenuItem key="subitem3" label="subitem3" icon="search-plus" />,
+                  <Menu.Item key="subitem1" label="subitem1" icon="history" />,
+                  <Menu.Item key="subitem2" label="subitem2" icon="apps" />,
+                  <Menu.Item key="subitem3" label="subitem3" icon="search-plus" />,
                 ]}
               />,
             ]}
           />
-          <MenuItem label="item3" icon="filter" />
+          <Menu.Item label="item3" icon="filter" />
         </Menu>
       </StoryExample>
     </VerticalGroup>

--- a/packages/grafana-ui/src/components/Menu/Menu.story.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.story.tsx
@@ -6,6 +6,7 @@ import { StoryExample } from '../../utils/storybook/StoryExample';
 import { VerticalGroup } from '../Layout/Layout';
 
 import { Menu } from './Menu';
+import mdx from './Menu.mdx';
 import { MenuGroup } from './MenuGroup';
 import { MenuItem } from './MenuItem';
 
@@ -14,6 +15,9 @@ const meta: ComponentMeta<typeof Menu> = {
   component: Menu,
   argTypes: {},
   parameters: {
+    docs: {
+      page: mdx,
+    },
     knobs: {
       disabled: true,
     },
@@ -26,20 +30,42 @@ const meta: ComponentMeta<typeof Menu> = {
   },
 };
 
-export const Simple: Story = (args) => {
+export const Examples: Story = (args) => {
   return (
     <VerticalGroup>
-      <StoryExample name="Simple">
+      <StoryExample name="Plain">
         <Menu>
-          <MenuItem label="Google" icon="search-plus" />
-          <MenuItem label="Filter" icon="filter" />
-          <MenuItem label="History" icon="history" />
-          <MenuItem label="Active" icon="history" active />
-          <MenuItem label="Apps" icon="apps" />
+          <Menu.Item label="Google" />
+          <Menu.Item label="Filter" />
+          <Menu.Item label="Active" active />
+          <Menu.Item label="I am a link" url="http://google.com" target="_blank" />
+          <Menu.Item label="Delete" destructive />
+        </Menu>
+      </StoryExample>
+      <StoryExample name="With icons and a divider">
+        <Menu>
+          <Menu.Item label="Google" icon="search-plus" />
+          <Menu.Item label="Filter" icon="filter" />
+          <Menu.Item label="History" icon="history" />
+          <Menu.Divider />
+          <Menu.Item label="Delete" icon="trash-alt" destructive />
         </Menu>
       </StoryExample>
       <StoryExample name="With header & groups">
-        <Menu header={args.header} ariaLabel="Menu header">
+        <Menu
+          header={
+            <GraphContextMenuHeader
+              timestamp="2020-11-25 19:04:25"
+              seriesColor="#00ff00"
+              displayName="A-series"
+              displayValue={{
+                text: '128',
+                suffix: 'km/h',
+              }}
+            />
+          }
+          ariaLabel="Menu header"
+        >
           <MenuGroup label="Group 1">
             <MenuItem label="item1" icon="history" />
             <MenuItem label="item2" icon="filter" />
@@ -75,20 +101,6 @@ export const Simple: Story = (args) => {
       </StoryExample>
     </VerticalGroup>
   );
-};
-
-Simple.args = {
-  header: (
-    <GraphContextMenuHeader
-      timestamp="2020-11-25 19:04:25"
-      seriesColor="#00ff00"
-      displayName="A-series"
-      displayValue={{
-        text: '128',
-        suffix: 'km/h',
-      }}
-    />
-  ),
 };
 
 export default meta;

--- a/packages/grafana-ui/src/components/Menu/Menu.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.tsx
@@ -1,11 +1,12 @@
 import { css } from '@emotion/css';
-import React, { ForwardRefExoticComponent, PropsWithoutRef, RefAttributes, useImperativeHandle, useRef } from 'react';
+import React, { useImperativeHandle, useRef } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../themes';
 
 import { MenuDivider } from './MenuDivider';
+import { MenuGroup } from './MenuGroup';
 import { MenuItem } from './MenuItem';
 import { useMenuFocus } from './hooks';
 
@@ -19,13 +20,7 @@ export interface MenuProps extends React.HTMLAttributes<HTMLDivElement> {
   onKeyDown?: React.KeyboardEventHandler;
 }
 
-export interface MenuType
-  extends ForwardRefExoticComponent<PropsWithoutRef<MenuProps> & RefAttributes<HTMLDivElement>> {
-  Item: typeof MenuItem;
-  Divider: typeof MenuDivider;
-}
-
-export const Menu: MenuType = React.forwardRef<HTMLDivElement, MenuProps>(
+const MenuComp = React.forwardRef<HTMLDivElement, MenuProps>(
   ({ header, children, ariaLabel, onOpen, onClose, onKeyDown, ...otherProps }, forwardedRef) => {
     const styles = useStyles2(getStyles);
 
@@ -49,11 +44,15 @@ export const Menu: MenuType = React.forwardRef<HTMLDivElement, MenuProps>(
       </div>
     );
   }
-) as MenuType;
+);
 
-Menu.Item = MenuItem;
-Menu.Divider = MenuDivider;
-Menu.displayName = 'Menu';
+MenuComp.displayName = 'Menu';
+
+export const Menu = Object.assign(MenuComp, {
+  Item: MenuItem,
+  Divider: MenuDivider,
+  Group: MenuGroup,
+});
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {

--- a/packages/grafana-ui/src/components/Menu/Menu.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.tsx
@@ -1,10 +1,12 @@
 import { css } from '@emotion/css';
-import React, { useImperativeHandle, useRef } from 'react';
+import React, { ForwardRefExoticComponent, PropsWithoutRef, RefAttributes, useImperativeHandle, useRef } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
 import { useStyles2 } from '../../themes';
 
+import { MenuDivider } from './MenuDivider';
+import { MenuItem } from './MenuItem';
 import { useMenuFocus } from './hooks';
 
 /** @internal */
@@ -18,8 +20,14 @@ export interface MenuProps extends React.HTMLAttributes<HTMLDivElement> {
   onKeyDown?: React.KeyboardEventHandler;
 }
 
+export interface MenuType
+  extends ForwardRefExoticComponent<PropsWithoutRef<MenuProps> & RefAttributes<HTMLDivElement>> {
+  Item: typeof MenuItem;
+  Divider: typeof MenuDivider;
+}
+
 /** @internal */
-export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(
+export const Menu: MenuType = React.forwardRef<HTMLDivElement, MenuProps>(
   ({ header, children, ariaLabel, onOpen, onClose, onKeyDown, ...otherProps }, forwardedRef) => {
     const styles = useStyles2(getStyles);
 
@@ -43,7 +51,10 @@ export const Menu = React.forwardRef<HTMLDivElement, MenuProps>(
       </div>
     );
   }
-);
+) as MenuType;
+
+Menu.Item = MenuItem;
+Menu.Divider = MenuDivider;
 Menu.displayName = 'Menu';
 
 /** @internal */

--- a/packages/grafana-ui/src/components/Menu/Menu.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.tsx
@@ -66,6 +66,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       box-shadow: ${theme.shadows.z3};
       display: inline-block;
       border-radius: ${theme.shape.borderRadius()};
+      padding: ${theme.spacing(0.5, 0)};
     `,
   };
 };

--- a/packages/grafana-ui/src/components/Menu/Menu.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.tsx
@@ -9,7 +9,6 @@ import { MenuDivider } from './MenuDivider';
 import { MenuItem } from './MenuItem';
 import { useMenuFocus } from './hooks';
 
-/** @internal */
 export interface MenuProps extends React.HTMLAttributes<HTMLDivElement> {
   /** React element rendered at the top of the menu */
   header?: React.ReactNode;
@@ -26,7 +25,6 @@ export interface MenuType
   Divider: typeof MenuDivider;
 }
 
-/** @internal */
 export const Menu: MenuType = React.forwardRef<HTMLDivElement, MenuProps>(
   ({ header, children, ariaLabel, onOpen, onClose, onKeyDown, ...otherProps }, forwardedRef) => {
     const styles = useStyles2(getStyles);
@@ -57,7 +55,6 @@ Menu.Item = MenuItem;
 Menu.Divider = MenuDivider;
 Menu.displayName = 'Menu';
 
-/** @internal */
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     header: css`

--- a/packages/grafana-ui/src/components/Menu/MenuDivider.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuDivider.tsx
@@ -15,6 +15,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     divider: css({
       height: 1,
       backgroundColor: theme.colors.border.weak,
+      margin: theme.spacing(0.5, 0),
     }),
   };
 };

--- a/packages/grafana-ui/src/components/Menu/MenuDivider.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuDivider.tsx
@@ -1,0 +1,21 @@
+import { css } from '@emotion/css';
+import React from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+
+import { useStyles2 } from '../../themes';
+
+export function MenuDivider() {
+  const styles = useStyles2(getStyles);
+  return <div className={styles.divider} />;
+}
+
+/** @internal */
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    divider: css({
+      height: 1,
+      backgroundColor: theme.colors.border.weak,
+    }),
+  };
+};

--- a/packages/grafana-ui/src/components/Menu/MenuDivider.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuDivider.tsx
@@ -10,7 +10,6 @@ export function MenuDivider() {
   return <div className={styles.divider} />;
 }
 
-/** @internal */
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     divider: css({

--- a/packages/grafana-ui/src/components/Menu/MenuItem.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.tsx
@@ -35,9 +35,9 @@ export interface MenuItemProps<T = any> {
   className?: string;
   /** Active */
   active?: boolean;
-
+  /** Show in destructive style (error color) */
+  destructive?: boolean;
   tabIndex?: number;
-
   /** List of menu items for the subMenu */
   childItems?: Array<ReactElement<MenuItemProps>>;
 }
@@ -55,6 +55,7 @@ export const MenuItem = React.memo(
       onClick,
       className,
       active,
+      destructive,
       childItems,
       role = 'menuitem',
       tabIndex = -1,
@@ -77,6 +78,7 @@ export const MenuItem = React.memo(
       {
         [styles.item]: true,
         [styles.activeItem]: isActive,
+        [styles.destructive]: destructive,
       },
       className
     );
@@ -159,6 +161,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       white-space: nowrap;
       color: ${theme.colors.text.primary};
       display: flex;
+      align-items: center;
       padding: 5px 12px 5px 10px;
       margin: 0;
       border: none;
@@ -179,6 +182,22 @@ const getStyles = (theme: GrafanaTheme2) => {
     `,
     activeItem: css`
       background: ${theme.colors.action.selected};
+    `,
+    destructive: css`
+      color: ${theme.colors.error.text};
+
+      svg {
+        color: ${theme.colors.error.text};
+      }
+
+      &:hover {
+        background: ${theme.colors.error.main};
+        color: ${theme.colors.error.contrastText};
+
+        svg {
+          color: ${theme.colors.error.contrastText};
+        }
+      }
     `,
     icon: css`
       opacity: 0.7;

--- a/packages/grafana-ui/src/components/Menu/MenuItem.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.tsx
@@ -77,7 +77,7 @@ export const MenuItem = React.memo(
     const itemStyle = cx(
       {
         [styles.item]: true,
-        [styles.activeItem]: isActive,
+        [styles.active]: isActive,
         [styles.destructive]: destructive,
       },
       className
@@ -180,8 +180,8 @@ const getStyles = (theme: GrafanaTheme2) => {
         ${getFocusStyles(theme)}
       }
     `,
-    activeItem: css`
-      background: ${theme.colors.action.selected};
+    active: css`
+      background: ${theme.colors.action.hover};
     `,
     destructive: css`
       color: ${theme.colors.error.text};
@@ -190,7 +190,9 @@ const getStyles = (theme: GrafanaTheme2) => {
         color: ${theme.colors.error.text};
       }
 
-      &:hover {
+      &:hover,
+      &:focus,
+      &:focus-visible {
         background: ${theme.colors.error.main};
         color: ${theme.colors.error.contrastText};
 

--- a/packages/grafana-ui/src/components/Menu/MenuItem.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.tsx
@@ -162,7 +162,8 @@ const getStyles = (theme: GrafanaTheme2) => {
       color: ${theme.colors.text.primary};
       display: flex;
       align-items: center;
-      padding: 5px 12px 5px 10px;
+      padding: ${theme.spacing(0.5, 2)};
+      min-height: ${theme.spacing(4)};
       margin: 0;
       border: none;
       width: 100%;
@@ -204,6 +205,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     icon: css`
       opacity: 0.7;
       margin-right: 10px;
+      margin-left: -4px;
       color: ${theme.colors.text.secondary};
     `,
   };

--- a/packages/grafana-ui/src/components/Menu/MenuItem.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import React, { ReactElement, useCallback, useMemo, useState, useRef, useImperativeHandle } from 'react';
+import React, { ReactElement, useCallback, useState, useRef, useImperativeHandle } from 'react';
 
 import { GrafanaTheme2, LinkTarget } from '@grafana/data';
 
@@ -72,8 +72,9 @@ export const MenuItem = React.memo(
       setIsSubMenuOpen(false);
       setIsActive(false);
     }, []);
-    const hasSubMenu = useMemo(() => childItems && childItems.length > 0, [childItems]);
-    const Wrapper = hasSubMenu ? 'div' : url === undefined ? 'button' : 'a';
+
+    const hasSubMenu = childItems && childItems.length > 0;
+    const ItemElement = hasSubMenu ? 'div' : url === undefined ? 'button' : 'a';
     const itemStyle = cx(
       {
         [styles.item]: true,
@@ -109,7 +110,7 @@ export const MenuItem = React.memo(
     };
 
     return (
-      <Wrapper
+      <ItemElement
         target={target}
         className={itemStyle}
         rel={target === '_blank' ? 'noopener noreferrer' : undefined}
@@ -146,7 +147,7 @@ export const MenuItem = React.memo(
             close={closeSubMenu}
           />
         )}
-      </Wrapper>
+      </ItemElement>
     );
   })
 );

--- a/packages/grafana-ui/src/components/Menu/MenuItem.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.tsx
@@ -150,9 +150,9 @@ export const MenuItem = React.memo(
     );
   })
 );
+
 MenuItem.displayName = 'MenuItem';
 
-/** @internal */
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     item: css`

--- a/packages/grafana-ui/src/components/Menu/SubMenu.tsx
+++ b/packages/grafana-ui/src/components/Menu/SubMenu.tsx
@@ -58,6 +58,7 @@ export const SubMenu: React.FC<SubMenuProps> = React.memo(
     );
   }
 );
+
 SubMenu.displayName = 'SubMenu';
 
 /** @internal */
@@ -70,7 +71,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     `,
     icon: css`
       opacity: 0.7;
-      margin-left: 10px;
+      margin-left: ${theme.spacing(2)};
       color: ${theme.colors.text.secondary};
     `,
     itemsWrapper: css`


### PR DESCRIPTION
* Fixes icon alignment bug in MenuItem (they were not centered) 
* Adds destructive prop to MenuItem which will make it show as red text color and red/max contrast on hover (Very similar to other component libs/design systems, Slack etc)  
* Adds a MenuDivider 
* Makes MenuItem and MenuDivider available as static properties on Menu component (Similar to many component libs, like antd and others).  
* Makes Menu internal story public 
* Adds Menu story docs 

Minor design tweaks 
* Increasing horizontal item padding to 16px
* Add small vertical padding (8px) to top and bottom of menu container (Looks like most menus have this, Slack, Antd, github, material UI)  

![Screenshot from 2022-07-24 11-45-40](https://user-images.githubusercontent.com/10999/180641544-575a9518-62be-43ff-a1b1-11801d742124.png)
Hover / focus state for destructive Menu.Item:
![Screenshot from 2022-07-24 11-46-56](https://user-images.githubusercontent.com/10999/180641576-ae0719ce-ab6a-4bcd-a6a4-05934a71ff38.png)

TODO for a future improvement 
* Add keyboardShortcut to MenuItem (Something we need if we are to use this for PanelMenu) 
* Deprecate childItems and make Menu.SubMenu a standalone more deliberate thing, MenuItem should not handle sub menus (As they cannot be destructive, have URLs and onClick handlers etc) so feels bad to mix them in the same component. And the child items should be handled via react children prop :) 
 