### PR TITLE
Update GitHub addToProject urls for observability-traces-and-profiling

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -151,7 +151,7 @@
     "name":"datasource/Tempo",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/110"
+      "url":"https://github.com/orgs/grafana/projects/221"
     }
   },
   {
@@ -167,7 +167,7 @@
     "name":"datasource/Jaeger",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/110"
+      "url":"https://github.com/orgs/grafana/projects/221"
     }
   },
   {
@@ -175,7 +175,7 @@
     "name":"datasource/Zipkin",
     "action":"addToProject",
     "addToProject":{
-      "url":"https://github.com/orgs/grafana/projects/110"
+      "url":"https://github.com/orgs/grafana/projects/221"
     }
   },
   {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the addToProject urls for the Tempo/Jaeger/Zipkin datasources to the [observability-traces-and-profiling project](https://github.com/orgs/grafana/projects/221/views/1).