### PR TITLE
[8.5.x] Alerting: Remove user input from error response

### DIFF
--- a/pkg/services/ngalert/api/lotex_am.go
+++ b/pkg/services/ngalert/api/lotex_am.go
@@ -9,12 +9,13 @@ import (
 	"net/http"
 	"strconv"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/web"
-	"gopkg.in/yaml.v3"
 )
 
 var endpoints = map[string]map[string]string{
@@ -62,7 +63,7 @@ func (am *LotexAM) withAMReq(
 ) response.Response {
 	recipient, err := strconv.ParseInt(web.Params(ctx.Req)[":Recipient"], 10, 64)
 	if err != nil {
-		return response.Error(http.StatusBadRequest, "Recipient is invalid", err)
+		return ErrResp(http.StatusBadRequest, errInvalidRecipientFormat, "")
 	}
 
 	ds, err := am.DataProxy.DataSourceCache.GetDatasource(ctx.Req.Context(), recipient, ctx.SignedInUser, ctx.SkipCache)

--- a/pkg/services/ngalert/api/lotex_prom.go
+++ b/pkg/services/ngalert/api/lotex_prom.go
@@ -80,7 +80,7 @@ func (p *LotexProm) RouteGetRuleStatuses(ctx *models.ReqContext) response.Respon
 func (p *LotexProm) getEndpoints(ctx *models.ReqContext) (*promEndpoints, error) {
 	recipient, err := strconv.ParseInt(web.Params(ctx.Req)[":Recipient"], 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("recipient is invalid")
+		return nil, errInvalidRecipientFormat
 	}
 
 	ds, err := p.DataProxy.DataSourceCache.GetDatasource(ctx.Req.Context(), recipient, ctx.SignedInUser, ctx.SkipCache)

--- a/pkg/services/ngalert/api/lotex_ruler.go
+++ b/pkg/services/ngalert/api/lotex_ruler.go
@@ -7,9 +7,10 @@ import (
 	"net/url"
 	"strconv"
 
+	"gopkg.in/yaml.v3"
+
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/web"
-	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -178,7 +179,7 @@ func (r *LotexRuler) RoutePostNameRulesConfig(ctx *models.ReqContext, conf apimo
 func (r *LotexRuler) validateAndGetPrefix(ctx *models.ReqContext) (string, error) {
 	recipient, err := strconv.ParseInt(web.Params(ctx.Req)[":Recipient"], 10, 64)
 	if err != nil {
-		return "", fmt.Errorf("recipient is invalid")
+		return "", errInvalidRecipientFormat
 	}
 
 	ds, err := r.DataProxy.DataSourceCache.GetDatasource(ctx.Req.Context(), recipient, ctx.SignedInUser, ctx.SkipCache)

--- a/pkg/services/ngalert/api/lotex_ruler_test.go
+++ b/pkg/services/ngalert/api/lotex_ruler_test.go
@@ -27,7 +27,7 @@ func TestLotexRuler_ValidateAndGetPrefix(t *testing.T) {
 		{
 			name:        "with an invalid recipient",
 			namedParams: map[string]string{":Recipient": "AAABBB"},
-			err:         errors.New("recipient is invalid"),
+			err:         errors.New("invalid recipient (datasource) identifier format. Only integer is expected"),
 		},
 		{
 			name:            "with an error while trying to fetch the datasource",

--- a/pkg/services/ngalert/api/util.go
+++ b/pkg/services/ngalert/api/util.go
@@ -25,7 +25,7 @@ import (
 )
 
 var searchRegex = regexp.MustCompile(`\{(\w+)\}`)
-
+var errInvalidRecipientFormat = errors.New("invalid recipient (datasource) identifier format. Only integer is expected")
 var NotImplementedResp = ErrResp(http.StatusNotImplemented, errors.New("endpoint not implemented"), "")
 
 func toMacaronPath(path string) string {
@@ -49,7 +49,7 @@ func backendType(ctx *models.ReqContext, cache datasources.CacheService) (apimod
 			}
 		}
 	}
-	return 0, fmt.Errorf("unexpected backend type (%v)", recipient)
+	return 0, errInvalidRecipientFormat
 }
 
 // macaron unsafely asserts the http.ResponseWriter is an http.CloseNotifier, which will panic.
@@ -100,7 +100,7 @@ func (p *AlertingProxy) withReq(
 
 	recipient, err := strconv.ParseInt(web.Params(ctx.Req)[":Recipient"], 10, 64)
 	if err != nil {
-		return ErrResp(http.StatusBadRequest, err, "Recipient is invalid")
+		return ErrResp(http.StatusBadRequest, errInvalidRecipientFormat, "")
 	}
 
 	p.DataProxy.ProxyDatasourceRequestWithID(newCtx, recipient)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR just removes any mention of the content of the recipient from the error message.


Related to https://github.com/grafana/grafana/pull/52965. The backport is not possible because there are too many changes in 9.x branches since then.