### PR TITLE
QueryEditorRow: Filter data on mount

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -82,6 +82,10 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   };
 
   componentDidMount() {
+    const { data, query } = this.props;
+    const dataFilteredByRefId = filterPanelDataToQuery(data, query.refId);
+    this.setState({ data: dataFilteredByRefId });
+
     this.loadDatasource();
   }
 


### PR DESCRIPTION
This works correctly on initial dashboard load. However, when an action is taken that triggers a "re-mount", e.g. opening the options pane on the right side of the page, the `data` prop becomes undefined.

Here's an example from cloud-monitor where a label disappears because it's derived from data present in `data`.
![alignment-gone](https://user-images.githubusercontent.com/1048831/186763168-24f84d26-fd36-42ae-8ecd-7ac451a8a81e.gif)


