### PR TITLE
Explore: Close drawer when the dashboard search modal is open

### DIFF
--- a/public/app/features/explore/ExploreDrawer.tsx
+++ b/public/app/features/explore/ExploreDrawer.tsx
@@ -28,7 +28,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme2) => {
       border-top: 1px solid ${theme.colors.border.weak};
       margin: ${theme.spacing(0, -2, 0, -2)};
       box-shadow: ${theme.shadows.z3};
-      z-index: ${theme.zIndex.sidemenu};
+      z-index: ${theme.zIndex.navbarFixed};
     `,
     drawerActive: css`
       opacity: 1;


### PR DESCRIPTION
**What this PR does / why we need it**:
Update: After feedback on the PR, the update only changes the z-index so the dashboard search is over the explore drawer. The dashboard search's z-index is navbarFixed+1 (https://github.com/grafana/grafana/blob/main/public/app/features/search/components/DashboardSearch.tsx#L80) so setting the explore drawer to navbarFixed seems to be the right move. The navbarFixed variable only seems to be used in places that will not interfere with the explore drawer.

---

~The search dashboards screen is a full screen modal, and not a route change. Because of this, anything that happens inside explore does not get erased when the search dashboard button is pressed. This means when you have the explore drawer open for query history or inspector, and then click "Search Dashboards", the drawer still stays open over the search dashboards screen.~

~The search dashboard screen appends a query param into the url, which we can use to tell if it is open or not. We set the drawer to undefined if this query param is appended.~

**Which issue(s) this PR fixes**:
Fixes #47820

