### PR TITLE
[AuthProxy] Allow for stripping header prefixes

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -605,6 +605,7 @@ sync_ttl = 60
 whitelist =
 headers =
 headers_encoded = false
+headers_strip_prefix =
 enable_login_token = false
 
 #################################### Auth JWT ##########################

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -595,6 +595,8 @@
 ;headers = Email:X-User-Email, Name:X-User-Name
 # Non-ASCII strings in header values are encoded using quoted-printable encoding
 ;headers_encoded = false
+# If a prefix appears in the headers you wish to strip, specify it
+;headers_strip_prefix = accounts.google.com:
 # Read the auth proxy docs for details on what the setting below enables
 ;enable_login_token = false
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/auth-proxy.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/auth-proxy.md
@@ -41,6 +41,8 @@ whitelist =
 headers =
 # Non-ASCII strings in header values are encoded using quoted-printable encoding
 ;headers_encoded = false
+# If a prefix appears in the headers you wish to strip, specify it
+;headers_strip_prefix = accounts.google.com:
 # Check out docs on this for more details on the below setting
 enable_login_token = false
 ```

--- a/pkg/services/contexthandler/authproxy/authproxy.go
+++ b/pkg/services/contexthandler/authproxy/authproxy.go
@@ -328,6 +328,10 @@ func (auth *AuthProxy) getDecodedHeader(reqCtx *models.ReqContext, headerName st
 		headerValue = util.DecodeQuotedPrintable(headerValue)
 	}
 
+	if auth.cfg.AuthProxyHeadersStripPrefix != "" {
+		headerValue = strings.TrimPrefix(headerValue, auth.cfg.AuthProxyHeadersStripPrefix)
+	}
+
 	return headerValue
 }
 

--- a/pkg/services/contexthandler/authproxy/authproxy_test.go
+++ b/pkg/services/contexthandler/authproxy/authproxy_test.go
@@ -207,4 +207,15 @@ func TestDecodeHeader(t *testing.T) {
 		header := auth.getDecodedHeader(reqCtx, auth.cfg.AuthProxyHeaderName)
 		assert.Equal(t, "München", header)
 	})
+
+	t.Run("should be able to strip a prefix", func(t *testing.T) {
+		auth, reqCtx := prepareMiddleware(t, cache, func(req *http.Request, cfg *setting.Cfg) {
+			cfg.AuthProxyHeaderName = "X-WEBAUTH-USER"
+			cfg.AuthProxyHeadersStripPrefix = "accounts.contoso.com:"
+			req.Header.Set(cfg.AuthProxyHeaderName, "accounts.contoso.com:callum_jones")
+		})
+
+		header := auth.getDecodedHeader(reqCtx, auth.cfg.AuthProxyHeaderName)
+		assert.Equal(t, "callum_jones", header)
+	})
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -304,15 +304,16 @@ type Cfg struct {
 	Azure *azsettings.AzureSettings
 
 	// Auth proxy settings
-	AuthProxyEnabled          bool
-	AuthProxyHeaderName       string
-	AuthProxyHeaderProperty   string
-	AuthProxyAutoSignUp       bool
-	AuthProxyEnableLoginToken bool
-	AuthProxyWhitelist        string
-	AuthProxyHeaders          map[string]string
-	AuthProxyHeadersEncoded   bool
-	AuthProxySyncTTL          int
+	AuthProxyEnabled            bool
+	AuthProxyHeaderName         string
+	AuthProxyHeaderProperty     string
+	AuthProxyAutoSignUp         bool
+	AuthProxyEnableLoginToken   bool
+	AuthProxyWhitelist          string
+	AuthProxyHeaders            map[string]string
+	AuthProxyHeadersEncoded     bool
+	AuthProxyHeadersStripPrefix string
+	AuthProxySyncTTL            int
 
 	// OAuth
 	OAuthCookieMaxAge int
@@ -1356,6 +1357,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	}
 
 	cfg.AuthProxyHeadersEncoded = authProxy.Key("headers_encoded").MustBool(false)
+	cfg.AuthProxyHeadersStripPrefix = authProxy.Key("headers_strip_prefix").MustString("")
 
 	return nil
 }


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Our Grafana instance sits behind Google IAP with a custom proxy in the middle. Our proxy does not pass through JWT tokens and so we need strip out the `accounts.google.com:` prefix in the headers. Annoyingly this proxy still keeps the `accounts.google.com:` prefix in headers. We'd like to see if Grafana could easily strip this.

I understand this is probably quite niche so if the team doesn't see fit (since you could solve this with adding another proxy in Grafana, albeit messy) feel free to reject.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

