### PR TITLE
Loki: refactor mock instance creation and clean up datasource test

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -7166,11 +7166,7 @@ exports[`better eslint`] = {
     "public/app/plugins/datasource/loki/datasource.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "public/app/plugins/datasource/loki/datasource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -7177,9 +7177,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/plugins/datasource/loki/language_provider.test.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/plugins/datasource/loki/language_provider.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -7200,10 +7198,6 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/datasource/loki/live_streams_result_transformer.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
-    "public/app/plugins/datasource/loki/mocks.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/plugins/datasource/loki/querybuilder/binaryScalarOperations.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -7158,11 +7158,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "7"]
     ],
-    "public/app/plugins/datasource/loki/datasource.test.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
-    ],
     "public/app/plugins/datasource/loki/datasource.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -7176,9 +7176,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
-    "public/app/plugins/datasource/loki/language_provider.test.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
     "public/app/plugins/datasource/loki/language_provider.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -83,7 +83,7 @@ exports[`no enzyme tests`] = {
     "public/app/plugins/datasource/influxdb/components/ConfigEditor.test.tsx:57753101": [
       [0, 19, 13, "RegExp match", "2409514259"]
     ],
-    "public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.test.tsx:1488067923": [
+    "public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.test.tsx:2984948507": [
       [0, 26, 13, "RegExp match", "2409514259"]
     ],
     "public/app/plugins/datasource/loki/components/LokiQueryEditor.test.tsx:146069464": [
@@ -7125,11 +7125,6 @@ exports[`better eslint`] = {
     ],
     "public/app/plugins/datasource/jaeger/util.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
-    "public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.test.tsx:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "public/app/plugins/datasource/loki/components/LokiLabelBrowser.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.test.tsx
@@ -2,19 +2,22 @@ import { mount, shallow } from 'enzyme';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
-import { ExploreMode, LoadingState, PanelData, toUtc, TimeRange } from '@grafana/data';
+import { LoadingState, PanelData, toUtc, TimeRange, HistoryItem } from '@grafana/data';
+import { TemplateSrv } from '@grafana/runtime';
 
 import { LokiDatasource } from '../datasource';
 import LokiLanguageProvider from '../language_provider';
-import { makeMockLokiDatasource } from '../mocks';
+import { createLokiDatasource } from '../mocks';
 import { LokiQuery } from '../types';
 
-import { LokiExploreQueryEditor } from './LokiExploreQueryEditor';
+import { LokiExploreQueryEditor, Props } from './LokiExploreQueryEditor';
 import { LokiOptionFields } from './LokiOptionFields';
 
-const setup = (renderMethod: any, propOverrides?: object) => {
-  const datasource: LokiDatasource = makeMockLokiDatasource({});
+const setup = (renderMethod: (c: JSX.Element) => ReturnType<typeof shallow> | ReturnType<typeof mount>) => {
+  const datasource: LokiDatasource = createLokiDatasource({} as unknown as TemplateSrv);
   datasource.languageProvider = new LokiLanguageProvider(datasource);
+  jest.spyOn(datasource, 'metadataRequest').mockResolvedValue([]);
+
   const onRunQuery = jest.fn();
   const onChange = jest.fn();
   const query: LokiQuery = { expr: '', refId: 'A', maxLines: 0 };
@@ -58,21 +61,18 @@ const setup = (renderMethod: any, propOverrides?: object) => {
       },
     },
   };
-  const history: any[] = [];
-  const exploreMode: ExploreMode = ExploreMode.Logs;
+  const history: Array<HistoryItem<LokiQuery>> = [];
 
-  const props: any = {
+  const props: Props = {
     query,
     data,
     range,
     datasource,
-    exploreMode,
     history,
     onChange,
     onRunQuery,
   };
 
-  Object.assign(props, { ...props, ...propOverrides });
   return renderMethod(<LokiExploreQueryEditor {...props} />);
 };
 

--- a/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiExploreQueryEditor.tsx
@@ -10,7 +10,7 @@ import { LokiQuery, LokiOptions } from '../types';
 import { LokiOptionFields } from './LokiOptionFields';
 import { LokiQueryField } from './LokiQueryField';
 
-type Props = QueryEditorProps<LokiDatasource, LokiQuery, LokiOptions>;
+export type Props = QueryEditorProps<LokiDatasource, LokiQuery, LokiOptions>;
 
 export const LokiExploreQueryEditor = memo((props: Props) => {
   const { query, data, datasource, history, onChange, onRunQuery, range } = props;

--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
@@ -53,9 +53,48 @@ exports[`LokiExploreQueryEditor should render component 1`] = `
   }
   data-testid="loki-editor-explore"
   datasource={
-    Object {
-      "getTimeRangeParams": [Function],
-      "interpolateString": [Function],
+    LokiDatasource {
+      "annotations": Object {
+        "QueryEditor": Object {
+          "$$typeof": Symbol(react.memo),
+          "compare": null,
+          "type": [Function],
+        },
+      },
+      "getLogRowContext": [Function],
+      "id": 0,
+      "instanceSettings": Object {
+        "access": "direct",
+        "id": 0,
+        "jsonData": Object {
+          "maxLines": "20",
+        },
+        "meta": Object {
+          "baseUrl": "",
+          "id": "id",
+          "info": Object {
+            "author": Object {
+              "name": "Test",
+            },
+            "description": "",
+            "links": Array [],
+            "logos": Object {
+              "large": "",
+              "small": "",
+            },
+            "screenshots": Array [],
+            "updated": "",
+            "version": "",
+          },
+          "module": "",
+          "name": "name",
+          "type": "datasource",
+        },
+        "name": "",
+        "type": "",
+        "uid": "",
+        "url": "myloggingurl",
+      },
       "languageProvider": LokiLanguageProvider {
         "cleanText": [Function],
         "datasource": [Circular],
@@ -245,7 +284,42 @@ exports[`LokiExploreQueryEditor should render component 1`] = `
         "start": [Function],
         "started": false,
       },
-      "metadataRequest": [Function],
+      "maxLines": 20,
+      "meta": Object {
+        "baseUrl": "",
+        "id": "id",
+        "info": Object {
+          "author": Object {
+            "name": "Test",
+          },
+          "description": "",
+          "links": Array [],
+          "logos": Object {
+            "large": "",
+            "small": "",
+          },
+          "screenshots": Array [],
+          "updated": "",
+          "version": "",
+        },
+        "module": "",
+        "name": "name",
+        "type": "datasource",
+      },
+      "metadataRequest": [MockFunction],
+      "name": "",
+      "prepareLogRowContextQueryTarget": [Function],
+      "runLiveQuery": [Function],
+      "streamOptionsProvider": [Function],
+      "streams": LiveStreams {
+        "streams": Object {},
+      },
+      "templateSrv": Object {},
+      "timeSrv": Object {
+        "timeRange": [Function],
+      },
+      "type": "",
+      "uid": "",
     }
   }
   history={Array []}

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -22,7 +22,7 @@ import { initialCustomVariableModelState } from '../../../features/variables/cus
 import { CustomVariableModel } from '../../../features/variables/types';
 
 import { LokiDatasource } from './datasource';
-import { makeMockLokiDatasource, createLokiDatasource } from './mocks';
+import { createMetadataRequest, createLokiDatasource } from './mocks';
 import { LokiOptions, LokiQuery, LokiQueryType } from './types';
 
 const templateSrvStub = {
@@ -449,20 +449,22 @@ describe('LokiDatasource', () => {
   });
 
   describe('metricFindQuery', () => {
-    const getTestContext = (mock: LokiDatasource) => {
+    const getTestContext = () => {
       const ds = createLokiDatasource(templateSrvStub);
-      ds.metadataRequest = mock.metadataRequest;
+      jest
+        .spyOn(ds, 'metadataRequest')
+        .mockImplementation(
+          createMetadataRequest(
+            { label1: ['value1', 'value2'], label2: ['value3', 'value4'] },
+            { '{label1="value1", label2="value2"}': [{ label5: 'value5' }] }
+          )
+        );
 
       return { ds };
     };
 
-    const mock = makeMockLokiDatasource(
-      { label1: ['value1', 'value2'], label2: ['value3', 'value4'] },
-      { '{label1="value1", label2="value2"}': [{ label5: 'value5' }] }
-    );
-
     it(`should return label names for Loki`, async () => {
-      const { ds } = getTestContext(mock);
+      const { ds } = getTestContext();
 
       const res = await ds.metricFindQuery('label_names()');
 
@@ -470,7 +472,7 @@ describe('LokiDatasource', () => {
     });
 
     it(`should return label values for Loki when no matcher`, async () => {
-      const { ds } = getTestContext(mock);
+      const { ds } = getTestContext();
 
       const res = await ds.metricFindQuery('label_values(label1)');
 
@@ -478,7 +480,7 @@ describe('LokiDatasource', () => {
     });
 
     it(`should return label values for Loki with matcher`, async () => {
-      const { ds } = getTestContext(mock);
+      const { ds } = getTestContext();
 
       const res = await ds.metricFindQuery('label_values({label1="value1", label2="value2"},label5)');
 
@@ -486,7 +488,7 @@ describe('LokiDatasource', () => {
     });
 
     it(`should return empty array when incorrect query for Loki`, async () => {
-      const { ds } = getTestContext(mock);
+      const { ds } = getTestContext();
 
       const res = await ds.metricFindQuery('incorrect_query');
 

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -308,7 +308,7 @@ describe('LokiDatasource', () => {
   });
 
   describe('when calling annotationQuery', () => {
-    const getTestContext = (frame: DataFrame, options: any = []) => {
+    const getTestContext = (frame: DataFrame, options = {}) => {
       const query = makeAnnotationQueryRequest(options);
 
       const ds = createLokiDatasource(templateSrvStub);
@@ -830,7 +830,7 @@ function assertAdHocFilters(query: string, expectedResults: string, ds: LokiData
   expect(result).toEqual(expectedResults);
 }
 
-function makeAnnotationQueryRequest(options: any): AnnotationQueryRequest<LokiQuery> {
+function makeAnnotationQueryRequest(options = {}): AnnotationQueryRequest<LokiQuery> {
   const timeRange = {
     from: dateTime(),
     to: dateTime(),
@@ -839,7 +839,9 @@ function makeAnnotationQueryRequest(options: any): AnnotationQueryRequest<LokiQu
     annotation: {
       expr: '{test=test}',
       refId: '',
-      datasource: 'loki',
+      datasource: {
+        type: 'loki',
+      },
       enable: true,
       name: 'test-annotation',
       iconColor: 'red',
@@ -847,7 +849,7 @@ function makeAnnotationQueryRequest(options: any): AnnotationQueryRequest<LokiQu
     },
     dashboard: {
       id: 1,
-    } as any,
+    },
     range: {
       ...timeRange,
       raw: timeRange,

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -114,7 +114,11 @@ describe('LokiDatasource', () => {
   });
 
   describe('when doing logs queries with limits', () => {
-    const runTest = async (queryMaxLines: number | undefined, dsMaxLines: string, expectedMaxLines: number) => {
+    const runTest = async (
+      queryMaxLines: number | undefined,
+      dsMaxLines: string | undefined,
+      expectedMaxLines: number
+    ) => {
       const settings = {
         jsonData: {
           maxLines: dsMaxLines,
@@ -145,7 +149,7 @@ describe('LokiDatasource', () => {
     });
 
     it('should use query max lines, if exists', async () => {
-      await runTest(80, '20', 80);
+      await runTest(80, undefined, 80);
     });
 
     it('should use query max lines, if both exist, even if it is higher than ds max lines', async () => {

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -160,19 +160,15 @@ describe('LokiDatasource', () => {
   describe('When using adhoc filters', () => {
     const DEFAULT_EXPR = 'rate({bar="baz", job="foo"} |= "bar" [5m])';
     const query: LokiQuery = { expr: DEFAULT_EXPR, refId: 'A' };
-    const originalAdhocFiltersMock = templateSrvStub.getAdhocFilters();
+    const mockedGetAdhocFilters = templateSrvStub.getAdhocFilters as jest.Mock;
     const ds = createLokiDatasource(templateSrvStub);
-
-    afterAll(() => {
-      templateSrvStub.getAdhocFilters.mockReturnValue(originalAdhocFiltersMock);
-    });
 
     it('should not modify expression with no filters', async () => {
       expect(ds.applyTemplateVariables(query, {}).expr).toBe(DEFAULT_EXPR);
     });
 
     it('should add filters to expression', async () => {
-      templateSrvStub.getAdhocFilters.mockReturnValue([
+      mockedGetAdhocFilters.mockReturnValue([
         {
           key: 'k1',
           operator: '=',
@@ -191,7 +187,7 @@ describe('LokiDatasource', () => {
     });
 
     it('should add escaping if needed to regex filter expressions', async () => {
-      templateSrvStub.getAdhocFilters.mockReturnValue([
+      mockedGetAdhocFilters.mockReturnValue([
         {
           key: 'k1',
           operator: '=~',
@@ -629,7 +625,7 @@ describe('LokiDatasource', () => {
         const templateSrvMock = {
           getAdhocFilters: (): AdHocFilter[] => adHocFilters,
           replace: (a: string) => a,
-        };
+        } as unknown as TemplateSrv;
         ds = createLokiDatasource(templateSrvMock);
       });
       describe('and query has no parser', () => {
@@ -664,7 +660,7 @@ describe('LokiDatasource', () => {
         const templateSrvMock = {
           getAdhocFilters: (): AdHocFilter[] => adHocFilters,
           replace: (a: string) => a,
-        };
+        } as unknown as TemplateSrv;
         ds = createLokiDatasource(templateSrvMock);
       });
       describe('and query has no parser', () => {

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -28,7 +28,7 @@ import { LokiOptions, LokiQuery, LokiQueryType } from './types';
 const templateSrvStub = {
   getAdhocFilters: jest.fn(() => [] as unknown[]),
   replace: jest.fn((a: string, ...rest: unknown[]) => a),
-};
+} as unknown as TemplateSrv;
 
 const testFrame: DataFrame = {
   refId: 'A',
@@ -125,7 +125,7 @@ describe('LokiDatasource', () => {
         },
       } as DataSourceInstanceSettings<LokiOptions>;
 
-      const ds = createLokiDatasource(templateSrvStub as unknown as TemplateSrv, settings);
+      const ds = createLokiDatasource(templateSrvStub, settings);
 
       // we need to check the final query before it is sent out,
       // and applyTemplateVariables is a convenient place to do that.
@@ -161,7 +161,7 @@ describe('LokiDatasource', () => {
     const DEFAULT_EXPR = 'rate({bar="baz", job="foo"} |= "bar" [5m])';
     const query: LokiQuery = { expr: DEFAULT_EXPR, refId: 'A' };
     const originalAdhocFiltersMock = templateSrvStub.getAdhocFilters();
-    const ds = createLokiDatasource(templateSrvStub as unknown as TemplateSrv);
+    const ds = createLokiDatasource(templateSrvStub);
 
     afterAll(() => {
       templateSrvStub.getAdhocFilters.mockReturnValue(originalAdhocFiltersMock);
@@ -214,7 +214,7 @@ describe('LokiDatasource', () => {
     let variable: CustomVariableModel;
 
     beforeEach(() => {
-      ds = createLokiDatasource(templateSrvStub as unknown as TemplateSrv);
+      ds = createLokiDatasource(templateSrvStub);
       variable = { ...initialCustomVariableModelState };
     });
 
@@ -258,7 +258,7 @@ describe('LokiDatasource', () => {
   describe('when performing testDataSource', () => {
     let ds: LokiDatasource;
     beforeEach(() => {
-      ds = createLokiDatasource(templateSrvStub as unknown as TemplateSrv);
+      ds = createLokiDatasource(templateSrvStub);
     });
 
     it('should return successfully when call succeeds with labels', async () => {
@@ -315,7 +315,7 @@ describe('LokiDatasource', () => {
     const getTestContext = (frame: DataFrame, options: any = []) => {
       const query = makeAnnotationQueryRequest(options);
 
-      const ds = createLokiDatasource(templateSrvStub as unknown as TemplateSrv);
+      const ds = createLokiDatasource(templateSrvStub);
       const response: DataQueryResponse = {
         data: [frame],
       };
@@ -454,7 +454,7 @@ describe('LokiDatasource', () => {
 
   describe('metricFindQuery', () => {
     const getTestContext = (mock: LokiDatasource) => {
-      const ds = createLokiDatasource(templateSrvStub as unknown as TemplateSrv);
+      const ds = createLokiDatasource(templateSrvStub);
       ds.metadataRequest = mock.metadataRequest;
 
       return { ds };
@@ -502,7 +502,7 @@ describe('LokiDatasource', () => {
     describe('when called with ADD_FILTER', () => {
       let ds: LokiDatasource;
       beforeEach(() => {
-        ds = createLokiDatasource(templateSrvStub as unknown as TemplateSrv);
+        ds = createLokiDatasource(templateSrvStub);
       });
 
       describe('and query has no parser', () => {
@@ -557,7 +557,7 @@ describe('LokiDatasource', () => {
       describe('and query has no parser', () => {
         let ds: LokiDatasource;
         beforeEach(() => {
-          ds = createLokiDatasource(templateSrvStub as unknown as TemplateSrv);
+          ds = createLokiDatasource(templateSrvStub);
         });
 
         it('then the correct label should be added for logs query', () => {
@@ -589,7 +589,7 @@ describe('LokiDatasource', () => {
         describe('and query has parser', () => {
           let ds: LokiDatasource;
           beforeEach(() => {
-            ds = createLokiDatasource(templateSrvStub as unknown as TemplateSrv);
+            ds = createLokiDatasource(templateSrvStub);
           });
 
           it('then the correct label should be added for logs query', () => {
@@ -629,7 +629,7 @@ describe('LokiDatasource', () => {
         const templateSrvMock = {
           getAdhocFilters: (): AdHocFilter[] => adHocFilters,
           replace: (a: string) => a,
-        } as unknown as TemplateSrv;
+        };
         ds = createLokiDatasource(templateSrvMock);
       });
       describe('and query has no parser', () => {
@@ -664,7 +664,7 @@ describe('LokiDatasource', () => {
         const templateSrvMock = {
           getAdhocFilters: (): AdHocFilter[] => adHocFilters,
           replace: (a: string) => a,
-        } as unknown as TemplateSrv;
+        };
         ds = createLokiDatasource(templateSrvMock);
       });
       describe('and query has no parser', () => {
@@ -688,7 +688,7 @@ describe('LokiDatasource', () => {
   });
 
   describe('prepareLogRowContextQueryTarget', () => {
-    const ds = createLokiDatasource(templateSrvStub as unknown as TemplateSrv);
+    const ds = createLokiDatasource(templateSrvStub);
     it('creates query with only labels from /labels API', async () => {
       const row: LogRowModel = {
         rowIndex: 0,
@@ -741,7 +741,7 @@ describe('LokiDatasource', () => {
   describe('logs volume data provider', () => {
     let ds: LokiDatasource;
     beforeEach(() => {
-      ds = createLokiDatasource(templateSrvStub as unknown as TemplateSrv);
+      ds = createLokiDatasource(templateSrvStub);
     });
 
     it('creates provider for logs query', () => {
@@ -783,7 +783,7 @@ describe('LokiDatasource', () => {
   describe('importing queries', () => {
     let ds: LokiDatasource;
     beforeEach(() => {
-      ds = createLokiDatasource(templateSrvStub as unknown as TemplateSrv);
+      ds = createLokiDatasource(templateSrvStub);
     });
 
     it('keeps all labels when no labels are loaded', async () => {
@@ -818,7 +818,7 @@ describe('LokiDatasource', () => {
 
 describe('applyTemplateVariables', () => {
   it('should add the adhoc filter to the query', () => {
-    const ds = createLokiDatasource(templateSrvStub as unknown as TemplateSrv);
+    const ds = createLokiDatasource(templateSrvStub);
     const spy = jest.spyOn(ds, 'addAdHocFilters');
     ds.applyTemplateVariables({ expr: '{test}', refId: 'A' }, {});
     expect(spy).toHaveBeenCalledWith('{test}');

--- a/public/app/plugins/datasource/loki/language_provider.test.ts
+++ b/public/app/plugins/datasource/loki/language_provider.test.ts
@@ -259,7 +259,7 @@ describe('Request URL', () => {
   it('should contain range params', async () => {
     const datasourceWithLabels = setup({ other: [] });
     const rangeParams = datasourceWithLabels.getTimeRangeParams();
-    const datasourceSpy = jest.spyOn(datasourceWithLabels as any, 'metadataRequest');
+    const datasourceSpy = jest.spyOn(datasourceWithLabels, 'metadataRequest');
 
     const instance = new LanguageProvider(datasourceWithLabels);
     instance.fetchLabels();

--- a/public/app/plugins/datasource/loki/language_provider.test.ts
+++ b/public/app/plugins/datasource/loki/language_provider.test.ts
@@ -2,10 +2,11 @@ import Plain from 'slate-plain-serializer';
 
 import { AbstractLabelOperator } from '@grafana/data';
 import { TypeaheadInput } from '@grafana/ui';
+import { TemplateSrv } from 'app/features/templating/template_srv';
 
 import { LokiDatasource } from './datasource';
 import LanguageProvider, { LokiHistoryItem } from './language_provider';
-import { makeMockLokiDatasource } from './mocks';
+import { createLokiDatasource, createMetadataRequest } from './mocks';
 import { LokiQueryType } from './types';
 
 jest.mock('app/store/store', () => ({
@@ -21,7 +22,7 @@ jest.mock('app/store/store', () => ({
 }));
 
 describe('Language completion provider', () => {
-  const datasource = makeMockLokiDatasource({});
+  const datasource = setup({});
 
   describe('query suggestions', () => {
     it('returns no suggestions on empty context', async () => {
@@ -90,7 +91,7 @@ describe('Language completion provider', () => {
 
   describe('fetchSeries', () => {
     it('should use match[] parameter', () => {
-      const datasource = makeMockLokiDatasource({}, { '{foo="bar"}': [{ label1: 'label_val1' }] });
+      const datasource = setup({}, { '{foo="bar"}': [{ label1: 'label_val1' }] });
       const languageProvider = new LanguageProvider(datasource);
       const fetchSeries = languageProvider.fetchSeries;
       const requestSpy = jest.spyOn(languageProvider, 'request');
@@ -105,11 +106,11 @@ describe('Language completion provider', () => {
 
   describe('fetchSeriesLabels', () => {
     it('should interpolate variable in series', () => {
-      const datasource: LokiDatasource = {
-        metadataRequest: () => ({ data: { data: [] as any[] } }),
-        getTimeRangeParams: () => ({ start: 0, end: 1 }),
-        interpolateString: (string: string) => string.replace(/\$/, 'interpolated-'),
-      } as any as LokiDatasource;
+      const datasource = setup({});
+      jest.spyOn(datasource, 'getTimeRangeParams').mockReturnValue({ start: 0, end: 1 });
+      jest
+        .spyOn(datasource, 'interpolateString')
+        .mockImplementation((string: string) => string.replace(/\$/, 'interpolated-'));
 
       const languageProvider = new LanguageProvider(datasource);
       const fetchSeriesLabels = languageProvider.fetchSeriesLabels;
@@ -126,7 +127,7 @@ describe('Language completion provider', () => {
 
   describe('label key suggestions', () => {
     it('returns all label suggestions on empty selector', async () => {
-      const datasource = makeMockLokiDatasource({ label1: [], label2: [] });
+      const datasource = setup({ label1: [], label2: [] });
       const provider = await getLanguageProvider(datasource);
       const input = createTypeaheadInput('{}', '', '', 1);
       const result = await provider.provideCompletionItems(input);
@@ -143,7 +144,7 @@ describe('Language completion provider', () => {
     });
 
     it('returns all label suggestions on selector when starting to type', async () => {
-      const datasource = makeMockLokiDatasource({ label1: [], label2: [] });
+      const datasource = setup({ label1: [], label2: [] });
       const provider = await getLanguageProvider(datasource);
       const input = createTypeaheadInput('{l}', '', '', 2);
       const result = await provider.provideCompletionItems(input);
@@ -162,10 +163,7 @@ describe('Language completion provider', () => {
 
   describe('label suggestions facetted', () => {
     it('returns facetted label suggestions based on selector', async () => {
-      const datasource = makeMockLokiDatasource(
-        { label1: [], label2: [] },
-        { '{foo="bar"}': [{ label1: 'label_val1' }] }
-      );
+      const datasource = setup({ label1: [], label2: [] }, { '{foo="bar"}': [{ label1: 'label_val1' }] });
       const provider = await getLanguageProvider(datasource);
       const input = createTypeaheadInput('{foo="bar",}', '', '', 11);
       const result = await provider.provideCompletionItems(input);
@@ -174,10 +172,7 @@ describe('Language completion provider', () => {
     });
 
     it('returns facetted label suggestions for multipule selectors', async () => {
-      const datasource = makeMockLokiDatasource(
-        { label1: [], label2: [] },
-        { '{baz="42",foo="bar"}': [{ label2: 'label_val2' }] }
-      );
+      const datasource = setup({ label1: [], label2: [] }, { '{baz="42",foo="bar"}': [{ label2: 'label_val2' }] });
       const provider = await getLanguageProvider(datasource);
       const input = createTypeaheadInput('{baz="42",foo="bar",}', '', '', 20);
       const result = await provider.provideCompletionItems(input);
@@ -188,7 +183,7 @@ describe('Language completion provider', () => {
 
   describe('label suggestions', () => {
     it('returns label values suggestions from Loki', async () => {
-      const datasource = makeMockLokiDatasource({ label1: ['label1_val1', 'label1_val2'], label2: [] });
+      const datasource = setup({ label1: ['label1_val1', 'label1_val2'], label2: [] });
       const provider = await getLanguageProvider(datasource);
       const input = createTypeaheadInput('{label1=}', '=', 'label1');
       let result = await provider.provideCompletionItems(input);
@@ -206,7 +201,7 @@ describe('Language completion provider', () => {
       ]);
     });
     it('returns label values suggestions from Loki when re-editing', async () => {
-      const datasource = makeMockLokiDatasource({ label1: ['label1_val1', 'label1_val2'], label2: [] });
+      const datasource = setup({ label1: ['label1_val1', 'label1_val2'], label2: [] });
       const provider = await getLanguageProvider(datasource);
       const input = createTypeaheadInput('{label1="label1_v"}', 'label1_v', 'label1', 17, [
         'attr-value',
@@ -228,7 +223,7 @@ describe('Language completion provider', () => {
 
   describe('label values', () => {
     it('should fetch label values if not cached', async () => {
-      const datasource = makeMockLokiDatasource({ testkey: ['label1_val1', 'label1_val2'], label2: [] });
+      const datasource = setup({ testkey: ['label1_val1', 'label1_val2'], label2: [] });
       const provider = await getLanguageProvider(datasource);
       const requestSpy = jest.spyOn(provider, 'request');
       const labelValues = await provider.fetchLabelValues('testkey');
@@ -237,7 +232,7 @@ describe('Language completion provider', () => {
     });
 
     it('should return cached values', async () => {
-      const datasource = makeMockLokiDatasource({ testkey: ['label1_val1', 'label1_val2'], label2: [] });
+      const datasource = setup({ testkey: ['label1_val1', 'label1_val2'], label2: [] });
       const provider = await getLanguageProvider(datasource);
       const requestSpy = jest.spyOn(provider, 'request');
       const labelValues = await provider.fetchLabelValues('testkey');
@@ -250,7 +245,7 @@ describe('Language completion provider', () => {
     });
 
     it('should encode special characters', async () => {
-      const datasource = makeMockLokiDatasource({ '`\\"testkey': ['label1_val1', 'label1_val2'], label2: [] });
+      const datasource = setup({ '`\\"testkey': ['label1_val1', 'label1_val2'], label2: [] });
       const provider = await getLanguageProvider(datasource);
       const requestSpy = jest.spyOn(provider, 'request');
       await provider.fetchLabelValues('`\\"testkey');
@@ -262,7 +257,7 @@ describe('Language completion provider', () => {
 
 describe('Request URL', () => {
   it('should contain range params', async () => {
-    const datasourceWithLabels = makeMockLokiDatasource({ other: [] });
+    const datasourceWithLabels = setup({ other: [] });
     const rangeParams = datasourceWithLabels.getTimeRangeParams();
     const datasourceSpy = jest.spyOn(datasourceWithLabels as any, 'metadataRequest');
 
@@ -274,7 +269,7 @@ describe('Request URL', () => {
 });
 
 describe('Query imports', () => {
-  const datasource = makeMockLokiDatasource({});
+  const datasource = setup({});
 
   it('returns empty queries', async () => {
     const instance = new LanguageProvider(datasource);
@@ -333,4 +328,22 @@ function createTypeaheadInput(
     value: valueWithSelection,
     labelKey,
   };
+}
+
+function setup(
+  labelsAndValues: Record<string, string[]>,
+  series?: Record<string, Array<Record<string, string>>>
+): LokiDatasource {
+  const datasource = createLokiDatasource({} as unknown as TemplateSrv);
+
+  const rangeMock = {
+    start: 1560153109000,
+    end: 1560163909000,
+  };
+
+  jest.spyOn(datasource, 'getTimeRangeParams').mockReturnValue(rangeMock);
+  jest.spyOn(datasource, 'metadataRequest').mockImplementation(createMetadataRequest(labelsAndValues, series));
+  jest.spyOn(datasource, 'interpolateString').mockImplementation((string: string) => string);
+
+  return datasource;
 }

--- a/public/app/plugins/datasource/loki/mocks.ts
+++ b/public/app/plugins/datasource/loki/mocks.ts
@@ -1,4 +1,5 @@
-import { DataSourceSettings } from '@grafana/data';
+import { DataSourceInstanceSettings, DataSourceSettings, PluginType, toUtc } from '@grafana/data';
+import { TemplateSrv } from '@grafana/runtime';
 
 import { getMockDataSource } from '../../../features/datasources/__mocks__';
 
@@ -54,4 +55,56 @@ export function createDefaultConfigOptions(): DataSourceSettings<LokiOptions> {
   return getMockDataSource<LokiOptions>({
     jsonData: { maxLines: '531' },
   });
+}
+
+const rawRange = {
+  from: toUtc('2018-04-25 10:00'),
+  to: toUtc('2018-04-25 11:00'),
+};
+
+const defaultTimeSrvMock = {
+  timeRange: () => ({
+    from: rawRange.from,
+    to: rawRange.to,
+    raw: rawRange,
+  }),
+};
+
+export function createLokiDatasource(templateSrvMock: TemplateSrv, timeSrvStub = defaultTimeSrvMock): LokiDatasource {
+  const instanceSettings: DataSourceInstanceSettings = {
+    url: 'myloggingurl',
+    id: 0,
+    uid: '',
+    type: '',
+    name: '',
+    meta: {
+      id: 'id',
+      name: 'name',
+      type: PluginType.datasource,
+      module: '',
+      baseUrl: '',
+      info: {
+        author: {
+          name: 'Test',
+        },
+        description: '',
+        links: [],
+        logos: {
+          large: '',
+          small: '',
+        },
+        screenshots: [],
+        updated: '',
+        version: '',
+      },
+    },
+    jsonData: {},
+    access: 'direct',
+  };
+
+  const customData = { ...(instanceSettings.jsonData || {}), maxLines: 20 };
+  const customSettings: DataSourceInstanceSettings = { ...instanceSettings, jsonData: customData };
+
+  // @ts-expect-error
+  return new LokiDatasource(customSettings, templateSrvMock, timeSrvStub);
 }

--- a/public/app/plugins/datasource/loki/mocks.ts
+++ b/public/app/plugins/datasource/loki/mocks.ts
@@ -70,8 +70,12 @@ const defaultTimeSrvMock = {
   }),
 };
 
-export function createLokiDatasource(templateSrvMock: TemplateSrv, timeSrvStub = defaultTimeSrvMock): LokiDatasource {
-  const instanceSettings: DataSourceInstanceSettings = {
+export function createLokiDatasource(
+  templateSrvMock: TemplateSrv,
+  settings: Partial<DataSourceInstanceSettings<LokiOptions>> = {},
+  timeSrvStub = defaultTimeSrvMock
+): LokiDatasource {
+  const customSettings: DataSourceInstanceSettings<LokiOptions> = {
     url: 'myloggingurl',
     id: 0,
     uid: '',
@@ -98,12 +102,12 @@ export function createLokiDatasource(templateSrvMock: TemplateSrv, timeSrvStub =
         version: '',
       },
     },
-    jsonData: {},
+    jsonData: {
+      maxLines: '20',
+    },
     access: 'direct',
+    ...settings,
   };
-
-  const customData = { ...(instanceSettings.jsonData || {}), maxLines: 20 };
-  const customSettings: DataSourceInstanceSettings = { ...instanceSettings, jsonData: customData };
 
   // @ts-expect-error
   return new LokiDatasource(customSettings, templateSrvMock, timeSrvStub);

--- a/public/app/plugins/datasource/loki/mocks.ts
+++ b/public/app/plugins/datasource/loki/mocks.ts
@@ -6,51 +6,6 @@ import { getMockDataSource } from '../../../features/datasources/__mocks__';
 import { LokiDatasource } from './datasource';
 import { LokiOptions } from './types';
 
-interface Labels {
-  [label: string]: string[];
-}
-
-interface Series {
-  [label: string]: string;
-}
-
-interface SeriesForSelector {
-  [selector: string]: Series[];
-}
-
-export function makeMockLokiDatasource(labelsAndValues: Labels, series?: SeriesForSelector): LokiDatasource {
-  // added % to allow urlencoded labelKeys. Note, that this is not confirm with Loki, as loki does not allow specialcharacters in labelKeys, but needed for tests.
-  const lokiLabelsAndValuesEndpointRegex = /^label\/([%\w]*)\/values/;
-  const lokiSeriesEndpointRegex = /^series/;
-
-  const lokiLabelsEndpoint = 'labels';
-  const rangeMock = {
-    start: 1560153109000,
-    end: 1560163909000,
-  };
-
-  const labels = Object.keys(labelsAndValues);
-  return {
-    getTimeRangeParams: () => rangeMock,
-    metadataRequest: (url: string, params?: { [key: string]: string }) => {
-      if (url === lokiLabelsEndpoint) {
-        return labels;
-      } else {
-        const labelsMatch = url.match(lokiLabelsAndValuesEndpointRegex);
-        const seriesMatch = url.match(lokiSeriesEndpointRegex);
-        if (labelsMatch) {
-          return labelsAndValues[labelsMatch[1]] || [];
-        } else if (seriesMatch && series && params) {
-          return series[params['match[]']] || [];
-        } else {
-          throw new Error(`Unexpected url error, ${url}`);
-        }
-      }
-    },
-    interpolateString: (string: string) => string,
-  } as any;
-}
-
 export function createDefaultConfigOptions(): DataSourceSettings<LokiOptions> {
   return getMockDataSource<LokiOptions>({
     jsonData: { maxLines: '531' },
@@ -111,4 +66,31 @@ export function createLokiDatasource(
 
   // @ts-expect-error
   return new LokiDatasource(customSettings, templateSrvMock, timeSrvStub);
+}
+
+export function createMetadataRequest(
+  labelsAndValues: Record<string, string[]>,
+  series?: Record<string, Array<Record<string, string>>>
+) {
+  // added % to allow urlencoded labelKeys. Note, that this is not confirm with Loki, as loki does not allow specialcharacters in labelKeys, but needed for tests.
+  const lokiLabelsAndValuesEndpointRegex = /^label\/([%\w]*)\/values/;
+  const lokiSeriesEndpointRegex = /^series/;
+  const lokiLabelsEndpoint = 'labels';
+  const labels = Object.keys(labelsAndValues);
+
+  return async function metadataRequestMock(url: string, params?: Record<string, string | number>) {
+    if (url === lokiLabelsEndpoint) {
+      return labels;
+    } else {
+      const labelsMatch = url.match(lokiLabelsAndValuesEndpointRegex);
+      const seriesMatch = url.match(lokiSeriesEndpointRegex);
+      if (labelsMatch) {
+        return labelsAndValues[labelsMatch[1]] || [];
+      } else if (seriesMatch && series && params) {
+        return series[params['match[]']] || [];
+      } else {
+        throw new Error(`Unexpected url error, ${url}`);
+      }
+    }
+  };
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Working on the coverage of #54102, I realized I needed a mock Loki datasource instance. That led me to read the current implementation of the datasource test, where I found some room for improvement, specially related with duplication, or different methods of creating the datasource instance.

Changes in this PR:

- Moved the mock creation code (that actually returns an instance and not an object) to the existing `mocks` module.
- Removed an incomplete Loki datasource mock factory function (`makeMockLokiDatasource()`) in favor of a factory function to create `metadataRequest()` mocks, which was most of its actual purpose.
- Fixed some type errors, many usages of `any`, etc.
- Refactored the datasource test to remove some duplication.
- Refactored LokiExploreQueryEditor test to use the new factory function and fixed some type issues.
- Refactored LanguageProvider test to use the new factory function and fixed some type issues.

**Which issue(s) this PR fixes**:

Part of https://github.com/grafana/grafana/pull/54102
Fixes https://github.com/grafana/grafana/issues/53127
Fixes https://github.com/grafana/grafana/issues/53132
Fixes https://github.com/grafana/grafana/issues/53125

**Special notes for your reviewer**:

Tests should continue passing as before these changes.
