### PR TITLE
Data Connections: Remove the placeholder for Recorded Queries

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -645,14 +645,6 @@ func (hs *HTTPServer) buildDataConnectionsNavLink(c *models.ReqContext) *dtos.Na
 		Url:         baseUrl + "/cloud-integrations",
 	})
 
-	children = append(children, &dtos.NavLink{
-		Id:          baseId + "-recorded-queries",
-		Text:        "Recorded queries",
-		Icon:        "record-audio",
-		Description: "Manage your recorded queries",
-		Url:         baseUrl + "/recorded-queries",
-	})
-
 	navLink = &dtos.NavLink{
 		Text:       "Data Connections",
 		Icon:       "link",

--- a/public/app/features/data-connections/DataConnectionsPage.tsx
+++ b/public/app/features/data-connections/DataConnectionsPage.tsx
@@ -11,7 +11,6 @@ import { useNavModel } from './hooks/useNavModel';
 import { CloudIntegrations } from './tabs/CloudIntegrations';
 import { DataSourcesEdit } from './tabs/DataSourcesEdit';
 import { Plugins } from './tabs/Plugins';
-import { RecordedQueries } from './tabs/RecordedQueries';
 
 export default function DataConnectionsPage() {
   const navModel = useNavModel();
@@ -33,7 +32,6 @@ export default function DataConnectionsPage() {
             <Route path={ROUTES.DataSources} component={DataSourcesList} />
             <Route path={ROUTES.Plugins} component={Plugins} />
             <Route path={ROUTES.CloudIntegrations} component={CloudIntegrations} />
-            <Route path={ROUTES.RecordedQueries} component={RecordedQueries} />
 
             {/* Default page */}
             <Route component={DataSourcesList} />

--- a/public/app/features/data-connections/constants.ts
+++ b/public/app/features/data-connections/constants.ts
@@ -11,5 +11,4 @@ export enum ROUTES {
   DataSourcesDashboards = '/data-connections/datasources/edit/:uid/dashboards',
   Plugins = '/data-connections/plugins',
   CloudIntegrations = '/data-connections/cloud-integrations',
-  RecordedQueries = '/data-connections/recorded-queries',
 }

--- a/public/app/features/data-connections/tabs/RecordedQueries/RecordedQueries.tsx
+++ b/public/app/features/data-connections/tabs/RecordedQueries/RecordedQueries.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export function RecordedQueries() {
-  return <div>The recorded queries tab is under development.</div>;
-}

--- a/public/app/features/data-connections/tabs/RecordedQueries/index.tsx
+++ b/public/app/features/data-connections/tabs/RecordedQueries/index.tsx
@@ -1,1 +1,0 @@
-export * from './RecordedQueries';


### PR DESCRIPTION
**Related issue:** https://github.com/grafana/grafana/issues/49907

### What does is it do?
We have decided that the Recorded Queries tab on the Data Connections page is not going to be part of the MVP, so I removing the placeholder for it. 