### PR TITLE
RBAC: Add cache for oss rbac permissions

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -666,7 +666,7 @@ managed_identity_client_id =
 
 #################################### Role-based Access Control ###########
 [rbac]
-# If enabled, cache permissions in a in memory cache (Enterprise only)
+# If enabled, cache permissions in a in memory cache
 permission_cache = true
 
 #################################### SMTP / Emailing #####################

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/fs"
+	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -379,7 +380,7 @@ func setupHTTPServerWithCfgDb(
 		acService = acmock
 	} else {
 		var err error
-		acService, err = acimpl.ProvideService(cfg, database.ProvideService(db), routeRegister)
+		acService, err = acimpl.ProvideService(cfg, database.ProvideService(db), routeRegister, localcache.ProvideService())
 		require.NoError(t, err)
 		ac = acimpl.ProvideAccessControl(cfg)
 	}

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -68,7 +68,10 @@ func (s *Service) GetUsageStats(_ context.Context) map[string]interface{} {
 }
 
 var actionsToFetch = append(
-	ossaccesscontrol.TeamAdminActions, append(ossaccesscontrol.DashboardAdminActions, ossaccesscontrol.FolderAdminActions...)...,
+	ossaccesscontrol.TeamAdminActions,
+	append(ossaccesscontrol.ServiceAccountAdminActions,
+		append(ossaccesscontrol.DashboardAdminActions, ossaccesscontrol.FolderAdminActions...)...,
+	)...,
 )
 
 // GetUserPermissions returns user permissions based on built-in roles

--- a/pkg/services/accesscontrol/acimpl/service.go
+++ b/pkg/services/accesscontrol/acimpl/service.go
@@ -68,10 +68,7 @@ func (s *Service) GetUsageStats(_ context.Context) map[string]interface{} {
 }
 
 var actionsToFetch = append(
-	ossaccesscontrol.TeamAdminActions,
-	append(ossaccesscontrol.ServiceAccountAdminActions,
-		append(ossaccesscontrol.DashboardAdminActions, ossaccesscontrol.FolderAdminActions...)...,
-	)...,
+	ossaccesscontrol.TeamAdminActions, append(ossaccesscontrol.DashboardAdminActions, ossaccesscontrol.FolderAdminActions...)...,
 )
 
 // GetUserPermissions returns user permissions based on built-in roles

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/infra/localcache"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -59,6 +60,7 @@ func TestUsageMetrics(t *testing.T) {
 				cfg,
 				database.ProvideService(sqlstore.InitTestDB(t)),
 				routing.NewRouteRegister(),
+				localcache.ProvideService(),
 			)
 			require.NoError(t, errInitAc)
 			assert.Equal(t, tt.expectedValue, s.GetUsageStats(context.Background())["stats.oss.accesscontrol.enabled.count"])

--- a/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/permissions_services.go
@@ -258,6 +258,20 @@ func (e DatasourcePermissionsService) MapActions(permission accesscontrol.Resour
 	return ""
 }
 
+var (
+	ServiceAccountEditActions = []string{
+		serviceaccounts.ActionRead,
+		serviceaccounts.ActionWrite,
+	}
+	ServiceAccountAdminActions = []string{
+		serviceaccounts.ActionRead,
+		serviceaccounts.ActionWrite,
+		serviceaccounts.ActionDelete,
+		serviceaccounts.ActionPermissionsRead,
+		serviceaccounts.ActionPermissionsWrite,
+	}
+)
+
 type ServiceAccountPermissionsService struct {
 	*resourcepermissions.Service
 }
@@ -283,8 +297,8 @@ func ProvideServiceAccountPermissions(
 			BuiltInRoles: false,
 		},
 		PermissionsToActions: map[string][]string{
-			"Edit":  {serviceaccounts.ActionRead, serviceaccounts.ActionWrite},
-			"Admin": {serviceaccounts.ActionRead, serviceaccounts.ActionWrite, serviceaccounts.ActionDelete, serviceaccounts.ActionPermissionsRead, serviceaccounts.ActionPermissionsWrite},
+			"Edit":  ServiceAccountEditActions,
+			"Admin": ServiceAccountAdminActions,
 		},
 		ReaderRoleName: "Service account permission reader",
 		WriterRoleName: "Service account permission writer",

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -202,6 +202,11 @@ func CreateGrafDir(t *testing.T, opts ...GrafanaOpts) (string, string) {
 	_, err = alertingSect.NewKey("max_attempts", "3")
 	require.NoError(t, err)
 
+	rbacSect, err := cfg.NewSection("rbac")
+	require.NoError(t, err)
+	_, err = rbacSect.NewKey("permission_cache", "false")
+	require.NoError(t, err)
+
 	getOrCreateSection := func(name string) (*ini.Section, error) {
 		section, err := cfg.GetSection(name)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
We have had the option to use permissions cache in enterprise for a while. We did not add it to oss because at the time we had no permissions stored in the db. With managed permissions we do and should add the possibility to use it. This will respect the permission_cache setting.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Enterprise pr https://github.com/grafana/grafana-enterprise/pull/3841
