### PR TITLE
DisplayProcessor: Handle reverse-ordered data when auto-showing millis

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -3,6 +3,7 @@ import { createTheme } from '../themes';
 import { FieldConfig, FieldType, ThresholdsMode } from '../types';
 import { DisplayProcessor, DisplayValue } from '../types/displayValue';
 import { MappingType, ValueMapping } from '../types/valueMapping';
+import { ArrayVector } from '../vector';
 
 import { getDisplayProcessor, getRawDisplayProcessor } from './displayProcessor';
 
@@ -339,6 +340,35 @@ describe('Format value', () => {
     expect(disp.text).toEqual('1.19');
     expect(disp.suffix).toEqual(' GiB');
   });
+
+  describe('number formatting for string values', () => {
+    it('should preserve string unchanged if unit is string', () => {
+      const processor = getDisplayProcessorFromConfig({ unit: 'string' }, FieldType.string);
+      expect(processor('22.1122334455').text).toEqual('22.1122334455');
+    });
+
+    it('should preserve string unchanged if no unit is specified', () => {
+      const processor = getDisplayProcessorFromConfig({}, FieldType.string);
+      expect(processor('22.1122334455').text).toEqual('22.1122334455');
+
+      // Support empty/missing strings
+      expect(processor(undefined).text).toEqual('');
+      expect(processor(null).text).toEqual('');
+      expect(processor('').text).toEqual('');
+    });
+
+    it('should format string as number if unit is `none`', () => {
+      const processor = getDisplayProcessorFromConfig({ unit: 'none' }, FieldType.string);
+      expect(processor('0x10').text).toEqual('16');
+    });
+
+    it('should not parse a 64 bit number when the data type is string', () => {
+      const value = '2882377905688543293';
+      const instance = getDisplayProcessorFromConfig({}, FieldType.string);
+      const disp = instance(value);
+      expect(disp.text).toEqual(value);
+    });
+  });
 });
 
 describe('Date display options', () => {
@@ -455,33 +485,48 @@ describe('Date display options', () => {
     expect(processor('2020-12-01T08:48:43.783337').text).toEqual('2020-12-01 09:48:43');
   });
 
-  describe('number formatting for string values', () => {
-    it('should preserve string unchanged if unit is string', () => {
-      const processor = getDisplayProcessorFromConfig({ unit: 'string' }, FieldType.string);
-      expect(processor('22.1122334455').text).toEqual('22.1122334455');
+  it('should include milliseconds when value range is < 60s', () => {
+    const processor = getDisplayProcessor({
+      timeZone: 'utc',
+      field: {
+        type: FieldType.time,
+        config: {},
+        values: new ArrayVector([Date.parse('2020-08-01T08:48:43.783337Z'), Date.parse('2020-08-01T08:49:15.123456Z')]),
+      },
+      theme: createTheme(),
     });
 
-    it('should preserve string unchanged if no unit is specified', () => {
-      const processor = getDisplayProcessorFromConfig({}, FieldType.string);
-      expect(processor('22.1122334455').text).toEqual('22.1122334455');
+    expect(processor('2020-08-01T08:48:43.783337Z').text).toEqual('2020-08-01 08:48:43.783');
+  });
 
-      // Support empty/missing strings
-      expect(processor(undefined).text).toEqual('');
-      expect(processor(null).text).toEqual('');
-      expect(processor('').text).toEqual('');
+  it('should not include milliseconds when value range is >= 60s (reversed)', () => {
+    const processor = getDisplayProcessor({
+      timeZone: 'utc',
+      field: {
+        type: FieldType.time,
+        config: {},
+        values: new ArrayVector([Date.parse('2020-08-01T08:49:15.123456Z'), Date.parse('2020-08-01T08:43:43.783337Z')]),
+      },
+      theme: createTheme(),
     });
 
-    it('should format string as number if unit is `none`', () => {
-      const processor = getDisplayProcessorFromConfig({ unit: 'none' }, FieldType.string);
-      expect(processor('0x10').text).toEqual('16');
+    expect(processor('2020-08-01T08:48:43Z').text).toEqual('2020-08-01 08:48:43');
+  });
+
+  it('should not include milliseconds when value range is < 60s with explicit unit time:', () => {
+    const processor = getDisplayProcessor({
+      timeZone: 'utc',
+      field: {
+        type: FieldType.time,
+        config: {
+          unit: 'time:YYYY-MM-DD HH:mm',
+        },
+        values: new ArrayVector([Date.parse('2020-08-01T08:48:43.783337Z'), Date.parse('2020-08-01T08:49:15.123456Z')]),
+      },
+      theme: createTheme(),
     });
 
-    it('should not parse a 64 bit number when the data type is string', () => {
-      const value = '2882377905688543293';
-      const instance = getDisplayProcessorFromConfig({}, FieldType.string);
-      const disp = instance(value);
-      expect(disp.text).toEqual(value);
-    });
+    expect(processor('2020-08-01T08:48:43.783337Z').text).toEqual('2020-08-01 08:48');
   });
 });
 

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -62,7 +62,7 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
         start /= 1e3;
         end /= 1e3;
       }
-      showMs = end - start < 60; //show ms when minute or less
+      showMs = Math.abs(end - start) < 60; //show ms when minute or less
     }
   } else if (field.type === FieldType.boolean) {
     if (!isBooleanUnit(unit)) {


### PR DESCRIPTION
Context: https://github.com/grafana/grafana/pull/37569#pullrequestreview-1099573015

Related: https://github.com/grafana/grafana/issues/48917