### PR TITLE
Alerting: Show integrations error feedback when expanding contact point in list

### DIFF
--- a/public/app/features/alerting/unified/Receivers.test.tsx
+++ b/public/app/features/alerting/unified/Receivers.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, within, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Provider } from 'react-redux';
@@ -92,7 +92,7 @@ const ui = {
   testContactPoint: byRole('button', { name: /send test notification/i }),
   cancelButton: byTestId('cancel-button'),
 
-  receiversTable: byTestId('receivers-table'),
+  receiversTable: byTestId('dynamic-table'),
   templatesTable: byTestId('templates-table'),
   alertManagerPicker: byTestId('alertmanager-picker'),
 
@@ -154,14 +154,14 @@ describe('Receivers', () => {
     await renderReceivers();
 
     // check that by default grafana templates & receivers are fetched rendered in appropriate tables
-    let receiversTable = await ui.receiversTable.find();
+    await ui.receiversTable.find();
     let templatesTable = await ui.templatesTable.find();
     let templateRows = templatesTable.querySelectorAll('tbody tr');
     expect(templateRows).toHaveLength(3);
     expect(templateRows[0]).toHaveTextContent('first template');
     expect(templateRows[1]).toHaveTextContent('second template');
     expect(templateRows[2]).toHaveTextContent('third template');
-    let receiverRows = receiversTable.querySelectorAll('tbody tr');
+    let receiverRows = within(screen.getByTestId('dynamic-table')).getAllByTestId('row');
     expect(receiverRows[0]).toHaveTextContent('default');
     expect(receiverRows[1]).toHaveTextContent('critical');
     expect(receiverRows).toHaveLength(2);
@@ -177,12 +177,12 @@ describe('Receivers', () => {
     expect(mocks.api.fetchConfig).toHaveBeenCalledTimes(2);
     expect(mocks.api.fetchConfig).toHaveBeenLastCalledWith('CloudManager');
 
-    receiversTable = await ui.receiversTable.find();
+    await ui.receiversTable.find();
     templatesTable = await ui.templatesTable.find();
     templateRows = templatesTable.querySelectorAll('tbody tr');
     expect(templateRows[0]).toHaveTextContent('foo template');
     expect(templateRows).toHaveLength(1);
-    receiverRows = receiversTable.querySelectorAll('tbody tr');
+    receiverRows = within(screen.getByTestId('dynamic-table')).getAllByTestId('row');
     expect(receiverRows[0]).toHaveTextContent('cloud-receiver');
     expect(receiverRows).toHaveLength(1);
     expect(locationService.getSearchObject()[ALERTMANAGER_NAME_QUERY_KEY]).toEqual('CloudManager');
@@ -325,8 +325,8 @@ describe('Receivers', () => {
     await renderReceivers('CloudManager');
 
     // click edit button for the receiver
-    const receiversTable = await ui.receiversTable.find();
-    const receiverRows = receiversTable.querySelectorAll<HTMLTableRowElement>('tbody tr');
+    await ui.receiversTable.find();
+    const receiverRows = within(screen.getByTestId('dynamic-table')).getAllByTestId('row');
     expect(receiverRows[0]).toHaveTextContent('cloud-receiver');
     await userEvent.click(byTestId('edit').get(receiverRows[0]));
 
@@ -420,12 +420,12 @@ describe('Receivers', () => {
     });
     await renderReceivers(dataSources.promAlertManager.name);
 
-    const receiversTable = await ui.receiversTable.find();
+    await ui.receiversTable.find();
     // there's no templates table for vanilla prom, API does not return templates
     expect(ui.templatesTable.query()).not.toBeInTheDocument();
 
     // click view button on the receiver
-    const receiverRows = receiversTable.querySelectorAll<HTMLTableRowElement>('tbody tr');
+    const receiverRows = within(screen.getByTestId('dynamic-table')).getAllByTestId('row');
     expect(receiverRows[0]).toHaveTextContent('cloud-receiver');
     expect(byTestId('edit').query(receiverRows[0])).not.toBeInTheDocument();
     await userEvent.click(byTestId('view').get(receiverRows[0]));
@@ -460,8 +460,8 @@ describe('Receivers', () => {
     await renderReceivers('CloudManager');
 
     // check that receiver from the default config is represented
-    const receiversTable = await ui.receiversTable.find();
-    const receiverRows = receiversTable.querySelectorAll<HTMLTableRowElement>('tbody tr');
+    await ui.receiversTable.find();
+    const receiverRows = within(screen.getByTestId('dynamic-table')).getAllByTestId('row');
     expect(receiverRows[0]).toHaveTextContent('default-email');
 
     // check that both config and status endpoints were called

--- a/public/app/features/alerting/unified/Receivers.tsx
+++ b/public/app/features/alerting/unified/Receivers.tsx
@@ -5,8 +5,7 @@ import { useDispatch } from 'react-redux';
 import { Redirect, Route, RouteChildrenProps, Switch, useLocation } from 'react-router-dom';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Stack } from '@grafana/experimental';
-import { Alert, LoadingPlaceholder, withErrorBoundary, useStyles2, Icon } from '@grafana/ui';
+import { Alert, LoadingPlaceholder, withErrorBoundary, useStyles2, Icon, Stack } from '@grafana/ui';
 
 import { AlertManagerPicker } from './components/AlertManagerPicker';
 import { AlertingPageWrapper } from './components/AlertingPageWrapper';

--- a/public/app/features/alerting/unified/api/grafana.test.ts
+++ b/public/app/features/alerting/unified/api/grafana.test.ts
@@ -88,7 +88,7 @@ describe('contactPointsStateDtoToModel method', () => {
         'contact point 1': {
           active: true,
           errorCount: 3,
-          integrations: {
+          notifiers: {
             email: [
               {
                 lastError:
@@ -124,7 +124,7 @@ describe('contactPointsStateDtoToModel method', () => {
         'contact point 2': {
           active: true,
           errorCount: 0,
-          integrations: {
+          notifiers: {
             email: [
               {
                 lastNotify: '2022-07-08 17:42:44.998893 +0000 UTC',

--- a/public/app/features/alerting/unified/api/grafana.ts
+++ b/public/app/features/alerting/unified/api/grafana.ts
@@ -28,7 +28,7 @@ export const contactPointsStateDtoToModel = (receiversStateDto: ReceiversStateDT
   // for each receiver from response
   receiversStateDto.forEach((cpState) => {
     //init receiver state
-    contactPointsState.receivers[cpState.name] = { active: cpState.active, integrations: {}, errorCount: 0 };
+    contactPointsState.receivers[cpState.name] = { active: cpState.active, notifiers: {}, errorCount: 0 };
     const receiverState = contactPointsState.receivers[cpState.name];
     //update integrations in response
     cpState.integrations.forEach((integrationStatusDTO) => {
@@ -42,11 +42,11 @@ export const contactPointsStateDtoToModel = (receiversStateDto: ReceiversStateDT
       const integrationType = getIntegrationType(integrationStatusDTO.name);
       if (integrationType) {
         //if type still does not exist in IntegrationsTypeState we initialize it with an empty array
-        if (!receiverState.integrations[integrationType]) {
-          receiverState.integrations[integrationType] = [];
+        if (!receiverState.notifiers[integrationType]) {
+          receiverState.notifiers[integrationType] = [];
         }
         // add error status for this type
-        receiverState.integrations[integrationType].push(integrationStatusDTO);
+        receiverState.notifiers[integrationType].push(integrationStatusDTO);
       }
     });
   });

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.test.tsx
@@ -1,8 +1,7 @@
-import { render } from '@testing-library/react';
+import { screen, render, within } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
-import { byRole } from 'testing-library-selector';
 
 import { locationService } from '@grafana/runtime';
 import {
@@ -53,10 +52,6 @@ const mockNotifier = (type: NotifierType, name: string): NotifierDTO => ({
   options: [],
 });
 
-const ui = {
-  table: byRole<HTMLTableElement>('table'),
-};
-
 describe('ReceiversTable', () => {
   it('render receivers with grafana notifiers', async () => {
     const receivers: Receiver[] = [
@@ -74,14 +69,12 @@ describe('ReceiversTable', () => {
 
     await renderReceieversTable(receivers, notifiers);
 
-    const table = await ui.table.find();
-
-    const rows = table.querySelector('tbody')?.querySelectorAll('tr')!;
+    const rows = within(screen.getByTestId('dynamic-table')).getAllByTestId('row');
     expect(rows).toHaveLength(2);
-    expect(rows[0].querySelectorAll('td')[0]).toHaveTextContent('with receivers');
-    expect(rows[0].querySelectorAll('td')[1]).toHaveTextContent('Google Chat, Sensu Go');
-    expect(rows[1].querySelectorAll('td')[0]).toHaveTextContent('without receivers');
-    expect(rows[1].querySelectorAll('td')[1].textContent).toEqual('');
+    expect(rows[0]).toHaveTextContent('with receivers');
+    expect(rows[0].querySelector('[data-column="Type"]')).toHaveTextContent('Google Chat, Sensu Go');
+    expect(rows[1]).toHaveTextContent('without receivers');
+    expect(rows[1].querySelector('[data-column="Type"]')).toHaveTextContent('');
   });
 
   it('render receivers with alertmanager notifers', async () => {
@@ -117,13 +110,11 @@ describe('ReceiversTable', () => {
 
     await renderReceieversTable(receivers, []);
 
-    const table = await ui.table.find();
-
-    const rows = table.querySelector('tbody')?.querySelectorAll('tr')!;
+    const rows = within(screen.getByTestId('dynamic-table')).getAllByTestId('row');
     expect(rows).toHaveLength(2);
-    expect(rows[0].querySelectorAll('td')[0]).toHaveTextContent('with receivers');
-    expect(rows[0].querySelectorAll('td')[1]).toHaveTextContent('Email, Webhook, OpsGenie, Foo');
-    expect(rows[1].querySelectorAll('td')[0]).toHaveTextContent('without receivers');
-    expect(rows[1].querySelectorAll('td')[1].textContent).toEqual('');
+    expect(rows[0]).toHaveTextContent('with receivers');
+    expect(rows[0].querySelector('[data-column="Type"]')).toHaveTextContent('Email, Webhook, OpsGenie, Foo');
+    expect(rows[1]).toHaveTextContent('without receivers');
+    expect(rows[1].querySelector('[data-column="Type"]')).toHaveTextContent('');
   });
 });

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -233,7 +233,6 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
   const rows: RowItemTableProps[] = useMemo(
     () =>
       config.alertmanager_config.receivers?.map((receiver: Receiver) => ({
-        id: receiver.id,
         id: receiver.name,
         data: {
           name: receiver.name,

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -234,6 +234,7 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
     () =>
       config.alertmanager_config.receivers?.map((receiver: Receiver) => ({
         id: receiver.id,
+        id: receiver.name,
         data: {
           name: receiver.name,
           types: Object.entries(extractNotifierTypeCounts(receiver, grafanaNotifiers.result ?? [])).map(

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -6,8 +6,8 @@ import { useDispatch } from 'react-redux';
 import { GrafanaTheme2 } from '@grafana/data';
 import { Button, ConfirmModal, Modal, useStyles2, Badge } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
-import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
-import { ContactPointsState } from 'app/types';
+import { AlertManagerCortexConfig, Receiver } from 'app/plugins/datasource/alertmanager/types';
+import { AccessControlAction, ContactPointsState, ReceiversState } from 'app/types';
 
 import { Authorize } from '../../components/Authorize';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
@@ -19,14 +19,77 @@ import { isVanillaPrometheusAlertManagerDataSource } from '../../utils/datasourc
 import { makeAMLink } from '../../utils/misc';
 import { extractNotifierTypeCounts } from '../../utils/receivers';
 import { initialAsyncRequestState } from '../../utils/redux';
+import { DynamicTable, DynamicTableColumnProps, DynamicTableItemProps } from '../DynamicTable';
 import { ProvisioningBadge } from '../Provisioning';
 import { ActionIcon } from '../rules/ActionIcon';
 
 import { ReceiversSection } from './ReceiversSection';
 
+interface UpdateActionProps extends ActionProps {
+  onClickDeleteReceiver: (receiverName: string) => void;
+}
+
+function UpdateActions({ permissions, alertManagerName, receiverName, onClickDeleteReceiver }: UpdateActionProps) {
+  return (
+    <>
+      <Authorize actions={[permissions.update]}>
+        <ActionIcon
+          aria-label="Edit"
+          data-testid="edit"
+          to={makeAMLink(
+            `/alerting/notifications/receivers/${encodeURIComponent(receiverName)}/edit`,
+            alertManagerName
+          )}
+          tooltip="Edit contact point"
+          icon="pen"
+        />
+      </Authorize>
+      <Authorize actions={[permissions.delete]}>
+        <ActionIcon
+          onClick={() => onClickDeleteReceiver(receiverName)}
+          tooltip="Delete contact point"
+          icon="trash-alt"
+        />
+      </Authorize>
+    </>
+  );
+}
+interface ActionProps {
+  permissions: {
+    read: AccessControlAction;
+    create: AccessControlAction;
+    update: AccessControlAction;
+    delete: AccessControlAction;
+  };
+  alertManagerName: string;
+  receiverName: string;
+}
+
+function ViewAction({ permissions, alertManagerName, receiverName }: ActionProps) {
+  return (
+    <Authorize actions={[permissions.update]}>
+      <ActionIcon
+        data-testid="view"
+        to={makeAMLink(`/alerting/notifications/receivers/${encodeURIComponent(receiverName)}/edit`, alertManagerName)}
+        tooltip="View contact point"
+        icon="file-alt"
+      />
+    </Authorize>
+  );
+}
+interface ReceiverItem {
+  name: string;
+  types: string[]; //??
+  provisioned?: boolean;
+}
+
 interface ReceiverErrorProps {
   errorCount: number;
 }
+
+type RowTableColumnProps = DynamicTableColumnProps<ReceiverItem>;
+type RowItemTableProps = DynamicTableItemProps<ReceiverItem>;
+
 function ReceiverError({ errorCount }: ReceiverErrorProps) {
   return (
     <Badge
@@ -57,14 +120,13 @@ interface Props {
 const useContactPointsState = (alertManagerName: string) => {
   const contactPointsStateRequest = useUnifiedAlertingSelector((state) => state.contactPointsState);
   const { result: contactPointsState } = (alertManagerName && contactPointsStateRequest) || initialAsyncRequestState;
-  const receivers = contactPointsState?.receivers ?? {};
+  const receivers: ReceiversState = contactPointsState?.receivers ?? {};
   const errorStateAvailable = Object.keys(receivers).length > 0; // this logic can change depending on how we implement this in the BE
   return { contactPointsState, errorStateAvailable };
 };
 
 export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
   const dispatch = useDispatch();
-  const tableStyles = useStyles2(getAlertTableStyles);
   const styles = useStyles2(getStyles);
   const isVanillaAM = isVanillaPrometheusAlertManagerDataSource(alertManagerName);
   const permissions = getNotificationsPermissions(alertManagerName);
@@ -91,25 +153,33 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
     setReceiverToDelete(undefined);
   };
 
-  const rows = useMemo(
+  const rows: RowItemTableProps[] = useMemo(
     () =>
-      config.alertmanager_config.receivers?.map((receiver) => ({
-        name: receiver.name,
-        types: Object.entries(extractNotifierTypeCounts(receiver, grafanaNotifiers.result ?? [])).map(
-          ([type, count]) => {
-            if (count > 1) {
-              return `${type} (${count})`;
+      config.alertmanager_config.receivers?.map((receiver: Receiver) => ({
+        id: receiver.id,
+        data: {
+          name: receiver.name,
+          types: Object.entries(extractNotifierTypeCounts(receiver, grafanaNotifiers.result ?? [])).map(
+            ([type, count]) => {
+              if (count > 1) {
+                return `${type} (${count})`;
+              }
+              return type;
             }
-            return type;
-          }
-        ),
-        provisioned: receiver.grafana_managed_receiver_configs?.some((receiver) => receiver.provenance),
+          ),
+          provisioned: receiver.grafana_managed_receiver_configs?.some((receiver) => receiver.provenance),
+        },
       })) ?? [],
     [config, grafanaNotifiers.result]
   );
-
-  const errorsByReceiver = (contactPointsState: ContactPointsState, receiverName: string) =>
-    contactPointsState.receivers[receiverName]?.errorCount ?? 0;
+  const columns = useGetColumns(
+    alertManagerName,
+    errorStateAvailable,
+    contactPointsState,
+    onClickDeleteReceiver,
+    permissions,
+    isVanillaAM
+  );
 
   return (
     <ReceiversSection
@@ -120,87 +190,20 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
       addButtonLabel="New contact point"
       addButtonTo={makeAMLink('/alerting/notifications/receivers/new', alertManagerName)}
     >
-      <table className={tableStyles.table} data-testid="receivers-table">
-        <colgroup>
-          <col />
-          <col />
-          <Authorize actions={[permissions.update, permissions.delete]}>
-            <col />
-          </Authorize>
-        </colgroup>
-        <thead>
-          <tr>
-            <th>Contact point name</th>
-            <th>Type</th>
-            {errorStateAvailable && <th>Health</th>}
-            <Authorize actions={[permissions.update, permissions.delete]}>
-              <th>Actions</th>
-            </Authorize>
-          </tr>
-        </thead>
-        <tbody>
-          {!rows.length && (
-            <tr className={tableStyles.evenRow}>
-              <td colSpan={3}>No receivers defined.</td>
-            </tr>
-          )}
-          {rows.map((receiver, idx) => (
-            <tr key={receiver.name} className={idx % 2 === 0 ? tableStyles.evenRow : undefined}>
-              <td>
-                {receiver.name} {receiver.provisioned && <ProvisioningBadge />}
-              </td>
-              <td>{receiver.types.join(', ')}</td>
-              {errorStateAvailable && (
-                <td>
-                  <ReceiverHealth
-                    errorsByReceiver={contactPointsState ? errorsByReceiver(contactPointsState, receiver.name) : 0}
-                  />
-                </td>
-              )}
-              <Authorize actions={[permissions.update, permissions.delete]}>
-                <td className={tableStyles.actionsCell}>
-                  {!isVanillaAM && !receiver.provisioned && (
-                    <>
-                      <Authorize actions={[permissions.update]}>
-                        <ActionIcon
-                          aria-label="Edit"
-                          data-testid="edit"
-                          to={makeAMLink(
-                            `/alerting/notifications/receivers/${encodeURIComponent(receiver.name)}/edit`,
-                            alertManagerName
-                          )}
-                          tooltip="Edit contact point"
-                          icon="pen"
-                        />
-                      </Authorize>
-                      <Authorize actions={[permissions.delete]}>
-                        <ActionIcon
-                          onClick={() => onClickDeleteReceiver(receiver.name)}
-                          tooltip="Delete contact point"
-                          icon="trash-alt"
-                        />
-                      </Authorize>
-                    </>
-                  )}
-                  {(isVanillaAM || receiver.provisioned) && (
-                    <Authorize actions={[permissions.update]}>
-                      <ActionIcon
-                        data-testid="view"
-                        to={makeAMLink(
-                          `/alerting/notifications/receivers/${encodeURIComponent(receiver.name)}/edit`,
-                          alertManagerName
-                        )}
-                        tooltip="View contact point"
-                        icon="file-alt"
-                      />
-                    </Authorize>
-                  )}
-                </td>
-              </Authorize>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <DynamicTable
+        items={rows}
+        cols={columns}
+        isExpandable={errorStateAvailable}
+        renderExpandedContent={
+          errorStateAvailable
+            ? ({ data }) => (
+                <div>
+                  {data.name} - {data.types}
+                </div>
+              )
+            : undefined
+        }
+      />
       {!!showCannotDeleteReceiverModal && (
         <Modal
           isOpen={true}
@@ -231,6 +234,77 @@ export const ReceiversTable: FC<Props> = ({ config, alertManagerName }) => {
     </ReceiversSection>
   );
 };
+
+function useGetColumns(
+  alertManagerName: string,
+  errorStateAvailable: boolean,
+  contactPointsState: ContactPointsState | undefined,
+  onClickDeleteReceiver: (receiverName: string) => void,
+  permissions: {
+    read: AccessControlAction;
+    create: AccessControlAction;
+    update: AccessControlAction;
+    delete: AccessControlAction;
+  },
+  isVanillaAM: boolean
+): RowTableColumnProps[] {
+  const tableStyles = useStyles2(getAlertTableStyles);
+  const baseColumns: RowTableColumnProps[] = [
+    {
+      id: 'name',
+      label: 'Contact point name',
+      renderCell: ({ data: { name, provisioned } }) => (
+        <>
+          {name} {provisioned && <ProvisioningBadge />}
+        </>
+      ),
+      size: 1,
+    },
+    {
+      id: 'type',
+      label: 'Type',
+      renderCell: ({ data: { types } }) => <>{types.join(', ')}</>,
+      size: 1,
+    },
+  ];
+  const healthColumn: RowTableColumnProps = {
+    id: 'health',
+    label: 'Health',
+    renderCell: ({ data: { name } }) => {
+      const errorsByReceiver = (contactPointsState: ContactPointsState, receiverName: string) =>
+        contactPointsState?.receivers[receiverName]?.errorCount ?? 0;
+      return contactPointsState && <ReceiverHealth errorsByReceiver={errorsByReceiver(contactPointsState, name)} />;
+    },
+    size: 1,
+  };
+
+  return [
+    ...baseColumns,
+    ...(errorStateAvailable ? [healthColumn] : []),
+    {
+      id: 'actions',
+      label: 'Actions',
+      renderCell: ({ data: { provisioned, name } }) => (
+        <Authorize actions={[permissions.update, permissions.delete]}>
+          <div className={tableStyles.actionsCell}>
+            {!isVanillaAM && !provisioned && (
+              <UpdateActions
+                permissions={permissions}
+                alertManagerName={alertManagerName}
+                receiverName={name}
+                onClickDeleteReceiver={onClickDeleteReceiver}
+              />
+            )}
+            {(isVanillaAM || provisioned) && (
+              <ViewAction permissions={permissions} alertManagerName={alertManagerName} receiverName={name} />
+            )}
+          </div>
+        </Authorize>
+      ),
+      size: '100px',
+    },
+  ];
+}
 
 const getStyles = (theme: GrafanaTheme2) => ({
   section: css`

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -3,8 +3,8 @@ import pluralize from 'pluralize';
 import React, { FC, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { GrafanaTheme2 } from '@grafana/data';
-import { Button, ConfirmModal, Modal, useStyles2, Badge } from '@grafana/ui';
+import { GrafanaTheme2, dateTime, dateTimeFormat } from '@grafana/data';
+import { Button, ConfirmModal, Modal, useStyles2, Badge, Icon, Stack } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AlertManagerCortexConfig, Receiver } from 'app/plugins/datasource/alertmanager/types';
 import { AccessControlAction, ContactPointsState, IntegrationTypesState, ReceiversState } from 'app/types';
@@ -134,6 +134,15 @@ interface IntegrationsTableProps {
   integrationTypesState: IntegrationTypesState;
 }
 
+function LastNotify({ lastNotify }: { lastNotify: string }) {
+  return (
+    <Stack alignItems="center">
+      <div>{dateTime(lastNotify).locale('en').fromNow(true)} ago</div>
+      <Icon name="exclamation-triangle" />
+      <div>{dateTimeFormat(lastNotify, { format: 'YYYY-MM-DD HH:mm:ss' })}</div>
+    </Stack>
+  );
+}
 function IntegrationsTable({ integrationTypesState }: IntegrationsTableProps) {
   function getIntegrationColumns(): RowIntegrationTableColumnProps[] {
     return [
@@ -154,7 +163,7 @@ function IntegrationsTable({ integrationTypesState }: IntegrationsTableProps) {
       {
         id: 'lastNotify',
         label: 'Last try to notify',
-        renderCell: ({ data: { lastNotify } }) => <>{lastNotify}</>,
+        renderCell: ({ data: { lastNotify } }) => <LastNotify lastNotify={lastNotify} />,
         size: 1,
       },
       {

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -114,6 +114,7 @@ const useContactPointsState = (alertManagerName: string) => {
 interface ReceiverItem {
   name: string;
   types: string[]; //??
+  types: string[];
   provisioned?: boolean;
 }
 
@@ -122,6 +123,7 @@ interface IntegrationItem {
   lastNotify: string;
   lastNotifyDuration: string;
   type: string;
+  sendResolve?: boolean;
 }
 
 type RowTableColumnProps = DynamicTableColumnProps<ReceiverItem>;
@@ -152,7 +154,7 @@ function IntegrationsTable({ integrationTypesState }: IntegrationsTableProps) {
         renderCell: ({ data: { lastError } }) => {
           return <ReceiverHealth errorsByReceiver={lastError ? 1 : 0} />;
         },
-        size: 1,
+        size: 0.5,
       },
       {
         id: 'name',
@@ -164,12 +166,18 @@ function IntegrationsTable({ integrationTypesState }: IntegrationsTableProps) {
         id: 'lastNotify',
         label: 'Last try to notify',
         renderCell: ({ data: { lastNotify } }) => <LastNotify lastNotify={lastNotify} />,
-        size: 1,
+        size: 3,
       },
       {
         id: 'lastNotifyDuration',
         label: 'Last duration',
         renderCell: ({ data: { lastNotifyDuration } }) => <>{lastNotifyDuration}</>,
+        size: 1,
+      },
+      {
+        id: 'sendResolve',
+        label: 'Send resolve',
+        renderCell: ({ data: { sendResolve } }) => <>{String(Boolean(sendResolve))}</>,
         size: 1,
       },
     ];

--- a/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversTable.tsx
@@ -113,7 +113,6 @@ const useContactPointsState = (alertManagerName: string) => {
 
 interface ReceiverItem {
   name: string;
-  types: string[]; //??
   types: string[];
   provisioned?: boolean;
 }
@@ -141,6 +140,7 @@ function LastNotify({ lastNotify }: { lastNotify: string }) {
     <Stack alignItems="center">
       <div>{dateTime(lastNotify).locale('en').fromNow(true)} ago</div>
       <Icon name="exclamation-triangle" />
+      <Icon name="clock-nine" />
       <div>{dateTimeFormat(lastNotify, { format: 'YYYY-MM-DD HH:mm:ss' })}</div>
     </Stack>
   );

--- a/public/app/types/alerting.ts
+++ b/public/app/types/alerting.ts
@@ -147,6 +147,7 @@ export interface IntegrationStatus {
   lastNotify: string;
   lastNotifyDuration: string;
   name: string;
+  sendResolve?: boolean;
 }
 
 export interface IntegrationTypesState {

--- a/public/app/types/alerting.ts
+++ b/public/app/types/alerting.ts
@@ -142,7 +142,7 @@ export interface NotificationChannelState {
   notificationChannel: any;
 }
 
-export interface IntegrationStatus {
+export interface NotifierStatus {
   lastError?: null | string;
   lastNotify: string;
   lastNotifyDuration: string;
@@ -150,13 +150,13 @@ export interface IntegrationStatus {
   sendResolve?: boolean;
 }
 
-export interface IntegrationTypesState {
-  [key: string]: IntegrationStatus[]; // key is the integration type
+export interface NotifiersState {
+  [key: string]: NotifierStatus[]; // key is the notifier type
 }
 
 export interface ReceiverState {
   active: boolean;
-  integrations: IntegrationTypesState;
+  notifiers: NotifiersState;
   errorCount: number; // errors by receiver
 }
 
@@ -171,7 +171,7 @@ export interface ContactPointsState {
 
 export interface ReceiversStateDTO {
   active: boolean;
-  integrations: IntegrationStatus[];
+  integrations: NotifierStatus[];
   name: string;
 }
 export interface AlertRulesState {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows expanding contact points showing its integrations error status.
This expansion is only shown in case the AM has error status available.

<img width="1848" alt="Screenshot 2022-07-27 at 20 08 52" src="https://user-images.githubusercontent.com/33540275/181437987-6916468f-17f8-4407-bd5e-b61fccbad85b.png">

**Special notes for your reviewer:**

To test this PR, you can use the `fakeResponse` in `grafana.ts` , so you see the the feature in action.

For that, uncomment it in grafana.ts and adapt it to your actual contact point list.

Afterwards, change this line to use this `fakeResponse`:

`  const fakeState: ContactPointsState = contactPointsStateDtoToModel(fakeResponse);`
