### PR TITLE
Loki Query Variables: Add support to select from existing labels

### DIFF
--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
@@ -10,17 +10,23 @@ import { LokiVariableQueryType } from '../types';
 
 import { LokiVariableQueryEditor, Props } from './VariableQueryEditor';
 
-const props: Props = {
-  datasource: createLokiDatasource({} as unknown as TemplateSrv),
-  query: {
-    refId: 'test',
-    type: LokiVariableQueryType.LabelNames,
-  },
-  onRunQuery: () => {},
-  onChange: () => {},
-};
+let props: Props;
 
 describe('LokiVariableQueryEditor', () => {
+  beforeEach(() => {
+    props = {
+      datasource: createLokiDatasource({} as unknown as TemplateSrv),
+      query: {
+        refId: 'test',
+        type: LokiVariableQueryType.LabelNames,
+      },
+      onRunQuery: () => {},
+      onChange: () => {},
+    };
+
+    jest.spyOn(props.datasource, 'labelNamesQuery').mockResolvedValue([]);
+  });
+
   test('Allows to create a Label names variable', async () => {
     const onChange = jest.fn();
 
@@ -40,13 +46,21 @@ describe('LokiVariableQueryEditor', () => {
 
   test('Allows to create a Label values variable', async () => {
     const onChange = jest.fn();
+    jest.spyOn(props.datasource, 'labelNamesQuery').mockResolvedValue([
+      {
+        text: 'moon',
+      },
+      {
+        text: 'luna',
+      },
+    ]);
 
     render(<LokiVariableQueryEditor {...props} onChange={onChange} />);
 
     expect(onChange).not.toHaveBeenCalled();
 
     await selectOptionInTest(screen.getByLabelText('Query type'), 'Label values');
-    await userEvent.type(screen.getByLabelText('Label'), 'label');
+    await selectOptionInTest(screen.getByLabelText('Label'), 'luna');
     await userEvent.type(screen.getByLabelText('Stream selector'), 'stream');
 
     await waitFor(() => expect(screen.getByDisplayValue('stream')).toBeInTheDocument());
@@ -55,20 +69,20 @@ describe('LokiVariableQueryEditor', () => {
 
     expect(onChange).toHaveBeenCalledWith({
       type: LokiVariableQueryType.LabelValues,
-      label: 'label',
+      label: 'luna',
       stream: 'stream',
       refId: 'LokiVariableQueryEditor-VariableQuery',
     });
   });
 
   test('Migrates legacy string queries to LokiVariableQuery instances', async () => {
-    const query = 'label_values(log stream selector, label)';
+    const query = 'label_values(log stream selector, label_selector)';
 
     // @ts-expect-error
     render(<LokiVariableQueryEditor {...props} onChange={() => {}} query={query} />);
 
     await waitFor(() => expect(screen.getByText('Label values')).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByDisplayValue('label')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('label_selector')).toBeInTheDocument());
     await waitFor(() => expect(screen.getByDisplayValue('log stream selector')).toBeInTheDocument());
   });
 });

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
@@ -10,9 +10,11 @@ import { LokiVariableQueryType } from '../types';
 
 import { LokiVariableQueryEditor, Props } from './VariableQueryEditor';
 
-let props: Props;
+const refId = 'LokiVariableQueryEditor-VariableQuery';
 
 describe('LokiVariableQueryEditor', () => {
+  let props: Props;
+
   beforeEach(() => {
     props = {
       datasource: createLokiDatasource({} as unknown as TemplateSrv),
@@ -29,18 +31,17 @@ describe('LokiVariableQueryEditor', () => {
 
   test('Allows to create a Label names variable', async () => {
     const onChange = jest.fn();
-
     render(<LokiVariableQueryEditor {...props} onChange={onChange} />);
 
     expect(onChange).not.toHaveBeenCalled();
 
-    await selectOptionInTest(screen.getByLabelText('Query type'), 'Label names');
+    await selectOptionInTest(screen.getByLabelText('Query type'), 'Label values');
 
     expect(onChange).toHaveBeenCalledWith({
-      type: LokiVariableQueryType.LabelNames,
+      type: LokiVariableQueryType.LabelValues,
       label: '',
       stream: '',
-      refId: 'LokiVariableQueryEditor-VariableQuery',
+      refId,
     });
   });
 
@@ -54,7 +55,6 @@ describe('LokiVariableQueryEditor', () => {
         text: 'luna',
       },
     ]);
-
     render(<LokiVariableQueryEditor {...props} onChange={onChange} />);
 
     expect(onChange).not.toHaveBeenCalled();
@@ -71,15 +71,33 @@ describe('LokiVariableQueryEditor', () => {
       type: LokiVariableQueryType.LabelValues,
       label: 'luna',
       stream: 'stream',
-      refId: 'LokiVariableQueryEditor-VariableQuery',
+      refId,
     });
   });
 
   test('Migrates legacy string queries to LokiVariableQuery instances', async () => {
     const query = 'label_values(log stream selector, label_selector)';
-
     // @ts-expect-error
     render(<LokiVariableQueryEditor {...props} onChange={() => {}} query={query} />);
+
+    await waitFor(() => expect(screen.getByText('Label values')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('label_selector')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByDisplayValue('log stream selector')).toBeInTheDocument());
+  });
+
+  test('Receives a query instance and assigns its values when editing', async () => {
+    render(
+      <LokiVariableQueryEditor
+        {...props}
+        onChange={() => {}}
+        query={{
+          type: LokiVariableQueryType.LabelValues,
+          label: 'label_selector',
+          stream: 'log stream selector',
+          refId,
+        }}
+      />
+    );
 
     await waitFor(() => expect(screen.getByText('Label values')).toBeInTheDocument());
     await waitFor(() => expect(screen.getByText('label_selector')).toBeInTheDocument());

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.test.tsx
@@ -75,6 +75,36 @@ describe('LokiVariableQueryEditor', () => {
     });
   });
 
+  test('Allows to create a Label values variable with custom label', async () => {
+    const onChange = jest.fn();
+    jest.spyOn(props.datasource, 'labelNamesQuery').mockResolvedValue([
+      {
+        text: 'moon',
+      },
+      {
+        text: 'luna',
+      },
+    ]);
+    render(<LokiVariableQueryEditor {...props} onChange={onChange} />);
+
+    expect(onChange).not.toHaveBeenCalled();
+
+    await selectOptionInTest(screen.getByLabelText('Query type'), 'Label values');
+    await userEvent.type(screen.getByLabelText('Label'), 'sol{enter}');
+    await userEvent.type(screen.getByLabelText('Stream selector'), 'stream');
+
+    await waitFor(() => expect(screen.getByDisplayValue('stream')).toBeInTheDocument());
+
+    await userEvent.click(document.body);
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: LokiVariableQueryType.LabelValues,
+      label: 'sol',
+      stream: 'stream',
+      refId,
+    });
+  });
+
   test('Migrates legacy string queries to LokiVariableQuery instances', async () => {
     const query = 'label_values(log stream selector, label_selector)';
     // @ts-expect-error

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -31,6 +31,10 @@ export const LokiVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
     setType(variableQuery.type);
     setLabel(variableQuery.label || '');
     setStream(variableQuery.stream || '');
+
+    if (variableQuery.label) {
+      setLabelOptions([{ label: variableQuery.label, value: variableQuery.label }]);
+    }
   }, [query]);
 
   useEffect(() => {

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -14,9 +14,12 @@ const variableOptions = [
 
 export type Props = QueryEditorProps<LokiDatasource, LokiQuery, LokiOptions, LokiVariableQuery>;
 
-export const LokiVariableQueryEditor: FC<Props> = ({ onChange, query }) => {
+const refId = 'LokiVariableQueryEditor-VariableQuery';
+
+export const LokiVariableQueryEditor: FC<Props> = ({ onChange, query, datasource }) => {
   const [type, setType] = useState<number | undefined>(undefined);
   const [label, setLabel] = useState('');
+  const [labelOptions, setLabelOptions] = useState<Array<SelectableValue<string>>>([]);
   const [stream, setStream] = useState('');
 
   useEffect(() => {
@@ -30,6 +33,16 @@ export const LokiVariableQueryEditor: FC<Props> = ({ onChange, query }) => {
     setStream(variableQuery.stream || '');
   }, [query]);
 
+  useEffect(() => {
+    if (type !== QueryType.LabelValues) {
+      return;
+    }
+
+    datasource.labelNamesQuery().then((labelNames: Array<{ text: string }>) => {
+      setLabelOptions(labelNames.map(({ text }) => ({ label: text, value: text })));
+    });
+  }, [datasource, type]);
+
   const onQueryTypeChange = (newType: SelectableValue<QueryType>) => {
     setType(newType.value);
     if (newType.value !== undefined) {
@@ -37,13 +50,13 @@ export const LokiVariableQueryEditor: FC<Props> = ({ onChange, query }) => {
         type: newType.value,
         label,
         stream,
-        refId: 'LokiVariableQueryEditor-VariableQuery',
+        refId,
       });
     }
   };
 
-  const onLabelChange = (e: FormEvent<HTMLInputElement>) => {
-    setLabel(e.currentTarget.value);
+  const onLabelChange = (newLabel: SelectableValue<string>) => {
+    setLabel(newLabel.value || '');
   };
 
   const onStreamChange = (e: FormEvent<HTMLInputElement>) => {
@@ -71,7 +84,14 @@ export const LokiVariableQueryEditor: FC<Props> = ({ onChange, query }) => {
       {type === QueryType.LabelValues && (
         <>
           <InlineField label="Label" labelWidth={20}>
-            <Input type="text" aria-label="Label" value={label} onChange={onLabelChange} onBlur={handleBlur} />
+            <Select
+              aria-label="Label"
+              onChange={onLabelChange}
+              onBlur={handleBlur}
+              value={label}
+              options={labelOptions}
+              width={16}
+            />
           </InlineField>
           <InlineField label="Stream selector" labelWidth={20}>
             <Input

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -98,13 +98,23 @@ export const LokiVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
               allowCustomValue
             />
           </InlineField>
-          <InlineField label="Stream selector" labelWidth={20} tooltip={<div>Optional</div>}>
+          <InlineField
+            label="Stream selector"
+            labelWidth={20}
+            tooltip={
+              <div>
+                Optional. If defined, a list of values for the label in the specified log stream selector is returned.
+              </div>
+            }
+          >
             <Input
               type="text"
               aria-label="Stream selector"
+              placeholder="Optional stream selector"
               value={stream}
               onChange={onStreamChange}
               onBlur={handleBlur}
+              width={22}
             />
           </InlineField>
         </>

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -95,6 +95,7 @@ export const LokiVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
               value={label}
               options={labelOptions}
               width={16}
+              allowCustomValue
             />
           </InlineField>
           <InlineField label="Stream selector" labelWidth={20}>

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -98,7 +98,7 @@ export const LokiVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
               allowCustomValue
             />
           </InlineField>
-          <InlineField label="Stream selector" labelWidth={20}>
+          <InlineField label="Stream selector" labelWidth={20} tooltip={<div>Optional</div>}>
             <Input
               type="text"
               aria-label="Stream selector"

--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -23,11 +23,11 @@ export const LokiVariableQueryEditor: FC<Props> = ({ onChange, query, datasource
   const [stream, setStream] = useState('');
 
   useEffect(() => {
-    if (!query || typeof query !== 'string') {
+    if (!query) {
       return;
     }
 
-    const variableQuery = migrateVariableQuery(query);
+    const variableQuery = typeof query === 'string' ? migrateVariableQuery(query) : query;
     setType(variableQuery.type);
     setLabel(variableQuery.label || '');
     setStream(variableQuery.stream || '');


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up of https://github.com/grafana/grafana/issues/52380, to change the input with a select, to allow the user to pick from existing labels from the datasource.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/54584

**Special notes for your reviewer**:

https://user-images.githubusercontent.com/1069378/188120917-ffc2fff0-16f2-4047-b516-5d5eed9103be.mov

Create a Loki variable. The expected outcome is an improved user experience from having to manually input one.