### PR TITLE
Alerting: make sure that resetting the policy uses an existing receiver

### DIFF
--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -131,6 +131,10 @@ func (nps *NotificationPolicyService) ResetPolicyTree(ctx context.Context, orgID
 	if err != nil {
 		return definitions.Route{}, err
 	}
+	// When resetting the policy, we have to make sure to use a receiver that
+	// does exist. Otherwise it can cause everything to crash as the default
+	// receiver used could already be deleted by the user.
+	route.Receiver = revision.cfg.AlertmanagerConfig.Receivers[0].Name
 	revision.cfg.AlertmanagerConfig.Config.Route = route
 
 	serialized, err := serializeAlertmanagerConfig(*revision.cfg)


### PR DESCRIPTION
See the comment in the change.