### PR TITLE
Chore: add missing properties to mocks

### DIFF
--- a/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/loki/components/__snapshots__/LokiExploreQueryEditor.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`LokiExploreQueryEditor should render component 1`] = `
           "type": "datasource",
         },
         "name": "",
+        "readOnly": false,
         "type": "",
         "uid": "",
         "url": "myloggingurl",

--- a/public/app/plugins/datasource/loki/mocks.ts
+++ b/public/app/plugins/datasource/loki/mocks.ts
@@ -57,6 +57,7 @@ export function createLokiDatasource(
         version: '',
       },
     },
+    readOnly: false,
     jsonData: {
       maxLines: '20',
     },

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
@@ -139,6 +139,7 @@ const defaultSettings: DataSourceInstanceSettings<TempoJsonData> = {
     module: '',
     baseUrl: '',
   },
+  readOnly: false,
   jsonData: {
     nodeGraph: {
       enabled: true,


### PR DESCRIPTION
a recent PR introduced a readOnly property to DatasourceInstanceSettings and this 2 files were missing it.