### PR TITLE
[v9.1.x] Chore: Upgrade `@grafana/lezer-logql` to `0.0.19`

### DIFF
--- a/package.json
+++ b/package.json
@@ -255,7 +255,7 @@
     "@grafana/e2e-selectors": "workspace:*",
     "@grafana/experimental": "^0.0.2-canary.32",
     "@grafana/google-sdk": "0.0.3",
-    "@grafana/lezer-logql": "0.0.14",
+    "@grafana/lezer-logql": "0.0.19",
     "@grafana/runtime": "workspace:*",
     "@grafana/schema": "workspace:*",
     "@grafana/ui": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4929,14 +4929,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/lezer-logql@npm:0.0.14":
-  version: 0.0.14
-  resolution: "@grafana/lezer-logql@npm:0.0.14"
-  dependencies:
-    lezer: ^0.13.5
+"@grafana/lezer-logql@npm:0.0.19":
+  version: 0.0.19
+  resolution: "@grafana/lezer-logql@npm:0.0.19"
   peerDependencies:
     "@lezer/lr": ^0.15.8
-  checksum: 4e35f455b6b7c286dfca9f3770df0d4c325057352dc8241665b667d798db09de54e1c14f7bfd34d4ae5bbef782d28994ceaf5c517fc18cff46ae3a47527e1990
+  checksum: 897756b37b22ec883fc99945decf43f7fb2da14e32b9e296db61aaf4dcc8bff39b9ab38a923645f6dcb5269c37ce29fbb6cc2b75d8f2dce95e62a2a7ccd41a88
   languageName: node
   linkType: hard
 
@@ -21302,7 +21300,7 @@ __metadata:
     "@grafana/eslint-config": 4.0.0
     "@grafana/experimental": ^0.0.2-canary.32
     "@grafana/google-sdk": 0.0.3
-    "@grafana/lezer-logql": 0.0.14
+    "@grafana/lezer-logql": 0.0.19
     "@grafana/runtime": "workspace:*"
     "@grafana/schema": "workspace:*"
     "@grafana/toolkit": "workspace:*"
@@ -25602,22 +25600,6 @@ __metadata:
   peerDependencies:
     "@lezer/lr": ^0.15.8
   checksum: cdce054700874ef95c779899bc8a6a774f83bc613d509011b7d3b8003f07fa853962291c44edf9232e7a927d0753fec77ec55d795abddda9d2efc044f78bb58a
-  languageName: node
-  linkType: hard
-
-"lezer-tree@npm:^0.13.2":
-  version: 0.13.2
-  resolution: "lezer-tree@npm:0.13.2"
-  checksum: b8be213c780191e0669c7f440aa563218ada762d2cf399b94e755a563cc7da8951929fa3ee65df9ef6586a81223c55cd662e1ec5b49060d892acca4198cf3596
-  languageName: node
-  linkType: hard
-
-"lezer@npm:^0.13.5":
-  version: 0.13.5
-  resolution: "lezer@npm:0.13.5"
-  dependencies:
-    lezer-tree: ^0.13.2
-  checksum: a5c3aa01c539aba3377a927063bcd63b311737a7abfd71ad2c2229ed4e48b7858f2e8e11e925f8f5286c2629251f77dfabf7505ea6c707499cd9917ca90934c8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We recently upgraded our `@grafana/lezer-logql` versions.

`0.1.0` for Grafana >= 9.2.x
`0.0.19` for Grafana < 9.2.x

This is basically a backport of https://github.com/grafana/grafana/pull/54878