### PR TITLE
Alerting: Fix legacy migration crash when rule name is too long

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
@@ -123,7 +123,6 @@ func createTestDashAlert() dashAlert {
 		Name:           "test",
 		ParsedSettings: &dashAlertSettings{},
 	}
-
 }
 
 func createTestDashAlertCondition() condition {

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
@@ -2,6 +2,7 @@ package ualert
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -82,5 +83,52 @@ func TestAddMigrationInfo(t *testing.T) {
 			require.Equal(t, tc.expectedLabels, labels)
 			require.Equal(t, tc.expectedAnnotations, annotations)
 		})
+	}
+}
+
+func TestMakeAlertRule(t *testing.T) {
+	t.Run("when mapping rule names", func(t *testing.T) {
+		t.Run("leaves basic names untouched", func(t *testing.T) {
+			m := newTestMigration(t)
+			da := createTestDashAlert()
+			cnd := createTestDashAlertCondition()
+
+			ar, err := m.makeAlertRule(cnd, da, "folder")
+
+			require.NoError(t, err)
+			require.Equal(t, da.Name, ar.Title)
+			require.Equal(t, ar.Title, ar.RuleGroup)
+		})
+
+		t.Run("truncates very long names to max length", func(t *testing.T) {
+			m := newTestMigration(t)
+			da := createTestDashAlert()
+			da.Name = strings.Repeat("a", DefaultFieldMaxLength+1)
+			cnd := createTestDashAlertCondition()
+
+			ar, err := m.makeAlertRule(cnd, da, "folder")
+
+			require.NoError(t, err)
+			require.Len(t, ar.Title, DefaultFieldMaxLength)
+			uniq := ar.Title[len(ar.Title)-11:]
+			require.Regexp(t, "^_.{10}$", uniq)
+			require.Equal(t, ar.Title, ar.RuleGroup)
+		})
+
+	})
+}
+
+func createTestDashAlert() dashAlert {
+	return dashAlert{
+		Id:             1,
+		Name:           "test",
+		ParsedSettings: &dashAlertSettings{},
+	}
+
+}
+
+func createTestDashAlertCondition() condition {
+	return condition{
+		Condition: "A",
 	}
 }

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_test.go
@@ -114,7 +114,6 @@ func TestMakeAlertRule(t *testing.T) {
 			require.Regexp(t, "^_.{10}$", uniq)
 			require.Equal(t, ar.Title, ar.RuleGroup)
 		})
-
 	})
 }
 

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -6,6 +6,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 )
 
+const UIDMaxLength = 40
+
 // AddMigration defines database migrations.
 func AddTablesMigrations(mg *migrator.Migrator) {
 	AddAlertDefinitionMigrations(mg, 60)
@@ -44,7 +46,7 @@ func AddAlertDefinitionMigrations(mg *migrator.Migrator, defaultIntervalSeconds 
 			{Name: "updated", Type: migrator.DB_DateTime, Nullable: false},
 			{Name: "interval_seconds", Type: migrator.DB_BigInt, Nullable: false, Default: fmt.Sprintf("%d", defaultIntervalSeconds)},
 			{Name: "version", Type: migrator.DB_Int, Nullable: false, Default: "0"},
-			{Name: "uid", Type: migrator.DB_NVarchar, Length: 40, Nullable: false, Default: "0"},
+			{Name: "uid", Type: migrator.DB_NVarchar, Length: UIDMaxLength, Nullable: false, Default: "0"},
 		},
 		Indices: []*migrator.Index{
 			{Cols: []string{"org_id", "title"}, Type: migrator.IndexType},
@@ -87,7 +89,7 @@ func AddAlertDefinitionVersionMigrations(mg *migrator.Migrator) {
 		Columns: []*migrator.Column{
 			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
 			{Name: "alert_definition_id", Type: migrator.DB_BigInt},
-			{Name: "alert_definition_uid", Type: migrator.DB_NVarchar, Length: 40, Nullable: false, Default: "0"},
+			{Name: "alert_definition_uid", Type: migrator.DB_NVarchar, Length: UIDMaxLength, Nullable: false, Default: "0"},
 			{Name: "parent_version", Type: migrator.DB_Int, Nullable: false},
 			{Name: "restored_from", Type: migrator.DB_Int, Nullable: false},
 			{Name: "version", Type: migrator.DB_Int, Nullable: false},
@@ -116,7 +118,7 @@ func AlertInstanceMigration(mg *migrator.Migrator) {
 		Name: "alert_instance",
 		Columns: []*migrator.Column{
 			{Name: "def_org_id", Type: migrator.DB_BigInt, Nullable: false},
-			{Name: "def_uid", Type: migrator.DB_NVarchar, Length: 40, Nullable: false, Default: "0"},
+			{Name: "def_uid", Type: migrator.DB_NVarchar, Length: UIDMaxLength, Nullable: false, Default: "0"},
 			{Name: "labels", Type: migrator.DB_Text, Nullable: false},
 			{Name: "labels_hash", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "current_state", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
@@ -174,9 +176,9 @@ func AddAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64)
 			{Name: "updated", Type: migrator.DB_DateTime, Nullable: false},
 			{Name: "interval_seconds", Type: migrator.DB_BigInt, Nullable: false, Default: fmt.Sprintf("%d", defaultIntervalSeconds)},
 			{Name: "version", Type: migrator.DB_Int, Nullable: false, Default: "0"},
-			{Name: "uid", Type: migrator.DB_NVarchar, Length: 40, Nullable: false, Default: "0"},
+			{Name: "uid", Type: migrator.DB_NVarchar, Length: UIDMaxLength, Nullable: false, Default: "0"},
 			// the following fields will correspond to a dashboard (or folder) UIID
-			{Name: "namespace_uid", Type: migrator.DB_NVarchar, Length: 40, Nullable: false},
+			{Name: "namespace_uid", Type: migrator.DB_NVarchar, Length: UIDMaxLength, Nullable: false},
 			{Name: "rule_group", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "no_data_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "'NoData'"},
 			{Name: "exec_err_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "'Alerting'"},
@@ -259,9 +261,9 @@ func AddAlertRuleVersionMigrations(mg *migrator.Migrator) {
 		Columns: []*migrator.Column{
 			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
 			{Name: "rule_org_id", Type: migrator.DB_BigInt},
-			{Name: "rule_uid", Type: migrator.DB_NVarchar, Length: 40, Nullable: false, Default: "0"},
+			{Name: "rule_uid", Type: migrator.DB_NVarchar, Length: UIDMaxLength, Nullable: false, Default: "0"},
 			// the following fields will correspond to a dashboard (or folder) UID
-			{Name: "rule_namespace_uid", Type: migrator.DB_NVarchar, Length: 40, Nullable: false},
+			{Name: "rule_namespace_uid", Type: migrator.DB_NVarchar, Length: UIDMaxLength, Nullable: false},
 			{Name: "rule_group", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
 			{Name: "parent_version", Type: migrator.DB_Int, Nullable: false},
 			{Name: "restored_from", Type: migrator.DB_Int, Nullable: false},

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -6,6 +6,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 )
 
+// DefaultFieldMaxLength is the standard size for most user-settable string fields in Alerting. Use this for typical string fields, unless you have a special reason not to.
+const DefaultFieldMaxLength = 190
+
+// UIDMaxLength is the standard size for fields that contain UIDs.
 const UIDMaxLength = 40
 
 // AddMigration defines database migrations.
@@ -40,8 +44,8 @@ func AddAlertDefinitionMigrations(mg *migrator.Migrator, defaultIntervalSeconds 
 		Columns: []*migrator.Column{
 			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
 			{Name: "org_id", Type: migrator.DB_BigInt, Nullable: false},
-			{Name: "title", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
-			{Name: "condition", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "title", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
+			{Name: "condition", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
 			{Name: "data", Type: migrator.DB_Text, Nullable: false},
 			{Name: "updated", Type: migrator.DB_DateTime, Nullable: false},
 			{Name: "interval_seconds", Type: migrator.DB_BigInt, Nullable: false, Default: fmt.Sprintf("%d", defaultIntervalSeconds)},
@@ -94,8 +98,8 @@ func AddAlertDefinitionVersionMigrations(mg *migrator.Migrator) {
 			{Name: "restored_from", Type: migrator.DB_Int, Nullable: false},
 			{Name: "version", Type: migrator.DB_Int, Nullable: false},
 			{Name: "created", Type: migrator.DB_DateTime, Nullable: false},
-			{Name: "title", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
-			{Name: "condition", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "title", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
+			{Name: "condition", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
 			{Name: "data", Type: migrator.DB_Text, Nullable: false},
 			{Name: "interval_seconds", Type: migrator.DB_BigInt, Nullable: false},
 		},
@@ -120,8 +124,8 @@ func AlertInstanceMigration(mg *migrator.Migrator) {
 			{Name: "def_org_id", Type: migrator.DB_BigInt, Nullable: false},
 			{Name: "def_uid", Type: migrator.DB_NVarchar, Length: UIDMaxLength, Nullable: false, Default: "0"},
 			{Name: "labels", Type: migrator.DB_Text, Nullable: false},
-			{Name: "labels_hash", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
-			{Name: "current_state", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "labels_hash", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
+			{Name: "current_state", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
 			{Name: "current_state_since", Type: migrator.DB_BigInt, Nullable: false},
 			{Name: "last_eval_time", Type: migrator.DB_BigInt, Nullable: false},
 		},
@@ -160,7 +164,7 @@ func AlertInstanceMigration(mg *migrator.Migrator) {
 
 	mg.AddMigration("add current_reason column related to current_state",
 		migrator.NewAddColumnMigration(alertInstance, &migrator.Column{
-			Name: "current_reason", Type: migrator.DB_NVarchar, Length: 190, Nullable: true,
+			Name: "current_reason", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: true,
 		}))
 }
 
@@ -170,8 +174,8 @@ func AddAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64)
 		Columns: []*migrator.Column{
 			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
 			{Name: "org_id", Type: migrator.DB_BigInt, Nullable: false},
-			{Name: "title", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
-			{Name: "condition", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "title", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
+			{Name: "condition", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
 			{Name: "data", Type: migrator.DB_Text, Nullable: false},
 			{Name: "updated", Type: migrator.DB_DateTime, Nullable: false},
 			{Name: "interval_seconds", Type: migrator.DB_BigInt, Nullable: false, Default: fmt.Sprintf("%d", defaultIntervalSeconds)},
@@ -179,7 +183,7 @@ func AddAlertRuleMigrations(mg *migrator.Migrator, defaultIntervalSeconds int64)
 			{Name: "uid", Type: migrator.DB_NVarchar, Length: UIDMaxLength, Nullable: false, Default: "0"},
 			// the following fields will correspond to a dashboard (or folder) UIID
 			{Name: "namespace_uid", Type: migrator.DB_NVarchar, Length: UIDMaxLength, Nullable: false},
-			{Name: "rule_group", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "rule_group", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
 			{Name: "no_data_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "'NoData'"},
 			{Name: "exec_err_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "'Alerting'"},
 		},
@@ -264,13 +268,13 @@ func AddAlertRuleVersionMigrations(mg *migrator.Migrator) {
 			{Name: "rule_uid", Type: migrator.DB_NVarchar, Length: UIDMaxLength, Nullable: false, Default: "0"},
 			// the following fields will correspond to a dashboard (or folder) UID
 			{Name: "rule_namespace_uid", Type: migrator.DB_NVarchar, Length: UIDMaxLength, Nullable: false},
-			{Name: "rule_group", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "rule_group", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
 			{Name: "parent_version", Type: migrator.DB_Int, Nullable: false},
 			{Name: "restored_from", Type: migrator.DB_Int, Nullable: false},
 			{Name: "version", Type: migrator.DB_Int, Nullable: false},
 			{Name: "created", Type: migrator.DB_DateTime, Nullable: false},
-			{Name: "title", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
-			{Name: "condition", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "title", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
+			{Name: "condition", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
 			{Name: "data", Type: migrator.DB_Text, Nullable: false},
 			{Name: "interval_seconds", Type: migrator.DB_BigInt, Nullable: false},
 			{Name: "no_data_state", Type: migrator.DB_NVarchar, Length: 15, Nullable: false, Default: "'NoData'"},
@@ -370,9 +374,9 @@ func AddProvisioningMigrations(mg *migrator.Migrator) {
 		Columns: []*migrator.Column{
 			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
 			{Name: "org_id", Type: migrator.DB_BigInt, Nullable: false},
-			{Name: "record_key", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
-			{Name: "record_type", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
-			{Name: "provenance", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "record_key", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
+			{Name: "record_type", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
+			{Name: "provenance", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
 		},
 		Indices: []*migrator.Index{
 			{Cols: []string{"record_type", "record_key", "org_id"}, Type: migrator.UniqueIndex},
@@ -388,9 +392,9 @@ func AddAlertImageMigrations(mg *migrator.Migrator) {
 		Name: "alert_image",
 		Columns: []*migrator.Column{
 			{Name: "id", Type: migrator.DB_BigInt, IsPrimaryKey: true, IsAutoIncrement: true},
-			{Name: "token", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
-			{Name: "path", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
-			{Name: "url", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "token", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
+			{Name: "path", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
+			{Name: "url", Type: migrator.DB_NVarchar, Length: DefaultFieldMaxLength, Nullable: false},
 			{Name: "created_at", Type: migrator.DB_DateTime, Nullable: false},
 			{Name: "expires_at", Type: migrator.DB_DateTime, Nullable: false},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

The rule column in ngalerting has a width of `190`. In legacy, dashboard alerts were part of JSON and had no implicit limit.

If you create a legacy alert with a name longer than 190 characters, it will cause the migration to crash.

This PR truncates the name and adds a uniquifier to the end if this happens. This prevents collisions caused by truncation. The user can then fix up the name in the UI if they care to. This is rare enough that I'm not concerned about this harming the UX of the migration.

I vetted other usages of this field in the  migration code. This doesn't break things like migrated notification policies or silences, which match on UID, not name.

**Which issue(s) this PR fixes**:

Fixes # https://github.com/grafana/grafana/issues/55044

**Special notes for your reviewer**:

