### PR TITLE
Prometheus: Add dashboard uid when tracing header in browsermode

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -482,7 +482,9 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
   rangeRaw?: RawTimeRange;
   timeInfo?: string; // The query time description (blue text in the upper right)
   panelId?: number;
+  /** @deprecate */
   dashboardId?: number;
+  dashboardUID?: string;
   publicDashboardAccessToken?: string;
 
   // Request Timing

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditorTableView.tsx
@@ -33,7 +33,13 @@ export function PanelEditorTableView({ width, height, panel, dashboard }: Props)
     const timeData = applyPanelTimeOverrides(panel, timeSrv.timeRange());
 
     const sub = panel.events.subscribe(RefreshEvent, () => {
-      panel.runAllPanelQueries(dashboard.id, dashboard.getTimezone(), timeData, width);
+      panel.runAllPanelQueries({
+        dashboardId: dashboard.id,
+        dashboardUID: dashboard.uid,
+        dashboardTimezone: dashboard.getTimezone(),
+        timeData,
+        width,
+      });
     });
     return () => {
       sub.unsubscribe();

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -318,13 +318,14 @@ export class PanelChrome extends PureComponent<Props, State> {
       if (this.state.refreshWhenInView) {
         this.setState({ refreshWhenInView: false });
       }
-      panel.runAllPanelQueries(
-        dashboard.id,
-        dashboard.getTimezone(),
+      panel.runAllPanelQueries({
+        dashboardId: dashboard.id,
+        dashboardUID: dashboard.uid,
+        dashboardTimezone: dashboard.getTimezone(),
+        publicDashboardAccessToken: dashboard.meta.publicDashboardAccessToken,
         timeData,
         width,
-        dashboard.meta.publicDashboardAccessToken
-      );
+      });
     } else {
       // The panel should render on refresh as well if it doesn't have a query, like clock panel
       this.setState({

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -492,6 +492,7 @@ describe('PanelModel', () => {
           run: jest.fn(),
         });
         const dashboardId = 123;
+        const dashboardUID = 'ggHbN42mk';
         const dashboardTimezone = 'browser';
         const width = 860;
         const timeData = {
@@ -506,7 +507,7 @@ describe('PanelModel', () => {
           } as TimeRange,
         } as TimeOverrideResult;
 
-        model.runAllPanelQueries(dashboardId, dashboardTimezone, timeData, width);
+        model.runAllPanelQueries({ dashboardId, dashboardUID, dashboardTimezone, timeData, width });
 
         expect(model.getQueryRunner).toBeCalled();
       });

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -50,6 +50,15 @@ export interface GridPos {
   static?: boolean;
 }
 
+type RunPanelQueryOptions = {
+  /** @deprecate */
+  dashboardId: number;
+  dashboardUID: string;
+  dashboardTimezone: string;
+  timeData: TimeOverrideResult;
+  width: number;
+  publicDashboardAccessToken?: string;
+};
 const notPersistedProperties: { [str: string]: boolean } = {
   events: true,
   isViewing: true,
@@ -323,18 +332,20 @@ export class PanelModel implements DataConfigSource, IPanelModel {
     }
   }
 
-  runAllPanelQueries(
-    dashboardId: number,
-    dashboardTimezone: string,
-    timeData: TimeOverrideResult,
-    width: number,
-    publicDashboardAccessToken?: string
-  ) {
+  runAllPanelQueries({
+    dashboardId,
+    dashboardUID,
+    dashboardTimezone,
+    timeData,
+    width,
+    publicDashboardAccessToken,
+  }: RunPanelQueryOptions) {
     this.getQueryRunner().run({
       datasource: this.datasource,
       queries: this.targets,
       panelId: this.id,
       dashboardId: dashboardId,
+      dashboardUID: dashboardUID,
       publicDashboardAccessToken,
       timezone: dashboardTimezone,
       timeRange: timeData.timeRange,

--- a/public/app/features/query/state/PanelQueryRunner.ts
+++ b/public/app/features/query/state/PanelQueryRunner.ts
@@ -46,7 +46,9 @@ export interface QueryRunnerOptions<
   datasource: DataSourceRef | DataSourceApi<TQuery, TOptions> | null;
   queries: TQuery[];
   panelId?: number;
+  /** @deprecate */
   dashboardId?: number;
+  dashboardUID?: string;
   publicDashboardAccessToken?: string;
   timezone: TimeZone;
   timeRange: TimeRange;
@@ -203,6 +205,7 @@ export class PanelQueryRunner {
       datasource,
       panelId,
       dashboardId,
+      dashboardUID,
       publicDashboardAccessToken,
       timeRange,
       timeInfo,
@@ -223,6 +226,7 @@ export class PanelQueryRunner {
       timezone,
       panelId,
       dashboardId,
+      dashboardUID,
       publicDashboardAccessToken,
       range: timeRange,
       timeInfo,

--- a/public/app/plugins/datasource/prometheus/datasource.test.ts
+++ b/public/app/plugins/datasource/prometheus/datasource.test.ts
@@ -1790,16 +1790,17 @@ describe('PrometheusDatasource for POST', () => {
     });
   });
 
-  describe('When querying prometheus via check headers X-Dashboard-Id and X-Panel-Id', () => {
-    const options = { dashboardId: 1, panelId: 2 };
+  describe('When querying prometheus via check headers X-Dashboard-Id X-Panel-Id and X-Dashboard-UID', () => {
+    const options = { dashboardId: 1, panelId: 2, dashboardUID: 'WFlOM-jM1' };
     const httpOptions = {
       headers: {} as { [key: string]: number | undefined },
     };
 
     it('with proxy access tracing headers should be added', () => {
       ds._addTracingHeaders(httpOptions as any, options as any);
-      expect(httpOptions.headers['X-Dashboard-Id']).toBe(1);
-      expect(httpOptions.headers['X-Panel-Id']).toBe(2);
+      expect(httpOptions.headers['X-Dashboard-Id']).toBe(options.dashboardId);
+      expect(httpOptions.headers['X-Panel-Id']).toBe(options.panelId);
+      expect(httpOptions.headers['X-Dashboard-UID']).toBe(options.dashboardUID);
     });
 
     it('with direct access tracing headers should not be added', () => {
@@ -1811,6 +1812,7 @@ describe('PrometheusDatasource for POST', () => {
       mockDs._addTracingHeaders(httpOptions as any, options as any);
       expect(httpOptions.headers['X-Dashboard-Id']).toBe(undefined);
       expect(httpOptions.headers['X-Panel-Id']).toBe(undefined);
+      expect(httpOptions.headers['X-Dashboard-UID']).toBe(undefined);
     });
   });
 });
@@ -1877,6 +1879,7 @@ describe('prepareTargets', () => {
         expr: 'up',
         headers: {
           'X-Dashboard-Id': undefined,
+          'X-Dashboard-UID': undefined,
           'X-Panel-Id': panelId,
         },
         hinting: undefined,
@@ -2038,6 +2041,7 @@ describe('prepareTargets', () => {
           expr: 'up',
           headers: {
             'X-Dashboard-Id': undefined,
+            'X-Dashboard-UID': undefined,
             'X-Panel-Id': panelId,
           },
           hinting: undefined,
@@ -2059,6 +2063,7 @@ describe('prepareTargets', () => {
           expr: 'up',
           headers: {
             'X-Dashboard-Id': undefined,
+            'X-Dashboard-UID': undefined,
             'X-Panel-Id': panelId,
           },
           hinting: undefined,
@@ -2099,6 +2104,7 @@ describe('prepareTargets', () => {
           expr: 'up',
           headers: {
             'X-Dashboard-Id': undefined,
+            'X-Dashboard-UID': undefined,
             'X-Panel-Id': panelId,
           },
           hinting: undefined,
@@ -2135,6 +2141,7 @@ describe('prepareTargets', () => {
         expr: 'up',
         headers: {
           'X-Dashboard-Id': undefined,
+          'X-Dashboard-UID': undefined,
           'X-Panel-Id': panelId,
         },
         hinting: undefined,

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -146,6 +146,7 @@ export class PrometheusDatasource
     const proxyMode = !this.url.match(/^http/);
     if (proxyMode) {
       httpOptions.headers['X-Dashboard-Id'] = options.dashboardId;
+      httpOptions.headers['X-Dashboard-UID'] = options.dashboardUID;
       httpOptions.headers['X-Panel-Id'] = options.panelId;
     }
   }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This change adds a new header( `X-Dashboard-UID` ) . The use of dashboardId should be replace by using dashboardUID to support [backend migration](https://github.com/grafana/grafana/issues/48331f)  of the new search feature

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #52863 

**Special notes for your reviewer**:
- As per discussion with @itsmylife  and @aocenas ,`_addTracingHeaders` will be deprecated later. So I'm not sure which one will be deprecated first between dashboardId or this method. Just to support both migrations, I have included the `dashboardUID` in the headers and the backend can consume it later whenever they need it.

