### PR TITLE
RBAC: Remove permissions for an action if the user has a wildcard scope

### DIFF
--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
@@ -2,6 +2,7 @@ package ossaccesscontrol
 
 import (
 	"context"
+	"sort"
 
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -129,7 +130,12 @@ func (ac *OSSAccessControlService) GetUserPermissions(ctx context.Context, user 
 		}
 	}
 
-	return permissions, nil
+	// we need to sort permissions in order to check if we can remove permission in favor of wildcards
+	sort.Slice(permissions, func(i, j int) bool {
+		return permissions[i].Scope < permissions[j].Scope
+	})
+
+	return accesscontrol.ReducePermissions(permissions), nil
 }
 
 func (ac *OSSAccessControlService) getFixedPermissions(ctx context.Context, user *models.SignedInUser) []accesscontrol.Permission {

--- a/pkg/services/accesscontrol/permission.go
+++ b/pkg/services/accesscontrol/permission.go
@@ -1,0 +1,24 @@
+package accesscontrol
+
+import (
+	"strings"
+)
+
+// ReducePermissions takes a sorted slice of permissions and removes all permission for an action if there is a wildcard scope
+func ReducePermissions(permissions []Permission) []Permission {
+	var out []Permission
+	wildcards := make(map[string]string)
+	for _, p := range permissions {
+		prefix, ok := wildcards[p.Action]
+		if ok && strings.HasPrefix(p.Scope, prefix) {
+			continue
+		}
+
+		prefix, last := p.Scope[:len(p.Scope)-1], p.Scope[len(p.Scope)-1]
+		if last == '*' {
+			wildcards[p.Action] = prefix
+		}
+		out = append(out, p)
+	}
+	return out
+}

--- a/pkg/services/accesscontrol/permission.go
+++ b/pkg/services/accesscontrol/permission.go
@@ -14,10 +14,13 @@ func ReducePermissions(permissions []Permission) []Permission {
 			continue
 		}
 
-		prefix, last := p.Scope[:len(p.Scope)-1], p.Scope[len(p.Scope)-1]
-		if last == '*' {
-			wildcards[p.Action] = prefix
+		if p.Scope != "" {
+			prefix, last := p.Scope[:len(p.Scope)-1], p.Scope[len(p.Scope)-1]
+			if last == '*' {
+				wildcards[p.Action] = prefix
+			}
 		}
+
 		out = append(out, p)
 	}
 	return out

--- a/pkg/services/accesscontrol/permission_test.go
+++ b/pkg/services/accesscontrol/permission_test.go
@@ -1,0 +1,69 @@
+package accesscontrol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptimizeScopes(t *testing.T) {
+	type testCase struct {
+		desc string
+		in   []Permission
+		out  []Permission
+	}
+
+	tests := []testCase{
+		{
+			desc: "Should only return wildcard scope",
+			in: []Permission{
+				{Action: "dashboards:read", Scope: "dashboards:*"},
+				{Action: "dashboards:read", Scope: "dashboards:uid:5"},
+				{Action: "dashboards:read", Scope: "dashboards:uid:10"},
+				{Action: "dashboards:read", Scope: "dashboards:uid:22"},
+				{Action: "dashboards:read", Scope: "dashboards:uid:999"},
+			},
+			out: []Permission{
+				{Action: "dashboards:read", Scope: "dashboards:*"},
+			},
+		},
+		{
+			desc: "Should only return wildcard scope for read action",
+			in: []Permission{
+				{Action: "dashboards:read", Scope: "dashboards:*"},
+				{Action: "dashboards:read", Scope: "dashboards:uid:5"},
+				{Action: "dashboards:read", Scope: "dashboards:uid:10"},
+				{Action: "dashboards:read", Scope: "dashboards:uid:22"},
+				{Action: "dashboards:read", Scope: "dashboards:uid:999"},
+				{Action: "dashboards:write", Scope: "dashboards:uid:5"},
+				{Action: "dashboards:write", Scope: "dashboards:uid:10"},
+			},
+			out: []Permission{
+				{Action: "dashboards:read", Scope: "dashboards:*"},
+				{Action: "dashboards:write", Scope: "dashboards:uid:5"},
+				{Action: "dashboards:write", Scope: "dashboards:uid:10"},
+			},
+		},
+		{
+			desc: "Should keep scopes with different prefix than wildcard scope",
+			in: []Permission{
+				{Action: "dashboards:read", Scope: "dashboards:*"},
+				{Action: "dashboards:read", Scope: "dashboards:uid:5"},
+				{Action: "dashboards:read", Scope: "dashboards:uid:10"},
+				{Action: "dashboards:read", Scope: "dashboards:uid:22"},
+				{Action: "dashboards:read", Scope: "folders:uid:1"},
+			},
+			out: []Permission{
+				{Action: "dashboards:read", Scope: "dashboards:*"},
+				{Action: "dashboards:read", Scope: "folders:uid:1"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			out := ReducePermissions(tt.in)
+			require.Equal(t, tt.out, out)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
When fetching permissions for a user we can remove all permissions for an action if the user has a wildcard scope.

For OSS we need to sort all permissions after we have fetched them from the db and resolved permissions for basic roles (stored in memory).

In order to guarantee that a miss configured wildcard scope does not revoke all access for a user, e.g. Action: `dashboards:read` with scope `alert:*` we only remove permissions matching the prefix of the scope. The downside to this is that if we have a folder scope for dashboard action all dashboard scopes will be kept  

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

