### PR TITLE
Chore: Refactor secrets plugin unit tests code

### DIFF
--- a/pkg/services/secrets/kvstore/plugin_fatal_crash_test.go
+++ b/pkg/services/secrets/kvstore/plugin_fatal_crash_test.go
@@ -24,6 +24,7 @@ import (
 func TestFatalPluginErr_PluginFailsToStartWithFatalFlagSet(t *testing.T) {
 	p, err := setupFatalCrashTest(t, true, true, false)
 	assert.Error(t, err)
+	assert.Equal(t, "mocked failed to start", err.Error())
 	assert.Nil(t, p.secretsKVStore)
 }
 
@@ -93,6 +94,7 @@ func TestFatalPluginErr_MigrationTestWithErrorDeletingUnifiedSecrets(t *testing.
 	}, p.kvstore)
 	err = migration.Migrate(context.Background())
 	assert.Error(t, err)
+	assert.Equal(t, "mocked del error", err.Error())
 
 	isFatal, err := isPluginStartupErrorFatal(context.Background(), GetNamespacedKVStore(p.kvstore))
 	assert.NoError(t, err)

--- a/pkg/services/secrets/kvstore/test_helpers.go
+++ b/pkg/services/secrets/kvstore/test_helpers.go
@@ -59,7 +59,7 @@ func (f *FakeSecretsKVStore) Set(ctx context.Context, orgId int64, namespace str
 
 func (f *FakeSecretsKVStore) Del(ctx context.Context, orgId int64, namespace string, typ string) error {
 	if f.delError {
-		return errors.New("bogus")
+		return errors.New("mocked del error")
 	}
 	delete(f.store, buildKey(orgId, namespace, typ))
 	return nil
@@ -239,7 +239,7 @@ type fakePluginClient struct {
 
 func (pc *fakePluginClient) Start(_ context.Context) error {
 	if pc.shouldFailOnStart {
-		return errors.New("failed to start")
+		return errors.New("mocked failed to start")
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactors some ugly unit test code I wrote to bypass the "dogsled" linter by just using a struct.

This corrects code in https://github.com/grafana/grafana/pull/53561 which had the 9.2.0 milestone.