### PR TITLE
GH Actions: change the action for `bot/no-new-info` label

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -41,6 +41,7 @@
     "type":"label",
     "name":"bot/no new info",
     "action":"close",
+    "removeLabel":"needs more info",
     "comment":"We've closed this issue since it needs more information and hasn't had any activity recently. We can re-open it after you you add more information. To avoid having your issue closed in the future, please read our [CONTRIBUTING](https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md) guidelines.\n\nHappy graphing!"
   },
   {


### PR DESCRIPTION
the community squad would like to tweak this label action so that it drops the pre-existing `needs-more-info` label whenever this is added. It will aid in our triage workflows 👍 