### PR TITLE
Plugins: Propagate distributed tracing headers to backend plugins

### DIFF
--- a/devenv/docker/blocks/jaeger/docker-compose.yaml
+++ b/devenv/docker/blocks/jaeger/docker-compose.yaml
@@ -3,6 +3,7 @@
     ports:
       - "6831:6831/udp"
       - "16686:16686"
+      - "14268:14268"
   # Additional loki to generate some traces
   # datasource URL: http://localhost:3100/
   loki:

--- a/go.mod
+++ b/go.mod
@@ -269,6 +269,7 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.31.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2576,6 +2576,8 @@ go.opentelemetry.io/collector/model v0.31.0 h1:IgMOkSBd/n/gV4EQQ1nJ+/ylddOlqTfMG
 go.opentelemetry.io/collector/model v0.31.0/go.mod h1:PcHNnM+RUl0uD8VkSn93PO78N7kQYhfqpI/eki57pl4=
 go.opentelemetry.io/contrib v0.21.0/go.mod h1:EH4yDYeNoaTqn/8yCWQmfNB78VHfGX2Jt2bvnvzBlGM=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.21.0/go.mod h1:Vm5u/mtkj1OMhtao0v+BGo2LUoLCgHYXvRmj0jWITlE=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.31.0 h1:li8u9OSMvLau7rMs8bmiL82OazG6MAkwPz2i6eS8TBQ=
+go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.31.0/go.mod h1:SY9qHHUES6W3oZnO1H2W8NvsSovIoXRg/A1AH9px8+I=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.21.0/go.mod h1:JQAtechjxLEL81EjmbRwxBq/XEzGaHcsPuDHAx54hg4=
 go.opentelemetry.io/contrib/propagators/jaeger v1.6.0 h1:tCc+sWgHVeOMp4zmUxHHTaoA5vQlGO089zfg97d+BvU=
 go.opentelemetry.io/contrib/propagators/jaeger v1.6.0/go.mod h1:cqu1XdBYBXqXHxZLJdK00G9rT5Hda7Fa938I8LVYz/Y=

--- a/pkg/plugins/backendplugin/grpcplugin/client.go
+++ b/pkg/plugins/backendplugin/grpcplugin/client.go
@@ -8,7 +8,10 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/pluginextensionv2"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin/secretsmanagerplugin"
+	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	goplugin "github.com/hashicorp/go-plugin"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc"
 )
 
 // Handshake is the HandshakeConfig used to configure clients and servers.
@@ -36,6 +39,16 @@ func newClientConfig(executablePath string, env []string, logger log.Logger,
 		VersionedPlugins: versionedPlugins,
 		Logger:           logWrapper{Logger: logger},
 		AllowedProtocols: []goplugin.Protocol{goplugin.ProtocolGRPC},
+		GRPCDialOptions: []grpc.DialOption{
+			grpc.WithChainUnaryInterceptor(
+				otelgrpc.UnaryClientInterceptor(),
+				grpc_opentracing.UnaryClientInterceptor(),
+			),
+			grpc.WithChainStreamInterceptor(
+				otelgrpc.StreamClientInterceptor(),
+				grpc_opentracing.StreamClientInterceptor(),
+			),
+		},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Propagates distributed tracing headers to backend plugins. In addition exposes port 14268 for jaeger docker block to allow tracing with opentelemetry config.

**Which issue(s) this PR fixes**:
Fixes #44655

**Special notes for your reviewer**:

