### PR TITLE
Alerting: Remove mention of host name from Alerting HA docs

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1232,11 +1232,11 @@ The interval string is a possibly signed sequence of decimal numbers, followed b
 
 ### ha_listen_address
 
-Listen address/hostname and port to receive unified alerting messages for other Grafana instances. The port is used for both TCP and UDP. It is assumed other Grafana instances are also running on the same port. The default value is `0.0.0.0:9094`.
+Listen IP address and port to receive unified alerting messages for other Grafana instances. The port is used for both TCP and UDP. It is assumed other Grafana instances are also running on the same port. The default value is `0.0.0.0:9094`.
 
 ### ha_advertise_address
 
-Explicit address/hostname and port to advertise other Grafana instances. The port is used for both TCP and UDP.
+Explicit IP address and port to advertise other Grafana instances. The port is used for both TCP and UDP.
 
 ### ha_peers
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1236,7 +1236,7 @@ Listen IP address and port to receive unified alerting messages for other Grafan
 
 ### ha_advertise_address
 
-Explicit IP address and port to advertize other Grafana instances. The port is used for both TCP and UDP.
+Explicit IP address and port to advertise other Grafana instances. The port is used for both TCP and UDP.
 
 ### ha_peers
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1236,7 +1236,7 @@ Listen IP address and port to receive unified alerting messages for other Grafan
 
 ### ha_advertise_address
 
-Explicit IP address and port to advertise other Grafana instances. The port is used for both TCP and UDP.
+Explicit IP address and port to advertize other Grafana instances. The port is used for both TCP and UDP.
 
 ### ha_peers
 


### PR DESCRIPTION

**What this PR does / why we need it**:
The documentation has some discrepancies with reality: Alertmanager does not support domain names for config parameters `ha_listen_address` and `ha_advertise_address`. Disregarding the fact that this may be a bug in Alertmanager (because it supports domain names for `ha_peers`) this PR fixes documentation to reflect the reality.

