### PR TITLE
GrafanaUI: Deprecate logs components

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogLabels.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogLabels.tsx
@@ -12,6 +12,7 @@ interface Props {
   labels: Labels;
 }
 
+/** @deprecated */
 export const LogLabels: FunctionComponent<Props> = ({ labels }) => {
   const styles = useStyles2(getStyles);
   const displayLabels = Object.keys(labels).filter((label) => !label.startsWith('_') && !HIDDEN_LABELS.includes(label));

--- a/packages/grafana-ui/src/components/Logs/LogLabels.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogLabels.tsx
@@ -12,7 +12,7 @@ interface Props {
   labels: Labels;
 }
 
-/** @deprecated */
+/** @deprecated will be removed in the next major version */
 export const LogLabels: FunctionComponent<Props> = ({ labels }) => {
   const styles = useStyles2(getStyles);
   const displayLabels = Object.keys(labels).filter((label) => !label.startsWith('_') && !HIDDEN_LABELS.includes(label));

--- a/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
@@ -101,6 +101,6 @@ export class UnThemedLogMessageAnsi extends PureComponent<Props, State> {
   }
 }
 
-/** @deprecated */
+/** @deprecated will be removed in the next major version */
 export const LogMessageAnsi = withTheme2(UnThemedLogMessageAnsi);
 LogMessageAnsi.displayName = 'LogMessageAnsi';

--- a/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
@@ -101,5 +101,6 @@ export class UnThemedLogMessageAnsi extends PureComponent<Props, State> {
   }
 }
 
+/** @deprecated */
 export const LogMessageAnsi = withTheme2(UnThemedLogMessageAnsi);
 LogMessageAnsi.displayName = 'LogMessageAnsi';

--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -188,5 +188,6 @@ class UnThemedLogRows extends PureComponent<Props, State> {
   }
 }
 
+/** @deprecated */
 export const LogRows = withTheme2(UnThemedLogRows);
 LogRows.displayName = 'LogsRows';

--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -188,6 +188,6 @@ class UnThemedLogRows extends PureComponent<Props, State> {
   }
 }
 
-/** @deprecated */
+/** @deprecated will be removed in the next major version */
 export const LogRows = withTheme2(UnThemedLogRows);
 LogRows.displayName = 'LogsRows';

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -4,7 +4,7 @@ import { GrafanaTheme2, LogLevel } from '@grafana/data';
 
 import { styleMixins } from '../../themes';
 
-/** @deprecated */
+/** @deprecated will be removed in the next major version */
 export const getLogRowStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
   let logColor = theme.isLight ? theme.v1.palette.gray5 : theme.v1.palette.gray2;
   const hoverBgColor = styleMixins.hoverColor(theme.colors.background.secondary, theme);

--- a/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
+++ b/packages/grafana-ui/src/components/Logs/getLogRowStyles.ts
@@ -4,6 +4,7 @@ import { GrafanaTheme2, LogLevel } from '@grafana/data';
 
 import { styleMixins } from '../../themes';
 
+/** @deprecated */
 export const getLogRowStyles = (theme: GrafanaTheme2, logLevel?: LogLevel) => {
   let logColor = theme.isLight ? theme.v1.palette.gray5 : theme.v1.palette.gray2;
   const hoverBgColor = styleMixins.hoverColor(theme.colors.background.secondary, theme);


### PR DESCRIPTION
in https://github.com/grafana/grafana/pull/55041 we started the move of logs-components from grafana-ui to the main grafana package. this pull request adds deprecated-markers to the exported components and functions.

the move of these components is needed because they are connected too much internally to the main grafana package. also, some changes are hard or impossible to do while keeping them in the grafana-ui package.

NOTE: we checked in the plugin dashboard, and none of those plugins were using any of these exports.


# Deprecation notice

The following components and functions related to logs are  deprecated in the `grafana-ui` package: `LogLabels`, `LogMessageAnsi`, `LogRows`, `getLogRowStyles`.
