### PR TITLE
Inspect: Hide Actions tab when it is empty

### DIFF
--- a/public/app/features/dashboard/components/Inspector/hooks.ts
+++ b/public/app/features/dashboard/components/Inspector/hooks.ts
@@ -65,7 +65,7 @@ export const useInspectTabs = (
     // This is a quick internal hack to allow custom actions in inspect
     // For 8.1, something like this should be exposed through grafana/runtime
     const supplier = (window as any).grafanaPanelInspectActionSupplier as PanelInspectActionSupplier;
-    if (supplier && supplier.getActions(panel)) {
+    if (supplier && supplier.getActions(panel)?.length) {
       tabs.push({
         label: t({ id: 'dashboard.inspect.actions-tab', message: 'Actions' }),
         value: InspectTab.Actions,


### PR DESCRIPTION
Every inspect panel play.grafana.com has an empty "Actions" https://play.grafana.org/d/000000012/grafana-play-home?orgId=1&inspect=9
<img width="604" alt="image" src="https://user-images.githubusercontent.com/705951/190532103-f5413618-3eab-4046-a780-fd7c2ac5ca4c.png">

This code has not changed since the 8.0 release, so likely a plugin was added that has slightly different behavior.