### PR TITLE
CI: Replace logging with anonymous defer functions

### DIFF
--- a/pkg/build/plugins/manifest.go
+++ b/pkg/build/plugins/manifest.go
@@ -99,7 +99,11 @@ func BuildManifest(ctx context.Context, dpath string, signingAdmin bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to get signed manifest from Grafana API: %w", err)
 	}
-	defer logError(resp.Body.Close())
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Println("failed to close response body, err: %w", err)
+		}
+	}()
 	if resp.StatusCode != 200 {
 		msg, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
@@ -114,7 +118,11 @@ func BuildManifest(ctx context.Context, dpath string, signingAdmin bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to create %s: %w", manifestPath, err)
 	}
-	defer logCloseError(f.Close)
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Println("failed to close file, err: %w", err)
+		}
+	}()
 	if _, err := io.Copy(f, resp.Body); err != nil {
 		return fmt.Errorf("failed to write %s: %w", manifestPath, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces logging functions with anonymous defer functions, since we encountered errors where we tried to copy the body of an already closed response.

