### PR TITLE
RBAC: Remove the flag from the config which states that you can disable RBAC

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -655,7 +655,6 @@ managed_identity_client_id =
 
 #################################### Role-based Access Control ###########
 [rbac]
-enabled = true
 # If enabled, cache permissions in a in memory cache (Enterprise only)
 permission_cache = true
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -638,8 +638,6 @@
 
 #################################### Role-based Access Control ###########
 [rbac]
-;enabled = true
-# If enabled, cache permissions in a in memory cache (Enterprise only)
 ;permission_cache = true
 #################################### SMTP / Emailing ##########################
 [smtp]


### PR DESCRIPTION
**What this PR does / why we need it**:

RBAC is enabled by default and we don't want to promote usage of the config to disable it.
