### PR TITLE
CI: Make `lint-drone` depend on `compile-build-cmd`

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,7 +31,7 @@ steps:
 - commands:
   - ./bin/build verify-drone
   depends_on:
-  - grabpl
+  - compile-build-cmd
   image: byrnedo/alpine-curl:0.1.8
   name: lint-drone
 trigger:
@@ -939,7 +939,7 @@ steps:
 - commands:
   - ./bin/build verify-drone
   depends_on:
-  - grabpl
+  - compile-build-cmd
   image: byrnedo/alpine-curl:0.1.8
   name: lint-drone
 trigger:
@@ -5062,6 +5062,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: 2f2295555b64af31bf1e0418463e642eb41f2a0089ed9250fe99743367c11ded
+hmac: a53ea9eebb70e652a3d3165d0ee31cb6b5057bf40b6109c0d53a9d9610f4d073
 
 ...

--- a/scripts/drone/steps/lib.star
+++ b/scripts/drone/steps/lib.star
@@ -167,7 +167,7 @@ def lint_drone_step():
             './bin/build verify-drone',
         ],
         'depends_on': [
-            'grabpl',
+            'compile-build-cmd',
         ],
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Changing the dependency for `lint-drone` to depend on `compile-build-cmd`, since depending on `grabpl` means that it runs too fast.