### PR TITLE
Adding urlparams to the routes schema

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -438,6 +438,24 @@
                 }
               }
             }
+          },
+          "urlParams": {
+            "type": "array",
+            "description": "Add URL parameters to a proxy route",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name of the URL parameter"
+                },
+                "content": {
+                  "type": "string",
+                  "description": "Value of the URL parameter"
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
Adds `urlParams` to `routes` property in plugin.json schema to match our documentation and plugin validation: https://grafana.com/docs/grafana/latest/developers/plugins/add-authentication-for-data-source-plugins/#add-a-dynamic-proxy-route-to-your-plugin