### PR TITLE
CI: Add storybook bucket for main builds

### DIFF
--- a/pkg/build/config/versions.go
+++ b/pkg/build/config/versions.go
@@ -54,6 +54,7 @@ var Versions = VersionMap{
 			Artifacts:            "grafana-downloads",
 			ArtifactsEnterprise2: "grafana-downloads-enterprise2",
 			CDNAssets:            "grafana-static-assets",
+			Storybook:            "grafana-storybook",
 		},
 	},
 	CustomMode: {
@@ -88,7 +89,6 @@ var Versions = VersionMap{
 			Artifacts:            "grafana-downloads",
 			ArtifactsEnterprise2: "grafana-downloads-enterprise2",
 			CDNAssets:            "grafana-static-assets",
-			Storybook:            "grafana-storybook",
 		},
 	},
 	ReleaseBranchMode: {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix after https://github.com/grafana/grafana/pull/55379 where accidentally we put storybook bucket under `CustomMode`.