### PR TITLE
RBAC: Enable rbac when creating new settings

### DIFF
--- a/pkg/api/annotations_test.go
+++ b/pkg/api/annotations_test.go
@@ -453,7 +453,7 @@ func deleteAnnotationsScenario(t *testing.T, desc string, url string, routePatte
 }
 
 func TestAPI_Annotations_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInEditor(sc.initCtx)
 	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
@@ -860,7 +860,7 @@ func TestService_AnnotationTypeScopeResolver(t *testing.T) {
 }
 
 func TestAPI_MassDeleteAnnotations_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInEditor(sc.initCtx)
 	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -330,6 +330,7 @@ func setupSimpleHTTPServer(features *featuremgmt.FeatureManager) *HTTPServer {
 		features = featuremgmt.WithFeatures()
 	}
 	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
 	cfg.IsFeatureToggleEnabled = features.IsEnabled
 
 	return &HTTPServer{
@@ -340,25 +341,19 @@ func setupSimpleHTTPServer(features *featuremgmt.FeatureManager) *HTTPServer {
 	}
 }
 
-func setupHTTPServer(t *testing.T, useFakeAccessControl bool, enableAccessControl bool) accessControlScenarioContext {
-	return setupHTTPServerWithCfg(t, useFakeAccessControl, enableAccessControl, setting.NewCfg())
+func setupHTTPServer(t *testing.T, useFakeAccessControl bool) accessControlScenarioContext {
+	return setupHTTPServerWithCfg(t, useFakeAccessControl, setting.NewCfg())
 }
 
-func setupHTTPServerWithCfg(t *testing.T, useFakeAccessControl, enableAccessControl bool, cfg *setting.Cfg) accessControlScenarioContext {
+func setupHTTPServerWithCfg(t *testing.T, useFakeAccessControl bool, cfg *setting.Cfg) accessControlScenarioContext {
 	db := sqlstore.InitTestDB(t, sqlstore.InitTestDBOpt{})
-	return setupHTTPServerWithCfgDb(t, useFakeAccessControl, enableAccessControl, cfg, db, db, featuremgmt.WithFeatures())
+	return setupHTTPServerWithCfgDb(t, useFakeAccessControl, cfg, db, db, featuremgmt.WithFeatures())
 }
 
-func setupHTTPServerWithCfgDb(t *testing.T, useFakeAccessControl, enableAccessControl bool, cfg *setting.Cfg, db *sqlstore.SQLStore, store sqlstore.Store, features *featuremgmt.FeatureManager) accessControlScenarioContext {
+func setupHTTPServerWithCfgDb(t *testing.T, useFakeAccessControl bool, cfg *setting.Cfg, db *sqlstore.SQLStore, store sqlstore.Store, features *featuremgmt.FeatureManager) accessControlScenarioContext {
 	t.Helper()
 
-	if enableAccessControl {
-		cfg.RBACEnabled = true
-		db.Cfg.RBACEnabled = true
-	} else {
-		cfg.RBACEnabled = false
-		db.Cfg.RBACEnabled = false
-	}
+	db.Cfg.RBACEnabled = cfg.RBACEnabled
 
 	license := &licensing.OSSLicensingService{}
 	routeRegister := routing.NewRouteRegister()
@@ -370,7 +365,7 @@ func setupHTTPServerWithCfgDb(t *testing.T, useFakeAccessControl, enableAccessCo
 	// Defining the accesscontrol service has to be done before registering routes
 	if useFakeAccessControl {
 		acmock = accesscontrolmock.New()
-		if !enableAccessControl {
+		if !cfg.RBACEnabled {
 			acmock = acmock.WithDisabled()
 		}
 		ac = acmock

--- a/pkg/api/org_invite_test.go
+++ b/pkg/api/org_invite_test.go
@@ -67,7 +67,7 @@ func TestOrgInvitesAPIEndpointAccess(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			sc := setupHTTPServer(t, true, true)
+			sc := setupHTTPServer(t, true)
 			userService := usertest.NewUserServiceFake()
 			userService.ExpectedUser = &user.User{ID: 2}
 			sc.hs.userService = userService

--- a/pkg/api/org_test.go
+++ b/pkg/api/org_test.go
@@ -44,7 +44,9 @@ var (
 // `/api/org` endpoints test
 
 func TestAPIEndpoint_GetCurrentOrg_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
@@ -63,7 +65,7 @@ func TestAPIEndpoint_GetCurrentOrg_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_GetCurrentOrg_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
@@ -87,7 +89,9 @@ func TestAPIEndpoint_GetCurrentOrg_AccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutCurrentOrg_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 
 	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
@@ -108,7 +112,7 @@ func TestAPIEndpoint_PutCurrentOrg_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutCurrentOrg_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	_, err := sc.db.CreateOrgWithMember("TestOrg", sc.initCtx.UserID)
@@ -135,7 +139,9 @@ func TestAPIEndpoint_PutCurrentOrg_AccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutCurrentOrgAddress_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 
 	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
@@ -156,7 +162,7 @@ func TestAPIEndpoint_PutCurrentOrgAddress_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutCurrentOrgAddress_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
@@ -202,7 +208,9 @@ func setupOrgsDBForAccessControlTests(t *testing.T, db sqlstore.Store, usr user.
 }
 
 func TestAPIEndpoint_CreateOrgs_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	setting.AllowUserOrgCreate = false
@@ -229,7 +237,7 @@ func TestAPIEndpoint_CreateOrgs_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_CreateOrgs_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	setupOrgsDBForAccessControlTests(t, sc.db, *sc.initCtx.SignedInUser, 0)
@@ -250,7 +258,9 @@ func TestAPIEndpoint_CreateOrgs_AccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_DeleteOrgs_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	setupOrgsDBForAccessControlTests(t, sc.db, *sc.initCtx.SignedInUser, 2)
@@ -268,7 +278,7 @@ func TestAPIEndpoint_DeleteOrgs_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_DeleteOrgs_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	setupOrgsDBForAccessControlTests(t, sc.db, *sc.initCtx.SignedInUser, 2)
@@ -291,7 +301,9 @@ func TestAPIEndpoint_DeleteOrgs_AccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_SearchOrgs_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	t.Run("Viewer cannot list Orgs", func(t *testing.T) {
@@ -307,7 +319,7 @@ func TestAPIEndpoint_SearchOrgs_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_SearchOrgs_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	t.Run("AccessControl allows listing Orgs with correct permissions", func(t *testing.T) {
@@ -328,7 +340,9 @@ func TestAPIEndpoint_SearchOrgs_AccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_GetOrg_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to fetch another one than the logged in one
@@ -347,7 +361,7 @@ func TestAPIEndpoint_GetOrg_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_GetOrg_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to fetch another one than the logged in one
@@ -371,7 +385,9 @@ func TestAPIEndpoint_GetOrg_AccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_GetOrgByName_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to fetch another one than the logged in one
@@ -390,7 +406,7 @@ func TestAPIEndpoint_GetOrgByName_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_GetOrgByName_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to fetch another one than the logged in one
@@ -409,7 +425,9 @@ func TestAPIEndpoint_GetOrgByName_AccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutOrg_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to update another one than the logged in one
@@ -430,7 +448,7 @@ func TestAPIEndpoint_PutOrg_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutOrg_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to update another one than the logged in one
@@ -457,7 +475,9 @@ func TestAPIEndpoint_PutOrg_AccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutOrgAddress_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to update another one than the logged in one
@@ -478,7 +498,7 @@ func TestAPIEndpoint_PutOrgAddress_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutOrgAddress_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create two orgs, to update another one than the logged in one

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/mockstore"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/services/user/usertest"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -138,7 +139,9 @@ func TestOrgUsersAPIEndpoint_userLoggedIn(t *testing.T) {
 }
 
 func TestOrgUsersAPIEndpoint_LegacyAccessControl_FolderAdmin(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Create a dashboard folder
@@ -175,7 +178,9 @@ func TestOrgUsersAPIEndpoint_LegacyAccessControl_FolderAdmin(t *testing.T) {
 }
 
 func TestOrgUsersAPIEndpoint_LegacyAccessControl_TeamAdmin(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	// Setup store teams
@@ -189,7 +194,9 @@ func TestOrgUsersAPIEndpoint_LegacyAccessControl_TeamAdmin(t *testing.T) {
 }
 
 func TestOrgUsersAPIEndpoint_LegacyAccessControl_Admin(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInOrgAdmin(sc.initCtx)
 
 	response := callAPI(sc.server, http.MethodGet, "/api/org/users/lookup", nil, t)
@@ -197,7 +204,9 @@ func TestOrgUsersAPIEndpoint_LegacyAccessControl_Admin(t *testing.T) {
 }
 
 func TestOrgUsersAPIEndpoint_LegacyAccessControl_Viewer(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	response := callAPI(sc.server, http.MethodGet, "/api/org/users/lookup", nil, t)
@@ -224,7 +233,7 @@ func TestOrgUsersAPIEndpoint_AccessControl(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			sc := setupHTTPServer(t, true, true)
+			sc := setupHTTPServer(t, true)
 			setInitCtxSignedInViewer(sc.initCtx)
 			setAccessControlPermissions(sc.acmock, test.permissions, sc.initCtx.OrgID)
 
@@ -338,7 +347,9 @@ func TestGetOrgUsersAPIEndpoint_AccessControlMetadata(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			sc := setupHTTPServer(t, false, tc.enableAccessControl)
+			cfg := setting.NewCfg()
+			cfg.RBACEnabled = tc.enableAccessControl
+			sc := setupHTTPServerWithCfg(t, false, cfg)
 			setupOrgUsersDBForAccessControlTests(t, sc.db)
 			setInitCtxSignedInUser(sc.initCtx, tc.user)
 
@@ -435,7 +446,9 @@ func TestGetOrgUsersAPIEndpoint_AccessControl(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			sc := setupHTTPServer(t, false, tc.enableAccessControl)
+			cfg := setting.NewCfg()
+			cfg.RBACEnabled = tc.enableAccessControl
+			sc := setupHTTPServerWithCfg(t, false, cfg)
 			setupOrgUsersDBForAccessControlTests(t, sc.db)
 			setInitCtxSignedInUser(sc.initCtx, tc.user)
 
@@ -533,7 +546,9 @@ func TestPostOrgUsersAPIEndpoint_AccessControl(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			sc := setupHTTPServer(t, false, tc.enableAccessControl)
+			cfg := setting.NewCfg()
+			cfg.RBACEnabled = tc.enableAccessControl
+			sc := setupHTTPServerWithCfg(t, false, cfg)
 			userService := usertest.NewUserServiceFake()
 			userService.ExpectedUser = &user.User{ID: 2}
 			sc.hs.userService = userService
@@ -659,7 +674,7 @@ func TestOrgUsersAPIEndpointWithSetPerms_AccessControl(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			sc := setupHTTPServer(t, true, true)
+			sc := setupHTTPServer(t, true)
 			userService := usertest.NewUserServiceFake()
 			userService.ExpectedUser = &user.User{ID: 2}
 			sc.hs.userService = userService
@@ -774,7 +789,9 @@ func TestPatchOrgUsersAPIEndpoint_AccessControl(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			sc := setupHTTPServer(t, false, tc.enableAccessControl)
+			cfg := setting.NewCfg()
+			cfg.RBACEnabled = tc.enableAccessControl
+			sc := setupHTTPServerWithCfg(t, false, cfg)
 			setupOrgUsersDBForAccessControlTests(t, sc.db)
 			setInitCtxSignedInUser(sc.initCtx, tc.user)
 
@@ -894,7 +911,9 @@ func TestDeleteOrgUsersAPIEndpoint_AccessControl(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			sc := setupHTTPServer(t, false, tc.enableAccessControl)
+			cfg := setting.NewCfg()
+			cfg.RBACEnabled = tc.enableAccessControl
+			sc := setupHTTPServerWithCfg(t, false, cfg)
 			setupOrgUsersDBForAccessControlTests(t, sc.db)
 			setInitCtxSignedInUser(sc.initCtx, tc.user)
 

--- a/pkg/api/preferences_test.go
+++ b/pkg/api/preferences_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/setting"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -33,7 +35,9 @@ var (
 )
 
 func TestAPIEndpoint_GetCurrentOrgPreferences_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	dashSvc := dashboards.NewFakeDashboardService(t)
 	dashSvc.On("GetDashboard", mock.Anything, mock.AnythingOfType("*models.GetDashboardQuery")).Run(func(args mock.Arguments) {
 		q := args.Get(1).(*models.GetDashboardQuery)
@@ -68,7 +72,7 @@ func TestAPIEndpoint_GetCurrentOrgPreferences_LegacyAccessControl(t *testing.T) 
 }
 
 func TestAPIEndpoint_GetCurrentOrgPreferences_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	prefService := preftest.NewPreferenceServiceFake()
@@ -96,7 +100,9 @@ func TestAPIEndpoint_GetCurrentOrgPreferences_AccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutCurrentOrgPreferences_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 
 	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
@@ -117,7 +123,7 @@ func TestAPIEndpoint_PutCurrentOrgPreferences_LegacyAccessControl(t *testing.T) 
 }
 
 func TestAPIEndpoint_PutCurrentOrgPreferences_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
@@ -146,7 +152,9 @@ func TestAPIEndpoint_PutCurrentOrgPreferences_AccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PatchUserPreferences(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 
 	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)
@@ -177,7 +185,9 @@ func TestAPIEndpoint_PatchUserPreferences(t *testing.T) {
 }
 
 func TestAPIEndpoint_PatchOrgPreferences(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 
 	_, err := sc.db.CreateOrgWithMember("TestOrg", testUserID)
 	require.NoError(t, err)

--- a/pkg/api/quota_test.go
+++ b/pkg/api/quota_test.go
@@ -42,7 +42,9 @@ func setupDBAndSettingsForAccessControlQuotaTests(t *testing.T, sc accessControl
 }
 
 func TestAPIEndpoint_GetCurrentOrgQuotas_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
@@ -60,7 +62,7 @@ func TestAPIEndpoint_GetCurrentOrgQuotas_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_GetCurrentOrgQuotas_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
@@ -83,7 +85,9 @@ func TestAPIEndpoint_GetCurrentOrgQuotas_AccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_GetOrgQuotas_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
@@ -101,7 +105,7 @@ func TestAPIEndpoint_GetOrgQuotas_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_GetOrgQuotas_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
@@ -124,7 +128,9 @@ func TestAPIEndpoint_GetOrgQuotas_AccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutOrgQuotas_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
@@ -144,7 +150,7 @@ func TestAPIEndpoint_PutOrgQuotas_LegacyAccessControl(t *testing.T) {
 }
 
 func TestAPIEndpoint_PutOrgQuotas_AccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	setInitCtxSignedInViewer(sc.initCtx)
 
 	setupDBAndSettingsForAccessControlQuotaTests(t, sc)

--- a/pkg/api/search_test.go
+++ b/pkg/api/search_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestHTTPServer_Search(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	sc.initCtx.IsSignedIn = true
 	sc.initCtx.SignedInUser = &user.SignedInUser{}
 

--- a/pkg/api/team_members_test.go
+++ b/pkg/api/team_members_test.go
@@ -150,8 +150,9 @@ var (
 
 func TestAddTeamMembersAPIEndpoint_LegacyAccessControl(t *testing.T) {
 	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
 	cfg.EditorsCanAdmin = true
-	sc := setupHTTPServerWithCfg(t, true, false, cfg)
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	guardian := manager.ProvideService(database.ProvideTeamGuardianStore(sc.db))
 	sc.hs.teamGuardian = guardian
 
@@ -198,7 +199,7 @@ func TestAddTeamMembersAPIEndpoint_LegacyAccessControl(t *testing.T) {
 }
 
 func TestGetTeamMembersAPIEndpoint_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	sc.hs.License = &licensing.OSSLicensingService{}
 
 	teamMemberCount := 3
@@ -252,7 +253,7 @@ func TestGetTeamMembersAPIEndpoint_RBAC(t *testing.T) {
 }
 
 func TestAddTeamMembersAPIEndpoint_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	sc.hs.License = &licensing.OSSLicensingService{}
 
 	teamMemberCount := 3
@@ -286,8 +287,9 @@ func TestAddTeamMembersAPIEndpoint_RBAC(t *testing.T) {
 
 func TestUpdateTeamMembersAPIEndpoint_LegacyAccessControl(t *testing.T) {
 	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
 	cfg.EditorsCanAdmin = true
-	sc := setupHTTPServerWithCfg(t, true, false, cfg)
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	guardian := manager.ProvideService(database.ProvideTeamGuardianStore(sc.db))
 	sc.hs.teamGuardian = guardian
 
@@ -332,7 +334,7 @@ func TestUpdateTeamMembersAPIEndpoint_LegacyAccessControl(t *testing.T) {
 }
 
 func TestUpdateTeamMembersAPIEndpoint_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	sc.hs.License = &licensing.OSSLicensingService{}
 
 	teamMemberCount := 3
@@ -364,8 +366,9 @@ func TestUpdateTeamMembersAPIEndpoint_RBAC(t *testing.T) {
 
 func TestDeleteTeamMembersAPIEndpoint_LegacyAccessControl(t *testing.T) {
 	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
 	cfg.EditorsCanAdmin = true
-	sc := setupHTTPServerWithCfg(t, true, false, cfg)
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	guardian := manager.ProvideService(database.ProvideTeamGuardianStore(sc.db))
 	sc.hs.teamGuardian = guardian
 
@@ -406,7 +409,7 @@ func TestDeleteTeamMembersAPIEndpoint_LegacyAccessControl(t *testing.T) {
 }
 
 func TestDeleteTeamMembersAPIEndpoint_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	sc.hs.License = &licensing.OSSLicensingService{}
 
 	teamMemberCount := 3

--- a/pkg/api/team_test.go
+++ b/pkg/api/team_test.go
@@ -8,11 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/infra/log/logtest"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -160,7 +159,9 @@ const (
 )
 
 func TestTeamAPIEndpoint_CreateTeam_LegacyAccessControl(t *testing.T) {
-	sc := setupHTTPServer(t, true, false)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 	setInitCtxSignedInOrgAdmin(sc.initCtx)
 
 	input := strings.NewReader(fmt.Sprintf(teamCmd, 1))
@@ -180,8 +181,9 @@ func TestTeamAPIEndpoint_CreateTeam_LegacyAccessControl(t *testing.T) {
 
 func TestTeamAPIEndpoint_CreateTeam_LegacyAccessControl_EditorsCanAdmin(t *testing.T) {
 	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
 	cfg.EditorsCanAdmin = true
-	sc := setupHTTPServerWithCfg(t, true, false, cfg)
+	sc := setupHTTPServerWithCfg(t, true, cfg)
 
 	setInitCtxSignedInEditor(sc.initCtx)
 	input := strings.NewReader(fmt.Sprintf(teamCmd, 1))
@@ -192,7 +194,7 @@ func TestTeamAPIEndpoint_CreateTeam_LegacyAccessControl_EditorsCanAdmin(t *testi
 }
 
 func TestTeamAPIEndpoint_CreateTeam_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 
 	setInitCtxSignedInViewer(sc.initCtx)
 	input := strings.NewReader(fmt.Sprintf(teamCmd, 1))
@@ -211,7 +213,7 @@ func TestTeamAPIEndpoint_CreateTeam_RBAC(t *testing.T) {
 }
 
 func TestTeamAPIEndpoint_SearchTeams_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	// Seed three teams
 	for i := 1; i <= 3; i++ {
 		_, err := sc.db.CreateTeam(fmt.Sprintf("team%d", i), fmt.Sprintf("team%d@example.org", i), 1)
@@ -255,7 +257,7 @@ func TestTeamAPIEndpoint_SearchTeams_RBAC(t *testing.T) {
 }
 
 func TestTeamAPIEndpoint_GetTeamByID_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	sc.db = sqlstore.InitTestDB(t)
 
 	_, err := sc.db.CreateTeam("team1", "team1@example.org", 1)
@@ -285,7 +287,7 @@ func TestTeamAPIEndpoint_GetTeamByID_RBAC(t *testing.T) {
 // Then the endpoint should return 200 if the user has accesscontrol.ActionTeamsWrite with teams:id:1 scope
 // else return 403
 func TestTeamAPIEndpoint_UpdateTeam_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	sc.db = sqlstore.InitTestDB(t)
 	_, err := sc.db.CreateTeam("team1", "", 1)
 
@@ -334,7 +336,7 @@ func TestTeamAPIEndpoint_UpdateTeam_RBAC(t *testing.T) {
 // Then the endpoint should return 200 if the user has accesscontrol.ActionTeamsDelete with teams:id:1 scope
 // else return 403
 func TestTeamAPIEndpoint_DeleteTeam_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	sc.db = sqlstore.InitTestDB(t)
 	_, err := sc.db.CreateTeam("team1", "", 1)
 	require.NoError(t, err)
@@ -366,7 +368,7 @@ func TestTeamAPIEndpoint_DeleteTeam_RBAC(t *testing.T) {
 // Then the endpoint should return 200 if the user has accesscontrol.ActionTeamsRead with teams:id:1 scope
 // else return 403
 func TestTeamAPIEndpoint_GetTeamPreferences_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	sc.db = sqlstore.InitTestDB(t)
 	_, err := sc.db.CreateTeam("team1", "", 1)
 
@@ -399,7 +401,7 @@ func TestTeamAPIEndpoint_GetTeamPreferences_RBAC(t *testing.T) {
 // Then the endpoint should return 200 if the user has accesscontrol.ActionTeamsWrite with teams:id:1 scope
 // else return 403
 func TestTeamAPIEndpoint_UpdateTeamPreferences_RBAC(t *testing.T) {
-	sc := setupHTTPServer(t, true, true)
+	sc := setupHTTPServer(t, true)
 	sqlStore := sqlstore.InitTestDB(t)
 	sc.db = sqlStore
 

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol_test.go
@@ -139,9 +139,8 @@ func TestUsageMetrics(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := setting.NewCfg()
-			if tt.enabled {
-				cfg.RBACEnabled = true
-			}
+			cfg.RBACEnabled = tt.enabled
+
 			s, errInitAc := ProvideService(
 				featuremgmt.WithFeatures(),
 				cfg,

--- a/pkg/services/alerting/store_test.go
+++ b/pkg/services/alerting/store_test.go
@@ -46,10 +46,12 @@ func TestIntegrationAlertingDataAccess(t *testing.T) {
 	var items []*models.Alert
 
 	setup := func(t *testing.T) {
+		cfg := setting.NewCfg()
+		cfg.RBACEnabled = false
 		store = &sqlStore{
 			db:  sqlstore.InitTestDB(t),
 			log: log.New(),
-			cfg: setting.NewCfg(),
+			cfg: cfg,
 		}
 
 		testDash = insertTestDashboard(t, store.db, "dashboard with alerts", 1, 0, false, "alert")

--- a/pkg/services/dashboards/service/dashboard_service_integration_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_integration_test.go
@@ -815,10 +815,12 @@ func permissionScenario(t *testing.T, desc string, canSave bool, fn permissionSc
 	}
 
 	t.Run(desc, func(t *testing.T) {
+		cfg := setting.NewCfg()
+		cfg.RBACEnabled = false
 		sqlStore := sqlstore.InitTestDB(t)
 		dashboardStore := database.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures())
 		service := ProvideDashboardService(
-			&setting.Cfg{}, dashboardStore, &dummyDashAlertExtractor{},
+			cfg, dashboardStore, &dummyDashAlertExtractor{},
 			featuremgmt.WithFeatures(),
 			accesscontrolmock.NewMockedPermissionsService(),
 			accesscontrolmock.NewMockedPermissionsService(),
@@ -872,6 +874,7 @@ func callSaveWithResult(t *testing.T, cmd models.SaveDashboardCommand, sqlStore 
 	dto := toSaveDashboardDto(cmd)
 	dashboardStore := database.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures())
 	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
 	cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures().IsEnabled
 	service := ProvideDashboardService(
 		cfg, dashboardStore, &dummyDashAlertExtractor{},
@@ -890,6 +893,7 @@ func callSaveWithError(cmd models.SaveDashboardCommand, sqlStore *sqlstore.SQLSt
 	dto := toSaveDashboardDto(cmd)
 	dashboardStore := database.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures())
 	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
 	cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures().IsEnabled
 	service := ProvideDashboardService(
 		cfg, dashboardStore, &dummyDashAlertExtractor{},
@@ -926,6 +930,7 @@ func saveTestDashboard(t *testing.T, title string, orgID, folderID int64, sqlSto
 
 	dashboardStore := database.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures())
 	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
 	cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures().IsEnabled
 	service := ProvideDashboardService(
 		cfg, dashboardStore, &dummyDashAlertExtractor{},
@@ -963,6 +968,7 @@ func saveTestFolder(t *testing.T, title string, orgID int64, sqlStore *sqlstore.
 
 	dashboardStore := database.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures())
 	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
 	cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures().IsEnabled
 	service := ProvideDashboardService(
 		cfg, dashboardStore, &dummyDashAlertExtractor{},

--- a/pkg/services/dashboards/service/folder_service_test.go
+++ b/pkg/services/dashboards/service/folder_service_test.go
@@ -45,6 +45,7 @@ func TestIntegrationFolderService(t *testing.T) {
 	t.Run("Folder service tests", func(t *testing.T) {
 		store := &dashboards.FakeDashboardStore{}
 		cfg := setting.NewCfg()
+		cfg.RBACEnabled = false
 		features := featuremgmt.WithFeatures()
 		cfg.IsFeatureToggleEnabled = features.IsEnabled
 		folderPermissions := acmock.NewMockedPermissionsService()

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -274,6 +274,7 @@ func createDashboard(t *testing.T, sqlStore *sqlstore.SQLStore, user user.Signed
 	dashAlertExtractor := alerting.ProvideDashAlertExtractorService(nil, nil, nil)
 	features := featuremgmt.WithFeatures()
 	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
 	cfg.IsFeatureToggleEnabled = features.IsEnabled
 	ac := acmock.New()
 	folderPermissions := acmock.NewMockedPermissionsService()
@@ -293,6 +294,7 @@ func createFolderWithACL(t *testing.T, sqlStore *sqlstore.SQLStore, title string
 	t.Helper()
 
 	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
 	features := featuremgmt.WithFeatures()
 	cfg.IsFeatureToggleEnabled = features.IsEnabled
 	ac := acmock.New()
@@ -404,7 +406,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 		sqlStore := sqlstore.InitTestDB(t)
 		dashboardStore := database.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures())
 		features := featuremgmt.WithFeatures()
-		ac := acmock.New()
+		ac := acmock.New().WithDisabled()
 		// TODO: Update tests to work with rbac
 		sqlStore.Cfg.RBACEnabled = false
 		folderPermissions := acmock.NewMockedPermissionsService()

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -1378,6 +1378,7 @@ func createDashboard(t *testing.T, sqlStore *sqlstore.SQLStore, user *user.Signe
 	dashboardStore := database.ProvideDashboardStore(sqlStore, featuremgmt.WithFeatures())
 	dashAlertService := alerting.ProvideDashAlertExtractorService(nil, nil, nil)
 	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
 	cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures().IsEnabled
 	ac := acmock.New()
 	service := dashboardservice.ProvideDashboardService(
@@ -1396,6 +1397,7 @@ func createFolderWithACL(t *testing.T, sqlStore *sqlstore.SQLStore, title string
 
 	ac := acmock.New()
 	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
 	cfg.IsFeatureToggleEnabled = featuremgmt.WithFeatures().IsEnabled
 	features := featuremgmt.WithFeatures()
 	folderPermissions := acmock.NewMockedPermissionsService()
@@ -1489,6 +1491,7 @@ func testScenario(t *testing.T, desc string, fn func(t *testing.T, sc scenarioCo
 
 	t.Run(desc, func(t *testing.T) {
 		cfg := setting.NewCfg()
+		cfg.RBACEnabled = false
 		orgID := int64(1)
 		role := org.RoleAdmin
 		sqlStore := sqlstore.InitTestDB(t)

--- a/pkg/services/publicdashboards/api/api_test.go
+++ b/pkg/services/publicdashboards/api/api_test.go
@@ -39,6 +39,7 @@ import (
 func TestAPIGetPublicDashboard(t *testing.T) {
 	t.Run("It should 404 if featureflag is not enabled", func(t *testing.T) {
 		cfg := setting.NewCfg()
+		cfg.RBACEnabled = false
 		qs := buildQueryDataService(t, nil, nil, nil)
 		service := publicdashboards.NewFakePublicDashboardService(t)
 		service.On("GetPublicDashboard", mock.Anything, mock.AnythingOfType("string")).
@@ -100,9 +101,12 @@ func TestAPIGetPublicDashboard(t *testing.T) {
 			service.On("GetPublicDashboardConfig", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("string")).
 				Return(&PublicDashboard{}, nil).Maybe()
 
+			cfg := setting.NewCfg()
+			cfg.RBACEnabled = false
+
 			testServer := setupTestServer(
 				t,
-				setting.NewCfg(),
+				cfg,
 				buildQueryDataService(t, nil, nil, nil),
 				featuremgmt.WithFeatures(featuremgmt.FlagPublicDashboards),
 				service,
@@ -177,9 +181,12 @@ func TestAPIGetPublicDashboardConfig(t *testing.T) {
 			service.On("GetPublicDashboardConfig", mock.Anything, mock.AnythingOfType("int64"), mock.AnythingOfType("string")).
 				Return(test.PublicDashboardResult, test.PublicDashboardErr)
 
+			cfg := setting.NewCfg()
+			cfg.RBACEnabled = false
+
 			testServer := setupTestServer(
 				t,
-				setting.NewCfg(),
+				cfg,
 				buildQueryDataService(t, nil, nil, nil),
 				featuremgmt.WithFeatures(featuremgmt.FlagPublicDashboards),
 				service,
@@ -241,9 +248,12 @@ func TestApiSavePublicDashboardConfig(t *testing.T) {
 			service.On("SavePublicDashboardConfig", mock.Anything, mock.AnythingOfType("*models.SavePublicDashboardConfigDTO")).
 				Return(&PublicDashboard{IsEnabled: true}, test.SaveDashboardErr)
 
+			cfg := setting.NewCfg()
+			cfg.RBACEnabled = false
+
 			testServer := setupTestServer(
 				t,
-				setting.NewCfg(),
+				cfg,
 				buildQueryDataService(t, nil, nil, nil),
 				featuremgmt.WithFeatures(featuremgmt.FlagPublicDashboards),
 				service,
@@ -309,10 +319,12 @@ func TestAPIQueryPublicDashboard(t *testing.T) {
 
 	setup := func(enabled bool) (*web.Mux, *publicdashboards.FakePublicDashboardService) {
 		service := publicdashboards.NewFakePublicDashboardService(t)
+		cfg := setting.NewCfg()
+		cfg.RBACEnabled = false
 
 		testServer := setupTestServer(
 			t,
-			setting.NewCfg(),
+			cfg,
 			qds,
 			featuremgmt.WithFeatures(featuremgmt.FlagPublicDashboards, enabled),
 			service,
@@ -551,13 +563,15 @@ func TestIntegrationUnauthenticatedUserCanGetPubdashPanelQueryData(t *testing.T)
 
 	// create public dashboard
 	store := publicdashboardsStore.ProvideStore(db)
-	service := publicdashboardsService.ProvideService(setting.NewCfg(), store)
+	cfg := setting.NewCfg()
+	cfg.RBACEnabled = false
+	service := publicdashboardsService.ProvideService(cfg, store)
 	pubdash, err := service.SavePublicDashboardConfig(context.Background(), savePubDashboardCmd)
 	require.NoError(t, err)
 
 	// setup test server
 	server := setupTestServer(t,
-		setting.NewCfg(),
+		cfg,
 		qds,
 		featuremgmt.WithFeatures(featuremgmt.FlagPublicDashboards),
 		service,

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -632,7 +632,6 @@ func initTestDB(migration registry.DatabaseMigrator, opts ...InitTestDBOpt) (*SQ
 
 		// set test db config
 		cfg := setting.NewCfg()
-		cfg.RBACEnabled = true
 		cfg.IsFeatureToggleEnabled = func(key string) bool {
 			for _, enabledFeature := range features {
 				if enabledFeature == key {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -838,9 +838,10 @@ var skipStaticRootValidation = false
 
 func NewCfg() *Cfg {
 	return &Cfg{
-		Logger: log.New("settings"),
-		Raw:    ini.Empty(),
-		Azure:  &azsettings.AzureSettings{},
+		Logger:      log.New("settings"),
+		Raw:         ini.Empty(),
+		Azure:       &azsettings.AzureSettings{},
+		RBACEnabled: true,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We noticed that when creating a new config rbac option is disabled by default. This should be enabled by default for tests

**Which issue(s) this PR fixes**:
Part of: https://github.com/grafana/grafana-enterprise/issues/3695

**Special notes for your reviewer**:
* For some tests I explicitly disabled rbac and is intending to fix them is smaller prs. Test that needs update are listed in the issue
