### PR TITLE
Fix paths for `auth/` build and volume paths

### DIFF
--- a/devenv/docker/blocks/auth/apache_proxy/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/apache_proxy/docker-compose.yaml
@@ -5,5 +5,5 @@
 # root_url = %(protocol)s://%(domain)s:10081/grafana/
 
   apacheproxy:
-    build: docker/blocks/apache_proxy
+    build: docker/blocks/auth/apache_proxy
     network_mode: host

--- a/devenv/docker/blocks/auth/apache_proxy_mac/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/apache_proxy_mac/docker-compose.yaml
@@ -5,6 +5,6 @@
 # root_url = %(protocol)s://%(domain)s:10081/grafana/
 
   apacheproxy:
-    build: docker/blocks/apache_proxy_mac
+    build: docker/blocks/auth/apache_proxy_mac
     ports:
       - "10081:10081"

--- a/devenv/docker/blocks/auth/jwt_proxy/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/jwt_proxy/docker-compose.yaml
@@ -6,7 +6,7 @@
       POSTGRES_USER: keycloak
       POSTGRES_PASSWORD: password
     volumes:
-      - ./docker/blocks/jwt_proxy/cloak.sql:/docker-entrypoint-initdb.d/cloak.sql
+      - ./docker/blocks/auth/jwt_proxy/cloak.sql:/docker-entrypoint-initdb.d/cloak.sql
     restart: unless-stopped
 
   oauthkeycloak:

--- a/devenv/docker/blocks/auth/nginx_proxy/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/nginx_proxy/docker-compose.yaml
@@ -5,5 +5,5 @@
 # root_url = %(protocol)s://%(domain)s:10080/grafana/
 
   nginxproxy:
-    build: docker/blocks/nginx_proxy
+    build: docker/blocks/auth/nginx_proxy
     network_mode: host

--- a/devenv/docker/blocks/auth/nginx_proxy_mac/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/nginx_proxy_mac/docker-compose.yaml
@@ -5,7 +5,7 @@
 # root_url = %(protocol)s://%(domain)s:10080/grafana/
 
   nginxproxy:
-    build: docker/blocks/nginx_proxy_mac
+    build: docker/blocks/auth/nginx_proxy_mac
     ports:
       - "10080:10080"
 

--- a/devenv/docker/blocks/auth/openldap-mac/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/openldap-mac/docker-compose.yaml
@@ -11,5 +11,5 @@
       - 636:636
     restart: unless-stopped
     volumes:
-      - ./docker/blocks/openldap-mac/prepopulate/:/tmp/smt/
-      - ./docker/blocks/openldap-mac/modules/:/tmp/smt/
+      - ./docker/blocks/auth/openldap-mac/prepopulate/:/tmp/smt/
+      - ./docker/blocks/auth/openldap-mac/modules/:/tmp/smt/

--- a/devenv/docker/blocks/auth/openldap-multiple/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/openldap-multiple/docker-compose.yaml
@@ -1,6 +1,6 @@
   admins-openldap:
     build: 
-      context: docker/blocks/multiple-openldap
+      context: docker/blocks/auth/openldap-multiple
       dockerfile: ./admins-ldap-server.Dockerfile
     environment:
       SLAPD_PASSWORD: grafana
@@ -11,7 +11,7 @@
 
   openldap:
     build: 
-      context: docker/blocks/multiple-openldap
+      context: docker/blocks/auth/openldap-multiple
       dockerfile: ./ldap-server.Dockerfile
     environment:
       SLAPD_PASSWORD: grafana

--- a/devenv/docker/blocks/auth/prometheus_basic_auth_proxy/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/prometheus_basic_auth_proxy/docker-compose.yaml
@@ -2,6 +2,6 @@
 # http://prometheus:9090 (Prometheus inside the docker compose)
 
   nginxproxy:
-    build: docker/blocks/prometheus_basic_auth_proxy
+    build: docker/blocks/auth/prometheus_basic_auth_proxy
     ports:
       - "10090:10090"

--- a/devenv/docker/blocks/auth/saml/docker-compose.yaml
+++ b/devenv/docker/blocks/auth/saml/docker-compose.yaml
@@ -11,6 +11,6 @@
       - "8080:8080"
       - "8443:8443"
     volumes:
-      - ./docker/blocks/saml/users.php:/var/www/simplesamlphp/config/authsources.php
+      - ./docker/blocks/auth/saml/users.php:/var/www/simplesamlphp/config/authsources.php
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

More fixes to broken links at `auth/` docker blocks
