### PR TITLE
plugin api: set handler name in context for metrics/traces

### DIFF
--- a/pkg/api/app_routes.go
+++ b/pkg/api/app_routes.go
@@ -40,6 +40,7 @@ func (hs *HTTPServer) initAppPluginRoutes(r *web.Mux) {
 		for _, route := range plugin.Routes {
 			url := util.JoinURLFragments("/api/plugin-proxy/"+plugin.ID, route.Path)
 			handlers := make([]web.Handler, 0)
+			handlers = append(handlers, middleware.ProvideRouteOperationName("/api/plugin-proxy"))
 			handlers = append(handlers, middleware.Auth(&middleware.AuthOptions{
 				ReqSignedIn: true,
 			}))
@@ -59,6 +60,7 @@ func (hs *HTTPServer) initAppPluginRoutes(r *web.Mux) {
 
 			handlers = append(handlers, AppPluginRoute(route, plugin.ID, hs))
 			for _, method := range strings.Split(route.Method, ",") {
+
 				r.Handle(strings.TrimSpace(method), url, handlers)
 			}
 

--- a/pkg/api/app_routes.go
+++ b/pkg/api/app_routes.go
@@ -60,7 +60,6 @@ func (hs *HTTPServer) initAppPluginRoutes(r *web.Mux) {
 
 			handlers = append(handlers, AppPluginRoute(route, plugin.ID, hs))
 			for _, method := range strings.Split(route.Method, ",") {
-
 				r.Handle(strings.TrimSpace(method), url, handlers)
 			}
 


### PR DESCRIPTION
plugin proxy requests are currently instrumented as `unknown`. This change sets the name of the handler so that metrics and tracing middleswares can use that instead of falling back to `unknown`

Signed-off-by: bergquist <carl.bergquist@gmail.com>
