### PR TITLE
CI: Fix `fetch-images` command

### DIFF
--- a/pkg/build/cmd/main.go
+++ b/pkg/build/cmd/main.go
@@ -136,16 +136,22 @@ func main() {
 			},
 		},
 		{
-			Name:  "docker",
-			Usage: "Handle Grafana Docker images",
+			Name:  "artifacts",
+			Usage: "Handle Grafana artifacts",
 			Subcommands: cli.Commands{
 				{
-					Name:      "fetch",
-					Usage:     "Fetch Grafana Docker images",
-					ArgsUsage: "[version]",
-					Action:    ArgCountWrapper(1, FetchImages),
-					Flags: []cli.Flag{
-						&editionFlag,
+					Name:  "docker",
+					Usage: "Handle Grafana Docker images",
+					Subcommands: cli.Commands{
+						{
+							Name:      "fetch",
+							Usage:     "Fetch Grafana Docker images",
+							ArgsUsage: "[version]",
+							Action:    ArgCountWrapper(1, FetchImages),
+							Flags: []cli.Flag{
+								&editionFlag,
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

After https://github.com/grafana/grafana/pull/55298, there was a misconfiguration in `main.go` - this PR fixes it by specifying the right subcmd signature.