### PR TITLE
Update grafana version tag to 9.1.0

### DIFF
--- a/docs/sources/setup-grafana/installation/kubernetes.md
+++ b/docs/sources/setup-grafana/installation/kubernetes.md
@@ -55,7 +55,7 @@ spec:
           - 0
       containers:
         - name: grafana
-          image: grafana/grafana:8.4.4
+          image: grafana/grafana:9.0.5
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000

--- a/docs/sources/setup-grafana/installation/kubernetes.md
+++ b/docs/sources/setup-grafana/installation/kubernetes.md
@@ -55,7 +55,7 @@ spec:
           - 0
       containers:
         - name: grafana
-          image: grafana/grafana:9.0.5
+          image: grafana/grafana:9.1.0
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000


### PR DESCRIPTION
The user doing cut and paste will not notice and will install a old version of Grafana
