### PR TITLE
Alerting: Fix boolean comparison on PostgreSQL

### DIFF
--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -460,7 +460,7 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 	}
 	var rules []*ngmodels.AlertRule
 	return st.SQLStore.WithDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		foldersSql := "SELECT D.uid, D.title FROM dashboard AS D WHERE is_folder = 1 AND EXISTS (SELECT 1 FROM alert_rule AS A WHERE D.uid = A.namespace_uid)"
+		foldersSql := "SELECT D.uid, D.title FROM dashboard AS D WHERE is_folder IS TRUE AND EXISTS (SELECT 1 FROM alert_rule AS A WHERE D.uid = A.namespace_uid)"
 		alertRulesSql := "SELECT * FROM alert_rule"
 		filter, args := st.getFilterByOrgsString()
 		if filter != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes a bug where the scheduler cannot fetch alert rules:

```
ERROR[09-05|18:20:20] scheduler failed to update alert rules   logger=ngalert err="failed to get alert rules: failed to fetch a list of folders that contain alert rules: pq: operator does not exist: boolean = integer"
```

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

