### PR TITLE
RBAC: Remove unused code for resource permission services

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -33,22 +33,21 @@ func newApi(ac accesscontrol.AccessControl, router routing.RouteRegister, manage
 func (a *api) registerEndpoints() {
 	auth := accesscontrol.Middleware(a.ac)
 	disable := disableMiddleware(a.ac.IsDisabled())
-	inheritanceSolver := solveInheritedScopes(a.service.options.InheritedScopesSolver)
 
 	a.router.Group(fmt.Sprintf("/api/access-control/%s", a.service.options.Resource), func(r routing.RouteRegister) {
 		actionRead := fmt.Sprintf("%s.permissions:read", a.service.options.Resource)
 		actionWrite := fmt.Sprintf("%s.permissions:write", a.service.options.Resource)
 		scope := accesscontrol.Scope(a.service.options.Resource, a.service.options.ResourceAttribute, accesscontrol.Parameter(":resourceID"))
 		r.Get("/description", auth(disable, accesscontrol.EvalPermission(actionRead)), routing.Wrap(a.getDescription))
-		r.Get("/:resourceID", inheritanceSolver, auth(disable, accesscontrol.EvalPermission(actionRead, scope)), routing.Wrap(a.getPermissions))
+		r.Get("/:resourceID", auth(disable, accesscontrol.EvalPermission(actionRead, scope)), routing.Wrap(a.getPermissions))
 		if a.service.options.Assignments.Users {
-			r.Post("/:resourceID/users/:userID", inheritanceSolver, auth(disable, accesscontrol.EvalPermission(actionWrite, scope)), routing.Wrap(a.setUserPermission))
+			r.Post("/:resourceID/users/:userID", auth(disable, accesscontrol.EvalPermission(actionWrite, scope)), routing.Wrap(a.setUserPermission))
 		}
 		if a.service.options.Assignments.Teams {
-			r.Post("/:resourceID/teams/:teamID", inheritanceSolver, auth(disable, accesscontrol.EvalPermission(actionWrite, scope)), routing.Wrap(a.setTeamPermission))
+			r.Post("/:resourceID/teams/:teamID", auth(disable, accesscontrol.EvalPermission(actionWrite, scope)), routing.Wrap(a.setTeamPermission))
 		}
 		if a.service.options.Assignments.BuiltInRoles {
-			r.Post("/:resourceID/builtInRoles/:builtInRole", inheritanceSolver, auth(disable, accesscontrol.EvalPermission(actionWrite, scope)), routing.Wrap(a.setBuiltinRolePermission))
+			r.Post("/:resourceID/builtInRoles/:builtInRole", auth(disable, accesscontrol.EvalPermission(actionWrite, scope)), routing.Wrap(a.setBuiltinRolePermission))
 		}
 	})
 }

--- a/pkg/services/accesscontrol/resourcepermissions/middleware.go
+++ b/pkg/services/accesscontrol/resourcepermissions/middleware.go
@@ -4,29 +4,8 @@ import (
 	"net/http"
 
 	"github.com/grafana/grafana/pkg/models"
-	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
 )
-
-// solveInheritedScopes will add the inherited scopes to the context param by prefix
-// Ex: params["folders:uid:"] = "folders:uid:BCeknZL7k"
-func solveInheritedScopes(solve InheritedScopesSolver) web.Handler {
-	return func(c *models.ReqContext) {
-		if solve != nil && util.IsValidShortUID(web.Params(c.Req)[":resourceID"]) {
-			params := web.Params(c.Req)
-			scopes, err := solve(c.Req.Context(), c.OrgID, params[":resourceID"])
-			if err != nil {
-				c.JsonApiErr(http.StatusNotFound, "Resource not found", err)
-				return
-			}
-			for _, scope := range scopes {
-				params[ac.ScopePrefix(scope)] = scope
-			}
-			web.SetURLParams(c.Req, params)
-		}
-	}
-}
 
 func disableMiddleware(shouldDisable bool) web.Handler {
 	return func(c *models.ReqContext) {


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/grafana/grafana/pull/50291 we removed functionally no longer needed due to changes in https://github.com/grafana/grafana/pull/50110. I missed removing the middleware to generate additions scopes

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

