### PR TITLE
PromQuery: Show exemplars in collapsed view

### DIFF
--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.test.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.test.tsx
@@ -68,6 +68,21 @@ describe('PromQueryBuilderOptions', () => {
 
     expect(screen.getByText('Type: Instant')).toBeInTheDocument();
   });
+
+  it('Should show "Exemplars: false" by default', async () => {
+    setup();
+    expect(screen.getByText('Exemplars: false')).toBeInTheDocument();
+  });
+
+  it('Should show "Exemplars: false" when query has "Exemplars: false"', async () => {
+    setup({ exemplar: false });
+    expect(screen.getByText('Exemplars: false')).toBeInTheDocument();
+  });
+
+  it('Should show "Exemplars: true" when query has "Exemplars: true"', async () => {
+    setup({ exemplar: true });
+    expect(screen.getByText('Exemplars: true')).toBeInTheDocument();
+  });
 });
 
 function setup(queryOverrides: Partial<PromQuery> = {}) {

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.tsx
@@ -92,7 +92,7 @@ export const PromQueryBuilderOptions = React.memo<Props>(({ query, app, onChange
         </EditorField>
         {shouldShowExemplarSwitch(query, app) && (
           <EditorField label="Exemplars">
-            <EditorSwitch value={query.exemplar} onChange={onExemplarChange} />
+            <EditorSwitch value={query.exemplar || false} onChange={onExemplarChange} />
           </EditorField>
         )}
         {query.intervalFactor && query.intervalFactor > 1 && (

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryBuilderOptions.tsx
@@ -57,7 +57,10 @@ export const PromQueryBuilderOptions = React.memo<Props>(({ query, app, onChange
 
   return (
     <EditorRow>
-      <QueryOptionGroup title="Options" collapsedInfo={getCollapsedInfo(query, formatOption.label!, queryTypeLabel)}>
+      <QueryOptionGroup
+        title="Options"
+        collapsedInfo={getCollapsedInfo(query, formatOption.label!, queryTypeLabel, app)}
+      >
         <PromQueryLegendEditor
           legendFormat={query.legendFormat}
           onChange={(legendFormat) => onChange({ ...query, legendFormat })}
@@ -120,7 +123,7 @@ function getQueryTypeValue(query: PromQuery) {
   return query.range && query.instant ? 'both' : query.instant ? 'instant' : 'range';
 }
 
-function getCollapsedInfo(query: PromQuery, formatOption: string, queryType: string): string[] {
+function getCollapsedInfo(query: PromQuery, formatOption: string, queryType: string, app?: CoreApp): string[] {
   const items: string[] = [];
 
   items.push(`Legend: ${getLegendModeLabel(query.legendFormat)}`);
@@ -128,10 +131,13 @@ function getCollapsedInfo(query: PromQuery, formatOption: string, queryType: str
   items.push(`Step: ${query.interval ?? 'auto'}`);
   items.push(`Type: ${queryType}`);
 
-  if (query.exemplar) {
-    items.push(`Exemplars: true`);
+  if (shouldShowExemplarSwitch(query, app)) {
+    if (query.exemplar) {
+      items.push(`Exemplars: true`);
+    } else {
+      items.push(`Exemplars: false`);
+    }
   }
-
   return items;
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
In Prometheus query builder's collapsed view, `Exemplars` state does not show when it is `false`
The fix now shows the correct state for `Exemplars` below:
![image](https://user-images.githubusercontent.com/10269640/180881480-c4b64e57-5f3d-4249-ac95-769894aa3c7d.png)

Additionally, the `EditorSwitch` component gets assigned with `undefined` which throws [uncontrolled component error](https://reactjs.org/docs/uncontrolled-components.html). Assigning `false` if no value is read from query

**Which issue(s) this PR fixes**:
Solving an [issue](https://github.com/grafana/grafana/issues/52239) 

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
Added 3 cases for each possible scenario, with Exemplars being

- at the creation of panel - `undefined`
- `false`
- `true`

It seems a bit too much compared to other cases written in the file, would look for a suggestion if you can guide me a better approach.