### PR TITLE
docs: general formatting and grammar improvements

### DIFF
--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Unzip artifact from base
         run: unzip -j base_built_packages.zip -d ./base && rm base_built_packages.zip
 
-      - name: Get link for the Github Action job
+      - name: Get link for the GitHub Action job
         id: job
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/metrics-collector.yml
+++ b/.github/workflows/metrics-collector.yml
@@ -8,7 +8,7 @@
 #
 # https://github.com/grafana/grafana-github-actions/blob/main/metrics-collector/index.ts
 #
-name: Github issue metrics collection
+name: GitHub issue metrics collection
 on:
   schedule:
     - cron: "*/10 * * * *"

--- a/contribute/breaking-changes-guide.md
+++ b/contribute/breaking-changes-guide.md
@@ -34,7 +34,7 @@ Any change that causes dependent software to behave differently is considered to
 It can list exported members of an NPM package or imports used by an NPM package,
 **but we are mainly using it for comparing different versions of the same package to see changes in the exported members.**
 
-A Github workflow runs against every pull request and comments a hint in case there are
+A GitHub workflow runs against every pull request and comments a hint in case there are
 possible breaking changes. It also adds the `"breaking change"` label to the pull request.
 
 ## How does the CI workflow look like?

--- a/contribute/documentation/README.md
+++ b/contribute/documentation/README.md
@@ -129,13 +129,13 @@ Suppose you are writing content for a site called _Doggie handbook_. You might o
 
 Before you begin writing, we recommend that you fork and clone the Grafana repository so that you can use a text editor locally to create branches, commit your changes, and create a PR.
 
-While this document doesn't include git commands or descriptions of Github operations, you might find these links useful.
+While this document doesn't include git commands or descriptions of GitHub operations, you might find these links useful.
 
 - [Install git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git): We store all source code, including documentation, in Git repositories.
 - [Fork a repo](https://docs.github.com/en/get-started/quickstart/fork-a-repo): Locate the repo you want to clone, and fork it.
 - [Clone a repo](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository): Clone the repository to your local machine.
 - [Create a branch](https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging): Before you make change, create a branch. Do not push changes against the `main` branch.
-- [Create a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request): After you add, commit, and push your changes, create a PR in Github.
+- [Create a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request): After you add, commit, and push your changes, create a PR in GitHub.
 
 #### Use a documentation template to contribute a topic
 
@@ -173,9 +173,9 @@ When you are ready for other people to review your work, perform the following t
 
 1. [Commit](https://git-scm.com/docs/git-commit) your changes.
 
-1. [Push](https://git-scm.com/docs/git-push) your changes to Github.
+1. [Push](https://git-scm.com/docs/git-push) your changes to GitHub.
 
-1. [Create a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) in Github.
+1. [Create a PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) in GitHub.
 
 The docs build system automatically conducts a series of tests to ensure that the content doesn't conflict with other content in the docs repository.
 

--- a/contribute/documentation/README.md
+++ b/contribute/documentation/README.md
@@ -4,7 +4,7 @@ We provide these guidelines to help our contributors make additions or correctio
 
 ## Welcome
 
-Welcome. We're glad you're here to help make our technical documentation even better. We develop content that leads our users to success using Grafana products. Technical accuracy is our primary consideration, and we value the use of inclusive language. We regard your feedback as a gift - thanks for reading through these guidelines.
+We're glad you're here to help make our technical documentation even better. We develop content that leads our users to success using Grafana products. Technical accuracy is our primary consideration, and we value the use of inclusive language. We regard your feedback as a gift - thanks for reading through these guidelines.
 
 ### Intended audience
 
@@ -19,7 +19,7 @@ All Grafana Enterprise and OSS documentation is located in the [Grafana open sou
 
 > The `_index.md` file is required.
 
-### Writing in markdown
+### Writing in Markdown
 
 We write technical documentation using [Markdown](https://en.wikipedia.org/wiki/Markdown). We've put together a short guide to help you how to structure and format your content.
 
@@ -100,7 +100,7 @@ At Grafana Labs, we use the principles of topic-based authoring when we write te
 Technical content is divided into three topic types: concept, task, and reference.
 
 - **Concept**: A concept topic explains _what_ a feature (or idea) is, and why it is important.
-- **Task**: A task topic explains _how_ to complete an end user procedure in the system. Task topics contain steps.
+- **Task**: A task topic explains _how_ to complete an end-user procedure in the system. Task topics contain steps.
 - **Reference** A reference topic contains lookup information that a user might consult when they complete a task. Documenting a list of values with descriptions is a common form of reference topic.
 
 **Example**
@@ -202,7 +202,7 @@ Pretend you are explaining your topic to a brand new Grafana user or developer.
 Use the following sentence structure when you write: _subject_—_verb_—_object_. If you are telling a user to do something, write an imperative sentence. For example “Enter the refresh rate time interval and click Save.”
 
 - You can also start a sentence with an _if_ clause, which positions the condition before the action.
-- Limit the number of words in a sentence to 20..
+- Limit the number of words in a sentence to 20.
 
 ### Use active voice
 

--- a/docs/sources/administration/provisioning/index.md
+++ b/docs/sources/administration/provisioning/index.md
@@ -26,8 +26,8 @@ See [Configuration]({{< relref "../../setup-grafana/configure-grafana/" >}}) for
 
 > **Note:** If you have installed Grafana using the `deb` or `rpm`
 > packages, then your configuration file is located at
-> `/etc/grafana/grafana.ini`. This path is specified in the Grafana
-> init.d script using `--config` file parameter.
+> `/etc/grafana/grafana.ini`. This file path is specified in the Grafana
+> init.d script using the `--config` parameter.
 
 ### Using Environment Variables
 

--- a/docs/sources/dashboards/dashboard-public.md
+++ b/docs/sources/dashboards/dashboard-public.md
@@ -60,4 +60,4 @@ publicDashboards = true
 - Annotations will not be displayed in public dashboards.
 - Grafana Live and real-time event streams are not supported.
 
-We are excited to share this enhancement with you and we’d love your feedback! Please check out the [Github](https://github.com/grafana/grafana/discussions/49253) discussion and join the conversation.
+We are excited to share this enhancement with you and we’d love your feedback! Please check out the [GitHub](https://github.com/grafana/grafana/discussions/49253) discussion and join the conversation.

--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -15,7 +15,7 @@ weight: 1300
 
 Grafana includes built-in support for Prometheus. This topic explains options, variables, querying, and other options specific to the Prometheus data source. Refer to [Add a data source]({{< relref "add-a-data-source/" >}}) for instructions on how to add a data source to Grafana. Only users with the organization admin role can add data sources.
 
-> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more.[Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
+> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more. [Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
 
 ## Prometheus settings
 
@@ -65,7 +65,7 @@ For more information about Prometheus query language, refer to the [Prometheus d
 
 ![Autocomplete](/static/img/docs/prometheus/autocomplete-9-1.png 'Autocomplete')
 
-Autocomplete kicks automatically in appropriate times during typing. Use `ctrl/cmd + space` to trigger autocomplete manually when needed. Autocomplete can suggest both static functions, aggregations and keywords but also dynamic items like metrics and labels. Autocomplete dropdown also shows documentation for the suggested items, either static one or dynamic metric documentation where available.
+Autocomplete kicks automatically in appropriate times during typing. Use `ctrl/cmd + space` to trigger autocomplete manually when needed. Autocomplete can suggest both static functions, aggregations, and keywords but also dynamic items like metrics and labels. Autocomplete dropdown also shows documentation for the suggested items, either static one or dynamic metric documentation where available.
 
 In [Explore]({{< relref "../explore/" >}}) use `shift + enter` to run the query.
 
@@ -164,7 +164,7 @@ Same set of option is available as in the `Code` mode. See the [Code mode option
 
 ## Templating
 
-Instead of hard-coding things like server, application and sensor name in your metric queries, you can use variables in their place.
+Instead of hard-coding things like server, application, and sensor name in your metric queries, you can use variables in their place.
 Variables are shown as dropdown select boxes at the top of the dashboard. These dropdowns make it easy to change the data
 being displayed in your dashboard.
 

--- a/docs/sources/datasources/testdata.md
+++ b/docs/sources/datasources/testdata.md
@@ -54,5 +54,5 @@ Otherwise the dashboard will not be updated automatically for other Grafana user
 
 ## Using test data in issues
 
-If you post an issue on Github regarding time series data or rendering of time series data, we strongly advise you to use this data source to replicate the data.
+If you post an issue on GitHub regarding time series data or rendering of time series data, we strongly advise you to use this data source to replicate the data.
 That makes it much easier for the developers to replicate and solve the issue you have.

--- a/docs/sources/developers/contribute.md
+++ b/docs/sources/developers/contribute.md
@@ -38,7 +38,7 @@ Our [style guides](https://github.com/grafana/grafana/tree/main/contribute/style
 
 - [Documentation style guide](https://github.com/grafana/grafana/blob/main/contribute/style-guides/documentation-style-guide.md) applies to all documentation created for Grafana products.
 
-- [End to end test framework](https://github.com/grafana/grafana/blob/main/contribute/style-guides/e2e.md) provides guidance for Grafana e2e tests.
+- [End-to-end test framework](https://github.com/grafana/grafana/blob/main/contribute/style-guides/e2e.md) provides guidance for Grafana e2e tests.
 
 - [Frontend style guide](https://github.com/grafana/grafana/blob/main/contribute/style-guides/frontend.md) provides rules and guidance on developing in React for Grafana.
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -16,13 +16,13 @@ Grafana has default and custom configuration files. You can customize your Grafa
 
 ## Configuration file location
 
-The default settings for a Grafana instance are stored in the `$WORKING_DIR/conf/defaults.ini` file. _Do not_ change this file.
+The default settings for a Grafana instance are stored in the `$WORKING_DIR/conf/defaults.ini` file. _Do not_ modify this file.
 
 Depending on your OS, your custom configuration file is either the `$WORKING_DIR/conf/defaults.ini` file or the `/usr/local/etc/grafana/grafana.ini` file. The custom configuration file path can be overridden using the `--config` parameter.
 
 ### Linux
 
-If you installed Grafana using the `deb` or `rpm` packages, then your configuration file is located at `/etc/grafana/grafana.ini` and a separate `custom.ini` is not used. This path is specified in the Grafana init.d script using `--config` file parameter.
+If you installed Grafana using the `deb` or `rpm` packages, then your configuration file is located at `/etc/grafana/grafana.ini` and a separate `custom.ini` is not used. This file path is specified in the Grafana init.d script using the `--config` parameter.
 
 ### Docker
 
@@ -38,12 +38,12 @@ By default, the configuration file is located at `/usr/local/etc/grafana/grafana
 
 ## Remove comments in the .ini files
 
-Grafana uses semicolons (the `;` char) to comment out lines in a `.ini` file. You must uncomment each line in the `custom.ini` or the `grafana.ini` file that you are modify by removing `;` from the beginning of that line. Otherwise your changes will be ignored.
+Grafana uses semicolons (the `;` char) to comment out lines in a `.ini` file. You must uncomment each line in the `custom.ini` or `grafana.ini` file that you're modifying by removing the prefixed `;` on that line, otherwise your changes will be ignored.
 
 For example:
 
 ```
-# The HTTP port  to use
+# The HTTP port to use
 ;http_port = 3000
 ```
 
@@ -110,7 +110,7 @@ logs = $__env{LOGDIR}/grafana
 
 ### File provider
 
-`file` reads a file from the filesystem. It trims whitespace from the
+The `file` provider reads a file from the filesystem. It trims whitespace from the
 beginning and the end of files.
 The database password in the following example would be replaced by
 the content of the `/etc/secrets/gf_sql_password` file:
@@ -122,7 +122,7 @@ password = $__file{/etc/secrets/gf_sql_password}
 
 ### Vault provider
 
-The `vault` provider allows you to manage your secrets with [Hashicorp Vault](https://www.hashicorp.com/products/vault).
+The `vault` provider allows you to manage your secrets with [HashiCorp Vault](https://www.hashicorp.com/products/vault).
 
 > Vault provider is only available in Grafana Enterprise v7.1+. For more information, refer to [Vault integration]({{< relref "../configure-security/configure-database-encryption/integrate-with-hashicorp-vault/" >}}) in [Grafana Enterprise]({{< relref "../../enterprise/" >}}).
 

--- a/docs/sources/setup-grafana/configure-security/configure-database-encryption/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-database-encryption/_index.md
@@ -115,7 +115,7 @@ Grafana integrates with the following key management systems:
 - [AWS KMS]({{< relref "encrypt-secrets-using-aws-kms/" >}})
 - [Azure Key Vault]({{< relref "encrypt-secrets-using-azure-key-vault/" >}})
 - [Google Cloud KMS]({{< relref "encrypt-secrets-using-google-cloud-kms/" >}})
-- [Hashicorp Key Vault]({{< relref "encrypt-secrets-using-hashicorp-key-vault/" >}})
+- [HashiCorp Key Vault]({{< relref "encrypt-secrets-using-hashicorp-key-vault/" >}})
 
 ## Changing your encryption mode to AES-GCM
 

--- a/docs/sources/setup-grafana/configure-security/configure-database-encryption/encrypt-secrets-using-hashicorp-key-vault.md
+++ b/docs/sources/setup-grafana/configure-security/configure-database-encryption/encrypt-secrets-using-hashicorp-key-vault.md
@@ -2,21 +2,21 @@
 aliases:
   - /docs/grafana/latest/enterprise/enterprise-encryption/using-hashicorp-key-vault-to-encrypt-database-secrets/
   - /docs/grafana/latest/setup-grafana/configure-security/configure-database-encryption/encrypt-secrets-using-hashicorp-key-vault/
-description: Learn how to use Hashicorp Vault to encrypt secrets in the Grafana database.
-title: Encrypt database secrets using Hashicorp Vault
+description: Learn how to use HashiCorp Vault to encrypt secrets in the Grafana database.
+title: Encrypt database secrets using HashiCorp Vault
 weight: 200
 ---
 
-# Encrypt database secrets using Hashicorp Vault
+# Encrypt database secrets using HashiCorp Vault
 
-You can use an encryption key from Hashicorp Vault to encrypt secrets in the Grafana database.
+You can use an encryption key from HashiCorp Vault to encrypt secrets in the Grafana database.
 
 **Prerequisites:**
 
-- Permissions to manage Hashicorp Vault to enable secrets engines and issue tokens.
+- Permissions to manage HashiCorp Vault to enable secrets engines and issue tokens.
 - Access to the Grafana [configuration]({{< relref "../../configure-grafana/#config-file-locations" >}}) file
 
-1. [Enable the transit secrets engine](https://www.vaultproject.io/docs/secrets/transit#setup) in Hashicorp Vault.
+1. [Enable the transit secrets engine](https://www.vaultproject.io/docs/secrets/transit#setup) in HashiCorp Vault.
 
 2. [Create a named encryption key](https://www.vaultproject.io/docs/secrets/transit#setup).
 
@@ -24,25 +24,25 @@ You can use an encryption key from Hashicorp Vault to encrypt secrets in the Gra
 
 4. From within Grafana, turn on [envelope encryption]({{< relref "/#envelop-encryption" >}}).
 
-5. Add your Hashicorp Vault details to the Grafana configuration file; depending on your operating system, is usually named `grafana.ini`:
+5. Add your HashiCorp Vault details to the Grafana configuration file; depending on your operating system, is usually named `grafana.ini`:
    <br><br>a. Add a new section to the configuration file, with a name in the format of `[security.encryption.hashicorpvault.<KEY-NAME>]`, where `<KEY-NAME>` is any name that uniquely identifies this key among other provider keys.
    <br><br>b. Fill in the section with the following values:
    <br>
 
-   - `token`: a periodic service token used to authenticate within Hashicorp Vault.
-   - `url`: URL of the Hashicorp Vault server.
+   - `token`: a periodic service token used to authenticate within HashiCorp Vault.
+   - `url`: URL of the HashiCorp Vault server.
    - `transit_engine_path`: mount point of the transit engine.
    - `key_ring`: name of the encryption key.
    - `token_renewal_interval`: specifies how often to renew token; should be less than the `period` value of a periodic service token.
 
-   An example of a Hashicorp Vault provider section in the `grafana.ini` file is as follows:
+   An example of a HashiCorp Vault provider section in the `grafana.ini` file is as follows:
 
    ```
-   # Example of Hashicorp Vault provider setup
+   # Example of HashiCorp Vault provider setup
    ;[security.encryption.hashicorpvault.example-encryption-key]
    # Token used to authenticate within Vault. We suggest to use periodic tokens: more on token types https://www.vaultproject.io/docs/concepts/tokens#service-tokens
    ;token =
-   # Location of the Hashicorp Vault server
+   # Location of the HashiCorp Vault server
    ;url = http://localhost:8200
    # Mount point of the transit secret engine
    ;transit_engine_path = transit

--- a/docs/sources/setup-grafana/configure-security/configure-database-encryption/integrate-with-hashicorp-vault.md
+++ b/docs/sources/setup-grafana/configure-security/configure-database-encryption/integrate-with-hashicorp-vault.md
@@ -2,15 +2,15 @@
 aliases:
   - /docs/grafana/latest/enterprise/vault/
   - /docs/grafana/latest/setup-grafana/configure-security/configure-database-encryption/integrate-with-hashicorp-vault/
-description: Learn how to integrate Grafana with Hashicorp Vault so that you can use
+description: Learn how to integrate Grafana with HashiCorp Vault so that you can use
   secrets for configuration and provisioning.
-title: Integrate Grafana with Hashicorp Vault
+title: Integrate Grafana with HashiCorp Vault
 weight: 500
 ---
 
-# Integrate Grafana with Hashicorp Vault
+# Integrate Grafana with HashiCorp Vault
 
-If you manage your secrets with [Hashicorp Vault](https://www.hashicorp.com/products/vault), you can use them for [Configuration]({{< relref "../../configure-grafana/" >}}) and [Provisioning]({{< relref "../../../administration/provisioning/" >}}).
+If you manage your secrets with [HashiCorp Vault](https://www.hashicorp.com/products/vault), you can use them for [Configuration]({{< relref "../../configure-grafana/" >}}) and [Provisioning]({{< relref "../../../administration/provisioning/" >}}).
 
 > **Note:** Available in [Grafana Enterprise]({{< relref "../../../enterprise/" >}}) and [Grafana Cloud Advanced]({{< ref "/docs/grafana-cloud" >}}).
 

--- a/docs/sources/setup-grafana/installation/debian.md
+++ b/docs/sources/setup-grafana/installation/debian.md
@@ -16,7 +16,7 @@ This page explains how to install Grafana dependencies, download and install Gra
 
 While the process for upgrading Grafana is very similar to installing Grafana, there are some key backup steps you should perform. Read [Upgrading Grafana]({{< relref "../upgrade-grafana/" >}}) for tips and guidance on updating an existing installation.
 
-> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more.[Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
+> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more. [Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
 
 ## 1. Download and install
 
@@ -176,7 +176,7 @@ Start Grafana by running:
 - Installs configuration file to `/etc/grafana/grafana.ini`
 - Installs systemd service (if systemd is available) name `grafana-server.service`
 - The default configuration sets the log file at `/var/log/grafana/grafana.log`
-- The default configuration specifies a SQLite3 db at `/var/lib/grafana/grafana.db`
+- The default configuration specifies a SQLite3 DB at `/var/lib/grafana/grafana.db`
 - Installs HTML/JS/CSS and other Grafana files at `/usr/share/grafana`
 
 ## Next steps

--- a/docs/sources/setup-grafana/installation/docker.md
+++ b/docs/sources/setup-grafana/installation/docker.md
@@ -9,7 +9,7 @@ weight: 200
 
 # Run Grafana Docker image
 
-You can install and run Grafana using the official Docker images. Our docker images come in two editions:
+You can install and run Grafana using the official Docker images. Our Docker images come in two editions:
 
 **Grafana Enterprise**: `grafana/grafana-enterprise`
 
@@ -17,11 +17,11 @@ You can install and run Grafana using the official Docker images. Our docker ima
 
 Each edition is available in two variants: Alpine and Ubuntu. See below.
 
-For documentation regarding the configuration of a docker image, refer to [configure a Grafana Docker image](https://grafana.com/docs/grafana/latest/administration/configure-docker/).
+For documentation regarding the configuration of a Docker image, refer to [configure a Grafana Docker image](https://grafana.com/docs/grafana/latest/administration/configure-docker/).
 
 This topic also contains important information about [migrating from earlier Docker image versions](#migrate-from-previous-docker-containers-versions).
 
-> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more.[Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
+> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more. [Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
 
 ## Alpine image (recommended)
 
@@ -33,7 +33,7 @@ The default images are based on the popular [Alpine Linux project](http://alpine
 
 The Alpine variant is highly recommended when security and final image size being as small as possible is desired. The main caveat to note is that it uses [musl libc](http://www.musl-libc.org) instead of [glibc and friends](http://www.etalabs.net/compare_libcs.html), so certain software might run into issues depending on the depth of their libc requirements. However, most software don't have an issue with this, so this variant is usually a very safe choice.
 
-> **Note:** Grafana docker images were based on [Ubuntu](https://ubuntu.com/) prior to version 6.4.0.
+> **Note:** Grafana Docker images were based on [Ubuntu](https://ubuntu.com/) prior to version 6.4.0.
 
 ## Ubuntu image
 
@@ -45,11 +45,11 @@ These images are based on [Ubuntu](https://ubuntu.com/), available in [the Ubunt
 
 ## Run Grafana
 
-You can run the latest Grafana version, run a specific version, or run an unstable version based on the main branch of the [grafana/grafana GitHub repository](https://github.com/grafana/grafana).
+You can run the latest Grafana version, run a specific version, or run an unstable version based on the main branch of the [Grafana GitHub repository](https://github.com/grafana/grafana).
 
 ### Run the latest stable version of Grafana
 
-> **Note:** If you are on a Linux system, you might need to add `sudo` before the command or add your user to the `docker` group.
+> **Note:** If you are on a Linux system, you might need to add `sudo` before the command or [add your user to the `docker` group](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user).
 
 ```bash
 docker run -d -p 3000:3000 grafana/grafana-enterprise
@@ -57,7 +57,7 @@ docker run -d -p 3000:3000 grafana/grafana-enterprise
 
 ### Run a specific version of Grafana
 
-> **Note:** If you are on a Linux system, you might need to add `sudo` before the command or add your user to the `docker` group.
+> **Note:** If you are on a Linux system, you might need to add `sudo` before the command or [add your user to the `docker` group](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user).
 
 ```bash
 docker run -d -p 3000:3000 --name grafana grafana/grafana-enterprise:<version number>
@@ -99,7 +99,7 @@ docker run -d \
 
 > Only available in Grafana v5.3.1 and later.
 
-You can install a plugin from a custom URL by specifying the URL like this: `GF_INSTALL_PLUGINS=<url to plugin zip>;<plugin install folder name>`.
+You can install a plugin from a custom URL by specifying the URL as follows: `GF_INSTALL_PLUGINS=<url to plugin zip>;<plugin install folder name>`.
 
 ```bash
 docker run -d \
@@ -133,7 +133,7 @@ docker run -d -p 3000:3000 --name=grafana grafana-custom
 
 ### Build with pre-installed plugins from other sources
 
-You can build a Docker image with plugins from other sources by specifying the URL like this: `GF_INSTALL_PLUGINS=<url to plugin zip>;<plugin install folder name>`.
+You can build a Docker image with plugins from other sources by specifying the URL as follows: `GF_INSTALL_PLUGINS=<url to plugin zip>;<plugin install folder name>`.
 
 ```bash
 cd packaging/docker/custom
@@ -151,7 +151,7 @@ Replace `Dockerfile` in above example with `ubuntu.Dockerfile` to build a custom
 
 > Only available in Grafana v6.5 and later. This is experimental.
 
-The [Grafana Image Renderer plugin]({{< relref "../image-rendering/#grafana-image-renderer-plugin" >}}) does not currently work if it is installed in a Grafana Docker image. You can build a custom Docker image by using the `GF_INSTALL_IMAGE_RENDERER_PLUGIN` build argument. This installs additional dependencies needed for the Grafana Image Renderer plugin to run.
+The [Grafana Image Renderer plugin]({{< relref "../image-rendering/#grafana-image-renderer-plugin" >}}) does not currently work if it's installed in a Grafana Docker image. You can build a custom Docker image by using the `GF_INSTALL_IMAGE_RENDERER_PLUGIN` build argument. This installs additional dependencies needed for the Grafana Image Renderer plugin to run.
 
 Example of how to build and run:
 
@@ -167,7 +167,7 @@ docker run -d -p 3000:3000 --name=grafana grafana-custom
 
 Replace `Dockerfile` in above example with `ubuntu.Dockerfile` to build a custom Ubuntu-based image (Grafana v6.5+).
 
-## Migrate from previous Docker containers versions
+## Migrate from previous Docker container versions
 
 This section contains important information if you want to migrate from previous Grafana container versions to a more current one.
 
@@ -177,15 +177,15 @@ The Grafana Docker image runs with the `root` group (id 0) instead of the `grafa
 
 ### Migrate to v6.5 or later
 
-Grafana Docker image now comes in two variants, one [Alpine](http://alpinelinux.org) based and one [Ubuntu](https://ubuntu.com/) based, see [Image Variants](#image-variants) for details.
+The Grafana Docker image now comes in two variants, one [Alpine](http://alpinelinux.org) based and one [Ubuntu](https://ubuntu.com/) based, see [Image Variants](#image-variants) for details.
 
 ### Migrate to v6.4 or later
 
-Grafana Docker image was changed to be based on [Alpine](http://alpinelinux.org) instead of [Ubuntu](https://ubuntu.com/).
+The Grafana Docker image was changed to be based on [Alpine](http://alpinelinux.org) instead of [Ubuntu](https://ubuntu.com/).
 
 ### Migrate to v5.1 or later
 
-The Docker container for Grafana has seen a major rewrite for 5.1.
+The Docker container for Grafana has seen a major rewrite for v5.1.
 
 **Important changes**
 
@@ -198,15 +198,15 @@ The Docker container for Grafana has seen a major rewrite for 5.1.
 
 #### Removal of implicit volumes
 
-Previously `/var/lib/grafana`, `/etc/grafana` and `/var/log/grafana` were defined as volumes in the `Dockerfile`. This led to the creation of three volumes each time a new instance of the Grafana container started, whether you wanted it or not.
+Previously `/var/lib/grafana`, `/etc/grafana`, and `/var/log/grafana` were defined as volumes in the `Dockerfile`. This led to the creation of three volumes each time a new instance of the Grafana container started, whether you wanted it or not.
 
 You should always be careful to define your own named volume for storage, but if you depended on these volumes, then you should be aware that an upgraded container will no longer have them.
 
-**Warning**: When migrating from an earlier version to 5.1 or later using Docker compose and implicit volumes, you need to use `docker inspect` to find out which volumes your container is mapped to so that you can map them to the upgraded container as well. You will also have to change file ownership (or user) as documented below.
+**Warning**: When migrating from an earlier version to v5.1 or later using Docker compose and implicit volumes, you need to use `docker inspect` to find out which volumes your container is mapped to, so that you can map them to the upgraded container as well. You will also have to change file ownership (or user) as documented below.
 
 #### User ID changes
 
-In Grafana v5.1, we changed the ID and group of the Grafana user and in v7.3 we changed the group. Unfortunately this means that files created prior to v5.1 won't have the correct permissions for later versions. We made this change so that it would be more likely that the Grafana users ID would be unique to Grafana. For example, on Ubuntu 16.04 `104` is already in use by the syslog user.
+In Grafana v5.1, we changed the ID and group of the Grafana user and in v7.3 we changed the group. Unfortunately, this means that files created prior to v5.1 won't have the correct permissions for later versions. We made this change so that it would be more likely that the Grafana users ID would be unique to Grafana. For example, on Ubuntu 16.04 `104` is already in use by the syslog user.
 
 | Version | User    | User ID | Group   | Group ID |
 | ------- | ------- | ------- | ------- | -------- |
@@ -255,7 +255,7 @@ Refer to the [Getting Started]({{< relref "../../getting-started/build-first-das
 
 ## Configure Docker image
 
-Refer to [Configure a Grafana Docker image]({{< relref "../configure-docker/" >}}) page for details on options for customizing your environment, logging, database, and so on.
+Refer to the [Configure a Grafana Docker image]({{< relref "../configure-docker/" >}}) page for details on options for customizing your environment, logging, database, and so on.
 
 ## Configure Grafana
 

--- a/docs/sources/setup-grafana/installation/kubernetes.md
+++ b/docs/sources/setup-grafana/installation/kubernetes.md
@@ -141,7 +141,7 @@ kubectl create secret generic ge-license --from-file=/path/to/your/license.jwt
 
 Create a Grafana configuration file with the name `grafana.ini`. Then paste the content below.
 
-> **Note:** You will have to update the `root_url` field to the url associated with the license you were given.
+> **Note:** You will have to update the `root_url` field to the URL associated with the license you were given.
 
 ```yaml
 [enterprise]
@@ -255,7 +255,7 @@ spec:
 
 > **Caution:** If you use `LoadBalancer` in the Service and depending on your cloud platform and network configuration, doing so might expose your Grafana instance to the Internet. To eliminate this risk, use `ClusterIP` to restrict access from within the cluster Grafana is deployed to.
 
-1. Send manifest to Kubernetes API Server
+1. Send the manifest to Kubernetes API Server
    `kubectl apply -f grafana.yaml`
 
 1. Check that it worked by running the following:

--- a/docs/sources/setup-grafana/installation/rpm.md
+++ b/docs/sources/setup-grafana/installation/rpm.md
@@ -17,7 +17,7 @@ This topic explains how to install Grafana dependencies, download and install Gr
 
 While the process for upgrading Grafana is very similar to installing Grafana, there are some key backup steps you should perform. Read [Upgrading Grafana]({{< relref "../upgrade-grafana/" >}}) for tips and guidance on updating an existing installation.
 
-> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more.[Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
+> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/features/#cloud-logs) to avoid the overhead of installing, maintaining, and scaling your observability stack. The free forever plan includes Grafana, 10K Prometheus series, 50 GB logs, and more. [Create a free account to get started](https://grafana.com/auth/sign-up/create-user?pg=docs-grafana-install&plcmt=in-text).
 
 ## 1. Download and install
 

--- a/docs/sources/whatsnew/whats-new-in-v8-3.md
+++ b/docs/sources/whatsnew/whats-new-in-v8-3.md
@@ -91,7 +91,7 @@ We’ve added new permissions to role-based access control to help you specify a
 
 ## Get your encryption key from a Key Management Service
 
-Grafana’s database contains secrets, like the credentials used to query data sources, send alert notifications and perform other functions within Grafana. These secrets are encrypted using keys, which are usually stored in Grafana’s configuration file. Now you can get your encryption key from Amazon KMS, Azure Key Vault, or Hashicorp Vault. This allows you to centrally manage your Grafana encryption key and reduce the chances it will leak.
+Grafana’s database contains secrets, like the credentials used to query data sources, send alert notifications and perform other functions within Grafana. These secrets are encrypted using keys, which are usually stored in Grafana’s configuration file. Now you can get your encryption key from Amazon KMS, Azure Key Vault, or HashiCorp Vault. This allows you to centrally manage your Grafana encryption key and reduce the chances it will leak.
 
 In order to support this, we’ve upgraded Grafana Enterprise to use envelope encryption, which complements the KMS integration by adding a layer of indirection to the encryption process. Instead of encrypting all secrets with a single key, Grafana uses a set of keys called data encryption keys (DEKs) to encrypt them. These data encryption keys are themselves encrypted with a single key encryption key (KEK). With envelope encryption, you can store a KEK in your KMS, and still quickly encrypt and decrypt data using DEKs stored within the Grafana database.
 

--- a/packages/grafana-data/src/themes/createTypography.ts
+++ b/packages/grafana-data/src/themes/createTypography.ts
@@ -64,7 +64,7 @@ export interface ThemeTypographyInput {
 }
 
 const defaultFontFamily = '"Roboto", "Helvetica", "Arial", sans-serif';
-const defaultFontFamilyMonospace = "'Roboto Mono', monospace";
+const defaultFontFamilyMonospace = '"Roboto Mono", monospace';
 
 export function createTypography(colors: ThemeColors, typographyInput: ThemeTypographyInput = {}): ThemeTypography {
   const {

--- a/public/sass/_variables.generated.scss
+++ b/public/sass/_variables.generated.scss
@@ -101,7 +101,7 @@ $height-lg: 48;
 /* stylelint-disable-next-line string-quotes */
 $font-family-sans-serif: "Roboto", "Helvetica", "Arial", sans-serif;
 /* stylelint-disable-next-line string-quotes */
-$font-family-monospace: 'Roboto Mono', monospace;
+$font-family-monospace: "Roboto Mono", monospace;
 
 $font-size-base: 14px !default;
 

--- a/scripts/check-breaking-changes.sh
+++ b/scripts/check-breaking-changes.sh
@@ -38,16 +38,16 @@ while IFS=" " read -r -a package; do
     STATUS=$?
 
     # Final exit code
-    # (non-zero if any of the packages failed the checks) 
+    # (non-zero if any of the packages failed the checks)
     if [ $STATUS -gt 0 ]
     then
         EXIT_CODE=1
-        GITHUB_MESSAGE="${GITHUB_MESSAGE}**\\\`${PACKAGE_PATH}\\\`** has possible breaking changes ([more info](${GITHUB_JOB_LINK}#step:${GITHUB_STEP_NUMBER}:1))<br />"    
+        GITHUB_MESSAGE="${GITHUB_MESSAGE}**\\\`${PACKAGE_PATH}\\\`** has possible breaking changes ([more info](${GITHUB_JOB_LINK}#step:${GITHUB_STEP_NUMBER}:1))<br />"
     fi
 
 done <<< "$PACKAGES"
 
-# "Export" the message to an environment variable that can be used across Github Actions steps
+# "Export" the message to an environment variable that can be used across GitHub Actions steps
 echo "::set-output name=is_breaking::$EXIT_CODE"
 echo "::set-output name=message::$GITHUB_MESSAGE"
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Just fixes some typos and makes other grammatical improvements to the docs.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Sorry for the really trivial PR!

I was just reading through the docs for Grafana. Just noticed some things that made reading it a bit uncomfortable, so I was fixing them along the way.

Some of the changes are subjective, so feel free to ask me to undo any particular change.

Most formatting changes were the result of my editor applying your `.editorconfig`. (i.e. trimming whitespace, or adding a new line at the end of a file.)

### Incorrect capitalization of nouns

* Github → GitHub
* docker → Docker
* Hashicorp → HashiCorp

### Spacing 

![image](https://user-images.githubusercontent.com/22801583/181632931-f97ecbe5-5045-45e6-adeb-0098dda00d40.png)

Adds a space before:

> Create a free account to get started

### Oxford comma

Weather a serial comma is used or not is fairly inconsistent. I opted to add them where they were missing in some places.

### Link docker group

> add your user to the `docker` group

Links this to the first-party documentation explaining what it is and caveats around it.
It's mostly, so users can see this warning:

> The docker group grants privileges equivalent to the root user. For details on how this impacts security in your system, see [Docker Daemon Attack Surface](https://docs.docker.com/engine/security/#docker-daemon-attack-surface).
> 
> — https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user

Nothing wrong with that, but just to make sure users are aware before they blindly add users to the docker group.

### Misc

And various other changes:
* Flat out typos (`file that you are modify by removing`)
* Uppercasing acronyms
* Using contractions where they are more comfortable to read
* Replacing words/terms with alternatives that are more common or familiar for the given context.
* Avoid starting sentences with a lowercase character.
* Removes the single word sentence "Welcome." from the Welcome section on the documentation README as it's redundant.
* Very minor change in CSS which just swapped the single/double quotes.