### PR TITLE
DataSource: Adding possibility to hide queries from the inspector

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -497,6 +497,9 @@ export interface DataQueryRequest<TQuery extends DataQuery = DataQuery> {
 
   // Explore state used by various datasources
   liveStreaming?: boolean;
+
+  // Make it possible to hide support queries from the inspector
+  hideFromInspector?: boolean;
 }
 
 export interface DataQueryTimings {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -87,6 +87,7 @@ describe('DataSourceWithBackend', () => {
             },
           ],
         },
+        "hideFromInspector": false,
         "method": "POST",
         "requestId": undefined,
         "url": "/api/ds/query",

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -1,5 +1,5 @@
 import { of } from 'rxjs';
-import { BackendSrv, BackendSrvRequest } from 'src/services';
+import { BackendSrv, BackendSrvRequest, FetchResponse } from 'src/services';
 
 import {
   DataSourceJsonData,
@@ -19,7 +19,7 @@ class MyDataSource extends DataSourceWithBackend<DataQuery, DataSourceJsonData> 
   }
 }
 
-const mockDatasourceRequest = jest.fn();
+const mockDatasourceRequest = jest.fn<Promise<FetchResponse>, BackendSrvRequest[]>();
 
 const backendSrv = {
   fetch: (options: BackendSrvRequest) => {
@@ -39,28 +39,15 @@ jest.mock('../services', () => ({
 
 describe('DataSourceWithBackend', () => {
   test('check the executed queries', () => {
-    const settings = {
-      name: 'test',
-      id: 1234,
-      uid: 'abc',
-      type: 'dummy',
-      jsonData: {},
-    } as DataSourceInstanceSettings<DataSourceJsonData>;
-
-    mockDatasourceRequest.mockReset();
-    mockDatasourceRequest.mockReturnValue(Promise.resolve({}));
-    const ds = new MyDataSource(settings);
-
-    ds.query({
+    const mock = runQueryAndReturnFetchMock({
       maxDataPoints: 10,
       intervalMs: 5000,
       targets: [{ refId: 'A' }, { refId: 'B', datasource: { type: 'sample' } }],
     } as DataQueryRequest);
 
-    const mock = mockDatasourceRequest.mock;
-    expect(mock.calls.length).toBe(1);
-
     const args = mock.calls[0][0];
+
+    expect(mock.calls.length).toBe(1);
     expect(args).toMatchInlineSnapshot(`
       Object {
         "data": Object {
@@ -95,6 +82,51 @@ describe('DataSourceWithBackend', () => {
     `);
   });
 
+  test('check that the executed queries is hidden from inspector', () => {
+    const mock = runQueryAndReturnFetchMock({
+      maxDataPoints: 10,
+      intervalMs: 5000,
+      targets: [{ refId: 'A' }, { refId: 'B', datasource: { type: 'sample' } }],
+      hideFromInspector: true,
+    } as DataQueryRequest);
+
+    const args = mock.calls[0][0];
+
+    expect(mock.calls.length).toBe(1);
+    expect(args).toMatchInlineSnapshot(`
+      Object {
+        "data": Object {
+          "queries": Array [
+            Object {
+              "datasource": Object {
+                "type": "dummy",
+                "uid": "abc",
+              },
+              "datasourceId": 1234,
+              "intervalMs": 5000,
+              "maxDataPoints": 10,
+              "refId": "A",
+            },
+            Object {
+              "datasource": Object {
+                "type": "sample",
+                "uid": "?",
+              },
+              "datasourceId": undefined,
+              "intervalMs": 5000,
+              "maxDataPoints": 10,
+              "refId": "B",
+            },
+          ],
+        },
+        "hideFromInspector": true,
+        "method": "POST",
+        "requestId": undefined,
+        "url": "/api/ds/query",
+      }
+    `);
+  });
+
   test('it converts results with channels to streaming queries', () => {
     const request: DataQueryRequest = {
       intervalMs: 100,
@@ -117,3 +149,23 @@ describe('DataSourceWithBackend', () => {
     expect(obs).toBeDefined();
   });
 });
+
+function runQueryAndReturnFetchMock(
+  request: DataQueryRequest
+): jest.MockContext<Promise<FetchResponse>, BackendSrvRequest[]> {
+  const settings = {
+    name: 'test',
+    id: 1234,
+    uid: 'abc',
+    type: 'dummy',
+    jsonData: {},
+  } as DataSourceInstanceSettings<DataSourceJsonData>;
+
+  mockDatasourceRequest.mockReset();
+  mockDatasourceRequest.mockReturnValue(Promise.resolve({} as FetchResponse));
+
+  const ds = new MyDataSource(settings);
+  ds.query(request);
+
+  return mockDatasourceRequest.mock;
+}

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -110,7 +110,7 @@ class DataSourceWithBackend<
    * Ideally final -- any other implementation may not work as expected
    */
   query(request: DataQueryRequest<TQuery>): Observable<DataQueryResponse> {
-    const { intervalMs, maxDataPoints, range, requestId } = request;
+    const { intervalMs, maxDataPoints, range, requestId, hideFromInspector = false } = request;
     let targets = request.targets;
 
     if (this.filterQuery) {
@@ -174,6 +174,7 @@ class DataSourceWithBackend<
         method: 'POST',
         data: body,
         requestId,
+        hideFromInspector,
       })
       .pipe(
         switchMap((raw) => {

--- a/public/app/core/logsModel.ts
+++ b/public/app/core/logsModel.ts
@@ -678,12 +678,16 @@ export function queryLogsVolume<TQuery extends DataQuery, TOptions extends DataS
 ): Observable<DataQueryResponse> {
   const timespan = options.range.to.valueOf() - options.range.from.valueOf();
   const intervalInfo = getIntervalInfo(logsVolumeRequest.scopedVars, timespan);
+
   logsVolumeRequest.interval = intervalInfo.interval;
   logsVolumeRequest.scopedVars.__interval = { value: intervalInfo.interval, text: intervalInfo.interval };
+
   if (intervalInfo.intervalMs !== undefined) {
     logsVolumeRequest.intervalMs = intervalInfo.intervalMs;
     logsVolumeRequest.scopedVars.__interval_ms = { value: intervalInfo.intervalMs, text: intervalInfo.intervalMs };
   }
+
+  logsVolumeRequest.hideFromInspector = true;
 
   return new Observable((observer) => {
     let rawLogsVolume: DataFrame[] = [];


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
When using the `datasource.query` method for any kind of support queries there are currently no way to exclude those queries from the inspector. Which will cause noice and steal attention from the real query. 

See the linked issue for an example on how this is used.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/46087

**Special notes for your reviewer**:
I'm not sure this is the way forward. I open this PR to get feedback on whether this is a good way forward or not.
