### PR TITLE
Tempo: Set the default query type even if queryType was set to 'clear'

### DIFF
--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -33,8 +33,10 @@ class TempoQueryFieldComponent extends React.PureComponent<Props> {
     super(props);
   }
 
+  // Set the default query type when the component mounts.
+  // Also do this if queryType is 'clear' (which is the case when the user changes the query type)
+  // so the default query type is also set if the user changes the query type & refreshes the page.
   async componentDidMount() {
-    // Set initial query type to ensure traceID field appears
     if (!this.props.query.queryType || this.props.query.queryType === 'clear') {
       this.props.onChange({
         ...this.props.query,

--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -35,7 +35,8 @@ class TempoQueryFieldComponent extends React.PureComponent<Props> {
 
   // Set the default query type when the component mounts.
   // Also do this if queryType is 'clear' (which is the case when the user changes the query type)
-  // so the default query type is also set if the user changes the query type & refreshes the page.
+  // otherwise if the user changes the query type and refreshes the page, no query type will be selected
+  // which is inconsistent with how the UI was originally when they selected the Tempo data source.
   async componentDidMount() {
     if (!this.props.query.queryType || this.props.query.queryType === 'clear') {
       this.props.onChange({

--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -35,7 +35,7 @@ class TempoQueryFieldComponent extends React.PureComponent<Props> {
 
   async componentDidMount() {
     // Set initial query type to ensure traceID field appears
-    if (!this.props.query.queryType) {
+    if (!this.props.query.queryType || this.props.query.queryType === 'clear') {
       this.props.onChange({
         ...this.props.query,
         queryType: DEFAULT_QUERY_TYPE,


### PR DESCRIPTION
When selecting the Tempo data source in Explore, the TraceID query type is selected by default. However, if the user changes the query type and refreshes the page, no query type is selected. Therefore, the behaviour when the component is mounted is inconsistent.

This PR fixes this so that even in the case where the user changes the query type and refreshes the page, the default query type (TraceID) will be selected.