### PR TITLE
JWT: Allow conventional bearer token in Authorization header

### DIFF
--- a/pkg/middleware/middleware_jwt_auth_test.go
+++ b/pkg/middleware/middleware_jwt_auth_test.go
@@ -79,6 +79,8 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 
 	middlewareScenario(t, "Valid token with bearer in authorization header", func(t *testing.T, sc *scenarioContext) {
 		myUsername := "vladimir"
+		// We can ignore gosec G101 since this does not contain any credentials.
+		// nolint:gosec
 		myToken := "some.jwt.token"
 		var verifiedToken string
 		sc.jwtAuthService.VerifyProvider = func(ctx context.Context, token string) (models.JWTClaims, error) {

--- a/pkg/middleware/middleware_jwt_auth_test.go
+++ b/pkg/middleware/middleware_jwt_auth_test.go
@@ -79,10 +79,10 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 
 	middlewareScenario(t, "Valid token with bearer in authorization header", func(t *testing.T, sc *scenarioContext) {
 		myUsername := "vladimir"
-		jwtToken := "some.jwt.token"
+		myToken := "some.jwt.token"
 		var verifiedToken string
 		sc.jwtAuthService.VerifyProvider = func(ctx context.Context, token string) (models.JWTClaims, error) {
-			verifiedToken = jwtToken
+			verifiedToken = myToken
 			return models.JWTClaims{
 				"sub":          myUsername,
 				"foo-username": myUsername,
@@ -90,8 +90,8 @@ func TestMiddlewareJWTAuth(t *testing.T) {
 		}
 		sc.userService.ExpectedSignedInUser = &user.SignedInUser{UserID: id, OrgID: orgID, Login: myUsername}
 
-		sc.fakeReq("GET", "/").withJWTAuthHeader("Bearer " + jwtToken).exec()
-		assert.Equal(t, verifiedToken, jwtToken)
+		sc.fakeReq("GET", "/").withJWTAuthHeader("Bearer " + myToken).exec()
+		assert.Equal(t, verifiedToken, myToken)
 		assert.Equal(t, 200, sc.resp.Code)
 		assert.True(t, sc.context.IsSignedIn)
 		assert.Equal(t, orgID, sc.context.OrgID)

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -81,6 +81,11 @@ func TestMiddleWareSecurityHeaders(t *testing.T) {
 func TestMiddlewareContext(t *testing.T) {
 	const noCache = "no-cache"
 
+	configureJWTAuthHeader := func(cfg *setting.Cfg) {
+		cfg.JWTAuthEnabled = true
+		cfg.JWTAuthHeaderName = "Authorization"
+	}
+
 	middlewareScenario(t, "middleware should add context to injector", func(t *testing.T, sc *scenarioContext) {
 		sc.fakeReq("GET", "/").exec()
 		assert.NotNil(t, sc.context)
@@ -164,6 +169,22 @@ func TestMiddlewareContext(t *testing.T) {
 		assert.Equal(t, orgID, sc.context.OrgID)
 		assert.Equal(t, org.RoleEditor, sc.context.OrgRole)
 	})
+
+	middlewareScenario(t, "Valid API key with JWT enabled", func(t *testing.T, sc *scenarioContext) {
+		const orgID int64 = 12
+		keyhash, err := util.EncodePassword("v5nAwpMafFP6znaS4urhdWDLS5511M42", "asd")
+		require.NoError(t, err)
+
+		sc.apiKeyService.ExpectedAPIKey = &apikey.APIKey{OrgId: orgID, Role: org.RoleEditor, Key: keyhash}
+
+		sc.fakeReq("GET", "/").withValidApiKey().exec()
+
+		require.Equal(t, 200, sc.resp.Code)
+
+		assert.True(t, sc.context.IsSignedIn)
+		assert.Equal(t, orgID, sc.context.OrgID)
+		assert.Equal(t, org.RoleEditor, sc.context.OrgRole)
+	}, configureJWTAuthHeader)
 
 	middlewareScenario(t, "Valid API key, but does not match DB hash", func(t *testing.T, sc *scenarioContext) {
 		const keyhash = "Something_not_matching"

--- a/pkg/services/auth/jwt/auth.go
+++ b/pkg/services/auth/jwt/auth.go
@@ -62,10 +62,7 @@ func sanitizeJWT(jwtToken string) string {
 	// JWT can be compact, JSON flatened or JSON general
 	// In every cases, parts are base64 strings without padding
 	// The padding char (=) should never interfer with data
-	jwtToken = strings.ReplaceAll(jwtToken, string(base64.StdPadding), "")
-
-	// Strip `Bearer` prefix if it exists
-	return strings.TrimPrefix(jwtToken, "Bearer ")
+	return strings.ReplaceAll(jwtToken, string(base64.StdPadding), "")
 }
 
 func (s *AuthService) Verify(ctx context.Context, strToken string) (models.JWTClaims, error) {

--- a/pkg/services/auth/jwt/auth.go
+++ b/pkg/services/auth/jwt/auth.go
@@ -62,7 +62,10 @@ func sanitizeJWT(jwtToken string) string {
 	// JWT can be compact, JSON flatened or JSON general
 	// In every cases, parts are base64 strings without padding
 	// The padding char (=) should never interfer with data
-	return strings.ReplaceAll(jwtToken, string(base64.StdPadding), "")
+	jwtToken = strings.ReplaceAll(jwtToken, string(base64.StdPadding), "")
+
+	// Strip `Bearer` prefix if it exists
+	return strings.TrimPrefix(jwtToken, "Bearer ")
 }
 
 func (s *AuthService) Verify(ctx context.Context, strToken string) (models.JWTClaims, error) {

--- a/pkg/services/contexthandler/auth_jwt.go
+++ b/pkg/services/contexthandler/auth_jwt.go
@@ -33,6 +33,9 @@ func (h *ContextHandler) initContextWithJWT(ctx *models.ReqContext, orgId int64)
 		return false
 	}
 
+	// Strip the 'Bearer' prefix if it exists.
+	jwtToken = strings.TrimPrefix(jwtToken, "Bearer ")
+
 	// The header is Authorization and the token does not look like a JWT,
 	// this is likely an API key. Pass it on.
 	if h.Cfg.JWTAuthHeaderName == "Authorization" && !looksLikeJWT(jwtToken) {

--- a/pkg/services/contexthandler/auth_jwt.go
+++ b/pkg/services/contexthandler/auth_jwt.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/login"
 	"github.com/grafana/grafana/pkg/models"
@@ -29,6 +30,12 @@ func (h *ContextHandler) initContextWithJWT(ctx *models.ReqContext, orgId int64)
 	}
 
 	if jwtToken == "" {
+		return false
+	}
+
+	// The header is Authorization and the token does not look like a JWT,
+	// this is likely an API key. Pass it on.
+	if h.Cfg.JWTAuthHeaderName == "Authorization" && !looksLikeJWT(jwtToken) {
 		return false
 	}
 
@@ -185,4 +192,10 @@ func searchClaimsForStringAttr(attributePath string, claims map[string]interface
 	}
 
 	return "", nil
+}
+
+func looksLikeJWT(token string) bool {
+	// A JWT must have 3 parts separated by `.`.
+	parts := strings.Split(token, ".")
+	return len(parts) == 3
 }

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -343,7 +343,7 @@ func (h *ContextHandler) initContextWithAPIKey(reqContext *models.ReqContext) bo
 }
 
 func looksLikeJWT(token string) bool {
-	// A JWT must have 3 parts seperated by `.`.
+	// A JWT must have 3 parts separated by `.`.
 	parts := strings.Split(token, ".")
 	return len(parts) == 3
 }

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -147,11 +147,11 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 		// then test if anonymous access is enabled
 		switch {
 		case h.initContextWithRenderAuth(reqContext):
+		case h.initContextWithJWT(reqContext, orgID):
 		case h.initContextWithAPIKey(reqContext):
 		case h.initContextWithBasicAuth(reqContext, orgID):
 		case h.initContextWithAuthProxy(reqContext, orgID):
 		case h.initContextWithToken(reqContext, orgID):
-		case h.initContextWithJWT(reqContext, orgID):
 		case h.initContextWithAnonymousUser(reqContext):
 		}
 
@@ -269,11 +269,6 @@ func (h *ContextHandler) initContextWithAPIKey(reqContext *models.ReqContext) bo
 	}
 
 	if errKey != nil {
-		// If JWT is enabled and the token looks like a JWT allow the JWT handler to try it.
-		if h.Cfg.JWTAuthEnabled && h.Cfg.JWTAuthHeaderName == "Authorization" && looksLikeJWT(keyString) {
-			return false
-		}
-
 		status := http.StatusInternalServerError
 		if errors.Is(errKey, apikeygen.ErrInvalidApiKey) {
 			status = http.StatusUnauthorized
@@ -340,12 +335,6 @@ func (h *ContextHandler) initContextWithAPIKey(reqContext *models.ReqContext) bo
 	reqContext.SignedInUser = querySignedInUserResult
 
 	return true
-}
-
-func looksLikeJWT(token string) bool {
-	// A JWT must have 3 parts separated by `.`.
-	parts := strings.Split(token, ".")
-	return len(parts) == 3
 }
 
 func (h *ContextHandler) initContextWithBasicAuth(reqContext *models.ReqContext, orgID int64) bool {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR fixes the issue that JWT tokens in the `Authorization` header are incorrectly declined by the API Key auth mechanism. It also allows the handling of JWT tokens with a `Bearer` prefix in a backwards compatible manner.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #54244

**Special notes for your reviewer**:

This was the only non-breaking way I have found to allow the desired behaviour. To lower the chance that the API Key auth will incorrectly allow the auth request to fall through, the test for weather it is a JWT token in the `Authorization` header has been made reasonable robust while attempting not to have too much of a performance impact. If more robustness is required at the cost of performance, there are further tests that can be performed on the token.

