### PR TITLE
Levitate: Update workflow to find type declaration via package.json

### DIFF
--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -34,8 +34,11 @@ jobs:
     - name: Build packages
       run: yarn packages:build
 
-    - name: Zip built packages
-      run: zip -r ./pr_built_packages.zip ./packages/**/dist
+    - name: Pack packages
+      run: yarn packages:pack --out ./%s.tgz 
+
+    - name: Zip built tarballed packages
+      run: zip -r ./base_built_packages.zip ./packages/**/*.tgz
 
     - name: Upload build output as artifact
       uses: actions/upload-artifact@v3
@@ -75,8 +78,11 @@ jobs:
     - name: Build packages
       run: yarn packages:build
 
-    - name: Zip built packages
-      run: zip -r ./base_built_packages.zip ./packages/**/dist
+    - name: Pack packages
+      run: yarn packages:pack --out ./%s.tgz
+
+    - name: Zip built tarballed packages
+      run: zip -r ./base_built_packages.zip ./packages/**/*.tgz
 
     - name: Upload build output as artifact
       uses: actions/upload-artifact@v3
@@ -105,10 +111,10 @@ jobs:
           name: buildBase
       
       - name: Unzip artifact from pr
-        run: unzip pr_built_packages.zip -d ./pr && rm pr_built_packages.zip
+        run: unzip -j pr_built_packages.zip -d ./pr && rm pr_built_packages.zip
 
       - name: Unzip artifact from base
-        run: unzip base_built_packages.zip -d ./base && rm base_built_packages.zip
+        run: unzip -j base_built_packages.zip -d ./base && rm base_built_packages.zip
 
       - name: Get link for the Github Action job
         id: job

--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -38,7 +38,7 @@ jobs:
       run: yarn packages:pack --out ./%s.tgz 
 
     - name: Zip built tarballed packages
-      run: zip -r ./base_built_packages.zip ./packages/**/*.tgz
+      run: zip -r ./pr_built_packages.zip ./packages/**/*.tgz
 
     - name: Upload build output as artifact
       uses: actions/upload-artifact@v3

--- a/scripts/check-breaking-changes.sh
+++ b/scripts/check-breaking-changes.sh
@@ -12,13 +12,19 @@ while IFS=" " read -r -a package; do
     PACKAGE_PATH=$(basename "$package")
 
     # Calculate current and previous package paths / names
-    PREV="./base/packages/$PACKAGE_PATH/dist/"
-    CURRENT="./pr/packages/$PACKAGE_PATH/dist/"
+    PREV="./base/$PACKAGE_PATH"
+    CURRENT="./pr/$PACKAGE_PATH"
 
     # Temporarily skipping these packages as they don't have any exposed static typing
     if [[ "$PACKAGE_PATH" == 'grafana-toolkit' || "$PACKAGE_PATH" == 'jaeger-ui-components' ]]; then
         continue
     fi
+
+    # Extract the npm package tarballs into separate directories e.g. ./base/@grafana-data.tgz -> ./base/grafana-data/
+    mkdir $PREV
+    tar -xf ./base/@$PACKAGE_PATH.tgz --strip-components=1 -C $PREV
+    mkdir $CURRENT
+    tar -xf ./pr/@$PACKAGE_PATH.tgz --strip-components=1 -C $CURRENT
 
     # Run the comparison and record the exit code
     echo ""


### PR DESCRIPTION
**What this PR does / why we need it**:
Following up on #51517 (which changed the way our NPM packages are packed and published). The breaking changes workflow is now passing the dist directory of each package to levitate which assumes to find the TS declaration file at `./index.d.ts`. 

This PR updates the workflow so it gives Levitate a directory of the complete package with package.json file so it can infer the declaration filepath from `types` or `typings` package.json property. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related PR: #51517

**Special notes for your reviewer**:
~Relies on grafana/levitate/pull/122 being merged for these changes to work / breaking changes workflow to pass.~
