### PR TITLE
Query editor: Allow query editors to create new query

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -382,6 +382,7 @@ export interface QueryEditorProps<
   onRunQuery: () => void;
   onChange: (value: TVQuery) => void;
   onBlur?: () => void;
+  onAddQuery?: (query: TQuery) => void;
   /**
    * Contains query response filtered by refId of QueryResultBase and possible query error
    */

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -381,8 +381,9 @@ export interface QueryEditorProps<
   query: TVQuery;
   onRunQuery: () => void;
   onChange: (value: TVQuery) => void;
+  onAddQuery: (query: TQuery) => void;
   onBlur?: () => void;
-  onAddQuery?: (query: TQuery) => void;
+
   /**
    * Contains query response filtered by refId of QueryResultBase and possible query error
    */

--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -381,9 +381,8 @@ export interface QueryEditorProps<
   query: TVQuery;
   onRunQuery: () => void;
   onChange: (value: TVQuery) => void;
-  onAddQuery: (query: TQuery) => void;
   onBlur?: () => void;
-
+  onAddQuery?: (query: TQuery) => void;
   /**
    * Contains query response filtered by refId of QueryResultBase and possible query error
    */

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -230,7 +230,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   }
 
   renderPluginEditor = () => {
-    const { query, onChange, queries, onRunQuery, app = CoreApp.PanelEditor, history } = this.props;
+    const { query, onChange, queries, onRunQuery, onAddQuery, app = CoreApp.PanelEditor, history } = this.props;
     const { datasource, data } = this.state;
 
     if (datasource?.components?.QueryCtrl) {
@@ -248,6 +248,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
             datasource={datasource}
             onChange={onChange}
             onRunQuery={onRunQuery}
+            onAddQuery={onAddQuery}
             data={data}
             range={getTimeSrv().timeRange()}
             queries={queries}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is needed for [Loki query patterns project](https://github.com/grafana/grafana/issues/52090), where we require a way how to create **new query from Loki query editor**. However, this might be generally useful for query editors - to create new query directly from them. 

<img width="828" alt="image" src="https://user-images.githubusercontent.com/30407135/189658089-ed260038-2608-4494-8653-4cdeb4c7186d.png">

Currently we pass `onAddQuery` to `QueryEditorRow` where we use it in `Duplicate query action`. In this PR, we pass it down to `QueryEditor` so any react query editor can use it as well.

<img width="689" alt="image" src="https://user-images.githubusercontent.com/30407135/189658652-1a56b83b-cefc-4f7e-880d-5c96edeb8536.png">

**Which issue(s) this PR fixes**:

Related to https://github.com/grafana/grafana/issues/52090

