### PR TITLE
Tempo: Remove unused theme param in getStyles

### DIFF
--- a/public/app/plugins/datasource/tempo/configuration/SearchSettings.tsx
+++ b/public/app/plugins/datasource/tempo/configuration/SearchSettings.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import React from 'react';
 
-import { DataSourcePluginOptionsEditorProps, GrafanaTheme, updateDatasourcePluginJsonDataOption } from '@grafana/data';
+import { DataSourcePluginOptionsEditorProps, updateDatasourcePluginJsonDataOption } from '@grafana/data';
 import { InlineField, InlineFieldRow, InlineSwitch, useStyles } from '@grafana/ui';
 
 import { TempoJsonData } from '../datasource';
@@ -32,7 +32,7 @@ export function SearchSettings({ options, onOptionsChange }: Props) {
   );
 }
 
-const getStyles = (theme: GrafanaTheme) => ({
+const getStyles = () => ({
   container: css`
     label: container;
     width: 100%;


### PR DESCRIPTION
**What this PR does**:
This PR removes the unused theme variable in the `getStyles`, as well as the import. This is because it is not used.


