### PR TITLE
PublicDashboards: allow disabling an existent public dashboard if it has template variables

### DIFF
--- a/pkg/services/publicdashboards/service/service.go
+++ b/pkg/services/publicdashboards/service/service.go
@@ -96,12 +96,8 @@ func (pd *PublicDashboardServiceImpl) GetPublicDashboardConfig(ctx context.Conte
 // SavePublicDashboardConfig is a helper method to persist the sharing config
 // to the database. It handles validations for sharing config and persistence
 func (pd *PublicDashboardServiceImpl) SavePublicDashboardConfig(ctx context.Context, u *user.SignedInUser, dto *SavePublicDashboardConfigDTO) (*PublicDashboard, error) {
+	// validate if dashboard exists
 	dashboard, err := pd.GetDashboard(ctx, dto.DashboardUid)
-	if err != nil {
-		return nil, err
-	}
-
-	err = validation.ValidateSavePublicDashboard(dto, dashboard)
 	if err != nil {
 		return nil, err
 	}
@@ -120,6 +116,11 @@ func (pd *PublicDashboardServiceImpl) SavePublicDashboardConfig(ctx context.Cont
 	// save changes
 	var pubdashUid string
 	if existingPubdash == nil {
+		err = validation.ValidateSavePublicDashboard(dto, dashboard)
+		if err != nil {
+			return nil, err
+		}
+
 		pubdashUid, err = pd.savePublicDashboardConfig(ctx, dto)
 	} else {
 		pubdashUid, err = pd.updatePublicDashboardConfig(ctx, dto)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
If a template variable is added after creating a public dashboard there is no way to disable it.
We remove validations allowing a user to update the public dashboard config and added an Alert indicating that the public dashboard won't work
We still are not allowing to create a new public dashboard if the original dashboard has template variables

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/4449

**Special notes for your reviewer**:
New Alert only for updating an existent public dashboard
![image](https://user-images.githubusercontent.com/20256983/190501173-f185b003-75c4-490b-90da-9a4928286a74.png)

Same behavior for public dashboard creation
![image](https://user-images.githubusercontent.com/20256983/190501326-0743c491-96c7-4159-aeb4-495dda979622.png)

