### PR TITLE
Changed migrator to use LockExecuteAndRelease.

### DIFF
--- a/pkg/infra/serverlock/serverlock.go
+++ b/pkg/infra/serverlock/serverlock.go
@@ -147,7 +147,7 @@ func (sl *ServerLockService) acquireForRelease(ctx context.Context, actionName s
 		if len(lockRows) > 0 {
 			result := lockRows[0]
 			if sl.isLockWithinInterval(result, maxInterval) {
-				return errors.New("there is already a lock for this operation")
+				return errors.New("there is already a lock for this operation: " + actionName)
 			} else {
 				// lock has timeouted, so we update the timestamp
 				result.LastExecution = time.Now().Unix()
@@ -157,7 +157,7 @@ func (sl *ServerLockService) acquireForRelease(ctx context.Context, actionName s
 					return err
 				}
 				if affected != 1 {
-					sl.log.Error("Expected rows affected to be 1 if there was no error.", "rowAffected", affected)
+					sl.log.Error("Expected rows affected to be 1 if there was no error.", "actionName", actionName, "rowAffected", affected)
 				}
 				return nil
 			}
@@ -175,7 +175,7 @@ func (sl *ServerLockService) acquireForRelease(ctx context.Context, actionName s
 
 			if affected != 1 {
 				// this means that there was no error but there is something not working correctly
-				sl.log.Error("Expected rows affected to be 1 if there was no error.", "rowAffected", affected)
+				sl.log.Error("Expected rows affected to be 1 if there was no error.", "actionName", actionName, "rowAffected", affected)
 			}
 		}
 		return nil
@@ -195,7 +195,7 @@ func (sl *ServerLockService) releaseLock(ctx context.Context, actionName string)
 		}
 		affected, err := res.RowsAffected()
 		if affected != 1 {
-			sl.log.Debug("Error releasing lock ", "affected", affected)
+			sl.log.Debug("Error releasing lock ", "actionName", actionName, "affected", affected)
 		}
 		return err
 	})

--- a/pkg/services/secrets/kvstore/migrations/migrator.go
+++ b/pkg/services/secrets/kvstore/migrations/migrator.go
@@ -42,7 +42,7 @@ func ProvideSecretMigrationService(
 // Migrate Run migration services. This will block until all services have exited.
 func (s *SecretMigrationServiceImpl) Migrate(ctx context.Context) error {
 	// Start migration services.
-	return s.ServerLockService.LockAndExecute(ctx, "migrate secrets to unified secrets", time.Minute*10, func(context.Context) {
+	return s.ServerLockService.LockExecuteAndRelease(ctx, "migrate secrets job", time.Minute*10, func(context.Context) {
 		for _, service := range s.Services {
 			serviceName := reflect.TypeOf(service).String()
 			logger.Debug("Starting secret migration service", "service", serviceName)


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes Secrets Migrator to plugin to use the new service ServerLockService.LockExecuteAndRelease() introduced in https://github.com/grafana/grafana/issues/52561


**Which issue(s) this PR fixes**:
Fixes https://github.com/grafana/grafana-partnerships-team/issues/317

**Special notes for your reviewer**:
- Also improves some error logs and messages
