### PR TITLE
Loki: Remove any from public/app/plugins/datasource/loki/configuration/ConfigEditor.test.tsx

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -92,7 +92,7 @@ exports[`no enzyme tests`] = {
     "public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx:146069464": [
       [0, 19, 13, "RegExp match", "2409514259"]
     ],
-    "public/app/plugins/datasource/loki/configuration/ConfigEditor.test.tsx:3658171175": [
+    "public/app/plugins/datasource/loki/configuration/ConfigEditor.test.tsx:2659566901": [
       [0, 17, 13, "RegExp match", "2409514259"]
     ],
     "public/app/plugins/datasource/loki/configuration/DebugSection.test.tsx:1551927716": [
@@ -7424,9 +7424,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"]
-    ],
-    "public/app/plugins/datasource/loki/configuration/ConfigEditor.test.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/plugins/datasource/loki/configuration/ConfigEditor.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/public/app/plugins/datasource/loki/configuration/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/ConfigEditor.test.tsx
@@ -24,7 +24,7 @@ describe('ConfigEditor', () => {
     const onChangeMock = jest.fn();
     const wrapper = mount(<ConfigEditor onOptionsChange={onChangeMock} options={createDefaultConfigOptions()} />);
     const inputWrapper = wrapper.find({ label: 'Maximum lines' }).find('input');
-    (inputWrapper.getDOMNode() as any).value = 42;
+    inputWrapper.getDOMNode<HTMLInputElement>().value = '42';
     inputWrapper.simulate('change');
     expect(onChangeMock.mock.calls[0][0].jsonData.maxLines).toBe('42');
   });


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing usage of `any` in `ConfigEditor`test.

**Which issue(s) this PR fixes**:

Fixes #53130

**Special notes for your reviewer**:

