### PR TITLE
Graphite Plugin: fix annotation migration regression with ref-ids

### DIFF
--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -193,17 +193,14 @@ export class GraphiteDatasource
       const streams: Array<Observable<DataQueryResponse>> = [];
 
       for (const target of options.targets) {
-        // hiding target is handled in buildGraphiteParams
-        if (target.fromAnnotations) {
-          streams.push(
-            new Observable((subscriber) => {
-              this.annotationEvents(options.range, target)
-                .then((events) => subscriber.next({ data: [toDataFrame(events)] }))
-                .catch((ex) => subscriber.error(new Error(ex)))
-                .finally(() => subscriber.complete());
-            })
-          );
-        }
+        streams.push(
+          new Observable((subscriber) => {
+            this.annotationEvents(options.range, target)
+              .then((events) => subscriber.next({ data: [toDataFrame(events)] }))
+              .catch((ex) => subscriber.error(new Error(ex)))
+              .finally(() => subscriber.complete());
+          })
+        );
       }
 
       return merge(...streams);


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/53275#issuecomment-1207260024

This is a fix for graphite queries that reference other queries by ref-id. There was a regression in the migration from angular to react for annotations. 

To test this fix:

1. write a query using a graphite datasource
      For example, query A
      `carbon.agents.a7c8a3109768-a.cache.bulk_queries1`
3. add a second query
4. reference query add in the second query
    scale(A#, 100)
