### PR TITLE
Grafana Backend: [BREAKING CHANGE] Establish a database version support policy.

### DIFF
--- a/devenv/docker/blocks/mysql/.env
+++ b/devenv/docker/blocks/mysql/.env
@@ -1,1 +1,1 @@
-mysql_version=5.6
+mysql_version=5.7

--- a/devenv/docker/blocks/mysql_tests/.env
+++ b/devenv/docker/blocks/mysql_tests/.env
@@ -1,1 +1,1 @@
-mysql_version=5.6
+mysql_version=5.7

--- a/devenv/docker/blocks/mysql_tests/Dockerfile
+++ b/devenv/docker/blocks/mysql_tests/Dockerfile
@@ -1,4 +1,4 @@
-ARG mysql_version=5.6
+ARG mysql_version=5.7
 FROM mysql:${mysql_version}
 ADD setup.sql /docker-entrypoint-initdb.d
 RUN chown -R mysql:mysql /docker-entrypoint-initdb.d/

--- a/devenv/docker/blocks/mysql_tests/docker-compose.yaml
+++ b/devenv/docker/blocks/mysql_tests/docker-compose.yaml
@@ -3,6 +3,7 @@
       context: docker/blocks/mysql_tests
       args:
         - mysql_version=${mysql_version}
+    platform: linux/amd64
     environment:
       MYSQL_ROOT_PASSWORD: rootpass
       MYSQL_DATABASE: grafana_tests

--- a/devenv/docker/blocks/postgres/.env
+++ b/devenv/docker/blocks/postgres/.env
@@ -1,1 +1,1 @@
-postgres_version=9.3
+postgres_version=10.15

--- a/devenv/docker/blocks/postgres_tests/.env
+++ b/devenv/docker/blocks/postgres_tests/.env
@@ -1,1 +1,1 @@
-postgres_version=9.3
+postgres_version=10.15

--- a/devenv/docker/blocks/postgres_tests/Dockerfile
+++ b/devenv/docker/blocks/postgres_tests/Dockerfile
@@ -1,4 +1,4 @@
-ARG postgres_version=9.3
+ARG postgres_version=10.15
 FROM postgres:${postgres_version}
 ADD setup.sql /docker-entrypoint-initdb.d
 RUN chown -R postgres:postgres /docker-entrypoint-initdb.d/

--- a/devenv/docker/ha_test/docker-compose.yaml
+++ b/devenv/docker/ha_test/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
         tag: nginx
 
   db:
-    image: mysql:5.6
+    image: mysql:5.7
     environment:
       MYSQL_ROOT_PASSWORD: rootpass
       MYSQL_DATABASE: grafana
@@ -41,7 +41,7 @@ services:
         condition: service_healthy
 
   # db:
-  #   image: postgres:9.3
+  #   image: postgres:10.15
   #   environment:
   #     POSTGRES_DATABASE: grafana
   #     POSTGRES_USER: grafana

--- a/docs/sources/setup-grafana/installation/_index.md
+++ b/docs/sources/setup-grafana/installation/_index.md
@@ -49,13 +49,15 @@ Grafana requires a database to store its configuration data, such as users, data
 
 Grafana supports the following databases:
 
-- SQLite
-- MySQL
-- PostgreSQL
+- [SQLite 3](https://www.sqlite.org/index.html)
+- [MySQL 5.7+](https://www.mysql.com/support/supportedplatforms/database.html)
+- [PostgreSQL 10+](https://www.postgresql.org/support/versioning/)
 
 By default, Grafana installs with and uses SQLite, which is an embedded database stored in the Grafana installation location.
 
-> **Note:** PostgreSQL versions 9.5.18, 9.4.23, 9.6.14, 10.9, 11.4, and 12-beta2 are affected by a bug (tracked by the PostgreSQL project as [bug #15865](https://www.postgresql.org/message-id/flat/15865-17940eacc8f8b081%40postgresql.org)) which prevents those versions from being used with Grafana. The bug has been fixed in more recent versions of PostgreSQL.
+Grafana will support the versions of these databases that are officially supported by the project at the time of a Grafana version's release. When a version becomes unsupported, Grafana may also drop support for that version. See the links above for the support policies for each project.
+
+> **Note:** PostgreSQL versions 10.9, 11.4, and 12-beta2 are affected by a bug (tracked by the PostgreSQL project as [bug #15865](https://www.postgresql.org/message-id/flat/15865-17940eacc8f8b081%40postgresql.org)) which prevents those versions from being used with Grafana. The bug has been fixed in more recent versions of PostgreSQL.
 
 ## Supported web browsers
 


### PR DESCRIPTION
State in the documents that we support the versions of our backend databases that are supported by the projects. For MySQL this is currently 5.7+ and for PostgreSQL it's 10+.

Incidentally, update the dev and test database versions to the minimum
supported version of the backend databases.