### PR TITLE
Tempo: Move interfaces & `TempoQueryType` from `datasource.ts` to `types.ts`

### DIFF
--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -29,7 +29,7 @@ import { TraceToLogsData } from 'app/core/components/TraceToLogs/TraceToLogsSett
 import { TraceToMetricsData } from 'app/core/components/TraceToMetrics/TraceToMetricsSettings';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 import { getTimeZone } from 'app/features/profile/state/selectors';
-import { TempoQuery } from 'app/plugins/datasource/tempo/datasource';
+import { TempoQuery } from 'app/plugins/datasource/tempo/types';
 import { StoreState } from 'app/types';
 import { ExploreId } from 'app/types/explore';
 

--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.test.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.test.tsx
@@ -2,7 +2,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { TempoDatasource, TempoQuery } from '../datasource';
+import { TempoDatasource } from '../datasource';
+import { TempoQuery } from '../types';
 
 import NativeSearch from './NativeSearch';
 

--- a/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/NativeSearch.tsx
@@ -23,9 +23,10 @@ import { notifyApp } from 'app/core/actions';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { dispatch } from 'app/store/store';
 
-import { TempoDatasource, TempoQuery } from '../datasource';
+import { TempoDatasource } from '../datasource';
 import TempoLanguageProvider from '../language_provider';
 import { tokenizer } from '../syntax';
+import { TempoQuery } from '../types';
 
 interface Props {
   datasource: TempoDatasource;

--- a/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/QueryField.tsx
@@ -18,8 +18,9 @@ import {
 import { LokiQueryField } from '../../loki/components/LokiQueryField';
 import { LokiDatasource } from '../../loki/datasource';
 import { LokiQuery } from '../../loki/types';
-import { TempoDatasource, TempoQuery, TempoQueryType } from '../datasource';
+import { TempoDatasource } from '../datasource';
 import { QueryEditor } from '../traceql/QueryEditor';
+import { TempoQuery, TempoQueryType } from '../types';
 
 import NativeSearch from './NativeSearch';
 import { ServiceGraphSection } from './ServiceGraphSection';

--- a/public/app/plugins/datasource/tempo/QueryEditor/ServiceGraphSection.tsx
+++ b/public/app/plugins/datasource/tempo/QueryEditor/ServiceGraphSection.tsx
@@ -9,7 +9,7 @@ import { Alert, InlineField, InlineFieldRow, useStyles2 } from '@grafana/ui';
 import { AdHocFilter } from '../../../../features/variables/adhoc/picker/AdHocFilter';
 import { AdHocVariableFilter } from '../../../../features/variables/types';
 import { PrometheusDatasource } from '../../prometheus/datasource';
-import { TempoQuery } from '../datasource';
+import { TempoQuery } from '../types';
 
 import { getDS } from './utils';
 

--- a/public/app/plugins/datasource/tempo/configuration/LokiSearchSettings.tsx
+++ b/public/app/plugins/datasource/tempo/configuration/LokiSearchSettings.tsx
@@ -5,7 +5,7 @@ import { DataSourcePluginOptionsEditorProps, GrafanaTheme, updateDatasourcePlugi
 import { DataSourcePicker } from '@grafana/runtime';
 import { Button, InlineField, InlineFieldRow, useStyles } from '@grafana/ui';
 
-import { TempoJsonData } from '../datasource';
+import { TempoJsonData } from '../types';
 
 interface Props extends DataSourcePluginOptionsEditorProps<TempoJsonData> {}
 

--- a/public/app/plugins/datasource/tempo/configuration/SearchSettings.tsx
+++ b/public/app/plugins/datasource/tempo/configuration/SearchSettings.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { DataSourcePluginOptionsEditorProps, updateDatasourcePluginJsonDataOption } from '@grafana/data';
 import { InlineField, InlineFieldRow, InlineSwitch, useStyles } from '@grafana/ui';
 
-import { TempoJsonData } from '../datasource';
+import { TempoJsonData } from '../types';
 
 interface Props extends DataSourcePluginOptionsEditorProps<TempoJsonData> {}
 

--- a/public/app/plugins/datasource/tempo/configuration/ServiceGraphSettings.tsx
+++ b/public/app/plugins/datasource/tempo/configuration/ServiceGraphSettings.tsx
@@ -5,7 +5,7 @@ import { DataSourcePluginOptionsEditorProps, GrafanaTheme, updateDatasourcePlugi
 import { DataSourcePicker } from '@grafana/runtime';
 import { Button, InlineField, InlineFieldRow, useStyles } from '@grafana/ui';
 
-import { TempoJsonData } from '../datasource';
+import { TempoJsonData } from '../types';
 
 interface Props extends DataSourcePluginOptionsEditorProps<TempoJsonData> {}
 

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -17,9 +17,7 @@ import config from 'app/core/config';
 
 import {
   DEFAULT_LIMIT,
-  TempoJsonData,
   TempoDatasource,
-  TempoQuery,
   buildExpr,
   buildLinkExpr,
   getRateAlignedValues,
@@ -29,6 +27,7 @@ import {
 } from './datasource';
 import mockJson from './mockJsonResponse.json';
 import mockServiceGraph from './mockServiceGraph.json';
+import { TempoJsonData, TempoQuery } from './types';
 
 jest.mock('@grafana/runtime', () => {
   return {

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -3,13 +3,11 @@ import { EMPTY, from, merge, Observable, of, throwError } from 'rxjs';
 import { catchError, concatMap, map, mergeMap, toArray } from 'rxjs/operators';
 
 import {
-  DataQuery,
   DataQueryRequest,
   DataQueryResponse,
   DataQueryResponseData,
   DataSourceApi,
   DataSourceInstanceSettings,
-  DataSourceJsonData,
   FieldType,
   isValidGoDuration,
   LoadingState,
@@ -30,7 +28,7 @@ import { TraceToLogsOptions } from 'app/core/components/TraceToLogs/TraceToLogsS
 import { serializeParams } from 'app/core/utils/fetch';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
 
-import { LokiOptions, LokiQuery } from '../loki/types';
+import { LokiOptions } from '../loki/types';
 import { PrometheusDatasource } from '../prometheus/datasource';
 import { PromQuery } from '../prometheus/types';
 
@@ -52,49 +50,7 @@ import {
   transformFromOTLP as transformFromOTEL,
   createTableFrameFromSearch,
 } from './resultTransformer';
-
-// search = Loki search, nativeSearch = Tempo search for backwards compatibility
-export type TempoQueryType = 'traceql' | 'search' | 'traceId' | 'serviceMap' | 'upload' | 'nativeSearch' | 'clear';
-
-export interface TempoJsonData extends DataSourceJsonData {
-  tracesToLogs?: TraceToLogsOptions;
-  serviceMap?: {
-    datasourceUid?: string;
-  };
-  search?: {
-    hide?: boolean;
-  };
-  nodeGraph?: NodeGraphOptions;
-  lokiSearch?: {
-    datasourceUid?: string;
-  };
-  spanBar?: {
-    tag: string;
-  };
-}
-
-export interface TempoQuery extends DataQuery {
-  query: string;
-  // Query to find list of traces, e.g., via Loki
-  linkedQuery?: LokiQuery;
-  search?: string;
-  queryType: TempoQueryType;
-  serviceName?: string;
-  spanName?: string;
-  minDuration?: string;
-  maxDuration?: string;
-  limit?: number;
-  serviceMapQuery?: string;
-}
-
-interface SearchQueryParams {
-  minDuration?: string;
-  maxDuration?: string;
-  limit?: number;
-  tags?: string;
-  start?: number;
-  end?: number;
-}
+import { SearchQueryParams, TempoQuery, TempoJsonData } from './types';
 
 export const DEFAULT_LIMIT = 20;
 

--- a/public/app/plugins/datasource/tempo/traceql/QueryEditor.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/QueryEditor.tsx
@@ -5,8 +5,8 @@ import React from 'react';
 import { QueryEditorProps } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
-import { TempoDatasource, TempoQuery } from '../datasource';
-import { defaultQuery, MyDataSourceOptions } from '../types';
+import { TempoDatasource } from '../datasource';
+import { defaultQuery, MyDataSourceOptions, TempoQuery } from '../types';
 
 import { TempoQueryBuilderOptions } from './TempoQueryBuilderOptions';
 import { TraceQLEditor } from './TraceQLEditor';

--- a/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { AutoSizeInput, EditorField, EditorRow } from '@grafana/ui';
 import { QueryOptionGroup } from 'app/plugins/datasource/prometheus/querybuilder/shared/QueryOptionGroup';
 
-import { TempoQuery } from '../datasource';
+import { TempoQuery } from '../types';
 
 interface Props {
   onChange: (value: TempoQuery) => void;

--- a/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/autocomplete.test.ts
@@ -1,8 +1,9 @@
 import { DataSourceInstanceSettings, PluginType } from '@grafana/data/src';
 import { monacoTypes } from '@grafana/ui';
 
-import { TempoDatasource, TempoJsonData } from '../datasource';
+import { TempoDatasource } from '../datasource';
 import TempoLanguageProvider from '../language_provider';
+import { TempoJsonData } from '../types';
 
 import { CompletionProvider } from './autocomplete';
 

--- a/public/app/plugins/datasource/tempo/types.ts
+++ b/public/app/plugins/datasource/tempo/types.ts
@@ -1,6 +1,52 @@
+import { DataQuery } from '@grafana/data';
 import { DataSourceJsonData } from '@grafana/data/src';
+import { NodeGraphOptions } from 'app/core/components/NodeGraphSettings';
+import { TraceToLogsOptions } from 'app/core/components/TraceToLogs/TraceToLogsSettings';
 
-import { TempoQuery } from './datasource';
+import { LokiQuery } from '../loki/types';
+
+export interface SearchQueryParams {
+  minDuration?: string;
+  maxDuration?: string;
+  limit?: number;
+  tags?: string;
+  start?: number;
+  end?: number;
+}
+
+export interface TempoJsonData extends DataSourceJsonData {
+  tracesToLogs?: TraceToLogsOptions;
+  serviceMap?: {
+    datasourceUid?: string;
+  };
+  search?: {
+    hide?: boolean;
+  };
+  nodeGraph?: NodeGraphOptions;
+  lokiSearch?: {
+    datasourceUid?: string;
+  };
+  spanBar?: {
+    tag: string;
+  };
+}
+
+// search = Loki search, nativeSearch = Tempo search for backwards compatibility
+export type TempoQueryType = 'traceql' | 'search' | 'traceId' | 'serviceMap' | 'upload' | 'nativeSearch' | 'clear';
+
+export interface TempoQuery extends DataQuery {
+  query: string;
+  // Query to find list of traces, e.g., via Loki
+  linkedQuery?: LokiQuery;
+  search?: string;
+  queryType: TempoQueryType;
+  serviceName?: string;
+  spanName?: string;
+  minDuration?: string;
+  maxDuration?: string;
+  limit?: number;
+  serviceMapQuery?: string;
+}
 
 export interface MyDataSourceOptions extends DataSourceJsonData {}
 


### PR DESCRIPTION
This PR moves all interfaces and `TempoQueryType` from `datasource.ts` to `types.ts` for better code organisation.

