### PR TITLE
Show alerting availability in data source details

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { cloneDeep } from 'lodash';
-import React, { FC, ReactNode, useState } from 'react';
+import React, { FC, useState } from 'react';
 
 import {
   CoreApp,
@@ -13,7 +13,7 @@ import {
   RelativeTimeRange,
   ThresholdsConfig,
 } from '@grafana/data';
-import { RelativeTimeRangePicker, useStyles2 } from '@grafana/ui';
+import { RelativeTimeRangePicker, useStyles2, Tooltip, Icon } from '@grafana/ui';
 import { isExpressionQuery } from 'app/features/expressions/guards';
 import { QueryEditorRow } from 'app/features/query/components/QueryEditorRow';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
@@ -58,18 +58,34 @@ export const QueryWrapper: FC<Props> = ({
   const isExpression = isExpressionQuery(query.model);
   const [pluginId, changePluginId] = useState<SupportedPanelPlugins>(isExpression ? TABLE : TIMESERIES);
 
-  const renderTimePicker = (query: AlertQuery, index: number): ReactNode => {
-    if (isExpressionQuery(query.model) || !onChangeTimeRange) {
+  function SelectingDataSourceTooltip() {
+    const styles = useStyles2(getStyles);
+    return (
+      <div className={styles.dsTooltip}>
+        <Tooltip content={<>Not finding the data source you want? Some data sources are not supported for alerting.</>}>
+          <Icon name="info-circle" />
+        </Tooltip>
+      </div>
+    );
+  }
+
+  function HeaderExtras({ query, index }: { query: AlertQuery; index: number }) {
+    if (!isExpressionQuery(query.model)) {
+      return (
+        <>
+          <SelectingDataSourceTooltip />
+          {onChangeTimeRange && (
+            <RelativeTimeRangePicker
+              timeRange={query.relativeTimeRange ?? getDefaultRelativeTimeRange()}
+              onChange={(range) => onChangeTimeRange(range, index)}
+            />
+          )}
+        </>
+      );
+    } else {
       return null;
     }
-
-    return (
-      <RelativeTimeRangePicker
-        timeRange={query.relativeTimeRange ?? getDefaultRelativeTimeRange()}
-        onChange={(range) => onChangeTimeRange(range, index)}
-      />
-    );
-  };
+  }
 
   return (
     <div className={styles.wrapper}>
@@ -87,7 +103,7 @@ export const QueryWrapper: FC<Props> = ({
         onAddQuery={() => onDuplicateQuery(cloneDeep(query))}
         onRunQuery={onRunQueries}
         queries={queries}
-        renderHeaderExtras={() => renderTimePicker(query, index)}
+        renderHeaderExtras={() => <HeaderExtras query={query} index={index} />}
         app={CoreApp.UnifiedAlerting}
         visualization={
           data.state !== LoadingState.NotStarted ? (
@@ -117,5 +133,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     margin-bottom: ${theme.spacing(1)};
     border: 1px solid ${theme.colors.border.medium};
     border-radius: ${theme.shape.borderRadius(1)};
+  `,
+  dsTooltip: css`
+    display: flex;
+    align-items: center;
+    margin-right: ${theme.spacing(2)};
   `,
 });

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -70,7 +70,9 @@ export const QueryWrapper: FC<Props> = ({
   }
 
   function HeaderExtras({ query, index }: { query: AlertQuery; index: number }) {
-    if (!isExpressionQuery(query.model)) {
+    if (isExpressionQuery(query.model)) {
+      return null;
+    } else {
       return (
         <>
           <SelectingDataSourceTooltip />
@@ -82,8 +84,6 @@ export const QueryWrapper: FC<Props> = ({
           )}
         </>
       );
-    } else {
-      return null;
     }
   }
 

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -62,8 +62,23 @@ export const QueryWrapper: FC<Props> = ({
     const styles = useStyles2(getStyles);
     return (
       <div className={styles.dsTooltip}>
-        <Tooltip content={<>Not finding the data source you want? Some data sources are not supported for alerting.</>}>
-          <Icon name="info-circle" />
+        <Tooltip
+          content={
+            <>
+              Not finding the data source you want? Some data sources are not supported for alerting. Click on the icon
+              for more information.
+            </>
+          }
+        >
+          <Icon
+            name="info-circle"
+            onClick={() =>
+              window.open(
+                ' https://grafana.com/docs/grafana/latest/alerting/fundamentals/data-source-alerting/',
+                '_blank'
+              )
+            }
+          />
         </Tooltip>
       </div>
     );
@@ -138,5 +153,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: flex;
     align-items: center;
     margin-right: ${theme.spacing(2)};
+    &:hover {
+      opacity: 0.85;
+      cursor: pointer;
+    }
   `,
 });

--- a/public/app/features/datasources/components/BasicSettings.tsx
+++ b/public/app/features/datasources/components/BasicSettings.tsx
@@ -1,7 +1,23 @@
-import React from 'react';
+import { css } from '@emotion/css';
+import React, { useEffect, useState } from 'react';
 
+import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { InlineField, InlineSwitch, Input } from '@grafana/ui';
+import { getDataSourceSrv } from '@grafana/runtime';
+import { InlineField, InlineSwitch, Input, Badge, useStyles2 } from '@grafana/ui';
+
+const useInitHasAlertingEnabled = (dataSourceName: string) => {
+  const [hasAlertingEnabled, setHasAlertingEnabled] = useState(false);
+
+  useEffect(() => {
+    const initDataSourceAlertingEnabled = async () => {
+      const ds = await getDataSourceSrv()?.get(dataSourceName);
+      setHasAlertingEnabled(Boolean(ds?.meta?.alerting ?? false));
+    };
+    dataSourceName && initDataSourceAlertingEnabled();
+  }, [dataSourceName]);
+  return hasAlertingEnabled;
+};
 
 export interface Props {
   dataSourceName: string;
@@ -11,40 +27,64 @@ export interface Props {
 }
 
 export function BasicSettings({ dataSourceName, isDefault, onDefaultChange, onNameChange }: Props) {
+  const hasAlertingEnabled = useInitHasAlertingEnabled(dataSourceName);
+
   return (
-    <div className="gf-form-group" aria-label="Datasource settings page basic settings">
-      <div className="gf-form-inline">
-        {/* Name */}
-        <div className="gf-form max-width-30">
-          <InlineField
-            label="Name"
-            tooltip="The name is used when you select the data source in panels. The default data source is
+    <>
+      <AlertingEnabled enabled={hasAlertingEnabled} />
+      <div className="gf-form-group" aria-label="Datasource settings page basic settings">
+        <div className="gf-form-inline">
+          {/* Name */}
+          <div className="gf-form max-width-30">
+            <InlineField
+              label="Name"
+              tooltip="The name is used when you select the data source in panels. The default data source is
               'preselected in new panels."
-            grow
-          >
-            <Input
-              id="basic-settings-name"
-              type="text"
-              value={dataSourceName}
-              placeholder="Name"
-              onChange={(event) => onNameChange(event.currentTarget.value)}
-              required
-              aria-label={selectors.pages.DataSource.name}
+              grow
+            >
+              <Input
+                id="basic-settings-name"
+                type="text"
+                value={dataSourceName}
+                placeholder="Name"
+                onChange={(event) => onNameChange(event.currentTarget.value)}
+                required
+                aria-label={selectors.pages.DataSource.name}
+              />
+            </InlineField>
+          </div>
+
+          {/* Is Default */}
+          <InlineField label="Default" labelWidth={8}>
+            <InlineSwitch
+              id="basic-settings-default"
+              value={isDefault}
+              onChange={(event: React.FormEvent<HTMLInputElement>) => {
+                onDefaultChange(event.currentTarget.checked);
+              }}
             />
           </InlineField>
         </div>
-
-        {/* Is Default */}
-        <InlineField label="Default" labelWidth={8}>
-          <InlineSwitch
-            id="basic-settings-default"
-            value={isDefault}
-            onChange={(event: React.FormEvent<HTMLInputElement>) => {
-              onDefaultChange(event.currentTarget.checked);
-            }}
-          />
-        </InlineField>
       </div>
+    </>
+  );
+}
+
+export function AlertingEnabled({ enabled }: { enabled: boolean }) {
+  const styles = useStyles2(getStyles);
+  return (
+    <div className={styles.badge}>
+      {enabled ? (
+        <Badge color="green" icon="check-circle" text="Alerting supported" />
+      ) : (
+        <Badge color="orange" icon="exclamation-triangle" text="Alerting not supported" />
+      )}
     </div>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  badge: css`
+    margin-bottom: ${theme.spacing(2)};
+  `,
+});

--- a/public/app/features/datasources/components/BasicSettings.tsx
+++ b/public/app/features/datasources/components/BasicSettings.tsx
@@ -1,23 +1,10 @@
 import { css } from '@emotion/css';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { InlineField, InlineSwitch, Input, Badge, useStyles2 } from '@grafana/ui';
-
-const useInitHasAlertingEnabled = (dataSourceName: string) => {
-  const [hasAlertingEnabled, setHasAlertingEnabled] = useState(false);
-
-  useEffect(() => {
-    const initDataSourceAlertingEnabled = async () => {
-      const ds = await getDataSourceSrv()?.get(dataSourceName);
-      setHasAlertingEnabled(Boolean(ds?.meta?.alerting ?? false));
-    };
-    dataSourceName && initDataSourceAlertingEnabled();
-  }, [dataSourceName]);
-  return hasAlertingEnabled;
-};
 
 export interface Props {
   dataSourceName: string;
@@ -27,7 +14,8 @@ export interface Props {
 }
 
 export function BasicSettings({ dataSourceName, isDefault, onDefaultChange, onNameChange }: Props) {
-  const hasAlertingEnabled = useInitHasAlertingEnabled(dataSourceName);
+  const ds = getDataSourceSrv()?.getInstanceSettings(dataSourceName);
+  const hasAlertingEnabled = Boolean(ds?.meta?.alerting ?? false);
 
   return (
     <>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an Alert info in data source details, showing if data source has alerting enabled or not.

Based on the outcome of UX session, we decided to show also an information Tooltip for the data source dropdown when creating an alert rule. When the user clicks this information Tooltip icon, it will open a new tab with the documentation about this.

We think this could help user to understand why this data source does not appear when creating a new alert.

**Which issue(s) this PR fixes**:

Fixes #51484 

**Special notes for your reviewer**:

-  Information Tooltip for the data source dropdown when creating an alert rule:


https://user-images.githubusercontent.com/33540275/184338398-5f64bdb5-d670-4fdc-ba3f-d2205f3b1c88.mp4



<img width="627" alt="Screenshot 2022-08-11 at 10 10 27" src="https://user-images.githubusercontent.com/33540275/184095695-15e4f4ce-7a1d-4141-8c34-147155cf3d1f.png">
<img width="677" alt="Screenshot 2022-08-11 at 10 45 12" src="https://user-images.githubusercontent.com/33540275/184096817-e0f37cfd-b531-4324-99ad-1a2e1b70f29e.png">


- Badge in the data source details showing if alerting is available or not for this data source:

<img width="935" alt="Screenshot 2022-08-09 at 16 56 56" src="https://user-images.githubusercontent.com/33540275/184096059-cb42dcb6-a3f2-4f95-91cf-780a9a59877a.png">

<img width="1045" alt="Screenshot 2022-08-09 at 16 56 39" src="https://user-images.githubusercontent.com/33540275/184096080-f281de6a-2df4-45e3-aa9c-909209deb92f.png">

This is an example of the result of this PR changes:



