### PR TITLE
PanelEdit: Add Decimal value formatter to disable and decimal rounding

### DIFF
--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -39,6 +39,7 @@ export const getCategories = (): ValueFormatCategory[] => [
     name: 'Misc',
     formats: [
       { name: 'Number', id: 'none', fn: toFixedUnit('') },
+      { name: 'Decimal', id: 'decimal', fn: stringFormater },
       { name: 'String', id: 'string', fn: stringFormater },
       {
         name: 'short',


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new unit value formatter "Decimal" (that is just the the String value formatter) to create a (hopefully) more obvious way to disable decimal values from being rounded.

We don't want to change the default behaviour of the number formatter because we optimise for most queries people make - Prometheus producing values with _many_ decimal points.

**Which issue(s) this PR fixes**:

Fixes #49388

**Special notes for your reviewer**:

I'm not sure if just aliasing the string formatter is the best approach, but it's essentially what @kaydelaney did in her [earlier PR](https://github.com/grafana/grafana/pull/49926). thoughts @torkelo @kaydelaney ?

