### PR TITLE
CI: Remove `gen-version` from windows pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1515,7 +1515,6 @@ steps:
   - gcloud auth activate-service-account --key-file=gcpkey.json
   - rm gcpkey.json
   - cp C:\App\nssm-2.24.zip .
-  - .\grabpl.exe gen-version --build-id $$env:DRONE_BUILD_NUMBER
   - .\grabpl.exe windows-installer --edition oss --build-id $$env:DRONE_BUILD_NUMBER
   - $$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]
   - gsutil cp $$fname gs://grafana-downloads/oss/main/
@@ -5115,6 +5114,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 6cefdb187edd20260ae51a32f160df1b5523fc48152112284db283b1152f8f4a
+hmac: 5a65475693af9542c3e2f416f041bdc83b13ff186b220a04cdc8c76559b3ecf2
 
 ...

--- a/scripts/drone/pipelines/windows.star
+++ b/scripts/drone/pipelines/windows.star
@@ -55,7 +55,6 @@ def windows(trigger, edition, ver_mode):
             'release',
         ):
             installer_commands.extend([
-                '.\\grabpl.exe gen-version {}'.format(ver_part),
                 '.\\grabpl.exe windows-installer --edition {} {}'.format(edition, ver_part),
                 '$$fname = ((Get-Childitem grafana*.msi -name) -split "`n")[0]',
             ])


### PR DESCRIPTION
**What this PR does / why we need it**:

After https://github.com/grafana/grafana/pull/54638, we can remove all the `gen-version` occurrences. 
This PR removes the last leftover from the windows-pipeline.
