### PR TITLE
RBAC: Fix background users to include permissions

### DIFF
--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -223,3 +223,14 @@ func GetOrgRoles(user *user.SignedInUser) []string {
 
 	return roles
 }
+
+func BackgroundUser(name string, role org.RoleType, orgID int64, permissions []Permission) *user.SignedInUser {
+	return &user.SignedInUser{
+		OrgID:   orgID,
+		OrgRole: role,
+		Login:   "grafana_" + name,
+		Permissions: map[int64]map[string][]string{
+			orgID: GroupScopesByAction(permissions),
+		},
+	}
+}

--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -224,7 +224,7 @@ func GetOrgRoles(user *user.SignedInUser) []string {
 	return roles
 }
 
-func BackgroundUser(name string, role org.RoleType, orgID int64, permissions []Permission) *user.SignedInUser {
+func BackgroundUser(name string, orgID int64, role org.RoleType, permissions []Permission) *user.SignedInUser {
 	return &user.SignedInUser{
 		OrgID:   orgID,
 		OrgRole: role,


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/grafana/grafana/pull/54910 we changed so that we short circuit the evaluate call if no permissions are set for the user. This broke some background users. Alerting user, fixed by https://github.com/grafana/grafana/pull/55127, recorded queries, fixed by https://github.com/grafana/grafana-enterprise/pull/3844 and PluginDashboard import.

This pr does two things. Add a new constructor for Background users and fixes the PluginDashboard user.

