### PR TITLE
UI/Card: Fix card items always having pointer cursor

### DIFF
--- a/packages/grafana-ui/src/components/Card/CardContainer.tsx
+++ b/packages/grafana-ui/src/components/Card/CardContainer.tsx
@@ -67,7 +67,7 @@ export const CardContainer = ({
 };
 
 export const getCardContainerStyles = stylesFactory(
-  (theme: GrafanaTheme2, disabled = false, disableHover = false, isSelected = false) => {
+  (theme: GrafanaTheme2, disabled = false, disableHover = false, isSelected) => {
     const isSelectable = isSelected !== undefined;
 
     return {


### PR DESCRIPTION
**What this PR does / why we need it**:

A regression introduced in https://github.com/grafana/grafana/pull/45538 would apply the `cursor: pointer` style to all instances of `<Card>` regardless of whether the card was interact-able or not.
