### PR TITLE
Geomap: Fix duplicate layer bug

### DIFF
--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -35,6 +35,7 @@ import { GeomapOverlay, OverlayProps } from './GeomapOverlay';
 import { GeomapTooltip } from './GeomapTooltip';
 import { DebugOverlay } from './components/DebugOverlay';
 import { MeasureOverlay } from './components/MeasureOverlay';
+import { MeasureVectorLayer } from './components/MeasureVectorLayer';
 import { GeomapHoverPayload, GeomapLayerHover } from './event';
 import { getGlobalStyles } from './globalStyles';
 import { defaultMarkersConfig, MARKERS_LAYER_ID } from './layers/data/markersLayer';
@@ -147,7 +148,7 @@ export class GeomapPanel extends Component<Props, State> {
     const { options, onOptionsChange } = this.props;
     const layers = this.layers;
     this.map?.getLayers().forEach((l) => {
-      if (l.get('name') !== undefined && l.get('name') === 'measureLayer') {
+      if (l instanceof MeasureVectorLayer) {
         this.map?.removeLayer(l);
         this.map?.addLayer(l);
       }

--- a/public/app/plugins/panel/geomap/GeomapPanel.tsx
+++ b/public/app/plugins/panel/geomap/GeomapPanel.tsx
@@ -146,6 +146,12 @@ export class GeomapPanel extends Component<Props, State> {
   private doOptionsUpdate(selected: number) {
     const { options, onOptionsChange } = this.props;
     const layers = this.layers;
+    this.map?.getLayers().forEach((l) => {
+      if (l.get('name') !== undefined && l.get('name') === 'measureLayer') {
+        this.map?.removeLayer(l);
+        this.map?.addLayer(l);
+      }
+    });
     onOptionsChange({
       ...options,
       basemap: layers[0].options,
@@ -227,6 +233,7 @@ export class GeomapPanel extends Component<Props, State> {
       });
     },
     reorder: (startIndex: number, endIndex: number) => {
+      // TODO look into reorder with respect to measure layer
       const result = Array.from(this.layers);
       const [removed] = result.splice(startIndex, 1);
       result.splice(endIndex, 0, removed);

--- a/public/app/plugins/panel/geomap/components/MeasureOverlay.tsx
+++ b/public/app/plugins/panel/geomap/components/MeasureOverlay.tsx
@@ -54,7 +54,6 @@ export const MeasureOverlay = ({ map, menuActiveState }: Props) => {
         // Initialize on first load
         setFirstLoad(false);
         vector.current.setZIndex(1);
-        vector.current.set('name', 'measureLayer');
         map.addLayer(vector.current);
         map.addInteraction(vector.current.modify);
       }

--- a/public/app/plugins/panel/geomap/components/MeasureOverlay.tsx
+++ b/public/app/plugins/panel/geomap/components/MeasureOverlay.tsx
@@ -53,6 +53,8 @@ export const MeasureOverlay = ({ map, menuActiveState }: Props) => {
       if (firstLoad) {
         // Initialize on first load
         setFirstLoad(false);
+        vector.current.setZIndex(1);
+        vector.current.set('name', 'measureLayer');
         map.addLayer(vector.current);
         map.addInteraction(vector.current.modify);
       }


### PR DESCRIPTION
What this PR does / why we need it:
When activating measure tools, any changes to map layers thereafter will lead to undesired behavior, including duplication of layers and loss of any measurements.

Before:
![Sep-02-2022 09-42-08](https://user-images.githubusercontent.com/60050885/188200261-4e21b8e7-fb3a-40aa-8091-61bf93567477.gif)

After:
![Sep-02-2022 09-43-10](https://user-images.githubusercontent.com/60050885/188200272-244f4844-deeb-4db9-9a91-3032fb78f534.gif)

Fixes #54401 