### PR TITLE
Fix: return proper values in dashboard thumbs service

### DIFF
--- a/pkg/services/dashboard_thumbs/dashboardthumbsimpl/dashboard_thumbs.go
+++ b/pkg/services/dashboard_thumbs/dashboardthumbsimpl/dashboard_thumbs.go
@@ -22,40 +22,25 @@ func ProvideService(
 
 func (s *Service) GetThumbnail(ctx context.Context, query *models.GetDashboardThumbnailCommand) (*models.DashboardThumbnail, error) {
 	dt, err := s.store.Get(ctx, query)
-	if err != nil {
-		return dt, err
-	}
-	return dt, nil
+	return dt, err
 }
 
 func (s *Service) SaveThumbnail(ctx context.Context, cmd *models.SaveDashboardThumbnailCommand) (*models.DashboardThumbnail, error) {
 	dt, err := s.store.Save(ctx, cmd)
-	if err != nil {
-		return dt, err
-	}
-	return dt, nil
+	return dt, err
 }
 
 func (s *Service) UpdateThumbnailState(ctx context.Context, cmd *models.UpdateThumbnailStateCommand) error {
 	err := s.store.UpdateState(ctx, cmd)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func (s *Service) FindThumbnailCount(ctx context.Context, cmd *models.FindDashboardThumbnailCountCommand) (int64, error) {
-	i, err := s.store.Count(ctx, cmd)
-	if err != nil {
-		return i, err
-	}
-	return 0, nil
+	n, err := s.store.Count(ctx, cmd)
+	return n, err
 }
 
 func (s *Service) FindDashboardsWithStaleThumbnails(ctx context.Context, cmd *models.FindDashboardsWithStaleThumbnailsCommand) ([]*models.DashboardWithStaleThumbnail, error) {
-	d, err := s.store.FindDashboardsWithStaleThumbnails(ctx, cmd)
-	if err != nil {
-		return d, err
-	}
-	return nil, nil
+	thumbs, err := s.store.FindDashboardsWithStaleThumbnails(ctx, cmd)
+	return thumbs, err
 }


### PR DESCRIPTION
Previously some values have been lost while propagating from the thumbs store to the thumbs service