### PR TITLE
CloudMonitoring: Set GCE Default Project on Service Account authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
     "@grafana/data": "workspace:*",
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/experimental": "^0.0.2-canary.36",
-    "@grafana/google-sdk": "0.0.3",
+    "@grafana/google-sdk": "0.0.4",
     "@grafana/lezer-logql": "0.0.14",
     "@grafana/runtime": "workspace:*",
     "@grafana/schema": "workspace:*",

--- a/public/app/plugins/datasource/cloud-monitoring/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/ConfigEditor/ConfigEditor.tsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react';
 
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { ConnectionConfig } from '@grafana/google-sdk';
+import { getBackendSrv, BackendSrv } from '@grafana/runtime';
 
 import { CloudMonitoringOptions, CloudMonitoringSecureJsonData } from '../../types';
 
@@ -9,9 +10,10 @@ export type Props = DataSourcePluginOptionsEditorProps<CloudMonitoringOptions, C
 
 export class ConfigEditor extends PureComponent<Props> {
   render() {
+    const backendSrv: BackendSrv = getBackendSrv();
     return (
       <>
-        <ConnectionConfig {...this.props}></ConnectionConfig>
+        <ConnectionConfig {...this.props} backendSrv={backendSrv}></ConnectionConfig>
       </>
     );
   }


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR bumps the Grafana Google SDK version which has improved auth handling. Also passes the `backendSrv` to the config editor for the datasource.

**Which issue(s) this PR fixes**:

Fixes #51327 

**Special notes for your reviewer**:

Dependant on grafana/grafana-google-sdk-react#7 being merged and released.
