### PR TITLE
CI: Split `store-packages` step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1683,7 +1683,7 @@ steps:
   image: alpine:3.15
   name: identify-runner
 - commands:
-  - ./bin/grabpl store-packages --edition oss --gcp-key /tmp/gcpkey.json --build-id
+  - ./bin/grabpl publish packages --edition oss --gcp-key /tmp/gcpkey.json --build-id
     ${DRONE_BUILD_NUMBER}
   depends_on:
   - gen-version
@@ -1699,7 +1699,7 @@ steps:
     GRAFANA_COM_API_KEY:
       from_secret: grafana_api_key
   image: grafana/grafana-ci-deploy:1.3.3
-  name: store-packages-oss
+  name: publish-packages-oss
 trigger:
   branch: main
   event:
@@ -3591,7 +3591,7 @@ steps:
   image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
-  - ./bin/grabpl store-packages --edition oss --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
+  - ./bin/grabpl publish packages --edition oss --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
   depends_on:
   - gen-version
   environment:
@@ -3606,7 +3606,16 @@ steps:
     GRAFANA_COM_API_KEY:
       from_secret: grafana_api_key
   image: grafana/grafana-ci-deploy:1.3.3
-  name: store-packages-oss
+  name: publish-packages-oss
+- commands:
+  - ./bin/grabpl publish grafana-com --edition oss ${DRONE_TAG}
+  depends_on:
+  - publish-packages-oss
+  environment:
+    GRAFANA_COM_API_KEY:
+      from_secret: grafana_api_key
+  image: grafana/grafana-ci-deploy:1.3.3
+  name: publish-grafanacom-oss
 trigger:
   event:
   - promote
@@ -3646,7 +3655,8 @@ steps:
   image: grafana/build-container:1.5.9
   name: gen-version
 - commands:
-  - ./bin/grabpl store-packages --edition enterprise --gcp-key /tmp/gcpkey.json ${DRONE_TAG}
+  - ./bin/grabpl publish packages --edition enterprise --gcp-key /tmp/gcpkey.json
+    ${DRONE_TAG}
   depends_on:
   - gen-version
   environment:
@@ -3661,7 +3671,16 @@ steps:
     GRAFANA_COM_API_KEY:
       from_secret: grafana_api_key
   image: grafana/grafana-ci-deploy:1.3.3
-  name: store-packages-enterprise
+  name: publish-packages-enterprise
+- commands:
+  - ./bin/grabpl publish grafana-com --edition enterprise ${DRONE_TAG}
+  depends_on:
+  - publish-packages-enterprise
+  environment:
+    GRAFANA_COM_API_KEY:
+      from_secret: grafana_api_key
+  image: grafana/grafana-ci-deploy:1.3.3
+  name: publish-grafanacom-enterprise
 trigger:
   event:
   - promote
@@ -5152,6 +5171,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 98f819899607b53f5e6899ec67302671054808a98db9c6fa373e9420d7adeea8
+hmac: d3f17852dfffd0a3112098c897af0aa9936ea3c157ec4786f4d61c2f36fed0da
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -369,17 +369,6 @@ def publish_artifacts_step(mode):
         'depends_on': ['grabpl'],
     }
 
-def publish_packages_step(edition):
-    return {
-        'name': 'publish-packages-{}'.format(edition),
-        'image': publish_image,
-        'environment': {
-            'GCP_KEY': from_secret('gcp_key'),
-        },
-        'commands': ['./bin/grabpl store-packages {}'.format(edition)],
-        'depends_on': ['grabpl'],
-    }
-
 def publish_artifacts_pipelines(mode):
     trigger = {
         'event': ['promote'],

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -37,7 +37,8 @@ load(
     'benchmark_ldap_step',
     'store_storybook_step',
     'upload_packages_step',
-    'store_packages_step',
+    'publish_packages_step',
+    'publish_grafanacom_step',
     'upload_cdn_step',
     'verify_gen_cue_step',
     'publish_images_step',
@@ -391,13 +392,15 @@ def publish_packages_pipeline():
     oss_steps = [
         download_grabpl_step(),
         gen_version_step(ver_mode='release'),
-        store_packages_step(edition='oss', ver_mode='release'),
+        publish_packages_step(edition='oss', ver_mode='release'),
+        publish_grafanacom_step(edition='oss', ver_mode='release'),
     ]
 
     enterprise_steps = [
         download_grabpl_step(),
         gen_version_step(ver_mode='release'),
-        store_packages_step(edition='enterprise', ver_mode='release'),
+        publish_packages_step(edition='enterprise', ver_mode='release'),
+        publish_grafanacom_step(edition='enterprise', ver_mode='release'),
     ]
     deps = [
         'publish-artifacts-public',

--- a/scripts/drone/pipelines/build.star
+++ b/scripts/drone/pipelines/build.star
@@ -29,7 +29,6 @@ load(
     'store_storybook_step',
     'release_canary_npm_packages_step',
     'upload_packages_step',
-    'store_packages_step',
     'upload_cdn_step',
     'verify_gen_cue_step',
     'test_a11y_frontend_step',

--- a/scripts/drone/pipelines/publish.star
+++ b/scripts/drone/pipelines/publish.star
@@ -3,7 +3,7 @@ load(
     'identify_runner_step',
     'gen_version_step',
     'download_grabpl_step',
-    'store_packages_step',
+    'publish_packages_step',
     'compile_build_cmd',
 )
 
@@ -18,7 +18,7 @@ def publish(trigger, ver_mode, edition):
         gen_version_step(ver_mode),
         compile_build_cmd(),
         identify_runner_step(),
-        store_packages_step(edition=edition, ver_mode=ver_mode),
+        publish_packages_step(edition=edition, ver_mode=ver_mode),
     ]
     return pipeline(
                    name='main-publish', edition=edition, trigger=dict(trigger, repo=['grafana/grafana']),


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, our `store-packages` step is doing too much. It publishes to grafana.com and also publishes packages to RPM and DEB repos.

This PR splits that step to two different ones, one to handle the publishing to grafana.com and another one to publish to packages repos.

Related PR: https://github.com/grafana/build-pipeline/pull/466