### PR TITLE
Alerting: Fix notifications for Microsoft Teams

### DIFF
--- a/pkg/services/ngalert/notifier/channels/teams.go
+++ b/pkg/services/ngalert/notifier/channels/teams.go
@@ -43,6 +43,7 @@ const (
 // AdaptiveCardsMessage represents a message for adaptive cards.
 type AdaptiveCardsMessage struct {
 	Attachments []AdaptiveCardsAttachment `json:"attachments"`
+	Summary     string                    `json:"summary,omitempty"` // Summary is the text shown in notifications
 	Type        string                    `json:"type"`
 }
 
@@ -317,6 +318,9 @@ func (tn *TeamsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 		},
 	})
 
+	msg := NewAdaptiveCardsMessage(card)
+	msg.Summary = tmpl(tn.Title)
+
 	// This check for tmplErr must happen before templating the URL
 	if tmplErr != nil {
 		tn.log.Warn("failed to template Teams message", "err", tmplErr.Error())
@@ -329,7 +333,7 @@ func (tn *TeamsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 		u = tn.URL
 	}
 
-	b, err := json.Marshal(NewAdaptiveCardsMessage(card))
+	b, err := json.Marshal(msg)
 	if err != nil {
 		return false, fmt.Errorf("failed to marshal JSON: %w", err)
 	}

--- a/pkg/services/ngalert/notifier/channels/teams_test.go
+++ b/pkg/services/ngalert/notifier/channels/teams_test.go
@@ -73,7 +73,8 @@ func TestTeamsNotifier(t *testing.T) {
 				},
 				"contentType": "application/vnd.microsoft.card.adaptive",
 			}},
-			"type": "message",
+			"summary": "[FIRING:1]  (val1)",
+			"type":    "message",
 		},
 		expMsgError: nil,
 	}, {
@@ -125,7 +126,8 @@ func TestTeamsNotifier(t *testing.T) {
 				},
 				"contentType": "application/vnd.microsoft.card.adaptive",
 			}},
-			"type": "message",
+			"summary": "alert1",
+			"type":    "message",
 		},
 		expMsgError: nil,
 	}, {

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -2229,6 +2229,7 @@ var expNonEmailNotifications = map[string][]string{
 			  "contentType": "application/vnd.microsoft.card.adaptive"
 		    }
 		  ],
+		  "summary": "[FIRING:1] TeamsAlert (default)",
 		  "type": "message"
 		}`,
 	},


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit fixes notifications for Microsoft Teams where notifications would just contain "Card" rather than the title.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

