### PR TITLE
TeamSync: Add description to group mapping

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5704,10 +5704,6 @@ exports[`better eslint`] = {
     "public/app/features/teams/CreateTeam.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/features/teams/TeamGroupSync.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
-    ],
     "public/app/features/teams/TeamMemberRow.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/public/app/features/teams/TeamGroupSync.test.tsx
+++ b/public/app/features/teams/TeamGroupSync.test.tsx
@@ -37,18 +37,23 @@ describe('TeamGroupSync', () => {
     setup({ addTeamGroup: mockAddGroup });
     // Empty List CTA "Add group" button is second in the DOM order
     await userEvent.click(screen.getAllByRole('button', { name: /add group/i })[1]);
-    expect(screen.getByRole('textbox', { name: /add external group/i })).toBeVisible();
+    expect(screen.getByRole('textbox', { name: /external group id/i })).toBeVisible();
 
-    await userEvent.type(screen.getByRole('textbox', { name: /add external group/i }), 'test/group');
+    await userEvent.type(screen.getByRole('textbox', { name: /external group id/i }), 'test/group');
+
+    expect(screen.getByRole('textbox', { name: /description/i })).toBeVisible();
+
+    await userEvent.type(screen.getByRole('textbox', { name: /description/i }), 'test group description');
+
     await userEvent.click(screen.getAllByRole('button', { name: /add group/i })[0]);
     await waitFor(() => {
-      expect(mockAddGroup).toHaveBeenCalledWith('test/group');
+      expect(mockAddGroup).toHaveBeenCalledWith('test/group', 'test group description');
     });
   });
 
   it('should call remove group', async () => {
     const mockRemoveGroup = jest.fn();
-    const mockGroup: TeamGroup = { teamId: 1, groupId: 'some/group' };
+    const mockGroup: TeamGroup = { teamId: 1, groupId: 'some/group', description: '' };
     setup({ removeTeamGroup: mockRemoveGroup, groups: [mockGroup] });
     await userEvent.click(screen.getByRole('button', { name: 'Remove group some/group' }));
     await waitFor(() => {

--- a/public/app/features/teams/TeamGroupSync.tsx
+++ b/public/app/features/teams/TeamGroupSync.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, SyntheticEvent } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { Input, Tooltip, Icon, Button, useTheme2, InlineField, InlineFieldRow } from '@grafana/ui';
@@ -32,6 +32,7 @@ interface OwnProps {
 interface State {
   isAdding: boolean;
   newGroupId: string;
+  newGroupDesc: string;
 }
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
@@ -42,7 +43,7 @@ const headerTooltip = `Sync LDAP, OAuth or SAML groups with your Grafana teams.`
 export class TeamGroupSync extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { isAdding: false, newGroupId: '' };
+    this.state = { isAdding: false, newGroupId: '', newGroupDesc: '' };
   }
 
   componentDidMount() {
@@ -57,14 +58,18 @@ export class TeamGroupSync extends PureComponent<Props, State> {
     this.setState({ isAdding: !this.state.isAdding });
   };
 
-  onNewGroupIdChanged = (event: any) => {
+  onNewGroupIdChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({ newGroupId: event.target.value });
   };
 
-  onAddGroup = (event: any) => {
+  onNewGroupDescChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ newGroupDesc: event.target.value });
+  };
+
+  onAddGroup = (event: SyntheticEvent) => {
     event.preventDefault();
-    this.props.addTeamGroup(this.state.newGroupId);
-    this.setState({ isAdding: false, newGroupId: '' });
+    this.props.addTeamGroup(this.state.newGroupId, this.state.newGroupDesc);
+    this.setState({ isAdding: false, newGroupId: '', newGroupDesc: '' });
   };
 
   onRemoveGroup = (group: TeamGroup) => {
@@ -80,6 +85,7 @@ export class TeamGroupSync extends PureComponent<Props, State> {
     return (
       <tr key={group.groupId}>
         <td>{group.groupId}</td>
+        <td>{group.description}</td>
         <td style={{ width: '1%' }}>
           <Button
             size="sm"
@@ -96,7 +102,7 @@ export class TeamGroupSync extends PureComponent<Props, State> {
   }
 
   render() {
-    const { isAdding, newGroupId } = this.state;
+    const { isAdding, newGroupId, newGroupDesc } = this.state;
     const { groups, isReadOnly } = this.props;
     return (
       <div>
@@ -131,7 +137,7 @@ export class TeamGroupSync extends PureComponent<Props, State> {
             <form onSubmit={this.onAddGroup}>
               <InlineFieldRow>
                 <InlineField
-                  label={'Add External Group'}
+                  label={'External Group ID'}
                   tooltip="LDAP Group Example: cn=users,ou=groups,dc=grafana,dc=org."
                 >
                   <Input
@@ -140,6 +146,16 @@ export class TeamGroupSync extends PureComponent<Props, State> {
                     placeholder=""
                     value={newGroupId}
                     onChange={this.onNewGroupIdChanged}
+                    disabled={isReadOnly}
+                  />
+                </InlineField>
+                <InlineField label={'Description'} tooltip="Mapping description for the group. Informative only.">
+                  <Input
+                    type="text"
+                    id={'add-desc'}
+                    placeholder=""
+                    value={newGroupDesc}
+                    onChange={this.onNewGroupDescChanged}
                     disabled={isReadOnly}
                   />
                 </InlineField>
@@ -175,6 +191,7 @@ export class TeamGroupSync extends PureComponent<Props, State> {
               <thead>
                 <tr>
                   <th>External Group ID</th>
+                  <th>Mapping Description</th>
                   <th style={{ width: '1%' }} />
                 </tr>
               </thead>

--- a/public/app/features/teams/__mocks__/teamMocks.ts
+++ b/public/app/features/teams/__mocks__/teamMocks.ts
@@ -66,6 +66,7 @@ export const getMockTeamGroups = (amount: number): TeamGroup[] => {
     groups.push({
       groupId: `group-${i}`,
       teamId: 1,
+      description: '',
     });
   }
 

--- a/public/app/features/teams/state/actions.ts
+++ b/public/app/features/teams/state/actions.ts
@@ -71,10 +71,10 @@ export function loadTeamGroups(): ThunkResult<void> {
   };
 }
 
-export function addTeamGroup(groupId: string): ThunkResult<void> {
+export function addTeamGroup(groupId: string, groupDesc: string): ThunkResult<void> {
   return async (dispatch, getStore) => {
     const team = getStore().team.team;
-    await getBackendSrv().post(`/api/teams/${team.id}/groups`, { groupId: groupId });
+    await getBackendSrv().post(`/api/teams/${team.id}/groups`, { groupId: groupId, description: groupDesc });
     dispatch(loadTeamGroups());
   };
 }

--- a/public/app/types/teams.ts
+++ b/public/app/types/teams.ts
@@ -24,6 +24,7 @@ export interface TeamMember {
 
 export interface TeamGroup {
   groupId: string;
+  description: string;
   teamId: number;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow adding team sync group description. 

Useful when the group ID is not human friendly such as an uuid.

![image](https://user-images.githubusercontent.com/8071073/181589545-edfb32b7-72dc-41e2-bcc8-bd2f1c903e80.png)


Enterprise PR: https://github.com/grafana/grafana/pull/52957

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

