### PR TITLE
codeowners: assign logs-devenvs to logs-squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,10 @@ go.sum @grafana/backend-platform
 # Backend code, developers environment
 /devenv/docker/blocks/auth @grafana/grafana-authnz-team
 
+# Logs code, developers environment
+/devenv/docker/blocks/loki* @grafana/observability-logs
+/devenv/docker/blocks/elastic* @grafana/observability-logs
+
 # Continuous Integration
 .drone.yml @grafana/grafana-release-eng
 .drone.star @grafana/grafana-release-eng


### PR DESCRIPTION
PR updates the CODEOWNERS file to assign the loki and elasticsearch `devenv` configs to the logs-squad.