### PR TITLE
Fix docker compose for `openldap` and `oauth`

### DIFF
--- a/devenv/docker/blocks/auth/oauth/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/oauth/docker-compose.yaml
@@ -6,7 +6,7 @@
       POSTGRES_USER: keycloak
       POSTGRES_PASSWORD: password
     volumes:
-      - ./docker/blocks/oauth/cloak.sql:/docker-entrypoint-initdb.d/cloak.sql
+      - ./docker/blocks/auth/oauth/cloak.sql:/docker-entrypoint-initdb.d/cloak.sql
     restart: unless-stopped
   
   oauthkeycloak:

--- a/devenv/docker/blocks/auth/openldap/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/openldap/docker-compose.yaml
@@ -1,6 +1,6 @@
   openldap:
     container_name: ldap
-    build: docker/blocks/openldap
+    build: docker/blocks/auth/openldap
     environment:
       SLAPD_PASSWORD: grafana
       SLAPD_DOMAIN: grafana.org


### PR DESCRIPTION
**What this PR does / why we need it**:

When all the development environments were grouped under `devenv/docker/blocks/auth` some references were not updated properly.

**Which issue(s) this PR fixes**:

This PR fixes the development environments for:

- `auth/openldap`
  - Fix build path
- `auth/oauth`
  - Fix volume path
