### PR TITLE
Alerting: Fix InfluxDB no data returns a frame

### DIFF
--- a/pkg/tsdb/influxdb/flux/executor.go
+++ b/pkg/tsdb/influxdb/flux/executor.go
@@ -51,14 +51,13 @@ func executeQuery(ctx context.Context, query queryModel, runner queryRunner, max
 	}
 
 	// Make sure there is at least one frame
-	if len(dr.Frames) == 0 {
-		dr.Frames = append(dr.Frames, data.NewFrame(""))
+	if len(dr.Frames) > 0 {
+		firstFrame := dr.Frames[0]
+		if firstFrame.Meta == nil {
+			firstFrame.SetMeta(&data.FrameMeta{})
+		}
+		firstFrame.Meta.ExecutedQueryString = flux
 	}
-	firstFrame := dr.Frames[0]
-	if firstFrame.Meta == nil {
-		firstFrame.SetMeta(&data.FrameMeta{})
-	}
-	firstFrame.Meta.ExecutedQueryString = flux
 	return dr
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is one of two possible fixes for #55085. It changes the InfluxDB plugin to match the behaviour of the Prometheus plugin such that queries that return no data will return no frames instead of a frame with no fields.

**Which issue(s) this PR fixes**:

Fixes #55085

**Special notes for your reviewer**:

