### PR TITLE
Elastic: eliminate react warning

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
@@ -1,4 +1,4 @@
-import React, { Context, createContext, PropsWithChildren, useCallback, useContext } from 'react';
+import React, { Context, createContext, PropsWithChildren, useCallback, useContext, useEffect } from 'react';
 
 import { TimeRange } from '@grafana/data';
 
@@ -52,11 +52,18 @@ export const ElasticsearchProvider = ({
     reducer
   );
 
+  const isUninitialized = !query.metrics || !query.bucketAggs || query.query === undefined;
+
   // This initializes the query by dispatching an init action to each reducer.
   // useStatelessReducer will then call `onChange` with the newly generated query
-  if (!query.metrics || !query.bucketAggs || query.query === undefined) {
-    dispatch(initQuery());
 
+  useEffect(() => {
+    if (isUninitialized) {
+      dispatch(initQuery());
+    }
+  });
+
+  if (isUninitialized) {
     return null;
   }
 


### PR DESCRIPTION
when the explore-page opens with the elasticsearch datasource, in some cases you get a react warning:
```
Cannot update a component (...) while rendering a different component
```

in react, you must not cause a `setState` in another component while doing your rendering.

this seems to happen because at https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx#L57-L61

while rendering the react-component, we synchronously call dispatch-action, which will (probably) cause a `setState` somewhere else.

my fix is to wrap the `dispatch` into an `useEffect`. it seems to work, and now we avoid the warning.

how to test:

1. go to explore, and choose an elasticsearch datasource.
2. now leave, go somewhere else, for example to the list-of-datasources page
3. go back to the explore-page (and elastic will appear automatically).
4. at this point you should not get the above-mentioned react-warning.