### PR TITLE
TimeSeries: Fix memory leak on viz re-init caused by KeyboardPlugin

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/plugins/KeyboardPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/KeyboardPlugin.tsx
@@ -87,7 +87,7 @@ const initHook = (u: uPlot) => {
     window.requestAnimationFrame(handlePressedKeys);
   };
 
-  vizLayoutViz.addEventListener('keydown', (e) => {
+  const onKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Tab') {
       // Hide the cursor if the user tabs away
       u.setCursor({ left: -5, top: -5 });
@@ -112,9 +112,9 @@ const initHook = (u: uPlot) => {
         window.requestAnimationFrame(handlePressedKeys);
       }
     }
-  });
+  };
 
-  vizLayoutViz.addEventListener('keyup', (e) => {
+  const onKeyUp = (e: KeyboardEvent) => {
     if (!KNOWN_KEYS.has(e.key)) {
       return;
     }
@@ -129,9 +129,9 @@ const initHook = (u: uPlot) => {
       u.setSelect(u.select);
       dragStartX = null;
     }
-  });
+  };
 
-  vizLayoutViz.addEventListener('focus', (e) => {
+  const onFocus = () => {
     // We only want to initialize the cursor if the user is using keyboard controls
     if (!vizLayoutViz?.matches(':focus-visible')) {
       return;
@@ -141,14 +141,30 @@ const initHook = (u: uPlot) => {
     const drawWidth = parseFloat(u.over.style.width);
     const drawHeight = parseFloat(u.over.style.height);
     u.setCursor({ left: drawWidth / 2, top: drawHeight / 2 });
-  });
+  };
 
-  vizLayoutViz.addEventListener('blur', (e) => {
+  const onBlur = () => {
     keysLastHandledAt = null;
     dragStartX = null;
     pressedKeys.clear();
     u.setSelect({ left: 0, top: 0, width: 0, height: 0 }, false);
-  });
+  };
+
+  vizLayoutViz.addEventListener('keydown', onKeyDown);
+  vizLayoutViz.addEventListener('keyup', onKeyUp);
+  vizLayoutViz.addEventListener('focus', onFocus);
+  vizLayoutViz.addEventListener('blur', onBlur);
+
+  const onDestroy = () => {
+    vizLayoutViz?.removeEventListener('keydown', onKeyDown);
+    vizLayoutViz?.removeEventListener('keyup', onKeyUp);
+    vizLayoutViz?.removeEventListener('focus', onFocus);
+    vizLayoutViz?.removeEventListener('blur', onBlur);
+
+    vizLayoutViz = null;
+  };
+
+  (u.hooks.destroy ??= []).push(onDestroy);
 };
 
 /**


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/53310
Fixes https://github.com/grafana/grafana/issues/53313

you can verify in Chrome's task manager (Shift+Esc) by doing 20x refreshes of this 10-series random-walk Explore page:

http://localhost:3000/explore?orgId=1&left=%7B%22datasource%22:%22PD8C576611E62080A%22,%22queries%22:%5B%7B%22scenarioId%22:%22random_walk%22,%22refId%22:%22A%22,%22seriesCount%22:10%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D