### PR TITLE
CI: Run `main-docs` pipeline only, when a docs PR is merged

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -799,6 +799,12 @@ trigger:
   branch: main
   event:
   - push
+  paths:
+    include:
+    - '*.md'
+    - docs/**
+    - packages/**
+    - latest.json
 type: docker
 volumes:
 - host:
@@ -876,6 +882,11 @@ trigger:
   branch: main
   event:
   - push
+  paths:
+    exclude:
+    - '*.md'
+    - docs/**
+    - latest.json
 type: docker
 volumes:
 - host:
@@ -980,6 +991,11 @@ trigger:
   branch: main
   event:
   - push
+  paths:
+    exclude:
+    - '*.md'
+    - docs/**
+    - latest.json
 type: docker
 volumes:
 - host:
@@ -1392,6 +1408,11 @@ trigger:
   branch: main
   event:
   - push
+  paths:
+    exclude:
+    - '*.md'
+    - docs/**
+    - latest.json
 type: docker
 volumes:
 - host:
@@ -1498,6 +1519,11 @@ trigger:
   branch: main
   event:
   - push
+  paths:
+    exclude:
+    - '*.md'
+    - docs/**
+    - latest.json
 type: docker
 volumes:
 - host:
@@ -1564,6 +1590,11 @@ trigger:
   branch: main
   event:
   - push
+  paths:
+    exclude:
+    - '*.md'
+    - docs/**
+    - latest.json
   repo:
   - grafana/grafana
 type: docker
@@ -1666,6 +1697,11 @@ trigger:
   branch: main
   event:
   - push
+  paths:
+    exclude:
+    - '*.md'
+    - docs/**
+    - latest.json
   repo:
   - grafana/grafana
 type: docker
@@ -1703,6 +1739,11 @@ trigger:
   branch: main
   event:
   - push
+  paths:
+    exclude:
+    - '*.md'
+    - docs/**
+    - latest.json
   status:
   - failure
 type: docker
@@ -5090,6 +5131,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 397deadc5d62537ccdb8a02e00a3cb397f3f23c3a175511ad53c31272b878dbd
+hmac: bd01c6115af9aa8242a179e2120196212b5149ed5d71ed5327c6e89f65915785
 
 ...

--- a/scripts/drone/events/main.star
+++ b/scripts/drone/events/main.star
@@ -9,6 +9,7 @@ load(
 load(
     'scripts/drone/pipelines/docs.star',
     'docs_pipelines',
+    'trigger_docs_main',
 )
 
 load(
@@ -48,6 +49,13 @@ ver_mode = 'main'
 trigger = {
     'event': ['push',],
     'branch': 'main',
+    'paths': {
+        'exclude': [
+            '*.md',
+            'docs/**',
+            'latest.json',
+        ],
+    },
 }
 
 def main_pipelines(edition):
@@ -68,7 +76,7 @@ def main_pipelines(edition):
     }
 
     pipelines = [
-        docs_pipelines(edition, ver_mode, trigger),
+        docs_pipelines(edition, ver_mode, trigger_docs_main()),
         test_frontend(trigger, ver_mode),
         test_backend(trigger, ver_mode),
         build_e2e(trigger, ver_mode, edition),

--- a/scripts/drone/events/pr.star
+++ b/scripts/drone/events/pr.star
@@ -31,7 +31,7 @@ load(
 load(
     'scripts/drone/pipelines/docs.star',
     'docs_pipelines',
-    'trigger_docs',
+    'trigger_docs_pr',
 )
 
 ver_mode = 'pr'
@@ -56,7 +56,7 @@ def pr_pipelines(edition):
         test_backend(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json']), ver_mode),
         build_e2e(trigger, ver_mode, edition),
         integration_tests(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json']), ver_mode, edition),
-        docs_pipelines(edition, ver_mode, trigger_docs())
+        docs_pipelines(edition, ver_mode, trigger_docs_pr())
     ]
 
 

--- a/scripts/drone/pipelines/docs.star
+++ b/scripts/drone/pipelines/docs.star
@@ -26,6 +26,14 @@ load(
     'pipeline',
 )
 
+docs_paths = {
+    'include': [
+        '*.md',
+        'docs/**',
+        'packages/**',
+        'latest.json',
+    ],
+}
 
 def docs_pipelines(edition, ver_mode, trigger):
     steps = [
@@ -67,14 +75,7 @@ def trigger_docs_main():
         'event': [
             'push',
         ],
-        'paths': {
-            'include': [
-                '*.md',
-                'docs/**',
-                'packages/**',
-                'latest.json',
-            ],
-        },
+        'paths': docs_paths,
     }
 
 def trigger_docs_pr():
@@ -82,12 +83,5 @@ def trigger_docs_pr():
         'event': [
             'pull_request',
         ],
-        'paths': {
-            'include': [
-                '*.md',
-                'docs/**',
-                'packages/**',
-                'latest.json',
-            ],
-        },
+        'paths': docs_paths,
     }

--- a/scripts/drone/pipelines/docs.star
+++ b/scripts/drone/pipelines/docs.star
@@ -61,7 +61,23 @@ def lint_docs():
     }
 
 
-def trigger_docs():
+def trigger_docs_main():
+    return {
+        'branch': 'main',
+        'event': [
+            'push',
+        ],
+        'paths': {
+            'include': [
+                '*.md',
+                'docs/**',
+                'packages/**',
+                'latest.json',
+            ],
+        },
+    }
+
+def trigger_docs_pr():
     return {
         'event': [
             'pull_request',


### PR DESCRIPTION
**What this PR does / why we need it**:

Using `pathschanged`, `main-docs` pipeline will run alone when a docs-only PR is merged. This way there won't be any need to trigger more pipelines, and also we won't package and produce another grafana version which doesn't have anything new.

Maybe a subject to change if we decide to store docs artifacts along with Grafana artifacts. 
