### PR TITLE
SearchSrv: stop using IDs

### DIFF
--- a/public/app/core/services/search_srv.ts
+++ b/public/app/core/services/search_srv.ts
@@ -4,7 +4,12 @@ import { contextSrv } from 'app/core/services/context_srv';
 import impressionSrv from 'app/core/services/impression_srv';
 import store from 'app/core/store';
 import { SECTION_STORAGE_KEY } from 'app/features/search/constants';
-import { DashboardSection, DashboardSearchItemType, DashboardSearchHit, SearchLayout } from 'app/features/search/types';
+import {
+  DashboardSection,
+  DashboardSearchItemType,
+  DashboardSearchItem,
+  SearchLayout,
+} from 'app/features/search/types';
 import { hasFilters } from 'app/features/search/utils';
 
 import { backendSrv } from './backend_srv';
@@ -30,7 +35,7 @@ export class SearchSrv {
     });
   }
 
-  private queryForRecentDashboards(): Promise<DashboardSearchHit[]> {
+  private queryForRecentDashboards(): Promise<DashboardSearchItem[]> {
     return new Promise((resolve) => {
       impressionSrv.getDashboardOpened().then((uids) => {
         const dashUIDs: string[] = take(uids, 30);
@@ -42,7 +47,7 @@ export class SearchSrv {
           return resolve(
             dashUIDs
               .map((orderId) => result.find((result) => result.uid === orderId))
-              .filter((hit) => hit && !hit.isStarred) as DashboardSearchHit[]
+              .filter((hit) => hit && !hit.isStarred) as DashboardSearchItem[]
           );
         });
       });
@@ -105,7 +110,7 @@ export class SearchSrv {
     });
   }
 
-  private handleSearchResult(sections: Sections, results: DashboardSearchHit[]): any {
+  private handleSearchResult(sections: Sections, results: DashboardSearchItem[]): any {
     if (results.length === 0) {
       return sections;
     }
@@ -113,9 +118,7 @@ export class SearchSrv {
     // create folder index
     for (const hit of results) {
       if (hit.type === 'dash-folder') {
-        // FIXME: Use hit.uid instead
-        sections[hit.id!] = {
-          id: hit.id,
+        sections[hit.uid!] = {
           uid: hit.uid,
           title: hit.title,
           expanded: false,
@@ -133,11 +136,10 @@ export class SearchSrv {
         continue;
       }
 
-      let section = sections[hit.folderId || 0];
+      let section = sections[hit.folderUid || 0];
       if (!section) {
-        if (hit.folderId) {
+        if (hit.folderUid) {
           section = {
-            id: hit.folderId,
             uid: hit.folderUid,
             title: hit.folderTitle,
             url: hit.folderUrl,
@@ -148,7 +150,7 @@ export class SearchSrv {
           };
         } else {
           section = {
-            id: 0,
+            uid: '',
             title: 'General',
             items: [],
             icon: 'folder-open',
@@ -157,7 +159,7 @@ export class SearchSrv {
           };
         }
         // add section
-        sections[hit.folderId || 0] = section;
+        sections[hit.folderUid || 0] = section;
       }
 
       section.expanded = true;

--- a/public/app/core/specs/search_srv.test.ts
+++ b/public/app/core/specs/search_srv.test.ts
@@ -158,24 +158,24 @@ describe('SearchSrv', () => {
               {
                 title: 'folder1',
                 type: 'dash-folder',
-                id: 1,
+                uid: 'folder-1',
               },
               {
                 title: 'dash with no folder',
                 type: 'dash-db',
-                id: 2,
+                uid: '2',
               },
               {
                 title: 'dash in folder1 1',
                 type: 'dash-db',
-                id: 3,
-                folderId: 1,
+                uid: '3',
+                folderUid: 'folder-1',
               },
               {
                 title: 'dash in folder1 2',
                 type: 'dash-db',
-                id: 4,
-                folderId: 1,
+                uid: '4',
+                folderUid: 'folder-1',
               },
             ])
           )

--- a/public/app/core/specs/search_srv.test.ts
+++ b/public/app/core/specs/search_srv.test.ts
@@ -202,15 +202,13 @@ describe('SearchSrv', () => {
       searchMock.mockImplementation(
         jest.fn().mockResolvedValue([
           {
-            id: 2,
+            folderUid: 'dash-with-no-folder-uid',
             title: 'dash with no folder',
             type: 'dash-db',
           },
           {
-            id: 3,
             title: 'dash in folder1 1',
             type: 'dash-db',
-            folderId: 1,
             folderUid: 'uid',
             folderTitle: 'folder1',
             folderUrl: '/dashboards/f/uid/folder1',
@@ -229,8 +227,7 @@ describe('SearchSrv', () => {
 
     it('should group results by folder', () => {
       expect(results).toHaveLength(2);
-      expect(results[0].id).toEqual(0);
-      expect(results[1].id).toEqual(1);
+      expect(results[0].uid).toEqual('dash-with-no-folder-uid');
       expect(results[1].uid).toEqual('uid');
       expect(results[1].title).toEqual('folder1');
       expect(results[1].url).toEqual('/dashboards/f/uid/folder1');


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
We don't want to relay in internal IDs anymore so this PR is using the dashboard and folder UID to organize the results returned by SearchSrv.
Main changes:
* Replace `DashboardSearchHit` by `DashboardSearchItem` to make sure IDs are not used
* Map folders by UID instead ID

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to #48850 
Fixes: #54270

**Special notes for your reviewer**:
SearchSrv results are not used in the Grafana app, only in the test. So the PR is trivial to review
