### PR TITLE
Preferences: Use search endpoint to get missing dashboard

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3003,8 +3003,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/core/components/SharedPreferences/SharedPreferences.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
+      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/core/components/TagFilter/TagBadge.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -111,27 +111,13 @@ export class SharedPreferences extends PureComponent<Props, State> {
 
   async componentDidMount() {
     const prefs = await this.service.load();
-    const dashboards = (await backendSrv.search({ starred: true })) as DashboardSearchItem[];
+    const dashboards = await backendSrv.search({ starred: true });
 
     if (prefs.homeDashboardUID && !dashboards.find((d) => d.uid === prefs.homeDashboardUID)) {
-      const missingDash = await backendSrv.getDashboardByUid(prefs.homeDashboardUID);
+      const missingDash = await backendSrv.search({ dashboardUIDs: prefs.homeDashboardUID });
 
-      if (missingDash?.dashboard) {
-        dashboards.push({
-          title: missingDash.dashboard.title,
-          tags: [],
-          type: DashboardSearchItemType.DashDB,
-          uid: missingDash.dashboard.uid,
-          uri: '', // uri is not part of dashboard metadata
-          url: missingDash.meta.url || '',
-          folderId: missingDash.meta.folderId,
-          folderTitle: missingDash.meta.folderTitle,
-          folderUid: missingDash.meta.folderUid,
-          folderUrl: missingDash.meta.folderUrl,
-          isStarred: missingDash.meta.isStarred || false,
-          slug: missingDash.meta.slug,
-          items: [],
-        });
+      if (missingDash.length > 0) {
+        dashboards.push(missingDash[0]);
       }
     }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Avoid translation from dashboard API format into search API format. Use the dashboard search endpoint instead to fetch the missing non-starred dashboard. 

|When the dashboard is not starred, still appears in the dropdown. It is fetched using `/search?dashboardUIDs=<uid>` |
|-|
|<img width="1118" alt="Captura de Pantalla 2022-08-10 a las 17 09 09" src="https://user-images.githubusercontent.com/5699976/183941093-795c0975-c83a-4109-98ad-cb76a127ce3b.png">|

**Which issue(s) this PR fixes**: 
Just small refactor while refactoring types.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

