### PR TITLE
CI: Add `CustomMode` in versions.go

### DIFF
--- a/pkg/build/config/version_mode.go
+++ b/pkg/build/config/version_mode.go
@@ -8,4 +8,5 @@ const (
 	TagMode           VersionMode = "release"
 	ReleaseBranchMode VersionMode = "branch"
 	PullRequestMode   VersionMode = "pull_request"
+	CustomMode        VersionMode = "custom"
 )

--- a/pkg/build/config/versions.go
+++ b/pkg/build/config/versions.go
@@ -47,6 +47,34 @@ var Versions = VersionMap{
 		PackagesBucketEnterprise2: "grafana-downloads-enterprise2",
 		CDNAssetsBucket:           "grafana-static-assets",
 	},
+	CustomMode: {
+		Variants: []Variant{
+			VariantArmV6,
+			VariantArmV7,
+			VariantArmV7Musl,
+			VariantArm64,
+			VariantArm64Musl,
+			VariantDarwinAmd64,
+			VariantWindowsAmd64,
+			VariantLinuxAmd64,
+			VariantLinuxAmd64Musl,
+		},
+		PluginSignature: PluginSignature{
+			Sign:      true,
+			AdminSign: true,
+		},
+		Docker: Docker{
+			ShouldSave: true,
+			Architectures: []Architecture{
+				ArchAMD64,
+				ArchARM64,
+				ArchARMv7, // GOARCH=ARM is used for both armv6 and armv7. They are differentiated by the GOARM variable.
+			},
+		},
+		PackagesBucket:            "grafana-downloads",
+		PackagesBucketEnterprise2: "grafana-downloads-enterprise2",
+		CDNAssetsBucket:           "grafana-static-assets",
+	},
 	ReleaseBranchMode: {
 		Variants: []Variant{
 			VariantArmV6,


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new mode in the config, it's necessary for the enterprise downstream builds.
