### PR TITLE
Docs: Publish v9.0.x docs to v9.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
         host: github.com
         github_pat: '${{ secrets.GH_BOT_ACCESS_TOKEN }}'
         source_folder: docs/sources
-        target_folder: content/docs/grafana/latest
+        target_folder: content/docs/grafana/v9.0
         allow_no_changes: 'true'
     - shell: bash
       run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

Repoint the docs publishing target for the v9.0.x branch to the `/v9.0` version directory, to avoid overwriting the latest docs with older docs.

**Which issue(s) this PR fixes**:

TBF

**Special notes for your reviewer**:

Modeled on https://github.com/grafana/grafana/pull/37609/commits/41b3ea6595f1e4587c810cf2d0ea7d681b34cb74