### PR TITLE
Alerting: Telegram: Truncate long messages to avoid send error.

### DIFF
--- a/pkg/services/ngalert/notifier/channels/telegram.go
+++ b/pkg/services/ngalert/notifier/channels/telegram.go
@@ -167,7 +167,7 @@ func (tn *TelegramNotifier) buildTelegramMessage(ctx context.Context, as []*type
 	
 	
 	m := make(map[string]string)
-	m["text"] = 
+	m["text"] = messageText
 	m["parse_mode"] = "html"
 	return m, nil
 }

--- a/pkg/services/ngalert/notifier/channels/telegram.go
+++ b/pkg/services/ngalert/notifier/channels/telegram.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
+	"github.com/prometheus/alertmanager/notify"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
@@ -158,8 +159,15 @@ func (tn *TelegramNotifier) buildTelegramMessage(ctx context.Context, as []*type
 	}()
 
 	tmpl, _ := TmplText(ctx, tn.tmpl, as, tn.log, &tmplErr)
+	// Telegram supports 4096 chars max
+	messageText, truncated := notify.Truncate(tmpl(tn.Message), 4096)
+	if truncated {
+		tn.log.Warn("Telegram message too long, truncate message", "original_message", tn.Message)
+	}
+	
+	
 	m := make(map[string]string)
-	m["text"] = tmpl(tn.Message)
+	m["text"] = 
 	m["parse_mode"] = "html"
 	return m, nil
 }

--- a/pkg/services/ngalert/notifier/channels/telegram.go
+++ b/pkg/services/ngalert/notifier/channels/telegram.go
@@ -165,7 +165,6 @@ func (tn *TelegramNotifier) buildTelegramMessage(ctx context.Context, as []*type
 		tn.log.Warn("Telegram message too long, truncate message", "original_message", tn.Message)
 	}
 	
-	
 	m := make(map[string]string)
 	m["text"] = messageText
 	m["parse_mode"] = "html"

--- a/pkg/services/ngalert/notifier/channels/telegram.go
+++ b/pkg/services/ngalert/notifier/channels/telegram.go
@@ -9,9 +9,9 @@ import (
 	"mime/multipart"
 	"os"
 
+	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
-	"github.com/prometheus/alertmanager/notify"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"

--- a/pkg/services/ngalert/notifier/channels/telegram.go
+++ b/pkg/services/ngalert/notifier/channels/telegram.go
@@ -164,7 +164,7 @@ func (tn *TelegramNotifier) buildTelegramMessage(ctx context.Context, as []*type
 	if truncated {
 		tn.log.Warn("Telegram message too long, truncate message", "original_message", tn.Message)
 	}
-	
+
 	m := make(map[string]string)
 	m["text"] = messageText
 	m["parse_mode"] = "html"


### PR DESCRIPTION
**What this PR does / why we need it**:

Telegram doesn't support messages longer than 4086 symbols.
A truncated message good than no message :)

**Which issue(s) this PR fixes**:

Fixes #48812

**Special notes for your reviewer**:

