### PR TITLE
Bar Gauge: fix flip direction when adding data links

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinksContextMenu.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinksContextMenu.tsx
@@ -62,7 +62,7 @@ export const DataLinksContextMenu: React.FC<DataLinksContextMenuProps> = ({ chil
         onClick={linkModel.onClick}
         target={linkModel.target}
         title={linkModel.title}
-        style={{ ...style, overflow: 'hidden' }}
+        style={{ ...style, overflow: 'hidden', display: 'flex' }}
         aria-label={selectors.components.DataLinksContextMenu.singleLink}
       >
         {children({})}


### PR DESCRIPTION
**What this PR does / why we need it**:
Bar Gauge (vertical orientation) flips direction when a data link is added.

**Which issue(s) this PR fixes**:

Fixes #53992 and #54936 

**Special notes for your reviewer**:

