### PR TITLE
GrafanaUI: Render PageToolbar's leftItems regardless of title's presence

### DIFF
--- a/packages/grafana-ui/src/components/PageLayout/PageToolbar.test.tsx
+++ b/packages/grafana-ui/src/components/PageLayout/PageToolbar.test.tsx
@@ -5,17 +5,9 @@ import { PageToolbar } from '..';
 
 describe('PageToolbar', () => {
   it('renders left items when title is not set', () => {
-    const testId = 'left-item';
-    render(
-      <PageToolbar
-        leftItems={[
-          <div key="left-item" data-testid={testId}>
-            Left Item!
-          </div>,
-        ]}
-      />
-    );
+    const leftItemContent = 'Left Item!';
+    render(<PageToolbar leftItems={[<div key="left-item">{leftItemContent}</div>]} />);
 
-    expect(screen.getByTestId(testId)).toBeInTheDocument();
+    expect(screen.getByText(leftItemContent)).toBeInTheDocument();
   });
 });

--- a/packages/grafana-ui/src/components/PageLayout/PageToolbar.test.tsx
+++ b/packages/grafana-ui/src/components/PageLayout/PageToolbar.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { PageToolbar } from '..';
+
+describe('PageToolbar', () => {
+  it('renders left items when title is not set', () => {
+    const testId = 'left-item';
+    render(
+      <PageToolbar
+        leftItems={[
+          <div key="left-item" data-testid={testId}>
+            Left Item!
+          </div>,
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId(testId)).toBeInTheDocument();
+  });
+});

--- a/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
+++ b/packages/grafana-ui/src/components/PageLayout/PageToolbar.tsx
@@ -61,12 +61,6 @@ export const PageToolbar: FC<Props> = React.memo(
       className
     );
 
-    const leftItemChildren = leftItems?.map((child, index) => (
-      <div className={styles.leftActionItem} key={index}>
-        {child}
-      </div>
-    ));
-
     const titleEl = (
       <>
         <span className={styles.noLinkTitle}>{title}</span>
@@ -112,22 +106,29 @@ export const PageToolbar: FC<Props> = React.memo(
               </>
             )}
 
-            {title && (
+            {(title || leftItems?.length) && (
               <div className={styles.titleWrapper}>
-                <h1 className={styles.h1Styles}>
-                  {titleHref ? (
-                    <Link
-                      aria-label="Search dashboard by name"
-                      className={cx(styles.titleText, styles.titleLink)}
-                      href={titleHref}
-                    >
-                      {titleEl}
-                    </Link>
-                  ) : (
-                    <div className={styles.titleText}>{titleEl}</div>
-                  )}
-                </h1>
-                {leftItemChildren}
+                {title && (
+                  <h1 className={styles.h1Styles}>
+                    {titleHref ? (
+                      <Link
+                        aria-label="Search dashboard by name"
+                        className={cx(styles.titleText, styles.titleLink)}
+                        href={titleHref}
+                      >
+                        {titleEl}
+                      </Link>
+                    ) : (
+                      <div className={styles.titleText}>{titleEl}</div>
+                    )}
+                  </h1>
+                )}
+
+                {leftItems?.map((child, index) => (
+                  <div className={styles.leftActionItem} key={index}>
+                    {child}
+                  </div>
+                ))}
               </div>
             )}
           </nav>


### PR DESCRIPTION
A recent change to PageToolbar made it stop rendering leftItems when the title was not set.

This PR changes it so leftItems are rendered regardless of title's presence.