### PR TITLE
Alerting: [POC] Notifications routing preview

### DIFF
--- a/packages/grafana-ui/src/components/Forms/RadioButtonList/RadioButtonList.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonList/RadioButtonList.tsx
@@ -51,7 +51,11 @@ export function RadioButtonList<T>({
             key={itemId}
             id={itemId}
             name={name}
-            label={option.label}
+            label={
+              <>
+                {option.label} {option.component && <option.component />}
+              </>
+            }
             description={option.description}
             checked={isChecked}
             disabled={isDisabled}

--- a/packages/grafana-ui/src/components/QueryEditor/Stack.tsx
+++ b/packages/grafana-ui/src/components/QueryEditor/Stack.tsx
@@ -8,6 +8,7 @@ import { useStyles2 } from '../../themes';
 interface StackProps {
   direction?: CSSProperties['flexDirection'];
   alignItems?: CSSProperties['alignItems'];
+  justifyContent?: CSSProperties['justifyContent'];
   wrap?: boolean;
   gap?: number;
 }
@@ -23,6 +24,7 @@ const getStyles = (theme: GrafanaTheme2, props: StackProps) => ({
     display: 'flex',
     flexDirection: props.direction ?? 'row',
     flexWrap: props.wrap ?? true ? 'wrap' : undefined,
+    justifyContent: props.justifyContent,
     alignItems: props.alignItems,
     gap: theme.spacing(props.gap ?? 2),
   }),

--- a/pkg/services/ngalert/api/api_configuration.go
+++ b/pkg/services/ngalert/api/api_configuration.go
@@ -43,6 +43,17 @@ func (srv ConfigSrv) RouteGetAlertmanagers(c *models.ReqContext) response.Respon
 	})
 }
 
+func (srv ConfigSrv) RouteGetPulblicAlertManagerConfig(c *models.ReqContext) response.Response {
+	cfg, err := srv.store.GetAdminConfiguration(c.OrgID)
+	if err != nil {
+		return ErrResp(http.StatusInternalServerError, err, "Failed to fetch configuration")
+	}
+
+	resp := apimodels.AlertmanagersChoice(cfg.SendAlertsTo.String())
+
+	return response.JSON(http.StatusOK, resp)
+}
+
 func (srv ConfigSrv) RouteGetNGalertConfig(c *models.ReqContext) response.Response {
 	if c.OrgRole != org.RoleAdmin {
 		return accessForbiddenResp()

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -179,6 +179,9 @@ func (api *API) authorize(method, path string) web.Handler {
 		http.MethodGet + "/api/v1/ngalert/alertmanagers":
 		return middleware.ReqOrgAdmin
 
+	case http.MethodGet + "/api/v1/ngalert/public_config":
+		return middleware.ReqSignedIn
+
 	// Grafana-only Provisioning Read Paths
 	case http.MethodGet + "/api/v1/provisioning/policies",
 		http.MethodGet + "/api/v1/provisioning/contact-points",

--- a/pkg/services/ngalert/api/configuration.go
+++ b/pkg/services/ngalert/api/configuration.go
@@ -21,6 +21,10 @@ func (f *ConfigurationApiHandler) handleRouteGetAlertmanagers(c *models.ReqConte
 	return f.grafana.RouteGetAlertmanagers(c)
 }
 
+func (f *ConfigurationApiHandler) handleRouteGetPublicAlertmanagersConfig(c *models.ReqContext) response.Response {
+	return f.grafana.RouteGetPulblicAlertManagerConfig(c)
+}
+
 func (f *ConfigurationApiHandler) handleRouteGetNGalertConfig(c *models.ReqContext) response.Response {
 	return f.grafana.RouteGetNGalertConfig(c)
 }

--- a/pkg/services/ngalert/api/generated_base_api_configuration.go
+++ b/pkg/services/ngalert/api/generated_base_api_configuration.go
@@ -22,6 +22,7 @@ type ConfigurationApi interface {
 	RouteDeleteNGalertConfig(*models.ReqContext) response.Response
 	RouteGetAlertmanagers(*models.ReqContext) response.Response
 	RouteGetNGalertConfig(*models.ReqContext) response.Response
+	RouteGetPublicAlertmanagersConfig(*models.ReqContext) response.Response
 	RoutePostNGalertConfig(*models.ReqContext) response.Response
 }
 
@@ -33,6 +34,9 @@ func (f *ConfigurationApiHandler) RouteGetAlertmanagers(ctx *models.ReqContext) 
 }
 func (f *ConfigurationApiHandler) RouteGetNGalertConfig(ctx *models.ReqContext) response.Response {
 	return f.handleRouteGetNGalertConfig(ctx)
+}
+func (f *ConfigurationApiHandler) RouteGetPublicAlertmanagersConfig(ctx *models.ReqContext) response.Response {
+	return f.handleRouteGetPublicAlertmanagersConfig(ctx)
 }
 func (f *ConfigurationApiHandler) RoutePostNGalertConfig(ctx *models.ReqContext) response.Response {
 	// Parse Request Body
@@ -72,6 +76,16 @@ func (api *API) RegisterConfigurationApiEndpoints(srv ConfigurationApi, m *metri
 				http.MethodGet,
 				"/api/v1/ngalert/admin_config",
 				srv.RouteGetNGalertConfig,
+				m,
+			),
+		)
+		group.Get(
+			toMacaronPath("/api/v1/ngalert/public_config"),
+			api.authorize(http.MethodGet, "/api/v1/ngalert/public_config"),
+			metrics.Instrument(
+				http.MethodGet,
+				"/api/v1/ngalert/public_config",
+				srv.RouteGetPublicAlertmanagersConfig,
 				m,
 			),
 		)

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -3348,6 +3348,7 @@
    "type": "object"
   },
   "alertGroups": {
+   "description": "AlertGroups alert groups",
    "items": {
     "$ref": "#/definitions/alertGroup"
    },
@@ -3517,6 +3518,7 @@
    "type": "array"
   },
   "gettableSilence": {
+   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3675,6 +3677,7 @@
    "type": "array"
   },
   "postableSilence": {
+   "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3712,7 +3715,6 @@
    "type": "object"
   },
   "receiver": {
-   "description": "Receiver receiver",
    "properties": {
     "name": {
      "description": "name",

--- a/pkg/services/ngalert/api/tooling/definitions/admin.go
+++ b/pkg/services/ngalert/api/tooling/definitions/admin.go
@@ -14,6 +14,16 @@ import (
 //     Responses:
 //		 200: GettableAlertmanagers
 
+// swagger:route GET /api/v1/ngalert/public_config configuration RouteGetPublicAlertmanagersConfig
+//
+// Get public configuration
+//
+// 		Produces:
+//    - application/json
+//
+//    Responses:
+//		200: AlertmanagersChoice
+
 // swagger:route GET /api/v1/ngalert/admin_config configuration RouteGetNGalertConfig
 //
 //  Get the NGalert configuration of the user's organization, returns 404 if no configuration is present.

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -3107,6 +3107,7 @@
    "type": "object"
   },
   "URL": {
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -3139,7 +3140,7 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "URL is a custom URL type that allows validation at configuration load time.",
+   "title": "A URL represents a parsed URL (technically, a URI reference).",
    "type": "object"
   },
   "Userinfo": {
@@ -3509,12 +3510,14 @@
    "type": "object"
   },
   "gettableAlerts": {
+   "description": "GettableAlerts gettable alerts",
    "items": {
     "$ref": "#/definitions/gettableAlert"
    },
    "type": "array"
   },
   "gettableSilence": {
+   "description": "GettableSilence gettable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -3674,7 +3677,6 @@
    "type": "array"
   },
   "postableSilence": {
-   "description": "PostableSilence postable silence",
    "properties": {
     "comment": {
      "description": "comment",
@@ -5553,6 +5555,23 @@
      }
     },
     "summary": "Get the discovered and dropped Alertmanagers of the user's organization based on the specified configuration.",
+    "tags": [
+     "configuration"
+    ]
+   }
+  },
+  "/api/v1/ngalert/public_config": {
+   "get": {
+    "description": "Get public configuration",
+    "operationId": "RouteGetPublicAlertmanagersConfig",
+    "produces": [
+     "application/json"
+    ],
+    "responses": {
+     "200": {
+      "$ref": "#/responses/AlertmanagersChoice"
+     }
+    },
     "tags": [
      "configuration"
     ]

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1757,6 +1757,23 @@
         }
       }
     },
+    "/api/v1/ngalert/public_config": {
+      "get": {
+        "description": "Get public configuration",
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "configuration"
+        ],
+        "operationId": "RouteGetPublicAlertmanagersConfig",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/AlertmanagersChoice"
+          }
+        }
+      }
+    },
     "/api/v1/provisioning/alert-rules": {
       "post": {
         "consumes": [
@@ -5612,8 +5629,9 @@
       }
     },
     "URL": {
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "URL is a custom URL type that allows validation at configuration load time.",
+      "title": "A URL represents a parsed URL (technically, a URI reference).",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -6017,6 +6035,7 @@
       "$ref": "#/definitions/gettableAlert"
     },
     "gettableAlerts": {
+      "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
         "$ref": "#/definitions/gettableAlert"
@@ -6024,6 +6043,7 @@
       "$ref": "#/definitions/gettableAlerts"
     },
     "gettableSilence": {
+      "description": "GettableSilence gettable silence",
       "type": "object",
       "required": [
         "comment",
@@ -6185,7 +6205,6 @@
       }
     },
     "postableSilence": {
-      "description": "PostableSilence postable silence",
       "type": "object",
       "required": [
         "comment",

--- a/public/app/features/alerting/unified/components/AlertManagerPicker.tsx
+++ b/public/app/features/alerting/unified/components/AlertManagerPicker.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import React, { FC, useMemo } from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
@@ -11,13 +11,14 @@ interface Props {
   current?: string;
   disabled?: boolean;
   dataSources: AlertManagerDataSource[];
+  className?: string;
 }
 
 function getAlertManagerLabel(alertManager: AlertManagerDataSource) {
   return alertManager.name === GRAFANA_RULES_SOURCE_NAME ? 'Grafana' : alertManager.name.slice(0, 37);
 }
 
-export const AlertManagerPicker: FC<Props> = ({ onChange, current, dataSources, disabled = false }) => {
+export const AlertManagerPicker: FC<Props> = ({ onChange, current, dataSources, disabled = false, className }) => {
   const styles = useStyles2(getStyles);
 
   const options: Array<SelectableValue<string>> = useMemo(() => {
@@ -31,7 +32,7 @@ export const AlertManagerPicker: FC<Props> = ({ onChange, current, dataSources, 
 
   return (
     <Field
-      className={styles.field}
+      className={cx(styles.field, className)}
       label={disabled ? 'Alertmanager' : 'Choose Alertmanager'}
       disabled={disabled || options.length === 1}
       data-testid="alertmanager-picker"

--- a/public/app/features/alerting/unified/components/rule-editor/AmAlertPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AmAlertPreview.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { useAsync } from 'react-use';
+
+import { LoadingPlaceholder, Stack, TagList } from '@grafana/ui';
+import { Matcher } from 'app/plugins/datasource/alertmanager/types';
+
+import { Labels } from '../../../../../types/unified-alerting-dto';
+import { useAlertManagersByPermission } from '../../hooks/useAlertManagerSources';
+import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
+import { fetchAlertManagerConfigAction } from '../../state/actions';
+import { labelsMatchMatchers, matcherFieldToMatcher, matcherToMatcherField } from '../../utils/alertmanager';
+import { AlertManagerPicker } from '../AlertManagerPicker';
+
+interface AmAlertPreviewProps {
+  alertLabels: Labels;
+}
+
+export function AmAlertPreview({ alertLabels }: AmAlertPreviewProps) {
+  const dispatch = useDispatch();
+
+  const alertmanagers = useAlertManagersByPermission('notification');
+  const [alertmanagerName, setAlertmanagerName] = useState<string | undefined>(alertmanagers[0]?.name);
+
+  const amConfigs = useUnifiedAlertingSelector((ua) => ua.amConfigs);
+  const amConfig = alertmanagerName ? amConfigs[alertmanagerName]?.result : undefined;
+
+  const amRoutes =
+    amConfig?.alertmanager_config.route?.routes?.map((route) => ({
+      matchers:
+        route.object_matchers?.map<Matcher>((match) =>
+          matcherFieldToMatcher({
+            name: match[0],
+            operator: match[1],
+            value: match[2],
+          })
+        ) ?? [],
+    })) ?? [];
+
+  const amConfigState = useAsync(async () => {
+    if (alertmanagerName) {
+      await dispatch(fetchAlertManagerConfigAction(alertmanagerName));
+    }
+  }, [alertmanagerName]);
+
+  return (
+    <div>
+      <AlertManagerPicker onChange={setAlertmanagerName} current={alertmanagerName} dataSources={alertmanagers} />
+      {amConfigState.loading && <LoadingPlaceholder text="Loading Alertmanager configuration" />}
+      <Stack direction="column" gap={2}>
+        {amRoutes.map((route, index) => {
+          const match = labelsMatchMatchers(alertLabels, route.matchers);
+
+          return (
+            <div key={index}>
+              Route #{index + 1}{' '}
+              <TagList
+                tags={route.matchers.map(matcherToMatcherField).map((m) => `${m.name}${m.operator}${m.value}`)}
+              />
+              {match ? 'MATCHING LABELS FOUND!!!' : 'NO MATCHES'}
+            </div>
+          );
+        })}
+      </Stack>
+    </div>
+  );
+}

--- a/public/app/features/alerting/unified/components/rule-editor/AmAlertPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AmAlertPreview.tsx
@@ -1,15 +1,22 @@
+import { css, cx } from '@emotion/css';
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useAsync } from 'react-use';
 
-import { LoadingPlaceholder, Stack, TagList } from '@grafana/ui';
-import { Matcher } from 'app/plugins/datasource/alertmanager/types';
+import { GrafanaTheme2 } from '@grafana/data/src';
+import { Icon, LoadingPlaceholder, Stack, Tag, TagList, Tooltip, useStyles2 } from '@grafana/ui';
+import { Matcher, Receiver, Route } from 'app/plugins/datasource/alertmanager/types';
 
 import { Labels } from '../../../../../types/unified-alerting-dto';
 import { useAlertManagersByPermission } from '../../hooks/useAlertManagerSources';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { fetchAlertManagerConfigAction } from '../../state/actions';
-import { labelsMatchMatchers, matcherFieldToMatcher, matcherToMatcherField } from '../../utils/alertmanager';
+import {
+  getLabelsMatchingMatcher,
+  labelsMatchMatchers,
+  matcherToMatcherField,
+  objectMatcherToMatcher,
+} from '../../utils/alertmanager';
 import { AlertManagerPicker } from '../AlertManagerPicker';
 
 interface AmAlertPreviewProps {
@@ -18,24 +25,10 @@ interface AmAlertPreviewProps {
 
 export function AmAlertPreview({ alertLabels }: AmAlertPreviewProps) {
   const dispatch = useDispatch();
+  const styles = useStyles2(getRouteLabelsMatchStyles);
 
-  const alertmanagers = useAlertManagersByPermission('notification');
-  const [alertmanagerName, setAlertmanagerName] = useState<string | undefined>(alertmanagers[0]?.name);
-
-  const amConfigs = useUnifiedAlertingSelector((ua) => ua.amConfigs);
-  const amConfig = alertmanagerName ? amConfigs[alertmanagerName]?.result : undefined;
-
-  const amRoutes =
-    amConfig?.alertmanager_config.route?.routes?.map((route) => ({
-      matchers:
-        route.object_matchers?.map<Matcher>((match) =>
-          matcherFieldToMatcher({
-            name: match[0],
-            operator: match[1],
-            value: match[2],
-          })
-        ) ?? [],
-    })) ?? [];
+  const alertManagers = useAlertManagersByPermission('notification');
+  const [alertmanagerName, setAlertmanagerName] = useState<string | undefined>(alertManagers[0]?.name);
 
   const amConfigState = useAsync(async () => {
     if (alertmanagerName) {
@@ -43,25 +36,172 @@ export function AmAlertPreview({ alertLabels }: AmAlertPreviewProps) {
     }
   }, [alertmanagerName]);
 
+  const amConfigs = useUnifiedAlertingSelector((ua) => ua.amConfigs);
+  const amConfig = alertmanagerName ? amConfigs[alertmanagerName]?.result : undefined;
+
+  const amRoutes = amConfig?.alertmanager_config.route?.routes ?? [];
+
+  const receivers = new Map(amConfig?.alertmanager_config.receivers?.map((receiver) => [receiver.name, receiver]));
+
   return (
-    <div>
-      <AlertManagerPicker onChange={setAlertmanagerName} current={alertmanagerName} dataSources={alertmanagers} />
+    <Stack gap={2} direction="column">
+      <AlertManagerPicker
+        onChange={setAlertmanagerName}
+        current={alertmanagerName}
+        dataSources={alertManagers}
+        className={styles.amPicker}
+      />
       {amConfigState.loading && <LoadingPlaceholder text="Loading Alertmanager configuration" />}
+
+      <h5>Alert Labels</h5>
+      <TagList tags={Object.entries(alertLabels).map((label) => labelToString(label))} />
+
+      <h5>Matching Notification policies</h5>
       <Stack direction="column" gap={2}>
         {amRoutes.map((route, index) => {
-          const match = labelsMatchMatchers(alertLabels, route.matchers);
-
+          // TODO This requires consideration of previous routes and the continue flag
+          const isMatchingRoute = labelsMatchMatchers(
+            alertLabels,
+            route.object_matchers?.map(objectMatcherToMatcher) ?? []
+          );
           return (
-            <div key={index}>
-              Route #{index + 1}{' '}
-              <TagList
-                tags={route.matchers.map(matcherToMatcherField).map((m) => `${m.name}${m.operator}${m.value}`)}
-              />
-              {match ? 'MATCHING LABELS FOUND!!!' : 'NO MATCHES'}
-            </div>
+            <RouteLabelsMatch
+              key={index}
+              className={cx(styles.route, { [styles.matchingRoute]: isMatchingRoute })}
+              isMatchingRoute={isMatchingRoute}
+              labels={alertLabels}
+              route={route}
+              routeIndex={index + 1}
+              receivers={receivers}
+            />
           );
         })}
       </Stack>
+    </Stack>
+  );
+}
+
+interface RouteLabelsMatchProps {
+  isMatchingRoute: boolean;
+  labels: Labels;
+  route: Route;
+  routeIndex?: number;
+  receivers?: Map<string, Receiver>;
+  className?: string;
+}
+
+function RouteLabelsMatch({ isMatchingRoute, labels, route, receivers = new Map(), className }: RouteLabelsMatchProps) {
+  const styles = useStyles2(getRouteLabelsMatchStyles);
+  const matchers = route.object_matchers?.map(objectMatcherToMatcher) ?? [];
+  const receiver = route.receiver ? receivers.get(route.receiver) : undefined;
+
+  return (
+    <div className={className}>
+      <Stack justifyContent="space-between">
+        {receiver ? (
+          <div>
+            {receiver.name} ({receiver.grafana_managed_receiver_configs?.map((gmc) => gmc.type).join(', ')})
+          </div>
+        ) : (
+          <div>
+            <Icon name="exclamation-triangle" /> Contact point not defined
+          </div>
+        )}
+      </Stack>
+      <Stack gap={2}>
+        {matchers.map((matcher, index) => {
+          const matchingLabels = getLabelsMatchingMatcher(labels, matcher);
+          const hasMatchingLabels = matchingLabels.length > 0;
+
+          const matchingLabelsTooltip = (
+            <>
+              <h6>Matching labels: </h6>
+              <Stack gap={2}>
+                {matchingLabels.map((label, index) => (
+                  <Tag key={index} name={labelToString(label)} colorIndex={1} />
+                ))}
+              </Stack>
+            </>
+          );
+
+          return hasMatchingLabels ? (
+            <Tooltip content={matchingLabelsTooltip}>
+              <Tag key={index} name={matcherToString(matcher)} colorIndex={isMatchingRoute ? 23 : 6} />
+            </Tooltip>
+          ) : (
+            <Tag key={index} name={matcherToString(matcher)} colorIndex={9} />
+          );
+        })}
+      </Stack>
+      <div>
+        {route.routes?.map((nestedRoute, index) => {
+          const isMatchingNestedRoute =
+            labelsMatchMatchers(labels, nestedRoute.object_matchers?.map(objectMatcherToMatcher) ?? []) &&
+            isMatchingRoute;
+
+          return (
+            <RouteLabelsMatch
+              key={index}
+              className={styles.nestedRoutes}
+              isMatchingRoute={isMatchingNestedRoute}
+              labels={labels}
+              route={nestedRoute}
+              routeIndex={index + 1}
+              receivers={receivers}
+            />
+          );
+        })}
+      </div>
     </div>
   );
+}
+
+function getRouteLabelsMatchStyles(theme: GrafanaTheme2) {
+  return {
+    amPicker: css`
+      margin-bottom: ${theme.spacing(0)};
+    `,
+    route: css`
+      padding: ${theme.spacing(1)};
+      border: 2px solid ${theme.colors.secondary.border};
+      border-radius: ${theme.shape.borderRadius(2)};
+      background-color: ${theme.colors.background.secondary};
+    `,
+    matchingRoute: css`
+      border: 2px solid ${theme.colors.primary.border};
+    `,
+    nestedRoutes: css`
+      position: relative;
+      padding-left: ${theme.spacing(4)};
+      border-left: 2px solid ${theme.colors.border.strong};
+
+      ::before {
+        content: '';
+        display: inline-block;
+        width: 20px;
+        height: 20px;
+        border-bottom: 2px solid ${theme.colors.border.strong};
+        position: absolute;
+        top: 0;
+        left: 0;
+      }
+
+      :last-child {
+        border-left: none;
+      }
+
+      :last-child:before {
+        border-left: 2px solid ${theme.colors.border.strong};
+      }
+    `,
+  };
+}
+
+function matcherToString(matcher: Matcher): string {
+  const { name, operator, value } = matcherToMatcherField(matcher);
+  return `${name}${operator}${value}`;
+}
+
+function labelToString(label: [key: string, value: string]) {
+  return `${label[0]}=${label[1]}`;
 }

--- a/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
@@ -26,6 +26,9 @@ export const NotificationsStep: FC = () => {
       .map((label) => [label.key, label.value])
   );
 
+  const queries = watch('queries');
+  const alertCondition = watch('condition');
+
   return (
     <RuleEditorSection
       stepNo={4}
@@ -59,8 +62,8 @@ export const NotificationsStep: FC = () => {
       </div>
       <Button onClick={setAmPreviewVisible}>Open Alertmanager preview</Button>
       {amPreviewVisible && (
-        <Drawer onClose={setAmPreviewVisible} width="50%" scrollableContent={true}>
-          <AmAlertPreview alertLabels={alertLabels} />
+        <Drawer onClose={setAmPreviewVisible} width="100%" scrollableContent={true}>
+          <AmAlertPreview alertLabels={alertLabels} queries={queries} alertCondition={alertCondition} />
         </Drawer>
       )}
     </RuleEditorSection>

--- a/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
@@ -20,7 +20,11 @@ export const NotificationsStep: FC = () => {
 
   const { watch } = useFormContext<RuleFormValues>();
 
-  const alertLabels = Object.fromEntries(watch('labels').map((label) => [label.key, label.value]));
+  const alertLabels = Object.fromEntries(
+    watch('labels')
+      .filter((label) => label.key.length > 0 && label.value.length > 0)
+      .map((label) => [label.key, label.value])
+  );
 
   return (
     <RuleEditorSection
@@ -55,7 +59,7 @@ export const NotificationsStep: FC = () => {
       </div>
       <Button onClick={setAmPreviewVisible}>Open Alertmanager preview</Button>
       {amPreviewVisible && (
-        <Drawer onClose={setAmPreviewVisible}>
+        <Drawer onClose={setAmPreviewVisible} width="50%" scrollableContent={true}>
           <AmAlertPreview alertLabels={alertLabels} />
         </Drawer>
       )}

--- a/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
@@ -1,16 +1,26 @@
 import { css } from '@emotion/css';
 import React, { FC, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { useToggle } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { Card, Link, useStyles2, useTheme2 } from '@grafana/ui';
+import { Button, Card, Drawer, Link, useStyles2, useTheme2 } from '@grafana/ui';
 
+import { RuleFormValues } from '../../types/rule-form';
+
+import { AmAlertPreview } from './AmAlertPreview';
 import LabelsField from './LabelsField';
 import { RuleEditorSection } from './RuleEditorSection';
 
 export const NotificationsStep: FC = () => {
   const [hideFlowChart, setHideFlowChart] = useState(false);
+  const [amPreviewVisible, setAmPreviewVisible] = useToggle(false);
   const styles = useStyles2(getStyles);
   const theme = useTheme2();
+
+  const { watch } = useFormContext<RuleFormValues>();
+
+  const alertLabels = Object.fromEntries(watch('labels').map((label) => [label.key, label.value]));
 
   return (
     <RuleEditorSection
@@ -43,6 +53,12 @@ export const NotificationsStep: FC = () => {
           </Card>
         </div>
       </div>
+      <Button onClick={setAmPreviewVisible}>Open Alertmanager preview</Button>
+      {amPreviewVisible && (
+        <Drawer onClose={setAmPreviewVisible}>
+          <AmAlertPreview alertLabels={alertLabels} />
+        </Drawer>
+      )}
     </RuleEditorSection>
   );
 };

--- a/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
@@ -62,7 +62,7 @@ export const NotificationsStep: FC = () => {
       </div>
       <Button onClick={setAmPreviewVisible}>Open Alertmanager preview</Button>
       {amPreviewVisible && (
-        <Drawer onClose={setAmPreviewVisible} width="100%" scrollableContent={true}>
+        <Drawer onClose={setAmPreviewVisible} width="60%" scrollableContent={true}>
           <AmAlertPreview alertLabels={alertLabels} queries={queries} alertCondition={alertCondition} />
         </Drawer>
       )}

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -92,7 +92,7 @@ export type Receiver = {
   [key: string]: any;
 };
 
-type ObjectMatcher = [name: string, operator: MatcherOperator, value: string];
+export type ObjectMatcher = [name: string, operator: MatcherOperator, value: string];
 
 export type Route = {
   receiver?: string;


### PR DESCRIPTION
POC for previewing notification policies during an alert creation/editing
## Notification policies preview  
- **Grafana managed alerts**  
	- We can display an AM selector to match the alert rule against a specific AM  
		- we can skip this step when there is only one AM  
		- If we had the AM configuration endpoint we could precisely show only these AMs which receive Grafana alerts  
	- We can run the queries to get labels for multi-dimensional alerts  
		- Then we combine them with the list of user defined labels  
		- And with the list of Grafana-added labels  
		- Whereas it's doable on FE, It would be nice to have an endpoint that does all of this for us  
- **Cloud alerts**  
	- The query endpoint should be enough to get the multi-dimensional alerts with their labels  
	- There is no easy way to associate alert generators with receivers, hence there won't be an easy way to display only reasonable AMs for a prom-based data source  
- **Notification policies matching evaluation**  
	- This is a bit tricky as there are a couple of things to be considered when checking if a policy matches the alert labels  
		- e.g. the `continue` flag  
	- Probably would be better to do it on the BE  
	- Although UX would be better if we do it on the FE  
	-  

![image](https://user-images.githubusercontent.com/6293563/185628808-6fa63b1f-aaa3-46cb-b7f8-d053c329a918.png)