### PR TITLE
Chore: Remove remaining IconName type assertions

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3294,9 +3294,6 @@ exports[`better eslint`] = {
     "public/app/features/admin/ldap/LdapPage.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/features/alerting/AlertRuleItem.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "public/app/features/alerting/AlertRuleList.test.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
@@ -3306,8 +3303,7 @@ exports[`better eslint`] = {
     ],
     "public/app/features/alerting/AlertTab.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
     ],
     "public/app/features/alerting/AlertTabCtrl.test.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -3669,9 +3665,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "6"]
     ],
     "public/app/features/api-keys/ApiKeysForm.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
-    "public/app/features/api-keys/ApiKeysTable.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/features/canvas/element.ts:5381": [
@@ -5011,8 +5004,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/features/plugins/admin/pages/PluginDetails.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
+      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/features/plugins/admin/state/actions.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
@@ -5302,9 +5294,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
-    "public/app/features/search/page/components/ManageActions.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "public/app/features/search/page/components/MoveToFolderModal.tsx:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"]
@@ -5366,8 +5355,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "2"]
     ],
     "public/app/features/storage/StoragePage.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
+      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/features/storage/storage.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
@@ -8409,11 +8397,11 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "10"],
-      [0, 0, 0, "Do not use any type assertions.", "11"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "11"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "12"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "13"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "14"],
-      [0, 0, 0, "Do not use any type assertions.", "15"],
+      [0, 0, 0, "Do not use any type assertions.", "14"],
+      [0, 0, 0, "Unexpected any. Specify a different type.", "15"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "16"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "17"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "18"],
@@ -8443,8 +8431,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "42"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "43"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "44"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "45"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "46"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "45"]
     ],
     "public/app/plugins/panel/graph/graph_tooltip.d.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
@@ -9292,8 +9279,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "2"]
     ],
     "public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Do not use any type assertions.", "1"]
+      [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/timeseries/plugins/annotations/AnnotationEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]

--- a/packages/grafana-ui/src/types/icon.ts
+++ b/packages/grafana-ui/src/types/icon.ts
@@ -52,6 +52,7 @@ const availableIcons = [
   'chart-line' as const,
   'check' as const,
   'check-circle' as const,
+  'check-square' as const,
   'circle' as const,
   'clipboard-alt' as const,
   'clock-nine' as const,

--- a/public/app/features/alerting/AlertRuleItem.test.tsx
+++ b/public/app/features/alerting/AlertRuleItem.test.tsx
@@ -12,7 +12,7 @@ const setup = (propOverrides?: object) => {
       name: 'Some rule',
       state: 'Open',
       stateText: 'state text',
-      stateIcon: 'icon',
+      stateIcon: 'anchor',
       stateClass: 'state class',
       stateAge: 'age',
       url: 'https://something.something.darkside',

--- a/public/app/features/alerting/AlertRuleItem.tsx
+++ b/public/app/features/alerting/AlertRuleItem.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import Highlighter from 'react-highlight-words';
 
-import { Icon, IconName, Button, LinkButton, Card } from '@grafana/ui';
+import { Icon, Button, LinkButton, Card } from '@grafana/ui';
 
 import { AlertRule } from '../../types';
 
@@ -29,7 +29,7 @@ const AlertRuleItem = ({ rule, search, onTogglePause }: Props) => {
     <Card>
       <Card.Heading>{renderText(rule.name)}</Card.Heading>
       <Card.Figure>
-        <Icon size="xl" name={rule.stateIcon as IconName} className={`alert-rule-item__icon ${rule.stateClass}`} />
+        <Icon size="xl" name={rule.stateIcon} className={`alert-rule-item__icon ${rule.stateClass}`} />
       </Card.Figure>
       <Card.Meta>
         <span key="state">

--- a/public/app/features/alerting/AlertTab.tsx
+++ b/public/app/features/alerting/AlertTab.tsx
@@ -4,7 +4,7 @@ import { connect, MapDispatchToProps, MapStateToProps } from 'react-redux';
 import { EventBusSrv } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { AngularComponent, config, getAngularLoader, getDataSourceSrv } from '@grafana/runtime';
-import { Alert, Button, ConfirmModal, Container, CustomScrollbar, HorizontalGroup, IconName, Modal } from '@grafana/ui';
+import { Alert, Button, ConfirmModal, Container, CustomScrollbar, HorizontalGroup, Modal } from '@grafana/ui';
 import EmptyListCTA from 'app/core/components/EmptyListCTA/EmptyListCTA';
 import { getPanelStateForModel } from 'app/features/panel/state/selectors';
 import { AppNotificationSeverity, StoreState } from 'app/types';

--- a/public/app/features/alerting/AlertTab.tsx
+++ b/public/app/features/alerting/AlertTab.tsx
@@ -220,7 +220,7 @@ class UnConnectedAlertTab extends PureComponent<Props, State> {
 
     const model = {
       title: 'Panel has no alert rule defined',
-      buttonIcon: 'bell' as IconName,
+      buttonIcon: 'bell' as const,
       onClick: this.onAddAlert,
       buttonTitle: 'Create Alert',
     };

--- a/public/app/features/api-keys/ApiKeysTable.tsx
+++ b/public/app/features/api-keys/ApiKeysTable.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import React, { FC } from 'react';
 
 import { dateTimeFormat, GrafanaTheme2, TimeZone } from '@grafana/data';
-import { Button, DeleteButton, HorizontalGroup, Icon, IconName, Tooltip, useTheme2 } from '@grafana/ui';
+import { Button, DeleteButton, HorizontalGroup, Icon, Tooltip, useTheme2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { AccessControlAction } from 'app/types';
 

--- a/public/app/features/api-keys/ApiKeysTable.tsx
+++ b/public/app/features/api-keys/ApiKeysTable.tsx
@@ -42,7 +42,7 @@ export const ApiKeysTable: FC<Props> = ({ apiKeys, timeZone, onDelete, onMigrate
                   {isExpired && (
                     <span className={styles.tooltipContainer}>
                       <Tooltip content="This API key has expired.">
-                        <Icon name={'exclamation-triangle' as IconName} />
+                        <Icon name="exclamation-triangle" />
                       </Tooltip>
                     </span>
                   )}

--- a/public/app/features/plugins/admin/pages/PluginDetails.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.tsx
@@ -4,7 +4,7 @@ import { usePrevious } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
-import { useStyles2, TabsBar, TabContent, Tab, Alert, IconName, toIconName } from '@grafana/ui';
+import { useStyles2, TabsBar, TabContent, Tab, Alert, toIconName } from '@grafana/ui';
 import { Layout } from '@grafana/ui/src/components/Layout/Layout';
 import { Page } from 'app/core/components/Page/Page';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';

--- a/public/app/features/plugins/admin/pages/PluginDetails.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.tsx
@@ -4,7 +4,7 @@ import { usePrevious } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
-import { useStyles2, TabsBar, TabContent, Tab, Alert, IconName } from '@grafana/ui';
+import { useStyles2, TabsBar, TabContent, Tab, Alert, IconName, toIconName } from '@grafana/ui';
 import { Layout } from '@grafana/ui/src/components/Layout/Layout';
 import { Page } from 'app/core/components/Page/Page';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
@@ -85,7 +85,7 @@ export default function PluginDetails({ match, queryParams }: Props): JSX.Elemen
                   key={tab.label}
                   label={tab.label}
                   href={tab.href}
-                  icon={tab.icon as IconName}
+                  icon={toIconName(tab.icon ?? '')}
                   active={tab.id === pageId}
                 />
               );

--- a/public/app/features/search/page/components/ManageActions.tsx
+++ b/public/app/features/search/page/components/ManageActions.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Button, HorizontalGroup, IconButton, IconName, useStyles2 } from '@grafana/ui';
+import { Button, HorizontalGroup, IconButton, useStyles2 } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { FolderDTO } from 'app/types';
 
@@ -45,7 +45,7 @@ export function ManageActions({ items, folder, onChange, clearSelection }: Props
     <div className={styles.actionRow} data-testid="manage-actions">
       <div className={styles.rowContainer}>
         <HorizontalGroup spacing="md" width="auto">
-          <IconButton name={'check-square' as IconName} onClick={clearSelection} title="Uncheck everything" />
+          <IconButton name="check-square" onClick={clearSelection} title="Uncheck everything" />
           <Button disabled={!canMove} onClick={onMove} icon="exchange-alt" variant="secondary">
             Move
           </Button>

--- a/public/app/features/storage/StoragePage.tsx
+++ b/public/app/features/storage/StoragePage.tsx
@@ -4,18 +4,7 @@ import { useAsync } from 'react-use';
 
 import { DataFrame, GrafanaTheme2, isDataFrame, ValueLinkConfig } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
-import {
-  useStyles2,
-  IconName,
-  Spinner,
-  TabsBar,
-  Tab,
-  Button,
-  HorizontalGroup,
-  LinkButton,
-  Alert,
-  toIconName,
-} from '@grafana/ui';
+import { useStyles2, Spinner, TabsBar, Tab, Button, HorizontalGroup, LinkButton, Alert, toIconName } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { Page } from 'app/core/components/Page/Page';
 import { useNavModel } from 'app/core/hooks/useNavModel';

--- a/public/app/features/storage/StoragePage.tsx
+++ b/public/app/features/storage/StoragePage.tsx
@@ -4,7 +4,18 @@ import { useAsync } from 'react-use';
 
 import { DataFrame, GrafanaTheme2, isDataFrame, ValueLinkConfig } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
-import { useStyles2, IconName, Spinner, TabsBar, Tab, Button, HorizontalGroup, LinkButton, Alert } from '@grafana/ui';
+import {
+  useStyles2,
+  IconName,
+  Spinner,
+  TabsBar,
+  Tab,
+  Button,
+  HorizontalGroup,
+  LinkButton,
+  Alert,
+  toIconName,
+} from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { Page } from 'app/core/components/Page/Page';
 import { useNavModel } from 'app/core/hooks/useNavModel';
@@ -178,7 +189,7 @@ export default function StoragePage(props: Props) {
     return (
       <div className={styles.wrapper}>
         <HorizontalGroup width="100%" justify="space-between" spacing={'md'} height={25}>
-          <Breadcrumb pathName={path} onPathChange={setPath} rootIcon={navModel.node.icon as IconName} />
+          <Breadcrumb pathName={path} onPathChange={setPath} rootIcon={toIconName(navModel.node.icon ?? '')} />
           <HorizontalGroup>
             {canViewDashboard && (
               <LinkButton icon="dashboard" href={`g/${path}`}>

--- a/public/app/plugins/panel/graph/graph.ts
+++ b/public/app/plugins/panel/graph/graph.ts
@@ -36,7 +36,7 @@ import {
   PanelEvents,
   toUtc,
 } from '@grafana/data';
-import { graphTickFormatter, graphTimeFormat, IconName, MenuItemProps, MenuItemsGroup } from '@grafana/ui';
+import { graphTickFormatter, graphTimeFormat, MenuItemProps, MenuItemsGroup } from '@grafana/ui';
 import { coreModule } from 'app/angular/core_module';
 import config from 'app/core/config';
 import { updateLegendValues } from 'app/core/core';
@@ -256,7 +256,7 @@ class GraphElement {
               ariaLabel: link.title,
               url: link.href,
               target: link.target,
-              icon: `${link.target === '_self' ? 'link' : 'external-link-alt'}` as IconName,
+              icon: link.target === '_self' ? 'link' : 'external-link-alt',
               onClick: link.onClick,
             };
           }),

--- a/public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ContextMenuPlugin.tsx
@@ -6,7 +6,6 @@ import { CartesianCoords2D, DataFrame, getFieldDisplayName, InterpolateFunction,
 import {
   ContextMenu,
   GraphContextMenuHeader,
-  IconName,
   MenuItemProps,
   MenuItemsGroup,
   MenuGroup,
@@ -263,7 +262,7 @@ export const ContextMenuView: React.FC<ContextMenuViewProps> = ({
                   ariaLabel: link.title,
                   url: link.href,
                   target: link.target,
-                  icon: `${link.target === '_self' ? 'link' : 'external-link-alt'}` as IconName,
+                  icon: link.target === '_self' ? 'link' : 'external-link-alt',
                   onClick: link.onClick,
                 };
               }),

--- a/public/app/types/alerting.ts
+++ b/public/app/types/alerting.ts
@@ -1,4 +1,5 @@
 import { SelectableValue } from '@grafana/data';
+import { IconName } from '@grafana/ui';
 
 export interface AlertRuleDTO {
   id: number;
@@ -25,7 +26,7 @@ export interface AlertRule {
   state: string;
   newStateDate?: string;
   stateText: string;
-  stateIcon: string;
+  stateIcon: IconName;
   stateClass: string;
   stateAge: string;
   url: string;


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes remaining `icon as IconName` type assertions in favor of the `toIconName` function. 

This PR changes:
 - alerting
 - plugins admin
 - api keys
 - manage dashboards
 - storage
 - timeseries panel

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
