### PR TITLE
fix(elasticsearch): remove deprecated elastic versions

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.test.tsx
@@ -38,7 +38,7 @@ describe('ConfigEditor', () => {
     expect(mockOnOptionsChange).toHaveBeenCalledWith(
       expect.objectContaining({
         jsonData: expect.objectContaining({
-          esVersion: '5.0.0',
+          esVersion: '7.0.0',
           timeField: '@timestamp',
           maxConcurrentShardRequests: 5,
         }),

--- a/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ConfigEditor.test.tsx
@@ -38,7 +38,7 @@ describe('ConfigEditor', () => {
     expect(mockOnOptionsChange).toHaveBeenCalledWith(
       expect.objectContaining({
         jsonData: expect.objectContaining({
-          esVersion: '7.0.0',
+          esVersion: '8.0.0',
           timeField: '@timestamp',
           maxConcurrentShardRequests: 5,
         }),

--- a/public/app/plugins/datasource/elasticsearch/utils.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/utils.test.ts
@@ -39,7 +39,7 @@ describe('removeEmpty', () => {
     expect(coerceESVersion('8.1.3')).toBe('8.1.3');
 
     // invalid string
-    expect(coerceESVersion('haha')).toBe('5.0.0');
+    expect(coerceESVersion('haha')).toBe('7.0.0');
 
     // known number
     expect(coerceESVersion(2)).toBe('2.0.0');
@@ -49,9 +49,9 @@ describe('removeEmpty', () => {
     expect(coerceESVersion(70)).toBe('7.0.0');
 
     // unknown number
-    expect(coerceESVersion(42)).toBe('5.0.0');
+    expect(coerceESVersion(42)).toBe('7.0.0');
 
     // undefined
-    expect(coerceESVersion(undefined)).toBe('5.0.0');
+    expect(coerceESVersion(undefined)).toBe('7.0.0');
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/utils.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/utils.test.ts
@@ -39,7 +39,7 @@ describe('removeEmpty', () => {
     expect(coerceESVersion('8.1.3')).toBe('8.1.3');
 
     // invalid string
-    expect(coerceESVersion('haha')).toBe('7.0.0');
+    expect(coerceESVersion('haha')).toBe('8.0.0');
 
     // known number
     expect(coerceESVersion(2)).toBe('2.0.0');
@@ -47,11 +47,12 @@ describe('removeEmpty', () => {
     expect(coerceESVersion(56)).toBe('5.6.0');
     expect(coerceESVersion(60)).toBe('6.0.0');
     expect(coerceESVersion(70)).toBe('7.0.0');
+    expect(coerceESVersion(8)).toBe('8.0.0');
 
     // unknown number
-    expect(coerceESVersion(42)).toBe('7.0.0');
+    expect(coerceESVersion(42)).toBe('8.0.0');
 
     // undefined
-    expect(coerceESVersion(undefined)).toBe('7.0.0');
+    expect(coerceESVersion(undefined)).toBe('8.0.0');
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/utils.ts
@@ -101,7 +101,7 @@ export const getScriptValue = (metric: MetricAggregationWithInlineScript) =>
  */
 export const coerceESVersion = (version: string | number | undefined): string => {
   if (typeof version === 'string') {
-    return valid(version) || '5.0.0';
+    return valid(version) || '7.0.0';
   }
 
   switch (version) {
@@ -114,8 +114,9 @@ export const coerceESVersion = (version: string | number | undefined): string =>
     case 70:
       return '7.0.0';
     case 5:
-    default:
       return '5.0.0';
+    default:
+      return '7.0.0';
   }
 };
 

--- a/public/app/plugins/datasource/elasticsearch/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/utils.ts
@@ -101,22 +101,22 @@ export const getScriptValue = (metric: MetricAggregationWithInlineScript) =>
  */
 export const coerceESVersion = (version: string | number | undefined): string => {
   if (typeof version === 'string') {
-    return valid(version) || '7.0.0';
+    return valid(version) || '8.0.0';
   }
 
   switch (version) {
     case 2:
       return '2.0.0';
+    case 5:
+      return '5.0.0';
     case 56:
       return '5.6.0';
     case 60:
       return '6.0.0';
     case 70:
       return '7.0.0';
-    case 5:
-      return '5.0.0';
     default:
-      return '7.0.0';
+      return '8.0.0';
   }
 };
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a default to `5.0.0` for Elasticsearch versions.

**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/54565

**Special notes for your reviewer**:

Configure a new Elasticsearch datasource. The default version should be the minimum supported version.