### PR TITLE
Alerting: Fix send resolved notifications

### DIFF
--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -174,12 +174,17 @@ func (a *State) resultNoData(alertRule *models.AlertRule, result eval.Result) {
 }
 
 func (a *State) NeedsSending(resendDelay time.Duration) bool {
-	if a.State == eval.Pending || a.State == eval.Normal && !a.Resolved {
+	if a.State == eval.Pending {
+		// We do not send notifications for pending states
 		return false
+	} else if a.State == eval.Normal {
+		// We should send a notification if the state is Normal because it was resolved
+		return a.Resolved
+	} else {
+		// We should send, and re-send notifications, each time LastSentAt is <= LastEvaluationTime + resendDelay
+		nextSent := a.LastSentAt.Add(resendDelay)
+		return nextSent.Before(a.LastEvaluationTime) || nextSent.Equal(a.LastEvaluationTime)
 	}
-	// if LastSentAt is before or equal to LastEvaluationTime + resendDelay, send again
-	nextSent := a.LastSentAt.Add(resendDelay)
-	return nextSent.Before(a.LastEvaluationTime) || nextSent.Equal(a.LastEvaluationTime)
 }
 
 func (a *State) Equals(b *State) bool {

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -174,13 +174,14 @@ func (a *State) resultNoData(alertRule *models.AlertRule, result eval.Result) {
 }
 
 func (a *State) NeedsSending(resendDelay time.Duration) bool {
-	if a.State == eval.Pending {
+	switch a.State {
+	case eval.Pending:
 		// We do not send notifications for pending states
 		return false
-	} else if a.State == eval.Normal {
+	case eval.Normal:
 		// We should send a notification if the state is Normal because it was resolved
 		return a.Resolved
-	} else {
+	default:
 		// We should send, and re-send notifications, each time LastSentAt is <= LastEvaluationTime + resendDelay
 		nextSent := a.LastSentAt.Add(resendDelay)
 		return nextSent.Before(a.LastEvaluationTime) || nextSent.Equal(a.LastEvaluationTime)

--- a/pkg/services/ngalert/state/state_test.go
+++ b/pkg/services/ngalert/state/state_test.go
@@ -71,25 +71,14 @@ func TestNeedsSending(t *testing.T) {
 			},
 		},
 		{
-			name:        "state: normal + resolved sends after a minute",
+			name:        "state: normal + resolved should send without waiting",
 			resendDelay: 1 * time.Minute,
 			expected:    true,
 			testState: &State{
 				State:              eval.Normal,
 				Resolved:           true,
 				LastEvaluationTime: evaluationTime,
-				LastSentAt:         evaluationTime.Add(-1 * time.Minute),
-			},
-		},
-		{
-			name:        "state: normal + resolved does _not_ send after 30 seconds (before one minute)",
-			resendDelay: 1 * time.Minute,
-			expected:    false,
-			testState: &State{
-				State:              eval.Normal,
-				Resolved:           true,
-				LastEvaluationTime: evaluationTime,
-				LastSentAt:         evaluationTime.Add(-30 * time.Second),
+				LastSentAt:         evaluationTime,
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes a bug where we did not send resolved alerts to Alertmanager for resolved alert instances. This meant that resolved notifications did not have the annotations from the resolved state, and a result did not also have the resolved screenshot.

**Which issue(s) this PR fixes**:

Fixes #54766

**Special notes for your reviewer**:

