### PR TITLE
POC/Schema: Generate datasource models from schema file

### DIFF
--- a/public/app/plugins/datasource/dashboard/models.cue
+++ b/public/app/plugins/datasource/dashboard/models.cue
@@ -1,0 +1,32 @@
+// Copyright 2021 Grafana Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grafanaplugin
+
+import "github.com/grafana/thema"
+
+Datasource: thema.#Lineage & {
+	name: "dashboard"
+	seqs: [
+		{
+			schemas: [
+				{
+					DataQuery: {
+						panelId?: number
+					} @cuetsy(kind="interface")
+				},
+			]
+		},
+	]
+}


### PR DESCRIPTION
This is the most basic hello world for a datasource schema.  The simplest core plugin we have so very low risk to play with :)

This needs to generate a typescript definition that matches:
https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/dashboard/types.ts#L5
```
export interface DashboardQuery extends DataQuery {
  panelId?: number;
}
```
and go files that live somewhere 🤷‍♂️ 