### PR TITLE
CI: Add `PackagesBucketEnterprise2` field in config

### DIFF
--- a/pkg/build/config/versions.go
+++ b/pkg/build/config/versions.go
@@ -43,8 +43,9 @@ var Versions = VersionMap{
 				ArchARMv7, // GOARCH=ARM is used for both armv6 and armv7. They are differentiated by the GOARM variable.
 			},
 		},
-		PackagesBucket:  "grafana-downloads",
-		CDNAssetsBucket: "grafana-static-assets",
+		PackagesBucket:            "grafana-downloads",
+		PackagesBucketEnterprise2: "grafana-downloads-enterprise2",
+		CDNAssetsBucket:           "grafana-static-assets",
 	},
 	ReleaseBranchMode: {
 		Variants: []Variant{


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds missing field in `versions.go` which indicates the package to store enterprise2 artifacts.