### PR TITLE
Dashboards: Correctly migrate mixed data source targets

### DIFF
--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -1813,6 +1813,12 @@ describe('DashboardModel', () => {
               {
                 datasource: 'prom',
               },
+              {
+                datasource: 'default',
+              },
+              {
+                datasource: null,
+              },
             ],
           },
           {
@@ -1847,6 +1853,8 @@ describe('DashboardModel', () => {
 
     it('should update target datasource props to refs', () => {
       expect(model.panels[2].targets[0].datasource).toEqual({ type: 'prometheus', uid: 'prom-uid' });
+      expect(model.panels[2].targets[1].datasource).toEqual({ type: 'prometheus', uid: 'prom2-uid' });
+      expect(model.panels[2].targets[2].datasource).toEqual({ type: 'prometheus', uid: 'prom2-uid' });
     });
 
     it('should update datasources in panels collapsed rows', () => {

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -43,6 +43,7 @@ import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { isConstant, isMulti } from 'app/features/variables/guard';
 import { alignCurrentWithMulti } from 'app/features/variables/shared/multiOptions';
 import { CloudWatchMetricsQuery, LegacyAnnotationQuery } from 'app/plugins/datasource/cloudwatch/types';
+import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 import { plugin as gaugePanelPlugin } from 'app/plugins/panel/gauge/module';
 import { plugin as statPanelPlugin } from 'app/plugins/panel/stat/module';
 
@@ -771,10 +772,14 @@ export class DashboardMigrator {
 
             for (const target of panel.targets) {
               if (target.datasource == null || target.datasource.uid == null) {
-                target.datasource = { ...panel.datasource };
+                if (panel.datasource?.uid !== MIXED_DATASOURCE_NAME) {
+                  target.datasource = { ...panel.datasource };
+                } else {
+                  target.datasource = migrateDatasourceNameToRef(target.datasource, { returnDefaultAsNull: false });
+                }
               }
 
-              if (panelDataSourceWasDefault && target.datasource.uid !== '__expr__') {
+              if (panelDataSourceWasDefault && target.datasource?.uid !== '__expr__') {
                 // We can have situations when default ds changed and the panel level data source is different from the queries
                 // In this case we use the query level data source as source for truth
                 panel.datasource = target.datasource as DataSourceRef;


### PR DESCRIPTION
Fixes #54113

v36 migration assumed, that the default data source is inherited from the panel data source. But, it ignored the fact that the panel data source can be mixed and assigned the mixed data source to all panel targets making the panels break.

