### PR TITLE
UnsavedChanges: Fix issue preventing library panel changes being made

### DIFF
--- a/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.tsx
+++ b/public/app/features/dashboard/components/DashboardPrompt/DashboardPrompt.tsx
@@ -67,7 +67,7 @@ export const DashboardPrompt = React.memo(({ dashboard }: Props) => {
     return () => window.removeEventListener('beforeunload', handleUnload);
   }, [dashboard, original]);
 
-  const forceRefresh = useRef(false);
+  const forceUpdate = useRef(false);
   const onHistoryBlock = (location: H.Location) => {
     const panelInEdit = dashboard.panelInEdit;
     const search = new URLSearchParams(location.search);
@@ -79,12 +79,12 @@ export const DashboardPrompt = React.memo(({ dashboard }: Props) => {
         panel: dashboard.panelInEdit as PanelModelWithLibraryPanel,
         folderId: dashboard.meta.folderId as number,
         onConfirm: () => {
-          forceRefresh.current = true;
+          forceUpdate.current = true;
           hideModal();
           moveToBlockedLocationAfterReactStateUpdate(location);
         },
         onDiscard: () => {
-          forceRefresh.current = false;
+          forceUpdate.current = false;
           dispatch(discardPanelChanges());
           moveToBlockedLocationAfterReactStateUpdate(location);
           hideModal();
@@ -98,7 +98,7 @@ export const DashboardPrompt = React.memo(({ dashboard }: Props) => {
     if (originalPath === location.pathname || !original) {
       // This is here due to timing reasons we want the exit panel editor state changes to happen before router update
       if (panelInEdit && !search.has('editPanel')) {
-        dispatch(exitPanelEditor(forceRefresh.current));
+        dispatch(exitPanelEditor(forceUpdate.current));
       }
 
       return true;

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -106,19 +106,19 @@ export function skipPanelUpdate(modifiedPanel: PanelModel, panelToUpdate: PanelM
   return false;
 }
 
-export function exitPanelEditor(forceRefresh = false): ThunkResult<void> {
+export function exitPanelEditor(forceUpdate = false): ThunkResult<void> {
   return async (dispatch, getStore) => {
     const dashboard = getStore().dashboard.getModel();
     const { getPanel, getSourcePanel, shouldDiscardChanges } = getStore().panelEditor;
     const panel = getPanel();
     const sourcePanel = getSourcePanel();
-    const libraryPanelChanged = panel.libraryPanel?.uid !== sourcePanel.libraryPanel?.uid;
+    const libraryPanelReplaced = panel.libraryPanel?.uid !== sourcePanel.libraryPanel?.uid;
 
     if (dashboard) {
       dashboard.exitPanelEditor();
     }
 
-    if ((forceRefresh || panel.hasChanged || libraryPanelChanged) && !shouldDiscardChanges) {
+    if ((forceUpdate || panel.hasChanged || libraryPanelReplaced) && !shouldDiscardChanges) {
       const modifiedSaveModel = panel.getSaveModel();
       const sourcePanel = getSourcePanel();
       const panelTypeChanged = sourcePanel.type !== panel.type;

--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -106,17 +106,19 @@ export function skipPanelUpdate(modifiedPanel: PanelModel, panelToUpdate: PanelM
   return false;
 }
 
-export function exitPanelEditor(): ThunkResult<void> {
+export function exitPanelEditor(forceRefresh = false): ThunkResult<void> {
   return async (dispatch, getStore) => {
     const dashboard = getStore().dashboard.getModel();
     const { getPanel, getSourcePanel, shouldDiscardChanges } = getStore().panelEditor;
     const panel = getPanel();
+    const sourcePanel = getSourcePanel();
+    const libraryPanelChanged = panel.libraryPanel?.uid !== sourcePanel.libraryPanel?.uid;
 
     if (dashboard) {
       dashboard.exitPanelEditor();
     }
 
-    if (panel.hasChanged && !shouldDiscardChanges) {
+    if ((forceRefresh || panel.hasChanged || libraryPanelChanged) && !shouldDiscardChanges) {
       const modifiedSaveModel = panel.getSaveModel();
       const sourcePanel = getSourcePanel();
       const panelTypeChanged = sourcePanel.type !== panel.type;


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue introduced with https://github.com/grafana/grafana/pull/52363 that caused changes made to a library panel to be ignored.

Before the panel editor is exited, we check `panel.hasChanged` to see if any changes have been made (really this just checks if panel.configRev is greater than 0). We present the user with a dialogue asking if they'd like to apply changes to the library panel, and if they do, the library panel is updated on the backend. `configRev` is then set to 0 so the dialogue doesn't pop up again when we navigate back to the dashboard. With #52363 though, we only refresh the panels if `configRev > 0`, which we just set to 0, so the change isn't made on the frontend.
I added a flag `forceRefresh` which is set if the user confirms the library panel changes and then pass that to `exitPanelEditor`. It's ugly, but not sure what else to do without a bigger refactor :( Let me know if you have any ideas!
