### PR TITLE
Chore: Change default log level for errutil.CoreStatus

### DIFF
--- a/pkg/util/errutil/status.go
+++ b/pkg/util/errutil/status.go
@@ -88,21 +88,21 @@ func (s CoreStatus) HTTPStatus() int {
 func (s CoreStatus) LogLevel() LogLevel {
 	switch s {
 	case StatusUnauthorized:
-		return LevelError
+		return LevelDebug
 	case StatusForbidden:
-		return LevelError
+		return LevelDebug
 	case StatusNotFound:
-		return LevelNever
+		return LevelDebug
 	case StatusTimeout:
-		return LevelError
+		return LevelDebug
 	case StatusTooManyRequests:
-		return LevelError
+		return LevelDebug
 	case StatusBadRequest:
-		return LevelError
+		return LevelDebug
 	case StatusValidationFailed:
-		return LevelError
+		return LevelDebug
 	case StatusNotImplemented:
-		return LevelError
+		return LevelDebug
 	case StatusUnknown, StatusInternal:
 		return LevelError
 	default:

--- a/pkg/util/errutil/status.go
+++ b/pkg/util/errutil/status.go
@@ -88,19 +88,19 @@ func (s CoreStatus) HTTPStatus() int {
 func (s CoreStatus) LogLevel() LogLevel {
 	switch s {
 	case StatusUnauthorized:
-		return LevelInfo
+		return LevelError
 	case StatusForbidden:
-		return LevelInfo
+		return LevelError
 	case StatusNotFound:
-		return LevelDebug
+		return LevelNever
 	case StatusTimeout:
-		return LevelInfo
+		return LevelError
 	case StatusTooManyRequests:
-		return LevelInfo
+		return LevelError
 	case StatusBadRequest:
-		return LevelInfo
+		return LevelError
 	case StatusValidationFailed:
-		return LevelInfo
+		return LevelError
 	case StatusNotImplemented:
 		return LevelError
 	case StatusUnknown, StatusInternal:


### PR DESCRIPTION
**What this PR does / why we need it**:
Proposal to change the default log levels for `errutil.CoreStatus`. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Not sure this proposal make sense, but now it defaults to error rather than info at least. Thoughts?
