### PR TITLE
Chore: Change var keyword to const in addTooltipSupport

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/addTooltipSupport.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/addTooltipSupport.ts
@@ -37,7 +37,7 @@ export const addTooltipSupport = ({
   // Ensure tooltip is closed on config changes
   isToolTipOpen.current = false;
 
-  var onMouseLeave = () => {
+  const onMouseLeave = () => {
     if (!isToolTipOpen.current) {
       setCoords(null);
     }
@@ -52,7 +52,7 @@ export const addTooltipSupport = ({
     ref_over.addEventListener('mouseleave', onMouseLeave);
   });
 
-  var clearPopupIfOpened = () => {
+  const clearPopupIfOpened = () => {
     if (isToolTipOpen.current) {
       setCoords(null);
       onUPlotClick();


### PR DESCRIPTION
Refactor keywords from `var` to `const` in this PR: https://github.com/grafana/grafana/pull/50226