### PR TITLE
Fix: Wrong swagger meta preventing spec generation

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -21,14 +21,11 @@
 //
 // SecurityDefinitions:
 // basic:
-//
-//	type: basic
-//
+//  type: basic
 // api_key:
-//
-//	type: apiKey
-//	name: Authorization
-//	in: header
+//  type: apiKey
+//  name: Authorization
+//  in: header
 //
 // swagger:meta
 package api


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an error on swagger meta that prevented specs generation

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/53708

**Special notes for your reviewer**:
This fix can be tested with a fresh checkout repo, executing `make all`. On previous versions would throw this error


```
$make build-go
(re)installing /Users/user/Work/go/bin/swagger-v0.29.0
SWAGGER_GENERATE_EXTENSION=false /Users/user/Work/go/bin/swagger-v0.29.0 generate spec -m -w pkg/server -o public/api-spec.json \
	-x "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions" \
	-x "github.com/prometheus/alertmanager" \
	-i pkg/api/swagger_tags.json
json: cannot unmarshal string into Go value of type spec.SecuritySchemeProps
make: *** [public/api-spec.json] Error 1 
```

But after the fix, it can be generated without a problem.
