### PR TITLE
Build: Reintroduce babel for grafana-ui

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -106,8 +106,10 @@
   },
   "devDependencies": {
     "@babel/core": "7.19.0",
+    "@babel/plugin-syntax-typescript": "^7.18.6",
     "@grafana/tsconfig": "^1.2.0-rc1",
     "@mdx-js/react": "1.6.22",
+    "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-node-resolve": "13.3.0",
     "@storybook/addon-a11y": "6.4.21",
     "@storybook/addon-actions": "6.4.21",
@@ -163,6 +165,7 @@
     "@types/uuid": "8.3.4",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.7",
     "babel-loader": "8.2.5",
+    "babel-plugin-macros": "^3.1.0",
     "common-tags": "1.8.2",
     "css-loader": "6.7.1",
     "css-minimizer-webpack-plugin": "4.0.0",

--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -1,3 +1,4 @@
+import { babel } from '@rollup/plugin-babel';
 import resolve from '@rollup/plugin-node-resolve';
 import path from 'path';
 import dts from 'rollup-plugin-dts';
@@ -7,10 +8,23 @@ import svg from 'rollup-plugin-svg-import';
 
 const pkg = require('./package.json');
 
+const cwd = process.env.PROJECT_CWD ?? '';
+
 export default [
   {
     input: 'src/index.ts',
-    plugins: [externals({ deps: true, packagePath: './package.json' }), resolve(), svg({ stringify: true }), esbuild()],
+    plugins: [
+      externals({ deps: true, packagePath: './package.json' }),
+      resolve(),
+      svg({ stringify: true }),
+      babel({
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+        babelHelpers: 'bundled',
+        plugins: [['@babel/plugin-syntax-typescript', { isTSX: true }], 'macros'],
+        babelrc: false,
+      }),
+      esbuild(),
+    ],
     output: [
       {
         format: 'cjs',
@@ -22,8 +36,7 @@ export default [
         sourcemap: true,
         dir: path.dirname(pkg.publishConfig.module),
         preserveModules: true,
-        // @ts-expect-error (TS cannot assure that `process.env.PROJECT_CWD` is a string)
-        preserveModulesRoot: path.join(process.env.PROJECT_CWD, `packages/grafana-ui/src`),
+        preserveModulesRoot: path.join(cwd, `packages/grafana-ui/src`),
       },
     ],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,6 +970,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^7.10.4, @babel/helper-module-imports@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/helper-module-imports@npm:7.18.6"
+  dependencies:
+    "@babel/types": ^7.18.6
+  checksum: f393f8a3b3304b1b7a288a38c10989de754f01d29caf62ce7c4e5835daf0a27b81f3ac687d9d2780d39685aae7b55267324b512150e7b2be967b0c493b6a1def
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-imports@npm:^7.16.0":
   version: 7.16.0
   resolution: "@babel/helper-module-imports@npm:7.16.0"
@@ -985,15 +994,6 @@ __metadata:
   dependencies:
     "@babel/types": ^7.16.7
   checksum: ddd2c4a600a2e9a4fee192ab92bf35a627c5461dbab4af31b903d9ba4d6b6e59e0ff3499fde4e2e9a0eebe24906f00b636f8b4d9bd72ff24d50e6618215c3212
-  languageName: node
-  linkType: hard
-
-"@babel/helper-module-imports@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/helper-module-imports@npm:7.18.6"
-  dependencies:
-    "@babel/types": ^7.18.6
-  checksum: f393f8a3b3304b1b7a288a38c10989de754f01d29caf62ce7c4e5835daf0a27b81f3ac687d9d2780d39685aae7b55267324b512150e7b2be967b0c493b6a1def
   languageName: node
   linkType: hard
 
@@ -5562,6 +5562,7 @@ __metadata:
   resolution: "@grafana/ui@workspace:packages/grafana-ui"
   dependencies:
     "@babel/core": 7.19.0
+    "@babel/plugin-syntax-typescript": ^7.18.6
     "@emotion/css": 11.9.0
     "@emotion/react": 11.9.3
     "@grafana/data": 9.2.0-pre
@@ -5578,6 +5579,7 @@ __metadata:
     "@react-aria/overlays": 3.10.1
     "@react-aria/utils": 3.13.1
     "@react-stately/menu": 3.4.1
+    "@rollup/plugin-babel": ^5.3.1
     "@rollup/plugin-node-resolve": 13.3.0
     "@sentry/browser": 6.19.7
     "@storybook/addon-a11y": 6.4.21
@@ -5635,6 +5637,7 @@ __metadata:
     "@wojtekmaj/enzyme-adapter-react-17": 0.6.7
     ansicolor: 1.1.100
     babel-loader: 8.2.5
+    babel-plugin-macros: ^3.1.0
     calculate-size: 1.1.1
     classnames: 2.3.1
     common-tags: 1.8.2
@@ -8992,6 +8995,23 @@ __metadata:
     react-redux:
       optional: true
   checksum: 831b5c74779262351d20efa0f4c06f794702bd55b14bd8f69362e29f82f7ad43aee66f39518914345ad9e9c6c93611acdeb576a70deda260733c3f098875aaca
+  languageName: node
+  linkType: hard
+
+"@rollup/plugin-babel@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "@rollup/plugin-babel@npm:5.3.1"
+  dependencies:
+    "@babel/helper-module-imports": ^7.10.4
+    "@rollup/pluginutils": ^3.1.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+    "@types/babel__core": ^7.1.9
+    rollup: ^1.20.0||^2.0.0
+  peerDependenciesMeta:
+    "@types/babel__core":
+      optional: true
+  checksum: 220d71e4647330f252ef33d5f29700aef2e8284a0b61acfcceb47617a7f96208aa1ed16eae75619424bf08811ede5241e271a6d031f07026dee6b3a2bdcdc638
   languageName: node
   linkType: hard
 
@@ -14830,7 +14850,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-macros@npm:3.1.0, babel-plugin-macros@npm:^3.0.1":
+"babel-plugin-macros@npm:3.1.0, babel-plugin-macros@npm:^3.0.1, babel-plugin-macros@npm:^3.1.0":
   version: 3.1.0
   resolution: "babel-plugin-macros@npm:3.1.0"
   dependencies:


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds babel in front of esbuild for grafana-ui to add in support for babel-macros, so later we can use lingui in grafana-ui.

Babel has been configured to do as little as possible, and it should _only_ apply babel macros, leaving esbuild to strip typescript and transform JSX.

Based on my testing, this adds about 3 seconds to the build time of Grafana UI. It also adds about 12 kB to the final bundle size, which is mostly/only increased whitespace (which I haven't investigated what exactly causes it)

![image](https://user-images.githubusercontent.com/46142/190632849-09378579-3687-4893-8a4c-da2b6d6a1d5a.png)


**Which issue(s) this PR fixes**:

Fixes https://github.com/grafana/grafana/issues/55221

**Special notes for your reviewer**:

