### PR TITLE
Hackday: Pass form validation props to config editor

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -8,6 +8,7 @@ import { AnnotationEvent, AnnotationQuery, AnnotationSupport } from './annotatio
 import { CoreApp } from './app';
 import { KeyValue, LoadingState, TableData, TimeSeries } from './data';
 import { DataFrame, DataFrameDTO } from './dataFrame';
+import { FormAPI } from './forms';
 import { PanelData } from './panel';
 import { GrafanaPlugin, PluginMeta } from './plugin';
 import { DataQuery } from './query';
@@ -22,6 +23,7 @@ export interface DataSourcePluginOptionsEditorProps<
 > {
   options: DataSourceSettings<JSONData, SecureJSONData>;
   onOptionsChange: (options: DataSourceSettings<JSONData, SecureJSONData>) => void;
+  formApi?: FormAPI;
 }
 
 // Utility type to extract the query type TQuery from a class extending DataSourceApi<TQuery, TOptions>

--- a/packages/grafana-data/src/types/forms.ts
+++ b/packages/grafana-data/src/types/forms.ts
@@ -1,0 +1,3 @@
+export interface FormAPI extends Record<string, any> {
+  errors: Record<string, any>;
+}

--- a/packages/grafana-data/src/types/index.ts
+++ b/packages/grafana-data/src/types/index.ts
@@ -52,3 +52,4 @@ export * from './alerts';
 export * from './slider';
 export * from './accesscontrol';
 export * from './icon';
+export * from './forms';

--- a/public/app/features/datasources/components/ButtonRow.tsx
+++ b/public/app/features/datasources/components/ButtonRow.tsx
@@ -39,7 +39,7 @@ export function ButtonRow({ canSave, canDelete, onDelete, onSubmit, onTest, expl
           type="submit"
           variant="primary"
           disabled={!canSave}
-          onClick={(event) => onSubmit(event)}
+          // onClick={(event) => onSubmit(event)}
           aria-label={selectors.pages.DataSource.saveAndTest}
         >
           Save &amp; test

--- a/public/app/features/datasources/components/DataSourcePluginSettings.tsx
+++ b/public/app/features/datasources/components/DataSourcePluginSettings.tsx
@@ -1,7 +1,7 @@
 import { cloneDeep } from 'lodash';
 import React, { PureComponent } from 'react';
 
-import { DataSourcePluginMeta, DataSourceSettings } from '@grafana/data';
+import { DataSourcePluginMeta, DataSourceSettings, FormAPI } from '@grafana/data';
 import { AngularComponent, getAngularLoader } from '@grafana/runtime';
 
 import { GenericDataSourcePlugin } from '../types';
@@ -11,6 +11,7 @@ export interface Props {
   dataSource: DataSourceSettings;
   dataSourceMeta: DataSourcePluginMeta;
   onModelChange: (dataSource: DataSourceSettings) => void;
+  formApi: FormAPI;
 }
 
 export class DataSourcePluginSettings extends PureComponent<Props> {
@@ -80,6 +81,7 @@ export class DataSourcePluginSettings extends PureComponent<Props> {
           React.createElement(plugin.components.ConfigEditor, {
             options: dataSource,
             onOptionsChange: this.onModelChanged,
+            formApi: this.props.formApi,
           })}
       </div>
     );

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 
 import { DataSourcePluginMeta, DataSourceSettings as DataSourceSettingsType } from '@grafana/data';
+import { Form } from '@grafana/ui';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
 import { DataSourceSettingsState, ThunkResult } from 'app/types';
 
@@ -133,39 +134,44 @@ export function EditDataSourceView({
   }
 
   return (
-    <form onSubmit={onSubmit}>
-      {!hasWriteRights && <DataSourceMissingRightsMessage />}
-      {readOnly && <DataSourceReadOnlyMessage />}
-      {dataSourceMeta.state && <DataSourcePluginState state={dataSourceMeta.state} />}
+    <Form onSubmit={onSubmit}>
+      {(formApi) => (
+        <>
+          {!hasWriteRights && <DataSourceMissingRightsMessage />}
+          {readOnly && <DataSourceReadOnlyMessage />}
+          {dataSourceMeta.state && <DataSourcePluginState state={dataSourceMeta.state} />}
 
-      <CloudInfoBox dataSource={dataSource} />
+          <CloudInfoBox dataSource={dataSource} />
 
-      <BasicSettings
-        dataSourceName={dataSource.name}
-        isDefault={dataSource.isDefault}
-        onDefaultChange={onDefaultChange}
-        onNameChange={onNameChange}
-      />
+          <BasicSettings
+            dataSourceName={dataSource.name}
+            isDefault={dataSource.isDefault}
+            onDefaultChange={onDefaultChange}
+            onNameChange={onNameChange}
+          />
 
-      {plugin && (
-        <DataSourcePluginSettings
-          plugin={plugin}
-          dataSource={dataSource}
-          dataSourceMeta={dataSourceMeta}
-          onModelChange={onOptionsChange}
-        />
+          {plugin && (
+            <DataSourcePluginSettings
+              plugin={plugin}
+              dataSource={dataSource}
+              dataSourceMeta={dataSourceMeta}
+              onModelChange={onOptionsChange}
+              formApi={formApi}
+            />
+          )}
+
+          <DataSourceTestingStatus testingStatus={testingStatus} />
+
+          <ButtonRow
+            onSubmit={onSubmit}
+            onDelete={onDelete}
+            onTest={onTest}
+            exploreUrl={exploreUrl}
+            canSave={!readOnly && hasWriteRights}
+            canDelete={!readOnly && hasDeleteRights}
+          />
+        </>
       )}
-
-      <DataSourceTestingStatus testingStatus={testingStatus} />
-
-      <ButtonRow
-        onSubmit={onSubmit}
-        onDelete={onDelete}
-        onTest={onTest}
-        exploreUrl={exploreUrl}
-        canSave={!readOnly && hasWriteRights}
-        canDelete={!readOnly && hasDeleteRights}
-      />
-    </form>
+    </Form>
   );
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This draft PR makes it possible for plugin developers to prevent the config editor form from being submitted when clicking _Save & test_ if the form is incomplete. 

In the AWS plugins, we sporadically get issues and escalations where user have problems configuring our data sources. Sometimes, it simple things causing the setup to fail, such as when the user has not filled in a field that is required. In some case, the error message propagated to the UI makes no sense to the user.

_In this example, the Secret key is missing._ 
![Screenshot from 2022-12-14 15-20-51](https://user-images.githubusercontent.com/2388950/207643298-d3091e35-6c85-4709-99fd-05051f5d870c.png)

The way the datasource config editor api is currently defined, it's not straightforward to prevent errors like these from happening. That is because the _Save & test_ button (AKA submit button) is rendered outside of the plugin context, meaning the plugin dev has no way of controlling whether the submit button should be valid and to stop the request if the form is incomplete. 

In this draft PR, the config editor form is rendered inside a grafana ui [Form](https://github.com/grafana/grafana/blob/main/packages/grafana-ui/src/components/Forms/Form.tsx#L18) component. This component uses react-hook-forms, and the react hook forms control functions are passed as props to the config editor. This allows the plugin developer to register validators and error messages for each field. That way, advanced validation can be applied onblur or when the submit button is clicked. 

This is an example of where it's used.
![error-handling](https://user-images.githubusercontent.com/2388950/207645312-4c3ea397-cf78-4282-b49c-b02f875abbde.gif)


**Special notes for your reviewer**:
In this pr, internals of a third party tool is propagated as a prop within the data source config api and that is probably not idea, but the forms component already exposes these props so in a way they're already a part of the plugin api. 
