### PR TITLE
Logs: do not show duplicate detected fields

### DIFF
--- a/packages/grafana-ui/src/components/Logs/logParser.ts
+++ b/packages/grafana-ui/src/components/Logs/logParser.ts
@@ -22,6 +22,11 @@ export const getAllFields = memoizeOne(
     const fields = parseMessage(row.entry);
     const derivedFields = getDerivedFields(row, getFieldLinks);
     const fieldsMap = [...derivedFields, ...fields].reduce((acc, field) => {
+      if (!field.links && row.labels[field.key] !== undefined) {
+        // if this field is already in the labels-section,
+        // and the field has no links in it, ignore it.
+        return acc;
+      }
       // Strip enclosing quotes for hashing. When values are parsed from log line the quotes are kept, but if same
       // value is in the dataFrame it will be without the quotes. We treat them here as the same value.
       const value = field.value.replace(/(^")|("$)/g, '');


### PR DESCRIPTION
NOTE: we will wait with this for now, there may be a better approach.

for example, when using Loki, with `logfmt` data, and running a query like `{...} | logfmt` , and opening the log-row-details, you will see every field two times: both in `log labels` and in `detected fields`.

this pull-request changes the logic so that detected-fields, that are already in `labels`, will not show up. we only do this for detected-fields without a `links` property, to make sure derived-fields-functionality is not affected.

how to test:
- `make devenv sources=loki`
- go to explore, run this loki query `{place="moon"} | json`
- open a log-row
- verify that labels like `float` and `counter` are only in the `log labels` section, not in the `detected fields` section

this is a (minor) change in functionality, i'm very interested in knowing what you think about it.