### PR TITLE
Alerting: Fix alert detail layout issue

### DIFF
--- a/public/app/features/alerting/unified/components/AnnotationDetailsField.tsx
+++ b/public/app/features/alerting/unified/components/AnnotationDetailsField.tsx
@@ -58,7 +58,7 @@ const AnnotationValue: FC<Props> = ({ annotationKey, value }) => {
 
 export const getStyles = (theme: GrafanaTheme) => ({
   well: css`
-    word-break: break-all;
+    word-break: break-word;
   `,
   link: css`
     word-break: break-all;

--- a/public/app/features/alerting/unified/components/Tokenize.tsx
+++ b/public/app/features/alerting/unified/components/Tokenize.tsx
@@ -18,7 +18,6 @@ function Tokenize({ input, delimiter = ['{{', '}}'] }: TokenizerProps) {
   const styles = useStyles2(getStyles);
 
   const [open, close] = delimiter;
-  const normalizedIput = normalizeInput(input);
 
   /**
    * This RegExp uses 2 named capture groups, text that comes before the token and the token itself
@@ -28,7 +27,7 @@ function Tokenize({ input, delimiter = ['{{', '}}'] }: TokenizerProps) {
    *  Some text {{ $labels.foo }}
    */
   const regex = new RegExp(`(?<before>.*?)(${open}(?<token>.*?)${close}|$)`, 'gm');
-  const lines = normalizedIput.split('\n');
+  const lines = input.split('\n');
 
   const output: React.ReactElement[] = [];
 
@@ -93,10 +92,6 @@ function Token({ content, description, type }: TokenProps) {
       </span>
     </HoverCard>
   );
-}
-
-function normalizeInput(input: string) {
-  return input.replace(/[^\S\r\n]+/g, ' ').trim();
 }
 
 function isVariable(input: string) {

--- a/public/app/features/alerting/unified/components/Tokenize.tsx
+++ b/public/app/features/alerting/unified/components/Tokenize.tsx
@@ -28,26 +28,31 @@ function Tokenize({ input, delimiter = ['{{', '}}'] }: TokenizerProps) {
    *  Some text {{ $labels.foo }}
    */
   const regex = new RegExp(`(?<before>.*?)(${open}(?<token>.*?)${close}|$)`, 'gm');
-
-  const matches = Array.from(normalizedIput.matchAll(regex));
+  const lines = normalizedIput.split('\n');
 
   const output: React.ReactElement[] = [];
 
-  matches.forEach((match, index) => {
-    const before = match.groups?.before;
-    const token = match.groups?.token?.trim();
+  lines.forEach((line) => {
+    const matches = Array.from(line.matchAll(regex));
 
-    if (before) {
-      output.push(<span key={`${index}-before`}>{before}</span>);
-    }
+    matches.forEach((match, index) => {
+      const before = match.groups?.before;
+      const token = match.groups?.token?.trim();
 
-    if (token) {
-      const type = tokenType(token);
-      const description = type === TokenType.Variable ? token : '';
-      const tokenContent = `${open} ${token} ${close}`;
+      if (before) {
+        output.push(<span key={`${index}-before`}>{before}</span>);
+      }
 
-      output.push(<Token key={`${index}-token`} content={tokenContent} type={type} description={description} />);
-    }
+      if (token) {
+        const type = tokenType(token);
+        const description = type === TokenType.Variable ? token : '';
+        const tokenContent = `${open} ${token} ${close}`;
+
+        output.push(<Token key={`${index}-token`} content={tokenContent} type={type} description={description} />);
+      }
+    });
+
+    output.push(<br />);
   });
 
   return <span className={styles.wrapper}>{output}</span>;
@@ -68,7 +73,8 @@ interface TokenProps {
 
 function Token({ content, description, type }: TokenProps) {
   const styles = useStyles2(getStyles);
-  const varName = content.trim();
+  // const varName = content.trim();
+  const varName = content;
 
   const disableCard = Boolean(type) === false;
 
@@ -90,7 +96,7 @@ function Token({ content, description, type }: TokenProps) {
 }
 
 function normalizeInput(input: string) {
-  return input.replace(/\s+/g, ' ').trim();
+  return input.replace(/[^\S\r\n]+/g, ' ').trim();
 }
 
 function isVariable(input: string) {
@@ -122,9 +128,7 @@ function tokenType(input: string) {
 
 const getStyles = (theme: GrafanaTheme2) => ({
   wrapper: css`
-    display: inline-flex;
-    align-items: center;
-    white-space: pre;
+    white-space: pre-wrap;
   `,
   token: css`
     cursor: default;

--- a/public/app/features/alerting/unified/components/Tokenize.tsx
+++ b/public/app/features/alerting/unified/components/Tokenize.tsx
@@ -72,8 +72,6 @@ interface TokenProps {
 
 function Token({ content, description, type }: TokenProps) {
   const styles = useStyles2(getStyles);
-  // const varName = content.trim();
-  const varName = content;
 
   const disableCard = Boolean(type) === false;
 
@@ -88,7 +86,7 @@ function Token({ content, description, type }: TokenProps) {
       }
     >
       <span>
-        <Badge className={styles.token} text={varName} color={'blue'} />
+        <Badge className={styles.token} text={content} color={'blue'} />
       </span>
     </HoverCard>
   );

--- a/public/app/features/alerting/unified/components/Tokenize.tsx
+++ b/public/app/features/alerting/unified/components/Tokenize.tsx
@@ -31,7 +31,7 @@ function Tokenize({ input, delimiter = ['{{', '}}'] }: TokenizerProps) {
 
   const output: React.ReactElement[] = [];
 
-  lines.forEach((line) => {
+  lines.forEach((line, index) => {
     const matches = Array.from(line.matchAll(regex));
 
     matches.forEach((match, index) => {
@@ -51,7 +51,7 @@ function Tokenize({ input, delimiter = ['{{', '}}'] }: TokenizerProps) {
       }
     });
 
-    output.push(<br />);
+    output.push(<br key={`${index}-newline`} />);
   });
 
   return <span className={styles.wrapper}>{output}</span>;


### PR DESCRIPTION
This would push certain elements beyond their parent container if the description / summary of an alert was really long

**before**
<img width="1382" alt="image" src="https://user-images.githubusercontent.com/868844/182655384-90dd0cc5-0449-4b3f-bf7f-86dd87d3613d.png">


**after**
<img width="1312" alt="image" src="https://user-images.githubusercontent.com/868844/182656133-a6aece22-21db-4d10-8931-1160b07719e9.png">

**Special notes for your reviewer**:

Additionally this preserves newlines when tokenize-ing the description of alert rules, whereas previously it would normalize the entire input.

