### PR TITLE
AppChrome: Fix race condition when updating chrome state on route changed

### DIFF
--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -29,32 +29,29 @@ export class AppChromeService {
     searchBarHidden: store.getBool(this.searchBarStorageKey, false),
   });
 
-  routeMounted(route: RouteDescriptor) {
-    this.currentRoute = route;
-    this.routeChangeHandled = false;
+  registerRouteRender(route: RouteDescriptor) {
+    if (this.currentRoute !== route) {
+      this.currentRoute = route;
+      this.routeChangeHandled = false;
+    }
   }
 
   update(update: Partial<AppChromeState>) {
     const current = this.state.getValue();
     const newState: AppChromeState = {
       ...current,
-      ...update,
     };
 
     // when route change update props from route and clear fields
     if (!this.routeChangeHandled) {
-      // Clear some state on route change unless supplied
-      if (!update.actions) {
-        newState.actions = undefined;
-      }
-
-      if (!update.sectionNav) {
-        newState.sectionNav = defaultSection;
-      }
-
+      newState.actions = undefined;
+      newState.pageNav = undefined;
+      newState.sectionNav = defaultSection;
       newState.chromeless = this.currentRoute?.chromeless;
       this.routeChangeHandled = true;
     }
+
+    Object.assign(newState, update);
 
     if (!isShallowEqual(current, newState)) {
       this.state.next(newState);

--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -14,9 +14,9 @@ export interface Props extends Omit<GrafanaRouteComponentProps, 'queryParams'> {
 export function GrafanaRoute(props: Props) {
   const { chrome } = useGrafana();
 
-  useEffect(() => {
-    chrome.routeMounted(props.route);
+  chrome.registerRouteRender(props.route);
 
+  useEffect(() => {
     updateBodyClassNames(props.route);
     cleanupDOM();
     // unbinds all and re-bind global keybindins
@@ -29,7 +29,7 @@ export function GrafanaRoute(props: Props) {
       navigationLogger('GrafanaRoute', false, 'Unmounted', props.route);
       updateBodyClassNames(props.route, true);
     };
-    // props.match instance change even though only query params changed so to make this effect only trigger on route mount we have to disable the exhaustive-deps
+    // props.match instance change even though only query params changed so to make this effect only trigger on route mount we have to disable exhaustive-deps
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -29,7 +29,9 @@ export function GrafanaRoute(props: Props) {
       navigationLogger('GrafanaRoute', false, 'Unmounted', props.route);
       updateBodyClassNames(props.route, true);
     };
-  }, [chrome, props.route, props.match]);
+    // props.match instance change even though only query params changed so to make this effect only trigger on route mount we have to disable the exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     cleanupDOM();


### PR DESCRIPTION
Fixes issue where the route mount effect triggers after the page (and Page) component renders. The routeMounted call clears some state so the app chrome does not include breadcrumbs and actions from the previous route. But
depending on the Page this clearing of state can happen after the new Page component already set the new state. Resulting in default state for breadcrumbs (will just have Home icon > Grafana). This happens on ndashboards > Browse and many other pages.

A bit tricky to fix. It's either the solution in this PR or introduce a new RouteContext so that we can access current route from Page component, but then we need to add some more complexity to Page to detect when the route has changed and add logic so the correct properties are cleared. 

* [x] Fixes race condition
* [x] reduces app chrome re-renders 