### PR TITLE
Provisioning Contact points: Support disableResolveMessage via YAML

### DIFF
--- a/pkg/services/provisioning/alerting/contact_point_types.go
+++ b/pkg/services/provisioning/alerting/contact_point_types.go
@@ -68,7 +68,7 @@ type ReceiverV1 struct {
 	UID                   values.StringValue `json:"uid" yaml:"uid"`
 	Type                  values.StringValue `json:"type" yaml:"type"`
 	Settings              values.JSONValue   `json:"settings" yaml:"settings"`
-	DisableResolveMessage values.BoolValue   `json:"disableResolveMessage"`
+	DisableResolveMessage values.BoolValue   `json:"disableResolveMessage" yaml:"disableResolveMessage"`
 }
 
 func (config *ReceiverV1) mapToModel(name string) (definitions.EmbeddedContactPoint, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows provisioning of disableResolveMessage in Contact Points via YAML, reduces the gap of provisioning options between JSON and YAML.

**Which issue(s) this PR fixes**:
Fixes #54121 