### PR TITLE
Chore: Added controls to ContextMenu story

### DIFF
--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenu.story.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenu.story.tsx
@@ -4,12 +4,11 @@ import React from 'react';
 
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
 import { IconButton } from '../IconButton/IconButton';
-import { MenuGroup } from '../Menu/MenuGroup';
-import { MenuItem } from '../Menu/MenuItem';
 
 import { ContextMenu, ContextMenuProps } from './ContextMenu';
 import mdx from './ContextMenu.mdx';
-import { WithContextMenu } from './WithContextMenu';
+import { renderMenuItems } from './ContextMenuStoryHelper';
+import { WithContextMenu, WithContextMenuProps } from './WithContextMenu';
 
 const meta: ComponentMeta<typeof ContextMenu> = {
   title: 'General/ContextMenu',
@@ -20,37 +19,15 @@ const meta: ComponentMeta<typeof ContextMenu> = {
       page: mdx,
     },
     controls: {
-      exclude: ['renderMenuItems', 'renderHeader'],
+      exclude: ['renderMenuItems', 'renderHeader', 'onClose', 'children'],
     },
   },
   args: {
     x: 200,
     y: 300,
     focusOnOpen: true,
+    renderMenuItems: renderMenuItems,
   },
-};
-
-const menuItems = [
-  {
-    label: 'Test',
-    items: [
-      { label: 'First', ariaLabel: 'First' },
-      { label: 'Second', ariaLabel: 'Second' },
-      { label: 'Third', ariaLabel: 'Third' },
-      { label: 'Fourth', ariaLabel: 'Fourth' },
-      { label: 'Fifth', ariaLabel: 'Fifth' },
-    ],
-  },
-];
-
-const renderMenuItems = () => {
-  return menuItems.map((group, index) => (
-    <MenuGroup key={`${group.label}${index}`} label={group.label}>
-      {group.items.map((item) => (
-        <MenuItem key={item.label} label={item.label} />
-      ))}
-    </MenuGroup>
-  ));
 };
 
 const renderHeader = (): React.ReactNode => {
@@ -68,9 +45,9 @@ export const Basic: ComponentStory<typeof ContextMenu> = (args: ContextMenuProps
   );
 };
 
-export const WithState = () => {
+export const WithState: ComponentStory<typeof WithContextMenu> = (args: WithContextMenuProps) => {
   return (
-    <WithContextMenu renderMenuItems={renderMenuItems}>
+    <WithContextMenu {...args}>
       {({ openMenu }) => <IconButton name="info-circle" onClick={openMenu} />}
     </WithContextMenu>
   );

--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenu.story.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenu.story.tsx
@@ -1,4 +1,5 @@
-import { ComponentMeta } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
 import React from 'react';
 
 import { withCenteredStory } from '../../utils/storybook/withCenteredStory';
@@ -6,7 +7,7 @@ import { IconButton } from '../IconButton/IconButton';
 import { MenuGroup } from '../Menu/MenuGroup';
 import { MenuItem } from '../Menu/MenuItem';
 
-import { ContextMenu } from './ContextMenu';
+import { ContextMenu, ContextMenuProps } from './ContextMenu';
 import mdx from './ContextMenu.mdx';
 import { WithContextMenu } from './WithContextMenu';
 
@@ -18,6 +19,14 @@ const meta: ComponentMeta<typeof ContextMenu> = {
     docs: {
       page: mdx,
     },
+    controls: {
+      exclude: ['renderMenuItems', 'renderHeader'],
+    },
+  },
+  args: {
+    x: 200,
+    y: 300,
+    focusOnOpen: true,
   },
 };
 
@@ -44,8 +53,19 @@ const renderMenuItems = () => {
   ));
 };
 
-export const Basic = () => {
-  return <ContextMenu x={10} y={11} onClose={() => {}} renderMenuItems={renderMenuItems} />;
+const renderHeader = (): React.ReactNode => {
+  return <h6>Menu</h6>;
+};
+
+export const Basic: ComponentStory<typeof ContextMenu> = (args: ContextMenuProps) => {
+  return (
+    <ContextMenu
+      {...args}
+      onClose={() => action('onClose')('closed menu')}
+      renderMenuItems={renderMenuItems}
+      renderHeader={renderHeader}
+    />
+  );
 };
 
 export const WithState = () => {

--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenu.story.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenu.story.tsx
@@ -35,14 +35,7 @@ const renderHeader = (): React.ReactNode => {
 };
 
 export const Basic: ComponentStory<typeof ContextMenu> = (args: ContextMenuProps) => {
-  return (
-    <ContextMenu
-      {...args}
-      onClose={() => action('onClose')('closed menu')}
-      renderMenuItems={renderMenuItems}
-      renderHeader={renderHeader}
-    />
-  );
+  return <ContextMenu {...args} onClose={() => action('onClose')('closed menu')} renderHeader={renderHeader} />;
 };
 
 export const WithState: ComponentStory<typeof WithContextMenu> = (args: WithContextMenuProps) => {

--- a/packages/grafana-ui/src/components/ContextMenu/ContextMenuStoryHelper.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/ContextMenuStoryHelper.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { MenuGroup } from '../Menu/MenuGroup';
+import { MenuItem } from '../Menu/MenuItem';
+
+const menuItems = [
+  {
+    label: 'Test',
+    items: [
+      { label: 'First', ariaLabel: 'First' },
+      { label: 'Second', ariaLabel: 'Second' },
+      { label: 'Third', ariaLabel: 'Third' },
+      { label: 'Fourth', ariaLabel: 'Fourth' },
+      { label: 'Fifth', ariaLabel: 'Fifth' },
+    ],
+  },
+];
+
+export const renderMenuItems = () => {
+  return menuItems.map((group, index) => (
+    <MenuGroup key={`${group.label}${index}`} label={group.label}>
+      {group.items.map((item) => (
+        <MenuItem key={item.label} label={item.label} />
+      ))}
+    </MenuGroup>
+  ));
+};

--- a/packages/grafana-ui/src/components/ContextMenu/WithContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/WithContextMenu.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { ContextMenu } from '../ContextMenu/ContextMenu';
 
-interface WithContextMenuProps {
+export interface WithContextMenuProps {
   /** Menu item trigger that accepts openMenu prop */
   children: (props: { openMenu: React.MouseEventHandler<HTMLElement> }) => JSX.Element;
   /** A function that returns an array of menu items */


### PR DESCRIPTION
**What this PR does / why we need it**: Adds controls to the ContextMenu component's story, this serves as documentation for the component as it highlights the different props you can pass to it and the effects they will have on the component's behavior.

**Which issue(s) this PR fixes**: #54221 

Fixes #54221 

**Special notes for your reviewer**: I wanted to add a Typography component instead of an h6 tag for the renderHeader prop value of the Component Story, however, I found that the Typography component has not been yet been completed there is an open issue for it here #52262. Also here is how the story looks:

![ContextMenuStory](https://user-images.githubusercontent.com/38387174/187111725-6234bd00-5994-4891-98e6-f6b7502c5e62.PNG)


