### PR TITLE
Access control: Fix test

### DIFF
--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -649,7 +649,7 @@ func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
 			desc:         "org viewer with the correct permissions can invite a user as a viewer in his org",
 			url:          "/api/org/invites",
 			method:       http.MethodPost,
-			permissions:  []*accesscontrol.Permission{{Action: accesscontrol.ActionUsersCreate}},
+			permissions:  []*accesscontrol.Permission{{Action: accesscontrol.ActionOrgUsersAdd, Scope: accesscontrol.ScopeUsersAll}},
 			input:        `{"loginOrEmail": "newUserEmail@test.com", "sendEmail": false, "role": "` + string(models.ROLE_VIEWER) + `"}`,
 		},
 		{


### PR DESCRIPTION
Fixes a failing test that was introduced by merging two backports one after another without rerunning the drone checks in between: https://github.com/grafana/grafana/pull/52904 and https://github.com/grafana/grafana/pull/52900