### PR TITLE
CI: Trigger `*-storybook` steps on UI changes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -424,6 +424,10 @@ steps:
     NODE_OPTIONS: --max_old_space_size=4096
   image: grafana/build-container:1.5.9
   name: build-storybook
+  when:
+    paths:
+      include:
+      - packages/grafana-ui/**
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -1174,6 +1178,10 @@ steps:
     NODE_OPTIONS: --max_old_space_size=4096
   image: grafana/build-container:1.5.9
   name: build-storybook
+  when:
+    paths:
+      include:
+      - packages/grafana-ui/**
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
@@ -1210,6 +1218,9 @@ steps:
   image: grafana/grafana-ci-deploy:1.3.3
   name: store-storybook
   when:
+    paths:
+      include:
+      - packages/grafana-ui/**
     repo:
     - grafana/grafana
 - commands:
@@ -1901,6 +1912,10 @@ steps:
     NODE_OPTIONS: --max_old_space_size=4096
   image: grafana/build-container:1.5.9
   name: build-storybook
+  when:
+    paths:
+      include:
+      - packages/grafana-ui/**
 - commands:
   - ./bin/grabpl upload-cdn --edition oss
   depends_on:
@@ -1944,6 +1959,10 @@ steps:
       from_secret: prerelease_bucket
   image: grafana/grafana-ci-deploy:1.3.3
   name: store-storybook
+  when:
+    paths:
+      include:
+      - packages/grafana-ui/**
 - commands:
   - ./bin/grabpl artifacts npm store --tag ${DRONE_TAG}
   depends_on:
@@ -3870,6 +3889,10 @@ steps:
     NODE_OPTIONS: --max_old_space_size=4096
   image: grafana/build-container:1.5.9
   name: build-storybook
+  when:
+    paths:
+      include:
+      - packages/grafana-ui/**
 - commands:
   - ./bin/grabpl upload-cdn --edition oss
   depends_on:
@@ -5092,6 +5115,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 2689da88c9d55f8949f4f9a26a850661fdec1ecf8f5da5c3713bde4ca481b8dd
+hmac: 8c812cebfce6e0c9aabaa4d85da9fda2f13eeedae60406a3a196c7488c4cdd6c
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -11,11 +11,9 @@ wix_image = 'grafana/ci-wix:0.1.1'
 
 disable_tests = False
 trigger_oss = {
-    'when': {
-        'repo': [
-            'grafana/grafana',
-        ]
-    }
+    'repo': [
+        'grafana/grafana',
+    ]
 }
 
 
@@ -249,6 +247,7 @@ def build_storybook_step(edition, ver_mode):
             'yarn storybook:build',
             './bin/grabpl verify-storybook',
         ],
+        ## 'when': trigger_storybook,
     }
 
 
@@ -278,7 +277,7 @@ def store_storybook_step(edition, ver_mode, trigger=None):
         'commands': commands,
     }
     if trigger and ver_mode in ("release-branch", "main"):
-        step.update(trigger)
+        step = dict(step, when=trigger)
     return step
 
 
@@ -345,7 +344,7 @@ def upload_cdn_step(edition, ver_mode, trigger=None):
         ],
     }
     if trigger and ver_mode in ("release-branch", "main"):
-        step.update(trigger)
+        step = dict(step, when=trigger)
     return step
 
 
@@ -596,7 +595,7 @@ def frontend_metrics_step(edition, trigger=None):
         ],
     }
     if trigger:
-        step.update(trigger)
+        step = dict(step, when=trigger)
     return step
 
 
@@ -824,7 +823,7 @@ def publish_images_step(edition, ver_mode, mode, docker_repo, trigger=None):
         }],
     }
     if trigger and ver_mode in ("release-branch", "main"):
-        step.update(trigger)
+        step = dict(step, when=trigger)
 
     return step
 
@@ -921,7 +920,7 @@ def release_canary_npm_packages_step(edition, trigger=None):
         ],
     }
     if trigger:
-        step.update(trigger)
+        step = dict(step, when=trigger)
     return step
 
 
@@ -954,7 +953,7 @@ def upload_packages_step(edition, ver_mode, trigger=None):
         'commands': ['./bin/grabpl upload-packages --edition {}'.format(edition),],
     }
     if trigger and ver_mode in ("release-branch", "main"):
-        step.update(trigger)
+        step = dict(step, when=trigger)
     return step
 
 

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -15,6 +15,13 @@ trigger_oss = {
         'grafana/grafana',
     ]
 }
+trigger_storybook = {
+    'paths': {
+        'include': [
+            'packages/grafana-ui/**',
+        ],
+    }
+}
 
 
 def slack_step(channel, template, secret):
@@ -247,7 +254,7 @@ def build_storybook_step(edition, ver_mode):
             'yarn storybook:build',
             './bin/grabpl verify-storybook',
         ],
-        ## 'when': trigger_storybook,
+        'when': trigger_storybook,
     }
 
 
@@ -275,9 +282,19 @@ def store_storybook_step(edition, ver_mode, trigger=None):
             'PRERELEASE_BUCKET': from_secret(prerelease_bucket)
         },
         'commands': commands,
+        'when': trigger_storybook,
     }
     if trigger and ver_mode in ("release-branch", "main"):
-        step = dict(step, when=trigger)
+        # no dict merge operation available, https://github.com/harness/drone-cli/pull/220
+        when_cond = {
+            'repo': ['grafana/grafana',],
+            'paths': {
+                'include': [
+                    'packages/grafana-ui/**',
+                ],
+            }
+        }
+        step = dict(step, when=when_cond)
     return step
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`build-storybook` and `store-storybook` steps, only make sense to run upon `packages/grafana-ui` changes. This PR does that. 

Note: After https://github.com/harness/drone-cli/pull/220 is merged, we can update our `.bingo` version for `drone-cli` to include dictionary merges, so we can make the chunk below prettier.

https://github.com/grafana/grafana/pull/54833/files#diff-b0900be261c985000fe0a4caf6060dddde3718a0edbf79670115f942d4611dedR288-R297
