### PR TITLE
Navigation: split logic, reenable unit test, copy whole node to prevent recursion error

### DIFF
--- a/public/app/core/selectors/navModel.test.ts
+++ b/public/app/core/selectors/navModel.test.ts
@@ -42,8 +42,7 @@ describe('getNavModel', () => {
     expect(navModel.node.parentItem?.id).toBe(navModel.main.id);
   });
 
-  // TODO reenable this test once we figure out the logic for 2nd level children
-  test.skip('returns the correct nav model for a 2nd-level child', () => {
+  test('returns the correct nav model for a 2nd-level child', () => {
     const navModel = getNavModel(navIndex, 'apps/subapp/child1');
     expect(navModel.main.id).toBe('apps');
     expect(navModel.node.id).toBe('apps/subapp/child1');

--- a/public/app/core/selectors/navModel.ts
+++ b/public/app/core/selectors/navModel.ts
@@ -18,10 +18,11 @@ const getNotFoundModel = (): NavModel => {
 export const getNavModel = (navIndex: NavIndex, id: string, fallback?: NavModel, onlyChild = false): NavModel => {
   if (navIndex[id]) {
     const node = navIndex[id];
-    const main = onlyChild ? node : getSectionRoot(node);
+    const nodeWithActive = enrichNodeWithActiveState(node);
+    const main = onlyChild ? nodeWithActive : getSectionRoot(nodeWithActive);
 
     return {
-      node,
+      node: nodeWithActive,
       main,
     };
   }
@@ -34,23 +35,27 @@ export const getNavModel = (navIndex: NavIndex, id: string, fallback?: NavModel,
 };
 
 function getSectionRoot(node: NavModelItem): NavModelItem {
-  if (!node.parentItem) {
-    return node;
+  return node.parentItem ? getSectionRoot(node.parentItem) : node;
+}
+
+function enrichNodeWithActiveState(node: NavModelItem): NavModelItem {
+  const nodeCopy = { ...node };
+  if (nodeCopy.parentItem) {
+    const root = (nodeCopy.parentItem = { ...nodeCopy.parentItem });
+
+    if (root.children) {
+      root.children = root.children.map((item) => {
+        if (item.id === node.id) {
+          return { ...nodeCopy, active: true };
+        }
+
+        return item;
+      });
+    }
+
+    nodeCopy.parentItem = enrichNodeWithActiveState(root);
   }
-
-  const root = (node.parentItem = { ...node.parentItem });
-
-  if (root.children) {
-    root.children = root.children.map((item) => {
-      if (item.id === node.id) {
-        return { ...item, active: true };
-      }
-
-      return item;
-    });
-  }
-
-  return getSectionRoot(root);
+  return nodeCopy;
 }
 
 export const getTitleFromNavModel = (navModel: NavModel) => {

--- a/public/app/core/selectors/navModel.ts
+++ b/public/app/core/selectors/navModel.ts
@@ -41,7 +41,8 @@ function getSectionRoot(node: NavModelItem): NavModelItem {
 function enrichNodeWithActiveState(node: NavModelItem): NavModelItem {
   const nodeCopy = { ...node };
   if (nodeCopy.parentItem) {
-    const root = (nodeCopy.parentItem = { ...nodeCopy.parentItem });
+    nodeCopy.parentItem = { ...nodeCopy.parentItem };
+    const root = nodeCopy.parentItem;
 
     if (root.children) {
       root.children = root.children.map((item) => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- follow on to https://github.com/grafana/grafana/pull/52562 and https://github.com/grafana/grafana/pull/52985
- splits `getSectionRoot` into 2 functions, `getSectionRoot` and `enrichNodeWithActiveState`
- avoids mutating the input node in `enrichNodeWithActiveState` by only ever interacting with a shallow clone of the node
- reenables the previously disabled unit test

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

