### PR TITLE
Public Dashboards: Replace simplejson with TimeSettings on dashboard struct

### DIFF
--- a/pkg/services/publicdashboards/database/database.go
+++ b/pkg/services/publicdashboards/database/database.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
@@ -183,7 +184,7 @@ func (d *PublicDashboardStoreImpl) SavePublicDashboardConfig(ctx context.Context
 // updates existing public dashboard configuration
 func (d *PublicDashboardStoreImpl) UpdatePublicDashboardConfig(ctx context.Context, cmd SavePublicDashboardConfigCommand) error {
 	err := d.sqlStore.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
-		timeSettingsJSON, err := cmd.PublicDashboard.TimeSettings.MarshalJSON()
+		timeSettingsJSON, err := json.Marshal(cmd.PublicDashboard.TimeSettings)
 		if err != nil {
 			return err
 		}

--- a/pkg/services/publicdashboards/database/database_test.go
+++ b/pkg/services/publicdashboards/database/database_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 // This is what the db sets empty time settings to
-var DefaultTimeSettings, _ = simplejson.NewJson([]byte(`{}`))
+var DefaultTimeSettings = &TimeSettings{}
 
 // Default time to pass in with seconds rounded
 var DefaultTime = time.Now().UTC().Round(time.Second)
@@ -361,7 +361,7 @@ func TestIntegrationUpdatePublicDashboard(t *testing.T) {
 			DashboardUid: savedDashboard.Uid,
 			OrgId:        savedDashboard.OrgId,
 			IsEnabled:    false,
-			TimeSettings: simplejson.NewFromAny(map[string]interface{}{"from": "now-8", "to": "now"}),
+			TimeSettings: &TimeSettings{From: "now-8", To: "now"},
 			UpdatedAt:    time.Now().UTC().Round(time.Second),
 			UpdatedBy:    8,
 		}

--- a/pkg/services/publicdashboards/models/models.go
+++ b/pkg/services/publicdashboards/models/models.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/tsdb/legacydata"
 )
@@ -58,12 +57,12 @@ var (
 )
 
 type PublicDashboard struct {
-	Uid          string           `json:"uid" xorm:"pk uid"`
-	DashboardUid string           `json:"dashboardUid" xorm:"dashboard_uid"`
-	OrgId        int64            `json:"-" xorm:"org_id"` // Don't ever marshal orgId to Json
-	TimeSettings *simplejson.Json `json:"timeSettings" xorm:"time_settings"`
-	IsEnabled    bool             `json:"isEnabled" xorm:"is_enabled"`
-	AccessToken  string           `json:"accessToken" xorm:"access_token"`
+	Uid          string        `json:"uid" xorm:"pk uid"`
+	DashboardUid string        `json:"dashboardUid" xorm:"dashboard_uid"`
+	OrgId        int64         `json:"-" xorm:"org_id"` // Don't ever marshal orgId to Json
+	TimeSettings *TimeSettings `json:"timeSettings" xorm:"time_settings"`
+	IsEnabled    bool          `json:"isEnabled" xorm:"is_enabled"`
+	AccessToken  string        `json:"accessToken" xorm:"access_token"`
 
 	CreatedBy int64 `json:"createdBy" xorm:"created_by"`
 	UpdatedBy int64 `json:"updatedBy" xorm:"updated_by"`
@@ -77,8 +76,8 @@ func (pd PublicDashboard) TableName() string {
 }
 
 type TimeSettings struct {
-	From string `json:"from"`
-	To   string `json:"to"`
+	From string `json:"from,omitempty"`
+	To   string `json:"to,omitempty"`
 }
 
 // build time settings object from json on public dashboard. If empty, use

--- a/pkg/services/publicdashboards/models/models.go
+++ b/pkg/services/publicdashboards/models/models.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"strconv"
 	"time"
 
@@ -78,6 +79,14 @@ func (pd PublicDashboard) TableName() string {
 type TimeSettings struct {
 	From string `json:"from,omitempty"`
 	To   string `json:"to,omitempty"`
+}
+
+func (ts *TimeSettings) FromDB(data []byte) error {
+	return json.Unmarshal(data, ts)
+}
+
+func (ts *TimeSettings) ToDB() ([]byte, error) {
+	return json.Marshal(ts)
 }
 
 // build time settings object from json on public dashboard. If empty, use

--- a/pkg/services/publicdashboards/models/models_test.go
+++ b/pkg/services/publicdashboards/models/models_test.go
@@ -34,7 +34,7 @@ func TestBuildTimeSettings(t *testing.T) {
 		{
 			name:      "should use dashboard time even if pubdash time exists",
 			dashboard: &models.Dashboard{Data: dashboardData},
-			pubdash:   &PublicDashboard{TimeSettings: simplejson.NewFromAny(map[string]interface{}{"from": "now-12", "to": "now"})},
+			pubdash:   &PublicDashboard{TimeSettings: &TimeSettings{From: "now-12", To: "now"}},
 			timeResult: TimeSettings{
 				From: fromMs,
 				To:   toMs,

--- a/pkg/services/publicdashboards/service/service.go
+++ b/pkg/services/publicdashboards/service/service.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/api/dtos"
-	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -109,7 +108,7 @@ func (pd *PublicDashboardServiceImpl) SavePublicDashboardConfig(ctx context.Cont
 
 	// set default value for time settings
 	if dto.PublicDashboard.TimeSettings == nil {
-		dto.PublicDashboard.TimeSettings = simplejson.New()
+		dto.PublicDashboard.TimeSettings = &TimeSettings{}
 	}
 
 	// get existing public dashboard if exists

--- a/pkg/services/publicdashboards/service/service_test.go
+++ b/pkg/services/publicdashboards/service/service_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/grafana/grafana/pkg/tsdb/intervalv2"
 )
 
-var timeSettings, _ = simplejson.NewJson([]byte(`{"from": "now-12h", "to": "now"}`))
-var defaultPubdashTimeSettings, _ = simplejson.NewJson([]byte(`{}`))
+var timeSettings = &TimeSettings{From: "now-12h", To: "now"}
+var defaultPubdashTimeSettings = &TimeSettings{}
 var dashboardData = simplejson.NewFromAny(map[string]interface{}{"time": map[string]interface{}{"from": "now-8h", "to": "now"}})
 var SignedInUser = &user.SignedInUser{UserID: 1234, Login: "user@login.com"}
 

--- a/pkg/services/publicdashboards/service/service_test.go
+++ b/pkg/services/publicdashboards/service/service_test.go
@@ -325,10 +325,7 @@ func TestUpdatePublicDashboard(t *testing.T) {
 		updatedPubdash, err := service.SavePublicDashboardConfig(context.Background(), SignedInUser, dto)
 		require.NoError(t, err)
 
-		timeSettings, err := simplejson.NewJson([]byte("{}"))
-		require.NoError(t, err)
-
-		assert.Equal(t, timeSettings, updatedPubdash.TimeSettings)
+		assert.Equal(t, &TimeSettings{}, updatedPubdash.TimeSettings)
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Since we should avoid using simplejson to ease code maintainability, this PR replaces the simplejson.Json type used in the TimeSettings field of the PublicDashboards struct in favor of using the already existing TimeSettings struct and the default `encoding/json` package. 

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/4484

**Special notes for your reviewer**:

