### PR TITLE
CI: Add `GCP_KEY` secret to the `artifacts-page` pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3714,6 +3714,9 @@ steps:
   - ./bin/grabpl artifacts-page
   depends_on:
   - grabpl
+  environment:
+    GCP_KEY:
+      from_secret: gcp_key
   image: grafana/build-container:1.5.9
   name: artifacts-page
 trigger:
@@ -5171,6 +5174,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: ee6ca0d5e6990802f6b69df6616b18f1c4a60dc541326dd4304f9e68f858dda4
+hmac: 4922e4495148755ec45cf230190acbd7f7b564c831d98e10697381dda5cb75ef
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1229,6 +1229,9 @@ def artifacts_page_step():
         'depends_on': [
             'grabpl',
         ],
+        'environment': {
+            'GCP_KEY': from_secret('gcp_key'),
+        },
         'commands': [
             './bin/grabpl artifacts-page',
         ],


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a mandatory secret to the `artifacts-page` generation pipeline.