### PR TITLE
[v9.0.x] Geomap: Fix tooltip offset bug

### DIFF
--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -355,8 +355,8 @@ export class GeomapPanel extends Component<Props, State> {
     const hover = toLonLat(this.map.getCoordinateFromPixel(pixel));
 
     const { hoverPayload } = this;
-    hoverPayload.pageX = mouse.pageX;
-    hoverPayload.pageY = mouse.pageY;
+    hoverPayload.pageX = mouse.offsetX;
+    hoverPayload.pageY = mouse.offsetY;
     hoverPayload.point = {
       lat: hover[1],
       lon: hover[0],


### PR DESCRIPTION
What this PR does / why we need it:
Tooltip offset bug fixed for 9.1.0 needs to be back-ported to 9.0.x due to escalation.

Fixes #53270 #52602 