### PR TITLE
Datasources: add `datasource uid` filter

### DIFF
--- a/pkg/services/datasources/permissions/datasource_permissions.go
+++ b/pkg/services/datasources/permissions/datasource_permissions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/datasources"
 )
 
@@ -11,11 +12,16 @@ var ErrNotImplemented = errors.New("not implemented")
 
 type DatasourcePermissionsService interface {
 	FilterDatasourcesBasedOnQueryPermissions(ctx context.Context, cmd *datasources.DatasourcesPermissionFilterQuery) error
+	FilterDatasourceUidsBasedOnQueryPermissions(ctx context.Context, user *models.SignedInUser, datasourceUids []string) ([]string, error)
 }
 
 // dummy method
 func (hs *OSSDatasourcePermissionsService) FilterDatasourcesBasedOnQueryPermissions(ctx context.Context, cmd *datasources.DatasourcesPermissionFilterQuery) error {
 	return ErrNotImplemented
+}
+
+func (hs *OSSDatasourcePermissionsService) FilterDatasourceUidsBasedOnQueryPermissions(ctx context.Context, user *models.SignedInUser, datasourceUids []string) ([]string, error) {
+	return nil, ErrNotImplemented
 }
 
 type OSSDatasourcePermissionsService struct{}

--- a/pkg/services/datasources/permissions/datasource_permissions_mocks.go
+++ b/pkg/services/datasources/permissions/datasource_permissions_mocks.go
@@ -3,12 +3,18 @@ package permissions
 import (
 	"context"
 
+	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/datasources"
 )
 
 type mockDatasourcePermissionService struct {
-	DsResult  []*datasources.DataSource
-	ErrResult error
+	DsResult    []*datasources.DataSource
+	DsUidResult []string
+	ErrResult   error
+}
+
+func (m *mockDatasourcePermissionService) FilterDatasourceUidsBasedOnQueryPermissions(ctx context.Context, user *models.SignedInUser, datasourceUids []string) ([]string, error) {
+	return m.DsUidResult, m.ErrResult
 }
 
 func (m *mockDatasourcePermissionService) FilterDatasourcesBasedOnQueryPermissions(ctx context.Context, cmd *datasources.DatasourcesPermissionFilterQuery) error {


### PR DESCRIPTION
Helper method that does not require retrieving `[]*model.DataSource` from the database if all you have are the UIDs

part of https://github.com/grafana/grafana/issues/47448