### PR TITLE
RBAC: Remove user permissions in org when user is removed

### DIFF
--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -410,14 +410,16 @@ func (hs *HTTPServer) removeOrgUserHelper(ctx context.Context, cmd *models.Remov
 	}
 
 	if cmd.UserWasDeleted {
+		// This should be called from appropriate service when moved
 		if err := hs.AccessControl.DeleteUserPermissions(ctx, accesscontrol.GlobalOrgID, cmd.UserId); err != nil {
-			hs.log.Warn("failed to delete permissions for user", "userID", cmd.UserId)
+			hs.log.Warn("failed to delete permissions for user", "userID", cmd.UserId, "orgID", accesscontrol.GlobalOrgID)
 		}
 		return response.Success("User deleted")
 	}
 
+	// This should be called from appropriate service when moved
 	if err := hs.AccessControl.DeleteUserPermissions(ctx, cmd.OrgId, cmd.UserId); err != nil {
-		hs.log.Warn("failed to delete permissions for user", "userID", cmd.UserId)
+		hs.log.Warn("failed to delete permissions for user", "userID", cmd.UserId, "orgID", cmd.OrgId)
 	}
 
 	return response.Success("User removed from organization")

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -412,7 +412,7 @@ func (hs *HTTPServer) removeOrgUserHelper(ctx context.Context, cmd *models.Remov
 	if cmd.UserWasDeleted {
 		// This should be called from appropriate service when moved
 		if err := hs.AccessControl.DeleteUserPermissions(ctx, accesscontrol.GlobalOrgID, cmd.UserId); err != nil {
-			hs.log.Warn("failed to delete permissions for user", "userID", cmd.UserId, "orgID", accesscontrol.GlobalOrgID)
+			hs.log.Warn("failed to delete permissions for user", "userID", cmd.UserId, "orgID", accesscontrol.GlobalOrgID, "err", err)
 		}
 		return response.Success("User deleted")
 	}

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -419,7 +419,7 @@ func (hs *HTTPServer) removeOrgUserHelper(ctx context.Context, cmd *models.Remov
 
 	// This should be called from appropriate service when moved
 	if err := hs.AccessControl.DeleteUserPermissions(ctx, cmd.OrgId, cmd.UserId); err != nil {
-		hs.log.Warn("failed to delete permissions for user", "userID", cmd.UserId, "orgID", cmd.OrgId)
+		hs.log.Warn("failed to delete permissions for user", "userID", cmd.UserId, "orgID", cmd.OrgId, "err", err)
 	}
 
 	return response.Success("User removed from organization")

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -937,6 +937,11 @@ func TestDeleteOrgUsersAPIEndpoint_AccessControl(t *testing.T) {
 				err = sc.db.GetOrgUsers(context.Background(), &getUsersQuery)
 				require.NoError(t, err)
 				assert.Len(t, getUsersQuery.Result, tc.expectedUserCount)
+
+				// check all permissions for user is removed in org
+				permission, err := sc.hs.AccessControl.GetUserPermissions(context.Background(), &user.SignedInUser{UserID: tc.targetUserId, OrgID: tc.targetOrg}, accesscontrol.Options{})
+				require.NoError(t, err)
+				assert.Len(t, permission, 0)
 			}
 		})
 	}

--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -36,7 +36,9 @@ type AccessControl interface {
 	// specific scope prefix (ex: datasources:name:)
 	RegisterScopeAttributeResolver(scopePrefix string, resolver ScopeAttributeResolver)
 
-	DeleteUserPermissions(ctx context.Context, userID int64) error
+	// DeleteUserPermissions removes all permissions user has in org and all permission to that user
+	// If orgID is set to 0 remove permissions from all orgs
+	DeleteUserPermissions(ctx context.Context, orgID, userID int64) error
 }
 
 type RoleRegistry interface {
@@ -47,7 +49,7 @@ type RoleRegistry interface {
 type PermissionsStore interface {
 	// GetUserPermissions returns user permissions with only action and scope fields set.
 	GetUserPermissions(ctx context.Context, query GetUserPermissionsQuery) ([]Permission, error)
-	DeleteUserPermissions(ctx context.Context, userID int64) error
+	DeleteUserPermissions(ctx context.Context, orgID, userID int64) error
 }
 
 type TeamPermissionsService interface {

--- a/pkg/services/accesscontrol/database/database.go
+++ b/pkg/services/accesscontrol/database/database.go
@@ -133,7 +133,6 @@ func deletePermissions(sess *sqlstore.DBSession, ids []int64) error {
 
 func (s *AccessControlStore) DeleteUserPermissions(ctx context.Context, orgID, userID int64) error {
 	err := s.sql.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-
 		roleDeleteQuery := "DELETE FROM user_role WHERE user_id = ?"
 		roleDeleteParams := []interface{}{roleDeleteQuery, userID}
 		if orgID != accesscontrol.GlobalOrgID {

--- a/pkg/services/accesscontrol/database/database.go
+++ b/pkg/services/accesscontrol/database/database.go
@@ -155,10 +155,10 @@ func (s *AccessControlStore) DeleteUserPermissions(ctx context.Context, orgID, u
 		}
 
 		roleQuery := "SELECT id FROM role WHERE name = ?"
-		roleParams := []interface{}{roleQuery, accesscontrol.ManagedUserRoleName(userID)}
+		roleParams := []interface{}{accesscontrol.ManagedUserRoleName(userID)}
 		if orgID != accesscontrol.GlobalOrgID {
 			roleQuery += " AND org_id = ?"
-			roleParams = []interface{}{roleQuery, accesscontrol.ManagedUserRoleName(userID), orgID}
+			roleParams = []interface{}{accesscontrol.ManagedUserRoleName(userID), orgID}
 		}
 
 		var roleIDs []int64

--- a/pkg/services/accesscontrol/database/database.go
+++ b/pkg/services/accesscontrol/database/database.go
@@ -133,18 +133,36 @@ func deletePermissions(sess *sqlstore.DBSession, ids []int64) error {
 
 func (s *AccessControlStore) DeleteUserPermissions(ctx context.Context, orgID, userID int64) error {
 	err := s.sql.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
+
+		roleDeleteQuery := "DELETE FROM user_role WHERE user_id = ?"
+		roleDeleteParams := []interface{}{roleDeleteQuery, userID}
+		if orgID != accesscontrol.GlobalOrgID {
+			roleDeleteQuery += " AND org_id = ?"
+			roleDeleteParams = []interface{}{roleDeleteQuery, userID, orgID}
+		}
+
 		// Delete user role assignments
-		if _, err := sess.Exec("DELETE FROM user_role WHERE user_id = ?", userID); err != nil {
+		if _, err := sess.Exec(roleDeleteParams...); err != nil {
 			return err
 		}
 
-		// Delete permissions that are scoped to user
-		if _, err := sess.Exec("DELETE FROM permission WHERE scope = ?", accesscontrol.Scope("users", "id", strconv.FormatInt(userID, 10))); err != nil {
-			return err
+		// only delete scopes to user if all permissions is removed (i.e. user is removed)
+		if orgID == accesscontrol.GlobalOrgID {
+			// Delete permissions that are scoped to user
+			if _, err := sess.Exec("DELETE FROM permission WHERE scope = ?", accesscontrol.Scope("users", "id", strconv.FormatInt(userID, 10))); err != nil {
+				return err
+			}
+		}
+
+		roleQuery := "SELECT id FROM role WHERE name = ?"
+		roleParams := []interface{}{roleQuery, accesscontrol.ManagedUserRoleName(userID)}
+		if orgID != accesscontrol.GlobalOrgID {
+			roleQuery += " AND org_id = ?"
+			roleParams = []interface{}{roleQuery, accesscontrol.ManagedUserRoleName(userID), orgID}
 		}
 
 		var roleIDs []int64
-		if err := sess.SQL("SELECT id FROM role WHERE name = ?", accesscontrol.ManagedUserRoleName(userID)).Find(&roleIDs); err != nil {
+		if err := sess.SQL(roleQuery, roleParams...).Find(&roleIDs); err != nil {
 			return err
 		}
 
@@ -152,20 +170,25 @@ func (s *AccessControlStore) DeleteUserPermissions(ctx context.Context, orgID, u
 			return nil
 		}
 
-		query := "DELETE FROM permission WHERE role_id IN(? " + strings.Repeat(",?", len(roleIDs)-1) + ")"
-		args := make([]interface{}, 0, len(roleIDs)+1)
-		args = append(args, query)
+		permissionDeleteQuery := "DELETE FROM permission WHERE role_id IN(? " + strings.Repeat(",?", len(roleIDs)-1) + ")"
+		permissionDeleteParams := make([]interface{}, 0, len(roleIDs)+1)
+		permissionDeleteParams = append(permissionDeleteParams, permissionDeleteQuery)
 		for _, id := range roleIDs {
-			args = append(args, id)
+			permissionDeleteParams = append(permissionDeleteParams, id)
 		}
 
 		// Delete managed user permissions
-		if _, err := sess.Exec(args...); err != nil {
+		if _, err := sess.Exec(permissionDeleteParams...); err != nil {
 			return err
 		}
 
+		managedRoleDeleteQuery := "DELETE FROM role WHERE id IN(? " + strings.Repeat(",?", len(roleIDs)-1) + ")"
+		managedRoleDeleteParams := []interface{}{managedRoleDeleteQuery}
+		for _, id := range roleIDs {
+			managedRoleDeleteParams = append(managedRoleDeleteParams, id)
+		}
 		// Delete managed user roles
-		if _, err := sess.Exec("DELETE FROM role WHERE name = ?", accesscontrol.ManagedUserRoleName(userID)); err != nil {
+		if _, err := sess.Exec(managedRoleDeleteParams...); err != nil {
 			return err
 		}
 

--- a/pkg/services/accesscontrol/database/database.go
+++ b/pkg/services/accesscontrol/database/database.go
@@ -131,7 +131,7 @@ func deletePermissions(sess *sqlstore.DBSession, ids []int64) error {
 	return nil
 }
 
-func (s *AccessControlStore) DeleteUserPermissions(ctx context.Context, userID int64) error {
+func (s *AccessControlStore) DeleteUserPermissions(ctx context.Context, orgID, userID int64) error {
 	err := s.sql.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
 		// Delete user role assignments
 		if _, err := sess.Exec("DELETE FROM user_role WHERE user_id = ?", userID); err != nil {

--- a/pkg/services/accesscontrol/database/database_test.go
+++ b/pkg/services/accesscontrol/database/database_test.go
@@ -152,7 +152,7 @@ func TestAccessControlStore_DeleteUserPermissions(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	err = store.DeleteUserPermissions(context.Background(), user.ID)
+	err = store.DeleteUserPermissions(context.Background(), user.OrgID, user.ID)
 	require.NoError(t, err)
 
 	permissions, err := store.GetUserPermissions(context.Background(), accesscontrol.GetUserPermissionsQuery{

--- a/pkg/services/accesscontrol/database/database_test.go
+++ b/pkg/services/accesscontrol/database/database_test.go
@@ -220,7 +220,6 @@ func TestAccessControlStore_DeleteUserPermissions(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, permissions, 1)
 	})
-
 }
 
 func createUserAndTeam(t *testing.T, sql *sqlstore.SQLStore, orgID int64) (*user.User, models.Team) {

--- a/pkg/services/accesscontrol/database/database_test.go
+++ b/pkg/services/accesscontrol/database/database_test.go
@@ -141,28 +141,86 @@ func TestAccessControlStore_GetUserPermissions(t *testing.T) {
 }
 
 func TestAccessControlStore_DeleteUserPermissions(t *testing.T) {
-	store, sql := setupTestEnv(t)
+	t.Run("expect permissions in all orgs to be deleted", func(t *testing.T) {
+		store, sql := setupTestEnv(t)
+		user, _ := createUserAndTeam(t, sql, 1)
 
-	user, _ := createUserAndTeam(t, sql, 1)
+		// generate permissions in org 1
+		_, err := store.SetUserResourcePermission(context.Background(), 1, accesscontrol.User{ID: user.ID}, types.SetResourcePermissionCommand{
+			Actions:    []string{"dashboards:write"},
+			Resource:   "dashboards",
+			ResourceID: "1",
+		}, nil)
+		require.NoError(t, err)
 
-	_, err := store.SetUserResourcePermission(context.Background(), 1, accesscontrol.User{ID: user.ID}, types.SetResourcePermissionCommand{
-		Actions:    []string{"dashboards:write"},
-		Resource:   "dashboards",
-		ResourceID: "1",
-	}, nil)
-	require.NoError(t, err)
+		// generate permissions in org 2
+		_, err = store.SetUserResourcePermission(context.Background(), 2, accesscontrol.User{ID: user.ID}, types.SetResourcePermissionCommand{
+			Actions:    []string{"dashboards:write"},
+			Resource:   "dashboards",
+			ResourceID: "1",
+		}, nil)
+		require.NoError(t, err)
 
-	err = store.DeleteUserPermissions(context.Background(), user.OrgID, user.ID)
-	require.NoError(t, err)
+		err = store.DeleteUserPermissions(context.Background(), accesscontrol.GlobalOrgID, user.ID)
+		require.NoError(t, err)
 
-	permissions, err := store.GetUserPermissions(context.Background(), accesscontrol.GetUserPermissionsQuery{
-		OrgID:   1,
-		UserID:  user.ID,
-		Roles:   []string{"Admin"},
-		Actions: []string{"dashboards:write"},
+		permissions, err := store.GetUserPermissions(context.Background(), accesscontrol.GetUserPermissionsQuery{
+			OrgID:  1,
+			UserID: user.ID,
+			Roles:  []string{"Admin"},
+		})
+		require.NoError(t, err)
+		assert.Len(t, permissions, 0)
+
+		permissions, err = store.GetUserPermissions(context.Background(), accesscontrol.GetUserPermissionsQuery{
+			OrgID:  2,
+			UserID: user.ID,
+			Roles:  []string{"Admin"},
+		})
+		require.NoError(t, err)
+		assert.Len(t, permissions, 0)
 	})
-	require.NoError(t, err)
-	assert.Len(t, permissions, 0)
+
+	t.Run("expect permissions in org 1 to be deleted", func(t *testing.T) {
+		store, sql := setupTestEnv(t)
+		user, _ := createUserAndTeam(t, sql, 1)
+
+		// generate permissions in org 1
+		_, err := store.SetUserResourcePermission(context.Background(), 1, accesscontrol.User{ID: user.ID}, types.SetResourcePermissionCommand{
+			Actions:    []string{"dashboards:write"},
+			Resource:   "dashboards",
+			ResourceID: "1",
+		}, nil)
+		require.NoError(t, err)
+
+		// generate permissions in org 2
+		_, err = store.SetUserResourcePermission(context.Background(), 2, accesscontrol.User{ID: user.ID}, types.SetResourcePermissionCommand{
+			Actions:    []string{"dashboards:write"},
+			Resource:   "dashboards",
+			ResourceID: "1",
+		}, nil)
+		require.NoError(t, err)
+
+		err = store.DeleteUserPermissions(context.Background(), 1, user.ID)
+		require.NoError(t, err)
+
+		permissions, err := store.GetUserPermissions(context.Background(), accesscontrol.GetUserPermissionsQuery{
+			OrgID:  1,
+			UserID: user.ID,
+			Roles:  []string{"Admin"},
+		})
+		require.NoError(t, err)
+		assert.Len(t, permissions, 0)
+
+		permissions, err = store.GetUserPermissions(context.Background(), accesscontrol.GetUserPermissionsQuery{
+			OrgID:  2,
+			UserID: user.ID,
+			Roles:  []string{"Admin"},
+		})
+		require.NoError(t, err)
+		assert.Len(t, permissions, 1)
+	})
+
 }
 
 func createUserAndTeam(t *testing.T, sql *sqlstore.SQLStore, orgID int64) (*user.User, models.Team) {

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -183,8 +183,8 @@ func (m *Mock) RegisterScopeAttributeResolver(scopePrefix string, resolver acces
 	}
 }
 
-func (m *Mock) DeleteUserPermissions(ctx context.Context, userID int64) error {
-	m.Calls.DeleteUserPermissions = append(m.Calls.DeleteUserPermissions, []interface{}{ctx, userID})
+func (m *Mock) DeleteUserPermissions(ctx context.Context, orgID, userID int64) error {
+	m.Calls.DeleteUserPermissions = append(m.Calls.DeleteUserPermissions, []interface{}{ctx, orgID, userID})
 	// Use override if provided
 	if m.DeleteUserPermissionsFunc != nil {
 		return m.DeleteUserPermissionsFunc(ctx, userID)

--- a/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/ossaccesscontrol.go
@@ -204,6 +204,6 @@ func (ac *OSSAccessControlService) RegisterScopeAttributeResolver(scopePrefix st
 	ac.scopeResolvers.AddScopeAttributeResolver(scopePrefix, resolver)
 }
 
-func (ac *OSSAccessControlService) DeleteUserPermissions(ctx context.Context, userID int64) error {
-	return ac.store.DeleteUserPermissions(ctx, userID)
+func (ac *OSSAccessControlService) DeleteUserPermissions(ctx context.Context, orgID int64, userID int64) error {
+	return ac.store.DeleteUserPermissions(ctx, orgID, userID)
 }

--- a/pkg/services/login/loginservice/loginservice.go
+++ b/pkg/services/login/loginservice/loginservice.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
@@ -21,12 +22,14 @@ func ProvideService(
 	userService user.Service,
 	quotaService quota.Service,
 	authInfoService login.AuthInfoService,
+	accessControl accesscontrol.AccessControl,
 ) *Implementation {
 	s := &Implementation{
 		SQLStore:        sqlStore,
 		userService:     userService,
 		QuotaService:    quotaService,
 		AuthInfoService: authInfoService,
+		accessControl:   accessControl,
 	}
 	return s
 }
@@ -37,6 +40,7 @@ type Implementation struct {
 	AuthInfoService login.AuthInfoService
 	QuotaService    quota.Service
 	TeamSync        login.TeamSyncFunc
+	accessControl   accesscontrol.AccessControl
 }
 
 // CreateUser creates inserts a new one.
@@ -310,6 +314,9 @@ func (ls *Implementation) syncOrgRoles(ctx context.Context, usr *user.User, extU
 			if errors.Is(err, models.ErrLastOrgAdmin) {
 				logger.Error(err.Error(), "userId", cmd.UserId, "orgId", cmd.OrgId)
 				continue
+			}
+			if err := ls.accessControl.DeleteUserPermissions(ctx, orgId, cmd.UserId); err != nil {
+				logger.Warn("failed to delete permissions for user", "userID", cmd.UserId, "orgID", orgId)
 			}
 
 			return err

--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -223,7 +223,7 @@ func (s *Service) Delete(ctx context.Context, cmd *user.DeleteUserCommand) error
 		return nil
 	})
 	g.Go(func() error {
-		if err := s.accessControlStore.DeleteUserPermissions(ctx, cmd.UserID); err != nil {
+		if err := s.accessControlStore.DeleteUserPermissions(ctx, accesscontrol.GlobalOrgID, cmd.UserID); err != nil {
 			return err
 		}
 		return nil

--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -158,16 +158,8 @@ class UnThemedOrgRow extends PureComponent<OrgRowProps> {
   }
 
   onOrgRemove = async () => {
-    const { org, user } = this.props;
+    const { org } = this.props;
     this.props.onOrgRemove(org.orgId);
-    if (contextSrv.licensedAccessControlEnabled()) {
-      if (
-        contextSrv.hasPermission(AccessControlAction.ActionUserRolesRemove) &&
-        contextSrv.hasPermission(AccessControlAction.ActionUserRolesAdd)
-      ) {
-        user && (await updateUserRoles([], user.id, org.orgId));
-      }
-    }
   };
 
   onChangeRoleClick = () => {


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove any dangling permissions when user is removed from an org.
Permissions for a org that user is not part of cannot be used, so this is more of a cleanup / not getting unexpected permissions when a user is re added to an org

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana-enterprise/issues/3608

**Special notes for your reviewer**:

