### PR TITLE
[Doc] Fix broken image rendering troubleshooting links

### DIFF
--- a/docs/sources/setup-grafana/image-rendering/troubleshooting.md
+++ b/docs/sources/setup-grafana/image-rendering/troubleshooting.md
@@ -30,9 +30,9 @@ filters = rendering:debug
 
 You can also enable more logs in image renderer service itself by:
 
-- Increasing the [log level]({{< relref "/#log-level" >}}).
-- Enabling [verbose logging]({{< relref "/#verbose-logging" >}}).
-- [Capturing headless browser output]({{< relref "/#capture-browser-output" >}}).
+- Increasing the [log level]({{< relref "image-rendering#log-level" >}}).
+- Enabling [verbose logging]({{< relref "image-rendering#verbose-logging" >}}).
+- [Capturing headless browser output]({{< relref "image-rendering#capture-browser-output" >}}).
 
 ## Missing libraries
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix broken links on the image-rendering troubleshooting page, https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/troubleshooting/

**Special notes for your reviewer**:
Please add a milestone. I'm not sure which one to use. 
