### PR TITLE
Prometheus: Remove metadata endpoint

### DIFF
--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -146,9 +146,19 @@ export default class PromQlLanguageProvider extends LanguageProvider {
   };
 
   async loadMetricsMetadata() {
-    this.metricsMetadata = fixSummariesMetadata(
-      await this.request('/api/v1/metadata', {}, {}, { showErrorAlert: false })
-    );
+    // The metadata endpoint is experimental and
+    // we have customers who are not implementing it.
+    // This is to be a temporary fix until the Observability Metrics Squad
+    // has time to implement the 2022Q3 plan
+    // to detect prometheus versions and implementations.
+    // This will allow us to see if endpoints such as api/v1/metadata
+    // are implemented or not and handle them as such
+    this.metricsMetadata = {};
+
+    // PREVIOUS IMPLEMENTATION FOR NOTES
+    // this.metricsMetadata = fixSummariesMetadata(
+    //   await this.request('/api/v1/metadata', {}, {}, { showErrorAlert: false })
+    // );
   }
 
   getLabelKeys(): string[] {

--- a/public/app/plugins/datasource/prometheus/language_provider.ts
+++ b/public/app/plugins/datasource/prometheus/language_provider.ts
@@ -18,7 +18,6 @@ import { PrometheusDatasource } from './datasource';
 import {
   addLimitInfo,
   extractLabelMatchers,
-  fixSummariesMetadata,
   parseSelector,
   processHistogramMetrics,
   processLabels,


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/3522

This fix temporarily removes the prometheus metadata endpoint. This endpoint is [experimental](https://prometheus.io/docs/prometheus/latest/querying/api/#querying-target-metadata) also not implemented in all prometheus instances and versions. The Observability Metrics Squad has a [plan](https://github.com/grafana/observability-metrics-squad/issues/22) for 2022Q3 in place to detect prom versions and implementations and then handle whether to hit the metadata endpoint or not. Until then, this fix removes access to the metadata endpoint. 

This affects the tooltips and suggestions for the query builder and the code editor https://github.com/grafana/grafana/pull/21124. The labels are used in tooltips in place of the metadata when the metadata is not present.



