### PR TITLE
Logs: Improve the color for unknown log level

### DIFF
--- a/public/app/core/logsModel.ts
+++ b/public/app/core/logsModel.ts
@@ -52,7 +52,7 @@ export const LogLevelColor = {
   [LogLevel.info]: colors[0],
   [LogLevel.debug]: colors[5],
   [LogLevel.trace]: colors[2],
-  [LogLevel.unknown]: getThemeColor('#8e8e8e', '#dde4ed'),
+  [LogLevel.unknown]: getThemeColor('#8e8e8e', '#bdc4cd'),
 };
 
 const MILLISECOND = 1;


### PR DESCRIPTION
in the logs-volume visualization, the unknown-log-level color was hard to see in light mode. i adjusted the color to be a little darker.

before:
<img width="257" alt="before" src="https://user-images.githubusercontent.com/51989/180765977-653e58c1-576a-4f55-8f27-1696139aff2e.png">

after:
<img width="255" alt="after" src="https://user-images.githubusercontent.com/51989/180766004-6d51e638-fd9d-4cc2-9fae-d5ca86b56f11.png">

NOTE: we may want to do a more complex checking of all the logs-volume-colors later, to make sure they all look nice in both light&dark modes.
