### PR TITLE
Storybook: use div #root styles on storybook preview instead of additional div wrapper

### DIFF
--- a/packages/grafana-ui/src/utils/storybook/withTheme.tsx
+++ b/packages/grafana-ui/src/utils/storybook/withTheme.tsx
@@ -17,11 +17,11 @@ const ThemeableStory: React.FunctionComponent<{ handleSassThemeChange: SassTheme
   handleSassThemeChange(theme);
 
   const css = `#root {
-    width: 100%,
-    padding: 20px,
-    display: flex,
-    minHeight: 100%,
-    background: ${theme.colors.background.primary}
+    width: 100%;
+    padding: 20px;
+    display: flex;
+    min-height: 100%;
+    background: ${theme.colors.background.primary};
   }`;
 
   return (

--- a/packages/grafana-ui/src/utils/storybook/withTheme.tsx
+++ b/packages/grafana-ui/src/utils/storybook/withTheme.tsx
@@ -16,20 +16,19 @@ const ThemeableStory: React.FunctionComponent<{ handleSassThemeChange: SassTheme
 
   handleSassThemeChange(theme);
 
+  const css = `#root {
+    width: 100%,
+    padding: 20px,
+    display: flex,
+    minHeight: 100%,
+    background: ${theme.colors.background.primary}
+  }`;
+
   return (
     <ThemeContext.Provider value={theme}>
-      <div
-        style={{
-          width: '100%',
-          padding: '20px',
-          display: 'flex',
-          minHeight: '100%',
-          background: `${theme.colors.background.primary}`,
-        }}
-      >
-        <GlobalStyles />
-        {children}
-      </div>
+      <GlobalStyles />
+      <style>{css}</style>
+      {children}
     </ThemeContext.Provider>
   );
 };


### PR DESCRIPTION
**What this PR does / why we need it**:

Hello this PR removes the additional wrapper around every themed stories, and prefers to set the background on the preview #root div instead.

Within story.to.design we use the selector of the first visible element inside the `#root` div to get the root of the representation of the story.

Previously a div wrapper was added inside each story using this `withTheme` decorator.
Without this PR the root for instance for a Button will be a full height flex div instead of just a Button.

This PR will help also story.to.design to generate correctly the stories in Figma.
Here is a screenshot of your storybook with a Button imported via story.to.design with the `Basic` story

![image](https://user-images.githubusercontent.com/1063530/189644337-7b38d265-6c2b-4ef2-87ac-758d84692dc0.png)
