### PR TITLE
Storage: allow public access to public files

### DIFF
--- a/pkg/services/store/service.go
+++ b/pkg/services/store/service.go
@@ -143,6 +143,15 @@ func ProvideService(sql *sqlstore.SQLStore, features featuremgmt.FeatureToggles,
 	}
 
 	authService := newStaticStorageAuthService(func(ctx context.Context, user *models.SignedInUser, storageName string) map[string]filestorage.PathFilter {
+		// Public is OK to read regardless of user settings
+		if storageName == RootPublicStatic {
+			return map[string]filestorage.PathFilter{
+				ActionFilesRead:   allowAllPathFilter,
+				ActionFilesWrite:  denyAllPathFilter,
+				ActionFilesDelete: denyAllPathFilter,
+			}
+		}
+
 		if user == nil {
 			return nil
 		}
@@ -171,12 +180,6 @@ func ProvideService(sql *sqlstore.SQLStore, features featuremgmt.FeatureToggles,
 		}
 
 		switch storageName {
-		case RootPublicStatic:
-			return map[string]filestorage.PathFilter{
-				ActionFilesRead:   allowAllPathFilter,
-				ActionFilesWrite:  denyAllPathFilter,
-				ActionFilesDelete: denyAllPathFilter,
-			}
 		case RootDevenv:
 			return map[string]filestorage.PathFilter{
 				ActionFilesRead:   allowAllPathFilter,


### PR DESCRIPTION
This issue came up while trying to understand why the geojson files were not showing up in the UI dropdown... turns out the recent auth additions blocked public access 

<img width="329" alt="image" src="https://user-images.githubusercontent.com/705951/181149385-cfa750c3-0626-463c-bb0d-eb6ad33f3e0b.png">
