### PR TITLE
RBAC: Disable RBACPermissionValidation by default

### DIFF
--- a/conf/provisioning/access-control/sample.yaml
+++ b/conf/provisioning/access-control/sample.yaml
@@ -19,9 +19,9 @@
 #       # <string, required> action allowed.
 #       - action: 'users:read'
 #         #<string> scope it applies to.
-#         scope: 'users:*'
+#         scope: 'global.users:*'
 #       - action: 'users:write'
-#         scope: 'users:*'
+#         scope: 'global.users:*'
 #       - action: 'users:create'
 #   - name: 'custom:global:users:reader'
 #     # <bool> overwrite org id and creates a global role.
@@ -42,9 +42,9 @@
 #     # <list> list of the permissions to add/remove on top of the copied ones.
 #     permissions:
 #       - action: 'users:read'
-#         scope: 'users:*'
+#         scope: 'global.users:*'
 #       - action: 'users:write'
-#         scope: 'users:*'
+#         scope: 'global.users:*'
 #         # <string> state of the permission. Defaults to 'present'. If 'absent', the permission will be removed.
 #         state: absent
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1356,7 +1356,7 @@ func readAccessControlSettings(iniFile *ini.File, cfg *Cfg) {
 	rbac := iniFile.Section("rbac")
 	cfg.RBACEnabled = rbac.Key("enabled").MustBool(true)
 	cfg.RBACPermissionCache = rbac.Key("permission_cache").MustBool(true)
-	cfg.RBACPermissionValidationEnabled = rbac.Key("permission_validation_enabled").MustBool(true)
+	cfg.RBACPermissionValidationEnabled = rbac.Key("permission_validation_enabled").MustBool(false)
 }
 
 func readUserSettings(iniFile *ini.File, cfg *Cfg) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR disables RBACPermissionValidation setting by default.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

