### PR TITLE
Dashboard: Fix crashing dashboard due to missing panel.targets in nested rows 

### DIFF
--- a/public/app/features/dashboard/state/initDashboard.test.ts
+++ b/public/app/features/dashboard/state/initDashboard.test.ts
@@ -160,6 +160,10 @@ function describeInitScenario(description: string, scenarioFn: ScenarioFn) {
                   title: 'Redshift and Azure',
                   type: 'stat',
                 },
+                {
+                  id: 9,
+                  type: 'text',
+                },
               ],
               title: 'Collapsed Panel',
               type: 'row',

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -115,7 +115,7 @@ const getQueriesByDatasource = (
   panels.forEach((panel) => {
     if (panel.panels) {
       getQueriesByDatasource(panel.panels, queries);
-    } else {
+    } else if (panel.targets) {
       panel.targets.forEach((target) => {
         if (target.datasource?.type) {
           if (queries[target.datasource.type]) {


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/52052  added a new event that collects all queries in a dashboard. 

The type for PanelModel when it comes to rows is not 100% accurate (should be fixed, but too big for a fix PR). panel.targets is not guaranteed to follow the PanelModel type guarantees (it's actually a serialized version, so not instance of PanelModel). 

Added a quick fix. 

Also removed the data source specific subscribe and analytics event in https://github.com/grafana/grafana/pull/52052, I think adding usage tracking is great but this feels too specific, This feels like it could be a generic data source usage analytics event. Why make it specific to azure? Should all data sources have to implement this? That feels very messy and hard to maintain (and make consistent). 

I think we should at least try to have a generic version first, if it proves impossible to get all the insights from generic version after giving it a real try,  we could start thinking of some ds specific additions to add those insights. But just having events and all data sources have to implement handlers for and adding their own rudderstack events feels like it's going to grow to a messy very quickly (And if any of those event handlers fail it would crash the dashboard) 