### PR TITLE
Chore: Fix prometheus docker block

### DIFF
--- a/devenv/docker/blocks/prometheus_random_data/Dockerfile
+++ b/devenv/docker/blocks/prometheus_random_data/Dockerfile
@@ -3,7 +3,7 @@
 # Builder image, where we build the example.
 FROM golang:1.17 AS builder
 # Download prometheus/client_golang/examples/random first
-RUN CGO_ENABLED=0 GOOS=linux go install -tags netgo -ldflags '-w' github.com/prometheus/client_golang/examples/random@latest
+RUN CGO_ENABLED=0 GOOS=linux go install -tags netgo -ldflags '-w' github.com/prometheus/client_golang/examples/random@v1.12.2
 
 # Final image.
 FROM scratch


### PR DESCRIPTION
Fixing below error (when running `make devenv sources=prometheus`) by pinning the github.com/prometheus/client_golang/examples/random to v1.12.2.

```
Successfully built 14df3cdb6334                                                                                                
Successfully tagged devenv_prometheus:latest                                                                                   
Building prometheus-random-data                                                                                                
Step 1/7 : FROM golang:1.17 AS builder                                                                                         
 ---> 21ec38e01969                                                                                                             
Step 2/7 : RUN CGO_ENABLED=0 GOOS=linux go install -tags netgo -ldflags '-w' github.com/prometheus/client_golang/examples/rando
m@latest                                                                                                                       
 ---> Running in 5fa1944f41fa                                                                                                  
go: downloading github.com/prometheus/client_golang v1.13.0                                                                    
go install: github.com/prometheus/client_golang/examples/random@latest (in github.com/prometheus/client_golang@v1.13.0):       
        The go.mod file for the module providing named packages contains one or                                                
        more exclude directives. It must not contain directives that would cause                                               
        it to be interpreted differently than if it were the main module.                                                      
ERROR: Service 'prometheus-random-data' failed to build : The command '/bin/sh -c CGO_ENABLED=0 GOOS=linux go install -tags net
go -ldflags '-w' github.com/prometheus/client_golang/examples/random@latest' returned a non-zero code: 1                       
make: *** [Makefile:169: devenv] Error 1   
```