### PR TITLE
InfluxDB: add scopedVars to tags to fix repeated panels querying all selected variables

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -499,7 +499,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       expandedQuery.tags = query.tags.map((tag) => {
         return {
           ...tag,
-          value: this.templateSrv.replace(tag.value, undefined, 'regex'),
+          value: this.templateSrv.replace(tag.value, scopedVars, 'regex'),
         };
       });
     }

--- a/public/app/plugins/datasource/influxdb/specs/datasource.test.ts
+++ b/public/app/plugins/datasource/influxdb/specs/datasource.test.ts
@@ -319,6 +319,19 @@ describe('InfluxDataSource', () => {
         });
         influxChecks(query);
       });
+
+      it('should apply all scopedVars to tags', () => {
+        ds.isFlux = false;
+        ds.access = 'proxy';
+        config.featureToggles.influxdbBackendMigration = true;
+        const query = ds.applyTemplateVariables(influxQuery, {
+          interpolationVar: { text: text, value: text },
+          interpolationVar2: { text: 'interpolationText2', value: 'interpolationText2' },
+        });
+        const value = query.tags[0].value;
+        const scopedVars = 'interpolationText|interpolationText2';
+        expect(value).toBe(scopedVars);
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/54587

This PR is to fix an influxDB issue where scopedVars were not being applied to tags. scopedVars are used for [repeated panels](https://grafana.com/blog/2020/06/09/learn-grafana-how-to-automatically-repeat-rows-and-panels-in-dynamic-dashboards/). 

Without scoped vars multi selected templated variables are all interpolated into the query
![Screen Shot 2022-09-08 at 6 32 01 PM](https://user-images.githubusercontent.com/25674746/189238166-aa3c8a26-0794-4f03-b25a-bff7dd1101e0.png)

With scoped vars each multi selected variable is used in each panel's query
![Screen Shot 2022-09-08 at 6 32 01 PM](https://user-images.githubusercontent.com/25674746/189238144-8de0d63a-5357-4496-8794-88ade82771c8.png)


How to test this:
1. Use an InfluxDB datasource with **InfluxQL**
2. Enable the influxBackendMigration feature toggle(add `influxBackendMigration = true` to you custom.ini file)
3. Create a single panel
4. Create a template variable with InfluxQL that is a tag, eg. `show tag values on mybucket from disk with key = "device"`
5. Make the variable multi select and include all 
![Screen Shot 2022-09-09 at 8 37 35 AM](https://user-images.githubusercontent.com/25674746/189351652-10f6573b-f9c7-48fd-9e10-da02e01bb02a.png)
6. Create a query using the query editor
7. Under Panel Options > Repeat Options, select the variable for Repeat by variable 
![Screen Shot 2022-09-09 at 8 39 45 AM](https://user-images.githubusercontent.com/25674746/189352015-ac2ba9f9-d0b6-439c-85d1-6e3754cc75c2.png)
8.  Apply this and return to the dashboard
9. Select multiple values from the template variable and after selecting, click away from the input to fire the onBlur event and create the repeated panel. 
![Screen Shot 2022-09-09 at 8 42 19 AM](https://user-images.githubusercontent.com/25674746/189352386-a9835f01-8ffd-4976-b79b-8657aa9d9db3.png)
10. In the first panel, check the query to make sure it interpolated only one of the selected variables. 
![Screen Shot 2022-09-09 at 8 43 16 AM](https://user-images.githubusercontent.com/25674746/189352620-e8614b5b-3739-4c42-872c-941e8ade2ec9.png)
