### PR TITLE
[GH metrics] update labels for GitHub metrics collector

### DIFF
--- a/.github/metrics-collector.json
+++ b/.github/metrics-collector.json
@@ -17,16 +17,16 @@
       "query": "label:\"needs more info\" is:open"
     },
     {
+      "name": "triage_needs_confirmation",
+      "query": "label:\"triage/needs-confirmation\" is:open"
+    },
+    {
       "name": "unlabeled",
       "query": "is:open is:issue no:label"
     },
     {
       "name": "open_prs",
       "query": "is:open is:pr"
-    },
-    {
-      "name": "milestone_7_4_open",
-      "query": "is:open is:issue milestone:7.4"
     }
   ]
 }


### PR DESCRIPTION
this collector dumps data into a graphite instance on ops. The community squad hopes to update the collector and start using it more

