### PR TITLE
RBAC: Fix resolver issue on wildcard resulting in wrong status code for endpoints

### DIFF
--- a/pkg/services/accesscontrol/errors.go
+++ b/pkg/services/accesscontrol/errors.go
@@ -6,4 +6,5 @@ var (
 	ErrFixedRolePrefixMissing = errors.New("fixed role should be prefixed with '" + FixedRolePrefix + "'")
 	ErrInvalidBuiltinRole     = errors.New("built-in role is not valid")
 	ErrInvalidScope           = errors.New("invalid scope")
+	ErrResolverNotFound       = errors.New("no resolver found")
 )

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -105,8 +105,11 @@ func (m *Mock) Evaluate(ctx context.Context, usr *user.SignedInUser, evaluator a
 		permissions = accesscontrol.GroupScopesByAction(userPermissions)
 	}
 
-	attributeMutator := m.scopeResolvers.GetScopeAttributeMutator(usr.OrgID)
-	resolvedEvaluator, err := evaluator.MutateScopes(ctx, attributeMutator)
+	if evaluator.Evaluate(permissions) {
+		return true, nil
+	}
+
+	resolvedEvaluator, err := evaluator.MutateScopes(ctx, m.scopeResolvers.GetScopeAttributeMutator(usr.OrgID))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/services/accesscontrol/mock/mock.go
+++ b/pkg/services/accesscontrol/mock/mock.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"errors"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -111,8 +112,12 @@ func (m *Mock) Evaluate(ctx context.Context, usr *user.SignedInUser, evaluator a
 
 	resolvedEvaluator, err := evaluator.MutateScopes(ctx, m.scopeResolvers.GetScopeAttributeMutator(usr.OrgID))
 	if err != nil {
+		if errors.Is(err, accesscontrol.ErrResolverNotFound) {
+			return false, nil
+		}
 		return false, err
 	}
+
 	return resolvedEvaluator.Evaluate(permissions), nil
 }
 

--- a/pkg/services/accesscontrol/ossaccesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/accesscontrol.go
@@ -45,6 +45,11 @@ func (a *AccessControl) Evaluate(ctx context.Context, user *user.SignedInUser, e
 		user.Permissions[user.OrgID] = accesscontrol.GroupScopesByAction(permissions)
 	}
 
+	// Test evaluation without scope resolver first, this will prevent 403 for wildcard scopes when resource does not exist
+	if evaluator.Evaluate(user.Permissions[user.OrgID]) {
+		return true, nil
+	}
+
 	resolvedEvaluator, err := evaluator.MutateScopes(ctx, a.resolvers.GetScopeAttributeMutator(user.OrgID))
 	if err != nil {
 		return false, err

--- a/pkg/services/accesscontrol/ossaccesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/accesscontrol.go
@@ -2,6 +2,7 @@ package ossaccesscontrol
 
 import (
 	"context"
+	"errors"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -52,8 +53,12 @@ func (a *AccessControl) Evaluate(ctx context.Context, user *user.SignedInUser, e
 
 	resolvedEvaluator, err := evaluator.MutateScopes(ctx, a.resolvers.GetScopeAttributeMutator(user.OrgID))
 	if err != nil {
+		if errors.Is(err, accesscontrol.ErrResolverNotFound) {
+			return false, nil
+		}
 		return false, err
 	}
+
 	return resolvedEvaluator.Evaluate(user.Permissions[user.OrgID]), nil
 }
 

--- a/pkg/services/accesscontrol/resolvers.go
+++ b/pkg/services/accesscontrol/resolvers.go
@@ -69,7 +69,7 @@ func (s *Resolvers) GetScopeAttributeMutator(orgID int64) ScopeAttributeMutator 
 			s.log.Debug("resolved scope", "scope", scope, "resolved_scopes", scopes)
 			return scopes, nil
 		}
-		return []string{scope}, nil
+		return nil, fmt.Errorf("no resolver found for scope: %s", scope)
 	}
 }
 

--- a/pkg/services/accesscontrol/resolvers.go
+++ b/pkg/services/accesscontrol/resolvers.go
@@ -69,7 +69,7 @@ func (s *Resolvers) GetScopeAttributeMutator(orgID int64) ScopeAttributeMutator 
 			s.log.Debug("resolved scope", "scope", scope, "resolved_scopes", scopes)
 			return scopes, nil
 		}
-		return nil, fmt.Errorf("no resolver found for scope: %s", scope)
+		return nil, ErrResolverNotFound
 	}
 }
 

--- a/pkg/services/accesscontrol/resolvers_test.go
+++ b/pkg/services/accesscontrol/resolvers_test.go
@@ -89,6 +89,14 @@ func TestResolvers_AttributeScope(t *testing.T) {
 			wantEvaluator: accesscontrol.EvalPermission("datasources:read", accesscontrol.Scope("datasources", "id", "5")),
 			wantCalls:     1,
 		},
+		{
+			name:          "should return error if no resolver is found for scope",
+			orgID:         1,
+			evaluator:     accesscontrol.EvalPermission("dashboards:read", "dashboards:id:1"),
+			wantEvaluator: nil,
+			wantCalls:     0,
+			wantErr:       accesscontrol.ErrResolverNotFound,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/services/accesscontrol/resolvers_test.go
+++ b/pkg/services/accesscontrol/resolvers_test.go
@@ -91,22 +91,24 @@ func TestResolvers_AttributeScope(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		resolvers := accesscontrol.NewResolvers(log.NewNopLogger())
+		t.Run(tt.name, func(t *testing.T) {
+			resolvers := accesscontrol.NewResolvers(log.NewNopLogger())
 
-		// Reset calls counter
-		calls = 0
-		// Register a resolution method
-		resolvers.AddScopeAttributeResolver("datasources:name:", fakeDataSourceResolver)
+			// Reset calls counter
+			calls = 0
+			// Register a resolution method
+			resolvers.AddScopeAttributeResolver("datasources:name:", fakeDataSourceResolver)
 
-		// Test
-		mutate := resolvers.GetScopeAttributeMutator(tt.orgID)
-		resolvedEvaluator, err := tt.evaluator.MutateScopes(context.Background(), mutate)
-		if tt.wantErr != nil {
-			assert.ErrorAs(t, err, &tt.wantErr, "expected an error during the resolution of the scope")
-			return
-		}
-		assert.NoError(t, err)
-		assert.EqualValues(t, tt.wantEvaluator, resolvedEvaluator, "permission did not match expected resolution")
-		assert.Equal(t, tt.wantCalls, calls, "cache has not been used")
+			// Test
+			mutate := resolvers.GetScopeAttributeMutator(tt.orgID)
+			resolvedEvaluator, err := tt.evaluator.MutateScopes(context.Background(), mutate)
+			if tt.wantErr != nil {
+				assert.ErrorAs(t, err, &tt.wantErr, "expected an error during the resolution of the scope")
+				return
+			}
+			assert.NoError(t, err)
+			assert.EqualValues(t, tt.wantEvaluator, resolvedEvaluator, "permission did not match expected resolution")
+			assert.Equal(t, tt.wantCalls, calls, "cache has not been used")
+		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When calling a endpoint that uses scope resolver a user with wildcard scope will get a 403 when the resource is not found

To get around this we can run the evaluation without trying to resolve scope as a first try. This would allow wildcard scopes to pass a later the appropriate status code will be returned from the handler.

To prevent running a evaluator that is guaranteed to fail twice I changed so that if we don't have a resolver for a scope we return a error instead  

**Which issue(s) this PR fixes**:

Fixes #53934

**Special notes for your reviewer**:

