### PR TITLE
Gauge: Fixes empty/broken Gauge panels with datalinks

### DIFF
--- a/packages/grafana-ui/src/components/DataLinks/DataLinksContextMenu.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinksContextMenu.tsx
@@ -62,7 +62,7 @@ export const DataLinksContextMenu: React.FC<DataLinksContextMenuProps> = ({ chil
         onClick={linkModel.onClick}
         target={linkModel.target}
         title={linkModel.title}
-        style={{ ...style, overflow: 'hidden', display: 'flex' }}
+        style={{ ...style, overflow: 'hidden', display: 'flex', flexGrow: 1 }}
         aria-label={selectors.components.DataLinksContextMenu.singleLink}
       >
         {children({})}


### PR DESCRIPTION
Fixes broken / empty Gauge panels (when they have data link and orientation: horizontal).

Could need some more testing to see if this breaks anything else where DataLinkContextMenu is used.

Introduced in recent PR https://github.com/grafana/grafana/pull/55065
