### PR TITLE
Query Builder: Fix spelling of "lose" in user visible message

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -568,11 +568,11 @@ export class LokiDatasource
             // and any other that were logged in the same ns but before the row. Right now these rows will be lost
             // because the are before but came it he response that should return only rows after.
             from: timestamp,
-            // convert to ns, we loose some precision here but it is not that important at the far points of the context
+            // convert to ns, we lose some precision here but it is not that important at the far points of the context
             to: toUtc(row.timeEpochMs + contextTimeBuffer),
           }
         : {
-            // convert to ns, we loose some precision here but it is not that important at the far points of the context
+            // convert to ns, we lose some precision here but it is not that important at the far points of the context
             from: toUtc(row.timeEpochMs - contextTimeBuffer),
             to: timestamp,
           };

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryEditorSelector.tsx
@@ -51,7 +51,7 @@ export const LokiQueryEditorSelector = React.memo<LokiQueryEditorProps>((props) 
 
       if (newEditorMode === QueryEditorMode.Builder) {
         const result = buildVisualQueryFromString(query.expr || '');
-        // If there are errors, give user a chance to decide if they want to go to builder as that can loose some data.
+        // If there are errors, give user a chance to decide if they want to go to builder as that can lose some data.
         if (result.errors.length) {
           setParseModalOpen(true);
           return;
@@ -81,7 +81,7 @@ export const LokiQueryEditorSelector = React.memo<LokiQueryEditorProps>((props) 
       <ConfirmModal
         isOpen={parseModalOpen}
         title="Query parsing"
-        body="There were errors while trying to parse the query. Continuing to visual builder may loose some parts of the query."
+        body="There were errors while trying to parse the query. Continuing to visual builder may lose some parts of the query."
         confirmText="Continue"
         onConfirm={() => {
           onChange({ ...query, editorMode: QueryEditorMode.Builder });

--- a/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
@@ -43,7 +43,7 @@ export const PromQueryEditorSelector = React.memo<Props>((props) => {
 
       if (newMetricEditorMode === QueryEditorMode.Builder) {
         const result = buildVisualQueryFromString(query.expr || '');
-        // If there are errors, give user a chance to decide if they want to go to builder as that can loose some data.
+        // If there are errors, give user a chance to decide if they want to go to builder as that can lose some data.
         if (result.errors.length) {
           setParseModalOpen(true);
           return;
@@ -77,7 +77,7 @@ export const PromQueryEditorSelector = React.memo<Props>((props) => {
       <ConfirmModal
         isOpen={parseModalOpen}
         title="Query parsing"
-        body="There were errors while trying to parse the query. Continuing to visual builder may loose some parts of the query."
+        body="There were errors while trying to parse the query. Continuing to visual builder may lose some parts of the query."
         confirmText="Continue"
         onConfirm={() => {
           changeEditorMode(query, QueryEditorMode.Builder, onChange);


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes spelling/usage of "lose" (verb) from incorrect "loose" (adjective).

Very minor change to two user visible error messages and several comments. 