### PR TITLE
Instrumentation: Fixes bug where database queries were instrumented twice 

### DIFF
--- a/pkg/services/sqlstore/database_wrapper.go
+++ b/pkg/services/sqlstore/database_wrapper.go
@@ -109,9 +109,17 @@ func (h *databaseQueryWrapper) instrument(ctx context.Context, status string, qu
 
 // OnError will be called if any error happens
 func (h *databaseQueryWrapper) OnError(ctx context.Context, err error, query string, args ...interface{}) error {
-	status := "error"
+	// Not a user error: driver is telling sql package that an
+	// optional interface method is not implemented. There is
+	// nothing to instrument here.
 	// https://golang.org/pkg/database/sql/driver/#ErrSkip
-	if err == nil || errors.Is(err, driver.ErrSkip) {
+	// https://github.com/DataDog/dd-trace-go/issues/270
+	if errors.Is(err, driver.ErrSkip) {
+		return nil
+	}
+
+	status := "error"
+	if err == nil {
 		status = "success"
 	}
 


### PR DESCRIPTION
This is a bug due to me miss understanding the `driver.ErrSkip` error from the sql package.

Instead of treating `driver.ErrSkip` as _not an error_ we should ignore it completely and return. The sql package will continue executing the same query later anyway. 

More details in https://github.com/DataDog/dd-trace-go/issues/270

Could potentially be fixed in https://github.com/qustavo/sqlhooks/issues/52 as well

to setup jaeger locally for testing
```
docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
make devenv sources=jaeger
```
you can find the jaeger UI at http://localhost:16686/


grafana.ini
```
[tracing.jaeger]
address = localhost:6831

[feature_toggles]
database_metrics = true
```

Signed-off-by: bergquist <carl.bergquist@gmail.com>
