### PR TITLE
Alerting: Fix crash when viewing alert group without interval

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleConfigStatus.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleConfigStatus.tsx
@@ -15,7 +15,7 @@ interface RuleConfigStatusProps {
 export function RuleConfigStatus({ rule }: RuleConfigStatusProps) {
   const styles = useStyles2(getStyles);
 
-  const { exceedsLimit } = checkEvaluationIntervalGlobalLimit(rule.group.interval ?? '');
+  const { exceedsLimit } = checkEvaluationIntervalGlobalLimit(rule.group.interval);
 
   if (!exceedsLimit) {
     return null;

--- a/public/app/features/alerting/unified/utils/config.ts
+++ b/public/app/features/alerting/unified/utils/config.ts
@@ -5,7 +5,11 @@ export function getAllDataSources(): Array<DataSourceInstanceSettings<DataSource
   return Object.values(config.datasources);
 }
 
-export function checkEvaluationIntervalGlobalLimit(alertGroupEvaluateEvery: string) {
+export function checkEvaluationIntervalGlobalLimit(alertGroupEvaluateEvery?: string) {
+  if (!alertGroupEvaluateEvery) {
+    return { globalLimit: 0, exceedsLimit: false };
+  }
+
   if (!isValidGoDuration(config.unifiedAlerting.minInterval)) {
     return { globalLimit: 0, exceedsLimit: false };
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a crash in the alerting view when viewing the details of an alert group without an explicit interval.

**Special notes for your reviewer**:

The typing seemed to be correct but we were defaulting to an empty string `''` which would fail to be parsed as a valid duration and throw here

https://github.com/grafana/grafana/blob/522e5af783e0791fbf596b8d3262a2178b3cc4bc/public/app/features/alerting/unified/utils/config.ts#L17

