### PR TITLE
Alerting: Fix order-of-magnitude bug in DTO conversion when reading rules

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -128,7 +128,7 @@ func NewAlertRule(rule models.AlertRule, provenance models.Provenance) Provision
 		FolderUID:    rule.NamespaceUID,
 		RuleGroup:    rule.RuleGroup,
 		Title:        rule.Title,
-		For:          model.Duration(rule.For.Seconds()),
+		For:          model.Duration(rule.For),
 		Condition:    rule.Condition,
 		Data:         rule.Data,
 		Updated:      rule.Updated,


### PR DESCRIPTION
**What this PR does / why we need it**:

In the same vein as: https://github.com/grafana/grafana/pull/53196

`GET`ting a rule would always return the wrong value for `for` because of this order-of-magnitude bug in the conversion method. `time.Duration` and `model.Duration` use the same order of magnitude in the underlying representation, and don't need to be adjusted. The adjustment caused the value to be wrong (typically the value was lowered so much it got truncated to 0s)

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

Didn't add a test for this as our entire DTO package needs better infra. Filed a debt issue instead https://github.com/grafana/grafana/issues/53689

