### PR TITLE
Alerting: set dashboard and panel id using annotations in provisioning api

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/api_ruler_validation.go
@@ -3,7 +3,6 @@ package api
 import (
 	"errors"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/grafana/grafana/pkg/models"
@@ -120,20 +119,9 @@ func validateRuleNode(
 		newAlertRule.Annotations = ruleNode.ApiRuleNode.Annotations
 		newAlertRule.Labels = ruleNode.ApiRuleNode.Labels
 
-		dashUID := ruleNode.ApiRuleNode.Annotations[ngmodels.DashboardUIDAnnotation]
-		panelID := ruleNode.ApiRuleNode.Annotations[ngmodels.PanelIDAnnotation]
-
-		if dashUID != "" && panelID == "" || dashUID == "" && panelID != "" {
-			return nil, fmt.Errorf("both annotations %s and %s must be specified", ngmodels.DashboardUIDAnnotation, ngmodels.PanelIDAnnotation)
-		}
-
-		if dashUID != "" {
-			panelIDValue, err := strconv.ParseInt(panelID, 10, 64)
-			if err != nil {
-				return nil, fmt.Errorf("annotation %s must be a valid integer Panel ID", ngmodels.PanelIDAnnotation)
-			}
-			newAlertRule.DashboardUID = &dashUID
-			newAlertRule.PanelID = &panelIDValue
+		err = newAlertRule.SetDashboardAndPanel()
+		if err != nil {
+			return nil, err
 		}
 	}
 	return &newAlertRule, nil

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -184,6 +185,31 @@ func (alertRule *AlertRule) Diff(rule *AlertRule, ignore ...string) cmputil.Diff
 	}
 	cmp.Equal(alertRule, rule, ops...)
 	return reporter.Diffs
+}
+
+// SetDashboardAndPanel will set the DashboardUID and PanlID
+// field be doing a lookup in the annotations. Errors when
+// the found annotations are not valid.
+func (alertRule *AlertRule) SetDashboardAndPanel() error {
+	if alertRule.Annotations == nil {
+		return nil
+	}
+	dashUID := alertRule.Annotations[DashboardUIDAnnotation]
+	panelID := alertRule.Annotations[PanelIDAnnotation]
+	if dashUID != "" && panelID == "" || dashUID == "" && panelID != "" {
+		return fmt.Errorf("both annotations %s and %s must be specified",
+			DashboardUIDAnnotation, PanelIDAnnotation)
+	}
+	if dashUID != "" {
+		panelIDValue, err := strconv.ParseInt(panelID, 10, 64)
+		if err != nil {
+			return fmt.Errorf("annotation %s must be a valid integer Panel ID",
+				PanelIDAnnotation)
+		}
+		alertRule.DashboardUID = &dashUID
+		alertRule.PanelID = &panelIDValue
+	}
+	return nil
 }
 
 // AlertRuleKey is the alert definition identifier

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -73,6 +73,10 @@ func (service *AlertRuleService) CreateAlertRule(ctx context.Context, rule model
 		return models.AlertRule{}, err
 	}
 	rule.IntervalSeconds = interval
+	err = rule.SetDashboardAndPanel()
+	if err != nil {
+		return models.AlertRule{}, err
+	}
 	rule.Updated = time.Now()
 	err = service.xact.InTransaction(ctx, func(ctx context.Context) error {
 		ids, err := service.ruleStore.InsertAlertRules(ctx, []models.AlertRule{
@@ -177,6 +181,10 @@ func (service *AlertRuleService) UpdateAlertRule(ctx context.Context, rule model
 	rule.Updated = time.Now()
 	rule.ID = storedRule.ID
 	rule.IntervalSeconds, err = service.ruleStore.GetRuleGroupInterval(ctx, rule.OrgID, rule.NamespaceUID, rule.RuleGroup)
+	if err != nil {
+		return models.AlertRule{}, err
+	}
+	err = rule.SetDashboardAndPanel()
 	if err != nil {
 		return models.AlertRule{}, err
 	}


### PR DESCRIPTION
This PR sets the dashboard and panel id by using the extracted function from the validation.

Fixes #53199