### PR TITLE
Explore: Dynamic panels

### DIFF
--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -123,6 +123,7 @@ export class PanelPlugin<
    * Legacy angular ctrl.  If this exists it will be used instead of the panel
    */
   angularPanelCtrl?: any;
+  explorePanel?: ComponentType<ExplorePanelProps>;
 
   constructor(panel: ComponentType<PanelProps<TOptions>> | null) {
     super();
@@ -378,5 +379,13 @@ export class PanelPlugin<
 
   hasPluginId(pluginId: string) {
     return this.meta.id === pluginId;
+  }
+
+  /**
+   * Use more specific component in explore to take advantage of some Explore specific features and props.
+   * @param panel
+   */
+  setExplorePanel(panel: ComponentType<ExplorePanelProps>) {
+    this.explorePanel = panel;
   }
 }

--- a/packages/grafana-data/src/types/data.ts
+++ b/packages/grafana-data/src/types/data.ts
@@ -42,8 +42,12 @@ export interface QueryResultMeta {
   /** Used to track transformation ids that where part of the processing */
   transformations?: string[];
 
-  /** Currently used to show results in Explore only in preferred visualisation option */
-  preferredVisualisationType?: PreferredVisualisationType;
+  /**
+   * Used in Explore to match what data source prefers as a visualisation for the data with existing panels.
+   * It is possible to define custom values for example to create data source and a visualisation to only match each
+   * other and providing a custom experience for a datasource.
+   */
+  preferredVisualisationType?: string;
 
   /** The path for live stream updates for this frame */
   channel?: string;

--- a/packages/grafana-data/src/types/explore.ts
+++ b/packages/grafana-data/src/types/explore.ts
@@ -27,3 +27,17 @@ export interface ExploreTracePanelState {
 export type SplitOpen = <T extends DataQuery = any>(
   options?: { datasourceUid: string; query: T; range?: TimeRange; panelsState?: ExplorePanelsState } | undefined
 ) => void;
+
+export type ExplorePanelProps = {
+  graphStyle: ExploreGraphStyle;
+  onChangeGraphStyle: (style: ExploreGraphStyle) => void;
+  data: DataFrame[];
+  absoluteRange: AbsoluteTimeRange;
+  range: TimeRange;
+  timeZone: TimeZone;
+  splitOpen: SplitOpen;
+  annotations?: DataFrame[];
+  loadingState: LoadingState;
+  // ...
+  // And some more
+}

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -314,6 +314,30 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
     );
   }
 
+  renderPanels(width: number) {
+    const {queryResponse, frames} = this.props;
+    const panels: React.ReactNode[] = [];
+
+    for (const key of Object.keys(frames)) {
+      // ley is basically a visualisationType that the dataFrame expects to be shown in.
+      const Panel = getPanelForVisType(key)
+
+      panels.push(
+        <ErrorBoundaryAlert key={key}>
+          <Panel
+            onChangeGraphStyle={this.onChangeGraphStyle}
+            data={frames[key]}
+            absoluteRange={this.props.absoluteRange}
+            range={this.props.range}
+            timeZone={this.props.timeZone}
+            // And more props here
+          />
+        </ErrorBoundaryAlert>
+      );
+    }
+    return panels;
+  }
+
   render() {
     const {
       datasourceInstance,
@@ -381,18 +405,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
                 return (
                   <main className={cx(styles.exploreMain)} style={{ width }}>
                     <ErrorBoundaryAlert>
-                      {showPanels && (
-                        <>
-                          {showMetrics && graphResult && (
-                            <ErrorBoundaryAlert>{this.renderGraphPanel(width)}</ErrorBoundaryAlert>
-                          )}
-                          {showTable && <ErrorBoundaryAlert>{this.renderTablePanel(width)}</ErrorBoundaryAlert>}
-                          {showLogs && <ErrorBoundaryAlert>{this.renderLogsPanel(width)}</ErrorBoundaryAlert>}
-                          {showNodeGraph && <ErrorBoundaryAlert>{this.renderNodeGraphPanel()}</ErrorBoundaryAlert>}
-                          {showTrace && <ErrorBoundaryAlert>{this.renderTraceViewPanel()}</ErrorBoundaryAlert>}
-                          {showNoData && <ErrorBoundaryAlert>{this.renderNoData()}</ErrorBoundaryAlert>}
-                        </>
-                      )}
+                      {showPanels && this.renderPanels()}
                       {showRichHistory && (
                         <RichHistoryContainer
                           width={width}

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -319,7 +319,7 @@ export class Explore extends React.PureComponent<Props, ExploreState> {
     const panels: React.ReactNode[] = [];
 
     for (const key of Object.keys(frames)) {
-      // ley is basically a visualisationType that the dataFrame expects to be shown in.
+      // key is basically a visualisationType that the dataFrame expects to be shown in.
       const Panel = getPanelForVisType(key)
 
       panels.push(

--- a/public/app/features/explore/utils/panelsRegistry.tsx
+++ b/public/app/features/explore/utils/panelsRegistry.tsx
@@ -12,7 +12,8 @@ import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
  * Based on visulastionType search existing registered panels and return matching one.
  */
 export async function getPanelForVisType(visType: string): Promise<React.ComponentType<ExplorePanelProps>> {
-  // For some visualisation we still may have hardcoded values/components
+  // For some visualisation we still may have hardcoded values/components for some time. Later we may try to figure
+  // out a good way to override them with custom panels.
   switch (visType) {
     case 'graph': {
       return GraphPanel;
@@ -55,13 +56,13 @@ export async function getPanelForVisType(visType: string): Promise<React.Compone
 }
 
 /**
- * Wrap panel adding a transform so we can use dashboard panels here.
+ * Wrap panel adding a transform so we can use dashboard panels Explore without modification.
  * @param Panel
  */
 function makePanelExploreCompatible(Panel: ComponentType<PanelProps<TOptions>>) {
   return function CompatibilityWrapper(props: ExplorePanelProps) {
     // This transform may not be 100% perfect so we may need to use some sensible zero/empty/noop values. We will have
-    // to see how much impact that will have but I would think even if that makes some panels loose some functionlity
+    // to see how much impact that will have but I would think even if that makes some panels loose some functionality
     // it may be still ok. If there are bugs we will have to fix them somehow.
     const dashboardProps = transformToDasboardProps(props)
     return <Panel {...dashboardProps}/>

--- a/public/app/features/explore/utils/panelsRegistry.tsx
+++ b/public/app/features/explore/utils/panelsRegistry.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import { ExplorePanelProps } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+import { Collapse } from '@grafana/ui';
+// // TODO: probably needs to be exported from ui directly
+import { FilterItem, FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR } from '@grafana/ui/src/components/Table/types';
+import { getAllPanelPluginMeta } from 'app/features/panel/state/util';
+import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
+
+/**
+ * Based on visulastionType search existing registered panels and return matching one.
+ */
+export async function getPanelForVisType(visType: string): Promise<React.ComponentType<ExplorePanelProps>> {
+  // For some visualisation we still may have hardcoded values/components
+  switch (visType) {
+    case 'graph': {
+      return GraphPanel;
+    }
+    case 'table': {
+      return TablePanel;
+    }
+
+    case 'nodeGraph': {
+      return NodeGraphPanel;
+    }
+
+    case 'logs': {
+      return LogsPanel;
+    }
+
+    case 'trace': {
+      return TraceViewPanel;
+    }
+    default: {
+      const panels = getAllPanelPluginMeta();
+      for (const panel of panels) {
+        const panelPlugin = await importPanelPlugin(panel.id);
+        // Check each panel and see if it is correct type for the data.
+        if (panelPlugin.visualisationType?.includes(visType)) {
+          // If there is explorePanel component use that.
+          if (panelPlugin.explorePanel) {
+            return panelPlugin.explorePanel;
+          } else {
+            return makePanelExploreCompatible(panelPlugin.panel);
+          }
+        }
+      }
+
+      // Probably ok fallback but maybe it makes sense to throw or show some info message that we did not find anything
+      // better.
+      return TablePanel;
+    }
+  }
+}
+
+/**
+ * Wrap panel adding a transform so we can use dashboard panels here.
+ * @param Panel
+ */
+function makePanelExploreCompatible(Panel: ComponentType<PanelProps<TOptions>>) {
+  return function CompatibilityWrapper(props: ExplorePanelProps) {
+    // This transform may not be 100% perfect so we may need to use some sensible zero/empty/noop values. We will have
+    // to see how much impact that will have but I would think even if that makes some panels loose some functionlity
+    // it may be still ok. If there are bugs we will have to fix them somehow.
+    const dashboardProps = transformToDasboardProps(props)
+    return <Panel {...dashboardProps}/>
+  }
+}

--- a/public/app/plugins/panel/calendar/module.tsx
+++ b/public/app/plugins/panel/calendar/module.tsx
@@ -1,0 +1,11 @@
+import {
+  PanelPlugin,
+} from '@grafana/data';
+
+export const plugin = new PanelPlugin<CalendarOptions, CalendarConfig>(Calendar)
+
+// This should work in explore because we defined a visualisationType in plugin.json and so will match if some
+// datasource returns DataFrame with preferredVisualisationType === 'calendar'.
+function Calendar(props: PanelProps<CalendarOptions>) {
+  return "Calendar"
+}

--- a/public/app/plugins/panel/calendar/plugin.json
+++ b/public/app/plugins/panel/calendar/plugin.json
@@ -1,0 +1,18 @@
+{
+  "type": "panel",
+  "name": "Calendar",
+  "id": "calendar",
+  "state": "beta",
+  "visualisationType": "calendar",
+
+  "info": {
+    "author": {
+      "name": "Grafana Labs",
+      "url": "https://grafana.com"
+    },
+    "logos": {
+      "small": "img/candlestick.svg",
+      "large": "img/candlestick.svg"
+    }
+  }
+}

--- a/public/app/plugins/panel/calendarV2/module.tsx
+++ b/public/app/plugins/panel/calendarV2/module.tsx
@@ -1,0 +1,31 @@
+import {
+  PanelPlugin,
+} from '@grafana/data';
+
+export const plugin = new PanelPlugin<CalendarOptions, CalendarConfig>(CalendarDasboard).setExplorePanel(CalendarExplore)
+
+function Calendar(props: CalendarProps) {
+  return "Calendar"
+}
+
+/**
+ * This one will be used in dashboard context
+ */
+function CalendarDashboard(props: PanelProps<CalendarOptions>) {
+  // use dashboard props to configure calendar component
+  return <Calendar/>
+}
+
+/**
+ * This one will be used in explore context.
+ *
+ * This alone isn't enough to be able to use this in explore. It still needs to have visualisationType set in plugin.json
+ * otherwise we will never match it to any data.
+ */
+function CalendarExplore(props: ExplorePanelProps) {
+  // use explore props to configure calendar component like some added interactivity
+  return <Calendar/>
+}
+
+
+

--- a/public/app/plugins/panel/calendarV2/plugin.json
+++ b/public/app/plugins/panel/calendarV2/plugin.json
@@ -1,0 +1,18 @@
+{
+  "type": "panel",
+  "name": "Calendar",
+  "id": "calendar",
+  "state": "beta",
+  "visualisationType": "calendar",
+
+  "info": {
+    "author": {
+      "name": "Grafana Labs",
+      "url": "https://grafana.com"
+    },
+    "logos": {
+      "small": "img/candlestick.svg",
+      "large": "img/candlestick.svg"
+    }
+  }
+}


### PR DESCRIPTION
This is a more minimalistic version of this pr https://github.com/grafana/grafana/pull/52057 (or can be considered pseudocode to add clarity).

So the main point of this is to allow in the future:
- Allow users and developers to use custom panel plugins in explore
- Later to allow overriding current panels (for example to use a different table plugin instead of the builtin one)

The main piece to make this happen is to be able to define in the dataFrame from the data source what is visualization type it wants the data to be shown in. This already exists as dataFrame has `preferredVisualisationType` property. At this point, this is just a predefined set of values but this change would make that just a string so the data source can specify any custom visualization they want.

The other end is adding `visualisationType` property on PanelPlugin. This will allow us to match `preferredVisualisationType` to `visualisationType` without needing to know the values beforehand. This allows creation of new custom data source and visualization that work together (as an example in this pr is a Calendar panel which would work with data source returning calendar data).

To make this easier for panel plugin developers, plugins need to specify only `visualisationType` in the plugin.json, allowing them to be matched to the data. In such case explore will try to provide similar props as in the dashboard. If Panel wants to take advantage of all the explore properties it can define a component specifically for explore with different props which can be then used.  