### PR TITLE
Explore: Allow split windows to be resized

### DIFF
--- a/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
@@ -18,6 +18,7 @@ interface Props {
   rightPaneVisible?: boolean;
   topPaneVisible?: boolean;
   updateUiState: (uiState: { topPaneSize?: number; rightPaneSize?: number }) => void;
+  minVerticalPaneWidth?: number;
 }
 
 export class SplitPaneWrapper extends PureComponent<Props> {
@@ -99,7 +100,8 @@ export class SplitPaneWrapper extends PureComponent<Props> {
   }
 
   render() {
-    const { rightPaneVisible, topPaneVisible, rightPaneComponents, leftPaneComponents, uiState } = this.props;
+    const { rightPaneVisible, topPaneVisible, rightPaneComponents, leftPaneComponents, uiState, minVerticalPaneWidth } =
+      this.props;
     // Limit options pane width to 90% of screen.
     const styles = getStyles(config.theme);
 
@@ -115,11 +117,15 @@ export class SplitPaneWrapper extends PureComponent<Props> {
       }
     }
 
+    const rightSize =
+      minVerticalPaneWidth && rightPaneSize < minVerticalPaneWidth ? minVerticalPaneWidth : rightPaneSize;
+
     return (
       <SplitPane
         split="vertical"
         maxSize={-300}
-        size={rightPaneSize}
+        minSize={minVerticalPaneWidth}
+        size={rightSize}
         primary="second"
         resizerClassName={styles.resizerV}
         onDragStarted={() => (document.body.style.cursor = 'col-resize')}

--- a/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
@@ -31,7 +31,6 @@ export class SplitPaneWrapper extends PureComponent<Props> {
   }
 
   componentWillUnmount() {
-    console.log('splitpane unmount');
     window.removeEventListener('resize', this.updateSplitPaneSize);
   }
 

--- a/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
@@ -117,17 +117,15 @@ export class SplitPaneWrapper extends PureComponent<Props> {
       }
     }
 
-    const rightSize =
-      minVerticalPaneWidth && rightPaneSize < minVerticalPaneWidth ? minVerticalPaneWidth : rightPaneSize;
-
     return (
       <SplitPane
         split="vertical"
         maxSize={-300}
         minSize={minVerticalPaneWidth}
-        size={rightSize}
+        size={rightPaneSize}
         primary="second"
         resizerClassName={styles.resizerV}
+        paneStyle={{ overflow: 'scroll' }}
         onDragStarted={() => (document.body.style.cursor = 'col-resize')}
         onDragFinished={(size) => this.onDragFinished(Pane.Right, size)}
       >

--- a/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
+++ b/public/app/core/components/SplitPaneWrapper/SplitPaneWrapper.tsx
@@ -16,6 +16,7 @@ interface Props {
   rightPaneComponents: ReactNode;
   uiState: { topPaneSize: number; rightPaneSize: number };
   rightPaneVisible?: boolean;
+  topPaneVisible?: boolean;
   updateUiState: (uiState: { topPaneSize?: number; rightPaneSize?: number }) => void;
 }
 
@@ -30,6 +31,7 @@ export class SplitPaneWrapper extends PureComponent<Props> {
   }
 
   componentWillUnmount() {
+    console.log('splitpane unmount');
     window.removeEventListener('resize', this.updateSplitPaneSize);
   }
 
@@ -98,7 +100,7 @@ export class SplitPaneWrapper extends PureComponent<Props> {
   }
 
   render() {
-    const { rightPaneVisible, rightPaneComponents, uiState } = this.props;
+    const { rightPaneVisible, topPaneVisible, rightPaneComponents, leftPaneComponents, uiState } = this.props;
     // Limit options pane width to 90% of screen.
     const styles = getStyles(config.theme);
 
@@ -107,7 +109,11 @@ export class SplitPaneWrapper extends PureComponent<Props> {
       uiState.rightPaneSize <= 1 ? uiState.rightPaneSize * window.innerWidth : uiState.rightPaneSize;
 
     if (!rightPaneVisible) {
-      return this.renderHorizontalSplit();
+      if (topPaneVisible) {
+        return this.renderHorizontalSplit();
+      } else {
+        return leftPaneComponents;
+      }
     }
 
     return (
@@ -120,7 +126,8 @@ export class SplitPaneWrapper extends PureComponent<Props> {
         onDragStarted={() => (document.body.style.cursor = 'col-resize')}
         onDragFinished={(size) => this.onDragFinished(Pane.Right, size)}
       >
-        {this.renderHorizontalSplit()}
+        {topPaneVisible && this.renderHorizontalSplit()}
+        {!topPaneVisible && leftPaneComponents}
         {rightPaneComponents}
       </SplitPane>
     );

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -450,6 +450,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
           <SplitPaneWrapper
             leftPaneComponents={this.renderPanelAndEditor(styles)}
             rightPaneComponents={this.renderOptionsPane()}
+            topPaneVisible={true}
             uiState={uiState}
             updateUiState={updatePanelEditorUIState}
             rightPaneVisible={uiState.isPanelOptionsVisible}

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -83,6 +83,7 @@ const dummyProps: Props = {
   splitOpen: (() => {}) as any,
   changeGraphStyle: () => {},
   graphStyle: 'lines',
+  minSize: 50,
 };
 
 jest.mock('@grafana/runtime/src/services/dataSourceSrv', () => {

--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -83,7 +83,7 @@ const dummyProps: Props = {
   splitOpen: (() => {}) as any,
   changeGraphStyle: () => {},
   graphStyle: 'lines',
-  minSize: 50,
+  containerWidth: 400,
 };
 
 jest.mock('@grafana/runtime/src/services/dataSourceSrv', () => {

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -71,7 +71,6 @@ const getStyles = (theme: GrafanaTheme2) => {
 export interface ExploreProps extends Themeable2 {
   exploreId: ExploreId;
   theme: GrafanaTheme2;
-  minWidth: number;
 }
 
 enum ExploreDrawer {
@@ -178,10 +177,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
   };
 
   onResize = (size: { height: number; width: number }) => {
-    console.log('resize', this.props.exploreId, this.props.minWidth, size.width);
-    if (size.width > this.props.minWidth) {
-      this.props.changeSize(this.props.exploreId, size);
-    }
+    this.props.changeSize(this.props.exploreId, size);
   };
 
   onStartScanning = () => {
@@ -351,6 +347,8 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
         queryResponse.traceFrames,
       ].every((e) => e.length === 0);
 
+    const minContentSize = 400;
+
     return (
       <CustomScrollbar
         testId={selectors.pages.Explore.General.scrollView}
@@ -378,13 +376,13 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
               <ResponseErrorContainer exploreId={exploreId} />
             </PanelContainer>
             <AutoSizer onResize={this.onResize} disableHeight defaultWidth={containerWidth}>
-              {({ width: inputWidth }) => {
-                if (inputWidth === 0) {
+              {({ width: widthResponse }) => {
+                if (widthResponse === 0) {
                   return null;
                 }
-                let width = this.props.minWidth;
-                if (inputWidth > this.props.minWidth) {
-                  width = inputWidth;
+                let width = widthResponse;
+                if (width < minContentSize) {
+                  width = minContentSize;
                 }
 
                 return (
@@ -492,5 +490,4 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 
 export default compose(connector, withTheme2)(Explore) as React.ComponentType<{
   exploreId: ExploreId;
-  minWidth: number;
 }>;

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -71,6 +71,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 export interface ExploreProps extends Themeable2 {
   exploreId: ExploreId;
   theme: GrafanaTheme2;
+  minSize: number;
 }
 
 enum ExploreDrawer {
@@ -177,7 +178,9 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
   };
 
   onResize = (size: { height: number; width: number }) => {
-    this.props.changeSize(this.props.exploreId, size);
+    if (size.width > this.props.minSize) {
+      this.props.changeSize(this.props.exploreId, size);
+    }
   };
 
   onStartScanning = () => {
@@ -479,4 +482,7 @@ const mapDispatchToProps = {
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
 
-export default compose(connector, withTheme2)(Explore) as React.ComponentType<{ exploreId: ExploreId }>;
+export default compose(connector, withTheme2)(Explore) as React.ComponentType<{
+  exploreId: ExploreId;
+  minSize: number;
+}>;

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -71,7 +71,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 export interface ExploreProps extends Themeable2 {
   exploreId: ExploreId;
   theme: GrafanaTheme2;
-  minSize: number;
+  minWidth: number;
 }
 
 enum ExploreDrawer {
@@ -178,7 +178,8 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
   };
 
   onResize = (size: { height: number; width: number }) => {
-    if (size.width > this.props.minSize) {
+    console.log('resize', this.props.exploreId, this.props.minWidth, size.width);
+    if (size.width > this.props.minWidth) {
       this.props.changeSize(this.props.exploreId, size);
     }
   };
@@ -377,9 +378,13 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
               <ResponseErrorContainer exploreId={exploreId} />
             </PanelContainer>
             <AutoSizer onResize={this.onResize} disableHeight defaultWidth={containerWidth}>
-              {({ width }) => {
-                if (width === 0) {
+              {({ width: inputWidth }) => {
+                if (inputWidth === 0) {
                   return null;
+                }
+                let width = this.props.minWidth;
+                if (inputWidth > this.props.minWidth) {
+                  width = inputWidth;
                 }
 
                 return (
@@ -487,5 +492,5 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 
 export default compose(connector, withTheme2)(Explore) as React.ComponentType<{
   exploreId: ExploreId;
-  minSize: number;
+  minWidth: number;
 }>;

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -332,6 +332,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
       showTrace,
       showNodeGraph,
       timeZone,
+      containerWidth,
     } = this.props;
     const { openDrawer } = this.state;
     const styles = getStyles(theme);
@@ -375,7 +376,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
               />
               <ResponseErrorContainer exploreId={exploreId} />
             </PanelContainer>
-            <AutoSizer onResize={this.onResize} disableHeight>
+            <AutoSizer onResize={this.onResize} disableHeight defaultWidth={containerWidth}>
               {({ width }) => {
                 if (width === 0) {
                   return null;
@@ -444,6 +445,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps) {
     showNodeGraph,
     loading,
     graphStyle,
+    containerWidth,
   } = item;
 
   return {
@@ -464,6 +466,7 @@ function mapStateToProps(state: StoreState, { exploreId }: ExploreProps) {
     showNodeGraph,
     loading,
     graphStyle,
+    containerWidth,
   };
 }
 

--- a/public/app/features/explore/ExplorePaneContainer.tsx
+++ b/public/app/features/explore/ExplorePaneContainer.tsx
@@ -65,8 +65,7 @@ class ExplorePaneContainerUnconnected extends React.PureComponent<Props> {
   }
 
   componentDidMount() {
-    const { initialized, exploreId, initialDatasource, initialQueries, initialRange, panelsState } = this.props;
-    const width = this.el?.offsetWidth ?? 0;
+    const { initialized, exploreId, initialDatasource, initialQueries, initialRange, panelsState, width } = this.props;
 
     // initialize the whole explore first time we mount and if browser history contains a change in datasource
     if (!initialized) {
@@ -75,7 +74,7 @@ class ExplorePaneContainerUnconnected extends React.PureComponent<Props> {
         initialDatasource,
         initialQueries,
         initialRange,
-        width,
+        width || 0,
         this.exploreEvents,
         panelsState
       );
@@ -136,6 +135,7 @@ function mapStateToProps(state: StoreState, props: OwnProps) {
     initialQueries,
     initialRange,
     panelsState,
+    width: state.explore[props.exploreId]?.containerWidth,
   };
 }
 

--- a/public/app/features/explore/ExplorePaneContainer.tsx
+++ b/public/app/features/explore/ExplorePaneContainer.tsx
@@ -27,6 +27,7 @@ import { lastSavedUrl } from './state/main';
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     explore: css`
+      overflow: scroll;
       display: flex;
       flex: 1 1 auto;
       flex-direction: column;
@@ -34,16 +35,12 @@ const getStyles = (theme: GrafanaTheme2) => {
         border-left: 1px dotted ${theme.colors.border.medium};
       }
     `,
-    exploreSplit: css`
-      width: 50%;
-    `,
   };
 };
 
 interface OwnProps extends Themeable2 {
   exploreId: ExploreId;
   urlQuery: string;
-  minWidth: number;
 }
 
 interface Props extends OwnProps, ConnectedProps<typeof connector> {}
@@ -108,7 +105,7 @@ class ExplorePaneContainerUnconnected extends React.PureComponent<Props> {
     const exploreClass = cx(styles.explore);
     return (
       <div className={exploreClass} ref={this.getRef} data-testid={selectors.pages.Explore.General.container}>
-        {initialized && <Explore exploreId={exploreId} minWidth={this.props.minWidth} />}
+        {initialized && <Explore exploreId={exploreId} />}
       </div>
     );
   }

--- a/public/app/features/explore/ExplorePaneContainer.tsx
+++ b/public/app/features/explore/ExplorePaneContainer.tsx
@@ -22,7 +22,7 @@ import { getFiscalYearStartMonth, getTimeZone } from '../profile/state/selectors
 
 import Explore from './Explore';
 import { initializeExplore, refreshExplore } from './state/explorePane';
-import { lastSavedUrl, cleanupPaneAction } from './state/main';
+import { lastSavedUrl } from './state/main';
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
@@ -43,7 +43,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 interface OwnProps extends Themeable2 {
   exploreId: ExploreId;
   urlQuery: string;
-  split: boolean;
+  minSize: number;
 }
 
 interface Props extends OwnProps, ConnectedProps<typeof connector> {}
@@ -84,7 +84,6 @@ class ExplorePaneContainerUnconnected extends React.PureComponent<Props> {
 
   componentWillUnmount() {
     this.exploreEvents.removeAllListeners();
-    this.props.cleanupPaneAction({ exploreId: this.props.exploreId });
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -105,12 +104,12 @@ class ExplorePaneContainerUnconnected extends React.PureComponent<Props> {
   };
 
   render() {
-    const { theme, split, exploreId, initialized } = this.props;
+    const { theme, exploreId, initialized } = this.props;
     const styles = getStyles(theme);
-    const exploreClass = cx(styles.explore, split && styles.exploreSplit);
+    const exploreClass = cx(styles.explore);
     return (
       <div className={exploreClass} ref={this.getRef} data-testid={selectors.pages.Explore.General.container}>
-        {initialized && <Explore exploreId={exploreId} />}
+        {initialized && <Explore exploreId={exploreId} minSize={this.props.minSize} />}
       </div>
     );
   }
@@ -143,7 +142,6 @@ function mapStateToProps(state: StoreState, props: OwnProps) {
 const mapDispatchToProps = {
   initializeExplore,
   refreshExplore,
-  cleanupPaneAction,
 };
 
 const connector = connect(mapStateToProps, mapDispatchToProps);

--- a/public/app/features/explore/ExplorePaneContainer.tsx
+++ b/public/app/features/explore/ExplorePaneContainer.tsx
@@ -43,7 +43,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 interface OwnProps extends Themeable2 {
   exploreId: ExploreId;
   urlQuery: string;
-  minSize: number;
+  minWidth: number;
 }
 
 interface Props extends OwnProps, ConnectedProps<typeof connector> {}
@@ -108,7 +108,7 @@ class ExplorePaneContainerUnconnected extends React.PureComponent<Props> {
     const exploreClass = cx(styles.explore);
     return (
       <div className={exploreClass} ref={this.getRef} data-testid={selectors.pages.Explore.General.container}>
-        {initialized && <Explore exploreId={exploreId} minSize={this.props.minSize} />}
+        {initialized && <Explore exploreId={exploreId} minWidth={this.props.minWidth} />}
       </div>
     );
   }

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -130,7 +130,7 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
       <div ref={topOfViewRef}>
         <PageToolbar
           aria-label="Explore toolbar"
-          title={exploreId === ExploreId.left ? 'Explore' : undefined}
+          title={exploreId === ExploreId.left ? 'Explore' : ''}
           pageIcon={exploreId === ExploreId.left ? 'compass' : undefined}
           leftItems={[
             exploreId === ExploreId.left && (

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -148,7 +148,7 @@ class UnConnectedExploreToolbar extends PureComponent<Props> {
       <div ref={topOfViewRef}>
         <PageToolbar
           aria-label="Explore toolbar"
-          title={exploreId === ExploreId.left ? 'Explore' : ''}
+          title={exploreId === ExploreId.left ? 'Explore' : undefined}
           pageIcon={exploreId === ExploreId.left ? 'compass' : undefined}
           leftItems={[
             exploreId === ExploreId.left && (

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -102,14 +102,20 @@ class WrapperUnconnected extends PureComponent<Props> {
         <div className={styles.exploreWrapper}>
           <SplitPaneWrapper
             topPaneVisible={false}
+            minVerticalPaneWidth={400}
             leftPaneComponents={
               <ErrorBoundaryAlert style="page" key="left">
-                <ExplorePaneContainer key="leftContainer" exploreId={ExploreId.left} urlQuery={left} minSize={100} />
+                <ExplorePaneContainer key="leftContainer" exploreId={ExploreId.left} urlQuery={left} minWidth={200} />
               </ErrorBoundaryAlert>
             }
             rightPaneComponents={
               <ErrorBoundaryAlert style="page" key="right">
-                <ExplorePaneContainer key="rightContainer" exploreId={ExploreId.right} urlQuery={right} minSize={100} />
+                <ExplorePaneContainer
+                  key="rightContainer"
+                  exploreId={ExploreId.right}
+                  urlQuery={right}
+                  minWidth={200}
+                />
               </ErrorBoundaryAlert>
             }
             uiState={{ topPaneSize: 0, rightPaneSize: rightContainerWidth || 0 }}

--- a/public/app/features/explore/Wrapper.tsx
+++ b/public/app/features/explore/Wrapper.tsx
@@ -96,8 +96,6 @@ class WrapperUnconnected extends PureComponent<Props> {
     const hasSplit = Boolean(left) && Boolean(right);
     const rightContainerWidth = this.props.exploreState[ExploreId.right]?.containerWidth;
 
-    //const isRightMain = !Boolean(left) && Boolean(right); // for SplitPaneWrapper, the left panel always shows, so we need to put right variables in the left panel if left is closed
-
     return (
       <div className={styles.pageScrollbarWrapper}>
         <ExploreActions exploreIdLeft={ExploreId.left} exploreIdRight={ExploreId.right} />

--- a/public/app/features/explore/state/explorePane.ts
+++ b/public/app/features/explore/state/explorePane.ts
@@ -1,4 +1,4 @@
-import { createAction, PayloadAction } from '@reduxjs/toolkit';
+import { createAction } from '@reduxjs/toolkit';
 import { isEqual } from 'lodash';
 import { AnyAction } from 'redux';
 
@@ -115,8 +115,10 @@ export const setUrlReplacedAction = createAction<SetUrlReplacedPayload>('explore
 export function changeSize(
   exploreId: ExploreId,
   { height, width }: { height: number; width: number }
-): PayloadAction<ChangeSizePayload> {
-  return changeSizeAction({ exploreId, height, width });
+): ThunkResult<void> {
+  return async (dispatch, getState) => {
+    dispatch(changeSizeAction({ exploreId, height, width }));
+  };
 }
 
 interface ChangeGraphStylePayload {

--- a/public/app/features/explore/state/main.ts
+++ b/public/app/features/explore/state/main.ts
@@ -12,7 +12,7 @@ import { RichHistorySearchFilters, RichHistorySettings } from '../../../core/uti
 import { ThunkResult } from '../../../types';
 import { TimeSrv } from '../../dashboard/services/TimeSrv';
 
-import { paneReducer } from './explorePane';
+import { changeSizeAction, paneReducer } from './explorePane';
 import { getUrlStateFromPaneState, makeExplorePaneState } from './utils';
 
 //
@@ -118,6 +118,11 @@ export const splitOpen: SplitOpen = (options): ThunkResult<void> => {
 
     const urlState = serializeStateToUrlParam(rightUrlState);
     locationService.partial({ right: urlState }, true);
+
+    dispatch(
+      changeSizeAction({ exploreId: ExploreId.right, height: window.innerHeight, width: window.innerWidth / 2 })
+    );
+    dispatch(changeSizeAction({ exploreId: ExploreId.left, height: window.innerHeight, width: window.innerWidth / 2 }));
   };
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fixes bug where datasource picker does not show in right pane
- Uses `SplitPaneWrapper` to allow Explore's split view to function like the dashboard edit panel view.
- Adds +/- button to allow for maximizing a certain pane

**Which issue(s) this PR fixes**:
Fixes #52415
Fixes #52106

**Special notes for your reviewer**:

