### PR TITLE
Adding logs during migration of secrets to plugin

### DIFF
--- a/pkg/services/secrets/kvstore/plugin_mig.go
+++ b/pkg/services/secrets/kvstore/plugin_mig.go
@@ -2,6 +2,7 @@ package kvstore
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -62,23 +63,28 @@ func (s *PluginSecretMigrationService) Migrate(ctx context.Context) error {
 		namespacedKVStore := GetNamespacedKVStore(s.kvstore)
 		wasFatal, err := isPluginStartupErrorFatal(ctx, namespacedKVStore)
 		if err != nil {
-			s.logger.Warn("unabled to determine whether plugin startup failures are fatal - continuing migration anyway.")
+			s.logger.Warn("unable to determine whether plugin startup failures are fatal - continuing migration anyway.")
 		}
 
 		allSec, err := secretsSql.GetAll(ctx)
 		if err != nil {
 			return nil
 		}
+		totalSec := len(allSec)
 		// We just set it again as the current secret store should be the plugin secret
-		for _, sec := range allSec {
+		s.logger.Debug(fmt.Sprintf("Total ammount of secrets to migrate: %d", totalSec))
+		for i, sec := range allSec {
+			s.logger.Debug(fmt.Sprintf("Migrating secret %d of %d", i+1, totalSec))
 			err = s.secretsStore.Set(ctx, *sec.OrgId, *sec.Namespace, *sec.Type, sec.Value)
 			if err != nil {
 				return err
 			}
 		}
-		s.logger.Debug("migrated unified secrets to plugin", "number of secrets", len(allSec))
+		s.logger.Debug("migrated unified secrets to plugin", "number of secrets", totalSec)
 		// as no err was returned, when we delete all the secrets from the sql store
 		for index, sec := range allSec {
+			s.logger.Debug(fmt.Sprintf("Cleaning secret %d of %d", index+1, totalSec))
+
 			err = secretsSql.Del(ctx, *sec.OrgId, *sec.Namespace, *sec.Type)
 			if err != nil {
 				s.logger.Error("plugin migrator encountered error while deleting unified secrets")
@@ -94,7 +100,7 @@ func (s *PluginSecretMigrationService) Migrate(ctx context.Context) error {
 				return err
 			}
 		}
-		s.logger.Debug("deleted unified secrets after migration", "number of secrets", len(allSec))
+		s.logger.Debug("deleted unified secrets after migration", "number of secrets", totalSec)
 	}
 	return nil
 }

--- a/pkg/services/secrets/kvstore/plugin_mig.go
+++ b/pkg/services/secrets/kvstore/plugin_mig.go
@@ -72,7 +72,7 @@ func (s *PluginSecretMigrationService) Migrate(ctx context.Context) error {
 		}
 		totalSec := len(allSec)
 		// We just set it again as the current secret store should be the plugin secret
-		s.logger.Debug(fmt.Sprintf("Total ammount of secrets to migrate: %d", totalSec))
+		s.logger.Debug(fmt.Sprintf("Total amount of secrets to migrate: %d", totalSec))
 		for i, sec := range allSec {
 			s.logger.Debug(fmt.Sprintf("Migrating secret %d of %d", i+1, totalSec))
 			err = s.secretsStore.Set(ctx, *sec.OrgId, *sec.Namespace, *sec.Type, sec.Value)

--- a/pkg/services/secrets/kvstore/plugin_mig.go
+++ b/pkg/services/secrets/kvstore/plugin_mig.go
@@ -74,7 +74,7 @@ func (s *PluginSecretMigrationService) Migrate(ctx context.Context) error {
 		// We just set it again as the current secret store should be the plugin secret
 		s.logger.Debug(fmt.Sprintf("Total amount of secrets to migrate: %d", totalSec))
 		for i, sec := range allSec {
-			s.logger.Debug(fmt.Sprintf("Migrating secret %d of %d", i+1, totalSec))
+			s.logger.Debug(fmt.Sprintf("Migrating secret %d of %d", i+1, totalSec), "current", i+1, "secretCount", totalSec)
 			err = s.secretsStore.Set(ctx, *sec.OrgId, *sec.Namespace, *sec.Type, sec.Value)
 			if err != nil {
 				return err
@@ -83,7 +83,7 @@ func (s *PluginSecretMigrationService) Migrate(ctx context.Context) error {
 		s.logger.Debug("migrated unified secrets to plugin", "number of secrets", totalSec)
 		// as no err was returned, when we delete all the secrets from the sql store
 		for index, sec := range allSec {
-			s.logger.Debug(fmt.Sprintf("Cleaning secret %d of %d", index+1, totalSec))
+			s.logger.Debug(fmt.Sprintf("Cleaning secret %d of %d", index+1, totalSec), "current", index+1, "secretCount", totalSec)
 
 			err = secretsSql.Del(ctx, *sec.OrgId, *sec.Namespace, *sec.Type)
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds logs on total and remaining secrets while are being migrated to the plugin

Fixes https://github.com/grafana/grafana-partnerships-team/issues/315

**Special notes for your reviewer**:
Examples of logs

Example of "Total amount" and "Migrating secret x of y" log:
 
![image](https://user-images.githubusercontent.com/34773040/183481811-bae8fc63-ccc0-4629-99cf-ea0283fc851f.png)

Example if "Cleaning secret x of y"
![image](https://user-images.githubusercontent.com/34773040/183481865-39b5ad3a-c5ca-41c7-9366-f6f5a985216f.png)


