### PR TITLE
[v9.1.x] Search: Avoid requesting all dashboards when in Folder View

### DIFF
--- a/public/app/features/search/page/components/SearchView.tsx
+++ b/public/app/features/search/page/components/SearchView.tsx
@@ -134,6 +134,11 @@ export const SearchView = ({
   };
 
   const results = useAsync(() => {
+    // No need to query all dashboards if we are in folder view
+    if (layout === SearchLayout.Folders) {
+      return Promise.resolve();
+    }
+
     const trackingInfo = {
       layout: query.layout,
       starred: query.starred,


### PR DESCRIPTION
Manual backport [ca2139e](https://github.com/grafana/grafana/commit/ca2139e9ce70dfc5fd78b37bae8c9cb7123cb782) from https://github.com/grafana/grafana/pull/55169