### PR TITLE
Timeseries: Fix panel options timezones editor save key

### DIFF
--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -17,9 +17,9 @@ export const plugin = new PanelPlugin<TimeSeriesOptions, GraphFieldConfig>(TimeS
     commonOptionsBuilder.addLegendOptions(builder);
 
     builder.addCustomEditor({
-      id: 'timezones',
+      id: 'timezone',
       name: 'Time zone',
-      path: 'timezones',
+      path: 'timezone',
       category: ['Axis'],
       editor: TimezonesEditor,
       defaultValue: undefined,


### PR DESCRIPTION
looks like this was missed in https://github.com/grafana/grafana/pull/53926 when reverting `timezones` -> `timezone`

this makes https://github.com/grafana/grafana/pull/52424 work again.