### PR TITLE
Tempo: Remove spanName from the query object if undefined

### DIFF
--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
@@ -142,6 +142,20 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
     }
   };
 
+  const onSpanNameChange = (v: SelectableValue<string>) => {
+    // If the 'x' icon is clicked to clear the selected span name, remove spanName from the query object.
+    if (!v) {
+      delete query.spanName;
+      return;
+    }
+    if (spanOptions?.find((obj) => obj.value === v.value)) {
+      onChange({
+        ...query,
+        spanName: v.value,
+      });
+    }
+  };
+
   const templateSrv: TemplateSrv = getTemplateSrv();
 
   return (
@@ -180,13 +194,7 @@ const NativeSearch = ({ datasource, query, onChange, onBlur, onRunQuery }: Props
                 loadOptions('spanName');
               }}
               isLoading={isLoading.spanName}
-              value={spanOptions?.find((v) => v?.value === query.spanName) || undefined}
-              onChange={(v) => {
-                onChange({
-                  ...query,
-                  spanName: v?.value || undefined,
-                });
-              }}
+              onChange={onSpanNameChange}
               placeholder="Select a span"
               isClearable
               onKeyDown={onKeyDown}


### PR DESCRIPTION
Currently, when using the native search feature, if the user selects a span name but then clears the span name field, the query object contains `spanName: undefined`.

This PR changes this so that in this situation, the query object doesn't contain the spanName property at all, making the query object cleaner.
