### PR TITLE
RBAC: Handle case when folder id is negative

### DIFF
--- a/pkg/services/dashboards/accesscontrol.go
+++ b/pkg/services/dashboards/accesscontrol.go
@@ -130,6 +130,10 @@ func NewDashboardUIDScopeResolver(db Store) (string, ac.ScopeAttributeResolver) 
 
 func resolveDashboardScope(ctx context.Context, db Store, orgID int64, dashboard *models.Dashboard) ([]string, error) {
 	var folderUID string
+	if dashboard.FolderId < 0 {
+		return []string{ScopeDashboardsProvider.GetResourceScopeUID(dashboard.Uid)}, nil
+	}
+
 	if dashboard.FolderId == 0 {
 		folderUID = ac.GeneralFolderUID
 	} else {
@@ -139,6 +143,7 @@ func resolveDashboardScope(ctx context.Context, db Store, orgID int64, dashboard
 		}
 		folderUID = folder.Uid
 	}
+
 	return []string{
 		ScopeDashboardsProvider.GetResourceScopeUID(dashboard.Uid),
 		ScopeFoldersProvider.GetResourceScopeUID(folderUID),


### PR DESCRIPTION
**What this PR does / why we need it**:
When a folder id of a dashboard is less than zero we get an folder not found error from the dashboard resolver. This makes it impossible to view the dashboard even with wildcard scopes

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

https://github.com/grafana/support-escalations/issues/3279

**Special notes for your reviewer**:

