### PR TITLE
Chore: cleanup datasources devenv

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -255,7 +255,6 @@ datasources:
         label: "Zipkin traces"
         description: "Related traces stored in Zipkin"
     jsonData:
-      something: here
       manageAlerts: false
       derivedFields:
         - name: "traceID"


### PR DESCRIPTION
Removes a tiny leftover property in `datasources.yaml` introduced by mistake