### PR TITLE
Graphite: Add error information to graphite queries tracing

### DIFF
--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -14,12 +14,12 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
-
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/httpclient"
@@ -153,22 +153,30 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	}
 
 	ctx, span := s.tracer.Start(ctx, "graphite query")
+	defer span.End()
+
 	span.SetAttributes("target", target, attribute.Key("target").String(target))
 	span.SetAttributes("from", from, attribute.Key("from").String(from))
 	span.SetAttributes("until", until, attribute.Key("until").String(until))
 	span.SetAttributes("datasource_id", dsInfo.Id, attribute.Key("datasource_id").Int64(dsInfo.Id))
 	span.SetAttributes("org_id", req.PluginContext.OrgID, attribute.Key("org_id").Int64(req.PluginContext.OrgID))
 
-	defer span.End()
 	s.tracer.Inject(ctx, graphiteReq.Header, span)
 
 	res, err := dsInfo.HTTPClient.Do(graphiteReq)
+	if res != nil {
+		span.SetAttributes("graphite.response.code", res.StatusCode, attribute.Key("graphite.response.code").Int(res.StatusCode))
+	}
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return &result, err
 	}
 
 	frames, err := s.toDataFrames(res)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return &result, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends graphite QueryData() instrumentation to include in the traces information about possible errors.
  - I've added an attribute about the graphite response code as well as records for errors if there are any.

The reason why I added this information to the traces is that we're seeing some alerts failing in Grafana with no data / value and we don't know the reason behind it. Because of this we'd like to see in the traces that graphite's response or parsing it is not the issue.
