### PR TITLE
PublicDashboards: Add link to public dashboards docs to sharing modal

### DIFF
--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard.tsx
@@ -137,6 +137,15 @@ export const SharePublicDashboard = (props: Props) => {
                   data-testid={selectors.WillBePublicCheckbox}
                   onChange={(e) => onAcknowledge('public', e.currentTarget.checked)}
                 />
+                <LinkButton
+                  variant="primary"
+                  href="https://grafana.com/docs/grafana/latest/dashboards/dashboard-public/"
+                  target="_blank"
+                  fill="text"
+                  icon="info-circle"
+                  rel="noopener noreferrer"
+                  tooltip="Learn more about public dashboards"
+                />
               </div>
               <br />
               <div>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

This PR adds a link to the Public Dashboards sharing modal to inform the user where he can learn more about public dashboards, redirecting him to the documentation.

<img width="706" alt="Sharing modal" src="https://user-images.githubusercontent.com/7741292/190224760-81006ea4-19cb-442e-a5ef-fba3a1220d42.png">

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/4465

**Special notes for your reviewer**:

