### PR TITLE
Auth: Extend auth token errors with user ID

### DIFF
--- a/pkg/models/user_token.go
+++ b/pkg/models/user_token.go
@@ -3,6 +3,7 @@ package models
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 
 	"github.com/grafana/grafana/pkg/registry"
@@ -33,7 +34,7 @@ type TokenExpiredError struct {
 	TokenID int64
 }
 
-func (e *TokenExpiredError) Error() string { return "user token expired" }
+func (e *TokenExpiredError) Error() string { return fmt.Sprintf("user token expired for user with id: %d", e.UserID) }
 
 type TokenRevokedError struct {
 	UserID                int64
@@ -41,7 +42,7 @@ type TokenRevokedError struct {
 	MaxConcurrentSessions int64
 }
 
-func (e *TokenRevokedError) Error() string { return "user token revoked" }
+func (e *TokenRevokedError) Error() string { return fmt.Sprintf("user token revoked for user with id: %d", e.UserID) }
 
 // UserToken represents a user token
 type UserToken struct {

--- a/pkg/models/user_token.go
+++ b/pkg/models/user_token.go
@@ -34,7 +34,7 @@ type TokenExpiredError struct {
 	TokenID int64
 }
 
-func (e *TokenExpiredError) Error() string { return fmt.Sprintf("user token expired for user with id: %d", e.UserID) }
+func (e *TokenExpiredError) Error() string { return fmt.Sprintf("user token expired for user with id %d", e.UserID) }
 
 type TokenRevokedError struct {
 	UserID                int64
@@ -42,7 +42,7 @@ type TokenRevokedError struct {
 	MaxConcurrentSessions int64
 }
 
-func (e *TokenRevokedError) Error() string { return fmt.Sprintf("user token revoked for user with id: %d", e.UserID) }
+func (e *TokenRevokedError) Error() string { return fmt.Sprintf("user token revoked for user with id %d", e.UserID) }
 
 // UserToken represents a user token
 type UserToken struct {

--- a/pkg/models/user_token.go
+++ b/pkg/models/user_token.go
@@ -3,7 +3,6 @@ package models
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
 
 	"github.com/grafana/grafana/pkg/registry"
@@ -34,7 +33,7 @@ type TokenExpiredError struct {
 	TokenID int64
 }
 
-func (e *TokenExpiredError) Error() string { return fmt.Sprintf("user token expired for user with id %d", e.UserID) }
+func (e *TokenExpiredError) Error() string { return "user token expired" }
 
 type TokenRevokedError struct {
 	UserID                int64
@@ -42,7 +41,7 @@ type TokenRevokedError struct {
 	MaxConcurrentSessions int64
 }
 
-func (e *TokenRevokedError) Error() string { return fmt.Sprintf("user token revoked for user with id %d", e.UserID) }
+func (e *TokenRevokedError) Error() string { return "user token revoked" }
 
 // UserToken represents a user token
 type UserToken struct {

--- a/pkg/services/auth/auth_token.go
+++ b/pkg/services/auth/auth_token.go
@@ -139,6 +139,7 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 	}
 
 	if model.RevokedAt > 0 {
+		s.log.Debug("user token has been revoked", "user ID", model.UserId, "token ID", model.Id)
 		return nil, &models.TokenRevokedError{
 			UserID:  model.UserId,
 			TokenID: model.Id,
@@ -146,6 +147,7 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 	}
 
 	if model.CreatedAt <= s.createdAfterParam() || model.RotatedAt <= s.rotatedAfterParam() {
+		s.log.Debug("user token has expired", "user ID", model.UserId, "token ID", model.Id)
 		return nil, &models.TokenExpiredError{
 			UserID:  model.UserId,
 			TokenID: model.Id,


### PR DESCRIPTION
**What this PR does / why we need it**:
Extends warning logs for auth token having expired or having been revoked to log the ID of the user that this token is associated with.

**Which issue(s) this PR fixes**:

Related to https://github.com/grafana/support-escalations/issues/3441