### PR TITLE
Grafana/toolkit: Fix incorrect image and font generation for plugin builds

### DIFF
--- a/packages/grafana-toolkit/src/config/webpack/loaders.ts
+++ b/packages/grafana-toolkit/src/config/webpack/loaders.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+import { getPluginId } from '../utils/getPluginId';
+
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 const supportedExtensions = ['css', 'scss', 'less', 'sass'];
@@ -109,7 +111,7 @@ export const getFileLoaders = () => {
       test: /\.(png|jpe?g|gif|svg)$/,
       type: 'asset/resource',
       generator: {
-        publicPath: `img/`,
+        publicPath: `public/plugins/${getPluginId()}/img/`,
         outputPath: 'img/',
       },
     },
@@ -117,7 +119,7 @@ export const getFileLoaders = () => {
       test: /\.(woff|woff2|eot|ttf|otf)(\?v=\d+\.\d+\.\d+)?$/,
       type: 'asset/resource',
       generator: {
-        publicPath: `fonts/`,
+        publicPath: `public/plugins/${getPluginId()}/fonts/`,
         outputPath: 'fonts/',
       },
     },


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/52661

The previous PR https://github.com/grafana/grafana/pull/52661 didn't correctly fix the issue with grafana toolkit generating images and svg paths.

This PR fixes the issue by generating absolute paths to public assets instead of relative paths.

Closes: https://github.com/grafana/grafana/issues/52923