### PR TITLE
Search: Fixes folder section not displaying dashboards

### DIFF
--- a/public/app/features/search/page/components/SearchView.tsx
+++ b/public/app/features/search/page/components/SearchView.tsx
@@ -164,8 +164,8 @@ export const SearchView = ({
   );
 
   const results = useAsync(() => {
-    // No need to query all dashboards if we are in folder view
-    if (layout === SearchLayout.Folders) {
+    // No need to query all dashboards if we are in search folder view
+    if (layout === SearchLayout.Folders && !folderDTO) {
       return Promise.resolve();
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This [PR](https://github.com/grafana/grafana/pull/55169) broke the folder view when you have selected a folder. This makes sure the change from that PR does not affect the `FolderSection` view.

**Which issue(s) this PR fixes**:

Fixes #55226
