### PR TITLE
Alerting: Resetting the notification policy tree to the default policy will also restore default contact points

### DIFF
--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -191,5 +191,5 @@ func (nps *NotificationPolicyService) ensureDefaultReceiverExists(cfg *definitio
 	}
 
 	nps.log.Error("Grafana Alerting has been configured with a default configuration that is internally inconsistent! The default configuration's notification policy must have a corresponding receiver.")
-	return fmt.Errorf("Grafana Alerting has been configured with a default configuration that is internally inconsistent! The default configuration's notification policy must have a corresponding receiver.")
+	return fmt.Errorf("inconsistent default configuration")
 }

--- a/pkg/services/ngalert/provisioning/testing.go
+++ b/pkg/services/ngalert/provisioning/testing.go
@@ -160,6 +160,15 @@ func (m *MockAMConfigStore_Expecter) SaveSucceeds() *MockAMConfigStore_Expecter 
 	return m
 }
 
+func (m *MockAMConfigStore_Expecter) SaveSucceedsIntercept(intercepted *models.SaveAlertmanagerConfigurationCmd) *MockAMConfigStore_Expecter {
+	m.UpdateAlertmanagerConfiguration(mock.Anything, mock.Anything).
+		Return(nil).
+		Run(func(ctx context.Context, cmd *models.SaveAlertmanagerConfigurationCmd) {
+			*intercepted = *cmd
+		})
+	return m
+}
+
 func (m *MockProvisioningStore_Expecter) GetReturns(p models.Provenance) *MockProvisioningStore_Expecter {
 	m.GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(p, nil)
 	return m


### PR DESCRIPTION
**What this PR does / why we need it**:

In order for a policy tree to be valid, it MUST point to a contact point. That's why our `grafana-default-email` receiver exists.

The DELETE operation on policies will reset the policy to the default one. However, if the user manually deleted the `grafana-default-email` receiver, the policy will now be pointing to a receiver that doesn't exist.

This PR makes it so the default contact point will also be restored when resetting the policy.

**Which issue(s) this PR fixes**:

n/a

**Special notes for your reviewer**:

