### PR TITLE
DevEnv: Gitignore docker-compose override file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ public/css/*.min.css
 
 # devenv
 /devenv/docker-compose.yaml
+/devenv/docker-compose.override.yaml
 /devenv/.env
 /devenv/docker/blocks/tempo/tempo-data/
 


### PR DESCRIPTION
Adds docker-composer override file to gitignore. Have been using the override file to change the platform of the mysql service when using an m1 mac.