### PR TITLE
Traces: Set default span link time range to one second

### DIFF
--- a/public/app/features/explore/TraceView/createSpanLink.test.ts
+++ b/public/app/features/explore/TraceView/createSpanLink.test.ts
@@ -121,6 +121,32 @@ describe('createSpanLinkFactory', () => {
       );
     });
 
+    it('with time range less than 1s', () => {
+      const createLink = setupSpanLinkFactory({
+        spanStartTimeShift: '0s',
+        spanEndTimeShift: '0s',
+      });
+      expect(createLink).toBeDefined();
+      const links = createLink!(
+        createTraceSpan({
+          process: {
+            serviceName: 'service',
+            tags: [
+              { key: 'hostname', value: 'hostname1' },
+              { key: 'ip', value: '192.168.0.1' },
+            ],
+          },
+        })
+      );
+      const linkDef = links?.logLinks?.[0];
+      expect(linkDef).toBeDefined();
+      expect(linkDef!.href).toBe(
+        `/explore?left=${encodeURIComponent(
+          '{"range":{"from":"2020-10-14T01:00:00.000Z","to":"2020-10-14T01:00:01.000Z"},"datasource":"loki1_uid","queries":[{"expr":"{hostname=\\"hostname1\\"}","refId":""}],"panelsState":{}}'
+        )}`
+      );
+    });
+
     it('filters by trace and span ID', () => {
       const createLink = setupSpanLinkFactory({
         filterBySpanID: true,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR sets our default span link time range to one second. This is needed as previously we didn't set this unless we were using Splunk.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/support-escalations/issues/3552

**To Test**:

- Click either of the two buttons in the pictures
- Observe that absolute time in explore panel has a range of one second
- Go to datasource config editor and change span start/end time shift
- Go back to explore and click either of those two buttons again
- Observer that absolute time in explore is set according to ds config span start/end time shift and not set to a range of one second (unless the span start/end time shift is less than one second)

![Screenshot 2022-08-11 at 09 33 37](https://user-images.githubusercontent.com/90795735/184095508-9c4c23fa-c431-4271-865c-e1c43a5e6263.png)
![Screenshot 2022-08-11 at 09 33 45](https://user-images.githubusercontent.com/90795735/184095512-8c6aa77a-f668-4101-b0f2-a088a430a429.png)

