### PR TITLE
Secrets: Add fallback to plugin on secrets kvstore

### DIFF
--- a/pkg/services/secrets/kvstore/fallback.go
+++ b/pkg/services/secrets/kvstore/fallback.go
@@ -21,13 +21,13 @@ func NewKVStoreWithFallback(store SecretsKVStore, fallback SecretsKVStore) *KVSt
 }
 
 func (kv *KVStoreWithFallback) Get(ctx context.Context, orgId int64, namespace string, typ string) (string, bool, error) {
-	value, ok, err := kv.store.Get(ctx, orgId, namespace, typ)
-	if err != nil || !ok {
-		value, ok, err := kv.fallback.Get(ctx, orgId, namespace, typ)
+	value, exists, err := kv.store.Get(ctx, orgId, namespace, typ)
+	if err != nil || !exists {
+		value, exists, err := kv.fallback.Get(ctx, orgId, namespace, typ)
 		kv.log.Debug("failed to get secret with plugin, using fallback", "orgId", orgId, "type", typ, "namespace", namespace, "error", err)
-		return value, ok, err
+		return value, exists, err
 	}
-	return value, ok, err
+	return value, exists, err
 }
 
 func (kv *KVStoreWithFallback) Set(ctx context.Context, orgId int64, namespace string, typ string, value string) error {

--- a/pkg/services/secrets/kvstore/fallback.go
+++ b/pkg/services/secrets/kvstore/fallback.go
@@ -1,0 +1,67 @@
+package kvstore
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+type KVStoreWithFallback struct {
+	log      log.Logger
+	store    SecretsKVStore
+	fallback SecretsKVStore
+}
+
+func NewKVStoreWithFallback(store SecretsKVStore, fallback SecretsKVStore) *KVStoreWithFallback {
+	return &KVStoreWithFallback{
+		log:      log.New("secrets.kvstore"),
+		store:    store,
+		fallback: fallback,
+	}
+}
+
+func (kv *KVStoreWithFallback) Get(ctx context.Context, orgId int64, namespace string, typ string) (string, bool, error) {
+	value, ok, err := kv.store.Get(ctx, orgId, namespace, typ)
+	if err != nil || !ok {
+		value, ok, err := kv.fallback.Get(ctx, orgId, namespace, typ)
+		kv.log.Debug("failed to get secret with plugin, using fallback", "orgId", orgId, "type", typ, "namespace", namespace, "error", err)
+		return value, ok, err
+	}
+	return value, ok, err
+}
+
+func (kv *KVStoreWithFallback) Set(ctx context.Context, orgId int64, namespace string, typ string, value string) error {
+	err := kv.store.Set(ctx, orgId, namespace, typ, value)
+	if err != nil {
+		kv.log.Debug("failed to set secret with plugin, using fallback", "orgId", orgId, "type", typ, "namespace", namespace, "error", err)
+		return kv.fallback.Set(ctx, orgId, namespace, typ, value)
+	}
+	return nil
+}
+
+func (kv *KVStoreWithFallback) Del(ctx context.Context, orgId int64, namespace string, typ string) error {
+	err := kv.store.Del(ctx, orgId, namespace, typ)
+	if err != nil {
+		kv.log.Debug("failed to delete secret with plugin, using fallback", "orgId", orgId, "type", typ, "namespace", namespace, "error", err)
+		return kv.fallback.Del(ctx, orgId, namespace, typ)
+	}
+	return nil
+}
+
+func (kv *KVStoreWithFallback) Keys(ctx context.Context, orgId int64, namespace string, typ string) ([]Key, error) {
+	keys, err := kv.store.Keys(ctx, orgId, namespace, typ)
+	if err != nil {
+		kv.log.Debug("failed to get secret keys with plugin, using fallback", "orgId", orgId, "type", typ, "namespace", namespace, "error", err)
+		return kv.fallback.Keys(ctx, orgId, namespace, typ)
+	}
+	return keys, err
+}
+
+func (kv *KVStoreWithFallback) Rename(ctx context.Context, orgId int64, namespace string, typ string, newNamespace string) error {
+	err := kv.store.Rename(ctx, orgId, namespace, typ, newNamespace)
+	if err != nil {
+		kv.log.Debug("failed to rename secret with plugin, using fallback", "orgId", orgId, "type", typ, "namespace", namespace, "newNamespace", newNamespace, "error", err)
+		return kv.fallback.Rename(ctx, orgId, namespace, typ, newNamespace)
+	}
+	return nil
+}

--- a/pkg/services/secrets/kvstore/fallback.go
+++ b/pkg/services/secrets/kvstore/fallback.go
@@ -31,21 +31,11 @@ func (kv *KVStoreWithFallback) Get(ctx context.Context, orgId int64, namespace s
 }
 
 func (kv *KVStoreWithFallback) Set(ctx context.Context, orgId int64, namespace string, typ string, value string) error {
-	err := kv.store.Set(ctx, orgId, namespace, typ, value)
-	if err != nil {
-		kv.log.Debug("failed to set secret with plugin, using fallback", "orgId", orgId, "type", typ, "namespace", namespace, "error", err)
-		return kv.fallback.Set(ctx, orgId, namespace, typ, value)
-	}
-	return nil
+	return kv.store.Set(ctx, orgId, namespace, typ, value)
 }
 
 func (kv *KVStoreWithFallback) Del(ctx context.Context, orgId int64, namespace string, typ string) error {
-	err := kv.store.Del(ctx, orgId, namespace, typ)
-	if err != nil {
-		kv.log.Debug("failed to delete secret with plugin, using fallback", "orgId", orgId, "type", typ, "namespace", namespace, "error", err)
-		return kv.fallback.Del(ctx, orgId, namespace, typ)
-	}
-	return nil
+	return kv.store.Del(ctx, orgId, namespace, typ)
 }
 
 func (kv *KVStoreWithFallback) Keys(ctx context.Context, orgId int64, namespace string, typ string) ([]Key, error) {
@@ -58,10 +48,5 @@ func (kv *KVStoreWithFallback) Keys(ctx context.Context, orgId int64, namespace 
 }
 
 func (kv *KVStoreWithFallback) Rename(ctx context.Context, orgId int64, namespace string, typ string, newNamespace string) error {
-	err := kv.store.Rename(ctx, orgId, namespace, typ, newNamespace)
-	if err != nil {
-		kv.log.Debug("failed to rename secret with plugin, using fallback", "orgId", orgId, "type", typ, "namespace", namespace, "newNamespace", newNamespace, "error", err)
-		return kv.fallback.Rename(ctx, orgId, namespace, typ, newNamespace)
-	}
-	return nil
+	return kv.store.Rename(ctx, orgId, namespace, typ, newNamespace)
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR adds a fallback SecretsKVStore using the default SQL implementation to the plugin SecretsKVStore.

This is needed to allow for secret retrieval during a background migration to the plugin, the background migration will be implemented to speed up Grafana startup given the plugin have a limited response time speed.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #52564 

**Special notes for your reviewer**:

