### PR TITLE
Plugins: Docker should not exit if a plugin install does not succeed

### DIFF
--- a/packaging/docker/custom/Dockerfile
+++ b/packaging/docker/custom/Dockerfile
@@ -43,9 +43,9 @@ RUN if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then \
         if expr match "$plugin" '.*\;.*'; then \
             pluginUrl=$(echo "$plugin" | cut -d';' -f 1); \
             pluginInstallFolder=$(echo "$plugin" | cut -d';' -f 2); \
-            grafana-cli --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}"; \
+            grafana-cli --debug --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}" || true; \
         else \
-            grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}; \
+            grafana-cli --debug --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin} || true; \
         fi \
     done \
 fi

--- a/packaging/docker/custom/Dockerfile
+++ b/packaging/docker/custom/Dockerfile
@@ -43,9 +43,9 @@ RUN if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then \
         if expr match "$plugin" '.*\;.*'; then \
             pluginUrl=$(echo "$plugin" | cut -d';' -f 1); \
             pluginInstallFolder=$(echo "$plugin" | cut -d';' -f 2); \
-            grafana-cli --debug --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}" || true; \
+            grafana-cli --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}" || true; \
         else \
-            grafana-cli --debug --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin} || true; \
+            grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin} || true; \
         fi \
     done \
 fi

--- a/packaging/docker/custom/ubuntu.Dockerfile
+++ b/packaging/docker/custom/ubuntu.Dockerfile
@@ -47,9 +47,9 @@ RUN if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then \
         if expr match "$plugin" '.*\;.*'; then \
             pluginUrl=$(echo "$plugin" | cut -d';' -f 1); \
             pluginInstallFolder=$(echo "$plugin" | cut -d';' -f 2); \
-            grafana-cli --debug --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}" || true; \
+            grafana-cli --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}" || true; \
         else \
-            grafana-cli --debug --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin} || true; \
+            grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin} || true; \
         fi \
     done \
 fi

--- a/packaging/docker/custom/ubuntu.Dockerfile
+++ b/packaging/docker/custom/ubuntu.Dockerfile
@@ -47,9 +47,9 @@ RUN if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then \
         if expr match "$plugin" '.*\;.*'; then \
             pluginUrl=$(echo "$plugin" | cut -d';' -f 1); \
             pluginInstallFolder=$(echo "$plugin" | cut -d';' -f 2); \
-            grafana-cli --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}"; \
+            grafana-cli --debug --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}" || true; \
         else \
-            grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}; \
+            grafana-cli --debug --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin} || true; \
         fi \
     done \
 fi

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -70,9 +70,9 @@ if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
     if [[ $plugin =~ .*\;.* ]]; then
         pluginUrl=$(echo "$plugin" | cut -d';' -f 1)
         pluginInstallFolder=$(echo "$plugin" | cut -d';' -f 2)
-        grafana-cli --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}"
+        grafana-cli --debug --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}" || true
     else
-        grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin}
+        grafana-cli --debug --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin} || true
     fi
   done
 fi

--- a/packaging/docker/run.sh
+++ b/packaging/docker/run.sh
@@ -70,9 +70,9 @@ if [ ! -z "${GF_INSTALL_PLUGINS}" ]; then
     if [[ $plugin =~ .*\;.* ]]; then
         pluginUrl=$(echo "$plugin" | cut -d';' -f 1)
         pluginInstallFolder=$(echo "$plugin" | cut -d';' -f 2)
-        grafana-cli --debug --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}" || true
+        grafana-cli --pluginUrl ${pluginUrl} --pluginsDir "${GF_PATHS_PLUGINS}" plugins install "${pluginInstallFolder}" || true
     else
-        grafana-cli --debug --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin} || true
+        grafana-cli --pluginsDir "${GF_PATHS_PLUGINS}" plugins install ${plugin} || true
     fi
   done
 fi


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
If there's an issue with [installing a plugin when running Grafana with Docker](https://grafana.com/docs/grafana/latest/setup-grafana/installation/docker/#install-plugins-in-the-docker-container) (incompatible version, not found, etc.), then do not abort the entire process.

Currently, the execution will terminate once `grafana-cli` returns a non zero exit status. 
With this change, the user will see:

```
➜  docker run --rm -it \
   -p 3000:3000 \
   -e "GF_INSTALL_PLUGINS=marcusolsson-csv-datasource 0.6.1,unknown-panel,redis-datasource" \
   grafana/grafana:51044-test

✔ Downloaded marcusolsson-csv-datasource v0.6.1 zip successfully

Please restart Grafana after installing plugins. Refer to Grafana documentation for instructions if necessary.

Error: ✗ Plugin not found (Grafana v9.0.7 linux-amd64)
✔ Downloaded redis-datasource v2.1.1 zip successfully

Please restart Grafana after installing plugins. Refer to Grafana documentation for instructions if necessary.

INFO [08-12|14:47:18] Starting Grafana                         logger=settings version=9.0.7 commit=eed942a502 branch=HEAD compiled=2022-08-10T09:18:27Z
...
```


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #51044

**Special notes for your reviewer**:
I made the choice to not include the same behaviour for the grafana image renderer plugin (ref `$GF_INSTALL_IMAGE_RENDERER_PLUGIN`) - this plugin in general has a different use case and with its own dedicated config, it feels appropriate. But I don't have strong feelings either way
