### PR TITLE
Chore: Add feature flag to prevent loading of legacy sass styles

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -64,4 +64,5 @@ export interface FeatureToggles {
   topnav?: boolean;
   customBranding?: boolean;
   traceqlEditor?: boolean;
+  hideLegacyStyles?: boolean;
 }

--- a/pkg/api/dtos/index.go
+++ b/pkg/api/dtos/index.go
@@ -27,6 +27,7 @@ type IndexViewData struct {
 	Sentry                  *setting.Sentry
 	ContentDeliveryURL      string
 	LoadingLogo             template.URL
+	LoadLegacyStyles        bool
 	// Nonce is a cryptographic identifier for use with Content Security Policy.
 	Nonce string
 }

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -825,6 +825,7 @@ func (hs *HTTPServer) setIndexViewData(c *models.ReqContext) (*dtos.IndexViewDat
 		Nonce:                   c.RequestNonce,
 		ContentDeliveryURL:      hs.Cfg.GetContentDeliveryURL(hs.License.ContentDeliveryPrefix()),
 		LoadingLogo:             "public/img/grafana_icon.svg",
+		LoadLegacyStyles:        !hs.Features.IsEnabled(featuremgmt.FlagHideLegacyStyles),
 	}
 
 	if !hs.AccessControl.IsDisabled() {

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -267,5 +267,10 @@ var (
 			Description: "Show the TraceQL editor in the explore page",
 			State:       FeatureStateAlpha,
 		},
+		{
+			Name:        "hideLegacyStyles",
+			Description: "Enable to prevent the loading of legacy SASS styles",
+			State:       FeatureStateAlpha,
+		},
 	}
 )

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -198,4 +198,8 @@ const (
 	// FlagTraceqlEditor
 	// Show the TraceQL editor in the explore page
 	FlagTraceqlEditor = "traceqlEditor"
+
+	// FlagHideLegacyStyles
+	// Enable to prevent the loading of legacy SASS styles
+	FlagHideLegacyStyles = "hideLegacyStyles"
 )

--- a/public/views/index-template.html
+++ b/public/views/index-template.html
@@ -21,11 +21,11 @@
     <link rel="apple-touch-icon" sizes="180x180" href="[[.AppleTouchIcon]]" />
     <link rel="mask-icon" href="[[.ContentDeliveryURL]]public/img/grafana_mask_icon.svg" color="#F05A28" />
 
-    [[ if eq .Theme "light" ]]
+    [[if .LoadLegacyStyles]] [[ if eq .Theme "light" ]]
     <link rel="stylesheet" href="[[.ContentDeliveryURL]]public/build/<%= htmlWebpackPlugin.files.cssChunks.light %>" />
     [[ else ]]
     <link rel="stylesheet" href="[[.ContentDeliveryURL]]public/build/<%= htmlWebpackPlugin.files.cssChunks.dark %>" />
-    [[ end ]]
+    [[ end ]] [[ end ]]
 
     <script nonce="[[.Nonce]]">
       performance.mark('frontend_boot_css_time_seconds');


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a feature flag to prevent loading of legacy styles to make it easier to spot work remaining as we remove our usage of the legacy sass styles.

Note, enabling this will visually break Grafana - that's expected. 

![2984_2022-08-31-14-44_chrome](https://user-images.githubusercontent.com/46142/187693706-8792879d-71a4-43d8-af33-9364fdfa4620.png)
![2985_2022-08-31-14-44_chrome](https://user-images.githubusercontent.com/46142/187693714-1198a4b7-a796-4d60-ab9c-c9a32415cfcd.png)



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

