### PR TITLE
CI: Run docs pipeline on `packages/**/*.md` changes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -705,7 +705,7 @@ trigger:
     include:
     - '*.md'
     - docs/**
-    - packages/**
+    - packages/**/*.md
     - latest.json
 type: docker
 volumes:
@@ -805,7 +805,7 @@ trigger:
     include:
     - '*.md'
     - docs/**
-    - packages/**
+    - packages/**/*.md
     - latest.json
 type: docker
 volumes:
@@ -5146,6 +5146,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 897b1edfa7ffaf637939a7ede5d5aa8a38c828c5b4ac4bc501836b988d295de9
+hmac: a6fff8b3e3e8664ef3e98e3acb2c68aaecdd2eb44fa40bd73ded8322564fb2fa
 
 ...

--- a/scripts/drone/pipelines/docs.star
+++ b/scripts/drone/pipelines/docs.star
@@ -30,7 +30,7 @@ docs_paths = {
     'include': [
         '*.md',
         'docs/**',
-        'packages/**',
+        'packages/**/*.md',
         'latest.json',
     ],
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

We realised that docs pipelines are running for every change under `packages/` which should be the case. We want the pipeline to run only for `*.md` files under that directory.