### PR TITLE
Chore: Enable ANSI_QUOTES for Mysql Database

### DIFF
--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -281,6 +281,10 @@ func (ss *SQLStore) buildConnectionString() (string, error) {
 			cnnstr += fmt.Sprintf("&tx_isolation=%s", val)
 		}
 
+		if ss.Cfg.IsFeatureToggleEnabled("mysqlAnsiQuotes") {
+			cnnstr += "&sql_mode='ANSI_QUOTES'"
+		}
+
 		cnnstr += ss.buildExtraConnectionString('&')
 	case migrator.Postgres:
 		addr, err := util.SplitHostPortDefault(ss.dbCfg.Host, "127.0.0.1", "5432")

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -72,6 +72,12 @@ var sqlStoreTestCases = []sqlStoreTest{
 		dbURL: "://invalid.com/",
 		err:   &url.Error{Op: "parse", URL: "://invalid.com/", Err: errors.New("missing protocol scheme")},
 	},
+	{
+		name:          "Sql mode set to ANSI_QUOTES",
+		dbType:        "mysql",
+		dbHost:        "[::1]",
+		connStrValues: []string{"sql_mode='ANSI_QUOTES'"},
+	},
 }
 
 func TestIntegrationSQLConnectionString(t *testing.T) {
@@ -111,6 +117,8 @@ func makeSQLStoreTestConfig(t *testing.T, dbType, host, dbURL string) *setting.C
 	require.NoError(t, err)
 	_, err = sec.NewKey("password", "pass")
 	require.NoError(t, err)
+
+	cfg.IsFeatureToggleEnabled = func(key string) bool { return true }
 
 	return cfg
 }

--- a/pkg/services/sqlstore/sqlutil/sqlutil.go
+++ b/pkg/services/sqlstore/sqlutil/sqlutil.go
@@ -30,7 +30,7 @@ func MySQLTestDB() TestDB {
 	}
 	return TestDB{
 		DriverName: "mysql",
-		ConnStr:    fmt.Sprintf("grafana:password@tcp(%s:%s)/grafana_tests?collation=utf8mb4_unicode_ci", host, port),
+		ConnStr:    fmt.Sprintf("grafana:password@tcp(%s:%s)/grafana_tests?collation=utf8mb4_unicode_ci&sql_mode='ANSI_QUOTES'", host, port),
 	}
 }
 

--- a/pkg/services/sqlstore/sqlutil/sqlutil.go
+++ b/pkg/services/sqlstore/sqlutil/sqlutil.go
@@ -28,9 +28,13 @@ func MySQLTestDB() TestDB {
 	if port == "" {
 		port = "3306"
 	}
+	conn_str := fmt.Sprintf("grafana:password@tcp(%s:%s)/grafana_tests?collation=utf8mb4_unicode_ci", host, port)
+	if _, present := os.LookupEnv("MYSQL_ANSI_QUOTES"); present {
+		conn_str += "&sql_mode='ANSI_QUOTES'"
+	}
 	return TestDB{
 		DriverName: "mysql",
-		ConnStr:    fmt.Sprintf("grafana:password@tcp(%s:%s)/grafana_tests?collation=utf8mb4_unicode_ci&sql_mode='ANSI_QUOTES'", host, port),
+		ConnStr:    conn_str,
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
Activation [PR](https://github.com/grafana/deployment_tools/pull/38705/files)

**How to test**:
`make devenv sources="mysql_tests"`

in custom.ini do following change to use mysql db
```
[feature_toggles]
enable = mysqlAnsiQuotes

[database]
type = mysql
host = 127.0.0.1:3306
name = grafana_tests
user = grafana
password = password
```

start Grafana on frontend and backend, since the change should be backward compatible, nothing should fails.