### PR TITLE
Chore: Remove unused code from `upload-cdn` step

### DIFF
--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -341,13 +341,6 @@ def e2e_tests_artifacts(edition):
 
 
 def upload_cdn_step(edition, ver_mode, trigger=None):
-    src_dir = ''
-    if ver_mode == "release":
-        bucket = "$${PRERELEASE_BUCKET}"
-        src_dir = " --src-dir artifacts/static-assets"
-    else:
-        bucket = "grafana-static-assets"
-
     deps = []
     if edition in 'enterprise2':
         deps.extend([


### PR DESCRIPTION
**What this PR does / why we need it**:

After the majority of the flags and arguments for `grabpl` have already been moved to a static config, we can clean up some parts of our `*.star` files. Removing the current condition since it's not needed.

No-op.