### PR TITLE
SupportSnapshots: Show type icons in table

### DIFF
--- a/public/app/features/dashboard/components/SupportSnapshot/utils.ts
+++ b/public/app/features/dashboard/components/SupportSnapshot/utils.ts
@@ -140,6 +140,9 @@ export async function getDebugDashboard(panel: PanelModel, rand: Randomize, time
         type: 'grafana',
         uid: 'grafana',
       },
+      options: {
+        showTypeIcons: true,
+      },
       targets: [
         {
           refId: 'A',
@@ -272,6 +275,9 @@ const embeddedDataTemplate: any = {
         w: 15,
         x: 0,
         y: 13,
+      },
+      options: {
+        showTypeIcons: true,
       },
       targets: [
         {


### PR DESCRIPTION
This updates the snapshot to show the type icons:

<img width="788" alt="image" src="https://user-images.githubusercontent.com/705951/189946640-7d2846ce-924b-4e30-9392-6b1514f420de.png">
