### PR TITLE
Loki: Fix a bug where adding adhoc filters was not possible

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -639,6 +639,22 @@ describe('LokiDatasource', () => {
         it('then the correct label should be added for metrics query', () => {
           assertAdHocFilters('rate({bar="baz"}[5m])', 'rate({bar="baz", job="grafana"}[5m])', ds);
         });
+
+        it('then the correct label should be added for metrics query and variable', () => {
+          assertAdHocFilters('rate({bar="baz"}[$__interval])', 'rate({bar="baz", job="grafana"}[$__interval])', ds);
+        });
+
+        it('then the correct label should be added for logs query with empty selector', () => {
+          assertAdHocFilters('{}', '{job="grafana"}', ds);
+        });
+
+        it('then the correct label should be added for metrics query with empty selector', () => {
+          assertAdHocFilters('rate({}[5m])', 'rate({job="grafana"}[5m])', ds);
+        });
+
+        it('then the correct label should be added for metrics query with empty selector and variable', () => {
+          assertAdHocFilters('rate({}[$__interval])', 'rate({job="grafana"}[$__interval])', ds);
+        });
       });
       describe('and query has parser', () => {
         it('then the correct label should be added for logs query', () => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -43,6 +43,7 @@ import { getTemplateSrv, TemplateSrv } from 'app/features/templating/template_sr
 
 import { serializeParams } from '../../../core/utils/fetch';
 import { renderLegendFormat } from '../prometheus/legend';
+import { replaceVariables, returnVariables } from '../prometheus/querybuilder/shared/parsingUtils';
 
 import LanguageProvider from './LanguageProvider';
 import { transformBackendResult } from './backendResultTransformer';
@@ -698,14 +699,14 @@ export class LokiDatasource
 
   addAdHocFilters(queryExpr: string) {
     const adhocFilters = this.templateSrv.getAdhocFilters(this.name);
-    let expr = queryExpr;
+    let expr = replaceVariables(queryExpr);
 
     expr = adhocFilters.reduce((acc: string, filter: { key: string; operator: string; value: string }) => {
       const { key, operator, value } = filter;
       return this.addLabelToQuery(acc, key, operator, value);
     }, expr);
 
-    return expr;
+    return returnVariables(expr);
   }
 
   addLabelToQuery(queryExpr: string, key: string, operator: string, value: string) {

--- a/public/app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils.ts
+++ b/public/app/plugins/datasource/prometheus/querybuilder/shared/parsingUtils.ts
@@ -65,7 +65,7 @@ const varTypeFunc = [
  * Get back the text with variables in their original format.
  * @param expr
  */
-function returnVariables(expr: string) {
+export function returnVariables(expr: string) {
   return expr.replace(/__V_(\d)__(.+?)__V__(?:__F__(\w+)__F__)?/g, (match, type, v, f) => {
     return varTypeFunc[parseInt(type, 10)](v, f);
   });


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding adhoc filters to metric queries with empty selectors and variables (like `$__interval`) was erroring. This fix replaces the variables before adding the adhoc filters.

**Which issue(s) this PR fixes**:

Fixes #54448

**Special notes for your reviewer**:
If you want to test ad-hoc filters:
1. Setup a dashboard.
2. Setup a dashboard-adhoc-variable from Loki.
3. Setup a panel with this query: `sum by(host) (count_over_time({}[$__interval]))`
4. Open the dashboard with the adhoc variable set. Something like this in the URL: `var-VARNAME=place%7C%3D%7Cmoon`
5. Before the fix: look at the Network tab in devtools and see that the query is in a wrong format.
6. With the fix: the query is formatted correctly.


