### PR TITLE
[WIP] Build: Fix failing webpack builds with node >= 17 and linux

### DIFF
--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -16,6 +16,9 @@ module.exports = {
     filename: '[name].[contenthash].js',
     // Keep publicPath relative for host.com/grafana/ deployments
     publicPath: 'public/build/',
+    // hashing with certain linux distros and nodejs > 16 causes build errors. See:
+    // https://github.com/webpack/webpack/issues/14532#issuecomment-947525539
+    hashFunction: 'xxhash64',
   },
   resolve: {
     extensions: ['.ts', '.tsx', '.es6', '.js', '.json', '.svg'],


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Attempts to workaround a FE build issue with certain linux distros and nodejs >= 17 by making use of a newer hashFunction (which will be default in webpack 6).

Ref: https://github.com/webpack/webpack/issues/14532
