### PR TITLE
Auth: Allow admins to manually change external user's role if `oauth_skip_org_role_update_sync` or saml `skip_org_role_sync` is enabled 

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1028,7 +1028,7 @@ exports[`better eslint`] = {
     ],
     "packages/grafana-runtime/src/config.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
+      [0, 0, 0, "Do not use any type assertions.", "1"],
       [0, 0, 0, "Do not use any type assertions.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -1029,8 +1029,7 @@ exports[`better eslint`] = {
     "packages/grafana-runtime/src/config.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
-      [0, 0, 0, "Do not use any type assertions.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "2"]
     ],
     "packages/grafana-runtime/src/services/AngularLoader.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"],

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml.md
@@ -297,7 +297,7 @@ For more information about roles and permissions in Grafana, refer to [Roles and
 
 Example configuration:
 
-```bash
+```ini
 [auth.saml]
 assertion_attribute_role = role
 role_values_editor = editor, developer
@@ -306,6 +306,17 @@ role_values_grafana_admin = superadmin
 ```
 
 **Important**: When role sync is configured, any changes of user roles and organization membership made manually in Grafana will be overwritten on next user login. Assign user organizations and roles in the IdP instead.
+
+> **Note:** Available in Grafana version 9.2 and later.
+
+If you don't want user organizations and roles to be synchronized with the IdP, you can use the `skip_org_role_sync` configuration option.
+
+Example configuration:
+
+```ini
+[auth.saml]
+skip_org_role_sync = true
+```
 
 ### Configure organization mapping
 

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -153,6 +153,7 @@ export interface GrafanaConfig {
   isPublicDashboardView: boolean;
   datasources: { [str: string]: DataSourceInstanceSettings };
   panels: { [key: string]: PanelPluginMeta };
+  auth: AuthSettings;
   minRefreshInterval: string;
   appSubUrl: string;
   windowTitlePrefix: string;
@@ -213,4 +214,8 @@ export interface GrafanaConfig {
   rudderstackDataPlaneUrl: string | undefined;
   rudderstackSdkUrl: string | undefined;
   rudderstackConfigUrl: string | undefined;
+}
+
+export interface AuthSettings {
+  OAuthSkipOrgRoleUpdateSync?: boolean;
 }

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -218,4 +218,5 @@ export interface GrafanaConfig {
 
 export interface AuthSettings {
   OAuthSkipOrgRoleUpdateSync?: boolean;
+  SAMLSkipOrgRoleSync?: boolean;
 }

--- a/packages/grafana-data/src/types/index.ts
+++ b/packages/grafana-data/src/types/index.ts
@@ -41,6 +41,7 @@ export type {
   BootData,
   OAuth,
   OAuthSettings,
+  AuthSettings,
   GrafanaConfig,
   BuildInfo,
   LicenseInfo,

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -28,7 +28,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   isPublicDashboardView: boolean;
   datasources: { [str: string]: DataSourceInstanceSettings } = {};
   panels: { [key: string]: PanelPluginMeta } = {};
-  auth: AuthSettings = {} as AuthSettings;
+  auth: AuthSettings = {};
   minRefreshInterval = '';
   appUrl = '';
   appSubUrl = '';

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -1,6 +1,7 @@
 import { merge } from 'lodash';
 
 import {
+  AuthSettings,
   BootData,
   BuildInfo,
   createTheme,
@@ -27,6 +28,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   isPublicDashboardView: boolean;
   datasources: { [str: string]: DataSourceInstanceSettings } = {};
   panels: { [key: string]: PanelPluginMeta } = {};
+  auth: AuthSettings = {} as AuthSettings;
   minRefreshInterval = '';
   appUrl = '';
   appSubUrl = '';
@@ -107,7 +109,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   pluginAdminExternalManageEnabled = false;
   pluginCatalogHiddenPlugins: string[] = [];
   expressionsEnabled = false;
-  customTheme?: any;
+  customTheme?: undefined;
   awsAllowedAuthProviders: string[] = [];
   awsAssumeRoleEnabled = false;
   azure: AzureSettings = {

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -137,7 +137,9 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"disableSanitizeHtml":                 hs.Cfg.DisableSanitizeHtml,
 		"pluginsToPreload":                    pluginsToPreload,
 		"auth": map[string]interface{}{
-			"OAuthSkipOrgRoleUpdateSync": hs.Cfg.OAuthSkipOrgRoleUpdateSync},
+			"OAuthSkipOrgRoleUpdateSync": hs.Cfg.OAuthSkipOrgRoleUpdateSync,
+			"SAMLSkipOrgRoleSync":        hs.Cfg.SectionWithEnvOverrides("auth.saml").Key("skip_org_role_sync").MustBool(false),
+		},
 		"buildInfo": map[string]interface{}{
 			"hideVersion":   hideVersion,
 			"version":       version,

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -136,6 +136,8 @@ func (hs *HTTPServer) getFrontendSettingsMap(c *models.ReqContext) (map[string]i
 		"editorsCanAdmin":                     hs.Cfg.EditorsCanAdmin,
 		"disableSanitizeHtml":                 hs.Cfg.DisableSanitizeHtml,
 		"pluginsToPreload":                    pluginsToPreload,
+		"auth": map[string]interface{}{
+			"OAuthSkipOrgRoleUpdateSync": hs.Cfg.OAuthSkipOrgRoleUpdateSync},
 		"buildInfo": map[string]interface{}{
 			"hideVersion":   hideVersion,
 			"version":       version,

--- a/public/app/features/admin/UserAdminPage.tsx
+++ b/public/app/features/admin/UserAdminPage.tsx
@@ -110,9 +110,11 @@ export class UserAdminPage extends PureComponent<Props> {
     const canReadLDAPStatus = contextSrv.hasPermission(AccessControlAction.LDAPStatusRead);
     const isOAuthUserWithSkippableSync =
       user?.isExternal && user?.authLabels?.some((r) => SyncedOAuthLabels.includes(r));
+    const isSAMLUser = user?.isExternal && user?.authLabels?.includes('SAML');
     const isUserSynced =
-      (user?.isExternal && !isOAuthUserWithSkippableSync) ||
-      (!config.auth.OAuthSkipOrgRoleUpdateSync && isOAuthUserWithSkippableSync);
+      (user?.isExternal && !(isOAuthUserWithSkippableSync || isSAMLUser)) ||
+      (!config.auth.OAuthSkipOrgRoleUpdateSync && isOAuthUserWithSkippableSync) ||
+      (!config.auth.SAMLSkipOrgRoleSync && isSAMLUser);
 
     const pageNav: NavModelItem = {
       text: user?.login ?? '',

--- a/public/app/features/admin/UserAdminPage.tsx
+++ b/public/app/features/admin/UserAdminPage.tsx
@@ -109,7 +109,7 @@ export class UserAdminPage extends PureComponent<Props> {
     const canReadSessions = contextSrv.hasPermission(AccessControlAction.UsersAuthTokenList);
     const canReadLDAPStatus = contextSrv.hasPermission(AccessControlAction.LDAPStatusRead);
     const isOAuthUserWithSkippableSync =
-      user && user.isExternal && user.authLabels && user.authLabels.some((r) => SyncedOAuthLabels.includes(r));
+      user?.isExternal && user?.authLabels?.some((r) => SyncedOAuthLabels.includes(r));
     const isUserSynced =
       (user?.isExternal && !isOAuthUserWithSkippableSync) ||
       (!config.auth.OAuthSkipOrgRoleUpdateSync && isOAuthUserWithSkippableSync);

--- a/public/app/features/admin/UserAdminPage.tsx
+++ b/public/app/features/admin/UserAdminPage.tsx
@@ -4,6 +4,7 @@ import { connect, ConnectedProps } from 'react-redux';
 import { NavModelItem } from '@grafana/data';
 import { featureEnabled } from '@grafana/runtime';
 import { Page } from 'app/core/components/Page/Page';
+import config from 'app/core/config';
 import { contextSrv } from 'app/core/core';
 import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { StoreState, UserDTO, UserOrg, UserSession, SyncInfo, UserAdminError, AccessControlAction } from 'app/types';
@@ -37,6 +38,8 @@ interface OwnProps extends GrafanaRouteComponentProps<{ id: string }> {
   isLoading: boolean;
   error?: UserAdminError;
 }
+
+const SyncedOAuthLabels: string[] = ['GitHub', 'GitLab', 'AzureAD', 'OAuth'];
 
 export class UserAdminPage extends PureComponent<Props> {
   async componentDidMount() {
@@ -105,6 +108,11 @@ export class UserAdminPage extends PureComponent<Props> {
     const isLDAPUser = user && user.isExternal && user.authLabels && user.authLabels.includes('LDAP');
     const canReadSessions = contextSrv.hasPermission(AccessControlAction.UsersAuthTokenList);
     const canReadLDAPStatus = contextSrv.hasPermission(AccessControlAction.LDAPStatusRead);
+    const isOAuthUserWithSkippableSync =
+      user && user.isExternal && user.authLabels && user.authLabels.some((r) => SyncedOAuthLabels.includes(r));
+    const isUserSynced =
+      (user?.isExternal && !isOAuthUserWithSkippableSync) ||
+      (!config.auth.OAuthSkipOrgRoleUpdateSync && isOAuthUserWithSkippableSync);
 
     const pageNav: NavModelItem = {
       text: user?.login ?? '',
@@ -137,7 +145,7 @@ export class UserAdminPage extends PureComponent<Props> {
             <UserOrgs
               user={user}
               orgs={orgs}
-              isExternalUser={user?.isExternal}
+              isExternalUser={isUserSynced}
               onOrgRemove={this.onOrgRemove}
               onOrgRoleChange={this.onOrgRoleChange}
               onOrgAdd={this.onOrgAdd}


### PR DESCRIPTION
**What this PR does / why we need it**:

Auth:
* Allow admins to change OAuth user role if it's not synced
* Allow admins to change SAML user role if it's not synced

Fixes https://github.com/grafana/grafana/issues/54688

**Special notes for your reviewer**:

