### PR TITLE
CI: Make `shellcheck` a standalone pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -180,13 +180,6 @@ steps:
   image: grafana/build-container:1.6.2
   name: codespell
 - commands:
-  - ./bin/build shellcheck
-  depends_on:
-  - grabpl
-  - compile-build-cmd
-  image: grafana/build-container:1.6.2
-  name: shellcheck
-- commands:
   - make lint-go
   depends_on:
   - wire-install
@@ -940,13 +933,6 @@ steps:
   - rm words_to_ignore.txt
   image: grafana/build-container:1.6.2
   name: codespell
-- commands:
-  - ./bin/build shellcheck
-  depends_on:
-  - grabpl
-  - compile-build-cmd
-  image: grafana/build-container:1.6.2
-  name: shellcheck
 - commands:
   - make lint-go
   depends_on:
@@ -2085,13 +2071,6 @@ steps:
     CGO_ENABLED: 0
   image: golang:1.19.1
   name: compile-build-cmd
-- commands:
-  - ./bin/build shellcheck
-  depends_on:
-  - grabpl
-  - compile-build-cmd
-  image: grafana/build-container:1.6.2
-  name: shellcheck
 - commands:
   - |-
     echo -e "unknwon
@@ -4030,13 +4009,6 @@ steps:
   image: golang:1.19.1
   name: compile-build-cmd
 - commands:
-  - ./bin/build shellcheck
-  depends_on:
-  - grabpl
-  - compile-build-cmd
-  image: grafana/build-container:1.6.2
-  name: shellcheck
-- commands:
   - |-
     echo -e "unknwon
     referer
@@ -5155,6 +5127,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 4bbc2634a2ab447c9f9e7fc38a8015570562edd36294b6c17025a72b87eed396
+hmac: f8201ab7fe1632df9158ee66cc0a9bff140e9a7e4b2044b34b8e4e30d424aaad
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -686,6 +686,47 @@ clone:
   retries: 3
 depends_on: []
 kind: pipeline
+name: shellcheck
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- commands:
+  - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
+  depends_on: []
+  environment:
+    CGO_ENABLED: 0
+  image: golang:1.19.1
+  name: compile-build-cmd
+- commands:
+  - ./bin/build shellcheck
+  depends_on:
+  - compile-build-cmd
+  image: koalaman/shellcheck:v0.8.0
+  name: shellcheck
+trigger:
+  event:
+  - pull_request
+  paths:
+    exclude:
+    - '*.md'
+    - docs/**
+    - latest.json
+    include:
+    - scripts/**.sh
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
+depends_on: []
+kind: pipeline
 name: main-docs
 node:
   type: no-parallel
@@ -5114,6 +5155,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 4dab9811ddd4be2ca5cd598be69ce216e82406ca4197fdaeb75691156d356382
+hmac: 780ad78593f60b778eb69464afd26aec18243eb6651382c53b6d080b5ba8318f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -686,7 +686,7 @@ clone:
   retries: 3
 depends_on: []
 kind: pipeline
-name: shellcheck
+name: pr-shellcheck
 node:
   type: no-parallel
 platform:
@@ -705,7 +705,7 @@ steps:
   - ./bin/build shellcheck
   depends_on:
   - compile-build-cmd
-  image: koalaman/shellcheck:v0.8.0
+  image: grafana/build-container:1.6.2
   name: shellcheck
 trigger:
   event:
@@ -716,7 +716,7 @@ trigger:
     - docs/**
     - latest.json
     include:
-    - scripts/**.sh
+    - '**.sh'
 type: docker
 volumes:
 - host:
@@ -5155,6 +5155,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 780ad78593f60b778eb69464afd26aec18243eb6651382c53b6d080b5ba8318f
+hmac: be233e03a7c7e269ff9e6b0888d1834efe6c144e74c436c2c19c71537405f738
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -716,7 +716,7 @@ trigger:
     - docs/**
     - latest.json
     include:
-    - '**.sh'
+    - scripts/**/*.sh
 type: docker
 volumes:
 - host:
@@ -5155,6 +5155,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: be233e03a7c7e269ff9e6b0888d1834efe6c144e74c436c2c19c71537405f738
+hmac: 4bbc2634a2ab447c9f9e7fc38a8015570562edd36294b6c17025a72b87eed396
 
 ...

--- a/scripts/drone/events/pr.star
+++ b/scripts/drone/events/pr.star
@@ -34,6 +34,11 @@ load(
     'trigger_docs_pr',
 )
 
+load(
+    'scripts/drone/pipelines/shellcheck.star',
+    'shellcheck_pipeline',
+)
+
 ver_mode = 'pr'
 trigger = {
     'event': [
@@ -56,7 +61,8 @@ def pr_pipelines(edition):
         test_backend(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json', 'devenv/**']), ver_mode),
         build_e2e(trigger, ver_mode, edition),
         integration_tests(get_pr_trigger(include_paths=['pkg/**', 'packaging/**', '.drone.yml', 'conf/**', 'go.sum', 'go.mod', 'public/app/plugins/**/plugin.json']), ver_mode, edition),
-        docs_pipelines(edition, ver_mode, trigger_docs_pr())
+        docs_pipelines(edition, ver_mode, trigger_docs_pr()),
+        shellcheck_pipeline(),
     ]
 
 

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -13,7 +13,6 @@ load(
     'lint_backend_step',
     'lint_frontend_step',
     'codespell_step',
-    'shellcheck_step',
     'test_backend_step',
     'test_backend_integration_step',
     'test_frontend_step',
@@ -170,8 +169,6 @@ def get_steps(edition, ver_mode):
     ]
 
     test_steps = []
-    if edition != 'enterprise':
-        test_steps.extend([shellcheck_step()])
 
     test_steps.extend([
         codespell_step(),

--- a/scripts/drone/pipelines/shellcheck.star
+++ b/scripts/drone/pipelines/shellcheck.star
@@ -1,5 +1,6 @@
 load(
     'scripts/drone/steps/lib.star',
+    'build_image',
     'compile_build_cmd'
 )
 
@@ -27,7 +28,7 @@ trigger = {
 def shellcheck_step():
     return {
         'name': 'shellcheck',
-        'image': 'koalaman/shellcheck:v0.8.0',
+        'image': build_image,
         'depends_on': [
             'compile-build-cmd',
         ],

--- a/scripts/drone/pipelines/shellcheck.star
+++ b/scripts/drone/pipelines/shellcheck.star
@@ -20,7 +20,7 @@ trigger = {
             'latest.json',
         ],
         'include': [
-            '**.sh'
+            'scripts/**/*.sh'
         ],
     },
 }

--- a/scripts/drone/pipelines/shellcheck.star
+++ b/scripts/drone/pipelines/shellcheck.star
@@ -1,0 +1,47 @@
+load(
+    'scripts/drone/steps/lib.star',
+    'compile_build_cmd'
+)
+
+load(
+    'scripts/drone/utils/utils.star',
+    'pipeline',
+)
+
+trigger = {
+    'event': [
+        'pull_request',
+    ],
+    'paths': {
+        'exclude': [
+            '*.md',
+            'docs/**',
+            'latest.json',
+        ],
+        'include': [
+            'scripts/**.sh'
+        ],
+    },
+}
+
+def shellcheck_step():
+    return {
+        'name': 'shellcheck',
+        'image': 'koalaman/shellcheck:v0.8.0',
+        'depends_on': [
+            'compile-build-cmd',
+        ],
+        'commands': [
+            './bin/build shellcheck',
+        ],
+    }
+
+def shellcheck_pipeline():
+    steps = [
+        compile_build_cmd(),
+        shellcheck_step(),
+    ]
+    return pipeline(
+            name='shellcheck', edition="oss", trigger=trigger, services=[], steps=steps,
+    )
+

--- a/scripts/drone/pipelines/shellcheck.star
+++ b/scripts/drone/pipelines/shellcheck.star
@@ -19,7 +19,7 @@ trigger = {
             'latest.json',
         ],
         'include': [
-            'scripts/**.sh'
+            '**.sh'
         ],
     },
 }
@@ -42,6 +42,6 @@ def shellcheck_pipeline():
         shellcheck_step(),
     ]
     return pipeline(
-            name='shellcheck', edition="oss", trigger=trigger, services=[], steps=steps,
+            name='pr-shellcheck', edition="oss", trigger=trigger, services=[], steps=steps,
     )
 

--- a/scripts/drone/pipelines/test_backend.star
+++ b/scripts/drone/pipelines/test_backend.star
@@ -4,7 +4,6 @@ load(
     'download_grabpl_step',
     'wire_install_step',
     'codespell_step',
-    'shellcheck_step',
     'lint_backend_step',
     'lint_drone_step',
     'test_backend_step',
@@ -28,7 +27,6 @@ def test_backend(trigger, ver_mode):
     ]
     test_steps = [
         codespell_step(),
-        shellcheck_step(),
         lint_backend_step(edition="oss"),
         test_backend_step(edition="oss"),
         test_backend_integration_step(edition="oss"),

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -630,20 +630,6 @@ def codespell_step():
     }
 
 
-def shellcheck_step():
-    return {
-        'name': 'shellcheck',
-        'image': build_image,
-        'depends_on': [
-            'grabpl',
-            'compile-build-cmd',
-        ],
-        'commands': [
-            './bin/build shellcheck',
-        ],
-    }
-
-
 def package_step(edition, ver_mode, include_enterprise2=False, variants=None):
     deps = [
         'build-plugins',


### PR DESCRIPTION
**What this PR does / why we need it**:

Shellcheck currently runs as a part of the `test-backend` pipeline. `test-backend` pipeline is triggered on backend only changes, which means that if there are changes to shellscripts and no backend changes, the shellscripts may be broken.

This PR introduces a new `shellcheck` pipeline which will get triggered only on changes under the `scripts/` directory.
