### PR TITLE
Alerting: Fix incorrect propagation of org ID and other fields in rule provisioning endpoints

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -255,6 +255,7 @@ func (srv *ProvisioningSrv) RouteRouteGetAlertRule(c *models.ReqContext, UID str
 
 func (srv *ProvisioningSrv) RoutePostAlertRule(c *models.ReqContext, ar definitions.ProvisionedAlertRule) response.Response {
 	upstreamModel, err := ar.UpstreamModel()
+	upstreamModel.OrgID = c.OrgID
 	if err != nil {
 		ErrResp(http.StatusBadRequest, err, "")
 	}
@@ -271,10 +272,9 @@ func (srv *ProvisioningSrv) RoutePostAlertRule(c *models.ReqContext, ar definiti
 		}
 		return ErrResp(http.StatusInternalServerError, err, "")
 	}
-	ar.ID = createdAlertRule.ID
-	ar.UID = createdAlertRule.UID
-	ar.Updated = createdAlertRule.Updated
-	return response.JSON(http.StatusCreated, ar)
+
+	resp := definitions.NewAlertRule(createdAlertRule, alerting_models.ProvenanceAPI)
+	return response.JSON(http.StatusCreated, resp)
 }
 
 func (srv *ProvisioningSrv) RoutePutAlertRule(c *models.ReqContext, ar definitions.ProvisionedAlertRule, UID string) response.Response {
@@ -282,6 +282,7 @@ func (srv *ProvisioningSrv) RoutePutAlertRule(c *models.ReqContext, ar definitio
 	if err != nil {
 		ErrResp(http.StatusBadRequest, err, "")
 	}
+	updated.OrgID = c.OrgID
 	updated.UID = UID
 	updatedAlertRule, err := srv.alertRules.UpdateAlertRule(c.Req.Context(), updated, alerting_models.ProvenanceAPI)
 	if errors.Is(err, alerting_models.ErrAlertRuleNotFound) {
@@ -296,8 +297,9 @@ func (srv *ProvisioningSrv) RoutePutAlertRule(c *models.ReqContext, ar definitio
 		}
 		return ErrResp(http.StatusInternalServerError, err, "")
 	}
-	ar.Updated = updatedAlertRule.Updated
-	return response.JSON(http.StatusOK, ar)
+
+	resp := definitions.NewAlertRule(updatedAlertRule, alerting_models.ProvenanceAPI)
+	return response.JSON(http.StatusOK, resp)
 }
 
 func (srv *ProvisioningSrv) RouteDeleteAlertRule(c *models.ReqContext, UID string) response.Response {


### PR DESCRIPTION
**What this PR does / why we need it**:

The rule POST/PUT endpoints were not correctly propagating the OrgID value from the request context into the provided object. This led to bizarre behavior in several situations, such as one where the PUT endpoint could actually create new rules.

This PR also improves the created rule in the response. Rather than echoing the user's input with a few patched fields which was unreliable (and contained the wrong data in some situations) we now actually return the created rule as it appears in the database.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

