### PR TITLE
CI: Run `gen-version` in windows pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1504,6 +1504,7 @@ steps:
   - gcloud auth activate-service-account --key-file=gcpkey.json
   - rm gcpkey.json
   - cp C:\App\nssm-2.24.zip .
+  - .\grabpl.exe gen-version --build-id $$env:DRONE_BUILD_NUMBER
   - .\grabpl.exe windows-installer --edition oss --build-id $$env:DRONE_BUILD_NUMBER
   - $$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]
   - gsutil cp $$fname gs://grafana-downloads/oss/main/
@@ -5092,6 +5093,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 93835e0362c0a924e8da207d3c89296a1d68f3997f86ac4859b356a872bc9f4a
+hmac: 54f9d4c1b212da26968eb3c35278ad82bc9d204ca0f6f99eb990df1b9950516b
 
 ...

--- a/scripts/drone/pipelines/windows.star
+++ b/scripts/drone/pipelines/windows.star
@@ -55,6 +55,7 @@ def windows(trigger, edition, ver_mode):
             'release',
         ):
             installer_commands.extend([
+                '.\\grabpl.exe gen-version {}'.format(ver_part),
                 '.\\grabpl.exe windows-installer --edition {} {}'.format(edition, ver_part),
                 '$$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]',
             ])


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently our `windows` pipelines fail because the windows related cli commands don't have the `BeforeFunc` function which calculates the Grafana version running.
This PR brings back the `gen-version` call for the windows pipelines.