### PR TITLE
Metrics: Instrument requests not matching any handler as `notfound`

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -516,7 +516,7 @@ func (hs *HTTPServer) applyRoutes() {
 	// then custom app proxy routes
 	hs.initAppPluginRoutes(hs.web)
 	// lastly not found route
-	hs.web.NotFound(middleware.ReqSignedIn, hs.NotFoundHandler)
+	hs.web.NotFound(middleware.ProvideRouteOperationName("notfound"), middleware.ReqSignedIn, hs.NotFoundHandler)
 }
 
 func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {

--- a/pkg/middleware/request_test.go
+++ b/pkg/middleware/request_test.go
@@ -38,3 +38,21 @@ func TestCanGetRouteNameFromContext(t *testing.T) {
 		assert.Equal(t, tc.expected, handler)
 	}
 }
+
+func TestOperationNameCanOnlyBeSetOnce(t *testing.T) {
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://grafana.com", nil)
+
+	// set the the initial operation name
+	req = addRouteNameToContext(req, "first")
+
+	// check that the operation name is set correctly
+	value, exists := routeOperationName(req)
+	assert.True(t, exists, "route name should exist")
+	assert.Equal(t, "first", value)
+
+	// check that it cannot be overwritten
+	req = addRouteNameToContext(req, "second")
+	value, exists = routeOperationName(req)
+	assert.True(t, exists, "route name should exist")
+	assert.Equal(t, "first", value)
+}

--- a/pkg/middleware/request_tracing.go
+++ b/pkg/middleware/request_tracing.go
@@ -27,9 +27,18 @@ var routeOperationNameKey = contextKey{}
 // Implements routing.RegisterNamedMiddleware.
 func ProvideRouteOperationName(name string) web.Handler {
 	return func(res http.ResponseWriter, req *http.Request, c *web.Context) {
-		ctx := context.WithValue(c.Req.Context(), routeOperationNameKey, name)
-		c.Req = c.Req.WithContext(ctx)
+		c.Req = addRouteNameToContext(c.Req, name)
 	}
+}
+
+func addRouteNameToContext(req *http.Request, operationName string) *http.Request {
+	// don't set route name if it's set
+	if _, exists := routeOperationName(req); exists {
+		return req
+	}
+
+	ctx := context.WithValue(req.Context(), routeOperationNameKey, operationName)
+	return req.WithContext(ctx)
 }
 
 var unnamedHandlers = []struct {


### PR DESCRIPTION
This helps us identify requests currently categorized as `unknown`. 