### PR TITLE
Geomap: Do not show markers with empty coordinates

### DIFF
--- a/public/app/features/geo/format/utils.ts
+++ b/public/app/features/geo/format/utils.ts
@@ -28,6 +28,12 @@ export function pointFieldFromGeohash(geohash: Field<string>): Field<Point> {
 export function pointFieldFromLonLat(lon: Field, lat: Field): Field<Point> {
   const buffer = new Array<Point>(lon.values.length);
   for (let i = 0; i < lon.values.length; i++) {
+    const longitude = lon.values.get(i);
+    const latitude = lat.values.get(i);
+    // If longitude or latitude are null, don't add them to buffer
+    if (longitude === null || latitude === null) {
+      continue;
+    }
     buffer[i] = new Point(fromLonLat([lon.values.get(i), lat.values.get(i)]));
   }
 

--- a/public/app/features/geo/format/utils.ts
+++ b/public/app/features/geo/format/utils.ts
@@ -30,11 +30,14 @@ export function pointFieldFromLonLat(lon: Field, lat: Field): Field<Point> {
   for (let i = 0; i < lon.values.length; i++) {
     const longitude = lon.values.get(i);
     const latitude = lat.values.get(i);
+
+    // TODO: Add unit tests to thoroughly test out edge cases
     // If longitude or latitude are null, don't add them to buffer
     if (longitude === null || latitude === null) {
       continue;
     }
-    buffer[i] = new Point(fromLonLat([lon.values.get(i), lat.values.get(i)]));
+
+    buffer[i] = new Point(fromLonLat([longitude, latitude]));
   }
 
   return {


### PR DESCRIPTION
What this PR does / why we need it:
Rows of coordinate data with empty locations are being displayed at 0, 0 when tied to a marker layer.

Before:
![image](https://user-images.githubusercontent.com/60050885/182950372-9f20c179-c548-45dc-bb69-3bdf9f618d63.png)

After:
![Pasted Graphic 1](https://user-images.githubusercontent.com/60050885/182950408-d95b1e31-8c1d-4bc3-a967-5c41baa4419a.png)

Fixes #51387 