### PR TITLE
Chore: Add context util that allow to provide cause of cancellation

### DIFF
--- a/pkg/util/contextutil.go
+++ b/pkg/util/contextutil.go
@@ -31,7 +31,6 @@ func WithCancelCause(parent context.Context) (context.Context, CancelCauseFunc) 
 	errOnce := sync.Once{}
 	result := &contextWithCancellableReason{
 		Context: ctx,
-		mtx:     sync.Mutex{},
 	}
 	cancelFn := func(reason error) {
 		errOnce.Do(func() {

--- a/pkg/util/contextutil.go
+++ b/pkg/util/contextutil.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"context"
+	"sync"
+)
+
+// this is a decorator for a regular context that contains a custom error and returns the
+type contextWithCancellableReason struct {
+	context.Context
+	err error
+}
+
+func (c *contextWithCancellableReason) Err() error {
+	if c.err != nil {
+		return c.err
+	}
+	return c.Context.Err()
+}
+
+type CancelCauseFunc func(error)
+
+// WithCancelCause creates a cancellable context that can be cancelled with a custom reason
+func WithCancelCause(parent context.Context) (context.Context, CancelCauseFunc) {
+	ctx, cancel := context.WithCancel(parent)
+	errOnce := sync.Once{}
+	result := &contextWithCancellableReason{
+		Context: ctx,
+	}
+	cancelFn := func(reason error) {
+		errOnce.Do(func() {
+			result.err = reason
+			cancel()
+		})
+	}
+	return result, cancelFn
+}

--- a/pkg/util/contextutil_test.go
+++ b/pkg/util/contextutil_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestWithCancelWithReason(t *testing.T) {
-	t.Run("should provide the custom reason", func(t *testing.T) {
+	t.Run("should add custom reason to the standard error", func(t *testing.T) {
 		expected := errors.New("test-err")
 		ctx, fn := WithCancelCause(context.Background())
 		fn(expected)
@@ -19,6 +19,7 @@ func TestWithCancelWithReason(t *testing.T) {
 			require.Fail(t, "the context was not cancelled")
 		}
 		require.ErrorIs(t, ctx.Err(), expected)
+		require.ErrorIs(t, ctx.Err(), context.Canceled)
 	})
 
 	t.Run("should return only the first reason if called multiple times", func(t *testing.T) {
@@ -40,6 +41,6 @@ func TestWithCancelWithReason(t *testing.T) {
 	t.Run("should return context.Canceled if no reason provided", func(t *testing.T) {
 		ctx, fn := WithCancelCause(context.Background())
 		fn(nil)
-		require.ErrorIs(t, ctx.Err(), context.Canceled)
+		require.Equal(t, ctx.Err(), context.Canceled)
 	})
 }

--- a/pkg/util/contextutil_test.go
+++ b/pkg/util/contextutil_test.go
@@ -1,0 +1,45 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithCancelWithReason(t *testing.T) {
+	t.Run("should provide the custom reason", func(t *testing.T) {
+		expected := errors.New("test-err")
+		ctx, fn := WithCancelCause(context.Background())
+		fn(expected)
+		select {
+		case <-ctx.Done():
+		default:
+			require.Fail(t, "the context was not cancelled")
+		}
+		require.ErrorIs(t, ctx.Err(), expected)
+	})
+
+	t.Run("should return only the first reason if called multiple times", func(t *testing.T) {
+		expected := errors.New("test-err")
+		ctx, fn := WithCancelCause(context.Background())
+		fn(expected)
+		fn(errors.New("other error"))
+		require.ErrorIs(t, ctx.Err(), expected)
+	})
+
+	t.Run("should return only the first reason if called multiple times", func(t *testing.T) {
+		expected := errors.New("test-err")
+		ctx, fn := WithCancelCause(context.Background())
+		fn(expected)
+		fn(errors.New("other error"))
+		require.ErrorIs(t, ctx.Err(), expected)
+	})
+
+	t.Run("should return context.Canceled if no reason provided", func(t *testing.T) {
+		ctx, fn := WithCancelCause(context.Background())
+		fn(nil)
+		require.ErrorIs(t, ctx.Err(), context.Canceled)
+	})
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The standard library wrapper `context.WithCancel` does not allow the user to provide the cause of cancellation. The feature will be implemented in future versions of the standard library. In the meantime, this PR introduces a tiny wrapper for context that allows users to provide a cause of the cancellation. 
The error that is returned by the wrapper is a combination of the standard `context.Canceled` and the one that the user provided. `error.Is` detects both of the errors. 

