### PR TITLE
BarGauge: Show empty bar when value, minValue and maxValue are all equal

### DIFF
--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.test.tsx
@@ -159,6 +159,10 @@ describe('BarGauge', () => {
     it('-30 to 30 and value 30', () => {
       expect(getValuePercent(30, -30, 30)).toEqual(1);
     });
+
+    it('returns 0 if the min, max and value are all the same value', () => {
+      expect(getValuePercent(25, 25, 25)).toEqual(0);
+    });
   });
 
   describe('Vertical bar', () => {

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -430,7 +430,12 @@ export function getCellColor(
 }
 
 export function getValuePercent(value: number, minValue: number, maxValue: number): number {
-  return Math.min((value - minValue) / (maxValue - minValue), 1);
+  // Need special logic for when minValue === maxValue === value to prevent returning NaN
+  if (maxValue === minValue && maxValue === value) {
+    return 0;
+  } else {
+    return Math.min((value - minValue) / (maxValue - minValue), 1);
+  }
 }
 
 /**

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -431,11 +431,8 @@ export function getCellColor(
 
 export function getValuePercent(value: number, minValue: number, maxValue: number): number {
   // Need special logic for when minValue === maxValue === value to prevent returning NaN
-  if (maxValue === minValue && maxValue === value) {
-    return 0;
-  } else {
-    return Math.min((value - minValue) / (maxValue - minValue), 1);
-  }
+  const valueRatio = Math.min((value - minValue) / (maxValue - minValue), 1);
+  return isNaN(valueRatio) ? 0 : valueRatio;
 }
 
 /**


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- if `value`, `minValue` and `maxValue` are all the same, then `getValuePercent` returns `NaN`: https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx#L432
- this means that the bar stays at the width of the previous value.
- one way to hit this is to have a `BarGauge` with a value, then restrict the time range so that there are no datapoints.
- this results in `value`, `minValue` and `maxValue` all being 0.
- instead, let's just return 0 in this special case.
  - this makes the most sense from the "no datapoints" scenario, and is probably better than returning `NaN` anyway.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/39210

**Special notes for your reviewer**:

