### PR TITLE
Docs: Add 9.1 to What's New index

### DIFF
--- a/docs/sources/whatsnew/_index.md
+++ b/docs/sources/whatsnew/_index.md
@@ -65,6 +65,7 @@ as info on deprecations, breaking changes and plugin development read the [relea
 
 ## Grafana 9
 
+- [What's new in 9.1]({{< relref "whats-new-in-v9-1/" >}})
 - [What's new in 9.0]({{< relref "whats-new-in-v9-0/" >}})
 
 ## Grafana 8


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a link to the Grafana 9.1 What's New document from the What's New index page.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

None