### PR TITLE
ElasticSearch: Fix lucene formatted variables being wrongly escaped

### DIFF
--- a/public/app/features/templating/formatRegistry.test.ts
+++ b/public/app/features/templating/formatRegistry.test.ts
@@ -1,0 +1,75 @@
+import { customBuilder } from '../variables/shared/testing/builders';
+
+import { FormatRegistryID, formatRegistry } from './formatRegistry';
+
+const dummyVar = customBuilder().withId('variable').build();
+describe('formatRegistry', () => {
+  describe('with lucene formatter', () => {
+    const { formatter } = formatRegistry.get(FormatRegistryID.lucene);
+
+    it('should escape single value', () => {
+      expect(
+        formatter(
+          {
+            value: 'foo bar',
+            text: '',
+            args: [],
+          },
+          dummyVar
+        )
+      ).toBe('foo\\ bar');
+    });
+
+    it('should not escape negative number', () => {
+      expect(
+        formatter(
+          {
+            value: '-1',
+            text: '',
+            args: [],
+          },
+          dummyVar
+        )
+      ).toBe('-1');
+    });
+
+    it('should escape string prepended with dash', () => {
+      expect(
+        formatter(
+          {
+            value: '-test',
+            text: '',
+            args: [],
+          },
+          dummyVar
+        )
+      ).toBe('\\-test');
+    });
+
+    it('should escape multi value', () => {
+      expect(
+        formatter(
+          {
+            value: ['foo bar', 'baz'],
+            text: '',
+            args: [],
+          },
+          dummyVar
+        )
+      ).toBe('("foo\\ bar" OR "baz")');
+    });
+
+    it('should escape empty value', () => {
+      expect(
+        formatter(
+          {
+            value: [],
+            text: '',
+            args: [],
+          },
+          dummyVar
+        )
+      ).toBe('__empty__');
+    });
+  });
+});

--- a/public/app/features/templating/formatRegistry.ts
+++ b/public/app/features/templating/formatRegistry.ts
@@ -260,6 +260,10 @@ export const formatRegistry = new Registry<FormatRegistryItem>(() => {
 });
 
 function luceneEscape(value: string) {
+  if (isNaN(+value) === false) {
+    return value;
+  }
+
   return value.replace(/([\!\*\+\-\=<>\s\&\|\(\)\[\]\{\}\^\~\?\:\\/"])/g, '\\$1');
 }
 

--- a/public/app/features/templating/formatRegistry.ts
+++ b/public/app/features/templating/formatRegistry.ts
@@ -1,6 +1,6 @@
 import { isArray, map, replace } from 'lodash';
 
-import { dateTime, Registry, RegistryItem, textUtil, VariableModel } from '@grafana/data';
+import { dateTime, Registry, RegistryItem, textUtil, TypedVariableModel } from '@grafana/data';
 import kbn from 'app/core/utils/kbn';
 
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../variables/constants';
@@ -13,7 +13,7 @@ export interface FormatOptions {
 }
 
 export interface FormatRegistryItem extends RegistryItem {
-  formatter(options: FormatOptions, variable: VariableModel): string;
+  formatter(options: FormatOptions, variable: TypedVariableModel): string;
 }
 
 export enum FormatRegistryID {


### PR DESCRIPTION
**What this PR does / why we need it**:
Some template variables when formatted with our Lucene formatter are incorrectly encoded. This PR fixes the following:

1. Negative numbers are assumed as string and then dashes are prepended with a leading `\`. This behaviour is fixed by checking, if a variable is a number and if so, it will not be escaped.
2. Multi level values: I don't believe that the other issues mentioned in #5314 are real bugs, but more the false usage of the `lucene` formatter, where something like `raw` should have been used.

**Which issue(s) this PR fixes**:

Fixes #5314

**Special notes for your reviewer**:
1. Create a dashboard with a template variable.
2. Use the variable in the query.
3. Use a negative number as the variable.
