### PR TITLE
E2E: Wait for the timezone to be applied before asserting the legend format

### DIFF
--- a/e2e/dashboards-suite/dashboard-time-zone.spec.ts
+++ b/e2e/dashboards-suite/dashboard-time-zone.spec.ts
@@ -61,8 +61,8 @@ e2e.scenario({
     e2e.components.Select.option().should('be.visible').contains(toTimeZone).click();
 
     // click to go back to the dashboard.
-    e2e.components.BackButton.backArrow().click({ force: true }).wait(5000);
-    e2e.components.RefreshPicker.runButtonV2().click();
+    e2e.components.BackButton.backArrow().click({ force: true });
+    e2e.components.RefreshPicker.runButtonV2().should('be.visible').click();
 
     for (const title of panelsToCheck) {
       e2e.components.Panels.Panel.containerByTitle(title)
@@ -76,7 +76,9 @@ e2e.scenario({
               const inUtc = timesInUtc[title];
               const inTz = element.text();
               const isCorrect = isTimeCorrect(inUtc, inTz, offset);
-              assert.isTrue(isCorrect, `Panel with title: "${title}"`);
+              expect(isCorrect, `Expect the panel "${title}" to have the new timezone applied but isn't`).to.be.equal(
+                true
+              );
             })
         );
     }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

-->

**What this PR does / why we need it**:
We detected flakiness in the test [dashboard-time-zone.spec.ts](https://drone.grafana.net/grafana/grafana/79262/3/15). While investigating we found:
* The error triggered is not descriptive enough. The problem is not that the panel is not visible, the assertion falling is when we check the formatting
* The assertion for the formating happens right after hitting the refresh button
* The refresh data depends on the network speed, this is why it fails sometimes. If it is not quick enough, when calling `within(assert)` it runs the code once, and it waits for the timeout, it doesn't keep trying the assertion. So it fails if the refresh takes longer than Cypress running since there is no waiting condition

How to solve it?
* Improve the error message to explain what assertion is failing: "The widget with the name "foo" has not been affected by the time zone change: <received> -> <expected>"
* Retry the assertion until the format it's applied, we just need to assert to `expect` and it should fix the main issue

This PR also removes the unnecessary 5 fixed seconds of waiting after clicking on back.

Fixes: #55445

