### PR TITLE
CI: Make `retrieve` and `release` `npm packages` allowed to fail

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3525,6 +3525,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
+  failure: ignore
   image: grafana/grafana-ci-deploy:1.3.3
   name: retrieve-npm-packages
 - commands:
@@ -3534,6 +3535,7 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
+  failure: ignore
   image: grafana/build-container:1.5.9
   name: release-npm-packages
 trigger:
@@ -5131,6 +5133,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: bd01c6115af9aa8242a179e2120196212b5149ed5d71ed5327c6e89f65915785
+hmac: cf7b07bd7aa1c46665d485693553ff98e7dacf0e4853c5d640437d0218c91db7
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -86,6 +86,7 @@ def retrieve_npm_packages_step():
         'depends_on': [
             'yarn-install',
         ],
+        'failure': 'ignore',
         'environment': {
             'GCP_KEY': from_secret('gcp_key'),
             'PRERELEASE_BUCKET': from_secret(prerelease_bucket)
@@ -102,6 +103,7 @@ def release_npm_packages_step():
         'depends_on': [
             'retrieve-npm-packages',
         ],
+        'failure': 'ignore',
         'environment': {
             'NPM_TOKEN': from_secret('npm_token'),
         },


### PR DESCRIPTION
**What this PR does / why we need it**:

During `9.1.0-beta1` release, we encountered a case where the artifacts pipeline failed for a reason, and npm retrieve/publish passed. Upon fixing the artifacts issues and restarting, the pipeline passed, but the npm pipeline failed, apparently because you cannot override npm packages, after a certain version is uploaded once.

After checking in with the team, even if one removes the npm packages from the registry you cannot re-publish packages with the same tag.

This PR makes npm packages retrieve/publish allowed to fail, so it won't block the whole process.
