### PR TITLE
Dashboard: Fix color of bold and italics text in panel description tooltip

### DIFF
--- a/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
@@ -177,13 +177,13 @@ function getStyles(theme: GrafanaTheme2) {
       code {
         border: none;
         display: inline;
-        background: ${colorManipulator.darken(tooltipBg, 0.3)};
+        background: ${colorManipulator.darken(tooltipBg, 0.1)};
         color: ${tooltipText};
       }
 
-      strong,
-      em {
-        color: ${colorManipulator.emphasize(tooltipBg)};
+      pre {
+        background: ${colorManipulator.darken(tooltipBg, 0.1)};
+        color: ${tooltipText};
       }
 
       a {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the color of bold, italics, and code blocks when we render markdown in Tooltips for Panels.

| Before |
| ------- |
| ![image](https://user-images.githubusercontent.com/46142/183402980-b242a2b2-8f53-4018-9b6d-ba2a63ca5cb2.png)  |



| After (dark) | After (light) |
| ------------- | -------------|
| ![2728_2022-08-08-11-43_chrome](https://user-images.githubusercontent.com/46142/183401883-48c3c2d4-7fb8-4a0c-9055-dd314250d59f.png)| ![2729_2022-08-08-11-43_chrome](https://user-images.githubusercontent.com/46142/183401898-5dfc67b6-a978-4eca-8d43-4a5c70b9ee08.png)|

**Which issue(s) this PR fixes**:

Fixes #53339

**Special notes for your reviewer**:

