### PR TITLE
Search: Show all dashboards in the folder view

### DIFF
--- a/public/app/features/search/page/components/FolderSection.tsx
+++ b/public/app/features/search/page/components/FolderSection.tsx
@@ -57,6 +57,7 @@ export const FolderSection: FC<SectionHeaderProps> = ({
       kind: ['dashboard'],
       location: section.uid,
       sort: 'name_sort',
+      limit: 1000, // this component does not have infinate scroll, so we need to load everything upfront
     };
     if (section.itemsUIDs) {
       query = {


### PR DESCRIPTION
In folder view, the search results were getting clipped.  This increases the limit to 1000 items in a folder.  Long term we want to remove this view, but this will help for now.

<img width="1272" alt="image" src="https://user-images.githubusercontent.com/705951/186465735-5fbfaa02-321b-4d1f-ac96-44376eed4bd7.png">
