### PR TITLE
KVStore: Allow empty value in kv_store

### DIFF
--- a/pkg/infra/kvstore/sql.go
+++ b/pkg/infra/kvstore/sql.go
@@ -66,7 +66,7 @@ func (kv *kvStoreSQL) Set(ctx context.Context, orgId int64, namespace string, ke
 		item.Updated = time.Now()
 
 		if has {
-			_, err = dbSession.ID(item.Id).Update(&item)
+			_, err = dbSession.Exec("UPDATE kv_store SET value = ?, updated = ? WHERE id = ?", item.Value, item.Updated, item.Id)
 			if err != nil {
 				kv.log.Debug("error updating kvstore value", "orgId", orgId, "namespace", namespace, "key", key, "value", value, "err", err)
 			} else {


### PR DESCRIPTION
For any reason (Xorm again?), we aren't allowed to set empty value using

```go
dbSession.ID(item.Id).Update(&item)
```

It logs a successful response but the value isn't changed in the database. 

Changing it with a raw sql fixes the issue.

Note: I put 9.1.x backport because its affecting to custom branding that it works from 9.1.0. But idk if we need to set it up 9.0.x or/and 8.5.x

Fixes https://github.com/grafana/grafana-enterprise/issues/3688