### PR TITLE
TimeSeries: fix regression with hardMin + hardMax ranging

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
@@ -72,6 +72,7 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
 
     let hardMinOnly = softMin == null && hardMin != null;
     let hardMaxOnly = softMax == null && hardMax != null;
+    let hasFixedRange = hardMinOnly && hardMaxOnly;
 
     // uPlot range function
     const rangeFn = (u: uPlot, dataMin: number | null, dataMax: number | null, scaleKey: string) => {
@@ -80,14 +81,14 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
       let minMax: uPlot.Range.MinMax = [dataMin, dataMax];
 
       // happens when all series on a scale are `show: false`, re-returning nulls will auto-disable axis
-      if (dataMin == null || dataMax == null) {
+      if (!hasFixedRange && dataMin == null && dataMax == null) {
         return minMax;
       }
 
       if (scale.distr === 1 || scale.distr === 2) {
         if (centeredZero) {
-          let absMin = Math.abs(dataMin);
-          let absMax = Math.abs(dataMax);
+          let absMin = Math.abs(dataMin!);
+          let absMax = Math.abs(dataMax!);
           let max = Math.max(absMin, absMax);
           dataMin = -max;
           dataMax = max;
@@ -96,7 +97,7 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
         // @ts-ignore here we may use hardMin / hardMax to make sure any extra padding is computed from a more accurate delta
         minMax = uPlot.rangeNum(hardMinOnly ? hardMin : dataMin, hardMaxOnly ? hardMax : dataMax, rangeConfig);
       } else if (scale.distr === 3) {
-        minMax = uPlot.rangeLog(dataMin, dataMax, scale.log ?? 10, true);
+        minMax = uPlot.rangeLog(dataMin!, dataMax!, scale.log ?? 10, true);
       }
 
       // if all we got were hard limits, treat them as static min/max
@@ -111,7 +112,8 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
       return minMax;
     };
 
-    let auto = !isTime && !(hardMinOnly && hardMaxOnly);
+    let auto = !isTime && !hasFixedRange;
+
     if (isBooleanUnit(scaleKey)) {
       auto = false;
       range = [0, 1];


### PR DESCRIPTION
this fixes a regression i introduced in https://github.com/grafana/grafana/pull/53671 for y ranging when both `hardMin` and `hardMax` are explicitly set. we should not return `[null,null]` in this case.

we have a few such charts that errored in gdev:

http://localhost:3000/d/aBXrJ0R7z/panel-tests-graph-ng-by-value-color-schemes?orgId=1
http://localhost:3000/d/eNsFjVBGz/panel-tests-graph-ng-softmin-softmax?orgId=1&viewPanel=24