### PR TITLE
PublicDashboards: Support subpaths when generating pubdash url

### DIFF
--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboardUtils.test.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboardUtils.test.tsx
@@ -1,5 +1,7 @@
 import { VariableModel } from 'app/features/variables/types';
 
+import { updateConfig } from '../../../../core/config';
+
 import {
   PublicDashboard,
   dashboardHasTemplateVariables,
@@ -23,9 +25,13 @@ describe('dashboardHasTemplateVariables', () => {
 });
 
 describe('generatePublicDashboardUrl', () => {
-  it('has the right uid', () => {
-    let pubdash = { accessToken: 'abcd1234' } as PublicDashboard;
-    expect(generatePublicDashboardUrl(pubdash)).toEqual(`${window.location.origin}/public-dashboards/abcd1234`);
+  it('uses the grafana config appUrl to generate the url', () => {
+    const appUrl = 'http://localhost/';
+    const accessToken = 'abcd1234';
+    updateConfig({ appUrl });
+    let pubdash = { accessToken } as PublicDashboard;
+
+    expect(generatePublicDashboardUrl(pubdash)).toEqual(`${appUrl}public-dashboards/${accessToken}`);
   });
 });
 

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboardUtils.ts
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboardUtils.ts
@@ -1,5 +1,6 @@
 import { getBackendSrv } from '@grafana/runtime';
 import { notifyApp } from 'app/core/actions';
+import { getConfig } from 'app/core/config';
 import { createSuccessNotification } from 'app/core/copy/appNotification';
 import { VariableModel } from 'app/features/variables/types';
 import { dispatch } from 'app/store/store';
@@ -61,6 +62,14 @@ export const publicDashboardPersisted = (publicDashboard: PublicDashboard): bool
   return publicDashboard.uid !== '' && publicDashboard.uid !== undefined;
 };
 
+/**
+ * Generate the public dashboard url. Uses the appUrl from the Grafana boot config, so urls will also be correct
+ * when Grafana is hosted on a subpath.
+ *
+ * All app urls from the Grafana boot config end with a slash.
+ *
+ * @param publicDashboard
+ */
 export const generatePublicDashboardUrl = (publicDashboard: PublicDashboard): string => {
-  return `${window.location.origin}/public-dashboards/${publicDashboard.accessToken}`;
+  return `${getConfig().appUrl}public-dashboards/${publicDashboard.accessToken}`;
 };


### PR DESCRIPTION
Use the base url from the Grafana boot config as the base url when generating a pubdash url.

fixes https://github.com/grafana/grafana/issues/54969

**How to test**
Edit your `custom.ini` to have:
```
root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
serve_from_sub_path = true
```