### PR TITLE
Chore: Use the DEFAULT_LIMIT variable for the default value of the TraceQL Limit field

### DIFF
--- a/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/tempo/traceql/TempoQueryBuilderOptions.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { AutoSizeInput, EditorField, EditorRow } from '@grafana/ui';
 import { QueryOptionGroup } from 'app/plugins/datasource/prometheus/querybuilder/shared/QueryOptionGroup';
 
+import { DEFAULT_LIMIT } from '../datasource';
 import { TempoQuery } from '../types';
 
 interface Props {
@@ -18,14 +19,14 @@ export const TempoQueryBuilderOptions = React.memo<Props>(({ onChange, query }) 
   return (
     <>
       <EditorRow>
-        <QueryOptionGroup title="Options" collapsedInfo={[`Limit: ${query.limit || 10}`]}>
+        <QueryOptionGroup title="Options" collapsedInfo={[`Limit: ${query.limit || DEFAULT_LIMIT}`]}>
           <EditorField label="Limit" tooltip="Maximum number of traces to return.">
             <AutoSizeInput
               className="width-4"
               placeholder="auto"
               type="number"
               min={1}
-              defaultValue={10}
+              defaultValue={DEFAULT_LIMIT}
               onCommitChange={onLimitChange}
               value={query.limit}
             />


### PR DESCRIPTION
This PR uses the `DEFAULT_LIMIT` variable defined in `.../datasource/tempo/datasource.ts` for the default value of the `Limit` field under the TraceQL query field. This keeps the default value of the limit field in sync with `DEFAULT_LIMIT`.

