### PR TITLE
RBAC: Remove service dependency in Evaluator component

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -66,7 +66,7 @@ func (hs *HTTPServer) registerRoutes() {
 	reqSnapshotPublicModeOrSignedIn := middleware.SnapshotPublicModeOrSignedIn(hs.Cfg)
 	redirectFromLegacyPanelEditURL := middleware.RedirectFromLegacyPanelEditURL(hs.Cfg)
 	authorize := ac.Middleware(hs.AccessControl)
-	authorizeInOrg := ac.AuthorizeInOrgMiddleware(hs.AccessControl, hs.userService)
+	authorizeInOrg := ac.AuthorizeInOrgMiddleware(hs.AccessControl, hs.accesscontrolService, hs.userService)
 	quota := middleware.Quota(hs.QuotaService)
 
 	r := hs.RouteRegister

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -381,7 +381,7 @@ func setupHTTPServerWithCfgDb(
 		var err error
 		acService, err = acimpl.ProvideService(cfg, database.ProvideService(db), routeRegister)
 		require.NoError(t, err)
-		ac = acimpl.ProvideAccessControl(cfg, acService)
+		ac = acimpl.ProvideAccessControl(cfg)
 	}
 
 	teamPermissionService, err := ossaccesscontrol.ProvideTeamPermissions(cfg, routeRegister, db, ac, license, acService)

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -706,7 +706,7 @@ func (hs *HTTPServer) buildDataConnectionsNavLink(c *models.ReqContext) *dtos.Na
 
 func (hs *HTTPServer) buildAdminNavLinks(c *models.ReqContext) []*dtos.NavLink {
 	hasAccess := ac.HasAccess(hs.AccessControl, c)
-	hasGlobalAccess := ac.HasGlobalAccess(hs.AccessControl, c)
+	hasGlobalAccess := ac.HasGlobalAccess(hs.AccessControl, hs.accesscontrolService, c)
 	adminNavLinks := []*dtos.NavLink{}
 
 	if hasAccess(ac.ReqGrafanaAdmin, ac.EvalPermission(ac.ActionUsersRead, ac.ScopeGlobalUsersAll)) {

--- a/pkg/api/quota_test.go
+++ b/pkg/api/quota_test.go
@@ -106,21 +106,22 @@ func TestAPIEndpoint_GetOrgQuotas_LegacyAccessControl(t *testing.T) {
 
 func TestAPIEndpoint_GetOrgQuotas_AccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, true)
-	setInitCtxSignedInViewer(sc.initCtx)
-
 	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
 
 	t.Run("AccessControl allows viewing another org quotas with correct permissions", func(t *testing.T) {
+		setInitCtxSignedInViewer(sc.initCtx)
 		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: ActionOrgsQuotasRead}}, 2)
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
 		assert.Equal(t, http.StatusOK, response.Code)
 	})
 	t.Run("AccessControl prevents viewing another org quotas with correct permissions in another org", func(t *testing.T) {
+		setInitCtxSignedInViewer(sc.initCtx)
 		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: ActionOrgsQuotasRead}}, 1)
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
 	})
 	t.Run("AccessControl prevents viewing another org quotas with incorrect permissions", func(t *testing.T) {
+		setInitCtxSignedInViewer(sc.initCtx)
 		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: "orgs:invalid"}}, 2)
 		response := callAPI(sc.server, http.MethodGet, fmt.Sprintf(getOrgsQuotasURL, 2), nil, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
@@ -151,12 +152,11 @@ func TestAPIEndpoint_PutOrgQuotas_LegacyAccessControl(t *testing.T) {
 
 func TestAPIEndpoint_PutOrgQuotas_AccessControl(t *testing.T) {
 	sc := setupHTTPServer(t, true)
-	setInitCtxSignedInViewer(sc.initCtx)
-
 	setupDBAndSettingsForAccessControlQuotaTests(t, sc)
 
 	input := strings.NewReader(testUpdateOrgQuotaCmd)
 	t.Run("AccessControl allows updating another org quotas with correct permissions", func(t *testing.T) {
+		setInitCtxSignedInViewer(sc.initCtx)
 		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: ActionOrgsQuotasWrite}}, 2)
 		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input, t)
 		assert.Equal(t, http.StatusOK, response.Code)
@@ -164,6 +164,7 @@ func TestAPIEndpoint_PutOrgQuotas_AccessControl(t *testing.T) {
 
 	input = strings.NewReader(testUpdateOrgQuotaCmd)
 	t.Run("AccessControl prevents updating another org quotas with correct permissions in another org", func(t *testing.T) {
+		setInitCtxSignedInViewer(sc.initCtx)
 		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: ActionOrgsQuotasWrite}}, 1)
 		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)
@@ -171,6 +172,7 @@ func TestAPIEndpoint_PutOrgQuotas_AccessControl(t *testing.T) {
 
 	input = strings.NewReader(testUpdateOrgQuotaCmd)
 	t.Run("AccessControl prevents updating another org quotas with incorrect permissions", func(t *testing.T) {
+		setInitCtxSignedInViewer(sc.initCtx)
 		setAccessControlPermissions(sc.acmock, []accesscontrol.Permission{{Action: "orgs:invalid"}}, 2)
 		response := callAPI(sc.server, http.MethodPut, fmt.Sprintf(putOrgsQuotasURL, 2, "org_user"), input, t)
 		assert.Equal(t, http.StatusForbidden, response.Code)

--- a/pkg/services/accesscontrol/acimpl/accesscontrol_test.go
+++ b/pkg/services/accesscontrol/acimpl/accesscontrol_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
-
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -65,8 +63,7 @@ func TestAccessControl_Evaluate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			fakeService := actest.FakeService{}
-			ac := ProvideAccessControl(setting.NewCfg(), fakeService)
+			ac := ProvideAccessControl(setting.NewCfg())
 
 			if tt.resolver != nil {
 				ac.RegisterScopeAttributeResolver(tt.resolverPrefix, tt.resolver)

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -271,6 +271,7 @@ func (dr *DashboardServiceImpl) SaveFolderForProvisionedDashboards(ctx context.C
 	dto.User = &user.SignedInUser{
 		UserID:      0,
 		OrgRole:     org.RoleAdmin,
+		OrgID:       dto.OrgId,
 		Permissions: map[int64]map[string][]string{dto.OrgId: provisionerPermissions},
 	}
 	cmd, err := dr.BuildSaveDashboardCommand(ctx, dto, false, false)

--- a/pkg/services/publicdashboards/api/common_test.go
+++ b/pkg/services/publicdashboards/api/common_test.go
@@ -45,16 +45,6 @@ func setupTestServer(
 	// build router to register routes
 	rr := routing.NewRouteRegister()
 
-	// build access control - FIXME we should be able to mock this, but to get
-	// tests going, we're going to instantiate full accesscontrol
-	//ac := accesscontrolmock.New()
-	//ac.WithDisabled()
-
-	// create a sqlstore for access control.
-	if db == nil {
-		db = sqlstore.InitTestDB(t)
-	}
-
 	var permissions []accesscontrol.Permission
 	if user != nil && user.Permissions != nil {
 		for action, scopes := range user.Permissions[user.OrgID] {


### PR DESCRIPTION
**What this PR does / why we need it**:
We want to remove the dependency on access control service.

We now need to inject service into HasGlobalAccess and AuthorizeInOrgMiddleware in order to fetch permissions for a different org.

Some tests needed to be updated.

Those in api package we just needed to set a new user for each request. For public dashboard i changed to use the fake service to provide specified permissions.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

