### PR TITLE
PromQL: Add placeholder text to editor

### DIFF
--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -303,6 +303,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
                     onChange={this.onChangeQuery}
                     onRunQuery={this.props.onRunQuery}
                     initialValue={query.expr ?? ''}
+                    placeholder="Enter a PromQL query…"
                   />
                 </div>
               </div>

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryField.tsx
@@ -70,11 +70,18 @@ function ensurePromQL(monaco: Monaco) {
   }
 }
 
-const getStyles = (theme: GrafanaTheme2) => {
+const getStyles = (theme: GrafanaTheme2, placeholder: string) => {
   return {
     container: css`
       border-radius: ${theme.shape.borderRadius()};
       border: 1px solid ${theme.components.input.borderColor};
+    `,
+    placeholder: css`
+      ::after {
+        content: '${placeholder}';
+        font-family: ${theme.typography.fontFamilyMonospace};
+        opacity: 0.3;
+      }
     `,
   };
 };
@@ -83,7 +90,7 @@ const MonacoQueryField = (props: Props) => {
   // we need only one instance of `overrideServices` during the lifetime of the react component
   const overrideServicesRef = useRef(getOverrideServices());
   const containerRef = useRef<HTMLDivElement>(null);
-  const { languageProvider, history, onBlur, onRunQuery, initialValue } = props;
+  const { languageProvider, history, onBlur, onRunQuery, initialValue, placeholder } = props;
 
   const lpRef = useLatest(languageProvider);
   const historyRef = useLatest(history);
@@ -93,7 +100,7 @@ const MonacoQueryField = (props: Props) => {
   const autocompleteDisposeFun = useRef<(() => void) | null>(null);
 
   const theme = useTheme2();
-  const styles = getStyles(theme);
+  const styles = getStyles(theme, placeholder);
 
   useEffect(() => {
     // when we unmount, we unregister the autocomplete-function, if it was registered
@@ -200,12 +207,40 @@ const MonacoQueryField = (props: Props) => {
             onRunQueryRef.current(editor.getValue());
           });
 
-          /* Something in this configuration of monaco doesn't bubble up [mod]+K, which the 
+          /* Something in this configuration of monaco doesn't bubble up [mod]+K, which the
           command palette uses. Pass the event out of monaco manually
           */
           editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyK, function () {
             global.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
           });
+
+          if (placeholder) {
+            const placeholderDecorators = [
+              {
+                range: new monaco.Range(1, 1, 1, 1),
+                options: {
+                  className: styles.placeholder,
+                  isWholeLine: true,
+                },
+              },
+            ];
+
+            let decorators: string[] = [];
+
+            const checkDecorators: () => void = () => {
+              const model = editor.getModel();
+
+              if (!model) {
+                return;
+              }
+
+              const newDecorators = model.getValueLength() === 0 ? placeholderDecorators : [];
+              decorators = model.deltaDecorations(decorators, newDecorators);
+            };
+
+            checkDecorators();
+            editor.onDidChangeModelContent(checkDecorators);
+          }
         }}
       />
     </div>

--- a/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldProps.ts
+++ b/public/app/plugins/datasource/prometheus/components/monaco-query-field/MonacoQueryFieldProps.ts
@@ -11,6 +11,7 @@ export type Props = {
   initialValue: string;
   languageProvider: PromQlLanguageProvider;
   history: Array<HistoryItem<PromQuery>>;
+  placeholder: string;
   onRunQuery: (value: string) => void;
   onBlur: (value: string) => void;
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

While learning about Grafana through the tutorials, there was a discrepancy between the docs and application.

> In the **Query editor**, where it says _Enter a PromQL query_
> 
> — https://grafana.com/tutorials/grafana-fundamentals/

It does **not** say "Enter a PromQL query" there, which creates confusion. I can see in other editors you do include the placeholder. I'm guessing it's because things like Loki are ultimately using an `Input` field, while for Prometheus, you're using an instance of Monaco Editor. 

This adds a `placeholder` property, namely for the PromQL editor for querying Prometheus.

#### Before

![image](https://user-images.githubusercontent.com/22801583/182902384-eeb0a2ad-1842-46db-ae04-39aa19474ad0.png)

#### After

![image](https://user-images.githubusercontent.com/22801583/183018689-4d4c43ba-3b28-4bb3-a08a-0a1e0eca9c49.png)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

* Fixes https://github.com/grafana/tutorials/issues/155

**Special notes for your reviewer**:

I made the styles similar to other placeholder fields, but in general, I think it'd be nice to make the placeholders italic. Maybe something to consider in future?

## Related

* Pairs with https://github.com/grafana/tutorials/pull/184