### PR TITLE
Breadcrumbs: refactor component to be more dumb, use LinkButton for icons

### DIFF
--- a/public/app/core/components/AppChrome/Breadcrumbs.tsx
+++ b/public/app/core/components/AppChrome/Breadcrumbs.tsx
@@ -2,11 +2,10 @@ import { css } from '@emotion/css';
 import React from 'react';
 
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
-import { useStyles2, Icon, IconName } from '@grafana/ui';
+import { useStyles2, Icon, IconName, LinkButton } from '@grafana/ui';
 
 export interface Props {
-  sectionNav: NavModelItem;
-  pageNav?: NavModelItem;
+  breadcrumbs: Breadcrumb[];
 }
 
 export interface Breadcrumb {
@@ -15,8 +14,34 @@ export interface Breadcrumb {
   href?: string;
 }
 
-export function Breadcrumbs({ sectionNav, pageNav }: Props) {
+export function Breadcrumbs({ breadcrumbs }: Props) {
   const styles = useStyles2(getStyles);
+
+  return (
+    <ul className={styles.breadcrumbs}>
+      {breadcrumbs.map((breadcrumb, index) => (
+        <li className={styles.breadcrumb} key={index}>
+          {breadcrumb.href && breadcrumb.text && (
+            <a className={styles.breadcrumbLink} href={breadcrumb.href}>
+              {breadcrumb.text}
+            </a>
+          )}
+          {breadcrumb.href && breadcrumb.icon && (
+            <LinkButton size="md" variant="secondary" fill="text" icon={breadcrumb.icon} href={breadcrumb.href} />
+          )}
+          {!breadcrumb.href && <span className={styles.breadcrumbLink}>{breadcrumb.text}</span>}
+          {index + 1 < breadcrumbs.length && (
+            <div className={styles.separator}>
+              <Icon name="angle-right" />
+            </div>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function buildBreadcrumbs(sectionNav: NavModelItem, pageNav?: NavModelItem) {
   const crumbs: Breadcrumb[] = [{ icon: 'home-alt', href: '/' }];
 
   function addCrumbs(node: NavModelItem) {
@@ -33,26 +58,7 @@ export function Breadcrumbs({ sectionNav, pageNav }: Props) {
     addCrumbs(pageNav);
   }
 
-  return (
-    <ul className={styles.breadcrumbs}>
-      {crumbs.map((breadcrumb, index) => (
-        <li className={styles.breadcrumb} key={index}>
-          {breadcrumb.href && (
-            <a className={styles.breadcrumbLink} href={breadcrumb.href}>
-              {breadcrumb.text}
-              {breadcrumb.icon && <Icon name={breadcrumb.icon} />}
-            </a>
-          )}
-          {!breadcrumb.href && <span className={styles.breadcrumbLink}>{breadcrumb.text}</span>}
-          {index + 1 < crumbs.length && (
-            <div className={styles.separator}>
-              <Icon name="angle-right" />
-            </div>
-          )}
-        </li>
-      ))}
-    </ul>
-  );
+  return crumbs;
 }
 
 const getStyles = (theme: GrafanaTheme2) => {
@@ -69,10 +75,12 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     separator: css({
       color: theme.colors.text.secondary,
-      padding: theme.spacing(0, 0.5),
     }),
     breadcrumbLink: css({
+      alignItems: 'center',
       color: theme.colors.text.primary,
+      display: 'flex',
+      padding: theme.spacing(0, 0.5),
       whiteSpace: 'nowrap',
       '&:hover': {
         textDecoration: 'underline',

--- a/public/app/core/components/AppChrome/NavToolbar.tsx
+++ b/public/app/core/components/AppChrome/NavToolbar.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
 import { Icon, IconButton, ToolbarButton, useStyles2 } from '@grafana/ui';
 
-import { Breadcrumbs } from './Breadcrumbs';
+import { Breadcrumbs, buildBreadcrumbs } from './Breadcrumbs';
 import { NavToolbarSeparator } from './NavToolbarSeparator';
 import { TOP_BAR_LEVEL_HEIGHT } from './types';
 
@@ -26,13 +26,14 @@ export function NavToolbar({
   onToggleSearchBar,
 }: Props) {
   const styles = useStyles2(getStyles);
+  const breadcrumbs = buildBreadcrumbs(sectionNav, pageNav);
 
   return (
     <div className={styles.pageToolbar}>
       <div className={styles.menuButton}>
         <IconButton name="bars" tooltip="Toggle menu" tooltipPlacement="bottom" size="xl" onClick={onToggleMegaMenu} />
       </div>
-      <Breadcrumbs sectionNav={sectionNav} pageNav={pageNav} />
+      <Breadcrumbs breadcrumbs={breadcrumbs} />
       <div className={styles.actions}>
         {actions}
         {actions && <NavToolbarSeparator />}
@@ -56,7 +57,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     menuButton: css({
       display: 'flex',
       alignItems: 'center',
-      paddingRight: theme.spacing(1),
     }),
     actions: css({
       display: 'flex',


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- refactor component to be more dumb
  - just pass a single prop, `breadcrumbs`, that is responsible for defining what's displayed by the component
  - expose a new function, `buildBreadcrumbs`, that consuming components can call to build the breadcrumb tree. or this can just be defined manually!
- use `LinkButton` for icons. better hover/focus styles, accessibility, etc
- fixes alignment between icon and text breadcrumbs

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

part of https://github.com/grafana/grafana/issues/50791

**Special notes for your reviewer**:

