### PR TITLE
Cloudwatch: Fix annotation query serialization issue

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -5,6 +5,7 @@ import {
   ArrayVector,
   DataFrame,
   dataFrameToJSON,
+  DataQueryRequest,
   dateTime,
   Field,
   FieldType,
@@ -28,12 +29,22 @@ import {
 import { validLogsQuery, validMetricsQuery } from './__mocks__/queries';
 import { LOGSTREAM_IDENTIFIER_INTERNAL, LOG_IDENTIFIER_INTERNAL } from './datasource';
 import {
+  CloudWatchAnnotationQuery,
   CloudWatchLogsQueryStatus,
   CloudWatchMetricsQuery,
   CloudWatchQuery,
   MetricEditorMode,
   MetricQueryType,
 } from './types';
+
+const mockTimeRange = {
+  from: dateTime(1546372800000),
+  to: dateTime(1546380000000),
+  raw: {
+    from: dateTime(1546372800000),
+    to: dateTime(1546380000000),
+  },
+};
 
 describe('datasource', () => {
   describe('query', () => {
@@ -311,23 +322,17 @@ describe('datasource', () => {
   });
 
   describe('annotation query', () => {
-    const query = {
-      range: { from: dateTime(), to: dateTime() },
-      rangeRaw: { from: 1483228800, to: 1483232400 },
+    const query: DataQueryRequest<CloudWatchAnnotationQuery> = {
+      range: mockTimeRange,
+      rangeRaw: mockTimeRange.raw,
       targets: [
         {
           actionPrefix: '',
           alarmNamePrefix: '',
-          alias: '',
           datasource: { type: 'cloudwatch' },
           dimensions: { InstanceId: 'i-12345678' },
-          enable: true,
-          expression: '',
-          iconColor: 'red',
-          id: '',
           matchExact: true,
           metricName: 'CPUUtilization',
-          name: 'CPU above 70',
           period: '300',
           prefixMatching: false,
           queryMode: 'Annotations',
@@ -337,6 +342,13 @@ describe('datasource', () => {
           statistic: 'Average',
         },
       ],
+      requestId: '',
+      interval: '',
+      intervalMs: 0,
+      scopedVars: {},
+      timezone: '',
+      app: '',
+      startTime: 0,
     };
 
     it('should issue the correct query', async () => {

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -339,7 +339,7 @@ export class CloudWatchDatasource
         namespace: this.templateSrv.replace(query.namespace),
         metricName: this.templateSrv.replace(query.metricName),
         dimensions: this.convertDimensionFormat(query.dimensions ?? {}, {}),
-        period: query.period ? parseInt(query.period, 10) : 300,
+        period: query.period ?? '',
         actionPrefix: query.actionPrefix ?? '',
         alarmNamePrefix: query.alarmNamePrefix ?? '',
         type: 'annotationQuery',


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue that was introduced in this [PR](https://github.com/grafana/grafana/pull/51999) when replacing simplejson with encoding/json. While doing so, assumption was made that the `period` field would always be a string. This is true for metric queries, but not for annotation queries so currently they receive a serialization error and fail. 

There should be no reason for annotation queries to not pass `period` as a string, like the other query types. This PR ensures that is the case.

**Which issue(s) this PR fixes**:

Fixes #54786

