### PR TITLE
Move GH workflow step to have node_id unchanged

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -37,6 +37,15 @@ jobs:
           echo "BOARD=${BOARD}" >> $GITHUB_ENV
           echo "CHANNEL=${CHANNEL}" >> $GITHUB_ENV
 
+      - name: "Add to GitHub board"
+        if: ${{ env.BOARD != 'null' }}
+        uses: leonsteinhaeuser/project-beta-automations@v1.3.0
+        with:
+          project_id: ${{ env.BOARD }}
+          organization: grafana
+          resource_node_id: ${{ github.event.issue.node_id }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: "Prepare payload"
         uses: frabert/replace-string-action@v2.0
         id: preparePayload
@@ -46,15 +55,6 @@ jobs:
           pattern: '"'
           replace-with: "'"
           flags: 'g'
-
-      - name: "Add to GitHub board"
-        if: ${{ env.BOARD != 'null' }}
-        uses: leonsteinhaeuser/project-beta-automations@v1.3.0
-        with:
-          project_id: ${{ env.BOARD }}
-          organization: grafana
-          resource_node_id: ${{ github.event.issue.node_id }}
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Send Slack notification"
         if: ${{ env.CHANNEL != 'null' }}


### PR DESCRIPTION
The current workflow does not place the issue in the board due to the issue `gh: Resource not accessible by integration gh: Could not resolve to a node with the global id of 'null'`. 

I suspect the step `Prepare payload` to update the `github.event.issue.node_id` value after having tested an identical workflow in another repository without that step which is working. 

This PR thus moves the board automation before any update of the node object which should fix the issue.