### PR TITLE
Access Control: Set permissions for Grafana's test data source

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"fmt"
+	
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -8,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/tsdb/grafanads"
 )
 
 // API related actions
@@ -96,6 +99,27 @@ func (hs *HTTPServer) declareFixedRoles() error {
 			},
 		},
 		Grants: []string{string(models.ROLE_ADMIN)},
+	}
+
+	builtInDatasourceReader := ac.RoleRegistration{
+		Role: ac.RoleDTO{
+			Name:        "fixed:datasources.builtin:reader",
+			DisplayName: "Built in data source reader",
+			Description: "Read and query Grafana's built in test data sources.",
+			Group:       "Data sources",
+			Permissions: []ac.Permission{
+				{
+					Action: datasources.ActionRead,
+					Scope:  fmt.Sprintf("%s%s", datasources.ScopePrefix, grafanads.DatasourceUID),
+				},
+				{
+					Action: datasources.ActionQuery,
+					Scope:  fmt.Sprintf("%s%s", datasources.ScopePrefix, grafanads.DatasourceUID),
+				},
+			},
+			Hidden: true,
+		},
+		Grants: []string{string(models.ROLE_VIEWER)},
 	}
 
 	// when running oss or enterprise without a license all users should be able to query data sources
@@ -395,7 +419,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 	}
 
 	return hs.AccessControl.DeclareFixedRoles(
-		provisioningWriterRole, datasourcesReaderRole, datasourcesWriterRole,
+		provisioningWriterRole, datasourcesReaderRole, builtInDatasourceReader, datasourcesWriterRole,
 		datasourcesIdReaderRole, orgReaderRole, orgWriterRole,
 		orgMaintainerRole, teamsCreatorRole, teamsWriterRole, datasourcesExplorerRole,
 		annotationsReaderRole, dashboardAnnotationsWriterRole, annotationsWriterRole,

--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"fmt"
-	
+
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/plugins"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows all users to view and query Grafana's built-in test data source. Otherwise users who did not have query access to any other data sources would not be able to query the test data source, as [we require](https://github.com/grafana/grafana/blob/v9.1.x/pkg/api/api.go#L482) `datasources:query` permission to access `POST /ds/query` endpoint.

This fix introduces a hidden role that grants everyone read and query access to Grafana's built in test data source.

**Special notes for your reviewer**:
I think we've had this bug for a while, but for some reason it wasn't as prominent in 9.0.x. I couldn't pinpoint the exact change that made it show up more in the UI in 9.1.x, but this seems to fix the problem.
