### PR TITLE
[v9.1.x] Elasticsearch: Use millisecond intervals in frontend

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/query_builder.ts
+++ b/public/app/plugins/datasource/elasticsearch/query_builder.ts
@@ -110,7 +110,7 @@ export class ElasticQueryBuilder {
       esAgg.offset = settings.offset;
     }
 
-    const interval = settings.interval === 'auto' ? '$__interval' : settings.interval;
+    const interval = settings.interval === 'auto' ? '${__interval_ms}ms' : settings.interval;
 
     esAgg.fixed_interval = interval;
 

--- a/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/specs/query_builder.test.ts
@@ -763,7 +763,7 @@ describe('ElasticQueryBuilder', () => {
                 extended_bounds: { max: '$timeTo', min: '$timeFrom' },
                 field: '@timestamp',
                 format: 'epoch_millis',
-                fixed_interval: '$__interval',
+                fixed_interval: '${__interval_ms}ms',
                 min_doc_count: 0,
               },
             },


### PR DESCRIPTION
Backport  448a67ab434a9405598de3d29b2a72031c1ae649 from https://github.com/grafana/grafana/pull/54202
