### PR TITLE
Elasticsearch: Use millisecond intervals in frontend

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -106,7 +106,7 @@ export class ElasticQueryBuilder {
       esAgg.offset = settings.offset;
     }
 
-    const interval = settings.interval === 'auto' ? '$__interval' : settings.interval;
+    const interval = settings.interval === 'auto' ? '${__interval_ms}ms' : settings.interval;
 
     esAgg.fixed_interval = interval;
 

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
@@ -738,7 +738,7 @@ describe('ElasticQueryBuilder', () => {
             extended_bounds: { max: '$timeTo', min: '$timeFrom' },
             field: '@timestamp',
             format: 'epoch_millis',
-            fixed_interval: '$__interval',
+            fixed_interval: '${__interval_ms}ms',
             min_doc_count: 0,
           },
         },


### PR DESCRIPTION
(fixes https://github.com/grafana/grafana/issues/54075 (the frontend part, the alerting-part is handled in https://github.com/grafana/grafana/pull/54157))

when using elasticsearch, for example in the "count" mode, we need to send the "interval" value to elasticsearch. we receive it from Grafana, and send it to elastic. it's a string, like "5s", "2d", "3y". the problem is, the elasticsearch-api does not accept the years-version, strings like "2y" for 2 years.

to handle this, we will always convert the interval-value to milliseconds, and send that value to elasticsearch. to be exact, we do not need to do the conversion, Grafana already provides us with a millisecond-version of interval in the variable `$__interval_ms`.


how to test:

1. make sure elasticsearch is running, for example with `make devenv sources=elastic`
2. in grafana, create a dashboard, with an elasticsearch query, set metric to "count", you should see a graph
3. if you look at the "query options" part, it will tell you the current interval value, for example , `interval=30s` like this :
<img width="779" alt="interval" src="https://user-images.githubusercontent.com/51989/186606340-18954271-cb91-40f5-a59b-839b5501c489.png">
 4. open your dev-tools so you can see the ajax-requests
 5. re-run the query with the refresh-dashboard button at the top-right (next to the time-range selector)
 6. you should see an ajax-request `_msearch`. find the request's post-data, it will contain two jsons, look at the second json, and the `"fixed_interval":` part. it should:
    - the value should be in milliseconds, like `"fixed_interval":"30000ms"`
    - the value should be the same as the one shown in the grafana user interface in step [3]
  7. change the time-range, and re-run the query. this will change the calculated interval-value. again, compare the ajax-request-interval-value with the grafana-ui-interval-value, they should match