### PR TITLE
Docs: Publish v9.1.x docs to /latest/

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: publish_docs
 on:
   push:
     branches:
-    - main
+    - v9.1.x
     paths:
     - 'docs/sources/**'
     - 'packages/grafana-*/**'
@@ -41,7 +41,7 @@ jobs:
         host: github.com
         github_pat: '${{ secrets.GH_BOT_ACCESS_TOKEN }}'
         source_folder: docs/sources
-        target_folder: content/docs/grafana/next
+        target_folder: content/docs/grafana/latest
         allow_no_changes: 'true'
     - shell: bash
       run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

Repoint the docs publishing target for the v9.1.x branch to the `/latest/` version directory, to avoid overwriting the next docs with older docs.

**Which issue(s) this PR fixes**:

TBF

**Special notes for your reviewer**:

Modeled on #50813