### PR TITLE
CI: Split `oss` and `enterprise` steps for release pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2549,17 +2549,6 @@ steps:
   image: grafana/grafana-ci-deploy:1.3.3
   name: upload-packages
 - commands:
-  - ./bin/grabpl artifacts npm store --tag ${DRONE_TAG}
-  depends_on:
-  - build-frontend-packages
-  environment:
-    GCP_KEY:
-      from_secret: gcp_key
-    PRERELEASE_BUCKET:
-      from_secret: prerelease_bucket
-  image: grafana/build-container:1.6.2
-  name: store-npm-packages
-- commands:
   - ./bin/grabpl package --jobs 8 --edition enterprise2  --sign ${DRONE_TAG}
   depends_on:
   - build-plugins
@@ -2589,6 +2578,17 @@ steps:
       from_secret: prerelease_bucket
   image: grafana/grafana-ci-deploy:1.3.3
   name: upload-cdn-assets-enterprise2
+- commands:
+  - ./bin/grabpl artifacts npm store --tag ${DRONE_TAG}
+  depends_on:
+  - build-frontend-packages
+  environment:
+    GCP_KEY:
+      from_secret: gcp_key
+    PRERELEASE_BUCKET:
+      from_secret: prerelease_bucket
+  image: grafana/build-container:1.6.2
+  name: store-npm-packages
 - commands:
   - ./bin/grabpl upload-packages --edition enterprise2
   depends_on:
@@ -5055,6 +5055,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 5ddbaf0b3a60ffec387d728b2141c59a4875d72108a71b2ee0baf278d2b4e939
+hmac: e21a281dc63df0317ad1082113a224b53fb5ef2f62d74eb2d7b6d11d80f0f079
 
 ...

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -151,13 +151,14 @@ def publish_image_pipelines(mode):
         name='publish-docker-enterprise-{}'.format(mode), trigger=trigger, steps=publish_image_steps(version='enterprise',  mode=mode, docker_repo='grafana-enterprise'), edition=""
     ),]
 
-def get_steps(edition, ver_mode):
+def get_oss_pipelines(trigger, ver_mode):
+    edition = 'oss'
+    services = integration_test_services(edition=edition)
+    volumes = integration_test_services_volumes()
     package_steps = []
     publish_steps = []
     should_publish = ver_mode == 'release'
     should_upload = should_publish or ver_mode in ('release-branch',)
-    include_enterprise = edition == 'enterprise'
-    edition2 = 'enterprise2'
     init_steps = [
         identify_runner_step(),
         download_grabpl_step(),
@@ -165,6 +166,119 @@ def get_steps(edition, ver_mode):
         wire_install_step(),
         yarn_install_step(),
         compile_build_cmd(),
+    ]
+
+    test_steps = []
+
+    test_steps.extend([
+        lint_backend_step(edition=edition),
+        lint_frontend_step(),
+        test_backend_step(edition=edition),
+        test_backend_integration_step(edition=edition),
+        test_frontend_step(),
+    ])
+
+    build_steps = [
+        build_backend_step(edition=edition, ver_mode=ver_mode),
+        build_frontend_step(edition=edition, ver_mode=ver_mode),
+        build_frontend_package_step(edition=edition, ver_mode=ver_mode),
+        build_plugins_step(edition=edition, ver_mode=ver_mode),
+    ]
+
+    integration_test_steps = [
+        postgres_integration_tests_step(edition=edition, ver_mode=ver_mode),
+        mysql_integration_tests_step(edition=edition, ver_mode=ver_mode),
+    ]
+
+    # Insert remaining steps
+    build_steps.extend([
+        package_step(edition=edition, ver_mode=ver_mode),
+        copy_packages_for_docker_step(),
+        build_docker_images_step(edition=edition, ver_mode=ver_mode, publish=True),
+        build_docker_images_step(edition=edition, ver_mode=ver_mode, ubuntu=True, publish=True),
+        grafana_server_step(edition=edition),
+    ])
+
+    if not disable_tests:
+        build_steps.extend([
+            e2e_tests_step('dashboards-suite', edition=edition, tries=3),
+            e2e_tests_step('smoke-tests-suite', edition=edition, tries=3),
+            e2e_tests_step('panels-suite', edition=edition, tries=3),
+            e2e_tests_step('various-suite', edition=edition, tries=3),
+            e2e_tests_artifacts(edition=edition),
+        ])
+
+    build_storybook = build_storybook_step(edition=edition, ver_mode=ver_mode)
+    if build_storybook:
+        build_steps.append(build_storybook)
+
+    if should_upload:
+        publish_steps.append(upload_cdn_step(edition=edition, ver_mode=ver_mode, trigger=trigger_oss))
+        publish_steps.append(upload_packages_step(edition=edition, ver_mode=ver_mode, trigger=trigger_oss))
+    if should_publish:
+        publish_step = store_storybook_step(edition=edition, ver_mode=ver_mode)
+        store_npm_step = store_npm_packages_step()
+        if publish_step:
+            publish_steps.append(publish_step)
+        if store_npm_step:
+            publish_steps.append(store_npm_step)
+    windows_package_steps = get_windows_steps(edition=edition, ver_mode=ver_mode)
+
+    windows_pipeline = pipeline(
+        name='{}-oss-windows'.format(ver_mode), edition=edition, trigger=trigger,
+        steps=[identify_runner_step('windows')] + windows_package_steps,
+        platform='windows', depends_on=[
+            'oss-build{}-publish-{}'.format(get_e2e_suffix(), ver_mode),
+        ],
+    )
+    pipelines = [
+        pipeline(
+            name='{}-oss-build{}-publish'.format(ver_mode, get_e2e_suffix()), edition=edition, trigger=trigger, services=[],
+            steps=init_steps + build_steps + package_steps + publish_steps,
+            volumes=volumes,
+        ),
+    ]
+    if not disable_tests:
+        pipelines.extend([
+            pipeline(
+                name='{}-oss-test'.format(ver_mode), edition=edition, trigger=trigger, services=[],
+                steps=init_steps + test_steps,
+                volumes=[],
+            ),
+            pipeline(
+                name='{}-oss-integration-tests'.format(ver_mode), edition=edition, trigger=trigger, services=services,
+                steps=[download_grabpl_step(), identify_runner_step(), verify_gen_cue_step(edition), wire_install_step(), ] + integration_test_steps,
+                volumes=volumes,
+            )
+        ])
+        deps = {
+            'depends_on': [
+                '{}-oss-build{}-publish'.format(ver_mode, get_e2e_suffix()),
+                '{}-oss-test'.format(ver_mode),
+                '{}-oss-integration-tests'.format(ver_mode)
+            ]
+        }
+        windows_pipeline.update(deps)
+
+    pipelines.extend([windows_pipeline])
+    return pipelines
+
+def get_enterprise_pipelines(trigger, ver_mode):
+    edition = 'enterprise'
+    services = integration_test_services(edition=edition)
+    volumes = integration_test_services_volumes()
+    package_steps = []
+    publish_steps = []
+    should_publish = ver_mode == 'release'
+    should_upload = should_publish or ver_mode in ('release-branch',)
+    include_enterprise = edition == 'enterprise'
+    edition2 = 'enterprise2'
+    init_steps = [
+        download_grabpl_step(),
+        identify_runner_step(),
+        clone_enterprise_step(ver_mode),
+        init_enterprise_step(ver_mode),
+        compile_build_cmd(edition),
     ]
 
     test_steps = []
@@ -221,8 +335,12 @@ def get_steps(edition, ver_mode):
         build_steps.append(build_storybook)
 
     if should_upload:
-        publish_steps.append(upload_cdn_step(edition=edition, ver_mode=ver_mode, trigger=trigger_oss))
-        publish_steps.append(upload_packages_step(edition=edition, ver_mode=ver_mode, trigger=trigger_oss))
+        publish_steps.extend([
+            upload_cdn_step(edition=edition, ver_mode=ver_mode, trigger=trigger_oss),
+            upload_packages_step(edition=edition, ver_mode=ver_mode, trigger=trigger_oss),
+            package_step(edition=edition2, ver_mode=ver_mode, include_enterprise2=include_enterprise, variants=['linux-amd64']),
+            upload_cdn_step(edition=edition2, ver_mode=ver_mode),
+        ])
     if should_publish:
         publish_step = store_storybook_step(edition=edition, ver_mode=ver_mode)
         store_npm_step = store_npm_packages_step()
@@ -232,79 +350,17 @@ def get_steps(edition, ver_mode):
             publish_steps.append(store_npm_step)
     windows_package_steps = get_windows_steps(edition=edition, ver_mode=ver_mode)
 
-    if include_enterprise:
-        publish_steps.extend([
-            package_step(edition=edition2, ver_mode=ver_mode, include_enterprise2=include_enterprise, variants=['linux-amd64']),
-            upload_cdn_step(edition=edition2, ver_mode=ver_mode),
-        ])
-        if should_upload:
-            step = upload_packages_step(edition=edition2, ver_mode=ver_mode)
-            if step:
-                publish_steps.append(step)
+    if should_upload:
+        step = upload_packages_step(edition=edition2, ver_mode=ver_mode)
+        if step:
+            publish_steps.append(step)
 
-    return init_steps, test_steps, build_steps, integration_test_steps, package_steps, windows_package_steps, publish_steps
-
-def get_oss_pipelines(trigger, ver_mode):
-    edition = 'oss'
-    services = integration_test_services(edition=edition)
-    volumes = integration_test_services_volumes()
-    init_steps, test_steps, build_steps, integration_test_steps, package_steps, windows_package_steps, publish_steps = get_steps(edition=edition, ver_mode=ver_mode)
-    windows_pipeline = pipeline(
-        name='{}-oss-windows'.format(ver_mode), edition=edition, trigger=trigger,
-        steps=[identify_runner_step('windows')] + windows_package_steps,
-        platform='windows', depends_on=[
-            'oss-build{}-publish-{}'.format(get_e2e_suffix(), ver_mode),
-        ],
-    )
-    pipelines = [
-        pipeline(
-            name='{}-oss-build{}-publish'.format(ver_mode, get_e2e_suffix()), edition=edition, trigger=trigger, services=[],
-            steps=init_steps + build_steps + package_steps + publish_steps,
-            volumes=volumes,
-        ),
-    ]
-    if not disable_tests:
-        pipelines.extend([
-            pipeline(
-                name='{}-oss-test'.format(ver_mode), edition=edition, trigger=trigger, services=[],
-                steps=init_steps + test_steps,
-                volumes=[],
-            ),
-            pipeline(
-                name='{}-oss-integration-tests'.format(ver_mode), edition=edition, trigger=trigger, services=services,
-                steps=[download_grabpl_step(), identify_runner_step(), verify_gen_cue_step(edition), wire_install_step(), ] + integration_test_steps,
-                volumes=volumes,
-            )
-        ])
-        deps = {
-            'depends_on': [
-                '{}-oss-build{}-publish'.format(ver_mode, get_e2e_suffix()),
-                '{}-oss-test'.format(ver_mode),
-                '{}-oss-integration-tests'.format(ver_mode)
-            ]
-        }
-        windows_pipeline.update(deps)
-
-    pipelines.extend([windows_pipeline])
-    return pipelines
-
-def get_enterprise_pipelines(trigger, ver_mode):
-    edition = 'enterprise'
-    services = integration_test_services(edition=edition)
-    volumes = integration_test_services_volumes()
     deps_on_clone_enterprise_step = {
         'depends_on': [
             'init-enterprise',
         ]
     }
-    _, test_steps, build_steps, integration_test_steps, package_steps, windows_package_steps, publish_steps = get_steps(edition=edition, ver_mode=ver_mode)
-    init_steps = [
-        download_grabpl_step(),
-        identify_runner_step(),
-        clone_enterprise_step(ver_mode),
-        init_enterprise_step(ver_mode),
-        compile_build_cmd(edition),
-    ]
+
     for step in [wire_install_step(), yarn_install_step(), verify_gen_cue_step(edition)]:
         step.update(deps_on_clone_enterprise_step)
         init_steps.extend([step])

--- a/scripts/drone/events/release.star
+++ b/scripts/drone/events/release.star
@@ -156,7 +156,7 @@ def get_steps(edition, ver_mode):
     publish_steps = []
     should_publish = ver_mode == 'release'
     should_upload = should_publish or ver_mode in ('release-branch',)
-    include_enterprise2 = edition == 'enterprise'
+    include_enterprise = edition == 'enterprise'
     edition2 = 'enterprise2'
     init_steps = [
         identify_runner_step(),
@@ -189,7 +189,7 @@ def get_steps(edition, ver_mode):
         mysql_integration_tests_step(edition=edition, ver_mode=ver_mode),
     ]
 
-    if include_enterprise2:
+    if include_enterprise:
         test_steps.extend([
             lint_backend_step(edition=edition2),
             test_backend_step(edition=edition2),
@@ -200,7 +200,7 @@ def get_steps(edition, ver_mode):
 
     # Insert remaining steps
     build_steps.extend([
-        package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise2),
+        package_step(edition=edition, ver_mode=ver_mode, include_enterprise2=include_enterprise),
         copy_packages_for_docker_step(),
         build_docker_images_step(edition=edition, ver_mode=ver_mode, publish=True),
         build_docker_images_step(edition=edition, ver_mode=ver_mode, ubuntu=True, publish=True),
@@ -232,9 +232,9 @@ def get_steps(edition, ver_mode):
             publish_steps.append(store_npm_step)
     windows_package_steps = get_windows_steps(edition=edition, ver_mode=ver_mode)
 
-    if include_enterprise2:
+    if include_enterprise:
         publish_steps.extend([
-            package_step(edition=edition2, ver_mode=ver_mode, include_enterprise2=include_enterprise2, variants=['linux-amd64']),
+            package_step(edition=edition2, ver_mode=ver_mode, include_enterprise2=include_enterprise, variants=['linux-amd64']),
             upload_cdn_step(edition=edition2, ver_mode=ver_mode),
         ])
         if should_upload:


### PR DESCRIPTION
**What this PR does / why we need it**:

No-op-y (one change in `.drone.yml` which is just a step moved.
Makes our starlark files easier to understand, amid `enterprise` and `enterprise2` split.

Related issue: https://github.com/grafana/grafana/issues/55151

