### PR TITLE
Dev: Bump eslint sdk for vscode

### DIFF
--- a/.yarn/sdks/eslint/package.json
+++ b/.yarn/sdks/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "8.17.0-sdk",
+  "version": "8.20.0-sdk",
   "main": "./lib/api.js",
   "type": "commonjs"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps the eslint sdk as vscode didn't find the 8.17 version for me and so eslint didn't work.

