### PR TITLE
Library Panel: Allow to delete them when deprecated

### DIFF
--- a/public/app/features/panel/components/VizTypePicker/PanelTypeCard.tsx
+++ b/public/app/features/panel/components/VizTypePicker/PanelTypeCard.tsx
@@ -104,8 +104,9 @@ const getStyles = (theme: GrafanaTheme2) => {
     itemDisabled: css`
       cursor: default;
 
+      &,
       &:hover {
-        background: ${theme.colors.background.secondary};
+        background: ${theme.colors.action.disabledBackground};
       }
     `,
     current: css`
@@ -114,7 +115,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       background: ${theme.colors.action.selected};
     `,
     disabled: css`
-      opacity: 0.2;
+      opacity: ${theme.colors.action.disabledOpacity};
       filter: grayscale(1);
       cursor: default;
       pointer-events: none;

--- a/public/app/features/panel/components/VizTypePicker/PanelTypeCard.tsx
+++ b/public/app/features/panel/components/VizTypePicker/PanelTypeCard.tsx
@@ -29,9 +29,10 @@ export const PanelTypeCard: React.FC<Props> = ({
   children,
 }) => {
   const styles = useStyles2(getStyles);
+  const isDisabled = disabled || plugin.state === PluginState.deprecated;
   const cssClass = cx({
     [styles.item]: true,
-    [styles.disabled]: disabled || plugin.state === PluginState.deprecated,
+    [styles.itemDisabled]: isDisabled,
     [styles.current]: isCurrent,
   });
 
@@ -39,18 +40,18 @@ export const PanelTypeCard: React.FC<Props> = ({
     <div
       className={cssClass}
       aria-label={selectors.components.PluginVisualization.item(plugin.name)}
-      onClick={disabled ? undefined : onClick}
+      onClick={isDisabled ? undefined : onClick}
       title={isCurrent ? 'Click again to close this section' : plugin.name}
     >
-      <img className={styles.img} src={plugin.info.logos.small} alt="" />
+      <img className={cx(styles.img, { [styles.disabled]: isDisabled })} src={plugin.info.logos.small} alt="" />
 
-      <div className={styles.itemContent}>
+      <div className={cx(styles.itemContent, { [styles.disabled]: isDisabled })}>
         <div className={styles.name}>{title}</div>
         {description ? <span className={styles.description}>{description}</span> : null}
         {children}
       </div>
       {showBadge && (
-        <div className={cx(styles.badge, disabled && styles.disabled)}>
+        <div className={cx(styles.badge, { [styles.disabled]: isDisabled })}>
           <PanelPluginBadge plugin={plugin} />
         </div>
       )}
@@ -100,6 +101,13 @@ const getStyles = (theme: GrafanaTheme2) => {
       position: relative;
       padding: ${theme.spacing(0, 1)};
     `,
+    itemDisabled: css`
+      cursor: default;
+
+      &:hover {
+        background: ${theme.colors.background.secondary};
+      }
+    `,
     current: css`
       label: currentVisualizationItem;
       border: 1px solid ${theme.colors.primary.border};
@@ -138,6 +146,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       background: ${theme.colors.background.primary};
     `,
     deleteButton: css`
+      cursor: pointer;
       margin-left: auto;
     `,
   };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When a library panel is using a deprecated plugin, it cannot be used but either remove. This PR enables the disabled state for the entire card except for the delete button, so the library panel can be removed.

The previous approach was applying the disabled state which includes `pointer-event: none` to the root and it was disabling clicks for the whole card. The changes apply the disabled state to the elements individually, but the delete button, so the button is still usable.

Also, the background is using now the disabled color instead of opacity.

|Before|After|
|-|-|
![2022-09-02 17 48 13](https://user-images.githubusercontent.com/5699976/188194338-f6d91ada-1ebc-4dce-b6b5-60bea593c0d5.gif)|![2022-09-02 18 05 05](https://user-images.githubusercontent.com/5699976/188194393-3d17d0c1-068c-43f5-98cd-b52317d34722.gif)

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #46672 

**Special notes for your reviewer**:

To test it locally, go to `PanelTypeCard.tsx` and set the prop `disable: true`.

Then go to http://localhost:3000/library-panels.