### PR TITLE
elastic: explain why moving_avg is 7.x only

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/utils.ts
@@ -110,6 +110,8 @@ export const metricAggregationConfig: MetricsConfiguration = {
     defaults: {},
   },
   moving_avg: {
+    // deprecated in 6.4.0, removed in 8.0.0,
+    // recommended replacement is moving_fn
     label: 'Moving Average',
     requiresField: true,
     isPipelineAgg: true,


### PR DESCRIPTION
in the elasticsearch datasource currently there is only a single feature that is "version dependent", `moving_avg`. i checked why it is so, and added a comment with the reason.

(info found at https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html)