### PR TITLE
UsersTable: Display Disabled flag in Organizations' Users table

### DIFF
--- a/pkg/models/org_user.go
+++ b/pkg/models/org_user.go
@@ -100,4 +100,5 @@ type OrgUserDTO struct {
 	Created       time.Time       `json:"-"`
 	LastSeenAtAge string          `json:"lastSeenAtAge"`
 	AccessControl map[string]bool `json:"accessControl,omitempty"`
+	IsDisabled    bool            `json:"isDisabled"`
 }

--- a/pkg/services/sqlstore/org_users.go
+++ b/pkg/services/sqlstore/org_users.go
@@ -152,6 +152,7 @@ func (ss *SQLStore) GetOrgUsers(ctx context.Context, query *models.GetOrgUsersQu
 			"user.last_seen_at",
 			"user.created",
 			"user.updated",
+			"user.is_disabled",
 		)
 		sess.Asc("user.email", "user.login")
 

--- a/public/app/features/users/UsersTable.test.tsx
+++ b/public/app/features/users/UsersTable.test.tsx
@@ -40,6 +40,14 @@ describe('Render', () => {
       expect(screen.getByText(user.name)).toBeInTheDocument();
     });
   });
+
+  it('should render disabled flag when any of the User is disabled', () => {
+    const usersData = getMockUsers(5);
+    usersData[0].isDisabled = true;
+    setup({ users: usersData });
+
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+  });
 });
 
 describe('Remove modal', () => {

--- a/public/app/features/users/UsersTable.test.tsx
+++ b/public/app/features/users/UsersTable.test.tsx
@@ -41,7 +41,7 @@ describe('Render', () => {
     });
   });
 
-  it('should render disabled flag when any of the User is disabled', () => {
+  it('should render disabled flag when any of the Users are disabled', () => {
     const usersData = getMockUsers(5);
     usersData[0].isDisabled = true;
     setup({ users: usersData });

--- a/public/app/features/users/UsersTable.tsx
+++ b/public/app/features/users/UsersTable.tsx
@@ -109,8 +109,12 @@ const UsersTable: FC<Props> = (props) => {
                   )}
                 </td>
 
+                <td className="width-1 text-center">
+                  {user.isDisabled && <span className="label label-tag label-tag--gray">Disabled</span>}
+                </td>
+
                 {contextSrv.hasPermissionInMetadata(AccessControlAction.OrgUsersRemove, user) && (
-                  <td>
+                  <td className="text-right">
                     <Button
                       size="sm"
                       variant="destructive"
@@ -122,10 +126,6 @@ const UsersTable: FC<Props> = (props) => {
                     />
                   </td>
                 )}
-
-                <td className="width-1 text-center">
-                  {user.isDisabled && <span className="label label-tag label-tag--gray">Disabled</span>}
-                </td>
               </tr>
             );
           })}

--- a/public/app/features/users/UsersTable.tsx
+++ b/public/app/features/users/UsersTable.tsx
@@ -58,6 +58,7 @@ const UsersTable: FC<Props> = (props) => {
             <th>Seen</th>
             <th>Role</th>
             <th style={{ width: '34px' }} />
+            <th></th>
           </tr>
         </thead>
         <tbody>
@@ -121,6 +122,10 @@ const UsersTable: FC<Props> = (props) => {
                     />
                   </td>
                 )}
+
+                <td className="width-1 text-center">
+                  {user.isDisabled && <span className="label label-tag label-tag--gray">Disabled</span>}
+                </td>
               </tr>
             );
           })}

--- a/public/app/features/users/__mocks__/userMocks.ts
+++ b/public/app/features/users/__mocks__/userMocks.ts
@@ -14,7 +14,8 @@ export const getMockUsers = (amount: number) => {
       orgId: 1,
       role: 'Admin',
       userId: i,
-    });
+      isDisabled: false,
+    } as OrgUser);
   }
 
   return users as OrgUser[];

--- a/public/app/features/users/__mocks__/userMocks.ts
+++ b/public/app/features/users/__mocks__/userMocks.ts
@@ -15,7 +15,7 @@ export const getMockUsers = (amount: number) => {
       role: 'Admin',
       userId: i,
       isDisabled: false,
-    } as OrgUser);
+    });
   }
 
   return users as OrgUser[];

--- a/public/app/types/user.ts
+++ b/public/app/types/user.ts
@@ -11,6 +11,7 @@ export interface OrgUser extends WithAccessControlMetadata {
   orgId: number;
   role: OrgRole;
   userId: number;
+  isDisabled: boolean;
 }
 
 export interface User {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR does add a new column to the Organizations' Users table that indicates if the User is disabled. Previously, only Server Admins could see the disabled state of a User on their Admin page.

**Which issue(s) this PR fixes**:
Fixes #51388 

**Special notes for your reviewer**:
<img width="755" alt="image" src="https://user-images.githubusercontent.com/1585112/184354604-ca4ae4de-8846-486d-ae45-f5a640f0b576.png">


