### PR TITLE
GrafanaUI: Add minWidth prop to Select

### DIFF
--- a/packages/grafana-ui/src/components/Select/Select.story.tsx
+++ b/packages/grafana-ui/src/components/Select/Select.story.tsx
@@ -4,7 +4,7 @@ import { Meta, Story } from '@storybook/react';
 import React, { useState } from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { Icon, Select, AsyncSelect, MultiSelect, AsyncMultiSelect } from '@grafana/ui';
+import { EditorField, Icon, Select, AsyncSelect, MultiSelect, AsyncMultiSelect } from '@grafana/ui';
 
 import { getAvailableIcons, IconName } from '../../types';
 import { withCenteredStory, withHorizontallyCenteredStory } from '../../utils/storybook/withCenteredStory';
@@ -306,6 +306,30 @@ export const WidthAuto: Story = (args) => {
           {...args}
           width="auto"
         />
+      </div>
+    </>
+  );
+};
+
+export const MinWidth: Story = (args) => {
+  const [value, setValue] = useState<SelectableValue<string>>({ label: 'Avg', value: 'average' });
+
+  return (
+    <>
+      <div style={{ width: '100%' }}>
+        <EditorField label="Group by function">
+          <Select
+            options={generateOptions()}
+            value={value}
+            onChange={(v) => {
+              setValue(v);
+              action('onChange')(v);
+            }}
+            {...args}
+            width="auto"
+            minWidth={13}
+          />
+        </EditorField>
       </div>
     </>
   );

--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -140,13 +140,14 @@ export function SelectBase<T>({
   width,
   isValidNewOption,
   formatOptionLabel,
+  minWidth,
 }: SelectBaseProps<T>) {
   const theme = useTheme2();
   const styles = getSelectStyles(theme);
 
   const reactSelectRef = useRef<{ controlRef: HTMLElement }>(null);
   const [closeToBottom, setCloseToBottom] = useState<boolean>(false);
-  const selectStyles = useCustomSelectStyles(theme, width);
+  const selectStyles = useCustomSelectStyles(theme, width, minWidth);
 
   // Infer the menu position for asynchronously loaded options. menuPlacement="auto" doesn't work when the menu is
   // automatically opened when the component is created (it happens in SegmentSelect by setting menuIsOpen={true}).

--- a/packages/grafana-ui/src/components/Select/resetSelectStyles.ts
+++ b/packages/grafana-ui/src/components/Select/resetSelectStyles.ts
@@ -43,7 +43,11 @@ export default function resetSelectStyles(theme: GrafanaTheme2) {
   };
 }
 
-export function useCustomSelectStyles(theme: GrafanaTheme2, width: number | string | undefined) {
+export function useCustomSelectStyles(
+  theme: GrafanaTheme2,
+  width: number | string | undefined,
+  minWidth?: number | undefined
+) {
   return useMemo(() => {
     return {
       ...resetSelectStyles(theme),
@@ -68,11 +72,12 @@ export function useCustomSelectStyles(theme: GrafanaTheme2, width: number | stri
       container: () => ({
         width: width ? theme.spacing(width) : '100%',
         display: width === 'auto' ? 'inline-flex' : 'flex',
+        minWidth: minWidth ? theme.spacing(minWidth) : 'auto',
       }),
       option: (provided: any, state: any) => ({
         ...provided,
         opacity: state.isDisabled ? 0.5 : 1,
       }),
     };
-  }, [theme, width]);
+  }, [theme, width, minWidth]);
 }

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -83,6 +83,7 @@ export interface SelectCommonProps<T> {
   ) => boolean;
   /** Message to display isLoading=true*/
   loadingMessage?: string;
+  minWidth?: number;
 }
 
 export interface SelectAsyncProps<T> {


### PR DESCRIPTION
**What this PR does / why we need it**:
A `minWidth` prop for Select is useful in cases where the selected option
or the placeholder is quite short compared to its label.

**Before**
![image](https://user-images.githubusercontent.com/1048831/181613005-28354298-593f-451b-b71e-945ebbc7c909.png)

**After**
![image](https://user-images.githubusercontent.com/1048831/181612925-4d2e696d-c484-4304-a958-91d789d21051.png)
