### PR TITLE
Chore: SQL store split for annotations

### DIFF
--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -63,9 +63,7 @@ func (hs *HTTPServer) GetAnnotations(c *models.ReqContext) response.Response {
 		}
 	}
 
-	repo := annotations.GetRepository()
-
-	items, err := repo.Find(c.Req.Context(), query)
+	items, err := hs.annotationsRepo.Find(c.Req.Context(), query)
 	if err != nil {
 		return response.Error(500, "Failed to get annotations", err)
 	}
@@ -135,8 +133,6 @@ func (hs *HTTPServer) PostAnnotation(c *models.ReqContext) response.Response {
 		return dashboardGuardianResponse(err)
 	}
 
-	repo := annotations.GetRepository()
-
 	if cmd.Text == "" {
 		err := &AnnotationError{"text field should not be empty"}
 		return response.Error(400, "Failed to save annotation", err)
@@ -154,7 +150,7 @@ func (hs *HTTPServer) PostAnnotation(c *models.ReqContext) response.Response {
 		Tags:        cmd.Tags,
 	}
 
-	if err := repo.Save(&item); err != nil {
+	if err := hs.annotationsRepo.Save(context.Background(), &item); err != nil {
 		if errors.Is(err, annotations.ErrTimerangeMissing) {
 			return response.Error(400, "Failed to save annotation", err)
 		}
@@ -194,8 +190,6 @@ func (hs *HTTPServer) PostGraphiteAnnotation(c *models.ReqContext) response.Resp
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
-	repo := annotations.GetRepository()
-
 	if cmd.What == "" {
 		err := &AnnotationError{"what field should not be empty"}
 		return response.Error(400, "Failed to save Graphite annotation", err)
@@ -234,7 +228,7 @@ func (hs *HTTPServer) PostGraphiteAnnotation(c *models.ReqContext) response.Resp
 		Tags:   tagsArray,
 	}
 
-	if err := repo.Save(&item); err != nil {
+	if err := hs.annotationsRepo.Save(context.Background(), &item); err != nil {
 		return response.Error(500, "Failed to save Graphite annotation", err)
 	}
 
@@ -267,9 +261,7 @@ func (hs *HTTPServer) UpdateAnnotation(c *models.ReqContext) response.Response {
 		return response.Error(http.StatusBadRequest, "annotationId is invalid", err)
 	}
 
-	repo := annotations.GetRepository()
-
-	annotation, resp := findAnnotationByID(c.Req.Context(), repo, annotationID, c.SignedInUser)
+	annotation, resp := findAnnotationByID(c.Req.Context(), hs.annotationsRepo, annotationID, c.SignedInUser)
 	if resp != nil {
 		return resp
 	}
@@ -288,7 +280,7 @@ func (hs *HTTPServer) UpdateAnnotation(c *models.ReqContext) response.Response {
 		Tags:     cmd.Tags,
 	}
 
-	if err := repo.Update(c.Req.Context(), &item); err != nil {
+	if err := hs.annotationsRepo.Update(c.Req.Context(), &item); err != nil {
 		return response.Error(500, "Failed to update annotation", err)
 	}
 
@@ -319,9 +311,7 @@ func (hs *HTTPServer) PatchAnnotation(c *models.ReqContext) response.Response {
 		return response.Error(http.StatusBadRequest, "annotationId is invalid", err)
 	}
 
-	repo := annotations.GetRepository()
-
-	annotation, resp := findAnnotationByID(c.Req.Context(), repo, annotationID, c.SignedInUser)
+	annotation, resp := findAnnotationByID(c.Req.Context(), hs.annotationsRepo, annotationID, c.SignedInUser)
 	if resp != nil {
 		return resp
 	}
@@ -356,7 +346,7 @@ func (hs *HTTPServer) PatchAnnotation(c *models.ReqContext) response.Response {
 		existing.EpochEnd = cmd.TimeEnd
 	}
 
-	if err := repo.Update(c.Req.Context(), &existing); err != nil {
+	if err := hs.annotationsRepo.Update(c.Req.Context(), &existing); err != nil {
 		return response.Error(500, "Failed to update annotation", err)
 	}
 
@@ -391,7 +381,6 @@ func (hs *HTTPServer) MassDeleteAnnotations(c *models.ReqContext) response.Respo
 		return response.Error(http.StatusBadRequest, "bad request data", err)
 	}
 
-	repo := annotations.GetRepository()
 	var deleteParams *annotations.DeleteParams
 
 	// validations only for RBAC. A user can mass delete all annotations in a (dashboard + panel) or a specific annotation
@@ -400,7 +389,7 @@ func (hs *HTTPServer) MassDeleteAnnotations(c *models.ReqContext) response.Respo
 		var dashboardId int64
 
 		if cmd.AnnotationId != 0 {
-			annotation, respErr := findAnnotationByID(c.Req.Context(), repo, cmd.AnnotationId, c.SignedInUser)
+			annotation, respErr := findAnnotationByID(c.Req.Context(), hs.annotationsRepo, cmd.AnnotationId, c.SignedInUser)
 			if respErr != nil {
 				return respErr
 			}
@@ -431,7 +420,7 @@ func (hs *HTTPServer) MassDeleteAnnotations(c *models.ReqContext) response.Respo
 		}
 	}
 
-	err = repo.Delete(c.Req.Context(), deleteParams)
+	err = hs.annotationsRepo.Delete(c.Req.Context(), deleteParams)
 
 	if err != nil {
 		return response.Error(500, "Failed to delete annotations", err)
@@ -454,9 +443,7 @@ func (hs *HTTPServer) GetAnnotationByID(c *models.ReqContext) response.Response 
 		return response.Error(http.StatusBadRequest, "annotationId is invalid", err)
 	}
 
-	repo := annotations.GetRepository()
-
-	annotation, resp := findAnnotationByID(c.Req.Context(), repo, annotationID, c.SignedInUser)
+	annotation, resp := findAnnotationByID(c.Req.Context(), hs.annotationsRepo, annotationID, c.SignedInUser)
 	if resp != nil {
 		return resp
 	}
@@ -485,9 +472,7 @@ func (hs *HTTPServer) DeleteAnnotationByID(c *models.ReqContext) response.Respon
 		return response.Error(http.StatusBadRequest, "annotationId is invalid", err)
 	}
 
-	repo := annotations.GetRepository()
-
-	annotation, resp := findAnnotationByID(c.Req.Context(), repo, annotationID, c.SignedInUser)
+	annotation, resp := findAnnotationByID(c.Req.Context(), hs.annotationsRepo, annotationID, c.SignedInUser)
 	if resp != nil {
 		return resp
 	}
@@ -496,7 +481,7 @@ func (hs *HTTPServer) DeleteAnnotationByID(c *models.ReqContext) response.Respon
 		return dashboardGuardianResponse(err)
 	}
 
-	err = repo.Delete(c.Req.Context(), &annotations.DeleteParams{
+	err = hs.annotationsRepo.Delete(c.Req.Context(), &annotations.DeleteParams{
 		OrgId: c.OrgID,
 		Id:    annotationID,
 	})
@@ -563,8 +548,7 @@ func (hs *HTTPServer) GetAnnotationTags(c *models.ReqContext) response.Response 
 		Limit: c.QueryInt64("limit"),
 	}
 
-	repo := annotations.GetRepository()
-	result, err := repo.FindTags(c.Req.Context(), query)
+	result, err := hs.annotationsRepo.FindTags(c.Req.Context(), query)
 	if err != nil {
 		return response.Error(500, "Failed to find annotation tags", err)
 	}
@@ -575,7 +559,7 @@ func (hs *HTTPServer) GetAnnotationTags(c *models.ReqContext) response.Response 
 // AnnotationTypeScopeResolver provides an ScopeAttributeResolver able to
 // resolve annotation types. Scope "annotations:id:<id>" will be translated to "annotations:type:<type>,
 // where <type> is the type of annotation with id <id>.
-func AnnotationTypeScopeResolver() (string, accesscontrol.ScopeAttributeResolver) {
+func AnnotationTypeScopeResolver(annotationsRepo annotations.Repository) (string, accesscontrol.ScopeAttributeResolver) {
 	prefix := accesscontrol.ScopeAnnotationsProvider.GetResourceScope("")
 	return prefix, accesscontrol.ScopeAttributeResolverFunc(func(ctx context.Context, orgID int64, initialScope string) ([]string, error) {
 		scopeParts := strings.Split(initialScope, ":")
@@ -601,7 +585,7 @@ func AnnotationTypeScopeResolver() (string, accesscontrol.ScopeAttributeResolver
 			},
 		}
 
-		annotation, resp := findAnnotationByID(ctx, annotations.GetRepository(), int64(annotationId), tempUser)
+		annotation, resp := findAnnotationByID(ctx, annotationsRepo, int64(annotationId), tempUser)
 		if resp != nil {
 			return nil, errors.New("could not resolve annotation type")
 		}

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -150,7 +150,7 @@ func (hs *HTTPServer) PostAnnotation(c *models.ReqContext) response.Response {
 		Tags:        cmd.Tags,
 	}
 
-	if err := hs.annotationsRepo.Save(context.Background(), &item); err != nil {
+	if err := hs.annotationsRepo.Save(c.Req.Context(), &item); err != nil {
 		if errors.Is(err, annotations.ErrTimerangeMissing) {
 			return response.Error(400, "Failed to save annotation", err)
 		}

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol/database"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/ossaccesscontrol"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/contexthandler/authproxy"
@@ -337,10 +338,11 @@ func setupSimpleHTTPServer(features *featuremgmt.FeatureManager) *HTTPServer {
 	cfg.IsFeatureToggleEnabled = features.IsEnabled
 
 	return &HTTPServer{
-		Cfg:           cfg,
-		Features:      features,
-		License:       &licensing.OSSLicensingService{},
-		AccessControl: accesscontrolmock.New().WithDisabled(),
+		Cfg:             cfg,
+		Features:        features,
+		License:         &licensing.OSSLicensingService{},
+		AccessControl:   accesscontrolmock.New().WithDisabled(),
+		annotationsRepo: annotationstest.NewFakeAnnotationsRepo(),
 	}
 }
 
@@ -408,6 +410,7 @@ func setupHTTPServerWithCfgDb(
 		),
 		preferenceService: preftest.NewPreferenceServiceFake(),
 		userService:       userMock,
+		annotationsRepo:   annotationstest.NewFakeAnnotationsRepo(),
 	}
 
 	for _, o := range options {

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/models"
 	accesscontrolmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/database"
 	"github.com/grafana/grafana/pkg/services/dashboards/service"
@@ -109,7 +110,7 @@ func newTestLive(t *testing.T, store *sqlstore.SQLStore) *live.GrafanaLive {
 		nil,
 		&usagestats.UsageStatsMock{T: t},
 		nil,
-		features, accesscontrolmock.New(), &dashboards.FakeDashboardService{})
+		features, accesscontrolmock.New(), &dashboards.FakeDashboardService{}, annotationstest.NewFakeAnnotationsRepo())
 	require.NoError(t, err)
 	return gLive
 }

--- a/pkg/server/wire.go
+++ b/pkg/server/wire.go
@@ -6,6 +6,8 @@ package server
 import (
 	"github.com/google/wire"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana/pkg/services/annotations"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationsimpl"
 
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/playlist/playlistimpl"
@@ -151,6 +153,8 @@ import (
 var wireBasicSet = wire.NewSet(
 	legacydataservice.ProvideService,
 	wire.Bind(new(legacydata.RequestHandler), new(*legacydataservice.Service)),
+	annotationsimpl.ProvideService,
+	wire.Bind(new(annotations.Repository), new(*annotationsimpl.RepositoryImpl)),
 	alerting.ProvideAlertStore,
 	alerting.ProvideAlertEngine,
 	wire.Bind(new(alerting.UsageStatsQuerier), new(*alerting.AlertEngine)),

--- a/pkg/services/alerting/engine_integration_test.go
+++ b/pkg/services/alerting/engine_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	datasources "github.com/grafana/grafana/pkg/services/datasources/fakes"
 	encryptionprovider "github.com/grafana/grafana/pkg/services/encryption/provider"
 	encryptionservice "github.com/grafana/grafana/pkg/services/encryption/service"
@@ -35,7 +36,8 @@ func TestIntegrationEngineTimeouts(t *testing.T) {
 
 	tracer := tracing.InitializeTracerForTest()
 	dsMock := &datasources.FakeDataSourceService{}
-	engine := ProvideAlertEngine(nil, nil, nil, usMock, encService, nil, tracer, nil, setting.NewCfg(), nil, nil, localcache.New(time.Minute, time.Minute), dsMock)
+	annotationsRepo := annotationstest.NewFakeAnnotationsRepo()
+	engine := ProvideAlertEngine(nil, nil, nil, usMock, encService, nil, tracer, nil, setting.NewCfg(), nil, nil, localcache.New(time.Minute, time.Minute), dsMock, annotationsRepo)
 	setting.AlertingNotificationTimeout = 30 * time.Second
 	setting.AlertingMaxAttempts = 3
 	engine.resultHandler = &FakeResultHandler{}

--- a/pkg/services/alerting/engine_test.go
+++ b/pkg/services/alerting/engine_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	fd "github.com/grafana/grafana/pkg/services/datasources/fakes"
 	encryptionprovider "github.com/grafana/grafana/pkg/services/encryption/provider"
@@ -128,7 +129,7 @@ func TestEngineProcessJob(t *testing.T) {
 	dsMock := &fd.FakeDataSourceService{
 		DataSources: []*datasources.DataSource{{Id: 1, Type: datasources.DS_PROMETHEUS}},
 	}
-	engine := ProvideAlertEngine(nil, nil, nil, usMock, encService, nil, tracer, store, setting.NewCfg(), nil, nil, localcache.New(time.Minute, time.Minute), dsMock)
+	engine := ProvideAlertEngine(nil, nil, nil, usMock, encService, nil, tracer, store, setting.NewCfg(), nil, nil, localcache.New(time.Minute, time.Minute), dsMock, annotationstest.NewFakeAnnotationsRepo())
 	setting.AlertingEvaluationTimeout = 30 * time.Second
 	setting.AlertingNotificationTimeout = 30 * time.Second
 	setting.AlertingMaxAttempts = 3

--- a/pkg/services/alerting/eval_context.go
+++ b/pkg/services/alerting/eval_context.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/setting"
@@ -42,11 +43,12 @@ type EvalContext struct {
 	Store             AlertStore
 	dashboardService  dashboards.DashboardService
 	DatasourceService datasources.DataSourceService
+	annotationRepo    annotations.Repository
 }
 
 // NewEvalContext is the EvalContext constructor.
 func NewEvalContext(alertCtx context.Context, rule *Rule, requestValidator models.PluginRequestValidator,
-	alertStore AlertStore, dashboardService dashboards.DashboardService, dsService datasources.DataSourceService) *EvalContext {
+	alertStore AlertStore, dashboardService dashboards.DashboardService, dsService datasources.DataSourceService, annotationRepo annotations.Repository) *EvalContext {
 	return &EvalContext{
 		Ctx:               alertCtx,
 		StartTime:         time.Now(),
@@ -60,6 +62,7 @@ func NewEvalContext(alertCtx context.Context, rule *Rule, requestValidator model
 		Store:             alertStore,
 		dashboardService:  dashboardService,
 		DatasourceService: dsService,
+		annotationRepo:    annotationRepo,
 	}
 }
 

--- a/pkg/services/alerting/eval_context_test.go
+++ b/pkg/services/alerting/eval_context_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/validations"
 )
 
 func TestStateIsUpdatedWhenNeeded(t *testing.T) {
-	ctx := NewEvalContext(context.Background(), &Rule{Conditions: []Condition{&conditionStub{firing: true}}}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+	ctx := NewEvalContext(context.Background(), &Rule{Conditions: []Condition{&conditionStub{firing: true}}}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 	t.Run("ok -> alerting", func(t *testing.T) {
 		ctx.PrevAlertState = models.AlertStateOK
@@ -199,7 +200,7 @@ func TestGetStateFromEvalContext(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		evalContext := NewEvalContext(context.Background(), &Rule{Conditions: []Condition{&conditionStub{firing: true}}}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		evalContext := NewEvalContext(context.Background(), &Rule{Conditions: []Condition{&conditionStub{firing: true}}}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		tc.applyFn(evalContext)
 		newState := evalContext.GetNewState()
@@ -391,7 +392,7 @@ func TestEvaluateNotificationTemplateFields(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
 			evalContext := NewEvalContext(context.Background(), &Rule{Name: "Rule name: ${value1}", Message: "Rule message: ${value2}",
-				Conditions: []Condition{&conditionStub{firing: true}}}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+				Conditions: []Condition{&conditionStub{firing: true}}}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 			evalContext.EvalMatches = test.evalMatches
 			evalContext.AllMatches = test.allMatches
 

--- a/pkg/services/alerting/eval_handler_test.go
+++ b/pkg/services/alerting/eval_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/validations"
 	"github.com/grafana/grafana/pkg/tsdb/legacydata"
 
@@ -29,7 +30,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 			Conditions: []Condition{&conditionStub{
 				firing: true,
 			}},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		handler.Eval(context)
 		require.Equal(t, true, context.Firing)
@@ -39,7 +40,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 	t.Run("Show return triggered with single passing condition2", func(t *testing.T) {
 		context := NewEvalContext(context.Background(), &Rule{
 			Conditions: []Condition{&conditionStub{firing: true, operator: "and"}},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		handler.Eval(context)
 		require.Equal(t, true, context.Firing)
@@ -52,7 +53,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 				&conditionStub{firing: true, operator: "and", matches: []*EvalMatch{{}, {}}},
 				&conditionStub{firing: false, operator: "and"},
 			},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		handler.Eval(context)
 		require.Equal(t, false, context.Firing)
@@ -65,7 +66,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 				&conditionStub{firing: true, operator: "and"},
 				&conditionStub{firing: false, operator: "or"},
 			},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		handler.Eval(context)
 		require.Equal(t, true, context.Firing)
@@ -78,7 +79,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 				&conditionStub{firing: true, operator: "and"},
 				&conditionStub{firing: false, operator: "and"},
 			},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		handler.Eval(context)
 		require.Equal(t, false, context.Firing)
@@ -92,7 +93,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 				&conditionStub{firing: true, operator: "and"},
 				&conditionStub{firing: false, operator: "or"},
 			},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		handler.Eval(context)
 		require.Equal(t, true, context.Firing)
@@ -106,7 +107,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 				&conditionStub{firing: false, operator: "and"},
 				&conditionStub{firing: false, operator: "or"},
 			},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		handler.Eval(context)
 		require.Equal(t, false, context.Firing)
@@ -120,7 +121,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 				&conditionStub{firing: false, operator: "and"},
 				&conditionStub{firing: true, operator: "and"},
 			},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		handler.Eval(context)
 		require.Equal(t, false, context.Firing)
@@ -134,7 +135,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 				&conditionStub{firing: false, operator: "or"},
 				&conditionStub{firing: true, operator: "or"},
 			},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		handler.Eval(context)
 		require.Equal(t, true, context.Firing)
@@ -148,7 +149,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 				&conditionStub{firing: false, operator: "or"},
 				&conditionStub{firing: false, operator: "or"},
 			},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		handler.Eval(context)
 		require.Equal(t, false, context.Firing)
@@ -163,7 +164,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 				&conditionStub{operator: "or", noData: false},
 				&conditionStub{operator: "or", noData: false},
 			},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		handler.Eval(context)
 		require.False(t, context.NoDataFound)
@@ -174,7 +175,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 			Conditions: []Condition{
 				&conditionStub{operator: "and", noData: true},
 			},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		handler.Eval(context)
 		require.Equal(t, false, context.Firing)
@@ -187,7 +188,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 				&conditionStub{operator: "and", noData: true},
 				&conditionStub{operator: "and", noData: false},
 			},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		handler.Eval(context)
 		require.True(t, context.NoDataFound)
@@ -199,7 +200,7 @@ func TestAlertingEvaluationHandler(t *testing.T) {
 				&conditionStub{operator: "or", noData: true},
 				&conditionStub{operator: "or", noData: false},
 			},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		handler.Eval(context)
 		require.True(t, context.NoDataFound)

--- a/pkg/services/alerting/notifier_test.go
+++ b/pkg/services/alerting/notifier_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/imguploader"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/services/validations"
@@ -20,18 +21,18 @@ import (
 func TestNotificationService(t *testing.T) {
 	testRule := &Rule{Name: "Test", Message: "Something is bad"}
 	store := &AlertStoreMock{}
-	evalCtx := NewEvalContext(context.Background(), testRule, &validations.OSSPluginRequestValidator{}, store, nil, nil)
+	evalCtx := NewEvalContext(context.Background(), testRule, &validations.OSSPluginRequestValidator{}, store, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 	testRuleTemplated := &Rule{Name: "Test latency ${quantile}", Message: "Something is bad on instance ${instance}"}
 
-	evalCtxWithMatch := NewEvalContext(context.Background(), testRuleTemplated, &validations.OSSPluginRequestValidator{}, store, nil, nil)
+	evalCtxWithMatch := NewEvalContext(context.Background(), testRuleTemplated, &validations.OSSPluginRequestValidator{}, store, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 	evalCtxWithMatch.EvalMatches = []*EvalMatch{{
 		Tags: map[string]string{
 			"instance": "localhost:3000",
 			"quantile": "0.99",
 		},
 	}}
-	evalCtxWithoutMatch := NewEvalContext(context.Background(), testRuleTemplated, &validations.OSSPluginRequestValidator{}, store, nil, nil)
+	evalCtxWithoutMatch := NewEvalContext(context.Background(), testRuleTemplated, &validations.OSSPluginRequestValidator{}, store, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 	notificationServiceScenario(t, "Given alert rule with upload image enabled should render and upload image and send notification",
 		evalCtx, true, func(sc *scenarioContext) {

--- a/pkg/services/alerting/notifiers/alertmanager_test.go
+++ b/pkg/services/alerting/notifiers/alertmanager_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	encryptionservice "github.com/grafana/grafana/pkg/services/encryption/service"
 	"github.com/grafana/grafana/pkg/services/validations"
 
@@ -68,7 +69,7 @@ func TestWhenAlertManagerShouldNotify(t *testing.T) {
 		am := &AlertmanagerNotifier{log: log.New("test.logger")}
 		evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
 			State: tc.prevState,
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		evalContext.Rule.State = tc.newState
 

--- a/pkg/services/alerting/notifiers/base_test.go
+++ b/pkg/services/alerting/notifiers/base_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/validations"
 
 	"github.com/stretchr/testify/assert"
@@ -170,7 +171,7 @@ func TestShouldSendAlertNotification(t *testing.T) {
 	for _, tc := range tcs {
 		evalContext := alerting.NewEvalContext(context.Background(), &alerting.Rule{
 			State: tc.prevState,
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 		if tc.state == nil {
 			tc.state = &models.AlertNotificationState{}

--- a/pkg/services/alerting/notifiers/dingding_test.go
+++ b/pkg/services/alerting/notifiers/dingding_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	encryptionservice "github.com/grafana/grafana/pkg/services/encryption/service"
 	"github.com/grafana/grafana/pkg/services/validations"
 
@@ -52,7 +53,7 @@ func TestDingDingNotifier(t *testing.T) {
 				&alerting.Rule{
 					State:   models.AlertStateAlerting,
 					Message: `{host="localhost"}`,
-				}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+				}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 			_, err = notifier.genBody(evalContext, "")
 			require.Nil(t, err)
 		})

--- a/pkg/services/alerting/notifiers/opsgenie_test.go
+++ b/pkg/services/alerting/notifiers/opsgenie_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	encryptionservice "github.com/grafana/grafana/pkg/services/encryption/service"
 	"github.com/grafana/grafana/pkg/services/notifications"
 	"github.com/grafana/grafana/pkg/services/validations"
@@ -105,7 +106,7 @@ func TestOpsGenieNotifier(t *testing.T) {
 				Message:       "someMessage",
 				State:         models.AlertStateAlerting,
 				AlertRuleTags: tagPairs,
-			}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+			}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 			evalContext.IsTestRun = true
 
 			tags := make([]string, 0)
@@ -154,7 +155,7 @@ func TestOpsGenieNotifier(t *testing.T) {
 				Message:       "someMessage",
 				State:         models.AlertStateAlerting,
 				AlertRuleTags: tagPairs,
-			}, nil, nil, nil, nil)
+			}, nil, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 			evalContext.IsTestRun = true
 
 			tags := make([]string, 0)
@@ -203,7 +204,7 @@ func TestOpsGenieNotifier(t *testing.T) {
 				Message:       "someMessage",
 				State:         models.AlertStateAlerting,
 				AlertRuleTags: tagPairs,
-			}, nil, nil, nil, nil)
+			}, nil, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 			evalContext.IsTestRun = true
 
 			tags := make([]string, 0)

--- a/pkg/services/alerting/notifiers/pagerduty_test.go
+++ b/pkg/services/alerting/notifiers/pagerduty_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	encryptionservice "github.com/grafana/grafana/pkg/services/encryption/service"
 	"github.com/grafana/grafana/pkg/services/validations"
 
@@ -142,7 +143,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 			Name:    "someRule",
 			Message: "someMessage",
 			State:   models.AlertStateAlerting,
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 		evalContext.IsTestRun = true
 
 		payloadJSON, err := pagerdutyNotifier.buildEventPayload(evalContext)
@@ -198,7 +199,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 			ID:    0,
 			Name:  "someRule",
 			State: models.AlertStateAlerting,
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 		evalContext.IsTestRun = true
 
 		payloadJSON, err := pagerdutyNotifier.buildEventPayload(evalContext)
@@ -256,7 +257,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 			Name:    "someRule",
 			Message: "someMessage",
 			State:   models.AlertStateAlerting,
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 		evalContext.IsTestRun = true
 		evalContext.EvalMatches = []*alerting.EvalMatch{
 			{
@@ -335,7 +336,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 				{Key: "severity", Value: "warning"},
 				{Key: "dedup_key", Value: "key-" + strings.Repeat("x", 260)},
 			},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 		evalContext.ImagePublicURL = "http://somewhere.com/omg_dont_panic.png"
 		evalContext.IsTestRun = true
 
@@ -414,7 +415,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 				{Key: "component", Value: "aComponent"},
 				{Key: "severity", Value: "info"},
 			},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 		evalContext.ImagePublicURL = "http://somewhere.com/omg_dont_panic.png"
 		evalContext.IsTestRun = true
 
@@ -493,7 +494,7 @@ func TestPagerdutyNotifier(t *testing.T) {
 				{Key: "component", Value: "aComponent"},
 				{Key: "severity", Value: "llama"},
 			},
-		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+		}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 		evalContext.ImagePublicURL = "http://somewhere.com/omg_dont_panic.png"
 		evalContext.IsTestRun = true
 

--- a/pkg/services/alerting/notifiers/pushover_test.go
+++ b/pkg/services/alerting/notifiers/pushover_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	encryptionservice "github.com/grafana/grafana/pkg/services/encryption/service"
 	"github.com/grafana/grafana/pkg/services/validations"
 
@@ -76,7 +77,7 @@ func TestGenPushoverBody(t *testing.T) {
 			evalContext := alerting.NewEvalContext(context.Background(),
 				&alerting.Rule{
 					State: models.AlertStateAlerting,
-				}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+				}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 			_, pushoverBody, err := notifier.genPushoverBody(evalContext, "", "")
 
 			require.Nil(t, err)
@@ -87,7 +88,7 @@ func TestGenPushoverBody(t *testing.T) {
 			evalContext := alerting.NewEvalContext(context.Background(),
 				&alerting.Rule{
 					State: models.AlertStateOK,
-				}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+				}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 			_, pushoverBody, err := notifier.genPushoverBody(evalContext, "", "")
 
 			require.Nil(t, err)

--- a/pkg/services/alerting/notifiers/telegram_test.go
+++ b/pkg/services/alerting/notifiers/telegram_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	encryptionservice "github.com/grafana/grafana/pkg/services/encryption/service"
 	"github.com/grafana/grafana/pkg/services/validations"
 
@@ -61,7 +62,7 @@ func TestTelegramNotifier(t *testing.T) {
 					Name:    "This is an alarm",
 					Message: "Some kind of message.",
 					State:   models.AlertStateOK,
-				}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+				}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 			caption := generateImageCaption(evalContext, "http://grafa.url/abcdef", "")
 			require.LessOrEqual(t, len(caption), 1024)
@@ -77,7 +78,7 @@ func TestTelegramNotifier(t *testing.T) {
 						Name:    "This is an alarm",
 						Message: "Some kind of message.",
 						State:   models.AlertStateOK,
-					}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+					}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 				caption := generateImageCaption(evalContext,
 					"http://grafa.url/abcdefaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -95,7 +96,7 @@ func TestTelegramNotifier(t *testing.T) {
 						Name:    "This is an alarm",
 						Message: "Some kind of message that is too long for appending to our pretty little message, this line is actually exactly 197 chars long and I will get there in the end I promise I will. Yes siree that's it. But suddenly Telegram increased the length so now we need some lorem ipsum to fix this test. Here we go: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur molestie cursus. Donec suscipit egestas nisi. Proin ut efficitur ex. Mauris mi augue, volutpat a nisi vel, euismod dictum arcu. Sed quis tempor eros, sed malesuada dolor. Ut orci augue, viverra sit amet blandit quis, faucibus sit amet ex. Duis condimentum efficitur lectus, id dignissim quam tempor id. Morbi sollicitudin rhoncus diam, id tincidunt lectus scelerisque vitae. Etiam imperdiet semper sem, vel eleifend ligula mollis eget. Etiam ultrices fringilla lacus, sit amet pharetra ex blandit quis. Suspendisse in egestas neque, et posuere lectus. Vestibulum eu ex dui. Sed molestie nulla a lobortis scelerisque. Nulla ipsum ex, iaculis vitae vehicula sit amet, fermentum eu eros.",
 						State:   models.AlertStateOK,
-					}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+					}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 				caption := generateImageCaption(evalContext,
 					"http://grafa.url/foo",
@@ -112,7 +113,7 @@ func TestTelegramNotifier(t *testing.T) {
 						Name:    "This is an alarm",
 						Message: "Some kind of message that is too long for appending to our pretty little message, this line is actually exactly 197 chars long and I will get there in the end I promise I will. Yes siree that's it. But suddenly Telegram increased the length so now we need some lorem ipsum to fix this test. Here we go: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur molestie cursus. Donec suscipit egestas nisi. Proin ut efficitur ex. Mauris mi augue, volutpat a nisi vel, euismod dictum arcu. Sed quis tempor eros, sed malesuada dolor. Ut orci augue, viverra sit amet blandit quis, faucibus sit amet ex. Duis condimentum efficitur lectus, id dignissim quam tempor id. Morbi sollicitudin rhoncus diam, id tincidunt lectus scelerisque vitae. Etiam imperdiet semper sem, vel eleifend ligula mollis eget. Etiam ultrices fringilla lacus, sit amet pharetra ex blandit quis. Suspendisse in egestas neque, et posuere lectus. Vestibulum eu ex dui. Sed molestie nulla a lobortis sceleri",
 						State:   models.AlertStateOK,
-					}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+					}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 
 				caption := generateImageCaption(evalContext,
 					"http://grafa.url/foo",

--- a/pkg/services/alerting/notifiers/victorops_test.go
+++ b/pkg/services/alerting/notifiers/victorops_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/alerting"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	encryptionservice "github.com/grafana/grafana/pkg/services/encryption/service"
 	"github.com/grafana/grafana/pkg/services/validations"
 
@@ -93,7 +94,7 @@ func TestVictoropsNotifier(t *testing.T) {
 					{Key: "keyOnly"},
 					{Key: "severity", Value: "warning"},
 				},
-			}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+			}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 			evalContext.IsTestRun = true
 
 			payload, err := victoropsNotifier.buildEventPayload(evalContext)
@@ -141,7 +142,7 @@ func TestVictoropsNotifier(t *testing.T) {
 					{Key: "keyOnly"},
 					{Key: "severity", Value: "warning"},
 				},
-			}, &validations.OSSPluginRequestValidator{}, nil, nil, nil)
+			}, &validations.OSSPluginRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 			evalContext.IsTestRun = true
 
 			payload, err := victoropsNotifier.buildEventPayload(evalContext)

--- a/pkg/services/alerting/result_handler.go
+++ b/pkg/services/alerting/result_handler.go
@@ -95,8 +95,7 @@ func (handler *defaultResultHandler) handle(evalContext *EvalContext) error {
 			Data:        annotationData,
 		}
 
-		annotationRepo := annotations.GetRepository()
-		if err := annotationRepo.Save(&item); err != nil {
+		if err := evalContext.annotationRepo.Save(evalContext.Ctx, &item); err != nil {
 			handler.log.Error("Failed to save annotation for new alert state", "error", err)
 		}
 	}

--- a/pkg/services/alerting/test_notification.go
+++ b/pkg/services/alerting/test_notification.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 )
 
 // NotificationTestCommand initiates an test
@@ -57,7 +58,7 @@ func createTestEvalContext(cmd *NotificationTestCommand) *EvalContext {
 		ID:          rand.Int63(),
 	}
 
-	ctx := NewEvalContext(context.Background(), testRule, fakeRequestValidator{}, nil, nil, nil)
+	ctx := NewEvalContext(context.Background(), testRule, fakeRequestValidator{}, nil, nil, nil, annotationstest.NewFakeAnnotationsRepo())
 	if cmd.Settings.Get("uploadImage").MustBool(true) {
 		ctx.ImagePublicURL = "https://grafana.com/assets/img/blog/mixed_styles.png"
 	}

--- a/pkg/services/alerting/test_rule.go
+++ b/pkg/services/alerting/test_rule.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
@@ -33,7 +34,7 @@ func (e *AlertEngine) AlertTest(orgID int64, dashboard *simplejson.Json, panelID
 
 		handler := NewEvalHandler(e.DataService)
 
-		context := NewEvalContext(context.Background(), rule, fakeRequestValidator{}, e.AlertStore, nil, e.datasourceService)
+		context := NewEvalContext(context.Background(), rule, fakeRequestValidator{}, e.AlertStore, nil, e.datasourceService, annotationstest.NewFakeAnnotationsRepo())
 		context.IsTestRun = true
 		context.IsDebug = true
 

--- a/pkg/services/annotations/annotations.go
+++ b/pkg/services/annotations/annotations.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/grafana/grafana/pkg/components/simplejson"
-	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -14,7 +12,7 @@ var (
 )
 
 type Repository interface {
-	Save(item *Item) error
+	Save(ctx context.Context, item *Item) error
 	Update(ctx context.Context, item *Item) error
 	Find(ctx context.Context, query *ItemQuery) ([]*ItemDTO, error)
 	Delete(ctx context.Context, params *DeleteParams) error
@@ -26,63 +24,7 @@ type AnnotationCleaner interface {
 	CleanAnnotations(ctx context.Context, cfg *setting.Cfg) (int64, int64, error)
 }
 
-type ItemQuery struct {
-	OrgId        int64    `json:"orgId"`
-	From         int64    `json:"from"`
-	To           int64    `json:"to"`
-	UserId       int64    `json:"userId"`
-	AlertId      int64    `json:"alertId"`
-	DashboardId  int64    `json:"dashboardId"`
-	DashboardUid string   `json:"dashboardUID"`
-	PanelId      int64    `json:"panelId"`
-	AnnotationId int64    `json:"annotationId"`
-	Tags         []string `json:"tags"`
-	Type         string   `json:"type"`
-	MatchAny     bool     `json:"matchAny"`
-	SignedInUser *user.SignedInUser
-
-	Limit int64 `json:"limit"`
-}
-
-// TagsQuery is the query for a tags search.
-type TagsQuery struct {
-	OrgID int64  `json:"orgId"`
-	Tag   string `json:"tag"`
-
-	Limit int64 `json:"limit"`
-}
-
-// Tag is the DB result of a tags search.
-type Tag struct {
-	Key   string
-	Value string
-	Count int64
-}
-
-// TagsDTO is the frontend DTO for Tag.
-type TagsDTO struct {
-	Tag   string `json:"tag"`
-	Count int64  `json:"count"`
-}
-
-// FindTagsResult is the result of a tags search.
-type FindTagsResult struct {
-	Tags []*TagsDTO `json:"tags"`
-}
-
-// GetAnnotationTagsResponse is a response struct for FindTagsResult.
-type GetAnnotationTagsResponse struct {
-	Result FindTagsResult `json:"result"`
-}
-
-type DeleteParams struct {
-	OrgId       int64
-	Id          int64
-	DashboardId int64
-	PanelId     int64
-}
-
-var repositoryInstance Repository
+// var repositoryInstance Repository
 var cleanerInstance AnnotationCleaner
 
 func GetAnnotationCleaner() AnnotationCleaner {
@@ -91,85 +33,4 @@ func GetAnnotationCleaner() AnnotationCleaner {
 
 func SetAnnotationCleaner(rep AnnotationCleaner) {
 	cleanerInstance = rep
-}
-
-func GetRepository() Repository {
-	return repositoryInstance
-}
-
-func SetRepository(rep Repository) {
-	repositoryInstance = rep
-}
-
-type Item struct {
-	Id          int64            `json:"id"`
-	OrgId       int64            `json:"orgId"`
-	UserId      int64            `json:"userId"`
-	DashboardId int64            `json:"dashboardId"`
-	PanelId     int64            `json:"panelId"`
-	Text        string           `json:"text"`
-	AlertId     int64            `json:"alertId"`
-	PrevState   string           `json:"prevState"`
-	NewState    string           `json:"newState"`
-	Epoch       int64            `json:"epoch"`
-	EpochEnd    int64            `json:"epochEnd"`
-	Created     int64            `json:"created"`
-	Updated     int64            `json:"updated"`
-	Tags        []string         `json:"tags"`
-	Data        *simplejson.Json `json:"data"`
-
-	// needed until we remove it from db
-	Type  string
-	Title string
-}
-
-func (i Item) TableName() string {
-	return "annotation"
-}
-
-type ItemDTO struct {
-	Id           int64            `json:"id"`
-	AlertId      int64            `json:"alertId"`
-	AlertName    string           `json:"alertName"`
-	DashboardId  int64            `json:"dashboardId"`
-	DashboardUID *string          `json:"dashboardUID"`
-	PanelId      int64            `json:"panelId"`
-	UserId       int64            `json:"userId"`
-	NewState     string           `json:"newState"`
-	PrevState    string           `json:"prevState"`
-	Created      int64            `json:"created"`
-	Updated      int64            `json:"updated"`
-	Time         int64            `json:"time"`
-	TimeEnd      int64            `json:"timeEnd"`
-	Text         string           `json:"text"`
-	Tags         []string         `json:"tags"`
-	Login        string           `json:"login"`
-	Email        string           `json:"email"`
-	AvatarUrl    string           `json:"avatarUrl"`
-	Data         *simplejson.Json `json:"data"`
-}
-
-type annotationType int
-
-const (
-	Organization annotationType = iota
-	Dashboard
-)
-
-func (a annotationType) String() string {
-	switch a {
-	case Organization:
-		return "organization"
-	case Dashboard:
-		return "dashboard"
-	default:
-		return ""
-	}
-}
-
-func (annotation *ItemDTO) GetType() annotationType {
-	if annotation.DashboardId != 0 {
-		return Dashboard
-	}
-	return Organization
 }

--- a/pkg/services/annotations/annotationsimpl/annotations.go
+++ b/pkg/services/annotations/annotationsimpl/annotations.go
@@ -1,0 +1,44 @@
+package annotationsimpl
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/annotations"
+	"github.com/grafana/grafana/pkg/services/sqlstore/db"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type RepositoryImpl struct {
+	store store
+}
+
+func ProvideService(db db.DB, cfg *setting.Cfg) *RepositoryImpl {
+	return &RepositoryImpl{
+		store: &SQLAnnotationRepo{
+			cfg: cfg,
+			db:  db,
+			log: log.New("annotations"),
+		},
+	}
+}
+
+func (r *RepositoryImpl) Save(ctx context.Context, item *annotations.Item) error {
+	return r.store.Add(ctx, item)
+}
+
+func (r *RepositoryImpl) Update(ctx context.Context, item *annotations.Item) error {
+	return r.store.Update(ctx, item)
+}
+
+func (r *RepositoryImpl) Find(ctx context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
+	return r.store.Get(ctx, query)
+}
+
+func (r *RepositoryImpl) Delete(ctx context.Context, params *annotations.DeleteParams) error {
+	return r.store.Delete(ctx, params)
+}
+
+func (r *RepositoryImpl) FindTags(ctx context.Context, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
+	return r.store.GetTags(ctx, query)
+}

--- a/pkg/services/annotations/annotationsimpl/store.go
+++ b/pkg/services/annotations/annotationsimpl/store.go
@@ -1,0 +1,15 @@
+package annotationsimpl
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/services/annotations"
+)
+
+type store interface {
+	Add(ctx context.Context, item *annotations.Item) error
+	Update(ctx context.Context, item *annotations.Item) error
+	Get(ctx context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error)
+	Delete(ctx context.Context, params *annotations.DeleteParams) error
+	GetTags(ctx context.Context, query *annotations.TagsQuery) (annotations.FindTagsResult, error)
+}

--- a/pkg/services/annotations/annotationstest/fake.go
+++ b/pkg/services/annotations/annotationstest/fake.go
@@ -1,0 +1,83 @@
+package annotationstest
+
+import (
+	"context"
+	"sync"
+
+	"github.com/grafana/grafana/pkg/services/annotations"
+)
+
+type fakeAnnotationsRepo struct {
+	mtx         sync.Mutex
+	annotations map[int64]annotations.Item
+}
+
+func NewFakeAnnotationsRepo() *fakeAnnotationsRepo {
+	return &fakeAnnotationsRepo{
+		annotations: map[int64]annotations.Item{},
+	}
+}
+
+func (repo *fakeAnnotationsRepo) Delete(_ context.Context, params *annotations.DeleteParams) error {
+	repo.mtx.Lock()
+	defer repo.mtx.Unlock()
+
+	if params.Id != 0 {
+		delete(repo.annotations, params.Id)
+	} else {
+		for _, v := range repo.annotations {
+			if params.DashboardId == v.DashboardId && params.PanelId == v.PanelId {
+				delete(repo.annotations, v.Id)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (repo *fakeAnnotationsRepo) Save(ctx context.Context, item *annotations.Item) error {
+	repo.mtx.Lock()
+	defer repo.mtx.Unlock()
+
+	if item.Id == 0 {
+		item.Id = int64(len(repo.annotations) + 1)
+	}
+	repo.annotations[item.Id] = *item
+	return nil
+}
+
+func (repo *fakeAnnotationsRepo) Update(_ context.Context, item *annotations.Item) error {
+	return nil
+}
+
+func (repo *fakeAnnotationsRepo) Find(_ context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
+	repo.mtx.Lock()
+	defer repo.mtx.Unlock()
+
+	if annotation, has := repo.annotations[query.AnnotationId]; has {
+		return []*annotations.ItemDTO{{Id: annotation.Id, DashboardId: annotation.DashboardId}}, nil
+	}
+	annotations := []*annotations.ItemDTO{{Id: 1, DashboardId: 0}}
+	return annotations, nil
+}
+
+func (repo *fakeAnnotationsRepo) FindTags(_ context.Context, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
+	result := annotations.FindTagsResult{
+		Tags: []*annotations.TagsDTO{},
+	}
+	return result, nil
+}
+
+func (repo *fakeAnnotationsRepo) Len() int {
+	repo.mtx.Lock()
+	defer repo.mtx.Unlock()
+
+	return len(repo.annotations)
+}
+
+func (repo *fakeAnnotationsRepo) Items() map[int64]annotations.Item {
+	repo.mtx.Lock()
+	defer repo.mtx.Unlock()
+
+	return repo.annotations
+}

--- a/pkg/services/annotations/models.go
+++ b/pkg/services/annotations/models.go
@@ -1,0 +1,135 @@
+package annotations
+
+import (
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/services/user"
+)
+
+type ItemQuery struct {
+	OrgId        int64    `json:"orgId"`
+	From         int64    `json:"from"`
+	To           int64    `json:"to"`
+	UserId       int64    `json:"userId"`
+	AlertId      int64    `json:"alertId"`
+	DashboardId  int64    `json:"dashboardId"`
+	DashboardUid string   `json:"dashboardUID"`
+	PanelId      int64    `json:"panelId"`
+	AnnotationId int64    `json:"annotationId"`
+	Tags         []string `json:"tags"`
+	Type         string   `json:"type"`
+	MatchAny     bool     `json:"matchAny"`
+	SignedInUser *user.SignedInUser
+
+	Limit int64 `json:"limit"`
+}
+
+// TagsQuery is the query for a tags search.
+type TagsQuery struct {
+	OrgID int64  `json:"orgId"`
+	Tag   string `json:"tag"`
+
+	Limit int64 `json:"limit"`
+}
+
+// Tag is the DB result of a tags search.
+type Tag struct {
+	Key   string
+	Value string
+	Count int64
+}
+
+// TagsDTO is the frontend DTO for Tag.
+type TagsDTO struct {
+	Tag   string `json:"tag"`
+	Count int64  `json:"count"`
+}
+
+// FindTagsResult is the result of a tags search.
+type FindTagsResult struct {
+	Tags []*TagsDTO `json:"tags"`
+}
+
+// GetAnnotationTagsResponse is a response struct for FindTagsResult.
+type GetAnnotationTagsResponse struct {
+	Result FindTagsResult `json:"result"`
+}
+
+type DeleteParams struct {
+	OrgId       int64
+	Id          int64
+	DashboardId int64
+	PanelId     int64
+}
+
+type Item struct {
+	Id          int64            `json:"id"`
+	OrgId       int64            `json:"orgId"`
+	UserId      int64            `json:"userId"`
+	DashboardId int64            `json:"dashboardId"`
+	PanelId     int64            `json:"panelId"`
+	Text        string           `json:"text"`
+	AlertId     int64            `json:"alertId"`
+	PrevState   string           `json:"prevState"`
+	NewState    string           `json:"newState"`
+	Epoch       int64            `json:"epoch"`
+	EpochEnd    int64            `json:"epochEnd"`
+	Created     int64            `json:"created"`
+	Updated     int64            `json:"updated"`
+	Tags        []string         `json:"tags"`
+	Data        *simplejson.Json `json:"data"`
+
+	// needed until we remove it from db
+	Type  string
+	Title string
+}
+
+func (i Item) TableName() string {
+	return "annotation"
+}
+
+type ItemDTO struct {
+	Id           int64            `json:"id"`
+	AlertId      int64            `json:"alertId"`
+	AlertName    string           `json:"alertName"`
+	DashboardId  int64            `json:"dashboardId"`
+	DashboardUID *string          `json:"dashboardUID"`
+	PanelId      int64            `json:"panelId"`
+	UserId       int64            `json:"userId"`
+	NewState     string           `json:"newState"`
+	PrevState    string           `json:"prevState"`
+	Created      int64            `json:"created"`
+	Updated      int64            `json:"updated"`
+	Time         int64            `json:"time"`
+	TimeEnd      int64            `json:"timeEnd"`
+	Text         string           `json:"text"`
+	Tags         []string         `json:"tags"`
+	Login        string           `json:"login"`
+	Email        string           `json:"email"`
+	AvatarUrl    string           `json:"avatarUrl"`
+	Data         *simplejson.Json `json:"data"`
+}
+
+type annotationType int
+
+const (
+	Organization annotationType = iota
+	Dashboard
+)
+
+func (a annotationType) String() string {
+	switch a {
+	case Organization:
+		return "organization"
+	case Dashboard:
+		return "dashboard"
+	default:
+		return ""
+	}
+}
+
+func (annotation *ItemDTO) GetType() annotationType {
+	if annotation.DashboardId != 0 {
+		return Dashboard
+	}
+	return Organization
+}

--- a/pkg/services/comments/service.go
+++ b/pkg/services/comments/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/comments/commentmodel"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -24,7 +25,7 @@ type Service struct {
 
 func ProvideService(cfg *setting.Cfg, store *sqlstore.SQLStore, live *live.GrafanaLive,
 	features featuremgmt.FeatureToggles, accessControl accesscontrol.AccessControl,
-	dashboardService dashboards.DashboardService, userService user.Service) *Service {
+	dashboardService dashboards.DashboardService, userService user.Service, annotationsRepo annotations.Repository) *Service {
 	s := &Service{
 		cfg:      cfg,
 		live:     live,
@@ -32,7 +33,7 @@ func ProvideService(cfg *setting.Cfg, store *sqlstore.SQLStore, live *live.Grafa
 		storage: &sqlStorage{
 			sql: store,
 		},
-		permissions: commentmodel.NewPermissionChecker(store, features, accessControl, dashboardService),
+		permissions: commentmodel.NewPermissionChecker(store, features, accessControl, dashboardService, annotationsRepo),
 		userService: userService,
 	}
 	return s

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -25,6 +25,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/plugincontext"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/comments/commentmodel"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -74,7 +75,7 @@ func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, r
 	pluginStore plugins.Store, cacheService *localcache.CacheService,
 	dataSourceCache datasources.CacheService, sqlStore *sqlstore.SQLStore, secretsService secrets.Service,
 	usageStatsService usagestats.Service, queryDataService *query.Service, toggles featuremgmt.FeatureToggles,
-	accessControl accesscontrol.AccessControl, dashboardService dashboards.DashboardService) (*GrafanaLive, error) {
+	accessControl accesscontrol.AccessControl, dashboardService dashboards.DashboardService, annotationsRepo annotations.Repository) (*GrafanaLive, error) {
 	g := &GrafanaLive{
 		Cfg:                   cfg,
 		Features:              toggles,
@@ -246,7 +247,7 @@ func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, r
 	g.GrafanaScope.Dashboards = dash
 	g.GrafanaScope.Features["dashboard"] = dash
 	g.GrafanaScope.Features["broadcast"] = features.NewBroadcastRunner(g.storage)
-	g.GrafanaScope.Features["comment"] = features.NewCommentHandler(commentmodel.NewPermissionChecker(g.SQLStore, g.Features, accessControl, dashboardService))
+	g.GrafanaScope.Features["comment"] = features.NewCommentHandler(commentmodel.NewPermissionChecker(g.SQLStore, g.Features, accessControl, dashboardService, annotationsRepo))
 
 	g.surveyCaller = survey.NewCaller(managedStreamRunner, node)
 	err = g.surveyCaller.SetupHandlers()

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -15,6 +15,8 @@ import (
 	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/annotations"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasourceproxy"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -41,7 +43,7 @@ func ProvideService(cfg *setting.Cfg, dataSourceCache datasources.CacheService, 
 	sqlStore *sqlstore.SQLStore, kvStore kvstore.KVStore, expressionService *expr.Service, dataProxy *datasourceproxy.DataSourceProxyService,
 	quotaService quota.Service, secretsService secrets.Service, notificationService notifications.Service, m *metrics.NGAlert,
 	folderService dashboards.FolderService, ac accesscontrol.AccessControl, dashboardService dashboards.DashboardService, renderService rendering.Service,
-	bus bus.Bus, accesscontrolService accesscontrol.Service) (*AlertNG, error) {
+	bus bus.Bus, accesscontrolService accesscontrol.Service, annotationsRepo annotations.Repository) (*AlertNG, error) {
 	ng := &AlertNG{
 		Cfg:                  cfg,
 		DataSourceCache:      dataSourceCache,
@@ -62,6 +64,7 @@ func ProvideService(cfg *setting.Cfg, dataSourceCache datasources.CacheService, 
 		renderService:        renderService,
 		bus:                  bus,
 		accesscontrolService: accesscontrolService,
+		annotationsRepo:      annotationsRepo,
 	}
 
 	if ng.IsDisabled() {
@@ -102,6 +105,7 @@ type AlertNG struct {
 	AlertsRouter         *sender.AlertsRouter
 	accesscontrol        accesscontrol.AccessControl
 	accesscontrolService accesscontrol.Service
+	annotationsRepo      annotations.Repository
 
 	bus bus.Bus
 }
@@ -165,7 +169,7 @@ func (ng *AlertNG) init() error {
 		AlertSender:   alertsRouter,
 	}
 
-	stateManager := state.NewManager(ng.Log, ng.Metrics.GetStateMetrics(), appUrl, store, store, ng.dashboardService, ng.imageService, clk)
+	stateManager := state.NewManager(ng.Log, ng.Metrics.GetStateMetrics(), appUrl, store, store, ng.dashboardService, ng.imageService, clk, annotationstest.NewFakeAnnotationsRepo())
 	scheduler := schedule.NewScheduler(schedCfg, appUrl, stateManager)
 
 	// if it is required to include folder title to the alerts, we need to subscribe to changes of alert title

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/annotations"
-	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/datasourceproxy"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -169,7 +168,7 @@ func (ng *AlertNG) init() error {
 		AlertSender:   alertsRouter,
 	}
 
-	stateManager := state.NewManager(ng.Log, ng.Metrics.GetStateMetrics(), appUrl, store, store, ng.dashboardService, ng.imageService, clk, annotationstest.NewFakeAnnotationsRepo())
+	stateManager := state.NewManager(ng.Log, ng.Metrics.GetStateMetrics(), appUrl, store, store, ng.dashboardService, ng.imageService, clk, ng.annotationsRepo)
 	scheduler := schedule.NewScheduler(schedCfg, appUrl, stateManager)
 
 	// if it is required to include folder title to the alerts, we need to subscribe to changes of alert title

--- a/pkg/services/ngalert/schedule/schedule_test.go
+++ b/pkg/services/ngalert/schedule/schedule_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/image"
@@ -112,7 +113,7 @@ func TestWarmStateCache(t *testing.T) {
 		InstanceStore: dbstore,
 		Metrics:       testMetrics.GetSchedulerMetrics(),
 	}
-	st := state.NewManager(schedCfg.Logger, testMetrics.GetStateMetrics(), nil, dbstore, dbstore, &dashboards.FakeDashboardService{}, &image.NoopImageService{}, clock.NewMock())
+	st := state.NewManager(schedCfg.Logger, testMetrics.GetStateMetrics(), nil, dbstore, dbstore, &dashboards.FakeDashboardService{}, &image.NoopImageService{}, clock.NewMock(), annotationstest.NewFakeAnnotationsRepo())
 	st.Warm(ctx)
 
 	t.Run("instance cache has expected entries", func(t *testing.T) {
@@ -166,7 +167,7 @@ func TestAlertingTicker(t *testing.T) {
 		Metrics:       testMetrics.GetSchedulerMetrics(),
 		AlertSender:   notifier,
 	}
-	st := state.NewManager(schedCfg.Logger, testMetrics.GetStateMetrics(), nil, dbstore, dbstore, &dashboards.FakeDashboardService{}, &image.NoopImageService{}, clock.NewMock())
+	st := state.NewManager(schedCfg.Logger, testMetrics.GetStateMetrics(), nil, dbstore, dbstore, &dashboards.FakeDashboardService{}, &image.NoopImageService{}, clock.NewMock(), annotationstest.NewFakeAnnotationsRepo())
 	appUrl := &url.URL{
 		Scheme: "http",
 		Host:   "localhost",

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/annotations"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
@@ -484,8 +484,6 @@ func TestSchedule_DeleteAlertRule(t *testing.T) {
 func setupScheduler(t *testing.T, rs *store.FakeRuleStore, is *store.FakeInstanceStore, registry *prometheus.Registry, senderMock *AlertsSenderMock, evalMock *eval.FakeEvaluator) *schedule {
 	t.Helper()
 
-	fakeAnnoRepo := store.NewFakeAnnotationsRepo()
-	annotations.SetRepository(fakeAnnoRepo)
 	mockedClock := clock.NewMock()
 	logger := log.New("ngalert schedule test")
 
@@ -531,7 +529,7 @@ func setupScheduler(t *testing.T, rs *store.FakeRuleStore, is *store.FakeInstanc
 		Metrics:     m.GetSchedulerMetrics(),
 		AlertSender: senderMock,
 	}
-	st := state.NewManager(schedCfg.Logger, m.GetStateMetrics(), nil, rs, is, &dashboards.FakeDashboardService{}, &image.NoopImageService{}, mockedClock)
+	st := state.NewManager(schedCfg.Logger, m.GetStateMetrics(), nil, rs, is, &dashboards.FakeDashboardService{}, &image.NoopImageService{}, mockedClock, annotationstest.NewFakeAnnotationsRepo())
 	return NewScheduler(schedCfg, appUrl, st)
 }
 

--- a/pkg/services/ngalert/state/manager_private_test.go
+++ b/pkg/services/ngalert/state/manager_private_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/benbjohnson/clock"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/annotations"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/ngalert/eval"
 	"github.com/grafana/grafana/pkg/services/ngalert/image"
@@ -98,7 +98,7 @@ func Test_maybeNewImage(t *testing.T) {
 			imageService := &CountingImageService{}
 			mgr := NewManager(log.NewNopLogger(), &metrics.State{}, nil,
 				&store.FakeRuleStore{}, &store.FakeInstanceStore{},
-				&dashboards.FakeDashboardService{}, imageService, clock.NewMock())
+				&dashboards.FakeDashboardService{}, imageService, clock.NewMock(), annotationstest.NewFakeAnnotationsRepo())
 			err := mgr.maybeTakeScreenshot(context.Background(), &ngmodels.AlertRule{}, test.state, test.oldState)
 			require.NoError(t, err)
 			if !test.shouldScreenshot {
@@ -156,9 +156,7 @@ func TestIsItStale(t *testing.T) {
 func TestClose(t *testing.T) {
 	instanceStore := &store.FakeInstanceStore{}
 	clk := clock.New()
-	st := NewManager(log.New("test_state_manager"), metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(), nil, nil, instanceStore, &dashboards.FakeDashboardService{}, &image.NotAvailableImageService{}, clk)
-	fakeAnnoRepo := store.NewFakeAnnotationsRepo()
-	annotations.SetRepository(fakeAnnoRepo)
+	st := NewManager(log.New("test_state_manager"), metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(), nil, nil, instanceStore, &dashboards.FakeDashboardService{}, &image.NotAvailableImageService{}, clk, annotationstest.NewFakeAnnotationsRepo())
 
 	_, rules := ngmodels.GenerateUniqueAlertRules(10, ngmodels.AlertRuleGen())
 	for _, rule := range rules {

--- a/pkg/services/ngalert/store/testing.go
+++ b/pkg/services/ngalert/store/testing.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/grafana/grafana/pkg/services/annotations"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/util"
 
@@ -480,48 +479,4 @@ func (f *FakeAdminConfigStore) UpdateAdminConfiguration(cmd UpdateAdminConfigura
 	f.Configs[cmd.AdminConfiguration.OrgID] = cmd.AdminConfiguration
 
 	return nil
-}
-
-type FakeAnnotationsRepo struct {
-	mtx   sync.Mutex
-	Items []*annotations.Item
-}
-
-func NewFakeAnnotationsRepo() *FakeAnnotationsRepo {
-	return &FakeAnnotationsRepo{
-		Items: make([]*annotations.Item, 0),
-	}
-}
-
-func (repo *FakeAnnotationsRepo) Len() int {
-	repo.mtx.Lock()
-	defer repo.mtx.Unlock()
-	return len(repo.Items)
-}
-
-func (repo *FakeAnnotationsRepo) Delete(_ context.Context, params *annotations.DeleteParams) error {
-	return nil
-}
-
-func (repo *FakeAnnotationsRepo) Save(item *annotations.Item) error {
-	repo.mtx.Lock()
-	defer repo.mtx.Unlock()
-	repo.Items = append(repo.Items, item)
-
-	return nil
-}
-func (repo *FakeAnnotationsRepo) Update(_ context.Context, item *annotations.Item) error {
-	return nil
-}
-
-func (repo *FakeAnnotationsRepo) Find(_ context.Context, query *annotations.ItemQuery) ([]*annotations.ItemDTO, error) {
-	annotations := []*annotations.ItemDTO{{Id: 1}}
-	return annotations, nil
-}
-
-func (repo *FakeAnnotationsRepo) FindTags(_ context.Context, query *annotations.TagsQuery) (annotations.FindTagsResult, error) {
-	result := annotations.FindTagsResult{
-		Tags: []*annotations.TagsDTO{},
-	}
-	return result, nil
 }

--- a/pkg/services/ngalert/tests/util.go
+++ b/pkg/services/ngalert/tests/util.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
+	"github.com/grafana/grafana/pkg/services/annotations/annotationstest"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	databasestore "github.com/grafana/grafana/pkg/services/dashboards/database"
 	dashboardservice "github.com/grafana/grafana/pkg/services/dashboards/service"
@@ -81,7 +82,7 @@ func SetupTestEnv(t *testing.T, baseInterval time.Duration) (*ngalert.AlertNG, *
 
 	ng, err := ngalert.ProvideService(
 		cfg, nil, nil, routing.NewRouteRegister(), sqlStore, nil, nil, nil, nil,
-		secretsService, nil, m, folderService, ac, &dashboards.FakeDashboardService{}, nil, bus, ac,
+		secretsService, nil, m, folderService, ac, &dashboards.FakeDashboardService{}, nil, bus, ac, annotationstest.NewFakeAnnotationsRepo(),
 	)
 	require.NoError(t, err)
 	return ng, &store.DBstore{

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -120,7 +120,6 @@ func newSQLStore(cfg *setting.Cfg, cacheService *localcache.CacheService, engine
 	dialect = ss.Dialect
 
 	// Init repo instances
-	annotations.SetRepository(&SQLAnnotationRepo{sql: ss})
 	annotations.SetAnnotationCleaner(&AnnotationCleanupService{batchSize: ss.Cfg.AnnotationCleanupJobBatchSize, log: log.New("annotationcleaner"), sqlstore: ss})
 
 	// if err := ss.Reset(); err != nil {

--- a/pkg/services/sqlstore/store.go
+++ b/pkg/services/sqlstore/store.go
@@ -2,15 +2,12 @@ package sqlstore
 
 import (
 	"context"
-	"time"
 
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 	"github.com/grafana/grafana/pkg/services/user"
 )
-
-var timeNow = time.Now
 
 type Store interface {
 	GetAdminStats(ctx context.Context, query *models.GetAdminStatsQuery) error


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:
This work changes the way the annotations repository is wired: it adds it as a dependency to the `api.HTTPServer`, `alerting.AlertEngine`, `ngalert.AlertNG` and `commentmodel. PermissionChecker` and removes `annotations.GetRepository` and `annotations.SetRepository`
It also uses the same fake service (returned by `annotationstest.NewFakeAnnotationsRepo()`) for all the tests (both API and ngalert)