### PR TITLE
Azure Monitor: Updated `grafana_ds_azuremonitor_dashboard_loaded` event, replaced array of queries for stats

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.test.ts
@@ -36,7 +36,6 @@ describe('queriesOnInitDashboard', () => {
     expect(reportInteraction).toHaveBeenCalledWith('grafana_ds_azuremonitor_dashboard_loaded', {
       dashboard_id: 'dashboard123',
       grafana_version: 'v9.0.0',
-      ds_version: '1.0.0',
       org_id: 1,
       azure_monitor_queries_executed: 2,
       azure_log_analytics_queries_executed: 1,

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.test.ts
@@ -36,6 +36,7 @@ describe('queriesOnInitDashboard', () => {
     expect(reportInteraction).toHaveBeenCalledWith('grafana_ds_azuremonitor_dashboard_loaded', {
       dashboard_id: 'dashboard123',
       grafana_version: 'v9.0.0',
+      ds_version: '1.0.0',
       org_id: 1,
       azure_monitor_queries_executed: 2,
       azure_log_analytics_queries_executed: 1,

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.test.ts
@@ -17,8 +17,10 @@ jest.mock('@grafana/runtime', () => {
             grafanaVersion: 'v9.0.0',
             queries: {
               'grafana-azure-monitor-datasource': [
-                { queryType: 'Azure Monitor', hide: true },
-                { queryType: 'Azure Resource Graph', hide: false },
+                { queryType: 'Azure Monitor', hide: false },
+                { queryType: 'Azure Log Analytics', hide: false },
+                { queryType: 'Azure Resource Graph', hide: true },
+                { queryType: 'Azure Monitor', hide: false },
               ],
             },
           })
@@ -35,11 +37,9 @@ describe('queriesOnInitDashboard', () => {
       dashboard_id: 'dashboard123',
       grafana_version: 'v9.0.0',
       org_id: 1,
-      user_id: 2,
-      queries: [
-        { query_type: 'Azure Monitor', hidden: true },
-        { query_type: 'Azure Resource Graph', hidden: false },
-      ],
+      azure_monitor_queries_executed: 2,
+      azure_log_analytics_queries_executed: 1,
+      azure_resource_graph_queries_hidden: 1,
     });
   });
 });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.test.ts
@@ -37,8 +37,11 @@ describe('queriesOnInitDashboard', () => {
       dashboard_id: 'dashboard123',
       grafana_version: 'v9.0.0',
       org_id: 1,
-      azure_monitor_queries_executed: 2,
-      azure_log_analytics_queries_executed: 1,
+      azure_monitor_queries: 2,
+      azure_log_analytics_queries: 1,
+      azure_resource_graph_queries: 0,
+      azure_monitor_queries_hidden: 0,
+      azure_log_analytics_queries_hidden: 0,
       azure_resource_graph_queries_hidden: 1,
     });
   });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.ts
@@ -27,7 +27,6 @@ getAppEvents().subscribe<DashboardLoadedEvent<AzureMonitorQuery>>(
     if (azureQueries && azureQueries.length > 0) {
       TrackAzureMonitorDashboardLoaded({
         grafana_version: grafanaVersion,
-        ds_version: pluginJson.info.version,
         dashboard_id: dashboardId,
         org_id: orgId,
         ...stats,

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.ts
@@ -16,16 +16,21 @@ getAppEvents().subscribe<DashboardLoadedEvent<AzureMonitorQuery>>(
   DashboardLoadedEvent,
   ({ payload: { dashboardId, orgId, userId, grafanaVersion, queries } }) => {
     const azureQueries = queries[pluginJson.id];
+    let stats: { [key: string]: number } = {};
+    azureQueries.forEach((query) => {
+      const statName =
+        (query.queryType?.toLowerCase().replaceAll(' ', '_') ?? 'unknown') +
+        '_queries_' +
+        (query.hide ? 'hidden' : 'executed');
+      stats[statName] = ~~stats[statName] + 1;
+    });
+
     if (azureQueries && azureQueries.length > 0) {
       reportInteraction('grafana_ds_azuremonitor_dashboard_loaded', {
         grafana_version: grafanaVersion,
         dashboard_id: dashboardId,
         org_id: orgId,
-        user_id: userId,
-        queries: azureQueries.map((query: AzureMonitorQuery) => ({
-          hidden: !!query.hide,
-          query_type: query.queryType,
-        })),
+        ...stats,
       });
     }
   }

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.ts
@@ -5,8 +5,8 @@ import { ConfigEditor } from './components/ConfigEditor';
 import AzureMonitorQueryEditor from './components/QueryEditor';
 import Datasource from './datasource';
 import pluginJson from './plugin.json';
-import { TrackAzureMonitorDashboardLoaded } from './tracking';
-import { AzureMonitorQuery, AzureDataSourceJsonData } from './types';
+import { trackAzureMonitorDashboardLoaded } from './tracking';
+import { AzureMonitorQuery, AzureDataSourceJsonData, AzureQueryType } from './types';
 
 export const plugin = new DataSourcePlugin<Datasource, AzureMonitorQuery, AzureDataSourceJsonData>(Datasource)
   .setConfigEditor(ConfigEditor)
@@ -17,19 +17,41 @@ getAppEvents().subscribe<DashboardLoadedEvent<AzureMonitorQuery>>(
   DashboardLoadedEvent,
   ({ payload: { dashboardId, orgId, userId, grafanaVersion, queries } }) => {
     const azureQueries = queries[pluginJson.id];
-    let stats: { [key: string]: number } = {};
+    let stats = {
+      [AzureQueryType.AzureMonitor]: {
+        hidden: 0,
+        visible: 0,
+      },
+      [AzureQueryType.LogAnalytics]: {
+        hidden: 0,
+        visible: 0,
+      },
+      [AzureQueryType.AzureResourceGraph]: {
+        hidden: 0,
+        visible: 0,
+      },
+    };
     azureQueries.forEach((query) => {
-      const statName =
-        (query.queryType ?? '').toLowerCase().replace(/ /gi, '_') + '_queries_' + (query.hide ? 'hidden' : 'executed');
-      stats[statName] = ~~stats[statName] + 1;
+      if (
+        query.queryType === AzureQueryType.AzureMonitor ||
+        query.queryType === AzureQueryType.LogAnalytics ||
+        query.queryType === AzureQueryType.AzureResourceGraph
+      ) {
+        stats[query.queryType][query.hide ? 'hidden' : 'visible']++;
+      }
     });
 
     if (azureQueries && azureQueries.length > 0) {
-      TrackAzureMonitorDashboardLoaded({
+      trackAzureMonitorDashboardLoaded({
         grafana_version: grafanaVersion,
         dashboard_id: dashboardId,
         org_id: orgId,
-        ...stats,
+        azure_monitor_queries: stats[AzureQueryType.AzureMonitor].visible,
+        azure_log_analytics_queries: stats[AzureQueryType.LogAnalytics].visible,
+        azure_resource_graph_queries: stats[AzureQueryType.AzureResourceGraph].visible,
+        azure_monitor_queries_hidden: stats[AzureQueryType.AzureMonitor].hidden,
+        azure_log_analytics_queries_hidden: stats[AzureQueryType.LogAnalytics].hidden,
+        azure_resource_graph_queries_hidden: stats[AzureQueryType.AzureResourceGraph].hidden,
       });
     }
   }

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/module.ts
@@ -28,6 +28,7 @@ getAppEvents().subscribe<DashboardLoadedEvent<AzureMonitorQuery>>(
     if (azureQueries && azureQueries.length > 0) {
       reportInteraction('grafana_ds_azuremonitor_dashboard_loaded', {
         grafana_version: grafanaVersion,
+        ds_version: pluginJson.info.version,
         dashboard_id: dashboardId,
         org_id: orgId,
         ...stats,

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/tracking.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/tracking.ts
@@ -11,7 +11,7 @@ import { reportInteraction } from '@grafana/runtime';
  * Dashboard: https://ops.grafana.net/d/Ad0pti0N/data-sources-adoption-tracking?orgId=1
  * Changelog:
  * - v9.1.0 : list of queries logged
- * - v9.1.2 : list removed in favour of stats, ds_version added, user_id removed
+ * - v9.1.2 : list removed in favour of stats, user_id removed
  */
 export const TrackAzureMonitorDashboardLoaded = (props: AzureMonitorDashboardLoadedProps) => {
   reportInteraction('grafana_ds_azuremonitor_dashboard_loaded', props);
@@ -21,8 +21,6 @@ type AzureMonitorDashboardLoadedProps = {
   grafana_version?: string;
   dashboard_id: string;
   org_id?: number;
-  /** version of Azure Monitor the user is running */
-  ds_version: string;
   /** number of executed queries (non hidden) of type Azure Monitor if any  */
   azure_monitor_queries_executed?: number;
   /** number of executed queries (non hidden) of type Azure Logs Analytics if any  */

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/tracking.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/tracking.ts
@@ -1,0 +1,38 @@
+import { reportInteraction } from '@grafana/runtime';
+
+/**
+ * Loaded the first time a dashboard containing azure queries is loaded (not on every render)
+ *
+ * This allows answering questions about:
+ * - the adoption of the three query types (Azure Monitor, Azure Logs Analytics and Azure Resource Graph)
+ * - stats about number of azure dashboards loaded, number of users
+ * - stats about the grafana and plugins versions used by our users
+ *
+ * Dashboard: https://ops.grafana.net/d/Ad0pti0N/data-sources-adoption-tracking?orgId=1
+ * Changelog:
+ * - v9.1.0 : list of queries logged
+ * - v9.1.2 : list removed in favour of stats, ds_version added, user_id removed
+ */
+export const TrackAzureMonitorDashboardLoaded = (props: AzureMonitorDashboardLoadedProps) => {
+  reportInteraction('grafana_ds_azuremonitor_dashboard_loaded', props);
+};
+
+type AzureMonitorDashboardLoadedProps = {
+  grafana_version?: string;
+  dashboard_id: string;
+  org_id?: number;
+  /** version of Azure Monitor the user is running */
+  ds_version: string;
+  /** number of executed queries (non hidden) of type Azure Monitor if any  */
+  azure_monitor_queries_executed?: number;
+  /** number of executed queries (non hidden) of type Azure Logs Analytics if any  */
+  azure_log_analytics_queries_executed?: number;
+  /** number of executed queries (non hidden) of type Azure Resource Graph if any  */
+  azure_resource_graph_queries_exectued?: number;
+  /** number of hidden queries (not executed) of type Azure Monitor if any  */
+  azure_monitor_queries_hidden?: number;
+  /** number of hidden queries (not executed) of type Azure Logs Analytics if any  */
+  azure_log_analytics_queries_hidden?: number;
+  /** number of hidden queries (not executed) of type Azure Resource Graph if any  */
+  azure_resource_graph_queries_hidden?: number;
+};

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/tracking.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/tracking.ts
@@ -13,24 +13,24 @@ import { reportInteraction } from '@grafana/runtime';
  * - v9.1.0 : list of queries logged
  * - v9.1.2 : list removed in favour of stats, user_id removed
  */
-export const TrackAzureMonitorDashboardLoaded = (props: AzureMonitorDashboardLoadedProps) => {
+export const trackAzureMonitorDashboardLoaded = (props: AzureMonitorDashboardLoadedProps) => {
   reportInteraction('grafana_ds_azuremonitor_dashboard_loaded', props);
 };
 
-type AzureMonitorDashboardLoadedProps = {
+export type AzureMonitorDashboardLoadedProps = {
   grafana_version?: string;
   dashboard_id: string;
   org_id?: number;
-  /** number of executed queries (non hidden) of type Azure Monitor if any  */
-  azure_monitor_queries_executed?: number;
-  /** number of executed queries (non hidden) of type Azure Logs Analytics if any  */
-  azure_log_analytics_queries_executed?: number;
-  /** number of executed queries (non hidden) of type Azure Resource Graph if any  */
-  azure_resource_graph_queries_exectued?: number;
+  /** number of non hidden queries of type Azure Monitor if any  */
+  azure_monitor_queries: number;
+  /** number of non hidden queries of type Azure Logs Analytics if any  */
+  azure_log_analytics_queries: number;
+  /** number of non hidden queries of type Azure Resource Graph if any  */
+  azure_resource_graph_queries: number;
   /** number of hidden queries (not executed) of type Azure Monitor if any  */
-  azure_monitor_queries_hidden?: number;
+  azure_monitor_queries_hidden: number;
   /** number of hidden queries (not executed) of type Azure Logs Analytics if any  */
-  azure_log_analytics_queries_hidden?: number;
+  azure_log_analytics_queries_hidden: number;
   /** number of hidden queries (not executed) of type Azure Resource Graph if any  */
-  azure_resource_graph_queries_hidden?: number;
+  azure_resource_graph_queries_hidden: number;
 };

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/tracking.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/tracking.ts
@@ -2,6 +2,7 @@ import { reportInteraction } from '@grafana/runtime';
 
 /**
  * Loaded the first time a dashboard containing azure queries is loaded (not on every render)
+ * Note: The queries used here are the ones pre-migration and pre-filterQuery
  *
  * This allows answering questions about:
  * - the adoption of the three query types (Azure Monitor, Azure Logs Analytics and Azure Resource Graph)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Tweaking our `grafana_ds_azuremonitor_dashboard_loaded` event to:
* remove user_id since some include the user email (privacy) and a better option (anonymous_id) is available out of the box in Rudderstack
* replace the huge array of queries prop for a much neater option: a few stats props (one per queryType/hidden combinaison = 6)

This PR also extracts the event tracking to a new file for documentation purposes

**Special notes for your reviewer**:

