### PR TITLE
Loki: Fix types in querybuilder state test

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -7550,10 +7550,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
-    "public/app/plugins/datasource/loki/querybuilder/state.test.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
-    ],
     "public/app/plugins/datasource/loki/querybuilder/state.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/public/app/plugins/datasource/loki/querybuilder/state.test.ts
+++ b/public/app/plugins/datasource/loki/querybuilder/state.test.ts
@@ -4,7 +4,7 @@ import { changeEditorMode, getQueryWithDefaults } from './state';
 
 describe('getQueryWithDefaults(', () => {
   it('should set defaults', () => {
-    expect(getQueryWithDefaults({ refId: 'A' } as any)).toEqual({
+    expect(getQueryWithDefaults({ refId: 'A', expr: '' })).toEqual({
       editorMode: 'builder',
       expr: '',
       queryType: 'range',
@@ -17,6 +17,6 @@ describe('getQueryWithDefaults(', () => {
       expect(query.editorMode).toBe(QueryEditorMode.Code);
     });
 
-    expect(getQueryWithDefaults({ refId: 'A' } as any).editorMode).toEqual(QueryEditorMode.Code);
+    expect(getQueryWithDefaults({ refId: 'A', expr: '' }).editorMode).toEqual(QueryEditorMode.Code);
   });
 });

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -49,6 +49,7 @@ export interface LokiQuery extends DataQuery {
   /* @deprecated now use queryType */
   instant?: boolean;
   editorMode?: QueryEditorMode;
+  refId: string;
 }
 
 export interface LokiOptions extends DataSourceJsonData {

--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -49,7 +49,6 @@ export interface LokiQuery extends DataQuery {
   /* @deprecated now use queryType */
   instant?: boolean;
   editorMode?: QueryEditorMode;
-  refId: string;
 }
 
 export interface LokiOptions extends DataSourceJsonData {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a seemingly missing `refId` property to `LokiQuery` intertface, and fixes the types in the state test.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/53122

**Special notes for your reviewer**:

Tests should not fail and no type errors should be caused by adding this new property.