### PR TITLE
Fix: Restore Grafana and Dashboard data source icons

### DIFF
--- a/public/app/plugins/datasource/dashboard/plugin.json
+++ b/public/app/plugins/datasource/dashboard/plugin.json
@@ -11,8 +11,8 @@
       "url": "https://grafana.com"
     },
     "logos": {
-      "small": "TODO",
-      "large": "TODO"
+      "small": "public/img/icn-datasource.svg",
+      "large": "public/img/icn-datasource.svg"
     }
   },
 

--- a/public/app/plugins/datasource/grafana/plugin.json
+++ b/public/app/plugins/datasource/grafana/plugin.json
@@ -11,8 +11,8 @@
       "url": "https://grafana.com"
     },
     "logos": {
-      "small": "TODO",
-      "large": "TODO"
+      "small": "public/img/icn-datasource.svg",
+      "large": "public/img/icn-datasource.svg"
     }
   },
   "backend": true,


### PR DESCRIPTION


**What this PR does / why we need it**:

Restores the icons for the `-- Grafana --` and `-- Dashboard --` data sources

![image](https://user-images.githubusercontent.com/46142/187920621-815e1cdf-d67e-4c15-9d0c-9145fd926002.png)


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #54579

**Special notes for your reviewer**:

