### PR TITLE
Alerting: validate am config changes before persisting

### DIFF
--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -189,7 +189,7 @@ func (ecp *ContactPointService) CreateContactPoint(ctx context.Context, orgID in
 	}
 
 	err = ecp.xact.InTransaction(ctx, func(ctx context.Context) error {
-		err = ecp.amStore.UpdateAlertmanagerConfiguration(ctx, &models.SaveAlertmanagerConfigurationCmd{
+		err = PersistConfig(ctx, ecp.amStore, &models.SaveAlertmanagerConfigurationCmd{
 			AlertmanagerConfiguration: string(data),
 			FetchedConfigurationHash:  revision.concurrencyToken,
 			ConfigurationVersion:      revision.version,
@@ -284,7 +284,7 @@ func (ecp *ContactPointService) UpdateContactPoint(ctx context.Context, orgID in
 		return err
 	}
 	return ecp.xact.InTransaction(ctx, func(ctx context.Context) error {
-		err = ecp.amStore.UpdateAlertmanagerConfiguration(ctx, &models.SaveAlertmanagerConfigurationCmd{
+		err = PersistConfig(ctx, ecp.amStore, &models.SaveAlertmanagerConfigurationCmd{
 			AlertmanagerConfiguration: string(data),
 			FetchedConfigurationHash:  revision.concurrencyToken,
 			ConfigurationVersion:      revision.version,
@@ -344,7 +344,7 @@ func (ecp *ContactPointService) DeleteContactPoint(ctx context.Context, orgID in
 		if err != nil {
 			return err
 		}
-		return ecp.amStore.UpdateAlertmanagerConfiguration(ctx, &models.SaveAlertmanagerConfigurationCmd{
+		return PersistConfig(ctx, ecp.amStore, &models.SaveAlertmanagerConfigurationCmd{
 			AlertmanagerConfiguration: string(data),
 			FetchedConfigurationHash:  revision.concurrencyToken,
 			ConfigurationVersion:      revision.version,

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -77,7 +77,7 @@ func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt definitio
 		OrgID:                     orgID,
 	}
 	err = svc.xact.InTransaction(ctx, func(ctx context.Context) error {
-		err = svc.config.UpdateAlertmanagerConfiguration(ctx, &cmd)
+		err = PersistConfig(ctx, svc.config, &cmd)
 		if err != nil {
 			return err
 		}
@@ -132,7 +132,7 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitio
 		OrgID:                     orgID,
 	}
 	err = svc.xact.InTransaction(ctx, func(ctx context.Context) error {
-		err = svc.config.UpdateAlertmanagerConfiguration(ctx, &cmd)
+		err = PersistConfig(ctx, svc.config, &cmd)
 		if err != nil {
 			return err
 		}
@@ -181,7 +181,7 @@ func (svc *MuteTimingService) DeleteMuteTiming(ctx context.Context, name string,
 		OrgID:                     orgID,
 	}
 	return svc.xact.InTransaction(ctx, func(ctx context.Context) error {
-		err = svc.config.UpdateAlertmanagerConfiguration(ctx, &cmd)
+		err = PersistConfig(ctx, svc.config, &cmd)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -102,7 +102,7 @@ func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgI
 		OrgID:                     orgID,
 	}
 	err = nps.xact.InTransaction(ctx, func(ctx context.Context) error {
-		err = nps.amStore.UpdateAlertmanagerConfiguration(ctx, &cmd)
+		err = PersistConfig(ctx, nps.amStore, &cmd)
 		if err != nil {
 			return err
 		}
@@ -145,7 +145,7 @@ func (nps *NotificationPolicyService) ResetPolicyTree(ctx context.Context, orgID
 		OrgID:                     orgID,
 	}
 	err = nps.xact.InTransaction(ctx, func(ctx context.Context) error {
-		err := nps.amStore.UpdateAlertmanagerConfiguration(ctx, &cmd)
+		err := PersistConfig(ctx, nps.amStore, &cmd)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/ngalert/provisioning/persist.go
+++ b/pkg/services/ngalert/provisioning/persist.go
@@ -2,7 +2,10 @@ package provisioning
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/quota"
@@ -44,4 +47,13 @@ type RuleStore interface {
 //go:generate mockery --name QuotaChecker --structname MockQuotaChecker --inpackage --filename quota_checker_mock.go --with-expecter
 type QuotaChecker interface {
 	CheckQuotaReached(ctx context.Context, target string, scopeParams *quota.ScopeParameters) (bool, error)
+}
+
+// PersistConfig validates to config before eventually persisting it if no error occurs
+func PersistConfig(ctx context.Context, store AMConfigStore, cmd *models.SaveAlertmanagerConfigurationCmd) error {
+	cfg := &definitions.PostableUserConfig{}
+	if err := json.Unmarshal([]byte(cmd.AlertmanagerConfiguration), cfg); err != nil {
+		return fmt.Errorf("change would result in an invalid configruation state: %w", err)
+	}
+	return store.UpdateAlertmanagerConfiguration(ctx, cmd)
 }

--- a/pkg/services/ngalert/provisioning/persist.go
+++ b/pkg/services/ngalert/provisioning/persist.go
@@ -53,7 +53,7 @@ type QuotaChecker interface {
 func PersistConfig(ctx context.Context, store AMConfigStore, cmd *models.SaveAlertmanagerConfigurationCmd) error {
 	cfg := &definitions.PostableUserConfig{}
 	if err := json.Unmarshal([]byte(cmd.AlertmanagerConfiguration), cfg); err != nil {
-		return fmt.Errorf("change would result in an invalid configruation state: %w", err)
+		return fmt.Errorf("change would result in an invalid configuration state: %w", err)
 	}
 	return store.UpdateAlertmanagerConfiguration(ctx, cmd)
 }

--- a/pkg/services/ngalert/provisioning/templates.go
+++ b/pkg/services/ngalert/provisioning/templates.go
@@ -66,7 +66,7 @@ func (t *TemplateService) SetTemplate(ctx context.Context, orgID int64, tmpl def
 		OrgID:                     orgID,
 	}
 	err = t.xact.InTransaction(ctx, func(ctx context.Context) error {
-		err = t.config.UpdateAlertmanagerConfiguration(ctx, &cmd)
+		err = PersistConfig(ctx, t.config, &cmd)
 		if err != nil {
 			return err
 		}
@@ -104,7 +104,7 @@ func (t *TemplateService) DeleteTemplate(ctx context.Context, orgID int64, name 
 		OrgID:                     orgID,
 	}
 	err = t.xact.InTransaction(ctx, func(ctx context.Context) error {
-		err = t.config.UpdateAlertmanagerConfiguration(ctx, &cmd)
+		err = PersistConfig(ctx, t.config, &cmd)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Before persisting any change that came through provisioning, we validate the config.