### PR TITLE
Alerting: Scheduler to fetch folders along with rules

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -346,8 +346,8 @@ type ListAlertRulesQuery struct {
 type GetAlertRulesForSchedulingQuery struct {
 	PopulateFolders bool
 
-	Rules         []*AlertRule
-	FoldersTitles map[string]string
+	ResultRules         []*AlertRule
+	ResultFoldersTitles map[string]string
 }
 
 // ListNamespaceAlertRulesQuery is the query for listing namespace alert rules

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -344,7 +344,10 @@ type ListAlertRulesQuery struct {
 }
 
 type GetAlertRulesForSchedulingQuery struct {
-	Result []*AlertRule
+	PopulateFolders bool
+
+	Rules         []*AlertRule
+	FoldersTitles map[string]string
 }
 
 // ListNamespaceAlertRulesQuery is the query for listing namespace alert rules

--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -43,6 +43,17 @@ func (sch *schedule) updateSchedulableAlertRules(ctx context.Context) error {
 			time.Since(start).Seconds())
 	}()
 
+	if !sch.schedulableAlertRules.isEmpty() {
+		keys, err := sch.ruleStore.GetAlertRulesKeysForScheduling(ctx)
+		if err != nil {
+			return err
+		}
+		if !sch.schedulableAlertRules.needsUpdate(keys) {
+			sch.log.Info("no changes detected. Skip updating")
+			return nil
+		}
+	}
+
 	q := models.GetAlertRulesForSchedulingQuery{
 		PopulateFolders: !sch.disableGrafanaFolder,
 	}

--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -60,7 +60,7 @@ func (sch *schedule) updateSchedulableAlertRules(ctx context.Context) error {
 	if err := sch.ruleStore.GetAlertRulesForScheduling(ctx, &q); err != nil {
 		return fmt.Errorf("failed to get alert rules: %w", err)
 	}
-	sch.log.Debug("alert rules fetched", "rules_count", len(q.Rules), "folders_count", len(q.FoldersTitles))
-	sch.schedulableAlertRules.set(q.Rules, q.FoldersTitles)
+	sch.log.Debug("alert rules fetched", "rules_count", len(q.ResultRules), "folders_count", len(q.ResultFoldersTitles))
+	sch.schedulableAlertRules.set(q.ResultRules, q.ResultFoldersTitles)
 	return nil
 }

--- a/pkg/services/ngalert/schedule/fetcher.go
+++ b/pkg/services/ngalert/schedule/fetcher.go
@@ -43,11 +43,13 @@ func (sch *schedule) updateSchedulableAlertRules(ctx context.Context) error {
 			time.Since(start).Seconds())
 	}()
 
-	q := models.GetAlertRulesForSchedulingQuery{}
+	q := models.GetAlertRulesForSchedulingQuery{
+		PopulateFolders: !sch.disableGrafanaFolder,
+	}
 	if err := sch.ruleStore.GetAlertRulesForScheduling(ctx, &q); err != nil {
 		return fmt.Errorf("failed to get alert rules: %w", err)
 	}
-	sch.log.Debug("alert rules fetched", "count", len(q.Result))
-	sch.schedulableAlertRules.set(q.Result)
+	sch.log.Debug("alert rules fetched", "rules_count", len(q.Rules), "folders_count", len(q.FoldersTitles))
+	sch.schedulableAlertRules.set(q.Rules, q.FoldersTitles)
 	return nil
 }

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -195,3 +195,22 @@ func (r *alertRulesRegistry) del(k models.AlertRuleKey) (*models.AlertRule, bool
 	}
 	return rule, ok
 }
+
+func (r *alertRulesRegistry) isEmpty() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.rules) == 0
+}
+
+func (r *alertRulesRegistry) needsUpdate(keys []models.AlertRuleKeyWithVersion) bool {
+	if len(r.rules) != len(keys) {
+		return true
+	}
+	for _, key := range keys {
+		rule, ok := r.rules[key.AlertRuleKey]
+		if !ok || rule.Version != key.Version {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -144,19 +144,20 @@ type evaluation struct {
 }
 
 type alertRulesRegistry struct {
-	rules map[models.AlertRuleKey]*models.AlertRule
-	mu    sync.Mutex
+	rules        map[models.AlertRuleKey]*models.AlertRule
+	folderTitles map[string]string
+	mu           sync.Mutex
 }
 
 // all returns all rules in the registry.
-func (r *alertRulesRegistry) all() []*models.AlertRule {
+func (r *alertRulesRegistry) all() ([]*models.AlertRule, map[string]string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	result := make([]*models.AlertRule, 0, len(r.rules))
 	for _, rule := range r.rules {
 		result = append(result, rule)
 	}
-	return result
+	return result, r.folderTitles
 }
 
 func (r *alertRulesRegistry) get(k models.AlertRuleKey) *models.AlertRule {
@@ -166,13 +167,15 @@ func (r *alertRulesRegistry) get(k models.AlertRuleKey) *models.AlertRule {
 }
 
 // set replaces all rules in the registry.
-func (r *alertRulesRegistry) set(rules []*models.AlertRule) {
+func (r *alertRulesRegistry) set(rules []*models.AlertRule, folders map[string]string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.rules = make(map[models.AlertRuleKey]*models.AlertRule)
 	for _, rule := range rules {
 		r.rules[rule.GetKey()] = rule
 	}
+	// return the map as is without copying because it is not mutated
+	r.folderTitles = folders
 }
 
 // update inserts or replaces a rule in the registry.

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -96,7 +96,7 @@ func newAlertRuleInfo(parent context.Context) *alertRuleInfo {
 //   - true when message was sent
 //   - false when the send operation is stopped
 // the second element contains a dropped message that was sent by a concurrent sender.
-func (a *alertRuleInfo) eval(t time.Time, rule *models.AlertRule) (bool, *evaluation) {
+func (a *alertRuleInfo) eval(eval *evaluation) (bool, *evaluation) {
 	// read the channel in unblocking manner to make sure that there is no concurrent send operation.
 	var droppedMsg *evaluation
 	select {
@@ -105,10 +105,7 @@ func (a *alertRuleInfo) eval(t time.Time, rule *models.AlertRule) (bool, *evalua
 	}
 
 	select {
-	case a.evalCh <- &evaluation{
-		scheduledAt: t,
-		rule:        rule,
-	}:
+	case a.evalCh <- eval:
 		return true, droppedMsg
 	case <-a.ctx.Done():
 		return false, droppedMsg
@@ -141,6 +138,7 @@ func (a *alertRuleInfo) update(lastVersion ruleVersion) bool {
 type evaluation struct {
 	scheduledAt time.Time
 	rule        *models.AlertRule
+	folderTitle string
 }
 
 type alertRulesRegistry struct {

--- a/pkg/services/ngalert/schedule/registry_test.go
+++ b/pkg/services/ngalert/schedule/registry_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func TestSchedule_alertRuleInfo(t *testing.T) {
@@ -91,15 +92,18 @@ func TestSchedule_alertRuleInfo(t *testing.T) {
 			r := newAlertRuleInfo(context.Background())
 			expected := time.Now()
 			resultCh := make(chan evalResponse)
-			rule := models.AlertRuleGen()()
+			data := &evaluation{
+				scheduledAt: expected,
+				rule:        models.AlertRuleGen()(),
+				folderTitle: util.GenerateShortUID(),
+			}
 			go func() {
-				result, dropped := r.eval(expected, rule)
+				result, dropped := r.eval(data)
 				resultCh <- evalResponse{result, dropped}
 			}()
 			select {
 			case ctx := <-r.evalCh:
-				require.Equal(t, rule, ctx.rule)
-				require.Equal(t, expected, ctx.scheduledAt)
+				require.Equal(t, data, ctx)
 				result := <-resultCh
 				require.True(t, result.success)
 				require.Nilf(t, result.droppedEval, "expected no dropped evaluations but got one")
@@ -113,12 +117,21 @@ func TestSchedule_alertRuleInfo(t *testing.T) {
 			time2 := time.UnixMilli(rand.Int63n(math.MaxInt64))
 			resultCh1 := make(chan evalResponse)
 			resultCh2 := make(chan evalResponse)
-			rule := models.AlertRuleGen()()
+			data := &evaluation{
+				scheduledAt: time1,
+				rule:        models.AlertRuleGen()(),
+				folderTitle: util.GenerateShortUID(),
+			}
+			data2 := &evaluation{
+				scheduledAt: time2,
+				rule:        data.rule,
+				folderTitle: data.folderTitle,
+			}
 			wg := sync.WaitGroup{}
 			wg.Add(1)
 			go func() {
 				wg.Done()
-				result, dropped := r.eval(time1, rule)
+				result, dropped := r.eval(data)
 				wg.Done()
 				resultCh1 <- evalResponse{result, dropped}
 			}()
@@ -126,7 +139,7 @@ func TestSchedule_alertRuleInfo(t *testing.T) {
 			wg.Add(2) // one when time1 is sent, another when go-routine for time2 has started
 			go func() {
 				wg.Done()
-				result, dropped := r.eval(time2, rule)
+				result, dropped := r.eval(data2)
 				resultCh2 <- evalResponse{result, dropped}
 			}()
 			wg.Wait() // at this point tick 1 has already been dropped
@@ -147,9 +160,13 @@ func TestSchedule_alertRuleInfo(t *testing.T) {
 		t.Run("eval should exit when context is cancelled", func(t *testing.T) {
 			r := newAlertRuleInfo(context.Background())
 			resultCh := make(chan evalResponse)
-			rule := models.AlertRuleGen()()
+			data := &evaluation{
+				scheduledAt: time.Now(),
+				rule:        models.AlertRuleGen()(),
+				folderTitle: util.GenerateShortUID(),
+			}
 			go func() {
-				result, dropped := r.eval(time.Now(), rule)
+				result, dropped := r.eval(data)
 				resultCh <- evalResponse{result, dropped}
 			}()
 			runtime.Gosched()
@@ -173,8 +190,12 @@ func TestSchedule_alertRuleInfo(t *testing.T) {
 		t.Run("eval should do nothing", func(t *testing.T) {
 			r := newAlertRuleInfo(context.Background())
 			r.stop(nil)
-			rule := models.AlertRuleGen()()
-			success, dropped := r.eval(time.Now(), rule)
+			data := &evaluation{
+				scheduledAt: time.Now(),
+				rule:        models.AlertRuleGen()(),
+				folderTitle: util.GenerateShortUID(),
+			}
+			success, dropped := r.eval(data)
 			require.False(t, success)
 			require.Nilf(t, dropped, "expected no dropped evaluations but got one")
 		})
@@ -218,7 +239,11 @@ func TestSchedule_alertRuleInfo(t *testing.T) {
 					case 1:
 						r.update(ruleVersion(rand.Int63()))
 					case 2:
-						r.eval(time.Now(), models.AlertRuleGen()())
+						r.eval(&evaluation{
+							scheduledAt: time.Now(),
+							rule:        models.AlertRuleGen()(),
+							folderTitle: util.GenerateShortUID(),
+						})
 					case 3:
 						r.stop(nil)
 					}

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -48,6 +48,7 @@ type AlertsSender interface {
 
 // RulesStore is a store that provides alert rules for scheduling
 type RulesStore interface {
+	GetAlertRulesKeysForScheduling(ctx context.Context) ([]ngmodels.AlertRuleKeyWithVersion, error)
 	GetAlertRulesForScheduling(ctx context.Context, query *ngmodels.GetAlertRulesForSchedulingQuery) error
 }
 

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -46,6 +46,11 @@ type AlertsSender interface {
 	Send(key ngmodels.AlertRuleKey, alerts definitions.PostableAlerts)
 }
 
+// RulesStore is a store that provides alert rules for scheduling
+type RulesStore interface {
+	GetAlertRulesForScheduling(ctx context.Context, query *ngmodels.GetAlertRulesForSchedulingQuery) error
+}
+
 type schedule struct {
 	// base tick rate (fastest possible configured check)
 	baseInterval time.Duration
@@ -73,7 +78,7 @@ type schedule struct {
 
 	evaluator eval.Evaluator
 
-	ruleStore store.RuleStore
+	ruleStore RulesStore
 
 	stateManager *state.Manager
 
@@ -100,7 +105,7 @@ type SchedulerCfg struct {
 	EvalAppliedFunc func(ngmodels.AlertRuleKey, time.Time)
 	StopAppliedFunc func(ngmodels.AlertRuleKey)
 	Evaluator       eval.Evaluator
-	RuleStore       store.RuleStore
+	RuleStore       RulesStore
 	InstanceStore   store.InstanceStore
 	Metrics         *metrics.Scheduler
 	AlertSender     AlertsSender

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -172,7 +172,7 @@ func (sch *schedule) DeleteAlertRule(keys ...ngmodels.AlertRuleKey) {
 		ruleInfo.stop(errRuleDeleted)
 	}
 	// Our best bet at this point is that we update the metrics with what we hope to schedule in the next tick.
-	alertRules := sch.schedulableAlertRules.all()
+	alertRules, _ := sch.schedulableAlertRules.all()
 	sch.metrics.SchedulableAlertRules.Set(float64(len(alertRules)))
 	sch.metrics.SchedulableAlertRulesHash.Set(float64(hashUIDs(alertRules)))
 }
@@ -194,7 +194,7 @@ func (sch *schedule) schedulePeriodic(ctx context.Context) error {
 			if err := sch.updateSchedulableAlertRules(ctx); err != nil {
 				sch.log.Error("scheduler failed to update alert rules", "err", err)
 			}
-			alertRules := sch.schedulableAlertRules.all()
+			alertRules, _ := sch.schedulableAlertRules.all()
 
 			// registeredDefinitions is a map used for finding deleted alert rules
 			// initially it is assigned to all known alert rules from the previous cycle

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -63,7 +63,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 
 			rule := models.AlertRuleGen(withQueryForState(t, evalState))()
 			ruleStore.PutRule(context.Background(), rule)
-
+			folder, _ := ruleStore.GetNamespaceByUID(context.Background(), rule.NamespaceUID, rule.OrgID, nil)
 			go func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				t.Cleanup(cancel)
@@ -75,6 +75,7 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 			evalChan <- &evaluation{
 				scheduledAt: expectedTime,
 				rule:        rule,
+				folderTitle: folder.Title,
 			}
 
 			actualTime := waitForTimeChannel(t, evalAppliedChan)
@@ -82,7 +83,6 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 
 			t.Run("it should add extra labels", func(t *testing.T) {
 				states := sch.stateManager.GetStatesForRuleUID(rule.OrgID, rule.UID)
-				folder, _ := ruleStore.GetNamespaceByUID(context.Background(), rule.NamespaceUID, rule.OrgID, nil)
 				for _, s := range states {
 					assert.Equal(t, rule.UID, s.Labels[models.RuleUIDLabel])
 					assert.Equal(t, rule.NamespaceUID, s.Labels[models.NamespaceUIDLabel])

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -45,7 +45,6 @@ type RuleStore interface {
 	DeleteAlertInstancesByRuleUID(ctx context.Context, orgID int64, ruleUID string) error
 	GetAlertRuleByUID(ctx context.Context, query *ngmodels.GetAlertRuleByUIDQuery) error
 	GetAlertRulesGroupByRuleUID(ctx context.Context, query *ngmodels.GetAlertRulesGroupByRuleUIDQuery) error
-	GetAlertRulesForScheduling(ctx context.Context, query *ngmodels.GetAlertRulesForSchedulingQuery) error
 	ListAlertRules(ctx context.Context, query *ngmodels.ListAlertRulesQuery) error
 	// GetRuleGroups returns the unique rule groups across all organizations.
 	GetRuleGroups(ctx context.Context, query *ngmodels.ListRuleGroupsQuery) error

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -435,6 +435,22 @@ func (st DBstore) getFilterByOrgsString() string {
 	return builder.String()
 }
 
+func (st DBstore) GetAlertRulesKeysForScheduling(ctx context.Context) ([]ngmodels.AlertRuleKeyWithVersion, error) {
+	var result []ngmodels.AlertRuleKeyWithVersion
+	err := st.SQLStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		alertRulesSql := "SELECT org_id, uid, version  FROM alert_rule"
+		filter := st.getFilterByOrgsString()
+		if filter != "" {
+			alertRulesSql += " WHERE " + filter
+		}
+		if err := sess.SQL(alertRulesSql).Find(&result); err != nil {
+			return err
+		}
+		return nil
+	})
+	return result, err
+}
+
 // GetAlertRulesForScheduling returns a short version of all alert rules except those that belong to an excluded list of organizations
 func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodels.GetAlertRulesForSchedulingQuery) error {
 	var folders []struct {

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -428,6 +428,7 @@ func (st DBstore) getFilterByOrgsString() string {
 		idx--
 		if idx == 0 {
 			builder.WriteString(")")
+			break
 		}
 		builder.WriteString(",")
 	}

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -461,12 +461,10 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 	return st.SQLStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		foldersSql := "SELECT D.uid, D.title FROM dashboard AS D WHERE is_folder = 1 AND EXISTS (SELECT 1 FROM alert_rule AS A WHERE D.uid = A.namespace_uid)"
 		alertRulesSql := "SELECT * FROM alert_rule"
-
 		filter := st.getFilterByOrgsString()
 		if filter != "" {
 			foldersSql += " AND " + filter
 			alertRulesSql += " WHERE " + filter
-
 		}
 
 		if err := sess.SQL(alertRulesSql).Find(&rules); err != nil {

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -92,3 +92,29 @@ func withIntervalMatching(baseInterval time.Duration) func(*models.AlertRule) {
 		rule.For = time.Duration(rule.IntervalSeconds*rand.Int63n(9)+1) * time.Second
 	}
 }
+
+func Test_getFilterByOrgsString(t *testing.T) {
+	t.Run("should return empty string if map is empty", func(t *testing.T) {
+		store := &DBstore{
+			Cfg: setting.UnifiedAlertingSettings{
+				DisabledOrgs: map[int64]struct{}{},
+			},
+		}
+		require.Empty(t, store.getFilterByOrgsString())
+	})
+	t.Run("should return correct expression if map is not empty", func(t *testing.T) {
+		orgs := map[int64]struct{}{
+			1: {},
+			2: {},
+			3: {},
+		}
+		store := &DBstore{
+			Cfg: setting.UnifiedAlertingSettings{
+				DisabledOrgs: orgs,
+			},
+		}
+
+		result := store.getFilterByOrgsString()
+		require.Equal(t, "NOT IN (1,2,3)", result)
+	})
+}

--- a/pkg/services/ngalert/store/testing.go
+++ b/pkg/services/ngalert/store/testing.go
@@ -174,6 +174,24 @@ func (f *FakeRuleStore) GetAlertRulesGroupByRuleUID(_ context.Context, q *models
 	}
 	return nil
 }
+func (f *FakeRuleStore) GetAlertRulesKeysForScheduling(_ context.Context) ([]models.AlertRuleKeyWithVersion, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	f.RecordedOps = append(f.RecordedOps, GenericRecordedQuery{
+		Name:   "GetAlertRulesKeysForScheduling",
+		Params: []interface{}{},
+	})
+	result := make([]models.AlertRuleKeyWithVersion, 0, len(f.Rules))
+	for _, rules := range f.Rules {
+		for _, rule := range rules {
+			result = append(result, models.AlertRuleKeyWithVersion{
+				Version:      rule.Version,
+				AlertRuleKey: rule.GetKey(),
+			})
+		}
+	}
+	return result, nil
+}
 
 // For now, we're not implementing namespace filtering.
 func (f *FakeRuleStore) GetAlertRulesForScheduling(_ context.Context, q *models.GetAlertRulesForSchedulingQuery) error {

--- a/pkg/services/ngalert/store/testing.go
+++ b/pkg/services/ngalert/store/testing.go
@@ -201,18 +201,18 @@ func (f *FakeRuleStore) GetAlertRulesForScheduling(_ context.Context, q *models.
 	if err := f.Hook(*q); err != nil {
 		return err
 	}
-	q.FoldersTitles = make(map[string]string)
+	q.ResultFoldersTitles = make(map[string]string)
 	for _, rules := range f.Rules {
 		for _, rule := range rules {
-			q.Rules = append(q.Rules, rule)
+			q.ResultRules = append(q.ResultRules, rule)
 			if !q.PopulateFolders {
 				continue
 			}
-			if _, ok := q.FoldersTitles[rule.NamespaceUID]; !ok {
+			if _, ok := q.ResultFoldersTitles[rule.NamespaceUID]; !ok {
 				if folders, ok := f.Folders[rule.OrgID]; ok {
 					for _, folder := range folders {
 						if folder.Uid == rule.NamespaceUID {
-							q.FoldersTitles[rule.NamespaceUID] = folder.Title
+							q.ResultFoldersTitles[rule.NamespaceUID] = folder.Title
 						}
 					}
 				}

--- a/pkg/services/ngalert/store/testing.go
+++ b/pkg/services/ngalert/store/testing.go
@@ -183,8 +183,23 @@ func (f *FakeRuleStore) GetAlertRulesForScheduling(_ context.Context, q *models.
 	if err := f.Hook(*q); err != nil {
 		return err
 	}
+	q.FoldersTitles = make(map[string]string)
 	for _, rules := range f.Rules {
-		q.Result = append(q.Result, rules...)
+		for _, rule := range rules {
+			q.Rules = append(q.Rules, rule)
+			if !q.PopulateFolders {
+				continue
+			}
+			if _, ok := q.FoldersTitles[rule.NamespaceUID]; !ok {
+				if folders, ok := f.Folders[rule.OrgID]; ok {
+					for _, folder := range folders {
+						if folder.Uid == rule.NamespaceUID {
+							q.FoldersTitles[rule.NamespaceUID] = folder.Title
+						}
+					}
+				}
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
PR https://github.com/grafana/grafana/pull/50262 introduced support for the label `grafana_folder` that is included in every alert. The evaluation routine was updated to pull folder information on its own. It happens every time the rule is updated. 

This PR introduces two changes:
1. It updates the scheduler to fetch folder titles along with rules that need to be scheduled. Benefits:
   - it reduces the number of calls to the database because each rule evaluation loop currently fetches folder title by its own.
   - simplifies the rule evaluation routine and data flows as it removes logic that maintains folder title in memory
   - reduces cohesion of the data layer into the domain layer, which makes the boundaries clear.
2. Updates scheduler to pre-fetch a subset of alert rule's fields (ID and Version) in order to check if the full fetch needs to be done. This reduces traffic from the scheduler.

Other Changes:
- Introduced a new interface `scheduler.RulesStorage` that contains only methods that are required for scheduler.
- Introduced a new model `AlertRuleKeyWithVersion`  that is used to fetch a limited set of fields.
- the scheduler's data cache (alertRulesRegistry) is updated to hold the map of the folder titles. This will be updated further when we migrate to rule groups.

**Special notes for your reviewer**: