### PR TITLE
Schema: Restore "hidden" in LegendDisplayMode

### DIFF
--- a/packages/grafana-schema/src/schema/mudball.cue
+++ b/packages/grafana-schema/src/schema/mudball.cue
@@ -133,7 +133,8 @@ GraphThresholdsStyleConfig: {
 LegendPlacement: "bottom" | "right" @cuetsy(kind="type")
 
 // TODO docs
-LegendDisplayMode: "list" | "table" @cuetsy(kind="enum")
+// Note: "hidden" needs to remain as an option for plugins compatibility
+LegendDisplayMode: "list" | "table" | "hidden" @cuetsy(kind="enum")
 
 // TODO docs
 TableSortByFieldState: {

--- a/packages/grafana-schema/src/schema/mudball.gen.ts
+++ b/packages/grafana-schema/src/schema/mudball.gen.ts
@@ -168,6 +168,7 @@ export interface GraphThresholdsStyleConfig {
 export type LegendPlacement = ('bottom' | 'right');
 
 export enum LegendDisplayMode {
+  Hidden = 'hidden',
   List = 'list',
   Table = 'table',
 }


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/52241 the "hidden" key for enum `LegendDisplayMode` was removed. This will cause some community plugins to break when building with grafana `9.1`. This PR puts back the `"hidden"` key bringing back compatibility.