### PR TITLE
Transformers: remove config from "join by labels" source fields

### DIFF
--- a/public/app/features/transformers/joinByLabels/joinByLabels.test.ts
+++ b/public/app/features/transformers/joinByLabels/joinByLabels.test.ts
@@ -11,6 +11,9 @@ describe('Join by labels', () => {
           {
             name: 'Value',
             type: FieldType.number,
+            config: {
+              displayNameFromDS: '111',
+            },
             values: [10, 200],
             labels: { what: 'Temp', cluster: 'A', job: 'J1' },
           },
@@ -22,6 +25,9 @@ describe('Join by labels', () => {
           {
             name: 'Value',
             type: FieldType.number,
+            config: {
+              displayNameFromDS: '222',
+            },
             values: [10, 200],
             labels: { what: 'Temp', cluster: 'B', job: 'J1' },
           },
@@ -33,6 +39,9 @@ describe('Join by labels', () => {
           {
             name: 'Value',
             type: FieldType.number,
+            config: {
+              displayNameFromDS: '333',
+            },
             values: [22, 77],
             labels: { what: 'Speed', cluster: 'B', job: 'J1' },
           },
@@ -46,6 +55,7 @@ describe('Join by labels', () => {
       },
       input
     );
+    expect(result.fields[result.fields.length - 1].config).toMatchInlineSnapshot(`Object {}`);
     expect(toRowsSnapshow(result)).toMatchInlineSnapshot(`
       Object {
         "columns": Array [

--- a/public/app/features/transformers/joinByLabels/joinByLabels.ts
+++ b/public/app/features/transformers/joinByLabels/joinByLabels.ts
@@ -124,7 +124,7 @@ export function joinByLabels(options: JoinByLabelsTransformOptions, data: DataFr
     const old = inputFields[allNames[i]];
     frame.fields.push({
       name: allNames[i],
-      config: old.config ?? {},
+      config: {},
       type: old.type ?? FieldType.number,
       values: new ArrayVector(nameValues[i]),
     });


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/52670 we added a transform that lets you extract the value field into a named column.  This worked great with simple test data... but when pushed to a real system, it looks like the `displayNameFromDS` is configured, so rather than having the expected name "cost" we end up with the original escaped labels name

<img width="326" alt="image" src="https://user-images.githubusercontent.com/705951/181163442-c38f9f98-efa1-401d-8ead-7655887bf895.png">

This PR removes the config object so this will not happen