### PR TITLE
GrafanaUI: Fixes ClipboardButton to always keep multi line content

### DIFF
--- a/packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.tsx
+++ b/packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.tsx
@@ -93,16 +93,17 @@ const copyText = async (text: string, buttonRef: React.MutableRefObject<HTMLButt
   } else {
     // Use a fallback method for browsers/contexts that don't support the Clipboard API.
     // See https://web.dev/async-clipboard/#feature-detection.
-    const input = document.createElement('input');
+    // Use textarea so the user can copy multi-line content.
+    const textarea = document.createElement('textarea');
     // Normally we'd append this to the body. However if we're inside a focus manager
     // from react-aria, we can't focus anything outside of the managed area.
     // Instead, let's append it to the button. Then we're guaranteed to be able to focus + copy.
-    buttonRef.current?.appendChild(input);
-    input.value = text;
-    input.focus();
-    input.select();
+    buttonRef.current?.appendChild(textarea);
+    textarea.value = text;
+    textarea.focus();
+    textarea.select();
     document.execCommand('copy');
-    input.remove();
+    textarea.remove();
   }
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:

If the browser the user was on when copying some text did not support `navigator.clipboard` OR if it was not in a secure context (`window.isSecureContext === true`) then the fallback method for the copy was using an `input` component which converts all the text into a single line (see https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.tsx#L91-L106).

So for instance if the user was copying a dashboard JSON, that would combine the whole JSON into 1 line. Using a `textarea` keeps the multiple lines.

**Which issue(s) this PR fixes**:

Fixes #52488

