### PR TITLE
Previews: fix `dashboard.thumbnails.ds_uids` migration

### DIFF
--- a/pkg/services/sqlstore/dashboard_thumbs.go
+++ b/pkg/services/sqlstore/dashboard_thumbs.go
@@ -128,7 +128,7 @@ func (ss *SQLStore) FindDashboardsWithStaleThumbnails(ctx context.Context, cmd *
 		args := []interface{}{models.ThumbnailStateStale}
 
 		if cmd.IncludeThumbnailsWithEmptyDsUIDs {
-			query += " OR dashboard_thumbnail.ds_uids = ?"
+			query += " OR dashboard_thumbnail.ds_uids = ? OR dashboard_thumbnail.ds_uids IS NULL"
 			args = append(args, "")
 		}
 		sess.Where(query+")", args...)

--- a/pkg/services/sqlstore/migrations/dashboard_thumbs_mig.go
+++ b/pkg/services/sqlstore/migrations/dashboard_thumbs_mig.go
@@ -26,6 +26,6 @@ func addDashboardThumbsMigrations(mg *migrator.Migrator) {
 	mg.AddMigration("add unique indexes for dashboard_thumbnail", migrator.NewAddIndexMigration(dashThumbs, dashThumbs.Indices[0]))
 	mg.AddMigration("Add ds_uids column to dashboard_thumbnail table", migrator.NewAddColumnMigration(dashThumbs,
 		// uids of datasources used in the dashboard when taking preview
-		&migrator.Column{Name: "ds_uids", Type: migrator.DB_Text, Nullable: false, Default: ""},
+		&migrator.Column{Name: "ds_uids", Type: migrator.DB_Text, Nullable: true, Default: ""},
 	))
 }


### PR DESCRIPTION
Fixes broken SQLlite migration, the querying logic will work with both versions of the column 