### PR TITLE
AngularPanels: Fixing changing angular panel options not taking having affect when coming back from panel edit

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/state/actions.ts
+++ b/public/app/features/dashboard/components/PanelEditor/state/actions.ts
@@ -116,7 +116,10 @@ export function exitPanelEditor(): ThunkResult<void> {
       dashboard.exitPanelEditor();
     }
 
-    if (panel.hasChanged && !shouldDiscardChanges) {
+    // For angular panels we always commit as panel.hasChanged will not have picked up changes done from angular
+    const commitChanges = !shouldDiscardChanges && (panel.hasChanged || panel.isAngularPlugin());
+
+    if (commitChanges) {
       const modifiedSaveModel = panel.getSaveModel();
       const sourcePanel = getSourcePanel();
       const panelTypeChanged = sourcePanel.type !== panel.type;

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -544,6 +544,7 @@ export class PanelModel implements DataConfigSource, IPanelModel {
 
     const clone = new PanelModel(sourceModel);
     clone.isEditing = true;
+    clone.plugin = this.plugin;
 
     const sourceQueryRunner = this.getQueryRunner();
 


### PR DESCRIPTION
Fixes https://github.com/grafana/support-escalations/issues/3678

This was harder to fix cleanly than I thought, tried a bunch of different angular watch methods but they fire when not making changes as well.
And watching just "panelCtrl.panel" with a deep watcher causes max recursion.

We have so few angular panels now so I figured we can maybe do simpler solution here and just always commit changes for
angular panels (even when no changes have been made).

Means dashboard unsaved changes warning will not be as accurate (will show after you go into panel edit and back for an angular panel) but
angular panels should become less common over time so think this is ok.

