### PR TITLE
Alerting: Fix UI bug when setting custom notification policy group by

### DIFF
--- a/public/app/features/alerting/unified/components/amroutes/AmRootRouteForm.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRootRouteForm.tsx
@@ -87,7 +87,7 @@ export const AmRootRouteForm: FC<AmRootRouteFormProps> = ({
                     setValue('groupBy', [...field.value, opt]);
                   }}
                   onChange={(value) => onChange(mapMultiSelectValueToStrings(value))}
-                  options={[...commonGroupByOptions, groupByOptions]}
+                  options={[...commonGroupByOptions, ...groupByOptions]}
                 />
               )}
               control={control}

--- a/public/app/features/alerting/unified/components/amroutes/AmRoutesExpandedForm.tsx
+++ b/public/app/features/alerting/unified/components/amroutes/AmRoutesExpandedForm.tsx
@@ -180,7 +180,7 @@ export const AmRoutesExpandedForm: FC<AmRoutesExpandedFormProps> = ({ onCancel, 
                       setValue('groupBy', [...field.value, opt]);
                     }}
                     onChange={(value) => onChange(mapMultiSelectValueToStrings(value))}
-                    options={[...commonGroupByOptions, groupByOptions]}
+                    options={[...commonGroupByOptions, ...groupByOptions]}
                   />
                 )}
                 control={control}


### PR DESCRIPTION
**What this PR does / why we need it**:

Custom values were not being displayed in the multiselect for notification policy `Group by` even though
they were correctly being saved.



**Which issue(s) this PR fixes**:
Escalation: https://github.com/grafana/support-escalations/issues/3785

**Special notes for your reviewer**:

Before:
![Peek 2022-09-01 17-24](https://user-images.githubusercontent.com/8484471/188016125-9db49485-05c9-4b9a-a876-8146b903e79b.gif)

After:
![Peek 2022-09-01 17-20](https://user-images.githubusercontent.com/8484471/188016137-bbbf6147-e661-477d-8663-33ac71e883b6.gif)
