### PR TITLE
Decimals: Fixes auto decimals to behave the same for positive and negative values

### DIFF
--- a/packages/grafana-data/src/valueFormats/valueFormats.test.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.test.ts
@@ -94,6 +94,15 @@ describe('valueFormats', () => {
 
       expect(toFixed(100.4)).toBe('100');
       expect(toFixed(100.5)).toBe('101');
+      expect(toFixed(27.4)).toBe('27.4');
+      expect(toFixed(27.5)).toBe('27.5');
+
+      expect(toFixed(-100)).toBe('-100');
+
+      expect(toFixed(-100.5)).toBe('-100');
+      expect(toFixed(-100.6)).toBe('-101');
+      expect(toFixed(-27.5)).toBe('-27.5');
+      expect(toFixed(-27.6)).toBe('-27.6');
     });
 
     it('toFixed should handle number correctly if decimal is not null', () => {

--- a/packages/grafana-data/src/valueFormats/valueFormats.ts
+++ b/packages/grafana-data/src/valueFormats/valueFormats.ts
@@ -80,10 +80,11 @@ export function toFixed(value: number, decimals?: DecimalCount): string {
 }
 
 function getDecimalsForValue(value: number): number {
-  const log10 = Math.floor(Math.log(Math.abs(value)) / Math.LN10);
+  const absValue = Math.abs(value);
+  const log10 = Math.floor(Math.log(absValue) / Math.LN10);
   let dec = -log10 + 1;
   const magn = Math.pow(10, -dec);
-  const norm = value / magn; // norm is between 1.0 and 10.0
+  const norm = absValue / magn; // norm is between 1.0 and 10.0
 
   // special case for 2.5, requires an extra decimal
   if (norm > 2.25) {


### PR DESCRIPTION
**What this PR does / why we need it**:

If you leave the "Decimals" option set to auto, negative and positive values behave differently:

![183403766-f934d171-1afd-4b58-b442-1ff17219f648](https://user-images.githubusercontent.com/100691367/185638462-03d35308-1fb7-4137-85f5-9df8f4528755.png)

This PR makes sure that there is no difference between how those are displayed and adds some tests for those cases.

**Which issue(s) this PR fixes**:

Fixes #53331

