### PR TITLE
Alerting: Fix enter key 'clicking' first button on form

### DIFF
--- a/packages/grafana-ui/src/components/Card/Card.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.tsx
@@ -97,7 +97,7 @@ const Heading = ({ children, className, 'aria-label': ariaLabel }: ChildProps & 
           {children}
         </a>
       ) : onClick ? (
-        <button onClick={onClick} className={styles.linkHack} aria-label={ariaLabel}>
+        <button onClick={onClick} className={styles.linkHack} aria-label={ariaLabel} type="button">
           {children}
         </button>
       ) : (

--- a/public/app/features/query/components/QueryEditorRowHeader.tsx
+++ b/public/app/features/query/components/QueryEditorRowHeader.tsx
@@ -91,6 +91,7 @@ export const QueryEditorRowHeader = <TQuery extends DataQuery>(props: Props<TQue
             title="Edit query name"
             onClick={onEditQuery}
             data-testid="query-name-div"
+            type="button"
           >
             <span className={styles.queryName}>{query.refId}</span>
             <Icon name="pen" className={styles.queryEditIcon} size="sm" />

--- a/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
+++ b/public/app/plugins/datasource/prometheus/components/PromQueryField.tsx
@@ -297,6 +297,7 @@ class PromQueryField extends React.PureComponent<PromQueryFieldProps, PromQueryF
                   className="gf-form-label query-keyword pointer"
                   onClick={this.onClickChooserButton}
                   disabled={buttonDisabled}
+                  type="button"
                 >
                   {chooserText}
                   <Icon name={labelBrowserVisible ? 'angle-down' : 'angle-right'} />


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fix not automatically clicking the first button on the alert rule form, when pressing enter key on any input in the alert rule form.

**Which issue(s) this PR fixes**:

Fixes [#318](https://github.com/grafana/alerting-squad/issues/318)


**BEFORE**

https://user-images.githubusercontent.com/33540275/190670070-678c6eae-1cd9-4011-99f0-ac6a26a869bb.mp4

**AFTER**


https://user-images.githubusercontent.com/33540275/190670509-b91308d1-42a6-47e3-bd76-372deed6f17a.mp4

