### PR TITLE
Chore: Change `JSON file` to `JSON File` for consistency with other tabs

### DIFF
--- a/public/app/plugins/datasource/jaeger/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/jaeger/components/QueryEditor.tsx
@@ -62,7 +62,7 @@ export function QueryEditor({ datasource, query, onChange, onRunQuery }: Props) 
               options={[
                 { value: 'search', label: 'Search' },
                 { value: undefined, label: 'TraceID' },
-                { value: 'upload', label: 'JSON file' },
+                { value: 'upload', label: 'JSON File' },
               ]}
               value={query.queryType}
               onChange={(v) =>

--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -78,7 +78,7 @@ class TempoQueryFieldComponent extends React.PureComponent<Props> {
 
     const queryTypeOptions: Array<SelectableValue<TempoQueryType>> = [
       { value: 'traceId', label: 'TraceID' },
-      { value: 'upload', label: 'JSON file' },
+      { value: 'upload', label: 'JSON File' },
       { value: 'serviceMap', label: 'Service Graph' },
     ];
 

--- a/public/app/plugins/datasource/zipkin/QueryField.tsx
+++ b/public/app/plugins/datasource/zipkin/QueryField.tsx
@@ -66,7 +66,7 @@ export const ZipkinQueryField = ({ query, onChange, onRunQuery, datasource }: Pr
           <RadioButtonGroup<ZipkinQueryType>
             options={[
               { value: 'traceID', label: 'TraceID' },
-              { value: 'upload', label: 'JSON file' },
+              { value: 'upload', label: 'JSON File' },
             ]}
             value={query.queryType || 'traceID'}
             onChange={(v) =>


### PR DESCRIPTION
This PR changes the label of the JSON file upload tab from `JSON file` to `JSON File`. This makes the label style consistent with the other tabs, where the first letter of each word is capitalised.