### PR TITLE
Collapse: Fix miss-aligned arrow icon

### DIFF
--- a/packages/grafana-ui/src/components/Collapse/Collapse.tsx
+++ b/packages/grafana-ui/src/components/Collapse/Collapse.tsx
@@ -79,7 +79,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   icon: css`
     label: collapse__icon;
-    margin: ${theme.spacing(0, 1, 0, -1)};
+    margin: ${theme.spacing(0.25, 1, 0, -1)};
   `,
 });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Arrow icon used for collapsing <Collapse /> component is miss-aligned. You can see example below: 

Fixed (arrow icon next to "Advanced"): 
<img width="1083" alt="image" src="https://user-images.githubusercontent.com/30407135/183628967-a33ed7e0-df68-4587-bfc0-ff5858bdb576.png">

Before (arrow icon next to "Advanced"): 
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/30407135/183629107-d7edd072-cb2b-42e6-90d9-1b5364b6754c.png">

This PR fixes the issue and correctly alligns the icon.

**Special notes for your reviewer**:
To test it out, you can:
1. Create new Azure Monitor data source (no need to config anything)
2. Go to Explore and click on Select resource button
3. Observe miss-aligned icon for Collapse component
