### PR TITLE
TimePicker: Fixes relative timerange of less than a day not displaying

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/CalendarBody.tsx
@@ -65,6 +65,9 @@ function dateInfo(date: Date): number[] {
 }
 
 export const getBodyStyles = (theme: GrafanaTheme2) => {
+  // If a time range is part of only 1 day but does not encompass the whole day,
+  // the class that react-calendar uses is '--hasActive' by itself (without being part of a '--range')
+  const hasActiveSelector = `.react-calendar__tile--hasActive:not(.react-calendar__tile--range)`;
   return {
     title: css`
       color: ${theme.colors.text.primary};
@@ -126,6 +129,7 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
         outline: 0;
       }
 
+      ${hasActiveSelector},
       .react-calendar__tile--active,
       .react-calendar__tile--active:hover {
         color: ${theme.colors.primary.contrastText};
@@ -152,11 +156,13 @@ export const getBodyStyles = (theme: GrafanaTheme2) => {
         }
       }
 
+      ${hasActiveSelector},
       .react-calendar__tile--rangeStart {
         border-top-left-radius: 20px;
         border-bottom-left-radius: 20px;
       }
 
+      ${hasActiveSelector},
       .react-calendar__tile--rangeEnd {
         border-top-right-radius: 20px;
         border-bottom-right-radius: 20px;


### PR DESCRIPTION
**What this PR does / why we need it**:

When the time range sent to `react-calendar` is less than 1 full day (i.e. today from 6pm - 8pm), it does not use any of the classes the `CalendarBody` component assumes a time range uses for that day (`react-calendar__tile--rangeStart`, `react-calendar__tile--rangeEnd` or `react-calendar__tile--active`), instead it uses the class `react-calendar__tile--hasActive` to denote that part of that day is selected. So we need to also have some styling in that class, which is the equivalent styling of those 3 classes I mentioned combined as it is the only day in the range.

Before:
<img width="491" alt="Screenshot 2022-08-19 at 18 14 19" src="https://user-images.githubusercontent.com/100691367/185672323-e1f71109-b4fe-4dc7-a597-1a3b0725e21b.png">

After:
<img width="556" alt="Screenshot 2022-08-19 at 18 14 51" src="https://user-images.githubusercontent.com/100691367/185672403-3febd350-d621-4f81-9337-f6a4a8527082.png">


**Which issue(s) this PR fixes**:

Fixes #53378

**Special notes**:

The `react-calendar__tile--hasActive` class is also used for partial days that are inside a multi day range, for instance if the range ends at 6pm, but then we do not want to use this extra class selector because the `--rangeEnd` is used and should already set the border radius correctly.