### PR TITLE
Alerting: remove interpolation of annotations from alert rule file provisioning

### DIFF
--- a/pkg/services/provisioning/alerting/rules_types.go
+++ b/pkg/services/provisioning/alerting/rules_types.go
@@ -122,7 +122,7 @@ func (rule *AlertRuleV1) mapToModel(orgID int64) (models.AlertRule, error) {
 	if alertRule.Condition == "" {
 		return models.AlertRule{}, fmt.Errorf("rule '%s' failed to parse: no condition set", alertRule.Title)
 	}
-	alertRule.Annotations = rule.Annotations.Value()
+	alertRule.Annotations = rule.Annotations.Raw
 	alertRule.Labels = rule.Labels.Value()
 	for _, queryV1 := range rule.Data {
 		query, err := queryV1.mapToModel()


### PR DESCRIPTION
Annotations might be used for summaries etc. thus they might have variables. It's sensible to remove interpolation for annotations, as I don't think anybody will use env vars there.

Fixes #54850 