### PR TITLE
CI: Run enterprise downstream build after OSS CI is successful

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1035,17 +1035,6 @@ steps:
       - pkg/build/**
     repo:
     - grafana/grafana
-- image: grafana/drone-downstream
-  name: trigger-enterprise-downstream
-  settings:
-    params:
-    - SOURCE_BUILD_NUMBER=${DRONE_COMMIT}
-    - SOURCE_COMMIT=${DRONE_COMMIT}
-    repositories:
-    - grafana/grafana-enterprise@main
-    server: https://drone.grafana.net
-    token:
-      from_secret: drone_token
 - commands:
   - ./bin/build build-backend --jobs 8 --edition oss --build-id ${DRONE_BUILD_NUMBER}
   depends_on:
@@ -1652,6 +1641,45 @@ trigger:
     - latest.json
   repo:
   - grafana/grafana
+type: docker
+volumes:
+- host:
+    path: /var/run/docker.sock
+  name: docker
+---
+clone:
+  retries: 3
+depends_on:
+- main-publish
+kind: pipeline
+name: main-trigger-downstream
+node:
+  type: no-parallel
+platform:
+  arch: amd64
+  os: linux
+services: []
+steps:
+- image: grafana/drone-downstream
+  name: trigger-enterprise-downstream
+  settings:
+    params:
+    - SOURCE_BUILD_NUMBER=${DRONE_COMMIT}
+    - SOURCE_COMMIT=${DRONE_COMMIT}
+    repositories:
+    - grafana/grafana-enterprise@main
+    server: https://drone.grafana.net
+    token:
+      from_secret: drone_token
+trigger:
+  branch: main
+  event:
+  - push
+  paths:
+    exclude:
+    - '*.md'
+    - docs/**
+    - latest.json
 type: docker
 volumes:
 - host:
@@ -5084,6 +5112,6 @@ kind: secret
 name: packages_secret_access_key
 ---
 kind: signature
-hmac: f5d430e8ea6ad2f889f24ffcaa5a2555e77b45fab364b6db85efa591bedc0a6b
+hmac: 3298924f36cbab63be3873f763ead9406f47dc8b98142678d69ea83b4012541c
 
 ...

--- a/scripts/drone/events/main.star
+++ b/scripts/drone/events/main.star
@@ -42,6 +42,11 @@ load(
     'publish',
 )
 
+load(
+    'scripts/drone/pipelines/trigger_downstream.star',
+    'enterprise_downstream_pipeline',
+)
+
 load('scripts/drone/vault.star', 'from_secret')
 
 
@@ -87,6 +92,7 @@ def main_pipelines(edition):
         template=drone_change_template, secret='drone-changes-webhook',
     ),
     publish(trigger, ver_mode, edition),
+    enterprise_downstream_pipeline(edition, ver_mode),
     notify_pipeline(
         name='main-notify', slack_channel='grafana-ci-notifications', trigger=dict(trigger, status=['failure']),
         depends_on=['main-test-frontend', 'main-test-backend', 'main-build-e2e-publish', 'main-integration-tests', 'main-windows', 'main-publish'],

--- a/scripts/drone/pipelines/build.star
+++ b/scripts/drone/pipelines/build.star
@@ -55,8 +55,9 @@ def build_e2e(trigger, ver_mode, edition):
     build_steps = []
     if ver_mode == 'main':
         build_steps.extend([trigger_test_release()])
+    if ver_mode == 'pr':
+        build_steps.extend([enterprise_downstream_step(edition=edition, ver_mode=ver_mode)])
     build_steps.extend([
-        enterprise_downstream_step(edition=edition, ver_mode=ver_mode),
         build_backend_step(edition=edition, ver_mode=ver_mode),
         build_frontend_step(edition=edition, ver_mode=ver_mode),
         build_frontend_package_step(edition=edition, ver_mode=ver_mode),

--- a/scripts/drone/pipelines/trigger_downstream.star
+++ b/scripts/drone/pipelines/trigger_downstream.star
@@ -1,0 +1,28 @@
+load(
+    'scripts/drone/steps/lib.star',
+    'enterprise_downstream_step',
+)
+
+load(
+    'scripts/drone/utils/utils.star',
+    'pipeline',
+)
+
+trigger = {
+    'event': ['push',],
+    'branch': 'main',
+    'paths': {
+        'exclude': [
+            '*.md',
+            'docs/**',
+            'latest.json',
+        ],
+    },
+}
+
+def enterprise_downstream_pipeline(edition, ver_mode):
+    steps = [enterprise_downstream_step(edition, ver_mode)]
+    deps = ['main-publish']
+    return pipeline(
+                name='main-trigger-downstream', edition=edition, trigger=trigger, services=[], steps=steps, depends_on=deps
+        )


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we trigger enterprise downstream pipelines way to early. The problem with this, is that say the latest OSS push against main is for some reason broken. When we push, the downstream build will get triggered on enterprise, which will result to broken builds in both OSS and Enterprise repo.

This PR handles that issue, by making sure that the enterprise downstream build will get triggered **only** if the OSS build is successful.
