### PR TITLE
Fix groups and users indentation

### DIFF
--- a/devenv/docker/blocks/openldap/notes.md
+++ b/devenv/docker/blocks/openldap/notes.md
@@ -25,26 +25,26 @@ Otherwise perform same actions for `ldap_dev_posix.toml` config.
 
 ## Groups & Users
 
-admins
-  ldap-admin
-  ldap-torkel
-backend
-  ldap-carl
-  ldap-torkel
-  ldap-leo
-frontend
-  ldap-torkel
-  ldap-tobias
-  ldap-daniel
-editors
-  ldap-editors
-no groups
-  ldap-viewer
+- admins
+  - ldap-admin
+  - ldap-torkel
+- backend
+  - ldap-carl
+  - ldap-torkel
+  - ldap-leo
+- frontend
+  - ldap-torkel
+  - ldap-tobias
+  - ldap-daniel
+- editors
+  - ldap-editors
+- no groups
+  - ldap-viewer
 
 
 ## Groups & Users (POSIX)
 
-admins
-  ldap-posix-admin
-no groups
-  ldap-posix
+- admins
+  - ldap-posix-admin
+- no groups
+  - ldap-posix


### PR DESCRIPTION
**What this PR does / why we need it:**

The following changes are needed for a proper indentation of the lists of users and groups in the documentation.