### PR TITLE
Loki: Hide loki sample queries from query inspector

### DIFF
--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -864,6 +864,20 @@ describe('LokiDatasource', () => {
       expect(queries[0].expr).toBe('{foo="bar"}');
     });
   });
+
+  describe('getDataSamples', () => {
+    it('hide request from inspector', () => {
+      const ds = createLokiDatasource(templateSrvStub);
+      const spy = jest.spyOn(ds, 'query').mockImplementation(() => of({} as DataQueryResponse));
+      ds.getDataSamples({ expr: '{job="bar"}', refId: 'A' });
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hideFromInspector: true,
+          requestId: 'log-samples',
+        })
+      );
+    });
+  });
 });
 
 describe('applyTemplateVariables', () => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -77,7 +77,13 @@ export const DEFAULT_MAX_LINES = 1000;
 export const LOKI_ENDPOINT = '/loki/api/v1';
 const NS_IN_MS = 1000000;
 
-function makeRequest(query: LokiQuery, range: TimeRange, app: CoreApp, requestId: string): DataQueryRequest<LokiQuery> {
+function makeRequest(
+  query: LokiQuery,
+  range: TimeRange,
+  app: CoreApp,
+  requestId: string,
+  hideFromInspector?: boolean
+): DataQueryRequest<LokiQuery> {
   const intervalInfo = rangeUtil.calculateInterval(range, 1);
   return {
     targets: [query],
@@ -89,6 +95,7 @@ function makeRequest(query: LokiQuery, range: TimeRange, app: CoreApp, requestId
     timezone: 'UTC',
     app,
     startTime: Date.now(),
+    hideFromInspector,
   };
 }
 
@@ -413,7 +420,7 @@ export class LokiDatasource
 
     // For samples, we use defaultTimeRange (now-6h/now) and limit od 10 lines so queries are small and fast
     const timeRange = getDefaultTimeRange();
-    const request = makeRequest(lokiLogsQuery, timeRange, CoreApp.Explore, 'log-samples');
+    const request = makeRequest(lokiLogsQuery, timeRange, CoreApp.Explore, 'log-samples', true);
     return await lastValueFrom(this.query(request).pipe(switchMap((res) => of(res.data))));
   }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Related of https://github.com/grafana/grafana/pull/54892. In https://github.com/grafana/grafana/pull/54892 we have added a way how to hide some queries from inspector ( e.g. log volume query). In this PR we are using it to hide sample queries used in query builder to create hints. 

**Fixed (this branch):**

https://user-images.githubusercontent.com/30407135/190129097-bb312b5a-d126-4a8f-aab0-b3098c9a9860.mov

**Current master:**

https://user-images.githubusercontent.com/30407135/190129141-d50f87b4-d17a-4b42-9efe-3f4b5170bf3a.mov


