### PR TITLE
[v9.0.x] Update whatsnew link for `v9.0.x`

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "betterer:stats": "ts-node --transpile-only --project ./scripts/cli/tsconfig.json ./scripts/cli/reportBettererStats.ts"
   },
   "grafana": {
-    "whatsNewUrl": "https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v8-5/",
+    "whatsNewUrl": "https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v9-0/",
     "releaseNotesUrl": "https://grafana.com/docs/grafana/next/release-notes/"
   },
   "lint-staged": {


### PR DESCRIPTION
**What this PR does / why we need it**:

Followup to https://github.com/grafana/grafana/pull/54154, but for `v9.0.x` branch.
