### PR TITLE
ValueMapping: Fix not being able to click the `Special` dropdown

### DIFF
--- a/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingEditRow.tsx
+++ b/public/app/features/dimensions/editors/ValueMappingsEditor/ValueMappingEditRow.tsx
@@ -129,9 +129,9 @@ export function ValueMappingEditRow({ mapping, index, onChange, onRemove, onDupl
   return (
     <Draggable key={id} draggableId={id} index={index}>
       {(provided) => (
-        <tr ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
+        <tr className={styles.dragRow} ref={provided.innerRef} {...provided.draggableProps}>
           <td>
-            <div className={styles.dragHandle}>
+            <div className={styles.dragHandle} {...provided.dragHandleProps}>
               <Icon name="draggabledots" size="lg" />
             </div>
           </td>
@@ -231,8 +231,23 @@ export function ValueMappingEditRow({ mapping, index, onChange, onRemove, onDupl
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
+  dragRow: css({
+    position: 'relative',
+  }),
   dragHandle: css({
     cursor: 'grab',
+    // create focus ring around the whole row when the drag handle is tab-focused
+    // needs position: relative on the drag row to work correctly
+    '&:focus-visible&:after': {
+      bottom: 0,
+      content: '""',
+      left: 0,
+      position: 'absolute',
+      right: 0,
+      top: 0,
+      outline: `2px solid ${theme.colors.primary.main}`,
+      outlineOffset: '-2px',
+    },
   }),
   rangeInputWrapper: css({
     display: 'flex',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- https://github.com/grafana/grafana/pull/52337 made the whole row a drag handle. this has a couple of problems:
  - the `Special` select dropdown is no longer clickable as the drag handle swallows the click event. i'm not entirely sure why it doesn't do the same for regular `Input`s, but i didn't dig any further because...
  - it creates nested interactive elements which [i think we should try to avoid](https://dequeuniversity.com/rules/axe/4.2/nested-interactive)
- instead, let's keep the drag handle functionality on the dots only, and style the row with css

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/52719

**Special notes for your reviewer**:

tested in chrome/firefox. this doesn't work in safari because safari still doesn't support `focus-visible` 🙄 