### PR TITLE
Build: Use specific nodejs version for levitate pipeline

### DIFF
--- a/.github/workflows/detect-breaking-changes-build.yml
+++ b/.github/workflows/detect-breaking-changes-build.yml
@@ -15,6 +15,10 @@ jobs:
       with: 
         path: './pr'
 
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16.16.0
+
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -55,6 +59,10 @@ jobs:
       with: 
         path: './base'
         ref: ${{ github.event.pull_request.base.ref }}
+
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16.16.0
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path


### PR DESCRIPTION
Manual backport for https://github.com/grafana/grafana/pull/54207

Due to a change in nodejs 16.17.0 https://github.com/yarnpkg/berry/issues/4778 there's a problem with yarn <3.2.2.

This change forces a specific nodejs version for the levitate pipeline to avoid issues with backports to older versions of grafana that use yarn <3.2.2 to build.