### PR TITLE
Service accounts: change managed permissions

### DIFF
--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -289,8 +289,7 @@ func ProvideServiceAccountPermissions(
 			ServiceAccounts: false,
 		},
 		PermissionsToActions: map[string][]string{
-			"View":  {serviceaccounts.ActionRead},
-			"Edit":  {serviceaccounts.ActionRead, serviceaccounts.ActionWrite, serviceaccounts.ActionDelete},
+			"Edit":  {serviceaccounts.ActionRead, serviceaccounts.ActionWrite},
 			"Admin": {serviceaccounts.ActionRead, serviceaccounts.ActionWrite, serviceaccounts.ActionDelete, serviceaccounts.ActionPermissionsRead, serviceaccounts.ActionPermissionsWrite},
 		},
 		ReaderRoleName: "Service account permission reader",


### PR DESCRIPTION
**What this PR does / why we need it**:
Change managed permissions to be more usable, we'll now have:
* "Edit" - allows reading service account info, adding and removing tokens for this service account, and changing service account's basic role;
* "Admin" - allows all of the above, plus deleting the service account and setting service account's managed permissions.

**Special notes for your reviewer**:
I'm not adding a migration for this, as service account managed permissions have not been released yet. This means that if anyone has used service account managed permissions in Grafana Ops (or another Grafana instance that builds from the main), their managed permissions could be a bit messed up. But I don't think this warrantees a migration.