### PR TITLE
Azure Monitor: Add support to customized routes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/gosimple/slug v1.12.0
 	github.com/grafana/cuetsy v0.1.1
 	github.com/grafana/grafana-aws-sdk v0.11.0
-	github.com/grafana/grafana-azure-sdk-go v1.3.0
+	github.com/grafana/grafana-azure-sdk-go v1.3.1
 	github.com/grafana/grafana-plugin-sdk-go v0.139.0
 	github.com/grafana/thema v0.0.0-20220817114012-ebeee841c104
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1378,6 +1378,8 @@ github.com/grafana/grafana-aws-sdk v0.11.0 h1:ncPD/UN0wNcKq3kEU90RdvrnK/6R4VW2Lo
 github.com/grafana/grafana-aws-sdk v0.11.0/go.mod h1:5Iw3xY7iXJfNaYHrRHMXa/kaB2lWoyntg71PPLGvSs8=
 github.com/grafana/grafana-azure-sdk-go v1.3.0 h1:zboQpq/ljBjqHo/6UQNZAUwqGTtnEGRYSEnqIQvLuAo=
 github.com/grafana/grafana-azure-sdk-go v1.3.0/go.mod h1:rgrnK9m6CgKlgx4rH3FFP/6dTdyRO6LYC2mVZov35yo=
+github.com/grafana/grafana-azure-sdk-go v1.3.1 h1:xTgBmbDxUPj3X9Pl9vgIOgZoDdtxWl0fYDuHrHr79jM=
+github.com/grafana/grafana-azure-sdk-go v1.3.1/go.mod h1:rgrnK9m6CgKlgx4rH3FFP/6dTdyRO6LYC2mVZov35yo=
 github.com/grafana/grafana-google-sdk-go v0.0.0-20211104130251-b190293eaf58 h1:2ud7NNM7LrGPO4x0NFR8qLq68CqI4SmB7I2yRN2w9oE=
 github.com/grafana/grafana-google-sdk-go v0.0.0-20211104130251-b190293eaf58/go.mod h1:Vo2TKWfDVmNTELBUM+3lkrZvFtBws0qSZdXhQxRdJrE=
 github.com/grafana/grafana-plugin-sdk-go v0.114.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -101,7 +101,7 @@ func NewInstanceSettings(cfg *setting.Cfg, clientProvider *httpclient.Provider, 
 
 		customizedCloudSettings, err := getCustomizedCloudSettings(cloud, settings.JSONData)
 		if err != nil {
-			return nil, fmt.Errorf("error getting credentials: %w", err)
+			return nil, err
 		}
 
 		routesForModel, err := getAzureRoutes(cloud, customizedCloudSettings)

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -99,6 +99,20 @@ func NewInstanceSettings(cfg *setting.Cfg, clientProvider *httpclient.Provider, 
 			return nil, fmt.Errorf("error getting credentials: %w", err)
 		}
 
+		routesForModel := routes[cloud]
+
+		if cloud == "AzureCustomizedCloud" {
+			customizedCloudSettings := types.AzureMonitorCustomizedCloudSettings{}
+			err = json.Unmarshal(settings.JSONData, &customizedCloudSettings)
+			if err != nil {
+				return nil, fmt.Errorf("error getting customized cloud settings: %w", err)
+			}
+			if customizedCloudSettings.CustomizedRoutes == nil {
+				return nil, fmt.Errorf("unable to instantiate routes, customizedRoutes must be set")
+			}
+			routesForModel = customizedCloudSettings.CustomizedRoutes
+		}
+
 		credentials, err := getAzureCredentials(cfg, jsonData, settings.DecryptedSecureJSONData)
 		if err != nil {
 			return nil, fmt.Errorf("error getting credentials: %w", err)
@@ -111,7 +125,7 @@ func NewInstanceSettings(cfg *setting.Cfg, clientProvider *httpclient.Provider, 
 			JSONData:                jsonDataObj,
 			DecryptedSecureJSONData: settings.DecryptedSecureJSONData,
 			DatasourceID:            settings.ID,
-			Routes:                  routes[cloud],
+			Routes:                  routesForModel,
 			Services:                map[string]types.DatasourceService{},
 		}
 

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/grafana/grafana-azure-sdk-go/azsettings"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
@@ -142,7 +143,7 @@ func getCustomizedCloudSettings(cloud string, jsonData json.RawMessage) (types.A
 }
 
 func getAzureRoutes(cloud string, jsonData json.RawMessage) (map[string]types.AzRoute, error) {
-	if cloud == "AzureCustomizedCloud" {
+	if cloud == azsettings.AzureCustomized {
 		customizedCloudSettings, err := getCustomizedCloudSettings(cloud, jsonData)
 		if err != nil {
 			return nil, err

--- a/pkg/tsdb/azuremonitor/azuremonitor.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor.go
@@ -99,12 +99,7 @@ func NewInstanceSettings(cfg *setting.Cfg, clientProvider *httpclient.Provider, 
 			return nil, fmt.Errorf("error getting credentials: %w", err)
 		}
 
-		customizedCloudSettings, err := getCustomizedCloudSettings(cloud, settings.JSONData)
-		if err != nil {
-			return nil, err
-		}
-
-		routesForModel, err := getAzureRoutes(cloud, customizedCloudSettings)
+		routesForModel, err := getAzureRoutes(cloud, settings.JSONData)
 		if err != nil {
 			return nil, err
 		}
@@ -138,20 +133,20 @@ func NewInstanceSettings(cfg *setting.Cfg, clientProvider *httpclient.Provider, 
 }
 
 func getCustomizedCloudSettings(cloud string, jsonData json.RawMessage) (types.AzureMonitorCustomizedCloudSettings, error) {
-	if cloud == "AzureCustomizedCloud" {
-		customizedCloudSettings := types.AzureMonitorCustomizedCloudSettings{}
-		err := json.Unmarshal(jsonData, &customizedCloudSettings)
-		if err != nil {
-			return types.AzureMonitorCustomizedCloudSettings{}, fmt.Errorf("error getting customized cloud settings: %w", err)
-		}
-		return customizedCloudSettings, nil
-	} else {
-		return types.AzureMonitorCustomizedCloudSettings{}, nil
+	customizedCloudSettings := types.AzureMonitorCustomizedCloudSettings{}
+	err := json.Unmarshal(jsonData, &customizedCloudSettings)
+	if err != nil {
+		return types.AzureMonitorCustomizedCloudSettings{}, fmt.Errorf("error getting customized cloud settings: %w", err)
 	}
+	return customizedCloudSettings, nil
 }
 
-func getAzureRoutes(cloud string, customizedCloudSettings types.AzureMonitorCustomizedCloudSettings) (map[string]types.AzRoute, error) {
+func getAzureRoutes(cloud string, jsonData json.RawMessage) (map[string]types.AzRoute, error) {
 	if cloud == "AzureCustomizedCloud" {
+		customizedCloudSettings, err := getCustomizedCloudSettings(cloud, jsonData)
+		if err != nil {
+			return nil, err
+		}
 		if customizedCloudSettings.CustomizedRoutes == nil {
 			return nil, fmt.Errorf("unable to instantiate routes, customizedRoutes must be set")
 		}

--- a/pkg/tsdb/azuremonitor/azuremonitor_test.go
+++ b/pkg/tsdb/azuremonitor/azuremonitor_test.go
@@ -51,6 +51,40 @@ func TestNewInstanceSettings(t *testing.T) {
 			},
 			Err: require.NoError,
 		},
+		{
+			name: "creates an instance for customized cloud",
+			settings: backend.DataSourceInstanceSettings{
+				JSONData:                []byte(`{"cloudName":"customizedazuremonitor","customizedRoutes":{"Route":{"URL":"url"}},"azureAuthType":"clientsecret"}`),
+				DecryptedSecureJSONData: map[string]string{"clientSecret": "secret"},
+				ID:                      50,
+			},
+			expectedModel: types.DatasourceInfo{
+				Cloud: "AzureCustomizedCloud",
+				Credentials: &azcredentials.AzureClientSecretCredentials{
+					AzureCloud:   "AzureCustomizedCloud",
+					ClientSecret: "secret",
+				},
+				Settings: types.AzureMonitorSettings{},
+				Routes: map[string]types.AzRoute{
+					"Route": {
+						URL: "url",
+					},
+				},
+				JSONData: map[string]interface{}{
+					"azureAuthType": "clientsecret",
+					"cloudName":     "customizedazuremonitor",
+					"customizedRoutes": map[string]interface{}{
+						"Route": map[string]interface{}{
+							"URL": "url",
+						},
+					},
+				},
+				DatasourceID:            50,
+				DecryptedSecureJSONData: map[string]string{"clientSecret": "secret"},
+				Services:                map[string]types.DatasourceService{},
+			},
+			Err: require.NoError,
+		},
 	}
 
 	cfg := &setting.Cfg{

--- a/pkg/tsdb/azuremonitor/credentials.go
+++ b/pkg/tsdb/azuremonitor/credentials.go
@@ -16,6 +16,7 @@ const (
 	azureMonitorChina        = "chinaazuremonitor"
 	azureMonitorUSGovernment = "govazuremonitor"
 	azureMonitorGermany      = "germanyazuremonitor"
+	azureMonitorCustomized   = "customizedazuremonitor"
 )
 
 func getAuthType(cfg *setting.Cfg, jsonData *simplejson.Json) string {
@@ -53,6 +54,8 @@ func getDefaultAzureCloud(cfg *setting.Cfg) (string, error) {
 		return azsettings.AzureUSGovernment, nil
 	case azsettings.AzureGermany:
 		return azsettings.AzureGermany, nil
+	case "AzureCustomizedCloud":
+		return "AzureCustomizedCloud", nil
 	case "":
 		// Not set cloud defaults to public
 		return azsettings.AzurePublic, nil
@@ -72,6 +75,8 @@ func normalizeAzureCloud(cloudName string) (string, error) {
 		return azsettings.AzureUSGovernment, nil
 	case azureMonitorGermany:
 		return azsettings.AzureGermany, nil
+	case azureMonitorCustomized:
+		return "AzureCustomizedCloud", nil
 	default:
 		err := fmt.Errorf("the cloud '%s' not supported", cloudName)
 		return "", err

--- a/pkg/tsdb/azuremonitor/credentials.go
+++ b/pkg/tsdb/azuremonitor/credentials.go
@@ -54,8 +54,8 @@ func getDefaultAzureCloud(cfg *setting.Cfg) (string, error) {
 		return azsettings.AzureUSGovernment, nil
 	case azsettings.AzureGermany:
 		return azsettings.AzureGermany, nil
-	case "AzureCustomizedCloud":
-		return "AzureCustomizedCloud", nil
+	case azsettings.AzureCustomized:
+		return azsettings.AzureCustomized, nil
 	case "":
 		// Not set cloud defaults to public
 		return azsettings.AzurePublic, nil
@@ -76,7 +76,7 @@ func normalizeAzureCloud(cloudName string) (string, error) {
 	case azureMonitorGermany:
 		return azsettings.AzureGermany, nil
 	case azureMonitorCustomized:
-		return "AzureCustomizedCloud", nil
+		return azsettings.AzureCustomized, nil
 	default:
 		err := fmt.Errorf("the cloud '%s' not supported", cloudName)
 		return "", err

--- a/pkg/tsdb/azuremonitor/types/types.go
+++ b/pkg/tsdb/azuremonitor/types/types.go
@@ -33,6 +33,11 @@ type AzureMonitorSettings struct {
 	AppInsightsAppId             string `json:"appInsightsAppId"`
 }
 
+// AzureMonitorCustomizedCloudSettings is the extended Azure Monitor settings for customized cloud
+type AzureMonitorCustomizedCloudSettings struct {
+	CustomizedRoutes map[string]AzRoute `json:"customizedRoutes"`
+}
+
 type DatasourceService struct {
 	URL        string
 	HTTPClient *http.Client


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
This PR aims to make it possible to use Grafana in specific non-public Azure cloud such as [Azure Stack Hub](https://azure.microsoft.com/en-us/products/azure-stack/hub/). Unlike other pre-defined clouds, they have variable configurations for authentication and service endpoints for different instances. So, it's not possible to hardcode those configurations in code or generate by rules. After this PR, user can use Grafana Azure Monitor data-source to talk with Azure Monitor service endpoints in those specific Azure clouds not defined in the well-known list.

This PR mainly changes the backend of Azure Monitor data-source. The routes will be overridden by some extra configuration from data-source if the cloud is customized cloud. For now, the extra configuration is supposed to be configured by script automatically, while add corresponding UX is also possible. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

N/A.

**Special notes for your reviewer**:
For the cloud name indicating customization, it is hard coded as `AzureCustomizedCloud` for now and will be updated to a new entry in `azsettings` if https://github.com/grafana/grafana-azure-sdk-go/pull/13 is completed.
