### PR TITLE
Access Control: Fix permission error during dashboard creation flow

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -648,10 +648,6 @@ func (l *LibraryElementService) getElementsForDashboardID(c context.Context, das
 
 // connectElementsToDashboardID adds connections for all elements Library Elements in a Dashboard.
 func (l *LibraryElementService) connectElementsToDashboardID(c context.Context, signedInUser *models.SignedInUser, elementUIDs []string, dashboardID int64) error {
-	if err := l.requireEditPermissionsOnDashboard(c, signedInUser, dashboardID); err != nil {
-		return err
-	}
-
 	err := l.SQLStore.WithTransactionalDbSession(c, func(session *sqlstore.DBSession) error {
 		_, err := session.Exec("DELETE FROM "+models.LibraryElementConnectionTableName+" WHERE kind=1 AND connection_id=?", dashboardID)
 		if err != nil {

--- a/pkg/services/libraryelements/guard.go
+++ b/pkg/services/libraryelements/guard.go
@@ -72,17 +72,3 @@ func (l *LibraryElementService) requireViewPermissionsOnFolder(ctx context.Conte
 
 	return nil
 }
-
-func (l *LibraryElementService) requireEditPermissionsOnDashboard(ctx context.Context, user *models.SignedInUser, dashboardID int64) error {
-	g := guardian.New(ctx, dashboardID, user.OrgId, user)
-
-	canEdit, err := g.CanEdit()
-	if err != nil {
-		return err
-	}
-	if !canEdit {
-		return dashboards.ErrDashboardUpdateAccessDenied
-	}
-
-	return nil
-}


### PR DESCRIPTION
**What this PR does / why we need it**:
Dashboard creation flow was failing as reported [here](https://raintank-corp.slack.com/archives/C036J5B39/p1659446800585189). This PR fixes it by removing a superfluous access control check.

**Why was dashboard creation failing**
It was because we [connect library elements](https://github.com/grafana/grafana/blob/v9.1.x/pkg/api/dashboard.go#L470-L474) to the new dashboards, but as part of library element connection flow we check whether the user has write permissions on the dashboard that library elements are being connected to. However, this dashboard has only just been created. So the user who created it will have write access to it, but it will not be reflected in their cached `Permissions`.

I also considered another approach that would refresh user's cache, but it was more work and felt overcomplicated.

It is safe to remove this permission check, as `connectElementsToDashboardID` is only called when a new dashboard is created or imported, and by design the user who creates/imports a dashboard will have write permissions on this dashboard.


