### PR TITLE
RBAC: Fix various ui issues for role picker

### DIFF
--- a/public/app/core/components/RolePicker/RolePicker.tsx
+++ b/public/app/core/components/RolePicker/RolePicker.tsx
@@ -107,11 +107,6 @@ export const RolePicker = ({
     setSelectedBuiltInRole(role);
   };
 
-  // if roles cannot be updated mark every role as non delegatable
-  if (!canUpdateRoles) {
-    roleOptions.map((r) => (r.delegatable = false));
-  }
-
   const onUpdate = (newRoles: Role[], newBuiltInRole?: OrgRole) => {
     if (onBuiltinRoleChange && newBuiltInRole && newBuiltInRole !== builtInRole) {
       onBuiltinRoleChange(newBuiltInRole);
@@ -124,10 +119,13 @@ export const RolePicker = ({
   };
 
   const getOptions = () => {
+    // if roles cannot be updated mark every role as non delegatable
+    const options = roleOptions.map((r) => ({ ...r, delegatable: canUpdateRoles && r.delegatable }));
+
     if (query && query.trim() !== '') {
-      return roleOptions.filter((option) => option.name?.toLowerCase().includes(query.toLowerCase()));
+      return options.filter((option) => option.name?.toLowerCase().includes(query.toLowerCase()));
     }
-    return roleOptions;
+    return options;
   };
 
   if (isLoading) {

--- a/public/app/core/components/RolePicker/RolePicker.tsx
+++ b/public/app/core/components/RolePicker/RolePicker.tsx
@@ -19,6 +19,7 @@ export interface Props {
   onRolesChange: (newRoles: Role[]) => void;
   onBuiltinRoleChange?: (newRole: OrgRole) => void;
   updateDisabled?: boolean;
+  canUpdateRoles?: boolean;
 }
 
 export const RolePicker = ({
@@ -32,6 +33,7 @@ export const RolePicker = ({
   onRolesChange,
   onBuiltinRoleChange,
   updateDisabled,
+  canUpdateRoles = true,
 }: Props): JSX.Element | null => {
   const [isOpen, setOpen] = useState(false);
   const [selectedRoles, setSelectedRoles] = useState<Role[]>(appliedRoles);
@@ -105,13 +107,20 @@ export const RolePicker = ({
     setSelectedBuiltInRole(role);
   };
 
+  // if roles cannot be updated mark every role as non delegatable
+  if (!canUpdateRoles) {
+    roleOptions.map((r) => (r.delegatable = false));
+  }
+
   const onUpdate = (newRoles: Role[], newBuiltInRole?: OrgRole) => {
     if (onBuiltinRoleChange && newBuiltInRole && newBuiltInRole !== builtInRole) {
       onBuiltinRoleChange(newBuiltInRole);
     }
-    onRolesChange(newRoles);
-    setOpen(false);
-    setQuery('');
+    if (canUpdateRoles) {
+      onRolesChange(newRoles);
+      setOpen(false);
+      setQuery('');
+    }
   };
 
   const getOptions = () => {

--- a/public/app/core/components/RolePicker/RolePicker.tsx
+++ b/public/app/core/components/RolePicker/RolePicker.tsx
@@ -18,7 +18,6 @@ export interface Props {
   showBuiltInRole?: boolean;
   onRolesChange: (newRoles: Role[]) => void;
   onBuiltinRoleChange?: (newRole: OrgRole) => void;
-  updateDisabled?: boolean;
   canUpdateRoles?: boolean;
   apply?: boolean;
 }
@@ -33,7 +32,6 @@ export const RolePicker = ({
   showBuiltInRole,
   onRolesChange,
   onBuiltinRoleChange,
-  updateDisabled,
   canUpdateRoles = true,
   apply = false,
 }: Props): JSX.Element | null => {
@@ -166,7 +164,7 @@ export const RolePicker = ({
             showGroups={query.length === 0 || query.trim() === ''}
             builtinRolesDisabled={builtinRolesDisabled}
             showBuiltInRole={showBuiltInRole}
-            updateDisabled={updateDisabled || false}
+            updateDisabled={builtinRolesDisabled && !canUpdateRoles}
             apply={apply}
             offset={offset}
           />

--- a/public/app/core/components/RolePicker/RolePicker.tsx
+++ b/public/app/core/components/RolePicker/RolePicker.tsx
@@ -20,6 +20,7 @@ export interface Props {
   onBuiltinRoleChange?: (newRole: OrgRole) => void;
   updateDisabled?: boolean;
   canUpdateRoles?: boolean;
+  apply?: boolean;
 }
 
 export const RolePicker = ({
@@ -34,6 +35,7 @@ export const RolePicker = ({
   onBuiltinRoleChange,
   updateDisabled,
   canUpdateRoles = true,
+  apply = false,
 }: Props): JSX.Element | null => {
   const [isOpen, setOpen] = useState(false);
   const [selectedRoles, setSelectedRoles] = useState<Role[]>(appliedRoles);
@@ -165,6 +167,7 @@ export const RolePicker = ({
             builtinRolesDisabled={builtinRolesDisabled}
             showBuiltInRole={showBuiltInRole}
             updateDisabled={updateDisabled || false}
+            apply={apply}
             offset={offset}
           />
         )}

--- a/public/app/core/components/RolePicker/RolePicker.tsx
+++ b/public/app/core/components/RolePicker/RolePicker.tsx
@@ -118,9 +118,9 @@ export const RolePicker = ({
     }
     if (canUpdateRoles) {
       onRolesChange(newRoles);
-      setOpen(false);
-      setQuery('');
     }
+    setQuery('');
+    setOpen(false);
   };
 
   const getOptions = () => {

--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -41,6 +41,7 @@ interface RolePickerMenuProps {
   onBuiltInRoleSelect?: (role: OrgRole) => void;
   onUpdate: (newRoles: Role[], newBuiltInRole?: OrgRole) => void;
   updateDisabled?: boolean;
+  apply?: boolean;
   offset: { vertical: number; horizontal: number };
 }
 
@@ -56,6 +57,7 @@ export const RolePickerMenu = ({
   onUpdate,
   updateDisabled,
   offset,
+  apply,
 }: RolePickerMenuProps): JSX.Element => {
   const [selectedOptions, setSelectedOptions] = useState<Role[]>(appliedRoles);
   const [selectedBuiltInRole, setSelectedBuiltInRole] = useState<OrgRole | undefined>(builtInRole);
@@ -267,11 +269,11 @@ export const RolePickerMenu = ({
         </CustomScrollbar>
         <div className={customStyles.menuButtonRow}>
           <HorizontalGroup justify="flex-end">
-            <Button size="sm" fill="text" onClick={onClearInternal}>
+            <Button size="sm" fill="text" onClick={onClearInternal} disabled={updateDisabled}>
               Clear all
             </Button>
-            <Button size="sm" onClick={onUpdateInternal}>
-              {updateDisabled ? `Apply` : `Update`}
+            <Button size="sm" onClick={onUpdateInternal} disabled={updateDisabled}>
+              {apply ? `Apply` : `Update`}
             </Button>
           </HorizontalGroup>
         </div>

--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -40,7 +40,6 @@ interface RolePickerMenuProps {
   onSelect: (roles: Role[]) => void;
   onBuiltInRoleSelect?: (role: OrgRole) => void;
   onUpdate: (newRoles: Role[], newBuiltInRole?: OrgRole) => void;
-  onClear?: () => void;
   updateDisabled?: boolean;
   offset: { vertical: number; horizontal: number };
 }
@@ -55,7 +54,6 @@ export const RolePickerMenu = ({
   onSelect,
   onBuiltInRoleSelect,
   onUpdate,
-  onClear,
   updateDisabled,
   offset,
 }: RolePickerMenuProps): JSX.Element => {
@@ -153,9 +151,6 @@ export const RolePickerMenu = ({
   };
 
   const onClearInternal = async () => {
-    if (onClear) {
-      onClear();
-    }
     setSelectedOptions([]);
   };
 

--- a/public/app/core/components/RolePicker/TeamRolePicker.tsx
+++ b/public/app/core/components/RolePicker/TeamRolePicker.tsx
@@ -1,7 +1,8 @@
 import React, { FC, useEffect } from 'react';
 import { useAsyncFn } from 'react-use';
 
-import { Role } from 'app/types';
+import { contextSrv } from 'app/core/core';
+import { Role, AccessControlAction } from 'app/types';
 
 import { RolePicker } from './RolePicker';
 // @ts-ignore
@@ -35,6 +36,10 @@ export const TeamRolePicker: FC<Props> = ({ teamId, orgId, roleOptions, disabled
     await getTeamRoles();
   };
 
+  const canUpdateRoles =
+    contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesAdd) &&
+    contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesRemove);
+
   return (
     <RolePicker
       onRolesChange={onRolesChange}
@@ -43,6 +48,7 @@ export const TeamRolePicker: FC<Props> = ({ teamId, orgId, roleOptions, disabled
       isLoading={loading}
       disabled={disabled}
       builtinRolesDisabled={builtinRolesDisabled}
+      canUpdateRoles={canUpdateRoles}
     />
   );
 };

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -58,14 +58,25 @@ export const UserRolePicker: FC<Props> = ({
     }
   }, [orgId, getUserRoles, pendingRoles]);
 
+  const canUpdateRoles =
+    contextSrv.hasPermission(AccessControlAction.ActionUserRolesAdd) ||
+    contextSrv.hasPermission(AccessControlAction.ActionUserRolesRemove);
+
+  // if a user cannot update roles of another user mark every role as non delegatable
+  if (!canUpdateRoles) {
+    roleOptions.map((r) => (r.delegatable = false));
+  }
+
   const onRolesChange = async (roles: Role[]) => {
+    if (!canUpdateRoles) {
+      return;
+    }
+
     if (!updateDisabled) {
       await updateUserRoles(roles, userId, orgId);
       await getUserRoles();
-    } else {
-      if (onApplyRoles) {
-        onApplyRoles(roles, userId, orgId);
-      }
+    } else if (onApplyRoles) {
+      onApplyRoles(roles, userId, orgId);
     }
   };
 

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -59,7 +59,7 @@ export const UserRolePicker: FC<Props> = ({
   }, [orgId, getUserRoles, pendingRoles]);
 
   const canUpdateRoles =
-    contextSrv.hasPermission(AccessControlAction.ActionUserRolesAdd) ||
+    contextSrv.hasPermission(AccessControlAction.ActionUserRolesAdd) &&
     contextSrv.hasPermission(AccessControlAction.ActionUserRolesRemove);
 
   // if a user cannot update roles of another user mark every role as non delegatable

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -16,7 +16,7 @@ export interface Props {
   builtInRoles?: { [key: string]: Role[] };
   disabled?: boolean;
   builtinRolesDisabled?: boolean;
-  updateDisabled?: boolean;
+  apply?: boolean;
   onApplyRoles?: (newRoles: Role[], userId: number, orgId: number | undefined) => void;
   pendingRoles?: Role[];
 }
@@ -30,13 +30,13 @@ export const UserRolePicker: FC<Props> = ({
   builtInRoles,
   disabled,
   builtinRolesDisabled,
-  updateDisabled,
+  apply = false,
   onApplyRoles,
   pendingRoles,
 }) => {
   const [{ loading, value: appliedRoles = [] }, getUserRoles] = useAsyncFn(async () => {
     try {
-      if (updateDisabled) {
+      if (apply) {
         if (pendingRoles?.length! > 0) {
           return pendingRoles;
         }
@@ -59,7 +59,7 @@ export const UserRolePicker: FC<Props> = ({
   }, [orgId, getUserRoles, pendingRoles]);
 
   const onRolesChange = async (roles: Role[]) => {
-    if (!updateDisabled) {
+    if (!apply) {
       await updateUserRoles(roles, userId, orgId);
       await getUserRoles();
     } else if (onApplyRoles) {
@@ -83,7 +83,7 @@ export const UserRolePicker: FC<Props> = ({
       disabled={disabled}
       builtinRolesDisabled={builtinRolesDisabled}
       showBuiltInRole
-      updateDisabled={updateDisabled || false}
+      apply={apply}
       canUpdateRoles={canUpdateRoles}
     />
   );

--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -58,20 +58,7 @@ export const UserRolePicker: FC<Props> = ({
     }
   }, [orgId, getUserRoles, pendingRoles]);
 
-  const canUpdateRoles =
-    contextSrv.hasPermission(AccessControlAction.ActionUserRolesAdd) &&
-    contextSrv.hasPermission(AccessControlAction.ActionUserRolesRemove);
-
-  // if a user cannot update roles of another user mark every role as non delegatable
-  if (!canUpdateRoles) {
-    roleOptions.map((r) => (r.delegatable = false));
-  }
-
   const onRolesChange = async (roles: Role[]) => {
-    if (!canUpdateRoles) {
-      return;
-    }
-
     if (!updateDisabled) {
       await updateUserRoles(roles, userId, orgId);
       await getUserRoles();
@@ -79,6 +66,10 @@ export const UserRolePicker: FC<Props> = ({
       onApplyRoles(roles, userId, orgId);
     }
   };
+
+  const canUpdateRoles =
+    contextSrv.hasPermission(AccessControlAction.ActionUserRolesAdd) &&
+    contextSrv.hasPermission(AccessControlAction.ActionUserRolesRemove);
 
   return (
     <RolePicker
@@ -93,6 +84,7 @@ export const UserRolePicker: FC<Props> = ({
       builtinRolesDisabled={builtinRolesDisabled}
       showBuiltInRole
       updateDisabled={updateDisabled || false}
+      canUpdateRoles={canUpdateRoles}
     />
   );
 };

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -386,7 +386,7 @@ export class AddToOrgModal extends PureComponent<AddToOrgModalProps, AddToOrgMod
               onBuiltinRoleChange={this.onOrgRoleChange}
               builtinRolesDisabled={false}
               roleOptions={roleOptions}
-              updateDisabled={true}
+              apply={true}
               onApplyRoles={this.onRoleUpdate}
               pendingRoles={this.state.pendingRoles}
             />

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -328,7 +328,7 @@ export class AddToOrgModal extends PureComponent<AddToOrgModalProps, AddToOrgMod
     this.props.onOrgAdd(selectedOrg!.id, role);
     // add the stored userRoles also
     if (contextSrv.licensedAccessControlEnabled()) {
-      if (contextSrv.hasPermission(AccessControlAction.OrgUsersWrite)) {
+      if (contextSrv.hasPermission(AccessControlAction.ActionUserRolesAdd)) {
         if (this.state.pendingUserId) {
           await updateUserRoles(this.state.pendingRoles, this.state.pendingUserId!, this.state.pendingOrgId!);
           // clear pending state

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -161,7 +161,10 @@ class UnThemedOrgRow extends PureComponent<OrgRowProps> {
     const { org, user } = this.props;
     this.props.onOrgRemove(org.orgId);
     if (contextSrv.licensedAccessControlEnabled()) {
-      if (contextSrv.hasPermission(AccessControlAction.OrgUsersRemove)) {
+      if (
+        contextSrv.hasPermission(AccessControlAction.ActionUserRolesRemove) &&
+        contextSrv.hasPermission(AccessControlAction.ActionUserRolesAdd)
+      ) {
         user && (await updateUserRoles([], user.id, org.orgId));
       }
     }

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -154,11 +154,6 @@ class UnThemedOrgRow extends PureComponent<OrgRowProps> {
           .then((roles) => this.setState({ roleOptions: roles }))
           .catch((e) => console.error(e));
       }
-      if (contextSrv.hasPermission(AccessControlAction.ActionBuiltinRolesList)) {
-        fetchRoleOptions(this.props.org.orgId)
-          .then((roles) => this.setState({ builtInRoles: roles }))
-          .catch((e) => console.error(e));
-      }
     }
   }
 

--- a/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
@@ -128,14 +128,13 @@ export const ServiceAccountCreatePage = ({}: Props): JSX.Element => {
                   <Field label="Role">
                     {contextSrv.licensedAccessControlEnabled() ? (
                       <UserRolePicker
+                        apply
                         userId={serviceAccount.id || 0}
                         orgId={serviceAccount.orgId}
                         builtInRole={serviceAccount.role}
                         builtInRoles={builtinRoles}
                         onBuiltinRoleChange={onRoleChange}
-                        builtinRolesDisabled={false}
                         roleOptions={roleOptions}
-                        updateDisabled={true}
                         onApplyRoles={onPendingRolesUpdate}
                         pendingRoles={pendingRoles}
                       />

--- a/public/app/features/serviceaccounts/components/ServiceAccountRoleRow.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountRoleRow.tsx
@@ -38,7 +38,7 @@ export const ServiceAccountRoleRow = ({
             onBuiltinRoleChange={onRoleChange}
             roleOptions={roleOptions}
             builtInRoles={builtInRoles}
-            builtinRolesDisabled={canUpdateRole}
+            builtinRolesDisabled={!canUpdateRole}
             disabled={serviceAccount.isDisabled}
           />
         </td>

--- a/public/app/features/serviceaccounts/components/ServiceAccountRoleRow.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountRoleRow.tsx
@@ -23,7 +23,6 @@ export const ServiceAccountRoleRow = ({
 }: Props): JSX.Element => {
   const inputId = `${label}-input`;
   const canUpdateRole = contextSrv.hasPermissionInMetadata(AccessControlAction.ServiceAccountsWrite, serviceAccount);
-  const rolePickerDisabled = !canUpdateRole || serviceAccount.isDisabled;
 
   return (
     <tr>
@@ -39,7 +38,8 @@ export const ServiceAccountRoleRow = ({
             onBuiltinRoleChange={onRoleChange}
             roleOptions={roleOptions}
             builtInRoles={builtInRoles}
-            disabled={rolePickerDisabled}
+            builtinRolesDisabled={canUpdateRole}
+            disabled={serviceAccount.isDisabled}
           />
         </td>
       ) : (
@@ -50,7 +50,7 @@ export const ServiceAccountRoleRow = ({
               inputId={inputId}
               aria-label="Role"
               value={serviceAccount.role}
-              disabled={rolePickerDisabled}
+              disabled={serviceAccount.isDisabled}
               onChange={onRoleChange}
             />
           </td>

--- a/public/app/features/serviceaccounts/components/ServiceAccountsListItem.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountsListItem.tsx
@@ -40,7 +40,6 @@ const ServiceAccountListItem = memo(
     const displayRolePicker =
       contextSrv.hasPermission(AccessControlAction.ActionRolesList) &&
       contextSrv.hasPermission(AccessControlAction.ActionUserRolesList);
-    const enableRolePicker = contextSrv.hasPermission(AccessControlAction.OrgUsersWrite) && canUpdateRole;
 
     return (
       <tr key={serviceAccount.id} className={cx({ [styles.disabled]: serviceAccount.isDisabled })}>
@@ -83,7 +82,8 @@ const ServiceAccountListItem = memo(
                 onBuiltinRoleChange={(newRole) => onRoleChange(newRole, serviceAccount)}
                 roleOptions={roleOptions}
                 builtInRoles={builtInRoles}
-                disabled={!enableRolePicker || serviceAccount.isDisabled}
+                builtinRolesDisabled={canUpdateRole}
+                disabled={serviceAccount.isDisabled}
               />
             )}
           </td>

--- a/public/app/features/serviceaccounts/components/ServiceAccountsListItem.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountsListItem.tsx
@@ -82,7 +82,7 @@ const ServiceAccountListItem = memo(
                 onBuiltinRoleChange={(newRole) => onRoleChange(newRole, serviceAccount)}
                 roleOptions={roleOptions}
                 builtInRoles={builtInRoles}
-                builtinRolesDisabled={canUpdateRole}
+                builtinRolesDisabled={!canUpdateRole}
                 disabled={serviceAccount.isDisabled}
               />
             )}

--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -73,13 +73,8 @@ export class TeamList extends PureComponent<Props, State> {
     const canDelete = contextSrv.hasAccessInMetadata(AccessControlAction.ActionTeamsDelete, team, isTeamAdmin);
     const canReadTeam = contextSrv.hasAccessInMetadata(AccessControlAction.ActionTeamsRead, team, isTeamAdmin);
     const canSeeTeamRoles = contextSrv.hasAccessInMetadata(AccessControlAction.ActionTeamsRolesList, team, false);
-    const canUpdateTeamRoles =
-      contextSrv.hasAccess(AccessControlAction.ActionTeamsRolesAdd, false) ||
-      contextSrv.hasAccess(AccessControlAction.ActionTeamsRolesRemove, false);
     const displayRolePicker =
-      contextSrv.licensedAccessControlEnabled() &&
-      contextSrv.hasPermission(AccessControlAction.ActionTeamsRolesList) &&
-      contextSrv.hasPermission(AccessControlAction.ActionRolesList);
+      contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionRolesList);
 
     return (
       <tr key={team.id}>
@@ -114,11 +109,7 @@ export class TeamList extends PureComponent<Props, State> {
           )}
         </td>
         {displayRolePicker && (
-          <td>
-            {canSeeTeamRoles && (
-              <TeamRolePicker teamId={team.id} roleOptions={this.state.roleOptions} disabled={!canUpdateTeamRoles} />
-            )}
-          </td>
+          <td>{canSeeTeamRoles && <TeamRolePicker teamId={team.id} roleOptions={this.state.roleOptions} />}</td>
         )}
         <td className="text-right">
           <DeleteButton

--- a/public/app/features/users/UsersTable.tsx
+++ b/public/app/features/users/UsersTable.tsx
@@ -90,11 +90,13 @@ const UsersTable: FC<Props> = (props) => {
                     <UserRolePicker
                       userId={user.userId}
                       orgId={orgId}
-                      builtInRole={user.role}
-                      onBuiltinRoleChange={(newRole) => onRoleChange(newRole, user)}
                       roleOptions={roleOptions}
                       builtInRoles={builtinRoles}
-                      disabled={!contextSrv.hasPermissionInMetadata(AccessControlAction.OrgUsersWrite, user)}
+                      builtInRole={user.role}
+                      onBuiltinRoleChange={(newRole) => onRoleChange(newRole, user)}
+                      builtinRolesDisabled={
+                        !contextSrv.hasPermissionInMetadata(AccessControlAction.OrgUsersWrite, user)
+                      }
                     />
                   ) : (
                     <OrgRolePicker


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr fixes various ui issues role picker has with permissions:

* Only mark roles as delegatable if user can delegate them and has permission to set roles for entity (user, team and serviceaccount)
* Remove duplicated fetch of roles in UserOrgs component, this was also behind wrong permission check
* Disable update and clear buttons if user cannot update builtin role or rbac roles (read only)
* Make role pickers for user, teams and service accounts behave similar

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

