### PR TITLE
Chore: Remove datasources from the Store interface

### DIFF
--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -203,7 +203,7 @@ func (hs *HTTPServer) getFSDataSources(c *models.ReqContext, enabledPlugins Enab
 
 	if c.OrgId != 0 {
 		query := datasources.GetDataSourcesQuery{OrgId: c.OrgId, DataSourceLimit: hs.Cfg.DataSourceLimit}
-		err := hs.SQLStore.GetDataSources(c.Req.Context(), &query)
+		err := hs.DataSourcesService.GetDataSources(c.Req.Context(), &query)
 
 		if err != nil {
 			return nil, err

--- a/pkg/infra/usagestats/service/api_test.go
+++ b/pkg/infra/usagestats/service/api_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
-	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/sqlstore/mockstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
@@ -51,7 +50,6 @@ func TestApi_getUsageStats(t *testing.T) {
 
 	sqlStore.ExpectedSystemStats = &models.SystemStats{}
 	sqlStore.ExpectedDataSourceStats = []*models.DataSourceStats{}
-	sqlStore.ExpectedDataSources = []*datasources.DataSource{}
 	sqlStore.ExpectedDataSourcesAccessStats = []*models.DataSourceAccessStats{}
 	sqlStore.ExpectedNotifierUsageStats = []*models.NotifierUsageStats{}
 

--- a/pkg/infra/usagestats/statscollector/service.go
+++ b/pkg/infra/usagestats/statscollector/service.go
@@ -257,7 +257,7 @@ func (s *Service) collectDatasourceStats(ctx context.Context) (map[string]interf
 func (s *Service) collectElasticStats(ctx context.Context) (map[string]interface{}, error) {
 	m := map[string]interface{}{}
 	esDataSourcesQuery := datasources.GetDataSourcesByTypeQuery{Type: datasources.DS_ES}
-	if err := s.sqlstore.GetDataSourcesByType(ctx, &esDataSourcesQuery); err != nil {
+	if err := s.datasources.GetDataSourcesByType(ctx, &esDataSourcesQuery); err != nil {
 		s.log.Error("Failed to get elasticsearch json data", "error", err)
 		return nil, err
 	}

--- a/pkg/infra/usagestats/statscollector/service_test.go
+++ b/pkg/infra/usagestats/statscollector/service_test.go
@@ -121,7 +121,7 @@ func TestFeatureUsageStats(t *testing.T) {
 
 func TestCollectingUsageStats(t *testing.T) {
 	sqlStore := mockstore.NewSQLStoreMock()
-	sqlStore.ExpectedDataSources = []*datasources.DataSource{
+	expectedDataSources := []*datasources.DataSource{
 		{
 			JsonData: simplejson.NewFromAny(map[string]interface{}{
 				"esVersion": "2.0.0",
@@ -149,7 +149,7 @@ func TestCollectingUsageStats(t *testing.T) {
 		Packaging:            "deb",
 		ReportingDistributor: "hosted-grafana",
 	}, sqlStore,
-		withDatasources(mockDatasourceService{datasources: sqlStore.ExpectedDataSources}))
+		withDatasources(mockDatasourceService{datasources: expectedDataSources}))
 
 	s.startTime = time.Now().Add(-1 * time.Minute)
 
@@ -204,19 +204,7 @@ func TestCollectingUsageStats(t *testing.T) {
 func TestElasticStats(t *testing.T) {
 	sqlStore := mockstore.NewSQLStoreMock()
 
-	s := createService(t, &setting.Cfg{
-		ReportingEnabled:     true,
-		BuildVersion:         "5.0.0",
-		AnonymousEnabled:     true,
-		BasicAuthEnabled:     true,
-		LDAPEnabled:          true,
-		AuthProxyEnabled:     true,
-		Packaging:            "deb",
-		ReportingDistributor: "hosted-grafana",
-	}, sqlStore,
-		withDatasources(mockDatasourceService{datasources: sqlStore.ExpectedDataSources}))
-
-	sqlStore.ExpectedDataSources = []*datasources.DataSource{
+	expectedDataSources := []*datasources.DataSource{
 		{
 			JsonData: simplejson.NewFromAny(map[string]interface{}{
 				"esVersion": "2.0.0",
@@ -233,6 +221,18 @@ func TestElasticStats(t *testing.T) {
 			}),
 		},
 	}
+
+	s := createService(t, &setting.Cfg{
+		ReportingEnabled:     true,
+		BuildVersion:         "5.0.0",
+		AnonymousEnabled:     true,
+		BasicAuthEnabled:     true,
+		LDAPEnabled:          true,
+		AuthProxyEnabled:     true,
+		Packaging:            "deb",
+		ReportingDistributor: "hosted-grafana",
+	}, sqlStore,
+		withDatasources(mockDatasourceService{datasources: expectedDataSources}))
 
 	metrics, err := s.collectElasticStats(context.Background())
 	require.NoError(t, err)
@@ -265,7 +265,7 @@ func TestDatasourceStats(t *testing.T) {
 		},
 	}
 
-	sqlStore.ExpectedDataSources = []*datasources.DataSource{
+	_ = []*datasources.DataSource{
 		{
 			JsonData: simplejson.NewFromAny(map[string]interface{}{
 				"esVersion": 2,

--- a/pkg/services/sqlstore/mockstore/mockstore.go
+++ b/pkg/services/sqlstore/mockstore/mockstore.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/apikey"
-	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/services/user"
@@ -21,7 +20,6 @@ type SQLStoreMock struct {
 	LatestUserId            int64
 
 	ExpectedUser                   *user.User
-	ExpectedDatasource             *datasources.DataSource
 	ExpectedAlert                  *models.Alert
 	ExpectedPluginSetting          *models.PluginSetting
 	ExpectedDashboards             []*models.Dashboard
@@ -31,11 +29,9 @@ type SQLStoreMock struct {
 	ExpectedTeamsByUser            []*models.TeamDTO
 	ExpectedSearchOrgList          []*models.OrgDTO
 	ExpectedSearchUsers            models.SearchUserQueryResult
-	ExpectedDatasources            []*datasources.DataSource
 	ExpectedOrg                    *models.Org
 	ExpectedSystemStats            *models.SystemStats
 	ExpectedDataSourceStats        []*models.DataSourceStats
-	ExpectedDataSources            []*datasources.DataSource
 	ExpectedDataSourcesAccessStats []*models.DataSourceAccessStats
 	ExpectedNotifierUsageStats     []*models.NotifierUsageStats
 	ExpectedPersistedDashboards    models.HitList
@@ -371,40 +367,6 @@ func (m *SQLStoreMock) GetDashboardTags(ctx context.Context, query *models.GetDa
 
 func (m *SQLStoreMock) GetDashboards(ctx context.Context, query *models.GetDashboardsQuery) error {
 	query.Result = m.ExpectedDashboards
-	return m.ExpectedError
-}
-
-func (m SQLStoreMock) GetDataSource(ctx context.Context, query *datasources.GetDataSourceQuery) error {
-	query.Result = m.ExpectedDatasource
-	return m.ExpectedError
-}
-
-func (m *SQLStoreMock) GetDataSources(ctx context.Context, query *datasources.GetDataSourcesQuery) error {
-	query.Result = m.ExpectedDataSources
-	return m.ExpectedError
-}
-
-func (m *SQLStoreMock) GetDataSourcesByType(ctx context.Context, query *datasources.GetDataSourcesByTypeQuery) error {
-	query.Result = m.ExpectedDataSources
-	return m.ExpectedError
-}
-
-func (m *SQLStoreMock) GetDefaultDataSource(ctx context.Context, query *datasources.GetDefaultDataSourceQuery) error {
-	query.Result = m.ExpectedDatasource
-	return m.ExpectedError
-}
-
-func (m *SQLStoreMock) DeleteDataSource(ctx context.Context, cmd *datasources.DeleteDataSourceCommand) error {
-	return m.ExpectedError
-}
-
-func (m *SQLStoreMock) AddDataSource(ctx context.Context, cmd *datasources.AddDataSourceCommand) error {
-	cmd.Result = m.ExpectedDatasource
-	return m.ExpectedError
-}
-
-func (m *SQLStoreMock) UpdateDataSource(ctx context.Context, cmd *datasources.UpdateDataSourceCommand) error {
-	cmd.Result = m.ExpectedDatasource
 	return m.ExpectedError
 }
 

--- a/pkg/services/sqlstore/store.go
+++ b/pkg/services/sqlstore/store.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/models"
-	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/services/user"
 )
@@ -70,13 +69,6 @@ type Store interface {
 	GetOrgUsers(ctx context.Context, query *models.GetOrgUsersQuery) error
 	SearchOrgUsers(ctx context.Context, query *models.SearchOrgUsersQuery) error
 	RemoveOrgUser(ctx context.Context, cmd *models.RemoveOrgUserCommand) error
-	GetDataSource(ctx context.Context, query *datasources.GetDataSourceQuery) error
-	GetDataSources(ctx context.Context, query *datasources.GetDataSourcesQuery) error
-	GetDataSourcesByType(ctx context.Context, query *datasources.GetDataSourcesByTypeQuery) error
-	GetDefaultDataSource(ctx context.Context, query *datasources.GetDefaultDataSourceQuery) error
-	DeleteDataSource(ctx context.Context, cmd *datasources.DeleteDataSourceCommand) error
-	AddDataSource(ctx context.Context, cmd *datasources.AddDataSourceCommand) error
-	UpdateDataSource(ctx context.Context, cmd *datasources.UpdateDataSourceCommand) error
 	Migrate(bool) error
 	Sync() error
 	Reset() error


### PR DESCRIPTION
Related to #46522 this PR removes datasource methods form the `sqlstore.Store` interface and from the mock. These methods are implemented as wrappers in the datasource service instead.