### PR TITLE
Loki: Fix wrong LogQL parsing leading to errors in ad-hoc filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/experimental": "^0.0.2-canary.36",
     "@grafana/google-sdk": "0.0.3",
-    "@grafana/lezer-logql": "0.0.15",
+    "@grafana/lezer-logql": "0.0.17",
     "@grafana/runtime": "workspace:*",
     "@grafana/schema": "workspace:*",
     "@grafana/slate-react": "0.22.10-grafana",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4981,12 +4981,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/lezer-logql@npm:0.0.15":
-  version: 0.0.15
-  resolution: "@grafana/lezer-logql@npm:0.0.15"
+"@grafana/lezer-logql@npm:0.0.17":
+  version: 0.0.17
+  resolution: "@grafana/lezer-logql@npm:0.0.17"
   peerDependencies:
     "@lezer/lr": ^1.0.0
-  checksum: 2dac2654b46ee255ae56f12e2c23ecb71a0eda2753f98117d61b79a10dd0f0b443420aa34dd3cbc243a92cd8983411823cb2bebfe04d5b86cf9c72236c054de1
+  checksum: c792128fdf0ea43a8fc10258bedc7141d72d7d9f682d31864019b37f4c606107c23f762692685f4236182a440bb1559778ffbb09f3b7a96ca3c7235e22eb43d7
   languageName: node
   linkType: hard
 
@@ -21767,7 +21767,7 @@ __metadata:
     "@grafana/eslint-config": 5.0.0
     "@grafana/experimental": ^0.0.2-canary.36
     "@grafana/google-sdk": 0.0.3
-    "@grafana/lezer-logql": 0.0.15
+    "@grafana/lezer-logql": 0.0.17
     "@grafana/runtime": "workspace:*"
     "@grafana/schema": "workspace:*"
     "@grafana/slate-react": 0.22.10-grafana


### PR DESCRIPTION
**What this PR does / why we need it**:
The LogQL parser in https://github.com/grafana/lezer-logql returned wrong positions for empty stream selectors followed by a duration variable like `$__interval`. This PR just updates to the right version of https://github.com/grafana/lezer-logql.

**Which issue(s) this PR fixes**:

Fixes #54448

**Special notes for your reviewer**:
If you want to test ad-hoc filters:
1. Setup a dashboard.
2. Setup a dashboard-adhoc-variable from Loki.
3. Setup a panel with this query: `sum by(host) (count_over_time({}[$__interval]))`
4. Open the dashboard with the adhoc variable set. Something like this in the URL: `var-VARNAME=place%7C%3D%7Cmoon`
5. Before the fix: look at the Network tab in devtools and see that the query is in a wrong format.
6. With the fix: the query is formatted correctly.

**Special notes for backporting**:
For now it does not seem possible to backport this, since https://github.com/grafana/lezer-logql needs a special release for this. I need to figure out a way to do this and then will create a manual backport to 9.1.x.
