### PR TITLE
Storybook: Add `storybook` bucket for main builds

### DIFF
--- a/pkg/build/config/versions.go
+++ b/pkg/build/config/versions.go
@@ -88,6 +88,7 @@ var Versions = VersionMap{
 			Artifacts:            "grafana-downloads",
 			ArtifactsEnterprise2: "grafana-downloads-enterprise2",
 			CDNAssets:            "grafana-static-assets",
+			Storybook:            "grafana-storybook",
 		},
 	},
 	ReleaseBranchMode: {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds missing string to config, for storybook canary deployment.