### PR TITLE
State Timeline: Prevent Label Text from Overflowing Labeled Segment

### DIFF
--- a/public/app/plugins/panel/state-timeline/timeline.ts
+++ b/public/app/plugins/panel/state-timeline/timeline.ts
@@ -319,9 +319,10 @@ export function getConfig(opts: TimelineCoreOptions) {
               for (let ix = 0; ix < dataY.length; ix++) {
                 if (dataY[ix] != null) {
                   const boxRect = boxRectsBySeries[sidx - 1][ix];
+                  const txt = formatValue(sidx, dataY[ix]);
+                  const valueRect = u.ctx.measureText(txt);
 
-                  // Todo refine this to better know when to not render text (when values do not fit)
-                  if (!boxRect || (showValue === VisibilityMode.Auto && boxRect.w < 25)) {
+                  if (!boxRect || (showValue === VisibilityMode.Auto && boxRect.w < valueRect.width)) {
                     continue;
                   }
 
@@ -331,7 +332,6 @@ export function getConfig(opts: TimelineCoreOptions) {
 
                   // center-aligned
                   let x = round(boxRect.x + xOff + boxRect.w / 2);
-                  const txt = formatValue(sidx, dataY[ix]);
 
                   if (mode === TimelineMode.Changes) {
                     if (alignValue === 'left') {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The current text overflow check in state-timeline works with a hardcoded width value.
This leads to values overflowing their boxes in a lot of scenarios.
![bilde](https://user-images.githubusercontent.com/3834726/180953163-34ff30d4-b7ab-4bd4-8653-324365057f25.png)

The fix improves this by using the text width instead of the hardcoded value, to make overflowing less frequent.
![bilde](https://user-images.githubusercontent.com/3834726/180953608-edf82e39-8f7d-4385-a8aa-f55a4cde8a74.png)


