### PR TITLE
Update `auth/jwt_proxy` and `auth/oauth` reference

### DIFF
--- a/devenv/docker/blocks/auth/jwt_proxy/readme.md
+++ b/devenv/docker/blocks/auth/jwt_proxy/readme.md
@@ -1,4 +1,4 @@
-# OAUTH BLOCK
+# JWT PROXY BLOCK
 ## Devenv setup jwt auth
 
 To launch the block, use the oauth source. Ex:
@@ -18,7 +18,7 @@ enabled = true
 header_name = X-Forwarded-Access-Token
 username_claim = login
 email_claim = email
-jwk_set_file = devenv/docker/blocks/oauth/jwks.json
+jwk_set_file = devenv/docker/blocks/auth/oauth/jwks.json
 cache_ttl = 60m
 expected_claims = {"iss": "http://env.grafana.local:8087/auth/realms/grafana", "azp": "grafana-oauth"}
 auto_sign_up = true
@@ -63,7 +63,7 @@ In case you want to make changes to the devenv setup, you can dump keycloak's DB
 
 ```bash
 cd devenv;
-docker-compose exec -T oauthkeycloakdb bash -c "pg_dump -U keycloak keycloak" > docker/blocks/jwt_proxy/cloak.sql
+docker-compose exec -T oauthkeycloakdb bash -c "pg_dump -U keycloak keycloak" > docker/blocks/auth/jwt_proxy/cloak.sql
 ```
 
 ## Connecting to keycloak:

--- a/devenv/docker/blocks/auth/oauth/readme.md
+++ b/devenv/docker/blocks/auth/oauth/readme.md
@@ -45,7 +45,7 @@ enabled = true
 header_name = X-JWT-Assertion
 username_claim = login
 email_claim = email
-jwk_set_file = devenv/docker/blocks/oauth/jwks.json
+jwk_set_file = devenv/docker/blocks/auth/oauth/jwks.json
 cache_ttl = 60m
 expected_claims = {"iss": "http://localhost:8087/auth/realms/grafana", "azp": "grafana-oauth"}
 auto_sign_up = true
@@ -105,7 +105,7 @@ In case you want to make changes to the devenv setup, you can dump keycloak's DB
 
 ```bash
 cd devenv;
-docker-compose exec -T oauthkeycloakdb bash -c "pg_dump -U keycloak keycloak" > docker/blocks/oauth/cloak.sql
+docker-compose exec -T oauthkeycloakdb bash -c "pg_dump -U keycloak keycloak" > docker/blocks/auth/oauth/cloak.sql
 ```
 
 ## Connecting to keycloak:


### PR DESCRIPTION
**What this PR does / why we need it**:

Commands referenced in the documentation and the examples are not accurate with the new location of the devenev `auth/` docker blocks.
