### PR TITLE
Chore: Make "why-did-you-render" a dynamic import

### DIFF
--- a/public/app/dev.ts
+++ b/public/app/dev.ts
@@ -1,9 +1,9 @@
 import React from 'react';
 
-export function initDevFeatures() {
+export async function initDevFeatures() {
   // if why-render is in url enable why did you render react extension
   if (window.location.search.indexOf('why-render') !== -1) {
-    const whyDidYouRender = require('@welldone-software/why-did-you-render');
+    const { default: whyDidYouRender } = await import('@welldone-software/why-did-you-render');
     whyDidYouRender(React, {
       trackAllPureComponents: true,
     });


### PR DESCRIPTION
Makes `why-did-you-render` a dynamic import so it's only fetched when needed.