### PR TITLE
RBAC: Only display unique permissions in list

### DIFF
--- a/public/app/core/components/AccessControl/PermissionList.tsx
+++ b/public/app/core/components/AccessControl/PermissionList.tsx
@@ -5,7 +5,7 @@ import { ResourcePermission } from './types';
 
 interface Props {
   title: string;
-  filterKey: 'builtInRole' | 'userLogin' | 'team';
+  compareKey: 'builtInRole' | 'userLogin' | 'team';
   items: ResourcePermission[];
   permissionLevels: string[];
   canSet: boolean;
@@ -13,11 +13,11 @@ interface Props {
   onChange: (resourcePermission: ResourcePermission, permission: string) => void;
 }
 
-export const PermissionList = ({ title, items, filterKey, permissionLevels, canSet, onRemove, onChange }: Props) => {
+export const PermissionList = ({ title, items, compareKey, permissionLevels, canSet, onRemove, onChange }: Props) => {
   const computed = useMemo(() => {
     const keep: { [key: string]: ResourcePermission } = {};
     for (let item of items) {
-      const key = item[filterKey]!;
+      const key = item[compareKey]!;
       if (!keep[key]) {
         keep[key] = item;
         continue;
@@ -28,7 +28,7 @@ export const PermissionList = ({ title, items, filterKey, permissionLevels, canS
       }
     }
     return Object.keys(keep).map((k) => keep[k]);
-  }, [items, filterKey]);
+  }, [items, compareKey]);
 
   if (computed.length === 0) {
     return null;

--- a/public/app/core/components/AccessControl/PermissionList.tsx
+++ b/public/app/core/components/AccessControl/PermissionList.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { PermissionListItem } from './PermissionListItem';
 import { ResourcePermission } from './types';
 
 interface Props {
   title: string;
+  filterKey: 'builtInRole' | 'userLogin' | 'team';
   items: ResourcePermission[];
   permissionLevels: string[];
   canSet: boolean;
@@ -12,8 +13,24 @@ interface Props {
   onChange: (resourcePermission: ResourcePermission, permission: string) => void;
 }
 
-export const PermissionList = ({ title, items, permissionLevels, canSet, onRemove, onChange }: Props) => {
-  if (items.length === 0) {
+export const PermissionList = ({ title, items, filterKey, permissionLevels, canSet, onRemove, onChange }: Props) => {
+  const computed = useMemo(() => {
+    const keep: { [key: string]: ResourcePermission } = {};
+    for (let item of items) {
+      const key = item[filterKey]!;
+      if (!keep[key]) {
+        keep[key] = item;
+        continue;
+      }
+
+      if (item.actions.length > keep[key].actions.length) {
+        keep[key] = item;
+      }
+    }
+    return Object.keys(keep).map((k) => keep[k]);
+  }, [items, filterKey]);
+
+  if (computed.length === 0) {
     return null;
   }
 
@@ -30,7 +47,7 @@ export const PermissionList = ({ title, items, permissionLevels, canSet, onRemov
           </tr>
         </thead>
         <tbody>
-          {items.map((item, index) => (
+          {computed.map((item, index) => (
             <PermissionListItem
               item={item}
               onRemove={onRemove}

--- a/public/app/core/components/AccessControl/Permissions.tsx
+++ b/public/app/core/components/AccessControl/Permissions.tsx
@@ -102,7 +102,7 @@ export const Permissions = ({
     () =>
       sortBy(
         items.filter((i) => i.teamId),
-        ['team']
+        ['team', 'isManaged']
       ),
     [items]
   );
@@ -110,7 +110,7 @@ export const Permissions = ({
     () =>
       sortBy(
         items.filter((i) => i.userId),
-        ['userLogin']
+        ['userLogin', 'isManaged']
       ),
     [items]
   );
@@ -118,7 +118,7 @@ export const Permissions = ({
     () =>
       sortBy(
         items.filter((i) => i.builtInRole),
-        ['builtInRole']
+        ['builtInRole', 'isManaged']
       ),
     [items]
   );
@@ -148,6 +148,7 @@ export const Permissions = ({
         <PermissionList
           title="Role"
           items={builtInRoles}
+          filterKey={'builtInRole'}
           permissionLevels={desc.permissions}
           onChange={onChange}
           onRemove={onRemove}
@@ -156,6 +157,7 @@ export const Permissions = ({
         <PermissionList
           title="User"
           items={users}
+          filterKey={'userLogin'}
           permissionLevels={desc.permissions}
           onChange={onChange}
           onRemove={onRemove}
@@ -164,6 +166,7 @@ export const Permissions = ({
         <PermissionList
           title="Team"
           items={teams}
+          filterKey={'team'}
           permissionLevels={desc.permissions}
           onChange={onChange}
           onRemove={onRemove}

--- a/public/app/core/components/AccessControl/Permissions.tsx
+++ b/public/app/core/components/AccessControl/Permissions.tsx
@@ -148,7 +148,7 @@ export const Permissions = ({
         <PermissionList
           title="Role"
           items={builtInRoles}
-          filterKey={'builtInRole'}
+          compareKey={'builtInRole'}
           permissionLevels={desc.permissions}
           onChange={onChange}
           onRemove={onRemove}
@@ -157,7 +157,7 @@ export const Permissions = ({
         <PermissionList
           title="User"
           items={users}
-          filterKey={'userLogin'}
+          compareKey={'userLogin'}
           permissionLevels={desc.permissions}
           onChange={onChange}
           onRemove={onRemove}
@@ -166,7 +166,7 @@ export const Permissions = ({
         <PermissionList
           title="Team"
           items={teams}
-          filterKey={'team'}
+          compareKey={'team'}
           permissionLevels={desc.permissions}
           onChange={onChange}
           onRemove={onRemove}


### PR DESCRIPTION
**What this PR does / why we need it**:
When permissions get displayed in the acl list there can be duplications. E.g. Admin has edit on dashboards but inherits Admin from folder. 

With this pr we only render the highest permission a user / team / role has.

Before change:
![2022-08-23-09:14:15](https://user-images.githubusercontent.com/23356117/186095444-21923953-6db5-4990-97a1-10995853dc80.png)

After change:
![2022-08-23-09:16:53](https://user-images.githubusercontent.com/23356117/186095474-cdb1a3ed-9b34-4201-956a-e5d1f68f4618.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/3289

**Special notes for your reviewer**:

