### PR TITLE
Alerting: refactor rule validation so it can be reused in provisioning

### DIFF
--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -144,5 +144,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 		templates:           api.Templates,
 		muteTimings:         api.MuteTimings,
 		alertRules:          api.AlertRules,
+		cfg:                 api.Cfg.UnifiedAlerting,
+		datasourceCache:     api.DatasourceCache,
 	}), m)
 }

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -1,7 +1,6 @@
 package definitions
 
 import (
-	"errors"
 	"time"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -98,25 +97,10 @@ type ProvisionedAlertRule struct {
 	Provenance models.Provenance `json:"provenance,omitempty"`
 }
 
-var (
-	ErrRuleMissingTitle     = errors.New("rule has no title set")
-	ErrRuleMissingFolderUID = errors.New("rule has no folder UID set")
-	ErrRuleMissingRuleGroup = errors.New("rule has no rule group set")
-)
-
 func (a *ProvisionedAlertRule) UpstreamModel() (models.AlertRule, error) {
 	forDur, err := time.ParseDuration(a.For.String())
 	if err != nil {
 		return models.AlertRule{}, err
-	}
-	if a.Title == "" {
-		return models.AlertRule{}, ErrRuleMissingTitle
-	}
-	if a.FolderUID == "" {
-		return models.AlertRule{}, ErrRuleMissingFolderUID
-	}
-	if a.RuleGroup == "" {
-		return models.AlertRule{}, ErrRuleMissingRuleGroup
 	}
 	return models.AlertRule{
 		ID:           a.ID,

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -1,6 +1,7 @@
 package definitions
 
 import (
+	"errors"
 	"time"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -97,10 +98,25 @@ type ProvisionedAlertRule struct {
 	Provenance models.Provenance `json:"provenance,omitempty"`
 }
 
+var (
+	ErrRuleMissingTitle     = errors.New("alert rules has no title set")
+	ErrRuleMissingFolderUID = errors.New("alert rules has no folder UID set")
+	ErrRuleMissingRuleGroup = errors.New("alert rule has no rule group set")
+)
+
 func (a *ProvisionedAlertRule) UpstreamModel() (models.AlertRule, error) {
 	forDur, err := time.ParseDuration(a.For.String())
 	if err != nil {
 		return models.AlertRule{}, err
+	}
+	if a.Title == "" {
+		return models.AlertRule{}, ErrRuleMissingTitle
+	}
+	if a.FolderUID == "" {
+		return models.AlertRule{}, ErrRuleMissingFolderUID
+	}
+	if a.RuleGroup == "" {
+		return models.AlertRule{}, ErrRuleMissingRuleGroup
 	}
 	return models.AlertRule{
 		ID:           a.ID,

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -99,9 +99,9 @@ type ProvisionedAlertRule struct {
 }
 
 var (
-	ErrRuleMissingTitle     = errors.New("alert rules has no title set")
-	ErrRuleMissingFolderUID = errors.New("alert rules has no folder UID set")
-	ErrRuleMissingRuleGroup = errors.New("alert rule has no rule group set")
+	ErrRuleMissingTitle     = errors.New("rule has no title set")
+	ErrRuleMissingFolderUID = errors.New("rule has no folder UID set")
+	ErrRuleMissingRuleGroup = errors.New("rule has no rule group set")
 )
 
 func (a *ProvisionedAlertRule) UpstreamModel() (models.AlertRule, error) {


### PR DESCRIPTION
This PR refactors the rule validation so it can be reused in provisioning. It's splitting up the validation into two parts: the creation of the model object and validation of the model object. The validation part is reused.