### PR TITLE
Docs: Update `whatsNewUrl` link in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "betterer:stats": "ts-node --transpile-only --project ./scripts/cli/tsconfig.json ./scripts/cli/reportBettererStats.ts"
   },
   "grafana": {
-    "whatsNewUrl": "https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v8-5/",
+    "whatsNewUrl": "https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v9-1/",
     "releaseNotesUrl": "https://grafana.com/docs/grafana/next/release-notes/"
   },
   "lint-staged": {


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the `whatsNewUrl` link in `package.json`, since it was not updated neither in `v9.0.0-beta1` nor in `v9.1.0-beta1` Grafana versions.
