### PR TITLE
Alerting: State manager to use InstanceStore

### DIFF
--- a/pkg/services/ngalert/eval/testing.go
+++ b/pkg/services/ngalert/eval/testing.go
@@ -18,7 +18,7 @@ func RandomState() State {
 		Alerting,
 		NoData,
 		Error,
-	}[rand.Intn(3)]
+	}[rand.Intn(4)]
 }
 
 func GenerateResults(count int, generator func() Result) Results {
@@ -36,7 +36,7 @@ func ResultGen(mutators ...ResultMutator) func() Result {
 		if state == Error {
 			err = fmt.Errorf("result_error")
 		}
-		return Result{
+		result := Result{
 			Instance:           models.GenerateAlertLabels(rand.Intn(5)+1, "result_"),
 			State:              state,
 			Error:              err,
@@ -45,6 +45,10 @@ func ResultGen(mutators ...ResultMutator) func() Result {
 			EvaluationString:   "",
 			Values:             nil,
 		}
+		for _, mutator := range mutators {
+			mutator(&result)
+		}
+		return result
 	}
 }
 

--- a/pkg/services/ngalert/eval/testing.go
+++ b/pkg/services/ngalert/eval/testing.go
@@ -1,0 +1,70 @@
+package eval
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+type ResultMutator func(r *Result)
+
+func RandomState() State {
+	return []State{
+		Normal,
+		Alerting,
+		NoData,
+		Error,
+	}[rand.Intn(3)]
+}
+
+func GenerateResults(count int, generator func() Result) Results {
+	var result = make(Results, 0, count)
+	for i := 0; i < count; i++ {
+		result = append(result, generator())
+	}
+	return result
+}
+
+func ResultGen(mutators ...ResultMutator) func() Result {
+	return func() Result {
+		state := RandomState()
+		var err error
+		if state == Error {
+			err = fmt.Errorf("result_error")
+		}
+		return Result{
+			Instance:           models.GenerateAlertLabels(rand.Intn(5)+1, "result_"),
+			State:              state,
+			Error:              err,
+			EvaluatedAt:        time.Time{},
+			EvaluationDuration: time.Duration(rand.Int63n(6)) * time.Second,
+			EvaluationString:   "",
+			Values:             nil,
+		}
+	}
+}
+
+func WithEvaluatedAt(time time.Time) ResultMutator {
+	return func(r *Result) {
+		r.EvaluatedAt = time
+	}
+}
+
+func WithState(state State) ResultMutator {
+	return func(r *Result) {
+		r.State = state
+		if state == Error {
+			r.Error = fmt.Errorf("with_state_error")
+		}
+	}
+}
+
+func WithLabels(labels data.Labels) ResultMutator {
+	return func(r *Result) {
+		r.Instance = labels
+	}
+}

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -227,6 +227,10 @@ type AlertRuleKey struct {
 	UID   string `xorm:"uid"`
 }
 
+func (k AlertRuleKey) LogContext() []interface{} {
+	return []interface{}{"rule_uid", k.UID, "org_id", k.OrgID}
+}
+
 type AlertRuleKeyWithVersion struct {
 	Version      int64
 	AlertRuleKey `xorm:"extends"`

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -74,8 +74,7 @@ type schedule struct {
 
 	evaluator eval.Evaluator
 
-	ruleStore     store.RuleStore
-	instanceStore store.InstanceStore
+	ruleStore store.RuleStore
 
 	stateManager *state.Manager
 
@@ -123,7 +122,6 @@ func NewScheduler(cfg SchedulerCfg, appURL *url.URL, stateManager *state.Manager
 		stopAppliedFunc:       cfg.StopAppliedFunc,
 		evaluator:             cfg.Evaluator,
 		ruleStore:             cfg.RuleStore,
-		instanceStore:         cfg.InstanceStore,
 		metrics:               cfg.Metrics,
 		appURL:                appURL,
 		disableGrafanaFolder:  cfg.Cfg.ReservedLabels.IsReservedLabelDisabled(ngmodels.FolderTitleLabel),
@@ -321,7 +319,6 @@ func (sch *schedule) ruleRoutine(grafanaCtx context.Context, key ngmodels.AlertR
 		}
 
 		processedStates := sch.stateManager.ProcessEvalResults(ctx, e.scheduledAt, e.rule, results, extraLabels)
-		sch.saveAlertStates(ctx, processedStates)
 		alerts := FromAlertStateToPostableAlerts(processedStates, sch.stateManager, sch.appURL)
 		if len(alerts.PostableAlerts) > 0 {
 			sch.alertsSender.Send(key, alerts)

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -516,14 +516,13 @@ func setupScheduler(t *testing.T, rs *store.FakeRuleStore, is *store.FakeInstanc
 	}
 
 	schedCfg := SchedulerCfg{
-		Cfg:           cfg,
-		C:             mockedClock,
-		Evaluator:     evaluator,
-		RuleStore:     rs,
-		InstanceStore: is,
-		Logger:        logger,
-		Metrics:       m.GetSchedulerMetrics(),
-		AlertSender:   senderMock,
+		Cfg:         cfg,
+		C:           mockedClock,
+		Evaluator:   evaluator,
+		RuleStore:   rs,
+		Logger:      logger,
+		Metrics:     m.GetSchedulerMetrics(),
+		AlertSender: senderMock,
 	}
 	st := state.NewManager(schedCfg.Logger, m.GetStateMetrics(), nil, rs, is, &dashboards.FakeDashboardService{}, &image.NoopImageService{}, mockedClock)
 	return NewScheduler(schedCfg, appUrl, st)

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -66,8 +66,9 @@ func NewManager(logger log.Logger, metrics *metrics.State, externalURL *url.URL,
 	return manager
 }
 
-func (st *Manager) Close() {
+func (st *Manager) Close(ctx context.Context) {
 	st.quit <- struct{}{}
+	st.flushState(ctx)
 }
 
 func (st *Manager) Warm(ctx context.Context) {
@@ -295,6 +296,42 @@ func (st *Manager) Put(states []*State) {
 	for _, s := range states {
 		st.set(s)
 	}
+}
+
+// flushState dumps the entire state to the database
+func (st *Manager) flushState(ctx context.Context) {
+	t := st.clock.Now()
+	st.log.Info("flushing the state")
+	st.cache.mtxStates.Lock()
+	defer st.cache.mtxStates.Unlock()
+	totalStates, errorsCnt := 0, 0
+	for _, orgStates := range st.cache.states {
+		for _, ruleStates := range orgStates {
+			for _, state := range ruleStates {
+				err := st.saveState(ctx, state)
+				totalStates++
+				if err != nil {
+					st.log.Error("failed to save alert state", append(state.GetRuleKey().LogContext(), "labels", state.Labels.String(), "state", state.State.String(), "err", err.Error()))
+					errorsCnt++
+				}
+			}
+		}
+	}
+	st.log.Info("the state has been flushed", "total_instances", totalStates, "errors", errorsCnt, "took", st.clock.Since(t))
+}
+
+func (st *Manager) saveState(ctx context.Context, s *State) error {
+	cmd := ngModels.SaveAlertInstanceCommand{
+		RuleOrgID:         s.OrgID,
+		RuleUID:           s.AlertRuleUID,
+		Labels:            ngModels.InstanceLabels(s.Labels),
+		State:             ngModels.InstanceStateType(s.State.String()),
+		StateReason:       s.StateReason,
+		LastEvalTime:      s.LastEvaluationTime,
+		CurrentStateSince: s.StartsAt,
+		CurrentStateEnd:   s.EndsAt,
+	}
+	return st.instanceStore.SaveAlertInstance(ctx, &cmd)
 }
 
 // TODO: why wouldn't you allow other types like NoData or Error?

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -36,6 +36,13 @@ type State struct {
 	Error                error
 }
 
+func (a *State) GetRuleKey() models.AlertRuleKey {
+	return models.AlertRuleKey{
+		OrgID: a.OrgID,
+		UID:   a.AlertRuleUID,
+	}
+}
+
 type Evaluation struct {
 	EvaluationTime  time.Time
 	EvaluationState eval.State


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Grafana database contains a table `alert_instance`. This table is used by alerting engine to persist the state of alerts between restarts. The table is exposed via InstanceStore repository. There are a few places where that repository is accessed. 
1. When Grafana starts it loads the information from the table to the state manager before evaluating the rules. This is the state manager's responsibility https://github.com/grafana/grafana/blob/085258c0351cb77126a87eae2421597145535f8e/pkg/services/ngalert/schedule/schedule.go#L283-L292 
2. When a rule is evaluated, the scheduler calls the state manager to process the evaluation results, and then the scheduler calls the InstanceStore to save the result provided by the state manager. https://github.com/grafana/grafana/blob/085258c0351cb77126a87eae2421597145535f8e/pkg/services/ngalert/schedule/schedule.go#L332
3.  When the scheduler is stopped (when Grafana stops, or an error occurs in the error group the scheduler is part of) it does many interactions with the database and state manager to flush the manager's state to the store. https://github.com/grafana/grafana/blob/085258c0351cb77126a87eae2421597145535f8e/pkg/services/ngalert/schedule/schedule.go#L283-L292

Therefore the InstanceStore ownership is divided between the scheduler and state manager but the state manager is the user and the source of the information provided by the repository. Therefore, it does not make sense to have a scheduler as a proxy. Moreover, the scheduler has to obtain information about the organizations and the request states for each in order to save them to the store.

This PR makes the state manager the only owner of the data stored provided by InstanceStore. This makes the boundaries clear, reduces the number of dependencies in the scheduler, and provides a way for further improvements. 

**Special notes for your reviewer:**
Also, I added some functions that would generate eval.Result. It will reduce the size of the tests 
