### PR TITLE
Example prometheus docker configurations

### DIFF
--- a/devenv/docker/blocks/prometheus-1.8.1/Dockerfile
+++ b/devenv/docker/blocks/prometheus-1.8.1/Dockerfile
@@ -1,0 +1,2 @@
+FROM prom/prometheus:v1.8.1
+ADD prometheus.yml /etc/prometheus/

--- a/devenv/docker/blocks/prometheus-1.8.1/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus-1.8.1/docker-compose.yaml
@@ -1,0 +1,10 @@
+  prometheus-1.8.1:
+    build: docker/blocks/prometheus-1.8.1
+    ports:
+      - "19091:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      --config.file=/etc/prometheus/prometheus.yml
+      --web.console.libraries=/usr/share/prometheus/console_libraries
+      --web.console.templates=/usr/share/prometheus/consoles

--- a/devenv/docker/blocks/prometheus-1.8.1/prometheus.yml
+++ b/devenv/docker/blocks/prometheus-1.8.1/prometheus.yml
@@ -1,0 +1,44 @@
+# my global config
+global:
+  scrape_interval:     10s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 10s # By default, scrape targets every 15 seconds.
+  # scrape_timeout is set to the global default (10s).
+
+# Load and evaluate rules in this file every 'evaluation_interval' seconds.
+rule_files:
+  - "alert.yml"
+  - "recording.yml"
+# - "second.rules"
+
+alerting:
+  alertmanagers:
+  - scheme: http
+    static_configs:
+    - targets:
+      - "alertmanager:9093"
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'node_exporter'
+    static_configs:
+      - targets: ['node_exporter:9100']
+
+  - job_name: 'fake-data-gen'
+    static_configs:
+      - targets: ['fake-prometheus-data:9091']
+
+  - job_name: 'grafana'
+    static_configs:
+      - targets: ['host.docker.internal:3000']
+
+  - job_name: 'prometheus-random-data'
+    static_configs:
+      - targets: ['prometheus-random-data:8080']
+
+  # - job_name: 'grafana-test-datasource'
+  #   metrics_path: /metrics/plugins/grafana-test-datasource
+  #   static_configs:
+  #     - targets: ['host.docker.internal:3000']

--- a/devenv/docker/blocks/prometheus-2.1.0/Dockerfile
+++ b/devenv/docker/blocks/prometheus-2.1.0/Dockerfile
@@ -1,0 +1,4 @@
+FROM prom/prometheus:v2.1.0
+ADD prometheus.yml /etc/prometheus/
+ADD recording.yml /etc/prometheus/
+ADD alert.yml /etc/prometheus/

--- a/devenv/docker/blocks/prometheus-2.1.0/alert.yml
+++ b/devenv/docker/blocks/prometheus-2.1.0/alert.yml
@@ -1,0 +1,11 @@
+groups:
+  - name: ALERT
+    rules:
+    - alert: AppCrash
+      expr: process_open_fds > 0
+      for: 15s
+      labels:
+        severity: critical
+      annotations:
+        summary: Number of open fds > 0
+        description: Just testing

--- a/devenv/docker/blocks/prometheus-2.1.0/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus-2.1.0/docker-compose.yaml
@@ -1,0 +1,11 @@
+  prometheus-2.1.0:
+    build: docker/blocks/prometheus-2.1.0
+    ports:
+      - "19092:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      --config.file=/etc/prometheus/prometheus.yml
+      --storage.tsdb.path=/prometheus
+      --web.console.libraries=/usr/share/prometheus/console_libraries
+      --web.console.templates=/usr/share/prometheus/consoles

--- a/devenv/docker/blocks/prometheus-2.1.0/prometheus.yml
+++ b/devenv/docker/blocks/prometheus-2.1.0/prometheus.yml
@@ -1,0 +1,44 @@
+# my global config
+global:
+  scrape_interval:     10s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 10s # By default, scrape targets every 15 seconds.
+  # scrape_timeout is set to the global default (10s).
+
+# Load and evaluate rules in this file every 'evaluation_interval' seconds.
+rule_files:
+  - "alert.yml"
+  - "recording.yml"
+# - "second.rules"
+
+alerting:
+  alertmanagers:
+  - scheme: http
+    static_configs:
+    - targets:
+      - "alertmanager:9093"
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'node_exporter'
+    static_configs:
+      - targets: ['node_exporter:9100']
+
+  - job_name: 'fake-data-gen'
+    static_configs:
+      - targets: ['fake-prometheus-data:9091']
+
+  - job_name: 'grafana'
+    static_configs:
+      - targets: ['host.docker.internal:3000']
+
+  - job_name: 'prometheus-random-data'
+    static_configs:
+      - targets: ['prometheus-random-data:8080']
+
+  # - job_name: 'grafana-test-datasource'
+  #   metrics_path: /metrics/plugins/grafana-test-datasource
+  #   static_configs:
+  #     - targets: ['host.docker.internal:3000']

--- a/devenv/docker/blocks/prometheus-2.1.0/recording.yml
+++ b/devenv/docker/blocks/prometheus-2.1.0/recording.yml
@@ -1,0 +1,16 @@
+groups:
+  - name: RECORDING_RULES
+    rules:
+      - record: instance_path:requests:rate5m
+        expr: rate(prometheus_http_requests_total{job="prometheus"}[5m])
+      - record: path:requests:rate5m
+        expr: sum without (instance)(instance_path:requests:rate5m{job="prometheus"})
+      - record: instance_path:reloads_failures:rate5m
+        expr: rate(prometheus_tsdb_reloads_failures_total{job="prometheus"}[5m])
+      - record: instance_path:reloads:rate5m
+        expr: rate(prometheus_tsdb_reloads_total{job="prometheus"}[5m])
+      - record: instance_path:request_failures_per_requests:ratio_rate5m
+        expr: |2
+            instance_path:reloads_failures:rate5m{job="prometheus"}
+          /
+            instance_path:reloads:rate5m{job="prometheus"}

--- a/devenv/docker/blocks/prometheus-2.12.0/Dockerfile
+++ b/devenv/docker/blocks/prometheus-2.12.0/Dockerfile
@@ -1,0 +1,4 @@
+FROM prom/prometheus:v2.12.0
+ADD prometheus.yml /etc/prometheus/
+ADD recording.yml /etc/prometheus/
+ADD alert.yml /etc/prometheus/

--- a/devenv/docker/blocks/prometheus-2.12.0/alert.yml
+++ b/devenv/docker/blocks/prometheus-2.12.0/alert.yml
@@ -1,0 +1,11 @@
+groups:
+  - name: ALERT
+    rules:
+    - alert: AppCrash
+      expr: process_open_fds > 0
+      for: 15s
+      labels:
+        severity: critical
+      annotations:
+        summary: Number of open fds > 0
+        description: Just testing

--- a/devenv/docker/blocks/prometheus-2.12.0/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus-2.12.0/docker-compose.yaml
@@ -1,0 +1,11 @@
+  prometheus-2.12.0:
+    build: docker/blocks/prometheus-2.12.0
+    ports:
+      - "19093:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      --config.file=/etc/prometheus/prometheus.yml
+      --storage.tsdb.path=/prometheus
+      --web.console.libraries=/usr/share/prometheus/console_libraries
+      --web.console.templates=/usr/share/prometheus/consoles

--- a/devenv/docker/blocks/prometheus-2.12.0/prometheus.yml
+++ b/devenv/docker/blocks/prometheus-2.12.0/prometheus.yml
@@ -1,0 +1,44 @@
+# my global config
+global:
+  scrape_interval:     10s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 10s # By default, scrape targets every 15 seconds.
+  # scrape_timeout is set to the global default (10s).
+
+# Load and evaluate rules in this file every 'evaluation_interval' seconds.
+rule_files:
+  - "alert.yml"
+  - "recording.yml"
+# - "second.rules"
+
+alerting:
+  alertmanagers:
+  - scheme: http
+    static_configs:
+    - targets:
+      - "alertmanager:9093"
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'node_exporter'
+    static_configs:
+      - targets: ['node_exporter:9100']
+
+  - job_name: 'fake-data-gen'
+    static_configs:
+      - targets: ['fake-prometheus-data:9091']
+
+  - job_name: 'grafana'
+    static_configs:
+      - targets: ['host.docker.internal:3000']
+
+  - job_name: 'prometheus-random-data'
+    static_configs:
+      - targets: ['prometheus-random-data:8080']
+
+  # - job_name: 'grafana-test-datasource'
+  #   metrics_path: /metrics/plugins/grafana-test-datasource
+  #   static_configs:
+  #     - targets: ['host.docker.internal:3000']

--- a/devenv/docker/blocks/prometheus-2.12.0/recording.yml
+++ b/devenv/docker/blocks/prometheus-2.12.0/recording.yml
@@ -1,0 +1,16 @@
+groups:
+  - name: RECORDING_RULES
+    rules:
+      - record: instance_path:requests:rate5m
+        expr: rate(prometheus_http_requests_total{job="prometheus"}[5m])
+      - record: path:requests:rate5m
+        expr: sum without (instance)(instance_path:requests:rate5m{job="prometheus"})
+      - record: instance_path:reloads_failures:rate5m
+        expr: rate(prometheus_tsdb_reloads_failures_total{job="prometheus"}[5m])
+      - record: instance_path:reloads:rate5m
+        expr: rate(prometheus_tsdb_reloads_total{job="prometheus"}[5m])
+      - record: instance_path:request_failures_per_requests:ratio_rate5m
+        expr: |2
+            instance_path:reloads_failures:rate5m{job="prometheus"}
+          /
+            instance_path:reloads:rate5m{job="prometheus"}

--- a/devenv/docker/blocks/prometheus-2.15.2/Dockerfile
+++ b/devenv/docker/blocks/prometheus-2.15.2/Dockerfile
@@ -1,0 +1,4 @@
+FROM prom/prometheus:v2.15.2
+ADD prometheus.yml /etc/prometheus/
+ADD recording.yml /etc/prometheus/
+ADD alert.yml /etc/prometheus/

--- a/devenv/docker/blocks/prometheus-2.15.2/alert.yml
+++ b/devenv/docker/blocks/prometheus-2.15.2/alert.yml
@@ -1,0 +1,11 @@
+groups:
+  - name: ALERT
+    rules:
+    - alert: AppCrash
+      expr: process_open_fds > 0
+      for: 15s
+      labels:
+        severity: critical
+      annotations:
+        summary: Number of open fds > 0
+        description: Just testing

--- a/devenv/docker/blocks/prometheus-2.15.2/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus-2.15.2/docker-compose.yaml
@@ -1,0 +1,11 @@
+  prometheus-2.15.2:
+    build: docker/blocks/prometheus-2.15.2
+    ports:
+      - "19090:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      --config.file=/etc/prometheus/prometheus.yml
+      --storage.tsdb.path=/prometheus
+      --web.console.libraries=/usr/share/prometheus/console_libraries
+      --web.console.templates=/usr/share/prometheus/consoles

--- a/devenv/docker/blocks/prometheus-2.15.2/prometheus.yml
+++ b/devenv/docker/blocks/prometheus-2.15.2/prometheus.yml
@@ -1,0 +1,44 @@
+# my global config
+global:
+  scrape_interval:     10s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 10s # By default, scrape targets every 15 seconds.
+  # scrape_timeout is set to the global default (10s).
+
+# Load and evaluate rules in this file every 'evaluation_interval' seconds.
+rule_files:
+  - "alert.yml"
+  - "recording.yml"
+# - "second.rules"
+
+alerting:
+  alertmanagers:
+  - scheme: http
+    static_configs:
+    - targets:
+      - "alertmanager:9093"
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'node_exporter'
+    static_configs:
+      - targets: ['node_exporter:9100']
+
+  - job_name: 'fake-data-gen'
+    static_configs:
+      - targets: ['fake-prometheus-data:9091']
+
+  - job_name: 'grafana'
+    static_configs:
+      - targets: ['host.docker.internal:3000']
+
+  - job_name: 'prometheus-random-data'
+    static_configs:
+      - targets: ['prometheus-random-data:8080']
+
+  # - job_name: 'grafana-test-datasource'
+  #   metrics_path: /metrics/plugins/grafana-test-datasource
+  #   static_configs:
+  #     - targets: ['host.docker.internal:3000']

--- a/devenv/docker/blocks/prometheus-2.15.2/recording.yml
+++ b/devenv/docker/blocks/prometheus-2.15.2/recording.yml
@@ -1,0 +1,16 @@
+groups:
+  - name: RECORDING_RULES
+    rules:
+      - record: instance_path:requests:rate5m
+        expr: rate(prometheus_http_requests_total{job="prometheus"}[5m])
+      - record: path:requests:rate5m
+        expr: sum without (instance)(instance_path:requests:rate5m{job="prometheus"})
+      - record: instance_path:reloads_failures:rate5m
+        expr: rate(prometheus_tsdb_reloads_failures_total{job="prometheus"}[5m])
+      - record: instance_path:reloads:rate5m
+        expr: rate(prometheus_tsdb_reloads_total{job="prometheus"}[5m])
+      - record: instance_path:request_failures_per_requests:ratio_rate5m
+        expr: |2
+            instance_path:reloads_failures:rate5m{job="prometheus"}
+          /
+            instance_path:reloads:rate5m{job="prometheus"}

--- a/devenv/docker/blocks/prometheus-2.18.0/Dockerfile
+++ b/devenv/docker/blocks/prometheus-2.18.0/Dockerfile
@@ -1,0 +1,4 @@
+FROM prom/prometheus:v2.18.0
+ADD prometheus.yml /etc/prometheus/
+ADD recording.yml /etc/prometheus/
+ADD alert.yml /etc/prometheus/

--- a/devenv/docker/blocks/prometheus-2.18.0/alert.yml
+++ b/devenv/docker/blocks/prometheus-2.18.0/alert.yml
@@ -1,0 +1,11 @@
+groups:
+  - name: ALERT
+    rules:
+    - alert: AppCrash
+      expr: process_open_fds > 0
+      for: 15s
+      labels:
+        severity: critical
+      annotations:
+        summary: Number of open fds > 0
+        description: Just testing

--- a/devenv/docker/blocks/prometheus-2.18.0/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus-2.18.0/docker-compose.yaml
@@ -1,0 +1,11 @@
+  prometheus-2.18.0:
+    build: docker/blocks/prometheus-2.18.0
+    ports:
+      - "19095:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      --config.file=/etc/prometheus/prometheus.yml
+      --storage.tsdb.path=/prometheus
+      --web.console.libraries=/usr/share/prometheus/console_libraries
+      --web.console.templates=/usr/share/prometheus/consoles

--- a/devenv/docker/blocks/prometheus-2.18.0/prometheus.yml
+++ b/devenv/docker/blocks/prometheus-2.18.0/prometheus.yml
@@ -1,0 +1,44 @@
+# my global config
+global:
+  scrape_interval:     10s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 10s # By default, scrape targets every 15 seconds.
+  # scrape_timeout is set to the global default (10s).
+
+# Load and evaluate rules in this file every 'evaluation_interval' seconds.
+rule_files:
+  - "alert.yml"
+  - "recording.yml"
+# - "second.rules"
+
+alerting:
+  alertmanagers:
+  - scheme: http
+    static_configs:
+    - targets:
+      - "alertmanager:9093"
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'node_exporter'
+    static_configs:
+      - targets: ['node_exporter:9100']
+
+  - job_name: 'fake-data-gen'
+    static_configs:
+      - targets: ['fake-prometheus-data:9091']
+
+  - job_name: 'grafana'
+    static_configs:
+      - targets: ['host.docker.internal:3000']
+
+  - job_name: 'prometheus-random-data'
+    static_configs:
+      - targets: ['prometheus-random-data:8080']
+
+  # - job_name: 'grafana-test-datasource'
+  #   metrics_path: /metrics/plugins/grafana-test-datasource
+  #   static_configs:
+  #     - targets: ['host.docker.internal:3000']

--- a/devenv/docker/blocks/prometheus-2.18.0/recording.yml
+++ b/devenv/docker/blocks/prometheus-2.18.0/recording.yml
@@ -1,0 +1,16 @@
+groups:
+  - name: RECORDING_RULES
+    rules:
+      - record: instance_path:requests:rate5m
+        expr: rate(prometheus_http_requests_total{job="prometheus"}[5m])
+      - record: path:requests:rate5m
+        expr: sum without (instance)(instance_path:requests:rate5m{job="prometheus"})
+      - record: instance_path:reloads_failures:rate5m
+        expr: rate(prometheus_tsdb_reloads_failures_total{job="prometheus"}[5m])
+      - record: instance_path:reloads:rate5m
+        expr: rate(prometheus_tsdb_reloads_total{job="prometheus"}[5m])
+      - record: instance_path:request_failures_per_requests:ratio_rate5m
+        expr: |2
+            instance_path:reloads_failures:rate5m{job="prometheus"}
+          /
+            instance_path:reloads:rate5m{job="prometheus"}

--- a/devenv/docker/blocks/prometheus-2.20.0/Dockerfile
+++ b/devenv/docker/blocks/prometheus-2.20.0/Dockerfile
@@ -1,0 +1,4 @@
+FROM prom/prometheus:v2.20.0
+ADD prometheus.yml /etc/prometheus/
+ADD recording.yml /etc/prometheus/
+ADD alert.yml /etc/prometheus/

--- a/devenv/docker/blocks/prometheus-2.20.0/alert.yml
+++ b/devenv/docker/blocks/prometheus-2.20.0/alert.yml
@@ -1,0 +1,11 @@
+groups:
+  - name: ALERT
+    rules:
+    - alert: AppCrash
+      expr: process_open_fds > 0
+      for: 15s
+      labels:
+        severity: critical
+      annotations:
+        summary: Number of open fds > 0
+        description: Just testing

--- a/devenv/docker/blocks/prometheus-2.20.0/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus-2.20.0/docker-compose.yaml
@@ -1,0 +1,11 @@
+  prometheus-2.20.0:
+    build: docker/blocks/prometheus-2.20.0
+    ports:
+      - "19096:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      --config.file=/etc/prometheus/prometheus.yml
+      --storage.tsdb.path=/prometheus
+      --web.console.libraries=/usr/share/prometheus/console_libraries
+      --web.console.templates=/usr/share/prometheus/consoles

--- a/devenv/docker/blocks/prometheus-2.20.0/prometheus.yml
+++ b/devenv/docker/blocks/prometheus-2.20.0/prometheus.yml
@@ -1,0 +1,44 @@
+# my global config
+global:
+  scrape_interval:     10s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 10s # By default, scrape targets every 15 seconds.
+  # scrape_timeout is set to the global default (10s).
+
+# Load and evaluate rules in this file every 'evaluation_interval' seconds.
+rule_files:
+  - "alert.yml"
+  - "recording.yml"
+# - "second.rules"
+
+alerting:
+  alertmanagers:
+  - scheme: http
+    static_configs:
+    - targets:
+      - "alertmanager:9093"
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'node_exporter'
+    static_configs:
+      - targets: ['node_exporter:9100']
+
+  - job_name: 'fake-data-gen'
+    static_configs:
+      - targets: ['fake-prometheus-data:9091']
+
+  - job_name: 'grafana'
+    static_configs:
+      - targets: ['host.docker.internal:3000']
+
+  - job_name: 'prometheus-random-data'
+    static_configs:
+      - targets: ['prometheus-random-data:8080']
+
+  # - job_name: 'grafana-test-datasource'
+  #   metrics_path: /metrics/plugins/grafana-test-datasource
+  #   static_configs:
+  #     - targets: ['host.docker.internal:3000']

--- a/devenv/docker/blocks/prometheus-2.20.0/recording.yml
+++ b/devenv/docker/blocks/prometheus-2.20.0/recording.yml
@@ -1,0 +1,16 @@
+groups:
+  - name: RECORDING_RULES
+    rules:
+      - record: instance_path:requests:rate5m
+        expr: rate(prometheus_http_requests_total{job="prometheus"}[5m])
+      - record: path:requests:rate5m
+        expr: sum without (instance)(instance_path:requests:rate5m{job="prometheus"})
+      - record: instance_path:reloads_failures:rate5m
+        expr: rate(prometheus_tsdb_reloads_failures_total{job="prometheus"}[5m])
+      - record: instance_path:reloads:rate5m
+        expr: rate(prometheus_tsdb_reloads_total{job="prometheus"}[5m])
+      - record: instance_path:request_failures_per_requests:ratio_rate5m
+        expr: |2
+            instance_path:reloads_failures:rate5m{job="prometheus"}
+          /
+            instance_path:reloads:rate5m{job="prometheus"}

--- a/devenv/docker/blocks/prometheus-2.23.0/Dockerfile
+++ b/devenv/docker/blocks/prometheus-2.23.0/Dockerfile
@@ -1,0 +1,4 @@
+FROM prom/prometheus:v2.23.0
+ADD prometheus.yml /etc/prometheus/
+ADD recording.yml /etc/prometheus/
+ADD alert.yml /etc/prometheus/

--- a/devenv/docker/blocks/prometheus-2.23.0/alert.yml
+++ b/devenv/docker/blocks/prometheus-2.23.0/alert.yml
@@ -1,0 +1,11 @@
+groups:
+  - name: ALERT
+    rules:
+    - alert: AppCrash
+      expr: process_open_fds > 0
+      for: 15s
+      labels:
+        severity: critical
+      annotations:
+        summary: Number of open fds > 0
+        description: Just testing

--- a/devenv/docker/blocks/prometheus-2.23.0/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus-2.23.0/docker-compose.yaml
@@ -1,0 +1,11 @@
+  prometheus-2.23.0:
+    build: docker/blocks/prometheus-2.23.0
+    ports:
+      - "19097:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      --config.file=/etc/prometheus/prometheus.yml
+      --storage.tsdb.path=/prometheus
+      --web.console.libraries=/usr/share/prometheus/console_libraries
+      --web.console.templates=/usr/share/prometheus/consoles

--- a/devenv/docker/blocks/prometheus-2.23.0/prometheus.yml
+++ b/devenv/docker/blocks/prometheus-2.23.0/prometheus.yml
@@ -1,0 +1,44 @@
+# my global config
+global:
+  scrape_interval:     10s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 10s # By default, scrape targets every 15 seconds.
+  # scrape_timeout is set to the global default (10s).
+
+# Load and evaluate rules in this file every 'evaluation_interval' seconds.
+rule_files:
+  - "alert.yml"
+  - "recording.yml"
+# - "second.rules"
+
+alerting:
+  alertmanagers:
+  - scheme: http
+    static_configs:
+    - targets:
+      - "alertmanager:9093"
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'node_exporter'
+    static_configs:
+      - targets: ['node_exporter:9100']
+
+  - job_name: 'fake-data-gen'
+    static_configs:
+      - targets: ['fake-prometheus-data:9091']
+
+  - job_name: 'grafana'
+    static_configs:
+      - targets: ['host.docker.internal:3000']
+
+  - job_name: 'prometheus-random-data'
+    static_configs:
+      - targets: ['prometheus-random-data:8080']
+
+  # - job_name: 'grafana-test-datasource'
+  #   metrics_path: /metrics/plugins/grafana-test-datasource
+  #   static_configs:
+  #     - targets: ['host.docker.internal:3000']

--- a/devenv/docker/blocks/prometheus-2.23.0/recording.yml
+++ b/devenv/docker/blocks/prometheus-2.23.0/recording.yml
@@ -1,0 +1,16 @@
+groups:
+  - name: RECORDING_RULES
+    rules:
+      - record: instance_path:requests:rate5m
+        expr: rate(prometheus_http_requests_total{job="prometheus"}[5m])
+      - record: path:requests:rate5m
+        expr: sum without (instance)(instance_path:requests:rate5m{job="prometheus"})
+      - record: instance_path:reloads_failures:rate5m
+        expr: rate(prometheus_tsdb_reloads_failures_total{job="prometheus"}[5m])
+      - record: instance_path:reloads:rate5m
+        expr: rate(prometheus_tsdb_reloads_total{job="prometheus"}[5m])
+      - record: instance_path:request_failures_per_requests:ratio_rate5m
+        expr: |2
+            instance_path:reloads_failures:rate5m{job="prometheus"}
+          /
+            instance_path:reloads:rate5m{job="prometheus"}

--- a/devenv/docker/blocks/prometheus-2.29.0/Dockerfile
+++ b/devenv/docker/blocks/prometheus-2.29.0/Dockerfile
@@ -1,0 +1,4 @@
+FROM prom/prometheus:v2.29.0
+ADD prometheus.yml /etc/prometheus/
+ADD recording.yml /etc/prometheus/
+ADD alert.yml /etc/prometheus/

--- a/devenv/docker/blocks/prometheus-2.29.0/alert.yml
+++ b/devenv/docker/blocks/prometheus-2.29.0/alert.yml
@@ -1,0 +1,11 @@
+groups:
+  - name: ALERT
+    rules:
+    - alert: AppCrash
+      expr: process_open_fds > 0
+      for: 15s
+      labels:
+        severity: critical
+      annotations:
+        summary: Number of open fds > 0
+        description: Just testing

--- a/devenv/docker/blocks/prometheus-2.29.0/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus-2.29.0/docker-compose.yaml
@@ -1,0 +1,11 @@
+  prometheus-2.29.0:
+    build: docker/blocks/prometheus-2.29.0
+    ports:
+      - "19098:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      --config.file=/etc/prometheus/prometheus.yml
+      --storage.tsdb.path=/prometheus
+      --web.console.libraries=/usr/share/prometheus/console_libraries
+      --web.console.templates=/usr/share/prometheus/consoles

--- a/devenv/docker/blocks/prometheus-2.29.0/prometheus.yml
+++ b/devenv/docker/blocks/prometheus-2.29.0/prometheus.yml
@@ -1,0 +1,44 @@
+# my global config
+global:
+  scrape_interval:     10s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 10s # By default, scrape targets every 15 seconds.
+  # scrape_timeout is set to the global default (10s).
+
+# Load and evaluate rules in this file every 'evaluation_interval' seconds.
+rule_files:
+  - "alert.yml"
+  - "recording.yml"
+# - "second.rules"
+
+alerting:
+  alertmanagers:
+  - scheme: http
+    static_configs:
+    - targets:
+      - "alertmanager:9093"
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'node_exporter'
+    static_configs:
+      - targets: ['node_exporter:9100']
+
+  - job_name: 'fake-data-gen'
+    static_configs:
+      - targets: ['fake-prometheus-data:9091']
+
+  - job_name: 'grafana'
+    static_configs:
+      - targets: ['host.docker.internal:3000']
+
+  - job_name: 'prometheus-random-data'
+    static_configs:
+      - targets: ['prometheus-random-data:8080']
+
+  # - job_name: 'grafana-test-datasource'
+  #   metrics_path: /metrics/plugins/grafana-test-datasource
+  #   static_configs:
+  #     - targets: ['host.docker.internal:3000']

--- a/devenv/docker/blocks/prometheus-2.29.0/recording.yml
+++ b/devenv/docker/blocks/prometheus-2.29.0/recording.yml
@@ -1,0 +1,16 @@
+groups:
+  - name: RECORDING_RULES
+    rules:
+      - record: instance_path:requests:rate5m
+        expr: rate(prometheus_http_requests_total{job="prometheus"}[5m])
+      - record: path:requests:rate5m
+        expr: sum without (instance)(instance_path:requests:rate5m{job="prometheus"})
+      - record: instance_path:reloads_failures:rate5m
+        expr: rate(prometheus_tsdb_reloads_failures_total{job="prometheus"}[5m])
+      - record: instance_path:reloads:rate5m
+        expr: rate(prometheus_tsdb_reloads_total{job="prometheus"}[5m])
+      - record: instance_path:request_failures_per_requests:ratio_rate5m
+        expr: |2
+            instance_path:reloads_failures:rate5m{job="prometheus"}
+          /
+            instance_path:reloads:rate5m{job="prometheus"}

--- a/devenv/docker/blocks/prometheus-2.33.1/Dockerfile
+++ b/devenv/docker/blocks/prometheus-2.33.1/Dockerfile
@@ -1,0 +1,4 @@
+FROM prom/prometheus:v2.33.1
+ADD prometheus.yml /etc/prometheus/
+ADD recording.yml /etc/prometheus/
+ADD alert.yml /etc/prometheus/

--- a/devenv/docker/blocks/prometheus-2.33.1/alert.yml
+++ b/devenv/docker/blocks/prometheus-2.33.1/alert.yml
@@ -1,0 +1,11 @@
+groups:
+  - name: ALERT
+    rules:
+    - alert: AppCrash
+      expr: process_open_fds > 0
+      for: 15s
+      labels:
+        severity: critical
+      annotations:
+        summary: Number of open fds > 0
+        description: Just testing

--- a/devenv/docker/blocks/prometheus-2.33.1/docker-compose.yaml
+++ b/devenv/docker/blocks/prometheus-2.33.1/docker-compose.yaml
@@ -1,0 +1,11 @@
+  prometheus-2.31.1:
+    build: docker/blocks/prometheus-2.33.1
+    ports:
+      - "19099:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    command: >
+      --config.file=/etc/prometheus/prometheus.yml
+      --storage.tsdb.path=/prometheus
+      --web.console.libraries=/usr/share/prometheus/console_libraries
+      --web.console.templates=/usr/share/prometheus/consoles

--- a/devenv/docker/blocks/prometheus-2.33.1/prometheus.yml
+++ b/devenv/docker/blocks/prometheus-2.33.1/prometheus.yml
@@ -1,0 +1,44 @@
+# my global config
+global:
+  scrape_interval:     10s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 10s # By default, scrape targets every 15 seconds.
+  # scrape_timeout is set to the global default (10s).
+
+# Load and evaluate rules in this file every 'evaluation_interval' seconds.
+rule_files:
+  - "alert.yml"
+  - "recording.yml"
+# - "second.rules"
+
+alerting:
+  alertmanagers:
+  - scheme: http
+    static_configs:
+    - targets:
+      - "alertmanager:9093"
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'node_exporter'
+    static_configs:
+      - targets: ['node_exporter:9100']
+
+  - job_name: 'fake-data-gen'
+    static_configs:
+      - targets: ['fake-prometheus-data:9091']
+
+  - job_name: 'grafana'
+    static_configs:
+      - targets: ['host.docker.internal:3000']
+
+  - job_name: 'prometheus-random-data'
+    static_configs:
+      - targets: ['prometheus-random-data:8080']
+
+  # - job_name: 'grafana-test-datasource'
+  #   metrics_path: /metrics/plugins/grafana-test-datasource
+  #   static_configs:
+  #     - targets: ['host.docker.internal:3000']

--- a/devenv/docker/blocks/prometheus-2.33.1/recording.yml
+++ b/devenv/docker/blocks/prometheus-2.33.1/recording.yml
@@ -1,0 +1,16 @@
+groups:
+  - name: RECORDING_RULES
+    rules:
+      - record: instance_path:requests:rate5m
+        expr: rate(prometheus_http_requests_total{job="prometheus"}[5m])
+      - record: path:requests:rate5m
+        expr: sum without (instance)(instance_path:requests:rate5m{job="prometheus"})
+      - record: instance_path:reloads_failures:rate5m
+        expr: rate(prometheus_tsdb_reloads_failures_total{job="prometheus"}[5m])
+      - record: instance_path:reloads:rate5m
+        expr: rate(prometheus_tsdb_reloads_total{job="prometheus"}[5m])
+      - record: instance_path:request_failures_per_requests:ratio_rate5m
+        expr: |2
+            instance_path:reloads_failures:rate5m{job="prometheus"}
+          /
+            instance_path:reloads:rate5m{job="prometheus"}


### PR DESCRIPTION
I'm pretty sure we don't want to merge all this duplicate markup, but I figured I'd document some examples of how we can stand up a bunch of different prometheus versions (all sharing the same data) for local development.

Usage: `make devenv sources=prometheus,prometheus-2.15.2,prometheus-1.8.1,prometheus-2.1.0,prometheus-2.12.0,prometheus-2.18.0,prometheus-2.20.0,prometheus-2.23.0,prometheus-2.33.1`

Couple of issues with the approach here.
  1. You have to run the current prometheus version alongside whatever versions 
  2. I couldn't build any of the docker containers older then 1.8 on my M1 mac, so that's the oldest version included
  3. Alerting and recording rules were not included in 1.8.1 (it didn't work so I deleted it, still works as a data source for graphs though 🤷 )
