### PR TITLE
Loki: Remove any from public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -98,7 +98,7 @@ exports[`no enzyme tests`] = {
     "public/app/plugins/datasource/loki/configuration/DebugSection.test.tsx:1551927716": [
       [0, 17, 13, "RegExp match", "2409514259"]
     ],
-    "public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx:3570129984": [
+    "public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx:3764084053": [
       [0, 19, 13, "RegExp match", "2409514259"]
     ],
     "public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx:2402631398": [
@@ -7420,12 +7420,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Do not use any type assertions.", "4"],
       [0, 0, 0, "Do not use any type assertions.", "5"]
-    ],
-    "public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
     "public/app/plugins/datasource/loki/configuration/DerivedFields.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx
+++ b/public/app/plugins/datasource/loki/configuration/DerivedField.test.tsx
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-import { DataSourceInstanceSettings } from '@grafana/data';
+import { DataSourceInstanceSettings, DataSourcePluginMeta } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
 
 import { DerivedField } from './DerivedField';
@@ -17,8 +17,8 @@ jest.mock('app/features/plugins/datasource_srv', () => ({
             name: 'metrics_ds',
             meta: {
               tracing: false,
-            } as any,
-          } as any,
+            } as DataSourcePluginMeta,
+          } as DataSourceInstanceSettings,
 
           {
             id: 2,
@@ -26,8 +26,8 @@ jest.mock('app/features/plugins/datasource_srv', () => ({
             name: 'tracing_ds',
             meta: {
               tracing: true,
-            } as any,
-          } as any,
+            } as DataSourcePluginMeta,
+          } as DataSourceInstanceSettings,
         ];
       },
     };


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing a usage of `any` in `DerivedField.test.tsx`.

**Which issue(s) this PR fixes**:

Fixes #53129

**Special notes for your reviewer**:

