### PR TITLE
Navigation Bar: Remove plugins link under Server Admin

### DIFF
--- a/docs/sources/administration/plugin-management/_index.md
+++ b/docs/sources/administration/plugin-management/_index.md
@@ -76,11 +76,8 @@ In order to be able to install / uninstall / update plugins using plugin catalog
 Before following the steps below, make sure you are logged in as a Grafana administrator.
 
 <a id="#plugin-catalog-entry"></a>
-Currently, there are two entry points to the Plugin catalog.
 
-- Grafana server administrators can find it at **Configuration >
-  Plugins**.
-- Organization administrators can find it at **Configuration > Plugins**.
+- Administrators can find the Plugin catalog at **Configuration > Plugins**.
 
 ### Browse plugins
 

--- a/docs/sources/administration/plugin-management/_index.md
+++ b/docs/sources/administration/plugin-management/_index.md
@@ -67,7 +67,7 @@ The Plugin catalog allows you to browse and manage plugins from within Grafana. 
 
 <div class="medium-6 columns">
   <video width="700" height="600" controls>
-    <source src="/static/assets/videos/plugins-catalog-install-8-1.mp4" type="video/mp4">
+    <source src="/static/assets/videos/plugins-catalog-install-9.2.mp4" type="video/mp4">
     Your browser does not support the video tag.
   </video>
 </div>
@@ -78,7 +78,7 @@ Before following the steps below, make sure you are logged in as a Grafana admin
 <a id="#plugin-catalog-entry"></a>
 Currently, there are two entry points to the Plugin catalog.
 
-- Grafana server administrators can find it at **Server Admin >
+- Grafana server administrators can find it at **Configuration >
   Plugins**.
 - Organization administrators can find it at **Configuration > Plugins**.
 
@@ -90,7 +90,7 @@ To browse for available plugins:
 1. Click the **All** filter to browse all available plugins.
 1. Click the **Data sources**, **Panels**, or **Applications** buttons to filter by plugin type.
 
-![Plugin catalog browse](/static/img/docs/plugins/plugins-catalog-browse-8-1.png)
+![Plugin catalog browse](/static/img/docs/plugins/plugins-catalog-browse-9.2.png)
 
 ### Install a plugin
 

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -366,7 +366,7 @@ func (hs *HTTPServer) setupConfigNodes(c *models.ReqContext) ([]*dtos.NavLink, e
 		})
 	}
 
-	if c.OrgRole == org.RoleAdmin {
+	if c.OrgRole == org.RoleAdmin || (hs.Cfg.PluginAdminEnabled && ac.ReqGrafanaAdmin(c)) {
 		configNodes = append(configNodes, &dtos.NavLink{
 			Text:        "Plugins",
 			Id:          "plugins",

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -724,12 +724,6 @@ func (hs *HTTPServer) buildAdminNavLinks(c *models.ReqContext) []*dtos.NavLink {
 		})
 	}
 
-	if hs.Cfg.PluginAdminEnabled && ac.ReqGrafanaAdmin(c) {
-		adminNavLinks = append(adminNavLinks, &dtos.NavLink{
-			Text: "Plugins", Id: "admin-plugins", Url: hs.Cfg.AppSubURL + "/admin/plugins", Icon: "plug",
-		})
-	}
-
 	return adminNavLinks
 }
 

--- a/public/app/features/plugins/admin/pages/Browse.tsx
+++ b/public/app/features/plugins/admin/pages/Browse.tsx
@@ -17,13 +17,12 @@ import { SearchField } from '../components/SearchField';
 import { Sorters } from '../helpers';
 import { useHistory } from '../hooks/useHistory';
 import { useGetAllWithFilters, useIsRemotePluginsAvailable, useDisplayMode } from '../state/hooks';
-import { PluginAdminRoutes, PluginListDisplayMode } from '../types';
+import { PluginListDisplayMode } from '../types';
 
 export default function Browse({ route }: GrafanaRouteComponentProps): ReactElement | null {
   const location = useLocation();
   const locationSearch = locationSearchToObject(location.search);
-  const navModelId = getNavModelId(route.routeName);
-  const navModel = useSelector((state: StoreState) => getNavModel(state.navIndex, navModelId));
+  const navModel = useSelector((state: StoreState) => getNavModel(state.navIndex, 'plugins'));
   const { displayMode, setDisplayMode } = useDisplayMode();
   const styles = useStyles2(getStyles);
   const history = useHistory();
@@ -173,13 +172,3 @@ const getStyles = (theme: GrafanaTheme2) => ({
     }
   `,
 });
-
-// Because the component is used under multiple paths (/plugins and /admin/plugins) we need to get
-// the correct navModel from the store
-const getNavModelId = (routeName?: string) => {
-  if (routeName === PluginAdminRoutes.HomeAdmin || routeName === PluginAdminRoutes.BrowseAdmin) {
-    return 'admin-plugins';
-  }
-
-  return 'plugins';
-};

--- a/public/app/features/plugins/admin/routes.tsx
+++ b/public/app/features/plugins/admin/routes.tsx
@@ -1,7 +1,9 @@
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+
 import { SafeDynamicImport } from 'app/core/components/DynamicImports/SafeDynamicImport';
 import { RouteDescriptor } from 'app/core/navigation/types';
 
-import { isGrafanaAdmin } from './permissions';
 import { PluginAdminRoutes } from './types';
 
 const DEFAULT_ROUTES = [
@@ -23,33 +25,13 @@ const DEFAULT_ROUTES = [
     routeName: PluginAdminRoutes.Details,
     component: SafeDynamicImport(() => import(/* webpackChunkName: "PluginPage" */ './pages/PluginDetails')),
   },
-];
-
-const ADMIN_ROUTES = [
   {
-    path: '/admin/plugins',
+    path: '/admin/plugins/*',
     navId: 'admin-plugins',
-    routeName: PluginAdminRoutes.HomeAdmin,
-    component: SafeDynamicImport(() => import(/* webpackChunkName: "PluginListPage" */ './pages/Browse')),
-  },
-  {
-    path: '/admin/plugins/browse',
-    navId: 'admin-plugins',
-    routeName: PluginAdminRoutes.BrowseAdmin,
-    component: SafeDynamicImport(() => import(/* webpackChunkName: "PluginListPage" */ './pages/Browse')),
-  },
-  {
-    path: '/admin/plugins/:pluginId/',
-    navId: 'admin-plugins',
-    routeName: PluginAdminRoutes.DetailsAdmin,
-    component: SafeDynamicImport(() => import(/* webpackChunkName: "PluginPage" */ './pages/PluginDetails')),
+    component: () => <Redirect to="/plugins" />,
   },
 ];
 
 export function getRoutes(): RouteDescriptor[] {
-  if (isGrafanaAdmin()) {
-    return [...DEFAULT_ROUTES, ...ADMIN_ROUTES];
-  }
-
   return DEFAULT_ROUTES;
 }

--- a/public/app/features/plugins/admin/types.ts
+++ b/public/app/features/plugins/admin/types.ts
@@ -21,9 +21,6 @@ export enum PluginAdminRoutes {
   Home = 'plugins-home',
   Browse = 'plugins-browse',
   Details = 'plugins-details',
-  HomeAdmin = 'plugins-home-admin',
-  BrowseAdmin = 'plugins-browse-admin',
-  DetailsAdmin = 'plugins-details-admin',
 }
 
 export enum PluginIconName {


### PR DESCRIPTION
Closes: https://github.com/grafana/grafana/issues/54267

Removes the plugin link under server admin
![image](https://user-images.githubusercontent.com/227916/187199251-0e46e04b-37f1-4d7a-b05c-f38dcdb5f142.png)


Leaves only the one under Configuration
![image](https://user-images.githubusercontent.com/227916/187199189-13d2f2fe-82cf-43e1-b579-70f5df384aa4.png)

For version 9.2 the links to `admin/plugin` are redirected to `/plugins`. This will be removed for grafana 10.

Related assets PR: https://github.com/grafana/website/pull/9870 