### PR TITLE
Geomap: Add Africa, Australia, Oceania, South Asia, and East Asia as initial view options

### DIFF
--- a/public/app/plugins/panel/geomap/view.ts
+++ b/public/app/plugins/panel/geomap/view.ts
@@ -68,7 +68,7 @@ export const centerPointRegistry = new Registry<MapCenterItems>(() => [
     name: 'South Asia',
     lat: 19.5,
     lon: 80,
-    zoom: 4.5,
+    zoom: 4,
   },
   {
     id: 'se-asia',
@@ -82,14 +82,14 @@ export const centerPointRegistry = new Registry<MapCenterItems>(() => [
     name: 'East Asia',
     lat: 33,
     lon: 120,
-    zoom: 4.5,
+    zoom: 4,
   },
   {
     id: 'australia',
     name: 'Australia',
     lat: -25,
     lon: 135,
-    zoom: 4.5,
+    zoom: 4,
   },
   {
     id: 'oceania',

--- a/public/app/plugins/panel/geomap/view.ts
+++ b/public/app/plugins/panel/geomap/view.ts
@@ -72,7 +72,7 @@ export const centerPointRegistry = new Registry<MapCenterItems>(() => [
   },
   {
     id: 'se-asia',
-    name: 'South-east Asia',
+    name: 'South-East Asia',
     lat: 10,
     lon: 106,
     zoom: 4,

--- a/public/app/plugins/panel/geomap/view.ts
+++ b/public/app/plugins/panel/geomap/view.ts
@@ -25,11 +25,22 @@ export const centerPointRegistry = new Registry<MapCenterItems>(() => [
     lon: 0,
   },
   {
+    id: MapCenterID.Coordinates as string,
+    name: 'Coordinates',
+  },
+  {
     id: 'north-america',
     name: 'North America',
     lat: 40,
     lon: -100,
     zoom: 4,
+  },
+  {
+    id: 'south-america',
+    name: 'South America',
+    lat: -20,
+    lon: -60,
+    zoom: 3,
   },
   {
     id: 'europe',
@@ -39,11 +50,25 @@ export const centerPointRegistry = new Registry<MapCenterItems>(() => [
     zoom: 4,
   },
   {
+    id: 'africa',
+    name: 'Africa',
+    lat: 0,
+    lon: 30,
+    zoom: 3,
+  },
+  {
     id: 'west-asia',
     name: 'West Asia',
     lat: 26,
     lon: 53,
     zoom: 4,
+  },
+  {
+    id: 's-asia',
+    name: 'South Asia',
+    lat: 19.5,
+    lon: 80,
+    zoom: 4.5,
   },
   {
     id: 'se-asia',
@@ -53,7 +78,24 @@ export const centerPointRegistry = new Registry<MapCenterItems>(() => [
     zoom: 4,
   },
   {
-    id: MapCenterID.Coordinates as string,
-    name: 'Coordinates',
+    id: 'e-asia',
+    name: 'East Asia',
+    lat: 33,
+    lon: 120,
+    zoom: 4.5,
+  },
+  {
+    id: 'australia',
+    name: 'Australia',
+    lat: -25,
+    lon: 135,
+    zoom: 4.5,
+  },
+  {
+    id: 'oceania',
+    name: 'Oceania',
+    lat: -10,
+    lon: -140,
+    zoom: 3,
   },
 ]);


### PR DESCRIPTION
👋 
a community user in the forum expressed a little disappointment that some continents are available as initial views while others are not.

In the interest of fairness, this PR suggests adding Africa, Australia, Oceania, and the two remaining Asian regions not already present: South Asia and East Asia.

Also: with this newer, longer list, I thought it might make more sense to bump the `coordinates` option to appear above the continents