### PR TITLE
Elasticsearch: Use millisecond intervals for alerting

### DIFF
--- a/pkg/tsdb/elasticsearch/time_series_query.go
+++ b/pkg/tsdb/elasticsearch/time_series_query.go
@@ -244,7 +244,14 @@ func addDateHistogramAgg(aggBuilder es.AggBuilder, bucketAgg *BucketAgg, timeFro
 		a.Format = bucketAgg.Settings.Get("format").MustString(es.DateFormatEpochMS)
 
 		if a.FixedInterval == "auto" {
-			a.FixedInterval = "$__interval"
+			// note this is not really a valid grafana-variable-handling,
+			// because normally this would not match `$__interval_ms`,
+			// but because how we apply these in the go-code, this will work
+			// correctly, and becomes something like `500ms`.
+			// a nicer way would be to use `${__interval_ms}ms`, but
+			// that format is not recognized where we apply these variables
+			// in the elasticsearch datasource
+			a.FixedInterval = "$__interval_msms"
 		}
 
 		if offset, err := bucketAgg.Settings.Get("offset").String(); err == nil {

--- a/pkg/tsdb/elasticsearch/time_series_query_test.go
+++ b/pkg/tsdb/elasticsearch/time_series_query_test.go
@@ -325,7 +325,7 @@ func TestExecuteTimeSeriesQuery(t *testing.T) {
 			require.Equal(t, firstLevel.Aggregation.Type, "date_histogram")
 			hAgg := firstLevel.Aggregation.Aggregation.(*es.DateHistogramAgg)
 			require.Equal(t, hAgg.Field, "@timestamp")
-			require.Equal(t, hAgg.FixedInterval, "$__interval")
+			require.Equal(t, hAgg.FixedInterval, "$__interval_msms")
 			require.Equal(t, hAgg.MinDocCount, 2)
 
 			t.Run("Should not include time_zone when timeZone is utc", func(t *testing.T) {


### PR DESCRIPTION
(handles part of https://github.com/grafana/grafana/issues/54075)

when using elasticsearch, for example in the "count" mode, we need to send the "interval" value to elasticsearch. we receive it from Grafana, and send it to elastic. it's a string, like "5s", "2d", "3y". the problem is, the elasticsearch-api does not accept the years-version, strings like "2y" for 2 years.

to handle this, we will always convert the interval-value to milliseconds, and send that value to elasticsearch. to be exact, we do not need to do the conversion, Grafana already provides us with a millisecond-version of interval in the variable `$__interval_ms`.

there will be multiple pull requests to fix this problem, this first one only deals with the alerting case.

how to test:

( NOTE: you will need to be able to see what http-request is sent from the grafana-server to the elasticsearch database. i recommend `mitmproxy` for this. if problems, contact me (@gabor) 😄 )

1. make sure elasticsearch is running, for example with `make devenv sources=elastic`
2. in grafana create a dashboard, with an elasticsearch query, set metric to "count", you should see a graph.
3. click on the  "alert" tab, and on "create alert rule from this panel". this will send you to the alerting section of grafana
4. click on the "run queries" button, and the graph should appear again. check the http-request that was sent to elasticsearch to create this graph. search in the http-request-post-data, for the `fixed_interval` part. verify that the value there is in milliseconds. also, check if that millisecond value is reasonable (i mean, that the value could be real, it's not 1milliseconds and such).