### PR TITLE
Docs: Update prometheus docs

### DIFF
--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -43,11 +43,11 @@ To access Prometheus settings, hover your mouse over the **Configuration** (gear
 
 ## Prometheus query editor
 
-Prometheus query editor is separated into 3 distinct modes that you can switch between. See docs for each section below.
+Prometheus query editor is separated into 2 distinct modes that you can switch between. See docs for each section below.
 
-![Editor toolbar](/static/img/docs/prometheus/header-8-5.png 'Editor toolbar')
+![Editor toolbar](/static/img/docs/prometheus/header-9-1.png 'Editor toolbar')
 
-At the top of the editor, select `Run queries` to run a query. Select `Explain | Builder | Code` tabs to switch between the editor modes. If the query editor is in Builder mode, there are additional elements explained in the Builder section.
+At the top of the editor, select `Run queries` to run a query. Select `Builder | Code` tabs to switch between the editor modes. If the query editor is in Builder mode, there are additional elements explained in the Builder section.
 
 > **Note:** In Explore, to run Prometheus queries, select `Run query`.
 
@@ -55,7 +55,7 @@ Each mode is synchronized with the other modes, so you can switch between them w
 
 ### Code mode
 
-![Code mode](/static/img/docs/prometheus/code-mode-8-5.png 'Code mode')
+![Code mode](/static/img/docs/prometheus/code-mode-9-1.png 'Code mode')
 
 Code mode allows you to write raw queries in a textual editor. It implements advanced autocomplete features and syntax highlighting to help with writing complex queries. In addition, it also contains `Metrics browser` to further aid with writing queries (see more docs below).
 
@@ -63,7 +63,7 @@ For more information about Prometheus query language, refer to the [Prometheus d
 
 #### Autocomplete
 
-![Autocomplete](/static/img/docs/prometheus/autocomplete-8-5.png 'Autocomplete')
+![Autocomplete](/static/img/docs/prometheus/autocomplete-9-1.png 'Autocomplete')
 
 Autocomplete kicks automatically in appropriate times during typing. Use `ctrl/cmd + space` to trigger autocomplete manually when needed. Autocomplete can suggest both static functions, aggregations and keywords but also dynamic items like metrics and labels. Autocomplete dropdown also shows documentation for the suggested items, either static one or dynamic metric documentation where available.
 
@@ -75,7 +75,7 @@ The metrics browser allows you to quickly find metrics and select relevant label
 When you open the browser you will see all available metrics and labels.
 If supported by your Prometheus instance, each metric will show its HELP and TYPE as a tooltip.
 
-![Metrics browser](/static/img/docs/prometheus/metric-browser-8-5.png 'Metrics browser')
+![Metrics browser](/static/img/docs/prometheus/metric-browser-9-1.png 'Metrics browser')
 
 When you select a metric, the browser narrows down the available labels to show only the ones applicable to the metric.
 You can then select one or more labels for which the available label values are shown in lists in the bottom section.
@@ -90,7 +90,7 @@ The "Validate selector" button will check with Prometheus how many time series a
 
 #### Options
 
-![Options](/static/img/docs/prometheus/options-8-5.png 'Options')
+![Options](/static/img/docs/prometheus/options-9-1.png 'Options')
 
 | Name        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -117,6 +117,7 @@ In addition to `Run query` button and mode switcher, in builder mode additional 
 | Name           | Description                                                                                                                       |
 | -------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | Query patterns | A list of useful operation patterns that can be used to quickly add multiple operations to your query to achieve a specific goal. |
+| Explain        | Toggle to show a step by step explanation of all query parts and the operations.                                                  |
 | Raw query      | Toggle to show raw query generated by the builder that will be sent to Prometheus instance.                                       |
 
 #### Metric and labels
@@ -129,7 +130,7 @@ Select desired labels and their values from the dropdown list. When metric is se
 
 #### Operations
 
-![Operations](/static/img/docs/prometheus/operations-8-5.gif 'Operations')
+![Operations](/static/img/docs/prometheus/operations-9-1.gif 'Operations')
 
 Use the `+ Operations` button to add operation to your query. Operations are grouped into sections for easier navigation. When the operations dropdown is open, write into the search input to search and filter operations list.
 
@@ -145,21 +146,21 @@ Some operations make sense only in specific order, if adding an operation would 
 
 In same cases the query editor can detect which operations would be most appropriate for a selected metric. In such cases it will show a hint next to the `+ Operations` button. Click on the hint to add the operations to your query.
 
+### Explain
+
+![Explain mode](/static/img/docs/prometheus/explain-9-1.png 'Explain mode')
+
+Explain mode helps with understanding the query. It shows a step by step explanation of all query parts and the operations.
+
 #### Raw query
 
-![Raw query](/static/img/docs/prometheus/raw-query-8-5.gif 'Raw query')
+![Raw query](/static/img/docs/prometheus/raw-query-9-1.gif 'Raw query')
 
 This section is shown only if the `Raw query` switch from the query editor top toolbar is set to `on`. It shows the raw query that will be created and executed by the query editor.
 
 #### Options
 
 Same set of option is available as in the `Code` mode. See the [Code mode options]({{< relref "#options" >}}) for details.
-
-### Explain mode
-
-![Explain mode](/static/img/docs/prometheus/explain-8-5.png 'Explain mode')
-
-Explain mode helps with understanding the query. It shows a step by step explanation of all query parts and the operations.
 
 ## Templating
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We have recently moved the `explain mode` into builder and code. See: https://github.com/grafana/grafana/pull/52935
This PR covers the docs aligned with the change.

Fixes: https://github.com/grafana/grafana/pull/53062