### PR TITLE
Build: Refactor cron_job_pipeline to take the cron name as a parameter

### DIFF
--- a/scripts/drone/events/cron.star
+++ b/scripts/drone/events/cron.star
@@ -10,18 +10,18 @@ def cronjobs(edition):
         scan_docker_image_pipeline(edition, 'main-ubuntu'),
     ]
 
-def cron_job_pipeline(name, steps):
+def cron_job_pipeline(cronName, name, steps):
     return {
         'kind': 'pipeline',
         'type': 'docker',
         'platform': {
-             'os': 'linux',
+            'os': 'linux',
             'arch': 'amd64',
         },
         'name': name,
         'trigger': {
             'event': 'cron',
-            'cron': 'nightly',
+            'cron': cronName,
         },
         'clone': {
             'retries': 3,
@@ -38,6 +38,7 @@ def scan_docker_image_pipeline(edition, tag):
     dockerImage='grafana/{}:{}'.format(edition, tag)
 
     return cron_job_pipeline(
+        cronName='nightly',
         name='scan-' + dockerImage + '-image',
         steps=[
             scan_docker_image_unkown_low_medium_vulnerabilities_step(dockerImage),


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**: This allows callers of cron_job_pipeline to specify the name of the cron they'd like to be used. This will allow new pipelines not intended to be used with the cron "nightly" to reuse cron_job_pipeline.


**Special notes**: no-op: `make drone` did not yield any changes in yml
