### PR TITLE
Image Renderer: Fixing the relative url path

### DIFF
--- a/docs/sources/setup-grafana/image-rendering/monitoring.md
+++ b/docs/sources/setup-grafana/image-rendering/monitoring.md
@@ -15,7 +15,7 @@ weight: 100
 
 # Monitoring the image renderer
 
-Rendering images requires a lot of memory, mainly because Grafana creates browser instances in the background for the actual rendering. Monitoring your service can help you allocate the right amount of resources to your rendering service and set the right [rendering mode]({{< relref "/#rendering-mode" >}}).
+Rendering images requires a lot of memory, mainly because Grafana creates browser instances in the background for the actual rendering. Monitoring your service can help you allocate the right amount of resources to your rendering service and set the right [rendering mode]({{< relref "./#rendering-mode" >}}).
 
 ## Enable Prometheus metrics endpoint
 


### PR DESCRIPTION
The link "rendering mode" on this [page](https://grafana.com/docs/grafana/next/setup-grafana/image-rendering/monitoring/) is leading to a 404. This PR fixes it.