### PR TITLE
Fix init script reference in stopGrafana

### DIFF
--- a/packaging/rpm/control/postinst
+++ b/packaging/rpm/control/postinst
@@ -18,10 +18,10 @@ startGrafana() {
 stopGrafana() {
 	if [ -x /bin/systemctl ] ; then
 		/bin/systemctl stop grafana-server.service > /dev/null 2>&1 || :
-	elif [ -x /etc/init.d/grafana-service ] ; then
-		/etc/init.d/grafana-service stop
-	elif [ -x /etc/rc.d/init.d/grafana-service ] ; then
-		/etc/rc.d/init.d/grafana-service stop
+	elif [ -x /etc/init.d/grafana-server ] ; then
+		/etc/init.d/grafana-server stop
+	elif [ -x /etc/rc.d/init.d/grafana-server ] ; then
+		/etc/rc.d/init.d/grafana-server stop
 	fi
 }
 


### PR DESCRIPTION
This fixes a bug that would prevent Grafana from restarting post-update.

**What this PR does / why we need it**:
Fix init script reference in stopGrafana which prevents Grafana from restarting on redhat-like systems without systemd, e.g. CentOS 6.
**Which issue(s) this PR fixes**:
Fixes #53612

**Special notes for your reviewer**:
`grafana-service` is not provided by the RPM and it looks like the original intent of this function was to call `/etc/init.d/grafana-server`. There are no other references to this file in the repository.
