### PR TITLE
Chore: Remove needless eslint ignore comment from variable utils

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -6132,7 +6132,9 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
-      [0, 0, 0, "Do not use any type assertions.", "10"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "10"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "11"],
+      [0, 0, 0, "Do not use any type assertions.", "12"]
     ],
     "public/app/plugins/datasource/alertmanager/DataSource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/public/app/features/variables/utils.ts
+++ b/public/app/features/variables/utils.ts
@@ -300,9 +300,7 @@ export function toVariablePayload<T extends any = undefined>(
   identifier: VariableIdentifier,
   data?: T
 ): VariablePayload<T>;
-// eslint-disable-next-line
 export function toVariablePayload<T extends any = undefined>(model: VariableModel, data?: T): VariablePayload<T>;
-// eslint-disable-next-line
 export function toVariablePayload<T extends any = undefined>(
   obj: VariableIdentifier | VariableModel,
   data?: T


### PR DESCRIPTION
**What this PR does / why we need it**:

These two eslint ignore comments are no longer needed [since I updated our eslint rules to support overloads](https://github.com/grafana/grafana/commit/4b4d546e32e0c52a1b71a350e518194f61a9c5ba#diff-e7e195d3d8fa5b82fa51ed952f3a179d429cbc46c0432ce1f7b357c54c162822R23-R25). Unfortunately I forgot to remove them.

betterer results go up because the any's were previously inadvertently ignored.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

