### PR TITLE
Canvas: Force update during element name change

### DIFF
--- a/public/app/plugins/panel/canvas/editor/LayerElementListEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/LayerElementListEditor.tsx
@@ -198,6 +198,7 @@ export class LayerElementListEditor extends PureComponent<Props> {
 
     const onNameChange = (element: ElementState, name: string) => {
       element.onChange({ ...element.options, name });
+      this.onSelect(element);
     };
 
     const showActions = (element: ElementState) => {


### PR DESCRIPTION
What this PR does / why we need it:
When renaming an element using inline edit, the name doesn't appear to update until a user selects another element.

Before:
![Jul-26-2022 11-14-21](https://user-images.githubusercontent.com/60050885/181081151-8168c3d0-d497-4533-9c8e-51c1117bf7e7.gif)

After:
![Jul-26-2022 11-10-56](https://user-images.githubusercontent.com/60050885/181080609-66f22b10-3919-4818-aa07-cfc9ecd97fe4.gif)

Fixes #52821

