### PR TITLE
Alerting: Fix LINE Messenger contact point panics and odd behavior

### DIFF
--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -810,7 +810,7 @@ func GetAvailableNotifiers() []*alerting.NotifierPlugin {
 			},
 		},
 		{
-			Type:        "LINE",
+			Type:        "line",
 			Name:        "LINE",
 			Description: "Send notifications to LINE notify",
 			Heading:     "LINE notify settings",

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -1414,7 +1414,7 @@ const alertmanagerConfig = `
         "grafana_managed_receiver_configs": [
           {
             "name": "line_test",
-            "type": "LINE",
+            "type": "line",
             "settings": {},
             "secureSettings": {
               "token": "mysecrettoken"
@@ -1908,7 +1908,7 @@ var expAlertmanagerConfigFromAPI = `
           {
             "uid": "",
             "name": "line_test",
-            "type": "LINE",
+            "type": "line",
             "disableResolveMessage": false,
             "settings": {},
             "secureFields": {


### PR DESCRIPTION
**What this PR does / why we need it**:

The structure that describes the possible notifiers referred to this notifier's type as `"LINE"`:
https://github.com/grafana/grafana/blob/25de383540265f10367d63de2a9632a0e9ffd30a/pkg/services/ngalert/notifier/channels_config/available_channels.go#L813

where, on the actual handling layer, its type string is `"line"`:
https://github.com/grafana/grafana/blob/25de383540265f10367d63de2a9632a0e9ffd30a/pkg/services/ngalert/notifier/channels/factory.go#L56

These do not match. This causes the line notifier to behave super strangely in a lot of different areas. Random areas of code panicking, etc, because it cannot find matches depending on the route.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:
I have a refactor in mind of this that would prevent this from happening. Keeping this PR small and streamlined, just fixing the issue.
