### PR TITLE
Sync: Move ActiveTokenCount to a new service

### DIFF
--- a/pkg/models/user_token.go
+++ b/pkg/models/user_token.go
@@ -71,10 +71,13 @@ type UserTokenService interface {
 	TryRotateToken(ctx context.Context, token *UserToken, clientIP net.IP, userAgent string) (bool, error)
 	RevokeToken(ctx context.Context, token *UserToken, soft bool) error
 	RevokeAllUserTokens(ctx context.Context, userId int64) error
-	ActiveTokenCount(ctx context.Context) (int64, error)
 	GetUserToken(ctx context.Context, userId, userTokenId int64) (*UserToken, error)
 	GetUserTokens(ctx context.Context, userId int64) ([]*UserToken, error)
 	GetUserRevokedTokens(ctx context.Context, userId int64) ([]*UserToken, error)
+}
+
+type ActiveTokenService interface {
+	ActiveTokenCount(ctx context.Context) (int64, error)
 }
 
 type UserTokenBackgroundService interface {

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -6,6 +6,7 @@ package server
 import (
 	"github.com/google/wire"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/playlist/playlistimpl"
 	"github.com/grafana/grafana/pkg/services/store/sanitizer"
 
@@ -222,6 +223,8 @@ var wireBasicSet = wire.NewSet(
 	influxdb.ProvideService,
 	wire.Bind(new(social.Service), new(*social.SocialService)),
 	oauthtoken.ProvideService,
+	auth.ProvideActiveAuthTokenService,
+	wire.Bind(new(models.ActiveTokenService), new(*auth.ActiveAuthTokenService)),
 	wire.Bind(new(oauthtoken.OAuthTokenService), new(*oauthtoken.Service)),
 	tempo.ProvideService,
 	loki.ProvideService,

--- a/pkg/services/quota/quotaimpl/quota.go
+++ b/pkg/services/quota/quotaimpl/quota.go
@@ -13,17 +13,17 @@ import (
 
 type Service struct {
 	store            store
-	AuthTokenService models.UserTokenService
+	authTokenService models.ActiveTokenService
 	Cfg              *setting.Cfg
 	SQLStore         sqlstore.Store
 	Logger           log.Logger
 }
 
-func ProvideService(db db.DB, cfg *setting.Cfg, tokenService models.UserTokenService, ss *sqlstore.SQLStore) quota.Service {
+func ProvideService(db db.DB, cfg *setting.Cfg, tokenService models.ActiveTokenService, ss *sqlstore.SQLStore) quota.Service {
 	return &Service{
 		store:            &sqlStore{db: db},
 		Cfg:              cfg,
-		AuthTokenService: tokenService,
+		authTokenService: tokenService,
 		SQLStore:         ss,
 		Logger:           log.New("quota_service"),
 	}
@@ -71,7 +71,7 @@ func (s *Service) CheckQuotaReached(ctx context.Context, target string, scopePar
 				return true, nil
 			}
 			if target == "session" {
-				usedSessions, err := s.AuthTokenService.ActiveTokenCount(ctx)
+				usedSessions, err := s.authTokenService.ActiveTokenCount(ctx)
 				if err != nil {
 					return false, err
 				}

--- a/pkg/services/store/service.go
+++ b/pkg/services/store/service.go
@@ -171,7 +171,7 @@ func ProvideService(
 		storages = append(storages,
 			newSQLStorage(RootStorageMeta{
 				Builtin: true,
-			}, RootResources,
+			}, RootSystem,
 				"System",
 				"Grafana system storage",
 				&StorageSQLConfig{}, sql, orgId))


### PR DESCRIPTION
This PR https://github.com/grafana/grafana/pull/52192 generates a dependency cycle in Enterprise.

The problem is that Enterprise implementation of `UserTokenService` uses UsageStats that finally ends in quota service.

The only function affected is `ActiveTokenCount` and Enterprise is calling to OSS service and it doesn't do anything else. So moving this function to a new service, allow us to remove the Enterprise dependency and avoid the dependency cycle issue.

Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/3656