### PR TITLE
Alerting: Increase alert rule operation perf by replacing subquery with threshold calculation

### DIFF
--- a/pkg/services/ngalert/store/alertmanager.go
+++ b/pkg/services/ngalert/store/alertmanager.go
@@ -206,9 +206,6 @@ func getInsertQuery(driver string) string {
 	}
 }
 
-const uintMax = ^uint(0)
-const intMax = int(uintMax >> 1)
-
 func (st *DBstore) deleteOldConfigurations(ctx context.Context, orgID int64, limit int) (int64, error) {
 	if limit < 1 {
 		return 0, fmt.Errorf("failed to delete old configurations: limit is set to '%d' but needs to be > 0", limit)


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a nested sub-query which joins to the same table used when deleting very old alertmanager configs. For some reason that I do not understand, this sub-query is extremely slow on mysql only. It caused the integration test times against mysql to go from 3 seconds to 817 seconds.

**Which issue(s) this PR fixes**:

This PR replaces the subquery with an in-memory threshold calculation. Rather than using SQL to figure out which configs we should retain, we rely on IDs being monotonically increasing. We now just delete everything with ID that is lower than the oldest retained record per org.

- Tolerant to gaps in IDs (like those that might happen with multiple orgs). We use SQL offset to find the oldest retained record, and then delete anything older than that.
- If new records are inserted during a deletion concurrently, we might end up retaining extra records. This is again inconsequential, we never over-delete, we only under-delete by a few records.

Fixes #53064

Final speedup: 817s to 0.92s => **888x faster**.

**Special notes for your reviewer**:

