### PR TITLE
Build prometheus_random_data block from full source to avoid `go install` failure with `exclude` directive

### DIFF
--- a/devenv/docker/blocks/prometheus_random_data/Dockerfile
+++ b/devenv/docker/blocks/prometheus_random_data/Dockerfile
@@ -2,8 +2,11 @@
 
 # Builder image, where we build the example.
 FROM golang:1.17 AS builder
-# Download prometheus/client_golang/examples/random first
-RUN CGO_ENABLED=0 GOOS=linux go install -tags netgo -ldflags '-w' github.com/prometheus/client_golang/examples/random@latest
+
+# Install from full module source instead of `go install`, since that works despite the `exclude`
+# directive in `go.mod` (https://github.com/golang/go/issues/44840)
+RUN git clone --depth 1 https://github.com/prometheus/client_golang.git
+RUN cd client_golang && CGO_ENABLED=0 GOOS=linux go install -tags netgo -ldflags '-w' ./examples/random
 
 # Final image.
 FROM scratch


### PR DESCRIPTION
**What this PR does / why we need it**: Fix devenv build as tested with `make devenv sources=grafana,loki,prometheus grafana_version=9.0.7`

**Which issue(s) this PR fixes**:

This fails – with Go 1.18 and earlier – because `go.mod` of that repository has recently introduced an `exclude` directive. Error:

```
go install: github.com/prometheus/client_golang/examples/random@latest (in github.com/prometheus/client_golang@v1.13.0):
    The go.mod file for the module providing named packages contains one or
    more exclude directives. It must not contain directives that would cause
    it to be interpreted differently than if it were the main module.
```

That directive was introduced in https://github.com/prometheus/client_golang/issues/1012#issuecomment-1090482644.