### PR TITLE
Navigation: Adds profile menu to top nav bar

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2753,6 +2753,15 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
+    "public/app/core/components/NavBar/TopNavBar/TopNavBarItem.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"]
+    ],
+    "public/app/core/components/NavBar/TopNavBar/TopNavBarItemMenuTrigger.tsx:5381": [
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "2"],
+      [0, 0, 0, "Do not use any type assertions.", "3"]
+    ],
     "public/app/core/components/OptionsUI/DashboardPicker.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/public/app/core/components/AppChrome/TopSearchBar.tsx
+++ b/public/app/core/components/AppChrome/TopSearchBar.tsx
@@ -1,15 +1,37 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import { cloneDeep } from 'lodash';
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 
-import { GrafanaTheme2 } from '@grafana/data';
-import { Dropdown, FilterInput, Icon, Menu, MenuItem, Tooltip, useStyles2 } from '@grafana/ui';
-import { contextSrv } from 'app/core/core';
+import { GrafanaTheme2, NavSection } from '@grafana/data';
+import { FilterInput, Icon, Tooltip, useStyles2 } from '@grafana/ui';
+import { StoreState } from 'app/types';
+
+import TopNavBarItem from '../NavBar/TopNavBar/TopNavBarItem';
+import { NavBarContext } from '../NavBar/context';
+import { enrichConfigItems, enrichWithInteractionTracking } from '../NavBar/utils';
+import { OrgSwitcher } from '../OrgSwitcher';
 
 import { TOP_BAR_LEVEL_HEIGHT } from './types';
 
 export function TopSearchBar() {
   const styles = useStyles2(getStyles);
+  const location = useLocation();
+  const navBarTree = useSelector((state: StoreState) => state.navBarTree);
+  const navTree = cloneDeep(navBarTree);
+  const [menuIdOpen, setMenuIdOpen] = useState<string | undefined>(undefined);
+  const [showSwitcherModal, setShowSwitcherModal] = useState(false);
+  const toggleSwitcherModal = () => {
+    setShowSwitcherModal(!showSwitcherModal);
+  };
+  const configItems = enrichConfigItems(
+    navTree.filter((item) => item.section === NavSection.Config),
+    location,
+    toggleSwitcherModal
+  ).map((item) => enrichWithInteractionTracking(item, false));
 
+  const profileNode = configItems.find((item) => item.id === 'profile');
   return (
     <div className={styles.container}>
       <div className={styles.leftContent}>
@@ -21,38 +43,31 @@ export function TopSearchBar() {
         <FilterInput placeholder="Search grafana" value={''} onChange={() => {}} className={styles.searchInput} />
       </div>
       <div className={styles.actions}>
-        <Tooltip placement="bottom" content="Help menu (todo)">
-          <button className={styles.actionItem}>
-            <Icon name="question-circle" size="lg" />
-          </button>
-        </Tooltip>
-        <Tooltip placement="bottom" content="Grafana news (todo)">
-          <button className={styles.actionItem}>
-            <Icon name="rss" size="lg" />
-          </button>
-        </Tooltip>
-        <Tooltip placement="bottom" content="User profile (todo)">
-          <Dropdown overlay={ProfileMenu}>
+        <NavBarContext.Provider
+          value={{
+            menuIdOpen: menuIdOpen,
+            setMenuIdOpen: setMenuIdOpen,
+          }}
+        >
+          <Tooltip placement="bottom" content="Help menu (todo)">
             <button className={styles.actionItem}>
-              <img src={contextSrv.user.gravatarUrl} />
+              <Icon name="question-circle" size="lg" />
             </button>
-          </Dropdown>
-        </Tooltip>
+          </Tooltip>
+          <Tooltip placement="bottom" content="Grafana news (todo)">
+            <button className={styles.actionItem}>
+              <Icon name="rss" size="lg" />
+            </button>
+          </Tooltip>
+          {profileNode && (
+            <Tooltip placement="bottom" content="User profile (todo)">
+              <TopNavBarItem link={profileNode} />
+            </Tooltip>
+          )}
+        </NavBarContext.Provider>
       </div>
+      {showSwitcherModal && <OrgSwitcher onDismiss={toggleSwitcherModal} />}
     </div>
-  );
-}
-
-/**
- * This is just temporary, needs syncing with the backend option like DisableSignoutMenu
- */
-export function ProfileMenu() {
-  return (
-    <Menu>
-      <MenuItem url="profile" label="Your profile" />
-      <MenuItem url="profile/notifications" label="Your notifications" />
-      <MenuItem url="logout" label="Sign out" />
-    </Menu>
   );
 }
 

--- a/public/app/core/components/NavBar/NavBarItemMenuItem.tsx
+++ b/public/app/core/components/NavBar/NavBarItemMenuItem.tsx
@@ -52,7 +52,7 @@ export function NavBarItemMenuItem({ item, state, onNavigate }: NavBarItemMenuIt
   const { keyboardProps } = useKeyboard({
     onKeyDown: (e) => {
       if (e.key === 'ArrowLeft') {
-        onLeft();
+        onLeft?.();
       }
       e.continuePropagation();
     },

--- a/public/app/core/components/NavBar/NavBarMenuItem.tsx
+++ b/public/app/core/components/NavBar/NavBarMenuItem.tsx
@@ -13,7 +13,6 @@ export interface Props {
   target?: HTMLAnchorElement['target'];
   text: React.ReactNode;
   url?: string;
-  adjustHeightForBorder?: boolean;
   isMobile?: boolean;
 }
 

--- a/public/app/core/components/NavBar/TopNavBar/TopNavBarItem.tsx
+++ b/public/app/core/components/NavBar/TopNavBar/TopNavBarItem.tsx
@@ -1,0 +1,111 @@
+import { css, cx } from '@emotion/css';
+import { useLingui } from '@lingui/react';
+import { Item } from '@react-stately/collections';
+import React from 'react';
+
+import { GrafanaTheme2, locationUtil, NavMenuItemType, NavModelItem } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
+import { IconName, useTheme2 } from '@grafana/ui';
+
+import { NavBarItemMenu } from '../NavBarItemMenu';
+import { getNavBarItemWithoutMenuStyles } from '../NavBarItemWithoutMenu';
+import { NavBarMenuItem } from '../NavBarMenuItem';
+import { useNavBarContext } from '../context';
+import menuItemTranslations from '../navBarItem-translations';
+import { getNavModelItemKey } from '../utils';
+
+import { TopNavBarItemMenuTrigger } from './TopNavBarItemMenuTrigger';
+
+export interface Props {
+  link: NavModelItem;
+}
+
+const TopNavBarItem = ({ link }: Props) => {
+  const { i18n } = useLingui();
+  const theme = useTheme2();
+  const menuItems = link.children ?? [];
+  const { menuIdOpen } = useNavBarContext();
+
+  const filteredItems = menuItems
+    .filter((item) => !item.hideFromMenu)
+    .map((i) => ({ ...i, menuItemType: NavMenuItemType.Item }));
+  const styles = getStyles(theme);
+  const section: NavModelItem = {
+    ...link,
+    children: filteredItems,
+    menuItemType: NavMenuItemType.Section,
+  };
+  const items: NavModelItem[] = [section].concat(filteredItems);
+
+  const onNavigate = (item: NavModelItem) => {
+    const { url, target, onClick } = item;
+    onClick?.();
+
+    if (url) {
+      if (!target && url.startsWith('/')) {
+        locationService.push(locationUtil.stripBaseFromUrl(url));
+      } else {
+        window.open(url, target);
+      }
+    }
+  };
+
+  const translationKey = link.id && menuItemTranslations[link.id];
+  const linkText = translationKey ? i18n._(translationKey) : link.text;
+
+  return (
+    <li className={cx(styles.container, { [styles.containerHover]: section.id === menuIdOpen })}>
+      <TopNavBarItemMenuTrigger item={section} label={linkText}>
+        <NavBarItemMenu
+          items={items}
+          adjustHeightForBorder={false}
+          disabledKeys={['divider', 'subtitle']}
+          aria-label={section.text}
+          onNavigate={onNavigate}
+        >
+          {(item: NavModelItem) => {
+            const translationKey = item.id && menuItemTranslations[item.id];
+            const itemText = translationKey ? i18n._(translationKey) : item.text;
+            const isSection = item.menuItemType === NavMenuItemType.Section;
+            const icon = item.showIconInNavbar && !isSection ? (item.icon as IconName) : undefined;
+
+            return (
+              <Item key={getNavModelItemKey(item)} textValue={item.text}>
+                <NavBarMenuItem
+                  isDivider={!isSection && item.divider}
+                  icon={icon}
+                  target={item.target}
+                  text={itemText}
+                  url={item.url}
+                  onClick={item.onClick}
+                  styleOverrides={cx(styles.primaryText, { [styles.header]: isSection })}
+                />
+              </Item>
+            );
+          }}
+        </NavBarItemMenu>
+      </TopNavBarItemMenuTrigger>
+    </li>
+  );
+};
+
+export default TopNavBarItem;
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  ...getNavBarItemWithoutMenuStyles(theme),
+  containerHover: css({
+    backgroundColor: theme.colors.action.hover,
+    color: theme.colors.text.primary,
+  }),
+  primaryText: css({
+    color: theme.colors.text.primary,
+  }),
+  header: css({
+    height: `calc(${theme.spacing(6)} - 1px)`,
+    fontSize: theme.typography.h4.fontSize,
+    fontWeight: theme.typography.h4.fontWeight,
+    padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
+    whiteSpace: 'nowrap',
+    width: '100%',
+  }),
+});

--- a/public/app/core/components/NavBar/TopNavBar/TopNavBarItemMenuTrigger.tsx
+++ b/public/app/core/components/NavBar/TopNavBar/TopNavBarItemMenuTrigger.tsx
@@ -1,0 +1,246 @@
+import { css, cx } from '@emotion/css';
+import { useButton } from '@react-aria/button';
+import { useDialog } from '@react-aria/dialog';
+import { FocusScope } from '@react-aria/focus';
+import { useFocusWithin, useHover, useKeyboard } from '@react-aria/interactions';
+import { useMenuTrigger } from '@react-aria/menu';
+import { DismissButton, OverlayContainer, useOverlay, useOverlayPosition } from '@react-aria/overlays';
+import { useMenuTriggerState } from '@react-stately/menu';
+import { MenuTriggerProps } from '@react-types/menu';
+import React, { ReactElement, useEffect, useState } from 'react';
+
+import { GrafanaTheme2, NavModelItem } from '@grafana/data';
+import { reportExperimentView } from '@grafana/runtime';
+import { Icon, IconName, Link, useTheme2 } from '@grafana/ui';
+
+import { getNavMenuPortalContainer } from '../NavBarMenuPortalContainer';
+import { NavFeatureHighlight } from '../NavFeatureHighlight';
+import { NavBarItemMenuContext, useNavBarContext } from '../context';
+
+export interface TopNavBarItemMenuTriggerProps extends MenuTriggerProps {
+  children: ReactElement;
+  item: NavModelItem;
+  label: string;
+}
+
+export function TopNavBarItemMenuTrigger(props: TopNavBarItemMenuTriggerProps): ReactElement {
+  const { item, label, children: menu, ...rest } = props;
+  const [menuHasFocus, setMenuHasFocus] = useState(false);
+  const { menuIdOpen, setMenuIdOpen } = useNavBarContext();
+  const theme = useTheme2();
+  const styles = getStyles(theme);
+
+  // Create state based on the incoming props
+  const state = useMenuTriggerState({ ...rest });
+
+  // Get props for the menu trigger and menu elements
+  const ref = React.useRef<HTMLElement>(null);
+  const { menuTriggerProps, menuProps } = useMenuTrigger({}, state, ref);
+
+  useEffect(() => {
+    if (item.highlightId) {
+      reportExperimentView(`feature-highlights-${item.highlightId}-nav`, 'test', '');
+    }
+  }, [item.highlightId]);
+
+  const { hoverProps } = useHover({
+    onHoverChange: (isHovering) => {
+      if (isHovering) {
+        state.open();
+        setMenuIdOpen(item.id);
+      } else {
+        state.close();
+        setMenuIdOpen(undefined);
+      }
+    },
+  });
+
+  useEffect(() => {
+    // close the menu when changing submenus
+    if (menuIdOpen !== item.id) {
+      state.close();
+      setMenuHasFocus(false);
+    } else {
+      state.open();
+    }
+  }, [menuIdOpen, state, item.id]);
+
+  const { keyboardProps } = useKeyboard({
+    onKeyDown: (e) => {
+      switch (e.key) {
+        case 'ArrowDown':
+          if (!state.isOpen) {
+            state.open();
+            setMenuIdOpen(item.id);
+          }
+          setMenuHasFocus(true);
+          break;
+        case 'Tab':
+          setMenuIdOpen(undefined);
+          break;
+        default:
+          break;
+      }
+    },
+  });
+
+  // Get props for the button based on the trigger props from useMenuTrigger
+  const { buttonProps } = useButton(menuTriggerProps, ref);
+  const Wrapper = item.highlightText ? NavFeatureHighlight : React.Fragment;
+  const itemContent = (
+    <Wrapper>
+      <span className={styles.icon}>
+        {item?.icon && <Icon name={item.icon as IconName} size="xl" />}
+        {item?.img && <img src={item.img} alt={`${item.text} logo`} />}
+      </span>
+    </Wrapper>
+  );
+  let element = (
+    <button
+      className={styles.element}
+      {...buttonProps}
+      {...keyboardProps}
+      {...hoverProps}
+      ref={ref as React.RefObject<HTMLButtonElement>}
+      onClick={item?.onClick}
+      aria-label={label}
+    >
+      {itemContent}
+    </button>
+  );
+
+  if (item?.url) {
+    element =
+      !item.target && item.url.startsWith('/') ? (
+        <Link
+          {...buttonProps}
+          {...keyboardProps}
+          {...hoverProps}
+          ref={ref as React.RefObject<HTMLAnchorElement>}
+          href={item.url}
+          target={item.target}
+          onClick={item?.onClick}
+          className={styles.element}
+          aria-label={label}
+        >
+          {itemContent}
+        </Link>
+      ) : (
+        <a
+          href={item.url}
+          target={item.target}
+          onClick={item?.onClick}
+          {...buttonProps}
+          {...keyboardProps}
+          {...hoverProps}
+          ref={ref as React.RefObject<HTMLAnchorElement>}
+          className={styles.element}
+          aria-label={label}
+        >
+          {itemContent}
+        </a>
+      );
+  }
+
+  const overlayRef = React.useRef<HTMLDivElement>(null);
+  const { dialogProps } = useDialog({}, overlayRef);
+  const { overlayProps } = useOverlay(
+    {
+      onClose: () => {
+        state.close();
+        setMenuIdOpen(undefined);
+      },
+      isOpen: state.isOpen,
+      isDismissable: true,
+    },
+    overlayRef
+  );
+
+  let { overlayProps: overlayPositionProps } = useOverlayPosition({
+    targetRef: ref,
+    overlayRef,
+    placement: 'bottom',
+    isOpen: state.isOpen,
+  });
+
+  const { focusWithinProps } = useFocusWithin({
+    onFocusWithin: (e) => {
+      if (e.target.id === ref.current?.id) {
+        // If focussing on the trigger itself, set the menu id that is open
+        setMenuIdOpen(item.id);
+        state.open();
+      }
+      e.target.scrollIntoView?.({
+        block: 'nearest',
+      });
+    },
+    onBlurWithin: (e) => {
+      if (e.target?.getAttribute('role') === 'menuitem' && !overlayRef.current?.contains(e.relatedTarget)) {
+        // If it is blurring from a menuitem to an element outside the current overlay
+        // close the menu that is open
+        setMenuIdOpen(undefined);
+      }
+    },
+  });
+
+  return (
+    <div className={cx(styles.element, 'dropdown')} {...focusWithinProps}>
+      {element}
+      {state.isOpen && (
+        <OverlayContainer portalContainer={getNavMenuPortalContainer()}>
+          <NavBarItemMenuContext.Provider
+            value={{
+              menuProps,
+              menuHasFocus,
+              onClose: () => state.close(),
+              onLeft: () => {
+                setMenuHasFocus(false);
+                ref.current?.focus();
+              },
+            }}
+          >
+            <FocusScope restoreFocus>
+              <div {...overlayProps} {...overlayPositionProps} {...dialogProps} {...hoverProps} ref={overlayRef}>
+                <DismissButton onDismiss={() => state.close()} />
+                {menu}
+                <DismissButton onDismiss={() => state.close()} />
+              </div>
+            </FocusScope>
+          </NavBarItemMenuContext.Provider>
+        </OverlayContainer>
+      )}
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  element: css({
+    backgroundColor: 'transparent',
+    border: 'none',
+    color: 'inherit',
+    display: 'grid',
+    padding: 0,
+    placeContent: 'center',
+    height: theme.spacing(5),
+    width: theme.spacing(5),
+
+    '&:focus-visible': {
+      backgroundColor: theme.colors.action.hover,
+      boxShadow: 'none',
+      color: theme.colors.text.primary,
+      outline: `${theme.shape.borderRadius(1)} solid ${theme.colors.primary.main}`,
+      outlineOffset: `-${theme.shape.borderRadius(1)}`,
+      transition: 'none',
+    },
+  }),
+  icon: css({
+    height: '100%',
+    width: '100%',
+
+    img: {
+      borderRadius: '50%',
+      height: theme.spacing(3),
+      width: theme.spacing(3),
+    },
+  }),
+});

--- a/public/app/core/components/NavBar/TopNavBar/TopNavBarItemMenuTrigger.tsx
+++ b/public/app/core/components/NavBar/TopNavBar/TopNavBarItemMenuTrigger.tsx
@@ -193,10 +193,6 @@ export function TopNavBarItemMenuTrigger(props: TopNavBarItemMenuTriggerProps): 
               menuProps,
               menuHasFocus,
               onClose: () => state.close(),
-              onLeft: () => {
-                setMenuHasFocus(false);
-                ref.current?.focus();
-              },
             }}
           >
             <FocusScope restoreFocus>

--- a/public/app/core/components/NavBar/context.tsx
+++ b/public/app/core/components/NavBar/context.tsx
@@ -3,7 +3,7 @@ import { createContext, HTMLAttributes, useContext } from 'react';
 export interface NavBarItemMenuContextProps {
   menuHasFocus: boolean;
   onClose: () => void;
-  onLeft: () => void;
+  onLeft?: () => void;
   menuProps?: HTMLAttributes<HTMLElement>;
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds logic for the correct menu items in the profile menu for the top nav bar

<img width="350" alt="Screenshot 2022-08-31 at 15 24 42" src="https://user-images.githubusercontent.com/100691367/187702685-6a34b6d1-66d4-4902-b775-d2487cfa4d80.png">

**Which issue(s) this PR fixes**:

Fixes #53947

**Special notes for your reviewer**:

This is done by copying some of the logic of the `NavBarItem` and making some changes to work for the top nav bar (like going to the menu by pressing down instead of right), these NavBar components can be refactored quite a bit to remove logic that we don't need for TopNav if this is the approach we want. Also this does not fix the issue https://github.com/grafana/grafana/issues/47514
The alternative approach is to use `Dropdown`. Then we would need to make a decision on which logic from the old nav bar we want to port over, for example do we want to ever allow dividers in these menu items, or icons, ... Also the `MenuItem` used in the `Dropdown` does not allow icons on the right of the label like this:
<img width="304" alt="Screenshot 2022-08-31 at 16 25 30" src="https://user-images.githubusercontent.com/100691367/187717229-c71f2445-98d2-431b-b64f-1c44e2325a76.png">

