### PR TITLE
Navigation: use navId and pageNav on Alerting - Contact Points page

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -596,7 +596,7 @@ func (hs *HTTPServer) buildAlertNavLinks(c *models.ReqContext) []*dtos.NavLink {
 	if hasAccess(ac.ReqOrgAdminOrEditor, ac.EvalAny(ac.EvalPermission(ac.ActionAlertingNotificationsRead), ac.EvalPermission(ac.ActionAlertingNotificationsExternalRead))) {
 		alertChildNavs = append(alertChildNavs, &dtos.NavLink{
 			Text: "Contact points", Id: "receivers", Url: hs.Cfg.AppSubURL + "/alerting/notifications",
-			Icon: "comment-alt-share",
+			Icon: "comment-alt-share", SubTitle: "Manage the settings of your contact points",
 		})
 		alertChildNavs = append(alertChildNavs, &dtos.NavLink{Text: "Notification policies", Id: "am-routes", Url: hs.Cfg.AppSubURL + "/alerting/routes", Icon: "sitemap"})
 	}

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -171,7 +171,7 @@ const unifiedRoutes: RouteDescriptor[] = [
     ),
   },
   {
-    path: '/alerting/notifications/templates/new',
+    path: '/alerting/notifications/:type/new',
     roles: evaluateAccess(
       [AccessControlAction.AlertingNotificationsWrite, AccessControlAction.AlertingNotificationsExternalWrite],
       ['Editor', 'Admin']
@@ -181,7 +181,7 @@ const unifiedRoutes: RouteDescriptor[] = [
     ),
   },
   {
-    path: '/alerting/notifications/templates/:id/edit',
+    path: '/alerting/notifications/:type/:id/edit',
     roles: evaluateAccess(
       [AccessControlAction.AlertingNotificationsWrite, AccessControlAction.AlertingNotificationsExternalWrite],
       ['Editor', 'Admin']
@@ -191,27 +191,7 @@ const unifiedRoutes: RouteDescriptor[] = [
     ),
   },
   {
-    path: '/alerting/notifications/receivers/new',
-    roles: evaluateAccess(
-      [AccessControlAction.AlertingNotificationsWrite, AccessControlAction.AlertingNotificationsExternalWrite],
-      ['Editor', 'Admin']
-    ),
-    component: SafeDynamicImport(
-      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/unified/Receivers')
-    ),
-  },
-  {
-    path: '/alerting/notifications/receivers/:id/edit',
-    roles: evaluateAccess(
-      [AccessControlAction.AlertingNotificationsWrite, AccessControlAction.AlertingNotificationsExternalWrite],
-      ['Editor', 'Admin']
-    ),
-    component: SafeDynamicImport(
-      () => import(/* webpackChunkName: "NotificationsListPage" */ 'app/features/alerting/unified/Receivers')
-    ),
-  },
-  {
-    path: '/alerting/notifications/global-config',
+    path: '/alerting/notifications/:type',
     roles: evaluateAccess(
       [AccessControlAction.AlertingNotificationsWrite, AccessControlAction.AlertingNotificationsExternalWrite],
       ['Editor', 'Admin']

--- a/public/app/features/alerting/unified/Receivers.tsx
+++ b/public/app/features/alerting/unified/Receivers.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { Redirect, Route, RouteChildrenProps, Switch, useLocation } from 'react-router-dom';
 
+import { NavModelItem } from '@grafana/data';
 import { Alert, LoadingPlaceholder, withErrorBoundary } from '@grafana/ui';
 
 import { AlertManagerPicker } from './components/AlertManagerPicker';
@@ -27,6 +28,7 @@ const Receivers: FC = () => {
 
   const location = useLocation();
   const isRoot = location.pathname.endsWith('/alerting/notifications');
+  const isEditing = location.pathname.endsWith('/edit');
 
   const configRequests = useUnifiedAlertingSelector((state) => state.amConfigs);
 
@@ -56,9 +58,31 @@ const Receivers: FC = () => {
 
   const disableAmSelect = !isRoot;
 
+  const contactPointInfoPage = () => {
+    let text = 'New contact point';
+    let subTitle = 'Create a new contact poing to your notifications';
+    if (isEditing) {
+      const urlToArray = location.pathname.split('/');
+      const urlArrayLength = urlToArray.length;
+      const contactPointName = urlToArray[urlArrayLength - 2];
+      text = contactPointName;
+      subTitle = 'Edit `' + text + '` settings';
+    } else if (isRoot) {
+      text = 'Contact points';
+      subTitle = 'Manage the settings of your contact points';
+    }
+    return { text, subTitle };
+  };
+
+  const pageNav: NavModelItem = {
+    text: contactPointInfoPage().text,
+    icon: 'comment-alt-share',
+    subTitle: contactPointInfoPage().subTitle,
+  };
+
   if (!alertManagerSourceName) {
     return isRoot ? (
-      <AlertingPageWrapper pageId="receivers">
+      <AlertingPageWrapper pageId="receivers" pageNav={pageNav}>
         <NoAlertManagerWarning availableAlertManagers={alertManagers} />
       </AlertingPageWrapper>
     ) : (
@@ -67,7 +91,7 @@ const Receivers: FC = () => {
   }
 
   return (
-    <AlertingPageWrapper pageId="receivers">
+    <AlertingPageWrapper pageId="receivers" pageNav={pageNav}>
       <AlertManagerPicker
         current={alertManagerSourceName}
         disabled={disableAmSelect}

--- a/public/app/features/alerting/unified/Receivers.tsx
+++ b/public/app/features/alerting/unified/Receivers.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { Redirect, Route, RouteChildrenProps, Switch, useParams } from 'react-router-dom';
+import { Redirect, Route, RouteChildrenProps, Switch, useLocation, useParams } from 'react-router-dom';
 
 import { NavModelItem } from '@grafana/data';
 import { Alert, LoadingPlaceholder, withErrorBoundary } from '@grafana/ui';
@@ -29,7 +29,8 @@ const Receivers: FC = () => {
   type PageType = 'receivers' | 'templates' | 'global-config';
 
   const { id, type } = useParams<{ id?: string; type?: PageType }>();
-  const isRoot = Boolean(!type);
+  const location = useLocation();
+  const isRoot = location.pathname.endsWith('/alerting/notifications');
 
   const configRequests = useUnifiedAlertingSelector((state) => state.amConfigs);
 

--- a/public/app/features/alerting/unified/components/AlertingPageWrapper.tsx
+++ b/public/app/features/alerting/unified/components/AlertingPageWrapper.tsx
@@ -1,23 +1,17 @@
 import React, { FC } from 'react';
-import { useSelector } from 'react-redux';
 
+import { NavModelItem } from '@grafana/data';
 import { Page } from 'app/core/components/Page/Page';
-import { getNavModel } from 'app/core/selectors/navModel';
-import { StoreState } from 'app/types/store';
 
 interface Props {
   pageId: string;
   isLoading?: boolean;
+  pageNav?: NavModelItem;
 }
 
-export const AlertingPageWrapper: FC<Props> = ({ children, pageId, isLoading }) => {
-  const navModel = getNavModel(
-    useSelector((state: StoreState) => state.navIndex),
-    pageId
-  );
-
+export const AlertingPageWrapper: FC<Props> = ({ children, pageId, pageNav, isLoading }) => {
   return (
-    <Page navModel={navModel}>
+    <Page pageNav={pageNav} navId={pageId}>
       <Page.Contents isLoading={isLoading}>{children}</Page.Contents>
     </Page>
   );

--- a/public/app/features/alerting/unified/components/receivers/GlobalConfigForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/GlobalConfigForm.tsx
@@ -1,10 +1,8 @@
-import { css } from '@emotion/css';
 import React, { FC } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { useDispatch } from 'react-redux';
 
-import { GrafanaTheme2 } from '@grafana/data';
-import { Alert, Button, HorizontalGroup, LinkButton, useStyles2 } from '@grafana/ui';
+import { Alert, Button, HorizontalGroup, LinkButton } from '@grafana/ui';
 import { useCleanup } from 'app/core/hooks/useCleanup';
 import { AlertManagerCortexConfig } from 'app/plugins/datasource/alertmanager/types';
 
@@ -33,7 +31,6 @@ export const GlobalConfigForm: FC<Props> = ({ config, alertManagerSourceName }) 
   useCleanup((state) => state.unifiedAlerting.saveAMConfig);
   const { loading, error } = useUnifiedAlertingSelector((state) => state.saveAMConfig);
   const readOnly = isVanillaPrometheusAlertManagerDataSource(alertManagerSourceName);
-  const styles = useStyles2(getStyles);
 
   const formAPI = useForm<FormValues>({
     // making a copy here beacuse react-hook-form will mutate these, and break if the object is frozen. for real.
@@ -71,7 +68,6 @@ export const GlobalConfigForm: FC<Props> = ({ config, alertManagerSourceName }) 
   return (
     <FormProvider {...formAPI}>
       <form onSubmit={handleSubmit(onSubmitCallback)}>
-        <h4 className={styles.heading}>Global config</h4>
         {error && (
           <Alert severity="error" title="Error saving receiver">
             {error.message || String(error)}
@@ -113,9 +109,3 @@ export const GlobalConfigForm: FC<Props> = ({ config, alertManagerSourceName }) 
     </FormProvider>
   );
 };
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  heading: css`
-    margin: ${theme.spacing(4, 0)};
-  `,
-});


### PR DESCRIPTION
**What this PR does / why we need it**:
Use `navId` instead of `navModel` and add a `subTitle` add `pageNav`.

**Which issue(s) this PR fixes**:
Fixes [#54278](https://github.com/grafana/grafana/issues/54278)

**Special notes for your reviewer**:

Contact Points  
-|
![Nav_alerting_contactPoints](https://user-images.githubusercontent.com/65417731/187465163-a72ce139-2acf-424a-9a18-a9935df3ac6a.png)

Edit Contact Point | New Contact Point
-|-
![Nav_alerting_editContactPoint](https://user-images.githubusercontent.com/65417731/187465463-361a85c6-953b-416c-aae6-3f9485ac0e91.png)|![Nav_alerting_newContactPoint](https://user-images.githubusercontent.com/65417731/187465381-11ce50a7-5080-427b-b441-cc15d33c7c94.png)|
