### PR TITLE
CloudWatch: returnData should default to true

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -356,10 +356,8 @@ func (e *cloudWatchExecutor) QueryData(ctx context.Context, req *backend.QueryDa
 		return e.executeLogAlertQuery(ctx, req)
 	}
 
-	queryType := model.QueryType
-
 	var result *backend.QueryDataResponse
-	switch queryType {
+	switch model.QueryType {
 	case "annotationQuery":
 		result, err = e.executeAnnotationQuery(req.PluginContext, model, q)
 	case "logAction":

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -73,6 +73,11 @@ const (
 	alertMaxAttempts = 8
 	alertPollPeriod  = 1000 * time.Millisecond
 	logsQueryMode    = "Logs"
+
+	// QueryTypes
+	annotationQuery = "annotationQuery"
+	logAction       = "logAction"
+	timeSeriesQuery = "timeSeriesQuery"
 )
 
 var plog = log.New("tsdb.cloudwatch")
@@ -358,11 +363,11 @@ func (e *cloudWatchExecutor) QueryData(ctx context.Context, req *backend.QueryDa
 
 	var result *backend.QueryDataResponse
 	switch model.QueryType {
-	case "annotationQuery":
+	case annotationQuery:
 		result, err = e.executeAnnotationQuery(req.PluginContext, model, q)
-	case "logAction":
+	case logAction:
 		result, err = e.executeLogActions(ctx, req)
-	case "timeSeriesQuery":
+	case timeSeriesQuery:
 		fallthrough
 	default:
 		result, err = e.executeTimeSeriesQuery(ctx, req)

--- a/pkg/tsdb/cloudwatch/request_parser.go
+++ b/pkg/tsdb/cloudwatch/request_parser.go
@@ -37,7 +37,7 @@ type QueryJson struct {
 	Statistic         *string                `json:"statistic,omitempty"`
 	Statistics        []*string              `json:"statistics,omitempty"`
 	TimezoneUTCOffset string                 `json:"timezoneUTCOffset,omitempty"`
-	QueryType         string                 `json:"queryType,omitempty"`
+	QueryType         string                 `json:"type,omitempty"`
 	Hide              *bool                  `json:"hide,omitempty"`
 	Alias             *string                `json:"alias,omitempty"`
 }
@@ -166,7 +166,7 @@ func parseRequestQuery(model QueryJson, refId string, startTime time.Time, endTi
 		Label:             "",
 		MatchExact:        true,
 		Statistic:         "",
-		ReturnData:        false,
+		ReturnData:        true,
 		UsedExpression:    "",
 		RefId:             refId,
 		Id:                model.Id,

--- a/pkg/tsdb/cloudwatch/request_parser.go
+++ b/pkg/tsdb/cloudwatch/request_parser.go
@@ -58,7 +58,7 @@ func (e *cloudWatchExecutor) parseQueries(queries []backend.DataQuery, startTime
 		}
 
 		queryType := model.QueryType
-		if queryType != "timeSeriesQuery" && queryType != "" {
+		if queryType != timeSeriesQuery && queryType != "" {
 			continue
 		}
 

--- a/pkg/tsdb/cloudwatch/request_parser_test.go
+++ b/pkg/tsdb/cloudwatch/request_parser_test.go
@@ -293,6 +293,34 @@ func TestRequestParser(t *testing.T) {
 		})
 	})
 
+	t.Run("hide and returnData", func(t *testing.T) {
+		t.Run("default", func(t *testing.T) {
+			query := getBaseJsonQuery()
+			query.QueryType = "timeSeriesQuery"
+			res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+			require.NoError(t, err)
+			require.True(t, res.ReturnData)
+		})
+		t.Run("hide is true", func(t *testing.T) {
+			query := getBaseJsonQuery()
+			query.QueryType = "timeSeriesQuery"
+			true := true
+			query.Hide = &true
+			res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+			require.NoError(t, err)
+			require.False(t, res.ReturnData)
+		})
+		t.Run("hide is false", func(t *testing.T) {
+			query := getBaseJsonQuery()
+			query.QueryType = "timeSeriesQuery"
+			false := false
+			query.Hide = &false
+			res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+			require.NoError(t, err)
+			require.True(t, res.ReturnData)
+		})
+	})
+
 	t.Run("ID is the string `query` appended with refId if refId is a valid MetricData ID", func(t *testing.T) {
 		query := getBaseJsonQuery()
 		res, err := parseRequestQuery(query, "ref1", time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))

--- a/pkg/tsdb/cloudwatch/request_parser_test.go
+++ b/pkg/tsdb/cloudwatch/request_parser_test.go
@@ -11,6 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestQueryJSON(t *testing.T) {
+	jsonString := []byte(`{
+		"type": "timeSeriesQuery"
+	}`)
+	var res QueryJson
+	err := json.Unmarshal(jsonString, &res)
+	require.NoError(t, err)
+	assert.Equal(t, "timeSeriesQuery", res.QueryType)
+}
+
 func TestRequestParser(t *testing.T) {
 	average := "Average"
 	false := false


### PR DESCRIPTION
When [simplejson was removed](https://github.com/grafana/grafana/commit/08f72f214e496954c453830549686cd117bc2894) some bugs were introduced into the requestParser that used the wrong value for `queryType` and changed `returnData` to default to false. This fixes those issues.

Fixes #52757
Fixes #52360 