### PR TITLE
Loki: Fix producing correct log volume query for query with comments

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -44,12 +44,18 @@ import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_sr
 import { serializeParams } from '../../../core/utils/fetch';
 import { renderLegendFormat } from '../prometheus/legend';
 
-import { addLabelFormatToQuery, addLabelToQuery, addNoPipelineErrorToQuery, addParserToQuery } from './addToQuery';
 import { transformBackendResult } from './backendResultTransformer';
 import { LokiAnnotationsQueryEditor } from './components/AnnotationsQueryEditor';
 import LanguageProvider from './language_provider';
 import { escapeLabelValueInSelector } from './language_utils';
 import { LiveStreams, LokiLiveTarget } from './live_streams';
+import {
+  addLabelFormatToQuery,
+  addLabelToQuery,
+  addNoPipelineErrorToQuery,
+  addParserToQuery,
+  removeCommentsFromQuery,
+} from './modifyQuery';
 import { getQueryHints } from './queryHints';
 import { getNormalizedLokiQuery, isLogsQuery, isValidQuery } from './query_utils';
 import { sortDataFrameByTime } from './sortDataFrame';
@@ -119,11 +125,12 @@ export class LokiDatasource
 
     const logsVolumeRequest = cloneDeep(request);
     logsVolumeRequest.targets = logsVolumeRequest.targets.filter(isQuerySuitable).map((target) => {
+      const query = removeCommentsFromQuery(target.expr);
       return {
         ...target,
         instant: false,
         volumeQuery: true,
-        expr: `sum by (level) (count_over_time(${target.expr}[$__interval]))`,
+        expr: `sum by (level) (count_over_time(${query}[$__interval]))`,
       };
     });
 

--- a/public/app/plugins/datasource/loki/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.test.ts
@@ -248,11 +248,29 @@ describe('removeCommentsFromQuery', () => {
       removeCommentsFromQuery('{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl #hello')
     ).toBe('{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl ');
   });
+
+  it('returns original query if no comments in log queries', () => {
+    expect(removeCommentsFromQuery('{job="grafana"}')).toBe('{job="grafana"}');
+    expect(removeCommentsFromQuery('{job="grafana"} | logfmt')).toBe('{job="grafana"} | logfmt');
+    expect(removeCommentsFromQuery('{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl')).toBe(
+      '{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl'
+    );
+  });
+
   it('strips comments in metrics queries', () => {
     expect(removeCommentsFromQuery('count_over_time({job="grafana"}[10m])#hello')).toBe(
       'count_over_time({job="grafana"}[10m])'
     );
     expect(removeCommentsFromQuery('count_over_time({job="grafana"} | logfmt[10m])#hello')).toBe(
+      'count_over_time({job="grafana"} | logfmt[10m])'
+    );
+  });
+
+  it('returns original query if no comments in metrics query', () => {
+    expect(removeCommentsFromQuery('count_over_time({job="grafana"}[10m])')).toBe(
+      'count_over_time({job="grafana"}[10m])'
+    );
+    expect(removeCommentsFromQuery('count_over_time({job="grafana"} | logfmt[10m])')).toBe(
       'count_over_time({job="grafana"} | logfmt[10m])'
     );
   });

--- a/public/app/plugins/datasource/loki/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.test.ts
@@ -1,4 +1,10 @@
-import { addLabelFormatToQuery, addLabelToQuery, addNoPipelineErrorToQuery, addParserToQuery } from './addToQuery';
+import {
+  addLabelFormatToQuery,
+  addLabelToQuery,
+  addNoPipelineErrorToQuery,
+  addParserToQuery,
+  removeCommentsFromQuery,
+} from './modifyQuery';
 
 describe('addLabelToQuery()', () => {
   it('should add label to simple query', () => {
@@ -230,6 +236,24 @@ describe('addLabelFormatToQuery', () => {
       )
     ).toBe(
       'rate({job="grafana"} | logfmt | label_format a=b | label_format level=lvl [5m]) + rate({job="grafana"} | logfmt | label_format a=b | label_format level=lvl [5m])'
+    );
+  });
+});
+
+describe('removeCommentsFromQuery', () => {
+  it('strips comments in log queries', () => {
+    expect(removeCommentsFromQuery('{job="grafana"}#hello')).toBe('{job="grafana"}');
+    expect(removeCommentsFromQuery('{job="grafana"} | logfmt #hello')).toBe('{job="grafana"} | logfmt ');
+    expect(
+      removeCommentsFromQuery('{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl #hello')
+    ).toBe('{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl ');
+  });
+  it('strips comments in metrics queries', () => {
+    expect(removeCommentsFromQuery('count_over_time({job="grafana"}[10m])#hello')).toBe(
+      'count_over_time({job="grafana"}[10m])'
+    );
+    expect(removeCommentsFromQuery('count_over_time({job="grafana"} | logfmt[10m])#hello')).toBe(
+      'count_over_time({job="grafana"} | logfmt[10m])'
     );
   });
 });

--- a/public/app/plugins/datasource/loki/modifyQuery.test.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.test.ts
@@ -241,37 +241,39 @@ describe('addLabelFormatToQuery', () => {
 });
 
 describe('removeCommentsFromQuery', () => {
-  it('strips comments in log queries', () => {
-    expect(removeCommentsFromQuery('{job="grafana"}#hello')).toBe('{job="grafana"}');
-    expect(removeCommentsFromQuery('{job="grafana"} | logfmt #hello')).toBe('{job="grafana"} | logfmt ');
-    expect(
-      removeCommentsFromQuery('{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl #hello')
-    ).toBe('{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl ');
+  it.each`
+    query                                                                             | expectedResult
+    ${'{job="grafana"}#hello'}                                                        | ${'{job="grafana"}'}
+    ${'{job="grafana"} | logfmt #hello'}                                              | ${'{job="grafana"} | logfmt '}
+    ${'{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl #hello'} | ${'{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl '}
+  `('strips comments in log query:  {$query}', ({ query, expectedResult }) => {
+    expect(removeCommentsFromQuery(query)).toBe(expectedResult);
   });
 
-  it('returns original query if no comments in log queries', () => {
-    expect(removeCommentsFromQuery('{job="grafana"}')).toBe('{job="grafana"}');
-    expect(removeCommentsFromQuery('{job="grafana"} | logfmt')).toBe('{job="grafana"} | logfmt');
-    expect(removeCommentsFromQuery('{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl')).toBe(
-      '{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl'
-    );
+  it.each`
+    query                                                                      | expectedResult
+    ${'{job="grafana"}'}                                                       | ${'{job="grafana"}'}
+    ${'{job="grafana"} | logfmt'}                                              | ${'{job="grafana"} | logfmt'}
+    ${'{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl'} | ${'{job="grafana", bar="baz"} |="test" | logfmt | label_format level=lvl'}
+  `('returns original query if no comments in log query:  {$query}', ({ query, expectedResult }) => {
+    expect(removeCommentsFromQuery(query)).toBe(expectedResult);
   });
 
-  it('strips comments in metrics queries', () => {
-    expect(removeCommentsFromQuery('count_over_time({job="grafana"}[10m])#hello')).toBe(
-      'count_over_time({job="grafana"}[10m])'
-    );
-    expect(removeCommentsFromQuery('count_over_time({job="grafana"} | logfmt[10m])#hello')).toBe(
-      'count_over_time({job="grafana"} | logfmt[10m])'
-    );
+  it.each`
+    query                                                       | expectedResult
+    ${'count_over_time({job="grafana"}[10m])#hello'}            | ${'count_over_time({job="grafana"}[10m])'}
+    ${'count_over_time({job="grafana"} | logfmt[10m])#hello'}   | ${'count_over_time({job="grafana"} | logfmt[10m])'}
+    ${'rate({job="grafana"} | logfmt | foo="bar" [10m])#hello'} | ${'rate({job="grafana"} | logfmt | foo="bar" [10m])'}
+  `('strips comments in metrics query:  {$query}', ({ query, expectedResult }) => {
+    expect(removeCommentsFromQuery(query)).toBe(expectedResult);
   });
 
-  it('returns original query if no comments in metrics query', () => {
-    expect(removeCommentsFromQuery('count_over_time({job="grafana"}[10m])')).toBe(
-      'count_over_time({job="grafana"}[10m])'
-    );
-    expect(removeCommentsFromQuery('count_over_time({job="grafana"} | logfmt[10m])')).toBe(
-      'count_over_time({job="grafana"} | logfmt[10m])'
-    );
+  it.each`
+    query                                                     | expectedResult
+    ${'count_over_time({job="grafana"}[10m])#hello'}          | ${'count_over_time({job="grafana"}[10m])'}
+    ${'count_over_time({job="grafana"} | logfmt[10m])#hello'} | ${'count_over_time({job="grafana"} | logfmt[10m])'}
+    ${'rate({job="grafana"} | logfmt | foo="bar" [10m])'}     | ${'rate({job="grafana"} | logfmt | foo="bar" [10m])'}
+  `('returns original query if no comments in metrics query:  {$query}', ({ query, expectedResult }) => {
+    expect(removeCommentsFromQuery(query)).toBe(expectedResult);
   });
 });

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -104,7 +104,7 @@ export function removeCommentsFromQuery(query: string): string {
   let newQuery = '';
   let prev = 0;
 
-  for (const lineCommentPosition of lineCommentPositions) {
+  for (let lineCommentPosition of lineCommentPositions) {
     const beforeComment = query.substring(prev, lineCommentPosition.from);
     const afterComment = query.substring(lineCommentPosition.to);
 

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -98,6 +98,11 @@ export function addLabelFormatToQuery(query: string, labelFormat: { originalLabe
  */
 export function removeCommentsFromQuery(query: string): string {
   const lineCommentPositions = getLineCommentPositions(query);
+
+  if (!lineCommentPositions.length) {
+    return query;
+  }
+
   let newQuery = '';
   let prev = 0;
 

--- a/public/app/plugins/datasource/loki/modifyQuery.ts
+++ b/public/app/plugins/datasource/loki/modifyQuery.ts
@@ -93,8 +93,6 @@ export function addLabelFormatToQuery(query: string, labelFormat: { originalLabe
 /**
  * Removes all comments from query.
  * It uses  LogQL parser to find all LineComments and removes them.
- *
- * @param query
  */
 export function removeCommentsFromQuery(query: string): string {
   const lineCommentPositions = getLineCommentPositions(query);
@@ -106,13 +104,12 @@ export function removeCommentsFromQuery(query: string): string {
   let newQuery = '';
   let prev = 0;
 
-  for (let i = 0; i < lineCommentPositions.length; i++) {
-    const match = lineCommentPositions[i];
-    const beforeComment = query.substring(prev, match.from);
-    const afterComment = query.substring(match.to);
+  for (const lineCommentPosition of lineCommentPositions) {
+    const beforeComment = query.substring(prev, lineCommentPosition.from);
+    const afterComment = query.substring(lineCommentPosition.to);
 
     newQuery += beforeComment + afterComment;
-    prev = match.to;
+    prev = lineCommentPosition.to;
   }
   return newQuery;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When using Loki in Explore, we are creating log volume (metrics) query based on user-typed log query. As mentioned in https://github.com/grafana/grafana/issues/53001, if the log query includes **comments**, the resulting query is incorrect.

In this PR, before creating metrics query, we are removing comments from log query and after that create log volume query. To remove comments, we use `lezer-logql` parser, find all occurrences of `LineComment` and then just remove it from query.

As a part of this PR I have renamed `addToQuery` file to `modifyQuery` as we are both adding and removing now. 

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/53001

**Special notes for your reviewer**:
To test this:
1. Run loki datasource `make devenv sources=loki`
2. In Explore, run any log query (e.g. `{source="data"}` or get inspired by queries in test) with or without comment (comments start with `#`)
3. Every log query with comments should produce log query without comment (you can always check it out in network tab and/or in panel inspector)

Fixed:

https://user-images.githubusercontent.com/30407135/182643376-537f9262-f597-4798-9b49-d80a6f4a3dc1.mov


Previously (current behavior on main):


https://user-images.githubusercontent.com/30407135/182643299-f5a1e75d-1493-4a66-9097-2a9cc803ce5d.mov

