### PR TITLE
Alerting: Fix migration failure

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/permissions.go
+++ b/pkg/services/sqlstore/migrations/ualert/permissions.go
@@ -45,6 +45,8 @@ type dashboardACL struct {
 	Updated time.Time
 }
 
+func (p dashboardACL) TableName() string { return "dashboard_acl" }
+
 type folderHelper struct {
 	sess *xorm.Session
 	mg   *migrator.Migrator

--- a/pkg/services/sqlstore/migrations/ualert/ualert.go
+++ b/pkg/services/sqlstore/migrations/ualert/ualert.go
@@ -315,7 +315,7 @@ func (m *migration) Exec(sess *xorm.Session, mg *migrator.Migrator) error {
 				err = folderHelper.setACL(f.OrgId, f.Id, permissions)
 				if err != nil {
 					return MigrationError{
-						Err:     fmt.Errorf("failed to set folder %d under organisation %d permissions: %w", folder.Id, folder.OrgId, err),
+						Err:     fmt.Errorf("failed to set folder %d under organisation %d permissions: %w", f.Id, f.OrgId, err),
 						AlertId: da.Id,
 					}
 				}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
While I reviewed another PR I discovered two issues with the alerting migration:
* `nil pointer dereference` because [folder](https://github.com/grafana/grafana/blob/9d6faa7e9af7b840a4e5b641f32029aacc090f44/pkg/services/sqlstore/migrations/ualert/ualert.go#L318) was `nil`
* `ERROR[08-03|18:16:18] Executing migration failed               logger=migrator id="move dashboard alerts to unified alerting" error="failed to migrate alert 9: failed to set folder 1674 under organisation 1 permissions: no such table: dashboard_a_c_l"`; this was introduced when this model renamed from `dashboardAcl` to `dashboardACL` and affects `9.1.x`

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
To reproduce one has to force the migration to re-run [by rolling back to the legacy alerting](https://grafana.com/docs/grafana/latest/alerting/migrating-alerts/roll-back/) and then [enable Grafana alerting](https://grafana.com/docs/grafana/latest/alerting/migrating-alerts/opt-in/)