### PR TITLE
Chore: Set Postgres default version for devenv and tests to 9.5

### DIFF
--- a/devenv/docker/blocks/postgres/.env
+++ b/devenv/docker/blocks/postgres/.env
@@ -1,1 +1,1 @@
-postgres_version=9.3
+postgres_version=9.5

--- a/devenv/docker/blocks/postgres_tests/.env
+++ b/devenv/docker/blocks/postgres_tests/.env
@@ -1,1 +1,1 @@
-postgres_version=9.3
+postgres_version=9.5

--- a/devenv/docker/blocks/postgres_tests/Dockerfile
+++ b/devenv/docker/blocks/postgres_tests/Dockerfile
@@ -1,4 +1,4 @@
-ARG postgres_version=9.3
+ARG postgres_version=9.5
 FROM postgres:${postgres_version}
 ADD setup.sql /docker-entrypoint-initdb.d
 RUN chown -R postgres:postgres /docker-entrypoint-initdb.d/


### PR DESCRIPTION
**What this PR does / why we need it**:

Set Postgres default version for devenv and tests to 9.5

Using the default makefile commands the integration tests for Postgres
fail due to tests under ngalert service using 'ON CONFLICT' that is only
available in Postgres version >= 9.5.
The errors are not very descriptive, this might cause some wasted time for new
contributors.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
Logs showing the issue:

```
 FAIL: TestIntegrationAlertInstanceOperations (0.88s)
    util.go:129: alert definition: {orgID: 1, UID: 0yZq4Ci4k} with title: "an alert definition TyZqVCiVzz" interval: 60 created
    util.go:129: alert definition: {orgID: 1, UID: XsW34Ci4k} with title: "an alert definition lyWq4CiVkz" interval: 60 created
    util.go:129: alert definition: {orgID: 1, UID: nUWq4jm4k} with title: "an alert definition GUZ34jm4kz" interval: 60 created
    util.go:129: alert definition: {orgID: 1, UID: B8Wq4CiVz} with title: "an alert definition x8WqVCiVzz" interval: 60 created
    --- FAIL: TestIntegrationAlertInstanceOperations/can_save_and_read_new_alert_instance (0.00s)
        instance_database_test.go:45:
            	Error Trace:	instance_database_test.go:45
            	Error:      	Received unexpected error:
            	            	pq: syntax error at or near "ON"
            	Test:       	TestIntegrationAlertInstanceOperations/can_save_and_read_new_alert_instance
    --- FAIL: TestIntegrationAlertInstanceOperations/can_save_and_read_new_alert_instance_with_no_labels (0.00s)
        instance_database_test.go:70:
            	Error Trace:	instance_database_test.go:70
            	Error:      	Received unexpected error:
            	            	pq: syntax error at or near "ON"
            	Test:       	TestIntegrationAlertInstanceOperations/can_save_and_read_new_alert_instance_with_no_labels
    --- FAIL: TestIntegrationAlertInstanceOperations/can_save_two_instances_with_same_org_id,_uid_and_different_labels (0.00s)
        instance_database_test.go:94:
            	Error Trace:	instance_database_test.go:94
            	Error:      	Received unexpected error:
            	            	pq: syntax error at or near "ON"
            	Test:       	TestIntegrationAlertInstanceOperations/can_save_two_instances_with_same_org_id,_uid_and_different_labels
    --- FAIL: TestIntegrationAlertInstanceOperations/can_list_all_added_instances_in_org (0.00s)
        instance_database_test.go:124:
            	Error Trace:	instance_database_test.go:124
            	Error:      	"[]" should have 4 item(s), but has 0
            	Test:       	TestIntegrationAlertInstanceOperations/can_list_all_added_instances_in_org
    --- FAIL: TestIntegrationAlertInstanceOperations/can_list_all_added_instances_in_org_filtered_by_current_state (0.00s)
        instance_database_test.go:136:
            	Error Trace:	instance_database_test.go:136
            	Error:      	"[]" should have 1 item(s), but has 0
            	Test:       	TestIntegrationAlertInstanceOperations/can_list_all_added_instances_in_org_filtered_by_current_state
    --- FAIL: TestIntegrationAlertInstanceOperations/update_instance_with_same_org_id,_uid_and_different_labels (0.00s)
        instance_database_test.go:148:
            	Error Trace:	instance_database_test.go:148
            	Error:      	Received unexpected error:
            	            	pq: syntax error at or near "ON"
            	Test:       	TestIntegrationAlertInstanceOperations/update_instance_with_same_org_id,_uid_and_different_labels
FAIL
coverage: 23.2% of statements
FAIL	github.com/grafana/grafana/pkg/services/ngalert/store	5.809s
FAIL
```

