### PR TITLE
Fix a typo on the Manage dashboard links page

### DIFF
--- a/docs/sources/dashboards/manage-dashboard-links/index.md
+++ b/docs/sources/dashboards/manage-dashboard-links/index.md
@@ -20,7 +20,7 @@ menuTitle: Manage dashboard links
 weight: 400
 ---
 
-# Manage dasboard links
+# Manage dashboard links
 
 You can use links to navigate between commonly-used dashboards or to connect others to your visualizations. Links let you create shortcuts to other dashboards, panels, and even external websites.
 


### PR DESCRIPTION
Just fixing a type I noticed while browsing the [docs](https://grafana.com/docs/grafana/latest/dashboards/manage-dashboard-links/)