### PR TITLE
CI: Remove `packages-bucket` argument

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1572,8 +1572,7 @@ steps:
   - rm gcpkey.json
   - cp C:\App\nssm-2.24.zip .
   - .\grabpl.exe gen-version --build-id $$env:DRONE_BUILD_NUMBER
-  - .\grabpl.exe windows-installer --edition oss --packages-bucket grafana-downloads
-    --build-id $$env:DRONE_BUILD_NUMBER
+  - .\grabpl.exe windows-installer --edition oss --build-id $$env:DRONE_BUILD_NUMBER
   - $$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]
   - gsutil cp $$fname gs://grafana-downloads/oss/main/
   - gsutil cp "$$fname.sha256" gs://grafana-downloads/oss/main/
@@ -3580,8 +3579,7 @@ steps:
   image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
-  - ./bin/grabpl store-packages --edition oss --packages-bucket grafana-downloads
-    --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
+  - ./bin/grabpl store-packages --edition oss --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
   depends_on:
   - gen-version
   environment:
@@ -3636,8 +3634,7 @@ steps:
   image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
-  - ./bin/grabpl store-packages --edition enterprise --packages-bucket grafana-downloads
-    --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
+  - ./bin/grabpl store-packages --edition enterprise --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
   depends_on:
   - gen-version
   environment:
@@ -5137,6 +5134,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: b9301d95898fe313f97e9b344aa74b797cc5b55871d38b8fe7a2fa5a2b2da3ad
+hmac: e7c5243dd58f49260d0dce8bf6c221901ecd3eb8545f9b624e4a8998ee96910e
 
 ...

--- a/scripts/drone/pipelines/windows.star
+++ b/scripts/drone/pipelines/windows.star
@@ -33,7 +33,6 @@ def windows(trigger, edition, ver_mode):
     if (ver_mode == 'main' and (edition not in ('enterprise', 'enterprise2'))) or ver_mode in (
         'release', 'release-branch',
     ):
-        bucket_part = ''
         bucket = '%PRERELEASE_BUCKET%/artifacts/downloads'
         if ver_mode == 'release':
             ver_part = '${DRONE_TAG}'
@@ -41,7 +40,6 @@ def windows(trigger, edition, ver_mode):
         else:
             dir = 'main'
             bucket = 'grafana-downloads'
-            bucket_part = ' --packages-bucket {}'.format(bucket)
             build_no = 'DRONE_BUILD_NUMBER'
             ver_part = '--build-id $$env:{}'.format(build_no)
         installer_commands = [
@@ -58,7 +56,7 @@ def windows(trigger, edition, ver_mode):
         ):
             installer_commands.extend([
                 '.\\grabpl.exe gen-version {}'.format(ver_part),
-                '.\\grabpl.exe windows-installer --edition {}{} {}'.format(edition, bucket_part, ver_part),
+                '.\\grabpl.exe windows-installer --edition {} {}'.format(edition, ver_part),
                 '$$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]',
             ])
             if ver_mode == 'main':

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -995,7 +995,7 @@ def upload_packages_step(edition, ver_mode, trigger=None):
 
 def store_packages_step(edition, ver_mode):
     if ver_mode == 'release':
-        cmd = './bin/grabpl store-packages --edition {} --packages-bucket grafana-downloads --gcp-key /tmp/gcpkey.json ${{DRONE_TAG}}'.format(
+        cmd = './bin/grabpl store-packages --edition {} --gcp-key /tmp/gcpkey.json ${{DRONE_TAG}}'.format(
             edition,
         )
     elif ver_mode == 'main':
@@ -1046,7 +1046,6 @@ def get_windows_steps(edition, ver_mode):
     if (ver_mode == 'main' and (edition not in ('enterprise', 'enterprise2'))) or ver_mode in (
         'release', 'release-branch',
     ):
-        bucket_part = ''
         bucket = '%PRERELEASE_BUCKET%/artifacts/downloads'
         if ver_mode == 'release':
             ver_part = '${DRONE_TAG}'
@@ -1054,7 +1053,6 @@ def get_windows_steps(edition, ver_mode):
         else:
             dir = 'main'
             bucket = 'grafana-downloads'
-            bucket_part = ' --packages-bucket {}'.format(bucket)
             build_no = 'DRONE_BUILD_NUMBER'
             ver_part = '--build-id $$env:{}'.format(build_no)
         installer_commands = [
@@ -1071,7 +1069,7 @@ def get_windows_steps(edition, ver_mode):
         ):
             installer_commands.extend([
                 '.\\grabpl.exe gen-version {}'.format(ver_part),
-                '.\\grabpl.exe windows-installer --edition {}{} {}'.format(edition, bucket_part, ver_part),
+                '.\\grabpl.exe windows-installer --edition {} {}'.format(edition, ver_part),
                 '$$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]',
             ])
             if ver_mode == 'main':


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes `packages-bucket` argument, from `grabpl` commands, as the logic is now moved into the configuration files in the build pipeline tool.