### PR TITLE
Docs: create new explore page for concepts

### DIFF
--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -7,11 +7,13 @@ title: Alerting fundamentals
 weight: 110
 ---
 
-# Alerting fundamentals
+# Explore Grafana Alerting
 
-This section includes the following fundamental concepts of Grafana Alerting:
+Whether you're starting or expanding your implementation of Grafana Alerting, learn more about the key concepts and available features that help you create, manage, and take action on your alerts and improve your team’s ability to resolve issues quickly.
 
-- [Annotations and labels for alerting rules]({{< relref "annotation-label/" >}})
-- [Alertmanager]({{< relref "alertmanager/" >}})
-- [State and health of alerting rules]({{< relref "state-and-health/" >}})
-- [Evaluating Grafana managed alerts]({{< relref "evaluate-grafana-alerts/" >}})
+- [Data sources](https://grafana.com/docs/grafana/latest/alerting/fundamentals/data-source-alerting/)
+- [Alert rules](https://grafana.com/docs/grafana/latest/alerting/fundamentals/alert-rules/)
+- [Alerting on numeric data](https://grafana.com/docs/grafana/latest/alerting/fundamentals/evaluate-grafana-alerts/)
+- [Alertmanager](https://grafana.com/docs/grafana/latest/alerting/fundamentals/alertmanager/)
+- [Annotations and labels for alerting rules](https://grafana.com/docs/grafana/latest/alerting/fundamentals/annotation-label/)
+- [State and health of alerting rules](https://grafana.com/docs/grafana/latest/alerting/fundamentals/state-and-health/)

--- a/docs/sources/alerting/fundamentals/_index.md
+++ b/docs/sources/alerting/fundamentals/_index.md
@@ -4,7 +4,7 @@ aliases:
   - /docs/grafana/latest/alerting/metrics/
   - /docs/grafana/latest/alerting/unified-alerting/fundamentals/
 title: Alerting fundamentals
-weight: 110
+weight: 105
 ---
 
 # Explore Grafana Alerting

--- a/docs/sources/alerting/migrating-alerts/_index.md
+++ b/docs/sources/alerting/migrating-alerts/_index.md
@@ -6,7 +6,7 @@ aliases:
   - /docs/grafana/latest/alerting/difference-old-new/
 description: Upgrade Grafana alerts
 title: Upgrade to Grafana Alerting
-weight: 101
+weight: 110
 ---
 
 # Upgrade to Grafana Alerting


### PR DESCRIPTION
Changes fundamentals page to "Explore Grafana Alerting" which will include all the conceptual, high level feature topics (a kind of glossary as it were) targeting pre-sales -- get inspired - these are our features and this is why you want them!