### PR TITLE
Datasources: Fix accessing metadata for datasource plugins

### DIFF
--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -45,7 +45,7 @@ export function EditDataSource({ uid, pageId }: Props) {
 
   const dispatch = useDispatch();
   const dataSource = useDataSource(uid);
-  const dataSourceMeta = useDataSourceMeta(uid);
+  const dataSourceMeta = useDataSourceMeta(dataSource.type);
   const dataSourceSettings = useDataSourceSettings();
   const dataSourceRights = useDataSourceRights(uid);
   const exploreUrl = useDataSourceExploreUrl(uid);

--- a/public/app/features/datasources/state/hooks.ts
+++ b/public/app/features/datasources/state/hooks.ts
@@ -115,8 +115,8 @@ export const useDataSourceExploreUrl = (uid: string) => {
   return exploreUrl;
 };
 
-export const useDataSourceMeta = (uid: string): DataSourcePluginMeta => {
-  return useSelector((state: StoreState) => getDataSourceMeta(state.dataSources, uid));
+export const useDataSourceMeta = (pluginType: string): DataSourcePluginMeta => {
+  return useSelector((state: StoreState) => getDataSourceMeta(state.dataSources, pluginType));
 };
 
 export const useDataSourceSettings = () => {


### PR DESCRIPTION
### The problem
Unfortunately during the refactoring work in https://github.com/grafana/grafana/pull/51874 I have used the `uid` to get the datasource meta instead of the plugin `type`, which caused Angular datasource plugins not to be able to render their custom settings. Thanks @zoltanbedi for reporting it! 🙏 

### The solution
Passing down the plugin type (the identifier of the datasource plugin) solves the issue. 