### PR TITLE
PluginLoader: Alias slate-react as @grafana/slate-react

### DIFF
--- a/public/app/features/plugins/plugin_loader.ts
+++ b/public/app/features/plugins/plugin_loader.ts
@@ -86,6 +86,7 @@ exposeToPlugin('react-router-dom', reactRouter);
 exposeToPlugin('prismjs', prismjs);
 exposeToPlugin('slate', slate);
 exposeToPlugin('slate-react', slateReact);
+exposeToPlugin('@grafana/slate-react', slateReact); // for backwards compatibility with older plugins
 exposeToPlugin('slate-plain-serializer', slatePlain);
 exposeToPlugin('react', react);
 exposeToPlugin('react-dom', reactDom);


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue with plugins requesting the "@grafana/slate-react" package which was removed in a [previous PR](https://github.com/grafana/grafana/pull/54566).

