### PR TITLE
Stars: Support UIDs

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -203,6 +203,8 @@ func (hs *HTTPServer) registerRoutes() {
 			userRoute.Get("/stars", routing.Wrap(hs.GetStars))
 			userRoute.Post("/stars/dashboard/:id", routing.Wrap(hs.StarDashboard))
 			userRoute.Delete("/stars/dashboard/:id", routing.Wrap(hs.UnstarDashboard))
+			userRoute.Post("/stars/dashboard/uid/:uid", routing.Wrap(hs.StarDashboardUID))
+			userRoute.Delete("/stars/dashboard/uid/:uid", routing.Wrap(hs.UnstarDashboardUID))
 
 			userRoute.Put("/password", routing.Wrap(hs.ChangeUserPassword))
 			userRoute.Get("/quotas", routing.Wrap(hs.GetUserQuotas))

--- a/pkg/api/stars.go
+++ b/pkg/api/stars.go
@@ -32,7 +32,7 @@ func (hs *HTTPServer) GetStars(c *models.ReqContext) response.Response {
 		return response.Error(500, "Failed to get user stars", err)
 	}
 
-	return response.JSON(200, iuserstars.UserStarsUID)
+	return response.JSON(200, iuserstars.DashboardUIDs)
 }
 
 // swagger:route POST /user/stars/dashboard/{dashboard_id} signed_in_user listStarredDashboards

--- a/pkg/services/dashboards/database/database_test.go
+++ b/pkg/services/dashboards/database/database_test.go
@@ -33,7 +33,7 @@ func TestIntegrationDashboardDataAccess(t *testing.T) {
 
 	setup := func() {
 		sqlStore = sqlstore.InitTestDB(t)
-		starService = starimpl.ProvideService(sqlStore, sqlStore.Cfg)
+		starService = starimpl.ProvideService(sqlStore, nil, sqlStore.Cfg)
 		dashboardStore = ProvideDashboardStore(sqlStore, testFeatureToggles)
 		savedFolder = insertTestDashboard(t, dashboardStore, "1 test dash folder", 1, 0, true, "prod", "webapp")
 		savedDash = insertTestDashboard(t, dashboardStore, "test dash 23", 1, savedFolder.Id, false, "prod", "webapp")

--- a/pkg/services/star/model.go
+++ b/pkg/services/star/model.go
@@ -54,6 +54,6 @@ type IsStarredByUserQuery struct {
 }
 
 type GetUserStarsResult struct {
-	UserStars    map[int64]bool
-	UserStarsUID []string `json:"userStarsUid"`
+	UserStars     map[int64]bool
+	DashboardUIDs []string
 }

--- a/pkg/services/star/model.go
+++ b/pkg/services/star/model.go
@@ -14,24 +14,26 @@ type Star struct {
 // COMMANDS
 
 type StarDashboardCommand struct {
-	UserID      int64 `xorm:"user_id"`
-	DashboardID int64 `xorm:"dashboard_id"`
+	UserID       int64  `xorm:"user_id"`
+	DashboardID  int64  `xorm:"dashboard_id"`
+	DashboardUID string `xorm:"-"`
 }
 
 func (cmd *StarDashboardCommand) Validate() error {
-	if cmd.DashboardID == 0 || cmd.UserID == 0 {
+	if cmd.DashboardID == 0 && cmd.DashboardUID == "" || cmd.UserID == 0 {
 		return ErrCommandValidationFailed
 	}
 	return nil
 }
 
 type UnstarDashboardCommand struct {
-	UserID      int64 `xorm:"user_id"`
-	DashboardID int64 `xorm:"dashboard_id"`
+	UserID       int64  `xorm:"user_id"`
+	DashboardID  int64  `xorm:"dashboard_id"`
+	DashboardUID string `xorm:"-"`
 }
 
 func (cmd *UnstarDashboardCommand) Validate() error {
-	if cmd.DashboardID == 0 || cmd.UserID == 0 {
+	if cmd.DashboardID == 0 && cmd.DashboardUID == "" || cmd.UserID == 0 {
 		return ErrCommandValidationFailed
 	}
 	return nil
@@ -41,14 +43,17 @@ func (cmd *UnstarDashboardCommand) Validate() error {
 // QUERIES
 
 type GetUserStarsQuery struct {
+	OrgID  int64 `xorm:"-"`
 	UserID int64 `xorm:"user_id"`
 }
 
 type IsStarredByUserQuery struct {
-	UserID      int64 `xorm:"user_id"`
-	DashboardID int64 `xorm:"dashboard_id"`
+	UserID       int64  `xorm:"user_id"`
+	DashboardID  int64  `xorm:"dashboard_id"`
+	DashboardUID string `xorm:"-"`
 }
 
 type GetUserStarsResult struct {
-	UserStars map[int64]bool
+	UserStars    map[int64]bool
+	UserStarsUID []string `json:"userStarsUid"`
 }

--- a/pkg/services/star/starimpl/inmemory_store.go
+++ b/pkg/services/star/starimpl/inmemory_store.go
@@ -1,0 +1,55 @@
+package starimpl
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/services/star"
+)
+
+type inmemory struct {
+	starsByUserID map[int64]map[int64]bool
+}
+
+func newInmemory() *inmemory {
+	return &inmemory{starsByUserID: map[int64]map[int64]bool{}}
+}
+
+func (i *inmemory) Get(ctx context.Context, query *star.IsStarredByUserQuery) (bool, error) {
+	usrStars, hasStars := i.starsByUserID[query.UserID]
+	if !hasStars {
+		return false, nil
+	}
+
+	_, starred := usrStars[query.DashboardID]
+	return starred, nil
+}
+
+func (i *inmemory) Insert(ctx context.Context, command *star.StarDashboardCommand) error {
+	usrStars, hasStars := i.starsByUserID[command.UserID]
+	if !hasStars {
+		usrStars = map[int64]bool{}
+	}
+
+	usrStars[command.DashboardID] = true
+	i.starsByUserID[command.UserID] = usrStars
+	return nil
+}
+
+func (i *inmemory) Delete(ctx context.Context, command *star.UnstarDashboardCommand) error {
+	_, hasStars := i.starsByUserID[command.UserID]
+	if !hasStars {
+		return nil
+	}
+
+	delete(i.starsByUserID[command.UserID], command.DashboardID)
+	return nil
+}
+
+func (i *inmemory) DeleteByUser(ctx context.Context, usr int64) error {
+	delete(i.starsByUserID, usr)
+	return nil
+}
+
+func (i *inmemory) List(ctx context.Context, query *star.GetUserStarsQuery) (*star.GetUserStarsResult, error) {
+	return &star.GetUserStarsResult{UserStars: i.starsByUserID[query.UserID]}, nil
+}

--- a/pkg/services/star/starimpl/inmemory_store_test.go
+++ b/pkg/services/star/starimpl/inmemory_store_test.go
@@ -1,0 +1,13 @@
+package starimpl
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+)
+
+func TestInmemory(t *testing.T) {
+	testIntegrationUserStarsDataAccess(t, func(_ *sqlstore.SQLStore) store {
+		return newInmemory()
+	})
+}

--- a/pkg/services/star/starimpl/star.go
+++ b/pkg/services/star/starimpl/star.go
@@ -3,16 +3,19 @@ package starimpl
 import (
 	"context"
 
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/sqlstore/db"
 	"github.com/grafana/grafana/pkg/services/star"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
 type Service struct {
-	store store
+	store      store
+	dashboards dashboards.DashboardService
 }
 
-func ProvideService(db db.DB, cfg *setting.Cfg) star.Service {
+func ProvideService(db db.DB, dashboard dashboards.DashboardService, cfg *setting.Cfg) star.Service {
 	if cfg.IsFeatureToggleEnabled("newDBLibrary") {
 		return &Service{
 			store: &sqlxStore{
@@ -24,6 +27,7 @@ func ProvideService(db db.DB, cfg *setting.Cfg) star.Service {
 		store: &sqlStore{
 			db: db,
 		},
+		dashboards: dashboard,
 	}
 }
 
@@ -31,6 +35,14 @@ func (s *Service) Add(ctx context.Context, cmd *star.StarDashboardCommand) error
 	if err := cmd.Validate(); err != nil {
 		return err
 	}
+	if cmd.DashboardUID != "" {
+		id, err := s.getDashboardID(ctx, cmd.DashboardUID)
+		if err != nil {
+			return err
+		}
+		cmd.DashboardID = id
+	}
+
 	return s.store.Insert(ctx, cmd)
 }
 
@@ -38,17 +50,75 @@ func (s *Service) Delete(ctx context.Context, cmd *star.UnstarDashboardCommand) 
 	if err := cmd.Validate(); err != nil {
 		return err
 	}
+	if cmd.DashboardUID != "" {
+		id, err := s.getDashboardID(ctx, cmd.DashboardUID)
+		if err != nil {
+			return err
+		}
+		cmd.DashboardID = id
+	}
+
 	return s.store.Delete(ctx, cmd)
 }
 
 func (s *Service) IsStarredByUser(ctx context.Context, query *star.IsStarredByUserQuery) (bool, error) {
+	if query.DashboardUID != "" {
+		id, err := s.getDashboardID(ctx, query.DashboardUID)
+		if err != nil {
+			return false, err
+		}
+		query.DashboardID = id
+	}
+
 	return s.store.Get(ctx, query)
 }
 
 func (s *Service) GetByUser(ctx context.Context, cmd *star.GetUserStarsQuery) (*star.GetUserStarsResult, error) {
-	return s.store.List(ctx, cmd)
+	stars, err := s.store.List(ctx, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]int64, 0, len(stars.UserStars))
+	for id := range stars.UserStars {
+		ids = append(ids, id)
+	}
+
+	query := &models.GetDashboardsQuery{DashboardIds: ids}
+	err = s.dashboards.GetDashboards(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	uids := make([]string, 0, len(ids))
+	for _, dashboard := range query.Result {
+		if dashboard == nil {
+			continue
+		}
+		if dashboard.OrgId != cmd.OrgID {
+			delete(stars.UserStars, dashboard.Id)
+			continue
+		}
+
+		uids = append(uids, dashboard.Uid)
+	}
+	stars.UserStarsUID = uids
+
+	return stars, err
 }
 
 func (s *Service) DeleteByUser(ctx context.Context, userID int64) error {
 	return s.store.DeleteByUser(ctx, userID)
+}
+
+func (s *Service) getDashboardID(ctx context.Context, uid string) (int64, error) {
+	query := &models.GetDashboardQuery{
+		Uid: uid,
+	}
+	err := s.dashboards.GetDashboard(ctx, query)
+	if err != nil {
+		return 0, err
+	}
+
+	return query.Result.Id, nil
 }

--- a/pkg/services/star/starimpl/star.go
+++ b/pkg/services/star/starimpl/star.go
@@ -95,7 +95,7 @@ func (s *Service) GetByUser(ctx context.Context, cmd *star.GetUserStarsQuery) (*
 		if dashboard == nil {
 			continue
 		}
-		if dashboard.OrgId != cmd.OrgID {
+		if cmd.OrgID != 0 && dashboard.OrgId != cmd.OrgID {
 			delete(stars.UserStars, dashboard.Id)
 			continue
 		}

--- a/pkg/services/star/starimpl/star.go
+++ b/pkg/services/star/starimpl/star.go
@@ -102,7 +102,7 @@ func (s *Service) GetByUser(ctx context.Context, cmd *star.GetUserStarsQuery) (*
 
 		uids = append(uids, dashboard.Uid)
 	}
-	stars.UserStarsUID = uids
+	stars.DashboardUIDs = uids
 
 	return stars, err
 }

--- a/pkg/services/star/starimpl/star_test.go
+++ b/pkg/services/star/starimpl/star_test.go
@@ -1,0 +1,239 @@
+package starimpl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/star"
+)
+
+type lightweightDashboard struct {
+	UID   string
+	ID    int64
+	OrgID int64
+}
+
+var testDashboards = []lightweightDashboard{
+	{
+		UID:   "blueberries",
+		ID:    1,
+		OrgID: 1,
+	},
+	{
+		UID:   "lingonberries",
+		ID:    2,
+		OrgID: 1,
+	},
+	{
+		UID:   "blackberries",
+		ID:    3,
+		OrgID: 1,
+	},
+	{
+		UID:   "raspberries",
+		ID:    4,
+		OrgID: 1,
+	},
+	{
+		UID:   "bananas",
+		ID:    5,
+		OrgID: 2,
+	},
+}
+
+func TestStarByUID(t *testing.T) {
+	svc := serviceForTest(t, testDashboards)
+
+	// curl -XPOST "http://admin:admin@localhost:3000/api/user/stars/dashboard/uid/blueberries"
+	// Star a dashboard.
+	require.NoError(t, svc.Add(context.Background(), &star.StarDashboardCommand{
+		UserID:       1,
+		DashboardUID: testDashboards[0].UID,
+	}))
+
+	// curl "http://admin:admin@localhost:3000/api/user/stars"
+	// Returns the newly starred dashboard.
+	stars, err := svc.GetByUser(context.Background(), &star.GetUserStarsQuery{
+		OrgID:  1,
+		UserID: 1,
+	})
+	require.NoError(t, err)
+	assert.True(t, stars.UserStars[testDashboards[0].ID])
+	assert.Equal(t, testDashboards[0].UID, stars.UserStarsUID[0])
+
+	// curl -XDELETE "http://admin:admin@localhost:3000/api/user/stars/dashboard/uid/blueberries"
+	// Remove the starred dashboard.
+	require.NoError(t, svc.Delete(context.Background(), &star.UnstarDashboardCommand{
+		UserID:       1,
+		DashboardUID: testDashboards[0].UID,
+	}))
+
+	// curl "http://admin:admin@localhost:3000/api/user/stars"
+	// Empty response, all starred dashboards are removed.
+	stars, err = svc.GetByUser(context.Background(), &star.GetUserStarsQuery{
+		OrgID:  1,
+		UserID: 1,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, stars.UserStars)
+	assert.Empty(t, stars.UserStarsUID)
+}
+
+func TestStarByID(t *testing.T) {
+	svc := serviceForTest(t, testDashboards)
+
+	// curl -XPOST "http://admin:admin@localhost:3000/api/user/stars/dashboard/1"
+	// Star a dashboard.
+	require.NoError(t, svc.Add(context.Background(), &star.StarDashboardCommand{
+		UserID:      1,
+		DashboardID: testDashboards[0].ID,
+	}))
+
+	// curl "http://admin:admin@localhost:3000/api/user/stars"
+	// Returns the newly starred dashboard.
+	stars, err := svc.GetByUser(context.Background(), &star.GetUserStarsQuery{
+		OrgID:  1,
+		UserID: 1,
+	})
+	require.NoError(t, err)
+	assert.True(t, stars.UserStars[testDashboards[0].ID])
+	assert.Equal(t, testDashboards[0].UID, stars.UserStarsUID[0])
+
+	// curl -XDELETE "http://admin:admin@localhost:3000/api/user/stars/dashboard/1"
+	// Remove the starred dashboard.
+	require.NoError(t, svc.Delete(context.Background(), &star.UnstarDashboardCommand{
+		UserID:      1,
+		DashboardID: testDashboards[0].ID,
+	}))
+
+	// curl "http://admin:admin@localhost:3000/api/user/stars"
+	// Empty response, all starred dashboards are removed.
+	stars, err = svc.GetByUser(context.Background(), &star.GetUserStarsQuery{
+		OrgID:  1,
+		UserID: 1,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, stars.UserStars)
+	assert.Empty(t, stars.UserStarsUID)
+}
+
+func TestStarOrgs(t *testing.T) {
+	svc := serviceForTest(t, testDashboards)
+
+	// curl -XPOST "http://admin:admin@localhost:3000/api/user/stars/dashboard/1"
+	// Star a dashboard from org 2.
+	require.NoError(t, svc.Add(context.Background(), &star.StarDashboardCommand{
+		UserID:      1,
+		DashboardID: testDashboards[4].ID,
+	}))
+
+	// curl "http://admin:admin@localhost:3000/api/user/stars"
+	// Empty response, the dashboard is in another ~castle~ org.
+	stars, err := svc.GetByUser(context.Background(), &star.GetUserStarsQuery{
+		OrgID:  1,
+		UserID: 1,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, stars.UserStars)
+	assert.Empty(t, stars.UserStarsUID)
+}
+
+func TestStarUsers(t *testing.T) {
+	svc := serviceForTest(t, testDashboards)
+
+	// curl -XPOST "http://admin:admin@localhost:3000/api/user/stars/dashboard/1"
+	// Star a dashboard with user 1.
+	require.NoError(t, svc.Add(context.Background(), &star.StarDashboardCommand{
+		UserID:      1,
+		DashboardID: testDashboards[1].ID,
+	}))
+
+	// curl "http://admin:admin@localhost:3000/api/user/stars"
+	// Returns starred dashboard.
+	stars, err := svc.GetByUser(context.Background(), &star.GetUserStarsQuery{
+		OrgID:  1,
+		UserID: 1,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, stars.UserStars)
+	assert.NotEmpty(t, stars.UserStarsUID)
+
+	// curl "http://otheruser:password@localhost:3000/api/user/stars"
+	// Empty response, the dashboard is starred by user 1.
+	stars, err = svc.GetByUser(context.Background(), &star.GetUserStarsQuery{
+		OrgID:  1,
+		UserID: 2,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, stars.UserStars)
+	assert.Empty(t, stars.UserStarsUID)
+
+	// Delete all stars from user 1.
+	require.NoError(t, svc.DeleteByUser(context.Background(), 1))
+
+	// curl "http://admin:admin@localhost:3000/api/user/stars"
+	// Empty response, all dashboards have been unstarred.
+	stars, err = svc.GetByUser(context.Background(), &star.GetUserStarsQuery{
+		OrgID:  1,
+		UserID: 1,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, stars.UserStars)
+	assert.Empty(t, stars.UserStarsUID)
+}
+
+func serviceForTest(t testing.TB, dashs []lightweightDashboard) *Service {
+	dashboardsMock := dashboards.NewFakeDashboardService(t)
+	dashboardsMock.On("GetDashboards", mock.Anything, mock.AnythingOfType("*models.GetDashboardsQuery")).Maybe().Run(func(args mock.Arguments) {
+		query := args.Get(1).(*models.GetDashboardsQuery)
+		res := dashboardListFromLWDashboards(query.DashboardUIds, query.DashboardIds, dashs)
+		query.Result = res
+	}).Return(nil)
+	dashboardsMock.On("GetDashboard", mock.Anything, mock.AnythingOfType("*models.GetDashboardQuery")).Maybe().Run(func(args mock.Arguments) {
+		query := args.Get(1).(*models.GetDashboardQuery)
+		res := dashboardListFromLWDashboards([]string{query.Uid}, []int64{query.Id}, dashs)
+		query.Result = res[0]
+	}).Return(nil)
+
+	return &Service{
+		store:      newInmemory(),
+		dashboards: dashboardsMock,
+	}
+}
+
+func dashboardListFromLWDashboards(targetUIDs []string, targetIDs []int64, dashs []lightweightDashboard) []*models.Dashboard {
+	// this is used to make the dashboard mock behave a bit more
+	// like a fake. It's _very_ hacky, but it basically returns dashboards
+	// that match the asked-for dashboard.
+
+	ids := map[int64]struct{}{}
+	uids := map[string]struct{}{}
+	for _, id := range targetIDs {
+		ids[id] = struct{}{}
+	}
+	for _, uid := range targetUIDs {
+		uids[uid] = struct{}{}
+	}
+
+	res := []*models.Dashboard{}
+	for _, dash := range dashs {
+		_, UIDinQ := uids[dash.UID]
+		_, IDinQ := ids[dash.ID]
+		if !UIDinQ && !IDinQ {
+			continue
+		}
+
+		res = append(res, &models.Dashboard{
+			Uid:   dash.UID,
+			Id:    dash.ID,
+			OrgId: dash.OrgID,
+		})
+	}
+	return res
+}

--- a/pkg/services/star/starimpl/star_test.go
+++ b/pkg/services/star/starimpl/star_test.go
@@ -65,7 +65,7 @@ func TestStarByUID(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, stars.UserStars[testDashboards[0].ID])
-	assert.Equal(t, testDashboards[0].UID, stars.UserStarsUID[0])
+	assert.Equal(t, testDashboards[0].UID, stars.DashboardUIDs[0])
 
 	// curl -XDELETE "http://admin:admin@localhost:3000/api/user/stars/dashboard/uid/blueberries"
 	// Remove the starred dashboard.
@@ -82,7 +82,7 @@ func TestStarByUID(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Empty(t, stars.UserStars)
-	assert.Empty(t, stars.UserStarsUID)
+	assert.Empty(t, stars.DashboardUIDs)
 }
 
 func TestStarByID(t *testing.T) {
@@ -103,7 +103,7 @@ func TestStarByID(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, stars.UserStars[testDashboards[0].ID])
-	assert.Equal(t, testDashboards[0].UID, stars.UserStarsUID[0])
+	assert.Equal(t, testDashboards[0].UID, stars.DashboardUIDs[0])
 
 	// curl -XDELETE "http://admin:admin@localhost:3000/api/user/stars/dashboard/1"
 	// Remove the starred dashboard.
@@ -120,7 +120,7 @@ func TestStarByID(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Empty(t, stars.UserStars)
-	assert.Empty(t, stars.UserStarsUID)
+	assert.Empty(t, stars.DashboardUIDs)
 }
 
 func TestStarOrgs(t *testing.T) {
@@ -141,7 +141,7 @@ func TestStarOrgs(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Empty(t, stars.UserStars)
-	assert.Empty(t, stars.UserStarsUID)
+	assert.Empty(t, stars.DashboardUIDs)
 }
 
 func TestStarUsers(t *testing.T) {
@@ -162,7 +162,7 @@ func TestStarUsers(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.NotEmpty(t, stars.UserStars)
-	assert.NotEmpty(t, stars.UserStarsUID)
+	assert.NotEmpty(t, stars.DashboardUIDs)
 
 	// curl "http://otheruser:password@localhost:3000/api/user/stars"
 	// Empty response, the dashboard is starred by user 1.
@@ -172,7 +172,7 @@ func TestStarUsers(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Empty(t, stars.UserStars)
-	assert.Empty(t, stars.UserStarsUID)
+	assert.Empty(t, stars.DashboardUIDs)
 
 	// Delete all stars from user 1.
 	require.NoError(t, svc.DeleteByUser(context.Background(), 1))
@@ -185,7 +185,7 @@ func TestStarUsers(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Empty(t, stars.UserStars)
-	assert.Empty(t, stars.UserStarsUID)
+	assert.Empty(t, stars.DashboardUIDs)
 }
 
 func serviceForTest(t testing.TB, dashs []lightweightDashboard) *Service {


### PR DESCRIPTION
**What this PR does / why we need it**:

- Adds UID support to the stars service + APIs.
- Adds tests to the stars service.

