### PR TITLE
Plugins: unlock on plugin startup failure

### DIFF
--- a/pkg/plugins/manager/process/process.go
+++ b/pkg/plugins/manager/process/process.go
@@ -54,9 +54,9 @@ func (m *Manager) Start(ctx context.Context, pluginID string) error {
 
 	m.log.Info("Plugin registered", "pluginID", p.ID)
 	m.mu.Lock()
-	err := startPluginAndRestartKilledProcesses(ctx, p)
-	m.mu.Unlock()
-	if err != nil {
+	defer m.mu.Unlock()
+
+	if err := startPluginAndRestartKilledProcesses(ctx, p); err != nil {
 		return err
 	}
 

--- a/pkg/plugins/manager/process/process.go
+++ b/pkg/plugins/manager/process/process.go
@@ -54,12 +54,13 @@ func (m *Manager) Start(ctx context.Context, pluginID string) error {
 
 	m.log.Info("Plugin registered", "pluginID", p.ID)
 	m.mu.Lock()
-	if err := startPluginAndRestartKilledProcesses(ctx, p); err != nil {
+	err := startPluginAndRestartKilledProcesses(ctx, p)
+	m.mu.Unlock()
+	if err != nil {
 		return err
 	}
 
 	p.Logger().Debug("Successfully started backend plugin process")
-	m.mu.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
This fixes blocking startup if errors exist in the plugin