### PR TITLE
Transformations: Fix clearing of transformation select fields

### DIFF
--- a/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
@@ -23,7 +23,7 @@ export const GroupingToMatrixTransformerEditor: React.FC<TransformerUIProps<Grou
     (value: SelectableValue<string>) => {
       onChange({
         ...options,
-        columnField: value.value,
+        columnField: value?.value,
       });
     },
     [onChange, options]
@@ -33,7 +33,7 @@ export const GroupingToMatrixTransformerEditor: React.FC<TransformerUIProps<Grou
     (value: SelectableValue<string>) => {
       onChange({
         ...options,
-        rowField: value.value,
+        rowField: value?.value,
       });
     },
     [onChange, options]
@@ -43,7 +43,7 @@ export const GroupingToMatrixTransformerEditor: React.FC<TransformerUIProps<Grou
     (value: SelectableValue<string>) => {
       onChange({
         ...options,
-        valueField: value.value,
+        valueField: value?.value,
       });
     },
     [onChange, options]

--- a/public/app/features/transformers/editors/SeriesToFieldsTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/SeriesToFieldsTransformerEditor.tsx
@@ -23,7 +23,7 @@ export const SeriesToFieldsTransformerEditor: React.FC<TransformerUIProps<Series
     (value: SelectableValue<string>) => {
       onChange({
         ...options,
-        byField: value.value,
+        byField: value?.value,
       });
     },
     [onChange, options]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When trying to use the `x` to clear the values in the select fields for the Outer join and Grouping to matrix transformations, the following error occurs and the clearing does not occur successfully:
```
Uncaught TypeError: Cannot read properties of null (reading 'value')
```

Adding optional chaining operators to the erroring fields' `onChange` to allow for proper clearing.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/53915