### PR TITLE
Storage: add global `system` storage

### DIFF
--- a/pkg/services/store/http.go
+++ b/pkg/services/store/http.go
@@ -13,7 +13,6 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/models"
-	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -284,13 +283,10 @@ func (s *standardStorageService) getConfig(c *models.ReqContext) response.Respon
 	orgId := c.OrgId
 	t := s.tree
 	t.assureOrgIsInitialized(orgId)
-	for _, f := range t.rootsByOrgId[ac.GlobalOrgID] {
-		roots = append(roots, f.Meta())
-	}
-	if orgId != ac.GlobalOrgID {
-		for _, f := range t.rootsByOrgId[orgId] {
-			roots = append(roots, f.Meta())
-		}
+
+	storages := t.getStorages(orgId)
+	for _, s := range storages {
+		roots = append(roots, s.Meta())
 	}
 	return response.JSON(200, roots)
 }

--- a/pkg/services/store/service.go
+++ b/pkg/services/store/service.go
@@ -40,8 +40,8 @@ const brandingStorage = "branding"
 const SystemBrandingStorage = "system/" + brandingStorage
 
 var (
-	SystemBrandingReader = &models.SignedInUser{OrgId: 1}
-	SystemBrandingAdmin  = &models.SignedInUser{OrgId: 1}
+	SystemBrandingReader = &models.SignedInUser{OrgId: ac.GlobalOrgID}
+	SystemBrandingAdmin  = &models.SignedInUser{OrgId: ac.GlobalOrgID}
 )
 
 const MAX_UPLOAD_SIZE = 1 * 1024 * 1024 // 3MB
@@ -178,6 +178,8 @@ func ProvideService(
 
 		return storages
 	}
+
+	globalRoots = append(globalRoots, initializeOrgStorages(ac.GlobalOrgID)...)
 
 	authService := newStaticStorageAuthService(func(ctx context.Context, user *models.SignedInUser, storageName string) map[string]filestorage.PathFilter {
 		// Public is OK to read regardless of user settings

--- a/pkg/services/store/tree.go
+++ b/pkg/services/store/tree.go
@@ -89,15 +89,42 @@ func (t *nestedTree) GetFile(ctx context.Context, orgId int64, path string) (*fi
 	return store.Get(ctx, path)
 }
 
+func (t *nestedTree) getStorages(orgId int64) []storageRuntime {
+	globalStorages := make([]storageRuntime, 0)
+	for _, s := range t.rootsByOrgId[ac.GlobalOrgID] {
+		globalStorages = append(globalStorages, s)
+	}
+
+	if orgId == ac.GlobalOrgID {
+		return globalStorages
+	}
+
+	orgPrefixes := make(map[string]bool)
+	storages := make([]storageRuntime, 0)
+
+	for _, s := range t.rootsByOrgId[orgId] {
+		storages = append(storages, s)
+		orgPrefixes[s.Meta().Config.Prefix] = true
+	}
+
+	for _, s := range globalStorages {
+		// prefer org-specific storage over global with the same prefix
+		if ok := orgPrefixes[s.Meta().Config.Prefix]; !ok {
+			storages = append(storages, s)
+		}
+	}
+
+	return storages
+}
+
 func (t *nestedTree) ListFolder(ctx context.Context, orgId int64, path string, accessFilter filestorage.PathFilter) (*StorageListFrame, error) {
 	if path == "" || path == "/" {
 		t.assureOrgIsInitialized(orgId)
 
 		idx := 0
-		count := len(t.rootsByOrgId[ac.GlobalOrgID])
-		if orgId != ac.GlobalOrgID {
-			count += len(t.rootsByOrgId[orgId])
-		}
+
+		storages := t.getStorages(orgId)
+		count := len(storages)
 
 		names := data.NewFieldFromFieldType(data.FieldTypeString, count)
 		title := data.NewFieldFromFieldType(data.FieldTypeString, count)
@@ -107,23 +134,13 @@ func (t *nestedTree) ListFolder(ctx context.Context, orgId int64, path string, a
 		names.Name = nameListFrameField
 		descr.Name = descriptionListFrameField
 		mtype.Name = mediaTypeListFrameField
-		for _, f := range t.rootsByOrgId[ac.GlobalOrgID] {
+		for _, f := range storages {
 			meta := f.Meta()
 			names.Set(idx, meta.Config.Prefix)
 			title.Set(idx, meta.Config.Name)
 			descr.Set(idx, meta.Config.Description)
 			mtype.Set(idx, "directory")
 			idx++
-		}
-		if orgId != ac.GlobalOrgID {
-			for _, f := range t.rootsByOrgId[orgId] {
-				meta := f.Meta()
-				names.Set(idx, meta.Config.Prefix)
-				title.Set(idx, meta.Config.Name)
-				descr.Set(idx, meta.Config.Description)
-				mtype.Set(idx, "directory")
-				idx++
-			}
 		}
 
 		frame := data.NewFrame("", names, title, descr, mtype)

--- a/pkg/services/store/tree.go
+++ b/pkg/services/store/tree.go
@@ -91,9 +91,7 @@ func (t *nestedTree) GetFile(ctx context.Context, orgId int64, path string) (*fi
 
 func (t *nestedTree) getStorages(orgId int64) []storageRuntime {
 	globalStorages := make([]storageRuntime, 0)
-	for _, s := range t.rootsByOrgId[ac.GlobalOrgID] {
-		globalStorages = append(globalStorages, s)
-	}
+	globalStorages = append(globalStorages, t.rootsByOrgId[ac.GlobalOrgID]...)
 
 	if orgId == ac.GlobalOrgID {
 		return globalStorages


### PR DESCRIPTION
This PR 
- moves the custom branding assets to `GlobalOrgID` system storage, and
- changes internal logic within `StorageService` so that admins see storages from their own org, if a storage exists both in the `GlobalOrgID`, and in their own org
