### PR TITLE
FolderPage: Do not create browser history step when adding slug to url

### DIFF
--- a/public/app/features/search/components/DashboardListPage.tsx
+++ b/public/app/features/search/components/DashboardListPage.tsx
@@ -31,7 +31,7 @@ export const DashboardListPage: FC<Props> = memo(({ match, location }) => {
       const path = locationUtil.stripBaseFromUrl(folder.url);
 
       if (path !== location.pathname) {
-        locationService.push(path);
+        locationService.replace(path);
       }
 
       return { folder, pageNav: folderNav };


### PR DESCRIPTION
When loading the dashboard folder page we redirect (Update URL) if the page url does not contain the folder slug. This PR fixes so that that URL update does not add a browser history item so that you can move back to the page you came from.
