### PR TITLE
[v9.1.x] Correlations: Use correct fallback handlers (#54511)

### DIFF
--- a/pkg/services/correlations/api.go
+++ b/pkg/services/correlations/api.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/datasources"
-
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -19,10 +18,10 @@ func (s *CorrelationsService) registerAPIEndpoints() {
 	authorize := ac.Middleware(s.AccessControl)
 
 	s.RouteRegister.Group("/api/datasources/uid/:uid/correlations", func(entities routing.RouteRegister) {
-		entities.Post("/", middleware.ReqSignedIn, authorize(ac.ReqOrgAdmin, ac.EvalPermission(datasources.ActionWrite, uidScope)), routing.Wrap(s.createHandler))
-		entities.Delete("/:correlationUID", middleware.ReqSignedIn, authorize(ac.ReqOrgAdmin, ac.EvalPermission(datasources.ActionWrite, uidScope)), routing.Wrap(s.deleteHandler))
-		entities.Patch("/:correlationUID", middleware.ReqSignedIn, authorize(ac.ReqOrgAdmin, ac.EvalPermission(datasources.ActionWrite, uidScope)), routing.Wrap(s.updateHandler))
-	})
+		entities.Post("/", authorize(middleware.ReqOrgAdmin, ac.EvalPermission(datasources.ActionWrite, uidScope)), routing.Wrap(s.createHandler))
+		entities.Delete("/:correlationUID", authorize(middleware.ReqOrgAdmin, ac.EvalPermission(datasources.ActionWrite, uidScope)), routing.Wrap(s.deleteHandler))
+		entities.Patch("/:correlationUID", authorize(middleware.ReqOrgAdmin, ac.EvalPermission(datasources.ActionWrite, uidScope)), routing.Wrap(s.updateHandler))
+	}, middleware.ReqSignedIn)
 }
 
 // swagger:route POST /datasources/uid/{sourceUID}/correlations correlations createCorrelation


### PR DESCRIPTION
Manual backport of #54511

* Correlations: Use correct fallback handlers

* Add signed in middleware to all routes

(cherry picked from commit be6b8d91eb089f9634d28a2b836ebbaa2ed22222)

