### PR TITLE
PublicDashboards: Ignore time range input and changes on public dashboard

### DIFF
--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -12,7 +12,7 @@ import {
 } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import appEvents from 'app/core/app_events';
-import { config, getConfig } from 'app/core/config';
+import { config } from 'app/core/config';
 import { contextSrv, ContextSrv } from 'app/core/services/context_srv';
 import { getShiftedTimeRange, getZoomedTimeRange } from 'app/core/utils/timePicker';
 import { getTimeRange } from 'app/features/dashboard/utils/timeRange';
@@ -149,7 +149,7 @@ export class TimeSrv {
 
   private initTimeFromUrl() {
     // If we are in a public dashboard ignore the time range in the url
-    if (getConfig().isPublicDashboardView) {
+    if (config.isPublicDashboardView) {
       return;
     }
 
@@ -281,7 +281,7 @@ export class TimeSrv {
 
   setTime(time: RawTimeRange, updateUrl = true) {
     // If we are in a public dashboard ignore time range changes
-    if (getConfig().isPublicDashboardView) {
+    if (config.isPublicDashboardView) {
       return;
     }
 

--- a/public/app/features/dashboard/services/TimeSrv.ts
+++ b/public/app/features/dashboard/services/TimeSrv.ts
@@ -12,7 +12,7 @@ import {
 } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import appEvents from 'app/core/app_events';
-import { config } from 'app/core/config';
+import { config, getConfig } from 'app/core/config';
 import { contextSrv, ContextSrv } from 'app/core/services/context_srv';
 import { getShiftedTimeRange, getZoomedTimeRange } from 'app/core/utils/timePicker';
 import { getTimeRange } from 'app/features/dashboard/utils/timeRange';
@@ -148,6 +148,11 @@ export class TimeSrv {
   }
 
   private initTimeFromUrl() {
+    // If we are in a public dashboard ignore the time range in the url
+    if (getConfig().isPublicDashboardView) {
+      return;
+    }
+
     const params = locationService.getSearch();
 
     if (params.get('time') && params.get('time.window')) {
@@ -275,6 +280,11 @@ export class TimeSrv {
   }
 
   setTime(time: RawTimeRange, updateUrl = true) {
+    // If we are in a public dashboard ignore time range changes
+    if (getConfig().isPublicDashboardView) {
+      return;
+    }
+
     extend(this.time, time);
 
     // disable refresh if zoom in or zoom out


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:

Due to time range not being implemented on Public Dashboards, the ability to zoom and set the time range using the URL should be disable to prevent confusion when seeing data on timeseries panels and other panels, since timeseries panels will zoom in on the frontend but the time range of the queries will still be the same on the backend, resulting in discrepancies between timeseries panels and other panels like gauge and stat.

**Which issue(s) this PR fixes**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/54189

**Special notes for your reviewer**:

Example discrepancy seen:

In green the zoomed in timeseries data showing the max value as 147, while in red the Stat panel shows the max value as 153.
![Example discrepancy](https://user-images.githubusercontent.com/7741292/191082581-032d5722-4ecf-4d25-961d-9ab3b948d6d2.png)
