### PR TITLE
Panel: Disable legends when showLegend is false prior to schema v37

### DIFF
--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -793,7 +793,10 @@ export class DashboardMigrator {
 
     if (oldVersion < 37) {
       panelUpgrades.push((panel: PanelModel) => {
-        if (panel.options?.legend && panel.options.legend.displayMode === 'hidden') {
+        if (
+          panel.options?.legend &&
+          (panel.options.legend.displayMode === 'hidden' || panel.options.legend.showLegend === false)
+        ) {
           panel.options.legend.displayMode = 'list';
           panel.options.legend.showLegend = false;
         } else if (panel.options?.legend) {

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -795,6 +795,7 @@ export class DashboardMigrator {
       panelUpgrades.push((panel: PanelModel) => {
         if (
           panel.options?.legend &&
+          // There were two ways to hide the legend, this normalizes to `legend.showLegend`
           (panel.options.legend.displayMode === 'hidden' || panel.options.legend.showLegend === false)
         ) {
           panel.options.legend.displayMode = 'list';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Because of the migration logic, if any schema older than v37 includes `showLegend: false` that value is ignored and fallen back to `true` since the accepted value is `displayMode === 'hidden'` for those versions. [This Mimir dashboard](https://github.com/grafana/mimir/blob/cacd7593458475964391ce27acf2f3059d290a6c/operations/mimir-mixin-compiled/dashboards/mimir-writes.json#L655-L679) is generated with that option which breaks the experience. To solve this, we will allow older versions of the schema to be able to use `showLegend` which is the actual way of toggling it.

**Which issue(s) this PR fixes**:
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #54472
