### PR TITLE
RBAC: Fix dashboard filter in SQLBuilder

### DIFF
--- a/pkg/services/alerting/store_test.go
+++ b/pkg/services/alerting/store_test.go
@@ -12,6 +12,7 @@ import (
 	dashver "github.com/grafana/grafana/pkg/services/dashboardversion"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/db"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 
 	"github.com/stretchr/testify/require"
@@ -46,6 +47,7 @@ func TestIntegrationAlertingDataAccess(t *testing.T) {
 		store = &sqlStore{
 			db:  sqlstore.InitTestDB(t),
 			log: log.New(),
+			cfg: setting.NewCfg(),
 		}
 
 		testDash = insertTestDashboard(t, store.db, "dashboard with alerts", 1, 0, false, "alert")

--- a/pkg/services/dashboards/database/acl.go
+++ b/pkg/services/dashboards/database/acl.go
@@ -102,7 +102,7 @@ func (d *DashboardStore) HasEditPermissionInFolders(ctx context.Context, query *
 			return nil
 		}
 
-		builder := &sqlstore.SQLBuilder{}
+		builder := sqlstore.NewSqlBuilder(d.sqlStore.Cfg)
 		builder.Write("SELECT COUNT(dashboard.id) AS count FROM dashboard WHERE dashboard.org_id = ? AND dashboard.is_folder = ?",
 			query.SignedInUser.OrgId, d.dialect.BooleanStr(true))
 		builder.WriteDashboardPermissionFilter(query.SignedInUser, models.PERMISSION_EDIT)
@@ -130,7 +130,7 @@ func (d *DashboardStore) HasAdminPermissionInDashboardsOrFolders(ctx context.Con
 			return nil
 		}
 
-		builder := &sqlstore.SQLBuilder{}
+		builder := sqlstore.NewSqlBuilder(d.sqlStore.Cfg)
 		builder.Write("SELECT COUNT(dashboard.id) AS count FROM dashboard WHERE dashboard.org_id = ?", query.SignedInUser.OrgId)
 		builder.WriteDashboardPermissionFilter(query.SignedInUser, models.PERMISSION_ADMIN)
 

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -223,7 +223,7 @@ func (l *LibraryElementService) deleteLibraryElement(c context.Context, signedIn
 func getLibraryElements(c context.Context, store *sqlstore.SQLStore, signedInUser *models.SignedInUser, params []Pair) ([]LibraryElementDTO, error) {
 	libraryElements := make([]LibraryElementWithMeta, 0)
 	err := store.WithDbSession(c, func(session *sqlstore.DBSession) error {
-		builder := sqlstore.SQLBuilder{}
+		builder := sqlstore.NewSqlBuilder(store.Cfg)
 		builder.Write(selectLibraryElementDTOWithMeta)
 		builder.Write(", 'General' as folder_name ")
 		builder.Write(", '' as folder_uid ")
@@ -327,7 +327,7 @@ func (l *LibraryElementService) getAllLibraryElements(c context.Context, signedI
 		return LibraryElementSearchResult{}, folderFilter.parseError
 	}
 	err := l.SQLStore.WithDbSession(c, func(session *sqlstore.DBSession) error {
-		builder := sqlstore.SQLBuilder{}
+		builder := sqlstore.NewSqlBuilder(l.Cfg)
 		if folderFilter.includeGeneralFolder {
 			builder.Write(selectLibraryElementDTOWithMeta)
 			builder.Write(", 'General' as folder_name ")
@@ -561,7 +561,7 @@ func (l *LibraryElementService) getConnections(c context.Context, signedInUser *
 			return err
 		}
 		var libraryElementConnections []libraryElementConnectionWithMeta
-		builder := sqlstore.SQLBuilder{}
+		builder := sqlstore.NewSqlBuilder(l.Cfg)
 		builder.Write("SELECT lec.*, u1.login AS created_by_name, u1.email AS created_by_email, dashboard.uid AS connection_uid")
 		builder.Write(" FROM " + models.LibraryElementConnectionTableName + " AS lec")
 		builder.Write(" LEFT JOIN " + l.SQLStore.Dialect.Quote("user") + " AS u1 ON lec.created_by = u1.id")

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -403,21 +403,20 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 		sqlStore := sqlstore.InitTestDB(t)
 		dashboardStore := database.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures())
 		features := featuremgmt.WithFeatures()
-		cfg := setting.NewCfg()
-		cfg.IsFeatureToggleEnabled = features.IsEnabled
 		ac := acmock.New()
+		sqlStore.Cfg.RBACEnabled = false
 		folderPermissions := acmock.NewMockedPermissionsService()
 		dashboardPermissions := acmock.NewMockedPermissionsService()
 		dashboardService := dashboardservice.ProvideDashboardService(
-			cfg, dashboardStore, nil,
+			sqlStore.Cfg, dashboardStore, nil,
 			features, folderPermissions, dashboardPermissions, ac,
 		)
 		guardian.InitLegacyGuardian(sqlStore, dashboardService)
 		service := LibraryElementService{
-			Cfg:      cfg,
+			Cfg:      sqlStore.Cfg,
 			SQLStore: sqlStore,
 			folderService: dashboardservice.ProvideFolderService(
-				cfg, dashboardService, dashboardStore, nil,
+				sqlStore.Cfg, dashboardService, dashboardStore, nil,
 				features, folderPermissions, ac, busmock.New(),
 			),
 		}

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -404,6 +404,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 		dashboardStore := database.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures())
 		features := featuremgmt.WithFeatures()
 		ac := acmock.New()
+		// TODO: Update tests to work with rbac
 		sqlStore.Cfg.RBACEnabled = false
 		folderPermissions := acmock.NewMockedPermissionsService()
 		dashboardPermissions := acmock.NewMockedPermissionsService()

--- a/pkg/services/sqlstore/sqlbuilder.go
+++ b/pkg/services/sqlstore/sqlbuilder.go
@@ -3,11 +3,10 @@ package sqlstore
 import (
 	"bytes"
 
-	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/setting"
-
 	"github.com/grafana/grafana/pkg/models"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/sqlstore/permissions"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func NewSqlBuilder(cfg *setting.Cfg) SQLBuilder {

--- a/pkg/services/sqlstore/sqlbuilder_test.go
+++ b/pkg/services/sqlstore/sqlbuilder_test.go
@@ -299,7 +299,13 @@ func createDummyACL(t *testing.T, sqlStore *SQLStore, dashboardPermission *Dashb
 func getDashboards(t *testing.T, sqlStore *SQLStore, search Search, aclUserID int64) []*dashboardResponse {
 	t.Helper()
 
-	builder := &SQLBuilder{}
+	old := sqlStore.Cfg.RBACEnabled
+	sqlStore.Cfg.RBACEnabled = false
+	defer func() {
+		sqlStore.Cfg.RBACEnabled = old
+	}()
+
+	builder := NewSqlBuilder(sqlStore.Cfg)
 	signedInUser := &models.SignedInUser{
 		UserId: 9999999999,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
I noticed the function `WriteDashboardPermissionFilter` that has duplicated code from the dashboard permission filter, this does not respect if RBAC is enabled.

To fix this I reused the existing filter and use the RBAC filter if it is enabled

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/3684

**Special notes for your reviewer**:
* Disabled RBAC for library elements test due to needing a lot of changes to make them work correctly with RBAC (going to look at this in a different pr)

