### PR TITLE
Docs/adds cloud support disclaimer

### DIFF
--- a/docs/sources/datasources/loki.md
+++ b/docs/sources/datasources/loki.md
@@ -45,6 +45,8 @@ The Derived Fields configuration allows you to:
 
 For example, you can use this functionality to link to your tracing backend directly from your logs, or link to a user profile page if a userId is present in the log line. These links appear in the [log details]({{< relref "../explore/logs-integration/#labels-and-detected-fields" >}}).
 
+> **Note:** Grafana Cloud users can request modifications to this feature by [opening a support ticket in the Cloud Portal](https://grafana.com/profile/org#support).
+
 Each derived field consists of:
 
 - **Name -** Shown in the log details as a label.

--- a/docs/sources/datasources/tempo.md
+++ b/docs/sources/datasources/tempo.md
@@ -33,6 +33,7 @@ To access Tempo settings, click the **Configuration** (gear) icon, then click **
 ### Trace to logs
 
 > **Note:** This feature is available in Grafana 7.4+.
+> Grafana Cloud users can access this feature by [opening a support ticket in the Cloud Portal](https://grafana.com/profile/org#support).
 
 This is a configuration for the [trace to logs feature]({{< relref "../explore/trace-integration/" >}}). Select target data source (at this moment limited to Loki or Splunk \[logs\] data sources) and select which tags will be used in the logs query.
 
@@ -49,6 +50,7 @@ This is a configuration for the [trace to logs feature]({{< relref "../explore/t
 ### Trace to metrics
 
 > **Note:** This feature is behind the `traceToMetrics` feature toggle.
+> Grafana Cloud users can access this feature by [opening a support ticket in the Cloud Portal](https://grafana.com/profile/org#support).
 
 To configure trace to metrics, select the target Prometheus data source and create any desired linked queries.
 

--- a/docs/sources/whatsnew/whats-new-in-v9-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-1.md
@@ -97,6 +97,7 @@ To learn more about the Geomap panel, see the [documentation]({{< relref "../vis
 
 You can now link metrics queries to your traces.
 This feature can be accessed by enabling the `traceToMetrics` feature toggle.
+Grafana Cloud users can access this feature by opening a support ticket in the Cloud Portal.
 
 In your tracing datasource configuration, select a metrics datasource, add tags, and write your queries.
 Each query appears as a link on each span.
@@ -114,6 +115,7 @@ You can now get Application Performance Management (APM) data with Grafana.
 The data is shown in a table in the Tempo datasource under the Service Graph tab.
 To access the feature, enable the `tempoApmTable` feature toggle.
 To receive the data for the APM table, you must also enable the metrics generator.
+Grafana Cloud users can access this feature by opening a support ticket in the Cloud Portal.
 
 The APM table displays rate, errors, and duration (RED) metrics.
 To view your top five RED span metrics, use the table summary view.
@@ -132,6 +134,7 @@ To learn more about the APM table, see the [documentation]({{< relref "../dataso
 #### (Alpha) Public dashboards
 
 Public dashboards are available as an alpha feature that can be enabled with the `publicDashboards` feature toggle.
+Grafana Cloud users can access this feature by opening a support ticket in the Cloud Portal.
 
 You can generate a link for dashboards that you'd like to share publicly.
 Anyone with the link will be able to access that dashboard, and nothing else.

--- a/docs/sources/whatsnew/whats-new-in-v9-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-1.md
@@ -45,6 +45,8 @@ You can now easily embed Grafana in other applications by adding a JWT token dir
 When the JWT token is passed through the request URL to Grafana, Grafana validates and authenticates the token linked to a specific user, allowing access to dashboards which that user can view.
 To see JWT URL embedding in action, see the [sample project](https://github.com/grafana/grafana-iframe-oauth-sample).
 
+Grafana Cloud users can access this feature by [opening a support ticket in the Cloud Portal](https://grafana.com/profile/org#support).
+
 {{< figure src="/static/img/docs/dashboards/jwt-url-embedding-9-1.png" max-width="750px" caption="A JWT token used to embed Grafana" >}}
 
 #### Organization role mapping for GitHub OAuth2 authentication
@@ -52,6 +54,8 @@ To see JWT URL embedding in action, see the [sample project](https://github.com/
 You can now use GitHub OAuth2 to map users or teams to specific [Grafana organization roles]({{< relref "../administration/roles-and-permissions/#organization-roles" >}}) by using `role_attribute_path` configuration option.
 Grafana will use [JMESPath](https://jmespath.org/examples.html) for path lookup and role mapping.
 For more information, see the [documentation]({{< relref "../setup-grafana/configure-security/configure-authentication/github/#map-roles" >}}).
+
+Grafana Cloud users can access this feature by [opening a support ticket in the Cloud Portal](https://grafana.com/profile/org#support).
 
 {{< figure src="/static/img/docs/permissions/org-role-mapping-github-9-1.png" max-width="750px" caption="Configuring GitHub OAuth2 authentication with role mapping" >}}
 

--- a/docs/sources/whatsnew/whats-new-in-v9-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-1.md
@@ -97,7 +97,7 @@ To learn more about the Geomap panel, see the [documentation]({{< relref "../vis
 
 You can now link metrics queries to your traces.
 This feature can be accessed by enabling the `traceToMetrics` feature toggle.
-Grafana Cloud users can access this feature by opening a support ticket in the Cloud Portal.
+Grafana Cloud users can access this feature by [opening a support ticket in the Cloud Portal](https://grafana.com/profile/org#support).
 
 In your tracing datasource configuration, select a metrics datasource, add tags, and write your queries.
 Each query appears as a link on each span.
@@ -115,7 +115,8 @@ You can now get Application Performance Management (APM) data with Grafana.
 The data is shown in a table in the Tempo datasource under the Service Graph tab.
 To access the feature, enable the `tempoApmTable` feature toggle.
 To receive the data for the APM table, you must also enable the metrics generator.
-Grafana Cloud users can access this feature by opening a support ticket in the Cloud Portal.
+
+Grafana Cloud users can access this feature by [opening a support ticket in the Cloud Portal](https://grafana.com/profile/org#support).
 
 The APM table displays rate, errors, and duration (RED) metrics.
 To view your top five RED span metrics, use the table summary view.
@@ -134,7 +135,7 @@ To learn more about the APM table, see the [documentation]({{< relref "../dataso
 #### (Alpha) Public dashboards
 
 Public dashboards are available as an alpha feature that can be enabled with the `publicDashboards` feature toggle.
-Grafana Cloud users can access this feature by opening a support ticket in the Cloud Portal.
+Grafana Cloud users can access this feature by [opening a support ticket in the Cloud Portal](https://grafana.com/profile/org#support).
 
 You can generate a link for dashboards that you'd like to share publicly.
 Anyone with the link will be able to access that dashboard, and nothing else.


### PR DESCRIPTION
This PR adds a disclaimer to beta features that instructs cloud users to open a support ticket in order to access the feature.