### PR TITLE
CI: Change base image for `npm` storage

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2034,7 +2034,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.3
+  image: grafana/build-container:1.5.9
   name: store-npm-packages
 trigger:
   event:
@@ -2651,7 +2651,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/grafana-ci-deploy:1.3.3
+  image: grafana/build-container:1.5.9
   name: store-npm-packages
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise2  --sign ${DRONE_TAG}
@@ -5137,6 +5137,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 95d70728803bf8ff4b203111a35dc9ac74188d4cd83be5707cdddc0999c0ff83
+hmac: b9301d95898fe313f97e9b344aa74b797cc5b55871d38b8fe7a2fa5a2b2da3ad
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -66,7 +66,7 @@ load('scripts/drone/vault.star', 'from_secret', 'github_token', 'pull_secret', '
 def store_npm_packages_step():
     return {
         'name': 'store-npm-packages',
-        'image': publish_image,
+        'image': build_image,
         'depends_on': [
             'build-frontend-packages',
         ],


### PR DESCRIPTION
**What this PR does / why we need it**:

After `grabpl` `v3.0.1`, we started using a different approach on how we store, retrieve and release npm packages. 
The store process, needs `yarn` installed, while it isn't installed on the `grafana/grafana-ci-deploy` image. Instead of installing `yarn` in that image, we can (for now) use the `grafana/build-container` image which already has `yarn` installed.
Eventually, we should create small images to handle with these situations.