### PR TITLE
RBAC: Remove sort and unique values when fetching permissions

### DIFF
--- a/pkg/services/accesscontrol/database/database.go
+++ b/pkg/services/accesscontrol/database/database.go
@@ -27,7 +27,7 @@ func (s *AccessControlStore) GetUserPermissions(ctx context.Context, query acces
 		filter, params := userRolesFilter(query.OrgID, query.UserID, query.Roles)
 
 		// TODO: optimize this
-		q := `SELECT DISTINCT
+		q := `SELECT
 			permission.action,
 			permission.scope
 			FROM permission
@@ -44,10 +44,6 @@ func (s *AccessControlStore) GetUserPermissions(ctx context.Context, query acces
 				params = append(params, a)
 			}
 		}
-
-		q += `
-			ORDER BY permission.scope
-		`
 
 		if err := sess.SQL(q, params...).Find(&result); err != nil {
 			return err

--- a/pkg/services/accesscontrol/database/database.go
+++ b/pkg/services/accesscontrol/database/database.go
@@ -26,7 +26,6 @@ func (s *AccessControlStore) GetUserPermissions(ctx context.Context, query acces
 	err := s.sql.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		filter, params := userRolesFilter(query.OrgID, query.UserID, query.Roles)
 
-		// TODO: optimize this
 		q := `SELECT
 			permission.action,
 			permission.scope


### PR DESCRIPTION
**What this PR does / why we need it**:
The performance gain when fetching unique and sorted permissions was less than the time it takes to fetch permissions.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

