### PR TITLE
Adding hint about not being mandatory

### DIFF
--- a/docs/sources/developers/http_api/data_source.md
+++ b/docs/sources/developers/http_api/data_source.md
@@ -743,7 +743,7 @@ Content-Type: application/json
 
 `GET /api/datasources/uid/:uid/health`
 
-Makes a call to the health endpoint of data source identified by the given `uid`.
+Makes a call to the health endpoint of data source identified by the given `uid`. This is not mandatory - every plugin author has to <a href="https://grafana.com/tutorials/build-a-data-source-backend-plugin/#add-support-for-health-checks" target="_blank">implement support for health checks</a> in their plugin themselves.
 
 ### Examples
 

--- a/docs/sources/developers/http_api/data_source.md
+++ b/docs/sources/developers/http_api/data_source.md
@@ -714,7 +714,7 @@ Proxies all calls to the actual data source identified by the `uid`.
 
 `GET /api/datasources/:datasourceId/health`
 
-Makes a call to the health endpoint of data source identified by the given `dashboardId`.
+Makes a call to the health endpoint of data source identified by the given `datasourceId`. This is not mandatory - every plugin author has to <a href="https://grafana.com/tutorials/build-a-data-source-backend-plugin/#add-support-for-health-checks" target="_blank">implement support for health checks</a> in their plugin themselves.
 
 ### Examples
 


### PR DESCRIPTION
Improves this part of documentation to make it more explicit on how health checks in datasources work: https://grafana.com/docs/grafana/latest/developers/http_api/data_source/#check-data-source-health