### PR TITLE
Alerting: Extract default message embed into named constant

### DIFF
--- a/pkg/services/ngalert/notifier/channels/default_template.go
+++ b/pkg/services/ngalert/notifier/channels/default_template.go
@@ -8,8 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const DefaultMessageTitleEmbed = `{{ template "default.title" . }}`
-const DefaultMessageEmbed = `{{ template "default.message" . }}`
+const (
+	DefaultMessageTitleEmbed = `{{ template "default.title" . }}`
+	DefaultMessageEmbed      = `{{ template "default.message" . }}`
+)
 
 var DefaultTemplateString = `
 {{ define "__subject" }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ if gt (.Alerts.Resolved | len) 0 }}, RESOLVED:{{ .Alerts.Resolved | len }}{{ end }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}{{ end }}

--- a/pkg/services/ngalert/notifier/channels/default_template.go
+++ b/pkg/services/ngalert/notifier/channels/default_template.go
@@ -9,6 +9,7 @@ import (
 )
 
 const DefaultMessageTitleEmbed = `{{ template "default.title" . }}`
+const DefaultMessageEmbed = `{{ template "default.message" . }}`
 
 var DefaultTemplateString = `
 {{ define "__subject" }}[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ if gt (.Alerts.Resolved | len) 0 }}, RESOLVED:{{ .Alerts.Resolved | len }}{{ end }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}{{ end }}

--- a/pkg/services/ngalert/notifier/channels/default_template_test.go
+++ b/pkg/services/ngalert/notifier/channels/default_template_test.go
@@ -88,7 +88,7 @@ func TestDefaultTemplateString(t *testing.T) {
 			expected:       `[FIRING:2, RESOLVED:2]  (alert1)`,
 		},
 		{
-			templateString: `{{ template "default.message" .}}`,
+			templateString: DefaultMessageEmbed,
 			expected: `**Firing**
 
 Value: 1234

--- a/pkg/services/ngalert/notifier/channels/dingding.go
+++ b/pkg/services/ngalert/notifier/channels/dingding.go
@@ -32,7 +32,7 @@ func NewDingDingConfig(config *NotificationChannelConfig) (*DingDingConfig, erro
 	return &DingDingConfig{
 		NotificationChannelConfig: config,
 		MsgType:                   config.Settings.Get("msgType").MustString(defaultDingdingMsgType),
-		Message:                   config.Settings.Get("message").MustString(`{{ template "default.message" .}}`),
+		Message:                   config.Settings.Get("message").MustString(DefaultMessageEmbed),
 		URL:                       config.Settings.Get("url").MustString(),
 	}, nil
 }

--- a/pkg/services/ngalert/notifier/channels/discord.go
+++ b/pkg/services/ngalert/notifier/channels/discord.go
@@ -61,7 +61,7 @@ func NewDiscordConfig(config *NotificationChannelConfig) (*DiscordConfig, error)
 	}
 	return &DiscordConfig{
 		NotificationChannelConfig: config,
-		Content:                   config.Settings.Get("message").MustString(`{{ template "default.message" . }}`),
+		Content:                   config.Settings.Get("message").MustString(DefaultMessageEmbed),
 		AvatarURL:                 config.Settings.Get("avatar_url").MustString(),
 		WebhookURL:                discordURL,
 		UseDiscordUsername:        config.Settings.Get("use_discord_username").MustBool(false),

--- a/pkg/services/ngalert/notifier/channels/googlechat.go
+++ b/pkg/services/ngalert/notifier/channels/googlechat.go
@@ -55,7 +55,7 @@ func NewGoogleChatConfig(config *NotificationChannelConfig) (*GoogleChatConfig, 
 	return &GoogleChatConfig{
 		NotificationChannelConfig: config,
 		URL:                       url,
-		Content:                   config.Settings.Get("message").MustString(`{{ template "default.message" . }}`),
+		Content:                   config.Settings.Get("message").MustString(DefaultMessageEmbed),
 	}, nil
 }
 

--- a/pkg/services/ngalert/notifier/channels/kafka.go
+++ b/pkg/services/ngalert/notifier/channels/kafka.go
@@ -100,7 +100,7 @@ func (kn *KafkaNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, 
 	bodyJSON.Set("alert_state", state)
 	bodyJSON.Set("description", tmpl(DefaultMessageTitleEmbed))
 	bodyJSON.Set("client", "Grafana")
-	bodyJSON.Set("details", tmpl(`{{ template "default.message" . }}`))
+	bodyJSON.Set("details", tmpl(DefaultMessageEmbed))
 
 	ruleURL := joinUrlPath(kn.tmpl.ExternalURL.String(), "/alerting/list", kn.log)
 	bodyJSON.Set("client_url", ruleURL)

--- a/pkg/services/ngalert/notifier/channels/line.go
+++ b/pkg/services/ngalert/notifier/channels/line.go
@@ -86,7 +86,7 @@ func (ln *LineNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool, e
 		"%s\n%s\n\n%s",
 		tmpl(DefaultMessageTitleEmbed),
 		ruleURL,
-		tmpl(`{{ template "default.message" . }}`),
+		tmpl(DefaultMessageEmbed),
 	)
 	if tmplErr != nil {
 		ln.log.Warn("failed to template Line message", "err", tmplErr.Error())

--- a/pkg/services/ngalert/notifier/channels/opsgenie.go
+++ b/pkg/services/ngalert/notifier/channels/opsgenie.go
@@ -205,7 +205,7 @@ func (on *OpsgenieNotifier) buildOpsgenieMessage(ctx context.Context, alerts mod
 			"%s\n%s\n\n%s",
 			tmpl(DefaultMessageTitleEmbed),
 			ruleURL,
-			tmpl(`{{ template "default.message" . }}`),
+			tmpl(DefaultMessageEmbed),
 		)
 	}
 

--- a/pkg/services/ngalert/notifier/channels/pushover.go
+++ b/pkg/services/ngalert/notifier/channels/pushover.go
@@ -106,7 +106,7 @@ func NewPushoverConfig(config *NotificationChannelConfig, decryptFunc GetDecrypt
 		AlertingSound:             config.Settings.Get("sound").MustString(),
 		OKSound:                   config.Settings.Get("okSound").MustString(),
 		Upload:                    config.Settings.Get("uploadImage").MustBool(true),
-		Message:                   config.Settings.Get("message").MustString(`{{ template "default.message" .}}`),
+		Message:                   config.Settings.Get("message").MustString(DefaultMessageEmbed),
 	}, nil
 }
 

--- a/pkg/services/ngalert/notifier/channels/sensugo.go
+++ b/pkg/services/ngalert/notifier/channels/sensugo.go
@@ -72,7 +72,7 @@ func NewSensuGoConfig(config *NotificationChannelConfig, decryptFunc GetDecrypte
 		Namespace:                 config.Settings.Get("namespace").MustString(),
 		Handler:                   config.Settings.Get("handler").MustString(),
 		APIKey:                    apikey,
-		Message:                   config.Settings.Get("message").MustString(`{{ template "default.message" .}}`),
+		Message:                   config.Settings.Get("message").MustString(DefaultMessageEmbed),
 	}, nil
 }
 

--- a/pkg/services/ngalert/notifier/channels/slack.go
+++ b/pkg/services/ngalert/notifier/channels/slack.go
@@ -101,7 +101,7 @@ func buildSlackNotifier(factoryConfig FactoryConfig) (*SlackNotifier, error) {
 		settings.Username = "Grafana"
 	}
 	if settings.Text == "" {
-		settings.Text = `{{ template "default.message" . }}`
+		settings.Text = DefaultMessageEmbed
 	}
 	if settings.Title == "" {
 		settings.Title = DefaultMessageTitleEmbed

--- a/pkg/services/ngalert/notifier/channels/telegram.go
+++ b/pkg/services/ngalert/notifier/channels/telegram.go
@@ -67,7 +67,7 @@ func NewTelegramConfig(config *NotificationChannelConfig, fn GetDecryptedValueFn
 		NotificationChannelConfig: config,
 		BotToken:                  botToken,
 		ChatID:                    chatID,
-		Message:                   config.Settings.Get("message").MustString(`{{ template "default.message" . }}`),
+		Message:                   config.Settings.Get("message").MustString(DefaultMessageEmbed),
 	}, nil
 }
 

--- a/pkg/services/ngalert/notifier/channels/threema.go
+++ b/pkg/services/ngalert/notifier/channels/threema.go
@@ -127,7 +127,7 @@ func (tn *ThreemaNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool
 	message := fmt.Sprintf("%s%s\n\n*Message:*\n%s\n*URL:* %s\n",
 		stateEmoji,
 		tmpl(DefaultMessageTitleEmbed),
-		tmpl(`{{ template "default.message" . }}`),
+		tmpl(DefaultMessageEmbed),
 		path.Join(tn.tmpl.ExternalURL.String(), "/alerting/list"),
 	)
 

--- a/pkg/services/ngalert/notifier/channels/victorops.go
+++ b/pkg/services/ngalert/notifier/channels/victorops.go
@@ -115,7 +115,7 @@ func (vn *VictoropsNotifier) Notify(ctx context.Context, as ...*types.Alert) (bo
 	bodyJSON.Set("entity_id", groupKey.Hash())
 	bodyJSON.Set("entity_display_name", tmpl(DefaultMessageTitleEmbed))
 	bodyJSON.Set("timestamp", time.Now().Unix())
-	bodyJSON.Set("state_message", tmpl(`{{ template "default.message" . }}`))
+	bodyJSON.Set("state_message", tmpl(DefaultMessageEmbed))
 	bodyJSON.Set("monitoring_tool", "Grafana v"+setting.BuildVersion)
 
 	_ = withStoredImages(ctx, vn.log, vn.images,

--- a/pkg/services/ngalert/notifier/channels/webhook.go
+++ b/pkg/services/ngalert/notifier/channels/webhook.go
@@ -160,7 +160,7 @@ func (wn *WebhookNotifier) Notify(ctx context.Context, as ...*types.Alert) (bool
 		TruncatedAlerts: numTruncated,
 		OrgID:           wn.orgID,
 		Title:           tmpl(DefaultMessageTitleEmbed),
-		Message:         tmpl(`{{ template "default.message" . }}`),
+		Message:         tmpl(DefaultMessageEmbed),
 	}
 	if types.Alerts(as...).Status() == model.AlertFiring {
 		msg.State = string(models.AlertStateAlerting)

--- a/pkg/services/ngalert/notifier/channels/wecom.go
+++ b/pkg/services/ngalert/notifier/channels/wecom.go
@@ -40,7 +40,7 @@ func NewWeComConfig(config *NotificationChannelConfig, decryptFunc GetDecryptedV
 	return &WeComConfig{
 		NotificationChannelConfig: config,
 		URL:                       url,
-		Message:                   config.Settings.Get("message").MustString(`{{ template "default.message" .}}`),
+		Message:                   config.Settings.Get("message").MustString(DefaultMessageEmbed),
 		Title:                     config.Settings.Get("title").MustString(DefaultMessageTitleEmbed),
 	}, nil
 }

--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -135,7 +135,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 				{ // New in 8.0.
 					Label:        "Message",
 					Element:      ElementTypeTextArea,
-					Placeholder:  `{{ template "default.message" . }}`,
+					Placeholder:  channels.DefaultMessageEmbed,
 					PropertyName: "message",
 				},
 			},
@@ -263,7 +263,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					Label:        "Summary",
 					Description:  "You can use templates for summary",
 					Element:      ElementTypeTextArea,
-					Placeholder:  `{{ template "default.message" . }}`,
+					Placeholder:  channels.DefaultMessageEmbed,
 					PropertyName: "summary",
 				},
 			},
@@ -372,7 +372,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 				{ // New in 8.0.
 					Label:        "Message",
 					Element:      ElementTypeTextArea,
-					Placeholder:  `{{ template "default.message" . }}`,
+					Placeholder:  channels.DefaultMessageEmbed,
 					PropertyName: "message",
 				},
 			},
@@ -550,7 +550,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 				{ // New in 8.0.
 					Label:        "Message",
 					Element:      ElementTypeTextArea,
-					Placeholder:  `{{ template "default.message" . }}`,
+					Placeholder:  channels.DefaultMessageEmbed,
 					PropertyName: "message",
 				},
 			},
@@ -587,7 +587,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 				{ // New in 8.0.
 					Label:        "Message",
 					Element:      ElementTypeTextArea,
-					Placeholder:  `{{ template "default.message" . }}`,
+					Placeholder:  channels.DefaultMessageEmbed,
 					PropertyName: "message",
 				},
 			},
@@ -618,7 +618,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 				{ // New in 8.0.
 					Label:        "Message",
 					Element:      ElementTypeTextArea,
-					Placeholder:  `{{ template "default.message" . }}`,
+					Placeholder:  channels.DefaultMessageEmbed,
 					PropertyName: "message",
 				},
 			},
@@ -708,7 +708,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					Label:        "Message",
 					Description:  "Custom WeCom message. You can use template variables.",
 					Element:      ElementTypeTextArea,
-					Placeholder:  `{{ template "default.message" . }}`,
+					Placeholder:  channels.DefaultMessageEmbed,
 					PropertyName: "message",
 				},
 				{ // New in 9.1.
@@ -761,7 +761,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 					Description:  "Mention a group using @ or a user using <@ID> when notifying in a channel",
 					Element:      ElementTypeInput,
 					InputType:    InputTypeText,
-					Placeholder:  `{{ template "default.message" . }}`,
+					Placeholder:  channels.DefaultMessageEmbed,
 					PropertyName: "message",
 				},
 				{
@@ -803,7 +803,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 				{
 					Label:        "Message",
 					Element:      ElementTypeTextArea,
-					Placeholder:  `{{ template "default.message" . }}`,
+					Placeholder:  channels.DefaultMessageEmbed,
 					PropertyName: "message",
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a simple PR that extracts the default message embed into a constant, much like we did for the default title.

This is a follow-up on review feedback from @yuri-tceretian: https://github.com/grafana/grafana/pull/55271#discussion_r974668717

split in a separate change as it was faster to find-and-replace all instances.

**Special notes for your reviewer**:

n/a

