### PR TITLE
CI: Trigger `pr-integration-tests` pipeline only on backend changes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -576,9 +576,16 @@ trigger:
   - pull_request
   paths:
     exclude:
-    - '*.md'
     - docs/**
-    - latest.json
+    - '*.md'
+    include:
+    - pkg/**
+    - packaging/**
+    - .drone.yml
+    - conf/**
+    - go.sum
+    - go.mod
+    - public/app/plugins/**/plugin.json
 type: docker
 volumes:
 - host:
@@ -4986,6 +4993,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: d97f2ec8017ba6e3f16913e08ee1d53c4e653f87b6113fd3763e1ad557306810
+hmac: 93e3de94385da76cd62e8626cd67b6cc5a5f3812e41f60934dadbac87f11526e
 
 ...

--- a/scripts/drone/events/pr.star
+++ b/scripts/drone/events/pr.star
@@ -55,7 +55,7 @@ def pr_pipelines(edition):
         test_frontend(get_pr_trigger(exclude_paths=['pkg/**', 'packaging/**', 'go.sum', 'go.mod']), ver_mode),
         test_backend(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json']), ver_mode),
         build_e2e(trigger, ver_mode, edition),
-        integration_tests(trigger, ver_mode, edition),
+        integration_tests(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json']), ver_mode, edition),
         docs_pipelines(edition, ver_mode, trigger_docs())
     ]
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes `pr-integration-tests` pipeline to run only on backend changes.