### PR TITLE
Build: Check if `dist` directory exists

### DIFF
--- a/pkg/build/cmd/genversions.go
+++ b/pkg/build/cmd/genversions.go
@@ -81,16 +81,18 @@ func GenerateVersions(c *cli.Context) error {
 	}
 
 	const distDir = "dist"
-	if err := os.RemoveAll(distDir); err != nil {
-		return err
-	}
-	if err := os.Mkdir(distDir, 0750); err != nil {
-		return err
-	}
+	if _, err := os.Stat(distDir); os.IsNotExist(err) {
+		if err := os.RemoveAll(distDir); err != nil {
+			return err
+		}
+		if err := os.Mkdir(distDir, 0750); err != nil {
+			return err
+		}
 
-	// nolint:gosec
-	if err := os.WriteFile(filepath.Join(distDir, "version.json"), jsonMetadata, 0664); err != nil {
-		return err
+		// nolint:gosec
+		if err := os.WriteFile(filepath.Join(distDir, "version.json"), jsonMetadata, 0664); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Now that the `version.json` file is produced before any subcommand runs, we need to make sure that we won't bump into concurrency issues. Checking if the `dist/` directory exists will prevent that from happening.
