### PR TITLE
BarchartPanel: Revert threshold color fix

### DIFF
--- a/public/app/plugins/panel/barchart/BarChartPanel.tsx
+++ b/public/app/plugins/panel/barchart/BarChartPanel.tsx
@@ -217,7 +217,7 @@ export const BarChartPanel: React.FunctionComponent<Props> = ({
   };
 
   // Color by value
-  let getColor: ((seriesIdx: number, valueIdx: number, value: any) => string) | undefined = undefined;
+  let getColor: ((seriesIdx: number, valueIdx: number) => string) | undefined = undefined;
 
   let fillOpacity = 1;
 
@@ -226,7 +226,7 @@ export const BarChartPanel: React.FunctionComponent<Props> = ({
     const disp = colorByField.display!;
     fillOpacity = (colorByField.config.custom.fillOpacity ?? 100) / 100;
     // gradientMode? ignore?
-    getColor = (seriesIdx: number, valueIdx: number, value: any) => disp(value).color!;
+    getColor = (seriesIdx: number, valueIdx: number) => disp(colorByField.values.get(valueIdx)).color!;
   }
 
   const prepConfig = (alignedFrame: DataFrame, allFrames: DataFrame[], getTimeRange: () => TimeRange) => {


### PR DESCRIPTION
**What this PR does / why we need it**:

This reverts commit 11c79cd6da1cf4824e1a48d98d0b5935b1a22351.

#52038 caused a regression where value mapping colors did not work.
