### PR TITLE
Alerting: Show alerting enabled for Alertmanager data sources

### DIFF
--- a/public/app/features/datasources/components/BasicSettings.tsx
+++ b/public/app/features/datasources/components/BasicSettings.tsx
@@ -16,10 +16,11 @@ export interface Props {
 export function BasicSettings({ dataSourceName, isDefault, onDefaultChange, onNameChange }: Props) {
   const ds = getDataSourceSrv()?.getInstanceSettings(dataSourceName);
   const hasAlertingEnabled = Boolean(ds?.meta?.alerting ?? false);
+  const isAlertManagerDatasource = ds?.type === 'alertmanager';
 
   return (
     <>
-      <AlertingEnabled enabled={hasAlertingEnabled} />
+      {<AlertingEnabled enabled={hasAlertingEnabled || isAlertManagerDatasource} />}
       <div className="gf-form-group" aria-label="Datasource settings page basic settings">
         <div className="gf-form-inline">
           {/* Name */}


### PR DESCRIPTION
**What this PR does / why we need it**:

The AlertManager data sources are implicitly supported but with the current implementation they show as "alerting not supported" – which is confusing and misleading :D 

<img width="709" alt="image" src="https://user-images.githubusercontent.com/868844/185914639-3eb451bc-31cc-4f8c-8a9b-c174cf814207.png">


