### PR TITLE
FIX: RBAC prevents deleting empty snapshots

### DIFF
--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -335,7 +335,7 @@ func (hs *HTTPServer) DeleteDashboardSnapshot(c *models.ReqContext) response.Res
 		if dashboardID != 0 {
 			guardian := guardian.New(c.Req.Context(), dashboardID, c.OrgID, c.SignedInUser)
 			canEdit, err := guardian.CanEdit()
-			// check for permissions only if the dahboard is found
+			// check for permissions only if the dashboard is found
 			if err != nil && !errors.Is(err, dashboards.ErrDashboardNotFound) {
 				return response.Error(http.StatusInternalServerError, "Error while checking permissions for snapshot", err)
 			}

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -111,13 +111,13 @@ func (hs *HTTPServer) CreateDashboardSnapshot(c *models.ReqContext) response.Res
 
 	if cmd.External {
 		if !setting.ExternalEnabled {
-			c.JsonApiErr(403, "External dashboard creation is disabled", nil)
+			c.JsonApiErr(http.StatusForbidden, "External dashboard creation is disabled", nil)
 			return nil
 		}
 
 		response, err := createExternalDashboardSnapshot(cmd)
 		if err != nil {
-			c.JsonApiErr(500, "Failed to create external snapshot", err)
+			c.JsonApiErr(http.StatusInternalServerError, "Failed to create external snapshot", err)
 			return nil
 		}
 
@@ -130,11 +130,16 @@ func (hs *HTTPServer) CreateDashboardSnapshot(c *models.ReqContext) response.Res
 
 		metrics.MApiDashboardSnapshotExternal.Inc()
 	} else {
+		if cmd.Dashboard.Get("id").MustInt64() == 0 {
+			c.JSON(http.StatusBadRequest, "Creating a local snapshot requires a dashboard")
+			return nil
+		}
+
 		if cmd.Key == "" {
 			var err error
 			cmd.Key, err = util.GetRandomString(32)
 			if err != nil {
-				c.JsonApiErr(500, "Could not generate random string", err)
+				c.JsonApiErr(http.StatusInternalServerError, "Could not generate random string", err)
 				return nil
 			}
 		}
@@ -143,7 +148,7 @@ func (hs *HTTPServer) CreateDashboardSnapshot(c *models.ReqContext) response.Res
 			var err error
 			cmd.DeleteKey, err = util.GetRandomString(32)
 			if err != nil {
-				c.JsonApiErr(500, "Could not generate random string", err)
+				c.JsonApiErr(http.StatusInternalServerError, "Could not generate random string", err)
 				return nil
 			}
 		}
@@ -154,7 +159,7 @@ func (hs *HTTPServer) CreateDashboardSnapshot(c *models.ReqContext) response.Res
 	}
 
 	if err := hs.dashboardsnapshotsService.CreateDashboardSnapshot(c.Req.Context(), &cmd); err != nil {
-		c.JsonApiErr(500, "Failed to create snapshot", err)
+		c.JsonApiErr(http.StatusInternalServerError, "Failed to create snapshot", err)
 		return nil
 	}
 
@@ -300,7 +305,7 @@ func (hs *HTTPServer) DeleteDashboardSnapshotByDeleteKey(c *models.ReqContext) r
 func (hs *HTTPServer) DeleteDashboardSnapshot(c *models.ReqContext) response.Response {
 	key := web.Params(c.Req)[":key"]
 	if len(key) == 0 {
-		return response.Error(404, "Snapshot not found", nil)
+		return response.Error(http.StatusNotFound, "Snapshot not found", nil)
 	}
 
 	query := &dashboardsnapshots.GetDashboardSnapshotQuery{Key: key}
@@ -310,13 +315,13 @@ func (hs *HTTPServer) DeleteDashboardSnapshot(c *models.ReqContext) response.Res
 		return response.Err(err)
 	}
 	if query.Result == nil {
-		return response.Error(404, "Failed to get dashboard snapshot", nil)
+		return response.Error(http.StatusNotFound, "Failed to get dashboard snapshot", nil)
 	}
 
 	if query.Result.External {
 		err := deleteExternalDashboardSnapshot(query.Result.ExternalDeleteUrl)
 		if err != nil {
-			return response.Error(500, "Failed to delete external dashboard", err)
+			return response.Error(http.StatusInternalServerError, "Failed to delete external dashboard", err)
 		}
 	} else {
 		// When creating an external snapshot, its dashboard content is empty. This means that the mustInt here returns a 0,
@@ -325,22 +330,26 @@ func (hs *HTTPServer) DeleteDashboardSnapshot(c *models.ReqContext) response.Res
 		// all permissions must be explicit, so the lack of a rule for dashboard 0 means the guardian will reject.
 		dashboardID := query.Result.Dashboard.Get("id").MustInt64()
 
-		guardian := guardian.New(c.Req.Context(), dashboardID, c.OrgID, c.SignedInUser)
-		canEdit, err := guardian.CanEdit()
-		// check for permissions only if the dahboard is found
-		if err != nil && !errors.Is(err, dashboards.ErrDashboardNotFound) {
-			return response.Error(500, "Error while checking permissions for snapshot", err)
-		}
+		// If for some reason the snapshot is not external and yet targets no dashboard (ID set 0), RBAC access-control
+		// can be skipped.
+		if dashboardID != 0 {
+			guardian := guardian.New(c.Req.Context(), dashboardID, c.OrgID, c.SignedInUser)
+			canEdit, err := guardian.CanEdit()
+			// check for permissions only if the dahboard is found
+			if err != nil && !errors.Is(err, dashboards.ErrDashboardNotFound) {
+				return response.Error(http.StatusInternalServerError, "Error while checking permissions for snapshot", err)
+			}
 
-		if !canEdit && query.Result.UserId != c.SignedInUser.UserID && !errors.Is(err, dashboards.ErrDashboardNotFound) {
-			return response.Error(403, "Access denied to this snapshot", nil)
+			if !canEdit && query.Result.UserId != c.SignedInUser.UserID && !errors.Is(err, dashboards.ErrDashboardNotFound) {
+				return response.Error(http.StatusForbidden, "Access denied to this snapshot", nil)
+			}
 		}
 	}
 
 	cmd := &dashboardsnapshots.DeleteDashboardSnapshotCommand{DeleteKey: query.Result.DeleteKey}
 
 	if err := hs.dashboardsnapshotsService.DeleteDashboardSnapshot(c.Req.Context(), cmd); err != nil {
-		return response.Error(500, "Failed to delete dashboard snapshot", err)
+		return response.Error(http.StatusInternalServerError, "Failed to delete dashboard snapshot", err)
 	}
 
 	return response.JSON(http.StatusOK, util.DynMap{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
As reported by @gjed, and analysed by @dprokop in #51189 deleting an "empty" snapshot is prevented by RBAC (no permission targetting `dashboard ID = 0`).

This PR intends to skip the access-control check should that be the case, **but also** prevent creation of a local snapshot targeting no dashboard.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/51189

**Special notes for your reviewer**:

