### PR TITLE
fix: update coremodel generator to use filepath.Dir to get the Grafana root dir

### DIFF
--- a/pkg/framework/coremodel/gen.go
+++ b/pkg/framework/coremodel/gen.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/load"
 	"github.com/grafana/cuetsy"
-	gcgen "github.com/grafana/grafana/pkg/codegen"
 	"github.com/grafana/thema"
+
+	gcgen "github.com/grafana/grafana/pkg/codegen"
 )
 
 var lib = thema.NewLibrary(cuecontext.New())
@@ -37,8 +37,7 @@ func main() {
 	}
 
 	// TODO this binds us to only having coremodels in a single directory. If we need more, compgen is the way
-	grootp := strings.Split(cwd, sep)
-	groot := filepath.Join(sep, filepath.Join(grootp[:len(grootp)-3]...))
+	groot := filepath.Dir(filepath.Dir(filepath.Dir(cwd))) // the working dir is <grafana_dir>/pkg/framework/coremodel. Going up 3 dirs we get the grafana root
 
 	cmroot := filepath.Join(groot, "pkg", "coremodel")
 	tsroot := filepath.Join(groot, "packages", "grafana-schema", "src", "schema")


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
The current approach does not work in Windows
when I run `go generate ./public/app/plugins && go generate ./pkg/framework/coremodel` 
I get 
```
 could not read coremodels parent dir \C:Users\yuriy\go\src\grafana-oss\pkg\coremodel: open \C:Users\yuriy\go\src\grafana-oss\pkg\coremodel: The filename, directory name, or volume label syntax is incorrect.
exit status 1
```
This PR fixes it.
**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer**:

