### PR TITLE
Admin: Add support to configure default admin email 

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -247,6 +247,7 @@ admin_user = admin
 # default admin password, can be changed before first start of grafana, or in profile settings
 admin_password = admin
 
+# default admin email, created on startup
 admin_email = admin@localhost
 
 # used for signing

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -247,6 +247,8 @@ admin_user = admin
 # default admin password, can be changed before first start of grafana, or in profile settings
 admin_password = admin
 
+admin_email = admin@localhost
+
 # used for signing
 secret_key = SW2YcwTIb9zpOOhoPsMm
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -247,6 +247,9 @@
 # default admin password, can be changed before first start of grafana,  or in profile settings
 ;admin_password = admin
 
+# default admin email, created on startup
+;admin_email = admin@localhost
+
 # used for signing
 ;secret_key = SW2YcwTIb9zpOOhoPsMm
 

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -214,7 +214,7 @@ func (ss *SQLStore) ensureMainOrgAndAdminUser() error {
 			ss.log.Debug("Creating default admin user")
 			if _, err := ss.createUser(ctx, sess, user.CreateUserCommand{
 				Login:    ss.Cfg.AdminUser,
-				Email:    ss.Cfg.AdminUser + "@localhost",
+				Email:    ss.Cfg.AdminEmail,
 				Password: ss.Cfg.AdminPassword,
 				IsAdmin:  true,
 			}); err != nil {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -292,6 +292,7 @@ type Cfg struct {
 	BasicAuthEnabled             bool
 	AdminUser                    string
 	AdminPassword                string
+	AdminEmail                   string
 
 	// AWS Plugin Auth
 	AWSAllowedAuthProviders []string
@@ -1248,6 +1249,7 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.DisableInitAdminCreation = security.Key("disable_initial_admin_creation").MustBool(false)
 	cfg.AdminUser = valueAsString(security, "admin_user", "")
 	cfg.AdminPassword = valueAsString(security, "admin_password", "")
+	cfg.AdminEmail = valueAsString(security, "admin_email", "")
 
 	return nil
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1249,7 +1249,7 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.DisableInitAdminCreation = security.Key("disable_initial_admin_creation").MustBool(false)
 	cfg.AdminUser = valueAsString(security, "admin_user", "")
 	cfg.AdminPassword = valueAsString(security, "admin_password", "")
-	cfg.AdminEmail = valueAsString(security, "admin_email", cfg.AdminUser + "@localhost")
+	cfg.AdminEmail = valueAsString(security, "admin_email", fmt.Sprintf("%s@localhost", cfg.AdminUser))
 
 	return nil
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1249,7 +1249,7 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.DisableInitAdminCreation = security.Key("disable_initial_admin_creation").MustBool(false)
 	cfg.AdminUser = valueAsString(security, "admin_user", "")
 	cfg.AdminPassword = valueAsString(security, "admin_password", "")
-	cfg.AdminEmail = valueAsString(security, "admin_email", "")
+	cfg.AdminEmail = valueAsString(security, "admin_email", cfg.AdminUser + "@localhost")
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it:**
Implements admin_email config option. 

**Which issue(s) this PR fixes:**
Fixes #52336

