### PR TITLE
RolePicker: Fix RolePicker menu positioning

### DIFF
--- a/public/app/core/components/RolePicker/RolePicker.tsx
+++ b/public/app/core/components/RolePicker/RolePicker.tsx
@@ -131,7 +131,7 @@ export const RolePicker = ({
   }
 
   return (
-    <div data-testid="role-picker" style={{ position: 'relative' }} ref={ref}>
+    <div data-testid="role-picker" style={{ position: 'relative', width: ROLE_PICKER_WIDTH }} ref={ref}>
       <ClickOutsideWrapper onClick={onClickOutside}>
         <RolePickerInput
           builtInRole={selectedBuiltInRole}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the positioning of the RolePicker's menu when the RolePicker's wrapper div expands to the full width of its parent. This is the case on the Edit ServiceAccount page. The calculation of the menu's position amended in https://github.com/grafana/grafana/pull/50769 and it explicitly calculates with the predefined width of the RolePicker so I added the predefined width to the wrapper div as well.

**Which issue(s) this PR fixes**:

Fixes #52800 

**Special notes for your reviewer**:

@Clarity-89, could you please take a look at this and verify that it doesn't break your changes? 

**Screenshot**
<img width="400" alt="image" src="https://user-images.githubusercontent.com/1585112/182587400-0063a506-f268-4549-85b8-3854141131a5.png">
