### PR TITLE
Docs: Fix Cloud availability of JWT URL Embedding

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt.md
@@ -62,14 +62,14 @@ If `auto_sign_up` is enabled, then the `sub` claim is used as the "external Auth
 If you want to embed Grafana in an iframe while maintaning user identity and role checks,
 you can use JWT authentication to authenticate the iframe.
 
-> **Note**: for scenarios where verifying viewer identity is not required,
-> [public dashboards]({{< relref "../../../dashboards/dashboard-public" >}}) embedding should be used.
+> **Note**: For Grafana Cloud, or scenarios where verifying viewer identity is not required,
+> embed [public dashboards]({{< relref "../../../dashboards/dashboard-public" >}}).
 
 In this scenario, you will need to configure Grafana to accept a JWT
 provided in the HTTP header and a reverse proxy should rewrite requests to the
 Grafana instance to include the JWT in the request's headers.
 
-> **Note**: for embedding to work `allow_embedding` must be enabled in the [security section]({{< relref "../../configure-grafana#allow_embedding" >}}).
+> **Note**: For embedding to work, you must enable `allow_embedding` in the [security section]({{< relref "../../configure-grafana#allow_embedding" >}}). This setting is not available in Grafana Cloud.
 
 In a scenario where it is not possible to rewrite the request headers you
 can use URL login instead.

--- a/docs/sources/whatsnew/whats-new-in-v9-1.md
+++ b/docs/sources/whatsnew/whats-new-in-v9-1.md
@@ -45,7 +45,7 @@ You can now easily embed Grafana in other applications by adding a JWT token dir
 When the JWT token is passed through the request URL to Grafana, Grafana validates and authenticates the token linked to a specific user, allowing access to dashboards which that user can view.
 To see JWT URL embedding in action, see the [sample project](https://github.com/grafana/grafana-iframe-oauth-sample).
 
-Grafana Cloud users can access this feature by [opening a support ticket in the Cloud Portal](https://grafana.com/profile/org#support).
+> **Note:** JWT URL Embedding and `allow_embedding` are not available to Grafana Cloud users. For Grafana Cloud, use the [Public Dashboards]({{< relref "../dashboards/dashboard-public/" >}}) feature. To enable that, [open a ticket with our Support team](https://grafana.com/docs/grafana-cloud/account-management/support/).
 
 {{< figure src="/static/img/docs/dashboards/jwt-url-embedding-9-1.png" max-width="750px" caption="A JWT token used to embed Grafana" >}}
 


### PR DESCRIPTION
Per @callmehyde, clarify that JWT URL Embedding is not available in Grafana Cloud.