### PR TITLE
Analytics: Measure search queries and results interactions

### DIFF
--- a/packages/grafana-ui/src/components/Card/Card.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.tsx
@@ -17,7 +17,7 @@ export interface Props extends Omit<CardContainerProps, 'disableEvents' | 'disab
   /** Link to redirect to on card click. If provided, the Card inner content will be rendered inside `a` */
   href?: string;
   /** On click handler for the Card */
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent<HTMLElement>) => void;
   /** @deprecated Use `Card.Heading` instead */
   heading?: ReactNode;
   /** @deprecated Use `Card.Description` instead */
@@ -37,7 +37,7 @@ export interface CardInterface extends FC<Props> {
 
 const CardContext = React.createContext<{
   href?: string;
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent<HTMLElement>) => void;
   disabled?: boolean;
   isSelected?: boolean;
 } | null>(null);
@@ -93,7 +93,7 @@ const Heading = ({ children, className, 'aria-label': ariaLabel }: ChildProps & 
   return (
     <h2 className={cx(styles.heading, className)}>
       {href ? (
-        <a href={href} className={styles.linkHack} aria-label={ariaLabel}>
+        <a href={href} className={styles.linkHack} aria-label={ariaLabel} onClick={onClick}>
           {children}
         </a>
       ) : onClick ? (

--- a/public/app/features/search/components/SearchCard.tsx
+++ b/public/app/features/search/components/SearchCard.tsx
@@ -20,13 +20,14 @@ export interface Props {
   item: DashboardSectionItem;
   onTagSelected?: (name: string) => any;
   onToggleChecked?: OnToggleChecked;
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
 export function getThumbnailURL(uid: string, isLight?: boolean) {
   return `/api/dashboards/uid/${uid}/img/thumb/${isLight ? 'light' : 'dark'}`;
 }
 
-export function SearchCard({ editable, item, onTagSelected, onToggleChecked }: Props) {
+export function SearchCard({ editable, item, onTagSelected, onToggleChecked, onClick }: Props) {
   const [hasImage, setHasImage] = useState(true);
   const [lastUpdated, setLastUpdated] = useState<string | null>(null);
   const [showExpandedView, setShowExpandedView] = useState(false);
@@ -118,6 +119,7 @@ export function SearchCard({ editable, item, onTagSelected, onToggleChecked }: P
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       onMouseMove={onMouseMove}
+      onClick={onClick}
     >
       <div className={styles.imageContainer}>
         <SearchCheckbox
@@ -152,6 +154,7 @@ export function SearchCard({ editable, item, onTagSelected, onToggleChecked }: P
               imageWidth={320}
               item={item}
               lastUpdated={lastUpdated}
+              onClick={onClick}
             />
           </div>
         </Portal>

--- a/public/app/features/search/components/SearchCardExpanded.tsx
+++ b/public/app/features/search/components/SearchCardExpanded.tsx
@@ -16,9 +16,10 @@ export interface Props {
   imageWidth: number;
   item: DashboardSectionItem;
   lastUpdated?: string | null;
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
-export function SearchCardExpanded({ className, imageHeight, imageWidth, item, lastUpdated }: Props) {
+export function SearchCardExpanded({ className, imageHeight, imageWidth, item, lastUpdated, onClick }: Props) {
   const theme = useTheme2();
   const [hasImage, setHasImage] = useState(true);
   const imageSrc = getThumbnailURL(item.uid!, theme.isLight);
@@ -27,7 +28,7 @@ export function SearchCardExpanded({ className, imageHeight, imageWidth, item, l
   const folderTitle = item.folderTitle || 'General';
 
   return (
-    <a className={classNames(className, styles.card)} key={item.uid} href={item.url}>
+    <a className={classNames(className, styles.card)} key={item.uid} href={item.url} onClick={onClick}>
       <div className={styles.imageContainer}>
         {hasImage ? (
           <img

--- a/public/app/features/search/components/SearchItem.tsx
+++ b/public/app/features/search/components/SearchItem.tsx
@@ -15,6 +15,7 @@ export interface Props {
   editable?: boolean;
   onTagSelected: (name: string) => any;
   onToggleChecked?: OnToggleChecked;
+  onClickItem?: (event: React.MouseEvent<HTMLElement>) => void;
 }
 
 const selectors = e2eSelectors.components.Search;
@@ -29,7 +30,7 @@ const getIconFromMeta = (meta = ''): IconName => {
 };
 
 /** @deprecated */
-export const SearchItem: FC<Props> = ({ item, editable, onToggleChecked, onTagSelected }) => {
+export const SearchItem: FC<Props> = ({ item, editable, onToggleChecked, onTagSelected, onClickItem }) => {
   const styles = useStyles2(getStyles);
   const tagSelected = useCallback(
     (tag: string, event: React.MouseEvent<HTMLElement>) => {
@@ -59,6 +60,7 @@ export const SearchItem: FC<Props> = ({ item, editable, onToggleChecked, onTagSe
       href={item.url}
       style={{ minHeight: SEARCH_ITEM_HEIGHT }}
       className={styles.container}
+      onClick={onClickItem}
     >
       <Card.Heading>{item.title}</Card.Heading>
       <Card.Figure align={'center'} className={styles.checkbox}>

--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -25,6 +25,7 @@ export interface DashboardSection {
 interface SectionHeaderProps {
   selection?: SelectionChecker;
   selectionToggle?: SelectionToggle;
+  onClickItem?: (e: React.MouseEvent<HTMLElement>) => void;
   onTagSelected: (tag: string) => void;
   section: DashboardSection;
   renderStandaloneBody?: boolean; // render the body on its own
@@ -34,6 +35,7 @@ interface SectionHeaderProps {
 export const FolderSection: FC<SectionHeaderProps> = ({
   section,
   selectionToggle,
+  onClickItem,
   onTagSelected,
   selection,
   renderStandaloneBody,
@@ -137,6 +139,7 @@ export const FolderSection: FC<SectionHeaderProps> = ({
             }
           }}
           editable={Boolean(selection != null)}
+          onClickItem={onClickItem}
         />
       );
     });

--- a/public/app/features/search/page/components/FolderView.tsx
+++ b/public/app/features/search/page/components/FolderView.tsx
@@ -15,11 +15,18 @@ import { SearchResultsProps } from '../components/SearchResultsTable';
 
 import { DashboardSection, FolderSection } from './FolderSection';
 
-type Props = Pick<SearchResultsProps, 'selection' | 'selectionToggle' | 'onTagSelected'> & {
+type Props = Pick<SearchResultsProps, 'selection' | 'selectionToggle' | 'onTagSelected' | 'onClickItem'> & {
   tags?: string[];
   hidePseudoFolders?: boolean;
 };
-export const FolderView = ({ selection, selectionToggle, onTagSelected, tags, hidePseudoFolders }: Props) => {
+export const FolderView = ({
+  selection,
+  selectionToggle,
+  onTagSelected,
+  tags,
+  hidePseudoFolders,
+  onClickItem,
+}: Props) => {
   const styles = useStyles2(getStyles);
 
   const results = useAsync(async () => {
@@ -73,6 +80,7 @@ export const FolderView = ({ selection, selectionToggle, onTagSelected, tags, hi
               onTagSelected={onTagSelected}
               section={section}
               tags={tags}
+              onClickItem={onClickItem}
             />
           )}
         </div>

--- a/public/app/features/search/page/components/SearchResultsCards.tsx
+++ b/public/app/features/search/page/components/SearchResultsCards.tsx
@@ -21,10 +21,9 @@ export const SearchResultsCards = React.memo(
     height,
     selection,
     selectionToggle,
-    clearSelection,
     onTagSelected,
-    onDatasourceChange,
     keyboardEvents,
+    onClickItem,
   }: SearchResultsProps) => {
     const styles = useStyles2(getStyles);
     const infiniteLoaderRef = useRef<InfiniteLoader>(null);
@@ -89,11 +88,12 @@ export const SearchResultsCards = React.memo(
                 }
               }}
               editable={Boolean(selection != null)}
+              onClickItem={onClickItem}
             />
           </div>
         );
       },
-      [response.view, highlightIndex, styles, onTagSelected, selection, selectionToggle]
+      [response.view, highlightIndex, styles, onTagSelected, selection, selectionToggle, onClickItem]
     );
 
     if (!response.totalRows) {

--- a/public/app/features/search/page/components/SearchResultsGrid.tsx
+++ b/public/app/features/search/page/components/SearchResultsGrid.tsx
@@ -20,6 +20,7 @@ export const SearchResultsGrid = ({
   selection,
   selectionToggle,
   onTagSelected,
+  onClickItem,
   keyboardEvents,
 }: SearchResultsProps) => {
   const styles = useStyles2(getStyles);
@@ -35,6 +36,7 @@ export const SearchResultsGrid = ({
       }
     },
     onTagSelected,
+    onClick: onClickItem,
   };
 
   const itemCount = response.totalRows ?? response.view.length;

--- a/public/app/features/search/page/components/SearchResultsTable.tsx
+++ b/public/app/features/search/page/components/SearchResultsTable.tsx
@@ -26,6 +26,7 @@ export type SearchResultsProps = {
   clearSelection: () => void;
   onTagSelected: (tag: string) => void;
   onDatasourceChange?: (datasource?: string) => void;
+  onClickItem?: (event: React.MouseEvent<HTMLElement>) => void;
   keyboardEvents: Observable<React.KeyboardEvent>;
 };
 
@@ -45,6 +46,7 @@ export const SearchResultsTable = React.memo(
     clearSelection,
     onTagSelected,
     onDatasourceChange,
+    onClickItem,
     keyboardEvents,
   }: SearchResultsProps) => {
     const styles = useStyles2(getStyles);
@@ -121,14 +123,14 @@ export const SearchResultsTable = React.memo(
                   cell={cell}
                   columnIndex={index}
                   columnCount={row.cells.length}
-                  userProps={{ href: url }}
+                  userProps={{ href: url, onClick: onClickItem }}
                 />
               );
             })}
           </div>
         );
       },
-      [rows, prepareRow, response.view.fields.url?.values, highlightIndex, styles, tableStyles]
+      [rows, prepareRow, response.view.fields.url?.values, highlightIndex, styles, tableStyles, onClickItem]
     );
 
     if (!rows.length) {

--- a/public/app/features/search/page/components/SearchView.tsx
+++ b/public/app/features/search/page/components/SearchView.tsx
@@ -5,6 +5,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 import { Observable } from 'rxjs';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 import { useStyles2, Spinner, Button } from '@grafana/ui';
 import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
@@ -112,13 +113,34 @@ export const SearchView = ({
       });
     },
     1000,
-    [folderDTO, query.layout, query.starred, query.sort?.value, query.query?.length, query.tag?.length]
+    []
   );
 
+  const onClickItem = () => {
+    reportInteraction('grafana_search_result_clicked', {
+      layout: query.layout,
+      starred: query.starred,
+      sortValue: query.sort?.value,
+      query: query.query,
+      tagCount: query.tag?.length,
+      includePanels: false,
+    });
+  };
+
   const results = useAsync(() => {
+    reportInteraction('grafana_search_query_submitted', {
+      layout: query.layout,
+      starred: query.starred,
+      sortValue: query.sort?.value,
+      query: query.query,
+      tagCount: query.tag?.length,
+      includePanels: false,
+    });
+
     if (searchQuery.starred) {
       return getGrafanaSearcher().starred(searchQuery);
     }
+
     return getGrafanaSearcher().search(searchQuery);
   }, [searchQuery]);
 
@@ -200,6 +222,7 @@ export const SearchView = ({
             renderStandaloneBody={true}
             tags={query.tag}
             key={listKey}
+            onClickItem={onClickItem}
           />
         );
       }
@@ -211,6 +234,7 @@ export const SearchView = ({
           tags={query.tag}
           onTagSelected={onTagAdd}
           hidePseudoFolders={hidePseudoFolders}
+          onClickItem={onClickItem}
         />
       );
     }
@@ -229,6 +253,7 @@ export const SearchView = ({
               onTagSelected: onTagAdd,
               keyboardEvents,
               onDatasourceChange: query.datasource ? onDatasourceChange : undefined,
+              onClickItem: onClickItem,
             };
 
             if (layout === SearchLayout.Grid) {

--- a/public/app/features/search/page/components/columns.tsx
+++ b/public/app/features/search/page/components/columns.tsx
@@ -126,7 +126,7 @@ export const generateColumns = (
         classNames += ' ' + styles.missingTitleText;
       }
       return (
-        <a {...p.cellProps} href={p.userProps.href} className={classNames} title={name}>
+        <a {...p.cellProps} href={p.userProps.href} onClick={p.userProps.onClick} className={classNames} title={name}>
           {name}
         </a>
       );

--- a/public/app/features/search/page/reporting.ts
+++ b/public/app/features/search/page/reporting.ts
@@ -2,25 +2,41 @@ import { config, reportInteraction } from '@grafana/runtime';
 
 import { SearchLayout } from '../types';
 
-export const reportDashboardListViewed = (
-  dashboardListType: 'manage_dashboards' | 'dashboard_search',
-  query: {
-    layout?: SearchLayout;
-    starred?: boolean;
-    sortValue?: string;
-    query?: string;
-    tagCount?: number;
-  }
-) => {
+interface QueryProps {
+  layout: SearchLayout;
+  starred: boolean;
+  sortValue: string;
+  query: string;
+  tagCount: number;
+  includePanels: boolean;
+}
+
+type DashboardListType = 'manage_dashboards' | 'dashboard_search';
+
+export const reportDashboardListViewed = (dashboardListType: DashboardListType, query: QueryProps) => {
+  reportInteraction(`${dashboardListType}_viewed`, getQuerySearchContext(query));
+};
+
+export const reportSearchResultInteraction = (dashboardListType: DashboardListType, query: QueryProps) => {
+  reportInteraction(`${dashboardListType}_result_clicked`, getQuerySearchContext(query));
+};
+
+export const reportSearchQueryInteraction = (dashboardListType: DashboardListType, query: QueryProps) => {
+  reportInteraction(`${dashboardListType}_query_submitted`, getQuerySearchContext(query));
+};
+
+const getQuerySearchContext = (query: QueryProps) => {
   const showPreviews = query.layout === SearchLayout.Grid;
   const previewsEnabled = Boolean(config.featureToggles.panelTitleSearch);
   const previews = previewsEnabled ? (showPreviews ? 'on' : 'off') : 'feature_disabled';
-  reportInteraction(`${dashboardListType}_viewed`, {
+
+  return {
     previews,
     layout: query.layout,
     starredFilter: query.starred ?? false,
     sort: query.sortValue ?? '',
     tagCount: query.tagCount ?? 0,
     queryLength: query.query?.length ?? 0,
-  });
+    includePanels: query.includePanels ?? false,
+  };
 };

--- a/public/app/features/search/page/reporting.ts
+++ b/public/app/features/search/page/reporting.ts
@@ -25,6 +25,13 @@ export const reportSearchQueryInteraction = (dashboardListType: DashboardListTyp
   reportInteraction(`${dashboardListType}_query_submitted`, getQuerySearchContext(query));
 };
 
+export const reportSearchFailedQueryInteraction = (
+  dashboardListType: DashboardListType,
+  { error, ...query }: QueryProps & { error?: string }
+) => {
+  reportInteraction(`${dashboardListType}_query_failed`, { ...getQuerySearchContext(query), error });
+};
+
 const getQuerySearchContext = (query: QueryProps) => {
   const showPreviews = query.layout === SearchLayout.Grid;
   const previewsEnabled = Boolean(config.featureToggles.panelTitleSearch);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR implements analytics to get:
* The conversion current search experience conversion rate: User queries vs User result clicks
* Know what are the most useful filters by the users when searching
* Know the conversion rate of each filter
* Funnel: Users than open search -> Users searches -> Users clicking on an item

I have added `onClick` to search items and `onClickItem` for elements containing more than one element.

Depending on where the search happens we will have different namespaces for the events:
* From Dashboard browse: `manage_dashboards`
* From Search: `dashboard_search`

The events we will track are:
* `<namespace>_viewed` is triggered only once, when the search modal is open
* `<namespace>_query_submitted` is triggered when the user add/remove a filter, or introduces a new name
* `<namespace>_result_clicked` is triggered when the users open a dashboard/folder/panel.

All events contain the same properties to make the data easy to aggregate:
- tagsCount : number -> Number of tags used as filter
- query : string -> Name used as filter
- includePanel : boolean -> If the query include panel results
- layout: list | grid | folder -> How the results are displayed
- starred: boolean -> If results are filtered by starred
- sortValue: string -> Sorted by

|Manage Dashboard|Search|
|-|-|
![2022-07-28 18 00 41](https://user-images.githubusercontent.com/5699976/181586637-f951a570-5ffe-404b-a1b7-1ea76332abca.gif)|![2022-07-28 17 57 14](https://user-images.githubusercontent.com/5699976/181586058-ab34b52c-8df0-48af-944d-ed5f49543e99.gif)


**Which issue(s) this PR fixes**: 


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #52451 

**Special notes for your reviewer**:
If you wanna test locally if the events are sent, you can add a console log to `reportInteraction`.
```diff
export const reportInteraction = (interactionName: string, properties?: Record<string, any>) => {
+ console.log('Reporting interaction:', interactionName, properties);
  getEchoSrv().addEvent<InteractionEchoEvent>({
    type: EchoEventType.Interaction,
    payload: {
      interactionName,
      properties,
    },
  });
};
```
Make sure you test it with and without the FFs: `dashboardPreviews panelTitleSearch`