### PR TITLE
docs: updates whats new version number and link

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -71,8 +71,8 @@ title: Grafana documentation
         <h4>Provisioning</h4>
         <p>Learn how to automate your Grafana configuration.</p>
     </a>
-    <a href="{{< relref "whatsnew/whats-new-in-v8-0/" >}}" class="nav-cards__item nav-cards__item--guide">
-        <h4>What's new in v8.0</h4>
+    <a href="{{< relref "whatsnew/whats-new-in-v9-0/" >}}" class="nav-cards__item nav-cards__item--guide">
+        <h4>What's new in v9.0</h4>
         <p>Explore the features and enhancements in the latest release.</p>
     </a>
 


### PR DESCRIPTION
This PR updates the what's new version number and link on the Grafana docs landing page.