### PR TITLE
Elasticsearch: Reuse http client in the backend

### DIFF
--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -62,7 +62,6 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 
 func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.InstanceFactoryFunc {
 	return func(settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-
 		jsonData := map[string]interface{}{}
 		err := json.Unmarshal(settings.JSONData, &jsonData)
 		if err != nil {

--- a/pkg/tsdb/elasticsearch/elasticsearch.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch.go
@@ -29,7 +29,7 @@ func ProvideService(httpClientProvider httpclient.Provider) *Service {
 	eslog.Debug("initializing")
 
 	return &Service{
-		im:                 datasource.NewInstanceManager(newInstanceSettings()),
+		im:                 datasource.NewInstanceManager(newInstanceSettings(httpClientProvider)),
 		httpClientProvider: httpClientProvider,
 		intervalCalculator: intervalv2.NewCalculator(),
 	}
@@ -51,7 +51,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 		return &backend.QueryDataResponse{}, fmt.Errorf("query contains no queries")
 	}
 
-	client, err := es.NewClient(ctx, s.httpClientProvider, dsInfo, req.Queries[0].TimeRange)
+	client, err := es.NewClient(ctx, dsInfo, req.Queries[0].TimeRange)
 	if err != nil {
 		return &backend.QueryDataResponse{}, err
 	}
@@ -60,8 +60,9 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	return query.execute()
 }
 
-func newInstanceSettings() datasource.InstanceFactoryFunc {
+func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.InstanceFactoryFunc {
 	return func(settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+
 		jsonData := map[string]interface{}{}
 		err := json.Unmarshal(settings.JSONData, &jsonData)
 		if err != nil {
@@ -70,6 +71,11 @@ func newInstanceSettings() datasource.InstanceFactoryFunc {
 		httpCliOpts, err := settings.HTTPClientOptions()
 		if err != nil {
 			return nil, fmt.Errorf("error getting http options: %w", err)
+		}
+
+		httpCli, err := httpClientProvider.New(httpCliOpts)
+		if err != nil {
+			return nil, err
 		}
 
 		// Set SigV4 service namespace
@@ -128,7 +134,7 @@ func newInstanceSettings() datasource.InstanceFactoryFunc {
 		model := es.DatasourceInfo{
 			ID:                         settings.ID,
 			URL:                        settings.URL,
-			HTTPClientOpts:             httpCliOpts,
+			HTTPClient:                 httpCli,
 			Database:                   settings.Database,
 			MaxConcurrentShardRequests: int64(maxConcurrentShardRequests),
 			ESVersion:                  version,

--- a/pkg/tsdb/elasticsearch/elasticsearch_test.go
+++ b/pkg/tsdb/elasticsearch/elasticsearch_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/stretchr/testify/require"
 )
 
@@ -63,7 +64,7 @@ func TestNewInstanceSettings(t *testing.T) {
 			JSONData: json.RawMessage(settingsJSON),
 		}
 
-		_, err = newInstanceSettings()(dsSettings)
+		_, err = newInstanceSettings(httpclient.NewProvider())(dsSettings)
 		require.NoError(t, err)
 	})
 
@@ -84,7 +85,7 @@ func TestNewInstanceSettings(t *testing.T) {
 				JSONData: json.RawMessage(settingsJSON),
 			}
 
-			_, err = newInstanceSettings()(dsSettings)
+			_, err = newInstanceSettings(httpclient.NewProvider())(dsSettings)
 			require.NoError(t, err)
 		})
 
@@ -104,7 +105,7 @@ func TestNewInstanceSettings(t *testing.T) {
 				JSONData: json.RawMessage(settingsJSON),
 			}
 
-			_, err = newInstanceSettings()(dsSettings)
+			_, err = newInstanceSettings(httpclient.NewProvider())(dsSettings)
 			require.EqualError(t, err, "elasticsearch version is required, err=elasticsearch version=1234 is not supported")
 		})
 
@@ -124,7 +125,7 @@ func TestNewInstanceSettings(t *testing.T) {
 				JSONData: json.RawMessage(settingsJSON),
 			}
 
-			_, err = newInstanceSettings()(dsSettings)
+			_, err = newInstanceSettings(httpclient.NewProvider())(dsSettings)
 			require.EqualError(t, err, "elasticsearch version is required, err=Invalid Semantic Version")
 		})
 
@@ -143,7 +144,7 @@ func TestNewInstanceSettings(t *testing.T) {
 				JSONData: json.RawMessage(settingsJSON),
 			}
 
-			_, err = newInstanceSettings()(dsSettings)
+			_, err = newInstanceSettings(httpclient.NewProvider())(dsSettings)
 			require.EqualError(t, err, "elasticsearch version is required, err=elasticsearch version <nil>, cannot be cast to int")
 		})
 	})
@@ -164,7 +165,7 @@ func TestNewInstanceSettings(t *testing.T) {
 				JSONData: json.RawMessage(settingsJSON),
 			}
 
-			_, err = newInstanceSettings()(dsSettings)
+			_, err = newInstanceSettings(httpclient.NewProvider())(dsSettings)
 			require.EqualError(t, err, "timeField cannot be cast to string")
 		})
 
@@ -184,7 +185,7 @@ func TestNewInstanceSettings(t *testing.T) {
 				JSONData: json.RawMessage(settingsJSON),
 			}
 
-			_, err = newInstanceSettings()(dsSettings)
+			_, err = newInstanceSettings(httpclient.NewProvider())(dsSettings)
 			require.EqualError(t, err, "elasticsearch time field name is required")
 		})
 	})


### PR DESCRIPTION
fixes https://github.com/grafana/grafana/issues/54233

the elasticsearch go-code (used by alerting) currently creates a new http-client-object for every request. this is bad (see original issue at https://github.com/grafana/grafana/issues/54233 for an explanation)

this PR changes it so that the http-client-object is only created when the datasource is started.  we basically replace the `httpClientOpts` object with the `httpClient` object, which we create at the beginning.

how to test:
- make sure the elasticsearch go code works
   - create a dashboard
   - add an elastic query
   - start creating an alert from the dashboard
   - press the [run queries] button on the alert-config-page
   - if you see the resulting graph then it works