### PR TITLE
graphite and opentsdb integration tests for http header handling

### DIFF
--- a/pkg/tests/api/graphite/graphite_test.go
+++ b/pkg/tests/api/graphite/graphite_test.go
@@ -1,0 +1,114 @@
+package graphite
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationGraphite(t *testing.T) {
+	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
+		DisableAnonymous: true,
+	})
+
+	grafanaListeningAddr, testEnv := testinfra.StartGrafanaEnv(t, dir, path)
+	ctx := context.Background()
+
+	createUser(t, testEnv.SQLStore, user.CreateUserCommand{
+		DefaultOrgRole: string(org.RoleAdmin),
+		Password:       "admin",
+		Login:          "admin",
+	})
+
+	var outgoingRequest *http.Request
+	outgoingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		outgoingRequest = r
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(outgoingServer.Close)
+
+	jsonData := simplejson.NewFromAny(map[string]interface{}{
+		"httpMethod":      "post",
+		"httpHeaderName1": "X-CUSTOM-HEADER",
+	})
+	secureJSONData := map[string]string{
+		"basicAuthPassword": "basicAuthPassword",
+		"httpHeaderValue1":  "custom-header-value",
+	}
+
+	uid := "influxdb"
+	err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.AddDataSourceCommand{
+		OrgId:          1,
+		Access:         datasources.DS_ACCESS_PROXY,
+		Name:           "graphite",
+		Type:           datasources.DS_GRAPHITE,
+		Uid:            uid,
+		Url:            outgoingServer.URL,
+		BasicAuth:      true,
+		BasicAuthUser:  "basicAuthUser",
+		JsonData:       jsonData,
+		SecureJsonData: secureJSONData,
+	})
+	require.NoError(t, err)
+
+	t.Run("When calling query should set expected headers on outgoing HTTP request", func(t *testing.T) {
+		query := simplejson.NewFromAny(map[string]interface{}{
+			"datasource": map[string]interface{}{
+				"uid": uid,
+			},
+			"expr":         "up",
+			"instantQuery": true,
+			"target":       "target",
+		})
+		buf1 := &bytes.Buffer{}
+		err = json.NewEncoder(buf1).Encode(dtos.MetricRequest{
+			From:    "now-1h",
+			To:      "now",
+			Queries: []*simplejson.Json{query},
+		})
+		require.NoError(t, err)
+		u := fmt.Sprintf("http://admin:admin@%s/api/ds/query", grafanaListeningAddr)
+		// nolint:gosec
+		resp, err := http.Post(u, "application/json", buf1)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		_, err = io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		require.NotNil(t, outgoingRequest)
+		require.Equal(t, "custom-header-value", outgoingRequest.Header.Get("X-CUSTOM-HEADER"))
+		username, pwd, ok := outgoingRequest.BasicAuth()
+		require.True(t, ok)
+		require.Equal(t, "basicAuthUser", username)
+		require.Equal(t, "basicAuthPassword", pwd)
+	})
+}
+
+func createUser(t *testing.T, store *sqlstore.SQLStore, cmd user.CreateUserCommand) int64 {
+	t.Helper()
+
+	store.Cfg.AutoAssignOrg = true
+	store.Cfg.AutoAssignOrgId = 1
+
+	u, err := store.CreateUser(context.Background(), cmd)
+	require.NoError(t, err)
+	return u.ID
+}

--- a/pkg/tests/api/opentdsb/opentdsb_test.go
+++ b/pkg/tests/api/opentdsb/opentdsb_test.go
@@ -1,0 +1,113 @@
+package opentdsb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/services/sqlstore"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationOpenTSDB(t *testing.T) {
+	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
+		DisableAnonymous: true,
+	})
+
+	grafanaListeningAddr, testEnv := testinfra.StartGrafanaEnv(t, dir, path)
+	ctx := context.Background()
+
+	createUser(t, testEnv.SQLStore, user.CreateUserCommand{
+		DefaultOrgRole: string(org.RoleAdmin),
+		Password:       "admin",
+		Login:          "admin",
+	})
+
+	var outgoingRequest *http.Request
+	outgoingServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		outgoingRequest = r
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(outgoingServer.Close)
+
+	jsonData := simplejson.NewFromAny(map[string]interface{}{
+		"httpMethod":      "post",
+		"httpHeaderName1": "X-CUSTOM-HEADER",
+	})
+	secureJSONData := map[string]string{
+		"basicAuthPassword": "basicAuthPassword",
+		"httpHeaderValue1":  "custom-header-value",
+	}
+
+	uid := "influxdb"
+	err := testEnv.Server.HTTPServer.DataSourcesService.AddDataSource(ctx, &datasources.AddDataSourceCommand{
+		OrgId:          1,
+		Access:         datasources.DS_ACCESS_PROXY,
+		Name:           "opentsdb",
+		Type:           datasources.DS_OPENTSDB,
+		Uid:            uid,
+		Url:            outgoingServer.URL,
+		BasicAuth:      true,
+		BasicAuthUser:  "basicAuthUser",
+		JsonData:       jsonData,
+		SecureJsonData: secureJSONData,
+	})
+	require.NoError(t, err)
+
+	t.Run("When calling query should set expected headers on outgoing HTTP request", func(t *testing.T) {
+		query := simplejson.NewFromAny(map[string]interface{}{
+			"datasource": map[string]interface{}{
+				"uid": uid,
+			},
+			"expr":         "up",
+			"instantQuery": true,
+		})
+		buf1 := &bytes.Buffer{}
+		err = json.NewEncoder(buf1).Encode(dtos.MetricRequest{
+			From:    "now-1h",
+			To:      "now",
+			Queries: []*simplejson.Json{query},
+		})
+		require.NoError(t, err)
+		u := fmt.Sprintf("http://admin:admin@%s/api/ds/query", grafanaListeningAddr)
+		// nolint:gosec
+		resp, err := http.Post(u, "application/json", buf1)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		t.Cleanup(func() {
+			err := resp.Body.Close()
+			require.NoError(t, err)
+		})
+		_, err = io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		require.NotNil(t, outgoingRequest)
+		require.Equal(t, "custom-header-value", outgoingRequest.Header.Get("X-CUSTOM-HEADER"))
+		username, pwd, ok := outgoingRequest.BasicAuth()
+		require.True(t, ok)
+		require.Equal(t, "basicAuthUser", username)
+		require.Equal(t, "basicAuthPassword", pwd)
+	})
+}
+
+func createUser(t *testing.T, store *sqlstore.SQLStore, cmd user.CreateUserCommand) int64 {
+	t.Helper()
+
+	store.Cfg.AutoAssignOrg = true
+	store.Cfg.AutoAssignOrgId = 1
+
+	u, err := store.CreateUser(context.Background(), cmd)
+	require.NoError(t, err)
+	return u.ID
+}


### PR DESCRIPTION
Fixes #
Part of https://github.com/grafana/grafana/issues/54314