### PR TITLE
TeamSync: Add orgs specifier to LDAP debug

### DIFF
--- a/pkg/services/ldap/ldap_groups.go
+++ b/pkg/services/ldap/ldap_groups.go
@@ -3,7 +3,7 @@ package ldap
 import "github.com/grafana/grafana/pkg/models"
 
 type Groups interface {
-	GetTeams(groups []string) ([]models.TeamOrgGroupDTO, error)
+	GetTeams(groups []string, orgIDs []int64) ([]models.TeamOrgGroupDTO, error)
 }
 
 type OSSGroups struct{}
@@ -12,6 +12,6 @@ func ProvideGroupsService() *OSSGroups {
 	return &OSSGroups{}
 }
 
-func (*OSSGroups) GetTeams(_ []string) ([]models.TeamOrgGroupDTO, error) {
+func (*OSSGroups) GetTeams(_ []string, _ []int64) ([]models.TeamOrgGroupDTO, error) {
 	return nil, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add orgs specifier to LDAP debug

