### PR TITLE
devenv: elastic: new version

### DIFF
--- a/devenv/docker/blocks/elastic/.env
+++ b/devenv/docker/blocks/elastic/.env
@@ -1,1 +1,1 @@
-elastic_version=8.3.3
+elastic_version=8.4.1


### PR DESCRIPTION
there was a new elastic version, so we are updating the devenv-files to get the newest elasticsearch when you run `make devenv sources=elastic`