### PR TITLE
TimeZone: Remove political reference

### DIFF
--- a/packages/grafana-data/src/datetime/timezones.ts
+++ b/packages/grafana-data/src/datetime/timezones.ts
@@ -341,7 +341,7 @@ const countryByCode: Record<string, string> = {
   OM: 'Oman',
   PK: 'Pakistan',
   PW: 'Palau',
-  PS: 'Palestinian Territory',
+  PS: 'Palestine, State of',
   PA: 'Panama',
   PG: 'Papua New Guinea',
   PY: 'Paraguay',

--- a/packages/grafana-data/src/datetime/timezones.ts
+++ b/packages/grafana-data/src/datetime/timezones.ts
@@ -341,7 +341,7 @@ const countryByCode: Record<string, string> = {
   OM: 'Oman',
   PK: 'Pakistan',
   PW: 'Palau',
-  PS: 'Palestinian Territory (Occupied)',
+  PS: 'Palestinian Territory',
   PA: 'Panama',
   PG: 'Papua New Guinea',
   PY: 'Paraguay',


### PR DESCRIPTION

**What this PR does / why we need it**:

Removes Israeli/Palestinian conflict political reference  

**Special notes for your reviewer**:

There is no place for one sided political reference in widely used open source tools 
