### PR TITLE
RBAC: Initiate store in service

### DIFF
--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/database"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/auth"
@@ -380,7 +379,7 @@ func setupHTTPServerWithCfgDb(
 		acService = acmock
 	} else {
 		var err error
-		acService, err = acimpl.ProvideService(cfg, database.ProvideService(db), routeRegister, localcache.ProvideService())
+		acService, err = acimpl.ProvideService(cfg, db, routeRegister, localcache.ProvideService())
 		require.NoError(t, err)
 		ac = acimpl.ProvideAccessControl(cfg)
 	}

--- a/pkg/cmd/grafana-cli/runner/wireexts_oss.go
+++ b/pkg/cmd/grafana-cli/runner/wireexts_oss.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/server/usagestatssvcs"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
-	acdb "github.com/grafana/grafana/pkg/services/accesscontrol/database"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -75,8 +74,6 @@ var wireExtsSet = wire.NewSet(
 	wire.Bind(new(plugins.PluginLoaderAuthorizer), new(*signature.UnsignedPluginAuthorizer)),
 	provider.ProvideService,
 	wire.Bind(new(plugins.BackendFactoryProvider), new(*provider.Service)),
-	acdb.ProvideService,
-	wire.Bind(new(accesscontrol.Store), new(*acdb.AccessControlStore)),
 	ldap.ProvideGroupsService,
 	wire.Bind(new(ldap.Groups), new(*ldap.OSSGroups)),
 	permissions.ProvideDatasourcePermissionsService,

--- a/pkg/server/wireexts_oss.go
+++ b/pkg/server/wireexts_oss.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/grafana/pkg/server/usagestatssvcs"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
-	acdb "github.com/grafana/grafana/pkg/services/accesscontrol/database"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -74,8 +73,6 @@ var wireExtsBasicSet = wire.NewSet(
 	wire.Bind(new(plugins.PluginLoaderAuthorizer), new(*signature.UnsignedPluginAuthorizer)),
 	provider.ProvideService,
 	wire.Bind(new(plugins.BackendFactoryProvider), new(*provider.Service)),
-	acdb.ProvideService,
-	wire.Bind(new(accesscontrol.Store), new(*acdb.AccessControlStore)),
 	osskmsproviders.ProvideService,
 	wire.Bind(new(kmsproviders.Service), new(osskmsproviders.Service)),
 	ldap.ProvideGroupsService,

--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -45,12 +45,6 @@ type Options struct {
 	ReloadCache bool
 }
 
-type Store interface {
-	// GetUserPermissions returns user permissions with only action and scope fields set.
-	GetUserPermissions(ctx context.Context, query GetUserPermissionsQuery) ([]Permission, error)
-	DeleteUserPermissions(ctx context.Context, orgID, userID int64) error
-}
-
 type TeamPermissionsService interface {
 	GetPermissions(ctx context.Context, user *user.SignedInUser, resourceID string) ([]ResourcePermission, error)
 	SetUserPermission(ctx context.Context, orgID int64, user User, resourceID, permission string) (*ResourcePermission, error)

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -58,7 +58,7 @@ func TestUsageMetrics(t *testing.T) {
 
 			s, errInitAc := ProvideService(
 				cfg,
-				database.ProvideService(sqlstore.InitTestDB(t)),
+				sqlstore.InitTestDB(t),
 				routing.NewRouteRegister(),
 				localcache.ProvideService(),
 			)

--- a/pkg/services/accesscontrol/database/database.go
+++ b/pkg/services/accesscontrol/database/database.go
@@ -13,12 +13,12 @@ const (
 	globalOrgID = 0
 )
 
-func ProvideService(sqlStore *sqlstore.SQLStore) *AccessControlStore {
-	return &AccessControlStore{sqlStore}
+func ProvideService(sql sqlstore.Store) *AccessControlStore {
+	return &AccessControlStore{sql}
 }
 
 type AccessControlStore struct {
-	sql *sqlstore.SQLStore
+	sql sqlstore.Store
 }
 
 func (s *AccessControlStore) GetUserPermissions(ctx context.Context, query accesscontrol.GetUserPermissionsQuery) ([]accesscontrol.Permission, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the access control store from wire and move store interface to acimpl package.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

