### PR TITLE
CloudMonitoring: Ensure default project is set correctly in VariableQueryEditor

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/VariableQueryEditor.test.tsx
@@ -34,6 +34,7 @@ const props: Props = {
     getMetricTypes: async (projectName: string) => Promise.resolve([]),
     getSLOServices: async (projectName: string) => Promise.resolve([]),
     getServiceLevelObjectives: (projectName: string, serviceId: string) => Promise.resolve([]),
+    ensureGCEDefaultProject: async () => Promise.resolve(''),
   } as unknown as CloudMonitoringDatasource,
   onRunQuery: () => {},
 };

--- a/public/app/plugins/datasource/cloud-monitoring/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/VariableQueryEditor.tsx
@@ -57,14 +57,12 @@ export class CloudMonitoringVariableQueryEditor extends PureComponent<Props, Var
 
   constructor(props: Props) {
     super(props);
-    this.state = Object.assign(
-      this.defaults,
-      { projectName: this.props.datasource.getDefaultProject() },
-      this.props.query
-    );
+    this.state = Object.assign(this.defaults, this.props.query);
   }
 
   async componentDidMount() {
+    await this.props.datasource.ensureGCEDefaultProject();
+    const projectName = this.props.datasource.getDefaultProject();
     const projects = (await this.props.datasource.getProjects()) as MetricDescriptor[];
     const metricDescriptors = await this.props.datasource.getMetricTypes(
       this.props.query.projectName || this.props.datasource.getDefaultProject()
@@ -88,7 +86,7 @@ export class CloudMonitoringVariableQueryEditor extends PureComponent<Props, Var
       getTemplateSrv().replace(selectedService)
     );
 
-    const sloServices = await this.props.datasource.getSLOServices(this.state.projectName);
+    const sloServices = await this.props.datasource.getSLOServices(projectName);
 
     const state: any = {
       services,
@@ -97,9 +95,10 @@ export class CloudMonitoringVariableQueryEditor extends PureComponent<Props, Var
       selectedMetricType,
       metricDescriptors,
       projects,
-      ...(await this.getLabels(selectedMetricType, this.state.projectName)),
+      ...(await this.getLabels(selectedMetricType, projectName)),
       sloServices,
       loading: false,
+      projectName,
     };
     this.setState(state, () => this.onPropsChange());
   }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR switches from instantiating the project name in the constructor to retrieving it in the `componentDidMount` function. This allows us to ensure that when GCE Service Account authentication is used, a project is retrieved before attempting to make calls to Google Cloud.

**Which issue(s) this PR fixes**:

Fixes #51327

**Special notes for your reviewer**:

