### PR TITLE
Configuration: Update ssl_mode documentation in sample.ini to match default.ini

### DIFF
--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -94,7 +94,8 @@
 # Example: mysql://user:secret@host:port/database
 ;url =
 
-# For "postgres" only, either "disable", "require" or "verify-full"
+# For "postgres", use either "disable", "require" or "verify-full"
+# For "mysql", use either "true", "false", or "skip-verify".
 ;ssl_mode = disable
 
 # Database drivers may support different transaction isolation levels.


### PR DESCRIPTION
sample.ini ssl_mode documentation does not match the current config documentations (online docs and default.ini).

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Documentation comment for ssl_mode in sample.ini reflects options before mysql TLS support was added in 2015. This is to update it to match default.ini and the site docs.

Reference:
- https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#ssl_mode
- https://github.com/grafana/grafana/blob/main/conf/defaults.ini#L107-L108

**Which issue(s) this PR fixes**:

n/a

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer**:

