### PR TITLE
pkg/web: remove Router and Logger from Context

### DIFF
--- a/pkg/services/ngalert/api/util_test.go
+++ b/pkg/services/ngalert/api/util_test.go
@@ -41,8 +41,7 @@ func TestToMacaronPath(t *testing.T) {
 func TestAlertingProxy_createProxyContext(t *testing.T) {
 	ctx := &models.ReqContext{
 		Context: &web.Context{
-			Router: web.NewRouter(),
-			Req:    &http.Request{},
+			Req: &http.Request{},
 		},
 		SignedInUser:          &user.SignedInUser{},
 		UserToken:             &models.UserToken{},
@@ -92,7 +91,6 @@ func TestAlertingProxy_createProxyContext(t *testing.T) {
 		newCtx := proxy.createProxyContext(ctx, req, resp)
 
 		require.NotEqual(t, ctx.Context.Resp, newCtx.Context.Resp)
-		require.Equal(t, ctx.Context.Router, newCtx.Context.Router)
 		require.Equal(t, ctx.Context.Req, newCtx.Context.Req)
 
 		require.NotEqual(t, 123, resp.Status())

--- a/pkg/web/context.go
+++ b/pkg/web/context.go
@@ -22,8 +22,6 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-
-	"github.com/grafana/grafana/pkg/infra/log"
 )
 
 // Context represents the runtime context of current request of Macaron instance.
@@ -31,11 +29,9 @@ import (
 type Context struct {
 	mws []Middleware
 
-	*Router
 	Req      *http.Request
 	Resp     ResponseWriter
 	template *template.Template
-	logger   log.Logger
 }
 
 func (ctx *Context) run() {
@@ -69,7 +65,6 @@ func (ctx *Context) RemoteAddr() string {
 	if len(addr) > 0 {
 		if parsedIP := net.ParseIP(addr); parsedIP == nil {
 			// if parsedIP is nil we clean addr and populate with RemoteAddr below
-			ctx.logger.Warn("Received invalid IP address in request headers, removed for log forgery prevention")
 			addr = ""
 		}
 	}

--- a/pkg/web/context_test.go
+++ b/pkg/web/context_test.go
@@ -86,8 +86,7 @@ func TestContext_RemoteAddr(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &Context{
-				Req:    tt.fields.Req,
-				logger: tt.fields.logger,
+				Req: tt.fields.Req,
 			}
 			if got := ctx.RemoteAddr(); got != tt.want {
 				t.Errorf("RemoteAddr() = %v, want %v", got, tt.want)

--- a/pkg/web/macaron.go
+++ b/pkg/web/macaron.go
@@ -24,8 +24,6 @@ import (
 	"context"
 	"net/http"
 	"strings"
-
-	"github.com/grafana/grafana/pkg/infra/log"
 )
 
 const _VERSION = "1.3.4.0805"
@@ -147,10 +145,8 @@ func mwFromHandler(handler Handler) Middleware {
 
 func (m *Macaron) createContext(rw http.ResponseWriter, req *http.Request) *Context {
 	c := &Context{
-		mws:    m.mws,
-		Router: m.Router,
-		Resp:   NewResponseWriter(req.Method, rw),
-		logger: log.New("macaron.context"),
+		mws:  m.mws,
+		Resp: NewResponseWriter(req.Method, rw),
 	}
 
 	c.Req = req.WithContext(context.WithValue(req.Context(), macaronContextKey{}, c))


### PR DESCRIPTION
`web.Context` previously held references to the current `*web.Router` albeit not using it.

It also had a log.Logger only being used once internally