### PR TITLE
AzureMonitor: Fix issue where custom metric namespaces are not included in the metric namespace list.

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.test.ts
@@ -125,7 +125,7 @@ describe('AzureMonitorDatasource', () => {
         const expected =
           basePath +
           '/providers/microsoft.insights/components/resource1' +
-          '/providers/microsoft.insights/metricNamespaces?region=global&api-version=2017-12-01-preview';
+          '/providers/microsoft.insights/metricNamespaces?api-version=2017-12-01-preview&region=global';
         expect(path).toBe(expected);
         return Promise.resolve(response);
       });
@@ -133,10 +133,13 @@ describe('AzureMonitorDatasource', () => {
 
     it('should return list of Metric Namspaces', () => {
       return ctx.ds.azureMonitorDatasource
-        .getMetricNamespaces({
-          resourceUri:
-            '/subscriptions/mock-subscription-id/resourceGroups/nodeapp/providers/microsoft.insights/components/resource1',
-        })
+        .getMetricNamespaces(
+          {
+            resourceUri:
+              '/subscriptions/mock-subscription-id/resourceGroups/nodeapp/providers/microsoft.insights/components/resource1',
+          },
+          true
+        )
         .then((results: Array<{ text: string; value: string }>) => {
           expect(results.length).toEqual(2);
           expect(results[0].text).toEqual('Azure.ApplicationInsights');

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/azure_monitor_datasource.ts
@@ -196,11 +196,12 @@ export default class AzureMonitorDatasource extends DataSourceWithBackend<AzureM
     });
   }
 
-  getMetricNamespaces(query: GetMetricNamespacesQuery) {
+  getMetricNamespaces(query: GetMetricNamespacesQuery, globalRegion: boolean) {
     const url = UrlBuilder.buildAzureMonitorGetMetricNamespacesUrl(
       this.resourcePath,
       this.apiPreviewVersion,
       this.replaceTemplateVariables(query),
+      globalRegion,
       this.templateSrv
     );
     return this.getResource(url)

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/url_builder.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/url_builder.test.ts
@@ -135,10 +135,11 @@ describe('AzureMonitorUrlBuilder', () => {
         {
           resourceUri: '/subscriptions/sub/resource-uri/resource',
         },
+        true,
         templateSrv
       );
       expect(url).toBe(
-        '/subscriptions/sub/resource-uri/resource/providers/microsoft.insights/metricNamespaces?region=global&api-version=2017-05-01-preview'
+        '/subscriptions/sub/resource-uri/resource/providers/microsoft.insights/metricNamespaces?api-version=2017-05-01-preview&region=global'
       );
     });
   });
@@ -172,11 +173,12 @@ describe('AzureMonitorUrlBuilder', () => {
             metricNamespace: 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes',
             resourceName: 'rn1/rn2/rn3',
           },
+          true,
           templateSrv
         );
         expect(url).toBe(
           '/subscriptions/sub1/resourceGroups/rg/providers/Microsoft.NetApp/netAppAccounts/rn1/capacityPools/rn2/volumes/rn3/' +
-            'providers/microsoft.insights/metricNamespaces?region=global&api-version=2017-05-01-preview'
+            'providers/microsoft.insights/metricNamespaces?api-version=2017-05-01-preview&region=global'
         );
       });
     });
@@ -192,11 +194,31 @@ describe('AzureMonitorUrlBuilder', () => {
             metricNamespace: 'Microsoft.Sql/servers/databases',
             resourceName: 'rn1/rn2',
           },
+          true,
           templateSrv
         );
         expect(url).toBe(
           '/subscriptions/sub1/resourceGroups/rg/providers/Microsoft.Sql/servers/rn1/databases/rn2/' +
-            'providers/microsoft.insights/metricNamespaces?region=global&api-version=2017-05-01-preview'
+            'providers/microsoft.insights/metricNamespaces?api-version=2017-05-01-preview&region=global'
+        );
+      });
+
+      it('should omit global region if specified', () => {
+        const url = UrlBuilder.buildAzureMonitorGetMetricNamespacesUrl(
+          '',
+          '2017-05-01-preview',
+          {
+            subscription: 'sub1',
+            resourceGroup: 'rg',
+            metricNamespace: 'Microsoft.Sql/servers/databases',
+            resourceName: 'rn1/rn2',
+          },
+          false,
+          templateSrv
+        );
+        expect(url).toBe(
+          '/subscriptions/sub1/resourceGroups/rg/providers/Microsoft.Sql/servers/rn1/databases/rn2/' +
+            'providers/microsoft.insights/metricNamespaces?api-version=2017-05-01-preview'
         );
       });
     });
@@ -212,11 +234,12 @@ describe('AzureMonitorUrlBuilder', () => {
             metricNamespace: 'Microsoft.Sql/servers',
             resourceName: 'rn',
           },
+          true,
           templateSrv
         );
         expect(url).toBe(
           '/subscriptions/sub1/resourceGroups/rg/providers/Microsoft.Sql/servers/rn/' +
-            'providers/microsoft.insights/metricNamespaces?region=global&api-version=2017-05-01-preview'
+            'providers/microsoft.insights/metricNamespaces?api-version=2017-05-01-preview&region=global'
         );
       });
     });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/url_builder.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_monitor/url_builder.ts
@@ -52,6 +52,7 @@ export default class UrlBuilder {
     baseUrl: string,
     apiVersion: string,
     query: GetMetricNamespacesQuery,
+    globalRegion: boolean,
     templateSrv: TemplateSrv
   ) {
     let resourceUri: string;
@@ -68,7 +69,9 @@ export default class UrlBuilder {
       });
     }
 
-    return `${baseUrl}${resourceUri}/providers/microsoft.insights/metricNamespaces?region=global&api-version=${apiVersion}`;
+    return `${baseUrl}${resourceUri}/providers/microsoft.insights/metricNamespaces?api-version=${apiVersion}${
+      globalRegion ? '&region=global' : ''
+    }`;
   }
 
   static buildAzureMonitorGetMetricNamesUrl(

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.test.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.test.ts
@@ -234,4 +234,40 @@ describe('AzureMonitor: metrics dataHooks', () => {
       });
     });
   });
+
+  describe('useMetricNamespaces', () => {
+    const metricNamespacesConfig = {
+      name: 'useMetricNamespaces',
+      hook: useMetricNamespaces,
+      emptyQueryPartial: {
+        resourceGroup: 'rg',
+        resourceName: 'rn',
+        metricNamespace: 'azure/vm',
+      },
+      customProperties: {},
+      expectedOptions: [
+        { label: 'Compute Virtual Machine', value: 'azure/vmc' },
+        { label: 'Database NS', value: 'azure/dbns' },
+        { label: 'azure/vm', value: 'azure/vm' },
+      ],
+    };
+
+    it('call getMetricNamespaces without global region', async () => {
+      const query = {
+        ...bareQuery,
+        azureMonitor: metricNamespacesConfig.emptyQueryPartial,
+      };
+      const { result, waitForNextUpdate } = renderHook(() =>
+        metricNamespacesConfig.hook(query, datasource, onChange, jest.fn())
+      );
+      await waitForNextUpdate(WAIT_OPTIONS);
+
+      expect(result.current).toEqual(metricNamespacesConfig.expectedOptions);
+      expect(datasource.azureMonitorDatasource.getMetricNamespaces).toHaveBeenCalledWith(
+        expect.objectContaining(metricNamespacesConfig.emptyQueryPartial),
+        // Here, "global" should be false
+        false
+      );
+    });
+  });
 });

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/components/MetricsQueryEditor/dataHooks.ts
@@ -48,12 +48,15 @@ export const useMetricNamespaces: DataHook = (query, datasource, onChange, setEr
         return;
       }
 
-      const results = await datasource.azureMonitorDatasource.getMetricNamespaces({
-        subscription,
-        metricNamespace,
-        resourceGroup,
-        resourceName,
-      });
+      const results = await datasource.azureMonitorDatasource.getMetricNamespaces(
+        {
+          subscription,
+          metricNamespace,
+          resourceGroup,
+          resourceName,
+        },
+        false
+      );
       const options = formatOptions(results, metricNamespace);
 
       // Do some cleanup of the query state if need be

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/datasource.ts
@@ -152,7 +152,7 @@ export default class Datasource extends DataSourceWithBackend<AzureMonitorQuery,
     if (resourceGroup) {
       url += `/resourceGroups/${resourceGroup};`;
     }
-    return this.azureMonitorDatasource.getMetricNamespaces({ resourceUri: url });
+    return this.azureMonitorDatasource.getMetricNamespaces({ resourceUri: url }, true);
   }
 
   getResourceNames(subscriptionId: string, resourceGroup?: string, metricNamespace?: string) {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/variables.ts
@@ -123,7 +123,7 @@ export class VariableSupport extends CustomVariableSupport<DataSource, AzureMoni
     }
 
     if (query.kind === 'MetricNamespaceQuery') {
-      return this.datasource.azureMonitorDatasource.getMetricNamespaces(query);
+      return this.datasource.azureMonitorDatasource.getMetricNamespaces(query, true);
     }
 
     if (query.kind === 'MetricNamesQuery') {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

We discovered that using the parameter `region=global` when requesting metric namespaces causes the returned list to omit namespaces with the `classification: "Custom"`. These namespaces are custom metric namespaces that should be included in the list of available namespaces in the dropdown selector:

![Screenshot from 2022-09-07 10-11-16](https://user-images.githubusercontent.com/4025665/188825981-fee21999-fa1c-4f98-a966-d4e3894f4815.png)

Unfortunately, this behavior is not documented in the [API documentation](https://docs.microsoft.com/en-us/rest/api/monitor/metric-namespaces/list?tabs=HTTP#namespaceclassification).

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

First part of #54757

**Special notes for your reviewer**:

It's still needed to fix the behavior when a custom namespace is selected.