### PR TITLE
CI: Trigger backend tests on `devenv/**` changes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -233,6 +233,7 @@ trigger:
     - go.sum
     - go.mod
     - public/app/plugins/**/plugin.json
+    - devenv/**
 type: docker
 volumes:
 - host:
@@ -5174,6 +5175,6 @@ kind: secret
 name: gcp_upload_artifacts_key
 ---
 kind: signature
-hmac: 4922e4495148755ec45cf230190acbd7f7b564c831d98e10697381dda5cb75ef
+hmac: 011db54ea09dbe5c8e9add487b5b1d46b1bbcefa480efc55c52c4cb2bcf084a2
 
 ...

--- a/scripts/drone/events/pr.star
+++ b/scripts/drone/events/pr.star
@@ -53,7 +53,7 @@ def pr_pipelines(edition):
     return [
         verify_drone(get_pr_trigger(include_paths=['scripts/drone/**', '.drone.yml', '.drone.star']), ver_mode),
         test_frontend(get_pr_trigger(exclude_paths=['pkg/**', 'packaging/**', 'go.sum', 'go.mod']), ver_mode),
-        test_backend(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json']), ver_mode),
+        test_backend(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json', 'devenv/**']), ver_mode),
         build_e2e(trigger, ver_mode, edition),
         integration_tests(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json']), ver_mode, edition),
         docs_pipelines(edition, ver_mode, trigger_docs_pr())


### PR DESCRIPTION
**What this PR does / why we need it**:
Some backend tests use files from `devenv/` directory. Currently, if those files are modified, `test-backend` pipeline doesn't run since this change is not considered to be a backend-related change.
This PR triggers `test-backend` pipeline for PRs on `devenv/**` changes, since we encountered failures on `main` branch which didn't appear on CI beforehand. 