### PR TITLE
alert: add imageURL for dingding notifier

### DIFF
--- a/pkg/services/ngalert/notifier/channels/dingding.go
+++ b/pkg/services/ngalert/notifier/channels/dingding.go
@@ -98,7 +98,7 @@ func (dd *DingDingNotifier) Notify(ctx context.Context, as ...*types.Alert) (boo
 	var tmplErr error
 	tmpl, data := TmplText(ctx, dd.tmpl, as, dd.log, &tmplErr)
 
-	// Augment our Alert data with ImageURLs if available.
+	// Augment our Alert data with ImageURLs if available
 	_ = withStoredImages(ctx, dd.log, dd.images,
 		func(index int, image ngmodels.Image) error {
 			if len(image.URL) != 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add imageURL for dingding notifier. to support dingding actionCard.
example: 
<img width="800" alt="image" src="https://user-images.githubusercontent.com/7465355/184913823-44ae5794-f00e-4ec0-b6e7-e3f9161040d0.png">

<img width="569" alt="image" src="https://user-images.githubusercontent.com/7465355/184914040-d72da9f9-7e9f-4cca-99c0-2378ca0f07ec.png">


