### PR TITLE
Chore: Remove any from `public/app/plugins/datasource/elasticsearch/hooks/useNextId.test.tsx`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6742,9 +6742,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "46"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "47"]
     ],
-    "public/app/plugins/datasource/elasticsearch/hooks/useNextId.test.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
     "public/app/plugins/datasource/elasticsearch/hooks/useStatelessReducer.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/public/app/plugins/datasource/elasticsearch/hooks/useNextId.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/hooks/useNextId.test.tsx
@@ -3,6 +3,7 @@ import React, { PropsWithChildren } from 'react';
 
 import { getDefaultTimeRange } from '@grafana/data';
 
+import { ElasticDatasource } from '../datasource';
 import { ElasticsearchProvider } from '../components/QueryEditor/ElasticsearchQueryContext';
 import { ElasticsearchQuery } from '../types';
 
@@ -20,7 +21,7 @@ describe('useNextId', () => {
       return (
         <ElasticsearchProvider
           query={query}
-          datasource={{} as any}
+          datasource={{} as ElasticDatasource}
           onChange={() => {}}
           onRunQuery={() => {}}
           range={getDefaultTimeRange()}

--- a/public/app/plugins/datasource/elasticsearch/hooks/useNextId.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/hooks/useNextId.test.tsx
@@ -3,8 +3,8 @@ import React, { PropsWithChildren } from 'react';
 
 import { getDefaultTimeRange } from '@grafana/data';
 
-import { ElasticDatasource } from '../datasource';
 import { ElasticsearchProvider } from '../components/QueryEditor/ElasticsearchQueryContext';
+import { ElasticDatasource } from '../datasource';
 import { ElasticsearchQuery } from '../types';
 
 import { useNextId } from './useNextId';


### PR DESCRIPTION
**What this PR does / why we need it**:
Removing `any` type assertions!

**Which issue(s) this PR fixes**:
Fixes #53399 :))
