### PR TITLE
Docs: Add 9.1 to What's New index

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -71,8 +71,8 @@ title: Grafana documentation
         <h4>Provisioning</h4>
         <p>Learn how to automate your Grafana configuration.</p>
     </a>
-    <a href="{{< relref "whatsnew/whats-new-in-v9-0/" >}}" class="nav-cards__item nav-cards__item--guide">
-        <h4>What's new in v9.0</h4>
+    <a href="{{< relref "whatsnew/whats-new-in-v9-1/" >}}" class="nav-cards__item nav-cards__item--guide">
+        <h4>What's new in v9.1</h4>
         <p>Explore the features and enhancements in the latest release.</p>
     </a>
 

--- a/docs/sources/whatsnew/_index.md
+++ b/docs/sources/whatsnew/_index.md
@@ -65,6 +65,7 @@ as info on deprecations, breaking changes and plugin development read the [relea
 
 ## Grafana 9
 
+- [What's new in 9.1]({{< relref "whats-new-in-v9-1/" >}})
 - [What's new in 9.0]({{< relref "whats-new-in-v9-0/" >}})
 
 ## Grafana 8


### PR DESCRIPTION
**What this PR does / why we need it**:

Links to the v9.1 What's New document from the What's New index, and updates the main docs index link to the What's New document.

**Which issue(s) this PR fixes**:

N/A; part of the v9.1 release process.

**Special notes for your reviewer**:

None.