### PR TITLE
Storybook: remove `UseState` + add controls support to `TimeZonePicker` story

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.story.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.story.tsx
@@ -1,41 +1,47 @@
 import { action } from '@storybook/addon-actions';
-import { ComponentMeta } from '@storybook/react';
+import { useArgs } from '@storybook/client-api';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
 import React from 'react';
 
 import { TimeZonePicker } from '@grafana/ui';
 
-import { UseState } from '../../utils/storybook/UseState';
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 
 const meta: ComponentMeta<typeof TimeZonePicker> = {
   title: 'Pickers and Editors/TimePickers/TimeZonePicker',
   component: TimeZonePicker,
   decorators: [withCenteredStory],
+  parameters: {
+    controls: {
+      exclude: ['inputId', 'onChange', 'onBlur'],
+    },
+  },
+  args: {
+    value: 'Europe/Stockholm',
+  },
+  argTypes: {
+    includeInternal: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
 };
 
-export const basic = () => {
+export const Basic: ComponentStory<typeof TimeZonePicker> = (args) => {
+  const [, updateArgs] = useArgs();
   return (
-    <UseState
-      initialState={{
-        value: 'Europe/Stockholm',
+    <TimeZonePicker
+      {...args}
+      onChange={(newValue) => {
+        if (!newValue) {
+          return;
+        }
+        action('on selected')(newValue);
+        updateArgs({ value: newValue });
       }}
-    >
-      {(value, updateValue) => {
-        return (
-          <TimeZonePicker
-            includeInternal={true}
-            value={value.value}
-            onChange={(newValue) => {
-              if (!newValue) {
-                return;
-              }
-              action('on selected')(newValue);
-              updateValue({ value: newValue });
-            }}
-          />
-        );
-      }}
-    </UseState>
+      onBlur={action('onBlur')}
+    />
   );
 };
 

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.story.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker.story.tsx
@@ -34,9 +34,6 @@ export const Basic: ComponentStory<typeof TimeZonePicker> = (args) => {
     <TimeZonePicker
       {...args}
       onChange={(newValue) => {
-        if (!newValue) {
-          return;
-        }
         action('on selected')(newValue);
         updateArgs({ value: newValue });
       }}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- removes `UseState` in favour of storybook's `client-api`
- adds controls support

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/53218

**Special notes for your reviewer**:

