### PR TITLE
Alerting: Fix mathexp.NoData cannot be reduced

### DIFF
--- a/pkg/expr/commands.go
+++ b/pkg/expr/commands.go
@@ -171,6 +171,8 @@ func (gr *ReduceCommand) Execute(_ context.Context, vars mathexp.Vars) (mathexp.
 				Text:     fmt.Sprintf("Reduce operation is not needed. Input query or expression %s is already reduced data.", gr.VarToReduce),
 			})
 			newRes.Values = append(newRes.Values, copyV)
+		case mathexp.NoData:
+			newRes.Values = append(newRes.Values, v.New())
 		default:
 			return newRes, fmt.Errorf("can only reduce type series, got type %v", val.Type())
 		}

--- a/pkg/expr/commands_test.go
+++ b/pkg/expr/commands_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	ptr "github.com/xorcare/pointer"
 
@@ -135,6 +136,32 @@ func TestReduceExecute(t *testing.T) {
 				require.Equal(t, data.NoticeSeverityWarning, notice.Severity)
 			}
 		})
+	})
+
+	t.Run("should return new NoData", func(t *testing.T) {
+		var noData mathexp.Values = []mathexp.Value{
+			mathexp.NoData{Frame: data.NewFrame("no data")},
+		}
+
+		vars := map[string]mathexp.Results{
+			varToReduce: {
+				Values: noData,
+			},
+		}
+
+		results, err := cmd.Execute(context.Background(), vars)
+		require.NoError(t, err)
+
+		require.Len(t, results.Values, 1)
+
+		v := results.Values[0]
+		assert.Equal(t, v, mathexp.NoData{}.New())
+
+		// should not be able to change the original frame
+		v.AsDataFrame().Name = "there is still no data"
+		assert.NotEqual(t, v, mathexp.NoData{}.New())
+		assert.NotEqual(t, v, noData[0])
+		assert.Equal(t, "no data", noData[0].AsDataFrame().Name)
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is one of two possible fixes for #55085. It changes the reduce function to reduce `mathexp.NoData` to a result with no values instead of an error "can only reduce type series, got type noData".

**Which issue(s) this PR fixes**:

Fixes #55085

**Special notes for your reviewer**:
