### PR TITLE
Alerting: make sure to update contact point references when updating the name

### DIFF
--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -418,6 +418,7 @@ groupLoop:
 				// If we're renaming, we'll need to fix up the macro receiver group for consistency.
 				// Firstly, if we're the only receiver in the group, simply rename the group to match. Done!
 				if len(receiverGroup.GrafanaManagedReceivers) == 1 {
+					replaceReferences(receiverGroup.Name, target.Name, cfg.AlertmanagerConfig.Route)
 					receiverGroup.Name = target.Name
 					receiverGroup.GrafanaManagedReceivers[i] = target
 					configModified = true
@@ -459,4 +460,16 @@ groupLoop:
 	}
 
 	return configModified
+}
+
+func replaceReferences(oldName, newName string, routes ...*apimodels.Route) {
+	if len(routes) == 0 {
+		return
+	}
+	for _, route := range routes {
+		if route.Receiver == oldName {
+			route.Receiver = newName
+		}
+		replaceReferences(oldName, newName, route.Routes...)
+	}
 }

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -319,6 +319,16 @@ func TestStitchReceivers(t *testing.T) {
 			},
 			expModified: true,
 			expCfg: definitions.PostableApiAlertingConfig{
+				Config: definitions.Config{
+					Route: &definitions.Route{
+						Receiver: "receiver-1",
+						Routes: []*definitions.Route{
+							{
+								Receiver: "receiver-1",
+							},
+						},
+					},
+				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
 						Receiver: config.Receiver{
@@ -362,7 +372,7 @@ func TestStitchReceivers(t *testing.T) {
 			},
 		},
 		{
-			name: "rename with only one receiver in group, renames group",
+			name: "rename with only one receiver in group, renames group and references",
 			new: &definitions.PostableGrafanaReceiver{
 				UID:  "abc",
 				Name: "new-receiver",
@@ -370,6 +380,16 @@ func TestStitchReceivers(t *testing.T) {
 			},
 			expModified: true,
 			expCfg: definitions.PostableApiAlertingConfig{
+				Config: definitions.Config{
+					Route: &definitions.Route{
+						Receiver: "new-receiver",
+						Routes: []*definitions.Route{
+							{
+								Receiver: "new-receiver",
+							},
+						},
+					},
+				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
 						Receiver: config.Receiver{
@@ -421,6 +441,16 @@ func TestStitchReceivers(t *testing.T) {
 			},
 			expModified: true,
 			expCfg: definitions.PostableApiAlertingConfig{
+				Config: definitions.Config{
+					Route: &definitions.Route{
+						Receiver: "receiver-1",
+						Routes: []*definitions.Route{
+							{
+								Receiver: "receiver-1",
+							},
+						},
+					},
+				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
 						Receiver: config.Receiver{
@@ -472,6 +502,16 @@ func TestStitchReceivers(t *testing.T) {
 			},
 			expModified: true,
 			expCfg: definitions.PostableApiAlertingConfig{
+				Config: definitions.Config{
+					Route: &definitions.Route{
+						Receiver: "receiver-1",
+						Routes: []*definitions.Route{
+							{
+								Receiver: "receiver-1",
+							},
+						},
+					},
+				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
 						Receiver: config.Receiver{
@@ -533,6 +573,16 @@ func TestStitchReceivers(t *testing.T) {
 			},
 			expModified: true,
 			expCfg: definitions.PostableApiAlertingConfig{
+				Config: definitions.Config{
+					Route: &definitions.Route{
+						Receiver: "receiver-1",
+						Routes: []*definitions.Route{
+							{
+								Receiver: "receiver-1",
+							},
+						},
+					},
+				},
 				Receivers: []*definitions.PostableApiReceiver{
 					{
 						Receiver: config.Receiver{
@@ -604,6 +654,16 @@ func TestStitchReceivers(t *testing.T) {
 func createTestConfigWithReceivers() *definitions.PostableUserConfig {
 	return &definitions.PostableUserConfig{
 		AlertmanagerConfig: definitions.PostableApiAlertingConfig{
+			Config: definitions.Config{
+				Route: &definitions.Route{
+					Receiver: "receiver-1",
+					Routes: []*definitions.Route{
+						{
+							Receiver: "receiver-1",
+						},
+					},
+				},
+			},
 			Receivers: []*definitions.PostableApiReceiver{
 				{
 					Receiver: config.Receiver{
@@ -652,6 +712,16 @@ func createTestConfigWithReceivers() *definitions.PostableUserConfig {
 func createInconsistentTestConfigWithReceivers() *definitions.PostableUserConfig {
 	return &definitions.PostableUserConfig{
 		AlertmanagerConfig: definitions.PostableApiAlertingConfig{
+			Config: definitions.Config{
+				Route: &definitions.Route{
+					Receiver: "receiver-1",
+					Routes: []*definitions.Route{
+						{
+							Receiver: "receiver-1",
+						},
+					},
+				},
+			},
 			Receivers: []*definitions.PostableApiReceiver{
 				{
 					Receiver: config.Receiver{


### PR DESCRIPTION
This PR makes sure that we update the contact point references when updating it.