### PR TITLE
Loki: Remove any from public/app/plugins/datasource/loki/components/LokiQueryField.test.tsx

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -7398,10 +7398,6 @@ exports[`better eslint`] = {
     "public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/plugins/datasource/loki/components/LokiQueryField.test.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
-    ],
     "public/app/plugins/datasource/loki/components/LokiQueryField.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],

--- a/public/app/plugins/datasource/loki/components/LokiQueryField.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiQueryField.test.tsx
@@ -3,6 +3,10 @@ import React, { ComponentProps } from 'react';
 
 import { dateTime } from '@grafana/data';
 
+import { LokiDatasource } from '../datasource';
+import LokiLanguageProvider from '../language_provider';
+import syntax from '../syntax';
+
 import { LokiQueryField } from './LokiQueryField';
 
 type Props = ComponentProps<typeof LokiQueryField>;
@@ -12,12 +16,11 @@ const defaultProps: Props = {
     languageProvider: {
       start: () => Promise.resolve(['label1']),
       fetchLabels: Promise.resolve(['label1']),
-      getSyntax: () => {},
+      getSyntax: () => syntax,
       getLabelKeys: () => ['label1'],
-      getLabelValues: () => ['value1'],
-    } as any,
-    getInitHints: () => [],
-  } as any,
+      getLabelValues: () => Promise.resolve(['value1']),
+    } as unknown as LokiLanguageProvider,
+  } as LokiDatasource,
   range: {
     from: dateTime([2021, 1, 11, 12, 0, 0]),
     to: dateTime([2021, 1, 11, 18, 0, 0]),


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixing usage of `any` in `LokiQueryField.test.tsx`.

**Which issue(s) this PR fixes**:

Fixes #53131

**Special notes for your reviewer**:

