### PR TITLE
table: add annotations support

### DIFF
--- a/public/app/plugins/panel/table/module.tsx
+++ b/public/app/plugins/panel/table/module.tsx
@@ -163,6 +163,20 @@ export const plugin = new PanelPlugin<PanelOptions, TableFieldOptions>(TablePane
         path: 'footer.enablePagination',
         name: 'Enable pagination',
         editor: PaginationEditor,
+      })
+      .addSelect({
+        path: 'source',
+        name: 'Source of data',
+        description: 'Select which data to show',
+        settings: {
+          allowCustomValue: false,
+          options: [
+            { value: 'series', label: 'Series' },
+            { value: 'annotations', label: 'Annotations' },
+          ],
+        },
+        defaultValue: 'series',
       });
   })
-  .setSuggestionsSupplier(new TableSuggestionsSupplier());
+  .setSuggestionsSupplier(new TableSuggestionsSupplier())
+  .setDataSupport({ annotations: true, alertStates: true });


### PR DESCRIPTION
**What this PR does / why we need it**:
Old table panel had an ability to show annotations. New table panel can't do it. Moreover, annotations functionality has also been removed from table-old and replaced by stubs. This PR allows to use annotations as a source of data for table panel.

**Special notes for your reviewer**:
Unfortunately, this PR is not enough to make annotations usable for the table panel, as it can't properly show multi-line text (as table-old used to) and just merges lines in a single truncated line without word-wrap and column height adjustments. But at least it paves the way for this functionality.

I've tested this PR on v8.4.7. Current main returns error when I'm trying to build docker container.

