### PR TITLE
BarChart: fix top y tick clipping when x labels are rotated

### DIFF
--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -1,5 +1,5 @@
 import { orderBy } from 'lodash';
-import { Padding } from 'uplot';
+import uPlot, { Padding } from 'uplot';
 
 import {
   ArrayVector,
@@ -302,7 +302,7 @@ function getRotationPadding(frame: DataFrame, rotateLabel: number, valueMaxLengt
   // Add padding to the bottom to avoid clipping the rotated labels.
   const paddingBottom = Math.sin(((rotateLabel >= 0 ? rotateLabel : rotateLabel * -1) * Math.PI) / 180) * maxLength;
 
-  return [0, paddingRight, paddingBottom, paddingLeft];
+  return [Math.round(UPLOT_AXIS_FONT_SIZE * uPlot.pxRatio), paddingRight, paddingBottom, paddingLeft];
 }
 
 /** @internal */


### PR DESCRIPTION
Fixes #52914

avoids setting top chart padding to 0.

![image](https://user-images.githubusercontent.com/43234/181618440-2e0916b9-1775-4487-9b0f-be06b4bc9eaa.png)