### PR TITLE
Alerting: Fix default query's data source when no default datasource specified

### DIFF
--- a/public/app/features/alerting/unified/RuleEditor.test.tsx
+++ b/public/app/features/alerting/unified/RuleEditor.test.tsx
@@ -412,11 +412,14 @@ describe('RuleEditor', () => {
     };
 
     const dataSources = {
-      default: mockDataSource({
-        type: 'prometheus',
-        name: 'Prom',
-        isDefault: true,
-      }),
+      default: mockDataSource(
+        {
+          type: 'prometheus',
+          name: 'Prom',
+          isDefault: true,
+        },
+        { alerting: true }
+      ),
     };
 
     jest.spyOn(backendSrv, 'getFolderByUid').mockResolvedValue({

--- a/public/app/features/alerting/unified/components/rule-editor/QueryEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryEditor.test.tsx
@@ -64,10 +64,10 @@ describe('Query Editor', () => {
     ]);
   });
 
-  it('should select first data source supporting alerting when there is no default data source', async function () {
+  it('should select first data source supporting alerting when there is no default data source', async () => {
     const dsServer = new MockDataSourceSrv({
-      postgres: mockDataSource({ name: 'postgres' }, { alerting: true }),
       influx: mockDataSource({ name: 'influx' }, { alerting: true }),
+      postgres: mockDataSource({ name: 'postgres' }, { alerting: true }),
       [ExpressionDatasourceUID]: instanceSettings,
     });
     dsServer.get = () => Promise.resolve(new MockDataSourceApi());
@@ -82,7 +82,30 @@ describe('Query Editor', () => {
     const select = await ui.dataSourcePicker.find();
 
     expect(queryRef).toHaveLength(2);
+    expect(queryRef[0]).toHaveTextContent('A');
+    expect(queryRef[1]).toHaveTextContent('B');
     expect(select).toHaveTextContent('influx'); // Alphabetical order
     expect(ui.noDataSourcesWarning.query()).not.toBeInTheDocument();
+  });
+
+  it('should select the default data source when specified', async () => {
+    const dsServer = new MockDataSourceSrv({
+      influx: mockDataSource({ name: 'influx' }, { alerting: true }),
+      postgres: mockDataSource({ name: 'postgres', isDefault: true }, { alerting: true }),
+      [ExpressionDatasourceUID]: instanceSettings,
+    });
+    dsServer.get = () => Promise.resolve(new MockDataSourceApi());
+
+    setDataSourceSrv(dsServer);
+
+    const defaultQueries = getDefaultQueries();
+
+    render(<QueryEditor onChange={() => null} value={defaultQueries} />);
+
+    const queryRef = await ui.queryNames.findAll();
+    const select = await ui.dataSourcePicker.find();
+
+    expect(queryRef).toHaveLength(2);
+    expect(select).toHaveTextContent('postgres'); // Default data source
   });
 });

--- a/public/app/features/alerting/unified/components/rule-editor/QueryEditor.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryEditor.test.tsx
@@ -1,6 +1,23 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { byLabelText, byTestId, byText } from 'testing-library-selector';
+
 import { getDefaultRelativeTimeRange } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+import { setDataSourceSrv } from '@grafana/runtime';
+
+import { MockDataSourceApi } from '../../../../../../test/mocks/datasource_srv';
+import { ExpressionDatasourceUID, instanceSettings } from '../../../../expressions/ExpressionDatasource';
+import { mockDataSource, MockDataSourceSrv } from '../../mocks';
+import { getDefaultQueries } from '../../utils/rule-form';
 
 import { QueryEditor } from './QueryEditor';
+
+const ui = {
+  queryNames: byTestId<HTMLButtonElement>('query-name-div'),
+  dataSourcePicker: byLabelText<HTMLDivElement>(selectors.components.DataSourcePicker.container),
+  noDataSourcesWarning: byText('You appear to have no compatible data sources'),
+};
 
 const onChangeMock = jest.fn();
 describe('Query Editor', () => {
@@ -45,5 +62,27 @@ describe('Query Editor', () => {
       query,
       { ...query, ...{ refId: 'B', relativeTimeRange: defaultRange, model: { refId: 'B', hide: false } } },
     ]);
+  });
+
+  it('should select first data source supporting alerting when there is no default data source', async function () {
+    const dsServer = new MockDataSourceSrv({
+      postgres: mockDataSource({ name: 'postgres' }, { alerting: true }),
+      influx: mockDataSource({ name: 'influx' }, { alerting: true }),
+      [ExpressionDatasourceUID]: instanceSettings,
+    });
+    dsServer.get = () => Promise.resolve(new MockDataSourceApi());
+
+    setDataSourceSrv(dsServer);
+
+    const defaultQueries = getDefaultQueries();
+
+    render(<QueryEditor onChange={() => null} value={defaultQueries} />);
+
+    const queryRef = await ui.queryNames.findAll();
+    const select = await ui.dataSourcePicker.find();
+
+    expect(queryRef).toHaveLength(2);
+    expect(select).toHaveTextContent('influx'); // Alphabetical order
+    expect(ui.noDataSourcesWarning.query()).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/unified/utils/datasource.ts
+++ b/public/app/features/alerting/unified/utils/datasource.ts
@@ -182,7 +182,8 @@ export function getDatasourceAPIUid(dataSourceName: string) {
 }
 
 export function getFirstCompatibleDataSource(): DataSourceInstanceSettings<DataSourceJsonData> | undefined {
-  return getRulesDataSources()[0];
+  return getDataSourceSrv().getList({ alerting: true })[0];
+  // return getRulesDataSources()[0];
 }
 
 export function getDefaultOrFirstCompatibleDataSource(): DataSourceInstanceSettings<DataSourceJsonData> | undefined {

--- a/public/app/features/alerting/unified/utils/datasource.ts
+++ b/public/app/features/alerting/unified/utils/datasource.ts
@@ -183,7 +183,6 @@ export function getDatasourceAPIUid(dataSourceName: string) {
 
 export function getFirstCompatibleDataSource(): DataSourceInstanceSettings<DataSourceJsonData> | undefined {
   return getDataSourceSrv().getList({ alerting: true })[0];
-  // return getRulesDataSources()[0];
 }
 
 export function getDefaultOrFirstCompatibleDataSource(): DataSourceInstanceSettings<DataSourceJsonData> | undefined {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the default query's data source when there is no data source marked as default


