### PR TITLE
Plugins: Fix plugin registered startup log line

### DIFF
--- a/pkg/plugins/manager/manager.go
+++ b/pkg/plugins/manager/manager.go
@@ -211,6 +211,11 @@ func (m *PluginManager) registerAndStart(ctx context.Context, p *plugins.Plugin)
 	if err := m.pluginRegistry.Add(ctx, p); err != nil {
 		return err
 	}
+
+	if !p.IsCorePlugin() {
+		m.log.Info("Plugin registered", "pluginID", p.ID)
+	}
+
 	return m.processManager.Start(ctx, p.ID)
 }
 

--- a/pkg/plugins/manager/process/process.go
+++ b/pkg/plugins/manager/process/process.go
@@ -48,11 +48,6 @@ func (m *Manager) Start(ctx context.Context, pluginID string) error {
 		return nil
 	}
 
-	if p.IsCorePlugin() {
-		return nil
-	}
-
-	m.log.Info("Plugin registered", "pluginID", p.ID)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -104,6 +99,10 @@ func (m *Manager) shutdown(ctx context.Context) {
 func startPluginAndRestartKilledProcesses(ctx context.Context, p *plugins.Plugin) error {
 	if err := p.Start(ctx); err != nil {
 		return err
+	}
+
+	if p.IsCorePlugin() {
+		return nil
 	}
 
 	go func(ctx context.Context, p *plugins.Plugin) {

--- a/pkg/plugins/manager/process/process_test.go
+++ b/pkg/plugins/manager/process/process_test.go
@@ -18,25 +18,6 @@ func TestProcessManager_Start(t *testing.T) {
 		require.ErrorIs(t, err, backendplugin.ErrPluginNotRegistered)
 	})
 
-	t.Run("Cannot start a core plugin", func(t *testing.T) {
-		pluginID := "core-datasource"
-
-		bp := newFakeBackendPlugin(true)
-		p := createPlugin(t, bp, func(plugin *plugins.Plugin) {
-			plugin.ID = pluginID
-			plugin.Class = plugins.Core
-			plugin.Backend = true
-		})
-
-		m := NewManager(newFakePluginRegistry(map[string]*plugins.Plugin{
-			pluginID: p,
-		}))
-		err := m.Start(context.Background(), pluginID)
-		require.NoError(t, err)
-		require.True(t, p.Exited())
-		require.Zero(t, bp.startCount)
-	})
-
 	t.Run("Plugin state determines process start", func(t *testing.T) {
 		tcs := []struct {
 			name               string


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
A regression introduced in https://github.com/grafana/grafana/pull/54384. We stopped logging for plugins which were managed.

Before:
```
INFO [09-02|11:50:45] Plugin registered                        logger=plugin.process.manager pluginID=grafana-bigquery-datasource
INFO [09-02|11:50:45] Plugin registered                        logger=plugin.process.manager pluginID=grafana-github-datasource
```

After:
```
INFO [09-02|11:49:42] Plugin registered                        logger=plugin.manager pluginID=grafana-aws-secretsmanager
INFO [09-02|11:49:42] Plugin registered                        logger=plugin.manager pluginID=grafana-bigquery-datasource
INFO [09-02|11:49:42] Plugin registered                        logger=plugin.manager pluginID=grafana-github-datasource
INFO [09-02|11:49:42] Plugin registered                        logger=plugin.manager pluginID=grafana-image-renderer
```

I also moved the core plugin check when starting the backend process ticker as it makes more sense to be closer to that logic.

