### PR TITLE
Alerting: log some basic user interactions

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -1,0 +1,5 @@
+export const LogMessages = {
+  filterByLabel: 'filtering alert instances by label',
+  loadedList: 'loaded Alert Rules list',
+  leavingRuleGroupEdit: 'leaving rule group edit without saving',
+};

--- a/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.test.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import lodash from 'lodash'; // eslint-disable-line lodash/import-scope
+import React from 'react';
+
+import { logInfo } from '@grafana/runtime';
+
+import { LogMessages } from '../../Analytics';
+
+import { MatcherFilter } from './MatcherFilter';
+
+jest.mock('@grafana/runtime');
+
+describe('Analytics', () => {
+  it('Sends log info when filtering alert instances by label', async () => {
+    lodash.debounce = jest.fn().mockImplementation((fn) => fn);
+
+    render(<MatcherFilter onFilterChange={jest.fn()} />);
+
+    const searchInput = screen.getByTestId('search-query-input');
+    await userEvent.type(searchInput, 'job=');
+
+    expect(logInfo).toHaveBeenCalledWith(LogMessages.filterByLabel);
+  });
+});

--- a/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
@@ -1,7 +1,9 @@
 import { css } from '@emotion/css';
+import { debounce } from 'lodash';
 import React, { FormEvent } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { logInfo } from '@grafana/runtime';
 import { Label, Tooltip, Input, Icon, useStyles2, Stack } from '@grafana/ui';
 
 interface Props {
@@ -13,10 +15,11 @@ interface Props {
 
 export const MatcherFilter = ({ className, onFilterChange, defaultQueryString, queryString }: Props) => {
   const styles = useStyles2(getStyles);
-  const handleSearchChange = (e: FormEvent<HTMLInputElement>) => {
+  const handleSearchChange = debounce((e: FormEvent<HTMLInputElement>) => {
+    logInfo('filtering alert instances by label');
     const target = e.target as HTMLInputElement;
     onFilterChange(target.value);
-  };
+  }, 600);
   const searchIcon = <Icon name={'search'} />;
   return (
     <div className={className}>

--- a/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
+++ b/public/app/features/alerting/unified/components/alert-groups/MatcherFilter.tsx
@@ -6,6 +6,8 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { logInfo } from '@grafana/runtime';
 import { Label, Tooltip, Input, Icon, useStyles2, Stack } from '@grafana/ui';
 
+import { LogMessages } from '../../Analytics';
+
 interface Props {
   className?: string;
   queryString?: string;
@@ -16,7 +18,8 @@ interface Props {
 export const MatcherFilter = ({ className, onFilterChange, defaultQueryString, queryString }: Props) => {
   const styles = useStyles2(getStyles);
   const handleSearchChange = debounce((e: FormEvent<HTMLInputElement>) => {
-    logInfo('filtering alert instances by label');
+    logInfo(LogMessages.filterByLabel);
+
     const target = e.target as HTMLInputElement;
     onFilterChange(target.value);
   }, 600);

--- a/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/EditRuleGroupModal.tsx
@@ -18,7 +18,7 @@ import { EvaluationIntervalLimitExceeded } from '../InvalidIntervalWarning';
 interface ModalProps {
   namespace: CombinedRuleNamespace;
   group: CombinedRuleGroup;
-  onClose: () => void;
+  onClose: (saved?: boolean) => void;
 }
 
 interface FormValues {
@@ -46,7 +46,7 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
   // close modal if successfully saved
   useEffect(() => {
     if (dispatched && !loading && !error) {
-      onClose();
+      onClose(true);
     }
   }, [dispatched, loading, onClose, error]);
 
@@ -123,7 +123,13 @@ export function EditCloudGroupModal(props: ModalProps): React.ReactElement {
             )}
 
             <Modal.ButtonRow>
-              <Button variant="secondary" type="button" disabled={loading} onClick={onClose} fill="outline">
+              <Button
+                variant="secondary"
+                type="button"
+                disabled={loading}
+                onClick={() => onClose(false)}
+                fill="outline"
+              >
                 Close
               </Button>
               <Button type="submit" disabled={!isDirty || loading}>

--- a/public/app/features/alerting/unified/components/rules/RuleListGroupView.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListGroupView.tsx
@@ -4,6 +4,7 @@ import { logInfo } from '@grafana/runtime';
 import { AccessControlAction } from 'app/types';
 import { CombinedRuleNamespace } from 'app/types/unified-alerting';
 
+import { LogMessages } from '../../Analytics';
 import { isCloudRulesSource, isGrafanaRulesSource } from '../../utils/datasource';
 import { Authorize } from '../Authorize';
 
@@ -30,7 +31,7 @@ export const RuleListGroupView: FC<Props> = ({ namespaces, expandAll }) => {
   }, [namespaces]);
 
   useEffect(() => {
-    logInfo('loaded Alert Rules list');
+    logInfo(LogMessages.loadedList);
   }, []);
 
   return (

--- a/public/app/features/alerting/unified/components/rules/RuleListGroupView.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListGroupView.tsx
@@ -1,5 +1,6 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, useEffect, useMemo } from 'react';
 
+import { logInfo } from '@grafana/runtime';
 import { AccessControlAction } from 'app/types';
 import { CombinedRuleNamespace } from 'app/types/unified-alerting';
 
@@ -27,6 +28,10 @@ export const RuleListGroupView: FC<Props> = ({ namespaces, expandAll }) => {
       sorted.filter((ns) => isCloudRulesSource(ns.rulesSource)),
     ];
   }, [namespaces]);
+
+  useEffect(() => {
+    logInfo('loaded Alert Rules list');
+  }, []);
 
   return (
     <>

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Provider } from 'react-redux';

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.test.tsx
@@ -1,20 +1,28 @@
-import { render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { byTestId, byText } from 'testing-library-selector';
 
+import { logInfo } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { configureStore } from 'app/store/configureStore';
 import { CombinedRuleGroup, CombinedRuleNamespace } from 'app/types/unified-alerting';
 
+import { LogMessages } from '../../Analytics';
 import { useHasRuler } from '../../hooks/useHasRuler';
 import { disableRBAC, mockCombinedRule, mockDataSource } from '../../mocks';
 
 import { RulesGroup } from './RulesGroup';
 
 jest.mock('../../hooks/useHasRuler');
-
+jest.mock('@grafana/runtime', () => {
+  const original = jest.requireActual('@grafana/runtime');
+  return {
+    ...original,
+    logInfo: jest.fn(),
+  };
+});
 const mocks = {
   useHasRuler: jest.mocked(useHasRuler),
 };
@@ -128,6 +136,39 @@ describe('Rules group tests', () => {
       // Assert
       expect(ui.confirmDeleteModal.header.get()).toBeInTheDocument();
       expect(ui.confirmDeleteModal.confirmButton.get()).toBeInTheDocument();
+    });
+  });
+
+  describe('Analytics', () => {
+    beforeEach(() => {
+      contextSrv.isEditor = true;
+    });
+
+    const group: CombinedRuleGroup = {
+      name: 'TestGroup',
+      rules: [mockCombinedRule()],
+    };
+
+    const namespace: CombinedRuleNamespace = {
+      name: 'TestNamespace',
+      rulesSource: mockDataSource(),
+      groups: [group],
+    };
+
+    disableRBAC();
+
+    it('Should log info when closing the edit group rule modal without saving', async () => {
+      mockUseHasRuler(true, true);
+      renderRulesGroup(namespace, group);
+
+      await userEvent.click(ui.editGroupButton.get());
+
+      expect(screen.getByText('Close')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByText('Close'));
+
+      expect(screen.queryByText('Close')).not.toBeInTheDocument();
+      expect(logInfo).toHaveBeenCalledWith(LogMessages.leavingRuleGroupEdit);
     });
   });
 });

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -8,6 +8,7 @@ import { Badge, ConfirmModal, HorizontalGroup, Icon, Spinner, Tooltip, useStyles
 import { useDispatch } from 'app/types';
 import { CombinedRuleGroup, CombinedRuleNamespace } from 'app/types/unified-alerting';
 
+import { LogMessages } from '../../Analytics';
 import { useFolder } from '../../hooks/useFolder';
 import { useHasRuler } from '../../hooks/useHasRuler';
 import { deleteRulesGroupAction } from '../../state/actions';
@@ -182,7 +183,7 @@ export const RulesGroup: FC<Props> = React.memo(({ group, namespace, expandAll, 
 
   const closeEditModal = (saved = false) => {
     if (!saved) {
-      logInfo('leaving rule group edit without saving');
+      logInfo(LogMessages.leavingRuleGroupEdit);
     }
     setIsEditingGroup(false);
   };

--- a/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
+++ b/public/app/features/alerting/unified/components/rules/RulesGroup.tsx
@@ -3,6 +3,7 @@ import pluralize from 'pluralize';
 import React, { FC, useEffect, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
+import { logInfo } from '@grafana/runtime';
 import { Badge, ConfirmModal, HorizontalGroup, Icon, Spinner, Tooltip, useStyles2 } from '@grafana/ui';
 import { useDispatch } from 'app/types';
 import { CombinedRuleGroup, CombinedRuleNamespace } from 'app/types/unified-alerting';
@@ -179,6 +180,13 @@ export const RulesGroup: FC<Props> = React.memo(({ group, namespace, expandAll, 
     <RuleLocation namespace={namespace.name} group={group.name} />
   );
 
+  const closeEditModal = (saved = false) => {
+    if (!saved) {
+      logInfo('leaving rule group edit without saving');
+    }
+    setIsEditingGroup(false);
+  };
+
   return (
     <div className={styles.wrapper} data-testid="rule-group">
       <div className={styles.header} data-testid="rule-group-header">
@@ -215,9 +223,7 @@ export const RulesGroup: FC<Props> = React.memo(({ group, namespace, expandAll, 
       {!isCollapsed && (
         <RulesTable showSummaryColumn={true} className={styles.rulesTable} showGuidelines={true} rules={group.rules} />
       )}
-      {isEditingGroup && (
-        <EditCloudGroupModal group={group} namespace={namespace} onClose={() => setIsEditingGroup(false)} />
-      )}
+      {isEditingGroup && <EditCloudGroupModal group={group} namespace={namespace} onClose={() => closeEditModal()} />}
       {isReorderingGroup && (
         <ReorderCloudGroupModal group={group} namespace={namespace} onClose={() => setIsReorderingGroup(false)} />
       )}


### PR DESCRIPTION
This PR uses the [Grafana Javascript Agent](https://github.com/grafana/grafana-javascript-agent) which was previously enabled [here](https://github.com/grafana/grafana/pull/50801) to log a few user interactions to be displayed in a dashboard.

The whole list of the desired things to track is https://docs.google.com/spreadsheets/d/1g8SdO7IWY9TvD9svvlIY-MCtB0Am1si4ofRmucO59Dk/edit#gid=0. In this PR I'm only sending:

- Activity tracking: event of loading the alert rule list per distinct user (`msg=loaded Alert Rules list`)
- Activity tracking: action of leaving rule group edit page without saving (`msg=leaving rule group edit without saving`)
- Activity tracking: action of filtering alert instances. (`msg=filtering alert instances by label`)

This data is sent to Loki so that it's able to be queried from Grafana. To visualize it, I created a local Dashboard where I'm using LogQL to obtain relevant information from the logs:

<img width="1504" alt="image" src="https://user-images.githubusercontent.com/6271380/191047725-a71d0c60-6b00-4a1a-882e-a8bb8b0af19d.png">


Issue: https://github.com/grafana/grafana/issues/54904

