### PR TITLE
Admin: Allow for clickable link for external users tooltip

### DIFF
--- a/public/app/features/admin/UserOrgs.tsx
+++ b/public/app/features/admin/UserOrgs.tsx
@@ -470,6 +470,7 @@ const ExternalUserTooltip: React.FC = () => {
     <div className={styles.disabledTooltip}>
       <Tooltip
         placement="right-end"
+        interactive={true}
         content={
           <div>
             This user&apos;s built-in role is not editable because it is synchronized from your auth provider. Refer to


### PR DESCRIPTION
Tooltip needed to be marked as interactive for link to be clickable.

Fixes #54065