### PR TITLE
Loki: support template variables when running stream (live) mode

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -152,7 +152,15 @@ export class LokiDatasource
         ...fixedRequest,
         targets: streamQueries,
       };
-      return merge(...streamQueries.map((q) => doLokiChannelStream(q, this, streamRequest)));
+      return merge(
+        ...streamQueries.map((q) =>
+          doLokiChannelStream(
+            this.applyTemplateVariables(q, request.scopedVars),
+            this, // the datasource
+            streamRequest
+          )
+        )
+      );
     }
 
     if (fixedRequest.liveStreaming) {


### PR DESCRIPTION
@slim-bean reports that running loki live with template variables does not escape

This PR escapes them :)