### PR TITLE
Alerting: Fix width of Adaptive Cards in Teams notifications

### DIFF
--- a/pkg/services/ngalert/notifier/channels/teams.go
+++ b/pkg/services/ngalert/notifier/channels/teams.go
@@ -69,10 +69,10 @@ type AdaptiveCardsAttachment struct {
 // AdapativeCard repesents an Adaptive Card.
 // https://adaptivecards.io/explorer/AdaptiveCard.html
 type AdaptiveCard struct {
-	Body    []AdaptiveCardItem `json:"body"`
-	Schema  string             `json:"$schema"`
-	Type    string             `json:"type"`
-	Version string             `json:"version"`
+	Body    []AdaptiveCardItem
+	Schema  string
+	Type    string
+	Version string
 }
 
 // NewAdaptiveCard returns a prepared Adaptive Card.
@@ -83,6 +83,22 @@ func NewAdaptiveCard() AdaptiveCard {
 		Type:    "AdaptiveCard",
 		Version: "1.4",
 	}
+}
+
+func (c *AdaptiveCard) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Body    []AdaptiveCardItem     `json:"body"`
+		Schema  string                 `json:"$schema"`
+		Type    string                 `json:"type"`
+		Version string                 `json:"version"`
+		MsTeams map[string]interface{} `json:"msTeams,omitempty"`
+	}{
+		Body:    c.Body,
+		Schema:  c.Schema,
+		Type:    c.Type,
+		Version: c.Version,
+		MsTeams: map[string]interface{}{"width": "Full"},
+	})
 }
 
 // AppendItem appends an item, such as text or an image, to the Adaptive Card.

--- a/pkg/services/ngalert/notifier/channels/teams_test.go
+++ b/pkg/services/ngalert/notifier/channels/teams_test.go
@@ -70,6 +70,9 @@ func TestTeamsNotifier(t *testing.T) {
 					}},
 					"type":    "AdaptiveCard",
 					"version": "1.4",
+					"msTeams": map[string]interface{}{
+						"width": "Full",
+					},
 				},
 				"contentType": "application/vnd.microsoft.card.adaptive",
 			}},
@@ -123,6 +126,9 @@ func TestTeamsNotifier(t *testing.T) {
 					}},
 					"type":    "AdaptiveCard",
 					"version": "1.4",
+					"msTeams": map[string]interface{}{
+						"width": "Full",
+					},
 				},
 				"contentType": "application/vnd.microsoft.card.adaptive",
 			}},
@@ -176,6 +182,9 @@ func TestTeamsNotifier(t *testing.T) {
 					}},
 					"type":    "AdaptiveCard",
 					"version": "1.4",
+					"msTeams": map[string]interface{}{
+						"width": "Full",
+					},
 				},
 				"contentType": "application/vnd.microsoft.card.adaptive",
 			}},
@@ -228,6 +237,9 @@ func TestTeamsNotifier(t *testing.T) {
 					}},
 					"type":    "AdaptiveCard",
 					"version": "1.4",
+					"msTeams": map[string]interface{}{
+						"width": "Full",
+					},
 				},
 				"contentType": "application/vnd.microsoft.card.adaptive",
 			}},

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -2224,7 +2224,10 @@ var expNonEmailNotifications = map[string][]string{
 				  }
 				],
 				"type": "AdaptiveCard",
-				"version": "1.4"
+				"version": "1.4",
+				"msTeams": {
+				  "width": "Full"
+				}
 			  },
 			  "contentType": "application/vnd.microsoft.card.adaptive"
 		    }


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes the width of Adaptive Cards in Teams notifications to use the full width available.

<img width="1187" alt="Screenshot 2022-08-21 at 21 04 47" src="https://user-images.githubusercontent.com/85952834/185809085-709e265c-8dd7-4bbb-b567-c6905e1f1030.png">




**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

