### PR TITLE
Using GetLabels instead of get series on `label_values`

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -7776,9 +7776,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Do not use any type assertions.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"]
+      [0, 0, 0, "Do not use any type assertions.", "3"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
     "public/app/plugins/datasource/prometheus/query_hints.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
+++ b/public/app/plugins/datasource/prometheus/metric_find_query.test.ts
@@ -102,15 +102,11 @@ describe('PrometheusMetricFindQuery', () => {
       });
     });
 
-    it('label_values(metric, resource) should generate series query with correct time', async () => {
+    it('label_values(metric, resource) should generate labels query with correct time', async () => {
       const query = setupMetricFindQuery({
         query: 'label_values(metric, resource)',
         response: {
-          data: [
-            { __name__: 'metric', resource: 'value1' },
-            { __name__: 'metric', resource: 'value2' },
-            { __name__: 'metric', resource: 'value3' },
-          ],
+          data: ['value1', 'value2', 'value3'],
         },
       });
       const results = await query.process();
@@ -119,24 +115,19 @@ describe('PrometheusMetricFindQuery', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith({
         method: 'GET',
-        url: `/api/datasources/1/resources/api/v1/series?match${encodeURIComponent(
+        url: `/api/datasources/1/resources/api/v1/label/resource/values?match${encodeURIComponent(
           '[]'
         )}=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
         hideFromInspector: true,
-        showErrorAlert: false,
         headers: {},
       });
     });
 
-    it('label_values(metric{label1="foo", label2="bar", label3="baz"}, resource) should generate series query with correct time', async () => {
+    it('label_values(metric{label1="foo", label2="bar", label3="baz"}, resource) should generate labels query with correct time', async () => {
       const query = setupMetricFindQuery({
         query: 'label_values(metric{label1="foo", label2="bar", label3="baz"}, resource)',
         response: {
-          data: [
-            { __name__: 'metric', resource: 'value1' },
-            { __name__: 'metric', resource: 'value2' },
-            { __name__: 'metric', resource: 'value3' },
-          ],
+          data: ['value1', 'value2', 'value3'],
         },
       });
       const results = await query.process();
@@ -145,9 +136,8 @@ describe('PrometheusMetricFindQuery', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith({
         method: 'GET',
-        url: '/api/datasources/1/resources/api/v1/series?match%5B%5D=metric%7Blabel1%3D%22foo%22%2C%20label2%3D%22bar%22%2C%20label3%3D%22baz%22%7D&start=1524650400&end=1524654000',
+        url: '/api/datasources/1/resources/api/v1/label/resource/values?match%5B%5D=metric%7Blabel1%3D%22foo%22%2C%20label2%3D%22bar%22%2C%20label3%3D%22baz%22%7D&start=1524650400&end=1524654000',
         hideFromInspector: true,
-        showErrorAlert: false,
         headers: {},
       });
     });
@@ -156,11 +146,7 @@ describe('PrometheusMetricFindQuery', () => {
       const query = setupMetricFindQuery({
         query: 'label_values(metric, resource)',
         response: {
-          data: [
-            { __name__: 'metric', resource: 'value1' },
-            { __name__: 'metric', resource: 'value2' },
-            { __name__: 'metric', resource: '' },
-          ],
+          data: ['value1', 'value2', ''],
         },
       });
       const results = await query.process();
@@ -171,11 +157,10 @@ describe('PrometheusMetricFindQuery', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith({
         method: 'GET',
-        url: `/api/datasources/1/resources/api/v1/series?match${encodeURIComponent(
+        url: `/api/datasources/1/resources/api/v1/label/resource/values?match${encodeURIComponent(
           '[]'
         )}=metric&start=${raw.from.unix()}&end=${raw.to.unix()}`,
         hideFromInspector: true,
-        showErrorAlert: false,
         headers: {},
       });
     });


### PR DESCRIPTION
**What this PR does / why we need it**:
Hi,

First time trying to do some changes here so sorry if i missed some ritual.

Currently, if we use the function `label_values` to populate a variable on a dashboard with prometheus datasource we can have the following behavior:

* `label_values(label_name)` with 1 argument:
  *  Calls `/api/v1/label/<label_name>/values` API to retrieve the values of the given label
* `label_values(filter, label_name)` with 2 argument2:
 *  Calls `/api/v1/series?match[]=<filter>`
    * This returns all series that match the filter
 *  Filter out/dedup  on the UI the labels using  `<label_name>`


**Which issue(s) this PR fixes**:

The GetLabelNames API can receive both the `filter` and the `label_name` as parameter and return only the relevant information (already deduped etc).

This can decrease drastically the size of the response and the processing on the UI as the prometheus server will already return the data in right format. For instance, if before the filter was returning 10K series where we were interested on a `label_name` that had 10 values, instead of returning the 10K series and filtering on grafana, prometheus will return just the 10 values we are interested.

The new behavior is the following:
* `label_values(label_name)` with 1 argument:
  * No change
* `label_values(filter, label_name)` with 2 argument2:
 *  Calls `/api/v1/label/<label_name>/values?match[]=<filter>`
 * This will filter out all series that match with the filter and return the label values.

Extreme case below where we are fetching 1M timeseries from HEAD: 
![image](https://user-images.githubusercontent.com/4027760/186793173-40669617-9d45-4def-94fc-3be8d4a802eb.png)
![image](https://user-images.githubusercontent.com/4027760/186793148-73b7e0e9-806d-4c81-bca9-0a4d830a9eff.png)

Fixes #

**Special notes for your reviewer**:

