### PR TITLE
RBAC: Update the docs homepage to mention that RBAC is only enterprise

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/_index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/_index.md
@@ -14,7 +14,7 @@ weight: 120
 
 # Role-based access control (RBAC)
 
-> Note: Available only in Grafana Enterprise.
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}) and [Grafana Cloud Advanced]({{< ref "/docs/grafana-cloud" >}}).
 
 RBAC provides a standardized way of granting, changing, and revoking access when it comes to viewing and modifying Grafana resources, such as dashboards, reports, and administrative settings.
 

--- a/docs/sources/administration/roles-and-permissions/access-control/_index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/_index.md
@@ -14,6 +14,8 @@ weight: 120
 
 # Role-based access control (RBAC)
 
+> Note: Available only in Grafana Enterprise.
+
 RBAC provides a standardized way of granting, changing, and revoking access when it comes to viewing and modifying Grafana resources, such as dashboards, reports, and administrative settings.
 
 {{< section >}}

--- a/docs/sources/administration/roles-and-permissions/access-control/assign-rbac-roles.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/assign-rbac-roles.md
@@ -11,7 +11,7 @@ weight: 40
 
 # Assign RBAC roles
 
-> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}) and [Grafana Cloud Advanced]({{< ref "/docs/grafana-cloud" >}}).
 
 In this topic you'll learn how to use the role picker, provisioning, and the HTTP API to assign fixed and custom roles to users and teams.
 

--- a/docs/sources/administration/roles-and-permissions/access-control/assign-rbac-roles.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/assign-rbac-roles.md
@@ -11,6 +11,8 @@ weight: 40
 
 # Assign RBAC roles
 
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
+
 In this topic you'll learn how to use the role picker, provisioning, and the HTTP API to assign fixed and custom roles to users and teams.
 
 ## Assign fixed roles in the UI using the role picker

--- a/docs/sources/administration/roles-and-permissions/access-control/configure-rbac.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/configure-rbac.md
@@ -9,6 +9,8 @@ weight: 30
 
 # Configure RBAC in Grafana
 
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
+
 The table below describes all RBAC configuration options. Like any other Grafana configuration, you can apply these options as [environment variables]({{< relref "../../../setup-grafana/configure-grafana/#configure-with-environment-variables" >}}).
 
 | Setting            | Required | Description                                                                  | Default |

--- a/docs/sources/administration/roles-and-permissions/access-control/configure-rbac.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/configure-rbac.md
@@ -9,7 +9,7 @@ weight: 30
 
 # Configure RBAC in Grafana
 
-> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}) and [Grafana Cloud Advanced]({{< ref "/docs/grafana-cloud" >}}).
 
 The table below describes all RBAC configuration options. Like any other Grafana configuration, you can apply these options as [environment variables]({{< relref "../../../setup-grafana/configure-grafana/#configure-with-environment-variables" >}}).
 

--- a/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes.md
@@ -10,7 +10,7 @@ weight: 80
 
 # RBAC permissions, actions, and scopes
 
-> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}) and [Grafana Cloud Advanced]({{< ref "/docs/grafana-cloud" >}}).
 
 A permission is comprised of an action and a scope. When creating a custom role, consider the actions the user can perform and the resource(s) on which they can perform those actions.
 

--- a/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/custom-role-actions-scopes.md
@@ -10,6 +10,8 @@ weight: 80
 
 # RBAC permissions, actions, and scopes
 
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
+
 A permission is comprised of an action and a scope. When creating a custom role, consider the actions the user can perform and the resource(s) on which they can perform those actions.
 
 To learn more about the Grafana resources to which you can apply RBAC, refer to [Resources with RBAC permissions]({{< relref "../#fixed-roles" >}}).

--- a/docs/sources/administration/roles-and-permissions/access-control/manage-rbac-roles.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/manage-rbac-roles.md
@@ -12,6 +12,8 @@ weight: 50
 
 # Manage RBAC roles
 
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
+
 This section includes instructions for how to view permissions associated with roles, create custom roles, and update and delete roles.
 
 The following example includes the base64 username:password Basic Authorization. You cannot use authorization tokens in the request.

--- a/docs/sources/administration/roles-and-permissions/access-control/manage-rbac-roles.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/manage-rbac-roles.md
@@ -12,7 +12,7 @@ weight: 50
 
 # Manage RBAC roles
 
-> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}) and [Grafana Cloud Advanced]({{< ref "/docs/grafana-cloud" >}}).
 
 This section includes instructions for how to view permissions associated with roles, create custom roles, and update and delete roles.
 

--- a/docs/sources/administration/roles-and-permissions/access-control/plan-rbac-rollout-strategy.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/plan-rbac-rollout-strategy.md
@@ -23,6 +23,8 @@ Your rollout strategy should help you answer the following questions:
 
 ## Review basic role and fixed role definitions
 
+> **Note:** Fixed roles are available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
+
 As a first step in determining your permissions rollout strategy, we recommend that you become familiar with basic role and fixed role definitions. In addition to assigning fixed roles to any user and team, you can also modify basic roles permissions, which changes what a Viewer, Editor, or Admin can do. This flexibility means that there are many combinations of role assignments for you to consider. If you have a large number of Grafana users and teams, we recommend that you make a list of which fixed roles you might want to use.
 
 To learn more about basic roles and fixed roles, refer to the following documentation:
@@ -31,6 +33,8 @@ To learn more about basic roles and fixed roles, refer to the following document
 - [Fixed role definitions]({{< relref "./rbac-fixed-basic-role-definitions/#fixed-role-definitions" >}})
 
 ## User and team considerations
+
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
 
 RBAC is a flexible and powerful feature with many possible permissions assignment combinations available. Consider the follow guidelines when assigning permissions to users and teams.
 
@@ -54,6 +58,8 @@ For example:
 
 ## When to modify basic roles or create custom roles
 
+> **Note:** Custom roles are available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
+
 Consider the following guidelines when you determine if you should modify basic roles or create custom roles.
 
 - **Modify basic roles** when Grafana's definitions of what viewers, editors, and admins can do does not match your definition of these roles. You can add or remove permissions from any basic role.
@@ -63,6 +69,8 @@ Consider the following guidelines when you determine if you should modify basic 
 - **Create custom roles** when fixed role definitions don't meet you permissions requirements. For example, the `fixed:dashboards:writer` role allows users to delete dashboards. If you want some users or teams to be able to create and update but not delete dashboards, you can create a custom role with a name like `custom:dashboards:creator` that lacks the `dashboards:delete` permission.
 
 ## How to assign RBAC roles
+
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
 
 Use any of the following methods to assign RBAC roles to users and teams.
 

--- a/docs/sources/administration/roles-and-permissions/access-control/plan-rbac-rollout-strategy.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/plan-rbac-rollout-strategy.md
@@ -11,6 +11,8 @@ weight: 20
 
 # Plan your RBAC rollout strategy
 
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}) and [Grafana Cloud Advanced]({{< ref "/docs/grafana-cloud" >}}).
+
 An RBAC rollout strategy helps you determine _how_ you want to implement RBAC prior to assigning RBAC roles to users and teams.
 
 Your rollout strategy should help you answer the following questions:
@@ -23,8 +25,6 @@ Your rollout strategy should help you answer the following questions:
 
 ## Review basic role and fixed role definitions
 
-> **Note:** Fixed roles are available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
-
 As a first step in determining your permissions rollout strategy, we recommend that you become familiar with basic role and fixed role definitions. In addition to assigning fixed roles to any user and team, you can also modify basic roles permissions, which changes what a Viewer, Editor, or Admin can do. This flexibility means that there are many combinations of role assignments for you to consider. If you have a large number of Grafana users and teams, we recommend that you make a list of which fixed roles you might want to use.
 
 To learn more about basic roles and fixed roles, refer to the following documentation:
@@ -33,8 +33,6 @@ To learn more about basic roles and fixed roles, refer to the following document
 - [Fixed role definitions]({{< relref "./rbac-fixed-basic-role-definitions/#fixed-role-definitions" >}})
 
 ## User and team considerations
-
-> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
 
 RBAC is a flexible and powerful feature with many possible permissions assignment combinations available. Consider the follow guidelines when assigning permissions to users and teams.
 
@@ -58,8 +56,6 @@ For example:
 
 ## When to modify basic roles or create custom roles
 
-> **Note:** Custom roles are available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
-
 Consider the following guidelines when you determine if you should modify basic roles or create custom roles.
 
 - **Modify basic roles** when Grafana's definitions of what viewers, editors, and admins can do does not match your definition of these roles. You can add or remove permissions from any basic role.
@@ -69,8 +65,6 @@ Consider the following guidelines when you determine if you should modify basic 
 - **Create custom roles** when fixed role definitions don't meet you permissions requirements. For example, the `fixed:dashboards:writer` role allows users to delete dashboards. If you want some users or teams to be able to create and update but not delete dashboards, you can create a custom role with a name like `custom:dashboards:creator` that lacks the `dashboards:delete` permission.
 
 ## How to assign RBAC roles
-
-> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
 
 Use any of the following methods to assign RBAC roles to users and teams.
 

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions.md
@@ -11,6 +11,8 @@ weight: 70
 
 # RBAC role definitions
 
+> **Note:** Fixed roles are available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
+
 The following tables list permissions associated with basic and fixed roles.
 
 ## Basic role assignments

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions.md
@@ -11,7 +11,7 @@ weight: 70
 
 # RBAC role definitions
 
-> **Note:** Fixed roles are available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}) and [Grafana Cloud Advanced]({{< ref "/docs/grafana-cloud" >}}).
 
 The following tables list permissions associated with basic and fixed roles.
 

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-provisioning.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-provisioning.md
@@ -10,6 +10,8 @@ weight: 60
 
 # Grafana RBAC provisioning
 
+> **Note:** Custom roles are available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
+
 You can create, change or remove [Custom roles]({{< relref "./manage-rbac-roles/#create-custom-roles-using-provisioning" >}}) and create or remove [basic role assignments]({{< relref "./assign-rbac-roles/#assign-a-fixed-role-to-a-basic-role-using-provisioning" >}}), by adding one or more YAML configuration files in the `provisioning/access-control/` directory.
 
 Grafana performs provisioning during startup. After you make a change to the configuration file, you can reload it during runtime. You do not need to restart the Grafana server for your changes to take effect.

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-provisioning.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-provisioning.md
@@ -10,7 +10,7 @@ weight: 60
 
 # Grafana RBAC provisioning
 
-> **Note:** Custom roles are available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
+> **Note:** Available in [Grafana Enterprise]({{< relref "../../enterprise/" >}}) and [Grafana Cloud Advanced]({{< ref "/docs/grafana-cloud" >}}).
 
 You can create, change or remove [Custom roles]({{< relref "./manage-rbac-roles/#create-custom-roles-using-provisioning" >}}) and create or remove [basic role assignments]({{< relref "./assign-rbac-roles/#assign-a-fixed-role-to-a-basic-role-using-provisioning" >}}), by adding one or more YAML configuration files in the `provisioning/access-control/` directory.
 

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-provisioning.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-provisioning.md
@@ -12,8 +12,6 @@ weight: 60
 
 You can create, change or remove [Custom roles]({{< relref "./manage-rbac-roles/#create-custom-roles-using-provisioning" >}}) and create or remove [basic role assignments]({{< relref "./assign-rbac-roles/#assign-a-fixed-role-to-a-basic-role-using-provisioning" >}}), by adding one or more YAML configuration files in the `provisioning/access-control/` directory.
 
-If you choose to use provisioning to assign and manage role, you must first enable it.
-
 Grafana performs provisioning during startup. After you make a change to the configuration file, you can reload it during runtime. You do not need to restart the Grafana server for your changes to take effect.
 
 **Before you begin:**


### PR DESCRIPTION
**What this PR does / why we need it**:

When we moved RBAC documentation into Administration/Roles and permissions section, we also removed the notes that RBAC is an enterprise feature. This is [mentioned here](https://grafana.com/docs/grafana/next/administration/roles-and-permissions/#grafana-enterprise-user-permissions-features), but very invisible once you navigate to the RBAC page itself. 

This create confusion for Grafana OSS users, so this PR adds a note on top of the RBAC homepage to mention that it's an enterprise feature.

See feedback [here](https://github.com/grafana/grafana/issues/51634#issuecomment-1196804102)

**Special notes for your reviewer**:

Should we add the note to all RBAC sub pages? As it's still confusing when navigating through RBAC docs, without knowing that it's an enterprise only.

