### PR TITLE
Navigation: make sure `AppRoot` is lazily loaded

### DIFF
--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -13,7 +13,6 @@ import { getRoutes as getDataConnectionsRoutes } from 'app/features/data-connect
 import { DATASOURCES_ROUTES } from 'app/features/datasources/constants';
 import { getLiveRoutes } from 'app/features/live/pages/routes';
 import { getRoutes as getPluginCatalogRoutes } from 'app/features/plugins/admin/routes';
-import AppRootPage from 'app/features/plugins/components/AppRootPage';
 import { getProfileRoutes } from 'app/features/profile/routes';
 import { ServiceAccountPage } from 'app/features/serviceaccounts/ServiceAccountPage';
 import { AccessControlAction, DashboardRoutes } from 'app/types';
@@ -39,11 +38,14 @@ export function getAppRoutes(): RouteDescriptor[] {
           component: (props) => {
             const hasRoot = pluginHasRootPage(props.match.params.pluginId, config.bootData.navTree);
             const hasQueryParams = Object.keys(props.queryParams).length > 0;
-            return hasRoot || hasQueryParams ? (
-              <AppRootPage {...props} />
-            ) : (
-              <NavLandingPage navId={`plugin-page-${props.match.params.pluginId}`} />
-            );
+            if (hasRoot || hasQueryParams) {
+              const AppRootPage = SafeDynamicImport(
+                () => import(/* webpackChunkName: "AppRootPage" */ 'app/features/plugins/components/AppRootPage')
+              );
+              return <AppRootPage {...props} />;
+            } else {
+              return <NavLandingPage navId={`plugin-page-${props.match.params.pluginId}`} />;
+            }
           },
         },
       ]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

- a previous PR (https://github.com/grafana/grafana/pull/54576) imported `AppRoot` directly instead of dynamically, causing the unminified bundle to grow from ~16.3mb to ~17.6mb
- this makes sure it's dynamically imported!
- shout out to @leeoniya for noticing ❤️ 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

