### PR TITLE
Plugins: Ensure plugin uninstall success for "pre-installed" community plugins

### DIFF
--- a/pkg/plugins/manager/fakes/fakes.go
+++ b/pkg/plugins/manager/fakes/fakes.go
@@ -207,19 +207,22 @@ func (r *FakePluginRepo) GetPluginDownloadOptions(ctx context.Context, pluginID,
 }
 
 type FakePluginStorage struct {
-	AddFunc    func(_ context.Context, pluginID string, z *zip.ReadCloser) (*storage.ExtractedPluginArchive, error)
-	RemoveFunc func(_ context.Context, pluginID string) error
-	Added      map[string]string
-	Removed    map[string]int
+	AddFunc      func(_ context.Context, pluginID string, z *zip.ReadCloser) (*storage.ExtractedPluginArchive, error)
+	RegisterFunc func(_ context.Context, pluginID, pluginDir string) error
+	RemoveFunc   func(_ context.Context, pluginID string) error
+	Added        map[string]string
+	Removed      map[string]int
 }
 
-func (s *FakePluginStorage) Register(_ context.Context, pluginID, pluginDir string) error {
+func (s *FakePluginStorage) Register(ctx context.Context, pluginID, pluginDir string) error {
 	s.Added[pluginID] = pluginDir
+	if s.RegisterFunc != nil {
+		return s.RegisterFunc(ctx, pluginID, pluginDir)
+	}
 	return nil
 }
 
 func (s *FakePluginStorage) Add(ctx context.Context, pluginID string, z *zip.ReadCloser) (*storage.ExtractedPluginArchive, error) {
-	s.Added[pluginID] = z.File[0].Name
 	if s.AddFunc != nil {
 		return s.AddFunc(ctx, pluginID, z)
 	}

--- a/pkg/plugins/manager/fakes/fakes.go
+++ b/pkg/plugins/manager/fakes/fakes.go
@@ -213,6 +213,11 @@ type FakePluginStorage struct {
 	Removed    map[string]int
 }
 
+func (s *FakePluginStorage) Register(_ context.Context, pluginID, pluginDir string) error {
+	s.Added[pluginID] = pluginDir
+	return nil
+}
+
 func (s *FakePluginStorage) Add(ctx context.Context, pluginID string, z *zip.ReadCloser) (*storage.ExtractedPluginArchive, error) {
 	s.Added[pluginID] = z.File[0].Name
 	if s.AddFunc != nil {

--- a/pkg/plugins/manager/manager.go
+++ b/pkg/plugins/manager/manager.go
@@ -242,6 +242,12 @@ func (m *PluginManager) registerAndStart(ctx context.Context, p *plugins.Plugin)
 		m.log.Info("Plugin registered", "pluginID", p.ID)
 	}
 
+	if p.IsExternalPlugin() {
+		if err := m.pluginStorage.Register(ctx, p.ID, p.PluginDir); err != nil {
+			return err
+		}
+	}
+
 	return m.processManager.Start(ctx, p.ID)
 }
 

--- a/pkg/plugins/storage/fs.go
+++ b/pkg/plugins/storage/fs.go
@@ -73,6 +73,14 @@ func (fs *FS) Add(ctx context.Context, pluginID string, pluginArchive *zip.ReadC
 	}, nil
 }
 
+func (fs *FS) Register(_ context.Context, pluginID, pluginDir string) error {
+	fs.mu.Lock()
+	fs.store[pluginID] = pluginDir
+	fs.mu.Unlock()
+
+	return nil
+}
+
 func (fs *FS) Remove(_ context.Context, pluginID string) error {
 	fs.mu.RLock()
 	pluginDir, exists := fs.store[pluginID]

--- a/pkg/plugins/storage/fs.go
+++ b/pkg/plugins/storage/fs.go
@@ -61,10 +61,6 @@ func (fs *FS) Add(ctx context.Context, pluginID string, pluginArchive *zip.ReadC
 		})
 	}
 
-	fs.mu.Lock()
-	fs.store[pluginID] = pluginDir
-	fs.mu.Unlock()
-
 	return &ExtractedPluginArchive{
 		ID:           res.ID,
 		Version:      res.Info.Version,

--- a/pkg/plugins/storage/ifaces.go
+++ b/pkg/plugins/storage/ifaces.go
@@ -7,5 +7,6 @@ import (
 
 type Manager interface {
 	Add(ctx context.Context, pluginID string, rc *zip.ReadCloser) (*ExtractedPluginArchive, error)
+	Register(ctx context.Context, pluginID, pluginDir string) error
 	Remove(ctx context.Context, pluginID string) error
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
Discovered that we do not track state in the plugin file system manager component for external plugins that weren't installed at runtime. This PR fixes that 😄 

Note: This bug was introduced as part of https://github.com/grafana/grafana/pull/43046 (which is aimed for `9.2.0` so no backport is necessary)
