### PR TITLE
CI: Update `build-container` image to `v1.6.2`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -70,7 +70,7 @@ steps:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -88,14 +88,14 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-frontend
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
   failure: ignore
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -103,7 +103,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-frontend
 trigger:
   event:
@@ -159,13 +159,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - |-
@@ -177,14 +177,14 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: codespell
 - commands:
   - ./bin/build shellcheck
   depends_on:
   - grabpl
   - compile-build-cmd
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: shellcheck
 - commands:
   - make lint-go
@@ -192,19 +192,19 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-backend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-backend-integration
 trigger:
   event:
@@ -264,19 +264,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: yarn-install
 - failure: ignore
   image: grafana/drone-downstream
@@ -296,7 +296,7 @@ steps:
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -305,7 +305,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -313,14 +313,14 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
   depends_on:
   - yarn-install
   environment: null
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-plugins
 - commands:
   - . scripts/build/gpg-test-vars.sh && ./bin/grabpl package --jobs 8 --edition oss
@@ -331,7 +331,7 @@ steps:
   - build-frontend
   - build-frontend-packages
   environment: null
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -344,7 +344,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -422,7 +422,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-storybook
   when:
     paths:
@@ -433,7 +433,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: copy-packages-for-docker
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -531,13 +531,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - apt-get update
@@ -553,7 +553,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -569,7 +569,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: mysql-integration-tests
 trigger:
   event:
@@ -624,7 +624,7 @@ steps:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: yarn-install
 - commands:
   - |-
@@ -636,7 +636,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -644,7 +644,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-docs
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -652,7 +652,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-frontend-packages
 - commands:
   - mkdir -p /hugo/content/docs/grafana
@@ -708,7 +708,7 @@ steps:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: yarn-install
 - commands:
   - |-
@@ -720,7 +720,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: codespell
 - commands:
   - yarn run prettier:checkDocs
@@ -728,7 +728,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-docs
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -736,7 +736,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-frontend-packages
 - commands:
   - mkdir -p /hugo/content/docs/grafana
@@ -793,7 +793,7 @@ steps:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -811,14 +811,14 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-frontend
 - commands:
   - yarn betterer ci
   depends_on:
   - yarn-install
   failure: ignore
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: betterer-frontend
 - commands:
   - yarn run ci:test-frontend
@@ -826,7 +826,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-frontend
 trigger:
   branch: main
@@ -879,13 +879,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - |-
@@ -897,14 +897,14 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: codespell
 - commands:
   - ./bin/build shellcheck
   depends_on:
   - grabpl
   - compile-build-cmd
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: shellcheck
 - commands:
   - make lint-go
@@ -912,19 +912,19 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-backend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-backend-integration
 - commands:
   - ./bin/grabpl verify-drone
@@ -983,19 +983,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: yarn-install
 - commands:
   - git clone "https://$${GITHUB_TOKEN}@github.com/grafana/grafana-enterprise.git"
@@ -1016,7 +1016,7 @@ steps:
       from_secret: github_token
     TEST_TAG: v0.0.0-test
   failure: ignore
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: trigger-test-release
   when:
     paths:
@@ -1041,7 +1041,7 @@ steps:
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -1050,7 +1050,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -1058,7 +1058,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -1067,7 +1067,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-plugins
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -1085,7 +1085,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: package
 - commands:
   - ./scripts/grafana-server/start-server
@@ -1098,7 +1098,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -1176,7 +1176,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-storybook
   when:
     paths:
@@ -1187,7 +1187,7 @@ steps:
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: copy-packages-for-docker
 - commands:
   - yarn wait-on http://$HOST:$PORT
@@ -1231,7 +1231,7 @@ steps:
     GRAFANA_MISC_STATS_API_KEY:
       from_secret: grafana_misc_stats_api_key
   failure: ignore
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: publish-frontend-metrics
   when:
     repo:
@@ -1314,7 +1314,7 @@ steps:
   environment:
     NPM_TOKEN:
       from_secret: npm_token
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: release-canary-npm-packages
   when:
     repo:
@@ -1421,13 +1421,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - apt-get update
@@ -1443,7 +1443,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -1459,7 +1459,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: mysql-integration-tests
 trigger:
   branch: main
@@ -1715,19 +1715,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -1741,7 +1741,7 @@ steps:
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss ${DRONE_TAG}
@@ -1750,7 +1750,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss ${DRONE_TAG}
@@ -1758,7 +1758,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -1767,7 +1767,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-plugins
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss  --sign ${DRONE_TAG}
@@ -1785,14 +1785,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition oss --shouldSave
@@ -1831,7 +1831,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -1909,7 +1909,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-storybook
   when:
     paths:
@@ -1971,7 +1971,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: store-npm-packages
 trigger:
   event:
@@ -2023,19 +2023,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -2049,7 +2049,7 @@ steps:
   depends_on:
   - grabpl
   - compile-build-cmd
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: shellcheck
 - commands:
   - |-
@@ -2061,7 +2061,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: codespell
 - commands:
   - make lint-go
@@ -2069,7 +2069,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -2080,19 +2080,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -2100,7 +2100,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-frontend
 trigger:
   event:
@@ -2166,13 +2166,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - apt-get update
@@ -2188,7 +2188,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -2204,7 +2204,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: mysql-integration-tests
 trigger:
   event:
@@ -2320,7 +2320,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2336,7 +2336,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: init-enterprise
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -2350,13 +2350,13 @@ steps:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: yarn-install
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2366,14 +2366,14 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - ./bin/build build-backend --jobs 8 --edition enterprise ${DRONE_TAG}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -2382,7 +2382,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition enterprise ${DRONE_TAG}
@@ -2390,7 +2390,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition enterprise
@@ -2399,14 +2399,14 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-plugins
 - commands:
   - ./bin/build build-backend --jobs 8 --edition enterprise2 ${DRONE_TAG}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise  --sign ${DRONE_TAG}
@@ -2425,14 +2425,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition enterprise --shouldSave
@@ -2472,7 +2472,7 @@ steps:
     ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -2573,7 +2573,7 @@ steps:
       from_secret: gcp_key
     PRERELEASE_BUCKET:
       from_secret: prerelease_bucket
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: store-npm-packages
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise2  --sign ${DRONE_TAG}
@@ -2592,7 +2592,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: package-enterprise2
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise2
@@ -2668,7 +2668,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2684,7 +2684,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: init-enterprise
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -2698,13 +2698,13 @@ steps:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: yarn-install
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2714,7 +2714,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - |-
@@ -2726,7 +2726,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: codespell
 - commands:
   - make lint-go
@@ -2734,7 +2734,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -2745,19 +2745,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -2765,7 +2765,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-frontend
 - commands:
   - make lint-go
@@ -2773,13 +2773,13 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-backend-enterprise2
 - commands:
   - go test -tags=pro -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-backend-enterprise2
 trigger:
   event:
@@ -2853,7 +2853,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -2869,7 +2869,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: init-enterprise
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -2879,13 +2879,13 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - apt-get update
@@ -2901,7 +2901,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -2917,7 +2917,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -2926,7 +2926,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -2935,7 +2935,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: memcached-integration-tests
 trigger:
   event:
@@ -3432,7 +3432,7 @@ steps:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: yarn-install
 - commands:
   - ./bin/grabpl artifacts npm retrieve --tag v${TAG}
@@ -3454,7 +3454,7 @@ steps:
     NPM_TOKEN:
       from_secret: npm_token
   failure: ignore
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: release-npm-packages
 trigger:
   event:
@@ -3651,7 +3651,7 @@ steps:
   environment:
     GCP_KEY:
       from_secret: gcp_key
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: artifacts-page
 trigger:
   event:
@@ -3692,19 +3692,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -3718,7 +3718,7 @@ steps:
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -3727,7 +3727,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
@@ -3735,7 +3735,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition oss
@@ -3744,7 +3744,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-plugins
 - commands:
   - ./bin/grabpl package --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER} --sign
@@ -3762,14 +3762,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition oss --shouldSave
@@ -3808,7 +3808,7 @@ steps:
   environment:
     ARCH: linux-amd64
     PORT: 3001
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -3886,7 +3886,7 @@ steps:
   - build-frontend-packages
   environment:
     NODE_OPTIONS: --max_old_space_size=4096
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-storybook
   when:
     paths:
@@ -3967,19 +3967,19 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - grabpl
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: yarn-install
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -3993,7 +3993,7 @@ steps:
   depends_on:
   - grabpl
   - compile-build-cmd
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: shellcheck
 - commands:
   - |-
@@ -4005,7 +4005,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: codespell
 - commands:
   - make lint-go
@@ -4013,7 +4013,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -4024,19 +4024,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -4044,7 +4044,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-frontend
 trigger:
   ref:
@@ -4104,13 +4104,13 @@ steps:
     in output.'
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - apt-get update
@@ -4126,7 +4126,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -4142,7 +4142,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: mysql-integration-tests
 trigger:
   ref:
@@ -4242,7 +4242,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -4255,7 +4255,7 @@ steps:
   depends_on:
   - clone-enterprise
   environment: {}
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: init-enterprise
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -4269,13 +4269,13 @@ steps:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: yarn-install
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4285,14 +4285,14 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - ./bin/build build-backend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-backend
 - commands:
   - ./bin/build build-frontend --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -4301,7 +4301,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-frontend
 - commands:
   - ./bin/build build-frontend-packages --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -4309,7 +4309,7 @@ steps:
   - yarn-install
   environment:
     NODE_OPTIONS: --max_old_space_size=8192
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-frontend-packages
 - commands:
   - ./bin/build  build-plugins --jobs 8 --edition enterprise
@@ -4318,7 +4318,7 @@ steps:
   environment:
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-plugins
 - commands:
   - ./bin/build build-backend --jobs 8 --edition enterprise2 --build-id ${DRONE_BUILD_NUMBER}
@@ -4326,7 +4326,7 @@ steps:
   depends_on:
   - wire-install
   - compile-build-cmd
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: build-backend-enterprise2
 - commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise --build-id ${DRONE_BUILD_NUMBER}
@@ -4346,14 +4346,14 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: package
 - commands:
   - ls dist/*.tar.gz*
   - cp dist/*.tar.gz* packaging/docker/
   depends_on:
   - package
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: copy-packages-for-docker
 - commands:
   - ./bin/build build-docker --edition enterprise --shouldSave
@@ -4393,7 +4393,7 @@ steps:
     ARCH: linux-amd64
     PORT: 3001
     RUNDIR: scripts/grafana-server/tmp-grafana-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: grafana-server
 - commands:
   - apt-get install -y netcat
@@ -4509,7 +4509,7 @@ steps:
       from_secret: gpg_pub_key
     GRAFANA_API_KEY:
       from_secret: grafana_api_key
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: package-enterprise2
 - commands:
   - ./bin/grabpl upload-cdn --edition enterprise2
@@ -4579,7 +4579,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -4592,7 +4592,7 @@ steps:
   depends_on:
   - clone-enterprise
   environment: {}
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: init-enterprise
 - commands:
   - go build -o ./bin/build -ldflags '-extldflags -static' ./pkg/build/cmd
@@ -4606,13 +4606,13 @@ steps:
   - make gen-go
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - yarn install --immutable
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: yarn-install
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4622,7 +4622,7 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - |-
@@ -4634,7 +4634,7 @@ steps:
     wan" > words_to_ignore.txt
   - codespell -I words_to_ignore.txt docs/
   - rm words_to_ignore.txt
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: codespell
 - commands:
   - make lint-go
@@ -4642,7 +4642,7 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-backend
 - commands:
   - yarn run prettier:check
@@ -4653,19 +4653,19 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-frontend
 - commands:
   - go test -short -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-backend
 - commands:
   - go test -run Integration -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-backend-integration
 - commands:
   - yarn run ci:test-frontend
@@ -4673,7 +4673,7 @@ steps:
   - yarn-install
   environment:
     TEST_MAX_WORKERS: 50%
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-frontend
 - commands:
   - make lint-go
@@ -4681,13 +4681,13 @@ steps:
   - wire-install
   environment:
     CGO_ENABLED: "1"
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: lint-backend-enterprise2
 - commands:
   - go test -tags=pro -covermode=atomic -timeout=30m ./pkg/...
   depends_on:
   - wire-install
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: test-backend-enterprise2
 trigger:
   ref:
@@ -4755,7 +4755,7 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: clone-enterprise
 - commands:
   - mv bin/grabpl /tmp/
@@ -4768,7 +4768,7 @@ steps:
   depends_on:
   - clone-enterprise
   environment: {}
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: init-enterprise
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -4778,13 +4778,13 @@ steps:
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on:
   - init-enterprise
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: verify-gen-cue
 - commands:
   - make gen-go
   depends_on:
   - verify-gen-cue
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: wire-install
 - commands:
   - apt-get update
@@ -4800,7 +4800,7 @@ steps:
     GRAFANA_TEST_DB: postgres
     PGPASSWORD: grafanatest
     POSTGRES_HOST: postgres
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: postgres-integration-tests
 - commands:
   - apt-get update
@@ -4816,7 +4816,7 @@ steps:
   environment:
     GRAFANA_TEST_DB: mysql
     MYSQL_HOST: mysql
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: mysql-integration-tests
 - commands:
   - dockerize -wait tcp://redis:6379/0 -timeout 120s
@@ -4825,7 +4825,7 @@ steps:
   - wire-install
   environment:
     REDIS_URL: redis://redis:6379/0
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: redis-integration-tests
 - commands:
   - dockerize -wait tcp://memcached:11211 -timeout 120s
@@ -4834,7 +4834,7 @@ steps:
   - wire-install
   environment:
     MEMCACHED_HOSTS: memcached:11211
-  image: grafana/build-container:1.6.1
+  image: grafana/build-container:1.6.2
   name: memcached-integration-tests
 trigger:
   ref:
@@ -5114,6 +5114,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 20e4a947fba1881cbb9b18c8f11b2c896652c701e9c5018e135632034778b4f1
+hmac: 4dab9811ddd4be2ca5cd598be69ce216e82406ca4197fdaeb75691156d356382
 
 ...

--- a/scripts/build/ci-build/Dockerfile
+++ b/scripts/build/ci-build/Dockerfile
@@ -105,7 +105,7 @@ FROM debian:buster-20220822
 ENV GOVERSION=1.19.1 \
     PATH=/usr/local/go/bin:$PATH \
     GOPATH=/go \
-    NODEVERSION=16.17.0-1nodesource1 \
+    NODEVERSION=16.14.0-1nodesource1 \
     YARNVERSION=1.22.19-1
 
 # Use ARG so as not to persist environment variable in image

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -1,7 +1,7 @@
 load('scripts/drone/vault.star', 'from_secret', 'github_token', 'pull_secret', 'drone_token', 'prerelease_bucket')
 
 grabpl_version = 'v3.0.6'
-build_image = 'grafana/build-container:1.6.1'
+build_image = 'grafana/build-container:1.6.2'
 publish_image = 'grafana/grafana-ci-deploy:1.3.3'
 deploy_docker_image = 'us.gcr.io/kubernetes-dev/drone/plugins/deploy-image'
 alpine_image = 'alpine:3.15.6'


### PR DESCRIPTION
**What this PR does / why we need it**:

After https://github.com/grafana/grafana/pull/54902, `build-container` was updated to `v1.6.1`, which except from or the Go-related changes it included, also bumped the node version of the container to `16.17.0`.

Unfortunately, this broke npm packages flow (still investigating) and we needed to go back to `16.14.0` in order for our `npm` packages to show normally in the registry.

This PR updates the `build-container` to `1.6.2` to include the `node` version downgrade.