### PR TITLE
Devenv: Fix filebeat level labels in elastic7

### DIFF
--- a/devenv/docker/blocks/elastic7/filebeat.yml
+++ b/devenv/docker/blocks/elastic7/filebeat.yml
@@ -409,7 +409,7 @@ filebeat.inputs:
   enabled: true
   paths:
     - /var/log/grafana/grafana.log
-  include_lines: ['lvl=info']
+  include_lines: ['level=info']
   fields:
     app: grafana
     level: info
@@ -417,7 +417,7 @@ filebeat.inputs:
   enabled: true
   paths:
     - /var/log/grafana/grafana.log
-  include_lines: ['lvl=eror']
+  include_lines: ['level=eror']
   fields:
     app: grafana
     level: error
@@ -425,7 +425,7 @@ filebeat.inputs:
   enabled: true
   paths:
     - /var/log/grafana/grafana.log
-  include_lines: ['lvl=warn']
+  include_lines: ['level=warn']
   fields:
     app: grafana
     level: warning
@@ -433,7 +433,7 @@ filebeat.inputs:
   enabled: true
   paths:
     - /var/log/grafana/grafana.log
-  include_lines: ['lvl=dbug']
+  include_lines: ['level=dbug']
   fields:
     app: grafana
     level: debug


### PR DESCRIPTION
**What this PR does / why we need it**:

I noticed in https://github.com/grafana/grafana/pull/55214, that the configured level lables in filebeat do not match the level labels in Grafana. Using that configuration would lead to no files/logs ingested via filebeat. This PR changes the `lvl` labels to use `level` instead.
