### PR TITLE
LibraryElements: Fix inability to delete library panels under MySQL

### DIFF
--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -30,11 +30,14 @@ SELECT DISTINCT
 	, (SELECT COUNT(connection_id) FROM ` + models.LibraryElementConnectionTableName + ` WHERE element_id = le.id AND kind=1) AS connected_dashboards`
 )
 
+// redundant SELECT to trick mysql's optimizer
 const deleteInvalidConnections = `
 DELETE FROM library_element_connection
 WHERE connection_id IN (
-	SELECT connection_id as id FROM library_element_connection
-	WHERE element_id=? AND connection_id NOT IN (SELECT id as connection_id from dashboard)
+	SELECT connection_id FROM (
+		SELECT connection_id as id FROM library_element_connection
+		WHERE element_id=? AND connection_id NOT IN (SELECT id as connection_id from dashboard)
+	) as dummy
 )`
 
 func getFromLibraryElementDTOWithMeta(dialect migrator.Dialect) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue where library panels couldn't be deleted for Grafana instances using MySQL as the DB engine.
Unfortunately the previous attempt at a fix (#53460) didn't do the job, with the issue being more or less what's described [here](https://dev.mysql.com/doc/refman/5.6/en/update.html) (ctrl+f "ERROR 1093")
Hopefully it's actually fixed this time!

**Which issue(s) this PR fixes**:
Closes #53456
