### PR TITLE
CI: Add `export-version` command

### DIFF
--- a/pkg/build/cmd/exportversion.go
+++ b/pkg/build/cmd/exportversion.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/urfave/cli/v2"
-	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/urfave/cli/v2"
 )
 
 func ExportVersion(c *cli.Context) error {
@@ -18,12 +18,12 @@ func ExportVersion(c *cli.Context) error {
 	if err := os.RemoveAll(distDir); err != nil {
 		return err
 	}
-	if err := os.Mkdir(distDir, 0775); err != nil {
+	if err := os.Mkdir(distDir, 0750); err != nil {
 		return err
 	}
 
 	// nolint:gosec
-	if err := ioutil.WriteFile(filepath.Join(distDir, "grafana.version"), []byte(version), 0664); err != nil {
+	if err := os.WriteFile(filepath.Join(distDir, "grafana.version"), []byte(version), 0664); err != nil {
 		return err
 	}
 

--- a/pkg/build/cmd/exportversion.go
+++ b/pkg/build/cmd/exportversion.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/urfave/cli/v2"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+func ExportVersion(c *cli.Context) error {
+	metadata, err := GenerateMetadata(c)
+	if err != nil {
+		return err
+	}
+	version := metadata.GrafanaVersion
+
+	const distDir = "dist"
+	if err := os.RemoveAll(distDir); err != nil {
+		return err
+	}
+	if err := os.Mkdir(distDir, 0775); err != nil {
+		return err
+	}
+
+	// nolint:gosec
+	if err := ioutil.WriteFile(filepath.Join(distDir, "grafana.version"), []byte(version), 0664); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/build/cmd/exportversion.go
+++ b/pkg/build/cmd/exportversion.go
@@ -12,7 +12,6 @@ func ExportVersion(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	version := metadata.GrafanaVersion
 
 	const distDir = "dist"
 	if err := os.RemoveAll(distDir); err != nil {
@@ -23,7 +22,7 @@ func ExportVersion(c *cli.Context) error {
 	}
 
 	// nolint:gosec
-	if err := os.WriteFile(filepath.Join(distDir, "grafana.version"), []byte(version), 0664); err != nil {
+	if err := os.WriteFile(filepath.Join(distDir, "grafana.version"), []byte(metadata.GrafanaVersion), 0664); err != nil {
 		return err
 	}
 

--- a/pkg/build/cmd/main.go
+++ b/pkg/build/cmd/main.go
@@ -114,6 +114,11 @@ func main() {
 			ArgsUsage: "<api-key>",
 			Action:    ArgCountWrapper(1, PublishMetrics),
 		},
+		{
+			Name:   "export-version",
+			Usage:  "Exports version in dist/grafana.version",
+			Action: ExportVersion,
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

`export-version` command stores the Grafana version in a `dist/grafana.version` file.