### PR TITLE
OAuth: Do not enforce auto assign org role

### DIFF
--- a/pkg/login/social/azuread_oauth_test.go
+++ b/pkg/login/social/azuread_oauth_test.go
@@ -54,14 +54,14 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				ID:                "1234",
 			},
 			fields: fields{
-				SocialBase: &SocialBase{autoAssignOrgRole: "Viewer"},
+				SocialBase: &SocialBase{},
 			},
 			want: &BasicUserInfo{
 				Id:     "1234",
 				Name:   "My Name",
 				Email:  "me@example.com",
 				Login:  "me@example.com",
-				Role:   "Viewer",
+				Role:   "",
 				Groups: []string{},
 			},
 		},
@@ -93,14 +93,14 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				ID:                "1234",
 			},
 			fields: fields{
-				SocialBase: &SocialBase{autoAssignOrgRole: "Viewer"},
+				SocialBase: &SocialBase{},
 			},
 			want: &BasicUserInfo{
 				Id:     "1234",
 				Name:   "My Name",
 				Email:  "me@example.com",
 				Login:  "me@example.com",
-				Role:   "Viewer",
+				Role:   "",
 				Groups: []string{},
 			},
 		},
@@ -154,7 +154,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				Name:   "My Name",
 				Email:  "me@example.com",
 				Login:  "me@example.com",
-				Role:   "Viewer",
+				Role:   "",
 				Groups: []string{},
 			},
 		},
@@ -168,14 +168,14 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				ID:                "1234",
 			},
 			fields: fields{
-				SocialBase: &SocialBase{autoAssignOrgRole: "Editor"},
+				SocialBase: &SocialBase{},
 			},
 			want: &BasicUserInfo{
 				Id:     "1234",
 				Name:   "My Name",
 				Email:  "me@example.com",
 				Login:  "me@example.com",
-				Role:   "Editor",
+				Role:   "",
 				Groups: []string{},
 			},
 		},
@@ -239,7 +239,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 			name: "Editor roles in claim and GrafanaAdminAssignment enabled",
 			fields: fields{
 				SocialBase: newSocialBase("azuread",
-					&oauth2.Config{}, &OAuthInfo{AllowAssignGrafanaAdmin: true}, "")},
+					&oauth2.Config{}, &OAuthInfo{AllowAssignGrafanaAdmin: true})},
 			claims: &azureClaims{
 				Email:             "me@example.com",
 				PreferredUsername: "",
@@ -297,7 +297,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 			name: "Error if user is a member of allowed_groups",
 			fields: fields{
 				allowedGroups: []string{"foo", "bar"},
-				SocialBase:    &SocialBase{autoAssignOrgRole: "Viewer"},
+				SocialBase:    &SocialBase{},
 			},
 			claims: &azureClaims{
 				Email:             "me@example.com",
@@ -312,14 +312,14 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 				Name:   "My Name",
 				Email:  "me@example.com",
 				Login:  "me@example.com",
-				Role:   "Viewer",
+				Role:   "",
 				Groups: []string{"foo"},
 			},
 		},
 		{
 			name: "Fetch groups when ClaimsNames and ClaimsSources is set",
 			fields: fields{
-				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, ""),
+				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}),
 			},
 			claims: &azureClaims{
 				ID:                "1",
@@ -344,7 +344,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 		{
 			name: "Fetch empty role when strict attribute role is true and no match",
 			fields: fields{
-				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{RoleAttributeStrict: true}, ""),
+				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{RoleAttributeStrict: true}),
 			},
 			claims: &azureClaims{
 				Email:             "me@example.com",
@@ -360,7 +360,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 		{
 			name: "Fetch empty role when strict attribute role is true and no role claims returned",
 			fields: fields{
-				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{RoleAttributeStrict: true}, ""),
+				SocialBase: newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{RoleAttributeStrict: true}),
 			},
 			claims: &azureClaims{
 				Email:             "me@example.com",
@@ -383,7 +383,7 @@ func TestSocialAzureAD_UserInfo(t *testing.T) {
 			}
 
 			if tt.fields.SocialBase == nil {
-				s.SocialBase = newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{}, "")
+				s.SocialBase = newSocialBase("azuread", &oauth2.Config{}, &OAuthInfo{})
 			}
 
 			key := []byte("secret")

--- a/pkg/login/social/github_oauth_test.go
+++ b/pkg/login/social/github_oauth_test.go
@@ -116,7 +116,6 @@ func TestSocialGitHub_UserInfo(t *testing.T) {
 		userTeamsRawJSON         string
 		settingAutoAssignOrgRole string
 		roleAttributePath        string
-		autoAssignOrgRole        string
 		want                     *BasicUserInfo
 		wantErr                  bool
 	}{
@@ -124,7 +123,6 @@ func TestSocialGitHub_UserInfo(t *testing.T) {
 			name:              "Basic User info",
 			userRawJSON:       testGHUserJSON,
 			userTeamsRawJSON:  testGHUserTeamsJSON,
-			autoAssignOrgRole: "",
 			roleAttributePath: "",
 			want: &BasicUserInfo{
 				Id:     "1",
@@ -139,7 +137,6 @@ func TestSocialGitHub_UserInfo(t *testing.T) {
 			name:              "Admin mapping takes precedence over auto assign org role",
 			roleAttributePath: "[login==octocat] && 'Admin' || 'Viewer'",
 			userRawJSON:       testGHUserJSON,
-			autoAssignOrgRole: "Editor",
 			userTeamsRawJSON:  testGHUserTeamsJSON,
 			want: &BasicUserInfo{
 				Id:     "1",
@@ -154,7 +151,6 @@ func TestSocialGitHub_UserInfo(t *testing.T) {
 			name:              "Editor mapping via groups",
 			roleAttributePath: "contains(groups[*], '@github/justice-league') && 'Editor' || 'Viewer'",
 			userRawJSON:       testGHUserJSON,
-			autoAssignOrgRole: "Viewer",
 			userTeamsRawJSON:  testGHUserTeamsJSON,
 			want: &BasicUserInfo{
 				Id:     "1",
@@ -169,7 +165,6 @@ func TestSocialGitHub_UserInfo(t *testing.T) {
 			name:              "auto assign org role",
 			roleAttributePath: "",
 			userRawJSON:       testGHUserJSON,
-			autoAssignOrgRole: "Editor",
 			userTeamsRawJSON:  testGHUserTeamsJSON,
 			want: &BasicUserInfo{
 				Id:     "1",
@@ -202,7 +197,7 @@ func TestSocialGitHub_UserInfo(t *testing.T) {
 
 			s := &SocialGithub{
 				SocialBase: newSocialBase("github", &oauth2.Config{},
-					&OAuthInfo{RoleAttributePath: tt.roleAttributePath}, tt.autoAssignOrgRole),
+					&OAuthInfo{RoleAttributePath: tt.roleAttributePath}),
 				allowedOrganizations: []string{},
 				apiUrl:               server.URL + "/user",
 				teamIds:              []int{},

--- a/pkg/login/social/github_oauth_test.go
+++ b/pkg/login/social/github_oauth_test.go
@@ -154,7 +154,7 @@ func TestSocialGitHub_UserInfo(t *testing.T) {
 			name:              "Editor mapping via groups",
 			roleAttributePath: "contains(groups[*], '@github/justice-league') && 'Editor' || 'Viewer'",
 			userRawJSON:       testGHUserJSON,
-			autoAssignOrgRole: "Editor",
+			autoAssignOrgRole: "Viewer",
 			userTeamsRawJSON:  testGHUserTeamsJSON,
 			want: &BasicUserInfo{
 				Id:     "1",
@@ -176,7 +176,7 @@ func TestSocialGitHub_UserInfo(t *testing.T) {
 				Name:   "monalisa octocat",
 				Email:  "octocat@github.com",
 				Login:  "octocat",
-				Role:   "Editor",
+				Role:   "", // user will be automatically assigned role on user creation
 				Groups: []string{"https://github.com/orgs/github/teams/justice-league", "@github/justice-league"},
 			},
 		},

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -314,10 +314,6 @@ type groupStruct struct {
 
 func (s *SocialBase) extractRoleAndAdmin(rawJSON []byte, groups []string) (org.RoleType, bool) {
 	if s.roleAttributePath == "" {
-		if s.autoAssignOrgRole != "" {
-			return org.RoleType(s.autoAssignOrgRole), false
-		}
-
 		return "", false
 	}
 

--- a/pkg/login/social/social.go
+++ b/pkg/login/social/social.go
@@ -139,7 +139,7 @@ func ProvideService(cfg *setting.Cfg) *SocialService {
 		// GitHub.
 		if name == "github" {
 			ss.socialMap["github"] = &SocialGithub{
-				SocialBase:           newSocialBase(name, &config, info, cfg.AutoAssignOrgRole),
+				SocialBase:           newSocialBase(name, &config, info),
 				apiUrl:               info.ApiUrl,
 				teamIds:              sec.Key("team_ids").Ints(","),
 				allowedOrganizations: util.SplitString(sec.Key("allowed_organizations").String()),
@@ -149,7 +149,7 @@ func ProvideService(cfg *setting.Cfg) *SocialService {
 		// GitLab.
 		if name == "gitlab" {
 			ss.socialMap["gitlab"] = &SocialGitlab{
-				SocialBase:    newSocialBase(name, &config, info, cfg.AutoAssignOrgRole),
+				SocialBase:    newSocialBase(name, &config, info),
 				apiUrl:        info.ApiUrl,
 				allowedGroups: util.SplitString(sec.Key("allowed_groups").String()),
 			}
@@ -158,7 +158,7 @@ func ProvideService(cfg *setting.Cfg) *SocialService {
 		// Google.
 		if name == "google" {
 			ss.socialMap["google"] = &SocialGoogle{
-				SocialBase:   newSocialBase(name, &config, info, cfg.AutoAssignOrgRole),
+				SocialBase:   newSocialBase(name, &config, info),
 				hostedDomain: info.HostedDomain,
 				apiUrl:       info.ApiUrl,
 			}
@@ -167,7 +167,7 @@ func ProvideService(cfg *setting.Cfg) *SocialService {
 		// AzureAD.
 		if name == "azuread" {
 			ss.socialMap["azuread"] = &SocialAzureAD{
-				SocialBase:    newSocialBase(name, &config, info, cfg.AutoAssignOrgRole),
+				SocialBase:    newSocialBase(name, &config, info),
 				allowedGroups: util.SplitString(sec.Key("allowed_groups").String()),
 			}
 		}
@@ -175,7 +175,7 @@ func ProvideService(cfg *setting.Cfg) *SocialService {
 		// Okta
 		if name == "okta" {
 			ss.socialMap["okta"] = &SocialOkta{
-				SocialBase:    newSocialBase(name, &config, info, cfg.AutoAssignOrgRole),
+				SocialBase:    newSocialBase(name, &config, info),
 				apiUrl:        info.ApiUrl,
 				allowedGroups: util.SplitString(sec.Key("allowed_groups").String()),
 			}
@@ -184,7 +184,7 @@ func ProvideService(cfg *setting.Cfg) *SocialService {
 		// Generic - Uses the same scheme as GitHub.
 		if name == "generic_oauth" {
 			ss.socialMap["generic_oauth"] = &SocialGenericOAuth{
-				SocialBase:           newSocialBase(name, &config, info, cfg.AutoAssignOrgRole),
+				SocialBase:           newSocialBase(name, &config, info),
 				apiUrl:               info.ApiUrl,
 				teamsUrl:             info.TeamsUrl,
 				emailAttributeName:   info.EmailAttributeName,
@@ -213,8 +213,7 @@ func ProvideService(cfg *setting.Cfg) *SocialService {
 			}
 
 			ss.socialMap[grafanaCom] = &SocialGrafanaCom{
-				SocialBase: newSocialBase(name, &config, info,
-					cfg.AutoAssignOrgRole),
+				SocialBase:           newSocialBase(name, &config, info),
 				url:                  cfg.GrafanaComURL,
 				allowedOrganizations: util.SplitString(sec.Key("allowed_organizations").String()),
 			}
@@ -259,7 +258,6 @@ type SocialBase struct {
 
 	roleAttributePath   string
 	roleAttributeStrict bool
-	autoAssignOrgRole   string
 }
 
 type Error struct {
@@ -292,7 +290,6 @@ type Service interface {
 func newSocialBase(name string,
 	config *oauth2.Config,
 	info *OAuthInfo,
-	autoAssignOrgRole string,
 ) *SocialBase {
 	logger := log.New("oauth." + name)
 
@@ -302,7 +299,6 @@ func newSocialBase(name string,
 		allowSignup:             info.AllowSignup,
 		allowAssignGrafanaAdmin: info.AllowAssignGrafanaAdmin,
 		allowedDomains:          info.AllowedDomains,
-		autoAssignOrgRole:       autoAssignOrgRole,
 		roleAttributePath:       info.RoleAttributePath,
 		roleAttributeStrict:     info.RoleAttributeStrict,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

- The user on first login (if no role mapping is done) will be assigned `auto assign org role` but once that's done he won't be synced if strict mode is disabled and he has no role assigned.
