### PR TITLE
Geomap: Update language to match documentation and remove beta

### DIFF
--- a/pkg/tests/api/plugins/data/expectedListResp.json
+++ b/pkg/tests/api/plugins/data/expectedListResp.json
@@ -458,7 +458,7 @@
     "hasUpdate": false,
     "defaultNavUrl": "/plugins/geomap/",
     "category": "",
-    "state": "beta",
+    "state": "",
     "signature": "internal",
     "signatureType": "",
     "signatureOrg": ""

--- a/public/app/plugins/panel/geomap/module.tsx
+++ b/public/app/plugins/panel/geomap/module.tsx
@@ -44,8 +44,10 @@ export const plugin = new PanelPlugin<GeomapPanelOptions>(GeomapPanel)
     if (!state?.layers) {
       // TODO? show spinner?
     } else {
+      const layersCategory = ['Map layers'];
+      const basemapCategory = ['Basemap layer'];
       builder.addCustomEditor({
-        category: ['Data layer'],
+        category: layersCategory,
         id: 'layers',
         path: '',
         name: '',
@@ -57,7 +59,7 @@ export const plugin = new PanelPlugin<GeomapPanelOptions>(GeomapPanel)
         builder.addNestedOptions(
           getLayerEditor({
             state: selected,
-            category: ['Data layer'],
+            category: layersCategory,
             basemaps: false,
           })
         );
@@ -66,18 +68,18 @@ export const plugin = new PanelPlugin<GeomapPanelOptions>(GeomapPanel)
       const baselayer = state.layers[0];
       if (config.geomapDisableCustomBaseLayer) {
         builder.addCustomEditor({
-          category: ['Base layer'],
+          category: basemapCategory,
           id: 'layers',
           path: '',
           name: '',
           // eslint-disable-next-line react/display-name
-          editor: () => <div>The base layer is configured by the server admin.</div>,
+          editor: () => <div>The basemap layer is configured by the server admin.</div>,
         });
       } else if (baselayer) {
         builder.addNestedOptions(
           getLayerEditor({
             state: baselayer,
-            category: ['Base layer'],
+            category: basemapCategory,
             basemaps: true,
           })
         );
@@ -117,16 +119,16 @@ export const plugin = new PanelPlugin<GeomapPanelOptions>(GeomapPanel)
       })
       .addBooleanSwitch({
         category,
-        path: 'controls.showDebug',
-        name: 'Show debug',
-        description: 'Show map info',
+        path: 'controls.showMeasure',
+        name: 'Show measure tools',
+        description: 'Show tools for making measurements on the map',
         defaultValue: false,
       })
       .addBooleanSwitch({
         category,
-        path: 'controls.showMeasure',
-        name: 'Show measure tools',
-        description: 'Show tools for making measurements on the map',
+        path: 'controls.showDebug',
+        name: 'Show debug',
+        description: 'Show map info',
         defaultValue: false,
       })
       .addRadio({

--- a/public/app/plugins/panel/geomap/plugin.json
+++ b/public/app/plugins/panel/geomap/plugin.json
@@ -2,7 +2,6 @@
   "type": "panel",
   "name": "Geomap",
   "id": "geomap",
-  "state": "beta",
 
   "info": {
     "description": "Geomap panel",


### PR DESCRIPTION
What this PR does / why we need it:
Changes were made to documentation for 9.1. We need to make sure the panel is consistent with the documentation.

Closes #53328