### PR TITLE
Bug: Change from `arm` to `armv7` architecture for docker images build

### DIFF
--- a/pkg/build/config/variant.go
+++ b/pkg/build/config/variant.go
@@ -21,6 +21,7 @@ type Architecture string
 const (
 	ArchAMD64 Architecture = "amd64"
 	ArchARMv6 Architecture = "armv6"
+	ArchARMv7 Architecture = "armv7"
 	ArchARM64 Architecture = "arm64"
 	ArchARMHF Architecture = "armhf"
 	ArchARM   Architecture = "arm"

--- a/pkg/build/config/version_json_test.go
+++ b/pkg/build/config/version_json_test.go
@@ -40,7 +40,7 @@ var configJSON = []byte(`{
       "archs": [
         "amd64",
         "arm64",
-        "arm"
+        "armv7"
       ]
     },
     "packagesBucket": "grafana-downloads",
@@ -67,7 +67,7 @@ var configJSON = []byte(`{
       "archs": [
         "amd64",
         "arm64",
-        "arm"
+        "armv7"
       ]
     },
     "packagesBucket": "grafana-downloads",
@@ -95,7 +95,7 @@ var configJSON = []byte(`{
       "archs": [
         "amd64",
         "arm64",
-        "arm"
+        "armv7"
       ]
     },
     "packagesBucket": "grafana-prerelease/artifacts/downloads",
@@ -125,7 +125,7 @@ var configJSON = []byte(`{
       "archs": [
         "amd64",
         "arm64",
-        "arm"
+        "armv7"
       ]
     },
     "packagesBucket": "grafana-prerelease/artifacts/downloads",
@@ -155,7 +155,7 @@ var configJSON = []byte(`{
       "archs": [
         "amd64",
         "arm64",
-        "arm"
+        "armv7"
       ]
     },
     "packagesBucket": "grafana-prerelease/artifacts/downloads",

--- a/pkg/build/config/versions.go
+++ b/pkg/build/config/versions.go
@@ -40,7 +40,7 @@ var Versions = VersionMap{
 			Architectures: []Architecture{
 				ArchAMD64,
 				ArchARM64,
-				ArchARM, // GOARCH=ARM is used for both armv6 and armv7. They are differentiated by the GOARM variable.
+				ArchARMv7, // GOARCH=ARM is used for both armv6 and armv7. They are differentiated by the GOARM variable.
 			},
 		},
 		PackagesBucket:  "grafana-downloads",
@@ -67,7 +67,7 @@ var Versions = VersionMap{
 			Architectures: []Architecture{
 				ArchAMD64,
 				ArchARM64,
-				ArchARM,
+				ArchARMv7,
 			},
 		},
 		PackagesBucket:            "grafana-downloads",
@@ -95,7 +95,7 @@ var Versions = VersionMap{
 			Architectures: []Architecture{
 				ArchAMD64,
 				ArchARM64,
-				ArchARM,
+				ArchARMv7,
 			},
 		},
 		PackagesBucket:  "grafana-prerelease/artifacts/downloads",
@@ -125,7 +125,7 @@ var Versions = VersionMap{
 			Architectures: []Architecture{
 				ArchAMD64,
 				ArchARM64,
-				ArchARM,
+				ArchARMv7,
 			},
 		},
 		PackagesBucket:  "grafana-prerelease/artifacts/downloads",
@@ -155,7 +155,7 @@ var Versions = VersionMap{
 			Architectures: []Architecture{
 				ArchAMD64,
 				ArchARM64,
-				ArchARM,
+				ArchARMv7,
 			},
 		},
 		PackagesBucket:  "grafana-prerelease/artifacts/downloads",


### PR DESCRIPTION
**What this PR does / why we need it**:

After https://github.com/grafana/grafana/pull/53077 was introduced, the `build-docker-image` step broke, as `arm` architecture wasn't valid. This PR fixes that by replacing `arm` with `armv7` for docker builds. 
