### PR TITLE
fix typo in message-templating/_index.md

### DIFF
--- a/docs/sources/alerting/contact-points/message-templating/_index.md
+++ b/docs/sources/alerting/contact-points/message-templating/_index.md
@@ -55,7 +55,7 @@ You can use any of the following built-in template options to embed custom templ
 | ----------------------- | ------------------------------------------------------------- |
 | `default.title`         | Displays high-level status information.                       |
 | `default.message`       | Provides a formatted summary of firing and resolved alerts.   |
-| `teams.default.message` | Similar to `default.messsage`, formatted for Microsoft Teams. |
+| `teams.default.message` | Similar to `default.message`, formatted for Microsoft Teams. |
 
 ### HTML in message templates
 


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes a small typo

**Fixes:**
fixes typo in the message-templating/_index.md


