### PR TITLE
Fix download link in macOS install instructions

### DIFF
--- a/docs/sources/setup-grafana/installation/mac.md
+++ b/docs/sources/setup-grafana/installation/mac.md
@@ -37,7 +37,7 @@ Use [Homebrew](http://brew.sh/) to install the most recent released version of G
 
 ## Install standalone macOS binaries
 
-To install a nightly build, or to install the latest version of Grafana without Homebrew, go to the [Grafana download page](https://grafana.com/grafana/download/7.3.0-381ff45epre?platform=mac).
+To install a nightly build, or to install the latest version of Grafana without Homebrew, go to the [Grafana download page](https://grafana.com/grafana/download?platform=mac).
 
 1. Select the Grafana version you want to install. By default, the most recent released version is selected.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the download link in macOS docs. Updated to point to main download page, as with other platforms.

**Which issue(s) this PR fixes**:

The link was pointing to non-existing `7.3.0-381ff45epre` version, resulting in:
> The requested release was not found. Please check your link or head back to the [stable release](https://grafana.com/grafana/download).