### PR TITLE
Chore: Add changed enterprise devenv path to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ tsconfig.tsbuildinfo
 # Enterprise devenv
 /devenv/docker/blocks/grafana-enterprise
 /devenv/docker/blocks/saml-enterprise
+# This is the new place of the block, but I leave the previous here for a while
+/devenv/docker/blocks/auth/saml-enterprise
 
 /tmp
 tools/phantomjs/phantomjs


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR does add a new entry to `.gitignore` file, because the saml-enterprise devenv block's path has changed and leaves the previous setting in the file for a while to prevent committing the files accidentally.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

