### PR TITLE
Use GrafanaAlertStateDecision.Error in RuleEditor test

### DIFF
--- a/public/app/features/alerting/unified/RuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditor.test.tsx
@@ -294,7 +294,7 @@ describe('RuleEditor', () => {
             grafana_alert: {
               condition: 'B',
               data: getDefaultQueries(),
-              exec_err_state: 'Error',
+              exec_err_state: GrafanaAlertStateDecision.Error,
               no_data_state: 'NoData',
               title: 'my great new rule',
             },
@@ -505,7 +505,7 @@ describe('RuleEditor', () => {
               uid,
               condition: 'B',
               data: getDefaultQueries(),
-              exec_err_state: 'Error',
+              exec_err_state: GrafanaAlertStateDecision.Error,
               no_data_state: 'NoData',
               title: 'my great new rule',
             },


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR updates `RuleEditor.test` using `GrafanaAlertStateDecision.Error` instead of 'Error' string, to be consistent with the implementation.

**Special notes for your reviewer**:

