### PR TITLE
Navigation: use navId + pageNav on API key page

### DIFF
--- a/public/app/features/api-keys/ApiKeysPage.test.tsx
+++ b/public/app/features/api-keys/ApiKeysPage.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
 import React from 'react';
 
-import { NavModel } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { ApiKey, OrgRole } from 'app/types';
 
@@ -33,14 +32,6 @@ const setup = (propOverrides: Partial<Props>) => {
   const getApiKeysMigrationStatusMock = jest.fn();
   const hideApiKeysMock = jest.fn();
   const props: Props = {
-    navModel: {
-      main: {
-        text: 'Configuration',
-      },
-      node: {
-        text: 'Api Keys',
-      },
-    } as NavModel,
     apiKeys: [] as ApiKey[],
     searchQuery: '',
     hasFetched: false,

--- a/public/app/features/api-keys/ApiKeysPage.tsx
+++ b/public/app/features/api-keys/ApiKeysPage.tsx
@@ -10,7 +10,6 @@ import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
 import { Page } from 'app/core/components/Page/Page';
 import config from 'app/core/config';
 import { contextSrv } from 'app/core/core';
-import { getNavModel } from 'app/core/selectors/navModel';
 import { getTimeZone } from 'app/features/profile/state/selectors';
 import { AccessControlAction, ApiKey, NewApiKey, StoreState } from 'app/types';
 import { ShowModalReactEvent } from 'app/types/events';
@@ -39,7 +38,6 @@ function mapStateToProps(state: StoreState) {
   const canCreate = contextSrv.hasAccess(AccessControlAction.ActionAPIKeysCreate, true);
 
   return {
-    navModel: getNavModel(state.navIndex, 'apikeys'),
     apiKeys: getApiKeys(state.apiKeys),
     searchQuery: state.apiKeys.searchQuery,
     apiKeysCount: getApiKeysCount(state.apiKeys),
@@ -51,6 +49,11 @@ function mapStateToProps(state: StoreState) {
     apiKeysMigrated: state.apiKeys.apiKeysMigrated,
   };
 }
+
+const defaultPageProps = {
+  navId: 'apikeys',
+  subTitle: 'Manage and create API keys that are used to interact with Grafana HTTP APIs.',
+};
 
 const mapDispatchToProps = {
   loadApiKeys,
@@ -156,7 +159,6 @@ export class ApiKeysPageUnconnected extends PureComponent<Props, State> {
   render() {
     const {
       hasFetched,
-      navModel,
       apiKeysCount,
       apiKeys,
       searchQuery,
@@ -169,14 +171,14 @@ export class ApiKeysPageUnconnected extends PureComponent<Props, State> {
 
     if (!hasFetched) {
       return (
-        <Page navModel={navModel}>
+        <Page {...defaultPageProps}>
           <Page.Contents isLoading={true}>{}</Page.Contents>
         </Page>
       );
     }
 
     return (
-      <Page navModel={navModel}>
+      <Page {...defaultPageProps}>
         <Page.Contents isLoading={false}>
           <ApiKeysController>
             {({ isAdding, toggleIsAdding }) => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
- [x] convert to use navId instead of navModel
- [x] add subTitle


**Which issue(s) this PR fixes**:

Main topnav off
![main_topnav_off](https://user-images.githubusercontent.com/108552997/186716728-11612cb8-240b-4e9d-8371-2020ff30955d.png)

Main topnav on
![main_topnav_on](https://user-images.githubusercontent.com/108552997/186716759-4872da75-e2c7-4d83-a09d-aff48185ca13.png)

Branch topnav off
![branch_topnav_off](https://user-images.githubusercontent.com/108552997/186716705-838f4003-7e9d-455b-b85b-bdbeec377504.png)

Branch topnav on
![branch_topnav_on](https://user-images.githubusercontent.com/108552997/186716809-4b314c4c-4e93-4d10-801c-7e86a88a18b5.png)

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #53968 

**Special notes for your reviewer**:
- Kindly also check the subtitle if that is appropriate or needs correction.
