### PR TITLE
Docs: Fix link to config docs

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/enterprise-configuration.md
+++ b/docs/sources/setup-grafana/configure-grafana/enterprise-configuration.md
@@ -9,7 +9,7 @@ weight: 100
 
 # Configure Grafana Enterprise
 
-This page describes Grafana Enterprise-specific configuration options that you can specify in a `.ini` configuration file or using environment variables. Refer to [Configuration]({{< relref "/" >}}) for more information about available configuration options.
+This page describes Grafana Enterprise-specific configuration options that you can specify in a `.ini` configuration file or using environment variables. Refer to [Configuration]({{< relref "../" >}}) for more information about available configuration options.
 
 ## [enterprise]
 


### PR DESCRIPTION
On https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/enterprise-configuration/, the first "Configuration" relref target is `/` (https://grafana.com/). It should be `../` (https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/).

This PR fixes the link.