### PR TITLE
Docker: Install jq on `build-container` image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -66,13 +66,13 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: yarn-install
 - commands:
   - yarn run prettier:check
@@ -83,14 +83,14 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-frontend
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
   failure: ignore
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -98,7 +98,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-frontend
 trigger:
   event:
@@ -142,7 +142,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -151,13 +151,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - |-
@@ -169,13 +169,13 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: shellcheck
 - commands:
   - make lint-go
@@ -183,19 +183,19 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-backend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-backend-integration
 trigger:
   event:
@@ -242,7 +242,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -251,19 +251,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: yarn-install
 - failure: ignore
   image: grafana/drone-downstream
@@ -283,7 +283,7 @@ steps:
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -292,7 +292,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -301,7 +301,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss
@@ -309,7 +309,7 @@ steps:
   - gen-version
   - yarn-install
   environment: null
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-plugins
 - commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss
@@ -320,7 +320,7 @@ steps:
   - build-frontend
   - build-frontend-packages
   environment: null
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -333,7 +333,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -411,14 +411,14 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-storybook
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: copy-packages-for-docker
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -506,13 +506,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - apt-get update
@@ -528,7 +528,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -544,7 +544,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: mysql-integration-tests
 trigger:
   event:
@@ -590,13 +590,13 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: yarn-install
 - commands:
   - |-
@@ -608,7 +608,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -616,7 +616,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-docs
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -625,13 +625,13 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend-packages
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend-packages
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana
@@ -680,13 +680,13 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: yarn-install
 - commands:
   - |-
@@ -698,7 +698,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -706,7 +706,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-docs
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -715,13 +715,13 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend-packages
 - commands:
   - ./scripts/ci-reference-docs-lint.sh ci
   depends_on:
   - build-frontend-packages
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend-docs
 - commands:
   - mkdir -p /hugo/content/docs/grafana
@@ -765,13 +765,13 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: yarn-install
 - commands:
   - yarn run prettier:check
@@ -782,14 +782,14 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-frontend
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
   failure: ignore
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -797,7 +797,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-frontend
 trigger:
   branch: main
@@ -833,7 +833,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -842,13 +842,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - |-
@@ -860,13 +860,13 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: codespell
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: shellcheck
 - commands:
   - make lint-go
@@ -874,19 +874,19 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-backend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-backend-integration
 - commands:
   - ./bin/grabpl verify-drone
@@ -928,7 +928,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -937,19 +937,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: yarn-install
 - commands:
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
@@ -970,7 +970,7 @@ steps:
       from_secret: github_token
     TEST_TAG: v0.0.0-test
   failure: ignore
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: trigger-test-release
   when:
     paths:
@@ -994,7 +994,7 @@ steps:
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -1003,7 +1003,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -1012,7 +1012,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss
@@ -1022,7 +1022,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-plugins
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -1040,7 +1040,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -1053,7 +1053,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -1131,14 +1131,14 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-storybook
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: copy-packages-for-docker
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -1179,7 +1179,7 @@ steps:
     GRAFANA_MISC_STATS_API_KEY:
       from_secret: grafana_misc_stats_api_key
   failure: ignore
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: publish-frontend-metrics
   when:
     repo:
@@ -1260,7 +1260,7 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: release-canary-npm-packages
   when:
     repo:
@@ -1353,13 +1353,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - apt-get update
@@ -1375,7 +1375,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -1391,7 +1391,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: mysql-integration-tests
 trigger:
   branch: main
@@ -1524,7 +1524,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - echo $DRONE_RUNNER_NAME
@@ -1615,7 +1615,7 @@ steps:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1624,26 +1624,26 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: yarn-install
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss ${DRONE_TAG}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss ${DRONE_TAG}
@@ -1652,7 +1652,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss ${DRONE_TAG}
@@ -1661,7 +1661,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss
@@ -1671,7 +1671,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-plugins
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss  --sign ${DRONE_TAG}
@@ -1689,14 +1689,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition oss --shouldSave
@@ -1733,7 +1733,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -1811,7 +1811,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition oss
@@ -1912,7 +1912,7 @@ steps:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -1921,25 +1921,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: yarn-install
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: shellcheck
 - commands:
   - |-
@@ -1951,7 +1951,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: codespell
 - commands:
   - make lint-go
@@ -1959,7 +1959,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -1970,19 +1970,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -1990,7 +1990,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-frontend
 trigger:
   event:
@@ -2054,13 +2054,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - apt-get update
@@ -2076,7 +2076,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -2092,7 +2092,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: mysql-integration-tests
 trigger:
   event:
@@ -2207,7 +2207,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2223,25 +2223,25 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2251,14 +2251,14 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise ${DRONE_TAG}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -2267,7 +2267,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -2276,7 +2276,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise
@@ -2286,14 +2286,14 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-plugins
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 ${DRONE_TAG}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise  --sign ${DRONE_TAG}
@@ -2312,14 +2312,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition enterprise --shouldSave
@@ -2357,7 +2357,7 @@ steps:
     ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -2477,7 +2477,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: package-enterprise2
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise2
@@ -2553,7 +2553,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2569,25 +2569,25 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2597,7 +2597,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - |-
@@ -2609,7 +2609,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: codespell
 - commands:
   - make lint-go
@@ -2617,7 +2617,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -2628,19 +2628,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -2648,7 +2648,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-frontend
 - commands:
   - make lint-go
@@ -2656,13 +2656,13 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-backend-enterprise2
 - commands:
   - go test -tags=pro -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-backend-enterprise2
 trigger:
   event:
@@ -2736,7 +2736,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2752,7 +2752,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: init-enterprise
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2762,13 +2762,13 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - apt-get update
@@ -2784,7 +2784,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -2800,7 +2800,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -2809,7 +2809,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -2818,7 +2818,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: memcached-integration-tests
 trigger:
   event:
@@ -3302,7 +3302,7 @@ steps:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: yarn-install
 - commands:
   - ./bin/grabpl artifacts npm retrieve --tag v${TAG}
@@ -3322,7 +3322,7 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: release-npm-packages
 trigger:
   event:
@@ -3358,7 +3358,7 @@ steps:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - ./bin/grabpl store-packages --edition oss --packages-bucket grafana-downloads
@@ -3412,7 +3412,7 @@ steps:
   - ./bin/grabpl gen-version ${DRONE_TAG}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - ./bin/grabpl store-packages --edition enterprise --packages-bucket grafana-downloads
@@ -3463,7 +3463,7 @@ steps:
   - ./bin/grabpl artifacts-page
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: artifacts-page
 trigger:
   event:
@@ -3499,7 +3499,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3508,26 +3508,26 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: yarn-install
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -3536,7 +3536,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -3545,7 +3545,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition oss
@@ -3555,7 +3555,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-plugins
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -3573,14 +3573,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition oss --shouldSave
@@ -3617,7 +3617,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -3695,7 +3695,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-storybook
 - commands:
   - ./bin/grabpl upload-cdn --edition oss
@@ -3767,7 +3767,7 @@ steps:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -3776,25 +3776,25 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: yarn-install
 - commands:
   - ./bin/grabpl shellcheck
   depends_on:
   - grabpl
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: shellcheck
 - commands:
   - |-
@@ -3806,7 +3806,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: codespell
 - commands:
   - make lint-go
@@ -3814,7 +3814,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -3825,19 +3825,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -3845,7 +3845,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-frontend
 trigger:
   ref:
@@ -3903,13 +3903,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - apt-get update
@@ -3925,7 +3925,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -3941,7 +3941,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: mysql-integration-tests
 trigger:
   ref:
@@ -4039,7 +4039,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -4052,25 +4052,25 @@ steps:
   depends_on:
   - clone-enterprise
   environment: {}
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4080,14 +4080,14 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-backend
 - commands:
   - ./bin/grabpl build-frontend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -4096,7 +4096,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend
 - commands:
   - ./bin/grabpl build-frontend-packages --jobs 8 --edition enterprise --build-id
@@ -4106,7 +4106,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-frontend-packages
 - commands:
   - ./bin/grabpl build-plugins --jobs 8 --edition enterprise
@@ -4116,7 +4116,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-plugins
 - commands:
   - ./bin/grabpl build-backend --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
@@ -4124,7 +4124,7 @@ steps:
   depends_on:
   - gen-version
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -4144,14 +4144,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: copy-packages-for-docker
 - commands:
   - ./bin/grabpl build-docker --edition enterprise --shouldSave
@@ -4189,7 +4189,7 @@ steps:
     ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -4305,7 +4305,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: package-enterprise2
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise2
@@ -4375,7 +4375,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -4388,25 +4388,25 @@ steps:
   depends_on:
   - clone-enterprise
   environment: {}
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: init-enterprise
 - commands:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: yarn-install
 - commands:
   - ./bin/grabpl gen-version --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4416,7 +4416,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - |-
@@ -4428,7 +4428,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: codespell
 - commands:
   - make lint-go
@@ -4436,7 +4436,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -4447,19 +4447,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -4467,7 +4467,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-frontend
 - commands:
   - make lint-go
@@ -4475,13 +4475,13 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: lint-backend-enterprise2
 - commands:
   - go test -tags=pro -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: test-backend-enterprise2
 trigger:
   ref:
@@ -4549,7 +4549,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -4562,7 +4562,7 @@ steps:
   depends_on:
   - clone-enterprise
   environment: {}
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: init-enterprise
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4572,13 +4572,13 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: wire-install
 - commands:
   - apt-get update
@@ -4594,7 +4594,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -4610,7 +4610,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -4619,7 +4619,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -4628,7 +4628,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.5.8
+  image: grafana/build-container:1.5.9
   name: memcached-integration-tests
 trigger:
   ref:
@@ -4864,6 +4864,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 2d5af91789aad1299f5e8525b4c8fdeca5e7154ab2cd509547133ae9ff7295a6
+hmac: 419f84644385caa3d64cdfdf1f5dcd2b4ddfd02dfb5a24589de45e3ed03cb0bd
 
 ...

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -126,6 +126,7 @@ RUN apt-get update && \
         gcc             \
         g++             \
         git             \
+	jq		\
         make            \
         rpm             \
         xz-utils        \

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1,7 +1,7 @@
 load('scripts/drone/vault.star', 'from_secret', 'github_token', 'pull_secret', 'drone_token', 'prerelease_bucket')
 
 grabpl_version = 'v2.9.54'
-build_image = 'grafana/build-container:1.5.8'
+build_image = 'grafana/build-container:1.5.9'
 publish_image = 'grafana/grafana-ci-deploy:1.3.3'
 deploy_docker_image = 'us.gcr.io/kubernetes-dev/drone/plugins/deploy-image'
 alpine_image = 'alpine:3.15'


### PR DESCRIPTION
**What this PR does / why we need it**:

Installs [jq](https://stedolan.github.io/jq/manual/) on the `grafana/build-container` image, to get fields from `dist/version.json` produced file.
