### PR TITLE
Document urlDisplayLabel to make button appear

### DIFF
--- a/docs/sources/datasources/prometheus.md
+++ b/docs/sources/datasources/prometheus.md
@@ -286,7 +286,8 @@ datasources:
         # datasourceUid value can be anything, but it should be unique across all defined data source uids.
         - datasourceUid: my_jaeger_uid
           name: traceID
-
+          urlDisplayLabel: View
+          
         # Field with external link.
         - name: traceID
           url: 'http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Jaeger%22,%7B%22query%22:%22$${__value.raw}%22%7D%5D'


### PR DESCRIPTION
The `urlDisplayLabel` is required in order to make Grafana show a button when hovering a link over a displayed "exemplar dot". This should be documented.

See [this blog post](https://blog.qaware.de/posts/cloud-observability-grafana-spring-boot/) -> Search "Prometheus data source" for details.


