### PR TITLE
I18n: Wrap event-based modals with I18nProvider

### DIFF
--- a/public/app/core/internationalization/index.tsx
+++ b/public/app/core/internationalization/index.tsx
@@ -78,3 +78,15 @@ export function I18nProvider({ children }: I18nProviderProps) {
     </LinguiI18nProvider>
   );
 }
+
+// This is only really used for ModalManager, as that creates a new react root we need to make sure is localisable.
+export function provideI18n<P>(WrappedWithI18N: React.ComponentType<P>) {
+  const I18nProviderWrapper = (props: P) => {
+    return (
+      <I18nProvider>
+        <WrappedWithI18N {...props} />
+      </I18nProvider>
+    );
+  };
+  return I18nProviderWrapper;
+}

--- a/public/app/core/services/ModalManager.ts
+++ b/public/app/core/services/ModalManager.ts
@@ -9,6 +9,7 @@ import { copyPanel } from 'app/features/dashboard/utils/panel';
 
 import { ShowConfirmModalEvent, ShowConfirmModalPayload, ShowModalReactEvent } from '../../types/events';
 import { AngularModalProxy } from '../components/modals/AngularModalProxy';
+import { provideI18n } from '../internationalization';
 import { provideTheme } from '../utils/ConfigProvider';
 
 export class ModalManager {
@@ -32,7 +33,7 @@ export class ModalManager {
       },
     };
 
-    const elem = React.createElement(provideTheme(AngularModalProxy, config.theme2), modalProps);
+    const elem = React.createElement(provideI18n(provideTheme(AngularModalProxy, config.theme2)), modalProps);
     this.reactModalRoot.appendChild(this.reactModalNode);
     ReactDOM.render(elem, this.reactModalNode);
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

Modals triggered by `appEvents.publish(new ShowModalReactEvent(...))` are rendered in a _new_ react root with it's own context, so we need to provide that with the lingui i18n instance as well.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

