### PR TITLE
GrafanaUI: Deprecate all exports of Log components

### DIFF
--- a/packages/grafana-ui/src/components/Logs/LogDetails.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetails.tsx
@@ -22,8 +22,7 @@ import { LogDetailsRow } from './LogDetailsRow';
 import { getLogRowStyles } from './getLogRowStyles';
 import { getAllFields } from './logParser';
 
-//Components
-
+/** @deprecated will be removed in the next major version */
 export interface Props extends Themeable2 {
   row: LogRowModel;
   showDuplicates: boolean;
@@ -176,5 +175,6 @@ class UnThemedLogDetails extends PureComponent<Props> {
   }
 }
 
+/** @deprecated will be removed in the next major version */
 export const LogDetails = withTheme2(UnThemedLogDetails);
 LogDetails.displayName = 'LogDetails';

--- a/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogDetailsRow.tsx
@@ -12,8 +12,7 @@ import { IconButton } from '../IconButton/IconButton';
 import { LogLabelStats } from './LogLabelStats';
 import { getLogRowStyles } from './getLogRowStyles';
 
-//Components
-
+/** @deprecated will be removed in the next major version */
 export interface Props extends Themeable2 {
   parsedValue: string;
   parsedKey: string;
@@ -220,5 +219,6 @@ class UnThemedLogDetailsRow extends PureComponent<Props, State> {
   }
 }
 
+/** @deprecated will be removed in the next major version */
 export const LogDetailsRow = withTheme2(UnThemedLogDetailsRow);
 LogDetailsRow.displayName = 'LogDetailsRow';

--- a/packages/grafana-ui/src/components/Logs/LogLabelStats.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogLabelStats.tsx
@@ -96,5 +96,6 @@ class UnThemedLogLabelStats extends PureComponent<Props> {
   }
 }
 
+/** @deprecated will be removed in the next major version */
 export const LogLabelStats = withTheme2(UnThemedLogLabelStats);
 LogLabelStats.displayName = 'LogLabelStats';

--- a/packages/grafana-ui/src/components/Logs/LogLabelStatsRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogLabelStatsRow.tsx
@@ -51,6 +51,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
 });
 
+/** @deprecated will be removed in the next major version */
 export interface Props {
   active?: boolean;
   count: number;
@@ -58,6 +59,7 @@ export interface Props {
   value?: string;
 }
 
+/** @deprecated will be removed in the next major version */
 export const LogLabelStatsRow: FunctionComponent<Props> = ({ active, count, proportion, value }) => {
   const style = useStyles2(getStyles);
   const percent = `${Math.round(proportion * 100)}%`;

--- a/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogMessageAnsi.tsx
@@ -49,6 +49,7 @@ interface State {
   prevValue: string;
 }
 
+/** @deprecated will be removed in the next major version */
 export class UnThemedLogMessageAnsi extends PureComponent<Props, State> {
   state: State = {
     chunks: [],

--- a/packages/grafana-ui/src/components/Logs/LogRow.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRow.tsx
@@ -256,5 +256,6 @@ class UnThemedLogRow extends PureComponent<Props, State> {
   }
 }
 
+/** @deprecated will be removed in the next major version */
 export const LogRow = withTheme2(UnThemedLogRow);
 LogRow.displayName = 'LogRow';

--- a/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContext.tsx
@@ -123,6 +123,7 @@ const LogRowContextGroupHeader: React.FunctionComponent<LogRowContextGroupHeader
   );
 };
 
+/** @deprecated will be removed in the next major version */
 export const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps> = ({
   row,
   rows,
@@ -184,6 +185,7 @@ export const LogRowContextGroup: React.FunctionComponent<LogRowContextGroupProps
   );
 };
 
+/** @deprecated will be removed in the next major version */
 export const LogRowContext: React.FunctionComponent<LogRowContextProps> = ({
   row,
   context,

--- a/packages/grafana-ui/src/components/Logs/LogRowContextProvider.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowContextProvider.tsx
@@ -11,20 +11,25 @@ import {
   DataQueryError,
 } from '@grafana/data';
 
+/** @deprecated will be removed in the next major version */
 export interface RowContextOptions {
   direction?: 'BACKWARD' | 'FORWARD';
   limit?: number;
 }
 
+/** @deprecated will be removed in the next major version */
 export interface LogRowContextRows {
   before?: string[];
   after?: string[];
 }
+
+/** @deprecated will be removed in the next major version */
 export interface LogRowContextQueryErrors {
   before?: string;
   after?: string;
 }
 
+/** @deprecated will be removed in the next major version */
 export interface HasMoreContextRows {
   before: boolean;
   after: boolean;
@@ -48,6 +53,7 @@ interface LogRowContextProviderProps {
   }) => JSX.Element;
 }
 
+/** @deprecated will be removed in the next major version */
 export const getRowContexts = async (
   getRowContext: (row: LogRowModel, options?: RowContextOptions) => Promise<DataQueryResponse>,
   row: LogRowModel,
@@ -130,6 +136,7 @@ export const getRowContexts = async (
   };
 };
 
+/** @deprecated will be removed in the next major version */
 export const LogRowContextProvider: React.FunctionComponent<LogRowContextProviderProps> = ({
   getRowContext,
   row,

--- a/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessage.tsx
@@ -16,8 +16,7 @@ import { LogRowContext } from './LogRowContext';
 import { LogRowContextQueryErrors, HasMoreContextRows, LogRowContextRows } from './LogRowContextProvider';
 import { getLogRowStyles } from './getLogRowStyles';
 
-//Components
-
+/** @deprecated will be removed in the next major version */
 export const MAX_CHARACTERS = 100000;
 
 interface Props extends Themeable2 {
@@ -187,5 +186,6 @@ class UnThemedLogRowMessage extends PureComponent<Props> {
   }
 }
 
+/** @deprecated will be removed in the next major version */
 export const LogRowMessage = withTheme2(UnThemedLogRowMessage);
 LogRowMessage.displayName = 'LogRowMessage';

--- a/packages/grafana-ui/src/components/Logs/LogRowMessageDetectedFields.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRowMessageDetectedFields.tsx
@@ -8,6 +8,7 @@ import { Themeable2 } from '../../types/theme';
 
 import { getAllFields } from './logParser';
 
+/** @deprecated will be removed in the next major version */
 export interface Props extends Themeable2 {
   row: LogRowModel;
   showDetectedFields: string[];
@@ -45,5 +46,6 @@ class UnThemedLogRowMessageDetectedFields extends PureComponent<Props> {
   }
 }
 
+/** @deprecated will be removed in the next major version */
 export const LogRowMessageDetectedFields = withTheme2(UnThemedLogRowMessageDetectedFields);
 LogRowMessageDetectedFields.displayName = 'LogRowMessageDetectedFields';

--- a/packages/grafana-ui/src/components/Logs/LogRows.tsx
+++ b/packages/grafana-ui/src/components/Logs/LogRows.tsx
@@ -6,13 +6,14 @@ import { TimeZone, LogsDedupStrategy, LogRowModel, Field, LinkModel, LogsSortOrd
 import { withTheme2 } from '../../themes/index';
 import { Themeable2 } from '../../types/theme';
 
-//Components
 import { LogRow } from './LogRow';
 import { RowContextOptions } from './LogRowContextProvider';
 import { getLogRowStyles } from './getLogRowStyles';
 
+/** @deprecated will be removed in the next major version */
 export const PREVIEW_LIMIT = 100;
 
+/** @deprecated will be removed in the next major version */
 export interface Props extends Themeable2 {
   logRows?: LogRowModel[];
   deduplicatedRows?: LogRowModel[];

--- a/packages/grafana-ui/src/components/Logs/logParser.ts
+++ b/packages/grafana-ui/src/components/Logs/logParser.ts
@@ -16,6 +16,8 @@ type FieldDef = {
 /**
  * Returns all fields for log row which consists of fields we parse from the message itself and additional fields
  * found in the dataframe (they may contain links).
+ *
+ * @deprecated will be removed in the next major version
  */
 export const getAllFields = memoizeOne(
   (row: LogRowModel, getFieldLinks?: (field: Field, rowIndex: number) => Array<LinkModel<Field>>) => {


### PR DESCRIPTION
**What this PR does / why we need it**:
In addition to https://github.com/grafana/grafana/pull/55364 we are marking all exports - also the objects, which are not exported from `@grafana/ui` - as deprecated.

