### PR TITLE
CI: Refactor `versions.go`

### DIFF
--- a/pkg/build/cmd/buildbackend.go
+++ b/pkg/build/cmd/buildbackend.go
@@ -26,7 +26,7 @@ func BuildBackend(ctx *cli.Context) error {
 		}
 	)
 
-	mode, err := config.GetReleaseModeConfig(metadata.ReleaseMode.Mode)
+	buildConfig, err := config.GetBuildConfig(metadata.ReleaseMode.Mode)
 	if err != nil {
 		return fmt.Errorf("could not get version / package info for mode '%s': %w", metadata.ReleaseMode.Mode, err)
 	}
@@ -34,7 +34,7 @@ func BuildBackend(ctx *cli.Context) error {
 	const grafanaDir = "."
 
 	log.Printf("Building Grafana back-end, version %q, %s edition, variants [%v]",
-		version, edition, mode.Variants)
+		version, edition, buildConfig.Variants)
 
 	p := syncutil.NewWorkerPool(cfg.NumWorkers)
 	defer p.Close()
@@ -44,7 +44,7 @@ func BuildBackend(ctx *cli.Context) error {
 	}
 
 	g, _ := errutil.GroupWithContext(ctx.Context)
-	for _, variant := range mode.Variants {
+	for _, variant := range buildConfig.Variants {
 		variant := variant
 
 		opts := grafana.BuildVariantOpts{

--- a/pkg/build/cmd/buildbackend.go
+++ b/pkg/build/cmd/buildbackend.go
@@ -26,7 +26,7 @@ func BuildBackend(ctx *cli.Context) error {
 		}
 	)
 
-	mode, err := config.GetVersion(metadata.ReleaseMode.Mode)
+	mode, err := config.GetReleaseModeConfig(metadata.ReleaseMode.Mode)
 	if err != nil {
 		return fmt.Errorf("could not get version / package info for mode '%s': %w", metadata.ReleaseMode.Mode, err)
 	}

--- a/pkg/build/cmd/builddocker.go
+++ b/pkg/build/cmd/builddocker.go
@@ -20,7 +20,7 @@ func BuildDocker(c *cli.Context) error {
 	}
 
 	useUbuntu := c.Bool("ubuntu")
-	verMode, err := config.GetVersion(metadata.ReleaseMode.Mode)
+	verMode, err := config.GetReleaseModeConfig(metadata.ReleaseMode.Mode)
 	if err != nil {
 		return err
 	}

--- a/pkg/build/cmd/builddocker.go
+++ b/pkg/build/cmd/builddocker.go
@@ -20,12 +20,12 @@ func BuildDocker(c *cli.Context) error {
 	}
 
 	useUbuntu := c.Bool("ubuntu")
-	verMode, err := config.GetReleaseModeConfig(metadata.ReleaseMode.Mode)
+	buildConfig, err := config.GetBuildConfig(metadata.ReleaseMode.Mode)
 	if err != nil {
 		return err
 	}
 
-	shouldSave := verMode.Docker.ShouldSave
+	shouldSave := buildConfig.Docker.ShouldSave
 	if shouldSave {
 		if err := gcloud.ActivateServiceAccount(); err != nil {
 			return err
@@ -39,7 +39,7 @@ func BuildDocker(c *cli.Context) error {
 	log.Printf("Building Docker images, version %s, %s edition, Ubuntu based: %v...", version, edition,
 		useUbuntu)
 
-	for _, arch := range verMode.Docker.Architectures {
+	for _, arch := range buildConfig.Docker.Architectures {
 		if _, err := docker.BuildImage(version, arch, ".", useUbuntu, shouldSave, edition); err != nil {
 			return cli.Exit(err.Error(), 1)
 		}

--- a/pkg/build/cmd/buildinternalplugins.go
+++ b/pkg/build/cmd/buildinternalplugins.go
@@ -21,7 +21,7 @@ func BuildInternalPlugins(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	verMode, err := config.GetVersion(metadata.ReleaseMode.Mode)
+	verMode, err := config.GetReleaseModeConfig(metadata.ReleaseMode.Mode)
 	if err != nil {
 		return err
 	}

--- a/pkg/build/cmd/buildinternalplugins.go
+++ b/pkg/build/cmd/buildinternalplugins.go
@@ -21,7 +21,7 @@ func BuildInternalPlugins(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	verMode, err := config.GetReleaseModeConfig(metadata.ReleaseMode.Mode)
+	buildConfig, err := config.GetBuildConfig(metadata.ReleaseMode.Mode)
 	if err != nil {
 		return err
 	}
@@ -35,7 +35,7 @@ func BuildInternalPlugins(c *cli.Context) error {
 
 	var g *errutil.Group
 	g, ctx = errutil.GroupWithContext(ctx)
-	if err := plugins.Build(ctx, grafanaDir, p, g, verMode); err != nil {
+	if err := plugins.Build(ctx, grafanaDir, p, g, buildConfig); err != nil {
 		return cli.Exit(err.Error(), 1)
 	}
 	if err := g.Wait(); err != nil {

--- a/pkg/build/cmd/storestorybook.go
+++ b/pkg/build/cmd/storestorybook.go
@@ -18,7 +18,7 @@ func StoreStorybook(c *cli.Context) error {
 		return err
 	}
 
-	verMode, err := config.GetVersion(metadata.ReleaseMode.Mode)
+	releaseModeConfig, err := config.GetReleaseModeConfig(metadata.ReleaseMode.Mode)
 	if err != nil {
 		return err
 	}
@@ -26,8 +26,8 @@ func StoreStorybook(c *cli.Context) error {
 		return err
 	}
 
-	storybookBucket := verMode.StorybookBucket
-	srcPath := verMode.StorybookSrcDir
+	storybookBucket := releaseModeConfig.Buckets.Storybook
+	srcPath := releaseModeConfig.Buckets.StorybookSrcDir
 	srcPath = filepath.Join(srcPath, deployment)
 
 	gcs, err := storage.New()

--- a/pkg/build/cmd/storestorybook.go
+++ b/pkg/build/cmd/storestorybook.go
@@ -18,7 +18,7 @@ func StoreStorybook(c *cli.Context) error {
 		return err
 	}
 
-	releaseModeConfig, err := config.GetReleaseModeConfig(metadata.ReleaseMode.Mode)
+	buildConfig, err := config.GetBuildConfig(metadata.ReleaseMode.Mode)
 	if err != nil {
 		return err
 	}
@@ -26,8 +26,8 @@ func StoreStorybook(c *cli.Context) error {
 		return err
 	}
 
-	storybookBucket := releaseModeConfig.Buckets.Storybook
-	srcPath := releaseModeConfig.Buckets.StorybookSrcDir
+	storybookBucket := buildConfig.Buckets.Storybook
+	srcPath := buildConfig.Buckets.StorybookSrcDir
 	srcPath = filepath.Join(srcPath, deployment)
 
 	gcs, err := storage.New()

--- a/pkg/build/config/variant.go
+++ b/pkg/build/config/variant.go
@@ -40,3 +40,11 @@ type LibC string
 const (
 	LibCMusl = "musl"
 )
+
+// Distribution is the base os image where the Grafana image is built on.
+type Distribution string
+
+const (
+	Ubuntu Distribution = "ubuntu"
+	Alpine Distribution = "alpine"
+)

--- a/pkg/build/config/version.go
+++ b/pkg/build/config/version.go
@@ -42,8 +42,8 @@ type Buckets struct {
 	StorybookSrcDir      string `json:"storybookSrcDir,omitempty"`
 }
 
-// ReleaseModeConfig represents the "version.json" that defines all of the different variables used to build Grafana
-type ReleaseModeConfig struct {
+// BuildConfig represents the struct that defines all of the different variables used to build Grafana
+type BuildConfig struct {
 	Variants        []Variant       `json:"variants,omitempty"`
 	PluginSignature PluginSignature `json:"pluginSignature,omitempty"`
 	Docker          Docker          `json:"docker,omitempty"`
@@ -57,10 +57,10 @@ func (md *Metadata) GetReleaseMode() (ReleaseMode, error) {
 // VersionMap is a map of versions. Each key of the Versions map is an event that uses the the config as the value for that key.
 // For example, the 'pull_request' key will have data in it that might cause Grafana to be built differently in a pull request,
 // than the way it will be built in 'main'
-type VersionMap map[VersionMode]ReleaseModeConfig
+type VersionMap map[VersionMode]BuildConfig
 
-// GetReleaseModeConfig reads the embedded config.json and decodes it.
-func GetReleaseModeConfig(mode VersionMode) (*ReleaseModeConfig, error) {
+// GetBuildConfig reads the embedded config.json and decodes it.
+func GetBuildConfig(mode VersionMode) (*BuildConfig, error) {
 	if v, ok := Versions[mode]; ok {
 		return &v, nil
 	}

--- a/pkg/build/config/version.go
+++ b/pkg/build/config/version.go
@@ -29,33 +29,38 @@ type PluginSignature struct {
 
 type Docker struct {
 	ShouldSave    bool           `json:"shouldSave,omitempty"`
+	Distribution  []Distribution `json:"distribution,omitempty"`
 	Architectures []Architecture `json:"archs,omitempty"`
 }
 
-// Version represents the "version.json" that defines all of the different variables used to build Grafana
-type Version struct {
-	Variants                  []Variant       `json:"variants,omitempty"`
-	PluginSignature           PluginSignature `json:"pluginSignature,omitempty"`
-	Docker                    Docker          `json:"docker,omitempty"`
-	PackagesBucket            string          `json:"packagesBucket,omitempty"`
-	PackagesBucketEnterprise2 string          `json:"packagesBucketEnterprise2,omitempty"`
-	CDNAssetsBucket           string          `json:"CDNAssetsBucket,omitempty"`
-	CDNAssetsDir              string          `json:"CDNAssetsDir,omitempty"`
-	StorybookBucket           string          `json:"storybookBucket,omitempty"`
-	StorybookSrcDir           string          `json:"storybookSrcDir,omitempty"`
+type Buckets struct {
+	Artifacts            string `json:"artifacts,omitempty"`
+	ArtifactsEnterprise2 string `json:"artifactsEnterprise2,omitempty"`
+	CDNAssets            string `json:"CDNAssets,omitempty"`
+	CDNAssetsDir         string `json:"CDNAssetsDir,omitempty"`
+	Storybook            string `json:"storybook,omitempty"`
+	StorybookSrcDir      string `json:"storybookSrcDir,omitempty"`
+}
+
+// ReleaseModeConfig represents the "version.json" that defines all of the different variables used to build Grafana
+type ReleaseModeConfig struct {
+	Variants        []Variant       `json:"variants,omitempty"`
+	PluginSignature PluginSignature `json:"pluginSignature,omitempty"`
+	Docker          Docker          `json:"docker,omitempty"`
+	Buckets         Buckets         `json:"buckets,omitempty"`
 }
 
 func (md *Metadata) GetReleaseMode() (ReleaseMode, error) {
 	return md.ReleaseMode, nil
 }
 
-// Versions is a map of versions. Each key of the Versions map is an event that uses the the config as the value for that key.
+// VersionMap is a map of versions. Each key of the Versions map is an event that uses the the config as the value for that key.
 // For example, the 'pull_request' key will have data in it that might cause Grafana to be built differently in a pull request,
 // than the way it will be built in 'main'
-type VersionMap map[VersionMode]Version
+type VersionMap map[VersionMode]ReleaseModeConfig
 
-// GetVersions reads the embedded config.json and decodes it.
-func GetVersion(mode VersionMode) (*Version, error) {
+// GetReleaseModeConfig reads the embedded config.json and decodes it.
+func GetReleaseModeConfig(mode VersionMode) (*ReleaseModeConfig, error) {
 	if v, ok := Versions[mode]; ok {
 		return &v, nil
 	}

--- a/pkg/build/config/versions.go
+++ b/pkg/build/config/versions.go
@@ -17,6 +17,9 @@ var Versions = VersionMap{
 			Architectures: []Architecture{
 				ArchAMD64,
 			},
+			Distribution: []Distribution{
+				Alpine,
+			},
 		},
 	},
 	MainMode: {
@@ -42,10 +45,16 @@ var Versions = VersionMap{
 				ArchARM64,
 				ArchARMv7, // GOARCH=ARM is used for both armv6 and armv7. They are differentiated by the GOARM variable.
 			},
+			Distribution: []Distribution{
+				Alpine,
+				Ubuntu,
+			},
 		},
-		PackagesBucket:            "grafana-downloads",
-		PackagesBucketEnterprise2: "grafana-downloads-enterprise2",
-		CDNAssetsBucket:           "grafana-static-assets",
+		Buckets: Buckets{
+			Artifacts:            "grafana-downloads",
+			ArtifactsEnterprise2: "grafana-downloads-enterprise2",
+			CDNAssets:            "grafana-static-assets",
+		},
 	},
 	CustomMode: {
 		Variants: []Variant{
@@ -70,10 +79,16 @@ var Versions = VersionMap{
 				ArchARM64,
 				ArchARMv7, // GOARCH=ARM is used for both armv6 and armv7. They are differentiated by the GOARM variable.
 			},
+			Distribution: []Distribution{
+				Alpine,
+				Ubuntu,
+			},
 		},
-		PackagesBucket:            "grafana-downloads",
-		PackagesBucketEnterprise2: "grafana-downloads-enterprise2",
-		CDNAssetsBucket:           "grafana-static-assets",
+		Buckets: Buckets{
+			Artifacts:            "grafana-downloads",
+			ArtifactsEnterprise2: "grafana-downloads-enterprise2",
+			CDNAssets:            "grafana-static-assets",
+		},
 	},
 	ReleaseBranchMode: {
 		Variants: []Variant{
@@ -98,10 +113,16 @@ var Versions = VersionMap{
 				ArchARM64,
 				ArchARMv7,
 			},
+			Distribution: []Distribution{
+				Alpine,
+				Ubuntu,
+			},
 		},
-		PackagesBucket:            "grafana-downloads",
-		PackagesBucketEnterprise2: "grafana-downloads-enterprise2",
-		CDNAssetsBucket:           "grafana-static-assets",
+		Buckets: Buckets{
+			Artifacts:            "grafana-downloads",
+			ArtifactsEnterprise2: "grafana-downloads-enterprise2",
+			CDNAssets:            "grafana-static-assets",
+		},
 	},
 	TagMode: {
 		Variants: []Variant{
@@ -126,11 +147,18 @@ var Versions = VersionMap{
 				ArchARM64,
 				ArchARMv7,
 			},
+			Distribution: []Distribution{
+				Alpine,
+				Ubuntu,
+			},
 		},
-		PackagesBucket:  "grafana-prerelease/artifacts/downloads",
-		CDNAssetsBucket: "grafana-prerelease",
-		CDNAssetsDir:    "artifacts/static-assets",
-		StorybookBucket: "grafana-prerelease",
-		StorybookSrcDir: "artifacts/storybook",
+		Buckets: Buckets{
+			Artifacts:            "grafana-prerelease/artifacts/downloads",
+			ArtifactsEnterprise2: "grafana-prerelease/artifacts/downloads-enterprise2",
+			CDNAssets:            "grafana-prerelease",
+			CDNAssetsDir:         "artifacts/static-assets",
+			Storybook:            "grafana-prerelease",
+			StorybookSrcDir:      "artifacts/storybook",
+		},
 	},
 }

--- a/pkg/build/plugins/build.go
+++ b/pkg/build/plugins/build.go
@@ -18,7 +18,7 @@ type PluginSigningMode = int
 
 // BuildPlugins builds internal plugins.
 // The built plugins are placed in plugins-bundled/dist/.
-func Build(ctx context.Context, grafanaDir string, p syncutil.WorkerPool, g *errutil.Group, verMode *config.Version) error {
+func Build(ctx context.Context, grafanaDir string, p syncutil.WorkerPool, g *errutil.Group, verMode *config.ReleaseModeConfig) error {
 	log.Printf("Building plugins in %q...", grafanaDir)
 
 	root := filepath.Join(grafanaDir, "plugins-bundled", "internal")

--- a/pkg/build/plugins/build.go
+++ b/pkg/build/plugins/build.go
@@ -18,7 +18,7 @@ type PluginSigningMode = int
 
 // BuildPlugins builds internal plugins.
 // The built plugins are placed in plugins-bundled/dist/.
-func Build(ctx context.Context, grafanaDir string, p syncutil.WorkerPool, g *errutil.Group, verMode *config.ReleaseModeConfig) error {
+func Build(ctx context.Context, grafanaDir string, p syncutil.WorkerPool, g *errutil.Group, verMode *config.BuildConfig) error {
 	log.Printf("Building plugins in %q...", grafanaDir)
 
 	root := filepath.Join(grafanaDir, "plugins-bundled", "internal")


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactoring `versions.go` file, based on https://github.com/grafana/build-pipeline/pull/488

