### PR TITLE
SegmentInput: Omit allowCustomValue and allowEmptyValue props

### DIFF
--- a/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.tsx
@@ -10,7 +10,9 @@ import { getSegmentStyles } from './styles';
 
 import { useExpandableLabel, SegmentProps } from '.';
 
-export interface SegmentInputProps<T> extends SegmentProps<T>, Omit<HTMLProps<HTMLInputElement>, 'value' | 'onChange'> {
+export interface SegmentInputProps<T>
+  extends Omit<SegmentProps<T>, 'allowCustomValue' | 'allowEmptyValue'>,
+    Omit<HTMLProps<HTMLInputElement>, 'value' | 'onChange'> {
   value: string | number;
   onChange: (text: string | number) => void;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes `allowCustomValue` and `allowEmptyValue`, props that are not recognized by `input` element used within `SegmentInput` component.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #55351

**Special notes for your reviewer**:
@Clarity-89 FYI
