### PR TITLE
Add 'Search selected' in log explorer if datasource type is loki

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -49,6 +49,7 @@ interface Props extends Themeable2 {
   getRows: () => LogRowModel[];
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
+  onClickSearchSelected?: (value: string) => void;
   onContextClick?: () => void;
   getRowContext: (row: LogRowModel, options?: RowContextOptions) => Promise<DataQueryResponse>;
   getFieldLinks?: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
@@ -129,6 +130,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
       getRows,
       onClickFilterLabel,
       onClickFilterOutLabel,
+      onClickSearchSelected,
       onClickShowDetectedField,
       onClickHideDetectedField,
       enableLogDetails,
@@ -213,6 +215,7 @@ class UnThemedLogRow extends PureComponent<Props, State> {
               wrapLogMessage={wrapLogMessage}
               prettifyLogMessage={prettifyLogMessage}
               onToggleContext={this.toggleContext}
+              onClickSearchSelected={onClickSearchSelected}
             />
           )}
         </tr>

--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -33,6 +33,7 @@ interface Props extends Themeable2 {
   getRows: () => LogRowModel[];
   onToggleContext: () => void;
   updateLimit?: () => void;
+  onClickSearchSelected?: (value: string) => void;
 }
 
 const getStyles = (theme: GrafanaTheme2) => {
@@ -102,6 +103,21 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
     this.props.onToggleContext();
   };
 
+  onSearchSelected = (e: React.SyntheticEvent<HTMLElement>) => {
+    const text = window.getSelection()?.toString() || '';
+    if (!text.length) {
+      return;
+    }
+    const { onClickSearchSelected, contextIsOpen, onToggleContext } = this.props;
+    if (!onClickSearchSelected) {
+      return;
+    }
+    if (contextIsOpen) {
+      onToggleContext();
+    }
+    onClickSearchSelected(text);
+  };
+
   render() {
     const {
       row,
@@ -115,12 +131,14 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
       wrapLogMessage,
       prettifyLogMessage,
       onToggleContext,
+      onClickSearchSelected,
     } = this.props;
 
     const style = getLogRowStyles(theme, row.logLevel);
     const { hasAnsi, raw } = row;
     const restructuredEntry = restructureLog(raw, prettifyLogMessage);
     const styles = getStyles(theme);
+    const hasSearchSelectedSupport = window.getSelection !== undefined && onClickSearchSelected !== undefined;
 
     return (
       // When context is open, the position has to be NOT relative.
@@ -153,6 +171,15 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
               className={cx('log-row-context', style.context, { [styles.contextNewline]: !wrapLogMessage })}
             >
               {contextIsOpen ? 'Hide' : 'Show'} context
+            </span>
+          )}
+          {hasSearchSelectedSupport && (
+            <span
+              onMouseDown={this.onSearchSelected}
+              onClick={(e) => e.stopPropagation()}
+              className={cx('log-row-context', style.context, { [styles.contextNewline]: !wrapLogMessage })}
+            >
+              Search selected
             </span>
           )}
         </div>

--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -30,6 +30,7 @@ export interface Props extends Themeable2 {
   showContextToggle?: (row?: LogRowModel) => boolean;
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
+  onClickSearchSelected?: (value: string) => void;
   getRowContext?: (row: LogRowModel, options?: RowContextOptions) => Promise<any>;
   getFieldLinks?: (field: Field, rowIndex: number) => Array<LinkModel<Field>>;
   onClickShowDetectedField?: (key: string) => void;
@@ -92,6 +93,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
       timeZone,
       onClickFilterLabel,
       onClickFilterOutLabel,
+      onClickSearchSelected,
       theme,
       enableLogDetails,
       previewLimit,
@@ -142,6 +144,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
                 enableLogDetails={enableLogDetails}
                 onClickFilterLabel={onClickFilterLabel}
                 onClickFilterOutLabel={onClickFilterOutLabel}
+                onClickSearchSelected={onClickSearchSelected}
                 onClickShowDetectedField={onClickShowDetectedField}
                 onClickHideDetectedField={onClickHideDetectedField}
                 getFieldLinks={getFieldLinks}
@@ -169,6 +172,7 @@ class UnThemedLogRows extends PureComponent<Props, State> {
                 enableLogDetails={enableLogDetails}
                 onClickFilterLabel={onClickFilterLabel}
                 onClickFilterOutLabel={onClickFilterOutLabel}
+                onClickSearchSelected={onClickSearchSelected}
                 onClickShowDetectedField={onClickShowDetectedField}
                 onClickHideDetectedField={onClickHideDetectedField}
                 getFieldLinks={getFieldLinks}

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -157,6 +157,10 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
     this.onModifyQueries({ type: 'ADD_FILTER_OUT', options: { key, value } });
   };
 
+  onClickSearchSelected = (value: string) => {
+    this.onModifyQueries({ type: 'REPLACE_LINE_FILTERS', options: { key: '', value } });
+  };
+
   onClickAddQueryRowButton = () => {
     const { exploreId, queryKeys, datasourceInstance } = this.props;
     this.props.addQueryRow(exploreId, queryKeys.length, datasourceInstance);
@@ -263,7 +267,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
   }
 
   renderLogsPanel(width: number) {
-    const { exploreId, syncedTimes, theme, queryResponse } = this.props;
+    const { exploreId, syncedTimes, theme, queryResponse, datasourceInstance } = this.props;
     const spacing = parseInt(theme.spacing(2).slice(0, -2), 10);
     return (
       <LogsContainer
@@ -273,6 +277,9 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
         width={width - spacing}
         onClickFilterLabel={this.onClickFilterLabel}
         onClickFilterOutLabel={this.onClickFilterOutLabel}
+        onClickSearchSelected={
+          datasourceInstance && datasourceInstance?.type === 'loki' ? this.onClickSearchSelected : undefined
+        }
         onStartScanning={this.onStartScanning}
         onStopScanning={this.onStopScanning}
       />

--- a/public/app/features/explore/Logs.tsx
+++ b/public/app/features/explore/Logs.tsx
@@ -74,6 +74,7 @@ interface Props extends Themeable2 {
   onChangeTime: (range: AbsoluteTimeRange) => void;
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
+  onClickSearchSelected?: (value: string) => void;
   onStartScanning?: () => void;
   onStopScanning?: () => void;
   getRowContext?: (row: LogRowModel, options?: RowContextOptions) => Promise<any>;
@@ -289,6 +290,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
       loadingState,
       onClickFilterLabel,
       onClickFilterOutLabel,
+      onClickSearchSelected,
       timeZone,
       scanning,
       scanRange,
@@ -441,6 +443,7 @@ class UnthemedLogs extends PureComponent<Props, State> {
               getRowContext={this.props.getRowContext}
               onClickFilterLabel={onClickFilterLabel}
               onClickFilterOutLabel={onClickFilterOutLabel}
+              onClickSearchSelected={onClickSearchSelected}
               showContextToggle={showContextToggle}
               showLabels={showLabels}
               showTime={showTime}

--- a/public/app/features/explore/LogsContainer.tsx
+++ b/public/app/features/explore/LogsContainer.tsx
@@ -33,6 +33,7 @@ interface LogsContainerProps extends PropsFromRedux {
   loadingState: LoadingState;
   onClickFilterLabel?: (key: string, value: string) => void;
   onClickFilterOutLabel?: (key: string, value: string) => void;
+  onClickSearchSelected?: (value: string) => void;
   onStartScanning: () => void;
   onStopScanning: () => void;
 }
@@ -85,6 +86,7 @@ class LogsContainer extends PureComponent<LogsContainerProps> {
       loadLogsVolumeData,
       onClickFilterLabel,
       onClickFilterOutLabel,
+      onClickSearchSelected,
       onStartScanning,
       onStopScanning,
       absoluteRange,
@@ -150,6 +152,7 @@ class LogsContainer extends PureComponent<LogsContainerProps> {
               onChangeTime={this.onChangeTime}
               onClickFilterLabel={onClickFilterLabel}
               onClickFilterOutLabel={onClickFilterOutLabel}
+              onClickSearchSelected={onClickSearchSelected}
               onStartScanning={onStartScanning}
               onStopScanning={onStopScanning}
               absoluteRange={absoluteRange}

--- a/public/app/plugins/datasource/loki/addtoQuery.test.ts
+++ b/public/app/plugins/datasource/loki/addtoQuery.test.ts
@@ -1,4 +1,10 @@
-import { addLabelFormatToQuery, addLabelToQuery, addNoPipelineErrorToQuery, addParserToQuery } from './addToQuery';
+import {
+  addLabelFormatToQuery,
+  addLabelToQuery,
+  addNoPipelineErrorToQuery,
+  addParserToQuery,
+  replaceLineFiltersInQuery,
+} from './addToQuery';
 
 describe('addLabelToQuery()', () => {
   it('should add label to simple query', () => {
@@ -230,6 +236,30 @@ describe('addLabelFormatToQuery', () => {
       )
     ).toBe(
       'rate({job="grafana"} | logfmt | label_format a=b | label_format level=lvl [5m]) + rate({job="grafana"} | logfmt | label_format a=b | label_format level=lvl [5m])'
+    );
+  });
+});
+
+describe('replaceLineFiltersInQuery', () => {
+  it('should add line filter after labels if no existing line filter', () => {
+    expect(replaceLineFiltersInQuery('{job="grafana"}', 'replacement')).toBe('{job="grafana"} |= `replacement`');
+  });
+
+  it('should replace existing line filters', () => {
+    expect(replaceLineFiltersInQuery('{job="grafana"} |= "foo" |= "bar"', 'replacement')).toBe(
+      '{job="grafana"} |= `replacement`'
+    );
+  });
+
+  it('should not change pipeline if no existing line filter', () => {
+    expect(replaceLineFiltersInQuery('{job="grafana"} | logfmt', 'replacement')).toBe(
+      '{job="grafana"} |= `replacement` | logfmt'
+    );
+  });
+
+  it('should not change pipeline if line filters exists', () => {
+    expect(replaceLineFiltersInQuery('{job="grafana"} |="no parser" | logfmt', 'replacement')).toBe(
+      '{job="grafana"} |= `replacement` | logfmt'
     );
   });
 });

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -44,7 +44,13 @@ import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_sr
 import { serializeParams } from '../../../core/utils/fetch';
 import { renderLegendFormat } from '../prometheus/legend';
 
-import { addLabelFormatToQuery, addLabelToQuery, addNoPipelineErrorToQuery, addParserToQuery } from './addToQuery';
+import {
+  addLabelFormatToQuery,
+  addLabelToQuery,
+  addNoPipelineErrorToQuery,
+  addParserToQuery,
+  replaceLineFiltersInQuery,
+} from './addToQuery';
 import { transformBackendResult } from './backendResultTransformer';
 import { LokiAnnotationsQueryEditor } from './components/AnnotationsQueryEditor';
 import LanguageProvider from './language_provider';
@@ -410,6 +416,12 @@ export class LokiDatasource
       case 'ADD_FILTER_OUT': {
         if (action.options?.key && action.options?.value) {
           expression = this.addLabelToQuery(expression, action.options.key, '!=', action.options.value);
+        }
+        break;
+      }
+      case 'REPLACE_LINE_FILTERS': {
+        if (action.options?.value) {
+          expression = replaceLineFiltersInQuery(expression, action.options?.value);
         }
         break;
       }


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

It's not easy to do such operations for loki logs with grafana:

 `search logs` -> `find keywords` -> `search logs with keywords` -> `check context` -> `search logs with another keyword` -> ...

So I add a feature named "Search selected".

Here's usage example:

![](https://raw.githubusercontent.com/ye-will/grafana/loki_explore_search_selected_example/search_selected_example.gif)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

