### PR TITLE
Alerting: make sure that rules in rule group are nil if not provided

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -191,20 +191,19 @@ type AlertRuleGroup struct {
 }
 
 func (a *AlertRuleGroup) ToModel() (models.AlertRuleGroup, error) {
-	rules := make([]models.AlertRule, 0, len(a.Rules))
+	ruleGroup := models.AlertRuleGroup{
+		Title:     a.Title,
+		FolderUID: a.FolderUID,
+		Interval:  a.Interval,
+	}
 	for i := range a.Rules {
 		converted, err := a.Rules[i].UpstreamModel()
 		if err != nil {
 			return models.AlertRuleGroup{}, err
 		}
-		rules = append(rules, converted)
+		ruleGroup.Rules = append(ruleGroup.Rules, converted)
 	}
-	return models.AlertRuleGroup{
-		Title:     a.Title,
-		FolderUID: a.FolderUID,
-		Interval:  a.Interval,
-		Rules:     rules,
-	}, nil
+	return ruleGroup, nil
 }
 
 func NewAlertRuleGroupFromModel(d models.AlertRuleGroup) AlertRuleGroup {

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules_test.go
@@ -1,0 +1,35 @@
+package definitions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToModel(t *testing.T) {
+	t.Run("if no rules are provided the rule field should be nil", func(t *testing.T) {
+		ruleGroup := AlertRuleGroup{
+			Title:     "123",
+			FolderUID: "123",
+			Interval:  10,
+		}
+		tm, err := ruleGroup.ToModel()
+		require.NoError(t, err)
+		require.Nil(t, tm.Rules)
+	})
+	t.Run("if rules are provided the rule field should be not nil", func(t *testing.T) {
+		ruleGroup := AlertRuleGroup{
+			Title:     "123",
+			FolderUID: "123",
+			Interval:  10,
+			Rules: []ProvisionedAlertRule{
+				{
+					UID: "1",
+				},
+			},
+		}
+		tm, err := ruleGroup.ToModel()
+		require.NoError(t, err)
+		require.Len(t, tm.Rules, 1)
+	})
+}

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -72,6 +72,7 @@ func (service *AlertRuleService) CreateAlertRule(ctx context.Context, rule model
 		return models.AlertRule{}, err
 	}
 	rule.IntervalSeconds = interval
+
 	err = rule.SetDashboardAndPanel()
 	if err != nil {
 		return models.AlertRule{}, err

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -72,7 +72,6 @@ func (service *AlertRuleService) CreateAlertRule(ctx context.Context, rule model
 		return models.AlertRule{}, err
 	}
 	rule.IntervalSeconds = interval
-
 	err = rule.SetDashboardAndPanel()
 	if err != nil {
 		return models.AlertRule{}, err


### PR DESCRIPTION
This PR ensures that if no rules are provided, we do not delete any existing rules. Instead of creating a slice beforehand, we now leverage append which makes the code easier to understand.