### PR TITLE
Alerting: Fix links in Microsoft Teams notifications

### DIFF
--- a/pkg/services/ngalert/notifier/channels/default_template.go
+++ b/pkg/services/ngalert/notifier/channels/default_template.go
@@ -42,13 +42,13 @@ Labels:
 Annotations:
 {{ range .Annotations.SortedPairs }} - {{ .Name }} = {{ .Value }}
 {{ end }}
-{{ if gt (len .GeneratorURL) 0 }}Source: {{ .GeneratorURL }}
+{{ if gt (len .GeneratorURL) 0 }}Source: [{{ .GeneratorURL }}]({{ .GeneratorURL }})
 
-{{ end }}{{ if gt (len .SilenceURL) 0 }}Silence: {{ .SilenceURL }}
+{{ end }}{{ if gt (len .SilenceURL) 0 }}Silence: [{{ .SilenceURL }}]({{ .SilenceURL }})
 
-{{ end }}{{ if gt (len .DashboardURL) 0 }}Dashboard: {{ .DashboardURL }}
+{{ end }}{{ if gt (len .DashboardURL) 0 }}Dashboard: [{{ .DashboardURL }}]({{ .DashboardURL }})
 
-{{ end }}{{ if gt (len .PanelURL) 0 }}Panel: {{ .PanelURL }}
+{{ end }}{{ if gt (len .PanelURL) 0 }}Panel: [{{ .PanelURL }}]({{ .PanelURL }})
 
 {{ end }}
 {{ end }}{{ end }}

--- a/pkg/services/ngalert/notifier/channels/default_template_test.go
+++ b/pkg/services/ngalert/notifier/channels/default_template_test.go
@@ -147,13 +147,13 @@ Labels:
 Annotations:
  - ann1 = annv1
 
-Source: http://localhost/alert1
+Source: [http://localhost/alert1](http://localhost/alert1)
 
-Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1
+Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval1)
 
-Dashboard: http://localhost/grafana/d/dbuid123
+Dashboard: [http://localhost/grafana/d/dbuid123](http://localhost/grafana/d/dbuid123)
 
-Panel: http://localhost/grafana/d/dbuid123?viewPanel=puid123
+Panel: [http://localhost/grafana/d/dbuid123?viewPanel=puid123](http://localhost/grafana/d/dbuid123?viewPanel=puid123)
 
 
 
@@ -165,9 +165,9 @@ Labels:
 Annotations:
  - ann1 = annv2
 
-Source: http://localhost/alert2
+Source: [http://localhost/alert2](http://localhost/alert2)
 
-Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2
+Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval2)
 
 
 
@@ -182,13 +182,13 @@ Labels:
 Annotations:
  - ann1 = annv3
 
-Source: http://localhost/alert3
+Source: [http://localhost/alert3](http://localhost/alert3)
 
-Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval3
+Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval3](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval3)
 
-Dashboard: http://localhost/grafana/d/dbuid456
+Dashboard: [http://localhost/grafana/d/dbuid456](http://localhost/grafana/d/dbuid456)
 
-Panel: http://localhost/grafana/d/dbuid456?viewPanel=puid456
+Panel: [http://localhost/grafana/d/dbuid456?viewPanel=puid456](http://localhost/grafana/d/dbuid456?viewPanel=puid456)
 
 
 
@@ -200,9 +200,9 @@ Labels:
 Annotations:
  - ann1 = annv4
 
-Source: http://localhost/alert4
+Source: [http://localhost/alert4](http://localhost/alert4)
 
-Silence: http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval4
+Silence: [http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval4](http://localhost/grafana/alerting/silence/new?alertmanager=grafana&matcher=alertname%3Dalert1&matcher=lbl1%3Dval4)
 
 
 `,


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes links in Microsoft Teams notifications. Before this change links were not active, and instead just shown in plain text.

<img width="1187" alt="Screenshot 2022-08-22 at 09 41 17" src="https://user-images.githubusercontent.com/85952834/185878456-deeb0041-b384-435b-9d17-2ee17c8211b5.png">

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

