### PR TITLE
Azure Monitor: Fix migration issue with MetricDefinitionsQuery template variable query types

### DIFF
--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/dashboards/appInsightsGeoMap.json
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/dashboards/appInsightsGeoMap.json
@@ -822,7 +822,7 @@
         "options": [],
         "query": {
           "grafanaTemplateVariableFn": {
-            "kind": "MetricDefinitionsQuery",
+            "kind": "MetricNamespaceQuery",
             "rawQuery": "Namespaces($sub, $rg)",
             "resourceGroup": "$rg",
             "subscription": "$sub"

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/dashboards/networkInsightsDashboard.json
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/dashboards/networkInsightsDashboard.json
@@ -1870,7 +1870,7 @@
         "options": [],
         "query": {
           "grafanaTemplateVariableFn": {
-            "kind": "MetricDefinitionsQuery",
+            "kind": "MetricNamespaceQuery",
             "rawQuery": "namespaces($sub,$rg)",
             "resourceGroup": "$rg",
             "subscription": "$sub"
@@ -1898,7 +1898,7 @@
         "options": [],
         "query": {
           "grafanaTemplateVariableFn": {
-            "kind": "MetricDefinitionsQuery",
+            "kind": "MetricNamespaceQuery",
             "rawQuery": "namespaces($sub,$rg)",
             "resourceGroup": "$rg",
             "subscription": "$sub"
@@ -1926,7 +1926,7 @@
         "options": [],
         "query": {
           "grafanaTemplateVariableFn": {
-            "kind": "MetricDefinitionsQuery",
+            "kind": "MetricNamespaceQuery",
             "rawQuery": "namespaces($sub,$rg)",
             "resourceGroup": "$rg",
             "subscription": "$sub"
@@ -1954,7 +1954,7 @@
         "options": [],
         "query": {
           "grafanaTemplateVariableFn": {
-            "kind": "MetricDefinitionsQuery",
+            "kind": "MetricNamespaceQuery",
             "rawQuery": "namespaces($sub,$rg)",
             "resourceGroup": "$rg",
             "subscription": "$sub"

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/grafanaTemplateVariableFns.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/grafanaTemplateVariableFns.ts
@@ -258,7 +258,7 @@ const migrateGrafanaTemplateVariableFn = (query: AzureMonitorQuery) => {
     return query;
   }
 
-  const migratedQuery: AzureMonitorQuery = {
+  let migratedQuery: AzureMonitorQuery = {
     ...query,
   };
   if ('subscription' in grafanaTemplateVariableFn) {
@@ -287,6 +287,9 @@ const migrateGrafanaTemplateVariableFn = (query: AzureMonitorQuery) => {
     case 'MetricNamespaceQuery':
       migratedQuery.queryType = AzureQueryType.NamespacesQuery;
       break;
+    case 'MetricDefinitionsQuery':
+      migratedQuery.queryType = AzureQueryType.NamespacesQuery;
+      break;
     case 'MetricNamesQuery':
       migratedQuery.queryType = AzureQueryType.MetricNamesQuery;
       break;
@@ -295,6 +298,7 @@ const migrateGrafanaTemplateVariableFn = (query: AzureMonitorQuery) => {
       break;
   }
 
+  delete migratedQuery.grafanaTemplateVariableFn;
   return migratedQuery;
 };
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/grafanaTemplateVariableFns.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/grafanaTemplateVariableFns.ts
@@ -258,7 +258,7 @@ const migrateGrafanaTemplateVariableFn = (query: AzureMonitorQuery) => {
     return query;
   }
 
-  let migratedQuery: AzureMonitorQuery = {
+  const migratedQuery: AzureMonitorQuery = {
     ...query,
   };
   if ('subscription' in grafanaTemplateVariableFn) {

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/grafanaTemplateVariableFns.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/grafanaTemplateVariableFns.ts
@@ -298,7 +298,6 @@ const migrateGrafanaTemplateVariableFn = (query: AzureMonitorQuery) => {
       break;
   }
 
-  delete migratedQuery.grafanaTemplateVariableFn;
   return migratedQuery;
 };
 

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/types/templateVariables.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/types/templateVariables.ts
@@ -43,6 +43,7 @@ export interface MetricNamespaceQuery extends BaseGrafanaTemplateVariableQuery {
   metricNamespace?: string;
   resourceName?: string;
 }
+/** @deprecated Use MetricNamespaceQuery instead */
 export interface MetricDefinitionsQuery extends BaseGrafanaTemplateVariableQuery {
   kind: 'MetricDefinitionsQuery';
   subscription: string;

--- a/public/app/plugins/datasource/grafana-azure-monitor-datasource/types/templateVariables.ts
+++ b/public/app/plugins/datasource/grafana-azure-monitor-datasource/types/templateVariables.ts
@@ -43,6 +43,13 @@ export interface MetricNamespaceQuery extends BaseGrafanaTemplateVariableQuery {
   metricNamespace?: string;
   resourceName?: string;
 }
+export interface MetricDefinitionsQuery extends BaseGrafanaTemplateVariableQuery {
+  kind: 'MetricDefinitionsQuery';
+  subscription: string;
+  resourceGroup: string;
+  metricNamespace?: string;
+  resourceName?: string;
+}
 export interface MetricNamesQuery extends BaseGrafanaTemplateVariableQuery {
   kind: 'MetricNamesQuery';
   subscription: string;
@@ -62,6 +69,7 @@ export type GrafanaTemplateVariableQuery =
   | ResourceGroupsQuery
   | ResourceNamesQuery
   | MetricNamespaceQuery
+  | MetricDefinitionsQuery
   | MetricNamesQuery
   | WorkspacesQuery
   | UnknownQuery;


### PR DESCRIPTION
**What this PR does / why we need it**:
The new migration does not take into account `MetricDefinitionsQuery` type and if a template variable had that `kind` property, clicking on it in the template variables view triggers an infinite loop and the browser crashes.

This PR adds back the type thus fixing the issue

As `MetricDefinitionQuery` was removed previously by us, I also updated the imported dashboards to reflect that change

**Which issue(s) this PR fixes**:

Fixes [escalation #3850](https://github.com/grafana/support-escalations/issues/3860)

**Special notes for your reviewer**:

