### PR TITLE
logs: do not show tsNs and time-field

### DIFF
--- a/packages/grafana-ui/src/components/Logs/logParser.test.ts
+++ b/packages/grafana-ui/src/components/Logs/logParser.test.ts
@@ -151,6 +151,57 @@ describe('getAllFields', () => {
     expect(fields.length).toBe(1);
     expect(fields.find((field) => field.key === testStringField.name)).not.toBe(undefined);
   });
+
+  it('should filter out nanosecond-timestamp field', () => {
+    const logRow = createLogRow({
+      entryFieldIndex: 10,
+      dataFrame: new MutableDataFrame({
+        refId: 'A',
+        fields: [
+          {
+            name: 'tsNs',
+            type: FieldType.string,
+            config: {},
+            values: new ArrayVector(['abc']),
+          },
+        ],
+      }),
+    });
+
+    const fields = getAllFields(logRow);
+    expect(fields.length).toBe(0);
+  });
+
+  it('should filter out the first field of type=time, but not others of type=time', () => {
+    const logRow = createLogRow({
+      entryFieldIndex: 10,
+      dataFrame: new MutableDataFrame({
+        refId: 'A',
+        fields: [
+          {
+            name: 'Time1',
+            type: FieldType.time,
+            config: {},
+            values: new ArrayVector([1]),
+          },
+          {
+            name: 'Time2',
+            type: FieldType.time,
+            config: {},
+            values: new ArrayVector([2]),
+          },
+        ],
+      }),
+    });
+
+    const fields = getAllFields(logRow);
+    expect(fields.length).toBe(1);
+
+    const field1 = fields[0];
+
+    expect(field1.key).toBe('Time2');
+    expect(field1.value).toBe('2');
+  });
 });
 
 const testStringField = {

--- a/packages/grafana-ui/src/components/Logs/logParser.ts
+++ b/packages/grafana-ui/src/components/Logs/logParser.ts
@@ -97,6 +97,10 @@ function shouldRemoveField(field: Field, index: number, row: LogRowModel) {
   if (field.name === 'id') {
     return true;
   }
+  // "tsNs" field which we use for nanosecond-timestamps, if available
+  if (field.name === 'tsNs') {
+    return true;
+  }
   // entry field which we are showing as the log message
   if (row.entryFieldIndex === index) {
     return true;
@@ -108,6 +112,14 @@ function shouldRemoveField(field: Field, index: number, row: LogRowModel) {
   // field that has empty value (we want to keep 0 or empty string)
   if (field.values.get(row.rowIndex) == null) {
     return true;
+  }
+  // the first time-field
+  if (field.type === FieldType.time) {
+    // the first field of type=time is used as the timestamp for the log-row, we want to remove it
+    const firstTimeFieldIndex = row.dataFrame.fields.findIndex((f) => f.type === FieldType.time);
+    if (index === firstTimeFieldIndex) {
+      return true;
+    }
   }
   return false;
 }


### PR DESCRIPTION
in https://github.com/grafana/grafana/pull/53319, we removed the `labels` field from the "detected fields" section.

there are still 2 fields there that are used by the "system", and not meant for user-consumption:
- the timestamp field
- the nanosecond-timestamp field


i think we should remove those two too.

how to test:
- go to explore
- use a loki datasource, run a query
- open a log-row
- in the `detected fields` section you should not see a field named `Time` also you should not see a field named `tsNs`

