### PR TITLE
Navigation: implement responsive breadcrumb behaviour

### DIFF
--- a/public/app/core/components/Breadcrumbs/BreadcrumbItem.tsx
+++ b/public/app/core/components/Breadcrumbs/BreadcrumbItem.tsx
@@ -44,6 +44,10 @@ export function BreadcrumbItem(props: Props) {
 }
 
 const getStyles = (theme: GrafanaTheme2) => {
+  const separator = css({
+    color: theme.colors.text.secondary,
+  });
+
   return {
     breadcrumb: css({
       alignItems: 'center',
@@ -61,9 +65,21 @@ const getStyles = (theme: GrafanaTheme2) => {
       color: theme.colors.text.primary,
       display: 'flex',
       fontWeight: theme.typography.fontWeightMedium,
+
+      // logic for small screens
+      // hide any breadcrumbs that aren't the second to last child (the parent)
+      [theme.breakpoints.down('md')]: {
+        display: 'none',
+        '&:nth-last-child(2)': {
+          display: 'flex',
+          flexDirection: 'row-reverse',
+
+          [`.${separator}`]: {
+            transform: 'rotate(180deg)',
+          },
+        },
+      },
     }),
-    separator: css({
-      color: theme.colors.text.secondary,
-    }),
+    separator,
   };
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- hides all breadcrumbs except the second to last child (the parent) when the screen is smaller than the medium breakpoint
- puts the separator at the front and rotates it 


https://user-images.githubusercontent.com/20999846/184842544-5e583147-db2a-40e8-8f4f-cdbe676d5f41.mp4



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/53761

**Special notes for your reviewer**:

