### PR TITLE
Live: fix `StreamingDataFrame` length on `replace` action and schema change

### DIFF
--- a/public/app/features/live/centrifuge/LiveDataStream.test.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.test.ts
@@ -579,6 +579,8 @@ describe('LiveDataStream', () => {
           values: ['y'],
         },
       ]);
+      const deserializedFrame = StreamingDataFrame.deserialize(data.frame);
+      expect(deserializedFrame.length).toEqual(1);
     });
 
     it('should emit a full frame if received a status live channel event with error', async () => {

--- a/public/app/features/live/centrifuge/LiveDataStream.test.ts
+++ b/public/app/features/live/centrifuge/LiveDataStream.test.ts
@@ -353,6 +353,7 @@ describe('LiveDataStream', () => {
           values: [undefined, 'y'], //  bug in streamingDataFrame - fix!
         },
       ]);
+      expect(StreamingDataFrame.deserialize(data.frame).length).toEqual(2);
     });
 
     it('should emit a full frame if received a status live channel event with error', async () => {
@@ -369,6 +370,7 @@ describe('LiveDataStream', () => {
       const response = valuesCollection.lastValue();
 
       expectErrorResponse(response, StreamingResponseDataType.FullFrame);
+      expect(StreamingDataFrame.deserialize(response.data[0].frame).length).toEqual(2); // contains previously populated values
     });
 
     it('should buffer new values until subscriber is ready', async () => {
@@ -431,6 +433,7 @@ describe('LiveDataStream', () => {
           values: [2, 3],
         },
       ]);
+      expect(StreamingDataFrame.deserialize(response.data[0].frame).length).toEqual(2);
     });
 
     it(`should reduce buffer to a full frame with last error if one or more errors occur during subscriber's unavailability`, async () => {
@@ -597,6 +600,7 @@ describe('LiveDataStream', () => {
       const response = valuesCollection.lastValue();
 
       expectErrorResponse(response, StreamingResponseDataType.FullFrame);
+      expect(StreamingDataFrame.deserialize(response.data[0].frame).length).toEqual(0);
     });
 
     it('should buffer new values until subscriber is ready', async () => {
@@ -656,6 +660,8 @@ describe('LiveDataStream', () => {
           values: [3],
         },
       ]);
+      const data = response.data[0] as StreamingResponseData<StreamingResponseDataType.FullFrame>;
+      expect(StreamingDataFrame.deserialize(data.frame).length).toEqual(1);
     });
 
     it(`should reduce buffer to an empty full frame with last error if one or more errors occur during subscriber's unavailability`, async () => {
@@ -690,6 +696,7 @@ describe('LiveDataStream', () => {
           values: [],
         },
       ]);
+      expect(StreamingDataFrame.deserialize(response.data[0].frame).length).toEqual(0);
     });
 
     it('should ignore messages without payload', async () => {
@@ -753,6 +760,7 @@ describe('LiveDataStream', () => {
           values: ['y'], //  bug in streamingDataFrame - fix!
         },
       ]);
+      expect(StreamingDataFrame.deserialize(response.data[0].frame).length).toEqual(1);
     });
   });
 

--- a/public/app/features/live/data/StreamingDataFrame.ts
+++ b/public/app/features/live/data/StreamingDataFrame.ts
@@ -110,6 +110,8 @@ export class StreamingDataFrame implements DataFrame {
       values: (f.values as unknown[]).slice(numberOfItemsToRemove),
     }));
 
+    const length = dataFrameDTO.fields[0]?.values?.length ?? 0
+
     return {
       ...dataFrameDTO,
       // TODO: Labels and schema are not filtered by field
@@ -119,7 +121,7 @@ export class StreamingDataFrame implements DataFrame {
       name: this.name,
       refId: this.refId,
       meta: this.meta,
-      length: this.length,
+      length,
       timeFieldIndex: this.timeFieldIndex,
       pushMode: this.pushMode,
       packetInfo: this.packetInfo,


### PR DESCRIPTION
https://raintank-corp.slack.com/archives/C01FJF3LESW/p1660683929241519