### PR TITLE
Loki: Query Editor: Cheat Sheet: revise to match docs

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiCheatSheet.tsx
@@ -16,7 +16,7 @@ const LOGQL_EXAMPLES = [
     title: 'Log pipeline',
     expression: '{job="mysql"} |= "metrics" | logfmt | duration > 10s',
     label:
-      'This query targets the MySQL job, filters out logs that don’t contain the word "metrics" and parses each log line to extract more labels and filters with them.',
+      'This query targets the MySQL job, keeps logs that contain the substring "metrics", and then parses and filters the logs further.',
   },
   {
     title: 'Count over time',


### PR DESCRIPTION
resolves #53306 

revises cheat sheet description to better match docs here:
https://grafana.com/docs/loki/latest/logql/log_queries/#line-filter-expression