### PR TITLE
LDAP: Add role_attribute_strict option to ldap

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -616,6 +616,9 @@ enabled = false
 config_file = /etc/grafana/ldap.toml
 allow_sign_up = true
 
+# Role attribute strict denies user access if no group mapping is found
+role_attribute_strict = false
+
 # LDAP background sync (Enterprise only)
 # At 1 am every day
 sync_cron = "0 1 * * *"

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -602,6 +602,9 @@
 ;config_file = /etc/grafana/ldap.toml
 ;allow_sign_up = true
 
+# Role attribute strict denies user access if no group mapping is found
+; role_attribute_strict = false
+
 # LDAP background sync (Enterprise only)
 # At 1 am every day
 ;sync_cron = "0 1 * * *"

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/ldap.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/ldap.md
@@ -39,6 +39,9 @@ config_file = /etc/grafana/ldap.toml
 # Allow sign up should almost always be true (default) to allow new Grafana users to be created (if LDAP authentication is ok). If set to
 # false only pre-existing Grafana users will be able to login (if LDAP authentication is ok).
 allow_sign_up = true
+
+# Role attribute strict denies user access if no group mapping is found
+role_attribute_strict = false
 ```
 
 ## Grafana LDAP Configuration

--- a/pkg/login/ldap_login.go
+++ b/pkg/login/ldap_login.go
@@ -56,7 +56,7 @@ var loginUsingLDAP = func(ctx context.Context, query *models.LoginUserQuery, log
 	}
 
 	if query.Cfg.LDAPRoleAttributeStrict && len(externalUser.OrgRoles) == 0 {
-		ldapLogger.Error("Refusing log in", "err", ErrNoOrgRole)
+		ldapLogger.Error("Denying log in", "err", ErrNoOrgRole)
 		return false, ErrNoOrgRole
 	}
 

--- a/pkg/login/ldap_login.go
+++ b/pkg/login/ldap_login.go
@@ -53,6 +53,12 @@ var loginUsingLDAP = func(ctx context.Context, query *models.LoginUserQuery, log
 		return true, err
 	}
 
+	if query.Cfg.LDAPRoleAttributeStrict && len(externalUser.OrgRoles) == 0 {
+		err := fmt.Errorf("no org role found")
+		ldapLogger.Error("Refusing log in", "err", err)
+		return false, err
+	}
+
 	upsert := &models.UpsertUserCommand{
 		ReqContext:    query.ReqContext,
 		ExternalUser:  externalUser,

--- a/pkg/login/ldap_login.go
+++ b/pkg/login/ldap_login.go
@@ -13,6 +13,8 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
+var ErrNoOrgRole = errors.New("no organization role found in ldap group mappings")
+
 // getLDAPConfig gets LDAP config
 var getLDAPConfig = multildap.GetConfig
 
@@ -54,9 +56,8 @@ var loginUsingLDAP = func(ctx context.Context, query *models.LoginUserQuery, log
 	}
 
 	if query.Cfg.LDAPRoleAttributeStrict && len(externalUser.OrgRoles) == 0 {
-		err := fmt.Errorf("no org role found")
-		ldapLogger.Error("Refusing log in", "err", err)
-		return false, err
+		ldapLogger.Error("Refusing log in", "err", ErrNoOrgRole)
+		return false, ErrNoOrgRole
 	}
 
 	upsert := &models.UpsertUserCommand{

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -396,8 +396,9 @@ type Cfg struct {
 	FeedbackLinksEnabled                bool
 
 	// LDAP
-	LDAPEnabled     bool
-	LDAPAllowSignup bool
+	LDAPEnabled             bool
+	LDAPAllowSignup         bool
+	LDAPRoleAttributeStrict bool
 
 	Quota QuotaSettings
 
@@ -1089,6 +1090,7 @@ func (cfg *Cfg) readLDAPConfig() {
 	LDAPActiveSyncEnabled = ldapSec.Key("active_sync_enabled").MustBool(false)
 	LDAPAllowSignup = ldapSec.Key("allow_sign_up").MustBool(true)
 	cfg.LDAPAllowSignup = LDAPAllowSignup
+	cfg.LDAPRoleAttributeStrict = ldapSec.Key("role_attribute_strict").MustBool(false)
 }
 
 func (cfg *Cfg) handleAWSConfig() {


### PR DESCRIPTION
Co-authored-by: Jguer <joao.guerreiro@grafana.com>

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When a user can log in against an ldap, he is saved in the db even if no group mapping (to org role) has been found. Resulting in the user getting the default `auto_assign_org_role`.
This PR intends to add the `role_attribute_strict` option to ldap auth to prevent user log in should no mapping be found.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/support-escalations/issues/3377

**Special notes for your reviewer**:

