### PR TITLE
Analytics: Use Fullstory to get behavioral data

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -215,6 +215,9 @@ google_analytics_ua_id =
 # Google Tag Manager ID, only enabled if you specify an id here
 google_tag_manager_id =
 
+# Fullstory org id, only enabled if you specify an org id here
+fullstory_org_id = 
+
 # Rudderstack write key, enabled only if rudderstack_data_plane_url is also set
 rudderstack_write_key =
 

--- a/package.json
+++ b/package.json
@@ -250,6 +250,7 @@
   "dependencies": {
     "@emotion/css": "11.9.0",
     "@emotion/react": "11.9.3",
+    "@fullstory/browser": "^1.6.1",
     "@grafana/agent-core": "0.4.0",
     "@grafana/agent-web": "0.4.0",
     "@grafana/aws-sdk": "0.0.37",

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -211,6 +211,7 @@ export interface GrafanaConfig {
   feedbackLinksEnabled: boolean;
   secretsManagerPluginEnabled: boolean;
   googleAnalyticsId: string | undefined;
+  fullstoryOrgId: string | undefined;
   rudderstackWriteKey: string | undefined;
   rudderstackDataPlaneUrl: string | undefined;
   rudderstackSdkUrl: string | undefined;

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -63,4 +63,5 @@ export interface FeatureToggles {
   internationalization?: boolean;
   topnav?: boolean;
   customBranding?: boolean;
+  fullstoryUserTracking?: boolean;
 }

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -134,6 +134,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
     enabled: true,
   };
   googleAnalyticsId: undefined;
+  fullstoryOrgId: undefined;
   rudderstackWriteKey: undefined;
   rudderstackDataPlaneUrl: undefined;
   rudderstackSdkUrl: undefined;

--- a/packages/grafana-runtime/src/services/EchoSrv.ts
+++ b/packages/grafana-runtime/src/services/EchoSrv.ts
@@ -83,6 +83,7 @@ export enum EchoEventType {
   Interaction = 'interaction',
   ExperimentView = 'experimentview',
   GrafanaJavascriptAgent = 'grafana-javascript-agent',
+  Fullstory = 'fullstory-sdk',
 }
 
 /**

--- a/packages/grafana-runtime/src/types/analytics.ts
+++ b/packages/grafana-runtime/src/types/analytics.ts
@@ -108,6 +108,13 @@ export interface InteractionEchoEventPayload {
 export type InteractionEchoEvent = EchoEvent<EchoEventType.Interaction, InteractionEchoEventPayload>;
 
 /**
+ * Describes Fullstory custom interaction event with predefined {@link EchoEventType.EchoEventType} type.
+ *
+ * @public
+ */
+export type FullstoryEchoEvent = EchoEvent<EchoEventType.Fullstory, InteractionEchoEventPayload>;
+
+/**
  * Describes the payload of an experimentview event.
  *
  * @public

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -118,6 +118,7 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"profileEnabled":                      setting.ProfileEnabled,
 		"queryHistoryEnabled":                 hs.Cfg.QueryHistoryEnabled,
 		"googleAnalyticsId":                   setting.GoogleAnalyticsId,
+		"fullstoryOrgId":                      setting.FullstoryOrgId,
 		"rudderstackWriteKey":                 setting.RudderstackWriteKey,
 		"rudderstackDataPlaneUrl":             setting.RudderstackDataPlaneUrl,
 		"rudderstackSdkUrl":                   setting.RudderstackSdkUrl,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -265,7 +265,6 @@ var (
 		{
 			Name:        "fullstoryUserTracking",
 			Description: "Enables Fullstory cliend SDK to do user analytics",
-			State:       FeatureStateAlpha,
 		},
 	}
 )

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -262,5 +262,10 @@ var (
 			Description: "Replaces whitelabeling with the new custom branding feature",
 			State:       FeatureStateAlpha,
 		},
+		{
+			Name:        "fullstoryUserTracking",
+			Description: "Enables Fullstory cliend SDK to do user analytics",
+			State:       FeatureStateAlpha,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -194,4 +194,8 @@ const (
 	// FlagCustomBranding
 	// Replaces whitelabeling with the new custom branding feature
 	FlagCustomBranding = "customBranding"
+
+	// FlagFullstoryUserTracking
+	// Enables Fullstory cliend SDK to do user analytics
+	FlagFullstoryUserTracking = "fullstoryUserTracking"
 )

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -137,6 +137,7 @@ var (
 	// analytics
 	GoogleAnalyticsId       string
 	GoogleTagManagerId      string
+	FullstoryOrgId          string
 	RudderstackDataPlaneUrl string
 	RudderstackWriteKey     string
 	RudderstackSdkUrl       string
@@ -953,6 +954,7 @@ func (cfg *Cfg) Load(args CommandLineArgs) error {
 	cfg.CheckForPluginUpdates = analytics.Key("check_for_plugin_updates").MustBool(true)
 	GoogleAnalyticsId = analytics.Key("google_analytics_ua_id").String()
 	GoogleTagManagerId = analytics.Key("google_tag_manager_id").String()
+	FullstoryOrgId = analytics.Key("fullstory_org_id").String()
 	RudderstackWriteKey = analytics.Key("rudderstack_write_key").String()
 	RudderstackDataPlaneUrl = analytics.Key("rudderstack_data_plane_url").String()
 	RudderstackSdkUrl = analytics.Key("rudderstack_sdk_url").String()

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -53,6 +53,7 @@ import { Echo } from './core/services/echo/Echo';
 import { reportPerformance } from './core/services/echo/EchoSrv';
 import { PerformanceBackend } from './core/services/echo/backends/PerformanceBackend';
 import { ApplicationInsightsBackend } from './core/services/echo/backends/analytics/ApplicationInsightsBackend';
+import { FullstoryBackend } from './core/services/echo/backends/analytics/FullstoryBackend';
 import { GAEchoBackend } from './core/services/echo/backends/analytics/GABackend';
 import { RudderstackBackend } from './core/services/echo/backends/analytics/RudderstackBackend';
 import { GrafanaJavascriptAgentBackend } from './core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend';
@@ -204,6 +205,10 @@ function initEchoSrv() {
 
   if (contextSrv.user.orgRole !== '') {
     registerEchoBackend(new PerformanceBackend({}));
+  }
+
+  if (config.featureToggles.fullstoryUserTracking && config.fullstoryOrgId) {
+    registerEchoBackend(new FullstoryBackend({ orgId: config.fullstoryOrgId }));
   }
 
   if (config.sentry.enabled) {

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -208,7 +208,9 @@ function initEchoSrv() {
   }
 
   if (config.featureToggles.fullstoryUserTracking && config.fullstoryOrgId) {
-    registerEchoBackend(new FullstoryBackend({ orgId: config.fullstoryOrgId }));
+    registerEchoBackend(
+      new FullstoryBackend({ orgId: config.fullstoryOrgId, devMode: process.env.NODE_ENV === 'development' })
+    );
   }
 
   if (config.sentry.enabled) {

--- a/public/app/core/services/echo/backends/analytics/FullstoryBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/FullstoryBackend.ts
@@ -17,6 +17,6 @@ export class FullstoryBackend implements EchoBackend<FullstoryEchoEvent, Fullsto
   // Not using custom events, Fullstory track every interaction automatically
   addEvent = (e: FullstoryEchoEvent) => {};
 
-  // Not using Echo buffering, addEvent above sends events to GA as soon as they appear
+  // Not using Echo buffering
   flush = () => {};
 }

--- a/public/app/core/services/echo/backends/analytics/FullstoryBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/FullstoryBackend.ts
@@ -5,14 +5,13 @@ import { EchoBackend, EchoEventType, FullstoryEchoEvent } from '@grafana/runtime
 export interface FullstoryBackendOptions {
   orgId: string;
   devMode?: boolean;
-  debug?: boolean;
 }
 
 export class FullstoryBackend implements EchoBackend<FullstoryEchoEvent, FullstoryBackendOptions> {
   supportedEvents = [EchoEventType.Fullstory];
 
   constructor(public options: FullstoryBackendOptions) {
-    init({ orgId: options.orgId, devMode: options.devMode ?? false, debug: options.debug ?? false });
+    init({ orgId: options.orgId, devMode: options.devMode ?? false, debug: options.devMode ?? false });
   }
 
   // Not using custom events, Fullstory track every interaction automatically

--- a/public/app/core/services/echo/backends/analytics/FullstoryBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/FullstoryBackend.ts
@@ -1,0 +1,23 @@
+import { init } from '@fullstory/browser';
+
+import { EchoBackend, EchoEventType, FullstoryEchoEvent } from '@grafana/runtime';
+
+export interface FullstoryBackendOptions {
+  orgId: string;
+  devMode?: boolean;
+  debug?: boolean;
+}
+
+export class FullstoryBackend implements EchoBackend<FullstoryEchoEvent, FullstoryBackendOptions> {
+  supportedEvents = [EchoEventType.Fullstory];
+
+  constructor(public options: FullstoryBackendOptions) {
+    init({ orgId: options.orgId, devMode: options.devMode ?? false, debug: options.debug ?? false });
+  }
+
+  // Not using custom events, Fullstory track every interaction automatically
+  addEvent = (e: FullstoryEchoEvent) => {};
+
+  // Not using Echo buffering, addEvent above sends events to GA as soon as they appear
+  flush = () => {};
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4719,6 +4719,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fullstory/browser@npm:^1.6.1":
+  version: 1.6.1
+  resolution: "@fullstory/browser@npm:1.6.1"
+  checksum: 79bb1c05b92b6bb6163566eeceb2ddf8e7e7bf5b9d629d99a937cecc21eafc019a0149c78d968e623424cbc84e9ce10e162e8ab56e59d47d259ca8e364f5c249
+  languageName: node
+  linkType: hard
+
 "@gar/promisify@npm:^1.0.1":
   version: 1.1.2
   resolution: "@gar/promisify@npm:1.1.2"
@@ -21555,6 +21562,7 @@ __metadata:
     "@emotion/css": 11.9.0
     "@emotion/eslint-plugin": 11.7.0
     "@emotion/react": 11.9.3
+    "@fullstory/browser": ^1.6.1
     "@grafana/agent-core": 0.4.0
     "@grafana/agent-web": 0.4.0
     "@grafana/api-documenter": 7.11.2


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
As part of the Grafana Hackathon, we want to test how behavioral data can help Grafana teams understand why Grafana is hard to use and what are the main pain points the user finds when interacting with the product.

Why Fullstory?
- Track every user interaction by default, so no custom tracking per feature is needed
- Allow session recording but it masks sensitive data
- Allow you to create journeys and funnels out-of-the-box, using the selectors of the elements
- K6 is already using it and they are happy with it

![Captura de Pantalla 2022-08-12 a las 19 55 34](https://user-images.githubusercontent.com/5699976/184639894-45ee29b9-4777-4cce-8fb1-bc86c08cd2cb.png)


**Special notes for your reviewer**:
This implementation will be under FF and it will be only enabled for the internal Grafana Labs account. The tracking will be disabled if the `fullstory_org_id` config is undefined.

To test this PR: 
1. Access to Fullstory Grafana account settings and add to your `custom.ini` the following options:
```
[feature_toggles]
enable = fullstoryUserTracking

[analytics]
fullstory_org_id = '<check_org_id_in_grafana_fullstory>'
```

2. Go to `app.ts` and remove the condition to enable `devMode` for Fullstory SDK.
```diff
new FullstoryBackend({ 
    orgId: config.fullstoryOrgId, 
-   devMode: process.env.NODE_ENV === 'development' 
})
```
3. Run Grafana locally and interact with the UI
4. Go to the Fullstory home page and look for sessions, you will see a session active with the recording of your behavior.
<img width="1918" alt="Captura de Pantalla 2022-08-15 a las 14 50 41" src="https://user-images.githubusercontent.com/5699976/184638117-fba3a31a-b0b8-4f7c-9649-7d5a8682bd51.png">

