### PR TITLE
CloudMonitoring: Remove link setting for SLO queries

### DIFF
--- a/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloudmonitoring/cloudmonitoring.go
@@ -658,12 +658,14 @@ func addConfigData(frames data.Frames, dl string, unit string) data.Frames {
 		if frames[i].Fields[1].Config == nil {
 			frames[i].Fields[1].Config = &data.FieldConfig{}
 		}
-		deepLink := data.DataLink{
-			Title:       "View in Metrics Explorer",
-			TargetBlank: true,
-			URL:         dl,
+		if len(dl) > 0 {
+			deepLink := data.DataLink{
+				Title:       "View in Metrics Explorer",
+				TargetBlank: true,
+				URL:         dl,
+			}
+			frames[i].Fields[1].Config.Links = append(frames[i].Fields[1].Config.Links, deepLink)
 		}
-		frames[i].Fields[1].Config.Links = append(frames[i].Fields[1].Config.Links, deepLink)
 		if len(unit) > 0 {
 			if val, ok := cloudMonitoringUnitMappings[unit]; ok {
 				frames[i].Fields[1].Config.Unit = val

--- a/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
+++ b/pkg/tsdb/cloudmonitoring/time_series_filter_test.go
@@ -459,6 +459,19 @@ func TestTimeSeriesFilter(t *testing.T) {
 			}, *res.Frames[0].Meta)
 		})
 	})
+
+	t.Run("when data comes from a slo query, it should skip the link", func(t *testing.T) {
+		data, err := loadTestFile("./test-data/3-series-response-distribution-exponential.json")
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(data.TimeSeries))
+
+		res := &backend.DataResponse{}
+		query := &cloudMonitoringTimeSeriesFilter{Params: url.Values{}, Slo: "yes"}
+		err = query.parseResponse(res, data, "")
+		require.NoError(t, err)
+		frames := res.Frames
+		assert.Equal(t, len(frames[0].Fields[1].Config.Links), 0)
+	})
 }
 
 func loadTestFile(path string) (cloudMonitoringResponse, error) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

SLO queries do not include a link but it was being set to an empty string, causing the issue described in #52753 when some panels try to read the link info.

![Screenshot from 2022-08-01 13-12-57](https://user-images.githubusercontent.com/4025665/182136039-df4600e3-b920-4a50-9694-9956c8897d94.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #52753

**Special notes for your reviewer**:

