### PR TITLE
chore: add coverage repoort for OX-related PRs

### DIFF
--- a/.github/workflows/ox-code-coverage.yml
+++ b/.github/workflows/ox-code-coverage.yml
@@ -1,0 +1,18 @@
+name: Observability Experience test code coverage
+on:
+  pull_request:
+    paths:
+      - 'pkg/services/queryhistory/**'
+      - 'pkg/services/correlations/**'
+      - 'public/app/features/explore/**'
+      - 'public/app/features/correlations/**'
+    branches-ignore:
+      - dependabot/**
+      - backport-*
+
+jobs:
+  workflow-call:
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.10
+    with:
+      frontend-path-regexp: public\/app\/features\/(explore|correlations)
+      backend-path-regexp: pkg\/services\/(queryhistory|correlations)


### PR DESCRIPTION
adds coverage report for PRs touching files in:
- `pkg/services/queryhistory/**`
- `pkg/services/correlations/**`
- `public/app/features/explore/**`
- `public/app/features/correlations/**`

fixes https://github.com/grafana/grafana/issues/55319