### PR TITLE
Storybook: remove `UseState` from legacy `Select` story

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1439,12 +1439,7 @@ exports[`better eslint`] = {
     ],
     "packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Do not use any type assertions.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Do not use any type assertions.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "packages/grafana-ui/src/components/Forms/Legacy/Select/SelectOption.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.story.internal.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.story.internal.tsx
@@ -1,15 +1,15 @@
 import { action } from '@storybook/addon-actions';
-import { Meta, Story } from '@storybook/react';
-import React, { useState, useCallback } from 'react';
+import { useArgs } from '@storybook/client-api';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import React, { useCallback } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 
-import { UseState } from '../../../../utils/storybook/UseState';
 import { withCenteredStory } from '../../../../utils/storybook/withCenteredStory';
 
 import { Select, AsyncSelect as AsyncSelectComponent } from './Select';
 
-const meta: Meta = {
+const meta: ComponentMeta<typeof Select> = {
   title: 'Forms/Legacy/Select',
   component: Select,
   decorators: [withCenteredStory],
@@ -31,7 +31,6 @@ const meta: Meta = {
         'id',
         'inputId',
         'defaultValue',
-        'loading',
         'aria-label',
         'noOptionsMessage',
         'onChange',
@@ -66,21 +65,16 @@ const options = [
   { label: 'Another label', value: 'Another value ' },
 ];
 
-export const Basic: Story = (args) => {
+export const Basic: ComponentStory<typeof Select> = (args) => {
+  const [, updateArgs] = useArgs();
   return (
-    <UseState initialState={initialValue}>
-      {(value, updateValue) => {
-        return (
-          <Select
-            {...args}
-            onChange={(value: SelectableValue<string>) => {
-              action('onChanged fired')(value);
-              updateValue(value);
-            }}
-          />
-        );
+    <Select
+      {...args}
+      onChange={(value) => {
+        action('onChange fired')(value);
+        updateArgs({ value });
       }}
-    </UseState>
+    />
   );
 };
 Basic.args = {
@@ -89,32 +83,32 @@ Basic.args = {
   width: 20,
 };
 
-export const AsyncSelect: Story = (args) => {
-  const [isLoading, setIsLoading] = useState<boolean>(args.loading);
-  const [asyncValue, setAsyncValue] = useState<SelectableValue<string>>();
-  const loadAsyncOptions = useCallback((inputValue) => {
-    return new Promise<Array<SelectableValue<string>>>((resolve) => {
-      setTimeout(() => {
-        setIsLoading(false);
-        resolve(options.filter((option) => option.label && option.label.includes(inputValue)));
-      }, 1000);
-    });
-  }, []);
+export const AsyncSelect: ComponentStory<typeof AsyncSelectComponent> = (args) => {
+  const [, updateArgs] = useArgs();
+  const loadAsyncOptions = useCallback(
+    (inputValue) => {
+      return new Promise<Array<SelectableValue<string>>>((resolve) => {
+        setTimeout(() => {
+          updateArgs({ isLoading: false });
+          resolve(options.filter((option) => option.label && option.label.includes(inputValue)));
+        }, 1000);
+      });
+    },
+    [updateArgs]
+  );
   return (
     <AsyncSelectComponent
       {...args}
-      value={asyncValue}
-      isLoading={isLoading}
       loadOptions={loadAsyncOptions}
       onChange={(value) => {
         action('onChange')(value);
-        setAsyncValue(value);
+        updateArgs({ value });
       }}
     />
   );
 };
 AsyncSelect.args = {
-  loading: true,
+  isLoading: true,
   defaultOptions: true,
   width: 20,
 };

--- a/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx
@@ -6,7 +6,7 @@ import { default as ReactAsyncSelect } from 'react-select/async';
 import Creatable from 'react-select/creatable';
 
 // Components
-import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { SelectableValue } from '@grafana/data';
 
 import { ThemeContext } from '../../../../themes';
 import { CustomScrollbar } from '../../../CustomScrollbar/CustomScrollbar';
@@ -54,7 +54,7 @@ export const MenuList = (props: any) => {
 export class Select<T> extends PureComponent<LegacySelectProps<T>> {
   static contextType = ThemeContext;
 
-  static defaultProps: Partial<LegacySelectProps<any>> = {
+  static defaultProps: Partial<LegacySelectProps<unknown>> = {
     className: '',
     isDisabled: false,
     isSearchable: true,
@@ -118,7 +118,7 @@ export class Select<T> extends PureComponent<LegacySelectProps<T>> {
     const creatableOptions: any = {};
 
     if (allowCustomValue) {
-      SelectComponent = Creatable as any;
+      SelectComponent = Creatable;
       creatableOptions.formatCreateLabel = formatCreateLabel ?? ((input: string) => input);
     }
 
@@ -142,7 +142,7 @@ export class Select<T> extends PureComponent<LegacySelectProps<T>> {
               onChange={onChange}
               options={options}
               placeholder={placeholder || 'Choose'}
-              styles={resetSelectStyles(this.context as GrafanaTheme2)}
+              styles={resetSelectStyles(this.context)}
               isDisabled={isDisabled}
               isLoading={isLoading}
               isClearable={isClearable}
@@ -168,7 +168,9 @@ export class Select<T> extends PureComponent<LegacySelectProps<T>> {
 }
 
 export class AsyncSelect<T> extends PureComponent<AsyncProps<T>> {
-  static defaultProps: Partial<AsyncProps<any>> = {
+  static contextType = ThemeContext;
+
+  static defaultProps: Partial<AsyncProps<unknown>> = {
     className: '',
     components: {},
     loadingMessage: () => 'Loading...',
@@ -245,7 +247,7 @@ export class AsyncSelect<T> extends PureComponent<AsyncProps<T>> {
               defaultOptions={defaultOptions}
               placeholder={placeholder || 'Choose'}
               //@ts-expect-error
-              styles={resetSelectStyles()}
+              styles={resetSelectStyles(this.context)}
               loadingMessage={() => loadingMessage}
               noOptionsMessage={noOptionsMessage}
               isDisabled={isDisabled}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- removes `UseState` from the legacy `Select` story
- fixes the async select component to correctly pass the theme (this fixes the async select story)
- fixes some types

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

