### PR TITLE
Alerting: Refactor one notifier to use encoding/json to parse settings instead of simplejson

### DIFF
--- a/pkg/services/ngalert/notifier/channels/slack.go
+++ b/pkg/services/ngalert/notifier/channels/slack.go
@@ -71,7 +71,7 @@ func buildSlackNotifier(factoryConfig FactoryConfig) (*SlackNotifier, error) {
 	channelConfig := factoryConfig.Config
 	decryptFunc := factoryConfig.DecryptFunc
 	var settings slackSettings
-	err := factoryConfig.Config.marshalSettings(&settings)
+	err := factoryConfig.Config.unmarshalSettings(&settings)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/notifier/channels/slack.go
+++ b/pkg/services/ngalert/notifier/channels/slack.go
@@ -50,21 +50,6 @@ type SlackNotifier struct {
 	Token          string
 }
 
-type SlackConfig struct {
-	*NotificationChannelConfig
-	URL            *url.URL
-	Username       string
-	IconEmoji      string
-	IconURL        string
-	Recipient      string
-	Text           string
-	Title          string
-	MentionUsers   []string
-	MentionGroups  []string
-	MentionChannel string
-	Token          string
-}
-
 type slackSettings struct {
 	EndpointURL    string `json:"endpointUrl,omitempty" yaml:"endpointUrl,omitempty"`
 	URL            string `json:"url,omitempty" yaml:"url,omitempty"`

--- a/pkg/services/ngalert/notifier/channels/slack.go
+++ b/pkg/services/ngalert/notifier/channels/slack.go
@@ -66,18 +66,17 @@ func SlackFactory(fc FactoryConfig) (NotificationChannel, error) {
 }
 
 func buildSlackNotifier(factoryConfig FactoryConfig) (*SlackNotifier, error) {
-	channelConfig := factoryConfig.Config
 	decryptFunc := factoryConfig.DecryptFunc
 	var settings slackSettings
 	err := factoryConfig.Config.unmarshalSettings(&settings)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal settings: %w", err)
 	}
 
 	if settings.EndpointURL == "" {
 		settings.EndpointURL = SlackAPIEndpoint
 	}
-	slackURL := decryptFunc(context.Background(), channelConfig.SecureSettings, "url", settings.URL)
+	slackURL := decryptFunc(context.Background(), factoryConfig.Config.SecureSettings, "url", settings.URL)
 	if slackURL == "" {
 		slackURL = settings.EndpointURL
 	}
@@ -94,7 +93,7 @@ func buildSlackNotifier(factoryConfig FactoryConfig) (*SlackNotifier, error) {
 	if settings.MentionChannel != "" && settings.MentionChannel != "here" && settings.MentionChannel != "channel" {
 		return nil, fmt.Errorf("invalid value for mentionChannel: %q", settings.MentionChannel)
 	}
-	settings.Token = decryptFunc(context.Background(), channelConfig.SecureSettings, "token", settings.Token)
+	settings.Token = decryptFunc(context.Background(), factoryConfig.Config.SecureSettings, "token", settings.Token)
 	if settings.Token == "" && settings.URL == SlackAPIEndpoint {
 		return nil, errors.New("token must be specified when using the Slack chat API")
 	}

--- a/pkg/services/ngalert/notifier/channels/slack.go
+++ b/pkg/services/ngalert/notifier/channels/slack.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 
+	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -62,6 +63,34 @@ type SlackConfig struct {
 	MentionGroups  []string
 	MentionChannel string
 	Token          string
+}
+
+type slackSettings struct {
+	EndpointURL    string `json:"endpointUrl,omitempty" yaml:"endpointUrl,omitempty"`
+	URL            string `json:"url,omitempty" yaml:"url,omitempty"`
+	Token          string `json:"token,omitempty" yaml:"token,omitempty"`
+	Recipient      string `json:"recipient,omitempty" yaml:"recipient,omitempty"`
+	Text           string `json:"text,omitempty" yaml:"text,omitempty"`
+	Title          string `json:"title,omitempty" yaml:"title,omitempty"`
+	Username       string `json:"username,omitempty" yaml:"username,omitempty"`
+	IconEmoji      string `json:"icon_emoji,omitempty" yaml:"icon_emoji,omitempty"`
+	IconURL        string `json:"icon_url,omitempty" yaml:"icon_url,omitempty"`
+	MentionChannel string `json:"mentionChannel,omitempty" yaml:"mentionChannel,omitempty"`
+	MentionUsers   string `json:"mentionUsers,omitempty" yaml:"mentionUsers,omitempty"`
+	MentionGroups  string `json:"mentionGroups,omitempty" yaml:"mentionGroups,omitempty"`
+}
+
+func newSlackSettings(stgs *simplejson.Json) (slackSettings, error) {
+	ser, err := stgs.Encode()
+	if err != nil {
+		return slackSettings{}, err
+	}
+	var settings slackSettings
+	err = json.Unmarshal(ser, &settings)
+	if err != nil {
+		return slackSettings{}, err
+	}
+	return settings, nil
 }
 
 func SlackFactory(fc FactoryConfig) (NotificationChannel, error) {

--- a/pkg/services/ngalert/notifier/channels/slack.go
+++ b/pkg/services/ngalert/notifier/channels/slack.go
@@ -18,7 +18,6 @@ import (
 	"github.com/prometheus/alertmanager/template"
 	"github.com/prometheus/alertmanager/types"
 
-	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/models"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -67,19 +66,6 @@ type slackSettings struct {
 	MentionGroups    []string `json:"-" yaml:"-"`
 }
 
-func newSlackSettings(stgs *simplejson.Json) (slackSettings, error) {
-	ser, err := stgs.Encode()
-	if err != nil {
-		return slackSettings{}, err
-	}
-	var settings slackSettings
-	err = json.Unmarshal(ser, &settings)
-	if err != nil {
-		return slackSettings{}, err
-	}
-	return settings, nil
-}
-
 // SlackFactory creates a new NotificationChannel that sends notifications to Slack.
 func SlackFactory(fc FactoryConfig) (NotificationChannel, error) {
 	ch, err := buildSlackNotifier(fc)
@@ -95,7 +81,8 @@ func SlackFactory(fc FactoryConfig) (NotificationChannel, error) {
 func buildSlackNotifier(factoryConfig FactoryConfig) (*SlackNotifier, error) {
 	channelConfig := factoryConfig.Config
 	decryptFunc := factoryConfig.DecryptFunc
-	settings, err := newSlackSettings(factoryConfig.Config.Settings)
+	var settings slackSettings
+	err := factoryConfig.Config.marshalSettings(&settings)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/ngalert/notifier/channels/slack.go
+++ b/pkg/services/ngalert/notifier/channels/slack.go
@@ -39,20 +39,18 @@ type SlackNotifier struct {
 }
 
 type slackSettings struct {
-	EndpointURL      string   `json:"endpointUrl,omitempty" yaml:"endpointUrl,omitempty"`
-	URL              string   `json:"url,omitempty" yaml:"url,omitempty"`
-	Token            string   `json:"token,omitempty" yaml:"token,omitempty"`
-	Recipient        string   `json:"recipient,omitempty" yaml:"recipient,omitempty"`
-	Text             string   `json:"text,omitempty" yaml:"text,omitempty"`
-	Title            string   `json:"title,omitempty" yaml:"title,omitempty"`
-	Username         string   `json:"username,omitempty" yaml:"username,omitempty"`
-	IconEmoji        string   `json:"icon_emoji,omitempty" yaml:"icon_emoji,omitempty"`
-	IconURL          string   `json:"icon_url,omitempty" yaml:"icon_url,omitempty"`
-	MentionChannel   string   `json:"mentionChannel,omitempty" yaml:"mentionChannel,omitempty"`
-	MentionUsersStr  string   `json:"mentionUsers,omitempty" yaml:"mentionUsers,omitempty"`
-	MentionUsers     []string `json:"-" yaml:"-"`
-	MentionGroupsStr string   `json:"mentionGroups,omitempty" yaml:"mentionGroups,omitempty"`
-	MentionGroups    []string `json:"-" yaml:"-"`
+	EndpointURL    string                `json:"endpointUrl,omitempty" yaml:"endpointUrl,omitempty"`
+	URL            string                `json:"url,omitempty" yaml:"url,omitempty"`
+	Token          string                `json:"token,omitempty" yaml:"token,omitempty"`
+	Recipient      string                `json:"recipient,omitempty" yaml:"recipient,omitempty"`
+	Text           string                `json:"text,omitempty" yaml:"text,omitempty"`
+	Title          string                `json:"title,omitempty" yaml:"title,omitempty"`
+	Username       string                `json:"username,omitempty" yaml:"username,omitempty"`
+	IconEmoji      string                `json:"icon_emoji,omitempty" yaml:"icon_emoji,omitempty"`
+	IconURL        string                `json:"icon_url,omitempty" yaml:"icon_url,omitempty"`
+	MentionChannel string                `json:"mentionChannel,omitempty" yaml:"mentionChannel,omitempty"`
+	MentionUsers   CommaSeparatedStrings `json:"mentionUsers,omitempty" yaml:"mentionUsers,omitempty"`
+	MentionGroups  CommaSeparatedStrings `json:"mentionGroups,omitempty" yaml:"mentionGroups,omitempty"`
 }
 
 // SlackFactory creates a new NotificationChannel that sends notifications to Slack.
@@ -99,20 +97,6 @@ func buildSlackNotifier(factoryConfig FactoryConfig) (*SlackNotifier, error) {
 	settings.Token = decryptFunc(context.Background(), channelConfig.SecureSettings, "token", settings.Token)
 	if settings.Token == "" && settings.URL == SlackAPIEndpoint {
 		return nil, errors.New("token must be specified when using the Slack chat API")
-	}
-	settings.MentionUsers = []string{}
-	for _, u := range strings.Split(settings.MentionUsersStr, ",") {
-		u = strings.TrimSpace(u)
-		if u != "" {
-			settings.MentionUsers = append(settings.MentionUsers, u)
-		}
-	}
-	settings.MentionGroups = []string{}
-	for _, g := range strings.Split(settings.MentionGroupsStr, ",") {
-		g = strings.TrimSpace(g)
-		if g != "" {
-			settings.MentionGroups = append(settings.MentionGroups, g)
-		}
 	}
 	if settings.Username == "" {
 		settings.Username = "Grafana"

--- a/pkg/services/ngalert/notifier/channels/slack_test.go
+++ b/pkg/services/ngalert/notifier/channels/slack_test.go
@@ -271,9 +271,10 @@ func TestSlackNotifier(t *testing.T) {
 				// TODO: allow changing the associated values for different tests.
 				NotificationService: notificationService,
 				DecryptFunc:         decryptFn,
+				Template:            tmpl,
 			}
 
-			cfg, err := NewSlackConfig(fc)
+			pn, err := buildSlackNotifier(fc)
 			if c.expInitError != "" {
 				require.Error(t, err)
 				require.Equal(t, c.expInitError, err.Error())
@@ -306,7 +307,6 @@ func TestSlackNotifier(t *testing.T) {
 
 			ctx := notify.WithGroupKey(context.Background(), "alertname")
 			ctx = notify.WithGroupLabels(ctx, model.LabelSet{"alertname": ""})
-			pn := NewSlackNotifier(cfg, fc.ImageStore, fc.NotificationService, tmpl)
 			ok, err := pn.Notify(ctx, c.alerts...)
 			if c.expMsgError != nil {
 				require.Error(t, err)

--- a/pkg/services/ngalert/notifier/channels/util.go
+++ b/pkg/services/ngalert/notifier/channels/util.go
@@ -171,7 +171,7 @@ type NotificationChannelConfig struct {
 	SecureSettings        map[string][]byte `json:"secureSettings"`
 }
 
-func (c NotificationChannelConfig) marshalSettings(v interface{}) error {
+func (c NotificationChannelConfig) unmarshalSettings(v interface{}) error {
 	ser, err := c.Settings.Encode()
 	if err != nil {
 		return err

--- a/pkg/services/ngalert/notifier/channels/util.go
+++ b/pkg/services/ngalert/notifier/channels/util.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -168,6 +169,18 @@ type NotificationChannelConfig struct {
 	DisableResolveMessage bool              `json:"disableResolveMessage"`
 	Settings              *simplejson.Json  `json:"settings"`
 	SecureSettings        map[string][]byte `json:"secureSettings"`
+}
+
+func (c NotificationChannelConfig) marshalSettings(v interface{}) error {
+	ser, err := c.Settings.Encode()
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(ser, v)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 type httpCfg struct {

--- a/pkg/services/ngalert/notifier/channels/util.go
+++ b/pkg/services/ngalert/notifier/channels/util.go
@@ -14,11 +14,13 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/prometheus/alertmanager/notify"
 	"github.com/prometheus/alertmanager/types"
 	"github.com/prometheus/common/model"
+	"gopkg.in/yaml.v2"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -261,4 +263,57 @@ func joinUrlPath(base, additionalPath string, logger log.Logger) string {
 // and set a boundary for multipart body. DO NOT set this outside tests.
 var GetBoundary = func() string {
 	return ""
+}
+
+type CommaSeparatedStrings []string
+
+func (r *CommaSeparatedStrings) UnmarshalJSON(b []byte) error {
+	var str string
+	if err := json.Unmarshal(b, &str); err != nil {
+		return err
+	}
+	if len(str) > 0 {
+		res := CommaSeparatedStrings(splitCommaDelimitedString(str))
+		*r = res
+	}
+	return nil
+}
+
+func (r *CommaSeparatedStrings) MarshalJSON() ([]byte, error) {
+	if r == nil {
+		return nil, nil
+	}
+	str := strings.Join(*r, ",")
+	return json.Marshal(str)
+}
+
+func (r *CommaSeparatedStrings) UnmarshalYAML(b []byte) error {
+	var str string
+	if err := yaml.Unmarshal(b, &str); err != nil {
+		return err
+	}
+	if len(str) > 0 {
+		res := CommaSeparatedStrings(splitCommaDelimitedString(str))
+		*r = res
+	}
+	return nil
+}
+
+func (r *CommaSeparatedStrings) MarshalYAML() ([]byte, error) {
+	if r == nil {
+		return nil, nil
+	}
+	str := strings.Join(*r, ",")
+	return yaml.Marshal(str)
+}
+
+func splitCommaDelimitedString(str string) []string {
+	split := strings.Split(str, ",")
+	res := make([]string, 0, len(split))
+	for _, s := range split {
+		if tr := strings.TrimSpace(s); tr != "" {
+			res = append(res, tr)
+		}
+	}
+	return res
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a refactor that I believe would benefit all of our notifiers. I'm PR'ing it against just one notifier first, in order to gauge our opinions on it.

Instead of using `simplejson` to loosely parse notifier settings which is [bug-prone](https://github.com/grafana/grafana/issues/55139), this PR instead makes notifiers declare a well-defined struct for their settings.

This has some benefits:
- Improves validation for all settings fields and eliminates bugs (see attached issue)
- The total set of fields for each notifier is now clear and obvious. Settings are easier to reason about.
- Simplifies notifier construction logic by removing a layer of indirection
- Eliminates repetition/mapping of settings fields, which was a vector for bugs
- Makes our notifiers more in-line with [Prometheus's notifiers](https://github.com/prometheus/alertmanager/blob/3d624c0552e173aa57bbdad52a55788e38744252/notify/slack/slack.go). They also use settings structs.

**Which issue(s) this PR fixes**:

Contributes to https://github.com/grafana/grafana/issues/55139

This PR fixes the above issue, in the slack notifier.

**Special notes for your reviewer**:

### **Consider reviewing this PR commit-by-commit.**

The commits are carefully laid out in such a way as to explain how this refactor works.