### PR TITLE
Only reset keybindings on route change, not param change

### DIFF
--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -19,9 +19,6 @@ export function GrafanaRoute(props: Props) {
 
     updateBodyClassNames(props.route);
     cleanupDOM();
-    // unbinds all and re-bind global keybindins
-    keybindingSrv.reset();
-    keybindingSrv.initGlobals();
     reportPageview();
     navigationLogger('GrafanaRoute', false, 'Mounted', props.match);
 
@@ -30,6 +27,12 @@ export function GrafanaRoute(props: Props) {
       updateBodyClassNames(props.route, true);
     };
   }, [chrome, props.route, props.match]);
+
+  useEffect(() => {
+    // unbinds all and re-bind global keybindins
+    keybindingSrv.reset();
+    keybindingSrv.initGlobals();
+  }, [chrome, props.route]);
 
   useEffect(() => {
     cleanupDOM();


### PR DESCRIPTION
In https://github.com/grafana/grafana/commit/b782d9aa128feee16b6b46a52832282fe6003529#diff-3a5fd1172ddb677414b14f84c476bda79186d8694e614b5f4ff54aec52818369 , `GrafanaRoute` was changed from using component lifecycle methods to hooks. One of the changes here meant that the keybindings would be reset, with the global keybindings re-initialized, with any change to the route or params. This is incorrect - we only need the keybindings reset on route changes. The dashboard and explore specific keybindings are only added in their respective components so with that change, they are not re-added if just the params change and dont re-initialize the component.

This adds another hook that only fires on route changes that resets and reinitializes the keybindings.