### PR TITLE
Geomap: Fix geohash editor settings

### DIFF
--- a/public/app/features/geo/editor/locationEditor.ts
+++ b/public/app/features/geo/editor/locationEditor.ts
@@ -51,7 +51,7 @@ export function addLocationFields<TOptions>(
 
     case FrameGeometrySourceMode.Geohash:
       builder.addFieldNamePicker({
-        path: `${prefix}.geohash`,
+        path: `${prefix}geohash`,
         name: 'Geohash field',
         settings: {
           filter: (f: Field) => f.type === FieldType.string,

--- a/public/app/features/geo/utils/location.test.ts
+++ b/public/app/features/geo/utils/location.test.ts
@@ -67,4 +67,31 @@ describe('handle location parsing', () => {
       ]
     `);
   });
+
+  it('auto support geohash fields', async () => {
+    const frame = toDataFrame({
+      name: 'simple',
+      fields: [
+        { name: 'name', type: FieldType.string, values: names },
+        { name: 'geohash', type: FieldType.string, values: ['9q94r', 'dr5rs'] },
+      ],
+    });
+
+    const matchers = await getLocationMatchers({
+      mode: FrameGeometrySourceMode.Geohash,
+    });
+    const geo = getGeometryField(frame, matchers).field!;
+    expect(geo.values.toArray().map((p) => toLonLat((p as Point).getCoordinates()))).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          -122.01416015625001,
+          36.979980468750014,
+        ],
+        Array [
+          -73.98193359375,
+          40.71533203125,
+        ],
+      ]
+    `);
+  });
 });


### PR DESCRIPTION
Fixes #45814

This updates the query editor to save field mappings to the proper path.  Previously it was saving:

### Before
```{
 "location: {
    "": {
       "geohash": "field name"
    },
    "mode": "geohash"
  }
}
```

### After
```{
 "location: {
    "geohash": "field name"
    "mode": "geohash"
  }
}
```

We can add an e2e test in a PR that is not backported to 8x