### PR TITLE
CloudWatch: Fix display name of metric and namespace

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import selectEvent from 'react-select-event';
 
+import { toOption } from '@grafana/data';
+
 import { MetricStatEditor } from '..';
 import { setupMockedDataSource } from '../../__mocks__/CloudWatchDataSource';
 import { MetricStat } from '../../types';
@@ -189,6 +191,16 @@ describe('MetricStatEditor', () => {
       expect(onChange.mock.calls).toEqual([
         [{ ...propsNamespaceMetrics.metricStat, metricName: 'm1', namespace: 'n2' }],
       ]);
+    });
+  });
+
+  describe('metric value', () => {
+    it('should be displayed when a custom value is used and its value is not in the select options', async () => {
+      const expected = 'CPUUtilzation';
+      await act(async () => {
+        render(<MetricStatEditor {...props} metricStat={{ ...props.metricStat, metricName: expected }} />);
+      });
+      expect(await screen.findByText(expected)).toBeInTheDocument();
     });
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.test.tsx
@@ -3,8 +3,6 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import selectEvent from 'react-select-event';
 
-import { toOption } from '@grafana/data';
-
 import { MetricStatEditor } from '..';
 import { setupMockedDataSource } from '../../__mocks__/CloudWatchDataSource';
 import { MetricStat } from '../../types';

--- a/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/MetricStatEditor/MetricStatEditor.tsx
@@ -61,7 +61,7 @@ export function MetricStatEditor({
           <EditorField label="Namespace" width={26}>
             <Select
               aria-label="Namespace"
-              value={metricStat.namespace}
+              value={metricStat?.namespace && toOption(metricStat.namespace)}
               allowCustomValue
               options={namespaces}
               onChange={({ value: namespace }) => {
@@ -74,7 +74,7 @@ export function MetricStatEditor({
           <EditorField label="Metric name" width={16}>
             <Select
               aria-label="Metric name"
-              value={metricStat.metricName || null}
+              value={metricStat?.metricName && toOption(metricStat.metricName)}
               allowCustomValue
               options={metrics}
               onChange={({ value: metricName }) => {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures that metric name and namespace is displayed in the UI. Before this fix, they would not be displayed correctly in case their values wasn't in the list of options. This is circumvented by passing the selectable value object as value to the `Select` component instead of passing just the string value.

**Which issue(s) this PR fixes**:

Fixes #54727

**Special notes for your reviewer**:
This issue was found in AMG, version 8.4.7 so I might need to be backported to 8.4.x. Will investigate this and report back here. 
