### PR TITLE
Alerting: Scheduler to use evaluation data instead AlertRule directly

### DIFF
--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -96,7 +96,7 @@ func newAlertRuleInfo(parent context.Context) *alertRuleInfo {
 //   - true when message was sent
 //   - false when the send operation is stopped
 // the second element contains a dropped message that was sent by a concurrent sender.
-func (a *alertRuleInfo) eval(t time.Time, rule *models.AlertRule) (bool, *evaluation) {
+func (a *alertRuleInfo) eval(t time.Time, data evaluationData) (bool, *evaluation) {
 	// read the channel in unblocking manner to make sure that there is no concurrent send operation.
 	var droppedMsg *evaluation
 	select {
@@ -106,8 +106,8 @@ func (a *alertRuleInfo) eval(t time.Time, rule *models.AlertRule) (bool, *evalua
 
 	select {
 	case a.evalCh <- &evaluation{
-		scheduledAt: t,
-		rule:        rule,
+		scheduledAt:    t,
+		evaluationData: data,
 	}:
 		return true, droppedMsg
 	case <-a.ctx.Done():
@@ -140,7 +140,11 @@ func (a *alertRuleInfo) update(lastVersion ruleVersion) bool {
 
 type evaluation struct {
 	scheduledAt time.Time
-	rule        *models.AlertRule
+	evaluationData
+}
+
+type evaluationData struct {
+	rule *models.AlertRule
 }
 
 type alertRulesRegistry struct {

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -76,7 +76,9 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 
 			evalChan <- &evaluation{
 				scheduledAt: expectedTime,
-				rule:        rule,
+				evaluationData: evaluationData{
+					rule: rule,
+				},
 			}
 
 			actualTime := waitForTimeChannel(t, evalAppliedChan)
@@ -234,7 +236,9 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 		// init evaluation loop so it got the rule version
 		evalChan <- &evaluation{
 			scheduledAt: sch.clock.Now(),
-			rule:        rule,
+			evaluationData: evaluationData{
+				rule: rule,
+			},
 		}
 
 		waitForTimeChannel(t, evalAppliedChan)
@@ -313,7 +317,9 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 
 		evalChan <- &evaluation{
 			scheduledAt: sch.clock.Now(),
-			rule:        rule,
+			evaluationData: evaluationData{
+				rule: rule,
+			},
 		}
 
 		waitForTimeChannel(t, evalAppliedChan)
@@ -383,7 +389,9 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 
 			evalChan <- &evaluation{
 				scheduledAt: sch.clock.Now(),
-				rule:        rule,
+				evaluationData: evaluationData{
+					rule: rule,
+				},
 			}
 
 			waitForTimeChannel(t, evalAppliedChan)
@@ -416,7 +424,9 @@ func TestSchedule_ruleRoutine(t *testing.T) {
 
 		evalChan <- &evaluation{
 			scheduledAt: sch.clock.Now(),
-			rule:        rule,
+			evaluationData: evaluationData{
+				rule: rule,
+			},
 		}
 
 		waitForTimeChannel(t, evalAppliedChan)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR introduces a container `evaluationData` as the unit of work that is passed around from the cache to rule evaluation loop. This is needed for further changes made in https://github.com/grafana/grafana/pull/52842 and migration to group evaluation. 
**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

