### PR TITLE
CloudWatch: Add data source specific metrics

### DIFF
--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -104,6 +104,21 @@ var (
 
 	// MPublicDashboardRequestCount is a metric counter for public dashboards requests
 	MPublicDashboardRequestCount prometheus.Counter
+
+	// MCloudWatchMetricsQueryTotal is a metric counter for the total number of CloudWatch metrics queries
+	MCloudWatchMetricsQueryTotal *prometheus.CounterVec
+
+	// MCloudWatchLogsQueryTotal is a metric counter for the total number of CloudWatch logs queries
+	MCloudWatchLogsQueryTotal *prometheus.CounterVec
+
+	// MCloudWatchAnnotationQueryTotal is a metric counter for the total number of CloudWatch annotation queries
+	MCloudWatchAnnotationQueryTotal *prometheus.CounterVec
+
+	// MCloudWatchResourceQueryTOtal is a metric counter for the total number of CloudWatch resource requests
+	MCloudWatchResourceQueryTOtal *prometheus.CounterVec
+
+	// MCloudwatchQueriesFailuresTotal is a metric counter for the total number of CloudWatch query failures
+	MCloudwatchQueriesFailuresTotal *prometheus.CounterVec
 )
 
 // Timers
@@ -387,6 +402,49 @@ func init() {
 		[]string{"status", "type"},
 	)
 
+	MAlertingResultState = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name:      "alerting_result_total",
+		Help:      "alert execution result counter",
+		Namespace: ExporterName,
+	}, []string{"state"})
+
+	MCloudWatchMetricsQueryTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: ExporterName,
+			Name:      "cloudwatch_metrics_queries_total",
+		},
+		[]string{"mode", "type"},
+	)
+
+	MCloudWatchLogsQueryTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: ExporterName,
+			Name:      "cloudwatch_logs_queries_total",
+		},
+		[]string{"sub_type"},
+	)
+	MCloudWatchAnnotationQueryTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: ExporterName,
+			Name:      "cloudwatch_annotation_queries_total",
+		},
+		[]string{"api"},
+	)
+	MCloudWatchResourceQueryTOtal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: ExporterName,
+			Name:      "cloudwatch_resource_queries_total",
+		},
+		[]string{"path"},
+	)
+	MCloudwatchQueriesFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: ExporterName,
+			Name:      "cloudwatch_queries_failures_total",
+		},
+		[]string{"query_type"},
+	)
+
 	MRenderingQueue = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "rendering_queue_size",
 		Help:      "size of rendering queue",
@@ -664,5 +722,10 @@ func initMetricVars() {
 		StatsTotalDataKeys,
 		MStatTotalPublicDashboards,
 		MPublicDashboardRequestCount,
+		MCloudWatchMetricsQueryTotal,
+		MCloudWatchLogsQueryTotal,
+		MCloudWatchAnnotationQueryTotal,
+		MCloudWatchResourceQueryTOtal,
+		MCloudwatchQueriesFailuresTotal,
 	)
 }

--- a/pkg/tsdb/cloudwatch/annotation_query.go
+++ b/pkg/tsdb/cloudwatch/annotation_query.go
@@ -51,7 +51,7 @@ func (e *cloudWatchExecutor) executeAnnotationQuery(pluginCtx backend.PluginCont
 
 	var alarmNames []*string
 	if model.PrefixMatching {
-		metrics.MCloudWatchAnnotationQueryTotal.WithLabelValues(model.Region, "DescribeAlarmsInput").Inc()
+		metrics.MCloudWatchAnnotationQueryTotal.WithLabelValues("DescribeAlarmsInput").Inc()
 		params := &cloudwatch.DescribeAlarmsInput{
 			MaxRecords:      aws.Int64(100),
 			ActionPrefix:    aws.String(actionPrefix),
@@ -66,7 +66,7 @@ func (e *cloudWatchExecutor) executeAnnotationQuery(pluginCtx backend.PluginCont
 		if model.Region == "" || model.Namespace == "" || model.MetricName == "" || statistic == "" {
 			return result, errors.New("invalid annotations query")
 		}
-		metrics.MCloudWatchAnnotationQueryTotal.WithLabelValues(model.Region, "DescribeAlarmsForMetricInput").Inc()
+		metrics.MCloudWatchAnnotationQueryTotal.WithLabelValues("DescribeAlarmsForMetricInput").Inc()
 		var qd []*cloudwatch.Dimension
 		for k, v := range model.Dimensions {
 			if vv, ok := v.([]interface{}); ok {

--- a/pkg/tsdb/cloudwatch/annotation_query.go
+++ b/pkg/tsdb/cloudwatch/annotation_query.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/infra/metrics"
 )
 
 type annotationEvent struct {
@@ -50,6 +51,7 @@ func (e *cloudWatchExecutor) executeAnnotationQuery(pluginCtx backend.PluginCont
 
 	var alarmNames []*string
 	if model.PrefixMatching {
+		metrics.MCloudWatchAnnotationQueryTotal.WithLabelValues(model.Region, "DescribeAlarmsInput").Inc()
 		params := &cloudwatch.DescribeAlarmsInput{
 			MaxRecords:      aws.Int64(100),
 			ActionPrefix:    aws.String(actionPrefix),
@@ -64,7 +66,7 @@ func (e *cloudWatchExecutor) executeAnnotationQuery(pluginCtx backend.PluginCont
 		if model.Region == "" || model.Namespace == "" || model.MetricName == "" || statistic == "" {
 			return result, errors.New("invalid annotations query")
 		}
-
+		metrics.MCloudWatchAnnotationQueryTotal.WithLabelValues(model.Region, "DescribeAlarmsForMetricInput").Inc()
 		var qd []*cloudwatch.Dimension
 		for k, v := range model.Dimensions {
 			if vv, ok := v.([]interface{}); ok {

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -79,51 +79,7 @@ const (
 	annotationQuery = "annotationQuery"
 	logAction       = "logAction"
 	timeSeriesQuery = "timeSeriesQuery"
-	namespace       = "grafana"
 )
-
-// var (
-// 	metricsQueryCounter = promauto.NewCounterVec(
-// 		prometheus.CounterOpts{
-// 			Namespace: namespace,
-// 			Subsystem: "cludwatchds",
-// 			Name:      "cloudwatch_metrics_queries_total",
-// 		},
-// 		[]string{"mode", "type"},
-// 	)
-// 	logsQueryCounter = promauto.NewCounterVec(
-// 		prometheus.CounterOpts{
-// 			Namespace: namespace,
-// 			Subsystem: "cludwatchds",
-// 			Name:      "cloudwatch_logs_queries_total",
-// 		},
-// 		[]string{"sub_type"},
-// 	)
-// 	annotationQueryCounter = promauto.NewCounterVec(
-// 		prometheus.CounterOpts{
-// 			Namespace: namespace,
-// 			Subsystem: "cludwatchds",
-// 			Name:      "cloudwatch_annotation_queries_total",
-// 		},
-// 		[]string{"api"},
-// 	)
-// 	resourceQueryCounter = promauto.NewCounterVec(
-// 		prometheus.CounterOpts{
-// 			Namespace: namespace,
-// 			Subsystem: "cludwatchds",
-// 			Name:      "cloudwatch_resource_queries_total",
-// 		},
-// 		[]string{"path"},
-// 	)
-// 	cloudwatchQueriesFailuresCounter = promauto.NewCounterVec(
-// 		prometheus.CounterOpts{
-// 			Namespace: namespace,
-// 			Subsystem: "cludwatchds",
-// 			Name:      "cloudwatch_queries_failures_total",
-// 		},
-// 		[]string{"query_type"},
-// 	)
-// )
 
 var plog = log.New("tsdb.cloudwatch")
 var aliasFormat = regexp.MustCompile(`\{\{\s*(.+?)\s*\}\}`)

--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/infra/metrics"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -118,6 +119,8 @@ func (e *cloudWatchExecutor) executeLogAction(ctx context.Context, model LogQuer
 	if model.Region != "" {
 		region = model.Region
 	}
+
+	metrics.MCloudWatchLogsQueryTotal.WithLabelValues(model.SubType).Inc()
 
 	logsClient, err := e.getCWLogsClient(pluginCtx, region)
 	if err != nil {

--- a/pkg/tsdb/cloudwatch/metric_data_input_builder.go
+++ b/pkg/tsdb/cloudwatch/metric_data_input_builder.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
@@ -29,6 +30,7 @@ func (e *cloudWatchExecutor) buildMetricDataInput(startTime time.Time, endTime t
 		if err != nil {
 			return nil, &queryError{err, query.RefId}
 		}
+		metrics.MCloudWatchMetricsQueryTotal.WithLabelValues(query.MetricEditorMode.String(), query.MetricQueryType.String()).Inc()
 		metricDataInput.MetricDataQueries = append(metricDataInput.MetricDataQueries, metricDataQuery)
 	}
 

--- a/pkg/tsdb/cloudwatch/resource_handler.go
+++ b/pkg/tsdb/cloudwatch/resource_handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
+	"github.com/grafana/grafana/pkg/infra/metrics"
 )
 
 func (e *cloudWatchExecutor) newResourceMux() *http.ServeMux {
@@ -27,7 +28,9 @@ func (e *cloudWatchExecutor) newResourceMux() *http.ServeMux {
 type handleFn func(pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error)
 
 func handleResourceReq(handleFunc handleFn) func(rw http.ResponseWriter, req *http.Request) {
+
 	return func(rw http.ResponseWriter, req *http.Request) {
+		metrics.MCloudWatchResourceQueryTOtal.WithLabelValues(req.URL.Path).Inc()
 		ctx := req.Context()
 		pluginContext := httpadapter.PluginConfigFromContext(ctx)
 		err := req.ParseForm()

--- a/pkg/tsdb/cloudwatch/time_series_query.go
+++ b/pkg/tsdb/cloudwatch/time_series_query.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/metrics"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -88,6 +89,7 @@ func (e *cloudWatchExecutor) executeTimeSeriesQuery(ctx context.Context, req *ba
 		dataResponse := backend.DataResponse{
 			Error: fmt.Errorf("metric request error: %q", err),
 		}
+		metrics.MCloudwatchQueriesFailuresTotal.WithLabelValues(timeSeriesQuery).Inc()
 		resultChan <- &responseWrapper{
 			DataResponse: &dataResponse,
 		}

--- a/pkg/tsdb/cloudwatch/types.go
+++ b/pkg/tsdb/cloudwatch/types.go
@@ -41,12 +41,34 @@ const (
 	MetricQueryTypeQuery
 )
 
+func (queryType metricQueryType) String() string {
+	switch queryType {
+	case MetricQueryTypeSearch:
+		return "search"
+	case MetricQueryTypeQuery:
+		return "query"
+	}
+
+	return ""
+}
+
 type metricEditorMode uint32
 
 const (
 	MetricEditorModeBuilder metricEditorMode = iota
 	MetricEditorModeRaw
 )
+
+func (editorMode metricEditorMode) String() string {
+	switch editorMode {
+	case MetricEditorModeBuilder:
+		return "builder"
+	case MetricEditorModeRaw:
+		return "code"
+	}
+
+	return ""
+}
 
 type gmdApiMode uint32
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a few CloudWatch data source specific Prometheus metrics which will allow us to better understand how the data source is being used and how often it fails. This provides an alternative way to track adoption compared to using the echo service in the frontend. 

These metrics are being exposed under `/metrics` on the grafana API. In Hosted Grafana, these metrics are scraped and they can be monitored in ops.grafana.net through the `ops-cortex` data source. See [this](https://ops.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22000000134%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22editorMode%22:%22code%22,%22expr%22:%22rate%28grafana_aws_cloudwatch_get_metric_data_total%7Bcluster%3D%5C%22ops-us-east-0%5C%22%7D%5B$__rate_interval%5D%29%22,%22legendFormat%22:%22__auto%22,%22range%22:true,%22instant%22:true%7D%5D,%22range%22:%7B%22from%22:%22now-15m%22,%22to%22:%22now%22%7D%7D) metric for example. Please note that metrics defined by a data source are only collected and made available on `/metrics` if the data source is a core plugin. Adding this capability to external plugins is currently being worked on [here](https://github.com/grafana/deployment_tools/pull/25360). 


**Description of the metrics**
```
metric: cloudwatch_metrics_queries_total
labels: mode, type
```
This metric will allow us to see the total number of metrics queries. The labels will allow us to see the proportion of `Search` vs `Query (Metric Insights)` query types and also within these query types we'll be able to monitor the proportion of `Builder` vs `Code Editor` mode. 
  
```
metric: cloudwatch_logs_queries_total
labels: sub_type
```
This metric will allow us to see the total number of logs queries. The sub_type label will allow us to see the split between sub query types such as `startQuery`, `getQueryStatus` etc. This will allow us to get an understanding of how the async logs api is being used.

```
metric: cloudwatch_annotation_queries_total
labels: api
```
This metric will allow us to see the total number of annotation queries. The api label will allow us to see how many users are using prefix matching vs metric matching.

```
metric: cloudwatch_resource_queries_total
labels: path
```
This metric will allow us to see the total number of resource requests. The `path` is the resource query type, e.g `/regions` or `/dimension-values`. This will allow us to detect for example if a resource request is called unreasonably often, maybe due to badly implemented query editor.

```
metric: cloudwatch_queries_failures_total
labels: query_type
```
This metric will allow us to see the total number of errors in the plugin. The `query_type` could be `logs|metrics|resource|annotation`. Currently, it includes expected errors such as when a user is trying to divide something with 0, but I think it may be better to remove them and just include unhandled errors? Anyway, this metric can be used in correlation to our changes on the main branch. For example, a change in main might lead to a spike of errors in ops.grafana.net. If we have alarms on that, we might be able to fix the problem before it even reaches our customers.  



**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
It might be that there are already similar metrics provided by core grafana that we can use. For example, I think annotation request count (with data source as label) should be collected by the platform. 

Another thing that would be really valuable would be if each of the above metrics could have a label for source of request/origin so that we could see where the request originated from. For example dashboard, explore, alerting, recorded queries etc.  
