### PR TITLE
Panel plugins: Support changing skipDataQuery programmatically

### DIFF
--- a/packages/grafana-data/src/panel/PanelPlugin.ts
+++ b/packages/grafana-data/src/panel/PanelPlugin.ts
@@ -379,4 +379,13 @@ export class PanelPlugin<
   hasPluginId(pluginId: string) {
     return this.meta.id === pluginId;
   }
+
+  isSkipDataQuery = (opts?: TOptions): boolean => {
+    return Boolean(this.meta.skipDataQuery);
+  };
+
+  setSkipDataQuery(fn: (opts?: TOptions) => boolean) {
+    this.isSkipDataQuery = fn;
+    return this;
+  }
 }

--- a/public/app/features/dashboard/components/Inspector/PanelInspector.tsx
+++ b/public/app/features/dashboard/components/Inspector/PanelInspector.tsx
@@ -35,7 +35,7 @@ const PanelInspectorUnconnected: React.FC<Props> = ({ panel, dashboard, plugin }
   const location = useLocation();
   const { data, isLoading, error } = usePanelLatestData(panel, dataOptions, true);
   const metaDs = useDatasourceMetadata(data);
-  const tabs = useInspectTabs(panel, dashboard, plugin, error, metaDs);
+  const tabs = useInspectTabs(panel, dashboard, error, metaDs);
   const defaultTab = new URLSearchParams(location.search).get('inspectTab') as InspectTab;
 
   const onClose = () => {

--- a/public/app/features/dashboard/components/Inspector/hooks.ts
+++ b/public/app/features/dashboard/components/Inspector/hooks.ts
@@ -2,12 +2,10 @@ import { t } from '@lingui/macro';
 import { useMemo } from 'react';
 import useAsync from 'react-use/lib/useAsync';
 
-import { DataQueryError, DataSourceApi, PanelData, PanelPlugin } from '@grafana/data';
+import { DataQueryError, DataSourceApi, PanelData } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { InspectTab } from 'app/features/inspector/types';
-
-import { supportsDataQuery } from '../PanelEditor/utils';
 
 import { PanelInspectActionSupplier } from './PanelInspectActions';
 
@@ -41,13 +39,12 @@ export const useDatasourceMetadata = (data?: PanelData) => {
 export const useInspectTabs = (
   panel: PanelModel,
   dashboard: DashboardModel,
-  plugin: PanelPlugin | undefined | null,
   error?: DataQueryError,
   metaDs?: DataSourceApi
 ) => {
   return useMemo(() => {
     const tabs = [];
-    if (supportsDataQuery(plugin)) {
+    if (panel.supportsDataQuery) {
       tabs.push({ label: t({ id: 'dashboard.inspect.data-tab', message: 'Data' }), value: InspectTab.Data });
       tabs.push({ label: t({ id: 'dashboard.inspect.stats-tab', message: 'Stats' }), value: InspectTab.Stats });
     }
@@ -72,9 +69,9 @@ export const useInspectTabs = (
       });
     }
 
-    if (dashboard.meta.canEdit && supportsDataQuery(plugin)) {
+    if (dashboard.meta.canEdit && panel.supportsDataQuery) {
       tabs.push({ label: t({ id: 'dashboard.inspect.query-tab', message: 'Query' }), value: InspectTab.Query });
     }
     return tabs;
-  }, [panel, plugin, metaDs, dashboard, error]);
+  }, [panel, metaDs, dashboard, error]);
 };

--- a/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelEditor.tsx
@@ -268,7 +268,7 @@ export class PanelEditorUnconnected extends PureComponent<Props> {
 
   renderPanelAndEditor(styles: EditorStyles) {
     const { panel, dashboard, plugin, tab } = this.props;
-    const tabs = getPanelEditorTabs(tab, plugin);
+    const tabs = getPanelEditorTabs(tab, panel);
     const isOnlyPanel = tabs.length === 0;
     const panelPane = this.renderPanel(styles, isOnlyPanel);
 

--- a/public/app/features/dashboard/components/PanelEditor/utils.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/utils.test.ts
@@ -1,6 +1,6 @@
 import { FieldConfig, FieldConfigSource, PanelPlugin, standardFieldConfigEditorRegistry } from '@grafana/data';
 
-import { setOptionImmutably, supportsDataQuery, updateDefaultFieldConfigValue } from './utils';
+import { setOptionImmutably, updateDefaultFieldConfigValue } from './utils';
 
 describe('standardFieldConfigEditorRegistry', () => {
   const dummyConfig: FieldConfig = {

--- a/public/app/features/dashboard/components/PanelEditor/utils.ts
+++ b/public/app/features/dashboard/components/PanelEditor/utils.ts
@@ -1,6 +1,6 @@
 import { omit } from 'lodash';
 
-import { FieldConfigSource, PanelPlugin } from '@grafana/data';
+import { FieldConfigSource } from '@grafana/data';
 import { GRID_CELL_HEIGHT, GRID_CELL_VMARGIN, GRID_COLUMN_COUNT } from 'app/core/constants';
 
 import { PanelModel } from '../../state/PanelModel';
@@ -32,9 +32,9 @@ export function calculatePanelSize(mode: DisplayMode, width: number, height: num
   };
 }
 
-export function supportsDataQuery(plugin: PanelPlugin | undefined | null): boolean {
-  return plugin?.meta.skipDataQuery === false;
-}
+// export function supportsDataQuery(plugin: PanelPlugin | undefined | null): boolean {
+//   return plugin?.meta.skipDataQuery === false;
+// }
 
 export const updateDefaultFieldConfigValue = (
   config: FieldConfigSource,

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -406,7 +406,7 @@ export class PanelChrome extends PureComponent<Props, State> {
   }
 
   get wantsQueryExecution() {
-    return !(this.props.plugin.meta.skipDataQuery || this.hasPanelSnapshot);
+    return this.props.panel.supportsDataQuery && !this.hasPanelSnapshot;
   }
 
   onChangeTimeRange = (timeRange: AbsoluteTimeRange) => {

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -275,6 +275,13 @@ export class PanelModel implements DataConfigSource, IPanelModel {
     return this.configRev > 0;
   }
 
+  get supportsDataQuery(): boolean {
+    if (!this.plugin) {
+      return false;
+    }
+    return !this.plugin.isSkipDataQuery(this.options);
+  }
+
   updateOptions(options: object) {
     this.options = options;
     this.configRev++;

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -131,7 +131,9 @@ export function getPanelMenu(
     shortcut: 'p s',
   });
 
-  if (contextSrv.hasAccessToExplore() && !(panel.plugin && panel.plugin.meta.skipDataQuery)) {
+  const hasDataQuery = panel.plugin && !panel.plugin.isSkipDataQuery(panel.options);
+
+  if (contextSrv.hasAccessToExplore() && hasDataQuery) {
     menu.push({
       text: 'Explore',
       iconClassName: 'compass',
@@ -150,7 +152,7 @@ export function getPanelMenu(
   const inspectMenu: PanelMenuItem[] = [];
 
   // Only show these inspect actions for data plugins
-  if (panel.plugin && !panel.plugin.meta.skipDataQuery) {
+  if (hasDataQuery) {
     const dataTextTranslation = t({
       id: 'panel.header-menu.inspect-data',
       message: `Data`,

--- a/public/app/features/inspector/QueryInspector.tsx
+++ b/public/app/features/inspector/QueryInspector.tsx
@@ -7,7 +7,6 @@ import { selectors } from '@grafana/e2e-selectors';
 import { config, RefreshEvent } from '@grafana/runtime';
 import { Button, ClipboardButton, JSONFormatter, LoadingPlaceholder, Stack } from '@grafana/ui';
 import { backendSrv } from 'app/core/services/backend_srv';
-import { supportsDataQuery } from 'app/features/dashboard/components/PanelEditor/utils';
 import { PanelModel } from 'app/features/dashboard/state';
 
 import { getPanelInspectorStyles } from './styles';
@@ -254,7 +253,7 @@ export class QueryInspector extends PureComponent<Props, State> {
     const styles = getPanelInspectorStyles();
     const haveData = Object.keys(response).length > 0;
 
-    if (panel && !supportsDataQuery(panel.plugin)) {
+    if (panel && !panel.supportsDataQuery) {
       return null;
     }
 

--- a/public/app/plugins/panel/text/models.cue
+++ b/public/app/plugins/panel/text/models.cue
@@ -30,6 +30,9 @@ Panel: thema.#Lineage & {
 
                     For markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)
                     """
+
+						// Execute a query and add results to variable context
+						query: bool | *false 
 					} @cuetsy(kind="interface")
 				},
 			]

--- a/public/app/plugins/panel/text/models.gen.ts
+++ b/public/app/plugins/panel/text/models.gen.ts
@@ -16,6 +16,7 @@ export enum TextMode {
 export interface PanelOptions {
   content: string;
   mode: TextMode;
+  query: boolean;
 }
 
 export const defaultPanelOptions: Partial<PanelOptions> = {
@@ -23,4 +24,5 @@ export const defaultPanelOptions: Partial<PanelOptions> = {
 
 For markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)`,
   mode: TextMode.Markdown,
+  query: false,
 };

--- a/public/app/plugins/panel/text/module.tsx
+++ b/public/app/plugins/panel/text/module.tsx
@@ -27,6 +27,15 @@ export const plugin = new PanelPlugin<PanelOptions>(TextPanel)
         description: 'Content of the panel',
         editor: TextPanelEditor,
         defaultValue: defaultPanelOptions.content,
+      })
+      .addBooleanSwitch({
+        path: 'query',
+        name: 'Execute query',
+        description: 'Run a query and include the results in template variable context',
+        defaultValue: defaultPanelOptions.query,
       });
+  })
+  .setSkipDataQuery((opts?: PanelOptions) => {
+    return opts?.query !== true;
   })
   .setMigrationHandler(textPanelMigrationHandler);


### PR DESCRIPTION
I am revisiting an old effort to support formatting query results in a text panel.  See https://github.com/grafana/grafana/pull/41095

One thing I did not like about that approach is that it would execute a query for all text panels even though the results would be almost never used.  This PR allows plugins to implement their own logic (based on options) to decide if the plugin should execute a query or not. 

![2022-08-17_18-09-24 (1)](https://user-images.githubusercontent.com/705951/185270239-37af1a2d-8f2b-4c1c-b541-013a39ea19e5.gif)

This is needed for text panel, but seems like somethign we should add at the panel plugin model
