### PR TITLE
Tracing: Add new [tracing.opentelemetry] custom_attributes config setting

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1028,6 +1028,11 @@ zipkin_propagation = false
 # Not disabling is the most common setting when using Zipkin elsewhere in your infrastructure.
 disable_shared_zipkin_spans = false
 
+[tracing.opentelemetry]
+
+# attributes that will always be included in when creating new spans. ex (key1:value1,key2:value2)
+custom_attribs =
+
 [tracing.opentelemetry.jaeger]
 # jaeger destination (ex http://localhost:14268/api/traces)
 address =

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1031,7 +1031,7 @@ disable_shared_zipkin_spans = false
 [tracing.opentelemetry]
 
 # attributes that will always be included in when creating new spans. ex (key1:value1,key2:value2)
-custom_attribs =
+custom_attributes =
 
 [tracing.opentelemetry.jaeger]
 # jaeger destination (ex http://localhost:14268/api/traces)

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -992,6 +992,10 @@
 # Not disabling is the most common setting when using Zipkin elsewhere in your infrastructure.
 ;disable_shared_zipkin_spans = false
 
+[tracing.opentelemetry]
+# attributes that will always be included in when creating new spans. ex (key1:value1,key2:value2)
+;custom_attribs = key1:value1,key2:value2
+
 [tracing.opentelemetry.jaeger]
 # jaeger destination (ex http://localhost:14268/api/traces)
 ; address = http://localhost:14268/api/traces

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -994,7 +994,7 @@
 
 [tracing.opentelemetry]
 # attributes that will always be included in when creating new spans. ex (key1:value1,key2:value2)
-;custom_attribs = key1:value1,key2:value2
+;custom_attributes = key1:value1,key2:value2
 
 [tracing.opentelemetry.jaeger]
 # jaeger destination (ex http://localhost:14268/api/traces)

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1566,6 +1566,18 @@ Setting this to `true` turns off shared RPC spans. Leaving this available is the
 
 <hr>
 
+## [tracing.opentelemetry]
+
+Configure general parameters shared between OpenTelemetry providers.
+
+### custom_attributes
+
+Comma-separated list of attributes to include in all new spans, such as `key1:value1,key2:value2`.
+
+Can be set with the environment variable `OTEL_RESOURCE_ATTRIBUTES` (use `=` instead of `:` with the environment variable).
+
+<hr>
+
 ## [tracing.opentelemetry.jaeger]
 
 Configure Grafana's Jaeger client for distributed tracing.

--- a/pkg/infra/tracing/optentelemetry_tracing_test.go
+++ b/pkg/infra/tracing/optentelemetry_tracing_test.go
@@ -1,0 +1,76 @@
+package tracing
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestSplitCustomAttribs(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []attribute.KeyValue
+	}{
+		{
+			input:    "key1:value:1",
+			expected: []attribute.KeyValue{attribute.String("key1", "value:1")},
+		},
+		{
+			input: "key1:value1,key2:value2",
+			expected: []attribute.KeyValue{
+				attribute.String("key1", "value1"),
+				attribute.String("key2", "value2"),
+			},
+		},
+		{
+			input:    "",
+			expected: []attribute.KeyValue{},
+		},
+		{
+			input:    "key1",
+			expected: []attribute.KeyValue{},
+		},
+	}
+
+	for _, test := range tests {
+		attribs := splitCustomAttribs(test.input)
+		assert.EqualValues(t, test.expected, attribs)
+	}
+}
+
+func TestOptentelemetry_ParseSettingsOpentelemetry(t *testing.T) {
+	cfg := setting.NewCfg()
+	otel := &Opentelemetry{Cfg: cfg}
+
+	otelsect := cfg.Raw.Section("tracing.opentelemetry")
+	jaegersect := cfg.Raw.Section("tracing.opentelemetry.jaeger")
+	otlpsect := cfg.Raw.Section("tracing.opentelemetry.otlp")
+
+	assert.NoError(t, otel.parseSettingsOpentelemetry())
+	assert.Equal(t, noopExporter, otel.enabled)
+
+	otelsect.Key("custom_attributes")
+	assert.NoError(t, otel.parseSettingsOpentelemetry())
+	assert.Empty(t, otel.customAttribs)
+
+	otelsect.Key("custom_attributes").SetValue("key1:value1,key2:value2")
+	assert.NoError(t, otel.parseSettingsOpentelemetry())
+	expected := []attribute.KeyValue{
+		attribute.String("key1", "value1"),
+		attribute.String("key2", "value2"),
+	}
+	assert.Equal(t, expected, otel.customAttribs)
+
+	jaegersect.Key("address").SetValue("somehost:6831")
+	assert.NoError(t, otel.parseSettingsOpentelemetry())
+	assert.Equal(t, "somehost:6831", otel.address)
+	assert.Equal(t, jaegerExporter, otel.enabled)
+
+	jaegersect.Key("address").SetValue("")
+	otlpsect.Key("address").SetValue("somehost:4317")
+	assert.NoError(t, otel.parseSettingsOpentelemetry())
+	assert.Equal(t, "somehost:4317", otel.address)
+	assert.Equal(t, otlpExporter, otel.enabled)
+}

--- a/pkg/infra/tracing/optentelemetry_tracing_test.go
+++ b/pkg/infra/tracing/optentelemetry_tracing_test.go
@@ -28,15 +28,27 @@ func TestSplitCustomAttribs(t *testing.T) {
 			input:    "",
 			expected: []attribute.KeyValue{},
 		},
-		{
-			input:    "key1",
-			expected: []attribute.KeyValue{},
-		},
 	}
 
 	for _, test := range tests {
-		attribs := splitCustomAttribs(test.input)
+		attribs, err := splitCustomAttribs(test.input)
+		assert.NoError(t, err)
 		assert.EqualValues(t, test.expected, attribs)
+	}
+}
+
+func TestSplitCustomAttribs_Malformed(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []attribute.KeyValue
+	}{
+		{input: "key1=value1"},
+		{input: "key1"},
+	}
+
+	for _, test := range tests {
+		_, err := splitCustomAttribs(test.input)
+		assert.Error(t, err)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new config section `tracing.opentelemetry` with item `custom_attributes` to allow setting custom key:value pairs for OTel traces.

This is the equivalent of the `always_included_tag` setting in `tracing.jaeger`, but I named it `custom_attributes` since I thought that name describes a bit better what it does.

**Which issue(s) this PR fixes**:

Fixes #54037

**Special notes for your reviewer**:

_If possible_ I'd like to backport this to 9.1.x, but I'm not sure if adding new config items is allowed in a patch release...

Signed-off-by: Dave Henderson <dave.henderson@grafana.com>