### PR TITLE
Update README build references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ build-docker-full-ubuntu: ## Build Docker image based on Ubuntu for development.
 ##@ Services
 
 # create docker-compose file with provided sources and start them
-# example: make devenv sources=postgres,openldap
+# example: make devenv sources=postgres,auth/openldap
 ifeq ($(sources),)
 devenv:
 	@printf 'You have to define sources for this command \nexample: make devenv sources=postgres,openldap\n'

--- a/devenv/docker/blocks/auth/jwt_proxy/readme.md
+++ b/devenv/docker/blocks/auth/jwt_proxy/readme.md
@@ -4,7 +4,7 @@
 To launch the block, use the oauth source. Ex:
 
 ```bash
-make devenv sources="jwt_proxy"
+make devenv sources="auth/jwt_proxy"
 ```
 
 Here is the conf you need to add to your configuration file (conf/custom.ini):

--- a/devenv/docker/blocks/auth/oauth/readme.md
+++ b/devenv/docker/blocks/auth/oauth/readme.md
@@ -4,7 +4,7 @@
 
 To launch the block, use the oauth source. Ex:
 ```bash
-make devenv sources="oauth"
+make devenv sources="auth/oauth"
 ```
 
 Here is the conf you need to add to your configuration file (conf/custom.ini):
@@ -34,7 +34,7 @@ role_attribute_path = contains(roles[*], 'admin') && 'Admin' || contains(roles[*
 To launch the block, use the oauth source. Ex:
 
 ```bash
-make devenv sources="oauth"
+make devenv sources="auth/oauth"
 ```
 
 Here is the conf you need to add to your configuration file (conf/custom.ini):

--- a/devenv/docker/blocks/auth/openldap-mac/README.md
+++ b/devenv/docker/blocks/auth/openldap-mac/README.md
@@ -7,7 +7,7 @@ This Docker block is an updated version from [OpenLDAP](../openldap/) block. Thi
 First build and deploy the `openldap` container.
 
 ```bash
-make devenv sources=openldap-mac
+make devenv sources=auth/openldap-mac
 ```
 
 ### Exposed ports


### PR DESCRIPTION
**What this PR does / why we need it**:

When the development environments for logins were moved under `auth/`, some documentation got outdated.

**Which issue(s) this PR fixes**:

None

Fixes #

This updates the documentation steps to build an auth environment.
