### PR TITLE
[v9.1.x] Make retrieve and release npm packages allowed to fail (#53191)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3432,6 +3432,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
+  failure: ignore
   image: grafana/grafana-ci-deploy:1.3.3
   name: retrieve-npm-packages
 - commands:
@@ -3441,6 +3442,7 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
+  failure: ignore
   image: grafana/build-container:1.5.9
   name: release-npm-packages
 trigger:
@@ -5016,6 +5018,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 710e3af4e83d49bce6403c31135075bbd2fbc302b985e0dea201157950805924
+hmac: 1ca37da2d5a2ca7290349339aaa494e24e51e27699dca658813d99abc55ee63c
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -86,6 +86,7 @@ def retrieve_npm_packages_step():
         'depends_on': [
             'yarn-install',
         ],
+        'failure': 'ignore',
         'environment': {
             'GCP_KEY': from_secret('gcp_key'),
             'PRERELEASE_BUCKET': from_secret(prerelease_bucket)
@@ -102,6 +103,7 @@ def release_npm_packages_step():
         'depends_on': [
             'retrieve-npm-packages',
         ],
+        'failure': 'ignore',
         'environment': {
             'NPM_TOKEN': from_secret('npm_token'),
         },


### PR DESCRIPTION
**What this PR does / why we need it**:

Backports #53191

(cherry picked from commit 1d1fb0712456415161ee6bce079457969bec187e)