### PR TITLE
Azure Monitor: Early error if the client secret is not set

### DIFF
--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -266,7 +266,10 @@ func checkAzureMonitorResourceGraphHealth(dsInfo types.DatasourceInfo) (*http.Re
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	dsInfo, err := s.getDSInfo(req.PluginContext)
 	if err != nil {
-		return nil, err
+		return &backend.CheckHealthResult{
+			Status:  backend.HealthStatusError,
+			Message: err.Error(),
+		}, nil
 	}
 
 	status := backend.HealthStatusOk

--- a/pkg/tsdb/azuremonitor/credentials.go
+++ b/pkg/tsdb/azuremonitor/credentials.go
@@ -109,6 +109,9 @@ func getAzureCredentials(cfg *setting.Cfg, jsonData *simplejson.Json, secureJson
 		if err != nil {
 			return nil, err
 		}
+		if secureJsonData["clientSecret"] == "" {
+			return nil, fmt.Errorf("unable to instantiate credentials, clientSecret must be set")
+		}
 		credentials := &azcredentials.AzureClientSecretCredentials{
 			AzureCloud:   cloud,
 			TenantId:     jsonData.Get("tenantId").MustString(),

--- a/pkg/tsdb/azuremonitor/credentials_test.go
+++ b/pkg/tsdb/azuremonitor/credentials_test.go
@@ -197,5 +197,13 @@ func TestCredentials_getAzureCredentials(t *testing.T) {
 			// Azure Monitor datasource doesn't support custom IdP authorities (Authority is always empty)
 			assert.Equal(t, "", clientSecretCredentials.Authority)
 		})
+
+		t.Run("should error if no client secret is set", func(t *testing.T) {
+			cfg := &setting.Cfg{}
+			_, err := getAzureCredentials(cfg, jsonData, map[string]string{
+				"clientSecret": "",
+			})
+			require.ErrorContains(t, err, "clientSecret must be set")
+		})
 	})
 }

--- a/pkg/tsdb/azuremonitor/httpclient.go
+++ b/pkg/tsdb/azuremonitor/httpclient.go
@@ -1,8 +1,10 @@
 package azuremonitor
 
 import (
+	"fmt"
 	"net/http"
 
+	"github.com/grafana/grafana-azure-sdk-go/azcredentials"
 	"github.com/grafana/grafana-azure-sdk-go/azhttpclient"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 
@@ -18,6 +20,9 @@ func newHTTPClient(route types.AzRoute, model types.DatasourceInfo, cfg *setting
 
 	// Use Azure credentials if the route has OAuth scopes configured
 	if len(route.Scopes) > 0 {
+		if cred, ok := model.Credentials.(*azcredentials.AzureClientSecretCredentials); ok && cred.ClientSecret == "" {
+			return nil, fmt.Errorf("unable to initialize HTTP Client: clientSecret not found")
+		}
 		azhttpclient.AddAzureAuthentication(&opts, cfg.Azure, model.Credentials, route.Scopes)
 	}
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/credentials.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/credentials.ts
@@ -152,10 +152,7 @@ export function updateCredentials(
         },
         secureJsonData: {
           ...options.secureJsonData,
-          clientSecret:
-            typeof credentials.clientSecret === 'string' && credentials.clientSecret.length > 0
-              ? credentials.clientSecret
-              : undefined,
+          clientSecret: typeof credentials.clientSecret === 'string' ? credentials.clientSecret : undefined,
         },
         secureJsonFields: {
           ...options.secureJsonFields,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

There is an [escalation](https://github.com/grafana/support-escalations/issues/3352) in which the user is reporting that sometimes, they are not able to use an Azure data source, all requests fail with an error: `failed to retrieve Azure access token: secret can't be empty string`. To workaround the issue, they go to the config page of the data source and re-saving it seems to solve the issue.

As far as I can tell, the only way to trigger that error is trying to retrieve a token when the client secret is empty. To verify this assumption I am adding some checks that verify that the client secret is not empty before trying to retrieve a token.

Apart from that, I noticed two minor issues that I am solving in this PR:

 - When trying to edit a data source, removing the client secret, the previous secret was used anyway, this is because we were not saving the change if the length of the secret was 0. This behavior was a bit confusing so I removed it.
 - In the health check, if the backend failed to retrieve a data source, it was failing with a cryptic 500 error. I modified it to return the real error to the user.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to #https://github.com/grafana/support-escalations/issues/3352

**Special notes for your reviewer**:

This is not meant to solve the original issue posted by the user (which I believe is not something related to the plugin code but to the Grafana deployment), only to give more hints if the error happens again.

